### PR TITLE
roachtest: Fix ycsb workload to avoid column families

### DIFF
--- a/pkg/cmd/roachtest/tests/logical_data_replication.go
+++ b/pkg/cmd/roachtest/tests/logical_data_replication.go
@@ -44,7 +44,7 @@ type ycsbWorkload struct {
 }
 
 func (ycsb ycsbWorkload) sourceInitCmd(tenantName string, nodes option.NodeListOption) string {
-	cmd := roachtestutil.NewCommand(`./cockroach workload init ycsb`).
+	cmd := roachtestutil.NewCommand(`./cockroach workload init ycsb --families=false`).
 		MaybeFlag(ycsb.initRows > 0, "insert-count", ycsb.initRows).
 		MaybeFlag(ycsb.initSplits > 0, "splits", ycsb.initSplits).
 		Arg("{pgurl%s:%s}", nodes, tenantName)
@@ -52,7 +52,7 @@ func (ycsb ycsbWorkload) sourceInitCmd(tenantName string, nodes option.NodeListO
 }
 
 func (ycsb ycsbWorkload) sourceRunCmd(tenantName string, nodes option.NodeListOption) string {
-	cmd := roachtestutil.NewCommand(`./cockroach workload run ycsb`).
+	cmd := roachtestutil.NewCommand(`./cockroach workload run ycsb --families=false`).
 		Option("tolerate-errors").
 		Flag("workload", ycsb.workloadType).
 		MaybeFlag(ycsb.debugRunDuration > 0, "duration", ycsb.debugRunDuration).


### PR DESCRIPTION
The update_heavy test had failures because the ycsb workload was using column families, which aren't supported for LDR.

Release note: none
Fixes: #128740