### PR TITLE
changefeedccl: don't hide error encountered during table resolution

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -809,8 +809,7 @@ func getTableDescriptors(
 	if err != nil {
 		var m *backupresolver.MissingTableErr
 		if errors.As(err, &m) {
-			tableName := m.GetTableName()
-			err = errors.Errorf("table %q does not exist", tableName)
+			err = errors.Wrapf(m.Unwrap(), "table %q does not exist", m.GetTableName())
 		}
 		err = errors.Wrap(err, "failed to resolve targets in the CHANGEFEED stmt")
 		if !initialHighWater.IsEmpty() {

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -714,7 +714,7 @@ func TestMissingTableErr(t *testing.T) {
 
 	t.Run("changefeed on non existing table fails", func(t *testing.T) {
 		kvSQL := sqlutils.MakeSQLRunner(s.DB)
-		kvSQL.ExpectErr(t, `^pq: failed to resolve targets in the CHANGEFEED stmt: table "foo" does not exist$`,
+		kvSQL.ExpectErr(t, `^pq: failed to resolve targets in the CHANGEFEED stmt: table "foo" does not exist`,
 			`CREATE CHANGEFEED FOR foo`,
 		)
 	})


### PR DESCRIPTION
Stop masking the error returned if table resolution fails. The `*backupresolver.MissingTableErr` already includes the table name in its `Error()` method, in addition to the wrapped error, which is currently dropped. This is a debugging step for the linked issue.

Part of: #128255

Release note: None