### PR TITLE
server: allow VIEWACTIVITY users access to /_admin/v1/stmtbundle

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -81,6 +81,7 @@ import (
 	gwutil "github.com/grpc-ecosystem/grpc-gateway/utilities"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
 )
 
@@ -275,13 +276,15 @@ func (s *adminServer) RegisterGateway(
 			http.Error(w, "invalid id", http.StatusBadRequest)
 			return
 		}
-		// Add default user when running in Insecure mode because we don't
-		// retrieve the user from gRPC metadata (which falls back to `root`)
-		// but from HTTP metadata (which does not).
-		if s.sqlServer.cfg.Insecure {
-			ctx := req.Context()
-			ctx = authserver.ContextWithHTTPAuthInfo(ctx, username.RootUser, 0)
-			req = req.WithContext(ctx)
+
+		// The privilege checks in the privilege checker below checks the user in the incoming
+		// gRPC metadata.
+		md := authserver.TranslateHTTPAuthInfoToGRPCMetadata(req.Context(), req)
+		authCtx := metadata.NewIncomingContext(req.Context(), md)
+		authCtx = s.AnnotateCtx(authCtx)
+		if err := s.privilegeChecker.RequireViewActivityAndNoViewActivityRedactedPermission(authCtx); err != nil {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
 		}
 		s.getStatementBundle(req.Context(), id, w)
 	})
@@ -2601,12 +2604,12 @@ func (s *adminServer) QueryPlan(
 }
 
 // getStatementBundle retrieves the statement bundle with the given id and
-// writes it out as an attachment.
+// writes it out as an attachment. Note this function assumes the user has
+// permission to access the statement bundle.
 func (s *adminServer) getStatementBundle(ctx context.Context, id int64, w http.ResponseWriter) {
-	sqlUsername := authserver.UserFromHTTPAuthInfoContext(ctx)
 	row, err := s.internalExecutor.QueryRowEx(
 		ctx, "admin-stmt-bundle", nil, /* txn */
-		sessiondata.InternalExecutorOverride{User: sqlUsername},
+		sessiondata.NodeUserSessionDataOverride,
 		"SELECT bundle_chunks FROM system.statement_diagnostics WHERE id=$1 AND bundle_chunks IS NOT NULL",
 		id,
 	)
@@ -2625,7 +2628,7 @@ func (s *adminServer) getStatementBundle(ctx context.Context, id int64, w http.R
 	for _, chunkID := range chunkIDs {
 		chunkRow, err := s.internalExecutor.QueryRowEx(
 			ctx, "admin-stmt-bundle", nil, /* txn */
-			sessiondata.InternalExecutorOverride{User: sqlUsername},
+			sessiondata.NodeUserSessionDataOverride,
 			"SELECT data FROM system.statement_bundle_chunks WHERE id=$1",
 			chunkID,
 		)


### PR DESCRIPTION
This commit gives users with the VIEWACTIVITY system grant access to `/_admin/v1/stmtbundle` on the admin server. This allows these users to download stmt bundles via DB console.

Epic: none
Part of: #121301

Release note (ui change): Users with VIEWACTIVITY can download stmt bundles from DB console.