### PR TITLE
roachprod: azure GC supports cleanup for multiple subscriptions

### DIFF
--- a/pkg/roachprod/cloud/BUILD.bazel
+++ b/pkg/roachprod/cloud/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/roachprod/ui",
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/aws",
+        "//pkg/roachprod/vm/azure",
         "//pkg/roachprod/vm/gce",
         "//pkg/util/timeutil",
         "@com_github_aws_aws_sdk_go//aws",

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1731,9 +1731,13 @@ func GC(l *logger.Logger, dryrun bool) error {
 		return cloud.GCAWS(l, dryrun)
 	})
 
+	addOpFn(func() error {
+		return cloud.GCAzure(l, dryrun)
+	})
+
 	// ListCloud may fail for a provider, but we can still attempt GC on
 	// the clusters we do have.
-	cld, _ := cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true, IncludeProviders: []string{gce.ProviderName, azure.ProviderName}})
+	cld, _ := cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true, IncludeProviders: []string{gce.ProviderName}})
 	addOpFn(func() error {
 		return cloud.GCClusters(l, cld, dryrun)
 	})

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -39,7 +39,8 @@ import (
 )
 
 const (
-	defaultSubscription = "e2e-infra"
+	defaultSubscription  = "e2e-adhoc"
+	SubscriptionIDEnvVar = "AZURE_SUBSCRIPTION_ID"
 	// ProviderName is "azure".
 	ProviderName = "azure"
 	remoteUser   = "ubuntu"
@@ -85,6 +86,9 @@ type Provider struct {
 	OperationTimeout time.Duration
 	// Wait for deletions to finish before returning.
 	SyncDelete bool
+	// The list of subscription names to use. Currently only used by GC.
+	// If left empty then falls back to env var then default subscription.
+	SubscriptionNames []string
 
 	mu struct {
 		syncutil.Mutex
@@ -499,7 +503,7 @@ func (p *Provider) DeleteCluster(l *logger.Logger, name string) error {
 		// We have seen occurrences of Azure resource groups losing the necessary tags
 		// needed for roachprod to find them. The cluster may need to be manually deleted
 		// through the Azure portal.
-		return errors.Newf("**** MANUAL INTERVENTION REQUIRED ****\nDeleteCluster: Found no azure resource groups with tag cluster: %s", name)
+		return errors.Newf("**** MANUAL INTERVENTION REQUIRED IF ERROR SEEN MULTIPLE TIMES ****\nDeleteCluster: Found no azure resource groups with tag cluster: %s", name)
 	}
 
 	if !p.SyncDelete {
@@ -1546,6 +1550,57 @@ func (p *Provider) createUltraDisk(
 	return disk, err
 }
 
+// SetSubscription takes in a subscription name then finds and stores the ID
+// in the Provider instance.
+func (p *Provider) SetSubscription(ctx context.Context, subscription string) error {
+	subscriptionId, err := p.findSubscriptionID(ctx, subscription)
+	if err != nil {
+		return err
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.mu.subscriptionId = subscriptionId
+
+	return nil
+}
+
+// findSubscriptionID takes in a subscription name and returns the ID.
+func (p *Provider) findSubscriptionID(ctx context.Context, subscription string) (string, error) {
+	authorizer, err := p.getAuthorizer()
+	if err != nil {
+		return "", err
+	}
+	sc := subscriptions.NewClient()
+	sc.Authorizer = authorizer
+
+	it, err := sc.ListComplete(ctx)
+	if err != nil {
+		return "", errors.Wrapf(err, "error listing Azure subscriptions")
+	}
+
+	var subscriptionId string
+
+	// Iterate through all subscriptions to find the matching subscription name.
+	for it.NotDone() {
+		s := it.Value().SubscriptionID
+		name := it.Value().DisplayName
+		if s != nil && name != nil {
+			if *name == subscription {
+				subscriptionId = *s
+				break
+			}
+		}
+		if err = it.NextWithContext(ctx); err != nil {
+			return "", err
+		}
+	}
+	if subscriptionId == "" {
+		return "", errors.Newf("could not find Azure subscription: %s", subscription)
+	}
+
+	return subscriptionId, nil
+}
+
 // getSubscription returns env.AZURE_SUBSCRIPTION_ID if it exists
 // or the ID of the defaultSubscription.
 // The value is memoized in the Provider instance.
@@ -1556,43 +1611,19 @@ func (p *Provider) getSubscription(ctx context.Context) (string, error) {
 		return p.mu.subscriptionId
 	}()
 
+	// Use the saved subscriptionID.
 	if subscriptionId != "" {
 		return subscriptionId, nil
 	}
 
-	subscriptionId = os.Getenv("AZURE_SUBSCRIPTION_ID")
+	subscriptionId = os.Getenv(SubscriptionIDEnvVar)
 
 	// Fallback to retrieving the defaultSubscription.
 	if subscriptionId == "" {
-		authorizer, err := p.getAuthorizer()
+		var err error
+		subscriptionId, err = p.findSubscriptionID(ctx, defaultSubscription)
 		if err != nil {
-			return "", err
-		}
-		sc := subscriptions.NewClient()
-		sc.Authorizer = authorizer
-
-		it, err := sc.ListComplete(ctx)
-		if err != nil {
-			return "", errors.Wrapf(err, "error listing Azure subscriptions")
-		}
-
-		// Iterate through all subscriptions to find the defaultSubscription.
-		// We have to do this as Azure requires the ID not just the name.
-		for it.NotDone() {
-			s := it.Value().SubscriptionID
-			name := it.Value().DisplayName
-			if s != nil && name != nil {
-				if *name == defaultSubscription {
-					subscriptionId = *s
-					break
-				}
-			}
-			if err = it.NextWithContext(ctx); err != nil {
-				return "", err
-			}
-		}
-		if subscriptionId == "" {
-			return "", errors.Newf("Could not find default subscription: %s", defaultSubscription)
+			return "", errors.Wrapf(err, "Error finding default Azure subscription. Check that you have permission to view the subscription or use a different subscription by specifying the %s env var", SubscriptionIDEnvVar)
 		}
 	}
 

--- a/pkg/roachprod/vm/azure/flags.go
+++ b/pkg/roachprod/vm/azure/flags.go
@@ -90,6 +90,8 @@ func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 func (o *ProviderOpts) ConfigureClusterFlags(*pflag.FlagSet, vm.MultipleProjectsOption) {
 }
 
-// ConfigureClusterCleanupFlags is part of ProviderOpts. This implementation is a no-op.
+// ConfigureClusterCleanupFlags is part of ProviderOpts.
 func (o *ProviderOpts) ConfigureClusterCleanupFlags(flags *pflag.FlagSet) {
+	flags.StringSliceVar(&providerInstance.SubscriptionNames, ProviderName+"-subscription-names", []string{},
+		"Azure subscription names as a comma-separated string")
 }


### PR DESCRIPTION
Previously Azure GC assumed that only one subscription ID would be used at a time. However the current structure of our Azure subscriptions makes a distinction between user "adhoc" roachprod clusters and nightly "infra" clusters. As a result, roachprod clusters can live in two different subscriptions.

This change adds the azure-subscription-name flag to support cleaning up in multiple subscriptions.

Additionally it also switches the default subscription ID to e2e-adhoc, which is what users should use.

Fixes: #129057
Release note: none
Epic: none