### PR TITLE
release-24.1: roachtest: update rebalance-load mixed-version tests for shared-process

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_tpcc_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_tpcc_overload.go
@@ -120,7 +120,7 @@ func verifyNodeLiveness(
 	if err := retry.WithMaxAttempts(ctx, retry.Options{
 		MaxBackoff: 500 * time.Millisecond,
 	}, 60, func() (err error) {
-		response, err = getMetrics(ctx, c, t, adminURLs[0], now.Add(-runDuration), now, []tsQuery{
+		response, err = getMetrics(ctx, c, t, adminURLs[0], "", now.Add(-runDuration), now, []tsQuery{
 			{
 				name:      "cr.node.liveness.heartbeatfailures",
 				queryType: total,

--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -160,7 +160,7 @@ func runDiskStalledWALFailover(
 		t.Fatal("process exited unexectedly")
 	}
 
-	data := mustGetMetrics(ctx, c, t, adminURL,
+	data := mustGetMetrics(ctx, c, t, adminURL, install.SystemInterfaceName,
 		workloadStartAt.Add(time.Minute),
 		timeutil.Now().Add(-time.Minute),
 		[]tsQuery{
@@ -309,7 +309,7 @@ func runDiskStalledDetection(
 	}
 
 	stallAt := timeutil.Now()
-	response := mustGetMetrics(ctx, c, t, adminURL, workloadStartAt, stallAt, []tsQuery{
+	response := mustGetMetrics(ctx, c, t, adminURL, install.SystemInterfaceName, workloadStartAt, stallAt, []tsQuery{
 		{name: "cr.node.sql.query.count", queryType: total},
 	})
 	cum := response.Results[0].Datapoints
@@ -361,7 +361,7 @@ func runDiskStalledDetection(
 
 	{
 		now := timeutil.Now()
-		response := mustGetMetrics(ctx, c, t, adminURL, workloadStartAt, now, []tsQuery{
+		response := mustGetMetrics(ctx, c, t, adminURL, install.SystemInterfaceName, workloadStartAt, now, []tsQuery{
 			{name: "cr.node.sql.query.count", queryType: total},
 		})
 		cum := response.Results[0].Datapoints


### PR DESCRIPTION
Backport 1/1 commits from #129117.

/cc @cockroachdb/release

---

In this commit, we update the `rebalance/by-load` mixed-version tests so that they can run on shared-process deployments. As usual, we need to enable some features on tenants before initializing the workload. In addition, we pass the virtual cluster cookie when fetching system metrics.

Informs: #127378

Release note: None

Release justification: test only changes.