### PR TITLE
sql: deprecate enforce_home_region_follower_reads_enabled

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
@@ -348,8 +348,10 @@ sleep 5s
 statement ok
 SET enforce_home_region = true
 
-statement ok
+query T noticetrace
 SET enforce_home_region_follower_reads_enabled = true
+----
+NOTICE: enforce_home_region_follower_reads_enabled is deprecated and will be removed in a future release
 
 # An insert with uniqueness checks which access all regions should error out.
 retry

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2787,13 +2787,23 @@ var varGen = map[string]sessionVar{
 	// CockroachDB extension.
 	`enforce_home_region_follower_reads_enabled`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`enforce_home_region_follower_reads_enabled`),
-		Set: func(_ context.Context, m sessionDataMutator, s string) error {
-			b, err := paramparse.ParseBoolVar("enforce_home_region_follower_reads_enabled", s)
-			if err != nil {
-				return err
-			}
-			m.SetEnforceHomeRegionFollowerReadsEnabled(b)
-			return nil
+		SetWithPlanner: func(ctx context.Context, p *planner, local bool, s string) error {
+			p.BufferClientNotice(ctx, pgnotice.Newf(
+				"enforce_home_region_follower_reads_enabled is deprecated and will be removed in a future "+
+					"release",
+			))
+			return p.applyOnSessionDataMutators(
+				ctx,
+				local,
+				func(m sessionDataMutator) error {
+					b, err := paramparse.ParseBoolVar("enforce_home_region_follower_reads_enabled", s)
+					if err != nil {
+						return err
+					}
+					m.SetEnforceHomeRegionFollowerReadsEnabled(b)
+					return nil
+				},
+			)
 		},
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return formatBoolAsPostgresSetting(evalCtx.SessionData().EnforceHomeRegionFollowerReadsEnabled), nil


### PR DESCRIPTION
Informs: #113765

Release note (sql change): Session variable
`enforce_home_region_follower_reads_enabled` is now deprecated, and will be removed in a future release. (Note that related session variable `enforce_home_region` is _not_ deprecated.)