### PR TITLE
kvflowcontrolpb,kvserverpb: add AdmittedResponseForRange

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb/BUILD.bazel
@@ -7,7 +7,10 @@ proto_library(
     srcs = ["kvflowcontrol.proto"],
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_gogo_protobuf//gogoproto:gogo_proto"],
+    deps = [
+        "//pkg/raft/raftpb:raftpb_proto",
+        "@com_github_gogo_protobuf//gogoproto:gogo_proto",
+    ],
 )
 
 go_proto_library(
@@ -17,6 +20,7 @@ go_proto_library(
     proto = ":kvflowcontrolpb_proto",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/raft/raftpb",
         "//pkg/roachpb",  # keep
         "@com_github_gogo_protobuf//gogoproto",
     ],

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb/kvflowcontrol.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb/kvflowcontrol.go
@@ -53,3 +53,11 @@ func (a AdmittedRaftLogEntries) SafeFormat(w redact.SafePrinter, _ rune) {
 	w.Printf("admitted-entries (r%s s%s pri=%s up-to-%s)",
 		a.RangeID, a.StoreID, admissionpb.WorkPriority(a.AdmissionPriority), a.UpToRaftLogPosition)
 }
+
+func (a AdmittedResponseForRange) String() string {
+	return redact.StringWithoutMarkers(a)
+}
+
+func (a AdmittedResponseForRange) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("admitted-response (s%s r%s %s)", a.LeaderStoreID, a.RangeID, a.Msg.String())
+}

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb/kvflowcontrol.proto
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb/kvflowcontrol.proto
@@ -13,6 +13,7 @@ package cockroach.kv.kvserver.kvflowcontrol.kvflowcontrolpb;
 option go_package = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb";
 
 import "gogoproto/gogo.proto";
+import "raft/raftpb/raft.proto";
 
 // RaftAdmissionMeta contains information used by admission control for the
 // select raft commands that use replication admission control. It contains a
@@ -77,6 +78,8 @@ message RaftAdmissionMeta {
   // small write sizes). The ideas above are too complicated.
 }
 
+// AdmittedRaftLogEntries is only used by RACv1.
+//
 // AdmittedRaftLogEntries represents a set of raft log entries that were
 // admitted below raft. These are identified by:
 // - the range ID (there's one per raft group);
@@ -125,4 +128,24 @@ message RaftLogPosition {
 
   uint64 term = 1;
   uint64 index = 2;
+}
+
+// AdmittedResponseForRange is only used in RACv2. It contains a MsgAppResp
+// from a follower to a leader, that was generated to advance the admitted
+// vector for that follower, maintained by the leader.
+message AdmittedResponseForRange {
+  option (gogoproto.goproto_stringer) = false;
+
+  // LeaderStoreID is used to route the request when this message is received
+  // at the leader node.
+  uint64 leader_store_id = 1 [(gogoproto.customname) = "LeaderStoreID",
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.StoreID"];
+
+  // RangeID of the raft group to which the MsgAppResp is directed. Used for
+  // routing at the leader node.
+  int64 range_id = 2 [(gogoproto.customname) = "RangeID",
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"];
+
+  // Msg is the MsgAppResp containing the admitted vector.
+  raftpb.Message msg = 3 [(gogoproto.nullable) = false];
 }

--- a/pkg/kv/kvserver/kvserverpb/raft.proto
+++ b/pkg/kv/kvserver/kvserverpb/raft.proto
@@ -104,6 +104,10 @@ message RaftMessageRequest {
   // priority of the Entries in the Message are overridden to be
   // raftpb.LowPri.
   bool low_priority_override = 13;
+
+  // AdmittedResponse is used in RACv2, for piggybacking MsgAppResp messages
+  // from a follower to a leader, that advance admitted for a follower.
+  repeated kv.kvserver.kvflowcontrol.kvflowcontrolpb.AdmittedResponseForRange admitted_response = 14 [(gogoproto.nullable) = false];
   reserved 10;
 }
 


### PR DESCRIPTION
For piggybacking a MsgAppResp message from a follower to the leader, to advance admitted. Also, RaftMessageRequest.AdmittedResponse contains these piggybacked messages

Informs #128309

Epic: CRDB-37515

Release note: None