### PR TITLE
release-23.2: roachtest: backup-restore/mixed-version support for shared-process

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -13,6 +13,7 @@ package tests
 import (
 	"context"
 	gosql "database/sql"
+	"fmt"
 	"math/rand"
 	"time"
 
@@ -34,11 +35,11 @@ var (
 	// sizes that may get set for all user databases.
 	maxRangeSizeBytes = []int64{4 << 20 /* 4 MiB*/, 32 << 20 /* 32 MiB */, 128 << 20}
 
-	// SystemSettingsValuesBoundOnRangeSize defines the cluster settings that
+	// clusterSettingsValuesBoundOnRangeSize defines the cluster settings that
 	// should scale in proportion to the range size. For example, if the range
 	// size is halved, all the values of these cluster settings should also be
 	// halved.
-	systemSettingsScaledOnRangeSize = []string{
+	clusterSettingsScaledOnRangeSize = []string{
 		"backup.restore_span.target_size",
 		"bulkio.backup.file_size",
 		"kv.bulk_sst.target_size",
@@ -114,7 +115,15 @@ func backupRestoreRoundTrip(
 	m := c.NewMonitor(ctx, roachNodes)
 
 	m.Go(func(ctx context.Context) error {
-		testUtils, err := newCommonTestUtils(ctx, t, c, roachNodes, sp.mock)
+		connectFunc := func(node int) (*gosql.DB, error) {
+			conn, err := c.ConnE(ctx, t.L(), node)
+			if err != nil {
+				return nil, fmt.Errorf("failed to connect to node %d: %w", node, err)
+			}
+
+			return conn, err
+		}
+		testUtils, err := newCommonTestUtils(ctx, t, c, connectFunc, roachNodes, sp.mock)
 		if err != nil {
 			return err
 		}
@@ -136,7 +145,7 @@ func backupRestoreRoundTrip(
 		if err := testUtils.setShortJobIntervals(ctx, testRNG); err != nil {
 			return err
 		}
-		if err := testUtils.setClusterSettings(ctx, t.L(), testRNG); err != nil {
+		if err := testUtils.setClusterSettings(ctx, t.L(), c, testRNG); err != nil {
 			return err
 		}
 		if sp.metamorphicRangeSize {
@@ -160,7 +169,10 @@ func backupRestoreRoundTrip(
 
 			// Run backups.
 			t.L().Printf("starting backup %d", i+1)
-			collection, err := d.createBackupCollection(ctx, t.L(), testRNG, bspec, bspec, "round-trip-test-backup", true)
+			collection, err := d.createBackupCollection(
+				ctx, t.L(), testRNG, bspec, bspec, "round-trip-test-backup",
+				true /* internalSystemsJobs */, false, /* isMultitenant */
+			)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -81,6 +81,11 @@ const (
 
 	// the test will not pause a backup job more than `maxPauses` times.
 	maxPauses = 3
+
+	// These constants are used to define the scope of the cluster
+	// settings used in this test.
+	systemOnly       = "system-only"
+	applicationLevel = "application-level"
 )
 
 var (
@@ -125,7 +130,7 @@ var (
 		"zones":        "SHOW ZONE CONFIGURATIONS",
 	}
 
-	// systemSettingValues is a mapping from system setting names to
+	// clusterSettingValues is a mapping from cluster setting names to
 	// possible values they can assume in this test. The system settings
 	// listed here are chosen based on availability of documentation
 	// (see below), meaning a customer could have reasonably set them;
@@ -135,14 +140,14 @@ var (
 	//
 	// Documentation:
 	// https://www.cockroachlabs.com/docs/stable/cluster-settings.html
-	systemSettingValues = map[string][]string{
-		"bulkio.backup.file_size":                        {"8MiB", "32MiB", "512MiB", "750MiB"},
-		"bulkio.backup.read_timeout":                     {"2m0s", "10m0s"},
-		"bulkio.backup.read_with_priority_after":         {"20s", "5m0s"},
-		"bulkio.stream_ingestion.minimum_flush_interval": {"1s", "10s", "30s"},
-		"kv.bulk_io_write.max_rate":                      {"250MiB", "500MiB", "2TiB"},
-		"kv.bulk_sst.max_allowed_overage":                {"16MiB", "256MiB"},
-		"kv.bulk_sst.target_size":                        {"4MiB", "64MiB", "128MiB"},
+	clusterSettingValues = map[string]metamorphicSetting{
+		"bulkio.backup.file_size":                        tenantSetting("8MiB", "32MiB", "512MiB", "750MiB"),
+		"bulkio.backup.read_timeout":                     tenantSetting("2m0s", "10m0s"),
+		"bulkio.backup.read_with_priority_after":         tenantSetting("20s", "5m0s"),
+		"bulkio.stream_ingestion.minimum_flush_interval": systemSetting("1s", "10s", "30s"),
+		"kv.bulk_io_write.max_rate":                      systemSetting("250MiB", "500MiB", "2TiB"),
+		"kv.bulk_sst.max_allowed_overage":                systemSetting("16MiB", "256MiB"),
+		"kv.bulk_sst.target_size":                        systemSetting("4MiB", "64MiB", "128MiB"),
 		// The default is currently 384 MB, which was set to be about 75% of a
 		// range's worth of data. This configuration will reduce the size of this
 		// setting to test restore_span_covering correctness, at the cost of a
@@ -150,12 +155,12 @@ var (
 		//
 		// Note that a size of 0 indicates that target_size will not be used while
 		// constructing restore span entries.
-		"backup.restore_span.target_size": {"0 B", "4 MiB", "32 MiB", "128 MiB"},
+		"backup.restore_span.target_size": tenantSetting("0 B", "4 MiB", "32 MiB", "128 MiB"),
 	}
 
-	systemSettingNames = func() []string {
-		names := make([]string, 0, len(systemSettingValues))
-		for name := range systemSettingValues {
+	clusterSettingNames = func() []string {
+		names := make([]string, 0, len(clusterSettingValues))
+		for name := range clusterSettingValues {
 			names = append(names, name)
 		}
 
@@ -187,6 +192,18 @@ var (
 
 	schemaChangeDB = "schemachange"
 )
+
+func systemSetting(values ...string) metamorphicSetting {
+	return metamorphicSetting{Scope: systemOnly, Values: values}
+}
+
+func tenantSetting(values ...string) metamorphicSetting {
+	return metamorphicSetting{Scope: applicationLevel, Values: values}
+}
+
+func (s metamorphicSetting) IsSystemOnly() bool {
+	return s.Scope == systemOnly
+}
 
 // sanitizeVersionForBackup takes the string representation of a
 // version and removes any characters that would not be allowed in a
@@ -251,6 +268,14 @@ type (
 	// backup as well.
 	encryptionPassphrase struct {
 		passphrase string
+	}
+
+	// metamorphicSetting encodes the space of possible values a cluster
+	// setting may assume during this test, along with the scope where
+	// it applies (system or tenant).
+	metamorphicSetting struct {
+		Scope  string
+		Values []string
 	}
 
 	// backupScope is the interface to be implemented by each backup scope
@@ -1173,9 +1198,9 @@ func newBackupRestoreTestDriver(
 }
 
 func (mvb *mixedVersionBackup) initBackupRestoreTestDriver(
-	ctx context.Context, l *logger.Logger, rng *rand.Rand,
+	ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper,
 ) error {
-	u, err := mvb.CommonTestUtils(ctx)
+	u, err := mvb.CommonTestUtils(ctx, h)
 	if err != nil {
 		return err
 	}
@@ -1196,15 +1221,19 @@ func (mvb *mixedVersionBackup) initBackupRestoreTestDriver(
 
 // newBackupScope chooses a random backup type (table, database,
 // cluster) with equal probability.
-func (d *BackupRestoreTestDriver) newBackupScope(rng *rand.Rand) backupScope {
+func (d *BackupRestoreTestDriver) newBackupScope(rng *rand.Rand, isMultitenant bool) backupScope {
 	possibleTypes := []backupScope{
 		newTableBackup(rng, d.dbs, d.tables),
 		newDatabaseBackup(rng, d.dbs, d.tables),
 	}
-	if !d.cluster.IsLocal() {
-		// Cluster backups cannot be restored on nodelocal because the cluster is
-		// wiped before cluster restore.
-		possibleTypes = append(possibleTypes, newClusterBackup(rng, d.dbs, d.tables))
+	if !d.cluster.IsLocal() && !isMultitenant {
+		// Cluster backups cannot be restored on nodelocal because the
+		// cluster is wiped before cluster restore. Cluster restores in
+		// multitenant deployments are also not supported by this test at
+		// the moment.
+		possibleTypes = append(
+			possibleTypes, newClusterBackup(rng, d.dbs, d.tables),
+		)
 	}
 
 	return possibleTypes[rng.Intn(len(possibleTypes))]
@@ -1381,7 +1410,7 @@ func (u *CommonTestUtils) loadTablesForDBs(
 
 // setMaxRangeSizeAndDependentSettings chooses a random default range size from
 // maxRangeSize bytes and scales the cluster settings in
-// systemSettingsScaledOnRangeSize such that rangeSize/settingValue remains the
+// clusterSettingsScaledOnRangeSize such that rangeSize/settingValue remains the
 // same.
 func (u *CommonTestUtils) setMaxRangeSizeAndDependentSettings(
 	ctx context.Context, t test.Test, rng *rand.Rand, dbs []string,
@@ -1405,7 +1434,7 @@ func (u *CommonTestUtils) setMaxRangeSizeAndDependentSettings(
 		}
 	}
 
-	for _, setting := range systemSettingsScaledOnRangeSize {
+	for _, setting := range clusterSettingsScaledOnRangeSize {
 		var humanizedCurrentValue string
 		if err := u.QueryRow(ctx, rng, fmt.Sprintf("SHOW CLUSTER SETTING %s", setting)).Scan(&humanizedCurrentValue); err != nil {
 			return err
@@ -1427,13 +1456,13 @@ func (u *CommonTestUtils) setMaxRangeSizeAndDependentSettings(
 }
 
 // setClusterSettings may set up to numCustomSettings cluster settings
-// as defined in `systemSettingValues`. The system settings changed
+// as defined in `clusterSettingValues`. The system settings changed
 // are logged. This function should be called *before* the upgrade
 // begins; the cockroach documentation says explicitly that changing
 // cluster settings is not supported in mixed-version, so we don't
 // test that scenario.
 func (u *CommonTestUtils) setClusterSettings(
-	ctx context.Context, l *logger.Logger, rng *rand.Rand,
+	ctx context.Context, l *logger.Logger, c cluster.Cluster, rng *rand.Rand,
 ) error {
 	const numCustomSettings = 3
 	const defaultSettingsProbability = 0.2
@@ -1443,14 +1472,32 @@ func (u *CommonTestUtils) setClusterSettings(
 		return nil
 	}
 
-	for j := 0; j < numCustomSettings; j++ {
-		setting := systemSettingNames[rng.Intn(len(systemSettingNames))]
-		possibleValues := systemSettingValues[setting]
-		value := possibleValues[rng.Intn(len(possibleValues))]
+	// Make sure to use a connection to the system tenant as it will be
+	// necessary when changing system-only cluster settings.
+	systemDB, err := c.ConnE(ctx, l, 1, option.VirtualClusterName(install.SystemInterfaceName))
+	if err != nil {
+		return errors.Wrap(err, "failed to connect to system tenant")
+	}
+	defer systemDB.Close()
 
-		l.Printf("setting cluster setting %q to %q", setting, value)
-		stmt := fmt.Sprintf("SET CLUSTER SETTING %s = '%s'", setting, value)
-		if err := u.Exec(ctx, rng, stmt); err != nil {
+	appDB := u.Connect(1) // no need to Close() this as it's a cached connection
+
+	for j := 0; j < numCustomSettings; j++ {
+		settingName := clusterSettingNames[rng.Intn(len(clusterSettingNames))]
+		setting := clusterSettingValues[settingName]
+		value := setting.Values[rng.Intn(len(setting.Values))]
+
+		l.Printf("setting %s cluster setting %q to %q", setting.Scope, settingName, value)
+		stmt := fmt.Sprintf("SET CLUSTER SETTING %s = '%s'", settingName, value)
+
+		var db *gosql.DB
+		if setting.IsSystemOnly() {
+			db = systemDB
+		} else {
+			db = appDB
+		}
+
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
 			return err
 		}
 	}
@@ -1461,7 +1508,7 @@ func (u *CommonTestUtils) setClusterSettings(
 func (mvb *mixedVersionBackup) setShortJobIntervals(
 	ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper,
 ) error {
-	u, err := mvb.CommonTestUtils(ctx)
+	u, err := mvb.CommonTestUtils(ctx, h)
 	if err != nil {
 		return err
 	}
@@ -1477,7 +1524,7 @@ func (mvb *mixedVersionBackup) systemTableWriter(
 	}
 	l.Printf("user tables loaded, starting random inserts")
 
-	u, err := mvb.CommonTestUtils(ctx)
+	u, err := mvb.CommonTestUtils(ctx, h)
 	if err != nil {
 		return err
 	}
@@ -1488,11 +1535,11 @@ func (mvb *mixedVersionBackup) systemTableWriter(
 func (mvb *mixedVersionBackup) setClusterSettings(
 	ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper,
 ) error {
-	u, err := mvb.CommonTestUtils(ctx)
+	u, err := mvb.CommonTestUtils(ctx, h)
 	if err != nil {
 		return err
 	}
-	return u.setClusterSettings(ctx, l, rng)
+	return u.setClusterSettings(ctx, l, mvb.cluster, rng)
 }
 
 // waitForDBs waits until every database in the `dbs` field
@@ -1549,7 +1596,7 @@ func (mvb *mixedVersionBackup) maybeTakePreviousVersionBackup(
 		return err
 	}
 
-	if err := mvb.initBackupRestoreTestDriver(ctx, l, rng); err != nil {
+	if err := mvb.initBackupRestoreTestDriver(ctx, l, rng, h); err != nil {
 		return err
 	}
 
@@ -1761,6 +1808,7 @@ func (d *BackupRestoreTestDriver) runBackup(
 	pauseProbability float64,
 	bType fmt.Stringer,
 	internalSystemJobs bool,
+	isMultitenant bool,
 ) (backupCollection, string, error) {
 	pauseAfter := 1024 * time.Hour // infinity
 	var pauseResumeDB *gosql.DB
@@ -1786,7 +1834,7 @@ func (d *BackupRestoreTestDriver) runBackup(
 	var collection backupCollection
 	switch b := bType.(type) {
 	case fullBackup:
-		btype := d.newBackupScope(rng)
+		btype := d.newBackupScope(rng, isMultitenant)
 		name := d.backupCollectionName(d.nextBackupID(), b.namePrefix, btype)
 		createOptions := newBackupOptions(rng)
 		collection = newBackupCollection(name, btype, createOptions, d.cluster.IsLocal())
@@ -1923,7 +1971,10 @@ func (mvb *mixedVersionBackup) createBackupCollection(
 		return err
 	}
 
-	collection, err := mvb.backupRestoreTestDriver.createBackupCollection(ctx, l, rng, fullBackupSpec, incBackupSpec, backupNamePrefix, internalSystemJobs)
+	collection, err := mvb.backupRestoreTestDriver.createBackupCollection(
+		ctx, l, rng, fullBackupSpec, incBackupSpec, backupNamePrefix,
+		internalSystemJobs, h.IsMultitenant(),
+	)
 	if err != nil {
 		return err
 	}
@@ -1945,6 +1996,7 @@ func (d *BackupRestoreTestDriver) createBackupCollection(
 	incBackupSpec backupSpec,
 	backupNamePrefix string,
 	internalSystemJobs bool,
+	isMultitenant bool,
 ) (*backupCollection, error) {
 	var collection backupCollection
 	var latestIncBackupEndTime string
@@ -1954,7 +2006,8 @@ func (d *BackupRestoreTestDriver) createBackupCollection(
 	if err := d.testUtils.runJobOnOneOf(ctx, l, fullBackupSpec.Execute.Nodes, func() error {
 		var err error
 		collection, fullBackupEndTime, err = d.runBackup(
-			ctx, l, rng, fullBackupSpec.Plan.Nodes, fullBackupSpec.PauseProbability, fullBackup{backupNamePrefix}, internalSystemJobs,
+			ctx, l, rng, fullBackupSpec.Plan.Nodes, fullBackupSpec.PauseProbability,
+			fullBackup{backupNamePrefix}, internalSystemJobs, isMultitenant,
 		)
 		return err
 	}); err != nil {
@@ -1972,7 +2025,8 @@ func (d *BackupRestoreTestDriver) createBackupCollection(
 		if err := d.testUtils.runJobOnOneOf(ctx, l, incBackupSpec.Execute.Nodes, func() error {
 			var err error
 			collection, latestIncBackupEndTime, err = d.runBackup(
-				ctx, l, rng, incBackupSpec.Plan.Nodes, incBackupSpec.PauseProbability, incrementalBackup{collection: collection, incNum: i + 1}, internalSystemJobs,
+				ctx, l, rng, incBackupSpec.Plan.Nodes, incBackupSpec.PauseProbability,
+				incrementalBackup{collection: collection, incNum: i + 1}, internalSystemJobs, isMultitenant,
 			)
 			return err
 		}); err != nil {
@@ -2378,7 +2432,7 @@ func (mvb *mixedVersionBackup) verifyAllBackups(
 	l.Printf("stopping background functions and workloads")
 	mvb.stopBackground()
 
-	u, err := mvb.CommonTestUtils(ctx)
+	u, err := mvb.CommonTestUtils(ctx, h)
 	if err != nil {
 		return err
 	}
@@ -2686,15 +2740,19 @@ type CommonTestUtils struct {
 // and puts these connections in a cache for reuse. The caller should remember to close all connections
 // once done with them to prevent any goroutine leaks (CloseConnections).
 func newCommonTestUtils(
-	ctx context.Context, t test.Test, c cluster.Cluster, nodes option.NodeListOption, mock bool,
+	ctx context.Context,
+	t test.Test,
+	c cluster.Cluster,
+	connectFunc func(int) (*gosql.DB, error),
+	nodes option.NodeListOption,
+	mock bool,
 ) (*CommonTestUtils, error) {
 	cc := make([]*gosql.DB, len(nodes))
 	for _, node := range nodes {
-		conn, err := c.ConnE(ctx, t.L(), node)
+		conn, err := connectFunc(node)
 		if err != nil {
-			return nil, fmt.Errorf("failed to connect to node %d: %w", node, err)
+			return nil, err
 		}
-
 		cc[node-1] = conn
 	}
 
@@ -2712,16 +2770,27 @@ func newCommonTestUtils(
 	return u, nil
 }
 
-func (mvb *mixedVersionBackup) CommonTestUtils(ctx context.Context) (*CommonTestUtils, error) {
+func (mvb *mixedVersionBackup) CommonTestUtils(
+	ctx context.Context, h *mixedversion.Helper,
+) (*CommonTestUtils, error) {
 	var err error
 	mvb.utilsOnce.Do(func() {
-		mvb.commonTestUtils, err = newCommonTestUtils(ctx, mvb.t, mvb.cluster, mvb.roachNodes, false)
+		connectFunc := func(node int) (*gosql.DB, error) { return h.Connect(node), nil }
+		mvb.commonTestUtils, err = newCommonTestUtils(
+			ctx, mvb.t, mvb.cluster, connectFunc, mvb.roachNodes, false,
+		)
 	})
 	return mvb.commonTestUtils, err
 }
 
 func (mvb *mixedVersionBackup) cleanUp(ctx context.Context) error {
-	u, err := mvb.CommonTestUtils(ctx)
+	if mvb.commonTestUtils == nil {
+		return nil
+	}
+
+	// The helper should not be necessary if we already set up a
+	// `commonTestUtils`.
+	u, err := mvb.CommonTestUtils(ctx, nil /* helper */)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
@@ -12,6 +12,7 @@ package tests
 
 import (
 	"context"
+	gosql "database/sql"
 	"math/rand"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -85,8 +86,13 @@ func executeSupportedDDLs(
 			nodes = helper.Context().NodesInPreviousVersion() // N.B. this is the set of oldNodes.
 		}
 	}
-	testUtils, err := newCommonTestUtils(ctx, t, c, helper.DefaultService().Descriptor.Nodes, false)
-	defer testUtils.CloseConnections()
+	connectFunc := func(node int) (*gosql.DB, error) { return helper.Connect(node), nil }
+	// NOTE: we intentionally don't call `testutils.CloseConnections()`
+	// here because these connnections are managed by the mixedversion
+	// framework, which already closes them at the end of the test.
+	testUtils, err := newCommonTestUtils(
+		ctx, t, c, connectFunc, helper.DefaultService().Descriptor.Nodes, false,
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Backport 1/1 commits from #128696.

/cc @cockroachdb/release

---

This commit updates the `backup-restore/mixed-version` test in order to enable shared-process deployments. The main differences are:

* changing the `CommonTestUtils` struct so that it is able to connect to the system tenant and the application tenant.
* disabling cluster backups in multi-tenant deployments. Disaster Recovery can add support for that if necessary.

Informs: #127378

Release note: None

Release justification: test only changes.