### PR TITLE
catalog: rename ByID to ByIDWithoutLeased

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1366,7 +1366,7 @@ func createImportingDescriptors(
 			// to the new tables being restored.
 			for _, table := range mutableTables {
 				// Collect all types used by this table.
-				dbDesc, err := descsCol.ByID(txn.KV()).WithoutDropped().Get().Database(ctx, table.GetParentID())
+				dbDesc, err := descsCol.ByIDWithoutLeased(txn.KV()).WithoutDropped().Get().Database(ctx, table.GetParentID())
 				if err != nil {
 					return err
 				}
@@ -1412,7 +1412,7 @@ func createImportingDescriptors(
 			if details.DescriptorCoverage != tree.AllDescriptors {
 				for _, table := range tableDescs {
 					if lc := table.GetLocalityConfig(); lc != nil {
-						desc, err := descsCol.ByID(txn.KV()).WithoutDropped().Get().Database(ctx, table.ParentID)
+						desc, err := descsCol.ByIDWithoutLeased(txn.KV()).WithoutDropped().Get().Database(ctx, table.ParentID)
 						if err != nil {
 							return err
 						}
@@ -3018,12 +3018,12 @@ func setGCTTLForDroppingTable(
 	log.VInfof(ctx, 2, "lowering TTL for table %q (%d)", tableToDrop.GetName(), tableToDrop.GetID())
 	// We get a mutable descriptor here because we are going to construct a
 	// synthetic descriptor collection in which they are online.
-	dbDesc, err := descsCol.ByID(txn.KV()).Get().Database(ctx, tableToDrop.GetParentID())
+	dbDesc, err := descsCol.ByIDWithoutLeased(txn.KV()).Get().Database(ctx, tableToDrop.GetParentID())
 	if err != nil {
 		return err
 	}
 
-	schemaDesc, err := descsCol.ByID(txn.KV()).Get().Schema(ctx, tableToDrop.GetParentSchemaID())
+	schemaDesc, err := descsCol.ByIDWithoutLeased(txn.KV()).Get().Schema(ctx, tableToDrop.GetParentSchemaID())
 	if err != nil {
 		return err
 	}
@@ -3090,7 +3090,7 @@ func (r *restoreResumer) removeExistingTypeBackReferences(
 			return typ, nil
 		}
 
-		dbDesc, err := descsCol.ByID(txn).WithoutDropped().Get().Database(ctx, tbl.GetParentID())
+		dbDesc, err := descsCol.ByIDWithoutLeased(txn).WithoutDropped().Get().Database(ctx, tbl.GetParentID())
 		if err != nil {
 			return err
 		}

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -317,7 +317,7 @@ func remapSchemas(
 		} else {
 			// If we found an existing schema, then we need to remap all references
 			// to this schema to the existing one.
-			desc, err := col.ByID(txn.KV()).Get().Schema(ctx, id)
+			desc, err := col.ByIDWithoutLeased(txn.KV()).Get().Schema(ctx, id)
 			if err != nil {
 				return false, err
 			}
@@ -406,7 +406,7 @@ func remapTables(
 		}
 
 		// Check privileges.
-		parentDB, err := col.ByID(txn.KV()).Get().Database(ctx, parentID)
+		parentDB, err := col.ByIDWithoutLeased(txn.KV()).Get().Database(ctx, parentID)
 		if err != nil {
 			return false, errors.Wrapf(err,
 				"failed to lookup parent DB %d", errors.Safe(parentID))
@@ -490,7 +490,7 @@ func remapTypes(
 				targetDB, typ.Name)
 		}
 		// Check privileges on the parent DB.
-		parentDB, err := col.ByID(txn.KV()).Get().Database(ctx, parentID)
+		parentDB, err := col.ByIDWithoutLeased(txn.KV()).Get().Database(ctx, parentID)
 		if err != nil {
 			return false, errors.Wrapf(err,
 				"failed to lookup parent DB %d", errors.Safe(parentID))
@@ -900,7 +900,7 @@ func getDatabaseIDAndDesc(
 		return dbID, nil, errors.Errorf("a database named %q needs to exist", targetDB)
 	}
 	// Check privileges on the parent DB.
-	dbDesc, err = col.ByID(txn).Get().Database(ctx, dbID)
+	dbDesc, err = col.ByIDWithoutLeased(txn).Get().Database(ctx, dbID)
 	if err != nil {
 		return 0, nil, errors.Wrapf(err,
 			"failed to lookup parent DB %d", errors.Safe(dbID))

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -493,7 +493,7 @@ func checkMultiRegionCompatible(
 		// For REGION BY TABLE IN <region> tables, allow the restore if the
 		// database has the region.
 		regionEnumID := database.GetRegionConfig().RegionEnumID
-		typeDesc, err := col.ByID(txn).Get().Type(ctx, regionEnumID)
+		typeDesc, err := col.ByIDWithoutLeased(txn).Get().Type(ctx, regionEnumID)
 		if err != nil {
 			return err
 		}

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -157,7 +157,7 @@ func fetchTableDescriptors(
 		// and lie within the primary index span. Deduplication is important
 		// here as requesting the same span twice will deadlock.
 		return targets.EachTableID(func(id catid.DescID) error {
-			tableDesc, err := descriptors.ByID(txn.KV()).WithoutNonPublic().Get().Table(ctx, id)
+			tableDesc, err := descriptors.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Table(ctx, id)
 			if err != nil {
 				return err
 			}

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1480,11 +1480,11 @@ func getQualifiedTableNameObj(
 	ctx context.Context, execCfg *sql.ExecutorConfig, txn *kv.Txn, desc catalog.TableDescriptor,
 ) (tree.TableName, error) {
 	col := execCfg.CollectionFactory.NewCollection(ctx)
-	db, err := col.ByID(txn).Get().Database(ctx, desc.GetParentID())
+	db, err := col.ByIDWithoutLeased(txn).Get().Database(ctx, desc.GetParentID())
 	if err != nil {
 		return tree.TableName{}, err
 	}
-	sc, err := col.ByID(txn).Get().Schema(ctx, desc.GetParentSchemaID())
+	sc, err := col.ByIDWithoutLeased(txn).Get().Schema(ctx, desc.GetParentSchemaID())
 	if err != nil {
 		return tree.TableName{}, err
 	}

--- a/pkg/ccl/changefeedccl/fetch_table_bytes.go
+++ b/pkg/ccl/changefeedccl/fetch_table_bytes.go
@@ -97,7 +97,7 @@ func getTableDesc(
 ) (catalog.TableDescriptor, error) {
 	var desc catalog.TableDescriptor
 	f := func(ctx context.Context, txn descs.Txn) error {
-		tableDesc, err := txn.Descriptors().ByID(txn.KV()).WithoutNonPublic().Get().Table(ctx, tableID)
+		tableDesc, err := txn.Descriptors().ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Table(ctx, tableID)
 		if err != nil {
 			return err
 		}

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -280,7 +280,7 @@ func (tf *schemaFeed) primeInitialTableDescs(ctx context.Context) error {
 		}
 		// Note that all targets are currently guaranteed to be tables.
 		return tf.targets.EachTableID(func(id descpb.ID) error {
-			tableDesc, err := descriptors.ByID(txn.KV()).WithoutNonPublic().Get().Table(ctx, id)
+			tableDesc, err := descriptors.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Table(ctx, id)
 			if err != nil {
 				return err
 			}

--- a/pkg/ccl/crosscluster/logical/logical_replication_job.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job.go
@@ -340,15 +340,15 @@ func (p *logicalReplicationPlanner) generateInitialPlanWithInfo(
 			srcTableDesc := plan.DescriptorMap[pair.SrcDescriptorID]
 
 			// Look up fully qualified destination table name
-			dstTableDesc, err := descriptors.ByID(txn.KV()).WithoutNonPublic().Get().Table(ctx, descpb.ID(pair.DstDescriptorID))
+			dstTableDesc, err := descriptors.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Table(ctx, descpb.ID(pair.DstDescriptorID))
 			if err != nil {
 				return errors.Wrapf(err, "failed to look up table descriptor %d", pair.DstDescriptorID)
 			}
-			dbDesc, err := descriptors.ByID(txn.KV()).WithoutNonPublic().Get().Database(ctx, dstTableDesc.GetParentID())
+			dbDesc, err := descriptors.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Database(ctx, dstTableDesc.GetParentID())
 			if err != nil {
 				return errors.Wrapf(err, "failed to look up database descriptor for table %d", pair.DstDescriptorID)
 			}
-			scDesc, err := descriptors.ByID(txn.KV()).WithoutNonPublic().Get().Schema(ctx, dstTableDesc.GetParentSchemaID())
+			scDesc, err := descriptors.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Schema(ctx, dstTableDesc.GetParentSchemaID())
 			if err != nil {
 				return errors.Wrapf(err, "failed to look up schema descriptor for table %d", pair.DstDescriptorID)
 			}

--- a/pkg/ccl/crosscluster/streamclient/randclient/random_stream_client.go
+++ b/pkg/ccl/crosscluster/streamclient/randclient/random_stream_client.go
@@ -373,7 +373,7 @@ func newRandomStreamClient(streamURL *url.URL, db descs.DB) (streamclient.Client
 	c.streamURL = streamURL
 	if c.config.existingTableID > 0 {
 		if err := db.DescsTxn(context.Background(), func(ctx context.Context, txn descs.Txn) error {
-			c.tableDesc, err = txn.Descriptors().ByID(txn.KV()).Get().Table(ctx, c.config.existingTableID)
+			c.tableDesc, err = txn.Descriptors().ByIDWithoutLeased(txn.KV()).Get().Table(ctx, c.config.existingTableID)
 			return err
 		}); err != nil {
 			return nil, err

--- a/pkg/server/migration_test.go
+++ b/pkg/server/migration_test.go
@@ -375,7 +375,7 @@ func TestUpgradeHappensAfterMigrations(t *testing.T) {
 
 	internalDB := s.ApplicationLayer().InternalDB().(descs.DB)
 	err := internalDB.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
-		systemDBDesc, err := txn.Descriptors().ByID(txn.KV()).Get().Database(ctx, keys.SystemDatabaseID)
+		systemDBDesc, err := txn.Descriptors().ByIDWithoutLeased(txn.KV()).Get().Database(ctx, keys.SystemDatabaseID)
 		if err != nil {
 			return err
 		}
@@ -409,7 +409,7 @@ SELECT version = crdb_internal.node_executable_version()
 	// - reminder to bump SystemDatabaseSchemaBootstrapVersion.
 	// - ensure that upgrades have run and updated the system database version.
 	err = internalDB.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
-		systemDBDesc, err := txn.Descriptors().ByID(txn.KV()).Get().Database(ctx, keys.SystemDatabaseID)
+		systemDBDesc, err := txn.Descriptors().ByIDWithoutLeased(txn.KV()).Get().Database(ctx, keys.SystemDatabaseID)
 		if err != nil {
 			return err
 		}

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2883,7 +2883,7 @@ func (s *systemStatusServer) HotRangesV2(
 						if err = s.sqlServer.distSQLServer.DB.DescsTxn(
 							ctx, func(ctx context.Context, txn descs.Txn) error {
 								col := txn.Descriptors()
-								desc, err := col.ByID(txn.KV()).WithoutNonPublic().Get().Table(ctx, descpb.ID(tableID))
+								desc, err := col.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Table(ctx, descpb.ID(tableID))
 								if err != nil {
 									return errors.Wrapf(err, "cannot get table descriptor with tableID: %d, %s", tableID, r.Desc)
 								}
@@ -2901,13 +2901,13 @@ func (s *systemStatusServer) HotRangesV2(
 									}
 								}
 
-								if dbDesc, err := col.ByID(txn.KV()).WithoutNonPublic().Get().Database(ctx, desc.GetParentID()); err != nil {
+								if dbDesc, err := col.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Database(ctx, desc.GetParentID()); err != nil {
 									log.Warningf(ctx, "cannot get database by descriptor ID: %s: %v", r.Desc, err)
 								} else {
 									dbName = dbDesc.GetName()
 								}
 
-								if schemaDesc, err := col.ByID(txn.KV()).WithoutNonPublic().Get().Schema(ctx, desc.GetParentSchemaID()); err != nil {
+								if schemaDesc, err := col.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Schema(ctx, desc.GetParentSchemaID()); err != nil {
 									log.Warningf(ctx, "cannot get schema name for range descriptor: %s: %v", r.Desc, err)
 								} else {
 									schemaName = schemaDesc.GetName()

--- a/pkg/spanconfig/spanconfigreconciler/reconciler.go
+++ b/pkg/spanconfig/spanconfigreconciler/reconciler.go
@@ -685,7 +685,7 @@ func (r *incrementalReconciler) filterForMissingTableIDs(
 			continue // nothing to do
 		}
 
-		desc, err := descsCol.ByID(txn).Get().Desc(ctx, descriptorUpdate.ID)
+		desc, err := descsCol.ByIDWithoutLeased(txn).Get().Desc(ctx, descriptorUpdate.ID)
 
 		considerAsMissing := false
 		if errors.Is(err, catalog.ErrDescriptorNotFound) {

--- a/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
+++ b/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
@@ -208,7 +208,7 @@ func (s *SQLTranslator) generateSpanConfigurations(
 	}
 
 	// We're dealing with a SQL object.
-	desc, err := s.txn.Descriptors().ByID(s.txn.KV()).Get().Desc(ctx, id)
+	desc, err := s.txn.Descriptors().ByIDWithoutLeased(s.txn.KV()).Get().Desc(ctx, id)
 	if err != nil {
 		if errors.Is(err, catalog.ErrDescriptorNotFound) {
 			return nil, nil // the descriptor has been deleted; nothing to do here
@@ -501,7 +501,7 @@ func (s *SQLTranslator) findDescendantLeafIDs(
 func (s *SQLTranslator) findDescendantLeafIDsForDescriptor(
 	ctx context.Context, id descpb.ID,
 ) (descpb.IDs, error) {
-	desc, err := s.txn.Descriptors().ByID(s.txn.KV()).Get().Desc(ctx, id)
+	desc, err := s.txn.Descriptors().ByIDWithoutLeased(s.txn.KV()).Get().Desc(ctx, id)
 	if err != nil {
 		if errors.Is(err, catalog.ErrDescriptorNotFound) {
 			return nil, nil // the descriptor has been deleted; nothing to do here

--- a/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/tenant_state.go
+++ b/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/tenant_state.go
@@ -198,7 +198,7 @@ func (s *Tenant) LookupTableDescriptorByID(
 		ctx context.Context, txn isql.Txn, descsCol *descs.Collection,
 	) error {
 		var err error
-		desc, err = descsCol.ByID(txn.KV()).Get().Table(ctx, id)
+		desc, err = descsCol.ByIDWithoutLeased(txn.KV()).Get().Table(ctx, id)
 		return err
 	}))
 	return desc

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -523,7 +523,7 @@ func (p *planner) checkCanDropSystemDatabaseRegion(ctx context.Context, region t
 		return err
 	}
 	typeIDsToFetch := typeIDsToFetchSet.Ordered()
-	dbTypes, err := p.Descriptors().ByID(p.txn).Get().Descs(ctx, typeIDsToFetch)
+	dbTypes, err := p.Descriptors().ByIDWithoutLeased(p.txn).Get().Descs(ctx, typeIDsToFetch)
 	if err != nil {
 		return errors.Wrapf(err, "failed to fetch multi-region enums while attempting to drop"+
 			" system database region %s", &region)

--- a/pkg/sql/alter_function.go
+++ b/pkg/sql/alter_function.go
@@ -214,7 +214,7 @@ func (n *alterFunctionRenameNode) startExec(params runParams) error {
 	// this one.
 	var dependentFuncs []string
 	for _, dep := range fnDesc.GetDependedOnBy() {
-		desc, err := params.p.Descriptors().ByID(params.p.Txn()).Get().Desc(params.ctx, dep.ID)
+		desc, err := params.p.Descriptors().ByIDWithoutLeased(params.p.Txn()).Get().Desc(params.ctx, dep.ID)
 		if err != nil {
 			return err
 		}
@@ -387,7 +387,7 @@ func (n *alterFunctionSetSchemaNode) startExec(params runParams) error {
 	// this one.
 	var dependentFuncs []string
 	for _, dep := range fnDesc.GetDependedOnBy() {
-		desc, err := params.p.Descriptors().ByID(params.p.Txn()).Get().Desc(params.ctx, dep.ID)
+		desc, err := params.p.Descriptors().ByIDWithoutLeased(params.p.Txn()).Get().Desc(params.ctx, dep.ID)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/alter_table_locality.go
+++ b/pkg/sql/alter_table_locality.go
@@ -70,7 +70,7 @@ func (p *planner) AlterTableLocality(
 	}
 
 	// Ensure that the database is multi-region enabled.
-	dbDesc, err := p.Descriptors().ByID(p.txn).WithoutNonPublic().Get().Database(ctx, tableDesc.GetParentID())
+	dbDesc, err := p.Descriptors().ByIDWithoutLeased(p.txn).WithoutNonPublic().Get().Database(ctx, tableDesc.GetParentID())
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (n *alterTableSetLocalityNode) alterTableLocalityGlobalToRegionalByTable(
 		)
 	}
 
-	dbDesc, err := params.p.Descriptors().ByID(params.p.txn).WithoutNonPublic().Get().Database(params.ctx, n.tableDesc.ParentID)
+	dbDesc, err := params.p.Descriptors().ByIDWithoutLeased(params.p.txn).WithoutNonPublic().Get().Database(params.ctx, n.tableDesc.ParentID)
 	if err != nil {
 		return err
 	}
@@ -181,7 +181,7 @@ func (n *alterTableSetLocalityNode) alterTableLocalityRegionalByTableToRegionalB
 		)
 	}
 
-	dbDesc, err := params.p.Descriptors().ByID(params.p.txn).WithoutNonPublic().Get().Database(params.ctx, n.tableDesc.ParentID)
+	dbDesc, err := params.p.Descriptors().ByIDWithoutLeased(params.p.txn).WithoutNonPublic().Get().Database(params.ctx, n.tableDesc.ParentID)
 	if err != nil {
 		return err
 	}
@@ -652,7 +652,7 @@ func setNewLocalityConfig(
 	kvTrace bool,
 ) error {
 	getMultiRegionTypeDesc := func() (*typedesc.Mutable, error) {
-		dbDesc, err := descsCol.ByID(txn).WithoutNonPublic().Get().Database(ctx, desc.GetParentID())
+		dbDesc, err := descsCol.ByIDWithoutLeased(txn).WithoutNonPublic().Get().Database(ctx, desc.GetParentID())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -756,7 +756,7 @@ func (sc *SchemaChanger) validateConstraints(
 	if err := sc.fixedTimestampTxn(ctx, readAsOf, func(
 		ctx context.Context, txn descs.Txn,
 	) error {
-		tableDesc, err = txn.Descriptors().ByID(txn.KV()).WithoutNonPublic().Get().Table(ctx, sc.descID)
+		tableDesc, err = txn.Descriptors().ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Table(ctx, sc.descID)
 		return err
 	}); err != nil {
 		return err
@@ -1397,7 +1397,7 @@ func (sc *SchemaChanger) updateJobRunningStatus(
 ) (tableDesc catalog.TableDescriptor, err error) {
 	err = DescsTxn(ctx, sc.execCfg, func(ctx context.Context, txn isql.Txn, col *descs.Collection) (err error) {
 		// Read table descriptor without holding a lease.
-		tableDesc, err = col.ByID(txn.KV()).Get().Table(ctx, sc.descID)
+		tableDesc, err = col.ByIDWithoutLeased(txn.KV()).Get().Table(ctx, sc.descID)
 		if err != nil {
 			return err
 		}
@@ -1452,7 +1452,7 @@ func (sc *SchemaChanger) validateIndexes(ctx context.Context) error {
 	if err := sc.fixedTimestampTxn(ctx, readAsOf, func(
 		ctx context.Context, txn descs.Txn,
 	) (err error) {
-		tableDesc, err = txn.Descriptors().ByID(txn.KV()).WithoutNonPublic().Get().Table(ctx, sc.descID)
+		tableDesc, err = txn.Descriptors().ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Table(ctx, sc.descID)
 		return err
 	}); err != nil {
 		return err
@@ -1588,7 +1588,7 @@ func ValidateConstraint(
 			)
 		case catconstants.ConstraintTypeFK:
 			fk := constraint.AsForeignKey()
-			targetTable, err := txn.Descriptors().ByID(txn.KV()).Get().Table(ctx, fk.GetReferencedTableID())
+			targetTable, err := txn.Descriptors().ByIDWithoutLeased(txn.KV()).Get().Table(ctx, fk.GetReferencedTableID())
 			if err != nil {
 				return err
 			}
@@ -2737,7 +2737,7 @@ func getTargetTablesAndFk(
 	if fk == nil {
 		return nil, nil, nil, errors.AssertionFailedf("foreign key %s does not exist", fkName)
 	}
-	targetTable, err = txn.Descriptors().ByID(txn.KV()).Get().Table(ctx, fk.ReferencedTableID)
+	targetTable, err = txn.Descriptors().ByIDWithoutLeased(txn.KV()).Get().Table(ctx, fk.ReferencedTableID)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -532,7 +532,7 @@ func TestCollectionPreservesPostDeserializationChanges(t *testing.T) {
 	require.NoError(t, sql.DescsTxn(ctx, &execCfg, func(
 		ctx context.Context, txn isql.Txn, col *descs.Collection,
 	) error {
-		immuts, err := col.ByID(txn.KV()).WithoutNonPublic().Get().Descs(ctx, []descpb.ID{dbID, scID, typID, tabID})
+		immuts, err := col.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Descs(ctx, []descpb.ID{dbID, scID, typID, tabID})
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/catalog/descs/getters.go
+++ b/pkg/sql/catalog/descs/getters.go
@@ -482,10 +482,10 @@ func defaultUnleasedFlags() (f getterFlags) {
 	return f
 }
 
-// ByID returns a ByIDGetterBuilder set up to look up descriptors by ID
+// ByIDWithoutLeased returns a ByIDGetterBuilder set up to look up descriptors by ID
 // in all layers except the leased descriptors layer. To opt in to the
 // leased descriptors, use ByIDWithLeased instead.
-func (tc *Collection) ByID(txn *kv.Txn) ByIDGetterBuilder {
+func (tc *Collection) ByIDWithoutLeased(txn *kv.Txn) ByIDGetterBuilder {
 	return ByIDGetterBuilder(makeGetterBase(txn, tc, getterFlags{
 		layerFilters: layerFilters{
 			withoutLeased: true,
@@ -493,7 +493,7 @@ func (tc *Collection) ByID(txn *kv.Txn) ByIDGetterBuilder {
 	}))
 }
 
-// ByIDWithLeased is like ByID but also looks up in the leased descriptors
+// ByIDWithLeased is like ByIDWithoutLeased but also looks up in the leased descriptors
 // layer. This may save a round-trip to KV at the expense of the descriptor
 // being slightly stale (one version off).
 func (tc *Collection) ByIDWithLeased(txn *kv.Txn) ByIDGetterBuilder {

--- a/pkg/sql/catalog/ingesting/privileges.go
+++ b/pkg/sql/catalog/ingesting/privileges.go
@@ -133,7 +133,7 @@ func getIngestingPrivilegesForTableOrSchema(
 		// If we are not creating the database as part of this ingestion, the
 		// schemas and tables in the database should be given privileges based on
 		// the parent database's default privileges.
-		parentDB, err := descsCol.ByID(txn).Get().Database(ctx, desc.GetParentID())
+		parentDB, err := descsCol.ByIDWithoutLeased(txn).Get().Database(ctx, desc.GetParentID())
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to lookup parent DB %d", errors.Safe(desc.GetParentID()))
 		}
@@ -159,7 +159,7 @@ func getIngestingPrivilegesForTableOrSchema(
 			} else {
 				// If we are restoring into an existing schema, resolve it, and fetch
 				// its default privileges.
-				parentSchema, err := descsCol.ByID(txn).Get().Schema(ctx, desc.GetParentSchemaID())
+				parentSchema, err := descsCol.ByIDWithoutLeased(txn).Get().Schema(ctx, desc.GetParentSchemaID())
 				if err != nil {
 					return nil,
 						errors.Wrapf(err, "failed to lookup parent schema %d", errors.Safe(desc.GetParentSchemaID()))

--- a/pkg/sql/catalog/ingesting/write_descs.go
+++ b/pkg/sql/catalog/ingesting/write_descs.go
@@ -233,7 +233,7 @@ func WriteDescriptors(
 func processTableForMultiRegion(
 	ctx context.Context, txn *kv.Txn, descsCol *descs.Collection, table catalog.TableDescriptor,
 ) error {
-	dbDesc, err := descsCol.ByID(txn).WithoutDropped().Get().Database(ctx, table.GetParentID())
+	dbDesc, err := descsCol.ByIDWithoutLeased(txn).WithoutDropped().Get().Database(ctx, table.GetParentID())
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/catalog/randgen/templates.go
+++ b/pkg/sql/catalog/randgen/templates.go
@@ -89,7 +89,7 @@ outer:
 	sort.Slice(sobjIDs, func(i, j int) bool { return sobjIDs[i] < sobjIDs[j] })
 
 	// Look up the descriptors from the IDs.
-	descs, err := g.ext.coll.ByID(g.ext.txn).WithoutNonPublic().Get().Descs(ctx, sobjIDs)
+	descs, err := g.ext.coll.ByIDWithoutLeased(g.ext.txn).WithoutNonPublic().Get().Descs(ctx, sobjIDs)
 	if err != nil {
 		panic(genError{errors.Wrap(err, "retrieving template descriptors")})
 	}

--- a/pkg/sql/conn_executor_jobs.go
+++ b/pkg/sql/conn_executor_jobs.go
@@ -120,7 +120,7 @@ func (ex *connExecutor) descIDsInSchemaChangeJobs() (catalog.DescriptorIDSet, er
 		if descIDsInJobs.Contains(idVersion.ID) {
 			continue
 		}
-		desc, err := ex.extraTxnState.descCollection.ByID(ex.state.mu.txn).Get().Desc(ex.Ctx(), idVersion.ID)
+		desc, err := ex.extraTxnState.descCollection.ByIDWithoutLeased(ex.state.mu.txn).Get().Desc(ex.Ctx(), idVersion.ID)
 		if err != nil {
 			return catalog.DescriptorIDSet{}, err
 		}

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -3669,7 +3669,7 @@ func createRoutinePopulate(
 			}
 		}
 
-		fnDescs, err := p.Descriptors().ByID(p.txn).WithoutNonPublic().Get().Descs(ctx, fnIDs)
+		fnDescs, err := p.Descriptors().ByIDWithoutLeased(p.txn).WithoutNonPublic().Get().Descs(ctx, fnIDs)
 		if err != nil {
 			return err
 		}
@@ -4822,7 +4822,7 @@ CREATE TABLE crdb_internal.zones (
 
 			var table catalog.TableDescriptor
 			if zs.Database != "" {
-				database, err := p.Descriptors().ByID(p.txn).WithoutNonPublic().Get().Database(ctx, descpb.ID(id))
+				database, err := p.Descriptors().ByIDWithoutLeased(p.txn).WithoutNonPublic().Get().Database(ctx, descpb.ID(id))
 				if err != nil {
 					return err
 				}
@@ -4832,7 +4832,7 @@ CREATE TABLE crdb_internal.zones (
 					continue
 				}
 			} else if zoneSpecifier.TableOrIndex.Table.ObjectName != "" {
-				tableEntry, err := p.Descriptors().ByID(p.txn).WithoutDropped().Get().Table(ctx, descpb.ID(id))
+				tableEntry, err := p.Descriptors().ByIDWithoutLeased(p.txn).WithoutDropped().Get().Table(ctx, descpb.ID(id))
 				if err != nil {
 					return err
 				}
@@ -5953,7 +5953,7 @@ var crdbInternalCatalogCommentsTable = virtualSchemaTable{
 					// constraint if it was just added. So if we can't find it, we'll
 					// try a non-leased descriptor.
 					var innerErr error
-					tableDesc, innerErr = p.Descriptors().ByID(p.txn).Get().Table(ctx, descpb.ID(key.ObjectID))
+					tableDesc, innerErr = p.Descriptors().ByIDWithoutLeased(p.txn).Get().Table(ctx, descpb.ID(key.ObjectID))
 					if innerErr != nil {
 						return errors.CombineErrors(innerErr, err)
 					}

--- a/pkg/sql/create_function_test.go
+++ b/pkg/sql/create_function_test.go
@@ -261,7 +261,7 @@ $$;
 `)
 
 	err = sql.TestingDescsTxn(ctx, s, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
-		funcDesc, err := col.ByID(txn.KV()).WithoutNonPublic().Get().Function(ctx, 112)
+		funcDesc, err := col.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Function(ctx, 112)
 		require.NoError(t, err)
 		require.Equal(t, funcDesc.GetName(), "f")
 

--- a/pkg/sql/create_schema.go
+++ b/pkg/sql/create_schema.go
@@ -78,7 +78,7 @@ func CreateUserDefinedSchemaDescriptor(
 			// and can't be in a dropping state.
 			if schemaID != descpb.InvalidID {
 				// Check if the object already exists in a dropped state
-				sc, err := txn.Descriptors().ByID(txn.KV()).Get().Schema(ctx, schemaID)
+				sc, err := txn.Descriptors().ByIDWithoutLeased(txn.KV()).Get().Schema(ctx, schemaID)
 				if err != nil || sc.SchemaKind() != catalog.SchemaUserDefined {
 					return nil, nil, err
 				}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -467,7 +467,7 @@ func (n *createTableNode) startExec(params runParams) error {
 	}
 
 	if desc.LocalityConfig != nil {
-		dbDesc, err := params.p.Descriptors().ByID(params.p.txn).WithoutNonPublic().Get().Database(params.ctx, desc.ParentID)
+		dbDesc, err := params.p.Descriptors().ByIDWithoutLeased(params.p.txn).WithoutNonPublic().Get().Database(params.ctx, desc.ParentID)
 		if err != nil {
 			return errors.Wrap(err, "error resolving database for multi-region")
 		}

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -108,7 +108,7 @@ func (n *createViewNode) startExec(params runParams) error {
 			ids.Add(id)
 		}
 		// Lookup the dependent tables in bulk to minimize round-trips to KV.
-		if _, err := params.p.Descriptors().ByID(params.p.Txn()).WithoutNonPublic().WithoutSynthetic().Get().Descs(params.ctx, ids.Ordered()); err != nil {
+		if _, err := params.p.Descriptors().ByIDWithoutLeased(params.p.Txn()).WithoutNonPublic().WithoutSynthetic().Get().Descs(params.ctx, ids.Ordered()); err != nil {
 			return err
 		}
 		for id := range n.planDeps {

--- a/pkg/sql/database_region_change_finalizer.go
+++ b/pkg/sql/database_region_change_finalizer.go
@@ -56,7 +56,7 @@ func newDatabaseRegionChangeFinalizer(
 
 	var regionalByRowTables []*tabledesc.Mutable
 	if err := func() error {
-		dbDesc, err := txn.Descriptors().ByID(txn.KV()).WithoutNonPublic().Get().Database(ctx, dbID)
+		dbDesc, err := txn.Descriptors().ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Database(ctx, dbID)
 		if err != nil {
 			return err
 		}
@@ -162,7 +162,7 @@ func (r *databaseRegionChangeFinalizer) updateGlobalTablesZoneConfig(
 
 	descsCol := r.localPlanner.Descriptors()
 
-	dbDesc, err := descsCol.ByID(txn.KV()).WithoutNonPublic().Get().Database(ctx, r.dbID)
+	dbDesc, err := descsCol.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Database(ctx, r.dbID)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/database_test.go
+++ b/pkg/sql/database_test.go
@@ -33,7 +33,7 @@ func TestDatabaseAccessors(t *testing.T) {
 	defer s.Stopper().Stop(context.Background())
 
 	if err := TestingDescsTxn(context.Background(), s, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
-		_, err := col.ByID(txn.KV()).Get().Database(ctx, keys.SystemDatabaseID)
+		_, err := col.ByIDWithoutLeased(txn.KV()).Get().Database(ctx, keys.SystemDatabaseID)
 		return err
 	}); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -63,7 +63,7 @@ func (p *planner) createDatabase(
 	if dbID, err := p.Descriptors().LookupDatabaseID(ctx, p.txn, dbName); err == nil && dbID != descpb.InvalidID {
 		if database.IfNotExists {
 			// Check if the database is in a dropping state
-			desc, err := p.Descriptors().ByID(p.txn).Get().Database(ctx, dbID)
+			desc, err := p.Descriptors().ByIDWithoutLeased(p.txn).Get().Database(ctx, dbID)
 			if err != nil {
 				return nil, false, err
 			}

--- a/pkg/sql/drop_cascade.go
+++ b/pkg/sql/drop_cascade.go
@@ -203,7 +203,7 @@ func (d *dropCascadeState) resolveCollectedObjects(
 			// knows how to handle function cascades.
 			var idsInOtherSchemas []descpb.ID
 			for _, dependedOnBy := range fn.DependedOnBy {
-				dependedOnByDesc, err := p.Descriptors().ByID(p.Txn()).Get().Desc(ctx, dependedOnBy.ID)
+				dependedOnByDesc, err := p.Descriptors().ByIDWithoutLeased(p.Txn()).Get().Desc(ctx, dependedOnBy.ID)
 				if err != nil {
 					return err
 				}

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -131,7 +131,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	tbDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), "t", "kv")
 	var dbDesc catalog.DatabaseDescriptor
 	require.NoError(t, sql.TestingDescsTxn(ctx, s, func(ctx context.Context, txn isql.Txn, col *descs.Collection) (err error) {
-		dbDesc, err = col.ByID(txn.KV()).Get().Database(ctx, tbDesc.GetParentID())
+		dbDesc, err = col.ByIDWithoutLeased(txn.KV()).Get().Database(ctx, tbDesc.GetParentID())
 		return err
 	}))
 
@@ -304,7 +304,7 @@ INSERT INTO t.kv2 VALUES ('c', 'd'), ('a', 'b'), ('e', 'a');
 	tb2Desc := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), "t", "kv2")
 	var dbDesc catalog.DatabaseDescriptor
 	require.NoError(t, sql.TestingDescsTxn(ctx, s, func(ctx context.Context, txn isql.Txn, col *descs.Collection) (err error) {
-		dbDesc, err = col.ByID(txn.KV()).Get().Database(ctx, tbDesc.GetParentID())
+		dbDesc, err = col.ByIDWithoutLeased(txn.KV()).Get().Database(ctx, tbDesc.GetParentID())
 		return err
 	}))
 
@@ -897,7 +897,7 @@ func TestDropTableWhileUpgradingFormat(t *testing.T) {
 	// Simulate a migration upgrading the table descriptor's format version after
 	// the table has been dropped but before the truncation has occurred.
 	if err := sql.TestingDescsTxn(ctx, s, func(ctx context.Context, txn isql.Txn, col *descs.Collection) (err error) {
-		tbl, err := col.ByID(txn.KV()).Get().Table(ctx, tableDesc.ID)
+		tbl, err := col.ByIDWithoutLeased(txn.KV()).Get().Table(ctx, tableDesc.ID)
 		if err != nil {
 			return err
 		}
@@ -1242,7 +1242,7 @@ func TestDropIndexOnHashShardedIndexWithStoredShardColumn(t *testing.T) {
 	tdb.QueryRow(t, query).Scan(&tableID)
 	require.NoError(t, sql.TestingDescsTxn(ctx, s,
 		func(ctx context.Context, txn isql.Txn, col *descs.Collection) (err error) {
-			tableDesc, err = col.ByID(txn.KV()).Get().Table(ctx, tableID)
+			tableDesc, err = col.ByIDWithoutLeased(txn.KV()).Get().Table(ctx, tableID)
 			return err
 		}))
 	shardIdx, err := catalog.MustFindIndexByName(tableDesc, "idx")
@@ -1260,7 +1260,7 @@ func TestDropIndexOnHashShardedIndexWithStoredShardColumn(t *testing.T) {
 	// Assert that the index is dropped but the shard column remains after dropping the index.
 	require.NoError(t, sql.TestingDescsTxn(ctx, s,
 		func(ctx context.Context, txn isql.Txn, col *descs.Collection) (err error) {
-			tableDesc, err = col.ByID(txn.KV()).Get().Table(ctx, tableID)
+			tableDesc, err = col.ByIDWithoutLeased(txn.KV()).Get().Table(ctx, tableID)
 			return err
 		}))
 	_, err = catalog.MustFindIndexByName(tableDesc, "idx")

--- a/pkg/sql/drop_type.go
+++ b/pkg/sql/drop_type.go
@@ -197,7 +197,7 @@ func (p *planner) removeTypeBackReferences(
 func (p *planner) addBackRefsFromAllTypesInTable(
 	ctx context.Context, desc *tabledesc.Mutable,
 ) error {
-	dbDesc, err := p.Descriptors().ByID(p.txn).WithoutNonPublic().Get().Database(ctx, desc.GetParentID())
+	dbDesc, err := p.Descriptors().ByIDWithoutLeased(p.txn).WithoutNonPublic().Get().Database(ctx, desc.GetParentID())
 	if err != nil {
 		return err
 	}
@@ -223,7 +223,7 @@ func (p *planner) addBackRefsFromAllTypesInTable(
 func (p *planner) removeBackRefsFromAllTypesInTable(
 	ctx context.Context, desc *tabledesc.Mutable,
 ) error {
-	dbDesc, err := p.Descriptors().ByID(p.txn).WithoutNonPublic().Get().Database(ctx, desc.GetParentID())
+	dbDesc, err := p.Descriptors().ByIDWithoutLeased(p.txn).WithoutNonPublic().Get().Database(ctx, desc.GetParentID())
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/gcjob/gc_job.go
+++ b/pkg/sql/gcjob/gc_job.go
@@ -135,7 +135,7 @@ func deleteTableData(
 	for _, droppedTable := range progress.Tables {
 		var table catalog.TableDescriptor
 		if err := sql.DescsTxn(ctx, cfg, func(ctx context.Context, txn isql.Txn, col *descs.Collection) (err error) {
-			table, err = col.ByID(txn.KV()).Get().Table(ctx, droppedTable.ID)
+			table, err = col.ByIDWithoutLeased(txn.KV()).Get().Table(ctx, droppedTable.ID)
 			return err
 		}); err != nil {
 			if isMissingDescriptorError(err) {

--- a/pkg/sql/gcjob/refresh_statuses.go
+++ b/pkg/sql/gcjob/refresh_statuses.go
@@ -105,7 +105,7 @@ func updateStatusForGCElements(
 	earliestDeadline := timeutil.Unix(0, int64(math.MaxInt64))
 
 	if err := sql.DescsTxn(ctx, execCfg, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
-		table, err := col.ByID(txn.KV()).Get().Table(ctx, tableID)
+		table, err := col.ByIDWithoutLeased(txn.KV()).Get().Table(ctx, tableID)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/gcjob/table_garbage_collection.go
+++ b/pkg/sql/gcjob/table_garbage_collection.go
@@ -51,7 +51,7 @@ func gcTables(
 
 		var table catalog.TableDescriptor
 		if err := sql.DescsTxn(ctx, execCfg, func(ctx context.Context, txn isql.Txn, col *descs.Collection) (err error) {
-			table, err = col.ByID(txn.KV()).Get().Table(ctx, droppedTable.ID)
+			table, err = col.ByIDWithoutLeased(txn.KV()).Get().Table(ctx, droppedTable.ID)
 			return err
 		}); err != nil {
 			if isMissingDescriptorError(err) {
@@ -290,7 +290,7 @@ func deleteTableDescriptorsAfterGC(
 
 		var table catalog.TableDescriptor
 		if err := sql.DescsTxn(ctx, execCfg, func(ctx context.Context, txn isql.Txn, col *descs.Collection) (err error) {
-			table, err = col.ByID(txn.KV()).Get().Table(ctx, droppedTable.ID)
+			table, err = col.ByIDWithoutLeased(txn.KV()).Get().Table(ctx, droppedTable.ID)
 			return err
 		}); err != nil {
 			if isMissingDescriptorError(err) {

--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -127,12 +127,12 @@ func doTestSchemaChangeGCJob(t *testing.T, dropItem DropItem, ttlTime TTLTime) {
 	var myTableDesc *tabledesc.Mutable
 	var myOtherTableDesc *tabledesc.Mutable
 	if err := sql.TestingDescsTxn(ctx, s, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
-		myImm, err := col.ByID(txn.KV()).Get().Table(ctx, myTableID)
+		myImm, err := col.ByIDWithoutLeased(txn.KV()).Get().Table(ctx, myTableID)
 		if err != nil {
 			return err
 		}
 		myTableDesc = tabledesc.NewBuilder(myImm.TableDesc()).BuildExistingMutableTable()
-		myOtherImm, err := col.ByID(txn.KV()).Get().Table(ctx, myOtherTableID)
+		myOtherImm, err := col.ByIDWithoutLeased(txn.KV()).Get().Table(ctx, myOtherTableID)
 		if err != nil {
 			return err
 		}
@@ -267,7 +267,7 @@ func doTestSchemaChangeGCJob(t *testing.T, dropItem DropItem, ttlTime TTLTime) {
 	}
 
 	if err := sql.TestingDescsTxn(ctx, s, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
-		myImm, err := col.ByID(txn.KV()).Get().Table(ctx, myTableID)
+		myImm, err := col.ByIDWithoutLeased(txn.KV()).Get().Table(ctx, myTableID)
 		if err != nil {
 			if ttlTime != FUTURE && (dropItem == TABLE || dropItem == DATABASE) {
 				// We dropped the table, so expect it to not be found.
@@ -277,7 +277,7 @@ func doTestSchemaChangeGCJob(t *testing.T, dropItem DropItem, ttlTime TTLTime) {
 			return err
 		}
 		myTableDesc = tabledesc.NewBuilder(myImm.TableDesc()).BuildExistingMutableTable()
-		myOtherImm, err := col.ByID(txn.KV()).Get().Table(ctx, myOtherTableID)
+		myOtherImm, err := col.ByIDWithoutLeased(txn.KV()).Get().Table(ctx, myOtherTableID)
 		if err != nil {
 			if ttlTime != FUTURE && dropItem == DATABASE {
 				// We dropped the entire database, so expect none of the tables to be found.

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -802,7 +802,7 @@ func (r *importResumer) parseBundleSchemaIfNeeded(ctx context.Context, phs inter
 			if err := sql.DescsTxn(ctx, p.ExecCfg(), func(
 				ctx context.Context, txn isql.Txn, descriptors *descs.Collection,
 			) (err error) {
-				dbDesc, err = descriptors.ByID(txn.KV()).WithoutNonPublic().Get().Database(ctx, parentID)
+				dbDesc, err = descriptors.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Database(ctx, parentID)
 				if err != nil {
 					return err
 				}
@@ -1220,7 +1220,7 @@ func (r *importResumer) checkForUDTModification(
 		ctx context.Context, txn *kv.Txn, col *descs.Collection,
 		savedTypeDesc *descpb.TypeDescriptor,
 	) error {
-		typeDesc, err := col.ByID(txn).Get().Type(ctx, savedTypeDesc.GetID())
+		typeDesc, err := col.ByIDWithoutLeased(txn).Get().Type(ctx, savedTypeDesc.GetID())
 		if err != nil {
 			return errors.Wrap(err, "resolving type descriptor when checking version mismatch")
 		}

--- a/pkg/sql/importer/import_planning.go
+++ b/pkg/sql/importer/import_planning.go
@@ -301,13 +301,13 @@ func resolveUDTsUsedByImportInto(
 	err := sql.DescsTxn(ctx, p.ExecCfg(), func(
 		ctx context.Context, txn isql.Txn, descriptors *descs.Collection,
 	) (err error) {
-		dbDesc, err = descriptors.ByID(txn.KV()).WithoutNonPublic().Get().Database(ctx, table.GetParentID())
+		dbDesc, err = descriptors.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Database(ctx, table.GetParentID())
 		if err != nil {
 			return err
 		}
 		typeIDs, _, err := table.GetAllReferencedTypeIDs(dbDesc,
 			func(id descpb.ID) (catalog.TypeDescriptor, error) {
-				immutDesc, err := descriptors.ByID(txn.KV()).WithoutNonPublic().Get().Type(ctx, id)
+				immutDesc, err := descriptors.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Type(ctx, id)
 				if err != nil {
 					return nil, err
 				}
@@ -318,7 +318,7 @@ func resolveUDTsUsedByImportInto(
 		}
 
 		for _, typeID := range typeIDs {
-			immutDesc, err := descriptors.ByID(txn.KV()).WithoutNonPublic().Get().Type(ctx, typeID)
+			immutDesc, err := descriptors.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Type(ctx, typeID)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -2093,7 +2093,7 @@ func TestFailedImportGC(t *testing.T) {
 	tableID := descpb.ID(dbID + 2)
 	var td catalog.TableDescriptor
 	if err := sql.TestingDescsTxn(ctx, tc.Server(0), func(ctx context.Context, txn isql.Txn, col *descs.Collection) (err error) {
-		td, err = col.ByID(txn.KV()).Get().Table(ctx, tableID)
+		td, err = col.ByIDWithoutLeased(txn.KV()).Get().Table(ctx, tableID)
 		return err
 	}); err != nil {
 		t.Fatal(err)
@@ -6467,7 +6467,7 @@ func TestImportPgDumpSchemas(t *testing.T) {
 		for _, schemaID := range schemaIDs {
 			// Expect that the schema descriptor is deleted.
 			if err := sql.TestingDescsTxn(ctx, tc.Server(0), func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
-				_, err := col.ByID(txn.KV()).Get().Schema(ctx, schemaID)
+				_, err := col.ByIDWithoutLeased(txn.KV()).Get().Schema(ctx, schemaID)
 				if pgerror.GetPGCode(err) == pgcode.InvalidSchemaName {
 					return nil
 				}
@@ -6483,7 +6483,7 @@ func TestImportPgDumpSchemas(t *testing.T) {
 		for _, tableID := range tableIDs {
 			// Expect that the table descriptor is deleted.
 			if err := sql.TestingDescsTxn(ctx, tc.Server(0), func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
-				_, err := col.ByID(txn.KV()).Get().Table(ctx, tableID)
+				_, err := col.ByIDWithoutLeased(txn.KV()).Get().Table(ctx, tableID)
 				if !testutils.IsError(err, "descriptor not found") {
 					return err
 				}

--- a/pkg/sql/importer/read_import_pgdump.go
+++ b/pkg/sql/importer/read_import_pgdump.go
@@ -280,7 +280,7 @@ func createPostgresSchemas(
 		ctx context.Context, txn descs.Txn,
 	) error {
 		schemaDescs = nil // reset for retries
-		dbDesc, err := txn.Descriptors().ByID(txn.KV()).WithoutNonPublic().Get().Database(ctx, parentID)
+		dbDesc, err := txn.Descriptors().ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Database(ctx, parentID)
 		if err != nil {
 			return err
 		}
@@ -877,7 +877,7 @@ func readPostgresStmt(
 		for _, name := range names {
 			tableName := name.ToUnresolvedObjectName().String()
 			if err := sql.DescsTxn(ctx, p.ExecCfg(), func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
-				dbDesc, err := col.ByID(txn.KV()).Get().Database(ctx, parentID)
+				dbDesc, err := col.ByIDWithoutLeased(txn.KV()).Get().Database(ctx, parentID)
 				if err != nil {
 					return err
 				}

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1009,11 +1009,11 @@ https://www.postgresql.org/docs/9.5/infoschema-referential-constraints.html`,
 				}
 				// Note: Cross DB references are deprecated, but this should be
 				// a cached look up when they don't exist.
-				refDB, err := p.Descriptors().ByID(p.Txn()).Get().Database(ctx, refTable.GetParentID())
+				refDB, err := p.Descriptors().ByIDWithoutLeased(p.Txn()).Get().Database(ctx, refTable.GetParentID())
 				if err != nil {
 					return err
 				}
-				refSchema, err := p.Descriptors().ByID(p.Txn()).Get().Schema(ctx, refTable.GetParentSchemaID())
+				refSchema, err := p.Descriptors().ByIDWithoutLeased(p.Txn()).Get().Schema(ctx, refTable.GetParentSchemaID())
 				if err != nil {
 					return err
 				}

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -466,7 +466,7 @@ func (oc *optCatalog) fullyQualifiedNameWithTxn(
 	}
 
 	dbID := desc.GetParentID()
-	dbDesc, err := oc.planner.Descriptors().ByID(txn).WithoutNonPublic().Get().Database(ctx, dbID)
+	dbDesc, err := oc.planner.Descriptors().ByIDWithoutLeased(txn).WithoutNonPublic().Get().Database(ctx, dbID)
 	if err != nil {
 		return cat.DataSourceName{}, err
 	}
@@ -476,7 +476,7 @@ func (oc *optCatalog) fullyQualifiedNameWithTxn(
 	if scID == keys.PublicSchemaID {
 		scName = catconstants.PublicSchemaName
 	} else {
-		scDesc, err := oc.planner.Descriptors().ByID(txn).WithoutNonPublic().Get().Schema(ctx, scID)
+		scDesc, err := oc.planner.Descriptors().ByIDWithoutLeased(txn).WithoutNonPublic().Get().Schema(ctx, scID)
 		if err != nil {
 			return cat.DataSourceName{}, err
 		}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1152,7 +1152,7 @@ func (r oneAtATimeSchemaResolver) getTableByID(id descpb.ID) (catalog.TableDescr
 }
 
 func (r oneAtATimeSchemaResolver) getSchemaByID(id descpb.ID) (catalog.SchemaDescriptor, error) {
-	return r.p.Descriptors().ByID(r.p.txn).Get().Schema(r.ctx, id)
+	return r.p.Descriptors().ByIDWithoutLeased(r.p.txn).Get().Schema(r.ctx, id)
 }
 
 // makeAllRelationsVirtualTableWithDescriptorIDIndex creates a virtual table that searches through
@@ -1549,7 +1549,7 @@ https://www.postgresql.org/docs/13/catalog-pg-default-acl.html`,
 			}
 		}
 		err := dbContext.ForEachSchema(func(id descpb.ID, name string) error {
-			schemaDescriptor, err := p.Descriptors().ByID(p.txn).Get().Schema(ctx, id)
+			schemaDescriptor, err := p.Descriptors().ByIDWithoutLeased(p.txn).Get().Schema(ctx, id)
 			if err != nil {
 				return err
 			}
@@ -1738,7 +1738,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-depend.html`,
 		return forEachSchema(ctx, p, dbContext, true, func(ctx context.Context, sc catalog.SchemaDescriptor) error {
 			pgProcTableOid := tableOid(pgProcDesc.GetID())
 			return sc.ForEachFunctionSignature(func(sig descpb.SchemaDescriptor_FunctionSignature) error {
-				funcDesc, err := p.Descriptors().ByID(p.txn).Get().Function(ctx, sig.ID)
+				funcDesc, err := p.Descriptors().ByIDWithoutLeased(p.txn).Get().Function(ctx, sig.ID)
 				if err != nil {
 					return err
 				}
@@ -2789,7 +2789,7 @@ https://www.postgresql.org/docs/16/catalog-pg-proc.html`,
 			func(ctx context.Context, dbDesc catalog.DatabaseDescriptor) error {
 				return forEachSchema(ctx, p, dbDesc, true /* requiresPrivileges */, func(ctx context.Context, scDesc catalog.SchemaDescriptor) error {
 					return scDesc.ForEachFunctionSignature(func(sig descpb.SchemaDescriptor_FunctionSignature) error {
-						fnDesc, err := p.Descriptors().ByID(p.Txn()).WithoutNonPublic().Get().Function(ctx, sig.ID)
+						fnDesc, err := p.Descriptors().ByIDWithoutLeased(p.Txn()).WithoutNonPublic().Get().Function(ctx, sig.ID)
 						if err != nil {
 							return err
 						}
@@ -2809,7 +2809,7 @@ https://www.postgresql.org/docs/16/catalog-pg-proc.html`,
 				ooid := coid.Oid
 
 				if funcdesc.IsOIDUserDefinedFunc(ooid) {
-					fnDesc, err := p.Descriptors().ByID(p.Txn()).WithoutNonPublic().Get().Function(ctx, funcdesc.UserDefinedFunctionOIDToID(ooid))
+					fnDesc, err := p.Descriptors().ByIDWithoutLeased(p.Txn()).WithoutNonPublic().Get().Function(ctx, funcdesc.UserDefinedFunctionOIDToID(ooid))
 					if err != nil {
 						if errors.Is(err, tree.ErrRoutineUndefined) {
 							return false, nil //nolint:returnerrcheck

--- a/pkg/sql/privileged_accessor.go
+++ b/pkg/sql/privileged_accessor.go
@@ -79,7 +79,7 @@ func (p *planner) LookupZoneConfigByNamespaceID(
 
 // IsSystemTable implements tree.PrivilegedAccessor.
 func (p *planner) IsSystemTable(ctx context.Context, id int64) (bool, error) {
-	tbl, err := p.Descriptors().ByID(p.Txn()).Get().Table(ctx, catid.DescID(id))
+	tbl, err := p.Descriptors().ByIDWithoutLeased(p.Txn()).Get().Table(ctx, catid.DescID(id))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/sql/reference_provider.go
+++ b/pkg/sql/reference_provider.go
@@ -140,7 +140,7 @@ func (f *referenceProviderFactory) NewReferenceProvider(
 	}
 
 	for typeID := range typeReferences {
-		desc, err := f.p.descCollection.ByID(f.p.txn).WithoutNonPublic().Get().Desc(ctx, typeID)
+		desc, err := f.p.descCollection.ByIDWithoutLeased(f.p.txn).WithoutNonPublic().Get().Desc(ctx, typeID)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -1298,7 +1298,7 @@ func (p *planner) ResetMultiRegionZoneConfigsForTable(
 // database's zone configuration to match what would have originally been set by
 // the multi-region syntax.
 func (p *planner) ResetMultiRegionZoneConfigsForDatabase(ctx context.Context, id int64) error {
-	dbDesc, err := p.Descriptors().ByID(p.txn).WithoutNonPublic().Get().Database(ctx, descpb.ID(id))
+	dbDesc, err := p.Descriptors().ByIDWithoutLeased(p.txn).WithoutNonPublic().Get().Database(ctx, descpb.ID(id))
 	if err != nil {
 		return err
 	}
@@ -1602,7 +1602,7 @@ func getDBAndRegionEnumDescs(
 	if useCache {
 		b = descsCol.ByIDWithLeased(txn)
 	} else {
-		b = descsCol.ByID(txn)
+		b = descsCol.ByIDWithoutLeased(txn)
 	}
 	if !includeOffline {
 		b = b.WithoutOffline()

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -210,7 +210,7 @@ func maybeFailOnDependentDescInRename(
 	if withLeased {
 		b = p.Descriptors().ByIDWithLeased(p.txn)
 	} else {
-		b = p.Descriptors().ByID(p.txn)
+		b = p.Descriptors().ByIDWithoutLeased(p.txn)
 	}
 	descs, err := b.WithoutNonPublic().Get().Descs(ctx, ids)
 	if err != nil {

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -329,7 +329,7 @@ func (n *renameTableNode) checkForCrossDbReferences(
 			tableID = fk.GetOriginTableID()
 		}
 
-		referencedTable, err := p.Descriptors().ByID(p.txn).WithoutNonPublic().Get().Table(ctx, tableID)
+		referencedTable, err := p.Descriptors().ByIDWithoutLeased(p.txn).WithoutNonPublic().Get().Table(ctx, tableID)
 		if err != nil {
 			return err
 		}
@@ -353,7 +353,7 @@ func (n *renameTableNode) checkForCrossDbReferences(
 	type crossDBDepType int
 	const owner, reference crossDBDepType = 0, 1
 	checkDepForCrossDbRef := func(depID descpb.ID, depType crossDBDepType) error {
-		dependentObject, err := p.Descriptors().ByID(p.txn).WithoutNonPublic().Get().Table(ctx, depID)
+		dependentObject, err := p.Descriptors().ByIDWithoutLeased(p.txn).WithoutNonPublic().Get().Table(ctx, depID)
 		if err != nil {
 			return err
 		}
@@ -449,7 +449,7 @@ func (n *renameTableNode) checkForCrossDbReferences(
 		if allowCrossDatabaseViews.Get(&p.execCfg.Settings.SV) {
 			return nil
 		}
-		dependentObject, err := p.Descriptors().ByID(p.txn).WithoutNonPublic().Get().Type(ctx, depID)
+		dependentObject, err := p.Descriptors().ByIDWithoutLeased(p.txn).WithoutNonPublic().Get().Type(ctx, depID)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/repair.go
+++ b/pkg/sql/repair.go
@@ -744,7 +744,7 @@ func (p *planner) ForceDeleteTableData(ctx context.Context, descID int64) error 
 
 	// Validate no descriptor exists for this table
 	id := descpb.ID(descID)
-	desc, err := p.Descriptors().ByID(p.txn).WithoutNonPublic().Get().Table(ctx, id)
+	desc, err := p.Descriptors().ByIDWithoutLeased(p.txn).WithoutNonPublic().Get().Table(ctx, id)
 	if err != nil && pgerror.GetPGCode(err) != pgcode.UndefinedTable {
 		return err
 	}
@@ -824,7 +824,7 @@ func (p *planner) UpsertDroppedRelationGCTTL(
 	}
 
 	// Fetch the descriptor and check that it's a dropped table.
-	tbl, err := p.Descriptors().ByID(p.txn).Get().Table(ctx, descpb.ID(id))
+	tbl, err := p.Descriptors().ByIDWithoutLeased(p.txn).Get().Table(ctx, descpb.ID(id))
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -567,7 +567,7 @@ func (p *planner) getFullyQualifiedNamesFromIDs(
 	ctx context.Context, ids []descpb.ID,
 ) (fullyQualifiedNames []string, _ error) {
 	for _, id := range ids {
-		desc, err := p.Descriptors().ByID(p.txn).Get().Desc(ctx, id)
+		desc, err := p.Descriptors().ByIDWithoutLeased(p.txn).Get().Desc(ctx, id)
 		if err != nil {
 			return nil, err
 		}
@@ -594,7 +594,7 @@ func (p *planner) getFullyQualifiedNamesFromIDs(
 func (p *planner) getQualifiedSchemaName(
 	ctx context.Context, desc catalog.SchemaDescriptor,
 ) (*tree.ObjectNamePrefix, error) {
-	dbDesc, err := p.Descriptors().ByID(p.txn).WithoutNonPublic().Get().Database(ctx, desc.GetParentID())
+	dbDesc, err := p.Descriptors().ByIDWithoutLeased(p.txn).WithoutNonPublic().Get().Database(ctx, desc.GetParentID())
 	if err != nil {
 		return nil, err
 	}
@@ -611,7 +611,7 @@ func (p *planner) getQualifiedSchemaName(
 func (p *planner) getQualifiedTypeName(
 	ctx context.Context, desc catalog.TypeDescriptor,
 ) (*tree.TypeName, error) {
-	dbDesc, err := p.Descriptors().ByID(p.txn).WithoutNonPublic().Get().Database(ctx, desc.GetParentID())
+	dbDesc, err := p.Descriptors().ByIDWithoutLeased(p.txn).WithoutNonPublic().Get().Database(ctx, desc.GetParentID())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -285,7 +285,7 @@ func (c *DatumRowConverter) getSequenceAnnotation(
 		if err := txn.SetFixedTimestamp(ctx, hlc.Timestamp{WallTime: evalCtx.TxnTimestamp.UnixNano()}); err != nil {
 			return err
 		}
-		seqs, err := descsCol.ByID(txn).Get().Descs(ctx, sequenceIDs.Ordered())
+		seqs, err := descsCol.ByIDWithoutLeased(txn).Get().Descs(ctx, sequenceIDs.Ordered())
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/rowexec/columnbackfiller.go
+++ b/pkg/sql/rowexec/columnbackfiller.go
@@ -199,7 +199,7 @@ func GetResumeSpans(
 	mutationID descpb.MutationID,
 	filter backfill.MutationFilter,
 ) ([]roachpb.Span, *jobs.Job, int, error) {
-	tableDesc, err := col.ByID(txn.KV()).Get().Table(ctx, tableID)
+	tableDesc, err := col.ByIDWithoutLeased(txn.KV()).Get().Table(ctx, tableID)
 	if err != nil {
 		return nil, nil, 0, err
 	}

--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -155,7 +155,7 @@ func (p *planner) waitForDescriptorSchemaChanges(
 			if err := txn.KV().SetFixedTimestamp(ctx, now); err != nil {
 				return err
 			}
-			desc, err := txn.Descriptors().ByID(txn.KV()).WithoutNonPublic().Get().Desc(ctx, descID)
+			desc, err := txn.Descriptors().ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Desc(ctx, descID)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -395,7 +395,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 				tbls := localPlanner.curPlan.mem.Metadata().AllTables()
 				for _, table := range tbls {
 					descID := table.Table.ID()
-					tbl, err := localPlanner.descCollection.ByID(localPlanner.Txn()).Get().Table(ctx, catid.DescID(descID))
+					tbl, err := localPlanner.descCollection.ByIDWithoutLeased(localPlanner.Txn()).Get().Table(ctx, catid.DescID(descID))
 					if err != nil {
 						return
 					}
@@ -719,7 +719,7 @@ func (sc *SchemaChanger) getTargetDescriptor(ctx context.Context) (catalog.Descr
 	if err := sc.txn(ctx, func(
 		ctx context.Context, txn descs.Txn,
 	) (err error) {
-		desc, err = txn.Descriptors().ByID(txn.KV()).Get().Desc(ctx, sc.descID)
+		desc, err = txn.Descriptors().ByIDWithoutLeased(txn.KV()).Get().Desc(ctx, sc.descID)
 		return err
 	}); err != nil {
 		return nil, err
@@ -1056,7 +1056,7 @@ func (sc *SchemaChanger) handlePermanentSchemaChangeError(
 // initialize the job running status.
 func (sc *SchemaChanger) initJobRunningStatus(ctx context.Context) error {
 	return sc.txn(ctx, func(ctx context.Context, txn descs.Txn) error {
-		desc, err := txn.Descriptors().ByID(txn.KV()).WithoutNonPublic().Get().Table(ctx, sc.descID)
+		desc, err := txn.Descriptors().ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Table(ctx, sc.descID)
 		if err != nil {
 			return err
 		}
@@ -1257,7 +1257,7 @@ func (sc *SchemaChanger) RunStateMachineBeforeBackfill(ctx context.Context) erro
 		if err != nil {
 			return err
 		}
-		dbDesc, err := txn.Descriptors().ByID(txn.KV()).WithoutNonPublic().Get().Database(ctx, tbl.GetParentID())
+		dbDesc, err := txn.Descriptors().ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Database(ctx, tbl.GetParentID())
 		if err != nil {
 			return err
 		}
@@ -1502,7 +1502,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 			return err
 		}
 
-		dbDesc, err := txn.Descriptors().ByID(txn.KV()).WithoutNonPublic().Get().Database(ctx, scTable.GetParentID())
+		dbDesc, err := txn.Descriptors().ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Database(ctx, scTable.GetParentID())
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -111,7 +111,7 @@ func (sr *schemaResolver) CurrentSearchPath() sessiondata.SearchPath {
 
 func (sr *schemaResolver) byIDGetterBuilder() descs.ByIDGetterBuilder {
 	if sr.skipDescriptorCache {
-		return sr.descCollection.ByID(sr.txn)
+		return sr.descCollection.ByIDWithoutLeased(sr.txn)
 	}
 	return sr.descCollection.ByIDWithLeased(sr.txn)
 }

--- a/pkg/sql/schemachanger/scdeps/build_deps.go
+++ b/pkg/sql/schemachanger/scdeps/build_deps.go
@@ -298,7 +298,7 @@ func (d *buildDeps) CurrentDatabase() string {
 
 // MustReadDescriptor implements the scbuild.CatalogReader interface.
 func (d *buildDeps) MustReadDescriptor(ctx context.Context, id descpb.ID) catalog.Descriptor {
-	desc, err := d.descsCollection.ByID(d.txn).Get().Desc(ctx, id)
+	desc, err := d.descsCollection.ByIDWithoutLeased(d.txn).Get().Desc(ctx, id)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/sql/schemachanger/scdeps/exec_deps.go
+++ b/pkg/sql/schemachanger/scdeps/exec_deps.go
@@ -155,12 +155,12 @@ func (d *txnDeps) InsertTemporarySchema(schemaName string, id descpb.ID, databas
 func (d *txnDeps) MustReadImmutableDescriptors(
 	ctx context.Context, ids ...descpb.ID,
 ) ([]catalog.Descriptor, error) {
-	return d.descsCollection.ByID(d.txn.KV()).WithoutSynthetic().Get().Descs(ctx, ids)
+	return d.descsCollection.ByIDWithoutLeased(d.txn.KV()).WithoutSynthetic().Get().Descs(ctx, ids)
 }
 
 // GetFullyQualifiedName implements the scmutationexec.CatalogReader interface
 func (d *txnDeps) GetFullyQualifiedName(ctx context.Context, id descpb.ID) (string, error) {
-	g := d.descsCollection.ByID(d.txn.KV()).WithoutSynthetic().Get()
+	g := d.descsCollection.ByIDWithoutLeased(d.txn.KV()).WithoutSynthetic().Get()
 	objectDesc, err := g.Desc(ctx, id)
 	if err != nil {
 		return "", err
@@ -338,7 +338,7 @@ func (d *txnDeps) CreatedJobs() []jobspb.JobID {
 func (d *txnDeps) GetResumeSpans(
 	ctx context.Context, tableID descpb.ID, indexID descpb.IndexID,
 ) ([]roachpb.Span, error) {
-	table, err := d.descsCollection.ByID(d.txn.KV()).WithoutNonPublic().WithoutSynthetic().Get().Table(ctx, tableID)
+	table, err := d.descsCollection.ByIDWithoutLeased(d.txn.KV()).WithoutNonPublic().WithoutSynthetic().Get().Table(ctx, tableID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/sqlinstance/instancestorage/instancestorage.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancestorage.go
@@ -573,7 +573,7 @@ func (s *Storage) readRegionsFromSystemDatabase(
 	descs := s.cf.NewCollection(ctx)
 	descs.SetDescriptorSessionDataProvider(catsessiondata.DefaultDescriptorSessionDataProvider)
 	defer descs.ReleaseAll(ctx)
-	systemDB, err := descs.ByID(txn).Get().Database(ctx, keys.SystemDatabaseID)
+	systemDB, err := descs.ByIDWithoutLeased(txn).Get().Database(ctx, keys.SystemDatabaseID)
 	if err != nil {
 		return nil, err
 	}
@@ -584,7 +584,7 @@ func (s *Storage) readRegionsFromSystemDatabase(
 	if err != nil {
 		return nil, err
 	}
-	typeEnum, err := descs.ByID(txn).Get().Type(ctx, regionEnumID)
+	typeEnum, err := descs.ByIDWithoutLeased(txn).Get().Type(ctx, regionEnumID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/table_test.go
+++ b/pkg/sql/table_test.go
@@ -441,7 +441,7 @@ CREATE TABLE test.tt (x test.t);
 	typLookup := func(ctx context.Context, id descpb.ID) (tree.TypeName, catalog.TypeDescriptor, error) {
 		var typeDesc catalog.TypeDescriptor
 		if err := TestingDescsTxn(ctx, s, func(ctx context.Context, txn isql.Txn, col *descs.Collection) (err error) {
-			typeDesc, err = col.ByID(txn.KV()).Get().Type(ctx, id)
+			typeDesc, err = col.ByIDWithoutLeased(txn.KV()).Get().Type(ctx, id)
 			return err
 		}); err != nil {
 			return tree.TypeName{}, nil, err

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -303,15 +303,15 @@ func cleanupTempSchemaObjects(
 					if _, ok := tblDescsByID[d.ID]; ok {
 						return nil
 					}
-					dTableDesc, err := descsCol.ByID(txn.KV()).WithoutNonPublic().Get().Table(ctx, d.ID)
+					dTableDesc, err := descsCol.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Table(ctx, d.ID)
 					if err != nil {
 						return err
 					}
-					db, err := descsCol.ByID(txn.KV()).WithoutNonPublic().Get().Database(ctx, dTableDesc.GetParentID())
+					db, err := descsCol.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Database(ctx, dTableDesc.GetParentID())
 					if err != nil {
 						return err
 					}
-					sc, err := descsCol.ByID(txn.KV()).WithoutNonPublic().Get().Schema(ctx, dTableDesc.GetParentSchemaID())
+					sc, err := descsCol.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Schema(ctx, dTableDesc.GetParentSchemaID())
 					if err != nil {
 						return err
 					}

--- a/pkg/sql/temporary_schema_test.go
+++ b/pkg/sql/temporary_schema_test.go
@@ -98,7 +98,7 @@ INSERT INTO perm_table VALUES (DEFAULT, 1);
 	) error {
 		// Add a hack to not wait for one version on the descriptors.
 		defer txn.Descriptors().ReleaseAll(ctx)
-		defaultDB, err := txn.Descriptors().ByID(txn.KV()).WithoutNonPublic().Get().Database(ctx, namesToID["defaultdb"])
+		defaultDB, err := txn.Descriptors().ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Database(ctx, namesToID["defaultdb"])
 		if err != nil {
 			return err
 		}

--- a/pkg/upgrade/upgrades/descriptor_utils.go
+++ b/pkg/upgrade/upgrades/descriptor_utils.go
@@ -39,7 +39,7 @@ func createSystemTable(
 	tableLocality tree.LocalityLevel,
 ) error {
 	return db.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
-		dbDesc, err := txn.Descriptors().ByID(txn.KV()).Get().Database(ctx, keys.SystemDatabaseID)
+		dbDesc, err := txn.Descriptors().ByIDWithoutLeased(txn.KV()).Get().Database(ctx, keys.SystemDatabaseID)
 		if err != nil {
 			return err
 		}

--- a/pkg/upgrade/upgrades/helpers_test.go
+++ b/pkg/upgrade/upgrades/helpers_test.go
@@ -163,7 +163,7 @@ func GetTable(
 	err := s.InternalDB().(descs.DB).DescsTxn(ctx, func(
 		ctx context.Context, txn descs.Txn,
 	) (err error) {
-		table, err = txn.Descriptors().ByID(txn.KV()).WithoutNonPublic().Get().Table(ctx, tableID)
+		table, err = txn.Descriptors().ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Table(ctx, tableID)
 		return err
 	})
 	require.NoError(t, err)

--- a/pkg/upgrade/upgrades/schema_changes.go
+++ b/pkg/upgrade/upgrades/schema_changes.go
@@ -152,7 +152,7 @@ func readTableDescriptor(
 	if err := d.DB.DescsTxn(ctx, func(
 		ctx context.Context, txn descs.Txn,
 	) (err error) {
-		t, err = txn.Descriptors().ByID(txn.KV()).WithoutNonPublic().Get().Table(ctx, tableID)
+		t, err = txn.Descriptors().ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Table(ctx, tableID)
 		return err
 	}); err != nil {
 		return nil, err


### PR DESCRIPTION
This makes the function name much more clear. Previously, it would be easy to assume that ByID would also include leased descriptors.

fixes https://github.com/cockroachdb/cockroach/issues/99506
Release note: None