### PR TITLE
rttanalysis: add benchmark for prisma types query

### DIFF
--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -106,6 +106,8 @@ exp,benchmark
 4,ORMQueries/pg_type
 133,ORMQueries/prisma_column_descriptions
 3,ORMQueries/prisma_column_descriptions_updated
+5,ORMQueries/prisma_types_16
+5,ORMQueries/prisma_types_4
 10,Revoke/revoke_all_on_1_table
 10,Revoke/revoke_all_on_2_tables
 10,Revoke/revoke_all_on_3_tables


### PR DESCRIPTION
Let's add this benchmark so that we can track any regressions and decide if we need to make
improvements. For now, it doesn't look like anything is needed, so I will close the linked issue.

```
goos: darwin
goarch: arm64
BenchmarkORMQueries
BenchmarkORMQueries/prisma_types_4         	      36	  31676249 ns/op	         5.000 roundtrips
BenchmarkORMQueries/prisma_types_16        	      27	  45180889 ns/op	         5.000 roundtrips
```

fixes https://github.com/cockroachdb/cockroach/issues/111047
Release note: None