### PR TITLE
release-23.1: opt: wrap virtual computed column projections in a cast

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cast
+++ b/pkg/sql/logictest/testdata/logic_test/cast
@@ -165,10 +165,7 @@ PREPARE insert_f4 AS INSERT INTO assn_cast(f4) VALUES ($1)
 statement ok
 EXECUTE insert_f4(18754999.99)
 
-# TODO(mgartner): Values are not correctly truncated when cast to FLOAT4, either
-# in an assignment or explicit context. The columns should have a value of
-# 1.8755e+07. See #73743.
-query F
+query F rowsort
 SELECT f4 FROM assn_cast WHERE f4 IS NOT NULL
 ----
 1.8755e+07

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -1374,3 +1374,39 @@ ALTER TABLE t81675 ADD COLUMN j INT GENERATED ALWAYS AS (i+1) VIRTUAL NOT NULL;
 
 statement ok
 DROP TABLE t81675;
+
+
+# Regression tests for #91817. Assignment casts should be applied to virtual
+# computed column projections when the expression type is not identical to the
+# column type.
+subtest regression_91817
+
+statement ok
+CREATE TABLE t91817a (
+  s STRING,
+  comp_s "char" AS (s) STORED,
+  comp_v "char" AS (s) VIRTUAL
+);
+INSERT INTO t91817a VALUES ('foo')
+
+# The stored and virtual computed columns should have the same value.
+query TTT
+SELECT * FROM t91817a
+----
+foo  f  f
+
+statement ok
+CREATE TABLE t91817b (
+  k INT2 PRIMARY KEY,
+  v INT2 GENERATED ALWAYS AS (k + 1) VIRTUAL
+);
+INSERT INTO t91817b VALUES (0)
+
+# This query should not cause an internal error.
+query T
+SELECT var_pop(v::INT8) OVER ()
+FROM t91817b
+GROUP BY k, v
+HAVING every(true)
+----
+0

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
@@ -3417,7 +3417,7 @@ top-k
       │    ├── columns: c:1(char) d:2(char)
       │    ├── computed column expressions
       │    │    └── d:2
-      │    │         └── const: ‹×› [type=string]
+      │    │         └── const: ‹×› [type=char]
       │    ├── stats: [rows=1000]
       │    ├── cost: 1129.02
       │    ├── fd: ()-->(2)
@@ -3793,7 +3793,7 @@ project
       │    │    ├── columns: c:1(char)
       │    │    ├── computed column expressions
       │    │    │    └── d:2
-      │    │    │         └── const: ‹×› [type=string]
+      │    │    │         └── const: ‹×› [type=char]
       │    │    ├── stats: [rows=1000]
       │    │    ├── cost: 1108.82
       │    │    ├── distribution: test

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -2639,7 +2639,7 @@ project
       │    │    └── crdb_internal_a_shard_8:2 IN (0, 1, 2, 3, 4, 5, 6, 7) [type=bool, outer=(2), constraints=(/2: [/0 - /0] [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5] [/6 - /6] [/7 - /7]; tight)]
       │    ├── computed column expressions
       │    │    └── crdb_internal_a_shard_8:2
-      │    │         └── mod(fnv32(crdb_internal.datums_to_bytes(i:1)), 8) [type=int]
+      │    │         └── mod(fnv32(crdb_internal.datums_to_bytes(i:1)), 8)::INT4 [type=int4]
       │    ├── stats: [rows=1000, distinct(1)=100, null(1)=0, distinct(2)=8, null(2)=0]
       │    │   histogram(2)=  0 125 0 125 0 125 0 125 0 125 0 125 0 125 0 125
       │    │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/asof"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/cast"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
@@ -879,11 +880,27 @@ func (b *Builder) addComputedColsForTable(
 			tableScope.appendOrdinaryColumnsFromTable(tabMeta, &tabMeta.Alias)
 		}
 
-		if texpr := tableScope.resolveAndRequireType(expr, tabCol.DatumType()); texpr != nil {
+		colType := tabCol.DatumType()
+		if texpr := tableScope.resolveAndRequireType(expr, colType); texpr != nil {
 			colID := tabMeta.MetaID.ColumnID(i)
 			var scalar opt.ScalarExpr
 			b.factory.FoldingControl().TemporarilyDisallowStableFolds(func() {
 				scalar = b.buildScalar(texpr, tableScope, nil, nil, nil)
+				// Add an assignment cast if the types are not identical.
+				scalarType := scalar.DataType()
+				if !colType.Identical(scalarType) {
+					// Assert that an assignment cast is available from the
+					// expression type to the column type.
+					if !cast.ValidCast(scalarType, colType, cast.ContextAssignment) {
+						panic(sqlerrors.NewInvalidAssignmentCastError(
+							scalarType, colType, string(tabCol.ColName()),
+						))
+					}
+					// TODO(mgartner): This should be an assignment cast, but
+					// until #81698 is addressed, that could cause reads to
+					// error after adding a virtual computed column to a table.
+					scalar = b.factory.ConstructCast(scalar, colType)
+				}
 			})
 			// Check if the expression contains non-immutable operators.
 			var sharedProps props.Shared

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -1727,7 +1727,7 @@ update decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    │    │    └── computed column expressions
       │    │    │    │    │         └── d:10
-      │    │    │    │    │              └── a:7 + c:9
+      │    │    │    │    │              └── (a:7 + c:9)::DECIMAL(10,1)
       │    │    │    │    └── projections
       │    │    │    │         ├── 1.1 [as=a_new:13]
       │    │    │    │         └── ARRAY[0.95, NULL, 15::DECIMAL(10,2)] [as=b_new:14]
@@ -1772,7 +1772,7 @@ update decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    │    │    └── computed column expressions
       │    │    │    │    │         └── d:10
-      │    │    │    │    │              └── a:7 + c:9
+      │    │    │    │    │              └── (a:7 + c:9)::DECIMAL(10,1)
       │    │    │    │    └── projections
       │    │    │    │         ├── 1.1 [as=a_new:13]
       │    │    │    │         └── ARRAY[0.95,NULL,15.00] [as=b_new:14]
@@ -1812,7 +1812,7 @@ update assn_cast
       │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    └── computed column expressions
       │    │    │         └── d_comp:15
-      │    │    │              └── d:14 + 10.0
+      │    │    │              └── (d:14 + 10.0)::DECIMAL(10)
       │    │    └── projections
       │    │         ├── ' ' [as=c_new:19]
       │    │         ├── 'foo' [as=qc_new:20]
@@ -1849,7 +1849,7 @@ update assn_cast
       │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    └── computed column expressions
       │    │    │         └── d_comp:15
-      │    │    │              └── d:14 + 10.0
+      │    │    │              └── (d:14 + 10.0)::DECIMAL(10)
       │    │    └── projections
       │    │         ├── ' ' [as=c_new:19]
       │    │         ├── 'foo' [as=qc_new:20]
@@ -1881,7 +1881,7 @@ update assn_cast
       │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    └── computed column expressions
       │    │    │         └── d_comp:15
-      │    │    │              └── d:14 + 10.0
+      │    │    │              └── (d:14 + 10.0)::DECIMAL(10)
       │    │    └── projections
       │    │         └── 10::INT2 [as=i_new:19]
       │    └── projections
@@ -1913,7 +1913,7 @@ update assn_cast
       │    │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    │    └── computed column expressions
       │    │    │    │         └── d_comp:15
-      │    │    │    │              └── d:14 + 10.0
+      │    │    │    │              └── (d:14 + 10.0)::DECIMAL(10)
       │    │    │    └── projections
       │    │    │         └── 1.45::DECIMAL(10,2) [as=d_new:19]
       │    │    └── projections
@@ -1948,7 +1948,7 @@ update assn_cast
       │    │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    │    └── computed column expressions
       │    │    │    │         └── d_comp:15
-      │    │    │    │              └── d:14 + 10.0
+      │    │    │    │              └── (d:14 + 10.0)::DECIMAL(10)
       │    │    │    └── projections
       │    │    │         └── 1.45 [as=d_new:19]
       │    │    └── projections
@@ -1986,7 +1986,7 @@ update decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    │    │    └── computed column expressions
       │    │    │    │    │         └── d:10
-      │    │    │    │    │              └── a:7 + c:9
+      │    │    │    │    │              └── (a:7 + c:9)::DECIMAL(10,1)
       │    │    │    │    └── projections
       │    │    │    │         ├── 1.1 [as=a_new:13]
       │    │    │    │         └── ARRAY[0.95, NULL, 15::DECIMAL(10,2)] [as=b_new:14]
@@ -2030,7 +2030,7 @@ update decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    │    │    └── computed column expressions
       │    │    │    │    │         └── d:10
-      │    │    │    │    │              └── a:7 + c:9
+      │    │    │    │    │              └── (a:7 + c:9)::DECIMAL(10,1)
       │    │    │    │    └── projections
       │    │    │    │         ├── 1.1 [as=a_new:13]
       │    │    │    │         └── ARRAY[0.95,NULL,15.00] [as=b_new:14]
@@ -2068,7 +2068,7 @@ update assn_cast
       │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    └── computed column expressions
       │    │    │         └── d_comp:15
-      │    │    │              └── d:14 + 10.0
+      │    │    │              └── (d:14 + 10.0)::DECIMAL(10)
       │    │    └── projections
       │    │         ├── ' ' [as=c_new:19]
       │    │         └── 10::INT2 [as=i_new:20]
@@ -2100,7 +2100,7 @@ update assn_cast
       │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    └── computed column expressions
       │    │    │         └── d_comp:15
-      │    │    │              └── d:14 + 10.0
+      │    │    │              └── (d:14 + 10.0)::DECIMAL(10)
       │    │    └── projections
       │    │         ├── ' ' [as=c_new:19]
       │    │         └── 10::INT2 [as=i_new:20]
@@ -2137,7 +2137,7 @@ update decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    │    │    └── computed column expressions
       │    │    │    │    │         └── d:10
-      │    │    │    │    │              └── a:7 + c:9
+      │    │    │    │    │              └── (a:7 + c:9)::DECIMAL(10,1)
       │    │    │    │    ├── max1-row
       │    │    │    │    │    ├── columns: n:13!null
       │    │    │    │    │    └── project
@@ -2185,7 +2185,7 @@ update decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 decimals.crdb_internal_mvcc_timestamp:11 decimals.tableoid:12
       │    │    │    │    │    └── computed column expressions
       │    │    │    │    │         └── d:10
-      │    │    │    │    │              └── a:7 + c:9
+      │    │    │    │    │              └── (a:7 + c:9)::DECIMAL(10,1)
       │    │    │    │    ├── max1-row
       │    │    │    │    │    ├── columns: u:13!null "?column?":18!null
       │    │    │    │    │    └── project
@@ -2236,7 +2236,7 @@ update assn_cast
       │    │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 assn_cast.rowid:16!null assn_cast.crdb_internal_mvcc_timestamp:17 assn_cast.tableoid:18
       │    │    │    │    └── computed column expressions
       │    │    │    │         └── d_comp:15
-      │    │    │    │              └── d:14 + 10.0
+      │    │    │    │              └── (d:14 + 10.0)::DECIMAL(10)
       │    │    │    ├── max1-row
       │    │    │    │    ├── columns: "?column?":24!null "?column?":25!null
       │    │    │    │    └── project
@@ -2283,7 +2283,7 @@ update assn_cast_on_update
       │    │    │    │    ├── columns: i:10 i2:11 d:12 d2:13 d_comp:14 b:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    │    └── computed column expressions
       │    │    │    │         └── d_comp:14
-      │    │    │    │              └── d:12
+      │    │    │    │              └── d:12::DECIMAL(10)
       │    │    │    └── projections
       │    │    │         ├── 1 [as=i_new:19]
       │    │    │         └── true [as=b_new:20]

--- a/pkg/sql/opt/optbuilder/testdata/update-col-cast-bug
+++ b/pkg/sql/opt/optbuilder/testdata/update-col-cast-bug
@@ -30,9 +30,9 @@ with &1 (cte)
            │    │    │    │    ├── columns: a:7(int2) b:8(int2) rowid:10(int!null) crdb_internal_mvcc_timestamp:11(decimal) tableoid:12(oid)
            │    │    │    │    └── computed column expressions
            │    │    │    │         └── t.c:9
-           │    │    │    │              └── a:7 + b:8 [type=int]
+           │    │    │    │              └── (a:7 + b:8)::INT2 [type=int2]
            │    │    │    └── projections
-           │    │    │         └── a:7 + b:8 [as=t.c:9, type=int]
+           │    │    │         └── (a:7 + b:8)::INT2 [as=t.c:9, type=int2]
            │    │    └── projections
            │    │         └── subquery [as=a_new:16, type=int2]
            │    │              └── max1-row

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -2404,7 +2404,7 @@ upsert decimals
       │    │    │    │    ├── columns: a:15!null b:16 c:17 d:18 crdb_internal_mvcc_timestamp:19 tableoid:20
       │    │    │    │    ├── computed column expressions
       │    │    │    │    │    └── d:18
-      │    │    │    │    │         └── a:15 + c:17
+      │    │    │    │    │         └── (a:15 + c:17)::DECIMAL(10,1)
       │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── a_cast:9 = a:15
@@ -2482,7 +2482,7 @@ upsert decimals
       │    │    │    │    ├── columns: a:14!null b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18 tableoid:19
       │    │    │    │    ├── computed column expressions
       │    │    │    │    │    └── d:17
-      │    │    │    │    │         └── a:14 + c:16
+      │    │    │    │    │         └── (a:14 + c:16)::DECIMAL(10,1)
       │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── a_cast:8 = a:14
@@ -2561,7 +2561,7 @@ upsert decimals
       │    │    │    │    ├── columns: a:14!null b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18 tableoid:19
       │    │    │    │    ├── computed column expressions
       │    │    │    │    │    └── d:17
-      │    │    │    │    │         └── a:14 + c:16
+      │    │    │    │    │         └── (a:14 + c:16)::DECIMAL(10,1)
       │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── a_cast:8 = a:14
@@ -2649,7 +2649,7 @@ upsert decimals
       │    │    │    │    │    │    ├── columns: a:15!null b:16 c:17 d:18 crdb_internal_mvcc_timestamp:19 tableoid:20
       │    │    │    │    │    │    ├── computed column expressions
       │    │    │    │    │    │    │    └── d:18
-      │    │    │    │    │    │    │         └── a:15 + c:17
+      │    │    │    │    │    │    │         └── (a:15 + c:17)::DECIMAL(10,1)
       │    │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── a_cast:9 = a:15
@@ -2742,7 +2742,7 @@ upsert decimals
       │    │    │    │    │    │    ├── columns: a:15!null b:16 c:17 d:18 crdb_internal_mvcc_timestamp:19 tableoid:20
       │    │    │    │    │    │    ├── computed column expressions
       │    │    │    │    │    │    │    └── d:18
-      │    │    │    │    │    │    │         └── a:15 + c:17
+      │    │    │    │    │    │    │         └── (a:15 + c:17)::DECIMAL(10,1)
       │    │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── a_cast:9 = a:15
@@ -2837,7 +2837,7 @@ upsert assn_cast
       │    │    │    ├── columns: k:22!null c:23 qc:24 i:25 s:26 d:27 d_comp:28 crdb_internal_mvcc_timestamp:29 tableoid:30
       │    │    │    ├── computed column expressions
       │    │    │    │    └── d_comp:28
-      │    │    │    │         └── d:27 + 10.0
+      │    │    │    │         └── (d:27 + 10.0)::DECIMAL(10)
       │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── k_cast:15 = k:22
@@ -2921,7 +2921,7 @@ upsert assn_cast
       │    │    │    ├── columns: k:21!null c:22 qc:23 i:24 s:25 d:26 d_comp:27 crdb_internal_mvcc_timestamp:28 tableoid:29
       │    │    │    ├── computed column expressions
       │    │    │    │    └── d_comp:27
-      │    │    │    │         └── d:26 + 10.0
+      │    │    │    │         └── (d:26 + 10.0)::DECIMAL(10)
       │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── k_cast:14 = k:21
@@ -2984,7 +2984,7 @@ insert assn_cast
       │    │    ├── columns: k:22!null c:23 qc:24 i:25 s:26 d:27 d_comp:28
       │    │    ├── computed column expressions
       │    │    │    └── d_comp:28
-      │    │    │         └── d:27 + 10.0
+      │    │    │         └── (d:27 + 10.0)::DECIMAL(10)
       │    │    └── flags: disabled not visible index feature
       │    └── filters
       │         └── k_cast:15 = k:22
@@ -3080,7 +3080,7 @@ upsert assn_cast
       │    │    │    │    │    ├── columns: k:21!null c:22 qc:23 i:24 s:25 d:26 d_comp:27 crdb_internal_mvcc_timestamp:28 tableoid:29
       │    │    │    │    │    ├── computed column expressions
       │    │    │    │    │    │    └── d_comp:27
-      │    │    │    │    │    │         └── d:26 + 10.0
+      │    │    │    │    │    │         └── (d:26 + 10.0)::DECIMAL(10)
       │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         └── k_cast:15 = k:21
@@ -3176,7 +3176,7 @@ upsert assn_cast
       │    │    │    ├── columns: k:19!null c:20 qc:21 i:22 s:23 d:24 d_comp:25 crdb_internal_mvcc_timestamp:26 tableoid:27
       │    │    │    ├── computed column expressions
       │    │    │    │    └── d_comp:25
-      │    │    │    │         └── d:24 + 10.0
+      │    │    │    │         └── (d:24 + 10.0)::DECIMAL(10)
       │    │    │    └── flags: disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:10 = k:19
@@ -3258,7 +3258,7 @@ upsert assn_cast
       │    │    │    │    │    ├── columns: k:18!null c:19 qc:20 i:21 s:22 d:23 d_comp:24 crdb_internal_mvcc_timestamp:25 tableoid:26
       │    │    │    │    │    ├── computed column expressions
       │    │    │    │    │    │    └── d_comp:24
-      │    │    │    │    │    │         └── d:23 + 10.0
+      │    │    │    │    │    │         └── (d:23 + 10.0)::DECIMAL(10)
       │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         └── column1:10 = k:18
@@ -3352,7 +3352,7 @@ upsert assn_cast
       │    │    ├── columns: k:20!null c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
       │    │    ├── computed column expressions
       │    │    │    └── d_comp:26
-      │    │    │         └── d:25 + 10.0
+      │    │    │         └── (d:25 + 10.0)::DECIMAL(10)
       │    │    └── flags: disabled not visible index feature
       │    └── filters
       │         └── column1:10 = k:20
@@ -3437,7 +3437,7 @@ upsert assn_cast
       │    │    ├── columns: k:20!null c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
       │    │    ├── computed column expressions
       │    │    │    └── d_comp:26
-      │    │    │         └── d:25 + 10.0
+      │    │    │         └── (d:25 + 10.0)::DECIMAL(10)
       │    │    └── flags: disabled not visible index feature
       │    └── filters
       │         └── column1:10 = k:20
@@ -3502,7 +3502,7 @@ insert assn_cast
       │    │    ├── columns: k:20!null c:21 qc:22 i:23 s:24 d:25 d_comp:26
       │    │    ├── computed column expressions
       │    │    │    └── d_comp:26
-      │    │    │         └── d:25 + 10.0
+      │    │    │         └── (d:25 + 10.0)::DECIMAL(10)
       │    │    └── flags: disabled not visible index feature
       │    └── filters
       │         └── column1:10 = k:20
@@ -3602,7 +3602,7 @@ upsert assn_cast
       │    │    │    │    │    │    ├── columns: k:20!null c:21 qc:22 i:23 s:24 d:25 d_comp:26 crdb_internal_mvcc_timestamp:27 tableoid:28
       │    │    │    │    │    │    ├── computed column expressions
       │    │    │    │    │    │    │    └── d_comp:26
-      │    │    │    │    │    │    │         └── d:25 + 10.0
+      │    │    │    │    │    │    │         └── (d:25 + 10.0)::DECIMAL(10)
       │    │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── column1:10 = k:20
@@ -3683,7 +3683,7 @@ upsert assn_cast_on_update
       │    │    │    │    │    │    ├── columns: k:12!null i:13 d:14 d2:15 d_comp:16 crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    │    │    │    ├── computed column expressions
       │    │    │    │    │    │    │    └── d_comp:16
-      │    │    │    │    │    │    │         └── d:14
+      │    │    │    │    │    │    │         └── d:14::DECIMAL(10)
       │    │    │    │    │    │    └── flags: disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── column1:8 = k:12

--- a/pkg/sql/opt/optbuilder/testdata/virtual-columns
+++ b/pkg/sql/opt/optbuilder/testdata/virtual-columns
@@ -7,6 +7,13 @@ CREATE TABLE t (
 ----
 
 exec-ddl
+CREATE TABLE t_cast (
+  a STRING PRIMARY KEY,
+  v CHAR AS (a) VIRTUAL
+)
+----
+
+exec-ddl
 CREATE TABLE t_idx (
   a INT PRIMARY KEY,
   b INT,
@@ -87,6 +94,22 @@ project
       └── projections
            └── a:1 + b:2 [as=v:3]
 
+# The projection for v should be casted to match the column type.
+build
+SELECT * FROM t_cast
+----
+project
+ ├── columns: a:1!null v:2!null
+ └── project
+      ├── columns: v:2!null a:1!null crdb_internal_mvcc_timestamp:3 tableoid:4
+      ├── scan t_cast
+      │    ├── columns: a:1!null crdb_internal_mvcc_timestamp:3 tableoid:4
+      │    └── computed column expressions
+      │         └── v:2
+      │              └── a:1::CHAR
+      └── projections
+           └── a:1::CHAR [as=v:2]
+
 # -- INSERT tests --
 
 build
@@ -154,6 +177,24 @@ project
            │    └── (1, 1)
            └── projections
                 └── column1:6 + column2:7 [as=v_comp:8]
+
+# The projection for v should be casted to match the column type.
+build
+INSERT INTO t_cast VALUES ('foo')
+----
+insert t_cast
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:5 => a:1
+ │    └── v_cast:6 => v:2
+ └── project
+      ├── columns: v_cast:6!null column1:5!null
+      ├── values
+      │    ├── columns: column1:5!null
+      │    └── ('foo',)
+      └── projections
+           └── assignment-cast: CHAR [as=v_cast:6]
+                └── column1:5
 
 build
 INSERT INTO t_idx VALUES (1, 1)
@@ -310,6 +351,28 @@ project
            │         └── a:6 + b:7 [as=v:8]
            └── filters
                 └── v:8 = 1
+
+# The projection for v should be casted to match the column type.
+build
+DELETE FROM t_cast RETURNING v
+----
+project
+ ├── columns: v:2!null
+ └── delete t_cast
+      ├── columns: a:1!null v:2!null
+      ├── fetch columns: a:5 v:6
+      ├── return-mapping:
+      │    ├── a:5 => a:1
+      │    └── v:6 => v:2
+      └── project
+           ├── columns: v:6!null a:5!null crdb_internal_mvcc_timestamp:7 tableoid:8
+           ├── scan t_cast
+           │    ├── columns: a:5!null crdb_internal_mvcc_timestamp:7 tableoid:8
+           │    └── computed column expressions
+           │         └── v:6
+           │              └── a:5::CHAR
+           └── projections
+                └── a:5::CHAR [as=v:6]
 
 build
 DELETE FROM t_idx WHERE a > 1
@@ -520,6 +583,40 @@ update t
       │         └── a:6 + 1 [as=a_new:11]
       └── projections
            └── a_new:11 + b:7 [as=v_comp:12]
+
+# The projections for v should be casted to match the column type.
+build
+UPDATE t_cast SET a = 'foo' RETURNING v
+----
+project
+ ├── columns: v:2!null
+ └── update t_cast
+      ├── columns: a:1!null v:2!null
+      ├── fetch columns: a:5 v:6
+      ├── update-mapping:
+      │    ├── a_new:9 => a:1
+      │    └── v_cast:10 => v:2
+      ├── return-mapping:
+      │    ├── a_new:9 => a:1
+      │    └── v_cast:10 => v:2
+      └── project
+           ├── columns: v_cast:10!null a:5!null v:6!null crdb_internal_mvcc_timestamp:7 tableoid:8 a_new:9!null
+           ├── project
+           │    ├── columns: a_new:9!null a:5!null v:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+           │    ├── project
+           │    │    ├── columns: v:6!null a:5!null crdb_internal_mvcc_timestamp:7 tableoid:8
+           │    │    ├── scan t_cast
+           │    │    │    ├── columns: a:5!null crdb_internal_mvcc_timestamp:7 tableoid:8
+           │    │    │    └── computed column expressions
+           │    │    │         └── v:6
+           │    │    │              └── a:5::CHAR
+           │    │    └── projections
+           │    │         └── a:5::CHAR [as=v:6]
+           │    └── projections
+           │         └── 'foo' [as=a_new:9]
+           └── projections
+                └── assignment-cast: CHAR [as=v_cast:10]
+                     └── a_new:9
 
 build
 UPDATE t_idx SET a=a+1
@@ -819,6 +916,26 @@ project
            └── projections
                 └── column1:6 + column2:7 [as=v_comp:8]
 
+# The projection for v should be casted to match the column type.
+build
+UPSERT INTO t_cast VALUES ('foo') RETURNING v
+----
+project
+ ├── columns: v:2!null
+ └── upsert t_cast
+      ├── columns: a:1!null v:2!null
+      ├── upsert-mapping:
+      │    ├── column1:5 => a:1
+      │    └── v_cast:6 => v:2
+      └── project
+           ├── columns: v_cast:6!null column1:5!null
+           ├── values
+           │    ├── columns: column1:5!null
+           │    └── ('foo',)
+           └── projections
+                └── assignment-cast: CHAR [as=v_cast:6]
+                     └── column1:5
+
 build
 UPSERT INTO t_check VALUES (1, 1)
 ----
@@ -889,6 +1006,50 @@ project
                 │    └── column2:7
                 └── first-agg [as=v_comp:8]
                      └── v_comp:8
+
+# The projections for v should be casted to match the column type.
+build
+INSERT INTO t_cast VALUES ('foo') ON CONFLICT DO NOTHING RETURNING v
+----
+project
+ ├── columns: v:2!null
+ └── insert t_cast
+      ├── columns: a:1!null v:2!null
+      ├── arbiter indexes: t_cast_pkey
+      ├── insert-mapping:
+      │    ├── column1:5 => a:1
+      │    └── v_cast:6 => v:2
+      ├── return-mapping:
+      │    ├── column1:5 => a:1
+      │    └── v_cast:6 => v:2
+      └── upsert-distinct-on
+           ├── columns: column1:5!null v_cast:6!null
+           ├── grouping columns: column1:5!null
+           ├── anti-join (hash)
+           │    ├── columns: column1:5!null v_cast:6!null
+           │    ├── project
+           │    │    ├── columns: v_cast:6!null column1:5!null
+           │    │    ├── values
+           │    │    │    ├── columns: column1:5!null
+           │    │    │    └── ('foo',)
+           │    │    └── projections
+           │    │         └── assignment-cast: CHAR [as=v_cast:6]
+           │    │              └── column1:5
+           │    ├── project
+           │    │    ├── columns: v:8!null a:7!null
+           │    │    ├── scan t_cast
+           │    │    │    ├── columns: a:7!null
+           │    │    │    ├── computed column expressions
+           │    │    │    │    └── v:8
+           │    │    │    │         └── a:7::CHAR
+           │    │    │    └── flags: disabled not visible index feature
+           │    │    └── projections
+           │    │         └── a:7::CHAR [as=v:8]
+           │    └── filters
+           │         └── column1:5 = a:7
+           └── aggregations
+                └── first-agg [as=v_cast:6]
+                     └── v_cast:6
 
 build
 INSERT INTO t_idx2 VALUES (1, 1, 1) ON CONFLICT (w) DO NOTHING

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -2154,7 +2154,7 @@ func (t *InternalType) Identical(other *InternalType) bool {
 		return false
 	}
 	if t.Locale != nil && other.Locale != nil {
-		if *t.Locale != *other.Locale {
+		if !lex.LocaleNamesAreEqual(*t.Locale, *other.Locale) {
 			return false
 		}
 	} else if t.Locale != nil {

--- a/pkg/sql/types/types_test.go
+++ b/pkg/sql/types/types_test.go
@@ -645,6 +645,94 @@ func TestEquivalent(t *testing.T) {
 	}
 }
 
+func TestIdentical(t *testing.T) {
+	testCases := []struct {
+		typ1      *T
+		typ2      *T
+		identical bool
+	}{
+		// ARRAY
+		{IntArray, IntArray, true},
+		{Int2Vector, Int2Vector, true},
+		{Int2Vector, IntArray, false},
+		{OidVector, MakeArray(Oid), false},
+		{MakeArray(Int), MakeArray(Int), true},
+		{MakeArray(Int), IntArray, true},
+		{MakeArray(Int), MakeArray(Int4), false},
+		{MakeArray(String), MakeArray(String), true},
+		{MakeArray(String), MakeArray(MakeChar(10)), false},
+		{MakeArray(String), MakeArray(MakeArray(String)), false},
+		{MakeArray(IntArray), IntArray, false},
+
+		// BIT
+		{MakeBit(1), MakeBit(1), true},
+		{MakeBit(1), MakeBit(2), false},
+		{MakeBit(1), MakeVarBit(1), false},
+		{MakeVarBit(10), Any, false},
+		{VarBit, Bytes, false},
+
+		// COLLATEDSTRING
+		{MakeCollatedString(String, "en"), MakeCollatedString(String, "en"), true},
+		{MakeCollatedString(String, "en_us"), MakeCollatedString(String, "en_US"), true},
+		{MakeCollatedString(String, "en_us"), MakeCollatedString(String, "en-US"), true},
+		{MakeCollatedString(String, "en_us"), MakeCollatedString(String, "de"), false},
+		{MakeCollatedString(String, "en"), MakeCollatedString(MakeVarChar(10), "en"), false},
+		{MakeCollatedString(String, "en"), String, false},
+		{MakeCollatedString(String, "en"), AnyCollatedString, false},
+		{AnyCollatedString, MakeCollatedString(String, "en"), false},
+		{MakeCollatedString(String, "en"), MakeCollatedString(String, "de"), false},
+
+		// DECIMAL
+		{Decimal, Decimal, true},
+		{Decimal, MakeDecimal(3, 2), false},
+		{MakeDecimal(3, 2), MakeDecimal(3, 2), true},
+		{MakeDecimal(3, 2), MakeDecimal(3, 0), false},
+		{Any, MakeDecimal(10, 0), false},
+		{Decimal, Float, false},
+
+		// INT
+		{Int2, Int2, true},
+		{Int4, Int4, true},
+		{Int2, Int4, false},
+		{Int4, Int, false},
+		{Int, Any, false},
+		{Int, IntArray, false},
+
+		// TUPLE
+		{MakeTuple([]*T{}), MakeTuple([]*T{}), true},
+		{MakeTuple([]*T{Int4, String}), MakeTuple([]*T{Int4, String}), true},
+		{MakeTuple([]*T{Int, String}), MakeTuple([]*T{Int4, String}), false},
+		{MakeTuple([]*T{Int, String}), AnyTuple, false},
+		{AnyTuple, MakeTuple([]*T{Int, String}), false},
+		{MakeLabeledTuple([]*T{Int4, String}, []string{"label1", "label2"}),
+			MakeLabeledTuple([]*T{Int4, String}, []string{"label1", "label2"}), true},
+		{MakeLabeledTuple([]*T{Int4, String}, []string{"label1", "label2"}),
+			MakeLabeledTuple([]*T{Int4, String}, []string{"label1", "label4"}), false},
+		{MakeTuple([]*T{String, Int}), MakeTuple([]*T{Int, String}), false},
+
+		// ENUM
+		{MakeEnum(15210, 15213), MakeEnum(15210, 15213), true},
+		{MakeEnum(15210, 15213), MakeEnum(15150, 15213), false},
+
+		// UNKNOWN
+		{Unknown, &T{InternalType: InternalType{
+			Family: UnknownFamily, Oid: oid.T_unknown, Locale: &emptyLocale}}, true},
+		{Any, Unknown, false},
+		{Unknown, Int, false},
+	}
+
+	for _, tc := range testCases {
+		if tc.identical && !tc.typ1.Identical(tc.typ2) {
+			t.Errorf("expected <%v> to be identical to <%v>",
+				tc.typ1.DebugString(), tc.typ2.DebugString())
+		}
+		if !tc.identical && tc.typ1.Identical(tc.typ2) {
+			t.Errorf("expected <%v> to not be identical to <%v>",
+				tc.typ1.DebugString(), tc.typ2.DebugString())
+		}
+	}
+}
+
 // TestMarshalCompat tests backwards-compatibility during marshal.
 func TestMarshalCompat(t *testing.T) {
 	intElemType := IntFamily


### PR DESCRIPTION
Backport 3/3 commits from #105736.

/cc @cockroachdb/release

---

#### sql/logictest: remove assignment cast TODO

This commit removes a TODO that was partially addressed by #82022.

Informs #73743

Release note: None

#### sql/types: fix T.Identical

This commit fixes a bug in `types.T.Identical` which caused it to return
false for collated string types with a different string-representation
of locales that represents the same locale logically. For example,
collated string types with locales `en_US` and `en_us` would not be
identical, even though these are both valid representations of the same
locale.

There is no release note because this has not caused any known bugs.

Release note: None

#### opt: wrap virtual computed column projections in a cast

optbuilder wraps an assignment cast around a virtual computed column
expression when writing to the table if the expression does not have the
same type as the virtual column. This matches the behavior of all writes
to columns of expressions that don't match the target column type.

However, the same cast was not applied to the projection of the virtual
column expression when reading from the table. This cast is necessary in
order to produce the correct value of the column - the projection must
produce the same value that would have been written to the table if the
column was a stored computed column. This commit corrects optbuilder so
that the cast is correctly added to the projection.

Note that this commit adds a standard cast, not an assignment cast, as a
temporary workaround until #81698 is addressed. This is because an
assignment cast can fail in cases when a regular cast will not. Because
we don't validate that all existing rows can successfully produce a new
virtual column expression during a backfill, adding an assignment cast
to the projection of the virtual column could cause future reads to
error. Once #81698 is addressed, we can change these casts to assignment
casts so that they directly match the values that would be written to
the same column if it were stored.

Fixes #91817
Informs #81698

Release note (bug fix): A bug has been fixed that could produce incorrect
values for virtual computed columns in rare cases. The bug only
presented when the virtual column expression's type did not match the
type of the virtual column.

---

Release justification: Minor bug fix that will silence test failures.

