### PR TITLE
cli, security: add --tenant-name-scope CLI flag

### DIFF
--- a/pkg/acceptance/cluster/certs.go
+++ b/pkg/acceptance/cluster/certs.go
@@ -63,14 +63,16 @@ func GenerateCerts(ctx context.Context) func() {
 	userScopes := []roachpb.TenantID{roachpb.SystemTenantID, roachpb.MustMakeTenantID(5)}
 	maybePanic(security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, certnames.EmbeddedCAKey),
-		keyLen, 48*time.Hour, false, username.RootUserName(), userScopes, true /* generate pk8 key */))
+		keyLen, 48*time.Hour, false, username.RootUserName(), userScopes,
+		nil /* tenantNames */, true /* generate pk8 key */))
 
 	// Test user.
 	// Scope test user to system tenant and tenant ID 5 which is what we use by default for acceptance
 	// tests.
 	maybePanic(security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, certnames.EmbeddedCAKey),
-		keyLen, 48*time.Hour, false, username.TestUserName(), userScopes, true /* generate pk8 key */))
+		keyLen, 48*time.Hour, false, username.TestUserName(), userScopes,
+		nil /* tenantNames */, true /* generate pk8 key */))
 
 	// Certs for starting a cockroach server. Key size is from cli/cert.go:defaultKeySize.
 	maybePanic(security.CreateNodePair(

--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -193,6 +193,7 @@ func runCreateClientCert(cmd *cobra.Command, args []string) error {
 			certCtx.overwriteFiles,
 			user,
 			certCtx.tenantScope,
+			certCtx.tenantNameScope,
 			certCtx.generatePKCS8Key),
 		"failed to generate client certificate and key")
 }

--- a/pkg/cli/cert_test.go
+++ b/pkg/cli/cert_test.go
@@ -17,6 +17,9 @@ func Example_cert() {
 	c.RunWithCAArgs([]string{"cert", "create-client", "foo"})
 	c.RunWithCAArgs([]string{"cert", "create-client", "Ομηρος"})
 	c.RunWithCAArgs([]string{"cert", "create-client", "0foo"})
+	c.RunWithCAArgs([]string{"cert", "create-client", "foo-1", "--tenant-scope", "1"})
+	c.RunWithCAArgs([]string{"cert", "create-client", "foo-tenant2", "--tenant-name-scope", "tenant2"})
+	c.RunWithCAArgs([]string{"cert", "create-client", "foo-1-tenant2", "--tenant-scope", "1", "--tenant-name-scope", "tenant2"})
 	c.RunWithCAArgs([]string{"cert", "create-client", ",foo"})
 	c.RunWithCAArgs([]string{"cert", "create-client", "--disable-username-validation", ",foo"})
 
@@ -24,6 +27,9 @@ func Example_cert() {
 	// cert create-client foo
 	// cert create-client Ομηρος
 	// cert create-client 0foo
+	// cert create-client foo-1 --tenant-scope 1
+	// cert create-client foo-tenant2 --tenant-name-scope tenant2
+	// cert create-client foo-1-tenant2 --tenant-scope 1 --tenant-name-scope tenant2
 	// cert create-client ,foo
 	// ERROR: failed to generate client certificate and key: username is invalid
 	// HINT: Usernames are case insensitive, must start with a letter, digit or underscore, may contain letters, digits, dashes, periods, or underscores, and must not exceed 63 characters.

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -843,6 +843,14 @@ This flag is optional. When omitted, the certificate is not scoped; i.e.
 it can be used with all tenants.`,
 	}
 
+	TenantScopeByNames = FlagInfo{
+		Name: "tenant-name-scope",
+		Description: `Assign a tenant scope using tenant names to the certificate.
+This will restrict the certificate to only be valid for the specified tenants.
+This flag is optional. When omitted, the certificate is not scoped; i.e.
+it can be used with all tenants.`,
+	}
+
 	GeneratePKCS8Key = FlagInfo{
 		Name:        "also-generate-pkcs8-key",
 		Description: `Also write the key in pkcs8 format to <certs-dir>/client.<username>.key.pk8.`,

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -250,9 +250,12 @@ var certCtx struct {
 	certPrincipalMap []string
 	// tenantScope indicates a tenantID(s) that a certificate is being
 	// scoped to. By creating a tenant-scoped certicate, the usage of that certificate
-	// is restricted to a specific tenant.
+	// is restricted to a specific tenant(s).
 	tenantScope []roachpb.TenantID
-
+	// tenantNameScope indicates a tenantName(s) that a certificate is being scoped to.
+	// By creating a tenant-scoped certificate, the usage of that certificate is
+	// restricted to a specific tenant(s).
+	tenantNameScope []roachpb.TenantName
 	// disableUsernameValidation removes the username syntax check on
 	// the input.
 	disableUsernameValidation bool
@@ -269,9 +272,9 @@ func setCertContextDefaults() {
 	certCtx.generatePKCS8Key = false
 	certCtx.disableUsernameValidation = false
 	certCtx.certPrincipalMap = nil
-	// Note: we set tenantScope to nil so that by default, client certs
-	// are not scoped to a specific tenant and can be used to connect to
-	// any tenant.
+	// Note: we set tenantScope and tenantNameScope to nil so that by default,
+	// client certs are not scoped to a specific tenant and can be used to
+	// connect to any tenant.
 	//
 	// Note that the scoping is generally useful for security, and it is
 	// used in CockroachCloud. However, CockroachCloud does not use our
@@ -283,6 +286,7 @@ func setCertContextDefaults() {
 	// other, defaulting to certs that are valid on every tenant is a
 	// good choice.
 	certCtx.tenantScope = nil
+	certCtx.tenantNameScope = nil
 }
 
 var sqlExecCtx = clisqlexec.Context{

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -1486,6 +1486,7 @@ func (c *transientCluster) generateCerts(ctx context.Context, certsDir string) (
 			true, /* overwrite */
 			username.RootUserName(),
 			nil,  /* tenantIDs - this makes it valid for all tenants */
+			nil,  /* tenantNames - this makes it valid for all tenants */
 			true, /* generatePKCS8Key */
 		); err != nil {
 			return err
@@ -1502,6 +1503,7 @@ func (c *transientCluster) generateCerts(ctx context.Context, certsDir string) (
 			true, /* overwrite */
 			demoUser,
 			nil,  /* tenantIDs - this makes it valid for all tenants */
+			nil,  /* tenantNames - this makes it valid for all tenants */
 			true, /* generatePKCS8Key */
 		); err != nil {
 			return err

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -1529,6 +1529,34 @@ func TestTenantID(t *testing.T) {
 	}
 }
 
+func TestTenantName(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	tests := []struct {
+		name        string
+		arg         string
+		errContains string
+	}{
+		{"empty tenant name text", "", "invalid tenant name: \"\""},
+		{"tenant name not valid", "a+bc", "invalid tenant name: \"a+bc\""},
+		{"tenant name \"abc\" is valid", "abc", ""},
+		{"tenant name \"system\" is valid", "system", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tns := tenantNameSetter{tenantNames: &[]roachpb.TenantName{}}
+			err := tns.Set(tt.arg)
+			if tt.errContains == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.arg, tns.String())
+			} else {
+				assert.True(t, strings.Contains(err.Error(), tt.errContains))
+			}
+		})
+	}
+}
+
 func TestTenantIDFromFile(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/security/certificate_manager_test.go
+++ b/pkg/security/certificate_manager_test.go
@@ -96,7 +96,13 @@ func TestManagerWithPrincipalMap(t *testing.T) {
 		certsDir, caKey, testKeySize, time.Hour*96, true, true,
 	))
 	require.NoError(t, security.CreateClientPair(
-		certsDir, caKey, testKeySize, time.Hour*48, true, username.TestUserName(), []roachpb.TenantID{roachpb.SystemTenantID}, false,
+		certsDir, caKey, testKeySize, time.Hour*48, true, username.TestUserName(),
+		[]roachpb.TenantID{roachpb.SystemTenantID}, nil /* tenantNameScope */, false,
+	))
+	require.NoError(t, security.CreateClientPair(
+		certsDir, caKey, testKeySize, time.Hour*48, true, username.TestUserName(),
+		nil /* tenantScope */, []roachpb.TenantName{roachpb.TenantName(roachpb.SystemTenantID.String())},
+		false,
 	))
 	require.NoError(t, security.CreateNodePair(
 		certsDir, caKey, testKeySize, time.Hour*48, true, []string{"127.0.0.1", "foo"},

--- a/pkg/security/certs.go
+++ b/pkg/security/certs.go
@@ -375,6 +375,7 @@ func CreateClientPair(
 	overwrite bool,
 	user username.SQLUsername,
 	tenantIDs []roachpb.TenantID,
+	tenantNames []roachpb.TenantName,
 	wantPKCS8Key bool,
 ) error {
 	if len(caKeyPath) == 0 {
@@ -411,7 +412,7 @@ func CreateClientPair(
 		return errors.Wrap(err, "could not generate new client key")
 	}
 
-	clientCert, err := GenerateClientCert(caCert, caPrivateKey, clientKey.Public(), lifetime, user, tenantIDs)
+	clientCert, err := GenerateClientCert(caCert, caPrivateKey, clientKey.Public(), lifetime, user, tenantIDs, tenantNames)
 	if err != nil {
 		return errors.Wrap(err, "error creating client certificate and key")
 	}

--- a/pkg/security/certs_test.go
+++ b/pkg/security/certs_test.go
@@ -183,47 +183,84 @@ func TestGenerateClientCerts(t *testing.T) {
 	securityassets.ResetLoader()
 	defer ResetTest()
 
-	certsDir := t.TempDir()
-
-	caKeyFile := certsDir + "/ca.key"
-	// Generate CA key and crt.
-	require.NoError(t, security.CreateCAPair(certsDir, caKeyFile, testKeySize,
-		time.Hour*72, false /* allowReuse */, false /* overwrite */))
-	user := username.MakeSQLUsernameFromPreNormalizedString("user")
-	tenantIDs := []roachpb.TenantID{roachpb.SystemTenantID, roachpb.MustMakeTenantID(123)}
-	// Create tenant-scoped client cert.
-	require.NoError(t, security.CreateClientPair(
-		certsDir,
-		caKeyFile,
-		testKeySize,
-		48*time.Hour,
-		false, /*overwrite */
-		user,
-		tenantIDs,
-		false /* wantPKCS8Key */))
-
-	// Load and verify the certificates.
-	cl := security.NewCertificateLoader(certsDir)
-	require.NoError(t, cl.Load())
-	infos := cl.Certificates()
-	for _, info := range infos {
-		require.NoError(t, info.Error)
+	type testCase struct {
+		desc        string
+		tenantIDs   []uint64
+		tenantNames []string
 	}
 
-	// We expect two certificates: the CA certificate and the tenant scoped client certificate.
-	require.Equal(t, 2, len(infos))
-	expectedClientCrtName := fmt.Sprintf("client.%s.crt", user)
-	expectedSANs, err := security.MakeTenantURISANs(user, tenantIDs)
-	require.NoError(t, err)
-	for _, info := range infos {
-		if info.Filename == "ca.crt" {
-			continue
+	testCases := []testCase{
+		{
+			desc:      "test_with_tenant_id_scope",
+			tenantIDs: []uint64{123},
+		},
+		{
+			desc:        "test_with_tenant_name_scope",
+			tenantNames: []string{"tenant10"},
+		},
+		{
+			desc:        "test_with_tenant_id_and_tanent_name_scope",
+			tenantIDs:   []uint64{123},
+			tenantNames: []string{"tenant10"},
+		},
+	}
+
+	for _, tc := range testCases {
+		certsDir := t.TempDir()
+
+		caKeyFile := certsDir + "/ca.key"
+		// Generate CA key and crt.
+		require.NoError(t, security.CreateCAPair(certsDir, caKeyFile, testKeySize,
+			time.Hour*72, false /* allowReuse */, false /* overwrite */))
+
+		tenantIDs := []roachpb.TenantID{roachpb.SystemTenantID}
+		for _, tenantID := range tc.tenantIDs {
+			tenantIDs = append(tenantIDs, roachpb.MustMakeTenantID(tenantID))
 		}
-		require.Equal(t, security.ClientPem, info.FileUsage)
-		require.Equal(t, expectedClientCrtName, info.Filename)
-		require.Equal(t, 1, len(info.ParsedCertificates))
-		require.Equal(t, len(tenantIDs), len(info.ParsedCertificates[0].URIs))
-		require.Equal(t, expectedSANs, info.ParsedCertificates[0].URIs)
+		var tenantNames []roachpb.TenantName
+		for _, tenantName := range tc.tenantNames {
+			tenantNames = append(tenantNames, roachpb.TenantName(tenantName))
+		}
+
+		// Create tenant-scoped client cert.
+		user := username.MakeSQLUsernameFromPreNormalizedString("user")
+		require.NoError(t, security.CreateClientPair(
+			certsDir,
+			caKeyFile,
+			testKeySize,
+			48*time.Hour,
+			false, /*overwrite */
+			user,
+			tenantIDs,
+			tenantNames,
+			false /* wantPKCS8Key */))
+
+		// Load and verify the certificates.
+		cl := security.NewCertificateLoader(certsDir)
+		require.NoError(t, cl.Load())
+		infos := cl.Certificates()
+		for _, info := range infos {
+			require.NoError(t, info.Error)
+		}
+
+		// We expect two certificates: the CA certificate and the tenant scoped client certificate.
+		require.Equal(t, 2, len(infos))
+		expectedClientCrtName := fmt.Sprintf("client.%s.crt", user)
+		expectedTenantIDSANs, err := security.MakeTenantURISANs(user, tenantIDs)
+		require.NoError(t, err)
+		expectedTenantNameSANs, err := security.MakeTenantNameURISANs(user, tenantNames)
+		require.NoError(t, err)
+		expectedSANs := append(expectedTenantIDSANs, expectedTenantNameSANs...)
+		for _, info := range infos {
+			if info.Filename == "ca.crt" {
+				continue
+			}
+			require.Equal(t, security.ClientPem, info.FileUsage)
+			require.Equal(t, expectedClientCrtName, info.Filename)
+			require.Equal(t, 1, len(info.ParsedCertificates))
+			require.Equal(t, len(tenantIDs)+len(tenantNames), len(info.ParsedCertificates[0].URIs))
+			require.Equal(t, expectedSANs, info.ParsedCertificates[0].URIs)
+		}
 	}
 }
 
@@ -290,6 +327,7 @@ func generateBaseCerts(certsDir string, clientCertLifetime time.Duration) error 
 			true,
 			username.RootUserName(),
 			[]roachpb.TenantID{roachpb.SystemTenantID},
+			nil, /* tenantNames */
 			false,
 		); err != nil {
 			return err
@@ -344,14 +382,16 @@ func generateSplitCACerts(certsDir string) error {
 
 	if err := security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, certnames.EmbeddedClientCAKey),
-		testKeySize, time.Hour*48, true, username.NodeUserName(), []roachpb.TenantID{roachpb.SystemTenantID}, false,
+		testKeySize, time.Hour*48, true, username.NodeUserName(),
+		[]roachpb.TenantID{roachpb.SystemTenantID}, nil /* tenantNames */, false,
 	); err != nil {
 		return errors.Wrap(err, "could not generate Client pair")
 	}
 
 	if err := security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, certnames.EmbeddedClientCAKey),
-		testKeySize, time.Hour*48, true, username.RootUserName(), []roachpb.TenantID{roachpb.SystemTenantID}, false,
+		testKeySize, time.Hour*48, true, username.RootUserName(),
+		[]roachpb.TenantID{roachpb.SystemTenantID}, nil, false,
 	); err != nil {
 		return errors.Wrap(err, "could not generate Client pair")
 	}

--- a/pkg/security/x509.go
+++ b/pkg/security/x509.go
@@ -35,11 +35,13 @@ import (
 const (
 	// Make certs valid a day before to handle clock issues, specifically
 	// boot2docker: https://github.com/boot2docker/boot2docker/issues/69
-	validFrom                = -time.Hour * 24
-	maxPathLength            = 1
-	caCommonName             = "Cockroach CA"
-	tenantURISANPrefixString = "crdb://"
-	tenantURISANFormatString = tenantURISANPrefixString + "tenant/%d/user/%s"
+	validFrom                    = -time.Hour * 24
+	maxPathLength                = 1
+	caCommonName                 = "Cockroach CA"
+	tenantURISANSchemeString     = "crdb"
+	tenantNamePrefixString       = "tenant-name"
+	tenantURISANFormatString     = tenantURISANSchemeString + "://" + "tenant/%d/user/%s"
+	tenantNameURISANFormatString = tenantURISANSchemeString + "://" + tenantNamePrefixString + "/%s/user/%s"
 
 	// TenantsOU is the OrganizationalUnit that determines a client certificate should be treated as a tenant client
 	// certificate (as opposed to a KV node client certificate).
@@ -253,7 +255,8 @@ func GenerateClientCert(
 	clientPublicKey crypto.PublicKey,
 	lifetime time.Duration,
 	user username.SQLUsername,
-	tenantID []roachpb.TenantID,
+	tenantIDs []roachpb.TenantID,
+	tenantNames []roachpb.TenantName,
 ) ([]byte, error) {
 
 	// TODO(marc): should we add extra checks?
@@ -275,11 +278,17 @@ func GenerateClientCert(
 	// Set client-specific fields.
 	// Client authentication only.
 	template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
-	urls, err := MakeTenantURISANs(user, tenantID)
+	tenantIDURLs, err := MakeTenantURISANs(user, tenantIDs)
 	if err != nil {
 		return nil, err
 	}
-	template.URIs = append(template.URIs, urls...)
+	tenantNameURLs, err := MakeTenantNameURISANs(user, tenantNames)
+	if err != nil {
+		return nil, err
+	}
+	template.URIs = append(template.URIs, tenantIDURLs...)
+	template.URIs = append(template.URIs, tenantNameURLs...)
+
 	certBytes, err := x509.CreateCertificate(rand.Reader, template, caCert, clientPublicKey, caPrivateKey)
 	if err != nil {
 		return nil, err
@@ -334,13 +343,34 @@ func MakeTenantURISANs(
 	return urls, nil
 }
 
-// URISANHasCRDBPrefix indicates whether a URI string has the tenant URI SAN prefix.
-func URISANHasCRDBPrefix(rawlURI string) bool {
-	return strings.HasPrefix(rawlURI, tenantURISANPrefixString)
+// MakeTenantNameURISANs constructs the tenant name SAN URI for the client certificate.
+func MakeTenantNameURISANs(
+	username username.SQLUsername, tenantNames []roachpb.TenantName,
+) ([]*url.URL, error) {
+	urls := make([]*url.URL, 0, len(tenantNames))
+	for _, tenantName := range tenantNames {
+		uri, err := url.Parse(fmt.Sprintf(tenantNameURISANFormatString, tenantName, username.Normalized()))
+		if err != nil {
+			return nil, err
+		}
+		urls = append(urls, uri)
+	}
+	return urls, nil
 }
 
-// ParseTenantURISAN extracts the user and tenant ID contained within a tenant URI SAN.
-func ParseTenantURISAN(rawURL string) (roachpb.TenantID, string, error) {
+// isCRDBSANURI indicates whether the URI uses CRDB scheme.
+func isCRDBSANURI(uri *url.URL) bool {
+	return uri.Scheme == tenantURISANSchemeString
+}
+
+// isTenantNameSANURI indicates whether the URI is using tenant name to identify the tenant.
+func isTenantNameSANURI(uri *url.URL) bool {
+	return uri.Host == tenantNamePrefixString
+}
+
+// parseTenantURISAN extracts the user and tenant ID contained within a tenant URI SAN.
+func parseTenantURISAN(uri *url.URL) (roachpb.TenantID, string, error) {
+	rawURL := uri.String()
 	r := strings.NewReader(rawURL)
 	var tID uint64
 	var username string
@@ -349,4 +379,17 @@ func ParseTenantURISAN(rawURL string) (roachpb.TenantID, string, error) {
 		return roachpb.TenantID{}, "", errors.Errorf("invalid tenant URI SAN %s", rawURL)
 	}
 	return roachpb.MustMakeTenantID(tID), username, nil
+}
+
+// parseTenantNameURISAN extracts the user and tenant name contained within a tenant URI SAN.
+func parseTenantNameURISAN(uri *url.URL) (roachpb.TenantName, string, error) {
+	if !isCRDBSANURI(uri) || !isTenantNameSANURI(uri) {
+		return roachpb.TenantName(""), "", errors.Errorf("invalid tenant-name URI SAN %q", uri.String())
+	}
+	parts := strings.Split(uri.Path, "/")
+	if len(parts) != 4 {
+		return roachpb.TenantName(""), "", errors.Errorf("invalid tenant-name URI SAN %q", uri.String())
+	}
+	tenantName, username := parts[1], parts[3]
+	return roachpb.TenantName(tenantName), username, nil
 }

--- a/pkg/security/x509_test.go
+++ b/pkg/security/x509_test.go
@@ -88,15 +88,16 @@ func TestGenerateCertLifetime(t *testing.T) {
 
 	// Create a Client certificate expiring in 4 days. Should get reduced to the CA lifetime.
 	clientDuration := time.Hour * 96
-	_, err = security.GenerateClientCert(caCert, testKey, testKey.Public(), clientDuration, username.TestUserName(), []roachpb.TenantID{roachpb.SystemTenantID})
+	_, err = security.GenerateClientCert(caCert, testKey, testKey.Public(), clientDuration, username.TestUserName(),
+		[]roachpb.TenantID{roachpb.SystemTenantID}, nil)
 	if !testutils.IsError(err, "CA lifetime is .*, shorter than the requested .*") {
 		t.Fatal(err)
 	}
 
 	// Try again, but expiring before the CA cert.
 	clientDuration = time.Hour * 24
-	clientBytes, err := security.GenerateClientCert(caCert, testKey, testKey.Public(), clientDuration, username.TestUserName(), []roachpb.TenantID{roachpb.SystemTenantID})
-
+	clientBytes, err := security.GenerateClientCert(caCert, testKey, testKey.Public(), clientDuration,
+		username.TestUserName(), []roachpb.TenantID{roachpb.SystemTenantID}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,5 +110,4 @@ func TestGenerateCertLifetime(t *testing.T) {
 	if a, e := clientCert.NotAfter, now.Add(clientDuration); !timesFuzzyEqual(a, e) {
 		t.Fatalf("client expiration differs from requested: %s vs %s", a, e)
 	}
-
 }


### PR DESCRIPTION
Currently client certificates can be generated with tenant scope using `cert create-client` command with `--tenant-scope` flag. Certificates generated with tenant scope restrict access to only those tenants. Tenant ID is an internal identifier to identify a specific tenant and it is not a great user experience to use it in customer facing interfaces (CLI in this case). The goal of the ticket [CRDB-28992](https://cockroachlabs.atlassian.net/browse/CRDB-28992) is to allow users to generate certificates with tenant scope using tenant names and use those certificates to authenticate. 

To complete this ticket, following changes are needed:
1.  Allow users to generate tenant scoped certs using tenant names. 
2. Use those certificates to authenticate. 

This PR addresses the first part of the changes. I'll send a followup PR for the second part of the changes. 

Changes in this PR allows users to use both `tenant-scope` and `tenant-name-scope` flags to specify the scopes. IMO, this will be useful for backward compatibility. We can eventually deprecate supporting `tenant-scope` flag. Another option is to make `tenant-scope`, `tenant-name-scope` flags mutually exclusive.

Informs: https://github.com/cockroachdb/cockroach/issues/105340
EPIC: CRDB-39093
Release note: None