### PR TITLE
storeliveness: persist support state and metas

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -219,6 +219,20 @@ var (
 	// is to allow a restarting node to discover approximately how long it has
 	// been down without needing to retrieve liveness records from the cluster.
 	localStoreLastUpSuffix = []byte("uptm")
+	// localStoreLivenessRequesterMeta stores the Store Liveness metadata
+	// corresponding to support requested by the local store. In particular,
+	// RequesterMeta stores the highest timestamp and highest epoch at which
+	// support has been requested.
+	localStoreLivenessRequesterMeta = []byte("slrm")
+	// localStoreLivenessSupporterMeta stores the Store Liveness metadata
+	// corresponding to support provided by the local store. In particular,
+	// SupporterMeta stores the highest timestamp at which support has been
+	// withdrawn.
+	localStoreLivenessSupporterMeta = []byte("slsm")
+	// localStoreLivenessSupportFor stores the Store Liveness support by the local
+	// store for a store in the cluster. It includes the epoch and expiration of
+	// support.
+	localStoreLivenessSupportFor = []byte("slsf")
 	// localRemovedLeakedRaftEntriesSuffix is DEPRECATED and remains to prevent
 	// reuse.
 	localRemovedLeakedRaftEntriesSuffix = []byte("dlre")

--- a/pkg/keys/doc.go
+++ b/pkg/keys/doc.go
@@ -218,6 +218,9 @@ var _ = [...]interface{}{
 	StoreIdentKey,                    // "iden"
 	StoreUnsafeReplicaRecoveryKey,    // "loqr"
 	StoreNodeTombstoneKey,            // "ntmb"
+	StoreLivenessRequesterMetaKey,    // "slrm"
+	StoreLivenessSupportForKey,       // "slsf"
+	StoreLivenessSupporterMetaKey,    // "slsm"
 	StoreCachedSettingsKey,           // "stng"
 	StoreLastUpKey,                   // "uptm"
 

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -102,6 +102,49 @@ func DecodeNodeTombstoneKey(key roachpb.Key) (roachpb.NodeID, error) {
 	return roachpb.NodeID(nodeID), err
 }
 
+// StoreLivenessRequesterMetaKey returns the key for the local store's Store
+// Liveness requester metadata.
+func StoreLivenessRequesterMetaKey() roachpb.Key {
+	return MakeStoreKey(localStoreLivenessRequesterMeta, nil)
+}
+
+// StoreLivenessSupporterMetaKey returns the key for the local store's Store
+// Liveness supporter metadata.
+func StoreLivenessSupporterMetaKey() roachpb.Key {
+	return MakeStoreKey(localStoreLivenessSupporterMeta, nil)
+}
+
+// StoreLivenessSupportForKey returns the key for the Store Liveness support
+// by the local store for a given store identified by nodeID and storeID.
+func StoreLivenessSupportForKey(nodeID roachpb.NodeID, storeID roachpb.StoreID) roachpb.Key {
+	nodeIDAndStoreID := uint64(nodeID)<<32 | uint64(storeID)
+	return MakeStoreKey(
+		localStoreLivenessSupportFor, encoding.EncodeUint64Ascending(nil, nodeIDAndStoreID),
+	)
+}
+
+// DecodeStoreLivenessSupportForKey returns the node ID and store ID of a given
+// localStoreLivenessSupportFor key.
+func DecodeStoreLivenessSupportForKey(key roachpb.Key) (roachpb.NodeID, roachpb.StoreID, error) {
+	suffix, detail, err := DecodeStoreKey(key)
+	if err != nil {
+		return 0, 0, err
+	}
+	if !suffix.Equal(localStoreLivenessSupportFor) {
+		return 0, 0, errors.Errorf("key with suffix %q != %q", suffix, localStoreLivenessSupportFor)
+	}
+	detail, nodeIDAndStoreID, err := encoding.DecodeUint64Ascending(detail)
+	if err != nil {
+		return 0, 0, err
+	}
+	if len(detail) != 0 {
+		return 0, 0, errors.Errorf("invalid key has trailing garbage: %q", detail)
+	}
+	nodeID := roachpb.NodeID(nodeIDAndStoreID >> 32)
+	storeID := roachpb.StoreID(nodeIDAndStoreID & math.MaxUint32)
+	return nodeID, storeID, nil
+}
+
 // StoreCachedSettingsKey returns a store-local key for store's cached settings.
 func StoreCachedSettingsKey(settingKey roachpb.Key) roachpb.Key {
 	return MakeStoreKey(localStoreCachedSettingsSuffix, encoding.EncodeBytesAscending(nil, settingKey))

--- a/pkg/kv/kvserver/storeliveness/BUILD.bazel
+++ b/pkg/kv/kvserver/storeliveness/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "storeliveness",
     srcs = [
         "fabric.go",
+        "persist.go",
         "requester_state.go",
         "supporter_state.go",
         "transport.go",
@@ -11,12 +12,15 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/keys",
         "//pkg/kv/kvserver/storeliveness/storelivenesspb",
         "//pkg/roachpb",
         "//pkg/rpc",
         "//pkg/rpc/nodedialer",
+        "//pkg/storage",
         "//pkg/util/hlc",
         "//pkg/util/log",
+        "//pkg/util/protoutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
@@ -28,6 +32,7 @@ go_library(
 go_test(
     name = "storeliveness_test",
     srcs = [
+        "persist_test.go",
         "store_liveness_test.go",
         "transport_test.go",
     ],
@@ -40,6 +45,7 @@ go_test(
         "//pkg/rpc",
         "//pkg/rpc/nodedialer",
         "//pkg/settings/cluster",
+        "//pkg/storage",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
         "//pkg/util",

--- a/pkg/kv/kvserver/storeliveness/persist.go
+++ b/pkg/kv/kvserver/storeliveness/persist.go
@@ -1,0 +1,100 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package storeliveness
+
+import (
+	"context"
+	"math"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	slpb "github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness/storelivenesspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+)
+
+// readRequesterMeta reads the RequesterMeta from disk.
+func readRequesterMeta(ctx context.Context, r storage.Reader) (slpb.RequesterMeta, error) {
+	var rm slpb.RequesterMeta
+	key := keys.StoreLivenessRequesterMetaKey()
+	err := readProto(ctx, r, key, &rm)
+	return rm, err
+}
+
+// readSupporterMeta reads the SupporterMeta from disk.
+func readSupporterMeta(ctx context.Context, r storage.Reader) (slpb.SupporterMeta, error) {
+	var sm slpb.SupporterMeta
+	key := keys.StoreLivenessSupporterMetaKey()
+	err := readProto(ctx, r, key, &sm)
+	return sm, err
+}
+
+func readProto(
+	ctx context.Context, r storage.Reader, key roachpb.Key, msg protoutil.Message,
+) error {
+	_, err := storage.MVCCGetProto(ctx, r, key, hlc.Timestamp{}, msg, storage.MVCCGetOptions{})
+	return err
+}
+
+// readSupportForState iterates over all StoreLivenessSupportForKeys and reads
+// SupportStates stored to disk. Before returning each of them, it populates the
+// Target field with the store identifier from the key.
+func readSupportForState(ctx context.Context, r storage.Reader) ([]slpb.SupportState, error) {
+	var sss []slpb.SupportState
+	minKey := keys.StoreLivenessSupportForKey(0, 0)
+	maxKey := keys.StoreLivenessSupportForKey(math.MaxInt32, math.MaxInt32)
+	_, err := storage.MVCCIterate(
+		ctx, r, minKey, maxKey, hlc.Timestamp{},
+		storage.MVCCScanOptions{}, func(kv roachpb.KeyValue) error {
+			sss = append(sss, slpb.SupportState{})
+			ss := &sss[len(sss)-1]
+			if err := kv.Value.GetProto(ss); err != nil {
+				return err
+			}
+			nodeID, storeID, err := keys.DecodeStoreLivenessSupportForKey(kv.Key)
+			if err != nil {
+				return err
+			}
+			ss.Target = slpb.StoreIdent{NodeID: nodeID, StoreID: storeID}
+			return nil
+		},
+	)
+	return sss, err
+}
+
+// writeRequesterMeta writes the RequesterMeta to disk.
+func writeRequesterMeta(ctx context.Context, rw storage.ReadWriter, rm slpb.RequesterMeta) error {
+	key := keys.StoreLivenessRequesterMetaKey()
+	return writeProto(ctx, rw, key, &rm)
+}
+
+// writeSupporterMeta writes the SupporterMeta to disk.
+func writeSupporterMeta(ctx context.Context, rw storage.ReadWriter, sm slpb.SupporterMeta) error {
+	key := keys.StoreLivenessSupporterMetaKey()
+	return writeProto(ctx, rw, key, &sm)
+}
+
+// writeSupportForState writes a single SupportState corresponding to a
+// supportFor entry. Before doing so, as an optimization, it clears the Target
+// field; the store identifier is available in StoreLivenessSupportForKey, and
+// it is populated into Target again upon read.
+func writeSupportForState(ctx context.Context, rw storage.ReadWriter, ss slpb.SupportState) error {
+	key := keys.StoreLivenessSupportForKey(ss.Target.NodeID, ss.Target.StoreID)
+	ss.Target.Reset()
+	return writeProto(ctx, rw, key, &ss)
+}
+
+func writeProto(
+	ctx context.Context, rw storage.ReadWriter, key roachpb.Key, msg protoutil.Message,
+) error {
+	return storage.MVCCPutProto(ctx, rw, key, hlc.Timestamp{}, msg, storage.MVCCWriteOptions{})
+}

--- a/pkg/kv/kvserver/storeliveness/persist_test.go
+++ b/pkg/kv/kvserver/storeliveness/persist_test.go
@@ -1,0 +1,79 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package storeliveness
+
+import (
+	"context"
+	"testing"
+
+	slpb "github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness/storelivenesspb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPersistReadAndWrite(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	engine := storage.NewDefaultInMemForTesting()
+	defer engine.Close()
+	rm := slpb.RequesterMeta{MaxEpoch: 3, MaxRequested: hlc.Timestamp{WallTime: 100, Logical: 1}}
+	sm := slpb.SupporterMeta{MaxWithdrawn: hlc.ClockTimestamp{WallTime: 200, Logical: 2}}
+	ss1 := slpb.SupportState{
+		Target:     slpb.StoreIdent{NodeID: 1, StoreID: 1},
+		Epoch:      1,
+		Expiration: hlc.Timestamp{WallTime: 300, Logical: 3},
+	}
+	ss2 := slpb.SupportState{
+		Target:     slpb.StoreIdent{NodeID: 2, StoreID: 2},
+		Epoch:      2,
+		Expiration: hlc.Timestamp{WallTime: 400, Logical: 4},
+	}
+
+	// Write RequesterMeta, read it, and make sure it's identical to the original.
+	if err := writeRequesterMeta(ctx, engine, rm); err != nil {
+		t.Errorf("writing RequesterMeta failed: %v", err)
+	}
+	rmRead, err := readRequesterMeta(ctx, engine)
+	if err != nil {
+		t.Errorf("reading RequesterMeta failed: %v", err)
+	}
+	require.Equal(t, rm, rmRead)
+
+	// Write SupporterMeta, read it, and make sure it's identical to the original.
+	if err := writeSupporterMeta(ctx, engine, sm); err != nil {
+		t.Errorf("writing SupporterMeta failed: %v", err)
+	}
+	smRead, err := readSupporterMeta(ctx, engine)
+	if err != nil {
+		t.Errorf("reading SupporterMeta failed: %v", err)
+	}
+	require.Equal(t, sm, smRead)
+
+	// Write two SupporterStates, read them, and make sure they're identical to
+	// the original ones.
+	if err := writeSupportForState(ctx, engine, ss1); err != nil {
+		t.Errorf("writing SupportState failed: %v", err)
+	}
+	if err := writeSupportForState(ctx, engine, ss2); err != nil {
+		t.Errorf("writing SupportState failed: %v", err)
+	}
+	ssRead, err := readSupportForState(ctx, engine)
+	if err != nil {
+		t.Errorf("reading SupportState failed: %v", err)
+	}
+	require.Equal(t, ss1, ssRead[0])
+	require.Equal(t, ss2, ssRead[1])
+}

--- a/pkg/kv/kvserver/storeliveness/requester_state.go
+++ b/pkg/kv/kvserver/storeliveness/requester_state.go
@@ -11,10 +11,12 @@
 package storeliveness
 
 import (
+	"context"
 	"sync/atomic"
 	"time"
 
 	slpb "github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness/storelivenesspb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
@@ -63,7 +65,7 @@ type requesterStateHandler struct {
 func newRequesterStateHandler() *requesterStateHandler {
 	rsh := &requesterStateHandler{
 		requesterState: requesterState{
-			meta:        slpb.RequesterMeta{MaxEpoch: 1},
+			meta:        slpb.RequesterMeta{},
 			supportFrom: make(map[slpb.StoreIdent]slpb.SupportState),
 		},
 	}
@@ -134,10 +136,26 @@ func (rsh *requesterStateHandler) removeStore(id slpb.StoreIdent) {
 
 // Functions for handling requesterState updates.
 
+// assertMeta ensures the meta in the inProgress view does not regress any of
+// the meta fields in the checkedIn view.
+func (rsfu *requesterStateForUpdate) assertMeta() {
+	assert(
+		rsfu.checkedIn.meta.MaxEpoch <= rsfu.inProgress.meta.MaxEpoch,
+		"max epoch regressed during update",
+	)
+	assert(
+		rsfu.checkedIn.meta.MaxRequested.LessEq(rsfu.inProgress.meta.MaxRequested),
+		"max requested regressed during update",
+	)
+}
+
 // getMeta returns the RequesterMeta from the inProgress view; if not present,
-// it falls back to the RequesterMeta from the checkedIn view.
+// it falls back to the RequesterMeta from the checkedIn view. If there are
+// fields in inProgress.meta that were not modified in this update, they will
+// contain the values from checkedIn.meta.
 func (rsfu *requesterStateForUpdate) getMeta() slpb.RequesterMeta {
 	if rsfu.inProgress.meta != (slpb.RequesterMeta{}) {
+		rsfu.assertMeta()
 		return rsfu.inProgress.meta
 	}
 	return rsfu.checkedIn.meta
@@ -161,6 +179,31 @@ func (rsfu *requesterStateForUpdate) getSupportFrom(
 func (rsfu *requesterStateForUpdate) reset() {
 	rsfu.inProgress.meta = slpb.RequesterMeta{}
 	clear(rsfu.inProgress.supportFrom)
+}
+
+// write writes the requester meta to disk if it changed in this update.
+func (rsfu *requesterStateForUpdate) write(ctx context.Context, rw storage.ReadWriter) error {
+	if rsfu.inProgress.meta == (slpb.RequesterMeta{}) {
+		return nil
+	}
+	rsfu.assertMeta()
+	if err := writeRequesterMeta(ctx, rw, rsfu.inProgress.meta); err != nil {
+		return err
+	}
+	return nil
+}
+
+// read reads the requester meta from disk and populates it in
+// requesterStateHandler.requesterState.
+func (rsh *requesterStateHandler) read(ctx context.Context, r storage.Reader) error {
+	meta, err := readRequesterMeta(ctx, r)
+	if err != nil {
+		return err
+	}
+	rsh.mu.Lock()
+	defer rsh.mu.Unlock()
+	rsh.requesterState.meta = meta
+	return nil
 }
 
 // checkOutUpdate returns the requesterStateForUpdate referenced in
@@ -188,12 +231,8 @@ func (rsh *requesterStateHandler) checkInUpdate(rsfu *requesterStateForUpdate) {
 	rsh.mu.Lock()
 	defer rsh.mu.Unlock()
 	if rsfu.inProgress.meta != (slpb.RequesterMeta{}) {
-		if !rsfu.inProgress.meta.MaxRequested.IsEmpty() {
-			rsfu.checkedIn.meta.MaxRequested = rsfu.inProgress.meta.MaxRequested
-		}
-		if rsfu.inProgress.meta.MaxEpoch != 0 {
-			rsfu.checkedIn.meta.MaxEpoch = rsfu.inProgress.meta.MaxEpoch
-		}
+		rsfu.assertMeta()
+		rsfu.checkedIn.meta = rsfu.inProgress.meta
 	}
 	for storeID, ss := range rsfu.inProgress.supportFrom {
 		rsfu.checkedIn.supportFrom[storeID] = ss
@@ -217,16 +256,15 @@ func (rsfu *requesterStateForUpdate) getHeartbeatsToSend(
 // liveness interval.
 func (rsfu *requesterStateForUpdate) updateMaxRequested(now hlc.Timestamp, interval time.Duration) {
 	newMaxRequested := now.Add(interval.Nanoseconds(), 0)
-	if rsfu.getMeta().MaxRequested.Less(newMaxRequested) {
-		rsfu.inProgress.meta.MaxRequested.Forward(newMaxRequested)
+	meta := rsfu.getMeta()
+	if meta.MaxRequested.Forward(newMaxRequested) {
+		// Update the entire meta struct to ensure MaxEpoch is not overwritten.
+		rsfu.inProgress.meta = meta
 	}
 }
 
 func (rsfu *requesterStateForUpdate) generateHeartbeats(from slpb.StoreIdent) []slpb.Message {
 	heartbeats := make([]slpb.Message, 0, len(rsfu.checkedIn.supportFrom))
-	// It's ok to read store IDs directly from rsfu.checkedIn.supportFrom since
-	// adding and removing stores is not allowed while there's an update in
-	// progress.
 	maxRequested := rsfu.getMeta().MaxRequested
 	// Assert that there are no updates in rsfu.inProgress.supportFrom to make
 	// sure we can iterate over rsfu.checkedIn.supportFrom in the loop below.
@@ -297,8 +335,10 @@ func handleHeartbeatResponse(
 
 // incrementMaxEpoch increments the inProgress view of MaxEpoch.
 func (rsfu *requesterStateForUpdate) incrementMaxEpoch() {
-	currentEpoch := rsfu.getMeta().MaxEpoch
-	rsfu.inProgress.meta.MaxEpoch = currentEpoch + 1
+	meta := rsfu.getMeta()
+	meta.MaxEpoch++
+	// Update the entire meta struct to ensure MaxRequested is not overwritten.
+	rsfu.inProgress.meta = meta
 }
 
 func assert(condition bool, msg string) {

--- a/pkg/kv/kvserver/storeliveness/supporter_state.go
+++ b/pkg/kv/kvserver/storeliveness/supporter_state.go
@@ -11,9 +11,11 @@
 package storeliveness
 
 import (
+	"context"
 	"sync/atomic"
 
 	slpb "github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness/storelivenesspb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
@@ -105,10 +107,22 @@ func (ssh *supporterStateHandler) getSupportFor(id slpb.StoreIdent) slpb.Support
 
 // Functions for handling supporterState updates.
 
+// assertMeta ensures the meta in the inProgress view does not regress any of
+// the meta fields in the checkedIn view.
+func (ssfu *supporterStateForUpdate) assertMeta() {
+	assert(
+		ssfu.checkedIn.meta.MaxWithdrawn.LessEq(ssfu.inProgress.meta.MaxWithdrawn),
+		"max withdrawn regressed during update",
+	)
+}
+
 // getMeta returns the SupporterMeta from the inProgress view; if not present,
-// it falls back to the SupporterMeta from the checkedIn view.
+// it falls back to the SupporterMeta from the checkedIn view. If there are
+// fields in inProgress.meta that were not modified in this update, they will
+// contain the values from checkedIn.meta.
 func (ssfu *supporterStateForUpdate) getMeta() slpb.SupporterMeta {
 	if ssfu.inProgress.meta != (slpb.SupporterMeta{}) {
+		ssfu.assertMeta()
 		return ssfu.inProgress.meta
 	}
 	return ssfu.checkedIn.meta
@@ -132,6 +146,47 @@ func (ssfu *supporterStateForUpdate) getSupportFor(
 func (ssfu *supporterStateForUpdate) reset() {
 	ssfu.inProgress.meta = slpb.SupporterMeta{}
 	clear(ssfu.inProgress.supportFor)
+}
+
+// write writes the supporter meta and supportFor to disk if they changed in
+// this update.
+func (ssfu *supporterStateForUpdate) write(ctx context.Context, rw storage.ReadWriter) error {
+	if ssfu.inProgress.meta == (slpb.SupporterMeta{}) && len(ssfu.inProgress.supportFor) == 0 {
+		return nil
+	}
+	if ssfu.inProgress.meta != (slpb.SupporterMeta{}) {
+		ssfu.assertMeta()
+		if err := writeSupporterMeta(ctx, rw, ssfu.inProgress.meta); err != nil {
+			return err
+		}
+	}
+	for _, ss := range ssfu.inProgress.supportFor {
+		if err := writeSupportForState(ctx, rw, ss); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// read reads the supporter meta and supportFor from disk and populates them in
+// supporterStateHandler.supporterState.
+func (ssh *supporterStateHandler) read(ctx context.Context, r storage.Reader) error {
+	meta, err := readSupporterMeta(ctx, r)
+	if err != nil {
+		return err
+	}
+	supportFor, err := readSupportForState(ctx, r)
+	if err != nil {
+		return err
+	}
+	ssh.mu.Lock()
+	defer ssh.mu.Unlock()
+	ssh.supporterState.meta = meta
+	ssh.supporterState.supportFor = make(map[slpb.StoreIdent]slpb.SupportState, len(supportFor))
+	for _, s := range supportFor {
+		ssh.supporterState.supportFor[s.Target] = s
+	}
+	return nil
 }
 
 // checkOutUpdate returns the supporterStateForUpdate referenced in
@@ -159,9 +214,8 @@ func (ssh *supporterStateHandler) checkInUpdate(ssfu *supporterStateForUpdate) {
 	ssh.mu.Lock()
 	defer ssh.mu.Unlock()
 	if ssfu.inProgress.meta != (slpb.SupporterMeta{}) {
-		if !ssfu.inProgress.meta.MaxWithdrawn.IsEmpty() {
-			ssfu.checkedIn.meta.MaxWithdrawn = ssfu.inProgress.meta.MaxWithdrawn
-		}
+		ssfu.assertMeta()
+		ssfu.checkedIn.meta = ssfu.inProgress.meta
 	}
 	for storeID, ss := range ssfu.inProgress.supportFor {
 		ssfu.checkedIn.supportFor[storeID] = ss
@@ -222,8 +276,9 @@ func (ssfu *supporterStateForUpdate) withdrawSupport(now hlc.ClockTimestamp) {
 		ssNew := maybeWithdrawSupport(ss, now)
 		if ss != ssNew {
 			ssfu.inProgress.supportFor[id] = ssNew
-			if ssfu.getMeta().MaxWithdrawn.Less(now) {
-				ssfu.inProgress.meta.MaxWithdrawn.Forward(now)
+			meta := ssfu.getMeta()
+			if meta.MaxWithdrawn.Forward(now) {
+				ssfu.inProgress.meta = meta
 			}
 		}
 	}

--- a/pkg/kv/kvserver/storeliveness/testdata/basic
+++ b/pkg/kv/kvserver/storeliveness/testdata/basic
@@ -16,13 +16,10 @@ heartbeats:
 
 handle-messages
   msg type=MsgHeartbeat from-node-id=2 from-store-id=2 epoch=2 expiration=200
+  msg type=MsgHeartbeatResp from-node-id=2 from-store-id=2 epoch=1 expiration=110
 ----
 responses:
 {Type:MsgHeartbeatResp From:{NodeID:1 StoreID:1} To:{NodeID:2 StoreID:2} Epoch:2 Expiration:200.000000000,0}
-
-handle-messages
-  msg type=MsgHeartbeatResp from-node-id=2 from-store-id=2 epoch=1 expiration=110
-----
 
 support-from node-id=2 store-id=2
 ----

--- a/pkg/kv/kvserver/storeliveness/testdata/multi-store
+++ b/pkg/kv/kvserver/storeliveness/testdata/multi-store
@@ -25,17 +25,14 @@ handle-messages
   msg type=MsgHeartbeat from-node-id=1 from-store-id=2 epoch=2 expiration=102
   msg type=MsgHeartbeat from-node-id=2 from-store-id=3 epoch=3 expiration=103
   msg type=MsgHeartbeat from-node-id=2 from-store-id=4 epoch=4 expiration=104
+  msg type=MsgHeartbeatResp from-node-id=1 from-store-id=2 epoch=1 expiration=110
+  msg type=MsgHeartbeatResp from-node-id=2 from-store-id=3 epoch=2 expiration=0
+  msg type=MsgHeartbeatResp from-node-id=2 from-store-id=4 epoch=1 expiration=110
 ----
 responses:
 {Type:MsgHeartbeatResp From:{NodeID:1 StoreID:1} To:{NodeID:1 StoreID:2} Epoch:2 Expiration:102.000000000,0}
 {Type:MsgHeartbeatResp From:{NodeID:1 StoreID:1} To:{NodeID:2 StoreID:3} Epoch:3 Expiration:103.000000000,0}
 {Type:MsgHeartbeatResp From:{NodeID:1 StoreID:1} To:{NodeID:2 StoreID:4} Epoch:4 Expiration:104.000000000,0}
-
-handle-messages
-  msg type=MsgHeartbeatResp from-node-id=1 from-store-id=2 epoch=1 expiration=110
-  msg type=MsgHeartbeatResp from-node-id=2 from-store-id=3 epoch=2 expiration=0
-  msg type=MsgHeartbeatResp from-node-id=2 from-store-id=4 epoch=1 expiration=110
-----
 
 debug-requester-state
 ----

--- a/pkg/kv/kvserver/storeliveness/testdata/restart
+++ b/pkg/kv/kvserver/storeliveness/testdata/restart
@@ -7,7 +7,8 @@ add-store node-id=2 store-id=2
 ----
 
 # -------------------------------------------------------------
-# Store (n1, s1) established support for and from (n2, s2).
+# Store (n1, s1) establishes support for and from (n2, s2).
+# Each store also withdraws support from the other.
 # -------------------------------------------------------------
 
 send-heartbeats now=100 liveness-interval=10s
@@ -17,27 +18,34 @@ heartbeats:
 
 handle-messages
   msg type=MsgHeartbeat from-node-id=2 from-store-id=2 epoch=2 expiration=200
+  msg type=MsgHeartbeatResp from-node-id=2 from-store-id=2 epoch=1 expiration=110
 ----
 responses:
 {Type:MsgHeartbeatResp From:{NodeID:1 StoreID:1} To:{NodeID:2 StoreID:2} Epoch:2 Expiration:200.000000000,0}
 
-handle-messages
-  msg type=MsgHeartbeatResp from-node-id=2 from-store-id=2 epoch=1 expiration=110
+withdraw-support now=201
 ----
+
+handle-messages
+  msg type=MsgHeartbeat from-node-id=2 from-store-id=2 epoch=3 expiration=300
+  msg type=MsgHeartbeatResp from-node-id=2 from-store-id=2 epoch=2 expiration=0
+----
+responses:
+{Type:MsgHeartbeatResp From:{NodeID:1 StoreID:1} To:{NodeID:2 StoreID:2} Epoch:3 Expiration:300.000000000,0}
 
 debug-requester-state
 ----
 meta:
-{MaxEpoch:1 MaxRequested:110.000000000,0}
+{MaxEpoch:2 MaxRequested:110.000000000,0}
 support from:
-{Target:{NodeID:2 StoreID:2} Epoch:1 Expiration:110.000000000,0}
+{Target:{NodeID:2 StoreID:2} Epoch:2 Expiration:0,0}
 
 debug-supporter-state
 ----
 meta:
-{MaxWithdrawn:0,0}
+{MaxWithdrawn:201.000000000,0}
 support for:
-{Target:{NodeID:2 StoreID:2} Epoch:2 Expiration:200.000000000,0}
+{Target:{NodeID:2 StoreID:2} Epoch:3 Expiration:300.000000000,0}
 
 # -------------------------------------------------------------
 # Store (n1, s1) restarts.
@@ -49,15 +57,15 @@ restart
 debug-requester-state
 ----
 meta:
-{MaxEpoch:2 MaxRequested:110.000000000,0}
+{MaxEpoch:3 MaxRequested:110.000000000,0}
 support from:
 
 debug-supporter-state
 ----
 meta:
-{MaxWithdrawn:0,0}
+{MaxWithdrawn:201.000000000,0}
 support for:
-{Target:{NodeID:2 StoreID:2} Epoch:2 Expiration:200.000000000,0}
+{Target:{NodeID:2 StoreID:2} Epoch:3 Expiration:300.000000000,0}
 
 # -------------------------------------------------------------
 # Store (n1, s1) sends heartbeats but it forgot about support
@@ -78,4 +86,4 @@ add-store node-id=2 store-id=2
 send-heartbeats now=200 liveness-interval=10s
 ----
 heartbeats:
-{Type:MsgHeartbeat From:{NodeID:1 StoreID:1} To:{NodeID:2 StoreID:2} Epoch:2 Expiration:210.000000000,0}
+{Type:MsgHeartbeat From:{NodeID:1 StoreID:1} To:{NodeID:2 StoreID:2} Epoch:3 Expiration:210.000000000,0}


### PR DESCRIPTION
This commit adds functionality to write some of the Store Liveness data structures to disk and read them back upon restart. This is a key requirement for the algorithm correctness in order to ensure that the following guarantees hold across restarts:

1. Once a store provides support for another store, it will continue to do so until the support expires.

2. If a store withdraws support from another store for a given epoch, it will not ever again provide support for that store and epoch.

3. If a store has support for a given epoch, it will not request support for a higher epoch before the previous support has expired.

The first two guarantees help establish the Support Durability Invariant, while the third helps establish the Lease Disjointness Invariant

Fixes: #125061

Release note: None