### PR TITLE
roachtest: multi-region/mixed-version support for shared-process

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_multi_region.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_multi_region.go
@@ -122,6 +122,13 @@ func registerMultiRegionMixedVersion(r registry.Registry) {
 			mvt.OnStartup(
 				"setup tpcc",
 				func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
+					if err := enableTenantSplitScatter(l, rng, h); err != nil {
+						return err
+					}
+					if err := enableTenantMultiRegion(l, rng, h); err != nil {
+						return err
+					}
+
 					setupTPCC(ctx, t, l, c, backgroundTPCCOpts)
 					// Update the `SetupType` so that the corresponding
 					// `runTPCC` calls don't attempt to import data again.


### PR DESCRIPTION
We enable required features on tenants before setting up the TPCC workload on the cluster.

Informs: #127378

Release note: None