### PR TITLE
backupccl: break read and write metrics by bucket

### DIFF
--- a/pkg/ccl/storageccl/BUILD.bazel
+++ b/pkg/ccl/storageccl/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
         "//pkg/testutils/serverutils",
         "//pkg/testutils/storageutils",
         "//pkg/testutils/testcluster",
+        "//pkg/util/cidr",
         "//pkg/util/encoding",
         "//pkg/util/humanizeutil",
         "//pkg/util/ioctx",

--- a/pkg/ccl/storageccl/external_sst_reader_test.go
+++ b/pkg/ccl/storageccl/external_sst_reader_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/storageutils"
+	"github.com/cockroachdb/cockroach/pkg/util/cidr"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -170,7 +171,7 @@ func TestNewExternalSSTReaderFailure(t *testing.T) {
 
 	ctx := context.Background()
 	settings := cluster.MakeTestingClusterSettings()
-	metrics := cloud.MakeMetrics()
+	metrics := cloud.MakeMetrics(cidr.NewLookup(&settings.SV))
 
 	const localFoo = "nodelocal://1/foo"
 

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -191,6 +191,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/buildutil",
         "//pkg/util/cgroups",
+        "//pkg/util/cidr",
         "//pkg/util/encoding",
         "//pkg/util/envutil",
         "//pkg/util/flagutil",

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -54,6 +54,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
+	"github.com/cockroachdb/cockroach/pkg/util/cidr"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/flagutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -482,7 +483,7 @@ func runDebugRangeData(cmd *cobra.Command, args []string) error {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 
-	earlyBootAccessor := cloud.NewEarlyBootExternalStorageAccessor(serverCfg.Settings, serverCfg.ExternalIODirConfig)
+	earlyBootAccessor := cloud.NewEarlyBootExternalStorageAccessor(serverCfg.Settings, serverCfg.ExternalIODirConfig, cidr.NewLookup(&serverCfg.Settings.SV))
 	opts := []storage.ConfigOption{storage.MustExist, storage.RemoteStorageFactory(earlyBootAccessor)}
 	if serverCfg.SharedStorage != "" {
 		es, err := cloud.ExternalStorageFromURI(ctx, serverCfg.SharedStorage,

--- a/pkg/cloud/BUILD.bazel
+++ b/pkg/cloud/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/isql",
+        "//pkg/util/cidr",
         "//pkg/util/ctxgroup",
         "//pkg/util/ioctx",
         "//pkg/util/log",

--- a/pkg/cloud/amazon/aws_kms.go
+++ b/pkg/cloud/amazon/aws_kms.go
@@ -148,7 +148,7 @@ func MakeAWSKMS(ctx context.Context, uri string, env cloud.KMSEnv) (cloud.KMS, e
 			// situation is.
 			region = "default-region"
 		}
-		client, err := cloud.MakeHTTPClient(env.ClusterSettings())
+		client, err := cloud.MakeHTTPClient(env.ClusterSettings(), cloud.NilMetrics, "aws", "KMS")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cloud/amazon/s3_storage_test.go
+++ b/pkg/cloud/amazon/s3_storage_test.go
@@ -630,7 +630,7 @@ func TestNewClientErrorsOnBucketRegion(t *testing.T) {
 		bucket: "bucket-does-not-exist-v1i3m",
 		auth:   cloud.AuthParamImplicit,
 	}
-	_, _, err = newClient(ctx, cfg, testSettings)
+	_, _, err = newClient(ctx, cloud.NilMetrics, cfg, testSettings)
 	require.Regexp(t, "could not find s3 bucket's region", err)
 }
 

--- a/pkg/cloud/azure/azure_storage.go
+++ b/pkg/cloud/azure/azure_storage.go
@@ -225,6 +225,13 @@ func makeAzureStorage(
 		return nil, errors.Wrap(err, "azure: account name is not valid")
 	}
 
+	t, err := cloud.MakeHTTPClient(args.Settings, args.MetricsRecorder, "azure", dest.AzureConfig.Container)
+	if err != nil {
+		return nil, errors.Wrap(err, "azure: unable to create transport")
+	}
+	var opts service.ClientOptions
+	opts.Transport = t
+
 	var azClient *service.Client
 	switch conf.Auth {
 	case cloudpb.AzureAuth_LEGACY:
@@ -232,7 +239,7 @@ func makeAzureStorage(
 		if err != nil {
 			return nil, errors.Wrap(err, "azure shared key credential")
 		}
-		azClient, err = service.NewClientWithSharedKeyCredential(u.String(), credential, nil)
+		azClient, err = service.NewClientWithSharedKeyCredential(u.String(), credential, &opts)
 		if err != nil {
 			return nil, err
 		}
@@ -241,7 +248,7 @@ func makeAzureStorage(
 		if err != nil {
 			return nil, errors.Wrap(err, "azure client secret credential")
 		}
-		azClient, err = service.NewClient(u.String(), credential, nil)
+		azClient, err = service.NewClient(u.String(), credential, &opts)
 		if err != nil {
 			return nil, err
 		}
@@ -265,7 +272,7 @@ func makeAzureStorage(
 		if err != nil {
 			return nil, errors.Wrap(err, "azure default credential")
 		}
-		azClient, err = service.NewClient(u.String(), credential, nil)
+		azClient, err = service.NewClient(u.String(), credential, &opts)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cloud/azure/azure_storage_test.go
+++ b/pkg/cloud/azure/azure_storage_test.go
@@ -259,7 +259,8 @@ func TestMakeAzureStorageURLFromEnvironment(t *testing.T) {
 		{environment: azure.USGovernmentCloud.Name, expected: "https://account.blob.core.usgovcloudapi.net/container"},
 	} {
 		t.Run(tt.environment, func(t *testing.T) {
-			sut, err := makeAzureStorage(context.Background(), cloud.EarlyBootExternalStorageContext{}, cloudpb.ExternalStorage{
+			testSettings := cluster.MakeTestingClusterSettings()
+			sut, err := makeAzureStorage(context.Background(), cloud.EarlyBootExternalStorageContext{Settings: testSettings}, cloudpb.ExternalStorage{
 				AzureConfig: &cloudpb.ExternalStorage_Azure{
 					Container:   "container",
 					Prefix:      "path",

--- a/pkg/cloud/external_storage.go
+++ b/pkg/cloud/external_storage.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/util/cidr"
 	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/errors"
@@ -170,7 +171,6 @@ type ExternalStorageContext struct {
 
 	BlobClientFactory blobs.BlobClientFactory
 	DB                isql.DB
-	MetricsRecorder   *Metrics
 }
 
 // ExternalStorageContext contains the dependencies passed to external storage
@@ -181,9 +181,10 @@ type EarlyBootExternalStorageContext struct {
 	// storage, but I am rather uncertain it is a good idea. We
 	// may be using this provider before we've even read our
 	// cached settings.
-	Settings *cluster.Settings
-	Options  []ExternalStorageOption
-	Limiters Limiters
+	Settings        *cluster.Settings
+	Options         []ExternalStorageOption
+	Limiters        Limiters
+	MetricsRecorder *Metrics
 }
 
 // ExternalStorageOptions holds dependencies and values that can be
@@ -207,13 +208,13 @@ type EarlyBootExternalStorageConstructor func(
 // NewEarlyBootExternalStorageAccessor creates an
 // EarlyBootExternalStorageAccessor
 func NewEarlyBootExternalStorageAccessor(
-	st *cluster.Settings, conf base.ExternalIODirConfig,
+	st *cluster.Settings, conf base.ExternalIODirConfig, lookup *cidr.Lookup,
 ) *EarlyBootExternalStorageAccessor {
 	return &EarlyBootExternalStorageAccessor{
 		conf:     conf,
 		settings: st,
 		limiters: MakeLimiters(&st.SV),
-		metrics:  MakeMetrics(),
+		metrics:  MakeMetrics(lookup),
 	}
 }
 

--- a/pkg/cloud/gcp/gcs_storage.go
+++ b/pkg/cloud/gcp/gcs_storage.go
@@ -190,7 +190,7 @@ func makeGCSStorage(
 		opts = append(opts, assumeOpt)
 	}
 
-	baseTransport, err := cloud.MakeTransport(args.Settings)
+	baseTransport, err := cloud.MakeTransport(args.Settings, args.MetricsRecorder, "gcs", conf.Bucket)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create http transport")
 	}

--- a/pkg/cloud/httpsink/http_storage.go
+++ b/pkg/cloud/httpsink/http_storage.go
@@ -71,7 +71,7 @@ func MakeHTTPStorage(
 		return nil, errors.Errorf("HTTP storage requested but prefix path not provided")
 	}
 
-	client, err := cloud.MakeHTTPClient(args.Settings)
+	client, err := cloud.MakeHTTPClient(args.Settings, args.MetricsRecorder, "http", base)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloud/impl_registry.go
+++ b/pkg/cloud/impl_registry.go
@@ -248,14 +248,14 @@ func MakeExternalStorage(
 	}
 	args := ExternalStorageContext{
 		EarlyBootExternalStorageContext: EarlyBootExternalStorageContext{
-			IOConf:   conf,
-			Settings: settings,
-			Options:  opts,
-			Limiters: limiters,
+			IOConf:          conf,
+			Settings:        settings,
+			Options:         opts,
+			Limiters:        limiters,
+			MetricsRecorder: cloudMetrics,
 		},
 		BlobClientFactory: blobClientFactory,
 		DB:                db,
-		MetricsRecorder:   cloudMetrics,
 	}
 
 	return makeExternalStorage[ExternalStorageContext](ctx, dest, conf, limiters, metrics, settings, args, getImpl, opts...)

--- a/pkg/cloud/metrics.go
+++ b/pkg/cloud/metrics.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/cockroachdb/cockroach/pkg/util/cidr"
 	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	io_prometheus_client "github.com/prometheus/client_model/go"
@@ -29,15 +30,11 @@ type Metrics struct {
 	CreatedReaders *metric.Counter
 	// OpenReaders is the number of currently open cloud readers.
 	OpenReaders *metric.Gauge
-	// ReadBytes counts the bytes read from cloud storage.
-	ReadBytes *metric.Counter
 
 	// Writers counts the cloud storage writers opened.
 	CreatedWriters *metric.Counter
 	// OpenReaders is the number of currently open cloud writers.
 	OpenWriters *metric.Gauge
-	// WriteBytes counts the bytes written to cloud storage.
-	WriteBytes *metric.Counter
 
 	// Listings counts the listing calls made to cloud storage.
 	Listings *metric.Counter
@@ -47,10 +44,13 @@ type Metrics struct {
 	// ConnsOpened, ConnsReused and TLSHandhakes track connection http info for cloud
 	// storage when collecting this info is enabled.
 	ConnsOpened, ConnsReused, TLSHandhakes *metric.Counter
+
+	// NetMetrics tracks connection level metrics.
+	NetMetrics *cidr.NetMetrics
 }
 
 // MakeMetrics returns a new instance of Metrics.
-func MakeMetrics() metric.Struct {
+func MakeMetrics(cidrLookup *cidr.Lookup) metric.Struct {
 	cloudReaders := metric.Metadata{
 		Name:        "cloud.readers_opened",
 		Help:        "Readers opened by all cloud operations",
@@ -131,15 +131,14 @@ func MakeMetrics() metric.Struct {
 	return &Metrics{
 		CreatedReaders: metric.NewCounter(cloudReaders),
 		OpenReaders:    metric.NewGauge(cloudOpenReaders),
-		ReadBytes:      metric.NewCounter(cloudReadBytes),
 		CreatedWriters: metric.NewCounter(cloudWriters),
 		OpenWriters:    metric.NewGauge(cloudOpenWriters),
-		WriteBytes:     metric.NewCounter(cloudWriteBytes),
 		Listings:       metric.NewCounter(listings),
 		ListingResults: metric.NewCounter(listingResults),
 		ConnsOpened:    metric.NewCounter(connsOpened),
 		ConnsReused:    metric.NewCounter(connsReused),
 		TLSHandhakes:   metric.NewCounter(tlsHandhakes),
+		NetMetrics:     cidrLookup.MakeNetMetrics(cloudWriteBytes, cloudReadBytes, "cloud", "bucket"),
 	}
 }
 
@@ -158,8 +157,8 @@ func (m *Metrics) Reader(
 	m.CreatedReaders.Inc(1)
 	m.OpenReaders.Inc(1)
 	return &metricsReader{
-		inner: r,
-		m:     m,
+		ReadCloserCtx: r,
+		m:             m,
 	}
 }
 
@@ -171,22 +170,15 @@ func (m *Metrics) Writer(_ context.Context, _ ExternalStorage, w io.WriteCloser)
 	m.CreatedWriters.Inc(1)
 	m.OpenWriters.Inc(1)
 	return &metricsWriter{
-		w: w,
-		m: m,
+		WriteCloser: w,
+		m:           m,
 	}
 }
 
 type metricsReader struct {
-	inner  ioctx.ReadCloserCtx
+	ioctx.ReadCloserCtx
 	m      *Metrics
 	closed bool
-}
-
-// Read implements the ioctx.ReadCloserCtx interface.
-func (mr *metricsReader) Read(ctx context.Context, p []byte) (int, error) {
-	n, err := mr.inner.Read(ctx, p)
-	mr.m.ReadBytes.Inc(int64(n))
-	return n, err
 }
 
 // Close implements the ioctx.ReadCloserCtx interface.
@@ -196,20 +188,13 @@ func (mr *metricsReader) Close(ctx context.Context) error {
 		mr.closed = true
 	}
 
-	return mr.inner.Close(ctx)
+	return mr.ReadCloserCtx.Close(ctx)
 }
 
 type metricsWriter struct {
-	w      io.WriteCloser
+	io.WriteCloser
 	m      *Metrics
 	closed bool
-}
-
-// Write implements the WriteCloser interface.
-func (mw *metricsWriter) Write(p []byte) (int, error) {
-	n, err := mw.w.Write(p)
-	mw.m.WriteBytes.Inc(int64(n))
-	return n, err
 }
 
 // Close implements the WriteCloser interface.
@@ -218,7 +203,5 @@ func (mw *metricsWriter) Close() error {
 		mw.m.OpenWriters.Dec(1)
 		mw.closed = true
 	}
-	return mw.w.Close()
+	return mw.WriteCloser.Close()
 }
-
-var _ io.WriteCloser = &metricsWriter{}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -336,7 +336,7 @@ func (cfg *BaseConfig) SetDefaults(
 	cfg.Config.InitDefaults()
 	cfg.InitTestingKnobs()
 	cfg.CidrLookup = cidr.NewLookup(&st.SV)
-	cfg.EarlyBootExternalStorageAccessor = cloud.NewEarlyBootExternalStorageAccessor(st, cfg.ExternalIODirConfig)
+	cfg.EarlyBootExternalStorageAccessor = cloud.NewEarlyBootExternalStorageAccessor(st, cfg.ExternalIODirConfig, cfg.CidrLookup)
 	cfg.DiskMonitorManager = disk.NewMonitorManager(vfs.Default)
 	cfg.DiskWriteStats = disk.NewWriteStatsManager(vfs.Default)
 }

--- a/pkg/util/cidr/BUILD.bazel
+++ b/pkg/util/cidr/BUILD.bazel
@@ -9,6 +9,8 @@ go_library(
         "//pkg/settings",
         "//pkg/util/envutil",
         "//pkg/util/log",
+        "//pkg/util/metric",
+        "//pkg/util/metric/aggmetric",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",

--- a/pkg/util/cidr/cidr.go
+++ b/pkg/util/cidr/cidr.go
@@ -12,7 +12,9 @@ package cidr
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	io "io"
 	"net"
 	"net/http"
@@ -24,6 +26,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/metric/aggmetric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -325,4 +329,141 @@ func (c *Lookup) LookupIP(ip net.IP) string {
 		}
 	}
 	return ""
+}
+
+type childNetMetrics struct {
+	WriteBytes *aggmetric.Counter
+	ReadBytes  *aggmetric.Counter
+}
+
+// NetMetrics are aggregate metrics around net.Conn mapped based on the CIDR lookup.
+type NetMetrics struct {
+	lookup     *Lookup
+	WriteBytes *aggmetric.AggCounter
+	ReadBytes  *aggmetric.AggCounter
+
+	mu struct {
+		syncutil.Mutex
+		childMetrics map[string]childNetMetrics
+	}
+}
+
+var _ metric.Struct = (*NetMetrics)(nil)
+
+// MetricStruct implements the metric.Struct interface.
+func (m *NetMetrics) MetricStruct() {}
+
+// MakeNetMetrics makes a new NetMetrics object with the given metric metadata.
+func (c *Lookup) MakeNetMetrics(metaWrite, metaRead metric.Metadata, labels ...string) *NetMetrics {
+	labels = append(labels, "remote")
+	nm := &NetMetrics{
+		lookup:     c,
+		WriteBytes: aggmetric.NewCounter(metaWrite, labels...),
+		ReadBytes:  aggmetric.NewCounter(metaRead, labels...),
+	}
+	nm.mu.childMetrics = make(map[string]childNetMetrics)
+	return nm
+}
+
+// DialContext is shorthand for the type of net.Conn.DialContext.
+type DialContext func(ctx context.Context, network, host string) (net.Conn, error)
+
+// Wrap returns a DialContext that wraps the connection with metrics.
+func (m *NetMetrics) Wrap(dial DialContext, labels ...string) DialContext {
+	return func(ctx context.Context, network, host string) (net.Conn, error) {
+		conn, err := dial(ctx, network, host)
+		if err != nil {
+			return conn, err
+		}
+		return m.track(conn, labels...), nil
+	}
+}
+
+// WrapTLS is like Wrap, but can be used if the underlying library doesn't
+// expose a way to plug in a dialer for TLS connections. This is unfortunately
+// pretty ugly... Copied from tls.Dial and kgo.DialTLS because they don't expose
+// a dial call with a DialContext. Ideally you don't have to use this if the
+// third party API does a sensible thing and exposes the ability to replace the
+// "DialContext" directly.
+func (m *NetMetrics) WrapTLS(dial DialContext, tlsCfg *tls.Config, labels ...string) DialContext {
+	return func(ctx context.Context, network, host string) (net.Conn, error) {
+		c := tlsCfg.Clone()
+		if c.ServerName == "" {
+			server, _, err := net.SplitHostPort(host)
+			if err != nil {
+				return nil, fmt.Errorf("unable to split host:port for dialing: %w", err)
+			}
+			c.ServerName = server
+		}
+
+		rawConn, err := dial(ctx, network, host)
+		if err != nil {
+			return nil, err
+		}
+		scopedConn := m.track(rawConn, labels...)
+
+		conn := tls.Client(rawConn, c)
+		if err := conn.HandshakeContext(ctx); err != nil {
+			scopedConn.Close()
+			return nil, err
+		}
+		return conn, nil
+	}
+}
+
+// track converts a connection to a wrapped connection with the given labels.
+func (m *NetMetrics) track(conn net.Conn, labels ...string) metricsConn {
+	var remote string
+	if ip, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
+		remote = m.lookup.LookupIP(ip.IP)
+	}
+	labels = append(labels, remote)
+	key := strings.Join(labels, "/")
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	nm, ok := m.mu.childMetrics[key]
+	if !ok {
+		nm = childNetMetrics{
+			WriteBytes: m.WriteBytes.AddChild(labels...),
+			ReadBytes:  m.ReadBytes.AddChild(labels...),
+		}
+		m.mu.childMetrics[key] = nm
+	}
+
+	return metricsConn{
+		Conn:       conn,
+		WriteBytes: nm.WriteBytes.Inc,
+		ReadBytes:  nm.ReadBytes.Inc,
+	}
+}
+
+// metricsConn wraps a net.Conn and increments the metrics on read and write.
+//
+// NB: If the cost of incrementing the metrics on every read and write is too
+// expensive, we could track the metrics internally and flush them periodically
+// or when the connection is closed.
+// NB: The metrics are cached with the connection, but potentially the cidr
+// mapping could change under us. Since we don't expect "indefinite" connections
+// we are OK with slightly stale metrics.
+type metricsConn struct {
+	net.Conn
+	WriteBytes func(int64)
+	ReadBytes  func(int64)
+}
+
+func (c metricsConn) Read(b []byte) (n int, err error) {
+	n, err = c.Conn.Read(b)
+	if err == nil && n > 0 {
+		c.ReadBytes(int64(n))
+	}
+	return n, err
+}
+
+func (c metricsConn) Write(b []byte) (n int, err error) {
+	n, err = c.Conn.Write(b)
+	if err == nil && n > 0 {
+		c.WriteBytes(int64(n))
+	}
+	return n, err
 }


### PR DESCRIPTION
Previously the read and write metrics were aggregate across all
containers or buckets. In some situations it is useful to break the
statistics out to detemine how much data is going to each. This PR
allows breaking the data out for the three main clouds.

Epic: [CRDB-41142](https://cockroachlabs.atlassian.net/browse/CRDB-41142)

Release note: None