### PR TITLE
sql/logictest: deflake schema_change_in_txn

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -746,12 +746,12 @@ SELECT status,
 ----
 failed  ALTER TABLE test.public.customers ADD COLUMN i INT8 DEFAULT … ers (n)
 
-query TT
-SELECT status,
+query BT
+SELECT status % '(running)|(succeeded)',
        regexp_replace(description, 'ROLL BACK JOB \d+.*', 'ROLL BACK JOB') as descr
   FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE GC' AND description LIKE 'GC for ROLL%' ORDER BY job_id DESC LIMIT 1
 ----
-running  GC for ROLLBACK of ALTER TABLE test.public.customers ADD CO … ers (n)
+true  GC for ROLLBACK of ALTER TABLE test.public.customers ADD CO … ers (n)
 
 subtest add_multiple_computed_elements
 


### PR DESCRIPTION
In the update test, there's a chance that a job succeeds quickly, so we
account for that by matching statuses of "running" or "succeeded".

Fixes #128746

Release note: None
