### PR TITLE
kvserver: fix empty lease logging

### DIFF
--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1330,7 +1330,11 @@ func (r *Replica) redirectOnOrAcquireLeaseForRequest(
 						}
 						return pErr
 					}
-					log.VEventf(ctx, 2, "lease acquisition succeeded: %+v", status.Lease)
+					// NB: it would be mildly better to print the lease that was actually acquired.
+					// As is, one may wonder if the "current lease" is the one we tried to acquire
+					// above.
+					lease, _ := r.GetLease()
+					log.VEventf(ctx, 2, "lease acquisition succeeded: %+v", lease)
 					return nil
 				case <-brSig.C():
 					llHandle.Cancel()


### PR DESCRIPTION
Fixes a log line. Previously, when a lease was acquired, we'd log

> lease acquisition succeeded: <empty>

This was because the printed field `status.Lease` came from a zero
`status`. `status` would only be populated if no lease acquisition
had been necessary in the first place.

It now prints the lease.

Found here[^1].

[^1]: https://cockroachlabs.slack.com/archives/C0KB9Q03D/p1723534137178379?thread_ts=1723502058.001399&cid=C0KB9Q03D

Epic: none
Release note: None
