### PR TITLE
sql/sem/tree: remove duplicate `tree.NewDOidWithName` function

### DIFF
--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -374,7 +374,9 @@ func (c *CustomFuncs) foldOIDFamilyCast(
 			}
 
 			c.mem.Metadata().AddDependency(opt.DepByName(&resName), ds, privilege.SELECT)
-			dOid = tree.NewDOidWithName(oid.Oid(ds.PostgresDescriptorID()), types.RegClass, string(tn.ObjectName))
+			dOid = tree.NewDOidWithTypeAndName(
+				oid.Oid(ds.PostgresDescriptorID()), types.RegClass, string(tn.ObjectName),
+			)
 
 		default:
 			return nil, false, nil

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2136,9 +2136,9 @@ https://www.postgresql.org/docs/9.5/catalog-pg-inherits.html`,
 }
 
 // Match the OIDs that Postgres uses for languages.
-var languageInternalOid = tree.NewDOidWithName(oid.Oid(12), types.Oid, "internal")
-var languageSqlOid = tree.NewDOidWithName(oid.Oid(14), types.Oid, "sql")
-var languagePlpgsqlOid = tree.NewDOidWithName(oid.Oid(14024), types.Oid, "plpgsql")
+var languageInternalOid = tree.NewDOidWithTypeAndName(oid.Oid(12), types.Oid, "internal")
+var languageSqlOid = tree.NewDOidWithTypeAndName(oid.Oid(14), types.Oid, "sql")
+var languagePlpgsqlOid = tree.NewDOidWithTypeAndName(oid.Oid(14024), types.Oid, "plpgsql")
 
 var pgCatalogLanguageTable = virtualSchemaTable{
 	comment: `available languages
@@ -2447,7 +2447,7 @@ https://www.postgresql.org/docs/9.6/view-pg-prepared-statements.html`,
 			paramNames := make([]string, len(placeholderTypes))
 
 			for i, placeholderType := range placeholderTypes {
-				paramTypes.Array[i] = tree.NewDOidWithName(
+				paramTypes.Array[i] = tree.NewDOidWithTypeAndName(
 					placeholderType.Oid(),
 					placeholderType,
 					placeholderType.SQLStandardName(),
@@ -4876,7 +4876,7 @@ https://www.postgresql.org/docs/9.6/catalog-pg-aggregate.html`,
 								}
 							}
 						}
-						regprocForZeroOid := tree.NewDOidWithName(0, types.RegProc, "-")
+						regprocForZeroOid := tree.NewDOidWithTypeAndName(0, types.RegProc, "-")
 						err := addRow(
 							tree.NewDOid(overload.Oid).AsRegProc(name), // aggfnoid
 							aggregateKind,     // aggkind

--- a/pkg/sql/resolve_oid.go
+++ b/pkg/sql/resolve_oid.go
@@ -87,7 +87,7 @@ func resolveOID(
 		return nil, true, pgerror.Newf(info.errType,
 			"%s %s does not exist", info.objName, toResolve)
 	}
-	return tree.NewDOidWithName(
+	return tree.NewDOidWithTypeAndName(
 		results[0].(*tree.DOid).Oid,
 		resultType,
 		tree.AsStringWithFlags(results[1], tree.FmtBareStrings),

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -550,7 +550,9 @@ func makeCreateRegDef(typ *types.T) builtinDefinition {
 			},
 			ReturnType: tree.FixedReturnType(typ),
 			Fn: func(_ context.Context, _ *eval.Context, d tree.Datums) (tree.Datum, error) {
-				return tree.NewDOidWithName(tree.MustBeDOid(d[0]).Oid, typ, string(tree.MustBeDString(d[1]))), nil
+				return tree.NewDOidWithTypeAndName(
+					tree.MustBeDOid(d[0]).Oid, typ, string(tree.MustBeDString(d[1])),
+				), nil
 			},
 			Info:       notUsableInfo,
 			Volatility: volatility.Immutable,

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -5562,16 +5562,6 @@ func MustBeDOid(e Expr) *DOid {
 	return i
 }
 
-// NewDOidWithName is a helper routine to create a *DOid initialized from a DInt
-// and a string.
-func NewDOidWithName(d oid.Oid, typ *types.T, name string) *DOid {
-	return &DOid{
-		Oid:          d,
-		semanticType: typ,
-		name:         name,
-	}
-}
-
 // AsRegProc changes the input DOid into a regproc with the given name and
 // returns it.
 func (d *DOid) AsRegProc(name string) *DOid {
@@ -5929,7 +5919,7 @@ func NewDefaultDatum(collationEnv *CollationEnvironment, t *types.T) (d Datum, e
 	case types.CollatedStringFamily:
 		return NewDCollatedString("", t.Locale(), collationEnv)
 	case types.OidFamily:
-		return NewDOidWithName(t.Oid(), t, t.SQLStandardName()), nil
+		return NewDOidWithTypeAndName(t.Oid(), t, t.SQLStandardName()), nil
 	case types.UnknownFamily:
 		return DNull, nil
 	case types.UuidFamily:

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -367,17 +367,17 @@ func TestFormatExpr2(t *testing.T) {
 		f        tree.FmtFlags
 		expected string
 	}{
-		{tree.NewDOidWithName(10, types.RegClass, "foo"),
+		{tree.NewDOidWithTypeAndName(10, types.RegClass, "foo"),
 			tree.FmtParsable, `crdb_internal.create_regclass(10,'foo'):::REGCLASS`},
-		{tree.NewDOidWithName(10, types.RegNamespace, "foo"),
+		{tree.NewDOidWithTypeAndName(10, types.RegNamespace, "foo"),
 			tree.FmtParsable, `crdb_internal.create_regnamespace(10,'foo'):::REGNAMESPACE`},
-		{tree.NewDOidWithName(10, types.RegProc, "foo"),
+		{tree.NewDOidWithTypeAndName(10, types.RegProc, "foo"),
 			tree.FmtParsable, `crdb_internal.create_regproc(10,'foo'):::REGPROC`},
-		{tree.NewDOidWithName(10, types.RegProcedure, "foo"),
+		{tree.NewDOidWithTypeAndName(10, types.RegProcedure, "foo"),
 			tree.FmtParsable, `crdb_internal.create_regprocedure(10,'foo'):::REGPROCEDURE`},
-		{tree.NewDOidWithName(10, types.RegRole, "foo"),
+		{tree.NewDOidWithTypeAndName(10, types.RegRole, "foo"),
 			tree.FmtParsable, `crdb_internal.create_regrole(10,'foo'):::REGROLE`},
-		{tree.NewDOidWithName(10, types.RegType, "foo"),
+		{tree.NewDOidWithTypeAndName(10, types.RegType, "foo"),
 			tree.FmtParsable, `crdb_internal.create_regtype(10,'foo'):::REGTYPE`},
 
 		// Ensure that nulls get properly type annotated when printed in an


### PR DESCRIPTION
The `tree.NewDOidWithName` function has been removed. All previous
callers now use `tree.NewDOidWithTypeAndName` which is exactly the same.

Epic: None

Release note: None
