### PR TITLE
sql: simplify outdated UPDATE execution logic

### DIFF
--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -196,7 +196,7 @@ func (r *insertRun) initRowContainer(params runParams, columns colinfo.ResultCol
 // processSourceRow processes one row from the source for insertion and, if
 // result rows are needed, saves it in the result row container.
 func (r *insertRun) processSourceRow(params runParams, rowVals tree.Datums) error {
-	if err := enforceLocalColumnConstraints(rowVals, r.insertCols); err != nil {
+	if err := enforceNotNullConstraints(rowVals, r.insertCols); err != nil {
 		return err
 	}
 

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1523,10 +1523,6 @@ func (ef *execFactory) ConstructUpdate(
 	// since it compiles tuples and subqueries into a simple sequence of target
 	// columns.
 	updateCols := makeColList(table, updateColOrdSet)
-	sourceSlots := make([]sourceSlot, len(updateCols))
-	for i := range sourceSlots {
-		sourceSlots[i] = scalarSlot{column: updateCols[i], sourceIndex: len(fetchCols) + i}
-	}
 
 	// Create the table updater, which does the bulk of the work.
 	internal := ef.planner.SessionData().Internal
@@ -1553,8 +1549,6 @@ func (ef *execFactory) ConstructUpdate(
 		run: updateRun{
 			tu:             tableUpdater{ru: ru},
 			checkOrds:      checks,
-			sourceSlots:    sourceSlots,
-			updateValues:   make(tree.Datums, len(ru.UpdateCols)),
 			numPassthrough: len(passthrough),
 		},
 	}

--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -267,7 +267,7 @@ func (tu *optTableUpserter) updateConflictingRow(
 	//   via GenerateInsertRow().
 	// - for the fetched part, we assume that the data in the table is
 	//   correct already.
-	if err := enforceLocalColumnConstraints(updateValues, tu.updateCols); err != nil {
+	if err := enforceNotNullConstraints(updateValues, tu.updateCols); err != nil {
 		return err
 	}
 

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -138,7 +138,7 @@ func (n *upsertNode) BatchedNext(params runParams) (bool, error) {
 // processSourceRow processes one row from the source for upsertion.
 // The table writer is in charge of accumulating the result rows.
 func (n *upsertNode) processSourceRow(params runParams, rowVals tree.Datums) error {
-	if err := enforceLocalColumnConstraints(rowVals, n.run.insertCols); err != nil {
+	if err := enforceNotNullConstraints(rowVals, n.run.insertCols); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
#### sql: remove computed column logic from heuristic planner

Vestigial logic in the `UPDATE` code path from the days of the heuristic
query planner has been removed. As an added bonus to simplifying the
code, this should reduce some allocations.

Release note: None

#### sql: rename `enforceLocalColumnConstraints`

The `enforceLocalColumnConstraints` function has been renamed to
`enforceNotNullConstraints` to clarify its behavior.

Release note: None

#### sql: remove column mapping during `UPDATE`

New values to write during an `UPDATE` always come directly after the
fetch values in the source row, i.e., the input row of an update
operator, and they are ordered the same as `ru.UpdateCols`. Therefore,
there is no need to map the source values. Instead, the update values
can simply be sliced from the source row.

This commit removes this unnecessary mapping logic and support data
structurres, including the `updateValues` buffer in `updateRun`,
`sourceSlot`, and `scalarSlot`. This simplifies the implementation and
will reduce allocations.

Epic: None

Release note: None
