### PR TITLE
ui: display very large ranges in problematic ranges

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -1326,6 +1326,7 @@ RangeProblems describes issues reported by a range. For internal use only.
 | raft_log_too_large | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  | When the raft log is too large, it can be a symptom of other issues. | [reserved](#support-status) |
 | circuit_breaker_error | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | [reserved](#support-status) |
 | paused_followers | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | [reserved](#support-status) |
+| range_too_large | [bool](#cockroach.server.serverpb.RaftDebugResponse-bool) |  |  | [reserved](#support-status) |
 
 
 
@@ -1575,6 +1576,7 @@ RangeProblems describes issues reported by a range. For internal use only.
 | raft_log_too_large | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  | When the raft log is too large, it can be a symptom of other issues. | [reserved](#support-status) |
 | circuit_breaker_error | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | [reserved](#support-status) |
 | paused_followers | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | [reserved](#support-status) |
+| range_too_large | [bool](#cockroach.server.serverpb.RangesResponse-bool) |  |  | [reserved](#support-status) |
 
 
 
@@ -3408,6 +3410,7 @@ Support status: [reserved](#support-status)
 | raft_log_too_large_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  | [reserved](#support-status) |
 | circuit_breaker_error_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  | [reserved](#support-status) |
 | paused_replica_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  | [reserved](#support-status) |
+| too_large_range_ids | [int64](#cockroach.server.serverpb.ProblemRangesResponse-int64) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -3956,6 +3959,7 @@ RangeProblems describes issues reported by a range. For internal use only.
 | raft_log_too_large | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  | When the raft log is too large, it can be a symptom of other issues. | [reserved](#support-status) |
 | circuit_breaker_error | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | [reserved](#support-status) |
 | paused_followers | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | [reserved](#support-status) |
+| range_too_large | [bool](#cockroach.server.serverpb.RangeResponse-bool) |  |  | [reserved](#support-status) |
 
 
 

--- a/pkg/server/problem_ranges.go
+++ b/pkg/server/problem_ranges.go
@@ -141,6 +141,10 @@ func (s *systemStatusServer) ProblemRanges(
 					problems.PausedReplicaIDs =
 						append(problems.PausedReplicaIDs, info.State.Desc.RangeID)
 				}
+				if info.Problems.RangeTooLarge {
+					problems.TooLargeRangeIds =
+						append(problems.TooLargeRangeIds, info.State.Desc.RangeID)
+				}
 			}
 			slices.Sort(problems.UnavailableRangeIDs)
 			slices.Sort(problems.RaftLeaderNotLeaseHolderRangeIDs)
@@ -152,6 +156,7 @@ func (s *systemStatusServer) ProblemRanges(
 			slices.Sort(problems.RaftLogTooLargeRangeIDs)
 			slices.Sort(problems.CircuitBreakerErrorRangeIDs)
 			slices.Sort(problems.PausedReplicaIDs)
+			slices.Sort(problems.TooLargeRangeIds)
 			response.ProblemsByNodeID[resp.nodeID] = problems
 		case <-ctx.Done():
 			return nil, status.Errorf(codes.DeadlineExceeded, ctx.Err().Error())

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -409,6 +409,7 @@ message RangeProblems {
   bool raft_log_too_large = 7;
   bool circuit_breaker_error = 9;
   bool paused_followers = 10;
+  bool range_too_large = 11;
 }
 
 // RangeStatistics describes statistics reported by a range. For internal use
@@ -1323,6 +1324,11 @@ message ProblemRangesResponse {
       (gogoproto.customname) = "PausedReplicaIDs",
       (gogoproto.casttype) =
           "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"
+    ];
+    repeated int64 too_large_range_ids = 12 [
+      (gogoproto.customname) = "TooLargeRangeIds",
+      (gogoproto.casttype) =
+        "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"
     ];
   }
   reserved 1 to 7;

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2495,6 +2495,7 @@ func (s *systemStatusServer) rangesHelper(
 				NoLease:                metrics.Leader && !metrics.LeaseValid && !metrics.Quiescent,
 				QuiescentEqualsTicking: raftStatus != nil && metrics.Quiescent == metrics.Ticking,
 				RaftLogTooLarge:        metrics.RaftLogTooLarge,
+				RangeTooLarge:          metrics.RangeTooLarge,
 				CircuitBreakerError:    len(state.CircuitBreakerError) > 0,
 				PausedFollowers:        metrics.PausedFollowerCount > 0,
 			},

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/problemRanges/connectionsTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/problemRanges/connectionsTable.tsx
@@ -83,6 +83,10 @@ const connectionTableColumns: ConnectionTableColumn[] = [
     extract: problem => problem.paused_replica_ids.length,
   },
   {
+    title: "Range Too Large",
+    extract: problem => problem.too_large_range_ids.length,
+  },
+  {
     title: "Total",
     extract: problem => {
       return (
@@ -95,7 +99,8 @@ const connectionTableColumns: ConnectionTableColumn[] = [
         problem.quiescent_equals_ticking_range_ids.length +
         problem.raft_log_too_large_range_ids.length +
         problem.circuit_breaker_error_range_ids.length +
-        problem.paused_replica_ids.length
+        problem.paused_replica_ids.length +
+        problem.too_large_range_ids.length
       );
     },
   },

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/problemRanges/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/problemRanges/index.tsx
@@ -230,6 +230,11 @@ export class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
           problems={problems}
           extract={problem => problem.paused_replica_ids}
         />
+        <ProblemRangeList
+          name="Range Too Large"
+          problems={problems}
+          extract={problem => problem.too_large_range_ids}
+        />
       </div>
     );
   }

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/range/rangeTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/range/rangeTable.tsx
@@ -492,6 +492,9 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
     if (problems.raft_log_too_large) {
       results = concat(results, "Raft log too large");
     }
+    if (problems.range_too_large) {
+      results = concat(results, "Range too large");
+    }
     if (awaitingGC) {
       results = concat(results, "Awaiting GC");
     }


### PR DESCRIPTION
This commit adds a column in the DB Console's page problematic ranges that displays the ranges that are too large. The threshold is set to be: 8 * the current range max size.

The two screenshots below show how that looks like. In order to generate that, I had to set the threshold multiplier to be 0.8 (instead of 8).
<img width="600" alt="Screenshot 2024-08-15 at 11 13 28 AM" src="https://github.com/user-attachments/assets/66aae63a-1140-4079-a12e-b925110d975e">

<img width="600" alt="Screenshot 2024-08-15 at 11 14 15 AM" src="https://github.com/user-attachments/assets/fb7e9f07-1fd6-473c-bdd6-b902af3c3306">


Fixes: #127843

Epic: None

Release note (ui change): Adding too large ranges to the problematic ranges
page in DB Console. If a range is larger than twice the max range
size, it will show up in the problematic ranges page.