### PR TITLE
changefeedccl: add COCKROACH_TEST_TENANT and COCKROACH_TEST_CDC_SINK env vars

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -333,6 +333,7 @@ go_test(
         "//pkg/util/cidr",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",
+        "//pkg/util/envutil",
         "//pkg/util/hlc",
         "//pkg/util/intsets",
         "//pkg/util/ioctx",

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -6486,7 +6486,7 @@ func TestChangefeedHandlesDrainingNodes(t *testing.T) {
 	// We use feedTestUseRootUserConnection to prevent the
 	// feed factory from trying to create a test user. Because the registry is draining, creating the test user
 	// will fail and the test will fail prematurely.
-	f, closeSink := makeFeedFactory(t, randomSinkType(feedTestEnterpriseSinks), tc.Server(1), tc.ServerConn(0),
+	f, closeSink := makeFeedFactory(t, randomSinkType(t, feedTestEnterpriseSinks), tc.Server(1), tc.ServerConn(0),
 		feedTestUseRootUserConnection)
 	defer closeSink()
 
@@ -6821,7 +6821,7 @@ func TestChangefeedTimelyResolvedTimestampUpdatePostRollingRestart(t *testing.T)
 
 	// For validation, the test requires an enterprise feed.
 	feedTestEnterpriseSinks(&opts)
-	sinkType := randomSinkTypeWithOptions(opts)
+	sinkType := randomSinkTypeWithOptions(t, opts)
 	f, closeSink := makeFeedFactoryWithOptions(t, sinkType, tc, tc.ServerConn(0), opts)
 	defer closeSink()
 	// The end time is captured post restart. The changefeed spans from before the
@@ -6925,7 +6925,7 @@ func TestChangefeedPropagatesTerminalError(t *testing.T) {
 			}
 		}()
 
-		sinkType := randomSinkTypeWithOptions(opts)
+		sinkType := randomSinkTypeWithOptions(t, opts)
 		f, closeSink := makeFeedFactoryWithOptions(t, sinkType, tc, tc.ServerConn(coordinatorID), opts)
 		defer closeSink()
 		feed := feed(t, f, "CREATE CHANGEFEED FOR foo")
@@ -8795,7 +8795,7 @@ func TestChangefeedMultiPodTenantPlanning(t *testing.T) {
 	// Ensure both pods can be assigned work
 	waitForTenantPodsActive(t, tenant1Server, 2)
 
-	feedFactory, cleanupSink := makeFeedFactory(t, randomSinkType(feedTestEnterpriseSinks), tenant1Server, tenant1DB)
+	feedFactory, cleanupSink := makeFeedFactory(t, randomSinkType(t, feedTestEnterpriseSinks), tenant1Server, tenant1DB)
 	defer cleanupSink()
 
 	// Run a changefeed across two tables to guarantee multiple spans that can be spread across the aggregators

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
@@ -629,13 +630,25 @@ var withDebugUseAfterFinish feedTestOption = func(opts *feedTestOptions) {
 }
 
 func newTestOptions() feedTestOptions {
-	// percentTenant is the percentage of tests that will be run against
-	// a SQL-node in a multi-tenant server. 1 for all tests to be run on a
-	// tenant.
-	const percentTenant = 0.5
 	return feedTestOptions{
-		useTenant: rand.Float32() < percentTenant,
+		useTenant: shouldUseTenant(),
 	}
+}
+
+func shouldUseTenant() bool {
+	tenantDecision, override := serverutils.TestTenantDecisionFromEnvironment(
+		base.DefaultTestTenantOptions{}, false)
+	if override {
+		if tenantDecision.SharedProcessMode() {
+			panic("shared mode multi-tenancy not supported by this CDC test framework")
+		}
+		return tenantDecision.TestTenantAlwaysEnabled()
+	}
+
+	// percentTenant is the percentage of tests that will be run against
+	// a SQL-node in a multi-tenant server.
+	const percentTenant = 0.5
+	return rand.Float32() < percentTenant
 }
 
 func makeOptions(opts ...feedTestOption) feedTestOptions {
@@ -887,21 +900,40 @@ func makeServerWithOptions(
 	return makeSystemServerWithOptions(t, options)
 }
 
-func randomSinkType(opts ...feedTestOption) string {
+func randomSinkType(t *testing.T, opts ...feedTestOption) string {
 	options := makeOptions(opts...)
-	return randomSinkTypeWithOptions(options)
+	return randomSinkTypeWithOptions(t, options)
 }
 
-func randomSinkTypeWithOptions(options feedTestOptions) string {
-	sinkWeights := map[string]int{
-		"kafka":        3,
-		"enterprise":   1,
-		"webhook":      1,
-		"pubsub":       1,
-		"sinkless":     2,
-		"cloudstorage": 0,
-		"pulsar":       1,
+var defaultSinkWeights = map[string]int{
+	"kafka":        3,
+	"enterprise":   1,
+	"webhook":      1,
+	"pubsub":       1,
+	"sinkless":     2,
+	"cloudstorage": 0,
+	"pulsar":       1,
+}
+
+func sinkTypeFromEnvironment(t *testing.T, sinkWeights map[string]int) (string, bool) {
+	const testSinkEnvVar = "COCKROACH_TEST_CDC_SINK"
+	if str, present := envutil.EnvString(testSinkEnvVar, 0); present {
+		w, ok := sinkWeights[str]
+		if !ok {
+			t.Fatalf("unknown sink specified in environment: %s", str)
+			return "", false
+		}
+		if w == 0 {
+			t.Fatalf("sink %q disabled by test options", str)
+			return "", false
+		}
+		return str, true
 	}
+	return "", false
+}
+
+func sinkWeightsForOptions(options feedTestOptions) map[string]int {
+	sinkWeights := defaultSinkWeights
 	if options.externalIODir != "" {
 		sinkWeights["cloudstorage"] = 3
 	}
@@ -916,6 +948,16 @@ func randomSinkTypeWithOptions(options feedTestOptions) string {
 			sinkWeights[sinkType] = 0
 		}
 	}
+	return sinkWeights
+}
+
+func randomSinkTypeWithOptions(t *testing.T, options feedTestOptions) string {
+	sinkWeights := sinkWeightsForOptions(options)
+	if sinkType, ok := sinkTypeFromEnvironment(t, sinkWeights); ok {
+		t.Logf("sink set by env var: %s", sinkType)
+		return sinkType
+	}
+
 	weightTotal := 0
 	for _, weight := range sinkWeights {
 		weightTotal += weight
@@ -1147,8 +1189,7 @@ func cdcTestNamedWithSystem(
 	options := makeOptions(testOpts...)
 	cleanupCloudStorage := addCloudStorageOptions(t, &options)
 	TestingClearSchemaRegistrySingleton()
-
-	sinkType := randomSinkTypeWithOptions(options)
+	sinkType := randomSinkTypeWithOptions(t, options)
 	if sinkType == "skip" {
 		return
 	}


### PR DESCRIPTION
This makes it a bit easier to stress a particular test failure.

Epic: none
Release note: None