### PR TITLE
workload/schemachanger: fix create index concurrently with drop column

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -210,7 +210,7 @@ WITH
 						WHERE
 							column_name = $2
 							AND index_name
-								!= table_name || '_pkey'
+								NOT LIKE '%%_pkey' -- renames would keep the old table name
 					)
 		),
 	matching_indexes

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1657,7 +1657,11 @@ func (og *operationGenerator) dropColumn(ctx context.Context, tx pgx.Tx) (*opStm
 	// us to use, we add an internal crdb_internal_idx_expr prefixed column to
 	// the table.
 	stmt.potentialExecErrors.add(pgcode.InvalidColumnReference)
-
+	// For legacy schema changer its possible for create index operations to interfere if they
+	// are in progress.
+	if !og.useDeclarativeSchemaChanger {
+		stmt.potentialExecErrors.add(pgcode.ObjectNotInPrerequisiteState)
+	}
 	stmt.sql = fmt.Sprintf(`ALTER TABLE %s DROP COLUMN %s`, tableName.String(), columnName.String())
 	return stmt, nil
 }


### PR DESCRIPTION
Previously, the DROP COLUMN operation inside the schemachanger workload could fail if a CREATE INDEX was being executed concurrently on the same table. To address this, this patch adds "index being added" in the potential execution errors. This patch also addresses a bug in the DROP COLUMN logic, where the primary key was incorrectly excluded if the table was renamed.

Fixes: #128664

Release note: None