### PR TITLE
kvcoord: log replica order on nearest routing policy

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -70,6 +70,7 @@ go_library(
         "//pkg/util/future",
         "//pkg/util/grpcutil",
         "//pkg/util/hlc",
+        "//pkg/util/humanizeutil",
         "//pkg/util/iterutil",
         "//pkg/util/limit",
         "//pkg/util/log",

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2571,8 +2571,8 @@ func (ds *DistSender) sendToReplicas(
 
 	case kvpb.RoutingPolicy_NEAREST:
 		// Order by latency.
-		log.VEvent(ctx, 2, "routing to nearest replica; leaseholder not required")
 		replicas.OptimizeReplicaOrder(ds.st, ds.nodeIDGetter(), ds.healthFunc, ds.latencyFunc, ds.locality)
+		log.VEventf(ctx, 2, "routing to nearest replica; leaseholder not required order=%v", replicas)
 
 	default:
 		log.Fatalf(ctx, "unknown routing policy: %s", ba.RoutingPolicy)


### PR DESCRIPTION
Previously, we would log an event when routing to the nearest replica,
which would then show up in traces and could be used to determine the
routing policy of a query.

It is also useful to know how the nearest replica was selected i.e.,
latency, locality or by health. Log the event after sorting by the
replicas' distance to the sender and include the replica order.

Informs: https://github.com/cockroachdb/cockroach/issues/129031
Release note: None