### PR TITLE
restore: only run proc lag checker on fully updgraded 24.3 clusters

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1552,7 +1552,7 @@ func TestRestoreReplanOnLag(t *testing.T) {
 	retryErrorChan := make(chan error)
 	defer close(retryErrorChan)
 	//Shorten replan frequency setting to reduce test runtime.
-	replanFreq := time.Second
+	replanFreq := time.Millisecond * 10
 
 	params := base.TestClusterArgs{}
 	knobs := base.TestingKnobs{

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backuputils"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/bulk"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -163,7 +164,11 @@ func newRestoreDataProcessor(
 					meta = bulkutil.ConstructTracingAggregatorProducerMeta(ctx,
 						rd.FlowCtx.NodeID.SQLInstanceID(), rd.FlowCtx.ID, rd.agg)
 				}
-				meta.BulkProcessorProgress = &execinfrapb.RemoteProducerMetadata_BulkProcessorProgress{Drained: true}
+				if clusterversion.V24_3.Version().LessEq(rd.spec.ResumeClusterVersion) {
+					// Only send the completion message if the restore job started on a
+					// 24.3 cluster or later.
+					meta.BulkProcessorProgress = &execinfrapb.RemoteProducerMetadata_BulkProcessorProgress{Drained: true}
+				}
 				return []execinfrapb.ProducerMetadata{*meta}
 			},
 		}); err != nil {

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -34,17 +34,18 @@ import (
 )
 
 type restoreJobMetadata struct {
-	jobID              jobspb.JobID
-	dataToRestore      restorationData
-	restoreTime        hlc.Timestamp
-	encryption         *jobspb.BackupEncryptionOptions
-	kmsEnv             cloud.KMSEnv
-	uris               []string
-	backupLocalityInfo []jobspb.RestoreDetails_BackupLocalityInfo
-	spanFilter         spanCoveringFilter
-	numImportSpans     int
-	execLocality       roachpb.Locality
-	exclusiveEndKeys   bool
+	jobID                jobspb.JobID
+	dataToRestore        restorationData
+	restoreTime          hlc.Timestamp
+	encryption           *jobspb.BackupEncryptionOptions
+	kmsEnv               cloud.KMSEnv
+	uris                 []string
+	backupLocalityInfo   []jobspb.RestoreDetails_BackupLocalityInfo
+	spanFilter           spanCoveringFilter
+	numImportSpans       int
+	execLocality         roachpb.Locality
+	exclusiveEndKeys     bool
+	resumeClusterVersion roachpb.Version
 }
 
 // distRestore plans a 2 stage distSQL flow for a distributed restore. It
@@ -112,13 +113,14 @@ func distRestore(
 		p := planCtx.NewPhysicalPlan()
 
 		restoreDataSpec := execinfrapb.RestoreDataSpec{
-			JobID:        int64(md.jobID),
-			RestoreTime:  md.restoreTime,
-			Encryption:   fileEncryption,
-			TableRekeys:  md.dataToRestore.getRekeys(),
-			TenantRekeys: md.dataToRestore.getTenantRekeys(),
-			PKIDs:        md.dataToRestore.getPKIDs(),
-			ValidateOnly: md.dataToRestore.isValidateOnly(),
+			JobID:                int64(md.jobID),
+			RestoreTime:          md.restoreTime,
+			Encryption:           fileEncryption,
+			TableRekeys:          md.dataToRestore.getRekeys(),
+			TenantRekeys:         md.dataToRestore.getTenantRekeys(),
+			PKIDs:                md.dataToRestore.getPKIDs(),
+			ValidateOnly:         md.dataToRestore.isValidateOnly(),
+			ResumeClusterVersion: md.resumeClusterVersion,
 		}
 
 		// Plan SplitAndScatter on the coordinator node.

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -22,6 +22,7 @@ option go_package = "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb";
 import "jobs/jobspb/jobs.proto";
 import "roachpb/io-formats.proto";
 import "sql/catalog/descpb/structured.proto";
+import "roachpb/metadata.proto";
 import "util/hlc/timestamp.proto";
 import "gogoproto/gogo.proto";
 import "roachpb/data.proto";
@@ -379,7 +380,10 @@ message RestoreDataSpec {
   reserved 7;
   optional bool validate_only = 8 [(gogoproto.nullable) = false];
   reserved 9;
-  // NEXT ID: 10.
+
+  // ResumeClusterVersion is the cluster version when the restore job resumed.
+  optional roachpb.Version resume_cluster_version = 10 [(gogoproto.nullable) = false];
+  // NEXT ID: 11.
 }
 
 // ExporterSpec is the specification for a processor that consumes rows and


### PR DESCRIPTION
The restore proc lag checker added in #128356 can fail a mixed version restore with an old coordinator, as detailed in #128758. This patch ensures the lag checker only runs once the restore has begun on a fully upgraded cluster.

Fixes #128758

Release note: none