### PR TITLE
Fix for issue DOC-10884

### DIFF
--- a/pkg/cmd/docs-issue-generation/jira.go
+++ b/pkg/cmd/docs-issue-generation/jira.go
@@ -78,7 +78,8 @@ func searchJiraDocsIssuesSingle(
 	for _, issue := range search.Issues {
 		prNumber, commitSha, err := extractPRNumberCommitFromDocsIssueBody(issue.RenderedFields.Description)
 		if err != nil {
-			return 0, 0, err
+			fmt.Sprintf("Error processing issue %s: %v", issue.Key, err)
+			continue // Skip this issue and continue with the next one
 		}
 		if prNumber != 0 && commitSha != "" {
 			_, ok := m[prNumber]


### PR DESCRIPTION
**Description** - We had an issue raised by Rich ( https://cockroachlabs.atlassian.net/browse/DOC-10080 ) where doc issues for few PR wasn't created because of abrupt failure in the script due to not finding SHA or pr number in the JIRA issue.

**JIRA issue** - https://cockroachlabs.atlassian.net/browse/DOC-10884

**Fix** - I have added a condition where even if SHA or PR number isn't found for one issue , it should still continue the execution for other PRs so that doc issues for them is created

**Is testing done** - Yes i have tested it on my local as no automated test was present for this 
