### PR TITLE
release-23.2: roachtest: update mixed-version follower read tests for shared-process

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/httpclient.go
+++ b/pkg/cmd/roachtest/roachtestutil/httpclient.go
@@ -174,7 +174,7 @@ func getSessionIDOnSingleNode(
 	ctx context.Context, c cluster.Cluster, l *logger.Logger, node option.NodeListOption,
 ) (string, error) {
 	loginCmd := fmt.Sprintf(
-		"%s auth-session login root --port={pgport%s} --certs-dir ./certs --format raw",
+		"%s auth-session login root --port={pgport%s} --certs-dir ./certs --only-cookie",
 		test.DefaultCockroachPath, node,
 	)
 	res, err := c.RunWithDetailsSingleNode(ctx, l, node, loginCmd)
@@ -182,17 +182,7 @@ func getSessionIDOnSingleNode(
 		return "", errors.Wrap(err, "failed to authenticate")
 	}
 
-	var sessionCookie string
-	for _, line := range strings.Split(res.Stdout, "\n") {
-		if strings.HasPrefix(line, "session=") {
-			sessionCookie = line
-		}
-	}
-	if sessionCookie == "" {
-		return "", fmt.Errorf("failed to find session cookie in `login` output")
-	}
-
-	return sessionCookie, nil
+	return res.Stdout, nil
 }
 
 func getSessionID(

--- a/pkg/cmd/roachtest/roachtestutil/httpclient.go
+++ b/pkg/cmd/roachtest/roachtestutil/httpclient.go
@@ -44,21 +44,29 @@ import (
 //
 // Note that this currently only supports requests to CRDB clusters.
 type RoachtestHTTPClient struct {
-	client    *httputil.Client
-	sessionID string
-	cluster   cluster.Cluster
-	l         *logger.Logger
+	client             *httputil.Client
+	sessionID          string
+	cluster            cluster.Cluster
+	l                  *logger.Logger
+	virtualClusterName string
 	// Used for safely adding to the cookie jar.
 	mu syncutil.Mutex
 }
 
 type RoachtestHTTPOptions struct {
-	Timeout time.Duration
+	Timeout            time.Duration
+	VirtualClusterName string
 }
 
 func HTTPTimeout(timeout time.Duration) func(options *RoachtestHTTPOptions) {
 	return func(options *RoachtestHTTPOptions) {
 		options.Timeout = timeout
+	}
+}
+
+func VirtualCluster(name string) func(*RoachtestHTTPOptions) {
+	return func(options *RoachtestHTTPOptions) {
+		options.VirtualClusterName = name
 	}
 }
 
@@ -87,12 +95,13 @@ func DefaultHTTPClient(
 	if httpOptions.Timeout != 0 {
 		roachtestHTTP.client.Timeout = httpOptions.Timeout
 	}
+	roachtestHTTP.virtualClusterName = httpOptions.VirtualClusterName
 
 	return &roachtestHTTP
 }
 
 func (r *RoachtestHTTPClient) Get(ctx context.Context, url string) (*http.Response, error) {
-	if err := r.addCookie(ctx, url); err != nil {
+	if err := r.addCookies(ctx, url); err != nil {
 		return nil, err
 	}
 	return r.client.Get(ctx, url)
@@ -101,7 +110,7 @@ func (r *RoachtestHTTPClient) Get(ctx context.Context, url string) (*http.Respon
 func (r *RoachtestHTTPClient) GetJSON(
 	ctx context.Context, path string, response protoutil.Message,
 ) error {
-	if err := r.addCookie(ctx, path); err != nil {
+	if err := r.addCookies(ctx, path); err != nil {
 		return err
 	}
 	return httputil.GetJSON(*r.client.Client, path, response)
@@ -110,7 +119,7 @@ func (r *RoachtestHTTPClient) GetJSON(
 func (r *RoachtestHTTPClient) PostProtobuf(
 	ctx context.Context, path string, request, response protoutil.Message,
 ) error {
-	if err := r.addCookie(ctx, path); err != nil {
+	if err := r.addCookies(ctx, path); err != nil {
 		return err
 	}
 	return httputil.PostProtobuf(ctx, *r.client.Client, path, request, response)
@@ -123,32 +132,38 @@ func (r *RoachtestHTTPClient) ResetSession() {
 	r.sessionID = ""
 }
 
-func (r *RoachtestHTTPClient) addCookie(ctx context.Context, cookieUrl string) error {
+func (r *RoachtestHTTPClient) addCookies(ctx context.Context, cookieUrl string) error {
 	// If the cluster is not running in secure mode, don't try to add cookies.
 	if !r.cluster.IsSecure() {
 		return nil
 	}
 	// If we haven't extracted the sessionID yet, do so.
 	if r.sessionID == "" {
-		id, err := getSessionID(ctx, r.cluster, r.l, r.cluster.All())
+		id, err := getSessionID(ctx, r.cluster, r.l, r.cluster.All(), r.virtualClusterName)
 		if err != nil {
-			return errors.Wrapf(err, "roachtestutil.addCookie: unable to extract sessionID")
+			return errors.Wrapf(err, "roachtestutil.addCookies: unable to extract sessionID")
 		}
 		r.sessionID = id
 	}
 
 	name, value, found := strings.Cut(r.sessionID, "=")
 	if !found {
-		return errors.New("Cookie not formatted correctly")
+		return errors.Newf("cookie not formatted correctly: %q", r.sessionID)
 	}
 
 	url, err := url.Parse(cookieUrl)
 	if err != nil {
-		return errors.Wrapf(err, "roachtestutil.addCookie: unable to parse cookieUrl")
+		return errors.Wrapf(err, "roachtestutil.addCookies: unable to parse cookieUrl")
 	}
-	err = r.SetCookies(url, []*http.Cookie{{Name: name, Value: value}})
+
+	cookies := []*http.Cookie{{Name: name, Value: value}}
+	if r.virtualClusterName != "" {
+		cookies = append(cookies, &http.Cookie{Name: "tenant", Value: r.virtualClusterName})
+	}
+
+	err = r.SetCookies(url, cookies)
 	if err != nil {
-		return errors.Wrapf(err, "roachtestutil.addCookie: unable to set cookie")
+		return errors.Wrapf(err, "roachtestutil.addCookies: unable to set cookies")
 	}
 
 	return nil
@@ -171,11 +186,20 @@ func (r *RoachtestHTTPClient) SetCookies(u *url.URL, cookies []*http.Cookie) err
 }
 
 func getSessionIDOnSingleNode(
-	ctx context.Context, c cluster.Cluster, l *logger.Logger, node option.NodeListOption,
+	ctx context.Context,
+	c cluster.Cluster,
+	l *logger.Logger,
+	node option.NodeListOption,
+	virtualClusterName string,
 ) (string, error) {
+	var virtualClusterSelector string
+	if virtualClusterName != "" {
+		virtualClusterSelector = fmt.Sprintf(":%s", virtualClusterName)
+	}
+
 	loginCmd := fmt.Sprintf(
-		"%s auth-session login root --port={pgport%s} --certs-dir ./certs --only-cookie",
-		test.DefaultCockroachPath, node,
+		"%s auth-session login root --url={pgurl%s%s} --certs-dir ./certs --only-cookie",
+		test.DefaultCockroachPath, node, virtualClusterSelector,
 	)
 	res, err := c.RunWithDetailsSingleNode(ctx, l, node, loginCmd)
 	if err != nil {
@@ -186,18 +210,22 @@ func getSessionIDOnSingleNode(
 }
 
 func getSessionID(
-	ctx context.Context, c cluster.Cluster, l *logger.Logger, nodes option.NodeListOption,
+	ctx context.Context,
+	c cluster.Cluster,
+	l *logger.Logger,
+	nodes option.NodeListOption,
+	virtualClusterName string,
 ) (string, error) {
 	var err error
 	var cookie string
 	// The session ID should be the same for all nodes so stop after we successfully
 	// get it from one node.
 	for _, node := range nodes {
-		cookie, err = getSessionIDOnSingleNode(ctx, c, l, c.Node(node))
+		cookie, err = getSessionIDOnSingleNode(ctx, c, l, c.Node(node), virtualClusterName)
 		if err == nil {
 			break
 		}
-		l.Printf("%s auth session login failed on node %d: %v", test.DefaultCockroachPath, node, err)
+		l.Printf("%s auth-session login failed on node %d: %v", test.DefaultCockroachPath, node, err)
 	}
 	if err != nil {
 		return "", errors.Wrapf(err, "roachtestutil.GetSessionID")

--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -35,7 +35,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgtype"
@@ -76,8 +78,33 @@ func registerFollowerReads(r registry.Registry) {
 					survival:          survival,
 					deadPrimaryRegion: insufficientQuorum,
 				}
-				data := initFollowerReadsDB(ctx, t, c, topology)
-				runFollowerReadsTest(ctx, t, c, topology, rc, data)
+				conns := struct {
+					mu      syncutil.Mutex
+					mapping map[int]*gosql.DB
+				}{
+					mapping: make(map[int]*gosql.DB),
+				}
+				connFunc := func(node int) *gosql.DB {
+					conns.mu.Lock()
+					defer conns.mu.Unlock()
+
+					if _, ok := conns.mapping[node]; !ok {
+						conn := c.Conn(ctx, t.L(), node)
+						conns.mapping[node] = conn
+					}
+
+					return conns.mapping[node]
+				}
+
+				defer func() {
+					for _, c := range conns.mapping {
+						c.Close()
+					}
+				}()
+
+				rng, _ := randutil.NewPseudoRand()
+				data := initFollowerReadsDB(ctx, t, t.L(), c, connFunc, connFunc, rng, topology)
+				runFollowerReadsTest(ctx, t, t.L(), c, rng, topology, rc, data)
 			},
 		})
 	}
@@ -183,7 +210,9 @@ type topologySpec struct {
 func runFollowerReadsTest(
 	ctx context.Context,
 	t test.Test,
+	l *logger.Logger,
 	c cluster.Cluster,
+	rng *rand.Rand,
 	topology topologySpec,
 	rc readConsistency,
 	data map[int]int64,
@@ -277,10 +306,7 @@ func runFollowerReadsTest(
 		),
 	)
 	if err != nil {
-		// 20.2 doesn't have this setting.
-		if !strings.Contains(err.Error(), "unknown cluster setting") {
-			t.Fatal(err)
-		}
+		t.Fatal(err)
 	}
 
 	// Read the follower read counts before issuing the follower reads to observe
@@ -295,7 +321,7 @@ func runFollowerReadsTest(
 	// Perform reads on each node and ensure we get the expected value. Do so for
 	// 15 seconds to give closed timestamps a chance to propagate and caches time
 	// to warm up.
-	t.L().Printf("warming up reads")
+	l.Printf("warming up reads")
 	g, gCtx := errgroup.WithContext(ctx)
 	k, v := chooseKV()
 	until := timeutil.Now().Add(15 * time.Second)
@@ -339,19 +365,19 @@ func runFollowerReadsTest(
 		if topology.deadPrimaryRegion && i <= 3 {
 			stopOpts := option.DefaultStopOpts()
 			stopOpts.RoachprodOpts.Sig = 9
-			c.Stop(ctx, t.L(), stopOpts, c.Node(i))
+			c.Stop(ctx, l, stopOpts, c.Node(i))
 			deadNodes[i] = struct{}{}
 		} else {
 			liveNodes[i] = struct{}{}
 		}
 	}
 
-	t.L().Printf("starting read load")
+	l.Printf("starting read load")
 	const loadDuration = 4 * time.Minute
 	timeoutCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	time.AfterFunc(loadDuration, func() {
-		t.L().Printf("stopping load")
+		l.Printf("stopping load")
 		cancel()
 	})
 	g, gCtx = errgroup.WithContext(timeoutCtx)
@@ -370,7 +396,7 @@ func runFollowerReadsTest(
 		t.Fatalf("error reading data: %v", err)
 	}
 	end := timeutil.Now()
-	t.L().Printf("load stopped")
+	l.Printf("load stopped")
 
 	// Depending on the test's topology, we expect a different set of nodes to
 	// perform follower reads.
@@ -400,7 +426,7 @@ func runFollowerReadsTest(
 			expectedLowRatioNodes = 1
 		}
 	}
-	verifyHighFollowerReadRatios(ctx, t, c, liveNodes, start, end, expectedLowRatioNodes)
+	verifyHighFollowerReadRatios(ctx, t, l, c, liveNodes, start, end, expectedLowRatioNodes)
 
 	if topology.multiRegion {
 		// Perform a ts query to verify that the SQL latencies were well below the
@@ -408,31 +434,44 @@ func runFollowerReadsTest(
 		//
 		// We don't do this for singleRegion since, in a single region, there's no
 		// low latency and high-latency regimes.
-		verifySQLLatency(ctx, t, c, liveNodes, start, end, maxLatencyThreshold)
+		verifySQLLatency(ctx, t, l, c, liveNodes, start, end, maxLatencyThreshold)
 	}
 
 	// Restart dead nodes, if necessary.
 	for i := range deadNodes {
-		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Node(i))
+		c.Start(ctx, l, option.DefaultStartOpts(), install.MakeClusterSettings(), c.Node(i))
 	}
 }
 
 // initFollowerReadsDB initializes a database for the follower reads test.
 // Returns the data inserted into the test table.
+//
+// The `connFunc` (and `systemConnFunc`) parameters capture how to
+// connect to the database in a test run. This allows us to use the
+// mixedersion helpers in mixed-version tests. We need to connect to
+// the system tenant to change relevant SystemOnly cluster settings,
+// and some mixed-version tests run in a multi-tenant deployment.
 func initFollowerReadsDB(
-	ctx context.Context, t test.Test, c cluster.Cluster, topology topologySpec,
+	ctx context.Context,
+	t test.Test,
+	l *logger.Logger,
+	c cluster.Cluster,
+	connectFunc, systemConnectFunc func(int) *gosql.DB,
+	rng *rand.Rand,
+	topology topologySpec,
 ) (data map[int]int64) {
-	db := c.Conn(ctx, t.L(), 1)
-	defer db.Close()
+	systemDB := systemConnectFunc(1)
+	db := connectFunc(1)
+
 	// Disable load based splitting and range merging because splits and merges
 	// interfere with follower reads. This test's workload regularly triggers load
 	// based splitting in the first phase creating small ranges which later
 	// in the test are merged. The merging tends to coincide with the final phase
 	// of the test which attempts to observe low latency reads leading to
 	// flakiness.
-	_, err := db.ExecContext(ctx, "SET CLUSTER SETTING kv.range_split.by_load_enabled = 'false'")
+	_, err := systemDB.ExecContext(ctx, "SET CLUSTER SETTING kv.range_split.by_load_enabled = 'false'")
 	require.NoError(t, err)
-	_, err = db.ExecContext(ctx, "SET CLUSTER SETTING kv.range_merge.queue_enabled = 'false'")
+	_, err = systemDB.ExecContext(ctx, "SET CLUSTER SETTING kv.range_merge.queue_enabled = 'false'")
 	require.NoError(t, err)
 
 	// Check the cluster regions.
@@ -480,7 +519,7 @@ func initFollowerReadsDB(
 	}
 
 	// Wait until the table has completed up-replication.
-	t.L().Printf("waiting for up-replication...")
+	l.Printf("waiting for up-replication...")
 	retryOpts := retry.Options{MaxBackoff: 15 * time.Second}
 	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 		// Check that the table has the expected number and location of voting and
@@ -528,7 +567,7 @@ func initFollowerReadsDB(
 			ctx, q1, votersCount, nonVotersCount, pq.Array(votersSet), pq.Array(nonVotersSet),
 		).Scan(&ok, &voters, &nonVoters)
 		if errors.Is(err, gosql.ErrNoRows) {
-			t.L().Printf("up-replication not complete, missing range")
+			l.Printf("up-replication not complete, missing range")
 			continue
 		}
 		require.NoError(t, err)
@@ -537,9 +576,9 @@ func initFollowerReadsDB(
 			break
 		}
 
-		t.L().Printf("up-replication not complete, "+
-			"found voters = %v (want %d in set %v) and non_voters = %s (want %d in set %v)",
-			voters, votersCount, votersSet, nonVoters, votersCount, votersSet)
+		l.Printf("up-replication not complete, "+
+			"found voters = %v (want %d in set %v) and non_voters = %v (want %d in set %v)",
+			voters, votersCount, votersSet, nonVoters, nonVotersCount, nonVotersSet)
 	}
 
 	if topology.multiRegion {
@@ -596,7 +635,7 @@ func initFollowerReadsDB(
 					break
 				}
 
-				t.L().Printf("rebalancing not complete, expected %d at risk ranges, "+
+				l.Printf("rebalancing not complete, expected %d at risk ranges, "+
 					"found %d", expAtRisk, atRisk)
 			}
 		}
@@ -607,7 +646,7 @@ func initFollowerReadsDB(
 	sem := make(chan struct{}, concurrency)
 	data = make(map[int]int64)
 	insert := func(ctx context.Context, k int) func() error {
-		v := rand.Int63()
+		v := rng.Int63()
 		data[k] = v
 		return func() error {
 			sem <- struct{}{}
@@ -649,6 +688,7 @@ func computeFollowerReadDuration(ctx context.Context, db *gosql.DB) (time.Durati
 func verifySQLLatency(
 	ctx context.Context,
 	t test.Test,
+	l *logger.Logger,
 	c cluster.Cluster,
 	liveNodes map[int]struct{},
 	start, end time.Time,
@@ -660,13 +700,11 @@ func verifySQLLatency(
 		adminNode = i
 		break
 	}
-	adminURLs, err := c.ExternalAdminUIAddr(ctx, t.L(), c.Node(adminNode))
+	adminURLs, err := c.ExternalAdminUIAddr(ctx, l, c.Node(adminNode))
 	if err != nil {
 		t.Fatal(err)
 	}
-	// follower-reads/mixed-version runs on insecure mode, so we need http.
-	// Tests that do run on secure mode will redirect to https.
-	url := "http://" + adminURLs[0] + "/ts/query"
+	url := "https://" + adminURLs[0] + "/ts/query"
 	var sources []string
 	for i := range liveNodes {
 		sources = append(sources, strconv.Itoa(i))
@@ -682,7 +720,7 @@ func verifySQLLatency(
 			SourceAggregator: tspb.TimeSeriesQueryAggregator_MAX.Enum(),
 		}},
 	}
-	client := roachtestutil.DefaultHTTPClient(c, t.L())
+	client := roachtestutil.DefaultHTTPClient(c, l)
 	var response tspb.TimeSeriesQueryResponse
 	if err := client.PostProtobuf(ctx, url, &request, &response); err != nil {
 		t.Fatal(err)
@@ -714,6 +752,7 @@ func verifySQLLatency(
 func verifyHighFollowerReadRatios(
 	ctx context.Context,
 	t test.Test,
+	l *logger.Logger,
 	c cluster.Cluster,
 	liveNodes map[int]struct{},
 	start, end time.Time,
@@ -731,11 +770,10 @@ func verifyHighFollowerReadRatios(
 		adminNode = i
 		break
 	}
-	adminURLs, err := c.ExternalAdminUIAddr(ctx, t.L(), c.Node(adminNode))
+	adminURLs, err := c.ExternalAdminUIAddr(ctx, l, c.Node(adminNode))
 	require.NoError(t, err)
-	// follower-reads/mixed-version runs on insecure mode, so we need http.
-	// Tests that do run on secure mode will redirect to https.
-	url := "http://" + adminURLs[0] + "/ts/query"
+
+	url := "https://" + adminURLs[0] + "/ts/query"
 	request := tspb.TimeSeriesQueryRequest{
 		StartNanos: start.UnixNano(),
 		EndNanos:   end.UnixNano(),
@@ -755,7 +793,11 @@ func verifyHighFollowerReadRatios(
 			Derivative: tspb.TimeSeriesQueryDerivative_NON_NEGATIVE_DERIVATIVE.Enum(),
 		})
 	}
-	client := roachtestutil.DefaultHTTPClient(c, t.L())
+	// Make sure to connect to the system tenant in case this test
+	// is running on a multitenant deployment.
+	client := roachtestutil.DefaultHTTPClient(
+		c, l, roachtestutil.VirtualCluster(install.SystemInterfaceName),
+	)
 	var response tspb.TimeSeriesQueryResponse
 	if err := client.PostProtobuf(ctx, url, &request, &response); err != nil {
 		t.Fatal(err)
@@ -788,7 +830,7 @@ func verifyHighFollowerReadRatios(
 		}
 	}
 
-	t.L().Printf("interval stats: %s", intervalsToString(stats))
+	l.Printf("interval stats: %s", intervalsToString(stats))
 
 	// Now count how many intervals have more than the tolerated number of nodes
 	// with low follower read ratios.
@@ -843,10 +885,12 @@ func getFollowerReadCounts(ctx context.Context, t test.Test, c cluster.Cluster) 
 			if err != nil {
 				return err
 			}
-			// follower-reads/mixed-version runs on insecure mode, so we need http.
-			// Tests that do run on secure mode will redirect to https.
-			url := "http://" + adminUIAddrs[0] + "/_status/vars"
-			client := roachtestutil.DefaultHTTPClient(c, t.L())
+			url := "https://" + adminUIAddrs[0] + "/_status/vars"
+			// Make sure to connect to the system tenant in case this test
+			// is running on a multitenant deployment.
+			client := roachtestutil.DefaultHTTPClient(
+				c, t.L(), roachtestutil.VirtualCluster(install.SystemInterfaceName),
+			)
 			resp, err := client.Get(ctx, url)
 			if err != nil {
 				return err
@@ -948,21 +992,25 @@ func runFollowerReadsMixedVersionTest(
 	rc readConsistency,
 	opts ...mixedversion.CustomOption,
 ) {
-	mvt := mixedversion.NewTest(ctx, t, t.L(), c, c.All(),
-		append([]mixedversion.CustomOption{
-			// Multi-tenant deployments are currently unsupported. See #127378.
-			mixedversion.EnabledDeploymentModes(mixedversion.SystemOnlyDeployment),
-		}, opts...)...,
-	)
+	mvt := mixedversion.NewTest(ctx, t, t.L(), c, c.All(), opts...)
 
 	var data map[int]int64
 	runInit := func(ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper) error {
-		data = initFollowerReadsDB(ctx, t, c, topology)
+		if topology.multiRegion &&
+			h.IsMultitenant() &&
+			!h.Context().FromVersion.AtLeast(mixedversion.TenantsAndSystemAlignedSettingsVersion) {
+			const setting = "sql.multi_region.allow_abstractions_for_secondary_tenants.enabled"
+			if err := setTenantSetting(l, r, h, setting, true); err != nil {
+				return errors.Wrapf(err, "setting %s", setting)
+			}
+		}
+
+		data = initFollowerReadsDB(ctx, t, l, c, h.Connect, h.System.Connect, r, topology)
 		return nil
 	}
 
 	runFollowerReads := func(ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper) error {
-		runFollowerReadsTest(ctx, t, c, topology, rc, data)
+		runFollowerReadsTest(ctx, t, l, c, r, topology, rc, data)
 		return nil
 	}
 


### PR DESCRIPTION
Backport 3/3 commits from #128596.

/cc @cockroachdb/release

---

As usual, a few changes were necessary because the test changed
cluster settings only visible to the system tenant. In addition, this
test performs HTTP calls to crdb endpoints. We use newly introduced
`VirtualCluster` option in the HTTP client in order to view system
statistics during the test.

Informs: #127378

Release note: None

Release justification: test only changes.