### PR TITLE
build system: use proxied docker mirror

### DIFF
--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -1,6 +1,6 @@
 # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
 # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
-FROM us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:focal
+FROM us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:focal
 ARG TARGETPLATFORM
 
 RUN apt-get update \

--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -1,6 +1,6 @@
 # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
 # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
-FROM us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/registry.access.redhat.com/ubi9/ubi-minimal
+FROM us-east1-docker.pkg.dev/crl-docker-sync/registry-access-redhat-com/ubi9/ubi-minimal
 ARG fips_enabled
 
 # For deployment, we need the following additionally installed:

--- a/build/teamcity/internal/cockroach/build/ci/nightly-bazel-builder-update-check.sh
+++ b/build/teamcity/internal/cockroach/build/ci/nightly-bazel-builder-update-check.sh
@@ -3,7 +3,7 @@ set -xeuo pipefail
 
 # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
 # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
-BASE_IMAGE="us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:focal"
+BASE_IMAGE="us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:focal"
 BAZEL_IMAGE="us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:latest-do-not-use"
 
 docker pull $BASE_IMAGE && docker pull $BAZEL_IMAGE

--- a/build/teamcity/internal/release/build-and-publish-patched-go.sh
+++ b/build/teamcity/internal/release/build-and-publish-patched-go.sh
@@ -18,7 +18,7 @@ mkdir -p "${toplevel}"/artifacts
 # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
 docker run --rm -i ${tty-} -v $this_dir/build-and-publish-patched-go:/bootstrap \
        -v "${toplevel}"/artifacts:/artifacts \
-       us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:focal /bootstrap/impl.sh
+       us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:focal /bootstrap/impl.sh
 tc_end_block "Build Go toolchains"
 
 tc_start_block "Build FIPS Go toolchains (linux/amd64)"

--- a/build/toolchains/toolchainbuild/crosstool-ng/buildtoolchains.sh
+++ b/build/toolchains/toolchainbuild/crosstool-ng/buildtoolchains.sh
@@ -12,4 +12,4 @@ mkdir -p "${toplevel}"/artifacts
 # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
 docker run --rm -i ${tty-} -v $this_dir:/bootstrap \
        -v "${toplevel}"/artifacts:/artifacts \
-       us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:focal-20210119 /bootstrap/perform-build.sh
+       us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:focal-20210119 /bootstrap/perform-build.sh

--- a/build/toolchains/toolchainbuild/osxcross/buildtoolchains.sh
+++ b/build/toolchains/toolchainbuild/osxcross/buildtoolchains.sh
@@ -12,4 +12,4 @@ mkdir -p "${toplevel}"/artifacts
 # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
 docker run --rm -i ${tty-} -v $this_dir:/bootstrap \
        -v "${toplevel}"/artifacts:/artifacts \
-       us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:focal-20210119 /bootstrap/perform-build.sh
+       us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:focal-20210119 /bootstrap/perform-build.sh

--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -58,7 +58,7 @@ import (
 const (
 	// We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
 	// See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
-	defaultImage  = "us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:focal-20210119"
+	defaultImage  = "us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:focal-20210119"
 	networkPrefix = "cockroachdb_acceptance"
 )
 

--- a/pkg/acceptance/compose/flyway/docker-compose.yml
+++ b/pkg/acceptance/compose/flyway/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   cockroach:
     # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
     # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
-    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:xenial-20210804
+    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:xenial-20210804
     command: /cockroach/cockroach start-single-node --insecure --listen-addr cockroach
     volumes:
       - ${COCKROACH_BINARY:-../../../../cockroach-linux-2.6.32-gnu-amd64}:/cockroach/cockroach

--- a/pkg/acceptance/compose/gss/docker-compose-python.yml
+++ b/pkg/acceptance/compose/gss/docker-compose-python.yml
@@ -7,7 +7,7 @@ services:
   cockroach:
     # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
     # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
-    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:xenial-20210804
+    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:xenial-20210804
     depends_on:
       - kdc
     command: /cockroach/cockroach --certs-dir=/certs start-single-node --listen-addr cockroach

--- a/pkg/acceptance/compose/gss/docker-compose.yml
+++ b/pkg/acceptance/compose/gss/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   cockroach:
     # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
     # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
-    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:xenial-20210804
+    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:xenial-20210804
     depends_on:
       - kdc
     command: /cockroach/cockroach --certs-dir=/certs start-single-node --listen-addr cockroach

--- a/pkg/compose/compare/docker-compose.yml
+++ b/pkg/compose/compare/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   cockroach1:
     # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
     # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
-    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:xenial-20170214
+    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:xenial-20170214
     user: ${UID}:${GID}
     command: /cockroach/cockroach start-single-node --insecure --store=/cockroach/store --spatial-libs=/cockroach/lib --listen-addr cockroach1
     volumes:
@@ -14,7 +14,7 @@ services:
   cockroach2:
     # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
     # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
-    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:xenial-20170214
+    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:xenial-20170214
     user: ${UID}:${GID}
     command: /cockroach/cockroach start-single-node --insecure --store=/cockroach/store --spatial-libs=/cockroach/lib --listen-addr cockroach2
     volumes:
@@ -26,7 +26,7 @@ services:
   test:
     # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
     # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
-    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-mirror/docker.io/library/ubuntu:xenial-20170214
+    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:xenial-20170214
     environment:
       - COCKROACH_DEV_LICENSE=$COCKROACH_DEV_LICENSE
       - COCKROACH_RUN_COMPOSE_COMPARE=${COCKROACH_RUN_COMPOSE_COMPARE}


### PR DESCRIPTION
Previously, we used a bespoke docker mirror, that requires explicit mirroring and setup. This makes the solution hard to maintain. The syncing process needs to go through all images and layers, what leads to rate limit errors.

This PR changes the manual mirror to the proxied caching mirror to simplify our setup and improve reliability.

Fixes: DEVINF-1276
Release note: None