### PR TITLE
release-23.2: sql: don't allow VOID parameters for UDFs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_regressions
+++ b/pkg/sql/logictest/testdata/logic_test/udf_regressions
@@ -608,3 +608,10 @@ SELECT nextval('s108297')
 2
 
 subtest end
+
+subtest void_parameter
+
+statement error pgcode 42P13 SQL functions cannot have arguments of type VOID
+CREATE FUNCTION f(param VOID) RETURNS UUID LANGUAGE SQL AS $$ SELECT NULL $$;
+
+subtest end

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -162,6 +162,11 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 		if err != nil {
 			panic(err)
 		}
+		if param.Class == tree.RoutineParamIn || param.Class == tree.RoutineParamInOut {
+			if typ.Family() == types.VoidFamily {
+				panic(pgerror.Newf(pgcode.InvalidFunctionDefinition, "SQL functions cannot have arguments of type VOID"))
+			}
+		}
 		// The parameter type must be supported by the current cluster version.
 		checkUnsupportedType(b.ctx, b.semaCtx, typ)
 		if types.IsRecordType(typ) {


### PR DESCRIPTION
Backport 1/1 commits from #129179.

/cc @cockroachdb/release

Release justification: bug fix

---

This matches the behavior in Postgres.

fixes https://github.com/cockroachdb/cockroach/issues/129169
fixes https://github.com/cockroachdb/cockroach/issues/128615
Release note (bug fix): Function input parameters can no longer be of the VOID type.
