### PR TITLE
roachtest: add subtest for disk bandwidth bottleneck for ingests

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -23,7 +23,7 @@ go_library(
         "admission_control_multitenant_fairness.go",
         "admission_control_row_level_ttl.go",
         "admission_control_snapshot_overload.go",
-        "admission_control_snapshot_overload_excise.go",
+        "admission_control_snapshot_overload_io.go",
         "admission_control_tpcc_overload.go",
         "allocation_bench.go",
         "allocator.go",

--- a/pkg/cmd/roachtest/tests/admission_control.go
+++ b/pkg/cmd/roachtest/tests/admission_control.go
@@ -35,7 +35,7 @@ func registerAdmission(r registry.Registry) {
 	registerMultiStoreOverload(r)
 	registerMultiTenantFairness(r)
 	registerSnapshotOverload(r)
-	registerSnapshotOverloadExcise(r)
+	registerSnapshotOverloadIO(r)
 	registerTPCCOverload(r)
 	registerTPCCSevereOverload(r)
 	registerIndexOverload(r)

--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -76,44 +76,8 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 
 			setAdmissionControl(ctx, t, c, true)
 
-			// TODO(aaditya): This function shares some of the logic with roachtestutil.DiskStaller. Consider merging the two.
-			setBandwidthLimit := func(nodes option.NodeListOption, rw string, bw int, max bool) error {
-				dataMount := "/mnt/data1"
-				res, err := c.RunWithDetailsSingleNode(context.TODO(), t.L(), option.WithNodes(nodes[:1]),
-					fmt.Sprintf("lsblk | grep %s | awk '{print $2}'", dataMount),
-				)
-				if err != nil {
-					t.Fatalf("error when determining block device: %s", err)
-				}
-				parts := strings.Split(strings.TrimSpace(res.Stdout), ":")
-				if len(parts) != 2 {
-					t.Fatalf("unexpected output from lsblk: %s", res.Stdout)
-				}
-				major, err := strconv.Atoi(parts[0])
-				if err != nil {
-					t.Fatalf("error when determining block device: %s", err)
-				}
-				minor, err := strconv.Atoi(parts[1])
-				if err != nil {
-					t.Fatalf("error when determining block device: %s", err)
-				}
-
-				cockroachIOController := filepath.Join("/sys/fs/cgroup/system.slice", roachtestutil.SystemInterfaceSystemdUnitName()+".service", "io.max")
-				bytesPerSecondStr := "max"
-				if !max {
-					bytesPerSecondStr = fmt.Sprintf("%d", bw)
-				}
-				return c.RunE(ctx, option.WithNodes(nodes), "sudo", "/bin/bash", "-c", fmt.Sprintf(
-					`'echo %d:%d %s=%s > %s'`,
-					major,
-					minor,
-					rw,
-					bytesPerSecondStr,
-					cockroachIOController,
-				))
-			}
-
-			if err := setBandwidthLimit(c.CRDBNodes(), "wbps", 128<<20 /* 128MiB */, false); err != nil {
+			dataDir := "/mnt/data1"
+			if err := setBandwidthLimit(ctx, t, c, c.CRDBNodes(), "wbps", 128<<20 /* 128MiB */, false, dataDir); err != nil {
 				t.Fatal(err)
 			}
 
@@ -230,4 +194,49 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 			m.Wait()
 		},
 	})
+}
+
+// TODO(aaditya): This function shares some of the logic with roachtestutil.DiskStaller. Consider merging the two.
+func setBandwidthLimit(
+	ctx context.Context,
+	t test.Test,
+	c cluster.Cluster,
+	nodes option.NodeListOption,
+	rw string,
+	bw int,
+	max bool,
+	dataDir string,
+) error {
+	res, err := c.RunWithDetailsSingleNode(context.TODO(), t.L(), option.WithNodes(nodes[:1]),
+		fmt.Sprintf("lsblk | grep %s | awk '{print $2}'", dataDir),
+	)
+	if err != nil {
+		t.Fatalf("error when determining block device: %s", err)
+	}
+	parts := strings.Split(strings.TrimSpace(res.Stdout), ":")
+	if len(parts) != 2 {
+		t.Fatalf("unexpected output from lsblk: %s", res.Stdout)
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		t.Fatalf("error when determining block device: %s", err)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		t.Fatalf("error when determining block device: %s", err)
+	}
+
+	cockroachIOController := filepath.Join("/sys/fs/cgroup/system.slice", roachtestutil.SystemInterfaceSystemdUnitName()+".service", "io.max")
+	bytesPerSecondStr := "max"
+	if !max {
+		bytesPerSecondStr = fmt.Sprintf("%d", bw)
+	}
+	return c.RunE(ctx, option.WithNodes(nodes), "sudo", "/bin/bash", "-c", fmt.Sprintf(
+		`'echo %d:%d %s=%s > %s'`,
+		major,
+		minor,
+		rw,
+		bytesPerSecondStr,
+		cockroachIOController,
+	))
 }

--- a/pkg/cmd/roachtest/tests/admission_control_snapshot_overload_io.go
+++ b/pkg/cmd/roachtest/tests/admission_control_snapshot_overload_io.go
@@ -37,9 +37,9 @@ import (
 // workload is run, and shortly after that, n3 is brought down. Upon restart, n3
 // starts to receive large amounts of snapshot data. With excises turned on, it
 // is expected that l0 sublevel counts and p99 latencies remain stable.
-func registerSnapshotOverloadExcise(r registry.Registry) {
+func registerSnapshotOverloadIO(r registry.Registry) {
 	r.Add(registry.TestSpec{
-		Name:             "admission-control/snapshot-overload-excise",
+		Name:             "admission-control/snapshot-overload-io-excise",
 		Owner:            registry.OwnerAdmissionControl,
 		Benchmark:        true,
 		CompatibleClouds: registry.OnlyGCE,

--- a/pkg/cmd/roachtest/tests/admission_control_snapshot_overload_io.go
+++ b/pkg/cmd/roachtest/tests/admission_control_snapshot_overload_io.go
@@ -71,6 +71,16 @@ func registerSnapshotOverloadIO(r registry.Registry) {
 		// low compaction rate. With Pebble's IngestAndExcise all the ingested
 		// sstables should ingest into L6.
 		limitCompactionConcurrency: true,
+		limitDiskBandwidth:         false,
+	}))
+
+	// This tests the behaviour of snpashot ingestion in bandwidth constrained
+	// environments.
+	r.Add(spec("bandwidth", admissionControlSnapshotOverloadIOOpts{
+		// 2x headroom from the ~500GB pre-population of the test.
+		volumeSize:                 1000,
+		limitCompactionConcurrency: false,
+		limitDiskBandwidth:         true,
 	}))
 
 }
@@ -78,6 +88,7 @@ func registerSnapshotOverloadIO(r registry.Registry) {
 type admissionControlSnapshotOverloadIOOpts struct {
 	volumeSize                 int
 	limitCompactionConcurrency bool
+	limitDiskBandwidth         bool
 }
 
 func runAdmissionControlSnapshotOverloadIO(
@@ -129,6 +140,18 @@ func runAdmissionControlSnapshotOverloadIO(
 		if _, err := db.ExecContext(
 			ctx, "SET CLUSTER SETTING kv.snapshot_rebalance.max_rate = '256MiB'"); err != nil {
 			t.Fatalf("failed to set kv.snapshot_rebalance.max_rate: %v", err)
+		}
+	}
+
+	if cfg.limitDiskBandwidth {
+		const bandwidthLimit = 128
+		dataDir := "/mnt/data1"
+		if err := setBandwidthLimit(ctx, t, c, c.CRDBNodes(), "wbps", bandwidthLimit<<20 /* 128MiB */, false, dataDir); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.ExecContext(
+			ctx, fmt.Sprintf("SET CLUSTER SETTING kvadmission.store.provisioned_bandwidth = '%dMiB'", bandwidthLimit)); err != nil {
+			t.Fatalf("failed to set kvadmission.store.provisioned_bandwidth: %v", err)
 		}
 	}
 
@@ -219,47 +242,50 @@ func runAdmissionControlSnapshotOverloadIO(
 			return float64(fromVec[0].Value), nil
 		}
 
-		// Assert on l0 sublevel count and p99 latencies.
-		latencyMetric := divQuery("histogram_quantile(0.99, sum by(le) (rate(sql_service_latency_bucket[2m])))", 1<<20 /* 1ms */)
-		const latencyThreshold = 100 // 100ms since the metric is scaled to 1ms above.
-		const sublevelMetric = "storage_l0_sublevels"
-		const sublevelThreshold = 20
-		var l0SublevelCount []float64
-		const sampleCountForL0Sublevel = 12
-		const collectionIntervalSeconds = 10.0
-		// Loop for ~120 minutes.
-		const numIterations = int(120 / (collectionIntervalSeconds / 60))
-		numErrors := 0
-		numSuccesses := 0
-		for i := 0; i < numIterations; i++ {
-			time.Sleep(collectionIntervalSeconds * time.Second)
-			val, err := getHistMetricVal(latencyMetric)
-			if err != nil {
-				numErrors++
-				continue
-			}
-			if val > latencyThreshold {
-				t.Fatalf("sql p99 latency %f exceeded threshold", val)
-			}
-			val, err = getMetricVal(sublevelMetric, "store")
-			if err != nil {
-				numErrors++
-				continue
-			}
-			l0SublevelCount = append(l0SublevelCount, val)
-			// We want to use the mean of the last 2m of data to avoid short-lived
-			// spikes causing failures.
-			if len(l0SublevelCount) >= sampleCountForL0Sublevel {
-				latestSampleMeanL0Sublevels := getMeanOverLastN(sampleCountForL0Sublevel, l0SublevelCount)
-				if latestSampleMeanL0Sublevels > sublevelThreshold {
-					t.Fatalf("sub-level mean %f over last %d iterations exceeded threshold", latestSampleMeanL0Sublevels, sampleCountForL0Sublevel)
+		// TODO(aaditya): assert on disk bandwidth subtest once integrated.
+		if !cfg.limitDiskBandwidth {
+			// Assert on l0 sublevel count and p99 latencies.
+			latencyMetric := divQuery("histogram_quantile(0.99, sum by(le) (rate(sql_service_latency_bucket[2m])))", 1<<20 /* 1ms */)
+			const latencyThreshold = 100 // 100ms since the metric is scaled to 1ms above.
+			const sublevelMetric = "storage_l0_sublevels"
+			const sublevelThreshold = 20
+			var l0SublevelCount []float64
+			const sampleCountForL0Sublevel = 12
+			const collectionIntervalSeconds = 10.0
+			// Loop for ~120 minutes.
+			const numIterations = int(120 / (collectionIntervalSeconds / 60))
+			numErrors := 0
+			numSuccesses := 0
+			for i := 0; i < numIterations; i++ {
+				time.Sleep(collectionIntervalSeconds * time.Second)
+				val, err := getHistMetricVal(latencyMetric)
+				if err != nil {
+					numErrors++
+					continue
 				}
+				if val > latencyThreshold {
+					t.Fatalf("sql p99 latency %f exceeded threshold", val)
+				}
+				val, err = getMetricVal(sublevelMetric, "store")
+				if err != nil {
+					numErrors++
+					continue
+				}
+				l0SublevelCount = append(l0SublevelCount, val)
+				// We want to use the mean of the last 2m of data to avoid short-lived
+				// spikes causing failures.
+				if len(l0SublevelCount) >= sampleCountForL0Sublevel {
+					latestSampleMeanL0Sublevels := getMeanOverLastN(sampleCountForL0Sublevel, l0SublevelCount)
+					if latestSampleMeanL0Sublevels > sublevelThreshold {
+						t.Fatalf("sub-level mean %f over last %d iterations exceeded threshold", latestSampleMeanL0Sublevels, sampleCountForL0Sublevel)
+					}
+				}
+				numSuccesses++
 			}
-			numSuccesses++
-		}
-		t.Status(fmt.Sprintf("done monitoring, errors: %d successes: %d", numErrors, numSuccesses))
-		if numErrors > numSuccesses {
-			t.Fatalf("too many errors retrieving metrics")
+			t.Status(fmt.Sprintf("done monitoring, errors: %d successes: %d", numErrors, numSuccesses))
+			if numErrors > numSuccesses {
+				t.Fatalf("too many errors retrieving metrics")
+			}
 		}
 		return nil
 	})

--- a/pkg/cmd/roachtest/tests/admission_control_snapshot_overload_io.go
+++ b/pkg/cmd/roachtest/tests/admission_control_snapshot_overload_io.go
@@ -31,208 +31,238 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// This test aims to test the behavior of range snapshots with splits and
-// excises enabled in the storage engine. It sets up a 3 node cluster, where the
-// cluster is pre-populated with about 500GB of data. Then, a foreground kv
-// workload is run, and shortly after that, n3 is brought down. Upon restart, n3
-// starts to receive large amounts of snapshot data. With excises turned on, it
-// is expected that l0 sublevel counts and p99 latencies remain stable.
+// This test aims to test the behavior of range snapshots under heavy load. It
+// sets up a 3 node cluster, where the cluster is pre-populated with about 500GB
+// of data. Then, a foreground kv workload is run, and shortly after that, n3 is
+// brought down. Upon restart, n3 starts to receive large amounts of snapshot
+// data. It is expected that l0 sublevel counts and p99 latencies remain stable.
 func registerSnapshotOverloadIO(r registry.Registry) {
-	r.Add(registry.TestSpec{
-		Name:             "admission-control/snapshot-overload-io-excise",
-		Owner:            registry.OwnerAdmissionControl,
-		Benchmark:        true,
-		CompatibleClouds: registry.OnlyGCE,
-		Suites:           registry.Suites(registry.Weekly),
+	spec := func(subtest string, cfg admissionControlSnapshotOverloadIOOpts) registry.TestSpec {
+		return registry.TestSpec{
+			Name:             "admission-control/snapshot-overload-io/" + subtest,
+			Owner:            registry.OwnerAdmissionControl,
+			Benchmark:        true,
+			CompatibleClouds: registry.OnlyGCE,
+			Suites:           registry.Suites(registry.Weekly),
+			Cluster: r.MakeClusterSpec(
+				4,
+				spec.CPU(4),
+				spec.WorkloadNode(),
+				spec.VolumeSize(cfg.volumeSize),
+				spec.ReuseNone(),
+				spec.DisableLocalSSD(),
+			),
+			Leases:  registry.MetamorphicLeases,
+			Timeout: 12 * time.Hour,
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				runAdmissionControlSnapshotOverloadIO(ctx, t, c, cfg)
+			},
+		}
+	}
+
+	// This tests the ability of the storage engine to handle a high rate of
+	// snapshots while maintaining a healthy LSM shape and stable p99 latencies.
+	r.Add(spec("excise", admissionControlSnapshotOverloadIOOpts{
 		// The test uses a large volume size to ensure high provisioned bandwidth
 		// from the cloud provider.
-		Cluster: r.MakeClusterSpec(4, spec.CPU(4), spec.WorkloadNode(), spec.VolumeSize(2000)),
-		Leases:  registry.MetamorphicLeases,
-		Timeout: 12 * time.Hour,
-		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if c.Spec().NodeCount < 4 {
-				t.Fatalf("expected at least 4 nodes, found %d", c.Spec().NodeCount)
-			}
+		volumeSize: 2000,
+		// COCKROACH_CONCURRENT_COMPACTIONS is set to 1 since we want to ensure
+		// that snapshot ingests don't result in LSM inversion even with a very
+		// low compaction rate. With Pebble's IngestAndExcise all the ingested
+		// sstables should ingest into L6.
+		limitCompactionConcurrency: true,
+	}))
 
-			envOptions := install.EnvOption{
-				// COCKROACH_CONCURRENT_COMPACTIONS is set to 1 since we want to ensure
-				// that snapshot ingests don't result in LSM inversion even with a very
-				// low compaction rate. With Pebble's IngestAndExcise all the ingested
-				// sstables should ingest into L6.
-				"COCKROACH_CONCURRENT_COMPACTIONS=1",
-				// COCKROACH_RAFT_LOG_TRUNCATION_THRESHOLD is reduced so that there is
-				// certainty that the restarted node will be caught up via snapshots,
-				// and not via raft log replay.
-				fmt.Sprintf("COCKROACH_RAFT_LOG_TRUNCATION_THRESHOLD=%d", 512<<10 /* 512KiB */),
-				// COCKROACH_CONCURRENT_SNAPSHOT* is increased so that the rate of
-				// snapshot application is high.
-				"COCKROACH_CONCURRENT_SNAPSHOT_APPLY_LIMIT=100",
-				"COCKROACH_CONCURRENT_SNAPSHOT_SEND_LIMIT=100",
-			}
+}
 
-			startOpts := option.NewStartOpts(option.NoBackupSchedule)
-			roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
-			roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
-			settings := install.MakeClusterSettings(envOptions)
-			c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
+type admissionControlSnapshotOverloadIOOpts struct {
+	volumeSize                 int
+	limitCompactionConcurrency bool
+}
 
-			db := c.Conn(ctx, t.L(), len(c.CRDBNodes()))
-			defer db.Close()
+func runAdmissionControlSnapshotOverloadIO(
+	ctx context.Context, t test.Test, c cluster.Cluster, cfg admissionControlSnapshotOverloadIOOpts,
+) {
+	if c.Spec().NodeCount < 4 {
+		t.Fatalf("expected at least 4 nodes, found %d", c.Spec().NodeCount)
+	}
 
-			t.Status(fmt.Sprintf("configuring cluster settings (<%s)", 30*time.Second))
-			{
-				// Defensive, since admission control is enabled by default.
-				setAdmissionControl(ctx, t, c, true)
-				// Ensure ingest splits and excises are enabled. (Enabled by default in v24.1+)
-				if _, err := db.ExecContext(
-					ctx, "SET CLUSTER SETTING kv.snapshot_receiver.excise.enabled = 'true'"); err != nil {
-					t.Fatalf("failed to set kv.snapshot_receiver.excise.enabled: %v", err)
-				}
-				if _, err := db.ExecContext(
-					ctx, "SET CLUSTER SETTING storage.ingest_split.enabled = 'true'"); err != nil {
-					t.Fatalf("failed to set storage.ingest_split.enabled: %v", err)
-				}
+	envOptions := install.EnvOption{
+		// COCKROACH_RAFT_LOG_TRUNCATION_THRESHOLD is reduced so that there is
+		// certainty that the restarted node will be caught up via snapshots,
+		// and not via raft log replay.
+		fmt.Sprintf("COCKROACH_RAFT_LOG_TRUNCATION_THRESHOLD=%d", 512<<10 /* 512KiB */),
+		// COCKROACH_CONCURRENT_SNAPSHOT* is increased so that the rate of
+		// snapshot application is high.
+		"COCKROACH_CONCURRENT_SNAPSHOT_APPLY_LIMIT=100",
+		"COCKROACH_CONCURRENT_SNAPSHOT_SEND_LIMIT=100",
+	}
 
-				// Set a high rebalance rate.
-				if _, err := db.ExecContext(
-					ctx, "SET CLUSTER SETTING kv.snapshot_rebalance.max_rate = '256MiB'"); err != nil {
-					t.Fatalf("failed to set kv.snapshot_rebalance.max_rate: %v", err)
-				}
-			}
+	if cfg.limitCompactionConcurrency {
+		envOptions = append(envOptions, "COCKROACH_CONCURRENT_COMPACTIONS=1")
+	}
 
-			// Setup the prometheus instance and client.
-			t.Status(fmt.Sprintf("setting up prometheus/grafana (<%s)", 2*time.Minute))
-			var statCollector clusterstats.StatCollector
-			promCfg := &prometheus.Config{}
-			promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
-				WithNodeExporter(c.CRDBNodes().InstallNodes()).
-				WithCluster(c.CRDBNodes().InstallNodes()).
-				WithGrafanaDashboardJSON(grafana.SnapshotAdmissionControlGrafanaJSON)
-			err := c.StartGrafana(ctx, t.L(), promCfg)
-			require.NoError(t, err)
-			cleanupFunc := func() {
-				if err := c.StopGrafana(ctx, t.L(), t.ArtifactsDir()); err != nil {
-					t.L().ErrorfCtx(ctx, "Error(s) shutting down prom/grafana %s", err)
-				}
-			}
-			defer cleanupFunc()
-			promClient, err := clusterstats.SetupCollectorPromClient(ctx, c, t.L(), promCfg)
-			require.NoError(t, err)
-			statCollector = clusterstats.NewStatsCollector(ctx, promClient)
+	startOpts := option.NewStartOpts(option.NoBackupSchedule)
+	roachtestutil.SetDefaultAdminUIPort(c, &startOpts.RoachprodOpts)
+	roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
+	settings := install.MakeClusterSettings(envOptions)
+	c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
 
-			// Initialize the kv database,
-			t.Status(fmt.Sprintf("initializing kv dataset (<%s)", 2*time.Hour))
-			c.Run(ctx, option.WithNodes(c.WorkloadNode()),
-				"./cockroach workload init kv --drop --insert-count=40000000 "+
-					"--max-block-bytes=12288 --min-block-bytes=12288 {pgurl:1-3}")
+	db := c.Conn(ctx, t.L(), len(c.CRDBNodes()))
+	defer db.Close()
 
-			t.Status(fmt.Sprintf("starting kv workload thread (<%s)", time.Minute))
-			m := c.NewMonitor(ctx, c.CRDBNodes())
-			m.Go(func(ctx context.Context) error {
-				c.Run(ctx, option.WithNodes(c.WorkloadNode()),
-					fmt.Sprintf("./cockroach workload run kv --tolerate-errors "+
-						"--splits=1000 --histograms=%s/stats.json --read-percent=75 "+
-						"--max-rate=600 --max-block-bytes=12288 --min-block-bytes=12288 "+
-						"--concurrency=4000 --duration=%s {pgurl:1-2}",
-						t.PerfArtifactsDir(), (6*time.Hour).String()))
-				return nil
-			})
+	t.Status(fmt.Sprintf("configuring cluster settings (<%s)", 30*time.Second))
+	{
+		// Defensive, since admission control is enabled by default.
+		setAdmissionControl(ctx, t, c, true)
+		// Ensure ingest splits and excises are enabled. (Enabled by default in v24.1+)
+		if _, err := db.ExecContext(
+			ctx, "SET CLUSTER SETTING kv.snapshot_receiver.excise.enabled = 'true'"); err != nil {
+			t.Fatalf("failed to set kv.snapshot_receiver.excise.enabled: %v", err)
+		}
+		if _, err := db.ExecContext(
+			ctx, "SET CLUSTER SETTING storage.ingest_split.enabled = 'true'"); err != nil {
+			t.Fatalf("failed to set storage.ingest_split.enabled: %v", err)
+		}
 
-			t.Status(fmt.Sprintf("waiting for data build up (<%s)", time.Hour))
-			time.Sleep(time.Hour)
+		// Set a high rebalance rate.
+		if _, err := db.ExecContext(
+			ctx, "SET CLUSTER SETTING kv.snapshot_rebalance.max_rate = '256MiB'"); err != nil {
+			t.Fatalf("failed to set kv.snapshot_rebalance.max_rate: %v", err)
+		}
+	}
 
-			t.Status(fmt.Sprintf("killing node 3... (<%s)", time.Minute))
-			c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(3))
+	// Setup the prometheus instance and client.
+	t.Status(fmt.Sprintf("setting up prometheus/grafana (<%s)", 2*time.Minute))
+	var statCollector clusterstats.StatCollector
+	promCfg := &prometheus.Config{}
+	promCfg.WithPrometheusNode(c.WorkloadNode().InstallNodes()[0]).
+		WithNodeExporter(c.CRDBNodes().InstallNodes()).
+		WithCluster(c.CRDBNodes().InstallNodes()).
+		WithGrafanaDashboardJSON(grafana.SnapshotAdmissionControlGrafanaJSON)
+	err := c.StartGrafana(ctx, t.L(), promCfg)
+	require.NoError(t, err)
+	cleanupFunc := func() {
+		if err := c.StopGrafana(ctx, t.L(), t.ArtifactsDir()); err != nil {
+			t.L().ErrorfCtx(ctx, "Error(s) shutting down prom/grafana %s", err)
+		}
+	}
+	defer cleanupFunc()
+	promClient, err := clusterstats.SetupCollectorPromClient(ctx, c, t.L(), promCfg)
+	require.NoError(t, err)
+	statCollector = clusterstats.NewStatsCollector(ctx, promClient)
 
-			t.Status(fmt.Sprintf("waiting for increased snapshot data and raft log truncation (<%s)", 2*time.Hour))
-			time.Sleep(2 * time.Hour)
+	// Initialize the kv database,
+	t.Status(fmt.Sprintf("initializing kv dataset (<%s)", 2*time.Hour))
+	c.Run(ctx, option.WithNodes(c.WorkloadNode()),
+		"./cockroach workload init kv --drop --insert-count=40000000 "+
+			"--max-block-bytes=12288 --min-block-bytes=12288 {pgurl:1-3}")
 
-			t.Status(fmt.Sprintf("starting node 3... (<%s)", time.Minute))
-			c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(envOptions), c.Node(3))
-
-			t.Status(fmt.Sprintf("waiting for snapshot transfers to finish %s", 2*time.Hour))
-			m.Go(func(ctx context.Context) error {
-				t.Status(fmt.Sprintf("starting monitoring thread (<%s)", time.Minute))
-				getMetricVal := func(query string, label string) (float64, error) {
-					point, err := statCollector.CollectPoint(ctx, t.L(), timeutil.Now(), query)
-					if err != nil {
-						t.L().Errorf("could not query prom %s", err.Error())
-						return 0, err
-					}
-					val := point[label]
-					for storeID, v := range val {
-						t.L().Printf("%s(store=%s): %f", query, storeID, v.Value)
-						// We only assert on the 3rd store.
-						if storeID == "3" {
-							return v.Value, nil
-						}
-					}
-					// Unreachable.
-					panic("unreachable")
-				}
-				getHistMetricVal := func(query string) (float64, error) {
-					at := timeutil.Now()
-					fromVal, warnings, err := promClient.Query(ctx, query, at)
-					if err != nil {
-						return 0, err
-					}
-					if len(warnings) > 0 {
-						return 0, errors.Newf("found warnings querying prometheus: %s", warnings)
-					}
-
-					fromVec := fromVal.(model.Vector)
-					if len(fromVec) == 0 {
-						return 0, errors.Newf("Empty vector result for query %s @ %s (%v)", query, at.Format(time.RFC3339), fromVal)
-					}
-					return float64(fromVec[0].Value), nil
-				}
-
-				// Assert on l0 sublevel count and p99 latencies.
-				latencyMetric := divQuery("histogram_quantile(0.99, sum by(le) (rate(sql_service_latency_bucket[2m])))", 1<<20 /* 1ms */)
-				const latencyThreshold = 100 // 100ms since the metric is scaled to 1ms above.
-				const sublevelMetric = "storage_l0_sublevels"
-				const sublevelThreshold = 20
-				var l0SublevelCount []float64
-				const sampleCountForL0Sublevel = 12
-				const collectionIntervalSeconds = 10.0
-				// Loop for ~120 minutes.
-				const numIterations = int(120 / (collectionIntervalSeconds / 60))
-				numErrors := 0
-				numSuccesses := 0
-				for i := 0; i < numIterations; i++ {
-					time.Sleep(collectionIntervalSeconds * time.Second)
-					val, err := getHistMetricVal(latencyMetric)
-					if err != nil {
-						numErrors++
-						continue
-					}
-					if val > latencyThreshold {
-						t.Fatalf("sql p99 latency %f exceeded threshold", val)
-					}
-					val, err = getMetricVal(sublevelMetric, "store")
-					if err != nil {
-						numErrors++
-						continue
-					}
-					l0SublevelCount = append(l0SublevelCount, val)
-					// We want to use the mean of the last 2m of data to avoid short-lived
-					// spikes causing failures.
-					if len(l0SublevelCount) >= sampleCountForL0Sublevel {
-						latestSampleMeanL0Sublevels := getMeanOverLastN(sampleCountForL0Sublevel, l0SublevelCount)
-						if latestSampleMeanL0Sublevels > sublevelThreshold {
-							t.Fatalf("sub-level mean %f over last %d iterations exceeded threshold", latestSampleMeanL0Sublevels, sampleCountForL0Sublevel)
-						}
-					}
-					numSuccesses++
-				}
-				t.Status(fmt.Sprintf("done monitoring, errors: %d successes: %d", numErrors, numSuccesses))
-				if numErrors > numSuccesses {
-					t.Fatalf("too many errors retrieving metrics")
-				}
-				return nil
-			})
-
-			m.Wait()
-		},
+	t.Status(fmt.Sprintf("starting kv workload thread (<%s)", time.Minute))
+	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m.Go(func(ctx context.Context) error {
+		c.Run(ctx, option.WithNodes(c.WorkloadNode()),
+			fmt.Sprintf("./cockroach workload run kv --tolerate-errors "+
+				"--splits=1000 --histograms=%s/stats.json --read-percent=75 "+
+				"--max-rate=600 --max-block-bytes=12288 --min-block-bytes=12288 "+
+				"--concurrency=4000 --duration=%s {pgurl:1-2}",
+				t.PerfArtifactsDir(), (6*time.Hour).String()))
+		return nil
 	})
+
+	t.Status(fmt.Sprintf("waiting for data build up (<%s)", time.Hour))
+	time.Sleep(time.Hour)
+
+	t.Status(fmt.Sprintf("killing node 3... (<%s)", time.Minute))
+	c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(3))
+
+	t.Status(fmt.Sprintf("waiting for increased snapshot data and raft log truncation (<%s)", 2*time.Hour))
+	time.Sleep(2 * time.Hour)
+
+	t.Status(fmt.Sprintf("starting node 3... (<%s)", time.Minute))
+	c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(envOptions), c.Node(3))
+
+	t.Status(fmt.Sprintf("waiting for snapshot transfers to finish %s", 2*time.Hour))
+	m.Go(func(ctx context.Context) error {
+		t.Status(fmt.Sprintf("starting monitoring thread (<%s)", time.Minute))
+		getMetricVal := func(query string, label string) (float64, error) {
+			point, err := statCollector.CollectPoint(ctx, t.L(), timeutil.Now(), query)
+			if err != nil {
+				t.L().Errorf("could not query prom %s", err.Error())
+				return 0, err
+			}
+			val := point[label]
+			for storeID, v := range val {
+				t.L().Printf("%s(store=%s): %f", query, storeID, v.Value)
+				// We only assert on the 3rd store.
+				if storeID == "3" {
+					return v.Value, nil
+				}
+			}
+			// Unreachable.
+			panic("unreachable")
+		}
+		getHistMetricVal := func(query string) (float64, error) {
+			at := timeutil.Now()
+			fromVal, warnings, err := promClient.Query(ctx, query, at)
+			if err != nil {
+				return 0, err
+			}
+			if len(warnings) > 0 {
+				return 0, errors.Newf("found warnings querying prometheus: %s", warnings)
+			}
+
+			fromVec := fromVal.(model.Vector)
+			if len(fromVec) == 0 {
+				return 0, errors.Newf("Empty vector result for query %s @ %s (%v)", query, at.Format(time.RFC3339), fromVal)
+			}
+			return float64(fromVec[0].Value), nil
+		}
+
+		// Assert on l0 sublevel count and p99 latencies.
+		latencyMetric := divQuery("histogram_quantile(0.99, sum by(le) (rate(sql_service_latency_bucket[2m])))", 1<<20 /* 1ms */)
+		const latencyThreshold = 100 // 100ms since the metric is scaled to 1ms above.
+		const sublevelMetric = "storage_l0_sublevels"
+		const sublevelThreshold = 20
+		var l0SublevelCount []float64
+		const sampleCountForL0Sublevel = 12
+		const collectionIntervalSeconds = 10.0
+		// Loop for ~120 minutes.
+		const numIterations = int(120 / (collectionIntervalSeconds / 60))
+		numErrors := 0
+		numSuccesses := 0
+		for i := 0; i < numIterations; i++ {
+			time.Sleep(collectionIntervalSeconds * time.Second)
+			val, err := getHistMetricVal(latencyMetric)
+			if err != nil {
+				numErrors++
+				continue
+			}
+			if val > latencyThreshold {
+				t.Fatalf("sql p99 latency %f exceeded threshold", val)
+			}
+			val, err = getMetricVal(sublevelMetric, "store")
+			if err != nil {
+				numErrors++
+				continue
+			}
+			l0SublevelCount = append(l0SublevelCount, val)
+			// We want to use the mean of the last 2m of data to avoid short-lived
+			// spikes causing failures.
+			if len(l0SublevelCount) >= sampleCountForL0Sublevel {
+				latestSampleMeanL0Sublevels := getMeanOverLastN(sampleCountForL0Sublevel, l0SublevelCount)
+				if latestSampleMeanL0Sublevels > sublevelThreshold {
+					t.Fatalf("sub-level mean %f over last %d iterations exceeded threshold", latestSampleMeanL0Sublevels, sampleCountForL0Sublevel)
+				}
+			}
+			numSuccesses++
+		}
+		t.Status(fmt.Sprintf("done monitoring, errors: %d successes: %d", numErrors, numSuccesses))
+		if numErrors > numSuccesses {
+			t.Fatalf("too many errors retrieving metrics")
+		}
+		return nil
+	})
+
+	m.Wait()
 }


### PR DESCRIPTION
Contains 3 commits. The first two are mainly code movement and file renaming to setup for the implementation in the last commit.

----

roachtest: rename snapshot ingest excise test

This is purely a file renaming patch to seperate it from the addition of
the sub-test that will add tighter bounds on disk bandwidth.

Informs https://github.com/cockroachdb/cockroach/issues/129122.

Release note: None

----

roachtest: rework snapshot ingest test for subtests

A code movement patch to set up the ability to add more tests for
snapshot ingests.

Informs https://github.com/cockroachdb/cockroach/issues/129122.

Release note: None

----

roachtest: add subtest for disk bandwidth bottleneck for ingests

This test uses cgroups to limit throughput and assess the effects of a
large snapshot ingestion. It currently skips asserting on LSM health and
latency since the AC integration is currently missing.

Closes https://github.com/cockroachdb/cockroach/issues/129122.

Release note: None