### PR TITLE
workload/schemachange: avoid using legacy schema changer for DSC ops

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -194,6 +194,11 @@ func (og *operationGenerator) randOp(
 			}
 		} else {
 			op = opType(og.params.ops.Int())
+			if _, ok := opDeclarativeVersion[op]; ok {
+				// If we're not using the declarative schema changer, then only
+				// generate operations that are not supported in declarative.
+				continue
+			}
 		}
 		if numOpsInTxn != 1 {
 			// DML and legacy PK changes are only allowed in single-statement transactions.

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -312,18 +312,25 @@ var opWeights = []int{
 // be downlevel. The declarative schema changer builder does have a supported
 // list, but it's not sufficient for that reason.
 var opDeclarativeVersion = map[opType]clusterversion.Key{
+	insertRow:  clusterversion.MinSupported,
+	selectStmt: clusterversion.MinSupported,
+	validate:   clusterversion.MinSupported,
+
 	alterTableAddColumn:               clusterversion.MinSupported,
 	alterTableAddConstraintForeignKey: clusterversion.MinSupported,
 	alterTableAddConstraintUnique:     clusterversion.MinSupported,
+	alterTableAlterPrimaryKey:         clusterversion.MinSupported,
 	alterTableDropColumn:              clusterversion.MinSupported,
 	alterTableDropConstraint:          clusterversion.MinSupported,
 	alterTableDropNotNull:             clusterversion.MinSupported,
 	alterTypeDropValue:                clusterversion.MinSupported,
 	commentOn:                         clusterversion.MinSupported,
 	createIndex:                       clusterversion.MinSupported,
+	createFunction:                    clusterversion.MinSupported,
 	createSchema:                      clusterversion.MinSupported,
 	createSequence:                    clusterversion.MinSupported,
 	dropIndex:                         clusterversion.MinSupported,
+	dropFunction:                      clusterversion.MinSupported,
 	dropSchema:                        clusterversion.MinSupported,
 	dropSequence:                      clusterversion.MinSupported,
 	dropTable:                         clusterversion.MinSupported,


### PR DESCRIPTION
### workload: mark more schema change ops as supported in declarative

These should have been added earlier, but were missed before.

### workload/schemachange: avoid using legacy schema changer for DSC ops

This reduces the surface area of what the workload covers, but should
help make it less flaky by testing fewer permutations of operations
under concurrency. This new approach might also be more realistic.

Epic: None
Release note: None