### PR TITLE
release-24.2.0-rc: telemetry: deflake generic query plan test

### DIFF
--- a/pkg/ccl/telemetryccl/testdata/telemetry/generic
+++ b/pkg/ccl/telemetryccl/testdata/telemetry/generic
@@ -29,7 +29,7 @@ WHERE v = $1
 ----
 
 feature-list
-sql.plan.type.*
+sql.plan.type.force-custom
 ----
 
 exec
@@ -63,6 +63,10 @@ feature-usage
 SELECT * FROM kv WHERE v = 100
 ----
 
+feature-list
+sql.plan.type.force-generic
+----
+
 exec
 SET plan_cache_mode = force_generic_plan
 ----
@@ -90,11 +94,19 @@ exec
 SET plan_cache_mode = auto
 ----
 
+feature-list
+sql.plan.type.auto-generic
+----
+
 # If the placeholder fast-path is used, the plan is always generic.
 feature-usage
 EXECUTE p_pk(100)
 ----
 sql.plan.type.auto-generic
+
+feature-list
+sql.plan.type.auto-custom
+----
 
 # The first five executions of p_join have custom plans while establishing an
 # average cost. One of the custom executions occurred above.
@@ -117,6 +129,11 @@ feature-usage
 EXECUTE p_join(5)
 ----
 sql.plan.type.auto-custom
+
+
+feature-list
+sql.plan.type.auto-generic
+----
 
 # The sixth execution uses a generic plan.
 feature-usage

--- a/pkg/ccl/telemetryccl/testdata/telemetry/generic
+++ b/pkg/ccl/telemetryccl/testdata/telemetry/generic
@@ -54,15 +54,6 @@ EXECUTE p_join(1)
 ----
 sql.plan.type.force-custom
 
-# Non-prepared statements do not increment plan type counters.
-feature-usage
-SELECT * FROM kv WHERE v = 100
-----
-
-feature-usage
-SELECT * FROM kv WHERE v = 100
-----
-
 feature-list
 sql.plan.type.force-generic
 ----


### PR DESCRIPTION
Backport:
  * 1/1 commits from "telemetry: deflake generic query plan telemetry test" (#128383)
  * 1/1 commits from "telemetry: remove expectation of no force-custom counter" (#128715)

Please see individual PRs for details.

/cc @cockroachdb/release

---
Release justification: test-only change