### PR TITLE
roachtest: add 24.3 min version to multitenant-upgrade

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -80,8 +80,8 @@ func runMultiTenantUpgrade(
 	versionToMinSupportedVersion := map[string]string{
 		"23.2": "23.1",
 		"24.1": "23.2",
-		// TODO: test out version skipping, since it is available internally.
 		"24.2": "24.1",
+		"24.3": "24.1",
 	}
 	curBinaryMajorAndMinorVersion := getMajorAndMinorVersionOnly(v)
 	currentBinaryMinSupportedVersion, ok := versionToMinSupportedVersion[curBinaryMajorAndMinorVersion]


### PR DESCRIPTION
As an aside, we should sunset this test in favor of one that uses the new mixed version framework, but lets do that once the PCR test has landed.

Fixes #128950

Release note: none