### PR TITLE
release-23.2: workload/schemachange: avoid using legacy schema changer for DSC ops

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -192,6 +192,11 @@ func (og *operationGenerator) randOp(
 			}
 		} else {
 			op = opType(og.params.ops.Int())
+			if _, ok := opDeclarativeVersion[op]; ok {
+				// If we're not using the declarative schema changer, then only
+				// generate operations that are not supported in declarative.
+				continue
+			}
 		}
 		og.resetOpState(useDeclarativeSchemaChanger)
 		stmt, err = opFuncs[op](og, ctx, tx)


### PR DESCRIPTION
Backport 1/2 commits from #129099.

/cc @cockroachdb/release

Release justification: test only change

---

This reduces the surface area of what the workload covers, but should
help make it less flaky by testing fewer permutations of operations
under concurrency. This new approach might also be more realistic.

Epic: None
Release note: None
