### PR TITLE
raft: consult StoreLiveness when handling MsgFortify

### DIFF
--- a/pkg/raft/testdata/async_storage_writes.txt
+++ b/pkg/raft/testdata/async_storage_writes.txt
@@ -115,7 +115,7 @@ stabilize
   1/11 EntryNormal ""
   Messages:
   2->AppendThread MsgStorageAppend Term:1 Log:1/11 Commit:10 Vote:1 Lead:1 LeadEpoch:1 Entries:[1/11 EntryNormal ""] Responses:[
-    2->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
+    2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
     2->1 MsgAppResp Term:1 Log:0/11
     AppendThread->2 MsgStorageAppendResp Term:0 Log:1/11
   ]
@@ -126,7 +126,7 @@ stabilize
   1/11 EntryNormal ""
   Messages:
   3->AppendThread MsgStorageAppend Term:1 Log:1/11 Commit:10 Vote:1 Lead:1 LeadEpoch:1 Entries:[1/11 EntryNormal ""] Responses:[
-    3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
+    3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
     3->1 MsgAppResp Term:1 Log:0/11
     AppendThread->3 MsgStorageAppendResp Term:0 Log:1/11
   ]
@@ -137,20 +137,20 @@ stabilize
   Processing:
   2->AppendThread MsgStorageAppend Term:1 Log:1/11 Commit:10 Vote:1 Lead:1 LeadEpoch:1 Entries:[1/11 EntryNormal ""]
   Responses:
-  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:1 Log:0/11
   AppendThread->2 MsgStorageAppendResp Term:0 Log:1/11
 > 3 processing append thread
   Processing:
   3->AppendThread MsgStorageAppend Term:1 Log:1/11 Commit:10 Vote:1 Lead:1 LeadEpoch:1 Entries:[1/11 EntryNormal ""]
   Responses:
-  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   3->1 MsgAppResp Term:1 Log:0/11
   AppendThread->3 MsgStorageAppendResp Term:0 Log:1/11
 > 1 receiving messages
-  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:1 Log:0/11
-  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   3->1 MsgAppResp Term:1 Log:0/11
 > 2 receiving messages
   AppendThread->2 MsgStorageAppendResp Term:0 Log:1/11

--- a/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
+++ b/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
@@ -238,7 +238,7 @@ Entries:
 Messages:
 1->AppendThread MsgStorageAppend Term:2 Log:2/12 Commit:11 Lead:3 LeadEpoch:1 Entries:[2/12 EntryNormal ""] Responses:[
   1->3 MsgVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
-  1->3 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
+  1->3 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   1->3 MsgAppResp Term:2 Log:0/12
   AppendThread->1 MsgStorageAppendResp Term:0 Log:2/12
 ]
@@ -483,7 +483,7 @@ Processing:
 1->AppendThread MsgStorageAppend Term:2 Log:2/12 Commit:11 Lead:3 LeadEpoch:1 Entries:[2/12 EntryNormal ""]
 Responses:
 1->3 MsgVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
-1->3 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
+1->3 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
 1->3 MsgAppResp Term:2 Log:0/12
 AppendThread->1 MsgStorageAppendResp Term:0 Log:2/12
 

--- a/pkg/raft/testdata/campaign.txt
+++ b/pkg/raft/testdata/campaign.txt
@@ -81,7 +81,7 @@ stabilize
   Entries:
   1/3 EntryNormal ""
   Messages:
-  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:1 Log:0/3
 > 3 handling Ready
   Ready MustSync=true:
@@ -89,12 +89,12 @@ stabilize
   Entries:
   1/3 EntryNormal ""
   Messages:
-  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   3->1 MsgAppResp Term:1 Log:0/3
 > 1 receiving messages
-  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:1 Log:0/3
-  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   3->1 MsgAppResp Term:1 Log:0/3
 > 1 handling Ready
   Ready MustSync=false:

--- a/pkg/raft/testdata/campaign_learner_must_vote.txt
+++ b/pkg/raft/testdata/campaign_learner_must_vote.txt
@@ -112,10 +112,10 @@ stabilize 2 3
   Ready MustSync=true:
   HardState Term:2 Vote:2 Commit:3 Lead:2 LeadEpoch:1
   Messages:
-  3->2 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
+  3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3)
 > 2 receiving messages
-  3->2 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
+  3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3)
   DEBUG 2 received MsgAppResp(rejected, hint: (index 3, term 1)) from 3 for index 4
   DEBUG 2 decreased progress of 3 to [StateProbe match=0 next=4]

--- a/pkg/raft/testdata/checkquorum.txt
+++ b/pkg/raft/testdata/checkquorum.txt
@@ -198,7 +198,7 @@ stabilize
   Entries:
   3/12 EntryNormal ""
   Messages:
-  1->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
+  1->2 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
   1->2 MsgAppResp Term:3 Log:0/12
 > 3 handling Ready
   Ready MustSync=true:
@@ -206,12 +206,12 @@ stabilize
   Entries:
   3/12 EntryNormal ""
   Messages:
-  3->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
+  3->2 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
   3->2 MsgAppResp Term:3 Log:0/12
 > 2 receiving messages
-  1->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
+  1->2 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
   1->2 MsgAppResp Term:3 Log:0/12
-  3->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
+  3->2 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
   3->2 MsgAppResp Term:3 Log:0/12
 > 2 handling Ready
   Ready MustSync=false:

--- a/pkg/raft/testdata/confchange_v2_replace_leader.txt
+++ b/pkg/raft/testdata/confchange_v2_replace_leader.txt
@@ -251,7 +251,7 @@ stabilize
   Entries:
   2/5 EntryNormal ""
   Messages:
-  1->4 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
+  1->4 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   1->4 MsgAppResp Term:2 Log:0/5
 > 2 handling Ready
   Ready MustSync=true:
@@ -259,7 +259,7 @@ stabilize
   Entries:
   2/5 EntryNormal ""
   Messages:
-  2->4 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
+  2->4 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   2->4 MsgAppResp Term:2 Log:0/5
 > 3 handling Ready
   Ready MustSync=true:
@@ -267,14 +267,14 @@ stabilize
   Entries:
   2/5 EntryNormal ""
   Messages:
-  3->4 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
+  3->4 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   3->4 MsgAppResp Term:2 Log:0/5
 > 4 receiving messages
-  1->4 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
+  1->4 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   1->4 MsgAppResp Term:2 Log:0/5
-  2->4 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
+  2->4 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   2->4 MsgAppResp Term:2 Log:0/5
-  3->4 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
+  3->4 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   3->4 MsgAppResp Term:2 Log:0/5
 > 4 handling Ready
   Ready MustSync=false:

--- a/pkg/raft/testdata/fortification_basic.txt
+++ b/pkg/raft/testdata/fortification_basic.txt
@@ -113,7 +113,7 @@ stabilize
   Entries:
   1/3 EntryNormal ""
   Messages:
-  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:2
   2->1 MsgAppResp Term:1 Log:0/3
 > 3 handling Ready
   Ready MustSync=true:
@@ -124,7 +124,7 @@ stabilize
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
   3->1 MsgAppResp Term:1 Log:0/3
 > 1 receiving messages
-  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:2
   2->1 MsgAppResp Term:1 Log:0/3
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
   3->1 MsgAppResp Term:1 Log:0/3

--- a/pkg/raft/testdata/fortification_leader_does_not_support_itself.txt
+++ b/pkg/raft/testdata/fortification_leader_does_not_support_itself.txt
@@ -114,7 +114,7 @@ stabilize
   Entries:
   1/3 EntryNormal ""
   Messages:
-  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:3
   2->1 MsgAppResp Term:1 Log:0/3
 > 3 handling Ready
   Ready MustSync=true:
@@ -122,12 +122,12 @@ stabilize
   Entries:
   1/3 EntryNormal ""
   Messages:
-  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:2
   3->1 MsgAppResp Term:1 Log:0/3
 > 1 receiving messages
-  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:3
   2->1 MsgAppResp Term:1 Log:0/3
-  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:2
   3->1 MsgAppResp Term:1 Log:0/3
 > 1 handling Ready
   Ready MustSync=false:
@@ -158,3 +158,9 @@ stabilize
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/3
   3->1 MsgAppResp Term:1 Log:0/3
+
+# TODO(arul): Consider adding a directive for the leader's support tracker and
+# printing it out here. We can see that 1 isn't supporting itself by the
+# "leader doesn't support itself" log line, but we don't have a reject message
+# in the test output. We should confirm that the support tracking is as expected
+# by printing out the SupportTracker on the leader.

--- a/pkg/raft/testdata/prevote.txt
+++ b/pkg/raft/testdata/prevote.txt
@@ -229,7 +229,7 @@ stabilize
   Entries:
   2/13 EntryNormal ""
   Messages:
-  1->2 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
+  1->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   1->2 MsgAppResp Term:2 Log:0/13
 > 3 handling Ready
   Ready MustSync=true:
@@ -237,12 +237,12 @@ stabilize
   Entries:
   2/13 EntryNormal ""
   Messages:
-  3->2 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
+  3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   3->2 MsgAppResp Term:2 Log:0/13
 > 2 receiving messages
-  1->2 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
+  1->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   1->2 MsgAppResp Term:2 Log:0/13
-  3->2 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
+  3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   3->2 MsgAppResp Term:2 Log:0/13
 > 2 handling Ready
   Ready MustSync=false:

--- a/pkg/raft/testdata/prevote_checkquorum.txt
+++ b/pkg/raft/testdata/prevote_checkquorum.txt
@@ -154,7 +154,7 @@ stabilize
   Entries:
   2/12 EntryNormal ""
   Messages:
-  1->3 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
+  1->3 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   1->3 MsgAppResp Term:2 Log:0/12
 > 2 handling Ready
   Ready MustSync=true:
@@ -162,12 +162,12 @@ stabilize
   Entries:
   2/12 EntryNormal ""
   Messages:
-  2->3 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
+  2->3 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   2->3 MsgAppResp Term:2 Log:0/12
 > 3 receiving messages
-  1->3 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
+  1->3 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   1->3 MsgAppResp Term:2 Log:0/12
-  2->3 MsgFortifyLeaderResp Term:2 Log:0/0 Rejected (Hint: 0)
+  2->3 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   2->3 MsgAppResp Term:2 Log:0/12
 > 3 handling Ready
   Ready MustSync=false:
@@ -320,7 +320,7 @@ stabilize
   Entries:
   3/13 EntryNormal ""
   Messages:
-  1->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
+  1->2 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
   1->2 MsgAppResp Term:3 Log:0/13
 > 3 handling Ready
   Ready MustSync=true:
@@ -329,12 +329,12 @@ stabilize
   Entries:
   3/13 EntryNormal ""
   Messages:
-  3->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
+  3->2 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
   3->2 MsgAppResp Term:3 Log:0/13
 > 2 receiving messages
-  1->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
+  1->2 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
   1->2 MsgAppResp Term:3 Log:0/13
-  3->2 MsgFortifyLeaderResp Term:3 Log:0/0 Rejected (Hint: 0)
+  3->2 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
   3->2 MsgAppResp Term:3 Log:0/13
 > 2 handling Ready
   Ready MustSync=false:

--- a/pkg/raft/testdata/probe_and_replicate.txt
+++ b/pkg/raft/testdata/probe_and_replicate.txt
@@ -496,10 +496,10 @@ stabilize 1 2
   Ready MustSync=true:
   HardState Term:8 Vote:1 Commit:18 Lead:1 LeadEpoch:1
   Messages:
-  2->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
+  2->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19)
 > 1 receiving messages
-  2->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
+  2->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19)
 > 1 handling Ready
   Ready MustSync=false:
@@ -532,10 +532,10 @@ stabilize 1 3
   Ready MustSync=true:
   HardState Term:8 Vote:1 Commit:14 Lead:1 LeadEpoch:1
   Messages:
-  3->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
+  3->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:1
   3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14)
 > 1 receiving messages
-  3->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
+  3->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:1
   3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14)
 > 1 handling Ready
   Ready MustSync=false:
@@ -593,10 +593,10 @@ stabilize 1 4
   Entries:
   8/21 EntryNormal ""
   Messages:
-  4->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
+  4->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:1
   4->1 MsgAppResp Term:8 Log:0/21
 > 1 receiving messages
-  4->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
+  4->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:1
   4->1 MsgAppResp Term:8 Log:0/21
 > 1 handling Ready
   Ready MustSync=false:
@@ -632,10 +632,10 @@ stabilize 1 5
   Ready MustSync=true:
   HardState Term:8 Commit:18 Lead:1 LeadEpoch:1
   Messages:
-  5->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
+  5->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:1
   5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18)
 > 1 receiving messages
-  5->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
+  5->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:1
   5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18)
 > 1 handling Ready
   Ready MustSync=false:
@@ -678,10 +678,10 @@ stabilize 1 6
   Ready MustSync=true:
   HardState Term:8 Vote:1 Commit:15 Lead:1 LeadEpoch:1
   Messages:
-  6->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
+  6->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:1
   6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17)
 > 1 receiving messages
-  6->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
+  6->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:1
   6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17)
 > 1 handling Ready
   Ready MustSync=false:
@@ -736,10 +736,10 @@ stabilize 1 7
   Ready MustSync=true:
   HardState Term:8 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   Messages:
-  7->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
+  7->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:1
   7->1 MsgAppResp Term:8 Log:3/20 Rejected (Hint: 20)
 > 1 receiving messages
-  7->1 MsgFortifyLeaderResp Term:8 Log:0/0 Rejected (Hint: 0)
+  7->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:1
   7->1 MsgAppResp Term:8 Log:3/20 Rejected (Hint: 20)
 > 1 handling Ready
   Ready MustSync=false:

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp_behind.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp_behind.txt
@@ -147,13 +147,13 @@ stabilize 3
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   Snapshot Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
-  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   3->1 MsgAppResp Term:1 Log:0/11
 
 stabilize 1
 ----
 > 1 receiving messages
-  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   3->1 MsgAppResp Term:1 Log:0/11
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=11 next=13 paused pendingSnap=12]
 > 1 handling Ready


### PR DESCRIPTION
Previously, we were always rejecting fortification requests. This patch correctly returns a fortification response by including the leader's supported store liveness epcoh in the MsgFortifyLeaderResp if the follower supports the leader in its StoreLiveness fabric.

Closes https://github.com/cockroachdb/cockroach/issues/125261

Release note: None