### PR TITLE
roachtest: deflake `admission-control/disk-bandwidth-limiter` on azure

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -80,7 +80,7 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 			setBandwidthLimit := func(nodes option.NodeListOption, rw string, bw int, max bool) error {
 				dataMount := "/mnt/data1"
 				if c.Cloud() == spec.Azure {
-					dataMount = "sda1"
+					dataMount = "/mnt"
 				}
 				res, err := c.RunWithDetailsSingleNode(context.TODO(), t.L(), option.WithNodes(nodes[:1]),
 					fmt.Sprintf("lsblk | grep %s | awk '{print $2}'", dataMount),


### PR DESCRIPTION
We tried fixing it earlier but turns out the roachtest mount config is different than the roachprod.

Fixes #129022.

Release note: None