### PR TITLE
dev: add temporary directory in sandbox for `compose`

### DIFF
--- a/pkg/cmd/dev/compose.go
+++ b/pkg/cmd/dev/compose.go
@@ -110,6 +110,7 @@ func (d *dev) compose(cmd *cobra.Command, _ []string) error {
 	args = append(args, "--test_output", "all")
 	args = append(args, "--test_env", "COCKROACH_DEV_LICENSE")
 	args = append(args, "--test_env", "COCKROACH_RUN_COMPOSE=true")
+	args = append(args, "--sandbox_add_mount_pair", os.TempDir())
 
 	logCommand("bazel", args...)
 	return d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)


### PR DESCRIPTION
Since `--[no]incompatible_sandbox_hermetic_tmp`'s default flipped to `true` in Bazel 7, `compose` tests broke as we stage the built artifacts in a temporary directory. If this wasn't set in `.bazelrc.user`, it needs to be added here or else the test will fail.

Closes: #128227
Epic: CRDB-17171
Release note: None