### PR TITLE
sql/license: Track start of no-license grace period for new clusters

### DIFF
--- a/pkg/settings/common.go
+++ b/pkg/settings/common.go
@@ -29,6 +29,7 @@ type common struct {
 	nonReportable bool
 	retired       bool
 	sensitive     bool
+	internalOnly  bool
 }
 
 // slotIdx is an integer in the range [0, MaxSetting) which is uniquely
@@ -95,6 +96,11 @@ func (c *common) getSlot() slotIdx {
 // ValueOrigin returns the origin of the current value of the setting.
 func (c *common) ValueOrigin(ctx context.Context, sv *Values) ValueOrigin {
 	return sv.getValueOrigin(ctx, c.slot)
+}
+
+// IsInternal returns true if only internal SQL can modify the setting.
+func (c *common) IsInternal() bool {
+	return c.internalOnly
 }
 
 // setReportable configures the reportability.

--- a/pkg/settings/masked.go
+++ b/pkg/settings/masked.go
@@ -96,6 +96,11 @@ func (s *MaskedSetting) IsUnsafe() bool {
 	return s.setting.IsUnsafe()
 }
 
+// IsInternal returns true if only internal SQL can modify the setting.
+func (s *MaskedSetting) IsInternal() bool {
+	return s.setting.IsInternal()
+}
+
 // TestingIsReportable is used in testing for reportability.
 func TestingIsReportable(s Setting) bool {
 	if _, ok := s.(*MaskedSetting); ok {

--- a/pkg/settings/options.go
+++ b/pkg/settings/options.go
@@ -76,6 +76,14 @@ func WithReportable(reportable bool) SettingOption {
 	}}
 }
 
+// WithInternalOnly will only allow the setting to change by an internal SQL. An
+// attempt to modify using an external user will fail.
+func WithInternalOnly() SettingOption {
+	return SettingOption{commonOpt: func(c *common) {
+		c.internalOnly = true
+	}}
+}
+
 // Retired marks the setting as obsolete. It also hides it from the
 // output of SHOW CLUSTER SETTINGS. Note: in many case the setting
 // definition can be removed outright, and its name added to the

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -88,6 +88,10 @@ type Setting interface {
 
 	// ValueOrigin returns the origin of the current value.
 	ValueOrigin(ctx context.Context, sv *Values) ValueOrigin
+
+	// IsInternal returns true if the setting can only set by internal SQL.
+	// Attempts by external users to modify the setting will fail.
+	IsInternal() bool
 }
 
 // NonMaskedSetting is the exported interface of non-masked settings. A

--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -448,3 +448,21 @@ query B
 SHOW CLUSTER SETTING sql.explain_analyze.include_ru_estimation.enabled FOR TENANT "cluster-10"
 ----
 false
+
+subtest internal_setting
+
+# Verify that the internal setting was applied correctly. Since the value can
+# change from run to run, we'll focus on confirming the presence of the setting
+# in the system table rather than checking its specific value.
+query I
+select count(*) FROM system.settings WHERE NAME = 'server.license_grace_period_start.timestamp';
+----
+1
+
+statement error the cluster setting 'server.license_grace_period_start.timestamp' can only be modified internally
+SET CLUSTER SETTING server.license_grace_period_start.timestamp = now()::INT64;
+
+statement error the cluster setting 'server.license_grace_period_start.timestamp' can only be modified internally
+RESET CLUSTER SETTING server.license_grace_period_start.timestamp;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -475,6 +475,7 @@ AND info NOT LIKE '%sql.defaults%'
 AND info NOT LIKE '%sql.distsql%'
 AND info NOT LIKE '%sql.testing%'
 AND info NOT LIKE '%sql.stats%'
+AND info NOT LIKE '%server.license_grace_period_start.timestamp%'
 ORDER BY "timestamp", info
 ----
 1  {"ApplicationName": "$ internal-optInToDiagnosticsStatReporting", "EventType": "set_cluster_setting", "SettingName": "diagnostics.reporting.enabled", "Statement": "SET CLUSTER SETTING \"diagnostics.reporting.enabled\" = true", "Tag": "SET CLUSTER SETTING", "User": "node", "Value": "true"}
@@ -494,6 +495,7 @@ AND info NOT LIKE '%sql.defaults%'
 AND info NOT LIKE '%sql.distsql%'
 AND info NOT LIKE '%sql.testing%'
 AND info NOT LIKE '%sql.stats%'
+AND info NOT LIKE '%server.license_grace_period_start.timestamp%'
 ORDER BY "timestamp", info
 ----
 1  {"ApplicationName": "$ internal-optInToDiagnosticsStatReporting", "EventType": "set_cluster_setting", "SettingName": "diagnostics.reporting.enabled", "Statement": "SET CLUSTER SETTING \"diagnostics.reporting.enabled\" = true", "Tag": "SET CLUSTER SETTING", "User": "node", "Value": "true"}

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -1304,6 +1304,7 @@ ORDER BY name
 ----
 cluster.secret
 diagnostics.reporting.enabled
+server.license_grace_period_start.timestamp
 sql.crdb_internal.table_row_statistics.as_of_time
 version
 
@@ -1328,6 +1329,9 @@ INSERT INTO system.settings (name, value) VALUES ('somesetting', 'somevalue')
 # Have to exclude kv.range_merge.queue.enabled  (with key name
 # kv.range_merge.queue_enabled) as it is not accessible
 # to tenants.
+#
+# Also, we need to exclude server.license_grace_period_start.timestamp because
+# it's value can change from run to run.
 query TT
 SELECT name, value
 FROM system.settings
@@ -1335,7 +1339,7 @@ WHERE name NOT LIKE 'sql.defaults%'
 AND name NOT LIKE 'sql.distsql%'
 AND name NOT LIKE 'sql.testing%'
 AND name NOT LIKE 'sql.stats%'
-AND name NOT IN ('version', 'cluster.secret', 'kv.range_merge.queue_enabled')
+AND name NOT IN ('version', 'cluster.secret', 'kv.range_merge.queue_enabled', 'server.license_grace_period_start.timestamp')
 ORDER BY name
 ----
 diagnostics.reporting.enabled                      true

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -422,6 +422,11 @@ func writeSettingInternal(
 	interlockInfo unsafeSettingInterlockInfo,
 ) (expectedEncodedValue string, err error) {
 	if err := func() error {
+		if setting.IsInternal() && !user.IsNodeUser() {
+			return pgerror.Newf(pgcode.InsufficientPrivilege,
+				"the cluster setting '%s' can only be modified internally", setting.Name())
+		}
+
 		var reportedValue string
 		if value == nil {
 			// This code is doing work for RESET CLUSTER SETTING.

--- a/pkg/upgrade/upgrades/BUILD.bazel
+++ b/pkg/upgrade/upgrades/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "permanent_ensure_sql_schema_telemetry_schedule.go",
         "permanent_key_visualizer_migration.go",
         "permanent_mvcc_statistics_migration.go",
+        "permanent_no_license_grace_period.go",
         "permanent_sql_stats_ttl.go",
         "permanent_system_activity_update_job.go",
         "permanent_upgrades.go",

--- a/pkg/upgrade/upgrades/permanent_no_license_grace_period.go
+++ b/pkg/upgrade/upgrades/permanent_no_license_grace_period.go
@@ -1,0 +1,65 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package upgrades
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/upgrade"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+var _ = settings.RegisterIntSetting(
+	settings.ApplicationLevel,
+	"server.license_grace_period_start.timestamp",
+	"this marks the start of the license grace period when no license exists. It is set programmatically.",
+	0,
+	settings.WithInternalOnly(),
+)
+
+// setNoLicenseGracePeriodStartTime will record the current time as the starting
+// point for the no-license grace period.
+func setNoLicenseGracePeriodStartTime(
+	ctx context.Context, _ clusterversion.ClusterVersion, deps upgrade.TenantDeps,
+) error {
+	// We record the current time in an internal config setting. This is used by
+	// the license check code to know how long to defer throttling if we are
+	// running without a license installed.
+	//
+	// We only want to set the timestamp once. If it was set in a prior version,
+	// then we preserve the existing value.
+	const lookupStmt = `
+			SELECT 1 FROM system.settings WHERE NAME = 'server.license_grace_period_start.timestamp'
+	`
+	var settingExists bool
+	callback := func(ctx context.Context, t isql.Txn) error {
+		if row, err := t.QueryRow(ctx, "Check if server.license_grace_period_start.timestamp is already set", t.KV(), lookupStmt); err != nil {
+			return err
+		} else {
+			settingExists = row != nil
+		}
+		return nil
+	}
+	if err := deps.DB.Txn(ctx, callback); err != nil {
+		return err
+	}
+	if settingExists {
+		log.Info(ctx, "The no-license grace period is already set.")
+		return nil
+	}
+	_, err := deps.InternalExecutor.Exec(
+		ctx, "set starting time for grace period", nil, /* txn */
+		`SET CLUSTER SETTING server.license_grace_period_start.timestamp = now()::INT64`)
+	return err
+}

--- a/pkg/upgrade/upgrades/permanent_upgrades.go
+++ b/pkg/upgrade/upgrades/permanent_upgrades.go
@@ -76,6 +76,7 @@ func bootstrapCluster(
 		{"create jobs metrics polling job", createJobsMetricsPollingJob},
 		{"create sql activity updater job", createActivityUpdateJobMigration},
 		{"create mvcc stats job", createMVCCStatisticsJob},
+		{"set the start time for the no-license grace period", setNoLicenseGracePeriodStartTime},
 	} {
 		log.Infof(ctx, "executing bootstrap step %q", u.name)
 		if err := u.fn(ctx, cv, deps); err != nil {


### PR DESCRIPTION
This update introduces a new configuration setting to track when the grace period begins for unlicensed servers:
server.license_grace_period_start.timestamp. The setting is programmatically applied and includes a restriction that prevents regular users from modifying it. Only internal SQL can alter this setting, ensuring that the grace period start time cannot be altered.

The new configuration setting is initialized during cluster setup. Changes for migrated clusters will be addressed in a follow-up change.

This update will be backported to versions 23.1, 23.2, 24.1, and 24.2.

Epic: CRDB-39988
Informs: CRDB-40064
Release note: None