### PR TITLE
roachtest: deflake mt upgrade test

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -81,7 +81,7 @@ func runMultiTenantUpgrade(
 		"23.2": "23.1",
 		"24.1": "23.2",
 		"24.2": "24.1",
-		"24.3": "24.1",
+		"24.3": "24.2",
 	}
 	curBinaryMajorAndMinorVersion := getMajorAndMinorVersionOnly(v)
 	currentBinaryMinSupportedVersion, ok := versionToMinSupportedVersion[curBinaryMajorAndMinorVersion]


### PR DESCRIPTION
This test isn't configured for version skipping yet. We probably should just migrate this test to the mixed version framework before we add version skipping.

Fixes #129029

Release note: none