### PR TITLE
roachprod: stop forcefully after grace period

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -268,7 +268,7 @@ func initFlags() {
 		}
 		stopProcessesCmd.Flags().IntVar(sigPtr, "sig", *sigPtr, "signal to pass to kill")
 		stopProcessesCmd.Flags().BoolVar(waitPtr, "wait", *waitPtr, "wait for processes to exit")
-		stopProcessesCmd.Flags().IntVar(gracePeriodPtr, "grace-period", *gracePeriodPtr, "approx number of seconds to wait for processes to exit")
+		stopProcessesCmd.Flags().IntVar(gracePeriodPtr, "grace-period", *gracePeriodPtr, "approx number of seconds to wait for processes to exit, before a forceful shutdown (SIGKILL) is performed")
 	}
 	deployCmd.Flags().DurationVar(&pause, "pause", pause, "duration to pause between node restarts")
 

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -68,10 +68,10 @@ var (
 	useTreeDist           = true
 	sig                   = 9
 	waitFlag              = false
-	maxWait               = 0
+	gracePeriod           = 0
 	deploySig             = 15
 	deployWaitFlag        = true
-	deployMaxWait         = 300
+	deployGracePeriod     = 300
 	pause                 = time.Duration(0)
 	createVMOpts          = vm.DefaultCreateOpts()
 	startOpts             = roachprod.DefaultStartOpts()
@@ -258,17 +258,17 @@ func initFlags() {
 		// See: https://github.com/spf13/cobra/issues/1398
 		sigPtr := &sig
 		waitPtr := &waitFlag
-		maxWaitPtr := &maxWait
+		gracePeriodPtr := &gracePeriod
 		// deployCmd is a special case, because it is used to stop processes in a
 		// rolling restart, and we want to drain the nodes by default.
 		if stopProcessesCmd == deployCmd {
 			sigPtr = &deploySig
 			waitPtr = &deployWaitFlag
-			maxWaitPtr = &deployMaxWait
+			gracePeriodPtr = &deployGracePeriod
 		}
 		stopProcessesCmd.Flags().IntVar(sigPtr, "sig", *sigPtr, "signal to pass to kill")
 		stopProcessesCmd.Flags().BoolVar(waitPtr, "wait", *waitPtr, "wait for processes to exit")
-		stopProcessesCmd.Flags().IntVar(maxWaitPtr, "max-wait", *maxWaitPtr, "approx number of seconds to wait for processes to exit")
+		stopProcessesCmd.Flags().IntVar(gracePeriodPtr, "grace-period", *gracePeriodPtr, "approx number of seconds to wait for processes to exit")
 	}
 	deployCmd.Flags().DurationVar(&pause, "pause", pause, "duration to pause between node restarts")
 

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -674,7 +674,7 @@ SIGHUP), unless you also configure --max-wait.
 		if sig == 9 /* SIGKILL */ && !cmd.Flags().Changed("wait") {
 			wait = true
 		}
-		stopOpts := roachprod.StopOpts{Wait: wait, MaxWait: maxWait, ProcessTag: tag, Sig: sig}
+		stopOpts := roachprod.StopOpts{Wait: wait, GracePeriod: gracePeriod, ProcessTag: tag, Sig: sig}
 		return roachprod.Stop(context.Background(), config.Logger, args[0], stopOpts)
 	}),
 }
@@ -759,7 +759,7 @@ non-terminating signal (e.g. SIGHUP), unless you also configure --max-wait.
 		}
 		stopOpts := roachprod.StopOpts{
 			Wait:               wait,
-			MaxWait:            maxWait,
+			GracePeriod:        gracePeriod,
 			Sig:                sig,
 			VirtualClusterName: virtualClusterName,
 			SQLInstance:        sqlInstance,
@@ -803,7 +803,7 @@ Currently available application options are:
 			versionArg = args[2]
 		}
 		return roachprod.Deploy(context.Background(), config.Logger, args[0], args[1],
-			versionArg, pause, deploySig, deployWaitFlag, deployMaxWait, secure)
+			versionArg, pause, deploySig, deployWaitFlag, deployGracePeriod, secure)
 	}),
 }
 

--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -74,6 +74,7 @@ go_library(
         "@com_github_spf13_cobra//:cobra",
         "@in_gopkg_yaml_v2//:yaml_v2",
         "@org_golang_x_sync//errgroup",
+        "@org_golang_x_sys//unix",
     ],
 )
 

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -57,6 +57,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	_ "github.com/lib/pq"
+	"golang.org/x/sys/unix"
 )
 
 func init() {
@@ -2341,16 +2342,15 @@ func (c *clusterImpl) StopE(
 	c.setStatusForClusterOpt("stopping", stopOpts.RoachtestOpts.Worker, nodes...)
 	defer c.clearStatusForClusterOpt(stopOpts.RoachtestOpts.Worker)
 
-	if c.goCoverDir != "" && stopOpts.RoachprodOpts.Sig == 9 /* SIGKILL */ {
-		// If we are trying to collect coverage, we don't want to kill processes;
-		// use SIGUSR1 which dumps coverage data and exits. Note that Cockroach
-		// v23.1 and earlier ignore SIGUSR1, so we still want to send SIGKILL.
+	if c.goCoverDir != "" && stopOpts.RoachprodOpts.Sig == int(unix.SIGKILL) {
+		// If we are trying to collect coverage, we first send a SIGUSR1
+		// which dumps coverage data and exits. Note that Cockroach v23.1
+		// and earlier ignore SIGUSR1, so we still want to send SIGKILL,
+		// and that's the underlying behaviour of `Stop`.
 		l.Printf("coverage mode: first trying to stop using SIGUSR1")
-		opts := stopOpts.RoachprodOpts
-		opts.Sig = 10 // SIGUSR1
-		opts.Wait = true
-		opts.GracePeriod = 10
-		_ = roachprod.Stop(ctx, l, c.MakeNodes(nodes...), opts)
+		stopOpts.RoachprodOpts.Sig = 10 // SIGUSR1
+		stopOpts.RoachprodOpts.Wait = true
+		stopOpts.RoachprodOpts.GracePeriod = 10
 	}
 	return errors.Wrap(roachprod.Stop(ctx, l, c.MakeNodes(nodes...), stopOpts.RoachprodOpts), "cluster.StopE")
 }

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2349,7 +2349,7 @@ func (c *clusterImpl) StopE(
 		opts := stopOpts.RoachprodOpts
 		opts.Sig = 10 // SIGUSR1
 		opts.Wait = true
-		opts.MaxWait = 10
+		opts.GracePeriod = 10
 		_ = roachprod.Stop(ctx, l, c.MakeNodes(nodes...), opts)
 	}
 	return errors.Wrap(roachprod.Stop(ctx, l, c.MakeNodes(nodes...), stopOpts.RoachprodOpts), "cluster.StopE")

--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -224,13 +224,13 @@ func NoBackupSchedule(opts interface{}) {
 }
 
 // Graceful performs a graceful stop of the cockroach process.
-func Graceful(maxWaitSeconds int) func(interface{}) {
+func Graceful(gracePeriodSeconds int) func(interface{}) {
 	return func(opts interface{}) {
 		switch opts := opts.(type) {
 		case *StopOpts:
 			opts.RoachprodOpts.Sig = 15 // SIGTERM
 			opts.RoachprodOpts.Wait = true
-			opts.RoachprodOpts.MaxWait = maxWaitSeconds
+			opts.RoachprodOpts.GracePeriod = gracePeriodSeconds
 		}
 	}
 }

--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -356,7 +356,7 @@ func RestartNodesWithNewBinary(
 	newVersion *Version,
 	settings ...install.ClusterSettingOption,
 ) error {
-	const maxWait = 300 // 5 minutes
+	const gracePeriod = 300 // 5 minutes
 
 	// NB: We could technically stage the binary on all nodes before
 	// restarting each one, but on Unix it's invalid to write to an
@@ -379,7 +379,7 @@ func RestartNodesWithNewBinary(
 		// TODO(yuzefovich): ideally, we would also check that the drain was
 		// successful since if it wasn't, then we might see flakes too.
 		if err := c.StopE(
-			ctx, l, option.NewStopOpts(option.Graceful(maxWait)), c.Node(node),
+			ctx, l, option.NewStopOpts(option.Graceful(gracePeriod)), c.Node(node),
 		); err != nil {
 			return err
 		}

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -37,9 +37,9 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// shudownMaxWait is the default maximum duration (in seconds) that we
+// shudownGracePeriod is the default grace period (in seconds) that we
 // will wait for a graceful shutdown.
-const shutdownMaxWait = 300
+const shutdownGracePeriod = 300
 
 func registerDecommission(r registry.Registry) {
 	{
@@ -300,7 +300,7 @@ func runDecommission(
 		})
 	}
 
-	stopOpts := option.NewStopOpts(option.Graceful(shutdownMaxWait))
+	stopOpts := option.NewStopOpts(option.Graceful(shutdownGracePeriod))
 
 	m.Go(func() error {
 		tBegin, whileDown := timeutil.Now(), true

--- a/pkg/cmd/roachtest/tests/decommissionbench.go
+++ b/pkg/cmd/roachtest/tests/decommissionbench.go
@@ -884,7 +884,7 @@ func runSingleDecommission(
 	// stuck with replicas in purgatory, by pinning them to a node.
 
 	// We stop nodes gracefully when needed.
-	stopOpts := option.NewStopOpts(option.Graceful(shutdownMaxWait))
+	stopOpts := option.NewStopOpts(option.Graceful(shutdownGracePeriod))
 
 	// Gather metadata for logging purposes and wait for balance.
 	var bytesUsed, rangeCount, totalRanges int64

--- a/pkg/cmd/roachtest/tests/encryption.go
+++ b/pkg/cmd/roachtest/tests/encryption.go
@@ -85,7 +85,7 @@ func registerEncryption(r registry.Registry) {
 			}
 
 			for i := 1; i <= nodes; i++ {
-				c.Stop(ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownMaxWait)), c.Node(i))
+				c.Stop(ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownGracePeriod)), c.Node(i))
 			}
 		}
 	}

--- a/pkg/cmd/roachtest/tests/jobs_util.go
+++ b/pkg/cmd/roachtest/tests/jobs_util.go
@@ -152,7 +152,7 @@ func executeNodeShutdown(
 	} else {
 		t.L().Printf(`stopping node gracefully %s`, target)
 		if err := c.StopE(
-			ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownMaxWait)), c.Node(cfg.shutdownNode),
+			ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownGracePeriod)), c.Node(cfg.shutdownNode),
 		); err != nil {
 			return errors.Wrapf(err, "could not stop node %s", target)
 		}

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -488,13 +488,9 @@ func registerKVQuiescenceDead(r registry.Registry) {
 			})
 			// Graceful shut down third node.
 			m.ExpectDeath()
-			if err := c.StopE(
+			c.Stop(
 				ctx, t.L(), option.NewStopOpts(option.Graceful(30)), c.Node(len(c.CRDBNodes())),
-			); err != nil {
-				t.L().Printf("graceful shutdown failed: %v", err)
-				// If graceful shutdown fails within 30 seconds, proceed with hard shutdown.
-				c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(len(c.CRDBNodes())))
-			}
+			)
 			// Measure qps with node down (i.e. without quiescence).
 			qpsOneDown := qps(func() {
 				// Use a different seed to make sure it's not just stepping into the

--- a/pkg/cmd/roachtest/tests/logical_data_replication.go
+++ b/pkg/cmd/roachtest/tests/logical_data_replication.go
@@ -359,7 +359,7 @@ func TestLDROnNodeShutdown(
 
 	// Graceful shutdown on both nodes
 	// TODO(naveen.setlur): maybe switch this to a less graceful shutdown via SIGKILL
-	stopOpts := option.NewStopOpts(option.Graceful(shutdownMaxWait))
+	stopOpts := option.NewStopOpts(option.Graceful(shutdownGracePeriod))
 	t.L().Printf("Shutting down node-left: %d", nodeToStopL)
 	monitor.ExpectDeath()
 	if err := c.StopE(ctx, t.L(), stopOpts, c.Node(nodeToStopL)); err != nil {

--- a/pkg/cmd/roachtest/tests/multi_region_system_database.go
+++ b/pkg/cmd/roachtest/tests/multi_region_system_database.go
@@ -67,7 +67,7 @@ func registerMultiRegionSystemDatabase(r registry.Registry) {
 			// Perform rolling restart to propagate region information to non-primary nodes
 			for i := 2; i <= nodes; i++ {
 				t.WorkerStatus("stop")
-				c.Stop(ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownMaxWait)), c.Node(i))
+				c.Stop(ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownGracePeriod)), c.Node(i))
 				t.WorkerStatus("start")
 				startOpts := option.DefaultStartOpts()
 				c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SecureOption(false)), c.Node(i))

--- a/pkg/roachprod/BUILD.bazel
+++ b/pkg/roachprod/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_dataexmachina_dev_side_eye_go//sideeyeclient",
+        "@org_golang_x_sys//unix",
     ],
 )
 

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -392,14 +392,14 @@ func (c *SyncedCluster) newSession(
 // for shared-process configurations.)
 //
 // When Stop needs to kill a process without other flags, the signal
-// is 9 (SIGKILL) and wait is true. If maxWait is non-zero, Stop stops
-// waiting after that approximate number of seconds.
+// is 9 (SIGKILL) and wait is true. If gracePeriod is non-zero, Stop
+// stops waiting after that approximate number of seconds.
 func (c *SyncedCluster) Stop(
 	ctx context.Context,
 	l *logger.Logger,
 	sig int,
 	wait bool,
-	maxWait int,
+	gracePeriod int,
 	virtualClusterLabel string,
 ) error {
 	// virtualClusterDisplay includes information about the virtual
@@ -443,7 +443,7 @@ func (c *SyncedCluster) Stop(
 		if wait {
 			display += " and waiting"
 		}
-		return c.kill(ctx, l, "stop", display, sig, wait, maxWait, virtualClusterLabel)
+		return c.kill(ctx, l, "stop", display, sig, wait, gracePeriod, virtualClusterLabel)
 	} else {
 		cmd := fmt.Sprintf("ALTER TENANT '%s' STOP SERVICE", virtualClusterName)
 		res, err := c.ExecSQL(ctx, l, c.Nodes[:1], "", 0, DefaultAuthMode(), "", /* database */
@@ -463,20 +463,20 @@ func (c *SyncedCluster) Stop(
 // Signal sends a signal to the CockroachDB process.
 func (c *SyncedCluster) Signal(ctx context.Context, l *logger.Logger, sig int) error {
 	display := fmt.Sprintf("%s: sending signal %d", c.Name, sig)
-	return c.kill(ctx, l, "signal", display, sig, false /* wait */, 0 /* maxWait */, "")
+	return c.kill(ctx, l, "signal", display, sig, false /* wait */, 0 /* gracePeriod */, "")
 }
 
 // kill sends the signal sig to all nodes in the cluster using the kill command.
 // cmdName and display specify the roachprod subcommand and a status message,
 // for output/logging. If wait is true, the command will wait for the processes
-// to exit, up to maxWait seconds.
+// to exit, up to gracePeriod seconds.
 func (c *SyncedCluster) kill(
 	ctx context.Context,
 	l *logger.Logger,
 	cmdName, display string,
 	sig int,
 	wait bool,
-	maxWait int,
+	gracePeriod int,
 	virtualClusterLabel string,
 ) error {
 	const timedOutMessage = "timed out"
@@ -508,7 +508,7 @@ func (c *SyncedCluster) kill(
     echo "${pid}: dead" >> %[1]s/roachprod.log
   done`,
 					c.LogDir(node, "", 0), // [1]
-					maxWait,               // [2]
+					gracePeriod,           // [2]
 					timedOutMessage,       // [3]
 				)
 			}
@@ -552,7 +552,7 @@ fi`,
 			if wait && strings.Contains(res.CombinedOut, timedOutMessage) {
 				return res, fmt.Errorf(
 					"timed out after %ds waiting for n%d to drain and shutdown",
-					maxWait, node,
+					gracePeriod, node,
 				)
 			}
 
@@ -563,7 +563,7 @@ fi`,
 // Wipe TODO(peter): document
 func (c *SyncedCluster) Wipe(ctx context.Context, l *logger.Logger, preserveCerts bool) error {
 	display := fmt.Sprintf("%s: wiping", c.Name)
-	if err := c.Stop(ctx, l, 9, true /* wait */, 0 /* maxWait */, ""); err != nil {
+	if err := c.Stop(ctx, l, 9, true /* wait */, 0 /* gracePeriod */, ""); err != nil {
 		return err
 	}
 	return c.Parallel(ctx, l, WithNodes(c.Nodes).WithDisplay(display), func(ctx context.Context, node Node) (*RunResultDetails, error) {

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -393,7 +393,8 @@ func (c *SyncedCluster) newSession(
 //
 // When Stop needs to kill a process without other flags, the signal
 // is 9 (SIGKILL) and wait is true. If gracePeriod is non-zero, Stop
-// stops waiting after that approximate number of seconds.
+// stops waiting after that approximate number of seconds, sending a
+// SIGKILL if the process is still running after that time.
 func (c *SyncedCluster) Stop(
 	ctx context.Context,
 	l *logger.Logger,
@@ -481,7 +482,7 @@ func (c *SyncedCluster) kill(
 ) error {
 	const timedOutMessage = "timed out"
 
-	if sig == 9 {
+	if sig == int(unix.SIGKILL) {
 		// `kill -9` without wait is never what a caller wants. See #77334.
 		wait = true
 	}
@@ -549,10 +550,13 @@ fi`,
 				return res, err
 			}
 
-			if wait && strings.Contains(res.CombinedOut, timedOutMessage) {
-				return res, fmt.Errorf(
-					"timed out after %ds waiting for n%d to drain and shutdown",
-					gracePeriod, node,
+			// If the process has not terminated after the grace period,
+			// perform a forceful termination.
+			if wait && sig != int(unix.SIGKILL) && strings.Contains(res.CombinedOut, timedOutMessage) {
+				l.Printf("n%d did not shutdown after %ds, performing a SIGKILL", node, gracePeriod)
+				return res, errors.Wrapf(
+					c.kill(ctx, l, cmdName, display, int(unix.SIGKILL), true, 0, virtualClusterLabel),
+					"failed to forcefully terminate n%d", node,
 				)
 			}
 
@@ -563,7 +567,7 @@ fi`,
 // Wipe TODO(peter): document
 func (c *SyncedCluster) Wipe(ctx context.Context, l *logger.Logger, preserveCerts bool) error {
 	display := fmt.Sprintf("%s: wiping", c.Name)
-	if err := c.Stop(ctx, l, 9, true /* wait */, 0 /* gracePeriod */, ""); err != nil {
+	if err := c.Stop(ctx, l, int(unix.SIGKILL), true /* wait */, 0 /* gracePeriod */, ""); err != nil {
 		return err
 	}
 	return c.Parallel(ctx, l, WithNodes(c.Nodes).WithDisplay(display), func(ctx context.Context, node Node) (*RunResultDetails, error) {

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -66,5 +66,5 @@ func StopServiceForVirtualCluster(
 	}
 
 	label := install.VirtualClusterLabel(stopOpts.VirtualClusterName, stopOpts.SQLInstance)
-	return c.Stop(ctx, l, stopOpts.Sig, stopOpts.Wait, stopOpts.MaxWait, label)
+	return c.Stop(ctx, l, stopOpts.Sig, stopOpts.Wait, stopOpts.GracePeriod, label)
 }

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -881,9 +881,9 @@ type StopOpts struct {
 	// If Wait is set, roachprod waits until the PID disappears (i.e. the
 	// process has terminated).
 	Wait bool // forced to true when Sig == 9
-	// If MaxWait is set, roachprod waits that approximate number of seconds
+	// GracePeriod is the mount of time (in seconds) roachprod will wait
 	// until the PID disappears.
-	MaxWait int
+	GracePeriod int
 
 	// Options that only apply to StopServiceForVirtualCluster
 	VirtualClusterID   int
@@ -894,10 +894,10 @@ type StopOpts struct {
 // DefaultStopOpts returns StopOpts populated with the default values used by Stop.
 func DefaultStopOpts() StopOpts {
 	return StopOpts{
-		ProcessTag: "",
-		Sig:        9,
-		Wait:       false,
-		MaxWait:    0,
+		ProcessTag:  "",
+		Sig:         9,
+		Wait:        false,
+		GracePeriod: 0,
 	}
 }
 
@@ -908,7 +908,7 @@ func Stop(ctx context.Context, l *logger.Logger, clusterName string, opts StopOp
 		return err
 	}
 
-	return c.Stop(ctx, l, opts.Sig, opts.Wait, opts.MaxWait, "")
+	return c.Stop(ctx, l, opts.Sig, opts.Wait, opts.GracePeriod, "")
 }
 
 // Signal sends a signal to nodes in the cluster.
@@ -2800,7 +2800,7 @@ func Deploy(
 	pauseDuration time.Duration,
 	sig int,
 	wait bool,
-	maxWait int,
+	gracePeriod int,
 	secure bool,
 ) error {
 	// Stage supports `workload` as well, so it needs to be excluded here. This
@@ -2829,7 +2829,7 @@ func Deploy(
 	for _, node := range c.TargetNodes() {
 		curNode := []install.Node{node}
 
-		err = c.WithNodes(curNode).Stop(ctx, l, sig, wait, maxWait, "")
+		err = c.WithNodes(curNode).Stop(ctx, l, sig, wait, gracePeriod, "")
 		if err != nil {
 			return err
 		}

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -58,6 +58,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
+	"golang.org/x/sys/unix"
 )
 
 // MalformedClusterNameError is returned when the cluster name passed to Create is invalid.
@@ -882,7 +883,8 @@ type StopOpts struct {
 	// process has terminated).
 	Wait bool // forced to true when Sig == 9
 	// GracePeriod is the mount of time (in seconds) roachprod will wait
-	// until the PID disappears.
+	// until the PID disappears. If the process is not terminated after
+	// that time, a hard stop (SIGKILL) is performed.
 	GracePeriod int
 
 	// Options that only apply to StopServiceForVirtualCluster
@@ -895,7 +897,7 @@ type StopOpts struct {
 func DefaultStopOpts() StopOpts {
 	return StopOpts{
 		ProcessTag:  "",
-		Sig:         9,
+		Sig:         int(unix.SIGKILL),
 		Wait:        false,
 		GracePeriod: 0,
 	}


### PR DESCRIPTION
**roachprod: rename `MaxWait` stop option to `GracePeriod`**
This better mirrors the terminology we use in our documentation:

https://www.cockroachlabs.com/docs/stable/node-shutdown#termination-grace-period

**roachprod: stop forcefully after grace period**
This changes the `Stop` method on roachprod to stop the cockroach
process forcefully if the process does not terminate after the
provided `gracePeriod`. This brings back the behaviour old behaviour
of `StopCockroachGracefullyOnNode` without the need for a custom
function for it.

We adopt this behaviour because it is the documented procedure on the
public documentation, and it's also how process
managers/orchestrators (such as Kubernetes) operate.

Informs: #129103
Informs: #121455

Release note: None