### PR TITLE
release-24.1: workload/schemachange: make column default errors more lenient

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2420,16 +2420,16 @@ func (og *operationGenerator) setColumnDefault(ctx context.Context, tx pgx.Tx) (
 			return nil, err
 		}
 		if newTyp == nil {
-			errCode := pgcode.UndefinedObject // Error: type 'IrrelevantType'::<newTypeName> does not exist.
-			// Setting default on generated column short-circuits and returns a syntax
+			stmt := makeOpStmt(OpStmtDDL)
+			stmt.potentialExecErrors.add(pgcode.UndefinedObject)
+			// In the case where our column is a computed column, we expect a syntax
 			// error.
 			if columnForDefault.generated {
-				errCode = pgcode.Syntax
+				stmt.potentialExecErrors.add(pgcode.Syntax)
 			}
-			return makeOpStmtForSingleError(OpStmtDDL,
-				fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN %s SET DEFAULT 'IrrelevantValue':::%s`,
-					tableName, lexbase.EscapeSQLIdent(columnForDefault.name), newTypeName.SQLString()),
-				errCode), nil
+			stmt.sql = fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN %s SET DEFAULT 'IrrelevantValue':::%s`,
+				tableName.String(), lexbase.EscapeSQLIdent(columnForDefault.name), newTypeName.SQLString())
+			return stmt, nil
 		}
 		datumTyp = newTyp
 	}
@@ -2441,7 +2441,8 @@ func (og *operationGenerator) setColumnDefault(ctx context.Context, tx pgx.Tx) (
 	}
 	// Generated columns cannot have default values.
 	if columnForDefault.generated {
-		stmt.expectedExecErrors.add(pgcode.Syntax)
+		stmt.potentialExecErrors.add(pgcode.Syntax)
+		stmt.potentialExecErrors.add(pgcode.InvalidTableDefinition)
 	}
 
 	strDefault := tree.AsStringWithFlags(defaultDatum, tree.FmtParsable)


### PR DESCRIPTION
Backport 1/1 commits from #129124.

/cc @cockroachdb/release

Release justification: test only change

---

The fix (and backports) for https://github.com/cockroachdb/cockroach/pull/127545 are not released yet; our
workload (across all versions) expects the following errors for
the following cases:
```
CREATE TABLE t (
    id SERIAL PRIMARY KEY,
    value1 INT,
    value2 INT,
    computed_column INT GENERATED ALWAYS AS (value1 + value2) STORED
);

-- 1. setting a default on a computed column should produce a
syntax error:
demo@127.0.0.1:26257/demoapp/movr> alter table t alter column computed_column set
                                -> default 42;
ERROR: computed column "computed_column" cannot also have a DEFAULT expression
SQLSTATE: 42601

-- 2. even if the default is referencing an invalid type, setting a
default on a computed column should produce a syntax error:
demo@127.0.0.1:26257/demoapp/movr> alter table t alter column computed_column set default
                                -> 'nonexistent'::typedoesntexist;
ERROR: computed column "computed_column" cannot also have a DEFAULT expression
SQLSTATE: 42601

-- 3. even if the default is NULL, we block setting a default on a
computed column:
demo@127.0.0.1:26257/demoapp/movr> alter table t alter column computed_column set default
                                -> NULL;
ERROR: computed column "computed_column" cannot also have a DEFAULT expression
SQLSTATE: 42601

```

This aligns with postgres behavior as well:
```
postgres=# CREATE TABLE t (
    id SERIAL PRIMARY KEY,
    value1 INT,
    value2 INT,
    computed_column INT GENERATED ALWAYS AS (value1 + value2) STORED
);
CREATE TABLE
-- 1. setting a default on a computed column should produce a
syntax error:
postgres=# alter table t alter column computed_column set default null;
ERROR:  42601: column "computed_column" of relation "t" is a generated column
LOCATION:  ATExecColumnDefault, tablecmds.c:7644
-- 2. even if the default is referencing an invalid type, setting a
default on a computed column should produce a syntax error:
postgres=# ALTER TABLE t ALTER COLUMN computed_column SET DEFAULT 'IrrelevantValue'::nonexistent;
ERROR:  42601: column "computed_column" of relation "t" is a generated column
LOCATION:  ATExecColumnDefault, tablecmds.c:7712
-- 3. even if the default is NULL, we block setting a default on a
computed column:
postgres=# ALTER TABLE t ALTER COLUMN computed_column SET DEFAULT NULL;
ERROR:  42601: column "computed_column" of relation "t" is a generated column
LOCATION:  ATExecColumnDefault, tablecmds.c:7712
```

Previously, before https://github.com/cockroachdb/cockroach/pull/127545, we would disallow setting a default on a
computed column, but provide a different error message than postgres
(42P16). In addition, we would allow setting a NULL default on a
computed column.

Fixes: #128946

Release note: None
