### PR TITLE
clusterversion: allow skip-version upgrade without env var

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/ts"
-	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -96,18 +95,7 @@ var serverCfg = func() server.Config {
 }()
 
 func makeClusterSettings() *cluster.Settings {
-	// Even though the code supports upgrading from multiple previous releases,
-	// skipping versions is experimental; by default, we only allow upgrading from
-	// the previous release.
-	//
-	// Version skipping can be enabled by setting COCKROACH_ALLOW_VERSION_SKIPPING=1.
-	var minSupported clusterversion.Key
-	if envutil.EnvOrDefaultBool("COCKROACH_ALLOW_VERSION_SKIPPING", false) {
-		minSupported = clusterversion.MinSupported
-	} else {
-		minSupported = clusterversion.PreviousRelease
-	}
-	st := cluster.MakeClusterSettingsWithVersions(clusterversion.Latest.Version(), minSupported.Version())
+	st := cluster.MakeClusterSettings()
 	logcrash.SetGlobalSettings(&st.SV)
 	return st
 }

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -489,16 +489,14 @@ func defaultTestOptions() testOptions {
 	return testOptions{
 		// We use fixtures more often than not as they are more likely to
 		// detect bugs, especially in migrations.
-		useFixturesProbability:  0.7,
-		upgradeTimeout:          clusterupgrade.DefaultUpgradeTimeout,
-		minUpgrades:             1,
-		maxUpgrades:             4,
-		minimumSupportedVersion: OldestSupportedVersion,
-		predecessorFunc:         randomPredecessor,
-		enabledDeploymentModes:  allDeploymentModes,
-		// TODO(radu): restore skipVersionProbability to 0.5 when we enable
-		// 24.1->24.3 upgrade (without a special env flag).
-		skipVersionProbability:         0,
+		useFixturesProbability:         0.7,
+		upgradeTimeout:                 clusterupgrade.DefaultUpgradeTimeout,
+		minUpgrades:                    1,
+		maxUpgrades:                    4,
+		minimumSupportedVersion:        OldestSupportedVersion,
+		predecessorFunc:                randomPredecessor,
+		enabledDeploymentModes:         allDeploymentModes,
+		skipVersionProbability:         0.5,
 		overriddenMutatorProbabilities: make(map[string]float64),
 	}
 }

--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -564,9 +564,9 @@ func runRestore(
 			}
 
 		}
-		opts := "WITH unsafe_restore_incompatible_version"
+		opts := ""
 		if runOnline {
-			opts = "WITH EXPERIMENTAL DEFERRED COPY, unsafe_restore_incompatible_version"
+			opts = "WITH EXPERIMENTAL DEFERRED COPY"
 		}
 		if err := maybeAddSomeEmptyTables(ctx, rd); err != nil {
 			return errors.Wrapf(err, "failed to add some empty tables")

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1333,7 +1333,6 @@ func (t *logicTest) newTestServerCluster(bootstrapBinaryPath, upgradeBinaryPath 
 		// We disable them here so that the test is more stable.
 		envVars = append(envVars, "COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING=true")
 	}
-	envVars = append(envVars, "COCKROACH_ALLOW_VERSION_SKIPPING=true")
 
 	opts := []testserver.TestServerOpt{
 		// During config initialization, NumNodes is required to be 3.


### PR DESCRIPTION
Starting from 24.3, we are now able to upgrade directly from
`MinSupported` without the need to set any environment variables.

Epic: none

Release note: None