### PR TITLE
logictest: deflake cross_version_tenant_backup

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cross_version_tenant_backup
+++ b/pkg/sql/logictest/testdata/logic_test/cross_version_tenant_backup
@@ -19,11 +19,11 @@ foo 3
 statement ok
 BACKUP TENANT 3 INTO 'userfile:///1/example'
 
-upgrade 0
+upgrade all
 
-upgrade 1
-
-upgrade 2
+# Wait for upgrade to finalize.
+statement ok
+SET CLUSTER SETTING version = crdb_internal.node_executable_version()
 
 statement ok
 RESTORE TENANT 3 FROM LATEST IN 'userfile:///1/example' with tenant_name = 'baz'


### PR DESCRIPTION
This makes the test less flaky by making sure finalization is complete before beginning the RESTORE.

fixes https://github.com/cockroachdb/cockroach/issues/129066
Release note: None