### PR TITLE
release-23.1: build system: use proxied docker mirror

### DIFF
--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:focal
+# We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+# See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+FROM us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:focal
 ARG TARGETPLATFORM
 
 RUN apt-get update \

--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -1,4 +1,6 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+# We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+# See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+FROM us-east1-docker.pkg.dev/crl-docker-sync/registry-access-redhat-com/ubi8/ubi-minimal
 ARG fips_enabled
 
 # For deployment, we need the following additionally installed:

--- a/build/teamcity/internal/cockroach/build/ci/nightly-bazel-builder-update-check.sh
+++ b/build/teamcity/internal/cockroach/build/ci/nightly-bazel-builder-update-check.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
-BASE_IMAGE="ubuntu:focal"
+# We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+# See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+BASE_IMAGE="us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:focal"
 BAZEL_IMAGE="us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:latest-do-not-use"
 
 docker pull $BASE_IMAGE && docker pull $BAZEL_IMAGE

--- a/build/teamcity/internal/release/build-and-publish-patched-go.sh
+++ b/build/teamcity/internal/release/build-and-publish-patched-go.sh
@@ -16,7 +16,7 @@ toplevel="$(dirname $(dirname $(dirname $(dirname $this_dir))))"
 mkdir -p "${toplevel}"/artifacts
 docker run --rm -i ${tty-} -v $this_dir/build-and-publish-patched-go:/bootstrap \
        -v "${toplevel}"/artifacts:/artifacts \
-       ubuntu:focal /bootstrap/impl.sh
+       us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:focal /bootstrap/impl.sh
 tc_end_block "Build Go toolchains"
 
 tc_start_block "Build FIPS Go toolchains (linux/amd64)"

--- a/build/toolchains/toolchainbuild/crosstool-ng/buildtoolchains.sh
+++ b/build/toolchains/toolchainbuild/crosstool-ng/buildtoolchains.sh
@@ -10,4 +10,4 @@ mkdir -p "${toplevel}"/artifacts
 # note: the Docker image should match the base image of `us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel`.
 docker run --rm -i ${tty-} -v $this_dir:/bootstrap \
        -v "${toplevel}"/artifacts:/artifacts \
-       ubuntu:focal-20210119 /bootstrap/perform-build.sh
+       us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:focal-20210119 /bootstrap/perform-build.sh

--- a/build/toolchains/toolchainbuild/osxcross/buildtoolchains.sh
+++ b/build/toolchains/toolchainbuild/osxcross/buildtoolchains.sh
@@ -10,4 +10,4 @@ mkdir -p "${toplevel}"/artifacts
 # note: the Docker image should match the base image of `us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel`.
 docker run --rm -i ${tty-} -v $this_dir:/bootstrap \
        -v "${toplevel}"/artifacts:/artifacts \
-       ubuntu:focal-20210119 /bootstrap/perform-build.sh
+       us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:focal-20210119 /bootstrap/perform-build.sh

--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -52,7 +52,9 @@ import (
 )
 
 const (
-	defaultImage  = "docker.io/library/ubuntu:focal-20210119"
+	// We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+	// See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+	defaultImage  = "us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:focal-20210119"
 	networkPrefix = "cockroachdb_acceptance"
 )
 

--- a/pkg/acceptance/compose/flyway/docker-compose.yml
+++ b/pkg/acceptance/compose/flyway/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   cockroach:
-    image: ubuntu:xenial-20210804
+    # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+    # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:xenial-20210804
     command: /cockroach/cockroach start-single-node --insecure --listen-addr cockroach
     volumes:
       - ${COCKROACH_BINARY:-../../../../cockroach-linux-2.6.32-gnu-amd64}:/cockroach/cockroach

--- a/pkg/acceptance/compose/gss/docker-compose-python.yml
+++ b/pkg/acceptance/compose/gss/docker-compose-python.yml
@@ -5,7 +5,9 @@ services:
       - ./kdc/start.sh:/start.sh
       - keytab:/keytab
   cockroach:
-    image: ubuntu:xenial-20210804
+    # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+    # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:xenial-20210804
     depends_on:
       - kdc
     command: /cockroach/cockroach --certs-dir=/certs start-single-node --listen-addr cockroach

--- a/pkg/acceptance/compose/gss/docker-compose.yml
+++ b/pkg/acceptance/compose/gss/docker-compose.yml
@@ -6,7 +6,9 @@ services:
       - ./kdc/start.sh:/start.sh
       - keytab:/keytab
   cockroach:
-    image: ubuntu:xenial-20210804
+    # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+    # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:xenial-20210804
     depends_on:
       - kdc
     command: /cockroach/cockroach --certs-dir=/certs start-single-node --listen-addr cockroach

--- a/pkg/compose/compare/docker-compose.yml
+++ b/pkg/compose/compare/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   cockroach1:
-    image: ubuntu:xenial-20170214
+    # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+    # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:xenial-20170214
     user: ${UID}:${GID}
     command: /cockroach/cockroach start-single-node --insecure --store=/cockroach/store --spatial-libs=/cockroach/lib --listen-addr cockroach1
     volumes:
@@ -10,7 +12,9 @@ services:
       - /etc/passwd:/etc/passwd:ro
       - /etc/group:/etc/group:ro
   cockroach2:
-    image: ubuntu:xenial-20170214
+    # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+    # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:xenial-20170214
     user: ${UID}:${GID}
     command: /cockroach/cockroach start-single-node --insecure --store=/cockroach/store --spatial-libs=/cockroach/lib --listen-addr cockroach2
     volumes:
@@ -20,7 +24,9 @@ services:
       - /etc/passwd:/etc/passwd:ro
       - /etc/group:/etc/group:ro
   test:
-    image: ubuntu:xenial-20170214
+    # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.
+    # See https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3462594561/Docker+image+sync for the details.
+    image: us-east1-docker.pkg.dev/crl-docker-sync/docker-io/library/ubuntu:xenial-20170214
     environment:
       - COCKROACH_DEV_LICENSE=$COCKROACH_DEV_LICENSE
     # compare.test is a binary built by the pkg/compose/prepare.sh in non-bazel builds


### PR DESCRIPTION
Backport 1/1 commits from #128826.

/cc @cockroachdb/release

---

Backport 1/1 commits from #128808.

/cc @cockroachdb/release

---

Previously, we used a bespoke docker mirror, that requires explicit mirroring and setup. This makes the solution hard to maintain. The syncing process needs to go through all images and layers, what leads to rate limit errors.

This PR changes the manual mirror to the proxied caching mirror to simplify our setup and improve reliability.

Fixes: DEVINF-1276
Release note: None
Release justification: build-system changes only
