### PR TITLE
backupccl: clean up SQLInstanceIDS proto field

### DIFF
--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -464,7 +464,7 @@ message GenerativeSplitAndScatterSpec {
   // MaxFileCount is the max number of files in an extending restore span entry.
   optional int64 max_file_count = 23[(gogoproto.nullable) = false];
   // SQLInstanceIDs is a slice of SQL instance IDs available for dist restore.
-  repeated int32 sql_instance_ids = 24[(gogoproto.nullable) = false, (gogoproto.customname) = "SQLInstanceIDs"];
+  repeated int32 sql_instance_ids = 24[(gogoproto.customname) = "SQLInstanceIDs"];
   reserved 19;
 }
 


### PR DESCRIPTION
`(gogoproto.nullable) = false` is redundant for
`GenerativeSplitAndScatterSpec.sql_instance_ids` since it is a slice of repeated non-nullable native type.

Epic: none
Release note: None