### PR TITLE
backupccl: remove not null flag from SQLInstanceID field in SSP spec

### DIFF
--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -460,7 +460,7 @@ message GenerativeSplitAndScatterSpec {
   // MaxFileCount is the max number of files in an extending restore span entry.
   optional int64 max_file_count = 23[(gogoproto.nullable) = false];
   // SQLInstanceIDs is a slice of SQL instance IDs available for dist restore.
-  repeated int32 sql_instance_ids = 24[(gogoproto.nullable) = false, (gogoproto.customname) = "SQLInstanceIDs"];
+  repeated int32 sql_instance_ids = 24[(gogoproto.customname) = "SQLInstanceIDs"];
   reserved 19;
 }
 


### PR DESCRIPTION
This flag is a noop for repeated fields and was producing a warning during proto generation.

Epic: none

Release note: none