### PR TITLE
sqlliveness: handle AmbiguousResultError gracefully on insert

### DIFF
--- a/pkg/sql/sqlliveness/slinstance/BUILD.bazel
+++ b/pkg/sql/sqlliveness/slinstance/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slinstance",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/kv/kvpb",
         "//pkg/settings/cluster",
         "//pkg/sql/enum",
         "//pkg/sql/sqlliveness",

--- a/pkg/sql/sqlliveness/slinstance/slinstance.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/enum"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
@@ -199,14 +200,6 @@ func (l *Instance) createSession(ctx context.Context) (*session, error) {
 	if l.currentRegion != nil {
 		region = l.currentRegion
 	}
-	id, err := slstorage.MakeSessionID(region, uuid.MakeV4())
-	if err != nil {
-		return nil, err
-	}
-
-	s := &session{
-		id: id,
-	}
 
 	opts := retry.Options{
 		InitialBackoff: 10 * time.Millisecond,
@@ -214,7 +207,17 @@ func (l *Instance) createSession(ctx context.Context) (*session, error) {
 		Multiplier:     1.5,
 	}
 	everySecond := log.Every(time.Second)
+	var err error
+	s := &session{}
 	for i, r := 0, retry.StartWithCtx(ctx, opts); r.Next(); {
+		// Allocate a new session ID initially or if we hit
+		// an ambiguous result error.
+		if len(s.id) == 0 {
+			s.id, err = slstorage.MakeSessionID(region, uuid.MakeV4())
+			if err != nil {
+				return nil, err
+			}
+		}
 		// If we fail to insert the session, then reset the start time
 		// and expiration, since otherwise there is a danger of inserting
 		// an expired session.
@@ -235,6 +238,14 @@ func (l *Instance) createSession(ctx context.Context) (*session, error) {
 			// of retrying.
 			if grpcutil.IsAuthError(err) {
 				break
+			}
+			// Previous insert was ambiguous, so select a new session ID,
+			// since there may be a row that exists.
+			if errors.HasType(err, (*kvpb.AmbiguousResultError)(nil)) {
+				log.Infof(ctx,
+					"failed to create a session due to an ambiguous result error: %s",
+					s.ID().String())
+				s.id = ""
 			}
 			continue
 		}


### PR DESCRIPTION
Previously, when inserting a new SQL liveness session, we extended the expiry between each InitPut to ensure that an expired session was never inserted. This worked well, but if an ambiguous result error was encountered, the row could already exist in the table with the old timestamp leading to a condition failed error.  To address this, this patch will also assign a new session ID if we encounter an ambiguous result error. This will ensure that we do not collide with the old session ID.

Fixes: #127301
Release note (bug fix): Starting up nodes could fail with: "could not insert session ...: unexpected value", if an ambigous result error was hit inserting into the sqlliveness table.