### PR TITLE
lease: fix goroutine starvation caused by test cluster setting

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -3674,7 +3674,7 @@ func TestLeaseDescriptorRangeFeedFailure(t *testing.T) {
 						// so the update is detected.
 						if p.Params.ExecutionPhase == scop.PostCommitPhase &&
 							enableAfterStageKnob.Load() &&
-							strings.Contains(p.Statements[0].Statement, "ADD COLUMN") {
+							strings.Contains(p.Statements[0].Statement, "ALTER TABLE t1 ADD COLUMN j INT DEFAULT 64") {
 							rangeFeedResetChan = srv.ApplicationLayer(1).LeaseManager().(*lease.Manager).TestingSetDisableRangeFeedCheckpointFn(true)
 						}
 						return nil
@@ -3684,7 +3684,7 @@ func TestLeaseDescriptorRangeFeedFailure(t *testing.T) {
 						// so the update is detected.
 						if p.Params.ExecutionPhase == scop.PostCommitPhase &&
 							enableAfterStageKnob.Load() &&
-							strings.Contains(p.Statements[0].Statement, "ADD COLUMN") {
+							strings.Contains(p.Statements[0].Statement, "ALTER TABLE t1 ADD COLUMN j INT DEFAULT 64") {
 							<-rangeFeedResetChan
 							srv.ApplicationLayer(1).LeaseManager().(*lease.Manager).TestingSetDisableRangeFeedCheckpointFn(false)
 							enableAfterStageKnob.Swap(false)


### PR DESCRIPTION
When a test overrides sql.catalog.descriptor_lease_duration to 0, then it was possible for the test to starve itself by creating a timer with zero duration that is repeatedly reset.

The bug occurred since after refreshTimer expired, it would call the jitteredLeaseDuration helper to get the new duration for the timer. If a test had overriden sql.catalog.descriptor_lease_duration to 0, this would cause the timer to keep being reset to 0 and starve other goroutines.

fixes https://github.com/cockroachdb/cockroach/issues/129097
fixes https://github.com/cockroachdb/cockroach/issues/129268
Release note: None