### PR TITLE
roachprod: more clearly log DestroyCluster progress

### DIFF
--- a/pkg/roachprod/cloud/BUILD.bazel
+++ b/pkg/roachprod/cloud/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/roachprod/config",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/promhelperclient",
+        "//pkg/roachprod/ui",
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/aws",
         "//pkg/roachprod/vm/gce",

--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/promhelperclient"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/ui"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce"
 	"github.com/cockroachdb/errors"
@@ -409,6 +410,7 @@ func ShrinkCluster(l *logger.Logger, c *Cluster, numNodes int) error {
 
 // DestroyCluster TODO(peter): document
 func DestroyCluster(l *logger.Logger, c *Cluster) error {
+	stopSpinner := ui.NewDefaultSpinner(l, "Destroying Prometheus configs").Start()
 	// check if any node is supported as promhelper cluster
 	for _, node := range c.VMs {
 		if _, ok := promhelperclient.SupportedPromProjects[node.Project]; ok &&
@@ -430,11 +432,17 @@ func DestroyCluster(l *logger.Logger, c *Cluster) error {
 			break
 		}
 	}
+	stopSpinner()
+
 	// DNS entries are destroyed first to ensure that the GC job will not try
 	// and clean-up entries prematurely.
+	stopSpinner = ui.NewDefaultSpinner(l, "Destroying DNS entries").Start()
 	dnsErr := vm.FanOutDNS(c.VMs, func(p vm.DNSProvider, vms vm.List) error {
 		return p.DeleteRecordsBySubdomain(context.Background(), c.Name)
 	})
+	stopSpinner()
+
+	stopSpinner = ui.NewDefaultSpinner(l, "Destroying VMs").Start()
 	// Allow both DNS and VM operations to run before returning any errors.
 	clusterErr := vm.FanOut(c.VMs, func(p vm.Provider, vms vm.List) error {
 		// Enable a fast-path for providers that can destroy a cluster in one shot.
@@ -443,6 +451,7 @@ func DestroyCluster(l *logger.Logger, c *Cluster) error {
 		}
 		return p.Delete(l, vms)
 	})
+	stopSpinner()
 	return errors.CombineErrors(dnsErr, clusterErr)
 }
 

--- a/pkg/roachprod/promhelperclient/client.go
+++ b/pkg/roachprod/promhelperclient/client.go
@@ -157,12 +157,11 @@ func (c *PromClient) DeleteClusterConfig(
 	if insecure {
 		url = fmt.Sprintf("%s?insecure=true", url)
 	}
-	l.Printf("invoking DELETE for URL: %s", url)
 	h := &http.Header{}
 	h.Set("Authorization", token)
 	response, err := c.httpDelete(ctx, url, h)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "DeleteClusterConfig: failed on url: %s", url)
 	}
 	if response.StatusCode != http.StatusNoContent {
 		defer func() { _ = response.Body.Close() }()
@@ -173,7 +172,7 @@ func (c *PromClient) DeleteClusterConfig(
 		if err != nil {
 			return err
 		}
-		return errors.Newf("request failed with status %d and error %s", response.StatusCode,
+		return errors.Newf("request failed with url %s status %d and error %s", url, response.StatusCode,
 			string(body))
 	}
 	return nil

--- a/pkg/roachprod/promhelperclient/client_test.go
+++ b/pkg/roachprod/promhelperclient/client_test.go
@@ -110,7 +110,7 @@ func TestDeleteClusterConfig(t *testing.T) {
 		}
 		err := c.DeleteClusterConfig(ctx, "c1", false, false, l)
 		require.NotNil(t, err)
-		require.Equal(t, "request failed with status 400 and error failed", err.Error())
+		require.Equal(t, "request failed with url http://prom_url.com/v1/instance-configs/c1 status 400 and error failed", err.Error())
 	})
 	t.Run("DeleteClusterConfig succeeds", func(t *testing.T) {
 		c.httpDelete = func(ctx context.Context, url string, h *http.Header) (


### PR DESCRIPTION
Previously, DestroyCluster would log an "invoking DELETE on..." indicating it was deleting the prometheus config and nothing else. This made it appear as though roachprod was hanging on prometheus teardown even though it usually takes < 1 second and was actually hanging on destroying the VMs.

This change adds spinners for DNS deletion and VM deletion, to show that progress has been made.

Fixes: none
Release note: none
Epic: none