### PR TITLE
roachtest: allow callers to set skip-version probability

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -501,18 +501,19 @@ func defaultTestOptions() testOptions {
 	}
 }
 
-// DisableSkipVersionUpgrades can be used by callers to disable the
-// experimental "skip version" upgrade testing. Useful if a test is
-// verifying something specific to an upgrade path from the previous
-// release to the current one.
+// DisableSkipVersionUpgrades can be used by callers to disable "skip
+// version" upgrades. Useful if a test is verifying something specific
+// to an upgrade path from the previous release to the current one;
+// otherwise, this option should not be used, as every feature should
+// work when skip-version upgrades are performed.
 func DisableSkipVersionUpgrades(opts *testOptions) {
-	withSkipVersionProbability(0)(opts)
+	WithSkipVersionProbability(0)(opts)
 }
 
-// withSkipVersionProbability allows callers to set the specific
+// WithSkipVersionProbability allows callers to set the specific
 // probability under which skip-version upgrades will happen in a test
-// run. Only used for testing at the moment.
-func withSkipVersionProbability(p float64) CustomOption {
+// run.
+func WithSkipVersionProbability(p float64) CustomOption {
 	return func(opts *testOptions) {
 		opts.skipVersionProbability = p
 	}

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion_test.go
@@ -194,7 +194,7 @@ func Test_choosePreviousReleases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := []CustomOption{NumUpgrades(tc.numUpgrades)}
 			if tc.enableSkipVersion {
-				opts = append(opts, withSkipVersionProbability(1))
+				opts = append(opts, WithSkipVersionProbability(1))
 			} else {
 				opts = append(opts, DisableSkipVersionUpgrades)
 			}

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
@@ -439,7 +439,7 @@ func createDataDrivenMixedVersionTest(
 			opts = append(opts, DisableMutators(arg.Vals[0]))
 
 		case "enable_skip_version":
-			opts = append(opts, withSkipVersionProbability(1))
+			opts = append(opts, WithSkipVersionProbability(1))
 
 		case "deployment_mode":
 			opts = append(opts, EnabledDeploymentModes(DeploymentMode(arg.Vals[0])))


### PR DESCRIPTION
Previously, callers were only able to _disable_ skip-version upgrades. In this commit, we allow callers to also set an arbitrary probability for skip-version upgrades.

In the immediate term, this can be used by tests that need to control whether skip-version upgrades happen, such as an upcoming PCR test that sets up two instances of `*mixedversion.Test` that should both skip-version or not.

Epic: none

Release note: None