### PR TITLE
crosscluster: use src table ID to look up table names

### DIFF
--- a/pkg/ccl/crosscluster/logical/BUILD.bazel
+++ b/pkg/ccl/crosscluster/logical/BUILD.bazel
@@ -113,6 +113,7 @@ go_test(
         "//pkg/ccl/storageccl",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
+        "//pkg/kv",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
         "//pkg/repstream/streampb",

--- a/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
@@ -129,18 +129,20 @@ func newLogicalReplicationWriterProcessor(
 	}
 
 	tableConfigs := make(map[descpb.ID]sqlProcessorTableConfig)
-	tableIDToName := make(map[int32]fullyQualifiedTableName)
-	for tableID, md := range spec.TableMetadata {
+	srcTableIDToDstMeta := make(map[descpb.ID]dstTableMetadata)
+	for dstTableID, md := range spec.TableMetadata {
 		desc := md.SourceDescriptor
-		tableConfigs[descpb.ID(tableID)] = sqlProcessorTableConfig{
+		tableConfigs[descpb.ID(dstTableID)] = sqlProcessorTableConfig{
 			srcDesc: tabledesc.NewBuilder(&desc).BuildImmutableTable(),
 			dstOID:  md.DestinationFunctionOID,
 		}
 
-		tableIDToName[tableID] = fullyQualifiedTableName{
+		srcTableID := desc.GetID()
+		srcTableIDToDstMeta[srcTableID] = dstTableMetadata{
 			database: md.DestinationParentDatabaseName,
 			schema:   md.DestinationParentSchemaName,
 			table:    md.DestinationTableName,
+			tableID:  descpb.ID(dstTableID),
 		}
 	}
 	bhPool := make([]BatchHandler, maxWriterWorkers)
@@ -216,7 +218,7 @@ func newLogicalReplicationWriterProcessor(
 			StreamID:    streampb.StreamID(spec.StreamID),
 			ProcessorID: processorID,
 		},
-		dlqClient: InitDeadLetterQueueClient(dlqDbExec, tableIDToName),
+		dlqClient: InitDeadLetterQueueClient(dlqDbExec, srcTableIDToDstMeta),
 		metrics:   flowCtx.Cfg.JobRegistry.MetricsStruct().JobSpecificMetrics[jobspb.TypeLogicalReplication].(*Metrics),
 	}
 	lrw.purgatory = purgatory{


### PR DESCRIPTION
Changes in this PR:
- Use source table IDs as keys for the map we use to look up fully qualified table names. This fixes the bug where we use destination table IDs as keys and attempt to look up table names with source table IDs.
- Use destination table ID to create dlq table names
- Minor refactoring

Epic: none
Release note: none