### PR TITLE
ui: remove unnecessary metric name prefixes

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
@@ -61,10 +61,7 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.node.admission.granter.slots_exhausted_duration.kv"
-            title={
-              "Admission Slots Exhausted " +
-              nodeDisplayName(nodeDisplayNameByID, nid)
-            }
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
             nonNegativeRate
           />
@@ -86,7 +83,7 @@ export default function (props: GraphDashboardProps) {
               key={nid}
               name="cr.node.admission.granter.io_tokens_exhausted_duration.kv"
               title={
-                "Regular (Foreground) IO Exhausted " +
+                "Regular (Foreground) " +
                 nodeDisplayName(nodeDisplayNameByID, nid)
               }
               sources={[nid]}
@@ -96,7 +93,7 @@ export default function (props: GraphDashboardProps) {
               key={nid}
               name="cr.node.admission.granter.elastic_io_tokens_exhausted_duration.kv"
               title={
-                "Elastic (Background) IO Exhausted " +
+                "Elastic (Background) " +
                 nodeDisplayName(nodeDisplayNameByID, nid)
               }
               sources={[nid]}
@@ -120,7 +117,7 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.store.admission.io.overload"
-              title={"IO Overload " + nodeDisplayName(nodeDisplayNameByID, nid)}
+              title={nodeDisplayName(nodeDisplayNameByID, nid)}
               sources={storeIDsForNode(storeIDsByNodeID, nid)}
             />
           </>
@@ -140,10 +137,7 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.node.admission.elastic_cpu.nanos_exhausted_duration"
-            title={
-              "Elastic CPU Exhausted " +
-              nodeDisplayName(nodeDisplayNameByID, nid)
-            }
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
             nonNegativeRate
           />
@@ -171,18 +165,14 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.node.admission.wait_durations.sql-kv-response-p99"
-              title={
-                "SQL-KV response " + nodeDisplayName(nodeDisplayNameByID, nid)
-              }
+              title={"SQL-KV " + nodeDisplayName(nodeDisplayNameByID, nid)}
               sources={[nid]}
               downsampleMax
             />
             <Metric
               key={nid}
               name="cr.node.admission.wait_durations.sql-sql-response-p99"
-              title={
-                "SQL-SQL response " + nodeDisplayName(nodeDisplayNameByID, nid)
-              }
+              title={"SQL-SQL " + nodeDisplayName(nodeDisplayNameByID, nid)}
               sources={[nid]}
               downsampleMax
             />
@@ -198,13 +188,13 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
       tooltip={`The 99th percentile latency of requests waiting in the Admission Control store queue.`}
     >
-      <Axis units={AxisUnits.Duration} label="Delay Duration">
+      <Axis units={AxisUnits.Duration} label="Write Delay Duration">
         {nodeIDs.map(nid => (
           <>
             <Metric
               key={nid}
               name="cr.node.admission.wait_durations.kv-stores-p99"
-              title={"KV write " + nodeDisplayName(nodeDisplayNameByID, nid)}
+              title={"KV " + nodeDisplayName(nodeDisplayNameByID, nid)}
               sources={[nid]}
               downsampleMax
             />
@@ -212,7 +202,7 @@ export default function (props: GraphDashboardProps) {
               key={nid}
               name="cr.node.admission.wait_durations.elastic-stores-p99"
               title={
-                "elastic (background) write " +
+                "Elastic " +
                 nodeDisplayName(nodeDisplayNameByID, nid)
               }
               sources={[nid]}
@@ -252,14 +242,14 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
       tooltip={`The 99th percentile latency of requests waiting in the Replication Admission Control queue. This metric is indicative of store overload on replicas.`}
     >
-      <Axis units={AxisUnits.Duration} label="Wait Duration">
+      <Axis units={AxisUnits.Duration} label="Flow Token Wait Duration">
         {nodeIDs.map(nid => (
           <>
             <Metric
               key={nid}
               name="cr.node.kvadmission.flow_controller.regular_wait_duration-p99"
               title={
-                "Regular flow token wait time " +
+                "Regular " +
                 nodeDisplayName(nodeDisplayNameByID, nid)
               }
               sources={[nid]}
@@ -269,7 +259,7 @@ export default function (props: GraphDashboardProps) {
               key={nid}
               name="cr.node.kvadmission.flow_controller.elastic_wait_duration-p99"
               title={
-                "Elastic flow token wait time " +
+                "Elastic " +
                 nodeDisplayName(nodeDisplayNameByID, nid)
               }
               sources={[nid]}
@@ -287,14 +277,14 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
       tooltip={`Blocked replication streams per node in Replication Admission Control, separated by admission priority {regular, elastic}.`}
     >
-      <Axis label="Count">
+      <Axis label="Blocked Stream Count">
         {nodeIDs.map(nid => (
           <>
             <Metric
               key={nid}
               name="cr.node.kvadmission.flow_controller.regular_blocked_stream_count"
               title={
-                "Blocked regular streams " +
+                "Regular " +
                 nodeDisplayName(nodeDisplayNameByID, nid)
               }
               sources={[nid]}
@@ -303,7 +293,7 @@ export default function (props: GraphDashboardProps) {
               key={nid}
               name="cr.node.kvadmission.flow_controller.elastic_blocked_stream_count"
               title={
-                "Blocked elastic streams " +
+                "Elastic " +
                 nodeDisplayName(nodeDisplayNameByID, nid)
               }
               sources={[nid]}
@@ -325,18 +315,12 @@ export default function (props: GraphDashboardProps) {
           <>
             <Metric
               name="cr.node.admission.elastic_cpu.utilization"
-              title={
-                "Elastic CPU Utilization " +
-                nodeDisplayName(nodeDisplayNameByID, nid)
-              }
+              title={nodeDisplayName(nodeDisplayNameByID, nid)}
               sources={[nid]}
             />
             <Metric
               name="cr.node.admission.elastic_cpu.utilization_limit"
-              title={
-                "Elastic CPU Utilization Limit " +
-                nodeDisplayName(nodeDisplayNameByID, nid)
-              }
+              title={nodeDisplayName(nodeDisplayNameByID, nid) + " Limit"}
               sources={[nid]}
             />
           </>
@@ -420,7 +404,7 @@ export default function (props: GraphDashboardProps) {
               key={nid}
               name="cr.store.storage.l0-sublevels"
               title={
-                "L0 Sublevels " + nodeDisplayName(nodeDisplayNameByID, nid)
+                nodeDisplayName(nodeDisplayNameByID, nid)
               }
               sources={storeIDsForNode(storeIDsByNodeID, nid)}
             />

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -466,15 +466,12 @@ export default function (props: GraphDashboardProps) {
       tenantSource={tenantSource}
       showMetricsInTooltip={true}
     >
-      <Axis label="replicas" units={AxisUnits.Count}>
+      <Axis label="Replaced Errors / Sec" units={AxisUnits.Count}>
         {nodeIDs.map(nid => (
           <Metric
             key={nid}
             name="cr.store.queue.replicate.replacedecommissioningreplica.error"
-            title={
-              nodeDisplayName(nodeDisplayNameByID, nid) +
-              " - Replaced Errors / Sec"
-            }
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={storeIDsForNode(storeIDsByNodeID, nid)}
             nonNegativeRate
           />


### PR DESCRIPTION
Metrics keyed by nodeID and prefixed with long strings become very difficult to read on the dashboard pages since they take up too much horizontal space. In all of these cases, the context provided by the graph title and Y axis label provide enough context to omit verbose legend labels.

Resolves: #128046

Release note (ui change): some metric charts on the overview and replication pages have more terse legends to facilitate easier browsing.