### PR TITLE
kvserver: skip rebalance multi-store under deadlock

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -182,6 +182,7 @@ func TestReplicateQueueRebalanceMultiStore(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t)
 	skip.UnderShort(t)
+	skip.UnderDeadlock(t)
 
 	testCases := []struct {
 		name          string


### PR DESCRIPTION
`TestReplicateQueueRebalanceMultiStore` spins up 8 stores and asserts on balancing of replicas and leaseholders. Under deadlock builds this is especially slow and prone to timeouts. Skip under deadlock.

Fixes: #128952
Release note: None