### PR TITLE
release-23.2: ui: add hovering focus behavior to metric graphs

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/nodes.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/nodes.spec.ts
@@ -312,7 +312,9 @@ describe("node data selectors without addresses", function () {
 
     it("returns empty collection for empty state", function () {
       const store = createAdminUIStore(createHashHistory());
-      expect(nodeDisplayNameByIDSelectorWithoutAddress(store.getState())).toEqual({});
+      expect(
+        nodeDisplayNameByIDSelectorWithoutAddress(store.getState()),
+      ).toEqual({});
     });
   });
   describe("store IDs by node ID", function () {

--- a/pkg/ui/workspaces/db-console/src/redux/nodes.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/nodes.spec.ts
@@ -20,6 +20,7 @@ import {
   LivenessStatus,
   sumNodeStats,
   numNodesByVersionsTagSelector,
+  nodeDisplayNameByIDSelectorWithoutAddress,
 } from "./nodes";
 import { nodesReducerObj, livenessReducerObj } from "./apiReducers";
 import { createAdminUIStore } from "./state";
@@ -215,6 +216,137 @@ describe("node data selectors", function () {
         ["v21.1.7", 1],
       ]);
       expect(numNodesByVersionsTagSelector(state)).toEqual(expectedResult);
+    });
+  });
+});
+
+describe("node data selectors without addresses", function () {
+  describe("display name by ID", function () {
+    it("display name is node id appended to address", function () {
+      const state: any = makeNodesState(
+        { id: 1, address: "addressA" },
+        { id: 2, address: "addressB" },
+        { id: 3, address: "addressC" },
+        { id: 4, address: "addressD" },
+      );
+
+      const addressesByID = nodeDisplayNameByIDSelectorWithoutAddress(state);
+      expect(addressesByID).toEqual({
+        1: "n1",
+        2: "n2",
+        3: "n3",
+        4: "n4",
+      });
+    });
+
+    it("generates unique names for re-used addresses", function () {
+      const state: any = makeNodesState(
+        { id: 1, address: "addressA" },
+        { id: 2, address: "addressB" },
+        { id: 3, address: "addressC" },
+        { id: 4, address: "addressD" },
+        { id: 5, address: "addressA" },
+        { id: 6, address: "addressC" },
+        { id: 7, address: "addressA" },
+      );
+
+      const addressesByID = nodeDisplayNameByIDSelectorWithoutAddress(state);
+      expect(addressesByID).toEqual({
+        1: "n1",
+        2: "n2",
+        3: "n3",
+        4: "n4",
+        5: "n5",
+        6: "n6",
+        7: "n7",
+      });
+    });
+
+    it("adds decommissioned flag to decommissioned nodes", function () {
+      const state: any = makeNodesState(
+        {
+          id: 1,
+          address: "addressA",
+          status: LivenessStatus.NODE_STATUS_DECOMMISSIONED,
+        },
+        { id: 2, address: "addressB" },
+        {
+          id: 3,
+          address: "addressC",
+          status: LivenessStatus.NODE_STATUS_DECOMMISSIONED,
+        },
+        { id: 4, address: "addressD", status: LivenessStatus.NODE_STATUS_DEAD },
+        {
+          id: 5,
+          address: "addressA",
+          status: LivenessStatus.NODE_STATUS_DECOMMISSIONED,
+        },
+        { id: 6, address: "addressC" },
+        { id: 7, address: "addressA" },
+        {
+          id: 8,
+          address: "addressE",
+          status: LivenessStatus.NODE_STATUS_DECOMMISSIONING,
+        },
+        {
+          id: 9,
+          address: "addressF",
+          status: LivenessStatus.NODE_STATUS_UNAVAILABLE,
+        },
+      );
+
+      const addressesByID = nodeDisplayNameByIDSelectorWithoutAddress(state);
+      expect(addressesByID[1]).toEqual("[decommissioned] n1");
+      expect(addressesByID).toEqual({
+        1: "[decommissioned] n1",
+        2: "n2",
+        3: "[decommissioned] n3",
+        4: "n4",
+        5: "[decommissioned] n5",
+        6: "n6",
+        7: "n7",
+        8: "n8",
+        9: "n9",
+      });
+    });
+
+    it("returns empty collection for empty state", function () {
+      const store = createAdminUIStore(createHashHistory());
+      expect(nodeDisplayNameByIDSelectorWithoutAddress(store.getState())).toEqual({});
+    });
+  });
+  describe("store IDs by node ID", function () {
+    it("correctly creates storeID map", function () {
+      const data = [
+        {
+          desc: { node_id: 1 },
+          store_statuses: [
+            { desc: { store_id: 1 } },
+            { desc: { store_id: 2 } },
+            { desc: { store_id: 3 } },
+          ],
+        },
+        {
+          desc: { node_id: 2 },
+          store_statuses: [{ desc: { store_id: 4 } }],
+        },
+        {
+          desc: { node_id: 3 },
+          store_statuses: [
+            { desc: { store_id: 5 } },
+            { desc: { store_id: 6 } },
+          ],
+        },
+      ];
+      const store = createAdminUIStore(createHashHistory());
+      store.dispatch(nodesReducerObj.receiveData(data));
+      const state = store.getState();
+
+      expect(selectStoreIDsByNodeID(state)).toEqual({
+        1: ["1", "2", "3"],
+        2: ["4"],
+        3: ["5", "6"],
+      });
     });
   });
 });

--- a/pkg/ui/workspaces/db-console/src/redux/nodes.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/nodes.ts
@@ -314,6 +314,7 @@ export function nodeCapacityStats(n: INodeStatus): CapacityStats {
 export function getDisplayName(
   node: INodeStatus | NoConnection,
   livenessStatus = LivenessStatus.NODE_STATUS_LIVE,
+  includeAddress = true,
 ) {
   const decommissionedString =
     livenessStatus === LivenessStatus.NODE_STATUS_DECOMMISSIONED
@@ -324,7 +325,11 @@ export function getDisplayName(
     return `${decommissionedString}(n${node.from.nodeID})`;
   }
   // as the only other type possible right now is INodeStatus we don't have a type guard for that
-  return `${decommissionedString}(n${node.desc.node_id}) ${node.desc.address.address_field}`;
+  if (includeAddress) {
+    return `${decommissionedString}(n${node.desc.node_id}) ${node.desc.address.address_field}`;
+  } else {
+    return `${decommissionedString}n${node.desc.node_id}`;
+  }
 }
 
 function isNoConnection(
@@ -351,6 +356,25 @@ export const nodeDisplayNameByIDSelector = createSelector(
         result[ns.desc.node_id] = getDisplayName(
           ns,
           livenessStatusByNodeID[ns.desc.node_id],
+          true,
+        );
+      });
+    }
+    return result;
+  },
+);
+
+export const nodeDisplayNameByIDSelectorWithoutAddress = createSelector(
+  partialNodeStatusesSelector,
+  livenessStatusByNodeIDSelector,
+  (nodeStatuses, livenessStatusByNodeID) => {
+    const result: { [key: string]: string } = {};
+    if (!_.isEmpty(nodeStatuses)) {
+      nodeStatuses.forEach(ns => {
+        result[ns.desc.node_id] = getDisplayName(
+          ns,
+          livenessStatusByNodeID[ns.desc.node_id],
+          false,
         );
       });
     }

--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
@@ -67,7 +67,6 @@ export interface OwnProps extends MetricsDataComponentProps {
   hoverOff?: typeof hoverOff;
   hoverState?: HoverState;
   preCalcGraphSize?: boolean;
-  legendAsTooltip?: boolean;
   showMetricsInTooltip?: boolean;
 }
 
@@ -357,7 +356,6 @@ export class InternalLineGraph extends React.Component<LineGraphProps, {}> {
         this.setNewTimeRange,
         () => this.xAxisDomain,
         () => this.yAxisDomain,
-        this.props.legendAsTooltip,
       );
 
       if (this.u) {
@@ -382,7 +380,6 @@ export class InternalLineGraph extends React.Component<LineGraphProps, {}> {
       data,
       tenantSource,
       preCalcGraphSize,
-      legendAsTooltip,
       showMetricsInTooltip,
     } = this.props;
     let tt = tooltip;
@@ -436,7 +433,6 @@ export class InternalLineGraph extends React.Component<LineGraphProps, {}> {
         </div>
       );
     }
-    const legendClassName = legendAsTooltip ? "linegraph-tooltip" : "linegraph";
     return (
       <Visualization
         title={title}
@@ -445,7 +441,7 @@ export class InternalLineGraph extends React.Component<LineGraphProps, {}> {
         loading={!data}
         preCalcGraphSize={preCalcGraphSize}
       >
-        <div className={legendClassName}>
+        <div className="linegraph">
           <div ref={this.el} />
         </div>
       </Visualization>

--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/linegraph.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/linegraph.spec.tsx
@@ -162,7 +162,6 @@ describe("<LineGraph>", function () {
           util.NanoToMilli(mockProps.timeInfo.start.toNumber()),
           util.NanoToMilli(mockProps.timeInfo.end.toNumber()),
         ),
-      false,
     );
     instance.u = new uPlot(mockOptions);
     const setDataSpy = jest.spyOn(instance.u, "setData");

--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/linegraph.styl
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/linegraph.styl
@@ -22,49 +22,50 @@ $viz-sides = 62px
     color gray
     text-decoration underline
 
-.linegraph-tooltip
-  height 100%
-  .uplot
+.u-legend
+  max-height: 300px
+  display flex
+  flex-wrap wrap
+  flex-direction row
+  align-items flex-start
+  align-content flex-start
+  overflow auto
+  > tr
     display flex
-    flex-direction column
-    > .u-legend
+    flex-direction row
+    align-items flex-end
+  > tr:first-child
+    flex-basis 100%
+    text-align left
+    color gray
+    .u-marker
       display none
-      position absolute
-      left 0
-      top 0
-      font-size 10px
-      background-color white
-      text-align left
-      margin-top 20px
-      z-index 100
-      pointer-events: none;
-      width: max-content;
-      border-radius: 5px
-      padding: 10px;
-      border 1px solid rgba(0,0,0,0.1)
 
-    // stick the legend to the char's bottom.
-    // Chart height is hardcoded to 300px (pkg/ui/src/views/cluster/util/graphs.ts)
-    > .u-legend.u-legend--place-bottom
-      position relative
-      top 0!important // Necessary because uPlot adds top/left on hover to make legend appear near mouse pointer
-      left 0!important // Necessary because uPlot adds top/left on hover to make legend appear near mouse pointer
-      width auto
-      margin-left -1px
-      margin-right -1px
-      padding-left 50px
-      // the first line in the legend represents Y-axis and it occupies an entire line
-      // to stand out from the rest of x-axis values
-      > tr:first-child
-        width 100%
-        font-size $font-size--small
-
-      > tr
-        min-width 30%
-
-  .u-legend:not(.u-legend--place-bottom)
-    .u-series
-      display block
+.u-tooltip
+  font-size 10pt
+  position absolute
+  background #fff
+  display none
+  border 1px solid black
+  padding 0 0.5em 0 0.5em
+  pointer-events none
+  z-index 100
+  white-space pre
+  .u-time
+    color gray
+    margin-top: 4px
+  .u-series
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    align-items: center;
+  .u-label
+    font-weight 600
+  .u-marker
+    height 1em
+    width 1em
+    display inline-block
+    vertical-align middle
 
 .no-data
   width 100%

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -48,6 +48,7 @@ import {
   nodeIDsSelector,
   nodeIDsStringifiedSelector,
   selectStoreIDsByNodeID,
+  nodeDisplayNameByIDSelectorWithoutAddress,
 } from "src/redux/nodes";
 import Alerts from "src/views/shared/containers/alerts";
 import { MetricsDataProvider } from "src/views/shared/containers/metricDataProvider";
@@ -524,7 +525,7 @@ export class NodeGraphs extends React.Component<
  */
 const nodeDropdownOptionsSelector = createSelector(
   nodeIDsSelector,
-  nodeDisplayNameByIDSelector,
+  state => nodeDisplayNameByIDSelector(state),
   livenessStatusByNodeIDSelector,
   (nodeIds, nodeDisplayNameByID, livenessStatusByNodeID): DropdownOption[] => {
     const base = [{ value: "", label: "Cluster" }];
@@ -552,7 +553,7 @@ const mapStateToProps = (state: AdminUIState): MapStateToProps => ({
   nodeIds: nodeIDsStringifiedSelector(state),
   storeIDsByNodeID: selectStoreIDsByNodeID(state),
   nodeDropdownOptions: nodeDropdownOptionsSelector(state),
-  nodeDisplayNameByID: nodeDisplayNameByIDSelector(state),
+  nodeDisplayNameByID: nodeDisplayNameByIDSelectorWithoutAddress(state),
   crossClusterReplicationEnabled: selectCrossClusterReplicationEnabled(state),
   tenantOptions: tenantDropdownOptions(state),
   currentTenant: getCookieValue("tenant"),

--- a/pkg/ui/workspaces/db-console/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/util/graphs.ts
@@ -77,7 +77,10 @@ export function formatMetricData(
   return formattedData;
 }
 
-function hoverTooltipPlugin(xFormatter: (v: number) => string, yFormatter: (v: number) => string) {
+function hoverTooltipPlugin(
+  xFormatter: (v: number) => string,
+  yFormatter: (v: number) => string,
+) {
   const shiftX = 10;
   const shiftY = 10;
   let tooltipLeftOffset = 0;
@@ -86,27 +89,27 @@ function hoverTooltipPlugin(xFormatter: (v: number) => string, yFormatter: (v: n
   const tooltip = document.createElement("div");
   tooltip.className = "u-tooltip";
 
-  let timeNode = document.createElement("div")
-  timeNode.className = "u-time"
-  tooltip.appendChild(timeNode)
+  const timeNode = document.createElement("div");
+  timeNode.className = "u-time";
+  tooltip.appendChild(timeNode);
 
-  let seriesNode = document.createElement("div")
-  seriesNode.className = "u-series"
+  const seriesNode = document.createElement("div");
+  seriesNode.className = "u-series";
 
-  let markerNode = document.createElement("div")
-  markerNode.className = "u-marker"
+  const markerNode = document.createElement("div");
+  markerNode.className = "u-marker";
 
-  let labelNode = document.createElement("div")
-  labelNode.className = "u-label"
+  const labelNode = document.createElement("div");
+  labelNode.className = "u-label";
 
-  let dataNode = document.createTextNode(`--`)
+  const dataNode = document.createTextNode(`--`);
 
-  seriesNode.appendChild(markerNode)
-  seriesNode.appendChild(labelNode)
-  seriesNode.appendChild(dataNode)
-  tooltip.appendChild(seriesNode)
+  seriesNode.appendChild(markerNode);
+  seriesNode.appendChild(labelNode);
+  seriesNode.appendChild(dataNode);
+  tooltip.appendChild(seriesNode);
 
-  let seriesIdx: number= null;
+  let seriesIdx: number = null;
   let dataIdx: number = null;
   let over: HTMLDivElement;
   let tooltipVisible = false;
@@ -132,20 +135,20 @@ function hoverTooltipPlugin(xFormatter: (v: number) => string, yFormatter: (v: n
 
     // `yAxis` is used instead of `y` here because that's below in the
     // `uPlot` config as the custom scale that we define.n
-    let top = u.valToPos(u.data[seriesIdx][dataIdx], 'yAxis');
-    let lft = u.valToPos(u.data[        0][dataIdx], 'x');
+    const top = u.valToPos(u.data[seriesIdx][dataIdx], "yAxis");
+    const lft = u.valToPos(u.data[0][dataIdx], "x");
 
-    tooltip.style.top  = (tooltipTopOffset  + top + shiftX) + "px";
-    tooltip.style.left = (tooltipLeftOffset + lft + shiftY) + "px";
+    tooltip.style.top = tooltipTopOffset + top + shiftX + "px";
+    tooltip.style.left = tooltipLeftOffset + lft + shiftY + "px";
 
-    timeNode.textContent = `Time: ${xFormatter(u.data[0][dataIdx])}`
-    labelNode.textContent = `${u.series[seriesIdx].label}:`
-    dataNode.textContent = ` ${yFormatter(u.data[seriesIdx][dataIdx])}`
+    timeNode.textContent = `Time: ${xFormatter(u.data[0][dataIdx])}`;
+    labelNode.textContent = `${u.series[seriesIdx].label}:`;
+    dataNode.textContent = ` ${yFormatter(u.data[seriesIdx][dataIdx])}`;
 
-    let stroke = u.series[seriesIdx].stroke;
-    if (typeof stroke === 'function' && stroke.length === 0) {
+    const stroke = u.series[seriesIdx].stroke;
+    if (typeof stroke === "function" && stroke.length === 0) {
       markerNode.style.background = stroke(u, seriesIdx) as string;
-    } else if (typeof stroke === 'string') {
+    } else if (typeof stroke === "string") {
       markerNode.style.borderColor = stroke;
     }
   }
@@ -158,36 +161,32 @@ function hoverTooltipPlugin(xFormatter: (v: number) => string, yFormatter: (v: n
           tooltipLeftOffset = parseFloat(over.style.left);
           tooltipTopOffset = parseFloat(over.style.top);
           u.root.querySelector(".u-wrap").appendChild(tooltip);
-        }
+        },
       ],
       setCursor: [
         (u: uPlot) => {
-          let c = u.cursor;
+          const c = u.cursor;
 
           if (dataIdx !== c.idx) {
             dataIdx = c.idx;
 
-            if (seriesIdx != null)
-              setTooltip(u);
+            if (seriesIdx != null) setTooltip(u);
           }
-        }
+        },
       ],
       setSeries: [
         (u: uPlot, sidx: number) => {
           if (seriesIdx !== sidx) {
             seriesIdx = sidx;
 
-            if (sidx == null)
-              hideTooltip();
-            else if (dataIdx !== null)
-              setTooltip(u);
+            if (sidx == null) hideTooltip();
+            else if (dataIdx !== null) setTooltip(u);
           }
-        }
+        },
       ],
-    }
+    },
   };
 }
-
 
 // configureUPlotLineChart constructs the uplot Options object based on
 // information about the metrics, axis, and data that we'd like to plot.
@@ -233,17 +232,17 @@ export function configureUPlotLineChart(
       isolate: true,
       markers: {
         stroke: () => {
-          return null
+          return null;
         },
         fill: (u: uPlot, i: number) => {
-          let stroke = u.series[i].stroke;
-          if (typeof stroke === 'function' && stroke.length === 0) {
+          const stroke = u.series[i].stroke;
+          if (typeof stroke === "function" && stroke.length === 0) {
             return stroke(u, i) as string;
-          } else if (typeof stroke === 'string') {
+          } else if (typeof stroke === "string") {
             return stroke;
           }
         },
-      }
+      },
     },
     // By default, uPlot expects unix seconds in the x axis.
     // This setting defaults it to milliseconds which our
@@ -314,7 +313,12 @@ export function configureUPlotLineChart(
         range: () => getLatestYAxisDomain().extent,
       },
     },
-    plugins: [hoverTooltipPlugin(getLatestXAxisDomain().guideFormat, getLatestYAxisDomain().guideFormat)],
+    plugins: [
+      hoverTooltipPlugin(
+        getLatestXAxisDomain().guideFormat,
+        getLatestYAxisDomain().guideFormat,
+      ),
+    ],
     hooks: {
       // setSelect is a hook that fires when a selection is made on the graph
       // by dragging a range to zoom.

--- a/pkg/ui/workspaces/db-console/src/views/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/sessions/sessionDetails.tsx
@@ -22,13 +22,13 @@ import {
   refreshNodes,
   refreshSessions,
 } from "src/redux/apiReducers";
-import { nodeDisplayNameByIDSelector } from "src/redux/nodes";
-import { SessionDetails, byteArrayToUuid } from "@cockroachlabs/cluster-ui";
+import { nodeDisplayNameByIDSelectorWithoutAddress } from "src/redux/nodes";
 import {
   terminateQueryAction,
   terminateSessionAction,
 } from "src/redux/sessions/sessionsSagas";
 import { setTimeScale } from "src/redux/timeScale";
+import { byteArrayToUuid, SessionDetails } from "@cockroachlabs/cluster-ui";
 
 type SessionsState = Pick<AdminUIState, "cachedData", "sessions">;
 
@@ -53,7 +53,7 @@ export const selectSession = createSelector(
 const SessionDetailsPageConnected = withRouter(
   connect(
     (state: AdminUIState, props: RouteComponentProps) => ({
-      nodeNames: nodeDisplayNameByIDSelector(state),
+      nodeNames: nodeDisplayNameByIDSelectorWithoutAddress(state),
       session: selectSession(state, props),
       sessionError: state.cachedData.sessions.lastError,
     }),


### PR DESCRIPTION
Backport 1/1 commits from #127786.

/cc @cockroachdb/release

---

This PR enables a few new behaviors on the metrics graphs in DB
Console:
* Show individual lines on hover
* Show closest point to mouse pointer
* Revamped legend that takes up static amount of space and
scrolls
* Node series names no longer include the IP address for brevity

Additionally there are some minor visual tweaks in the legend like a
gray colored timestamp, and circle series markers instead of squares.

Resolves: CRDB-37094
Resolves: https://github.com/cockroachdb/cockroach/issues/118645
Epic: CRDB-37557

Release note (ui change): the user experience for metrics charges in
DB Console now has hover behavior that focuses on individual lines and
shows values under the mouse pointer.

---

Release justification: high business impact UI change