### PR TITLE
release-24.1: storage: fix cases of unencoded key ranges

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -849,8 +849,8 @@ func DefaultPebbleOptions() *pebble.Options {
 	}
 	opts.Experimental.ShortAttributeExtractor = shortAttributeExtractorForValues
 	opts.Experimental.RequiredInPlaceValueBound = pebble.UserKeyPrefixBound{
-		Lower: keys.LocalRangeLockTablePrefix,
-		Upper: keys.LocalRangeLockTablePrefix.PrefixEnd(),
+		Lower: EncodeMVCCKey(MVCCKey{Key: keys.LocalRangeLockTablePrefix}),
+		Upper: EncodeMVCCKey(MVCCKey{Key: keys.LocalRangeLockTablePrefix.PrefixEnd()}),
 	}
 
 	for i := 0; i < len(opts.Levels); i++ {
@@ -1076,8 +1076,8 @@ func (p *Pebble) Download(ctx context.Context, span roachpb.Span, copy bool) err
 		return nil
 	}
 	downloadSpan := pebble.DownloadSpan{
-		StartKey:               span.Key,
-		EndKey:                 span.EndKey,
+		StartKey:               EncodeMVCCKey(MVCCKey{Key: span.Key}),
+		EndKey:                 EncodeMVCCKey(MVCCKey{Key: span.EndKey}),
 		ViaBackingFileDownload: copy,
 	}
 	return p.db.Download(ctx, []pebble.DownloadSpan{downloadSpan})
@@ -2301,7 +2301,11 @@ func (p *Pebble) PreIngestDelay(ctx context.Context) {
 
 // GetTableMetrics implements the Engine interface.
 func (p *Pebble) GetTableMetrics(start, end roachpb.Key) ([]enginepb.SSTableMetricsInfo, error) {
-	tableInfo, err := p.db.SSTables(pebble.WithKeyRangeFilter(start, end), pebble.WithProperties(), pebble.WithApproximateSpanBytes())
+	filterOpt := pebble.WithKeyRangeFilter(
+		EncodeMVCCKey(MVCCKey{Key: start}),
+		EncodeMVCCKey(MVCCKey{Key: end}),
+	)
+	tableInfo, err := p.db.SSTables(filterOpt, pebble.WithProperties(), pebble.WithApproximateSpanBytes())
 
 	if err != nil {
 		return []enginepb.SSTableMetricsInfo{}, err


### PR DESCRIPTION
Backport 1/1 commits from #128816.

/cc @cockroachdb/release

---

This is a backport of the fixes inside #128043. These are a few cases where we are passing unencoded key ranges to Pebble for various operations. This can result in an effective range that starts and/or ends sooner than intended (part of the key will be treated as the suffix).

Release justification: fix for Online Restore download phase and for key range table metrics.

Epic: none
Release note: None
