### PR TITLE
workload/schemachange: be more lenient for DROP DEFAULT error code

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1707,7 +1707,7 @@ func (og *operationGenerator) dropColumnDefault(ctx context.Context, tx pgx.Tx) 
 	}
 
 	stmt := makeOpStmt(OpStmtDDL)
-	stmt.expectedExecErrors.addAll(codesWithConditions{
+	stmt.potentialExecErrors.addAll(codesWithConditions{
 		{code: pgcode.UndefinedColumn, condition: !columnExists},
 		{code: pgcode.Syntax, condition: colIsVirtualComputed || colIsStoredComputed},
 	})


### PR DESCRIPTION
Since 5eedebc529adedc33b93ca5146aed82479a9c40e was backported to older branches, but does not yet appear in a release, the workload should be able to handle _not_ seeing an error code for the case of dropping a column default for a computed column.

fixes https://github.com/cockroachdb/cockroach/issues/127320
fixes https://github.com/cockroachdb/cockroach/issues/129163
Release note: None