### PR TITLE
crosscluster/logical: commit-in-batch single row in kv writer

### DIFF
--- a/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
@@ -931,7 +931,7 @@ func (t *txnBatch) HandleBatch(
 
 	stats := batchStats{}
 	var err error
-	if len(batch) == 1 && !useKVWriter {
+	if len(batch) == 1 {
 		s, err := t.rp.ProcessRow(ctx, nil /* txn */, batch[0].KeyValue, batch[0].PrevValue)
 		if err != nil {
 			return stats, err


### PR DESCRIPTION
Release note: none.
Epic: none.