### PR TITLE
admission,kvserver: plumbing for RACv2 callbacks

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -146,6 +146,7 @@ go_library(
         "//pkg/kv/kvserver/kvflowcontrol/kvflowdispatch",
         "//pkg/kv/kvserver/kvflowcontrol/kvflowhandle",
         "//pkg/kv/kvserver/kvflowcontrol/node_rac2",
+        "//pkg/kv/kvserver/kvflowcontrol/replica_rac2",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/kvserverpb",
         "//pkg/kv/kvserver/kvstorage",

--- a/pkg/kv/kvserver/kvadmission/BUILD.bazel
+++ b/pkg/kv/kvserver/kvadmission/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/kvflowcontrol",
         "//pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb",
+        "//pkg/kv/kvserver/kvflowcontrol/replica_rac2",
         "//pkg/kv/kvserver/raftlog",
         "//pkg/raft/raftpb",
         "//pkg/roachpb",

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -175,10 +175,13 @@ func (p *testAdmittedPiggybacker) AddMsgAppRespForLeader(
 
 type testACWorkQueue struct {
 	b *strings.Builder
+	// TODO(sumeer): test case that sets this to true.
+	returnFalse bool
 }
 
-func (q *testACWorkQueue) Admit(ctx context.Context, entry EntryForAdmission) {
-	fmt.Fprintf(q.b, " ACWorkQueue.Admit(%+v)\n", entry)
+func (q *testACWorkQueue) Admit(ctx context.Context, entry EntryForAdmission) bool {
+	fmt.Fprintf(q.b, " ACWorkQueue.Admit(%+v) = %t\n", entry, !q.returnFalse)
+	return !q.returnFalse
 }
 
 type testRangeControllerFactory struct {

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
@@ -96,7 +96,7 @@ HandleRaftReady:
  Replica.MuUnlock
 .....
 AdmitRaftEntries:
- ACWorkQueue.Admit({TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false CallbackState:{StoreID:2 RangeID:3 ReplicaID:5 LeaderTerm:50 Index:25 Priority:LowPri}})
+ ACWorkQueue.Admit({TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false CallbackState:{StoreID:2 RangeID:3 ReplicaID:5 LeaderTerm:50 Index:25 Priority:LowPri}}) = true
 leader-using-v2: true
 
 # Stable index is advanced to 25.
@@ -147,7 +147,7 @@ HandleRaftReady:
  Replica.MuUnlock
 .....
 AdmitRaftEntries:
- ACWorkQueue.Admit({TenantID:4 Priority:user-high-pri CreateTime:2 RequestedCount:100 Ingested:false CallbackState:{StoreID:2 RangeID:3 ReplicaID:5 LeaderTerm:50 Index:26 Priority:AboveNormalPri}})
+ ACWorkQueue.Admit({TenantID:4 Priority:user-high-pri CreateTime:2 RequestedCount:100 Ingested:false CallbackState:{StoreID:2 RangeID:3 ReplicaID:5 LeaderTerm:50 Index:26 Priority:AboveNormalPri}}) = true
 leader-using-v2: true
 
 # handleRaftReady is a noop.
@@ -241,7 +241,7 @@ HandleRaftReady:
  Replica.MuUnlock
 .....
 AdmitRaftEntries:
- ACWorkQueue.Admit({TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false CallbackState:{StoreID:2 RangeID:3 ReplicaID:5 LeaderTerm:50 Index:27 Priority:LowPri}})
+ ACWorkQueue.Admit({TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false CallbackState:{StoreID:2 RangeID:3 ReplicaID:5 LeaderTerm:50 Index:27 Priority:LowPri}}) = true
 leader-using-v2: true
 
 admitted-log-entry replica-id=5 leader-term=50 index=27 pri=3
@@ -378,7 +378,7 @@ HandleRaftReady:
  RangeController.HandleRaftEventRaftMuLocked([28])
 .....
 AdmitRaftEntries:
- ACWorkQueue.Admit({TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false CallbackState:{StoreID:2 RangeID:3 ReplicaID:5 LeaderTerm:52 Index:28 Priority:LowPri}})
+ ACWorkQueue.Admit({TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false CallbackState:{StoreID:2 RangeID:3 ReplicaID:5 LeaderTerm:52 Index:28 Priority:LowPri}}) = true
 leader-using-v2: true
 
 # Entry at index 28 is admitted, but stable index is 27.
@@ -641,7 +641,7 @@ HandleRaftReady:
  RangeController.HandleRaftEventRaftMuLocked([26])
 .....
 AdmitRaftEntries:
- ACWorkQueue.Admit({TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false CallbackState:{StoreID:2 RangeID:3 ReplicaID:5 LeaderTerm:50 Index:26 Priority:LowPri}})
+ ACWorkQueue.Admit({TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false CallbackState:{StoreID:2 RangeID:3 ReplicaID:5 LeaderTerm:50 Index:26 Priority:LowPri}}) = true
 leader-using-v2: true
 
 # Entry is admitted.

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1069,7 +1069,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 						continue // nothing to do
 					}
 					r.store.cfg.KVAdmissionController.AdmitRaftEntry(
-						ctx, tenantID, r.StoreID(), r.RangeID, entry,
+						ctx, tenantID, r.StoreID(), r.RangeID, r.replicaID, msgStorageAppend.Term, entry,
 					)
 				}
 			}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -577,8 +577,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	)
 
 	storesForFlowControl := kvserver.MakeStoresForFlowControl(stores)
+	storesForRACv2 := kvserver.MakeStoresForRACv2(stores)
 	kvflowTokenDispatch := kvflowdispatch.New(nodeRegistry, storesForFlowControl, nodeIDContainer)
-	admittedEntryAdaptor := newAdmittedLogEntryAdaptor(kvflowTokenDispatch)
+	admittedEntryAdaptor := newAdmittedLogEntryAdaptor(kvflowTokenDispatch, storesForRACv2)
 	admissionKnobs, ok := cfg.TestingKnobs.AdmissionControl.(*admission.TestingKnobs)
 	if !ok {
 		admissionKnobs = &admission.TestingKnobs{}

--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/raft/raftpb",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/util/admission/granter_test.go
+++ b/pkg/util/admission/granter_test.go
@@ -504,14 +504,7 @@ func (m *testMetricsProvider) setMetricsForStores(stores []int32, metrics pebble
 
 type noopOnLogEntryAdmitted struct{}
 
-func (n *noopOnLogEntryAdmitted) AdmittedLogEntry(
-	context.Context,
-	roachpb.NodeID,
-	admissionpb.WorkPriority,
-	roachpb.StoreID,
-	roachpb.RangeID,
-	LogPosition,
-) {
+func (n *noopOnLogEntryAdmitted) AdmittedLogEntry(context.Context, LogEntryAdmittedCallbackState) {
 }
 
 var _ OnLogEntryAdmitted = &noopOnLogEntryAdmitted{}


### PR DESCRIPTION
The plumbing changes allow for both RACv1 and RACv2 info to flow through admission control queues and be provided in the callback. The admittedLogEntryAdaptor demuxes to the relevant callback handler. kvserver.storesForRACv2 will further route to the relevant Replica -- this code will be added once Replica has a replica_rac2.Processor member.

Informs #128309

Epic: CRDB-37515

Release note: None