### PR TITLE
release-24.1: workload/schemachange: add expected error for computed col with FK

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -863,7 +863,11 @@ func (og *operationGenerator) addForeignKeyConstraint(
 	if err != nil {
 		return nil, err
 	}
-	childColumnIsStoredVirtual, err := og.columnIsStoredComputed(ctx, tx, childTable, childColumn.name)
+	childColumnIsStoredComputed, err := og.columnIsStoredComputed(ctx, tx, childTable, childColumn.name)
+	if err != nil {
+		return nil, err
+	}
+	parentColumnIsStoredComputed, err := og.columnIsStoredComputed(ctx, tx, parentTable, parentColumn.name)
 	if err != nil {
 		return nil, err
 	}
@@ -882,11 +886,11 @@ func (og *operationGenerator) addForeignKeyConstraint(
 	}
 
 	stmt := makeOpStmt(OpStmtDDL)
-	stmt.expectedExecErrors.addAll(codesWithConditions{
+	stmt.potentialExecErrors.addAll(codesWithConditions{
 		{code: pgcode.ForeignKeyViolation, condition: !parentColumnHasUniqueConstraint},
 		{code: pgcode.FeatureNotSupported, condition: childColumnIsVirtualComputed},
-		{code: pgcode.FeatureNotSupported, condition: childColumnIsStoredVirtual},
-		{code: pgcode.FeatureNotSupported, condition: parentColumnIsVirtualComputed},
+		{code: pgcode.FeatureNotSupported, condition: childColumnIsStoredComputed},
+		{code: pgcode.FeatureNotSupported, condition: parentColumnIsVirtualComputed || parentColumnIsStoredComputed},
 		{code: pgcode.DuplicateObject, condition: constraintExists},
 		{code: pgcode.DatatypeMismatch, condition: !childColumn.typ.Equivalent(parentColumn.typ)},
 	})


### PR DESCRIPTION
Backport 1/1 commits from #129344.

/cc @cockroachdb/release

Release justification: test only change

---

In fef5968922d we added support for a stored computed column to reference a foreign key. However, this is still not in 24.2 and earlier, so it should be considered an error by the workload.

fixes https://github.com/cockroachdb/cockroach/issues/129303
Release note: None
