### PR TITLE
release-23.2: bump cluster-ui to 23.2.9

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "23.2.8",
+  "version": "23.2.9",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release note: None


---

Release justification: build-only. no user-facing changes