### PR TITLE
roachprod: deploy kill node on timeout

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -72,6 +72,7 @@ var (
 	deploySig             = 15
 	deployWaitFlag        = true
 	deployMaxWait         = 300
+	deployKillOnTimeout   = true
 	pause                 = time.Duration(0)
 	createVMOpts          = vm.DefaultCreateOpts()
 	startOpts             = roachprod.DefaultStartOpts()
@@ -270,6 +271,7 @@ func initFlags() {
 		stopProcessesCmd.Flags().BoolVar(waitPtr, "wait", *waitPtr, "wait for processes to exit")
 		stopProcessesCmd.Flags().IntVar(maxWaitPtr, "max-wait", *maxWaitPtr, "approx number of seconds to wait for processes to exit")
 	}
+	deployCmd.Flags().BoolVar(&deployKillOnTimeout, "kill-on-timeout", deployKillOnTimeout, "instead of failing on timeout, kill the process")
 	deployCmd.Flags().DurationVar(&pause, "pause", pause, "duration to pause between node restarts")
 
 	syncCmd.Flags().BoolVar(&listOpts.IncludeVolumes, "include-volumes", false, "Include volumes when syncing")

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -803,7 +803,7 @@ Currently available application options are:
 			versionArg = args[2]
 		}
 		return roachprod.Deploy(context.Background(), config.Logger, args[0], args[1],
-			versionArg, pause, deploySig, deployWaitFlag, deployMaxWait, secure)
+			versionArg, pause, deploySig, deployWaitFlag, deployMaxWait, deployKillOnTimeout, secure)
 	}),
 }
 


### PR DESCRIPTION
Previously, if draining a node timed out the deploy command would fail. This change adds a new flag (that is true by default), which attempts to kill the node if the graceful stop and drain timed out.

Epic: None
Release note: None