### PR TITLE
rac2: implement wait for eval helper

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/util/buildutil",
         "//pkg/util/log",
         "//pkg/util/syncutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
     ],
 )
@@ -38,6 +39,7 @@ go_test(
         "//pkg/util/admission/admissionpb",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/syncutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_stretchr_testify//require",

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/wait_for_eval
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/wait_for_eval
@@ -1,0 +1,262 @@
+# This test demonstrates the behavior of concurrent WaitForEval operations with
+# binary token state management. 
+#
+# Start the first WaitForEval operation with a quorum of 2 and three handles.
+wait_for_eval name=a quorum=2
+handle: stream=s1 required=true
+handle: stream=s2 required=true
+handle: stream=s3 required=false
+----
+a: waiting
+
+# Start a second WaitForEval operation with a quorum of 2 and three handles.
+wait_for_eval name=b quorum=2
+handle: stream=s4 required=true
+handle: stream=s5 required=true
+handle: stream=s6 required=false
+----
+a: waiting
+b: waiting
+
+# Set tokens for streams s1 and s2 to positive, this should trigger the
+# completion of a but not b.
+set_tokens s1=positive s2=positive
+----
+s1: positive
+s2: positive
+s3: non-positive
+s4: non-positive
+s5: non-positive
+s6: non-positive
+
+check_state
+----
+a: wait_success
+b: waiting
+
+# Set tokens for stream s4 and s6 to positive, this won't trigger b as s5 is
+# required.
+set_tokens s4=positive s6=positive
+----
+s1: positive
+s2: positive
+s3: non-positive
+s4: positive
+s5: non-positive
+s6: positive
+
+# Check the state. b should still be waiting as s5 (required) has no tokens.
+check_state
+----
+a: wait_success
+b: waiting
+
+# Now set s5 to positive, which should complete b. Revert s1 to non-positive.
+set_tokens s5=positive s1=non-positive
+----
+s1: non-positive
+s2: positive
+s3: non-positive
+s4: positive
+s5: positive
+s6: positive
+
+check_state
+----
+a: wait_success
+b: wait_success
+
+# Test out multiple operations with overlapping streams
+wait_for_eval name=c quorum=2
+handle: stream=s1 required=false
+handle: stream=s4 required=false
+handle: stream=s7 required=false
+----
+a: wait_success
+b: wait_success
+c: waiting
+
+wait_for_eval name=d quorum=3
+handle: stream=s2 required=true
+handle: stream=s3 required=true
+handle: stream=s7 required=true
+----
+a: wait_success
+b: wait_success
+c: waiting
+d: waiting
+
+check_state
+----
+a: wait_success
+b: wait_success
+c: waiting
+d: waiting
+
+# Set s7 to positive, which should complete c but not d, as d has s5 required.
+set_tokens s7=positive
+----
+s1: non-positive
+s2: positive
+s3: non-positive
+s4: positive
+s5: positive
+s6: positive
+s7: positive
+
+check_state
+----
+a: wait_success
+b: wait_success
+c: wait_success
+d: waiting
+
+wait_for_eval name=e quorum=0
+handle: stream=s8 required=true
+handle: stream=s9 required=true
+handle: stream=s10 required=true
+----
+a: wait_success
+b: wait_success
+c: wait_success
+d: waiting
+e: waiting
+
+# Set only s8 to positive
+set_tokens s8=positive
+----
+s1: non-positive
+s10: non-positive
+s2: positive
+s3: non-positive
+s4: positive
+s5: positive
+s6: positive
+s7: positive
+s8: positive
+s9: non-positive
+
+# Cancel e before it completes.
+cancel name=e
+----
+a: wait_success
+b: wait_success
+c: wait_success
+d: waiting
+e: context_cancelled
+
+# Test out refresh signal on f.
+wait_for_eval name=f quorum=2
+handle: stream=s11 required=true
+handle: stream=s12 required=true
+handle: stream=s13 required=false
+----
+a: wait_success
+b: wait_success
+c: wait_success
+d: waiting
+e: context_cancelled
+f: waiting
+
+# Send a refresh signal before any tokens are available
+refresh name=f
+----
+a: wait_success
+b: wait_success
+c: wait_success
+d: waiting
+e: context_cancelled
+f: refresh_wait_signaled
+
+# Lastly, test out a WaitForEval operation with 3 handles overlapping the next
+# WaitForEval operation.
+wait_for_eval name=g quorum=3
+handle: stream=s14 required=true
+handle: stream=s15 required=true
+handle: stream=s16 required=true
+----
+a: wait_success
+b: wait_success
+c: wait_success
+d: waiting
+e: context_cancelled
+f: refresh_wait_signaled
+g: waiting
+
+wait_for_eval name=h quorum=2
+handle: stream=s14 required=false
+handle: stream=s15 required=true
+handle: stream=s17 required=true
+----
+a: wait_success
+b: wait_success
+c: wait_success
+d: waiting
+e: context_cancelled
+f: refresh_wait_signaled
+g: waiting
+h: waiting
+
+# Set some tokens to positive.
+set_tokens s14=positive s15=positive s17=positive
+----
+s1: non-positive
+s10: non-positive
+s11: non-positive
+s12: non-positive
+s13: non-positive
+s14: positive
+s15: positive
+s16: non-positive
+s17: positive
+s2: positive
+s3: non-positive
+s4: positive
+s5: positive
+s6: positive
+s7: positive
+s8: positive
+s9: non-positive
+
+check_state
+----
+a: wait_success
+b: wait_success
+c: wait_success
+d: waiting
+e: context_cancelled
+f: refresh_wait_signaled
+g: waiting
+h: wait_success
+
+# Set the last required token for g to positive, as well as d.
+set_tokens s16=positive s3=positive
+----
+s1: non-positive
+s10: non-positive
+s11: non-positive
+s12: non-positive
+s13: non-positive
+s14: positive
+s15: positive
+s16: positive
+s17: positive
+s2: positive
+s3: positive
+s4: positive
+s5: positive
+s6: positive
+s7: positive
+s8: positive
+s9: non-positive
+
+check_state
+----
+a: wait_success
+b: wait_success
+c: wait_success
+d: wait_success
+e: context_cancelled
+f: refresh_wait_signaled
+g: wait_success
+h: wait_success

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter_test.go
@@ -13,15 +13,18 @@ package rac2
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/datadriven"
 	"github.com/dustin/go-humanize"
 	"github.com/stretchr/testify/require"
@@ -290,5 +293,252 @@ func TestTokenCounter(t *testing.T) {
 		}
 		wg.Wait()
 		assertStateReset(t)
+	})
+}
+
+func (t *tokenCounter) testingHandle() waitHandle {
+	return waitHandle{wc: admissionpb.RegularWorkClass, b: t}
+}
+
+type namedTokenCounter struct {
+	*tokenCounter
+	parent *evalTestState
+	stream string
+}
+
+type evalTestState struct {
+	settings *cluster.Settings
+	mu       struct {
+		syncutil.Mutex
+		counters map[string]*namedTokenCounter
+		evals    map[string]*testEval
+	}
+}
+
+type testEval struct {
+	state     WaitEndState
+	handles   []tokenWaitingHandleInfo
+	quorum    int
+	cancel    context.CancelFunc
+	refreshCh chan struct{}
+}
+
+func newTestState() *evalTestState {
+	ts := &evalTestState{
+		settings: cluster.MakeTestingClusterSettings(),
+	}
+	// We will only use at most one token per stream, as we only require positive
+	// / non-positive token counts.
+	kvflowcontrol.RegularTokensPerStream.Override(context.Background(), &ts.settings.SV, 1)
+	ts.mu.counters = make(map[string]*namedTokenCounter)
+	ts.mu.evals = make(map[string]*testEval)
+	return ts
+}
+
+func (ts *evalTestState) getOrCreateTC(stream string) *namedTokenCounter {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	tc, exists := ts.mu.counters[stream]
+	if !exists {
+		tc = &namedTokenCounter{
+			parent:       ts,
+			tokenCounter: newTokenCounter(ts.settings),
+			stream:       stream,
+		}
+		// Ensure the token counter starts with no tokens initially.
+		tc.adjust(context.Background(),
+			admissionpb.RegularWorkClass,
+			-kvflowcontrol.Tokens(kvflowcontrol.RegularTokensPerStream.Get(&ts.settings.SV)),
+		)
+		ts.mu.counters[stream] = tc
+	}
+	return tc
+}
+
+func (ts *evalTestState) startWaitForEval(
+	name string, handles []tokenWaitingHandleInfo, quorum int,
+) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	refreshCh := make(chan struct{})
+	ts.mu.evals[name] = &testEval{
+		state:     -1,
+		handles:   handles,
+		quorum:    quorum,
+		cancel:    cancel,
+		refreshCh: refreshCh,
+	}
+
+	go func() {
+		state, _ := WaitForEval(ctx, refreshCh, handles, quorum, nil)
+		ts.mu.Lock()
+		defer ts.mu.Unlock()
+
+		ts.mu.evals[name].state = state
+	}()
+}
+
+func (ts *evalTestState) setCounterTokens(stream string, positive bool) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	tc, exists := ts.mu.counters[stream]
+	if !exists {
+		panic(fmt.Sprintf("no token counter found for stream: %s", stream))
+	}
+
+	wasPositive := tc.tokens(admissionpb.RegularWorkClass) > 0
+	if !wasPositive && positive {
+		tc.tokenCounter.adjust(context.Background(), admissionpb.RegularWorkClass, +1)
+	} else if wasPositive && !positive {
+		tc.tokenCounter.adjust(context.Background(), admissionpb.RegularWorkClass, -1)
+	}
+}
+
+func (ts *evalTestState) tokenCountsString() string {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	var streams []string
+	for stream := range ts.mu.counters {
+		streams = append(streams, stream)
+	}
+	sort.Strings(streams)
+
+	var b strings.Builder
+	for _, stream := range streams {
+		tc := ts.mu.counters[stream]
+		posString := "non-positive"
+		if tc.tokens(admissionpb.RegularWorkClass) > 0 {
+			posString = "positive"
+		}
+		b.WriteString(fmt.Sprintf("%s: %s\n", stream, posString))
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func (ts *evalTestState) evalStatesString() string {
+	// Introduce a sleep here to ensure that any evaluation which complete update
+	// state before we lock the mutex.
+	time.Sleep(100 * time.Millisecond)
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	var states []string
+	for name, op := range ts.mu.evals {
+		switch op.state {
+		case -1:
+			states = append(states, fmt.Sprintf("%s: waiting", name))
+		default:
+			states = append(states, fmt.Sprintf("%s: %s", name, op.state))
+		}
+	}
+	sort.Strings(states)
+	return strings.Join(states, "\n")
+}
+
+// TestWaitForEval is a datadriven test that exercises the WaitForEval function.
+//
+//   - wait_for_eval <name> <quorum> [handle: <stream> required=<true|false>]
+//     name: the name of the WaitForEval operation.
+//     quorum: the number of handles that must be unblocked for the operation to
+//     succeed.
+//     stream: the stream name.
+//     required: whether the handle is required for the operation to succeed.
+//
+//   - set_tokens <stream> <positive>
+//     stream: the stream name.
+//     positive: whether the stream should have positive tokens.
+//
+//   - check_state
+//     Prints the current state of all WaitForEval operations.
+//
+//   - cancel <name>
+//     name: the name of the WaitForEval operation to cancel.
+//
+//   - refresh <name>
+//     name: the name of the WaitForEval operation to refresh.
+func TestWaitForEval(t *testing.T) {
+	ts := newTestState()
+	datadriven.RunTest(t, "testdata/wait_for_eval", func(t *testing.T, d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "wait_for_eval":
+			var name string
+			var quorum int
+			var handles []tokenWaitingHandleInfo
+
+			d.ScanArgs(t, "name", &name)
+			d.ScanArgs(t, "quorum", &quorum)
+			for _, line := range strings.Split(d.Input, "\n") {
+				require.True(t, strings.HasPrefix(line, "handle:"))
+				line = strings.TrimPrefix(line, "handle:")
+				line = strings.TrimSpace(line)
+				parts := strings.Split(line, " ")
+				require.Len(t, parts, 2)
+
+				parts[0] = strings.TrimSpace(parts[0])
+				require.True(t, strings.HasPrefix(parts[0], "stream="))
+				parts[0] = strings.TrimPrefix(strings.TrimSpace(parts[0]), "stream=")
+				stream := parts[0]
+
+				parts[1] = strings.TrimSpace(parts[1])
+				require.True(t, strings.HasPrefix(parts[1], "required="))
+				parts[1] = strings.TrimPrefix(strings.TrimSpace(parts[1]), "required=")
+				required := parts[1] == "true"
+
+				handleInfo := tokenWaitingHandleInfo{
+					handle:       ts.getOrCreateTC(stream).testingHandle(),
+					requiredWait: required,
+				}
+				handles = append(handles, handleInfo)
+			}
+
+			ts.startWaitForEval(name, handles, quorum)
+			return ts.evalStatesString()
+
+		case "set_tokens":
+			for _, arg := range d.CmdArgs {
+				require.Equal(t, 1, len(arg.Vals))
+				ts.setCounterTokens(arg.Key, arg.Vals[0] == "positive")
+			}
+			return ts.tokenCountsString()
+
+		case "check_state":
+			return ts.evalStatesString()
+
+		case "cancel":
+			var name string
+			d.ScanArgs(t, "name", &name)
+			func() {
+				ts.mu.Lock()
+				defer ts.mu.Unlock()
+				if op, exists := ts.mu.evals[name]; exists {
+					op.cancel()
+				} else {
+					panic(fmt.Sprintf("no WaitForEval operation with name: %s", name))
+				}
+			}()
+			return ts.evalStatesString()
+
+		case "refresh":
+			var name string
+			d.ScanArgs(t, "name", &name)
+			func() {
+				ts.mu.Lock()
+				defer ts.mu.Unlock()
+				if op, exists := ts.mu.evals[name]; exists {
+					op.refreshCh <- struct{}{}
+				} else {
+					panic(fmt.Sprintf("no WaitForEval operation with name: %s", name))
+				}
+			}()
+			return ts.evalStatesString()
+
+		default:
+			panic(fmt.Sprintf("unknown command: %s", d.Cmd))
+		}
 	})
 }


### PR DESCRIPTION
`WaitForEval` (inside `token_counter.go`) will be used to implement the
`RangeController.WaitForEval(..)`, providing the ability to wait for:

1. A quorum of streams to have available tokens
2. All required streams to have available tokens

Note usage of this helper function is deferred to a later commit, along
with support for waiting on send stream state as an added condition.

Informs: https://github.com/cockroachdb/cockroach/issues/128910
Release note: None