### PR TITLE
raft: send follower's commit index in MsgAppResp

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1706,10 +1706,10 @@ func (r *Replica) sendRaftMessages(
 				}
 
 			case raftpb.MsgAppResp:
-				// A successful (non-reject) MsgAppResp contains one piece of
-				// information: the highest log index. Raft currently queues up
-				// one MsgAppResp per incoming MsgApp, and we may process
-				// multiple messages in one handleRaftReady call (because
+				// A successful (non-reject) MsgAppResp contains two pieces of
+				// information: the highest log index and the commit index. Raft
+				// currently queues up one MsgAppResp per incoming MsgApp, and we may
+				// process multiple messages in one handleRaftReady call (because
 				// multiple messages may arrive while we're blocked syncing to
 				// disk). If we get redundant MsgAppResps, drop all but the
 				// last (we've seen that too many MsgAppResps can overflow

--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -485,6 +485,7 @@ func (l *raftLog) matchTerm(id entryID) bool {
 	if err != nil {
 		return false
 	}
+
 	return t == id.term
 }
 

--- a/pkg/raft/node_test.go
+++ b/pkg/raft/node_test.go
@@ -462,7 +462,7 @@ func TestNodeStart(t *testing.T) {
 			HardState:        raftpb.HardState{Term: 2, Commit: 3, Vote: 1, Lead: 1},
 			Entries:          nil,
 			CommittedEntries: []raftpb.Entry{{Term: 2, Index: 3, Data: []byte("foo")}},
-			MustSync:         false,
+			MustSync:         true,
 		},
 	}
 	storage := NewMemoryStorage()

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -846,7 +846,8 @@ func (r *raft) appendEntry(es ...pb.Entry) (accepted bool) {
 	//  if r.maybeCommit() {
 	//  	r.bcastAppend()
 	//  }
-	r.send(pb.Message{To: r.id, Type: pb.MsgAppResp, Index: r.raftLog.lastIndex()})
+	r.send(pb.Message{To: r.id, Type: pb.MsgAppResp, Index: r.raftLog.lastIndex(),
+		Commit: r.raftLog.committed})
 	return true
 }
 
@@ -1751,7 +1752,8 @@ func (r *raft) handleAppendEntries(m pb.Message) {
 	}
 
 	if a.prev.index < r.raftLog.committed {
-		r.send(pb.Message{To: m.From, Type: pb.MsgAppResp, Index: r.raftLog.committed})
+		r.send(pb.Message{To: m.From, Type: pb.MsgAppResp, Index: r.raftLog.committed,
+			Commit: r.raftLog.committed})
 		return
 	}
 	if r.raftLog.maybeAppend(a) {
@@ -1761,7 +1763,8 @@ func (r *raft) handleAppendEntries(m pb.Message) {
 		// the commit index even if the MsgApp is stale.
 		lastIndex := a.lastIndex()
 		r.raftLog.commitTo(logMark{term: m.Term, index: min(m.Commit, lastIndex)})
-		r.send(pb.Message{To: m.From, Type: pb.MsgAppResp, Index: lastIndex})
+		r.send(pb.Message{To: m.From, Type: pb.MsgAppResp, Index: lastIndex,
+			Commit: r.raftLog.committed})
 		return
 	}
 	r.logger.Debugf("%x [logterm: %d, index: %d] rejected MsgApp [logterm: %d, index: %d] from %x",
@@ -1789,6 +1792,7 @@ func (r *raft) handleAppendEntries(m pb.Message) {
 		To:         m.From,
 		Type:       pb.MsgAppResp,
 		Index:      m.Index,
+		Commit:     r.raftLog.committed,
 		Reject:     true,
 		RejectHint: hintIndex,
 		LogTerm:    hintTerm,
@@ -1859,11 +1863,13 @@ func (r *raft) handleSnapshot(m pb.Message) {
 	if r.restore(s) {
 		r.logger.Infof("%x [commit: %d] restored snapshot [index: %d, term: %d]",
 			r.id, r.raftLog.committed, id.index, id.term)
-		r.send(pb.Message{To: m.From, Type: pb.MsgAppResp, Index: r.raftLog.lastIndex()})
+		r.send(pb.Message{To: m.From, Type: pb.MsgAppResp, Index: r.raftLog.lastIndex(),
+			Commit: r.raftLog.committed})
 	} else {
 		r.logger.Infof("%x [commit: %d] ignored snapshot [index: %d, term: %d]",
 			r.id, r.raftLog.committed, id.index, id.term)
-		r.send(pb.Message{To: m.From, Type: pb.MsgAppResp, Index: r.raftLog.committed})
+		r.send(pb.Message{To: m.From, Type: pb.MsgAppResp, Index: r.raftLog.committed,
+			Commit: r.raftLog.committed})
 	}
 }
 

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -663,14 +663,13 @@ func (r *raft) sendHeartbeat(to pb.PeerID) {
 	// or it might not have all the committed entries.
 	// The leader MUST NOT forward the follower's commit to
 	// an unmatched index.
-	commit := min(pr.Match, r.raftLog.committed)
+	//commit := min(pr.Match, r.raftLog.committed)
 	r.send(pb.Message{
-		To:     to,
-		Type:   pb.MsgHeartbeat,
-		Commit: commit,
-		Match:  pr.Match,
+		To:   to,
+		Type: pb.MsgHeartbeat,
+		//Commit: commit,
+		Match: pr.Match,
 	})
-	pr.SentCommit(commit)
 }
 
 // sendFortify sends a fortification RPC to the given peer.
@@ -1373,7 +1372,7 @@ func stepLeader(r *raft, m pb.Message) error {
 		// an MsgAppResp to acknowledge the appended entries in the last Ready.
 
 		pr.RecentActive = true
-
+		pr.MaybeUpdateCommit(m.Commit)
 		if m.Reject {
 			// RejectHint is the suggested next base entry for appending (i.e.
 			// we try to append entry RejectHint+1 next), and LogTerm is the
@@ -1767,6 +1766,7 @@ func (r *raft) handleAppendEntries(m pb.Message) {
 			Commit: r.raftLog.committed})
 		return
 	}
+
 	r.logger.Debugf("%x [logterm: %d, index: %d] rejected MsgApp [logterm: %d, index: %d] from %x",
 		r.id, r.raftLog.zeroTermOnOutOfBounds(r.raftLog.term(m.Index)), m.Index, m.LogTerm, m.Index, m.From)
 
@@ -1838,10 +1838,12 @@ func (r *raft) handleHeartbeat(m pb.Message) {
 	// commit index if accTerm >= m.Term.
 	// TODO(pav-kv): move this logic to raftLog.commitTo, once the accTerm has
 	// migrated to raftLog/unstable.
-	mark := logMark{term: m.Term, index: min(m.Commit, r.raftLog.lastIndex())}
-	if mark.term == r.raftLog.accTerm() {
-		r.raftLog.commitTo(mark)
-	}
+	//mark := logMark{term: m.Term, index: min(m.Commit, r.raftLog.lastIndex())}
+	//if mark.term == r.raftLog.accTerm() {
+	//	fmt.Printf("\nAdvanced the commit to %+v at follower:%+v\n", mark, m.To)
+	//	r.raftLog.commitTo(mark)
+	//}
+
 	r.send(pb.Message{To: m.From, Type: pb.MsgHeartbeatResp})
 }
 

--- a/pkg/raft/raft_paper_test.go
+++ b/pkg/raft/raft_paper_test.go
@@ -573,9 +573,8 @@ func TestFollowerCheckMsgApp(t *testing.T) {
 		r.becomeFollower(2, 2)
 
 		r.Step(pb.Message{From: 2, To: 1, Type: pb.MsgApp, Term: 2, LogTerm: tt.term, Index: tt.index})
-
 		assert.Equal(t, []pb.Message{
-			{From: 1, To: 2, Type: pb.MsgAppResp, Term: 2, Index: tt.windex, Reject: tt.wreject, RejectHint: tt.wrejectHint, LogTerm: tt.wlogterm},
+			{From: 1, To: 2, Type: pb.MsgAppResp, Term: 2, Index: tt.windex, Commit: 1, Reject: tt.wreject, RejectHint: tt.wrejectHint, LogTerm: tt.wlogterm},
 		}, r.readMessages(), "#%d", i)
 	}
 }

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -188,7 +188,7 @@ func MustSync(st, prevst pb.HardState, entsnum int) bool {
 		// TODO(arul): The st.LeadEpoch != prevst.LeadEpoch condition is currently
 		// untested because we don't set r.leadEpoch yet. We'll do so when we
 		// introduce MsgFortifyResp. Test this then.
-		st.Lead != prevst.Lead || st.LeadEpoch != prevst.LeadEpoch
+		st.Lead != prevst.Lead || st.LeadEpoch != prevst.LeadEpoch || st.Commit != prevst.Commit
 }
 
 func needStorageAppendMsg(r *raft, rd Ready) bool {

--- a/pkg/raft/rawnode_test.go
+++ b/pkg/raft/rawnode_test.go
@@ -767,11 +767,13 @@ func TestRawNodeCommitPaginationAfterRestart(t *testing.T) {
 		highestApplied = rd.CommittedEntries[n-1].Index
 		rawNode.Advance(rd)
 		rawNode.Step(pb.Message{
-			Type:   pb.MsgHeartbeat,
-			To:     1,
-			From:   2, // illegal, but we get away with it
-			Term:   1,
-			Commit: 11,
+			Type:    pb.MsgApp,
+			To:      1,
+			From:    2, // illegal, but we get away with it
+			Term:    1,
+			LogTerm: 1,
+			Index:   11,
+			Commit:  11,
 		})
 	}
 }

--- a/pkg/raft/rawnode_test.go
+++ b/pkg/raft/rawnode_test.go
@@ -524,7 +524,7 @@ func TestRawNodeStart(t *testing.T) {
 		HardState:        pb.HardState{Term: 1, Commit: 3, Vote: 1, Lead: 1},
 		Entries:          nil, // emitted & checked in intermediate Ready cycle
 		CommittedEntries: entries,
-		MustSync:         false, // since we're only applying, not appending
+		MustSync:         true, // because we are advancing the commit index
 	}
 
 	storage := NewMemoryStorage()
@@ -596,7 +596,7 @@ func TestRawNodeStart(t *testing.T) {
 	require.True(t, rawNode.HasReady())
 	rd = rawNode.Ready()
 	require.Empty(t, rd.Entries)
-	require.False(t, rd.MustSync)
+	require.True(t, rd.MustSync)
 	rawNode.Advance(rd)
 
 	rd.SoftState, want.SoftState = nil, nil

--- a/pkg/raft/testdata/async_storage_writes.txt
+++ b/pkg/raft/testdata/async_storage_writes.txt
@@ -93,7 +93,7 @@ stabilize
   1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->AppendThread MsgStorageAppend Term:1 Log:1/11 Commit:10 Vote:1 Lead:1 Entries:[1/11 EntryNormal ""] Responses:[
-    1->1 MsgAppResp Term:1 Log:0/11
+    1->1 MsgAppResp Term:1 Log:0/11 Commit:10
     AppendThread->1 MsgStorageAppendResp Term:0 Log:1/11
   ]
 > 2 receiving messages
@@ -106,7 +106,7 @@ stabilize
   Processing:
   1->AppendThread MsgStorageAppend Term:1 Log:1/11 Commit:10 Vote:1 Lead:1 Entries:[1/11 EntryNormal ""]
   Responses:
-  1->1 MsgAppResp Term:1 Log:0/11
+  1->1 MsgAppResp Term:1 Log:0/11 Commit:10
   AppendThread->1 MsgStorageAppendResp Term:0 Log:1/11
 > 2 handling Ready
   Ready MustSync=true:
@@ -116,7 +116,7 @@ stabilize
   Messages:
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
   2->AppendThread MsgStorageAppend Term:1 Log:1/11 Commit:10 Vote:1 Lead:1 Entries:[1/11 EntryNormal ""] Responses:[
-    2->1 MsgAppResp Term:1 Log:0/11
+    2->1 MsgAppResp Term:1 Log:0/11 Commit:10
     AppendThread->2 MsgStorageAppendResp Term:0 Log:1/11
   ]
 > 3 handling Ready
@@ -127,11 +127,11 @@ stabilize
   Messages:
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
   3->AppendThread MsgStorageAppend Term:1 Log:1/11 Commit:10 Vote:1 Lead:1 Entries:[1/11 EntryNormal ""] Responses:[
-    3->1 MsgAppResp Term:1 Log:0/11
+    3->1 MsgAppResp Term:1 Log:0/11 Commit:10
     AppendThread->3 MsgStorageAppendResp Term:0 Log:1/11
   ]
 > 1 receiving messages
-  1->1 MsgAppResp Term:1 Log:0/11
+  1->1 MsgAppResp Term:1 Log:0/11 Commit:10
   AppendThread->1 MsgStorageAppendResp Term:0 Log:1/11
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
@@ -139,17 +139,17 @@ stabilize
   Processing:
   2->AppendThread MsgStorageAppend Term:1 Log:1/11 Commit:10 Vote:1 Lead:1 Entries:[1/11 EntryNormal ""]
   Responses:
-  2->1 MsgAppResp Term:1 Log:0/11
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
   AppendThread->2 MsgStorageAppendResp Term:0 Log:1/11
 > 3 processing append thread
   Processing:
   3->AppendThread MsgStorageAppend Term:1 Log:1/11 Commit:10 Vote:1 Lead:1 Entries:[1/11 EntryNormal ""]
   Responses:
-  3->1 MsgAppResp Term:1 Log:0/11
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:10
   AppendThread->3 MsgStorageAppendResp Term:0 Log:1/11
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/11
-  3->1 MsgAppResp Term:1 Log:0/11
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:10
 > 2 receiving messages
   AppendThread->2 MsgStorageAppendResp Term:0 Log:1/11
 > 3 receiving messages
@@ -186,7 +186,7 @@ stabilize
   1/11 EntryNormal ""
   Messages:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:11 Vote:1 Lead:1 Responses:[
-    2->1 MsgAppResp Term:1 Log:0/11
+    2->1 MsgAppResp Term:1 Log:0/11 Commit:11
   ]
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/11 EntryNormal ""] Responses:[
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
@@ -198,7 +198,7 @@ stabilize
   1/11 EntryNormal ""
   Messages:
   3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:11 Vote:1 Lead:1 Responses:[
-    3->1 MsgAppResp Term:1 Log:0/11
+    3->1 MsgAppResp Term:1 Log:0/11 Commit:11
   ]
   3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/11 EntryNormal ""] Responses:[
     ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
@@ -209,12 +209,12 @@ stabilize
   Processing:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:11 Vote:1 Lead:1
   Responses:
-  2->1 MsgAppResp Term:1 Log:0/11
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 3 processing append thread
   Processing:
   3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:11 Vote:1 Lead:1
   Responses:
-  3->1 MsgAppResp Term:1 Log:0/11
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 2 processing apply thread
   Processing:
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
@@ -226,8 +226,8 @@ stabilize
   Responses:
   ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/11
-  3->1 MsgAppResp Term:1 Log:0/11
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:11
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 2 receiving messages
   ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
 > 3 receiving messages
@@ -247,7 +247,7 @@ process-ready 1 2 3
   1->2 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1"]
   1->3 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1"]
   1->AppendThread MsgStorageAppend Term:0 Log:1/12 Entries:[1/12 EntryNormal "prop_1"] Responses:[
-    1->1 MsgAppResp Term:1 Log:0/12
+    1->1 MsgAppResp Term:1 Log:0/12 Commit:11
     AppendThread->1 MsgStorageAppendResp Term:0 Log:1/12
   ]
 > 2 handling Ready
@@ -276,7 +276,7 @@ process-ready 1 2 3
   1/12 EntryNormal "prop_1"
   Messages:
   2->AppendThread MsgStorageAppend Term:0 Log:1/12 Entries:[1/12 EntryNormal "prop_1"] Responses:[
-    2->1 MsgAppResp Term:1 Log:0/12
+    2->1 MsgAppResp Term:1 Log:0/12 Commit:11
     AppendThread->2 MsgStorageAppendResp Term:0 Log:1/12
   ]
 > 3 handling Ready
@@ -285,7 +285,7 @@ process-ready 1 2 3
   1/12 EntryNormal "prop_1"
   Messages:
   3->AppendThread MsgStorageAppend Term:0 Log:1/12 Entries:[1/12 EntryNormal "prop_1"] Responses:[
-    3->1 MsgAppResp Term:1 Log:0/12
+    3->1 MsgAppResp Term:1 Log:0/12 Commit:11
     AppendThread->3 MsgStorageAppendResp Term:0 Log:1/12
   ]
 
@@ -303,7 +303,7 @@ process-ready 1 2 3
   1->2 MsgApp Term:1 Log:1/12 Commit:11 Entries:[1/13 EntryNormal "prop_2"]
   1->3 MsgApp Term:1 Log:1/12 Commit:11 Entries:[1/13 EntryNormal "prop_2"]
   1->AppendThread MsgStorageAppend Term:0 Log:1/13 Entries:[1/13 EntryNormal "prop_2"] Responses:[
-    1->1 MsgAppResp Term:1 Log:0/13
+    1->1 MsgAppResp Term:1 Log:0/13 Commit:11
     AppendThread->1 MsgStorageAppendResp Term:0 Log:1/13
   ]
 > 2 handling Ready
@@ -326,7 +326,7 @@ process-ready 1 2 3
   1/13 EntryNormal "prop_2"
   Messages:
   2->AppendThread MsgStorageAppend Term:0 Log:1/13 Entries:[1/13 EntryNormal "prop_2"] Responses:[
-    2->1 MsgAppResp Term:1 Log:0/13
+    2->1 MsgAppResp Term:1 Log:0/13 Commit:11
     AppendThread->2 MsgStorageAppendResp Term:0 Log:1/13
   ]
 > 3 handling Ready
@@ -335,7 +335,7 @@ process-ready 1 2 3
   1/13 EntryNormal "prop_2"
   Messages:
   3->AppendThread MsgStorageAppend Term:0 Log:1/13 Entries:[1/13 EntryNormal "prop_2"] Responses:[
-    3->1 MsgAppResp Term:1 Log:0/13
+    3->1 MsgAppResp Term:1 Log:0/13 Commit:11
     AppendThread->3 MsgStorageAppendResp Term:0 Log:1/13
   ]
 
@@ -345,27 +345,27 @@ process-append-thread 1 2 3
   Processing:
   1->AppendThread MsgStorageAppend Term:0 Log:1/12 Entries:[1/12 EntryNormal "prop_1"]
   Responses:
-  1->1 MsgAppResp Term:1 Log:0/12
+  1->1 MsgAppResp Term:1 Log:0/12 Commit:11
   AppendThread->1 MsgStorageAppendResp Term:0 Log:1/12
 > 2 processing append thread
   Processing:
   2->AppendThread MsgStorageAppend Term:0 Log:1/12 Entries:[1/12 EntryNormal "prop_1"]
   Responses:
-  2->1 MsgAppResp Term:1 Log:0/12
+  2->1 MsgAppResp Term:1 Log:0/12 Commit:11
   AppendThread->2 MsgStorageAppendResp Term:0 Log:1/12
 > 3 processing append thread
   Processing:
   3->AppendThread MsgStorageAppend Term:0 Log:1/12 Entries:[1/12 EntryNormal "prop_1"]
   Responses:
-  3->1 MsgAppResp Term:1 Log:0/12
+  3->1 MsgAppResp Term:1 Log:0/12 Commit:11
   AppendThread->3 MsgStorageAppendResp Term:0 Log:1/12
 
 deliver-msgs 1 2 3
 ----
-1->1 MsgAppResp Term:1 Log:0/12
+1->1 MsgAppResp Term:1 Log:0/12 Commit:11
 AppendThread->1 MsgStorageAppendResp Term:0 Log:1/12
-2->1 MsgAppResp Term:1 Log:0/12
-3->1 MsgAppResp Term:1 Log:0/12
+2->1 MsgAppResp Term:1 Log:0/12 Commit:11
+3->1 MsgAppResp Term:1 Log:0/12 Commit:11
 AppendThread->2 MsgStorageAppendResp Term:0 Log:1/12
 AppendThread->3 MsgStorageAppendResp Term:0 Log:1/12
 
@@ -394,7 +394,7 @@ process-ready 1 2 3
   1->2 MsgApp Term:1 Log:1/13 Commit:12 Entries:[1/14 EntryNormal "prop_3"]
   1->3 MsgApp Term:1 Log:1/13 Commit:12 Entries:[1/14 EntryNormal "prop_3"]
   1->AppendThread MsgStorageAppend Term:1 Log:1/14 Commit:12 Vote:1 Lead:1 Entries:[1/14 EntryNormal "prop_3"] Responses:[
-    1->1 MsgAppResp Term:1 Log:0/14
+    1->1 MsgAppResp Term:1 Log:0/14 Commit:12
     AppendThread->1 MsgStorageAppendResp Term:0 Log:1/14
   ]
   1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"] Responses:[
@@ -425,8 +425,8 @@ process-ready 1 2 3
   1/12 EntryNormal "prop_1"
   Messages:
   2->AppendThread MsgStorageAppend Term:1 Log:1/14 Commit:12 Vote:1 Lead:1 Entries:[1/14 EntryNormal "prop_3"] Responses:[
-    2->1 MsgAppResp Term:1 Log:0/13
-    2->1 MsgAppResp Term:1 Log:0/14
+    2->1 MsgAppResp Term:1 Log:0/13 Commit:12
+    2->1 MsgAppResp Term:1 Log:0/14 Commit:12
     AppendThread->2 MsgStorageAppendResp Term:0 Log:1/14
   ]
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"] Responses:[
@@ -441,8 +441,8 @@ process-ready 1 2 3
   1/12 EntryNormal "prop_1"
   Messages:
   3->AppendThread MsgStorageAppend Term:1 Log:1/14 Commit:12 Vote:1 Lead:1 Entries:[1/14 EntryNormal "prop_3"] Responses:[
-    3->1 MsgAppResp Term:1 Log:0/13
-    3->1 MsgAppResp Term:1 Log:0/14
+    3->1 MsgAppResp Term:1 Log:0/13 Commit:12
+    3->1 MsgAppResp Term:1 Log:0/14 Commit:12
     AppendThread->3 MsgStorageAppendResp Term:0 Log:1/14
   ]
   3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"] Responses:[
@@ -455,27 +455,27 @@ process-append-thread 1 2 3
   Processing:
   1->AppendThread MsgStorageAppend Term:0 Log:1/13 Entries:[1/13 EntryNormal "prop_2"]
   Responses:
-  1->1 MsgAppResp Term:1 Log:0/13
+  1->1 MsgAppResp Term:1 Log:0/13 Commit:11
   AppendThread->1 MsgStorageAppendResp Term:0 Log:1/13
 > 2 processing append thread
   Processing:
   2->AppendThread MsgStorageAppend Term:0 Log:1/13 Entries:[1/13 EntryNormal "prop_2"]
   Responses:
-  2->1 MsgAppResp Term:1 Log:0/13
+  2->1 MsgAppResp Term:1 Log:0/13 Commit:11
   AppendThread->2 MsgStorageAppendResp Term:0 Log:1/13
 > 3 processing append thread
   Processing:
   3->AppendThread MsgStorageAppend Term:0 Log:1/13 Entries:[1/13 EntryNormal "prop_2"]
   Responses:
-  3->1 MsgAppResp Term:1 Log:0/13
+  3->1 MsgAppResp Term:1 Log:0/13 Commit:11
   AppendThread->3 MsgStorageAppendResp Term:0 Log:1/13
 
 deliver-msgs 1 2 3
 ----
-1->1 MsgAppResp Term:1 Log:0/13
+1->1 MsgAppResp Term:1 Log:0/13 Commit:11
 AppendThread->1 MsgStorageAppendResp Term:0 Log:1/13
-2->1 MsgAppResp Term:1 Log:0/13
-3->1 MsgAppResp Term:1 Log:0/13
+2->1 MsgAppResp Term:1 Log:0/13 Commit:11
+3->1 MsgAppResp Term:1 Log:0/13 Commit:11
 AppendThread->2 MsgStorageAppendResp Term:0 Log:1/13
 AppendThread->3 MsgStorageAppendResp Term:0 Log:1/13
 
@@ -498,7 +498,7 @@ process-ready 1 2 3
   1->2 MsgApp Term:1 Log:1/14 Commit:13 Entries:[1/15 EntryNormal "prop_4"]
   1->3 MsgApp Term:1 Log:1/14 Commit:13 Entries:[1/15 EntryNormal "prop_4"]
   1->AppendThread MsgStorageAppend Term:1 Log:1/15 Commit:13 Vote:1 Lead:1 Entries:[1/15 EntryNormal "prop_4"] Responses:[
-    1->1 MsgAppResp Term:1 Log:0/15
+    1->1 MsgAppResp Term:1 Log:0/15 Commit:13
     AppendThread->1 MsgStorageAppendResp Term:0 Log:1/15
   ]
   1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
@@ -529,8 +529,8 @@ process-ready 1 2 3
   1/13 EntryNormal "prop_2"
   Messages:
   2->AppendThread MsgStorageAppend Term:1 Log:1/15 Commit:13 Vote:1 Lead:1 Entries:[1/15 EntryNormal "prop_4"] Responses:[
-    2->1 MsgAppResp Term:1 Log:0/14
-    2->1 MsgAppResp Term:1 Log:0/15
+    2->1 MsgAppResp Term:1 Log:0/14 Commit:13
+    2->1 MsgAppResp Term:1 Log:0/15 Commit:13
     AppendThread->2 MsgStorageAppendResp Term:0 Log:1/15
   ]
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
@@ -545,8 +545,8 @@ process-ready 1 2 3
   1/13 EntryNormal "prop_2"
   Messages:
   3->AppendThread MsgStorageAppend Term:1 Log:1/15 Commit:13 Vote:1 Lead:1 Entries:[1/15 EntryNormal "prop_4"] Responses:[
-    3->1 MsgAppResp Term:1 Log:0/14
-    3->1 MsgAppResp Term:1 Log:0/15
+    3->1 MsgAppResp Term:1 Log:0/14 Commit:13
+    3->1 MsgAppResp Term:1 Log:0/15 Commit:13
     AppendThread->3 MsgStorageAppendResp Term:0 Log:1/15
   ]
   3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
@@ -559,21 +559,21 @@ process-append-thread 1 2 3
   Processing:
   1->AppendThread MsgStorageAppend Term:1 Log:1/14 Commit:12 Vote:1 Lead:1 Entries:[1/14 EntryNormal "prop_3"]
   Responses:
-  1->1 MsgAppResp Term:1 Log:0/14
+  1->1 MsgAppResp Term:1 Log:0/14 Commit:12
   AppendThread->1 MsgStorageAppendResp Term:0 Log:1/14
 > 2 processing append thread
   Processing:
   2->AppendThread MsgStorageAppend Term:1 Log:1/14 Commit:12 Vote:1 Lead:1 Entries:[1/14 EntryNormal "prop_3"]
   Responses:
-  2->1 MsgAppResp Term:1 Log:0/13
-  2->1 MsgAppResp Term:1 Log:0/14
+  2->1 MsgAppResp Term:1 Log:0/13 Commit:12
+  2->1 MsgAppResp Term:1 Log:0/14 Commit:12
   AppendThread->2 MsgStorageAppendResp Term:0 Log:1/14
 > 3 processing append thread
   Processing:
   3->AppendThread MsgStorageAppend Term:1 Log:1/14 Commit:12 Vote:1 Lead:1 Entries:[1/14 EntryNormal "prop_3"]
   Responses:
-  3->1 MsgAppResp Term:1 Log:0/13
-  3->1 MsgAppResp Term:1 Log:0/14
+  3->1 MsgAppResp Term:1 Log:0/13 Commit:12
+  3->1 MsgAppResp Term:1 Log:0/14 Commit:12
   AppendThread->3 MsgStorageAppendResp Term:0 Log:1/14
 
 process-apply-thread 1 2 3
@@ -596,12 +596,12 @@ process-apply-thread 1 2 3
 
 deliver-msgs 1 2 3
 ----
-1->1 MsgAppResp Term:1 Log:0/14
+1->1 MsgAppResp Term:1 Log:0/14 Commit:12
 AppendThread->1 MsgStorageAppendResp Term:0 Log:1/14
-2->1 MsgAppResp Term:1 Log:0/13
-2->1 MsgAppResp Term:1 Log:0/14
-3->1 MsgAppResp Term:1 Log:0/13
-3->1 MsgAppResp Term:1 Log:0/14
+2->1 MsgAppResp Term:1 Log:0/13 Commit:12
+2->1 MsgAppResp Term:1 Log:0/14 Commit:12
+3->1 MsgAppResp Term:1 Log:0/13 Commit:12
+3->1 MsgAppResp Term:1 Log:0/14 Commit:12
 ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
 AppendThread->2 MsgStorageAppendResp Term:0 Log:1/14
 ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
@@ -643,7 +643,7 @@ process-ready 1 2 3
   1/14 EntryNormal "prop_3"
   Messages:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:14 Vote:1 Lead:1 Responses:[
-    2->1 MsgAppResp Term:1 Log:0/15
+    2->1 MsgAppResp Term:1 Log:0/15 Commit:14
   ]
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"] Responses:[
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
@@ -655,7 +655,7 @@ process-ready 1 2 3
   1/14 EntryNormal "prop_3"
   Messages:
   3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:14 Vote:1 Lead:1 Responses:[
-    3->1 MsgAppResp Term:1 Log:0/15
+    3->1 MsgAppResp Term:1 Log:0/15 Commit:14
   ]
   3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"] Responses:[
     ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
@@ -667,21 +667,21 @@ process-append-thread 1 2 3
   Processing:
   1->AppendThread MsgStorageAppend Term:1 Log:1/15 Commit:13 Vote:1 Lead:1 Entries:[1/15 EntryNormal "prop_4"]
   Responses:
-  1->1 MsgAppResp Term:1 Log:0/15
+  1->1 MsgAppResp Term:1 Log:0/15 Commit:13
   AppendThread->1 MsgStorageAppendResp Term:0 Log:1/15
 > 2 processing append thread
   Processing:
   2->AppendThread MsgStorageAppend Term:1 Log:1/15 Commit:13 Vote:1 Lead:1 Entries:[1/15 EntryNormal "prop_4"]
   Responses:
-  2->1 MsgAppResp Term:1 Log:0/14
-  2->1 MsgAppResp Term:1 Log:0/15
+  2->1 MsgAppResp Term:1 Log:0/14 Commit:13
+  2->1 MsgAppResp Term:1 Log:0/15 Commit:13
   AppendThread->2 MsgStorageAppendResp Term:0 Log:1/15
 > 3 processing append thread
   Processing:
   3->AppendThread MsgStorageAppend Term:1 Log:1/15 Commit:13 Vote:1 Lead:1 Entries:[1/15 EntryNormal "prop_4"]
   Responses:
-  3->1 MsgAppResp Term:1 Log:0/14
-  3->1 MsgAppResp Term:1 Log:0/15
+  3->1 MsgAppResp Term:1 Log:0/14 Commit:13
+  3->1 MsgAppResp Term:1 Log:0/15 Commit:13
   AppendThread->3 MsgStorageAppendResp Term:0 Log:1/15
 
 process-apply-thread 1 2 3
@@ -704,12 +704,12 @@ process-apply-thread 1 2 3
 
 deliver-msgs 1 2 3
 ----
-1->1 MsgAppResp Term:1 Log:0/15
+1->1 MsgAppResp Term:1 Log:0/15 Commit:13
 AppendThread->1 MsgStorageAppendResp Term:0 Log:1/15
-2->1 MsgAppResp Term:1 Log:0/14
-2->1 MsgAppResp Term:1 Log:0/15
-3->1 MsgAppResp Term:1 Log:0/14
-3->1 MsgAppResp Term:1 Log:0/15
+2->1 MsgAppResp Term:1 Log:0/14 Commit:13
+2->1 MsgAppResp Term:1 Log:0/15 Commit:13
+3->1 MsgAppResp Term:1 Log:0/14 Commit:13
+3->1 MsgAppResp Term:1 Log:0/15 Commit:13
 ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
 AppendThread->2 MsgStorageAppendResp Term:0 Log:1/15
 ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
@@ -751,7 +751,7 @@ process-ready 1 2 3
   1/15 EntryNormal "prop_4"
   Messages:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:15 Vote:1 Lead:1 Responses:[
-    2->1 MsgAppResp Term:1 Log:0/15
+    2->1 MsgAppResp Term:1 Log:0/15 Commit:15
   ]
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"] Responses:[
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
@@ -763,7 +763,7 @@ process-ready 1 2 3
   1/15 EntryNormal "prop_4"
   Messages:
   3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:15 Vote:1 Lead:1 Responses:[
-    3->1 MsgAppResp Term:1 Log:0/15
+    3->1 MsgAppResp Term:1 Log:0/15 Commit:15
   ]
   3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"] Responses:[
     ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
@@ -775,12 +775,12 @@ process-append-thread 2 3
   Processing:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:14 Vote:1 Lead:1
   Responses:
-  2->1 MsgAppResp Term:1 Log:0/15
+  2->1 MsgAppResp Term:1 Log:0/15 Commit:14
 > 3 processing append thread
   Processing:
   3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:14 Vote:1 Lead:1
   Responses:
-  3->1 MsgAppResp Term:1 Log:0/15
+  3->1 MsgAppResp Term:1 Log:0/15 Commit:14
 
 process-apply-thread 1 2 3
 ----
@@ -802,8 +802,8 @@ process-apply-thread 1 2 3
 
 deliver-msgs 1 2 3
 ----
-2->1 MsgAppResp Term:1 Log:0/15
-3->1 MsgAppResp Term:1 Log:0/15
+2->1 MsgAppResp Term:1 Log:0/15 Commit:14
+3->1 MsgAppResp Term:1 Log:0/15 Commit:14
 ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
 ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
 ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
@@ -823,12 +823,12 @@ process-append-thread 2 3
   Processing:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:15 Vote:1 Lead:1
   Responses:
-  2->1 MsgAppResp Term:1 Log:0/15
+  2->1 MsgAppResp Term:1 Log:0/15 Commit:15
 > 3 processing append thread
   Processing:
   3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:15 Vote:1 Lead:1
   Responses:
-  3->1 MsgAppResp Term:1 Log:0/15
+  3->1 MsgAppResp Term:1 Log:0/15 Commit:15
 
 process-apply-thread 1 2 3
 ----
@@ -850,8 +850,8 @@ process-apply-thread 1 2 3
 
 deliver-msgs 1 2 3
 ----
-2->1 MsgAppResp Term:1 Log:0/15
-3->1 MsgAppResp Term:1 Log:0/15
+2->1 MsgAppResp Term:1 Log:0/15 Commit:15
+3->1 MsgAppResp Term:1 Log:0/15 Commit:15
 ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
 ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
 ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]

--- a/pkg/raft/testdata/async_storage_writes.txt
+++ b/pkg/raft/testdata/async_storage_writes.txt
@@ -155,7 +155,7 @@ stabilize
 > 3 receiving messages
   AppendThread->3 MsgStorageAppendResp Term:0 Log:1/11
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:11 Lead:1
   CommittedEntries:
   1/11 EntryNormal ""
@@ -180,7 +180,7 @@ stabilize
   Responses:
   ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:11 Lead:1
   CommittedEntries:
   1/11 EntryNormal ""
@@ -192,7 +192,7 @@ stabilize
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
   ]
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:11 Lead:1
   CommittedEntries:
   1/11 EntryNormal ""
@@ -611,7 +611,7 @@ ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/12 EntryNormal "pro
 process-ready 1 2 3
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:14 Lead:1
   CommittedEntries:
   1/14 EntryNormal "prop_3"
@@ -637,7 +637,7 @@ process-ready 1 2 3
 > 1 handling Ready
   <empty Ready>
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:14 Lead:1
   CommittedEntries:
   1/14 EntryNormal "prop_3"
@@ -649,7 +649,7 @@ process-ready 1 2 3
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
   ]
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:14 Lead:1
   CommittedEntries:
   1/14 EntryNormal "prop_3"
@@ -719,7 +719,7 @@ ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "pro
 process-ready 1 2 3
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:15 Lead:1
   CommittedEntries:
   1/15 EntryNormal "prop_4"
@@ -745,7 +745,7 @@ process-ready 1 2 3
 > 1 handling Ready
   <empty Ready>
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:15 Lead:1
   CommittedEntries:
   1/15 EntryNormal "prop_4"
@@ -757,7 +757,7 @@ process-ready 1 2 3
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
   ]
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:15 Lead:1
   CommittedEntries:
   1/15 EntryNormal "prop_4"

--- a/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
+++ b/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
@@ -43,7 +43,7 @@ Messages:
 2->6 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "init_prop"]
 2->7 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "init_prop"]
 2->AppendThread MsgStorageAppend Term:0 Log:1/12 Entries:[1/12 EntryNormal "init_prop"] Responses:[
-  2->2 MsgAppResp Term:1 Log:0/12
+  2->2 MsgAppResp Term:1 Log:0/12 Commit:11
   AppendThread->2 MsgStorageAppendResp Term:0 Log:1/12
 ]
 
@@ -65,7 +65,7 @@ Entries:
 1/12 EntryNormal "init_prop"
 Messages:
 1->AppendThread MsgStorageAppend Term:0 Log:1/12 Entries:[1/12 EntryNormal "init_prop"] Responses:[
-  1->2 MsgAppResp Term:1 Log:0/12
+  1->2 MsgAppResp Term:1 Log:0/12 Commit:11
   AppendThread->1 MsgStorageAppendResp Term:0 Log:1/12
 ]
 
@@ -202,7 +202,7 @@ Messages:
 3->6 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 3->7 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 3->AppendThread MsgStorageAppend Term:2 Log:2/12 Commit:11 Vote:3 Lead:3 Entries:[2/12 EntryNormal ""] Responses:[
-  3->3 MsgAppResp Term:2 Log:0/12
+  3->3 MsgAppResp Term:2 Log:0/12 Commit:11
   AppendThread->3 MsgStorageAppendResp Term:0 Log:2/12
 ]
 
@@ -239,7 +239,7 @@ Messages:
 1->3 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
 1->AppendThread MsgStorageAppend Term:2 Log:2/12 Commit:11 Lead:3 Entries:[2/12 EntryNormal ""] Responses:[
   1->3 MsgVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
-  1->3 MsgAppResp Term:2 Log:0/12
+  1->3 MsgAppResp Term:2 Log:0/12 Commit:11
   AppendThread->1 MsgStorageAppendResp Term:0 Log:2/12
 ]
 
@@ -371,7 +371,7 @@ Messages:
 4->6 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
 4->7 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
 4->AppendThread MsgStorageAppend Term:3 Log:3/12 Commit:11 Vote:4 Lead:4 Entries:[3/12 EntryNormal ""] Responses:[
-  4->4 MsgAppResp Term:3 Log:0/12
+  4->4 MsgAppResp Term:3 Log:0/12 Commit:11
   AppendThread->4 MsgStorageAppendResp Term:0 Log:3/12
 ]
 
@@ -439,7 +439,7 @@ Entries:
 3/12 EntryNormal ""
 Messages:
 1->AppendThread MsgStorageAppend Term:0 Log:3/12 Entries:[3/12 EntryNormal ""] Responses:[
-  1->4 MsgAppResp Term:3 Log:0/12
+  1->4 MsgAppResp Term:3 Log:0/12 Commit:11
   AppendThread->1 MsgStorageAppendResp Term:0 Log:3/12
 ]
 
@@ -456,7 +456,7 @@ process-append-thread 1
 Processing:
 1->AppendThread MsgStorageAppend Term:0 Log:1/12 Entries:[1/12 EntryNormal "init_prop"]
 Responses:
-1->2 MsgAppResp Term:1 Log:0/12
+1->2 MsgAppResp Term:1 Log:0/12 Commit:11
 AppendThread->1 MsgStorageAppendResp Term:0 Log:1/12
 
 raft-log 1
@@ -483,7 +483,7 @@ Processing:
 1->AppendThread MsgStorageAppend Term:2 Log:2/12 Commit:11 Lead:3 Entries:[2/12 EntryNormal ""]
 Responses:
 1->3 MsgVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
-1->3 MsgAppResp Term:2 Log:0/12
+1->3 MsgAppResp Term:2 Log:0/12 Commit:11
 AppendThread->1 MsgStorageAppendResp Term:0 Log:2/12
 
 raft-log 1
@@ -516,7 +516,7 @@ process-append-thread 1
 Processing:
 1->AppendThread MsgStorageAppend Term:0 Log:3/12 Entries:[3/12 EntryNormal ""]
 Responses:
-1->4 MsgAppResp Term:3 Log:0/12
+1->4 MsgAppResp Term:3 Log:0/12 Commit:11
 AppendThread->1 MsgStorageAppendResp Term:0 Log:3/12
 
 raft-log 1

--- a/pkg/raft/testdata/campaign.txt
+++ b/pkg/raft/testdata/campaign.txt
@@ -97,7 +97,7 @@ stabilize
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
   3->1 MsgAppResp Term:1 Log:0/3 Commit:2
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:3 Lead:1
   CommittedEntries:
   1/3 EntryNormal ""
@@ -109,14 +109,14 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/3 Commit:3
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:3 Lead:1
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:3 Lead:1
   CommittedEntries:
   1/3 EntryNormal ""

--- a/pkg/raft/testdata/campaign.txt
+++ b/pkg/raft/testdata/campaign.txt
@@ -82,7 +82,7 @@ stabilize
   1/3 EntryNormal ""
   Messages:
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
-  2->1 MsgAppResp Term:1 Log:0/3
+  2->1 MsgAppResp Term:1 Log:0/3 Commit:2
 > 3 handling Ready
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:2 Lead:1
@@ -90,12 +90,12 @@ stabilize
   1/3 EntryNormal ""
   Messages:
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
-  3->1 MsgAppResp Term:1 Log:0/3
+  3->1 MsgAppResp Term:1 Log:0/3 Commit:2
 > 1 receiving messages
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
-  2->1 MsgAppResp Term:1 Log:0/3
+  2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
-  3->1 MsgAppResp Term:1 Log:0/3
+  3->1 MsgAppResp Term:1 Log:0/3 Commit:2
 > 1 handling Ready
   Ready MustSync=false:
   HardState Term:1 Vote:1 Commit:3 Lead:1
@@ -114,14 +114,14 @@ stabilize
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/3
+  2->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 3 handling Ready
   Ready MustSync=false:
   HardState Term:1 Vote:1 Commit:3 Lead:1
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/3
+  3->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/3
-  3->1 MsgAppResp Term:1 Log:0/3
+  2->1 MsgAppResp Term:1 Log:0/3 Commit:3
+  3->1 MsgAppResp Term:1 Log:0/3 Commit:3

--- a/pkg/raft/testdata/campaign_learner_must_vote.txt
+++ b/pkg/raft/testdata/campaign_learner_must_vote.txt
@@ -113,10 +113,10 @@ stabilize 2 3
   HardState Term:2 Vote:2 Commit:3 Lead:2
   Messages:
   3->2 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
-  3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3)
+  3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3) Commit:3
 > 2 receiving messages
   3->2 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
-  3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3)
+  3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3) Commit:3
   DEBUG 2 received MsgAppResp(rejected, hint: (index 3, term 1)) from 3 for index 4
   DEBUG 2 decreased progress of 3 to [StateProbe match=0 next=4]
 > 2 handling Ready
@@ -140,10 +140,10 @@ stabilize 2 3
   CommittedEntries:
   1/4 EntryConfChangeV2 v3
   Messages:
-  3->2 MsgAppResp Term:2 Log:0/5
+  3->2 MsgAppResp Term:2 Log:0/5 Commit:4
   INFO 3 switched to configuration voters=(1 2 3)
 > 2 receiving messages
-  3->2 MsgAppResp Term:2 Log:0/5
+  3->2 MsgAppResp Term:2 Log:0/5 Commit:4
 > 2 handling Ready
   Ready MustSync=false:
   HardState Term:2 Vote:2 Commit:5 Lead:2
@@ -159,6 +159,6 @@ stabilize 2 3
   CommittedEntries:
   2/5 EntryNormal ""
   Messages:
-  3->2 MsgAppResp Term:2 Log:0/5
+  3->2 MsgAppResp Term:2 Log:0/5 Commit:5
 > 2 receiving messages
-  3->2 MsgAppResp Term:2 Log:0/5
+  3->2 MsgAppResp Term:2 Log:0/5 Commit:5

--- a/pkg/raft/testdata/campaign_learner_must_vote.txt
+++ b/pkg/raft/testdata/campaign_learner_must_vote.txt
@@ -145,7 +145,7 @@ stabilize 2 3
 > 2 receiving messages
   3->2 MsgAppResp Term:2 Log:0/5 Commit:4
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:2 Commit:5 Lead:2
   CommittedEntries:
   2/5 EntryNormal ""
@@ -154,7 +154,7 @@ stabilize 2 3
 > 3 receiving messages
   2->3 MsgApp Term:2 Log:2/5 Commit:5
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:2 Commit:5 Lead:2
   CommittedEntries:
   2/5 EntryNormal ""

--- a/pkg/raft/testdata/checkquorum.txt
+++ b/pkg/raft/testdata/checkquorum.txt
@@ -214,7 +214,7 @@ stabilize
   3->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
   3->2 MsgAppResp Term:3 Log:0/12 Commit:11
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:3 Vote:2 Commit:12 Lead:2
   CommittedEntries:
   3/12 EntryNormal ""
@@ -226,14 +226,14 @@ stabilize
 > 3 receiving messages
   2->3 MsgApp Term:3 Log:3/12 Commit:12
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:3 Vote:2 Commit:12 Lead:2
   CommittedEntries:
   3/12 EntryNormal ""
   Messages:
   1->2 MsgAppResp Term:3 Log:0/12 Commit:12
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:3 Commit:12 Lead:2
   CommittedEntries:
   3/12 EntryNormal ""

--- a/pkg/raft/testdata/checkquorum.txt
+++ b/pkg/raft/testdata/checkquorum.txt
@@ -70,28 +70,28 @@ stabilize
   Ready MustSync=false:
   State:StateFollower
   Messages:
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
 > 2 receiving messages
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->2 MsgHeartbeat Term:1 Log:0/0
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
 > 2 handling Ready
   Ready MustSync=false:
   Messages:

--- a/pkg/raft/testdata/checkquorum.txt
+++ b/pkg/raft/testdata/checkquorum.txt
@@ -199,7 +199,7 @@ stabilize
   3/12 EntryNormal ""
   Messages:
   1->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
-  1->2 MsgAppResp Term:3 Log:0/12
+  1->2 MsgAppResp Term:3 Log:0/12 Commit:11
 > 3 handling Ready
   Ready MustSync=true:
   HardState Term:3 Commit:11 Lead:2
@@ -207,12 +207,12 @@ stabilize
   3/12 EntryNormal ""
   Messages:
   3->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
-  3->2 MsgAppResp Term:3 Log:0/12
+  3->2 MsgAppResp Term:3 Log:0/12 Commit:11
 > 2 receiving messages
   1->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
-  1->2 MsgAppResp Term:3 Log:0/12
+  1->2 MsgAppResp Term:3 Log:0/12 Commit:11
   3->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
-  3->2 MsgAppResp Term:3 Log:0/12
+  3->2 MsgAppResp Term:3 Log:0/12 Commit:11
 > 2 handling Ready
   Ready MustSync=false:
   HardState Term:3 Vote:2 Commit:12 Lead:2
@@ -231,14 +231,14 @@ stabilize
   CommittedEntries:
   3/12 EntryNormal ""
   Messages:
-  1->2 MsgAppResp Term:3 Log:0/12
+  1->2 MsgAppResp Term:3 Log:0/12 Commit:12
 > 3 handling Ready
   Ready MustSync=false:
   HardState Term:3 Commit:12 Lead:2
   CommittedEntries:
   3/12 EntryNormal ""
   Messages:
-  3->2 MsgAppResp Term:3 Log:0/12
+  3->2 MsgAppResp Term:3 Log:0/12 Commit:12
 > 2 receiving messages
-  1->2 MsgAppResp Term:3 Log:0/12
-  3->2 MsgAppResp Term:3 Log:0/12
+  1->2 MsgAppResp Term:3 Log:0/12 Commit:12
+  3->2 MsgAppResp Term:3 Log:0/12 Commit:12

--- a/pkg/raft/testdata/confchange_disable_validation.txt
+++ b/pkg/raft/testdata/confchange_disable_validation.txt
@@ -41,7 +41,7 @@ stabilize 1
   1/4 EntryNormal "foo"
   1/5 EntryConfChangeV2 l2 l3
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5 Lead:1
   CommittedEntries:
   1/4 EntryNormal "foo"

--- a/pkg/raft/testdata/confchange_drop_if_unapplied.txt
+++ b/pkg/raft/testdata/confchange_drop_if_unapplied.txt
@@ -50,7 +50,7 @@ stabilize 1
   1/4 EntryConfChangeV2 l2 l3
   INFO 1 switched to configuration voters=(1)&&(1) learners=(2 3)
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5 Lead:1
   CommittedEntries:
   1/5 EntryNormal ""

--- a/pkg/raft/testdata/confchange_v1_add_single.txt
+++ b/pkg/raft/testdata/confchange_v1_add_single.txt
@@ -90,7 +90,7 @@ stabilize
   HardState Term:1 Commit:4 Lead:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:1 Log:0/4 Commit:4
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:1 Log:0/4 Commit:4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 paused pendingSnap=4]

--- a/pkg/raft/testdata/confchange_v1_add_single.txt
+++ b/pkg/raft/testdata/confchange_v1_add_single.txt
@@ -47,7 +47,7 @@ stabilize
   1/3 EntryNormal ""
   1/4 EntryConfChange v2
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4 Lead:1
   CommittedEntries:
   1/3 EntryNormal ""
@@ -86,7 +86,7 @@ stabilize
   INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:4 Lead:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:

--- a/pkg/raft/testdata/confchange_v1_remove_leader.txt
+++ b/pkg/raft/testdata/confchange_v1_remove_leader.txt
@@ -223,12 +223,12 @@ stabilize
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:6
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:6
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
 > 2 receiving messages
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:6
+  1->2 MsgHeartbeat Term:1 Log:0/0
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:6
+  1->3 MsgHeartbeat Term:1 Log:0/0
 > 2 handling Ready
   Ready MustSync=false:
   Messages:

--- a/pkg/raft/testdata/confchange_v1_remove_leader.txt
+++ b/pkg/raft/testdata/confchange_v1_remove_leader.txt
@@ -70,8 +70,8 @@ stabilize 2
   1/4 EntryConfChange r1
   1/5 EntryNormal "foo"
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:1 Log:0/4 Commit:3
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:3
 
 # Put another entry in n1's log.
 propose 1 bar
@@ -92,8 +92,8 @@ stabilize 1
   1->2 MsgApp Term:1 Log:1/5 Commit:3 Entries:[1/6 EntryNormal "bar"]
   1->3 MsgApp Term:1 Log:1/5 Commit:3 Entries:[1/6 EntryNormal "bar"]
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:1 Log:0/4 Commit:3
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:3
 > 1 handling Ready
   Ready MustSync=false:
   HardState Term:1 Vote:1 Commit:5 Lead:1
@@ -129,18 +129,18 @@ stabilize 2
   1/4 EntryConfChange r1
   1/5 EntryNormal "foo"
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:3
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:4
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
   INFO 2 switched to configuration voters=(2 3)
 
 # ... which thankfully is what we see on the leader.
 stabilize 1
 ----
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:3
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:4
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
 
 # When n3 responds, quorum is reached and everything falls into place.
 stabilize
@@ -162,18 +162,18 @@ stabilize
   1/4 EntryConfChange r1
   1/5 EntryNormal "foo"
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/4
-  3->1 MsgAppResp Term:1 Log:0/5
-  3->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
+  3->1 MsgAppResp Term:1 Log:0/4 Commit:3
+  3->1 MsgAppResp Term:1 Log:0/5 Commit:3
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:3
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:4
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
   INFO 3 switched to configuration voters=(2 3)
 > 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:0/4
-  3->1 MsgAppResp Term:1 Log:0/5
-  3->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
+  3->1 MsgAppResp Term:1 Log:0/4 Commit:3
+  3->1 MsgAppResp Term:1 Log:0/5 Commit:3
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:3
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:4
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
 > 1 handling Ready
   Ready MustSync=false:
   HardState Term:1 Vote:1 Commit:6 Lead:1
@@ -192,17 +192,17 @@ stabilize
   CommittedEntries:
   1/6 EntryNormal "bar"
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:6
 > 3 handling Ready
   Ready MustSync=false:
   HardState Term:1 Vote:1 Commit:6 Lead:1
   CommittedEntries:
   1/6 EntryNormal "bar"
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/6
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:6
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:6
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:6
 
 # However not all is well. n1 is still leader but unconditionally drops all
 # proposals on the floor, so we're effectively stuck if it still heartbeats

--- a/pkg/raft/testdata/confchange_v1_remove_leader.txt
+++ b/pkg/raft/testdata/confchange_v1_remove_leader.txt
@@ -95,7 +95,7 @@ stabilize 1
   2->1 MsgAppResp Term:1 Log:0/4 Commit:3
   2->1 MsgAppResp Term:1 Log:0/5 Commit:3
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5 Lead:1
   CommittedEntries:
   1/4 EntryConfChange r1
@@ -175,7 +175,7 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/6 Commit:4
   3->1 MsgAppResp Term:1 Log:0/6 Commit:5
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:6 Lead:1
   CommittedEntries:
   1/6 EntryNormal "bar"
@@ -187,14 +187,14 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/6 Commit:6
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:6 Lead:1
   CommittedEntries:
   1/6 EntryNormal "bar"
   Messages:
   2->1 MsgAppResp Term:1 Log:0/6 Commit:6
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:6 Lead:1
   CommittedEntries:
   1/6 EntryNormal "bar"

--- a/pkg/raft/testdata/confchange_v1_remove_leader_stepdown.txt
+++ b/pkg/raft/testdata/confchange_v1_remove_leader_stepdown.txt
@@ -71,8 +71,8 @@ stabilize 2
   1/4 EntryConfChange r1
   1/5 EntryNormal "foo"
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:1 Log:0/4 Commit:3
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:3
 
 # Put another entry in n1's log.
 propose 1 bar
@@ -91,8 +91,8 @@ stabilize 1
   1->2 MsgApp Term:1 Log:1/5 Commit:3 Entries:[1/6 EntryNormal "bar"]
   1->3 MsgApp Term:1 Log:1/5 Commit:3 Entries:[1/6 EntryNormal "bar"]
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:1 Log:0/4 Commit:3
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:3
 > 1 handling Ready
   Ready MustSync=false:
   HardState Term:1 Vote:1 Commit:5 Lead:1
@@ -132,18 +132,18 @@ stabilize 2
   1/4 EntryConfChange r1
   1/5 EntryNormal "foo"
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:3
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:4
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
   INFO 2 switched to configuration voters=(2 3)
 
 # ...because the old leader n1 ignores the append responses.
 stabilize 1
 ----
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:3
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:4
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
 
 # When n3 responds, quorum is reached and everything falls into place.
 stabilize
@@ -165,18 +165,18 @@ stabilize
   1/4 EntryConfChange r1
   1/5 EntryNormal "foo"
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/4
-  3->1 MsgAppResp Term:1 Log:0/5
-  3->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
+  3->1 MsgAppResp Term:1 Log:0/4 Commit:3
+  3->1 MsgAppResp Term:1 Log:0/5 Commit:3
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:3
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:4
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
   INFO 3 switched to configuration voters=(2 3)
 > 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:0/4
-  3->1 MsgAppResp Term:1 Log:0/5
-  3->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
+  3->1 MsgAppResp Term:1 Log:0/4 Commit:3
+  3->1 MsgAppResp Term:1 Log:0/5 Commit:3
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:3
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:4
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
 
 # n1 can no longer propose.
 propose 1 baz

--- a/pkg/raft/testdata/confchange_v1_remove_leader_stepdown.txt
+++ b/pkg/raft/testdata/confchange_v1_remove_leader_stepdown.txt
@@ -94,7 +94,7 @@ stabilize 1
   2->1 MsgAppResp Term:1 Log:0/4 Commit:3
   2->1 MsgAppResp Term:1 Log:0/5 Commit:3
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5 Lead:1
   CommittedEntries:
   1/4 EntryConfChange r1

--- a/pkg/raft/testdata/confchange_v2_add_double_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_auto.txt
@@ -113,9 +113,9 @@ stabilize 1 2
   HardState Term:1 Commit:4 Lead:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:1 Log:0/4 Commit:4
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:1 Log:0/4 Commit:4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 paused pendingSnap=4]
 > 1 handling Ready
   Ready MustSync=false:
@@ -128,9 +128,9 @@ stabilize 1 2
   Entries:
   1/5 EntryConfChangeV2
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 1 handling Ready
   Ready MustSync=false:
   HardState Term:1 Vote:1 Commit:5 Lead:1
@@ -147,10 +147,10 @@ stabilize 1 2
   CommittedEntries:
   1/5 EntryConfChangeV2
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:5
   INFO 2 switched to configuration voters=(1 2 3)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:5
 
 # n3 immediately receives a snapshot in the final configuration.
 stabilize 1 3
@@ -188,9 +188,9 @@ stabilize 1 3
   HardState Term:1 Commit:5 Lead:1
   Snapshot Index:5 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/5
+  3->1 MsgAppResp Term:1 Log:0/5 Commit:5
 > 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:0/5
+  3->1 MsgAppResp Term:1 Log:0/5 Commit:5
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=5 next=6 paused pendingSnap=5]
 
 # Nothing else happens.
@@ -229,13 +229,13 @@ stabilize 2 3
   Entries:
   1/6 EntryConfChangeV2 r2 r3
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
 > 3 handling Ready
   Ready MustSync=true:
   Entries:
   1/6 EntryConfChangeV2 r2 r3
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/6
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
 
 # n1 gets some more proposals. This is part of a regression test: There used to
 # be a bug in which these proposals would prompt the leader to transition out of
@@ -263,8 +263,8 @@ stabilize 1
   1->2 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
   1->3 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6
-  3->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
 > 1 handling Ready
   Ready MustSync=false:
   HardState Term:1 Vote:1 Commit:6 Lead:1
@@ -306,10 +306,10 @@ stabilize 2 3
   CommittedEntries:
   1/6 EntryConfChangeV2 r2 r3
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/7
-  2->1 MsgAppResp Term:1 Log:0/8
-  2->1 MsgAppResp Term:1 Log:0/8
-  2->1 MsgAppResp Term:1 Log:0/9
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/8 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/8 Commit:6
+  2->1 MsgAppResp Term:1 Log:0/9 Commit:6
   INFO 2 switched to configuration voters=(1)&&(1 2 3) autoleave
 > 3 handling Ready
   Ready MustSync=true:
@@ -321,10 +321,10 @@ stabilize 2 3
   CommittedEntries:
   1/6 EntryConfChangeV2 r2 r3
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/7
-  3->1 MsgAppResp Term:1 Log:0/8
-  3->1 MsgAppResp Term:1 Log:0/8
-  3->1 MsgAppResp Term:1 Log:0/9
+  3->1 MsgAppResp Term:1 Log:0/7 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/8 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/8 Commit:6
+  3->1 MsgAppResp Term:1 Log:0/9 Commit:6
   INFO 3 switched to configuration voters=(1)&&(1 2 3) autoleave
 
 # n2 and n3 also leave the joint config and the dust settles. We see at the very
@@ -333,14 +333,14 @@ stabilize 2 3
 stabilize
 ----
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/7
-  2->1 MsgAppResp Term:1 Log:0/8
-  2->1 MsgAppResp Term:1 Log:0/8
-  2->1 MsgAppResp Term:1 Log:0/9
-  3->1 MsgAppResp Term:1 Log:0/7
-  3->1 MsgAppResp Term:1 Log:0/8
-  3->1 MsgAppResp Term:1 Log:0/8
-  3->1 MsgAppResp Term:1 Log:0/9
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/8 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/8 Commit:6
+  2->1 MsgAppResp Term:1 Log:0/9 Commit:6
+  3->1 MsgAppResp Term:1 Log:0/7 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/8 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/8 Commit:6
+  3->1 MsgAppResp Term:1 Log:0/9 Commit:6
 > 1 handling Ready
   Ready MustSync=false:
   HardState Term:1 Vote:1 Commit:9 Lead:1
@@ -372,9 +372,9 @@ stabilize
   1/8 EntryNormal "bar"
   1/9 EntryConfChangeV2
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/9
-  2->1 MsgAppResp Term:1 Log:0/9
-  2->1 MsgAppResp Term:1 Log:0/9
+  2->1 MsgAppResp Term:1 Log:0/9 Commit:7
+  2->1 MsgAppResp Term:1 Log:0/9 Commit:8
+  2->1 MsgAppResp Term:1 Log:0/9 Commit:9
   INFO 2 switched to configuration voters=(1)
 > 3 handling Ready
   Ready MustSync=false:
@@ -384,20 +384,20 @@ stabilize
   1/8 EntryNormal "bar"
   1/9 EntryConfChangeV2
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/9
-  3->1 MsgAppResp Term:1 Log:0/9
-  3->1 MsgAppResp Term:1 Log:0/9
+  3->1 MsgAppResp Term:1 Log:0/9 Commit:7
+  3->1 MsgAppResp Term:1 Log:0/9 Commit:8
+  3->1 MsgAppResp Term:1 Log:0/9 Commit:9
   INFO 3 switched to configuration voters=(1)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/9
+  2->1 MsgAppResp Term:1 Log:0/9 Commit:7
   raft: cannot step as peer not found
-  2->1 MsgAppResp Term:1 Log:0/9
+  2->1 MsgAppResp Term:1 Log:0/9 Commit:8
   raft: cannot step as peer not found
-  2->1 MsgAppResp Term:1 Log:0/9
+  2->1 MsgAppResp Term:1 Log:0/9 Commit:9
   raft: cannot step as peer not found
-  3->1 MsgAppResp Term:1 Log:0/9
+  3->1 MsgAppResp Term:1 Log:0/9 Commit:7
   raft: cannot step as peer not found
-  3->1 MsgAppResp Term:1 Log:0/9
+  3->1 MsgAppResp Term:1 Log:0/9 Commit:8
   raft: cannot step as peer not found
-  3->1 MsgAppResp Term:1 Log:0/9
+  3->1 MsgAppResp Term:1 Log:0/9 Commit:9
   raft: cannot step as peer not found

--- a/pkg/raft/testdata/confchange_v2_add_double_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_auto.txt
@@ -54,7 +54,7 @@ Entries:
 # it has to since we're carrying out two additions at once.
 process-ready 1
 ----
-Ready MustSync=false:
+Ready MustSync=true:
 HardState Term:1 Vote:1 Commit:4 Lead:1
 CommittedEntries:
 1/3 EntryNormal ""
@@ -109,7 +109,7 @@ stabilize 1 2
   INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:4 Lead:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
   Messages:
@@ -132,7 +132,7 @@ stabilize 1 2
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5 Lead:1
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -142,7 +142,7 @@ stabilize 1 2
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/5 Commit:5
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:5 Lead:1
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -184,7 +184,7 @@ stabilize 1 3
   INFO 3 [commit: 5, lastindex: 5, lastterm: 1] restored snapshot [index: 5, term: 1]
   INFO 3 [commit: 5] restored snapshot [index: 5, term: 1]
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:5 Lead:1
   Snapshot Index:5 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
@@ -266,7 +266,7 @@ stabilize 1
   2->1 MsgAppResp Term:1 Log:0/6 Commit:5
   3->1 MsgAppResp Term:1 Log:0/6 Commit:5
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:6 Lead:1
   CommittedEntries:
   1/6 EntryConfChangeV2 r2 r3
@@ -342,7 +342,7 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/8 Commit:6
   3->1 MsgAppResp Term:1 Log:0/9 Commit:6
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:9 Lead:1
   CommittedEntries:
   1/7 EntryNormal "foo"
@@ -365,7 +365,7 @@ stabilize
   1->3 MsgApp Term:1 Log:1/9 Commit:8
   1->3 MsgApp Term:1 Log:1/9 Commit:9
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:9 Lead:1
   CommittedEntries:
   1/7 EntryNormal "foo"
@@ -377,7 +377,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/9 Commit:9
   INFO 2 switched to configuration voters=(1)
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:9 Lead:1
   CommittedEntries:
   1/7 EntryNormal "foo"

--- a/pkg/raft/testdata/confchange_v2_add_double_implicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_implicit.txt
@@ -50,7 +50,7 @@ stabilize 1 2
   1/3 EntryNormal ""
   1/4 EntryConfChangeV2 v2
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4 Lead:1
   CommittedEntries:
   1/3 EntryNormal ""
@@ -92,7 +92,7 @@ stabilize 1 2
   INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:4 Lead:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
   Messages:
@@ -115,7 +115,7 @@ stabilize 1 2
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5 Lead:1
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -125,7 +125,7 @@ stabilize 1 2
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/5 Commit:5
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:5 Lead:1
   CommittedEntries:
   1/5 EntryConfChangeV2

--- a/pkg/raft/testdata/confchange_v2_add_double_implicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_implicit.txt
@@ -96,9 +96,9 @@ stabilize 1 2
   HardState Term:1 Commit:4 Lead:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:1 Log:0/4 Commit:4
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:1 Log:0/4 Commit:4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 paused pendingSnap=4]
 > 1 handling Ready
   Ready MustSync=false:
@@ -111,9 +111,9 @@ stabilize 1 2
   Entries:
   1/5 EntryConfChangeV2
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 1 handling Ready
   Ready MustSync=false:
   HardState Term:1 Vote:1 Commit:5 Lead:1
@@ -130,7 +130,7 @@ stabilize 1 2
   CommittedEntries:
   1/5 EntryConfChangeV2
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:5
   INFO 2 switched to configuration voters=(1 2)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:5

--- a/pkg/raft/testdata/confchange_v2_add_single_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_auto.txt
@@ -91,7 +91,7 @@ stabilize
   HardState Term:1 Commit:4 Lead:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:1 Log:0/4 Commit:4
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:1 Log:0/4 Commit:4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 paused pendingSnap=4]

--- a/pkg/raft/testdata/confchange_v2_add_single_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_auto.txt
@@ -48,7 +48,7 @@ stabilize
   1/3 EntryNormal ""
   1/4 EntryConfChangeV2 v2
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4 Lead:1
   CommittedEntries:
   1/3 EntryNormal ""
@@ -87,7 +87,7 @@ stabilize
   INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:4 Lead:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:

--- a/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
@@ -48,7 +48,7 @@ stabilize 1 2
   1/3 EntryNormal ""
   1/4 EntryConfChangeV2 v2
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4 Lead:1
   CommittedEntries:
   1/3 EntryNormal ""
@@ -87,7 +87,7 @@ stabilize 1 2
   INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:4 Lead:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
@@ -135,7 +135,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/5 Commit:4
   2->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:6 Lead:1
   CommittedEntries:
   1/5 EntryNormal ""
@@ -148,7 +148,7 @@ stabilize
   1->2 MsgApp Term:1 Log:1/6 Commit:5
   1->2 MsgApp Term:1 Log:1/6 Commit:6
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:6 Lead:1
   CommittedEntries:
   1/5 EntryNormal ""
@@ -186,7 +186,7 @@ stabilize
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/7 Commit:6
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:7 Lead:1
   CommittedEntries:
   1/7 EntryNormal ""
@@ -195,7 +195,7 @@ stabilize
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/7 Commit:7
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:7 Lead:1
   CommittedEntries:
   1/7 EntryNormal ""

--- a/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
@@ -91,9 +91,9 @@ stabilize 1 2
   HardState Term:1 Commit:4 Lead:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:1 Log:0/4 Commit:4
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:1 Log:0/4 Commit:4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 paused pendingSnap=4]
 
 # Check that we're not allowed to change membership again while in the joint state.
@@ -129,11 +129,11 @@ stabilize
   1/5 EntryNormal ""
   1/6 EntryConfChangeV2
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/5
-  2->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:4
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/5
-  2->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:4
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 1 handling Ready
   Ready MustSync=false:
   HardState Term:1 Vote:1 Commit:6 Lead:1
@@ -154,12 +154,12 @@ stabilize
   1/5 EntryNormal ""
   1/6 EntryConfChangeV2
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:6
   INFO 2 switched to configuration voters=(1 2)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6
-  2->1 MsgAppResp Term:1 Log:0/6
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:6
 
 # Check that trying to transition out again won't do anything.
 propose-conf-change 1
@@ -182,9 +182,9 @@ stabilize
   Entries:
   1/7 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/7
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:6
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/7
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:6
 > 1 handling Ready
   Ready MustSync=false:
   HardState Term:1 Vote:1 Commit:7 Lead:1
@@ -200,6 +200,6 @@ stabilize
   CommittedEntries:
   1/7 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/7
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:7
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/7
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:7

--- a/pkg/raft/testdata/confchange_v2_replace_leader.txt
+++ b/pkg/raft/testdata/confchange_v2_replace_leader.txt
@@ -65,16 +65,16 @@ stabilize
   Entries:
   1/4 EntryConfChangeV2 r1 v4
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:1 Log:0/4 Commit:3
 > 3 handling Ready
   Ready MustSync=true:
   Entries:
   1/4 EntryConfChangeV2 r1 v4
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/4
+  3->1 MsgAppResp Term:1 Log:0/4 Commit:3
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4
-  3->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:1 Log:0/4 Commit:3
+  3->1 MsgAppResp Term:1 Log:0/4 Commit:3
 > 1 handling Ready
   Ready MustSync=false:
   HardState Term:1 Vote:1 Commit:4 Lead:1
@@ -98,7 +98,7 @@ stabilize
   CommittedEntries:
   1/4 EntryConfChangeV2 r1 v4
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:1 Log:0/4 Commit:4
   INFO 2 switched to configuration voters=(2 3 4)&&(1 2 3)
 > 3 handling Ready
   Ready MustSync=false:
@@ -106,11 +106,11 @@ stabilize
   CommittedEntries:
   1/4 EntryConfChangeV2 r1 v4
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/4
+  3->1 MsgAppResp Term:1 Log:0/4 Commit:4
   INFO 3 switched to configuration voters=(2 3 4)&&(1 2 3)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4
-  3->1 MsgAppResp Term:1 Log:0/4
+  2->1 MsgAppResp Term:1 Log:0/4 Commit:4
+  3->1 MsgAppResp Term:1 Log:0/4 Commit:4
 > 4 receiving messages
   1->4 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 r1 v4]
   INFO 4 [term: 0] received a MsgApp message with higher term from 1 [term: 1]
@@ -139,9 +139,9 @@ stabilize
   HardState Term:1 Commit:4 Lead:1
   Snapshot Index:4 Term:1 ConfState:Voters:[2 3 4] VotersOutgoing:[1 2 3] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
-  4->1 MsgAppResp Term:1 Log:0/4
+  4->1 MsgAppResp Term:1 Log:0/4 Commit:4
 > 1 receiving messages
-  4->1 MsgAppResp Term:1 Log:0/4
+  4->1 MsgAppResp Term:1 Log:0/4 Commit:4
 
 
 # Transfer leadership while in the joint config.
@@ -252,7 +252,7 @@ stabilize
   2/5 EntryNormal ""
   Messages:
   1->4 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
-  1->4 MsgAppResp Term:2 Log:0/5
+  1->4 MsgAppResp Term:2 Log:0/5 Commit:4
 > 2 handling Ready
   Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:4 Lead:4
@@ -260,7 +260,7 @@ stabilize
   2/5 EntryNormal ""
   Messages:
   2->4 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
-  2->4 MsgAppResp Term:2 Log:0/5
+  2->4 MsgAppResp Term:2 Log:0/5 Commit:4
 > 3 handling Ready
   Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:4 Lead:4
@@ -268,14 +268,14 @@ stabilize
   2/5 EntryNormal ""
   Messages:
   3->4 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
-  3->4 MsgAppResp Term:2 Log:0/5
+  3->4 MsgAppResp Term:2 Log:0/5 Commit:4
 > 4 receiving messages
   1->4 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
-  1->4 MsgAppResp Term:2 Log:0/5
+  1->4 MsgAppResp Term:2 Log:0/5 Commit:4
   2->4 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
-  2->4 MsgAppResp Term:2 Log:0/5
+  2->4 MsgAppResp Term:2 Log:0/5 Commit:4
   3->4 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
-  3->4 MsgAppResp Term:2 Log:0/5
+  3->4 MsgAppResp Term:2 Log:0/5 Commit:4
 > 4 handling Ready
   Ready MustSync=false:
   HardState Term:2 Vote:4 Commit:5 Lead:4
@@ -297,25 +297,25 @@ stabilize
   CommittedEntries:
   2/5 EntryNormal ""
   Messages:
-  1->4 MsgAppResp Term:2 Log:0/5
+  1->4 MsgAppResp Term:2 Log:0/5 Commit:5
 > 2 handling Ready
   Ready MustSync=false:
   HardState Term:2 Vote:4 Commit:5 Lead:4
   CommittedEntries:
   2/5 EntryNormal ""
   Messages:
-  2->4 MsgAppResp Term:2 Log:0/5
+  2->4 MsgAppResp Term:2 Log:0/5 Commit:5
 > 3 handling Ready
   Ready MustSync=false:
   HardState Term:2 Vote:4 Commit:5 Lead:4
   CommittedEntries:
   2/5 EntryNormal ""
   Messages:
-  3->4 MsgAppResp Term:2 Log:0/5
+  3->4 MsgAppResp Term:2 Log:0/5 Commit:5
 > 4 receiving messages
-  1->4 MsgAppResp Term:2 Log:0/5
-  2->4 MsgAppResp Term:2 Log:0/5
-  3->4 MsgAppResp Term:2 Log:0/5
+  1->4 MsgAppResp Term:2 Log:0/5 Commit:5
+  2->4 MsgAppResp Term:2 Log:0/5 Commit:5
+  3->4 MsgAppResp Term:2 Log:0/5 Commit:5
 
 # Leadership transfer succeeded.
 raft-state
@@ -352,23 +352,23 @@ stabilize
   Entries:
   2/6 EntryConfChangeV2
   Messages:
-  1->4 MsgAppResp Term:2 Log:0/6
+  1->4 MsgAppResp Term:2 Log:0/6 Commit:5
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
   2/6 EntryConfChangeV2
   Messages:
-  2->4 MsgAppResp Term:2 Log:0/6
+  2->4 MsgAppResp Term:2 Log:0/6 Commit:5
 > 3 handling Ready
   Ready MustSync=true:
   Entries:
   2/6 EntryConfChangeV2
   Messages:
-  3->4 MsgAppResp Term:2 Log:0/6
+  3->4 MsgAppResp Term:2 Log:0/6 Commit:5
 > 4 receiving messages
-  1->4 MsgAppResp Term:2 Log:0/6
-  2->4 MsgAppResp Term:2 Log:0/6
-  3->4 MsgAppResp Term:2 Log:0/6
+  1->4 MsgAppResp Term:2 Log:0/6 Commit:5
+  2->4 MsgAppResp Term:2 Log:0/6 Commit:5
+  3->4 MsgAppResp Term:2 Log:0/6 Commit:5
 > 4 handling Ready
   Ready MustSync=false:
   HardState Term:2 Vote:4 Commit:6 Lead:4
@@ -391,7 +391,7 @@ stabilize
   CommittedEntries:
   2/6 EntryConfChangeV2
   Messages:
-  1->4 MsgAppResp Term:2 Log:0/6
+  1->4 MsgAppResp Term:2 Log:0/6 Commit:6
   INFO 1 switched to configuration voters=(2 3 4)
 > 2 handling Ready
   Ready MustSync=false:
@@ -399,7 +399,7 @@ stabilize
   CommittedEntries:
   2/6 EntryConfChangeV2
   Messages:
-  2->4 MsgAppResp Term:2 Log:0/6
+  2->4 MsgAppResp Term:2 Log:0/6 Commit:6
   INFO 2 switched to configuration voters=(2 3 4)
 > 3 handling Ready
   Ready MustSync=false:
@@ -407,13 +407,13 @@ stabilize
   CommittedEntries:
   2/6 EntryConfChangeV2
   Messages:
-  3->4 MsgAppResp Term:2 Log:0/6
+  3->4 MsgAppResp Term:2 Log:0/6 Commit:6
   INFO 3 switched to configuration voters=(2 3 4)
 > 4 receiving messages
-  1->4 MsgAppResp Term:2 Log:0/6
+  1->4 MsgAppResp Term:2 Log:0/6 Commit:6
   raft: cannot step as peer not found
-  2->4 MsgAppResp Term:2 Log:0/6
-  3->4 MsgAppResp Term:2 Log:0/6
+  2->4 MsgAppResp Term:2 Log:0/6 Commit:6
+  3->4 MsgAppResp Term:2 Log:0/6 Commit:6
 
 # n1 is out of the configuration.
 raft-state

--- a/pkg/raft/testdata/confchange_v2_replace_leader.txt
+++ b/pkg/raft/testdata/confchange_v2_replace_leader.txt
@@ -76,7 +76,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/4 Commit:3
   3->1 MsgAppResp Term:1 Log:0/4 Commit:3
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4 Lead:1
   CommittedEntries:
   1/4 EntryConfChangeV2 r1 v4
@@ -93,7 +93,7 @@ stabilize
   Messages:
   1->4 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 r1 v4]
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4 Lead:1
   CommittedEntries:
   1/4 EntryConfChangeV2 r1 v4
@@ -101,7 +101,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
   INFO 2 switched to configuration voters=(2 3 4)&&(1 2 3)
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4 Lead:1
   CommittedEntries:
   1/4 EntryConfChangeV2 r1 v4
@@ -135,7 +135,7 @@ stabilize
   INFO 4 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 4 [commit: 4] restored snapshot [index: 4, term: 1]
 > 4 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:4 Lead:1
   Snapshot Index:4 Term:1 ConfState:Voters:[2 3 4] VotersOutgoing:[1 2 3] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
@@ -277,7 +277,7 @@ stabilize
   3->4 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
   3->4 MsgAppResp Term:2 Log:0/5 Commit:4
 > 4 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:5 Lead:4
   CommittedEntries:
   2/5 EntryNormal ""
@@ -292,21 +292,21 @@ stabilize
 > 3 receiving messages
   4->3 MsgApp Term:2 Log:2/5 Commit:5
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:5 Lead:4
   CommittedEntries:
   2/5 EntryNormal ""
   Messages:
   1->4 MsgAppResp Term:2 Log:0/5 Commit:5
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:5 Lead:4
   CommittedEntries:
   2/5 EntryNormal ""
   Messages:
   2->4 MsgAppResp Term:2 Log:0/5 Commit:5
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:5 Lead:4
   CommittedEntries:
   2/5 EntryNormal ""
@@ -370,7 +370,7 @@ stabilize
   2->4 MsgAppResp Term:2 Log:0/6 Commit:5
   3->4 MsgAppResp Term:2 Log:0/6 Commit:5
 > 4 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:6 Lead:4
   CommittedEntries:
   2/6 EntryConfChangeV2
@@ -386,7 +386,7 @@ stabilize
 > 3 receiving messages
   4->3 MsgApp Term:2 Log:2/6 Commit:6
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:6 Lead:4
   CommittedEntries:
   2/6 EntryConfChangeV2
@@ -394,7 +394,7 @@ stabilize
   1->4 MsgAppResp Term:2 Log:0/6 Commit:6
   INFO 1 switched to configuration voters=(2 3 4)
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:6 Lead:4
   CommittedEntries:
   2/6 EntryConfChangeV2
@@ -402,7 +402,7 @@ stabilize
   2->4 MsgAppResp Term:2 Log:0/6 Commit:6
   INFO 2 switched to configuration voters=(2 3 4)
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:6 Lead:4
   CommittedEntries:
   2/6 EntryConfChangeV2

--- a/pkg/raft/testdata/confchange_v2_replace_leader_stepdown.txt
+++ b/pkg/raft/testdata/confchange_v2_replace_leader_stepdown.txt
@@ -93,23 +93,23 @@ stabilize
   Entries:
   1/5 EntryConfChangeV2
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 3 handling Ready
   Ready MustSync=true:
   Entries:
   1/5 EntryConfChangeV2
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/5
+  3->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 4 handling Ready
   Ready MustSync=true:
   Entries:
   1/5 EntryConfChangeV2
   Messages:
-  4->1 MsgAppResp Term:1 Log:0/5
+  4->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/5
-  3->1 MsgAppResp Term:1 Log:0/5
-  4->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:4
+  3->1 MsgAppResp Term:1 Log:0/5 Commit:4
+  4->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 1 handling Ready
   Ready MustSync=false:
   HardState Term:1 Vote:1 Commit:5 Lead:1
@@ -136,7 +136,7 @@ stabilize
   CommittedEntries:
   1/5 EntryConfChangeV2
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:5
   INFO 2 switched to configuration voters=(2 3 4)
 > 3 handling Ready
   Ready MustSync=false:
@@ -144,7 +144,7 @@ stabilize
   CommittedEntries:
   1/5 EntryConfChangeV2
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/5
+  3->1 MsgAppResp Term:1 Log:0/5 Commit:5
   INFO 3 switched to configuration voters=(2 3 4)
 > 4 handling Ready
   Ready MustSync=false:
@@ -152,12 +152,12 @@ stabilize
   CommittedEntries:
   1/5 EntryConfChangeV2
   Messages:
-  4->1 MsgAppResp Term:1 Log:0/5
+  4->1 MsgAppResp Term:1 Log:0/5 Commit:5
   INFO 4 switched to configuration voters=(2 3 4)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/5
-  3->1 MsgAppResp Term:1 Log:0/5
-  4->1 MsgAppResp Term:1 Log:0/5
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/5 Commit:5
+  4->1 MsgAppResp Term:1 Log:0/5 Commit:5
 
 # n1 is out of the configuration.
 raft-state

--- a/pkg/raft/testdata/confchange_v2_replace_leader_stepdown.txt
+++ b/pkg/raft/testdata/confchange_v2_replace_leader_stepdown.txt
@@ -111,7 +111,7 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/5 Commit:4
   4->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5 Lead:1
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -131,7 +131,7 @@ stabilize
   Ready MustSync=false:
   State:StateFollower
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5 Lead:1
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -139,7 +139,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/5 Commit:5
   INFO 2 switched to configuration voters=(2 3 4)
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5 Lead:1
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -147,7 +147,7 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/5 Commit:5
   INFO 3 switched to configuration voters=(2 3 4)
 > 4 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:5 Lead:1
   CommittedEntries:
   1/5 EntryConfChangeV2

--- a/pkg/raft/testdata/forget_leader.txt
+++ b/pkg/raft/testdata/forget_leader.txt
@@ -76,9 +76,9 @@ stabilize
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->4 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
+  1->4 MsgHeartbeat Term:1 Log:0/0
 > 2 handling Ready
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:11 Lead:0
@@ -86,11 +86,11 @@ stabilize
   Ready MustSync=true:
   HardState Term:1 Commit:11 Lead:0
 > 2 receiving messages
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:1 Log:0/0
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:1 Log:0/0
 > 4 receiving messages
-  1->4 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->4 MsgHeartbeat Term:1 Log:0/0
 > 2 handling Ready
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:11 Lead:1

--- a/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
+++ b/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
@@ -60,12 +60,12 @@ stabilize
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
 > 2 receiving messages
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:1 Log:0/0
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:1 Log:0/0
   INFO 3 became follower at term 1
 > 2 handling Ready
   Ready MustSync=false:

--- a/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
+++ b/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
@@ -185,7 +185,7 @@ stabilize 2
   Entries:
   2/13 EntryNormal "prop_1"
   Messages:
-  2->3 MsgAppResp Term:2 Log:0/13
+  2->3 MsgAppResp Term:2 Log:0/13 Commit:12
 
 forget-leader 2
 ----

--- a/pkg/raft/testdata/heartbeat_resp_recovers_from_probing.txt
+++ b/pkg/raft/testdata/heartbeat_resp_recovers_from_probing.txt
@@ -79,9 +79,9 @@ stabilize
 > 2 handling Ready
   Ready MustSync=false:
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/11
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/11
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:11
 
 status 1
 ----

--- a/pkg/raft/testdata/heartbeat_resp_recovers_from_probing.txt
+++ b/pkg/raft/testdata/heartbeat_resp_recovers_from_probing.txt
@@ -53,12 +53,12 @@ stabilize
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
 > 2 receiving messages
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:1 Log:0/0
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:1 Log:0/0
 > 2 handling Ready
   Ready MustSync=false:
   Messages:

--- a/pkg/raft/testdata/lagging_commit.txt
+++ b/pkg/raft/testdata/lagging_commit.txt
@@ -51,15 +51,15 @@ Entries:
 1/12 EntryNormal "data1"
 1/13 EntryNormal "data2"
 Messages:
-3->1 MsgAppResp Term:1 Log:0/12
-3->1 MsgAppResp Term:1 Log:0/13
+3->1 MsgAppResp Term:1 Log:0/12 Commit:11
+3->1 MsgAppResp Term:1 Log:0/13 Commit:11
 
 # Suppose there is a network blip which prevents the leader learning that the
 # follower 3 has appended the proposed entries to the log.
 deliver-msgs drop=(1)
 ----
-dropped: 3->1 MsgAppResp Term:1 Log:0/12
-dropped: 3->1 MsgAppResp Term:1 Log:0/13
+dropped: 3->1 MsgAppResp Term:1 Log:0/12 Commit:11
+dropped: 3->1 MsgAppResp Term:1 Log:0/13 Commit:11
 
 # In the meantime, the entries are committed, and the leader sends the commit
 # index to all the followers.
@@ -71,11 +71,11 @@ stabilize 1 2
   1/12 EntryNormal "data1"
   1/13 EntryNormal "data2"
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/12
-  2->1 MsgAppResp Term:1 Log:0/13
+  2->1 MsgAppResp Term:1 Log:0/12 Commit:11
+  2->1 MsgAppResp Term:1 Log:0/13 Commit:11
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/12
-  2->1 MsgAppResp Term:1 Log:0/13
+  2->1 MsgAppResp Term:1 Log:0/12 Commit:11
+  2->1 MsgAppResp Term:1 Log:0/13 Commit:11
 > 1 handling Ready
   Ready MustSync=false:
   HardState Term:1 Vote:1 Commit:13 Lead:1
@@ -97,11 +97,11 @@ stabilize 1 2
   1/12 EntryNormal "data1"
   1/13 EntryNormal "data2"
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/13
-  2->1 MsgAppResp Term:1 Log:0/13
+  2->1 MsgAppResp Term:1 Log:0/13 Commit:12
+  2->1 MsgAppResp Term:1 Log:0/13 Commit:13
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/13
-  2->1 MsgAppResp Term:1 Log:0/13
+  2->1 MsgAppResp Term:1 Log:0/13 Commit:12
+  2->1 MsgAppResp Term:1 Log:0/13 Commit:13
 
 # The network blip prevents the follower 3 from learning that the previously
 # appended entries are now committed.
@@ -169,6 +169,6 @@ stabilize 1 3
   1/12 EntryNormal "data1"
   1/13 EntryNormal "data2"
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/13
+  3->1 MsgAppResp Term:1 Log:0/13 Commit:13
 > 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:0/13
+  3->1 MsgAppResp Term:1 Log:0/13 Commit:13

--- a/pkg/raft/testdata/lagging_commit.txt
+++ b/pkg/raft/testdata/lagging_commit.txt
@@ -77,7 +77,7 @@ stabilize 1 2
   2->1 MsgAppResp Term:1 Log:0/12 Commit:11
   2->1 MsgAppResp Term:1 Log:0/13 Commit:11
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:13 Lead:1
   CommittedEntries:
   1/12 EntryNormal "data1"
@@ -91,7 +91,7 @@ stabilize 1 2
   1->2 MsgApp Term:1 Log:1/13 Commit:12
   1->2 MsgApp Term:1 Log:1/13 Commit:13
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:13 Lead:1
   CommittedEntries:
   1/12 EntryNormal "data1"
@@ -163,7 +163,7 @@ stabilize 1 3
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/13 Commit:13
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:13 Lead:1
   CommittedEntries:
   1/12 EntryNormal "data1"

--- a/pkg/raft/testdata/lagging_commit.txt
+++ b/pkg/raft/testdata/lagging_commit.txt
@@ -133,8 +133,8 @@ process-ready 1
 ----
 Ready MustSync=false:
 Messages:
-1->2 MsgHeartbeat Term:1 Log:0/0 Commit:13
-1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+1->2 MsgHeartbeat Term:1 Log:0/0
+1->3 MsgHeartbeat Term:1 Log:0/0
 
 # Since the heartbeat message does not bump the follower's commit index, it will
 # take another roundtrip with the leader to update it. As such, the total time
@@ -149,7 +149,7 @@ Messages:
 stabilize 1 3
 ----
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:1 Log:0/0
 > 3 handling Ready
   Ready MustSync=false:
   Messages:

--- a/pkg/raft/testdata/prevote.txt
+++ b/pkg/raft/testdata/prevote.txt
@@ -86,7 +86,7 @@ INFO 2 [logterm: 1, index: 12, vote: 1] rejected MsgPreVote from 3 [logterm: 1, 
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:12 Lead:1
   CommittedEntries:
   1/12 EntryNormal "prop_1"
@@ -107,7 +107,7 @@ stabilize
   1->3 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
   2->3 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:12 Lead:1
   CommittedEntries:
   1/12 EntryNormal "prop_1"
@@ -245,7 +245,7 @@ stabilize
   3->2 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
   3->2 MsgAppResp Term:2 Log:0/13 Commit:12
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:2 Commit:13 Lead:2
   CommittedEntries:
   2/13 EntryNormal ""
@@ -257,14 +257,14 @@ stabilize
 > 3 receiving messages
   2->3 MsgApp Term:2 Log:2/13 Commit:13
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:2 Commit:13 Lead:2
   CommittedEntries:
   2/13 EntryNormal ""
   Messages:
   1->2 MsgAppResp Term:2 Log:0/13 Commit:13
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:2 Commit:13 Lead:2
   CommittedEntries:
   2/13 EntryNormal ""

--- a/pkg/raft/testdata/prevote.txt
+++ b/pkg/raft/testdata/prevote.txt
@@ -49,7 +49,7 @@ Ready MustSync=true:
 Entries:
 1/12 EntryNormal "prop_1"
 Messages:
-2->1 MsgAppResp Term:1 Log:0/12
+2->1 MsgAppResp Term:1 Log:0/12 Commit:11
 
 # 3 is now behind on its log. Attempt to campaign.
 raft-log 3
@@ -76,7 +76,7 @@ INFO 3 has received 1 MsgPreVoteResp votes and 0 vote rejections
 
 deliver-msgs 1 2
 ----
-2->1 MsgAppResp Term:1 Log:0/12
+2->1 MsgAppResp Term:1 Log:0/12 Commit:11
 3->1 MsgPreVote Term:2 Log:1/11
 INFO 1 [logterm: 1, index: 12, vote: 1] rejected MsgPreVote from 3 [logterm: 1, index: 11] at term 1
 3->2 MsgPreVote Term:2 Log:1/11
@@ -112,7 +112,7 @@ stabilize
   CommittedEntries:
   1/12 EntryNormal "prop_1"
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/12
+  2->1 MsgAppResp Term:1 Log:0/12 Commit:12
 > 3 handling Ready
   Ready MustSync=true:
   State:StateFollower
@@ -122,12 +122,12 @@ stabilize
   CommittedEntries:
   1/12 EntryNormal "prop_1"
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/12
-  3->1 MsgAppResp Term:1 Log:0/12
+  3->1 MsgAppResp Term:1 Log:0/12 Commit:11
+  3->1 MsgAppResp Term:1 Log:0/12 Commit:12
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/12
-  3->1 MsgAppResp Term:1 Log:0/12
-  3->1 MsgAppResp Term:1 Log:0/12
+  2->1 MsgAppResp Term:1 Log:0/12 Commit:12
+  3->1 MsgAppResp Term:1 Log:0/12 Commit:11
+  3->1 MsgAppResp Term:1 Log:0/12 Commit:12
 
 # Let 2 campaign. It should succeed, since it's up-to-date on the log.
 campaign 2
@@ -230,7 +230,7 @@ stabilize
   2/13 EntryNormal ""
   Messages:
   1->2 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
-  1->2 MsgAppResp Term:2 Log:0/13
+  1->2 MsgAppResp Term:2 Log:0/13 Commit:12
 > 3 handling Ready
   Ready MustSync=true:
   HardState Term:2 Vote:2 Commit:12 Lead:2
@@ -238,12 +238,12 @@ stabilize
   2/13 EntryNormal ""
   Messages:
   3->2 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
-  3->2 MsgAppResp Term:2 Log:0/13
+  3->2 MsgAppResp Term:2 Log:0/13 Commit:12
 > 2 receiving messages
   1->2 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
-  1->2 MsgAppResp Term:2 Log:0/13
+  1->2 MsgAppResp Term:2 Log:0/13 Commit:12
   3->2 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
-  3->2 MsgAppResp Term:2 Log:0/13
+  3->2 MsgAppResp Term:2 Log:0/13 Commit:12
 > 2 handling Ready
   Ready MustSync=false:
   HardState Term:2 Vote:2 Commit:13 Lead:2
@@ -262,14 +262,14 @@ stabilize
   CommittedEntries:
   2/13 EntryNormal ""
   Messages:
-  1->2 MsgAppResp Term:2 Log:0/13
+  1->2 MsgAppResp Term:2 Log:0/13 Commit:13
 > 3 handling Ready
   Ready MustSync=false:
   HardState Term:2 Vote:2 Commit:13 Lead:2
   CommittedEntries:
   2/13 EntryNormal ""
   Messages:
-  3->2 MsgAppResp Term:2 Log:0/13
+  3->2 MsgAppResp Term:2 Log:0/13 Commit:13
 > 2 receiving messages
-  1->2 MsgAppResp Term:2 Log:0/13
-  3->2 MsgAppResp Term:2 Log:0/13
+  1->2 MsgAppResp Term:2 Log:0/13 Commit:13
+  3->2 MsgAppResp Term:2 Log:0/13 Commit:13

--- a/pkg/raft/testdata/prevote_checkquorum.txt
+++ b/pkg/raft/testdata/prevote_checkquorum.txt
@@ -170,7 +170,7 @@ stabilize
   2->3 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
   2->3 MsgAppResp Term:2 Log:0/12 Commit:11
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:3 Commit:12 Lead:3
   CommittedEntries:
   2/12 EntryNormal ""
@@ -182,14 +182,14 @@ stabilize
 > 2 receiving messages
   3->2 MsgApp Term:2 Log:2/12 Commit:12
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Commit:12 Lead:3
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
   1->3 MsgAppResp Term:2 Log:0/12 Commit:12
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:3 Commit:12 Lead:3
   CommittedEntries:
   2/12 EntryNormal ""
@@ -337,7 +337,7 @@ stabilize
   3->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
   3->2 MsgAppResp Term:3 Log:0/13 Commit:12
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:3 Vote:2 Commit:13 Lead:2
   CommittedEntries:
   3/13 EntryNormal ""
@@ -349,14 +349,14 @@ stabilize
 > 3 receiving messages
   2->3 MsgApp Term:3 Log:3/13 Commit:13
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:3 Vote:2 Commit:13 Lead:2
   CommittedEntries:
   3/13 EntryNormal ""
   Messages:
   1->2 MsgAppResp Term:3 Log:0/13 Commit:13
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:3 Commit:13 Lead:2
   CommittedEntries:
   3/13 EntryNormal ""

--- a/pkg/raft/testdata/prevote_checkquorum.txt
+++ b/pkg/raft/testdata/prevote_checkquorum.txt
@@ -155,7 +155,7 @@ stabilize
   2/12 EntryNormal ""
   Messages:
   1->3 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
-  1->3 MsgAppResp Term:2 Log:0/12
+  1->3 MsgAppResp Term:2 Log:0/12 Commit:11
 > 2 handling Ready
   Ready MustSync=true:
   HardState Term:2 Vote:3 Commit:11 Lead:3
@@ -163,12 +163,12 @@ stabilize
   2/12 EntryNormal ""
   Messages:
   2->3 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
-  2->3 MsgAppResp Term:2 Log:0/12
+  2->3 MsgAppResp Term:2 Log:0/12 Commit:11
 > 3 receiving messages
   1->3 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
-  1->3 MsgAppResp Term:2 Log:0/12
+  1->3 MsgAppResp Term:2 Log:0/12 Commit:11
   2->3 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
-  2->3 MsgAppResp Term:2 Log:0/12
+  2->3 MsgAppResp Term:2 Log:0/12 Commit:11
 > 3 handling Ready
   Ready MustSync=false:
   HardState Term:2 Vote:3 Commit:12 Lead:3
@@ -187,17 +187,17 @@ stabilize
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
-  1->3 MsgAppResp Term:2 Log:0/12
+  1->3 MsgAppResp Term:2 Log:0/12 Commit:12
 > 2 handling Ready
   Ready MustSync=false:
   HardState Term:2 Vote:3 Commit:12 Lead:3
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
-  2->3 MsgAppResp Term:2 Log:0/12
+  2->3 MsgAppResp Term:2 Log:0/12 Commit:12
 > 3 receiving messages
-  1->3 MsgAppResp Term:2 Log:0/12
-  2->3 MsgAppResp Term:2 Log:0/12
+  1->3 MsgAppResp Term:2 Log:0/12 Commit:12
+  2->3 MsgAppResp Term:2 Log:0/12 Commit:12
 
 # Node 3 is now the leader. Even though the leader is active, nodes 1 and 2 can
 # still win a prevote and election if they both explicitly campaign, since the
@@ -321,7 +321,7 @@ stabilize
   3/13 EntryNormal ""
   Messages:
   1->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
-  1->2 MsgAppResp Term:3 Log:0/13
+  1->2 MsgAppResp Term:3 Log:0/13 Commit:12
 > 3 handling Ready
   Ready MustSync=true:
   State:StateFollower
@@ -330,12 +330,12 @@ stabilize
   3/13 EntryNormal ""
   Messages:
   3->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
-  3->2 MsgAppResp Term:3 Log:0/13
+  3->2 MsgAppResp Term:3 Log:0/13 Commit:12
 > 2 receiving messages
   1->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
-  1->2 MsgAppResp Term:3 Log:0/13
+  1->2 MsgAppResp Term:3 Log:0/13 Commit:12
   3->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
-  3->2 MsgAppResp Term:3 Log:0/13
+  3->2 MsgAppResp Term:3 Log:0/13 Commit:12
 > 2 handling Ready
   Ready MustSync=false:
   HardState Term:3 Vote:2 Commit:13 Lead:2
@@ -354,14 +354,14 @@ stabilize
   CommittedEntries:
   3/13 EntryNormal ""
   Messages:
-  1->2 MsgAppResp Term:3 Log:0/13
+  1->2 MsgAppResp Term:3 Log:0/13 Commit:13
 > 3 handling Ready
   Ready MustSync=false:
   HardState Term:3 Commit:13 Lead:2
   CommittedEntries:
   3/13 EntryNormal ""
   Messages:
-  3->2 MsgAppResp Term:3 Log:0/13
+  3->2 MsgAppResp Term:3 Log:0/13 Commit:13
 > 2 receiving messages
-  1->2 MsgAppResp Term:3 Log:0/13
-  3->2 MsgAppResp Term:3 Log:0/13
+  1->2 MsgAppResp Term:3 Log:0/13 Commit:13
+  3->2 MsgAppResp Term:3 Log:0/13 Commit:13

--- a/pkg/raft/testdata/probe_and_replicate.txt
+++ b/pkg/raft/testdata/probe_and_replicate.txt
@@ -497,10 +497,10 @@ stabilize 1 2
   HardState Term:8 Vote:1 Commit:18 Lead:1
   Messages:
   2->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
-  2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19)
+  2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19) Commit:18
 > 1 receiving messages
   2->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
-  2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19)
+  2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19) Commit:18
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
@@ -519,9 +519,9 @@ stabilize 1 2
   6/20 EntryNormal "prop_6_20"
   8/21 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:8 Log:0/21
+  2->1 MsgAppResp Term:8 Log:0/21 Commit:18
 > 1 receiving messages
-  2->1 MsgAppResp Term:8 Log:0/21
+  2->1 MsgAppResp Term:8 Log:0/21 Commit:18
 
 stabilize 1 3
 ----
@@ -533,10 +533,10 @@ stabilize 1 3
   HardState Term:8 Vote:1 Commit:14 Lead:1
   Messages:
   3->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
-  3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14)
+  3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14) Commit:14
 > 1 receiving messages
   3->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
-  3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14)
+  3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14) Commit:14
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
@@ -576,9 +576,9 @@ stabilize 1 3
   5/17 EntryNormal "prop_5_17"
   6/18 EntryNormal ""
   Messages:
-  3->1 MsgAppResp Term:8 Log:0/21
+  3->1 MsgAppResp Term:8 Log:0/21 Commit:18
 > 1 receiving messages
-  3->1 MsgAppResp Term:8 Log:0/21
+  3->1 MsgAppResp Term:8 Log:0/21 Commit:18
 
 stabilize 1 4
 ----
@@ -594,10 +594,10 @@ stabilize 1 4
   8/21 EntryNormal ""
   Messages:
   4->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
-  4->1 MsgAppResp Term:8 Log:0/21
+  4->1 MsgAppResp Term:8 Log:0/21 Commit:18
 > 1 receiving messages
   4->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
-  4->1 MsgAppResp Term:8 Log:0/21
+  4->1 MsgAppResp Term:8 Log:0/21 Commit:18
 > 1 handling Ready
   Ready MustSync=false:
   HardState Term:8 Vote:1 Commit:21 Lead:1
@@ -619,9 +619,9 @@ stabilize 1 4
   6/20 EntryNormal "prop_6_20"
   8/21 EntryNormal ""
   Messages:
-  4->1 MsgAppResp Term:8 Log:0/21
+  4->1 MsgAppResp Term:8 Log:0/21 Commit:21
 > 1 receiving messages
-  4->1 MsgAppResp Term:8 Log:0/21
+  4->1 MsgAppResp Term:8 Log:0/21 Commit:21
 
 stabilize 1 5
 ----
@@ -633,10 +633,10 @@ stabilize 1 5
   HardState Term:8 Commit:18 Lead:1
   Messages:
   5->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
-  5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18)
+  5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18) Commit:18
 > 1 receiving messages
   5->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
-  5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18)
+  5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18) Commit:18
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
@@ -665,9 +665,9 @@ stabilize 1 5
   6/20 EntryNormal "prop_6_20"
   8/21 EntryNormal ""
   Messages:
-  5->1 MsgAppResp Term:8 Log:0/21
+  5->1 MsgAppResp Term:8 Log:0/21 Commit:21
 > 1 receiving messages
-  5->1 MsgAppResp Term:8 Log:0/21
+  5->1 MsgAppResp Term:8 Log:0/21 Commit:21
 
 stabilize 1 6
 ----
@@ -679,10 +679,10 @@ stabilize 1 6
   HardState Term:8 Vote:1 Commit:15 Lead:1
   Messages:
   6->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
-  6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17)
+  6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17) Commit:15
 > 1 receiving messages
   6->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
-  6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17)
+  6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17) Commit:15
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
@@ -723,9 +723,9 @@ stabilize 1 6
   6/20 EntryNormal "prop_6_20"
   8/21 EntryNormal ""
   Messages:
-  6->1 MsgAppResp Term:8 Log:0/21
+  6->1 MsgAppResp Term:8 Log:0/21 Commit:21
 > 1 receiving messages
-  6->1 MsgAppResp Term:8 Log:0/21
+  6->1 MsgAppResp Term:8 Log:0/21 Commit:21
 
 stabilize 1 7
 ----
@@ -737,10 +737,10 @@ stabilize 1 7
   HardState Term:8 Vote:1 Commit:13 Lead:1
   Messages:
   7->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
-  7->1 MsgAppResp Term:8 Log:3/20 Rejected (Hint: 20)
+  7->1 MsgAppResp Term:8 Log:3/20 Rejected (Hint: 20) Commit:13
 > 1 receiving messages
   7->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
-  7->1 MsgAppResp Term:8 Log:3/20 Rejected (Hint: 20)
+  7->1 MsgAppResp Term:8 Log:3/20 Rejected (Hint: 20) Commit:13
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
@@ -789,6 +789,6 @@ stabilize 1 7
   6/20 EntryNormal "prop_6_20"
   8/21 EntryNormal ""
   Messages:
-  7->1 MsgAppResp Term:8 Log:0/21
+  7->1 MsgAppResp Term:8 Log:0/21 Commit:21
 > 1 receiving messages
-  7->1 MsgAppResp Term:8 Log:0/21
+  7->1 MsgAppResp Term:8 Log:0/21 Commit:21

--- a/pkg/raft/testdata/probe_and_replicate.txt
+++ b/pkg/raft/testdata/probe_and_replicate.txt
@@ -599,7 +599,7 @@ stabilize 1 4
   4->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
   4->1 MsgAppResp Term:8 Log:0/21 Commit:18
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:8 Vote:1 Commit:21 Lead:1
   CommittedEntries:
   6/19 EntryNormal "prop_6_19"
@@ -612,7 +612,7 @@ stabilize 1 4
 > 4 receiving messages
   1->4 MsgApp Term:8 Log:8/21 Commit:21
 > 4 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:8 Commit:21 Lead:1
   CommittedEntries:
   6/19 EntryNormal "prop_6_19"

--- a/pkg/raft/testdata/replicate_pause.txt
+++ b/pkg/raft/testdata/replicate_pause.txt
@@ -171,7 +171,7 @@ stabilize 3
 > 3 handling Ready
   Ready MustSync=false:
   Messages:
-  3->1 MsgAppResp Term:1 Log:1/14 Rejected (Hint: 11)
+  3->1 MsgAppResp Term:1 Log:1/14 Rejected (Hint: 11) Commit:11
 
 log-level none
 ----

--- a/pkg/raft/testdata/replicate_pause.txt
+++ b/pkg/raft/testdata/replicate_pause.txt
@@ -131,15 +131,15 @@ stabilize 1
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:17
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
 
 stabilize 2 3
 ----
 > 2 receiving messages
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:17
+  1->2 MsgHeartbeat Term:1 Log:0/0
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:1 Log:0/0
 > 2 handling Ready
   Ready MustSync=false:
   Messages:

--- a/pkg/raft/testdata/single_node.txt
+++ b/pkg/raft/testdata/single_node.txt
@@ -29,7 +29,7 @@ stabilize
   Entries:
   1/4 EntryNormal ""
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4 Lead:1
   CommittedEntries:
   1/4 EntryNormal ""

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
@@ -117,14 +117,14 @@ stabilize 3
   HardState Term:1 Commit:11 Lead:1
   Snapshot Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/11
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 
 # The MsgAppResp lets the leader move the follower back to replicating state.
 # Leader sends another MsgAppResp, to communicate the updated commit index.
 stabilize 1
 ----
 > 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:0/11
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=11 next=12 paused pendingSnap=11]
 
 status 1

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
@@ -63,7 +63,7 @@ process-ready 1
 ----
 Ready MustSync=false:
 Messages:
-1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
+1->2 MsgHeartbeat Term:1 Log:0/0
 1->3 MsgHeartbeat Term:1 Log:0/0
 
 # Iterate until no more work is done by the new peer. It receives the heartbeat
@@ -137,7 +137,7 @@ status 1
 stabilize
 ----
 > 2 receiving messages
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:1 Log:0/0
 > 2 handling Ready
   Ready MustSync=false:
   Messages:

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
@@ -113,7 +113,7 @@ stabilize 3
   INFO 3 [commit: 11, lastindex: 11, lastterm: 1] restored snapshot [index: 11, term: 1]
   INFO 3 [commit: 11] restored snapshot [index: 11, term: 1]
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:11 Lead:1
   Snapshot Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp_behind.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp_behind.txt
@@ -143,7 +143,7 @@ dropped: 1->3 MsgSnap Term:1 Log:0/0
 stabilize 3
 ----
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:11 Lead:1
   Snapshot Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp_behind.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp_behind.txt
@@ -102,7 +102,7 @@ process-ready 3
 Ready MustSync=true:
 HardState Term:1 Vote:1 Commit:5 Lead:1
 Messages:
-3->1 MsgAppResp Term:1 Log:1/10 Rejected (Hint: 5)
+3->1 MsgAppResp Term:1 Log:1/10 Rejected (Hint: 5) Commit:5
 
 # 3 receives and applies the snapshot, but doesn't respond with MsgAppResp yet.
 deliver-msgs 3
@@ -121,7 +121,7 @@ INFO 3 [commit: 11] restored snapshot [index: 11, term: 1]
 stabilize 1
 ----
 > 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:1/10 Rejected (Hint: 5)
+  3->1 MsgAppResp Term:1 Log:1/10 Rejected (Hint: 5) Commit:5
   DEBUG 1 received MsgAppResp(rejected, hint: (index 5, term 1)) from 3 for index 10
   DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=6]
   DEBUG 1 [firstindex: 11, commit: 12] sent snapshot[index: 12, term: 1] to 3 [StateProbe match=0 next=6]
@@ -148,13 +148,13 @@ stabilize 3
   Snapshot Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
-  3->1 MsgAppResp Term:1 Log:0/11
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 
 stabilize 1
 ----
 > 1 receiving messages
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
-  3->1 MsgAppResp Term:1 Log:0/11
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=11 next=13 paused pendingSnap=12]
 > 1 handling Ready
   Ready MustSync=false:


### PR DESCRIPTION
This commit makes the follower send the commit index in the MsgAppResp.
This will be used in future commits to make the leader determine if
a follower's commit index is up-to-date or not, and decide whether it
needs an empty MsgApp based on that.

References: #125266

Epic: None

Release note: None