### PR TITLE
release-24.1: sql: don't allow VOID parameters for UDFs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_params
+++ b/pkg/sql/logictest/testdata/logic_test/udf_params
@@ -17,6 +17,9 @@ CREATE FUNCTION f(OUT param INT) RETURNS VOID AS $$ SELECT 1; $$ LANGUAGE SQL;
 statement error pgcode 42P13 pq: function result type must be int because of OUT parameters
 CREATE FUNCTION f(OUT param INT) RETURNS RECORD AS $$ SELECT 1; $$ LANGUAGE SQL;
 
+statement error pgcode 42P13 SQL functions cannot have arguments of type VOID
+CREATE FUNCTION f(param VOID) RETURNS UUID LANGUAGE SQL AS $$ SELECT NULL $$;
+
 statement ok
 CREATE FUNCTION f(OUT param INT) RETURNS INT AS $$ SELECT 1; $$ LANGUAGE SQL;
 

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -184,6 +184,11 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 		if param.Class == tree.RoutineParamInOut && param.Name == "" {
 			panic(unimplemented.NewWithIssue(121251, "unnamed INOUT parameters are not yet supported"))
 		}
+		if param.IsInParam() {
+			if typ.Family() == types.VoidFamily {
+				panic(pgerror.Newf(pgcode.InvalidFunctionDefinition, "SQL functions cannot have arguments of type VOID"))
+			}
+		}
 		if param.IsOutParam() {
 			outParamTypes = append(outParamTypes, typ)
 			paramName := string(param.Name)


### PR DESCRIPTION
Backport 1/1 commits from #129179.

/cc @cockroachdb/release

Release justification: bug fix

---

This matches the behavior in Postgres.

fixes https://github.com/cockroachdb/cockroach/issues/129169
fixes https://github.com/cockroachdb/cockroach/issues/128615
Release note (bug fix): Function input parameters can no longer be of the VOID type.
