### PR TITLE
kv: fix comment on QueryTxnResponse.QueriedTxn

### DIFF
--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -1377,8 +1377,8 @@ message QueryTxnRequest {
 // A QueryTxnResponse is the return value from the QueryTxn() method.
 message QueryTxnResponse {
   ResponseHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
-  // Contains the current state of the queried transaction. If the queried
-  // transaction record does not exist, this will be empty.
+  // Contains the current state of the queried transaction. If a transaction
+  // record is not found, one will be synthesized and returned.
   Transaction queried_txn = 2 [(gogoproto.nullable) = false];
   // txn_record_exists is set if the queried_txn comes from a transaction record
   // read from the database. If not set, then the txn record was "synthesized".

--- a/pkg/kv/kvserver/txnwait/queue.go
+++ b/pkg/kv/kvserver/txnwait/queue.go
@@ -1005,13 +1005,7 @@ func (q *Queue) queryTxnStatus(
 	}
 	br := b.RawResponse()
 	resp := br.Responses[0].GetInner().(*kvpb.QueryTxnResponse)
-	// ID can be nil if no HeartbeatTxn has been sent yet and we're talking to a
-	// 2.1 node.
-	// TODO(nvanbenschoten): Remove this in 2.3.
-	if updatedTxn := &resp.QueriedTxn; updatedTxn.ID != (uuid.UUID{}) {
-		return updatedTxn, resp.WaitingTxns, nil
-	}
-	return nil, nil, nil
+	return &resp.QueriedTxn, resp.WaitingTxns, nil
 }
 
 // forcePushAbort upgrades the PushTxn request to a "forced" push abort, which


### PR DESCRIPTION
This commit fixes a comment in the QueryTxnResponse.QueriedTxn field. It also addresses a related TODO.

Epic: None
Release note: None