### PR TITLE
roachprod-microbench: publish comparison results to InfluxDB

### DIFF
--- a/build/github/cockroach-microbench-ci.sh
+++ b/build/github/cockroach-microbench-ci.sh
@@ -64,7 +64,7 @@ if ! gcloud storage cp "$storage_bucket_url/$GITHUB_BASE_REF/$BASE_SHA.log" "$cl
   exit $success_exit_status
 fi
 
-if ! $roachprod_microbench_dir/roachprod-microbench compare "$cleaned_current_dir" "$cleaned_base_dir" --threshold="$threshold" --publish-sheets=false; then
+if ! $roachprod_microbench_dir/roachprod-microbench compare "$cleaned_current_dir" "$cleaned_base_dir" --threshold="$threshold"; then
   echo "There is an error during comparison. If it's a perf regression, please try to fix it. This won't block your change for merging currently."
   exit $error_exit_status
 fi

--- a/go.mod
+++ b/go.mod
@@ -166,6 +166,7 @@ require (
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20240215164046-eb0e60d27cb7
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/guptarohit/asciigraph v0.5.5
+	github.com/influxdata/influxdb-client-go/v2 v2.3.1-0.20210518120617-5d1fff431040
 	github.com/irfansharif/recorder v0.0.0-20211218081646-a21b46510fd6
 	github.com/jackc/pgx/v5 v5.4.2
 	github.com/jaegertracing/jaeger v1.18.1
@@ -274,6 +275,7 @@ require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/abbot/go-http-auth v0.4.1-0.20181019201920-860ed7f246ff // indirect
 	github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794 // indirect
+	github.com/ajstarks/svgo v0.0.0-20210923152817-c3b6e2f0c527 // indirect
 	github.com/alexbrainman/sspi v0.0.0-20210105120005-909beea2cc74 // indirect
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/apache/thrift v0.16.0 // indirect
@@ -293,6 +295,7 @@ require (
 	github.com/cockroachdb/swiss v0.0.0-20240612210725-f4de07ae6964 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
+	github.com/deepmap/oapi-codegen v1.6.0 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/djherbis/atime v1.1.0 // indirect
@@ -302,9 +305,12 @@ require (
 	github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3 // indirect
 	github.com/eapache/queue v1.1.0 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
+	github.com/fogleman/gg v1.3.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.5 // indirect
+	github.com/go-fonts/liberation v0.2.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
+	github.com/go-latex/latex v0.0.0-20210823091927-c0d11ff05a81 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -318,12 +324,14 @@ require (
 	github.com/go-openapi/spec v0.20.14 // indirect
 	github.com/go-openapi/swag v0.22.9 // indirect
 	github.com/go-openapi/validate v0.23.0 // indirect
+	github.com/go-pdf/fpdf v0.5.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
+	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
@@ -337,6 +345,7 @@ require (
 	github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 // indirect
 	github.com/jackc/puddle/v2 v2.2.0 // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
 	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect
@@ -416,7 +425,9 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.19.0 // indirect
+	golang.org/x/image v0.0.0-20210628002857-a66eb6448b8d // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
+	gonum.org/v1/plot v0.10.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -269,6 +269,7 @@ github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
+github.com/ajstarks/svgo v0.0.0-20210923152817-c3b6e2f0c527 h1:NImof/JkF93OVWZY+PINgl6fPtQyF6f+hNUtZ0QZA1c=
 github.com/ajstarks/svgo v0.0.0-20210923152817-c3b6e2f0c527/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -697,6 +698,7 @@ github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d/go.mod h1:tmAIfUFEirG/Y8jhZ9M+h36obRZAk/1fcSpXwAVlfqE=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 h1:HbphB4TFFXpv7MNrT52FGrrgVXF1owhMVTHFZIlnvd4=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0/go.mod h1:DZGJHZMqrU4JJqFAWUS2UO1+lbSKsdiOoYi9Zzey7Fc=
+github.com/deepmap/oapi-codegen v1.6.0 h1:w/d1ntwh91XI0b/8ja7+u5SvA4IFfM0UNNLmiDR1gg0=
 github.com/deepmap/oapi-codegen v1.6.0/go.mod h1:ryDa9AgbELGeB+YEXE1dR53yAjHwFvE9iAUlWl9Al3M=
 github.com/denisenkom/go-mssqldb v0.10.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/denisenkom/go-mssqldb v0.12.0/go.mod h1:iiK0YP1ZeepvmBQk/QpLEhhTNJgfzrpArPY/aFvc9yU=
@@ -807,6 +809,7 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
+github.com/fogleman/gg v1.3.0 h1:/7zJX8F6AaYQc57WQCyN9cAIz+4bCJGO9B+dyW29am8=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -852,9 +855,12 @@ github.com/go-chi/chi/v5 v5.0.0/go.mod h1:BBug9lr0cqtdAhsu6R4AAdvufI0/XBzAQSsUqJ
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
+github.com/go-fonts/dejavu v0.1.0 h1:JSajPXURYqpr+Cu8U9bt8K+XcACIHWqWrvWCKyeFmVQ=
 github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0gppep4g=
+github.com/go-fonts/latin-modern v0.2.0 h1:5/Tv1Ek/QCr20C6ZOz15vw3g7GELYL98KWr8Hgo+3vk=
 github.com/go-fonts/latin-modern v0.2.0/go.mod h1:rQVLdDMK+mK1xscDwsqM5J8U2jrRa3T0ecnM9pNujks=
 github.com/go-fonts/liberation v0.1.1/go.mod h1:K6qoJYypsmfVjWg8KOVDQhLc8UDgIK2HYqyqAO9z7GY=
+github.com/go-fonts/liberation v0.2.0 h1:jAkAWJP4S+OsrPLZM4/eC9iW7CtHy+HBXrEwZXWo5VM=
 github.com/go-fonts/liberation v0.2.0/go.mod h1:K6qoJYypsmfVjWg8KOVDQhLc8UDgIK2HYqyqAO9z7GY=
 github.com/go-fonts/stix v0.1.0/go.mod h1:w/c1f0ldAUlJmLBvlbkvVXLAD+tAMqobIIQpmnUIzUY=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -868,6 +874,7 @@ github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vb
 github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
 github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/go-latex/latex v0.0.0-20210118124228-b3d85cf34e07/go.mod h1:CO1AlKB2CSIqUrmQPqA0gdRIlnLEY0gK5JGjh37zN5U=
+github.com/go-latex/latex v0.0.0-20210823091927-c0d11ff05a81 h1:6zl3BbBhdnMkpSj2YY30qV3gDcVBGtFgVsV3+/i+mKQ=
 github.com/go-latex/latex v0.0.0-20210823091927-c0d11ff05a81/go.mod h1:SX0U8uGpxhq9o2S/CELCSUxEWWAuoCUcVCQWv7G2OCk=
 github.com/go-ldap/ldap/v3 v3.4.6 h1:ert95MdbiG7aWo/oPYp9btL3KJlMPKnP58r09rI8T+A=
 github.com/go-ldap/ldap/v3 v3.4.6/go.mod h1:IGMQANNtxpsOzj7uUAMjpGBaOVTC4DYyIy8VsTdxmtc=
@@ -1006,6 +1013,7 @@ github.com/go-openapi/validate v0.20.1/go.mod h1:b60iJT+xNNLfaQJUqLI7946tYiFEOuE
 github.com/go-openapi/validate v0.20.2/go.mod h1:e7OJoKNgd0twXZwIn0A43tHbvIcr/rZIVCbJBpTUoY0=
 github.com/go-openapi/validate v0.23.0 h1:2l7PJLzCis4YUGEoW6eoQw3WhyM65WSIcjX6SQnlfDw=
 github.com/go-openapi/validate v0.23.0/go.mod h1:EeiAZ5bmpSIOJV1WLfyYF9qp/B1ZgSaEpHTJHtN5cbE=
+github.com/go-pdf/fpdf v0.5.0 h1:GHpcYsiDV2hdo77VTOuTF9k1sN8F8IY7NjnCo9x+NPY=
 github.com/go-pdf/fpdf v0.5.0/go.mod h1:HzcnA+A23uwogo0tp9yU+l3V+KXhiESpt1PMayhOh5M=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.12.1/go.mod h1:IUMDtCfWo/w/mtMfIE/IG2K+Ey3ygWanZIBtBW0W2TM=
@@ -1093,6 +1101,7 @@ github.com/golang-jwt/jwt/v4 v4.2.0 h1:besgBTC8w8HjP6NzQdxwKH9Z5oQMZ24ThTrHp3cZ8
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang-sql/sqlexp v0.0.0-20170517235910-f1bb20e5a188/go.mod h1:vXjM/+wXQnTPR4KqTKDgJukSZ6amVRtWMPEjE6sQoK8=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/geo v0.0.0-20190916061304-5b978397cfec/go.mod h1:QZ0nwyI2jOfgRAoBvP+ab5aRr7c9x7lhGEJrKvBwjWI=
 github.com/golang/geo v0.0.0-20200319012246-673a6f80352d h1:C/hKUcHT483btRbeGkrRjJz+Zbcj8audldIi9tRJDCc=
@@ -1383,11 +1392,13 @@ github.com/influxdata/flux v0.120.1/go.mod h1:pGSAvyAA5d3et7SSzajaYShWYXmnRnJJq2
 github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69/go.mod h1:pwymjR6SrP3gD3pRj9RJwdl1j5s3doEEV8gS4X9qSzA=
 github.com/influxdata/influxdb v1.8.0/go.mod h1:SIzcnsjaHRFpmlxpJ4S3NT64qtEKYweNTUMb/vh0OMQ=
 github.com/influxdata/influxdb v1.9.3/go.mod h1:xD4ZjAgEJQO9/bX3NhFrssKtdNPi+ki1kjrttJRDhGc=
+github.com/influxdata/influxdb-client-go/v2 v2.3.1-0.20210518120617-5d1fff431040 h1:MBLCfcSsUyFPDJp6T7EoHp/Ph3Jkrm4EuUKLD2rUWHg=
 github.com/influxdata/influxdb-client-go/v2 v2.3.1-0.20210518120617-5d1fff431040/go.mod h1:vLNHdxTJkIf2mSLvGrpj8TCcISApPoXkaxP8g9uRlW8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/influxdata/influxql v1.1.0/go.mod h1:KpVI7okXjK6PRi3Z5B+mtKZli+R1DnZgb3N+tzevNgo=
 github.com/influxdata/influxql v1.1.1-0.20210223160523-b6ab99450c93/go.mod h1:gHp9y86a/pxhjJ+zMjNXiQAA197Xk9wLxaz+fGG+kWk=
 github.com/influxdata/line-protocol v0.0.0-20180522152040-32c6aa80de5e/go.mod h1:4kt73NQhadE3daL3WhR5EJ/J2ocX0PZzwxQ0gXJ7oFE=
+github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/influxdata/pkg-config v0.2.7/go.mod h1:EMS7Ll0S4qkzDk53XS3Z72/egBsPInt+BeRxb0WeSwk=
 github.com/influxdata/promql/v2 v2.12.0/go.mod h1:fxOPu+DY0bqCTCECchSRtWfc+0X19ybifQhZoQNF5D8=
@@ -2553,6 +2564,7 @@ golang.org/x/image v0.0.0-20200618115811-c13761719519/go.mod h1:FeLwcggjj3mMvU+o
 golang.org/x/image v0.0.0-20201208152932-35266b937fa6/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/image v0.0.0-20210216034530-4410531fe030/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/image v0.0.0-20210607152325-775e3b0c77b9/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
+golang.org/x/image v0.0.0-20210628002857-a66eb6448b8d h1:RNPAfi2nHY7C2srAV8A49jpsYr0ADedCk1wq6fTMTvs=
 golang.org/x/image v0.0.0-20210628002857-a66eb6448b8d/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
@@ -3007,6 +3019,7 @@ gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6d
 gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e/go.mod h1:kS+toOQn6AQKjmKJ7gzohV1XkqsFehRA2FbsbkopSuQ=
 gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b/go.mod h1:Wt8AAjI+ypCyYX3nZBvf6cAIx93T+c/OS2HFAYskSZc=
 gonum.org/v1/plot v0.9.0/go.mod h1:3Pcqqmp6RHvJI72kgb8fThyUnav364FOsdDo2aGW5lY=
+gonum.org/v1/plot v0.10.0 h1:ymLukg4XJlQnYUJCp+coQq5M7BsUJFk6XQE4HPflwdw=
 gonum.org/v1/plot v0.10.0/go.mod h1:JWIHJ7U20drSQb/aDpTetJzfC1KlAPldJLpkSy88dvQ=
 google.golang.org/api v0.0.0-20160322025152-9bf6e6e569ff/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20170206182103-3d017632ea10/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
@@ -3439,6 +3452,7 @@ modernc.org/token v1.0.0/go.mod h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM=
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
 modernc.org/z v1.3.0/go.mod h1:+mvgLH814oDjtATDdT3rs84JnUIpkvAF5B8AVkNlE2g=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
+rsc.io/pdf v0.1.1 h1:k1MczvYDUvJBe93bYd7wrZLLUEcLZAuF824/I4e5Xr4=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/cmd/roachprod-microbench/BUILD.bazel
+++ b/pkg/cmd/roachprod-microbench/BUILD.bazel
@@ -30,11 +30,13 @@ go_library(
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
+        "@com_github_influxdata_influxdb_client_go_v2//:influxdb-client-go",
         "@com_github_klauspost_pgzip//:pgzip",
         "@com_github_slack_go_slack//:slack",
         "@com_github_spf13_cobra//:cobra",
         "@org_golang_x_exp//maps",
         "@org_golang_x_perf//benchfmt",
+        "@org_golang_x_perf//benchseries",
     ],
 )
 

--- a/pkg/cmd/roachprod-microbench/compare.go
+++ b/pkg/cmd/roachprod-microbench/compare.go
@@ -11,6 +11,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log"
@@ -20,25 +21,39 @@ import (
 	"sort"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod-microbench/google"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod-microbench/model"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
+	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 	"github.com/slack-go/slack"
 	"golang.org/x/exp/maps"
 	"golang.org/x/perf/benchfmt"
+	"golang.org/x/perf/benchseries"
 )
 
 type compareConfig struct {
-	newDir             string
-	oldDir             string
-	sheetDesc          string
-	slackUser          string
-	slackChannel       string
-	slackToken         string
-	threshold          float64
-	publishGoogleSheet bool
+	slackConfig   slackConfig
+	influxConfig  influxConfig
+	experimentDir string
+	baselineDir   string
+	sheetDesc     string
+	threshold     float64
+}
+
+type slackConfig struct {
+	user    string
+	channel string
+	token   string
+}
+
+type influxConfig struct {
+	host     string
+	token    string
+	metadata map[string]string
 }
 
 type compare struct {
@@ -46,6 +61,16 @@ type compare struct {
 	service  *google.Service
 	packages []string
 	ctx      context.Context
+}
+
+var defaultInfluxMetadata = map[string]string{
+	"branch":      "master",
+	"machine":     "n2-standard-32",
+	"goarch":      "amd64",
+	"goos":        "linux",
+	"repository":  "cockroach",
+	"run-time":    timeutil.Now().Format(time.RFC3339),
+	"upload-time": timeutil.Now().Format(time.RFC3339),
 }
 
 const (
@@ -63,14 +88,21 @@ const slackCompareTemplateScript = `
 `
 
 func newCompare(config compareConfig) (*compare, error) {
-	// Use the old directory to infer package info.
-	packages, err := getPackagesFromLogs(config.oldDir)
+	// Use the baseline directory to infer package info.
+	packages, err := getPackagesFromLogs(config.baselineDir)
 	if err != nil {
 		return nil, err
 	}
+	// Add default metadata values to the influx config for any missing keys.
+	for k, v := range defaultInfluxMetadata {
+		if _, ok := config.influxConfig.metadata[k]; !ok {
+			config.influxConfig.metadata[k] = v
+		}
+	}
+
 	ctx := context.Background()
 	var service *google.Service
-	if config.publishGoogleSheet {
+	if config.sheetDesc != "" {
 		service, err = google.New(ctx)
 		if err != nil {
 			return nil, err
@@ -81,10 +113,15 @@ func newCompare(config compareConfig) (*compare, error) {
 
 func defaultCompareConfig() compareConfig {
 	return compareConfig{
-		threshold:          skipComparison, // Skip comparison by default
-		slackUser:          "microbench",
-		slackChannel:       "perf-ops",
-		publishGoogleSheet: true,
+		threshold: skipComparison, // Skip comparison by default
+		slackConfig: slackConfig{
+			user:    "microbench",
+			channel: "perf-ops",
+		},
+		influxConfig: influxConfig{
+			host:     "http://localhost:8086",
+			metadata: make(map[string]string),
+		},
 	}
 }
 
@@ -101,12 +138,12 @@ func (c *compare) readMetrics() (map[string]*model.MetricMap, error) {
 		// Read the previous and current results. If either is missing, we'll just
 		// skip it.
 		if err := processReportFile(results, "baseline", pkg,
-			filepath.Join(c.oldDir, getReportLogName(reportLogName, pkg))); err != nil {
+			filepath.Join(c.baselineDir, getReportLogName(reportLogName, pkg))); err != nil {
 			return nil, err
 
 		}
 		if err := processReportFile(results, "experiment", pkg,
-			filepath.Join(c.newDir, getReportLogName(reportLogName, pkg))); err != nil {
+			filepath.Join(c.experimentDir, getReportLogName(reportLogName, pkg))); err != nil {
 			log.Printf("failed to add report for %s: %s", pkg, err)
 			return nil, err
 		}
@@ -278,7 +315,7 @@ func (c *compare) postToSlack(
 
 	}
 
-	s := newSlackClient(c.slackUser, c.slackChannel, c.slackToken)
+	s := newSlackClient(c.slackConfig.user, c.slackConfig.channel, c.slackConfig.token)
 	return s.Post(
 		slack.MsgOptionText(fmt.Sprintf("Microbenchmark comparison summary: %s", c.sheetDesc), false),
 		slack.MsgOptionAttachments(attachments...),
@@ -316,6 +353,171 @@ func (c *compare) compareUsingThreshold(comparisonResultsMap model.ComparisonRes
 	}
 
 	return nil
+}
+
+func (c *compare) createBenchSeries() ([]*benchseries.ComparisonSeries, error) {
+	opts := benchseries.DefaultBuilderOptions()
+	opts.Experiment = "run-time"
+	opts.Compare = "cockroach"
+	builder, err := benchseries.NewBuilder(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var benchBuf bytes.Buffer
+	readFileFn := func(filePath string, required bool) error {
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			if !required && oserror.IsNotExist(err) {
+				return nil
+			}
+			return errors.Wrapf(err, "failed to read file %s", filePath)
+		}
+		benchBuf.Write(data)
+		benchBuf.WriteString("\n")
+		return nil
+	}
+
+	for k, v := range c.influxConfig.metadata {
+		benchBuf.WriteString(fmt.Sprintf("%s: %s\n", k, v))
+	}
+
+	logPaths := map[string]string{
+		"experiment": c.experimentDir,
+		"baseline":   c.baselineDir,
+	}
+	for logType, dir := range logPaths {
+		benchBuf.WriteString(fmt.Sprintf("cockroach: %s\n", logType))
+		logPath := filepath.Join(dir, "metadata.log")
+		if err = readFileFn(logPath, true); err != nil {
+			return nil, err
+		}
+		for _, pkg := range c.packages {
+			benchBuf.WriteString(fmt.Sprintf("pkg: %s\n", pkg))
+			logPath = filepath.Join(dir, getReportLogName(reportLogName, pkg))
+			if err = readFileFn(logPath, false); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	benchReader := benchfmt.NewReader(bytes.NewReader(benchBuf.Bytes()), "buffer")
+	recordsMap := make(map[string][]*benchfmt.Result)
+	seen := make(map[string]map[string]struct{})
+	for benchReader.Scan() {
+		switch rec := benchReader.Result().(type) {
+		case *benchfmt.SyntaxError:
+			// In case the benchmark log is corrupted or contains a syntax error, we
+			// want to return an error to the caller.
+			return nil, fmt.Errorf("syntax error: %v", rec)
+		case *benchfmt.Result:
+			var cmp, pkg string
+			for _, config := range rec.Config {
+				if config.Key == "pkg" {
+					pkg = string(config.Value)
+				}
+				if config.Key == opts.Compare {
+					cmp = string(config.Value)
+				}
+			}
+			key := pkg + packageSeparator + string(rec.Name)
+			// Update the name to include the package name. This is a workaround for
+			// `benchseries`, that currently does not support package names.
+			rec.Name = benchfmt.Name(key)
+			recordsMap[key] = append(recordsMap[key], rec.Clone())
+			// Determine if we've seen this package/benchmark combination for both
+			// the baseline and experiment run.
+			if _, ok := seen[key]; !ok {
+				seen[key] = make(map[string]struct{})
+			}
+			seen[key][cmp] = struct{}{}
+		}
+	}
+
+	// Add only the benchmarks that have been seen in both the baseline and
+	// experiment run.
+	for key, records := range recordsMap {
+		if len(seen[key]) != 2 {
+			continue
+		}
+		for _, rec := range records {
+			builder.Add(rec)
+		}
+	}
+
+	comparisons, err := builder.AllComparisonSeries(nil, benchseries.DUPE_REPLACE)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create comparison series")
+	}
+	return comparisons, nil
+}
+
+func (c *compare) pushToInfluxDB() error {
+	client := influxdb2.NewClient(c.influxConfig.host, c.influxConfig.token)
+	defer client.Close()
+	writeAPI := client.WriteAPI("cockroach", "microbench")
+	errorChan := writeAPI.Errors()
+
+	comparisons, err := c.createBenchSeries()
+	if err != nil {
+		return err
+	}
+
+	for _, cs := range comparisons {
+		cs.AddSummaries(0.95, 1000)
+		residues := make(map[string]string)
+		for _, r := range cs.Residues {
+			residues[r.S] = r.Slice[0]
+		}
+
+		for idx, benchmarkName := range cs.Benchmarks {
+			sum := cs.Summaries[0][idx]
+			if !sum.Defined() {
+				continue
+			}
+
+			experimentTime := cs.Series[0]
+			ts, err := benchseries.ParseNormalizedDateString(experimentTime)
+			if err != nil {
+				return errors.Wrap(err, "error parsing experiment commit date")
+			}
+			fields := map[string]interface{}{
+				"low":               sum.Low,
+				"center":            sum.Center,
+				"high":              sum.High,
+				"upload-time":       residues["upload-time"],
+				"baseline-commit":   cs.HashPairs[experimentTime].DenHash,
+				"experiment-commit": cs.HashPairs[experimentTime].NumHash,
+				"benchmarks-commit": residues["benchmarks-commit"],
+			}
+			pkg := strings.Split(benchmarkName, packageSeparator)[0]
+			benchmarkName = strings.Split(benchmarkName, packageSeparator)[1]
+			tags := map[string]string{
+				"name":         benchmarkName,
+				"unit":         cs.Unit,
+				"pkg":          pkg,
+				"repository":   "cockroach",
+				"branch":       residues["branch"],
+				"goarch":       residues["goarch"],
+				"goos":         residues["goos"],
+				"machine-type": residues["machine-type"],
+			}
+			p := influxdb2.NewPoint("benchmark-result", tags, fields, ts)
+			writeAPI.WritePoint(p)
+		}
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		writeAPI.Flush()
+	}()
+
+	select {
+	case err = <-errorChan:
+		return errors.Wrap(err, "failed to write to InfluxDB")
+	case <-done:
+		return nil
+	}
 }
 
 func processReportFile(builder *model.Builder, id, pkg, path string) error {

--- a/pkg/cmd/roachprod-microbench/compare_test.go
+++ b/pkg/cmd/roachprod-microbench/compare_test.go
@@ -71,8 +71,8 @@ func TestCompareBenchmarks(t *testing.T) {
 		require.NoError(t, err)
 		c := &compare{
 			compareConfig: compareConfig{
-				newDir: newDir,
-				oldDir: oldDir,
+				experimentDir: newDir,
+				baselineDir:   oldDir,
 			},
 			packages: packages,
 		}


### PR DESCRIPTION
Previously, microbenchmark results were published only to Google Sheets. This was sufficient to inspect a single comparison between two runs. But a history of microbenchmarks will give much more context when investigating a regression.

The change puts in place the first steps in building microbenchmark dashboards. New InfluxDB flags have been added to the compare command. If an InfluxDB auth token is set the compare command will also publish the results to the specified InfluxDB instance.

In order to make the published comparison results compatible with the dashboard it is intended to be displayed on, the golang benchseries perf packages are used to generate the low, center, and high measurement points. These are the bounds relating to the baseline and experiment revision being compared. Additionally, the commit SHAs, timestamps and machine info is added as metadata to each point.

The golang benchseries perf implementation does not yet support packages. But since we do have duplicate benchmark names in the cockroach repo we need to discern by package. Hence, we send the package as a prefix to benchseries and extract the package and benchmark name after processing.

Resolves: #128886

Epic: None
Release note: None