### PR TITLE
util/queue: add queue with fixed chunk size 

### DIFF
--- a/pkg/util/queue/BUILD.bazel
+++ b/pkg/util/queue/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "queue.go",
         "queue_test_helper.go",
+        "queue_with_fixed_chunk_size.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/queue",
     visibility = ["//visibility:public"],
@@ -19,6 +20,7 @@ go_test(
     srcs = ["queue_test.go"],
     embed = [":queue"],
     deps = [
+        "//pkg/testutils",
         "//pkg/util/randutil",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/util/queue/BUILD.bazel
+++ b/pkg/util/queue/BUILD.bazel
@@ -2,10 +2,16 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "queue",
-    srcs = ["queue.go"],
+    srcs = [
+        "queue.go",
+        "queue_test_helper.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/queue",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_cockroachdb_errors//:errors"],
+    deps = [
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//require",
+    ],
 )
 
 go_test(
@@ -14,7 +20,6 @@ go_test(
     embed = [":queue"],
     deps = [
         "//pkg/util/randutil",
-        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/util/queue/queue.go
+++ b/pkg/util/queue/queue.go
@@ -98,7 +98,7 @@ func (q *Queue[T]) Dequeue() (e T, ok bool) {
 	return e, true
 }
 
-func (q *Queue[T]) purge() {
+func (q *Queue[T]) removeAll() {
 	for q.head != nil {
 		q.head = q.head.next
 		// The previous value of q.head will be garbage collected.

--- a/pkg/util/queue/queue.go
+++ b/pkg/util/queue/queue.go
@@ -98,14 +98,6 @@ func (q *Queue[T]) Dequeue() (e T, ok bool) {
 	return e, true
 }
 
-func (q *Queue[T]) removeAll() {
-	for q.head != nil {
-		q.head = q.head.next
-		// The previous value of q.head will be garbage collected.
-	}
-	q.tail = q.head
-}
-
 type queueChunk[T any] struct {
 	events     []T
 	head, tail int

--- a/pkg/util/queue/queue_test.go
+++ b/pkg/util/queue/queue_test.go
@@ -14,108 +14,141 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func checkInvariants[T any](t *testing.T, q *Queue[T]) {
-	if q.head == nil && q.tail == nil {
-		require.True(t, q.Empty())
-	} else if q.head != nil && q.tail == nil {
-		t.Fatal("head is nil but tail is non-nil")
-	} else if q.head == nil && q.tail != nil {
-		t.Fatal("tail is nil but head is non-nil")
-	} else {
-		// The queue maintains an invariant that it contains no finished chunks.
-		require.False(t, q.head.finished())
-		require.False(t, q.tail.finished())
-
-		if q.head == q.tail {
-			require.Nil(t, q.head.next)
-		} else {
-			// q.tail is non-nil and not equal to q.head. There must be a non-empty
-			// chunk after q.head.
-			require.False(t, q.Empty())
-			if q.head.empty() {
-				require.False(t, q.head.next.empty())
-			}
-			// The q.tail is never empty in this case. The tail can only be empty
-			// when it is equal to q.head and q.head is empty.
-			require.False(t, q.tail.empty())
-		}
-	}
-}
 
 type testQueueItem struct {
 	i int64
 }
 
+// testQueueInterface is an interface that defines the operations that can be
+// done on a queue for testing.
+type testQueueInterface interface {
+	Enqueue(*testQueueItem)
+	Empty() bool
+	Dequeue() (*testQueueItem, bool)
+	removeAll()
+	checkInvariants(*testing.T)
+	checkEventCount(*testing.T, int)
+	checkNil(*testing.T)
+}
+
+var _ testQueueInterface = &Queue[*testQueueItem]{}
+
+func runQueueTest(t *testing.T, q testQueueInterface) {
+	eventCount := 1000000
+	t.Run("basic operation: add one event and remove it", func(t *testing.T) {
+		require.True(t, q.Empty())
+		q.Enqueue(&testQueueItem{})
+		require.False(t, q.Empty())
+		_, ok := q.Dequeue()
+		require.True(t, ok)
+		require.True(t, q.Empty())
+		q.checkInvariants(t)
+		q.checkEventCount(t, 0)
+	})
+
+	t.Run("fill and empty queue", func(t *testing.T) {
+		for i := 0; i < eventCount; i++ {
+			q.checkInvariants(t)
+			q.checkEventCount(t, i)
+			q.Enqueue(&testQueueItem{})
+		}
+		for eventCount != 0 {
+			require.Equal(t, eventCount <= 0, q.Empty())
+			_, ok := q.Dequeue()
+			require.True(t, ok)
+			eventCount--
+			q.checkInvariants(t)
+			q.checkEventCount(t, eventCount)
+		}
+		require.True(t, q.Empty())
+		q.checkInvariants(t)
+		q.checkEventCount(t, 0)
+		_, ok := q.Dequeue()
+		require.False(t, ok)
+		require.True(t, q.Empty())
+	})
+
+	t.Run("removeAll is noop for an empty queue", func(t *testing.T) {
+		q.removeAll()
+		q.checkNil(t)
+		q.checkInvariants(t)
+		q.checkEventCount(t, 0)
+		require.True(t, q.Empty())
+	})
+
+	t.Run("empty queue", func(t *testing.T) {
+		q.Enqueue(&testQueueItem{})
+		require.False(t, q.Empty())
+		q.Dequeue()
+		require.True(t, q.Empty())
+		q.checkInvariants(t)
+		q.checkEventCount(t, 0)
+	})
+
+	t.Run("fill and empty queue with random operations", func(t *testing.T) {
+		// Add events and assert they are consumed in fifo order.
+		var lastPop int64 = -1
+		var lastPush int64 = -1
+		for eventCount > 0 {
+			rng, _ := randutil.NewTestRand()
+			op := rng.Intn(5)
+			if op < 3 {
+				v := lastPush + 1
+				q.Enqueue(&testQueueItem{i: v})
+				lastPush++
+			} else {
+				e, ok := q.Dequeue()
+				if !ok {
+					require.Equal(t, lastPop, lastPush)
+					require.True(t, q.Empty())
+				} else {
+					require.Equal(t, lastPop+1, e.i)
+					lastPop++
+					eventCount--
+				}
+			}
+		}
+
+		t.Run("test removeAll", func(t *testing.T) {
+			for eventCount > 0 {
+				q.checkInvariants(t)
+				q.checkEventCount(t, eventCount)
+				rng, _ := randutil.NewTestRand()
+				op := rng.Intn(15)
+				sum := int64(0)
+				if op < 10 {
+					v := int64(rng.Intn(20000))
+					q.Enqueue(&testQueueItem{i: v})
+					sum += v
+				} else if op < 12 {
+					e, ok := q.Dequeue()
+					if !ok {
+						require.True(t, q.Empty())
+					} else {
+						sum -= e.i
+						eventCount--
+					}
+				} else {
+					q.removeAll()
+					q.checkNil(t)
+					eventCount = 0
+					q.checkInvariants(t)
+					q.checkEventCount(t, 0)
+				}
+			}
+		})
+	})
+}
+
 func TestQueue(t *testing.T) {
 	rng, _ := randutil.NewTestRand()
 
-	eventCount := 1000
 	chunkSize := rng.Intn(255) + 1
-
 	q, err := NewQueue[*testQueueItem](WithChunkSize[*testQueueItem](chunkSize))
 	require.NoError(t, err)
-	// Add one event and remove it
-	assert.True(t, q.Empty())
-	q.Enqueue(&testQueueItem{})
-	assert.False(t, q.Empty())
-	_, ok := q.Dequeue()
-	assert.True(t, ok)
-	assert.True(t, q.Empty())
-
-	// Fill 5 chunks and then pop each one, ensuring empty() returns the correct
-	// value each time.
-	checkInvariants(t, q)
-	for i := 0; i < eventCount; i++ {
-		q.Enqueue(&testQueueItem{})
-	}
-	checkInvariants(t, q)
-	for {
-		assert.Equal(t, eventCount <= 0, q.Empty())
-		_, ok = q.Dequeue()
-		if !ok {
-			assert.True(t, q.Empty())
-			break
-		} else {
-			eventCount--
-		}
-		checkInvariants(t, q)
-	}
-	assert.Equal(t, 0, eventCount)
-	q.Enqueue(&testQueueItem{})
-	assert.False(t, q.Empty())
-	q.Dequeue()
-	assert.True(t, q.Empty())
-
-	// Add events to fill 5 chunks and assert they are consumed in fifo order.
-	var lastPop int64 = -1
-	var lastPush int64 = -1
-	checkInvariants(t, q)
-	for eventCount > 0 {
-		op := rng.Intn(5)
-		if op < 3 {
-			q.Enqueue(&testQueueItem{i: lastPush + 1})
-			lastPush++
-		} else {
-			e, ok := q.Dequeue()
-			if !ok {
-				assert.Equal(t, lastPop, lastPush)
-				assert.True(t, q.Empty())
-			} else {
-				assert.Equal(t, lastPop+1, e.i)
-				lastPop++
-				eventCount--
-			}
-		}
-		checkInvariants(t, q)
-	}
-
-	q.removeAll()
-	require.Nil(t, q.head)
-	require.Nil(t, q.tail)
+	runQueueTest(t, q)
 }
 
 func TestChunkSize(t *testing.T) {
@@ -130,4 +163,27 @@ func TestChunkSize(t *testing.T) {
 	q, err = NewQueue[*testQueueItem]()
 	require.Equal(t, defaultChunkSize, q.chunkSize)
 	require.NoError(t, err)
+}
+
+func BenchmarkQueue(b *testing.B) {
+	b.ReportAllocs()
+	rng, _ := randutil.NewTestRand()
+
+	q, err := NewQueue[int]()
+	require.NoError(b, err)
+
+	for i := 0; i < b.N; i++ {
+		for i := 0; i < b.N; i++ {
+			q.Enqueue(1)
+		}
+		q.removeAll()
+	}
+
+	for i := 0; i < b.N; i++ {
+		if rng.Intn(2) == 0 {
+			q.Enqueue(1)
+		} else {
+			q.Dequeue()
+		}
+	}
 }

--- a/pkg/util/queue/queue_test.go
+++ b/pkg/util/queue/queue_test.go
@@ -13,6 +13,7 @@ package queue
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/stretchr/testify/require"
 )
@@ -34,6 +35,7 @@ type testQueueInterface interface {
 }
 
 var _ testQueueInterface = &Queue[*testQueueItem]{}
+var _ testQueueInterface = &QueueWithFixedChunkSize[*testQueueItem]{}
 
 func runQueueTest(t *testing.T, q testQueueInterface) {
 	eventCount := 1000000
@@ -131,11 +133,23 @@ func runQueueTest(t *testing.T, q testQueueInterface) {
 						eventCount--
 					}
 				} else {
-					q.removeAll()
-					q.checkNil(t)
-					eventCount = 0
-					q.checkInvariants(t)
-					q.checkEventCount(t, 0)
+					fixedQ, ok := q.(*QueueWithFixedChunkSize[*testQueueItem])
+					if op < 13 && !ok {
+						q.removeAll()
+						eventCount = 0
+						q.checkNil(t)
+						q.checkInvariants(t)
+						q.checkEventCount(t, 0)
+					} else {
+						actualSum := int64(0)
+						fixedQ.RemoveAll(func(e *testQueueItem) {
+							actualSum += e.i
+							eventCount--
+						})
+						fixedQ.checkNil(t)
+						q.checkEventCount(t, 0)
+						require.Equal(t, sum, actualSum)
+					}
 				}
 			}
 		})
@@ -144,11 +158,17 @@ func runQueueTest(t *testing.T, q testQueueInterface) {
 
 func TestQueue(t *testing.T) {
 	rng, _ := randutil.NewTestRand()
-
 	chunkSize := rng.Intn(255) + 1
-	q, err := NewQueue[*testQueueItem](WithChunkSize[*testQueueItem](chunkSize))
-	require.NoError(t, err)
-	runQueueTest(t, q)
+	testutils.RunTrueAndFalse(t, "queue with fixed chunk size", func(t *testing.T, fixedChunkSize bool) {
+		if fixedChunkSize {
+			q := NewQueueWithFixedChunkSize[*testQueueItem]()
+			runQueueTest(t, q)
+		} else {
+			q, err := NewQueue[*testQueueItem](WithChunkSize[*testQueueItem](chunkSize))
+			require.NoError(t, err)
+			runQueueTest(t, q)
+		}
+	})
 }
 
 func TestChunkSize(t *testing.T) {
@@ -165,20 +185,26 @@ func TestChunkSize(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func BenchmarkQueue(b *testing.B) {
+type testQueueInterfaceWithInt interface {
+	Enqueue(int)
+	Empty() bool
+	Dequeue() (int, bool)
+	removeAll()
+}
+
+func runBenchmarkRangefeed(b *testing.B, q testQueueInterfaceWithInt) {
 	b.ReportAllocs()
 	rng, _ := randutil.NewTestRand()
-
-	q, err := NewQueue[int]()
-	require.NoError(b, err)
-
+	// Run a mixed workload of Enqueue, removeAll, and Empty.
 	for i := 0; i < b.N; i++ {
 		for i := 0; i < b.N; i++ {
 			q.Enqueue(1)
 		}
 		q.removeAll()
+		_ = q.Empty()
 	}
 
+	// Run a mixed workload of Enqueue and Dequeue.
 	for i := 0; i < b.N; i++ {
 		if rng.Intn(2) == 0 {
 			q.Enqueue(1)
@@ -186,4 +212,14 @@ func BenchmarkQueue(b *testing.B) {
 			q.Dequeue()
 		}
 	}
+}
+
+func BenchmarkQueueWithFixedChunkSize(b *testing.B) {
+	q := NewQueueWithFixedChunkSize[int]()
+	runBenchmarkRangefeed(b, q)
+}
+
+func BenchmarkQueue(b *testing.B) {
+	q, _ := NewQueue[int]()
+	runBenchmarkRangefeed(b, q)
 }

--- a/pkg/util/queue/queue_test.go
+++ b/pkg/util/queue/queue_test.go
@@ -113,7 +113,7 @@ func TestQueue(t *testing.T) {
 		checkInvariants(t, q)
 	}
 
-	q.purge()
+	q.removeAll()
 	require.Nil(t, q.head)
 	require.Nil(t, q.tail)
 }

--- a/pkg/util/queue/queue_test_helper.go
+++ b/pkg/util/queue/queue_test_helper.go
@@ -16,10 +16,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+//lint:ignore U1000 unused
 func (q *QueueWithFixedChunkSize[T]) removeAll() {
 	q.RemoveAll(func(e T) {})
 }
 
+//lint:ignore U1000 unused
 func (q *Queue[T]) removeAll() {
 	for q.head != nil {
 		q.head = q.head.next
@@ -28,11 +30,13 @@ func (q *Queue[T]) removeAll() {
 	q.tail = q.head
 }
 
+//lint:ignore U1000 unused
 func (q *Queue[T]) checkNil(t *testing.T) {
 	require.Nil(t, q.head)
 	require.Nil(t, q.tail)
 }
 
+//lint:ignore U1000 unused
 func (q *QueueWithFixedChunkSize[T]) checkNil(t *testing.T) {
 	require.Nil(t, q.head)
 	require.Nil(t, q.tail)
@@ -40,14 +44,19 @@ func (q *QueueWithFixedChunkSize[T]) checkNil(t *testing.T) {
 
 // noop for Queue implementation since it doesn't track event count in the
 // queue.
+//
+//lint:ignore U1000 unused
 func (q *Queue[T]) checkEventCount(t *testing.T, _ int) {
 }
 
+//lint:ignore U1000 unused
 func (q *QueueWithFixedChunkSize[T]) checkEventCount(t *testing.T, count int) {
 	require.Equal(t, count, int(q.eventCount))
 }
 
 // checkInvariants checks the invariants of the queue.
+//
+//lint:ignore U1000 unused
 func (q *Queue[T]) checkInvariants(t *testing.T) {
 	if q.head == nil && q.tail == nil {
 		require.True(t, q.Empty())
@@ -78,6 +87,8 @@ func (q *Queue[T]) checkInvariants(t *testing.T) {
 
 // checkInvariants checks the invariants of the queue. Same as the Queue[T]
 // version. Cannot avoid duplication due to the lack of generics.
+//
+//lint:ignore U1000 unused
 func (q *QueueWithFixedChunkSize[T]) checkInvariants(t *testing.T) {
 	if q.head == nil && q.tail == nil {
 		require.True(t, q.Empty())

--- a/pkg/util/queue/queue_test_helper.go
+++ b/pkg/util/queue/queue_test_helper.go
@@ -1,0 +1,64 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package queue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func (q *Queue[T]) removeAll() {
+	for q.head != nil {
+		q.head = q.head.next
+		// The previous value of q.head will be garbage collected.
+	}
+	q.tail = q.head
+}
+
+func (q *Queue[T]) checkNil(t *testing.T) {
+	require.Nil(t, q.head)
+	require.Nil(t, q.tail)
+}
+
+// noop for Queue implementation since it doesn't track event count in the
+// queue.
+func (q *Queue[T]) checkEventCount(t *testing.T, _ int) {
+}
+
+// checkInvariants checks the invariants of the queue.
+func (q *Queue[T]) checkInvariants(t *testing.T) {
+	if q.head == nil && q.tail == nil {
+		require.True(t, q.Empty())
+	} else if q.head != nil && q.tail == nil {
+		t.Fatal("head is nil but tail is non-nil")
+	} else if q.head == nil && q.tail != nil {
+		t.Fatal("tail is nil but head is non-nil")
+	} else {
+		// The queue maintains an invariant that it contains no finished chunks.
+		require.False(t, q.head.finished())
+		require.False(t, q.tail.finished())
+
+		if q.head == q.tail {
+			require.Nil(t, q.head.next)
+		} else {
+			// q.tail is non-nil and not equal to q.head. There must be a non-empty
+			// chunk after q.head.
+			require.False(t, q.Empty())
+			if q.head.empty() {
+				require.False(t, q.head.next.empty())
+			}
+			// The q.tail is never empty in this case. The tail can only be empty
+			// when it is equal to q.head and q.head is empty.
+			require.False(t, q.tail.empty())
+		}
+	}
+}

--- a/pkg/util/queue/queue_test_helper.go
+++ b/pkg/util/queue/queue_test_helper.go
@@ -16,6 +16,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func (q *QueueWithFixedChunkSize[T]) removeAll() {
+	q.RemoveAll(func(e T) {})
+}
+
 func (q *Queue[T]) removeAll() {
 	for q.head != nil {
 		q.head = q.head.next
@@ -29,15 +33,55 @@ func (q *Queue[T]) checkNil(t *testing.T) {
 	require.Nil(t, q.tail)
 }
 
+func (q *QueueWithFixedChunkSize[T]) checkNil(t *testing.T) {
+	require.Nil(t, q.head)
+	require.Nil(t, q.tail)
+}
+
 // noop for Queue implementation since it doesn't track event count in the
 // queue.
 func (q *Queue[T]) checkEventCount(t *testing.T, _ int) {
+}
+
+func (q *QueueWithFixedChunkSize[T]) checkEventCount(t *testing.T, count int) {
+	require.Equal(t, count, int(q.eventCount))
 }
 
 // checkInvariants checks the invariants of the queue.
 func (q *Queue[T]) checkInvariants(t *testing.T) {
 	if q.head == nil && q.tail == nil {
 		require.True(t, q.Empty())
+	} else if q.head != nil && q.tail == nil {
+		t.Fatal("head is nil but tail is non-nil")
+	} else if q.head == nil && q.tail != nil {
+		t.Fatal("tail is nil but head is non-nil")
+	} else {
+		// The queue maintains an invariant that it contains no finished chunks.
+		require.False(t, q.head.finished())
+		require.False(t, q.tail.finished())
+
+		if q.head == q.tail {
+			require.Nil(t, q.head.next)
+		} else {
+			// q.tail is non-nil and not equal to q.head. There must be a non-empty
+			// chunk after q.head.
+			require.False(t, q.Empty())
+			if q.head.empty() {
+				require.False(t, q.head.next.empty())
+			}
+			// The q.tail is never empty in this case. The tail can only be empty
+			// when it is equal to q.head and q.head is empty.
+			require.False(t, q.tail.empty())
+		}
+	}
+}
+
+// checkInvariants checks the invariants of the queue. Same as the Queue[T]
+// version. Cannot avoid duplication due to the lack of generics.
+func (q *QueueWithFixedChunkSize[T]) checkInvariants(t *testing.T) {
+	if q.head == nil && q.tail == nil {
+		require.True(t, q.Empty())
+		require.Equal(t, q.eventCount, int64(0))
 	} else if q.head != nil && q.tail == nil {
 		t.Fatal("head is nil but tail is non-nil")
 	} else if q.head == nil && q.tail != nil {

--- a/pkg/util/queue/queue_with_fixed_chunk_size.go
+++ b/pkg/util/queue/queue_with_fixed_chunk_size.go
@@ -1,0 +1,186 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package queue
+
+import "sync"
+
+const fixedChunkSize = 4096
+
+func sharedEventQueueChunkSyncPool[T any]() *sync.Pool {
+	return &sync.Pool{
+		New: func() interface{} {
+			return new(queueChunkWithFixedSize[T])
+		},
+	}
+}
+
+func newEventQueueChunk[T any](p *sync.Pool) *queueChunkWithFixedSize[T] {
+	return p.Get().(*queueChunkWithFixedSize[T])
+}
+
+func releasePooledEventQueueChunk[T any](p *sync.Pool, e *queueChunkWithFixedSize[T]) {
+	*e = queueChunkWithFixedSize[T]{}
+	p.Put(e)
+}
+
+// QueueWithFixedChunkSize is like Queue but uses a fixed size for the chunked
+// linked list. Each chunk has a fixed size of 4096 elements. This
+// implementation uses sync.Pool to reduce the number of allocations. It should
+// be used when the queue is used to store a large number of elements.
+//
+// Enqueue, Dequeue, Len, Empty run in constant time. RemoveAll runs in linear
+// time with respect to the number of elements in the queue.
+//
+// See the Queue type for more details. This structure is not safe for
+// concurrent use.
+type QueueWithFixedChunkSize[T any] struct {
+	pool       *sync.Pool
+	head, tail *queueChunkWithFixedSize[T]
+	eventCount int64
+}
+
+// NewQueueWithFixedChunkSize returns a QueueWithFixedChunkSize of T.
+func NewQueueWithFixedChunkSize[T any]() *QueueWithFixedChunkSize[T] {
+	return &QueueWithFixedChunkSize[T]{
+		pool: sharedEventQueueChunkSyncPool[T](),
+	}
+}
+
+// Len returns the number of elements in the queue.
+func (q *QueueWithFixedChunkSize[T]) Len() int64 {
+	return q.eventCount
+}
+
+// Enqueue adds an element to the back of the queue. It is guaranteed that this
+// operation would succeed.
+func (q *QueueWithFixedChunkSize[T]) Enqueue(e T) {
+	// If the queue is empty, create a new chunk.
+	if q.tail == nil {
+		chunk := newEventQueueChunk[T](q.pool)
+		q.head, q.tail = chunk, chunk
+		q.head.push(e) // guaranteed to insert into new chunk
+		q.eventCount++
+		return
+	}
+
+	// If the current chunk is full (first push would do nothing and return
+	// false), create a new chunk and push again.
+	if !q.tail.push(e) {
+		chunk := newEventQueueChunk[T](q.pool)
+		q.tail.next = chunk
+		q.tail = chunk
+		q.tail.push(e) // guaranteed to insert into new chunk
+	}
+	q.eventCount++
+}
+
+// Empty returns true IFF the Queue is empty. Note that it is possible for the
+// queue to be considered empty but have a non-nil head. RemoveAll should be
+// used to clear the queue properly.
+func (q *QueueWithFixedChunkSize[T]) Empty() bool {
+	return q.Len() == 0
+}
+
+// Dequeue removes an element from the front of the queue and returns it. ok is
+// true if succeed and false if the queue is empty.
+func (q *QueueWithFixedChunkSize[T]) Dequeue() (e T, ok bool) {
+	if q.head == nil {
+		return e, false
+	}
+
+	e, ok = q.head.pop()
+	if !ok {
+		return e, false
+	}
+
+	// If everything has been consumed from the chunk, remove it.
+	if q.head.finished() {
+		if q.tail == q.head {
+			q.tail = q.head.next
+		}
+		removed := q.head
+		q.head = q.head.next
+		releasePooledEventQueueChunk[T](q.pool, removed)
+	}
+	q.eventCount--
+	return e, true
+}
+
+// RemoveAll removes all entries in the queue and calls the callback on each
+// entry. q.head == q.tail == nil after this call.
+func (q *QueueWithFixedChunkSize[T]) RemoveAll(callback func(e T)) {
+	for q.head != nil {
+		q.head.clearAll(func(e T) {
+			callback(e)
+			q.eventCount--
+		})
+		remove := q.head
+		q.head = q.head.next
+		releasePooledEventQueueChunk[T](q.pool, remove)
+	}
+	q.tail = q.head
+}
+
+type queueChunkWithFixedSize[T any] struct {
+	events     [fixedChunkSize]T
+	head, tail int
+	next       *queueChunkWithFixedSize[T] // linked-list element
+}
+
+// clearAll clears all the elements in the chunk to its zero value and calls the
+// callback on each element.
+func (c *queueChunkWithFixedSize[T]) clearAll(callback func(e T)) {
+	// Iterate over all the elements in the chunk and call the callback.
+	for i := c.head; i < c.tail; i++ {
+		callback(c.events[i])
+		var zeroValue T
+		// Clear the value to make the data garbage collectable.
+		c.events[i] = zeroValue
+	}
+}
+
+// push adds an element to the chunk. It returns true if succeed and false if
+// the chunk is full.
+func (c *queueChunkWithFixedSize[T]) push(e T) (inserted bool) {
+	if c.tail == len(c.events) {
+		return false
+	}
+
+	c.events[c.tail] = e
+	c.tail++
+	return true
+}
+
+// pop removes an element from the chunk and returns it. It returns true if
+// succeed and false if the chunk is empty.
+func (c *queueChunkWithFixedSize[T]) pop() (e T, ok bool) {
+	if c.head == c.tail {
+		return e, false
+	}
+
+	e = c.events[c.head]
+	var zeroValue T
+	// Clear the value to make the data garbage collectable.
+	c.events[c.head] = zeroValue
+	c.head++
+	return e, true
+}
+
+// finished returns true if all events have been inserted and consumed from the
+// chunk.
+func (c *queueChunkWithFixedSize[T]) finished() bool {
+	return c.head == len(c.events)
+}
+
+// empty returns true if tail == head. Note that the chunk itself is not nil.
+func (c *queueChunkWithFixedSize[T]) empty() bool {
+	return c.tail == c.head
+}


### PR DESCRIPTION
**util/queue: rename purge to removeAll**

This patch renames purge to removeAll since it is more descriptive of what the
function does.

Epic: none
Release note: none

---

**util/queue: add more tests**

This patch cleans the test code by modularizing the code, moving the test code
to helpers_test, and abstracting runQueueTest to use a testQueueInterface.
Currently, only Queue[T] implements it. But in a future patch, a new data
structure QueueWithFixedChunkSize[T] will also implement it.

Part of: https://github.com/cockroachdb/cockroach/issues/126560
Release note: none

--- 

**util/queue: add QueueWithFixedChunkSize**

This patch adds a new data structure QueueWithFixedChunkSize which is like Queue
but uses a fixed size for the chunked linked list. Each chunk has a fixed size
of 4000 elements. This implementation uses sync.Pool to reduce the number of
allocations. It should be used when the queue is used to store a large number of
elements.

Enqueue, Dequeue, Len, Empty run in constant time. RemoveAll runs in linear time
with respect to the number of elements in the queue. This structure is not safe
for concurrent use.

This patch adds a new data structure QueueWithFixedChunkSize which is like Queue
but uses a fixed size for the chunked linked list. Each chunk has a fixed size
of 4000 elements. This implementation uses sync.Pool to reduce the number of
allocations. It should be used when the queue is used to store a large number of
elements.

Enqueue, Dequeue, Len, Empty run in constant time. RemoveAll runs in linear time
with respect to the number of elements in the queue. This structure is not safe
for concurrent use.

```
BenchmarkQueueWithFixedChunkSize
BenchmarkQueueWithFixedChunkSize           18880            116079 ns/op               9 B/op          0 allocs/op
BenchmarkQueue
BenchmarkQueue                             28417            121969 ns/op          239060 B/op        446 allocs/op
```

Part of: https://github.com/cockroachdb/cockroach/issues/126560
Release note: none

---

**util/queue: fix linter failure**

TestLint/TestStaticCheck has some issues with generic methods. This patch works
around the issue by disabling them for these functions.

Epic: none
Release note: none