### PR TITLE
roachtest: upgrade hibernate version under test

### DIFF
--- a/pkg/cmd/roachtest/tests/hibernate.go
+++ b/pkg/cmd/roachtest/tests/hibernate.go
@@ -28,7 +28,7 @@ var hibernateReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d
 
 // WARNING: DO NOT MODIFY the name of the below constant/variable without approval from the docs team.
 // This is used by docs automation to produce a list of supported versions for ORM's.
-var supportedHibernateTag = "6.3.1"
+var supportedHibernateTag = "6.6.0"
 
 type hibernateOptions struct {
 	testName string


### PR DESCRIPTION
This fixes an issue with a missing dependency as well. See https://github.com/hibernate/hibernate-orm/commit/e4a0b6988f84e85e427484e65321e9583080ccb5

fixes https://github.com/cockroachdb/cockroach/issues/127203
fixes https://github.com/cockroachdb/cockroach/issues/127206
fixes https://github.com/cockroachdb/cockroach/issues/127248
fixes https://github.com/cockroachdb/cockroach/issues/127231
Release note: None