### PR TITLE
scjob: treat descriptor not found as permanent job error

### DIFF
--- a/pkg/jobs/errors.go
+++ b/pkg/jobs/errors.go
@@ -30,6 +30,8 @@ var errRetryJobSentinel = errors.New("retriable job error")
 
 // MarkAsRetryJobError marks an error as a retriable job error which
 // indicates that the registry should retry the job.
+// Note that if a job is _not_ in the NonCancelable state, it will _only_ be
+// retried if the error has been marked as a retry job error.
 func MarkAsRetryJobError(err error) error {
 	return errors.Mark(err, errRetryJobSentinel)
 }
@@ -42,8 +44,10 @@ func IsRetryJobError(err error) bool {
 // Registry does not retry a job that fails due to a permanent error.
 var errJobPermanentSentinel = errors.New("permanent job error")
 
-// MarkAsPermanentJobError marks an error as a permanent job error, which indicates
-// Registry to not retry the job when it fails due to this error.
+// MarkAsPermanentJobError marks an error as a permanent job error, which
+// indicates Registry to not retry the job when it fails due to this error.
+// Note that if a job is in the NonCancelable state, it will always be retried
+// _unless_ the error has been marked as permanent job error.
 func MarkAsPermanentJobError(err error) error {
 	return errors.Mark(err, errJobPermanentSentinel)
 }

--- a/pkg/sql/schemachanger/scjob/BUILD.bazel
+++ b/pkg/sql/schemachanger/scjob/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/settings/cluster",
         "//pkg/sql",
+        "//pkg/sql/catalog",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/descmetadata",
         "//pkg/sql/isql",
@@ -25,5 +26,6 @@ go_library(
         "//pkg/sql/schemachanger/scrun",
         "//pkg/util/log",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )


### PR DESCRIPTION
Retrying a schema change after hitting a descriptor not found error just
means the job will keep being unable to find it. We mark them as
permanent now to avoid causing infinite retries.

Note that most errors already cause the schema change job to fail, but
if the job is non-cancelable (which it might be in the PostCommit
phase), then it needs to be marked in order to not be retried.

fixes https://github.com/cockroachdb/cockroach/issues/129332
Release note: None