### PR TITLE
changefeedccl: fix flush_hist_nanos callback

### DIFF
--- a/pkg/ccl/changefeedccl/batching_sink.go
+++ b/pkg/ccl/changefeedccl/batching_sink.go
@@ -115,7 +115,6 @@ type rowEvent struct {
 // Flush implements the Sink interface, returning the first error that has
 // occured in the past EmitRow calls.
 func (s *batchingSink) Flush(ctx context.Context) error {
-	defer s.metrics.recordFlushRequestCallback()()
 	flushWaiter := make(chan struct{})
 	select {
 	case <-ctx.Done():

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -836,6 +836,7 @@ func (ca *changeAggregator) flushBufferedEvents() error {
 	if err := ca.eventConsumer.Flush(ca.Ctx()); err != nil {
 		return err
 	}
+	defer ca.sliMetrics.recordFlushRequestCallback()()
 	return ca.sink.Flush(ca.Ctx())
 }
 
@@ -1875,6 +1876,8 @@ func (cf *changeFrontier) maybeEmitResolved(newResolved hlc.Timestamp) error {
 	if !shouldEmit {
 		return nil
 	}
+
+	defer cf.sliMetrics.recordFlushRequestCallback()()
 	if err := emitResolvedTimestamp(cf.Ctx(), cf.encoder, cf.sink, newResolved); err != nil {
 		return err
 	}

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -579,7 +579,6 @@ func (s *bufferSink) EmitResolvedTimestamp(
 
 // Flush implements the Sink interface.
 func (s *bufferSink) Flush(_ context.Context) error {
-	defer s.metrics.recordFlushRequestCallback()()
 	return nil
 }
 
@@ -676,7 +675,6 @@ func (n *nullSink) EmitResolvedTimestamp(
 
 // Flush implements Sink interface.
 func (n *nullSink) Flush(ctx context.Context) error {
-	defer n.metrics.recordFlushRequestCallback()()
 	if log.V(2) {
 		log.Info(ctx, "flushing")
 	}

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -690,8 +690,6 @@ func (s *cloudStorageSink) Flush(ctx context.Context) error {
 		return errors.New(`cannot Flush on a closed sink`)
 	}
 
-	s.metrics.recordFlushRequestCallback()()
-
 	var err error
 	s.files.Ascend(func(i btree.Item) (wantMore bool) {
 		err = s.flushFile(ctx, i.(*cloudStorageSinkFile))
@@ -857,9 +855,7 @@ func (s *cloudStorageSink) asyncFlusher(ctx context.Context) error {
 			}
 
 			// flush file to storage.
-			flushDone := s.metrics.recordFlushRequestCallback()
 			err := req.file.flushToStorage(ctx, s.es, req.dest, s.metrics)
-			flushDone()
 
 			if err != nil {
 				log.Errorf(ctx, "error flushing file to storage: %s", err)

--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -443,8 +443,6 @@ func (s *kafkaSink) EmitResolvedTimestamp(
 
 // Flush implements the Sink interface.
 func (s *kafkaSink) Flush(ctx context.Context) error {
-	defer s.metrics.recordFlushRequestCallback()()
-
 	flushCh := make(chan struct{}, 1)
 	var inflight int64
 	var flushErr error

--- a/pkg/ccl/changefeedccl/sink_pubsub.go
+++ b/pkg/ccl/changefeedccl/sink_pubsub.go
@@ -252,8 +252,6 @@ func (p *deprecatedPubsubSink) Flush(ctx context.Context) error {
 }
 
 func (p *deprecatedPubsubSink) flush(ctx context.Context) error {
-	defer p.metrics.recordFlushRequestCallback()()
-
 	select {
 	case <-ctx.Done():
 		return ctx.Err()

--- a/pkg/ccl/changefeedccl/sink_sql.go
+++ b/pkg/ccl/changefeedccl/sink_sql.go
@@ -196,8 +196,6 @@ func (s *sqlSink) emit(
 
 // Flush implements the Sink interface.
 func (s *sqlSink) Flush(ctx context.Context) error {
-	defer s.metrics.recordFlushRequestCallback()()
-
 	if len(s.rowBuf) == 0 {
 		return nil
 	}

--- a/pkg/ccl/changefeedccl/sink_webhook.go
+++ b/pkg/ccl/changefeedccl/sink_webhook.go
@@ -705,8 +705,6 @@ func (s *deprecatedWebhookSink) EmitResolvedTimestamp(
 }
 
 func (s *deprecatedWebhookSink) Flush(ctx context.Context) error {
-	s.metrics.recordFlushRequestCallback()()
-
 	// Send flush request.
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
The flush_hist_nanos metric is calculated in a metrics callback. Before this change, the cloud storage and webhook v1 sinks would immediately call the callback before performing flush logic, which led to unexpectedly small flush_hist_nanos. This change moves the callback out of sink-specific logic so that the callback is correctly deferred for all sinks.

Epic: CRDB-37337
Fixes: #121248

Release note (bug fix): The changefeed.flush_hist_nanos metric now tracks the time it takes to flush for the cloud storage and old webhook sinks. Before this change, changefeed.flush_hist_nanos would appear erroneously as near 0 for these sinks.