### PR TITLE
kvserver/rangefeed: add cluster setting RangefeedUseBufferedSender

### DIFF
--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -5,6 +5,8 @@ go_library(
     srcs = [
         "budget.go",
         "buffered_registration.go",
+        "buffered_sender.go",
+        "buffered_stream.go",
         "catchup_scan.go",
         "event_size.go",
         "filter.go",

--- a/pkg/kv/kvserver/rangefeed/buffered_sender.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_sender.go
@@ -1,0 +1,109 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rangefeed
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+)
+
+//	┌─────────────────────────────────────────┐                                      MuxRangefeedEvent
+//	│            Node.MuxRangeFeed            │◄──────────────────────────────────────────────────┐
+//	└─────────────────┬───▲───────────────────┘                  ▲                                │
+//	 Sender.AddStream │   │LockedMuxStream.Send                  │                                │
+//			 ┌────────────▼───┴──────────┐                           │                                │
+//			 │ Buffered/Unbuffered Sender├───────────┐               │                                │
+//			 └────────────┬──────────────┘           │               │                                │
+//			 	   				  │                          │               │                                │
+//			 	   ┌────────▼─────────┐                │               │                                │
+//			 	   │ Stores.Rangefeed │                │               │                                │
+//			 	   └────────┬─────────┘                │               │                                │
+//			 	   				  │                          │               │                                │
+//			 	    ┌───────▼─────────┐         BufferedSender      BufferedSender                      │
+//			 	    │ Store.Rangefeed │ SendUnbuffered/SendBuffered SendBufferedError ─────► BufferedSender.run
+//			 	    └───────┬─────────┘ (catch-up scan)(live raft)     ▲
+//			 	   				  │                        ▲                 │
+//			 	   ┌────────▼──────────┐             │                 │
+//			 	   │ Replica.Rangefeed │             │                 │
+//			 	   └────────┬──────────┘             │                 │
+//			 	   				  │                        │                 │
+//			 	    ┌───────▼──────┐                 │                 │
+//			 	    │ Registration │                 │                 │
+//			 	    └──────┬───────┘                 │                 │
+//			 	    			 │      								   │					  		 │
+//			 	    			 │                         │                 │
+//			 	    			 └─────────────────────────┘─────────────────┘
+//			 	    		BufferedPerRangeEventSink.Send    BufferedPerRangeEventSink.Disconnect
+//
+// BufferedSender is embedded in every rangefeed.BufferedPerRangeEventSink,
+// serving as a helper which buffers events before forwarding events to the
+// underlying gRPC stream.
+//
+// Refer to the comments above UnbufferedSender for more details on the role of
+// senders in the entire rangefeed architecture.
+type BufferedSender struct {
+	// Note that lockedMuxStream wraps the underlying grpc server stream, ensuring
+	// thread safety.
+	sender ServerStreamSender
+
+	// metrics is used to record rangefeed metrics for the node.
+	metrics RangefeedMetricsRecorder
+}
+
+func NewBufferedSender(
+	sender ServerStreamSender, metrics RangefeedMetricsRecorder,
+) *BufferedSender {
+	return &BufferedSender{
+		sender:  sender,
+		metrics: metrics,
+	}
+}
+
+// SendBuffered buffers the event before sending them to the underlying
+// ServerStreamSender.
+func (bs *BufferedSender) SendBuffered(
+	event *kvpb.MuxRangeFeedEvent, alloc *SharedBudgetAllocation,
+) error {
+	panic("unimplemented: buffered sender for rangefeed #126560")
+}
+
+// SendUnbuffered bypasses the buffer and sends the event to the underlying
+// ServerStreamSender directly. Note that this can cause event re-ordering.
+// Caller is responsible for ensuring that events are sent in order.
+func (bs *BufferedSender) SendUnbuffered(
+	event *kvpb.MuxRangeFeedEvent, alloc *SharedBudgetAllocation,
+) error {
+	panic("unimplemented: buffered sender for rangefeed #126560")
+}
+
+func (bs *BufferedSender) SendBufferedError(ev *kvpb.MuxRangeFeedEvent) {
+	// Disconnect stream and cancel context. Then call SendBuffered with the error
+	// event.
+	panic("unimplemented: buffered sender for rangefeed #126560")
+}
+
+func (bs *BufferedSender) AddStream(streamID int64, cancel context.CancelFunc) {
+	panic("unimplemented: buffered sender for rangefeed #126560")
+}
+
+func (bs *BufferedSender) Start(ctx context.Context, stopper *stop.Stopper) error {
+	panic("unimplemented: buffered sender for rangefeed #126560")
+}
+
+func (bs *BufferedSender) Stop() {
+	panic("unimplemented: buffered sender for rangefeed #126560")
+}
+
+func (bs *BufferedSender) Error() chan error {
+	panic("unimplemented: buffered sender for rangefeed #126560")
+}

--- a/pkg/kv/kvserver/rangefeed/buffered_stream.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_stream.go
@@ -1,0 +1,109 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rangefeed
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
+// BufferedStream is a Stream that can buffer events before sending them to the
+// underlying Stream. Note that the caller may still choose to bypass the buffer
+// and send to the underlying Stream directly by calling Send directly. Doing so
+// can cause event re-ordering. Caller is responsible for ensuring that events
+// are sent in order.
+type BufferedStream interface {
+	Stream
+	// SendBuffered buffers the event before sending it to the underlying Stream.
+	SendBuffered(*kvpb.RangeFeedEvent, *SharedBudgetAllocation) error
+}
+
+// BufferedPerRangeEventSink is an implementation of BufferedStream which is
+// similar to PerRangeEventSink but buffers events in BufferedSender before
+// forwarding events to the underlying grpc stream.
+type BufferedPerRangeEventSink struct {
+	ctx      context.Context
+	rangeID  roachpb.RangeID
+	streamID int64
+	wrapped  *BufferedSender
+}
+
+func NewBufferedPerRangeEventSink(
+	ctx context.Context, rangeID roachpb.RangeID, streamID int64, wrapped *BufferedSender,
+) *BufferedPerRangeEventSink {
+	return &BufferedPerRangeEventSink{
+		ctx:      ctx,
+		rangeID:  rangeID,
+		streamID: streamID,
+		wrapped:  wrapped,
+	}
+}
+
+var _ kvpb.RangeFeedEventSink = (*BufferedPerRangeEventSink)(nil)
+var _ Stream = (*BufferedPerRangeEventSink)(nil)
+var _ BufferedStream = (*BufferedPerRangeEventSink)(nil)
+
+func (s *BufferedPerRangeEventSink) Context() context.Context {
+	return s.ctx
+}
+
+// SendIsThreadSafe is a no-op declaration method. It is a contract that the
+// Send method is thread-safe. Note that BufferedSender.SendBuffered is
+// thread-safe.
+func (s *BufferedPerRangeEventSink) SendIsThreadSafe() {}
+
+// SendBuffered buffers the event in BufferedSender and transfers the ownership
+// of SharedBudgetAllocation to BufferedSender. BufferedSender is responsible
+// for properly using and releasing it when an error occurs or when the event is
+// sent. The event is guaranteed to be sent unless BufferedSender terminates
+// before sending (such as due to broken grpc stream).
+//
+// If the function returns an error, it is safe to disconnect the stream and
+// assume that all future SendBuffered on this stream will return an error.
+func (s *BufferedPerRangeEventSink) SendBuffered(
+	event *kvpb.RangeFeedEvent, alloc *SharedBudgetAllocation,
+) error {
+	response := &kvpb.MuxRangeFeedEvent{
+		RangeFeedEvent: *event,
+		RangeID:        s.rangeID,
+		StreamID:       s.streamID,
+	}
+	return s.wrapped.SendBuffered(response, alloc)
+}
+
+// Send bypass the buffer and sends the event to the underlying grpc stream
+// directly. It blocks until the event is sent or an error occurs.
+func (s *BufferedPerRangeEventSink) Send(event *kvpb.RangeFeedEvent) error {
+	response := &kvpb.MuxRangeFeedEvent{
+		RangeFeedEvent: *event,
+		RangeID:        s.rangeID,
+		StreamID:       s.streamID,
+	}
+	return s.wrapped.SendUnbuffered(response, nil)
+}
+
+// Disconnect implements the Stream interface. BufferedSender is then
+// responsible for canceling the context of the stream. The actual rangefeed
+// disconnection from processor happens late when the error event popped from
+// the queue and about to be sent to the grpc stream. So caller should not rely
+// on immediate disconnection as cleanup takes place async.
+func (s *BufferedPerRangeEventSink) Disconnect(err *kvpb.Error) {
+	ev := &kvpb.MuxRangeFeedEvent{
+		StreamID: s.streamID,
+		RangeID:  s.rangeID,
+	}
+	ev.MustSetValue(&kvpb.RangeFeedError{
+		Error: *transformRangefeedErrToClientError(err),
+	})
+	s.wrapped.SendBufferedError(ev)
+}

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -316,10 +316,16 @@ func (p *ScheduledProcessor) Register(
 	p.syncEventC()
 
 	blockWhenFull := p.Config.EventChanTimeout == 0 // for testing
-	r := newBufferedRegistration(
-		span.AsRawSpanWithNoLocals(), startTS, catchUpIter, withDiff, withFiltering, withOmitRemote,
-		p.Config.EventChanCap, blockWhenFull, p.Metrics, stream, disconnectFn,
-	)
+	var r registration
+	if _, ok := stream.(BufferedStream); ok {
+		log.Fatalf(context.Background(),
+			"unimplemented: unbuffered registrations for rangefeed, see #126560")
+	} else {
+		r = newBufferedRegistration(
+			span.AsRawSpanWithNoLocals(), startTS, catchUpIter, withDiff, withFiltering, withOmitRemote,
+			p.Config.EventChanCap, blockWhenFull, p.Metrics, stream, disconnectFn,
+		)
+	}
 
 	filter := runRequest(p, func(ctx context.Context, p *ScheduledProcessor) *Filter {
 		if p.stopping {

--- a/pkg/kv/kvserver/rangefeed/unbuffered_sender.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_sender.go
@@ -87,7 +87,7 @@ type ServerStreamSender interface {
 //		                       │      								   │							 │						           				 │
 //			  	                 │                         │               │                               │
 //			         	 	         └─────────────────────────┘───────────────┘───────────────────────────────┘
-//			          			                            Stream.Send    Stream.Disconnect
+//			          			                  PerRangeEventSink.Send   PerRangeEventSink.Disconnect
 //
 // UnbufferedSender is embedded in every rangefeed.PerRangeEventSink, serving as
 // a helper to forward events to the underlying gRPC stream.
@@ -196,7 +196,7 @@ func (ubs *UnbufferedSender) SendUnbuffered(event *kvpb.MuxRangeFeedEvent) error
 
 // run forwards rangefeed completion errors back to the client. run is expected
 // to be called in a goroutine and will block until the context is done or the
-// stopper is quiesced. StreamMuxer will stop forward rangefeed completion
+// stopper is quiesced. UnbufferedSender will stop forward rangefeed completion
 // errors after run completes, but a node level shutdown from Node.MuxRangefeed
 // should happen soon.
 func (ubs *UnbufferedSender) run(ctx context.Context, stopper *stop.Stopper) error {

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -93,6 +93,18 @@ var RangeFeedUseScheduler = settings.RegisterBoolSetting(
 var RangefeedSchedulerDisabled = envutil.EnvOrDefaultBool("COCKROACH_RANGEFEED_DISABLE_SCHEDULER",
 	false)
 
+// RangefeedUseBufferedSender controls whether rangefeed uses a node level
+// buffered sender to buffer events instead of buffering events separately in a
+// channel at a per client per registration level. It is currently left
+// unimplemented and disabled everywhere (#126560). Panics if enabled.
+var RangefeedUseBufferedSender = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.rangefeed.buffered_stream_sender.enabled",
+	"use buffered sender for all range feeds instead of buffering events "+
+		"separately per client per range",
+	false,
+)
+
 func init() {
 	// Inject into kvserverbase to allow usage from kvcoord.
 	kvserverbase.RangeFeedRefreshInterval = RangeFeedRefreshInterval


### PR DESCRIPTION
This patch adds a cluster setting RangefeedUseBufferedSender. If enabled,
rangefeed will use unbuffered registrations - registrations will not buffer
events at rangfeed level. Instead, registrations will use a BufferedSender
to buffer events at a node level. Note that BufferedSender is left
unimplemented in this patch, and the setting is disabled everywhere. Using it
will cause a panic. We will implement BufferedSender in a follow-up patch.

This patch also introduces other components to make future commits cleaner.

The setting is left undocumented in release note since the feature is not
complete yet.

Part of: https://github.com/cockroachdb/cockroach/issues/129813
Release note: none