### PR TITLE
server: add latest telemetry contact timestamp

### DIFF
--- a/pkg/ccl/serverccl/diagnosticsccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/diagnosticsccl/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/system",
+        "//pkg/util/timeutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/ccl/serverccl/diagnosticsccl/reporter_test.go
+++ b/pkg/ccl/serverccl/diagnosticsccl/reporter_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/system"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
@@ -275,6 +276,68 @@ func TestServerReport(t *testing.T) {
 			require.Equal(t, prefs, zone.LeasePreferences)
 		}
 	}
+}
+
+func TestTelemetry_SuccessfulTelemetryPing(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	rt := startReporterTest(t, base.TestIsSpecificToStorageLayerAndNeedsASystemTenant)
+	defer rt.Close()
+
+	ctx := context.Background()
+	setupCluster(t, rt.serverDB)
+
+	for _, tc := range []struct {
+		name                  string
+		respError             error
+		respCode              int
+		expectTimestampUpdate bool
+	}{
+		{
+			name:                  "200 response",
+			respError:             nil,
+			respCode:              200,
+			expectTimestampUpdate: true,
+		},
+		{
+			name:                  "400 response",
+			respError:             nil,
+			respCode:              400,
+			expectTimestampUpdate: true,
+		},
+		{
+			name:                  "500 response",
+			respError:             nil,
+			respCode:              500,
+			expectTimestampUpdate: true,
+		},
+		{
+			name:                  "connection error",
+			respError:             errors.New("connection refused"),
+			expectTimestampUpdate: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer rt.diagServer.SetRespError(tc.respError)()
+			defer rt.diagServer.SetRespCode(tc.respCode)()
+
+			dr := rt.server.DiagnosticsReporter().(*diagnostics.Reporter)
+
+			before := timeutil.Now()
+			oldTimestamp := dr.LastSuccessfulTelemetryPing
+			require.LessOrEqual(t, dr.LastSuccessfulTelemetryPing, before)
+			dr.ReportDiagnostics(ctx)
+
+			if tc.expectTimestampUpdate {
+				require.GreaterOrEqual(t, dr.LastSuccessfulTelemetryPing, before)
+			} else {
+				require.Equal(t, oldTimestamp, dr.LastSuccessfulTelemetryPing)
+			}
+		})
+	}
+
 }
 
 func TestUsageQuantization(t *testing.T) {

--- a/pkg/testutils/diagutils/diag_test_server.go
+++ b/pkg/testutils/diagutils/diag_test_server.go
@@ -32,6 +32,10 @@ type Server struct {
 
 		numRequests int
 		last        *RequestData
+
+		// Testing knobs. Setting these will override response from the test server.
+		respError error
+		respCode  int
 	}
 }
 
@@ -81,6 +85,12 @@ func NewServer() *Server {
 			panic(err)
 		}
 		srv.mu.last = data
+
+		if srv.mu.respError != nil {
+			http.Error(w, srv.mu.respError.Error(), srv.mu.respCode)
+		} else if srv.mu.respCode != 0 {
+			w.WriteHeader(srv.mu.respCode)
+		}
 	}))
 
 	var err error
@@ -116,4 +126,24 @@ func (s *Server) LastRequestData() *RequestData {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.mu.last
+}
+
+func (s *Server) SetRespError(e error) func() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.mu.respError = e
+	return func() {
+		s.SetRespError(nil)
+	}
+}
+
+func (s *Server) SetRespCode(code int) func() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.mu.respCode = code
+	return func() {
+		s.SetRespCode(0)
+	}
 }


### PR DESCRIPTION
The `Reporter` struct in the `diagnostics` package now maintains a `LastSuccessfulTelemetryPing` field that's updated with the value of `timeutil.Now()` after every response from the telemetry cluster.

This time is updated regardless of the status code of the response. Any error from the HTTP client (this includes timeouts, DNS errors, etc.) will skip updating the timestamp.

Resolves: CRDB-41231
Epic: CRDB-40209
Release note: None