### PR TITLE
kvserver: log status when lease requested

### DIFF
--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1277,6 +1277,7 @@ func (r *Replica) redirectOnOrAcquireLeaseForRequest(
 		// timestamp is not covered by the new lease (though we try to protect
 		// against this in checkRequestTimeRLocked). So instead of assuming
 		// anything, we iterate and check again.
+		log.Eventf(ctx, "waiting for acquisition/transfer after status %+v", status)
 		pErr = func() (pErr *kvpb.Error) {
 			var slowTimer timeutil.Timer
 			defer slowTimer.Stop()


### PR DESCRIPTION
The lease acquisition loop is too silent, as seen in a recent
investigation[^1]. If we loop around multiple times, we ought
to at least log the status in each case which will give a clue
as to what was wrong with the previous lease.

[^1]: https://cockroachlabs.slack.com/archives/C0KB9Q03D/p1723534154297719?thread_ts=1723502058.001399&cid=C0KB9Q03D

Epic: none
Release note: None
