### PR TITLE
raft: persist Commit index if it changes

### DIFF
--- a/pkg/raft/node_test.go
+++ b/pkg/raft/node_test.go
@@ -462,7 +462,7 @@ func TestNodeStart(t *testing.T) {
 			HardState:        raftpb.HardState{Term: 2, Commit: 3, Vote: 1, Lead: 1, LeadEpoch: 1},
 			Entries:          nil,
 			CommittedEntries: []raftpb.Entry{{Term: 2, Index: 3, Data: []byte("foo")}},
-			MustSync:         false,
+			MustSync:         true,
 		},
 	}
 	storage := NewMemoryStorage()

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -174,6 +174,8 @@ type Config struct {
 	// threads are not responsible for understanding the response messages, only
 	// for delivering them to the correct target after performing the storage
 	// write.
+	// TODO(#129411): deprecate !AsyncStorageWrites mode as it's not used in
+	// CRDB.
 	AsyncStorageWrites bool
 
 	// MaxSizePerMsg limits the max byte size of each append message. Smaller

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -176,6 +176,7 @@ func (rn *RawNode) readyWithoutAccept() Ready {
 
 // MustSync returns true if the hard state and count of Raft entries indicate
 // that a synchronous write to persistent storage is required.
+// NOTE: MustSync isn't used under AsyncStorageWrites mode.
 func MustSync(st, prevst pb.HardState, entsnum int) bool {
 	// Persistent state on all servers:
 	// (Updated on stable storage before responding to RPCs)
@@ -185,7 +186,7 @@ func MustSync(st, prevst pb.HardState, entsnum int) bool {
 	// votedFor
 	// log entries[]
 	return entsnum != 0 || st.Vote != prevst.Vote || st.Term != prevst.Term ||
-		st.Lead != prevst.Lead || st.LeadEpoch != prevst.LeadEpoch
+		st.Lead != prevst.Lead || st.LeadEpoch != prevst.LeadEpoch || st.Commit != prevst.Commit
 }
 
 func needStorageAppendMsg(r *raft, rd Ready) bool {

--- a/pkg/raft/rawnode_test.go
+++ b/pkg/raft/rawnode_test.go
@@ -524,7 +524,7 @@ func TestRawNodeStart(t *testing.T) {
 		HardState:        pb.HardState{Term: 1, Commit: 3, Vote: 1, Lead: 1, LeadEpoch: 1},
 		Entries:          nil, // emitted & checked in intermediate Ready cycle
 		CommittedEntries: entries,
-		MustSync:         false, // since we're only applying, not appending
+		MustSync:         true, // because we are advancing the commit index
 	}
 
 	storage := NewMemoryStorage()
@@ -596,7 +596,7 @@ func TestRawNodeStart(t *testing.T) {
 	require.True(t, rawNode.HasReady())
 	rd = rawNode.Ready()
 	require.Empty(t, rd.Entries)
-	require.False(t, rd.MustSync)
+	require.True(t, rd.MustSync)
 	rawNode.Advance(rd)
 
 	rd.SoftState, want.SoftState = nil, nil

--- a/pkg/raft/testdata/async_storage_writes.txt
+++ b/pkg/raft/testdata/async_storage_writes.txt
@@ -157,7 +157,7 @@ stabilize
 > 3 receiving messages
   AppendThread->3 MsgStorageAppendResp Term:0 Log:1/11
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/11 EntryNormal ""
@@ -182,7 +182,7 @@ stabilize
   Responses:
   ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/11 EntryNormal ""
@@ -194,7 +194,7 @@ stabilize
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
   ]
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/11 EntryNormal ""
@@ -613,7 +613,7 @@ ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/12 EntryNormal "pro
 process-ready 1 2 3
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:14 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/14 EntryNormal "prop_3"
@@ -639,7 +639,7 @@ process-ready 1 2 3
 > 1 handling Ready
   <empty Ready>
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:14 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/14 EntryNormal "prop_3"
@@ -651,7 +651,7 @@ process-ready 1 2 3
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
   ]
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:14 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/14 EntryNormal "prop_3"
@@ -721,7 +721,7 @@ ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "pro
 process-ready 1 2 3
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:15 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/15 EntryNormal "prop_4"
@@ -747,7 +747,7 @@ process-ready 1 2 3
 > 1 handling Ready
   <empty Ready>
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:15 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/15 EntryNormal "prop_4"
@@ -759,7 +759,7 @@ process-ready 1 2 3
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
   ]
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:15 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/15 EntryNormal "prop_4"

--- a/pkg/raft/testdata/campaign.txt
+++ b/pkg/raft/testdata/campaign.txt
@@ -97,7 +97,7 @@ stabilize
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   3->1 MsgAppResp Term:1 Log:0/3 Commit:2
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/3 EntryNormal ""
@@ -109,14 +109,14 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/3 Commit:3
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/3 EntryNormal ""

--- a/pkg/raft/testdata/campaign_learner_must_vote.txt
+++ b/pkg/raft/testdata/campaign_learner_must_vote.txt
@@ -145,7 +145,7 @@ stabilize 2 3
 > 2 receiving messages
   3->2 MsgAppResp Term:2 Log:0/5 Commit:4
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:2 Commit:5 Lead:2 LeadEpoch:1
   CommittedEntries:
   2/5 EntryNormal ""
@@ -154,7 +154,7 @@ stabilize 2 3
 > 3 receiving messages
   2->3 MsgApp Term:2 Log:2/5 Commit:5
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:2 Commit:5 Lead:2 LeadEpoch:1
   CommittedEntries:
   2/5 EntryNormal ""

--- a/pkg/raft/testdata/checkquorum.txt
+++ b/pkg/raft/testdata/checkquorum.txt
@@ -214,7 +214,7 @@ stabilize
   3->2 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
   3->2 MsgAppResp Term:3 Log:0/12 Commit:11
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:3 Vote:2 Commit:12 Lead:2 LeadEpoch:1
   CommittedEntries:
   3/12 EntryNormal ""
@@ -226,14 +226,14 @@ stabilize
 > 3 receiving messages
   2->3 MsgApp Term:3 Log:3/12 Commit:12
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:3 Vote:2 Commit:12 Lead:2 LeadEpoch:1
   CommittedEntries:
   3/12 EntryNormal ""
   Messages:
   1->2 MsgAppResp Term:3 Log:0/12 Commit:12
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:3 Commit:12 Lead:2 LeadEpoch:1
   CommittedEntries:
   3/12 EntryNormal ""

--- a/pkg/raft/testdata/confchange_disable_validation.txt
+++ b/pkg/raft/testdata/confchange_disable_validation.txt
@@ -41,7 +41,7 @@ stabilize 1
   1/4 EntryNormal "foo"
   1/5 EntryConfChangeV2 l2 l3
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/4 EntryNormal "foo"

--- a/pkg/raft/testdata/confchange_drop_if_unapplied.txt
+++ b/pkg/raft/testdata/confchange_drop_if_unapplied.txt
@@ -50,7 +50,7 @@ stabilize 1
   1/4 EntryConfChangeV2 l2 l3
   INFO 1 switched to configuration voters=(1)&&(1) learners=(2 3)
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryNormal ""

--- a/pkg/raft/testdata/confchange_v1_add_single.txt
+++ b/pkg/raft/testdata/confchange_v1_add_single.txt
@@ -47,7 +47,7 @@ stabilize
   1/3 EntryNormal ""
   1/4 EntryConfChange v2
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/3 EntryNormal ""
@@ -86,7 +86,7 @@ stabilize
   INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:4 Lead:1 LeadEpoch:0
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:

--- a/pkg/raft/testdata/confchange_v1_remove_leader.txt
+++ b/pkg/raft/testdata/confchange_v1_remove_leader.txt
@@ -95,7 +95,7 @@ stabilize 1
   2->1 MsgAppResp Term:1 Log:0/4 Commit:3
   2->1 MsgAppResp Term:1 Log:0/5 Commit:3
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/4 EntryConfChange r1
@@ -175,7 +175,7 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/6 Commit:4
   3->1 MsgAppResp Term:1 Log:0/6 Commit:5
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/6 EntryNormal "bar"
@@ -187,14 +187,14 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/6 Commit:6
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/6 EntryNormal "bar"
   Messages:
   2->1 MsgAppResp Term:1 Log:0/6 Commit:6
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/6 EntryNormal "bar"

--- a/pkg/raft/testdata/confchange_v1_remove_leader_stepdown.txt
+++ b/pkg/raft/testdata/confchange_v1_remove_leader_stepdown.txt
@@ -94,7 +94,7 @@ stabilize 1
   2->1 MsgAppResp Term:1 Log:0/4 Commit:3
   2->1 MsgAppResp Term:1 Log:0/5 Commit:3
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/4 EntryConfChange r1

--- a/pkg/raft/testdata/confchange_v2_add_double_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_auto.txt
@@ -54,7 +54,7 @@ Entries:
 # it has to since we're carrying out two additions at once.
 process-ready 1
 ----
-Ready MustSync=false:
+Ready MustSync=true:
 HardState Term:1 Vote:1 Commit:4 Lead:1 LeadEpoch:1
 CommittedEntries:
 1/3 EntryNormal ""
@@ -109,7 +109,7 @@ stabilize 1 2
   INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:4 Lead:1 LeadEpoch:0
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
   Messages:
@@ -132,7 +132,7 @@ stabilize 1 2
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -142,7 +142,7 @@ stabilize 1 2
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/5 Commit:5
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:5 Lead:1 LeadEpoch:0
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -184,7 +184,7 @@ stabilize 1 3
   INFO 3 [commit: 5, lastindex: 5, lastterm: 1] restored snapshot [index: 5, term: 1]
   INFO 3 [commit: 5] restored snapshot [index: 5, term: 1]
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:5 Lead:1 LeadEpoch:0
   Snapshot Index:5 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
@@ -266,7 +266,7 @@ stabilize 1
   2->1 MsgAppResp Term:1 Log:0/6 Commit:5
   3->1 MsgAppResp Term:1 Log:0/6 Commit:5
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/6 EntryConfChangeV2 r2 r3
@@ -342,7 +342,7 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/8 Commit:6
   3->1 MsgAppResp Term:1 Log:0/9 Commit:6
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:9 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/7 EntryNormal "foo"
@@ -365,7 +365,7 @@ stabilize
   1->3 MsgApp Term:1 Log:1/9 Commit:8
   1->3 MsgApp Term:1 Log:1/9 Commit:9
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:9 Lead:1 LeadEpoch:0
   CommittedEntries:
   1/7 EntryNormal "foo"
@@ -377,7 +377,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/9 Commit:9
   INFO 2 switched to configuration voters=(1)
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:9 Lead:1 LeadEpoch:0
   CommittedEntries:
   1/7 EntryNormal "foo"

--- a/pkg/raft/testdata/confchange_v2_add_double_implicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_implicit.txt
@@ -50,7 +50,7 @@ stabilize 1 2
   1/3 EntryNormal ""
   1/4 EntryConfChangeV2 v2
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/3 EntryNormal ""
@@ -92,7 +92,7 @@ stabilize 1 2
   INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:4 Lead:1 LeadEpoch:0
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
   Messages:
@@ -115,7 +115,7 @@ stabilize 1 2
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -125,7 +125,7 @@ stabilize 1 2
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/5 Commit:5
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:5 Lead:1 LeadEpoch:0
   CommittedEntries:
   1/5 EntryConfChangeV2

--- a/pkg/raft/testdata/confchange_v2_add_single_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_auto.txt
@@ -48,7 +48,7 @@ stabilize
   1/3 EntryNormal ""
   1/4 EntryConfChangeV2 v2
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/3 EntryNormal ""
@@ -87,7 +87,7 @@ stabilize
   INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:4 Lead:1 LeadEpoch:0
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:

--- a/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
@@ -48,7 +48,7 @@ stabilize 1 2
   1/3 EntryNormal ""
   1/4 EntryConfChangeV2 v2
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/3 EntryNormal ""
@@ -87,7 +87,7 @@ stabilize 1 2
   INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:4 Lead:1 LeadEpoch:0
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
@@ -135,7 +135,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/5 Commit:4
   2->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryNormal ""
@@ -148,7 +148,7 @@ stabilize
   1->2 MsgApp Term:1 Log:1/6 Commit:5
   1->2 MsgApp Term:1 Log:1/6 Commit:6
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:6 Lead:1 LeadEpoch:0
   CommittedEntries:
   1/5 EntryNormal ""
@@ -186,7 +186,7 @@ stabilize
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/7 Commit:6
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/7 EntryNormal ""
@@ -195,7 +195,7 @@ stabilize
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/7 Commit:7
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:7 Lead:1 LeadEpoch:0
   CommittedEntries:
   1/7 EntryNormal ""

--- a/pkg/raft/testdata/confchange_v2_replace_leader.txt
+++ b/pkg/raft/testdata/confchange_v2_replace_leader.txt
@@ -76,7 +76,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/4 Commit:3
   3->1 MsgAppResp Term:1 Log:0/4 Commit:3
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/4 EntryConfChangeV2 r1 v4
@@ -93,7 +93,7 @@ stabilize
   Messages:
   1->4 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 r1 v4]
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/4 EntryConfChangeV2 r1 v4
@@ -101,7 +101,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
   INFO 2 switched to configuration voters=(2 3 4)&&(1 2 3)
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/4 EntryConfChangeV2 r1 v4
@@ -135,7 +135,7 @@ stabilize
   INFO 4 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 4 [commit: 4] restored snapshot [index: 4, term: 1]
 > 4 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:4 Lead:1 LeadEpoch:0
   Snapshot Index:4 Term:1 ConfState:Voters:[2 3 4] VotersOutgoing:[1 2 3] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
@@ -277,7 +277,7 @@ stabilize
   3->4 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   3->4 MsgAppResp Term:2 Log:0/5 Commit:4
 > 4 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:5 Lead:4 LeadEpoch:1
   CommittedEntries:
   2/5 EntryNormal ""
@@ -292,21 +292,21 @@ stabilize
 > 3 receiving messages
   4->3 MsgApp Term:2 Log:2/5 Commit:5
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:5 Lead:4 LeadEpoch:1
   CommittedEntries:
   2/5 EntryNormal ""
   Messages:
   1->4 MsgAppResp Term:2 Log:0/5 Commit:5
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:5 Lead:4 LeadEpoch:1
   CommittedEntries:
   2/5 EntryNormal ""
   Messages:
   2->4 MsgAppResp Term:2 Log:0/5 Commit:5
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:5 Lead:4 LeadEpoch:1
   CommittedEntries:
   2/5 EntryNormal ""
@@ -370,7 +370,7 @@ stabilize
   2->4 MsgAppResp Term:2 Log:0/6 Commit:5
   3->4 MsgAppResp Term:2 Log:0/6 Commit:5
 > 4 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:6 Lead:4 LeadEpoch:1
   CommittedEntries:
   2/6 EntryConfChangeV2
@@ -386,7 +386,7 @@ stabilize
 > 3 receiving messages
   4->3 MsgApp Term:2 Log:2/6 Commit:6
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:6 Lead:4 LeadEpoch:1
   CommittedEntries:
   2/6 EntryConfChangeV2
@@ -394,7 +394,7 @@ stabilize
   1->4 MsgAppResp Term:2 Log:0/6 Commit:6
   INFO 1 switched to configuration voters=(2 3 4)
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:6 Lead:4 LeadEpoch:1
   CommittedEntries:
   2/6 EntryConfChangeV2
@@ -402,7 +402,7 @@ stabilize
   2->4 MsgAppResp Term:2 Log:0/6 Commit:6
   INFO 2 switched to configuration voters=(2 3 4)
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:4 Commit:6 Lead:4 LeadEpoch:1
   CommittedEntries:
   2/6 EntryConfChangeV2

--- a/pkg/raft/testdata/confchange_v2_replace_leader_stepdown.txt
+++ b/pkg/raft/testdata/confchange_v2_replace_leader_stepdown.txt
@@ -111,7 +111,7 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/5 Commit:4
   4->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -131,7 +131,7 @@ stabilize
   Ready MustSync=false:
   State:StateFollower
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -139,7 +139,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/5 Commit:5
   INFO 2 switched to configuration voters=(2 3 4)
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -147,7 +147,7 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/5 Commit:5
   INFO 3 switched to configuration voters=(2 3 4)
 > 4 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:5 Lead:1 LeadEpoch:0
   CommittedEntries:
   1/5 EntryConfChangeV2

--- a/pkg/raft/testdata/fortification_basic.txt
+++ b/pkg/raft/testdata/fortification_basic.txt
@@ -129,7 +129,7 @@ stabilize
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
   3->1 MsgAppResp Term:1 Log:0/3 Commit:2
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:3
   CommittedEntries:
   1/3 EntryNormal ""
@@ -141,14 +141,14 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/3 Commit:3
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:2
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:0
   CommittedEntries:
   1/3 EntryNormal ""

--- a/pkg/raft/testdata/fortification_leader_does_not_support_itself.txt
+++ b/pkg/raft/testdata/fortification_leader_does_not_support_itself.txt
@@ -130,7 +130,7 @@ stabilize
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:2
   3->1 MsgAppResp Term:1 Log:0/3 Commit:2
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:0
   CommittedEntries:
   1/3 EntryNormal ""
@@ -142,14 +142,14 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/3 Commit:3
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:3
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:2
   CommittedEntries:
   1/3 EntryNormal ""

--- a/pkg/raft/testdata/lagging_commit.txt
+++ b/pkg/raft/testdata/lagging_commit.txt
@@ -77,7 +77,7 @@ stabilize 1 2
   2->1 MsgAppResp Term:1 Log:0/12 Commit:11
   2->1 MsgAppResp Term:1 Log:0/13 Commit:11
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/12 EntryNormal "data1"
@@ -91,7 +91,7 @@ stabilize 1 2
   1->2 MsgApp Term:1 Log:1/13 Commit:12
   1->2 MsgApp Term:1 Log:1/13 Commit:13
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/12 EntryNormal "data1"
@@ -163,7 +163,7 @@ stabilize 1 3
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/13 Commit:13
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/12 EntryNormal "data1"

--- a/pkg/raft/testdata/prevote.txt
+++ b/pkg/raft/testdata/prevote.txt
@@ -86,7 +86,7 @@ INFO 2 [logterm: 1, index: 12, vote: 1] rejected MsgPreVote from 3 [logterm: 1, 
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:12 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/12 EntryNormal "prop_1"
@@ -107,7 +107,7 @@ stabilize
   1->3 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
   2->3 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:12 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/12 EntryNormal "prop_1"
@@ -245,7 +245,7 @@ stabilize
   3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   3->2 MsgAppResp Term:2 Log:0/13 Commit:12
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:2 Commit:13 Lead:2 LeadEpoch:1
   CommittedEntries:
   2/13 EntryNormal ""
@@ -257,14 +257,14 @@ stabilize
 > 3 receiving messages
   2->3 MsgApp Term:2 Log:2/13 Commit:13
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:2 Commit:13 Lead:2 LeadEpoch:1
   CommittedEntries:
   2/13 EntryNormal ""
   Messages:
   1->2 MsgAppResp Term:2 Log:0/13 Commit:13
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:2 Commit:13 Lead:2 LeadEpoch:1
   CommittedEntries:
   2/13 EntryNormal ""

--- a/pkg/raft/testdata/prevote_checkquorum.txt
+++ b/pkg/raft/testdata/prevote_checkquorum.txt
@@ -170,7 +170,7 @@ stabilize
   2->3 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   2->3 MsgAppResp Term:2 Log:0/12 Commit:11
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:3 Commit:12 Lead:3 LeadEpoch:1
   CommittedEntries:
   2/12 EntryNormal ""
@@ -182,14 +182,14 @@ stabilize
 > 2 receiving messages
   3->2 MsgApp Term:2 Log:2/12 Commit:12
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Commit:12 Lead:3 LeadEpoch:1
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
   1->3 MsgAppResp Term:2 Log:0/12 Commit:12
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:2 Vote:3 Commit:12 Lead:3 LeadEpoch:1
   CommittedEntries:
   2/12 EntryNormal ""
@@ -337,7 +337,7 @@ stabilize
   3->2 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
   3->2 MsgAppResp Term:3 Log:0/13 Commit:12
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:3 Vote:2 Commit:13 Lead:2 LeadEpoch:1
   CommittedEntries:
   3/13 EntryNormal ""
@@ -349,14 +349,14 @@ stabilize
 > 3 receiving messages
   2->3 MsgApp Term:3 Log:3/13 Commit:13
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:3 Vote:2 Commit:13 Lead:2 LeadEpoch:1
   CommittedEntries:
   3/13 EntryNormal ""
   Messages:
   1->2 MsgAppResp Term:3 Log:0/13 Commit:13
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:3 Commit:13 Lead:2 LeadEpoch:1
   CommittedEntries:
   3/13 EntryNormal ""

--- a/pkg/raft/testdata/probe_and_replicate.txt
+++ b/pkg/raft/testdata/probe_and_replicate.txt
@@ -599,7 +599,7 @@ stabilize 1 4
   4->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:1
   4->1 MsgAppResp Term:8 Log:0/21 Commit:18
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:8 Vote:1 Commit:21 Lead:1 LeadEpoch:1
   CommittedEntries:
   6/19 EntryNormal "prop_6_19"
@@ -612,7 +612,7 @@ stabilize 1 4
 > 4 receiving messages
   1->4 MsgApp Term:8 Log:8/21 Commit:21
 > 4 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:8 Commit:21 Lead:1 LeadEpoch:1
   CommittedEntries:
   6/19 EntryNormal "prop_6_19"

--- a/pkg/raft/testdata/single_node.txt
+++ b/pkg/raft/testdata/single_node.txt
@@ -29,7 +29,7 @@ stabilize
   Entries:
   1/4 EntryNormal ""
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/4 EntryNormal ""

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
@@ -113,7 +113,7 @@ stabilize 3
   INFO 3 [commit: 11, lastindex: 11, lastterm: 1] restored snapshot [index: 11, term: 1]
   INFO 3 [commit: 11] restored snapshot [index: 11, term: 1]
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   HardState Term:1 Commit:11 Lead:1 LeadEpoch:0
   Snapshot Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:


### PR DESCRIPTION
This commit sets the MustSync field to true if the Commit index changes. This won't change the current behaviour where we sync the HardState fields if the MsgStorageAppend has any HardState fields set.
However, this commit sets the MustSync to stay consistent with the other fields. Future work could be done to remove the MustSync field all together.

Syncing the commit index shouldn't cause too much overhead because in the normal case, advancing the commit index on a follower is piggybacked on top of sending entries to the follower (which requires syncing anyways).  

References: #125266

Epic: None

Release note: None