### PR TITLE
raft: do not campaign if supporting fortified leader 

### DIFF
--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -1868,9 +1868,9 @@ func TestDisruptiveFollower(t *testing.T) {
 // Then pre-vote phase prevents this isolated node from forcing
 // current leader to step down, thus less disruptions.
 func TestDisruptiveFollowerPreVote(t *testing.T) {
-	n1 := newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)))
-	n2 := newTestRaft(2, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)))
-	n3 := newTestRaft(3, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)))
+	n1 := newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)), withFortificationDisabled())
+	n2 := newTestRaft(2, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)), withFortificationDisabled())
+	n3 := newTestRaft(3, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)), withFortificationDisabled())
 
 	n1.checkQuorum = true
 	n2.checkQuorum = true
@@ -3118,9 +3118,9 @@ func TestTransferNonMember(t *testing.T) {
 // Previously the cluster would come to a standstill when run with PreVote
 // enabled.
 func TestNodeWithSmallerTermCanCompleteElection(t *testing.T) {
-	n1 := newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)))
-	n2 := newTestRaft(2, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)))
-	n3 := newTestRaft(3, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)))
+	n1 := newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)), withFortificationDisabled())
+	n2 := newTestRaft(2, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)), withFortificationDisabled())
+	n3 := newTestRaft(3, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)), withFortificationDisabled())
 
 	n1.becomeFollower(1, None)
 	n2.becomeFollower(1, None)
@@ -3185,9 +3185,9 @@ func TestNodeWithSmallerTermCanCompleteElection(t *testing.T) {
 // TestPreVoteWithSplitVote verifies that after split vote, cluster can complete
 // election in next round.
 func TestPreVoteWithSplitVote(t *testing.T) {
-	n1 := newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)))
-	n2 := newTestRaft(2, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)))
-	n3 := newTestRaft(3, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)))
+	n1 := newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)), withFortificationDisabled())
+	n2 := newTestRaft(2, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)), withFortificationDisabled())
+	n3 := newTestRaft(3, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)), withFortificationDisabled())
 
 	n1.becomeFollower(1, None)
 	n2.becomeFollower(1, None)

--- a/pkg/raft/testdata/forget_leader.txt
+++ b/pkg/raft/testdata/forget_leader.txt
@@ -192,15 +192,10 @@ raft-state
 # ForgetLeader shouldn't affect the election timeout: if a follower
 # forgets the leader 1 tick before the election timeout fires, it
 # will still campaign on the next tick.
-set-randomized-election-timeout 2 timeout=3
-----
-ok
-
-tick-heartbeat 2
-----
-ok
-
-tick-heartbeat 2
+#
+# NB: We also must withdraw support in store liveness, because otherwise every
+# tick will reset the election timer.
+set-randomized-election-timeout 2 timeout=5
 ----
 ok
 
@@ -211,6 +206,14 @@ withdraw-support 2 3
 2 x 1 x 1
 3 x 1 1 1
 4 x 1 1 1
+
+tick-heartbeat 2
+----
+DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
+
+tick-heartbeat 2
+----
+ok
 
 forget-leader 2
 ----

--- a/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
+++ b/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
@@ -23,6 +23,13 @@ log-level debug
 ----
 ok
 
+withdraw-support 3 1
+----
+  1 2 3
+1 1 1 1
+2 1 1 1
+3 x 1 1
+
 # If 3 attempts to campaign, 2 rejects it because it has a leader.
 campaign 3
 ----
@@ -98,7 +105,7 @@ withdraw-support 2 1
   1 2 3
 1 1 1 1
 2 x 1 1
-3 1 1 1
+3 x 1 1
 
 # If 2 forgets the leader, then 3 can obtain prevotes and hold an election
 # despite 2 having heard from the leader recently.
@@ -205,7 +212,7 @@ withdraw-support 2 3
   1 2 3
 1 1 1 1
 2 x 1 x
-3 1 1 1
+3 x 1 1
 
 forget-leader 2
 ----
@@ -216,6 +223,13 @@ raft-log 1
 ----
 1/11 EntryNormal ""
 2/12 EntryNormal ""
+
+withdraw-support 1 3
+----
+  1 2 3
+1 1 1 x
+2 x 1 x
+3 x 1 1
 
 campaign 1
 ----

--- a/pkg/raft/testdata/fortification_followers_dont_call_election.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_call_election.txt
@@ -1,0 +1,200 @@
+# Test to ensure that a follower will not call an election if it's still
+# supporting a fortified leader.
+
+log-level debug
+----
+ok
+
+add-nodes 3 voters=(1,2,3) index=10
+----
+INFO 1 switched to configuration voters=(1 2 3)
+INFO 1 became follower at term 0
+INFO newRaft 1 [peers: [1,2,3], term: 0, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
+INFO 2 switched to configuration voters=(1 2 3)
+INFO 2 became follower at term 0
+INFO newRaft 2 [peers: [1,2,3], term: 0, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
+INFO 3 switched to configuration voters=(1 2 3)
+INFO 3 became follower at term 0
+INFO newRaft 3 [peers: [1,2,3], term: 0, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
+
+campaign 1
+----
+INFO 1 is starting a new election at term 0
+INFO 1 became candidate at term 1
+INFO 1 [logterm: 1, index: 10] sent MsgVote request to 2 at term 1
+INFO 1 [logterm: 1, index: 10] sent MsgVote request to 3 at term 1
+
+stabilize
+----
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  1->2 MsgVote Term:1 Log:1/10
+  1->3 MsgVote Term:1 Log:1/10
+  INFO 1 received MsgVoteResp from 1 at term 1
+  INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
+> 2 receiving messages
+  1->2 MsgVote Term:1 Log:1/10
+  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 2 became follower at term 1
+  INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
+> 3 receiving messages
+  1->3 MsgVote Term:1 Log:1/10
+  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 3 became follower at term 1
+  INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  2->1 MsgVoteResp Term:1 Log:0/0
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  3->1 MsgVoteResp Term:1 Log:0/0
+> 1 receiving messages
+  2->1 MsgVoteResp Term:1 Log:0/0
+  INFO 1 received MsgVoteResp from 2 at term 1
+  INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
+  INFO 1 became leader at term 1
+  3->1 MsgVoteResp Term:1 Log:0/0
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateLeader
+  HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
+  Entries:
+  1/11 EntryNormal ""
+  Messages:
+  1->2 MsgFortifyLeader Term:1 Log:0/0
+  1->3 MsgFortifyLeader Term:1 Log:0/0
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+  1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+> 2 receiving messages
+  1->2 MsgFortifyLeader Term:1 Log:0/0
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+> 3 receiving messages
+  1->3 MsgFortifyLeader Term:1 Log:0/0
+  1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
+  Entries:
+  1/11 EntryNormal ""
+  Messages:
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
+  Entries:
+  1/11 EntryNormal ""
+  Messages:
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:10
+> 1 receiving messages
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:10
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/11 EntryNormal ""
+  Messages:
+  1->2 MsgApp Term:1 Log:1/11 Commit:11
+  1->3 MsgApp Term:1 Log:1/11 Commit:11
+> 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/11 Commit:11
+> 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/11 Commit:11
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/11 EntryNormal ""
+  Messages:
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:11
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/11 EntryNormal ""
+  Messages:
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
+> 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:11
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
+
+store-liveness
+----
+  1 2 3
+1 1 1 1
+2 1 1 1
+3 1 1 1
+
+set-randomized-election-timeout 2 timeout=3
+----
+ok
+
+# Campaigning will fail when there is an active leader.
+campaign 2
+----
+DEBUG 2 ignoring MsgHup due to leader fortification
+
+tick-election 2
+----
+ok
+
+# Withdraw support from 2 for 1 and tick 2 once. This should trigger an election
+# (without having to wait out an entire randomized election timeout) because
+# we're smart in recognizing when store liveness support expires.
+# and tick an election. 2 should now be able to
+withdraw-support 2 1
+----
+  1 2 3
+1 1 1 1
+2 x 1 1
+3 1 1 1
+
+tick-heartbeat 2
+----
+DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
+INFO 2 is starting a new election at term 1
+INFO 2 became candidate at term 2
+INFO 2 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
+INFO 2 [logterm: 1, index: 11] sent MsgVote request to 3 at term 2
+
+# Set the randomized timeout for 3 to a value higher than election-timeout. This
+# way, tick-election is guaranteed to not call an election which would reset
+# the electionTimer (which would in-turn prevent 3 from granting 2 its vote).
+
+# Set the randomized timeout for 3 to 4, which is 1 tick more than the
+# election-tick. We then withdraw store liveness support from 3 for 1; 3 should
+# then wait for 1 tick before campaigning. This then shows that we're preserving
+# randomness that's baked into raft elections without waiting out an entire
+# election timeout.
+set-randomized-election-timeout 3 timeout=4
+----
+ok
+
+withdraw-support 3 1
+----
+  1 2 3
+1 1 1 1
+2 x 1 1
+3 x 1 1
+
+tick-heartbeat 3
+----
+DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
+
+tick-heartbeat 3
+----
+INFO 3 is starting a new election at term 1
+INFO 3 became candidate at term 2
+INFO 3 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
+INFO 3 [logterm: 1, index: 11] sent MsgVote request to 2 at term 2

--- a/pkg/raft/testdata/fortification_followers_dont_call_election_prevote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_call_election_prevote.txt
@@ -1,0 +1,230 @@
+# Test to ensure that a follower will not call an election if it's still
+# supporting a fortified leader.
+
+log-level debug
+----
+ok
+
+add-nodes 3 voters=(1,2,3) index=10 prevote=true
+----
+INFO 1 switched to configuration voters=(1 2 3)
+INFO 1 became follower at term 0
+INFO newRaft 1 [peers: [1,2,3], term: 0, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
+INFO 2 switched to configuration voters=(1 2 3)
+INFO 2 became follower at term 0
+INFO newRaft 2 [peers: [1,2,3], term: 0, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
+INFO 3 switched to configuration voters=(1 2 3)
+INFO 3 became follower at term 0
+INFO newRaft 3 [peers: [1,2,3], term: 0, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
+
+campaign 1
+----
+INFO 1 is starting a new election at term 0
+INFO 1 became pre-candidate at term 0
+INFO 1 [logterm: 1, index: 10] sent MsgPreVote request to 2 at term 0
+INFO 1 [logterm: 1, index: 10] sent MsgPreVote request to 3 at term 0
+
+stabilize
+----
+> 1 handling Ready
+  Ready MustSync=false:
+  State:StatePreCandidate
+  Messages:
+  1->2 MsgPreVote Term:1 Log:1/10
+  1->3 MsgPreVote Term:1 Log:1/10
+  INFO 1 received MsgPreVoteResp from 1 at term 0
+  INFO 1 has received 1 MsgPreVoteResp votes and 0 vote rejections
+> 2 receiving messages
+  1->2 MsgPreVote Term:1 Log:1/10
+  INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgPreVote for 1 [logterm: 1, index: 10] at term 0
+> 3 receiving messages
+  1->3 MsgPreVote Term:1 Log:1/10
+  INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgPreVote for 1 [logterm: 1, index: 10] at term 0
+> 2 handling Ready
+  Ready MustSync=false:
+  Messages:
+  2->1 MsgPreVoteResp Term:1 Log:0/0
+> 3 handling Ready
+  Ready MustSync=false:
+  Messages:
+  3->1 MsgPreVoteResp Term:1 Log:0/0
+> 1 receiving messages
+  2->1 MsgPreVoteResp Term:1 Log:0/0
+  INFO 1 received MsgPreVoteResp from 2 at term 0
+  INFO 1 has received 2 MsgPreVoteResp votes and 0 vote rejections
+  INFO 1 became candidate at term 1
+  INFO 1 [logterm: 1, index: 10] sent MsgVote request to 2 at term 1
+  INFO 1 [logterm: 1, index: 10] sent MsgVote request to 3 at term 1
+  3->1 MsgPreVoteResp Term:1 Log:0/0
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  1->2 MsgVote Term:1 Log:1/10
+  1->3 MsgVote Term:1 Log:1/10
+  INFO 1 received MsgVoteResp from 1 at term 1
+  INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
+> 2 receiving messages
+  1->2 MsgVote Term:1 Log:1/10
+  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 2 became follower at term 1
+  INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
+> 3 receiving messages
+  1->3 MsgVote Term:1 Log:1/10
+  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 3 became follower at term 1
+  INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  2->1 MsgVoteResp Term:1 Log:0/0
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  3->1 MsgVoteResp Term:1 Log:0/0
+> 1 receiving messages
+  2->1 MsgVoteResp Term:1 Log:0/0
+  INFO 1 received MsgVoteResp from 2 at term 1
+  INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
+  INFO 1 became leader at term 1
+  3->1 MsgVoteResp Term:1 Log:0/0
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateLeader
+  HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
+  Entries:
+  1/11 EntryNormal ""
+  Messages:
+  1->2 MsgFortifyLeader Term:1 Log:0/0
+  1->3 MsgFortifyLeader Term:1 Log:0/0
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+  1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+> 2 receiving messages
+  1->2 MsgFortifyLeader Term:1 Log:0/0
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+> 3 receiving messages
+  1->3 MsgFortifyLeader Term:1 Log:0/0
+  1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
+  Entries:
+  1/11 EntryNormal ""
+  Messages:
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
+  Entries:
+  1/11 EntryNormal ""
+  Messages:
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:10
+> 1 receiving messages
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:10
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/11 EntryNormal ""
+  Messages:
+  1->2 MsgApp Term:1 Log:1/11 Commit:11
+  1->3 MsgApp Term:1 Log:1/11 Commit:11
+> 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/11 Commit:11
+> 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/11 Commit:11
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/11 EntryNormal ""
+  Messages:
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:11
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/11 EntryNormal ""
+  Messages:
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
+> 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:11
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
+
+store-liveness
+----
+  1 2 3
+1 1 1 1
+2 1 1 1
+3 1 1 1
+
+set-randomized-election-timeout 2 timeout=3
+----
+ok
+
+# Campaigning will fail when there is an active leader.
+campaign 2
+----
+DEBUG 2 ignoring MsgHup due to leader fortification
+
+tick-election 2
+----
+ok
+
+# Withdraw support from 2 for 1 and tick 2 once. This should trigger an election
+# (without having to wait out an entire randomized election timeout) because
+# we're smart in recognizing when store liveness support expires.
+# and tick an election. 2 should now be able to
+withdraw-support 2 1
+----
+  1 2 3
+1 1 1 1
+2 x 1 1
+3 1 1 1
+
+tick-heartbeat 2
+----
+DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
+INFO 2 is starting a new election at term 1
+INFO 2 became pre-candidate at term 1
+INFO 2 [logterm: 1, index: 11] sent MsgPreVote request to 1 at term 1
+INFO 2 [logterm: 1, index: 11] sent MsgPreVote request to 3 at term 1
+
+# Set the randomized timeout for 3 to a value higher than election-timeout. This
+# way, tick-election is guaranteed to not call an election which would reset
+# the electionTimer (which would in-turn prevent 3 from granting 2 its vote).
+
+# Set the randomized timeout for 3 to 4, which is 1 tick more than the
+# election-tick. We then withdraw store liveness support from 3 for 1; 3 should
+# then wait for 1 tick before campaigning. This then shows that we're preserving
+# randomness that's baked into raft elections without waiting out an entire
+# election timeout.
+set-randomized-election-timeout 3 timeout=4
+----
+ok
+
+withdraw-support 3 1
+----
+  1 2 3
+1 1 1 1
+2 x 1 1
+3 x 1 1
+
+tick-heartbeat 3
+----
+DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
+
+tick-heartbeat 3
+----
+INFO 3 is starting a new election at term 1
+INFO 3 became pre-candidate at term 1
+INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 1 at term 1
+INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 2 at term 1

--- a/pkg/raft/testdata/prevote.txt
+++ b/pkg/raft/testdata/prevote.txt
@@ -56,6 +56,13 @@ raft-log 3
 ----
 1/11 EntryNormal ""
 
+withdraw-support 3 1
+----
+  1 2 3
+1 1 1 1
+2 1 1 1
+3 x 1 1
+
 campaign 3
 ----
 INFO 3 is starting a new election at term 1
@@ -128,6 +135,13 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/12 Commit:12
   3->1 MsgAppResp Term:1 Log:0/12 Commit:11
   3->1 MsgAppResp Term:1 Log:0/12 Commit:12
+
+withdraw-support 2 1
+----
+  1 2 3
+1 1 1 1
+2 x 1 1
+3 x 1 1
 
 # Let 2 campaign. It should succeed, since it's up-to-date on the log.
 campaign 2

--- a/pkg/raft/testdata/prevote_checkquorum.txt
+++ b/pkg/raft/testdata/prevote_checkquorum.txt
@@ -23,6 +23,13 @@ log-level debug
 ----
 ok
 
+withdraw-support 2 1
+----
+  1 2 3
+1 1 1 1
+2 x 1 1
+3 1 1 1
+
 # 2 should fail to campaign, leaving 1's leadership alone.
 campaign 2
 ----
@@ -58,6 +65,13 @@ ok
 tick-election 2
 ----
 ok
+
+withdraw-support 3 1
+----
+  1 2 3
+1 1 1 1
+2 x 1 1
+3 x 1 1
 
 campaign 3
 ----
@@ -199,6 +213,13 @@ stabilize
   1->3 MsgAppResp Term:2 Log:0/12 Commit:12
   2->3 MsgAppResp Term:2 Log:0/12 Commit:12
 
+withdraw-support 1 3
+----
+  1 2 3
+1 1 1 x
+2 x 1 1
+3 x 1 1
+
 # Node 3 is now the leader. Even though the leader is active, nodes 1 and 2 can
 # still win a prevote and election if they both explicitly campaign, since the
 # PreVote+CheckQuorum recent leader condition only applies to follower voters.
@@ -231,6 +252,13 @@ stabilize
 > 3 receiving messages
   1->3 MsgPreVote Term:3 Log:2/12
   INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 1 [logterm: 2, index: 12] at term 2: lease is not expired (remaining ticks: 3)
+
+withdraw-support 2 3
+----
+  1 2 3
+1 1 1 x
+2 x 1 x
+3 x 1 1
 
 campaign 2
 ----


### PR DESCRIPTION
This patch ensures that peers that have promised fortification support
to a leader do not campaign unless StoreLiveness indicates support for
the leader's epoch has expired. This patch only affects campaigning
(either directly or in response to the randomized election timeout
elapsing) -- in a subsequent patch, we'll handle voting.

Note that once StoreLiveness indicates support for the leader has
expired, we aim to act swiftly. In particular, care is taken to
ensure a follower doesn't need to wait out its election timeout before
campaigning. We do preserve randomness to prevent hung elections though.

Informs https://github.com/cockroachdb/cockroach/issues/125351

Release note: None