### PR TITLE
roachtest: small improvements in documentation and error reporting

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
@@ -72,10 +72,17 @@ type (
 	}
 )
 
+// Connect returns a connection pool to the given node. Note that
+// these connection pools are managed by the framework and therefore
+// *must not* be closed. They are closed automatically when the test
+// finishes.
 func (s *Service) Connect(node int) *gosql.DB {
 	return s.connFunc(node)
 }
 
+// RandomDB returns a connection pool to a random node in the
+// cluster. Do *not* call `Close` on the pool returned (see comment on
+// `Connect` function).
 func (s *Service) RandomDB(rng *rand.Rand) (int, *gosql.DB) {
 	node := s.Descriptor.Nodes.SeededRandNode(rng)[0]
 	return node, s.Connect(node)

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -572,8 +572,23 @@ func (t *Test) RNG() *rand.Rand {
 
 // InMixedVersion adds a new mixed-version hook to the test. The
 // functionality in the function passed as argument to this function
-// will be tested in arbitrary mixed-version states. If multiple
-// InMixedVersion hooks are passed, they may be executed
+// will be tested in arbitrary mixed-version states; specifically, it
+// can be called up to four times during each major upgrade
+// performed:
+//
+// 1. when the cluster upgrades to the new binary (`preserve_downgrade_option` set)
+// 2. when the cluster downgrades to the old binary
+// 3. when the cluster upgrades to the new binary again
+// 4. when the cluster is finalizing
+//
+// Note that not every major upgrade performs a downgrade. In those
+// cases, the InMixedVersion hook would only be called up to two times
+// (when the cluster upgrades to the new binary, and when the cluster
+// is finalizing the upgrade). Callers can use `h.Context().Stage` to
+// find out the stage in the upgrade in which the hook is being
+// called.
+//
+// If multiple InMixedVersion hooks are passed, they may be executed
 // concurrently.
 func (t *Test) InMixedVersion(desc string, fn stepFunc) {
 	var prevUpgradeStage UpgradeStage
@@ -612,10 +627,10 @@ func (t *Test) OnStartup(desc string, fn stepFunc) {
 	t.hooks.AddStartup(versionUpgradeHook{name: desc, fn: fn})
 }
 
-// AfterUpgradeFinalized registers a callback that is run once the
-// mixed-version test has brought the cluster to the latest version,
-// and allowed the upgrade to finalize successfully. If multiple such
-// hooks are passed, they will be executed concurrently.
+// AfterUpgradeFinalized registers a callback that is run once per
+// major upgrade performed in a test, after the upgrade is finalized
+// successfully.  If multiple such hooks are passed, they may be
+// executed concurrently.
 func (t *Test) AfterUpgradeFinalized(desc string, fn stepFunc) {
 	t.hooks.AddAfterUpgradeFinalized(versionUpgradeHook{name: desc, fn: fn})
 }

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
@@ -240,13 +240,13 @@ func (tr *testRunner) runStep(ctx context.Context, step testStep) error {
 	if ss, ok := step.(*singleStep); ok {
 		if ss.ID > tr.plan.startSystemID {
 			if err := tr.refreshServiceData(ctx, tr.systemService); err != nil {
-				return err
+				return errors.Wrapf(err, "preparing to run step %d", ss.ID)
 			}
 		}
 
 		if ss.ID > tr.plan.startTenantID && tr.tenantService != nil {
 			if err := tr.refreshServiceData(ctx, tr.tenantService); err != nil {
-				return err
+				return errors.Wrapf(err, "preparing to run step %d", ss.ID)
 			}
 		}
 	}


### PR DESCRIPTION
**roachtest: mixedversion documentation updates**

* comments were added to indicate that callers should not close the
  connection pools returned by helper functions.
* documentation for `InMixedVersion` and `AfterUpgradeFinalized` were
  updated to be more explicit about when the hooks passed to those
  functions can be called.

**roachtest: include step ID in failures to get debug information**

This commit updates the `mixedversion` framework so that we include
the step ID we were preparing to run when an error is found gathering
debug information (current binary and cluster versions on the
nodes). This makes it a little easier to understand these errors and
at what point in th test they happened.

Epic: none

Release note: None