### PR TITLE
schemachanger: support NaN/Inf as a default value in a function

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_params
+++ b/pkg/sql/logictest/testdata/logic_test/udf_params
@@ -658,6 +658,10 @@ CREATE FUNCTION my_sum(a INT, b INT DEFAULT (SELECT 1)) RETURNS INT LANGUAGE SQL
 statement error pgcode 0A000 subqueries are not allowed in DEFAULT expressions
 CREATE FUNCTION my_sum(a INT, b INT DEFAULT 1 + (SELECT 2 FROM (VALUES (NULL)))) RETURNS INT LANGUAGE SQL AS $$ SELECT a + b; $$;
 
+# Verify that 'NaN' can be used as a default.
+statement ok
+CREATE FUNCTION f_nan(a INT, b INT DEFAULT 2, c FLOAT DEFAULT 'NaN':::FLOAT) RETURNS INT LANGUAGE SQL AS $$ SELECT a + b; $$;
+
 statement ok
 CREATE FUNCTION my_sum(a INT, b INT, c INT) RETURNS INT LANGUAGE SQL AS $$ SELECT a + b + c; $$;
 

--- a/pkg/sql/schemachanger/scbuild/ast_annotator.go
+++ b/pkg/sql/schemachanger/scbuild/ast_annotator.go
@@ -31,7 +31,8 @@ func newAstAnnotator(original tree.Statement) (*astAnnotator, error) {
 	// Clone the original tree by re-parsing the input back into an AST. We need
 	// to keep tagged dollar quotes in case they're necessary to parse the
 	// original statement.
-	statement, err := parser.ParseOne(tree.AsStringWithFlags(original, tree.FmtTagDollarQuotes))
+	formatted := tree.AsStringWithFlags(original, tree.FmtTagDollarQuotes|tree.FmtParsableNumerics)
+	statement, err := parser.ParseOne(formatted)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/129017
Release note (bug fix): Fixed a bug where NaN or Inf could not be used as the default value for a parameter in CREATE FUNCTION statements.