### PR TITLE
dbconsole: fix legend for elastic CPU queue delay graph

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
@@ -236,7 +236,7 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.node.admission.wait_durations.elastic-cpu-p99"
-              title={"KV write " + nodeDisplayName(nodeDisplayNameByID, nid)}
+              title={nodeDisplayName(nodeDisplayNameByID, nid)}
               sources={[nid]}
               downsampleMax
             />


### PR DESCRIPTION
Fixes #128339.

Release note (ui change): Fixing the legend on overload page for `Admission Queueing Delay p99 – Background (Elastic) CPU`.