### PR TITLE
roachtest: make graceful stop an option instead of a function

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1109,27 +1109,6 @@ func (c *clusterImpl) setTest(t test.Test) {
 	c.l = t.L()
 }
 
-// StopCockroachGracefullyOnNode stops a running cockroach instance on the requested
-// node before a version upgrade.
-func (c *clusterImpl) StopCockroachGracefullyOnNode(
-	ctx context.Context, l *logger.Logger, node int,
-) error {
-	// A graceful shutdown is sending SIGTERM to the node, then waiting
-	// some reasonable amount of time, then sending a non-graceful SIGKILL.
-	gracefulOpts := option.DefaultStopOpts()
-	gracefulOpts.RoachprodOpts.Sig = 15 // SIGTERM
-	gracefulOpts.RoachprodOpts.Wait = true
-	gracefulOpts.RoachprodOpts.MaxWait = 60
-	if err := c.StopE(ctx, l, gracefulOpts, c.Node(node)); err != nil {
-		return err
-	}
-
-	// NB: we still call Stop to make sure the process is dead when we
-	// try to restart it (in case it takes longer than `MaxWait` for it
-	// to finish).
-	return c.StopE(ctx, l, option.DefaultStopOpts(), c.Node(node))
-}
-
 // Save marks the cluster as "saved" so that it doesn't get destroyed.
 func (c *clusterImpl) Save(ctx context.Context, msg string, l *logger.Logger) {
 	l.PrintfCtx(ctx, "saving cluster %s for debugging (--debug specified)", c)

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -65,7 +65,6 @@ type Cluster interface {
 	Stop(ctx context.Context, l *logger.Logger, stopOpts option.StopOpts, opts ...option.Option)
 	SignalE(ctx context.Context, l *logger.Logger, sig int, opts ...option.Option) error
 	Signal(ctx context.Context, l *logger.Logger, sig int, opts ...option.Option)
-	StopCockroachGracefullyOnNode(ctx context.Context, l *logger.Logger, node int) error
 	NewMonitor(context.Context, ...option.Option) Monitor
 
 	// Starting virtual clusters.

--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -112,6 +112,18 @@ func DefaultStopOpts() StopOpts {
 	return StopOpts{RoachprodOpts: roachprod.DefaultStopOpts()}
 }
 
+// NewStopOpts returns a StopOpts populated with default values when
+// called with no options. Pass customization functions to change the
+// stop options.
+func NewStopOpts(opts ...StartStopOption) StopOpts {
+	stopOpts := StopOpts{RoachprodOpts: roachprod.DefaultStopOpts()}
+	for _, opt := range opts {
+		opt(&stopOpts)
+	}
+
+	return stopOpts
+}
+
 // StopSharedVirtualClusterOpts creates StopOpts that can be used to
 // stop the shared process virtual cluster with the given name.
 func StopSharedVirtualClusterOpts(virtualClusterName string) StopOpts {
@@ -208,6 +220,18 @@ func NoBackupSchedule(opts interface{}) {
 	switch opts := opts.(type) {
 	case *StartOpts:
 		opts.RoachprodOpts.ScheduleBackups = false
+	}
+}
+
+// Graceful performs a graceful stop of the cockroach process.
+func Graceful(maxWaitSeconds int) func(interface{}) {
+	return func(opts interface{}) {
+		switch opts := opts.(type) {
+		case *StopOpts:
+			opts.RoachprodOpts.Sig = 15 // SIGTERM
+			opts.RoachprodOpts.Wait = true
+			opts.RoachprodOpts.MaxWait = maxWaitSeconds
+		}
 	}
 }
 

--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -356,6 +356,8 @@ func RestartNodesWithNewBinary(
 	newVersion *Version,
 	settings ...install.ClusterSettingOption,
 ) error {
+	const maxWait = 300 // 5 minutes
+
 	// NB: We could technically stage the binary on all nodes before
 	// restarting each one, but on Unix it's invalid to write to an
 	// executable file while it is currently running. So we do the
@@ -376,7 +378,9 @@ func RestartNodesWithNewBinary(
 		// this upgraded node for DistSQL plans (see #87154 for more details).
 		// TODO(yuzefovich): ideally, we would also check that the drain was
 		// successful since if it wasn't, then we might see flakes too.
-		if err := c.StopCockroachGracefullyOnNode(ctx, l, node); err != nil {
+		if err := c.StopE(
+			ctx, l, option.NewStopOpts(option.Graceful(maxWait)), c.Node(node),
+		); err != nil {
 			return err
 		}
 

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -37,6 +37,10 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// shudownMaxWait is the default maximum duration (in seconds) that we
+// will wait for a graceful shutdown.
+const shutdownMaxWait = 300
+
 func registerDecommission(r registry.Registry) {
 	{
 		numNodes := 4
@@ -296,6 +300,8 @@ func runDecommission(
 		})
 	}
 
+	stopOpts := option.NewStopOpts(option.Graceful(shutdownMaxWait))
+
 	m.Go(func() error {
 		tBegin, whileDown := timeutil.Now(), true
 		node := nodes
@@ -321,7 +327,7 @@ func runDecommission(
 			}
 
 			if whileDown {
-				if err := c.StopCockroachGracefullyOnNode(ctx, t.L(), node); err != nil {
+				if err := c.StopE(ctx, t.L(), stopOpts, c.Node(node)); err != nil {
 					return err
 				}
 			}
@@ -346,7 +352,7 @@ func runDecommission(
 			}
 
 			if !whileDown {
-				if err := c.StopCockroachGracefullyOnNode(ctx, t.L(), node); err != nil {
+				if err := c.StopE(ctx, t.L(), stopOpts, c.Node(node)); err != nil {
 					return err
 				}
 			}

--- a/pkg/cmd/roachtest/tests/decommissionbench.go
+++ b/pkg/cmd/roachtest/tests/decommissionbench.go
@@ -883,6 +883,9 @@ func runSingleDecommission(
 	// TODO(sarkesian): Consider adding a future test for decommissions that get
 	// stuck with replicas in purgatory, by pinning them to a node.
 
+	// We stop nodes gracefully when needed.
+	stopOpts := option.NewStopOpts(option.Graceful(shutdownMaxWait))
+
 	// Gather metadata for logging purposes and wait for balance.
 	var bytesUsed, rangeCount, totalRanges int64
 	var candidateStores, avgBytesPerReplica int64
@@ -939,7 +942,7 @@ func runSingleDecommission(
 
 	if stopFirst {
 		h.t.Status(fmt.Sprintf("gracefully stopping node%d", target))
-		if err := h.c.StopCockroachGracefullyOnNode(ctx, h.t.L(), target); err != nil {
+		if err := h.c.StopE(ctx, h.t.L(), stopOpts, c.Node(target)); err != nil {
 			return err
 		}
 		// Wait after stopping the node to distinguish the impact of the node being
@@ -997,7 +1000,7 @@ func runSingleDecommission(
 	if reuse {
 		if !stopFirst {
 			h.t.Status(fmt.Sprintf("gracefully stopping node%d", target))
-			if err := h.c.StopCockroachGracefullyOnNode(ctx, h.t.L(), target); err != nil {
+			if err := h.c.StopE(ctx, h.t.L(), stopOpts, c.Node(target)); err != nil {
 				return err
 			}
 		}

--- a/pkg/cmd/roachtest/tests/encryption.go
+++ b/pkg/cmd/roachtest/tests/encryption.go
@@ -85,9 +85,7 @@ func registerEncryption(r registry.Registry) {
 			}
 
 			for i := 1; i <= nodes; i++ {
-				if err := c.StopCockroachGracefullyOnNode(ctx, t.L(), i); err != nil {
-					t.Fatal(err)
-				}
+				c.Stop(ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownMaxWait)), c.Node(i))
 			}
 		}
 	}

--- a/pkg/cmd/roachtest/tests/jobs_util.go
+++ b/pkg/cmd/roachtest/tests/jobs_util.go
@@ -151,7 +151,9 @@ func executeNodeShutdown(
 		}
 	} else {
 		t.L().Printf(`stopping node gracefully %s`, target)
-		if err := c.StopCockroachGracefullyOnNode(ctx, t.L(), cfg.shutdownNode); err != nil {
+		if err := c.StopE(
+			ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownMaxWait)), c.Node(cfg.shutdownNode),
+		); err != nil {
 			return errors.Wrapf(err, "could not stop node %s", target)
 		}
 	}

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -488,13 +488,13 @@ func registerKVQuiescenceDead(r registry.Registry) {
 			})
 			// Graceful shut down third node.
 			m.ExpectDeath()
-			gracefulOpts := option.DefaultStopOpts()
-			gracefulOpts.RoachprodOpts.Sig = 15 // SIGTERM
-			gracefulOpts.RoachprodOpts.Wait = true
-			gracefulOpts.RoachprodOpts.MaxWait = 30
-			c.Stop(ctx, t.L(), gracefulOpts, c.Node(len(c.CRDBNodes())))
-			// If graceful shutdown fails within 30 seconds, proceed with hard shutdown.
-			c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(len(c.CRDBNodes())))
+			if err := c.StopE(
+				ctx, t.L(), option.NewStopOpts(option.Graceful(30)), c.Node(len(c.CRDBNodes())),
+			); err != nil {
+				t.L().Printf("graceful shutdown failed: %v", err)
+				// If graceful shutdown fails within 30 seconds, proceed with hard shutdown.
+				c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(len(c.CRDBNodes())))
+			}
 			// Measure qps with node down (i.e. without quiescence).
 			qpsOneDown := qps(func() {
 				// Use a different seed to make sure it's not just stepping into the

--- a/pkg/cmd/roachtest/tests/logical_data_replication.go
+++ b/pkg/cmd/roachtest/tests/logical_data_replication.go
@@ -359,15 +359,16 @@ func TestLDROnNodeShutdown(
 
 	// Graceful shutdown on both nodes
 	// TODO(naveen.setlur): maybe switch this to a less graceful shutdown via SIGKILL
+	stopOpts := option.NewStopOpts(option.Graceful(shutdownMaxWait))
 	t.L().Printf("Shutting down node-left: %d", nodeToStopL)
 	monitor.ExpectDeath()
-	if err := c.StopCockroachGracefullyOnNode(ctx, t.L(), nodeToStopL); err != nil {
+	if err := c.StopE(ctx, t.L(), stopOpts, c.Node(nodeToStopL)); err != nil {
 		t.Fatalf("Unable to shutdown node: %s", err)
 	}
 
 	t.L().Printf("Shutting down node-right: %d", nodeToStopR)
 	monitor.ExpectDeath()
-	if err := c.StopCockroachGracefullyOnNode(ctx, t.L(), nodeToStopR); err != nil {
+	if err := c.StopE(ctx, t.L(), stopOpts, c.Node(nodeToStopR)); err != nil {
 		t.Fatalf("Unable to shutdown node: %s", err)
 	}
 

--- a/pkg/cmd/roachtest/tests/multi_region_system_database.go
+++ b/pkg/cmd/roachtest/tests/multi_region_system_database.go
@@ -67,10 +67,7 @@ func registerMultiRegionSystemDatabase(r registry.Registry) {
 			// Perform rolling restart to propagate region information to non-primary nodes
 			for i := 2; i <= nodes; i++ {
 				t.WorkerStatus("stop")
-				err := c.StopCockroachGracefullyOnNode(ctx, t.L(), i)
-				if err != nil {
-					return
-				}
+				c.Stop(ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownMaxWait)), c.Node(i))
 				t.WorkerStatus("start")
 				startOpts := option.DefaultStartOpts()
 				c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SecureOption(false)), c.Node(i))


### PR DESCRIPTION
Previously, a few tests would use the `StopCockroachGracefullyOnNode`
function when they wanted a graceful shutdown. However, the start/stop
functions are already able to take options from the caller.

In this commit, we replace the custom function to perform a graceful
shutdown with a `Graceful` option that can be passed to `Stop`. This
is now composable with other options that can also be passed to `Stop`.

Epic: none

Release note: None