### PR TITLE
raft: respect leader fortification in MsgForgetLeader

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1732,7 +1732,7 @@ func stepFollower(r *raft, m pb.Message) error {
 			r.lead = None
 		}
 	case pb.MsgTimeoutNow:
-		r.logger.Infof("%x [term %d] received MsgTimeoutNow from %x and starts an election to get leadership.", r.id, r.Term, m.From)
+		r.logger.Infof("%x [term %d] received MsgTimeoutNow from %x and starts an election to get leadership", r.id, r.Term, m.From)
 		// Leadership transfers never use pre-vote even if r.preVote is true; we
 		// know we are not recovering from a partition so there is no need for the
 		// extra round trip.

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1727,10 +1727,12 @@ func stepFollower(r *raft, m pb.Message) error {
 		m.To = r.lead
 		r.send(m)
 	case pb.MsgForgetLeader:
-		if r.lead != None {
-			r.logger.Infof("%x forgetting leader %x at term %d", r.id, r.lead, r.Term)
-			r.lead = None
+		if r.lead == None {
+			r.logger.Infof("%x no leader at term %d; dropping forget leader msg", r.id, r.Term)
+			return nil
 		}
+		r.logger.Infof("%x forgetting leader %x at term %d", r.id, r.lead, r.Term)
+		r.lead = None
 	case pb.MsgTimeoutNow:
 		r.logger.Infof("%x [term %d] received MsgTimeoutNow from %x and starts an election to get leadership", r.id, r.Term, m.From)
 		// Leadership transfers never use pre-vote even if r.preVote is true; we

--- a/pkg/raft/testdata/confchange_v2_replace_leader.txt
+++ b/pkg/raft/testdata/confchange_v2_replace_leader.txt
@@ -167,7 +167,7 @@ stabilize
   1->4 MsgTimeoutNow Term:1 Log:0/0
 > 4 receiving messages
   1->4 MsgTimeoutNow Term:1 Log:0/0
-  INFO 4 [term 1] received MsgTimeoutNow from 1 and starts an election to get leadership.
+  INFO 4 [term 1] received MsgTimeoutNow from 1 and starts an election to get leadership
   INFO 4 is starting a new election at term 1
   INFO 4 became candidate at term 2
   INFO 4 [logterm: 1, index: 4] sent MsgVote request to 1 at term 2

--- a/pkg/raft/testdata/forget_leader.txt
+++ b/pkg/raft/testdata/forget_leader.txt
@@ -45,7 +45,7 @@ raft-state
 
 forget-leader 2
 ----
-ok
+INFO 2 no leader at term 1; dropping forget leader msg
 
 raft-state
 ----

--- a/pkg/raft/testdata/forget_leader.txt
+++ b/pkg/raft/testdata/forget_leader.txt
@@ -30,6 +30,20 @@ raft-state
 3: StateFollower (Voter) Term:1 Lead:1
 4: StateFollower (Non-Voter) Term:1 Lead:1
 
+# ForgetLeader is ignored if the follower is supporting the leader's store
+# liveness epoch.
+forget-leader 2
+----
+INFO 2 [term 1] ignored MsgForgetLeader from 0 due to leader fortification
+
+withdraw-support 2 1
+----
+  1 2 3 4
+1 1 1 1 1
+2 x 1 1 1
+3 1 1 1 1
+4 1 1 1 1
+
 # ForgetLeader causes a follower to forget its leader, but remain in the current
 # term. It's a noop if it's called again.
 forget-leader 2
@@ -54,7 +68,20 @@ raft-state
 3: StateFollower (Voter) Term:1 Lead:1
 4: StateFollower (Non-Voter) Term:1 Lead:1
 
-# ForgetLeader also works on learners.
+# ForgetLeader also works on learners, but only if they are not supporting the
+# leader's store liveness epoch.
+forget-leader 4
+----
+INFO 4 [term 1] ignored MsgForgetLeader from 0 due to leader fortification
+
+withdraw-support 4 1
+----
+  1 2 3 4
+1 1 1 1 1
+2 x 1 1 1
+3 1 1 1 1
+4 x 1 1 1
+
 forget-leader 4
 ----
 INFO 4 forgetting leader 1 at term 1
@@ -168,6 +195,14 @@ ok
 tick-heartbeat 2
 ----
 ok
+
+withdraw-support 2 3
+----
+  1 2 3 4
+1 1 1 1 1
+2 x 1 x 1
+3 1 1 1 1
+4 x 1 1 1
 
 forget-leader 2
 ----

--- a/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
+++ b/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
@@ -87,6 +87,19 @@ raft-state
 2: StateFollower (Voter) Term:1 Lead:1
 3: StateFollower (Voter) Term:1 Lead:1
 
+# ForgetLeader is ignored if the follower is supporting the leader's store
+# liveness epoch.
+forget-leader 2
+----
+INFO 2 [term 1] ignored MsgForgetLeader from 0 due to leader fortification
+
+withdraw-support 2 1
+----
+  1 2 3
+1 1 1 1
+2 x 1 1
+3 1 1 1
+
 # If 2 forgets the leader, then 3 can obtain prevotes and hold an election
 # despite 2 having heard from the leader recently.
 forget-leader 2
@@ -186,6 +199,13 @@ stabilize 2
   2/13 EntryNormal "prop_1"
   Messages:
   2->3 MsgAppResp Term:2 Log:0/13
+
+withdraw-support 2 3
+----
+  1 2 3
+1 1 1 1
+2 x 1 x
+3 1 1 1
 
 forget-leader 2
 ----


### PR DESCRIPTION
Fixes #124496.

This commit makes peers consult leader fortification state when processing a `MsgForgetLeader` message. If the leader is fortified and currently supported, the peer will ignore the message.

Epic: None
Release note: None