### PR TITLE
rac2: add token counter and stream metrics 

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "rac2",
     srcs = [
+        "metrics.go",
         "priority.go",
         "range_controller.go",
         "store_stream.go",
@@ -20,7 +21,9 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/buildutil",
+        "//pkg/util/hlc",
         "//pkg/util/log",
+        "//pkg/util/metric",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
@@ -49,6 +52,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/testutils/datapathutils",
         "//pkg/util/admission/admissionpb",
+        "//pkg/util/hlc",
         "//pkg/util/humanizeutil",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/metrics.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/metrics.go
@@ -1,0 +1,181 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rac2
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/redact"
+)
+
+// Aliases to make the code below slightly easier to read.
+const regular, elastic = admissionpb.RegularWorkClass, admissionpb.ElasticWorkClass
+
+var (
+	flowTokensAvailable = metric.Metadata{
+		Name:        "kvflowcontrol.tokens.%s.%s.available",
+		Help:        "Flow %s tokens available for %s requests, across all replication streams",
+		Measurement: "Bytes",
+		Unit:        metric.Unit_BYTES,
+	}
+	flowTokensDeducted = metric.Metadata{
+		Name:        "kvflowcontrol.tokens.%s.%s.deducted",
+		Help:        "Flow %s tokens deducted by %s requests, across all replication streams",
+		Measurement: "Bytes",
+		Unit:        metric.Unit_BYTES,
+	}
+	flowTokensReturned = metric.Metadata{
+		Name:        "kvflowcontrol.tokens.%s.%s.returned",
+		Help:        "Flow %s tokens returned by %s requests, across all replication streams",
+		Measurement: "Bytes",
+		Unit:        metric.Unit_BYTES,
+	}
+	flowTokensUnaccounted = metric.Metadata{
+		Name:        "kvflowcontrol.tokens.%s.%s.unaccounted",
+		Help:        "Flow %s tokens returned by %s requests that were unaccounted for, across all replication streams",
+		Measurement: "Bytes",
+		Unit:        metric.Unit_BYTES,
+	}
+	totalStreamCount = metric.Metadata{
+		Name:        "kvflowcontrol.streams.%s.%s.total_count",
+		Help:        "Total number of %s replication streams for %s requests",
+		Measurement: "Count",
+		Unit:        metric.Unit_COUNT,
+	}
+	blockedStreamCount = metric.Metadata{
+		Name:        "kvflowcontrol.streams.%s.%s.blocked_count",
+		Help:        "Number of %s replication streams with no flow tokens available for %s requests",
+		Measurement: "Count",
+		Unit:        metric.Unit_COUNT,
+	}
+)
+
+// annotateMetricTemplateWithWorkClass uses the given metric template to build
+// one suitable for the specific token type and work class.
+func annotateMetricTemplateWithWorkClassAndType(
+	wc admissionpb.WorkClass, tmpl metric.Metadata, t flowControlMetricType,
+) metric.Metadata {
+	rv := tmpl
+	rv.Name = fmt.Sprintf(tmpl.Name, t, wc)
+	rv.Help = fmt.Sprintf(tmpl.Help, t, wc)
+	return rv
+}
+
+type flowControlMetricType int
+
+const (
+	flowControlEvalMetricType flowControlMetricType = iota
+	flowControlSendMetricType
+	numFlowControlMetricTypes
+)
+
+func (f flowControlMetricType) String() string {
+	return redact.StringWithoutMarkers(f)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (f flowControlMetricType) SafeFormat(p redact.SafePrinter, _ rune) {
+	switch f {
+	case flowControlEvalMetricType:
+		p.SafeString("eval")
+	case flowControlSendMetricType:
+		p.SafeString("send")
+	default:
+		panic("unknown flowControlMetricType")
+	}
+}
+
+type tokenMetrics struct {
+	counterMetrics [numFlowControlMetricTypes]*tokenCounterMetrics
+	streamMetrics  [numFlowControlMetricTypes]*tokenStreamMetrics
+}
+
+func newTokenMetrics() *tokenMetrics {
+	m := &tokenMetrics{}
+	for _, typ := range []flowControlMetricType{
+		flowControlEvalMetricType,
+		flowControlSendMetricType,
+	} {
+		m.counterMetrics[typ] = newTokenCounterMetrics(typ)
+		m.streamMetrics[typ] = newTokenStreamMetrics(typ)
+	}
+	return m
+}
+
+type tokenCounterMetrics struct {
+	deducted    [admissionpb.NumWorkClasses]*metric.Counter
+	returned    [admissionpb.NumWorkClasses]*metric.Counter
+	unaccounted [admissionpb.NumWorkClasses]*metric.Counter
+}
+
+func newTokenCounterMetrics(t flowControlMetricType) *tokenCounterMetrics {
+	m := &tokenCounterMetrics{}
+	for _, wc := range []admissionpb.WorkClass{
+		admissionpb.RegularWorkClass,
+		admissionpb.ElasticWorkClass,
+	} {
+		m.deducted[wc] = metric.NewCounter(
+			annotateMetricTemplateWithWorkClassAndType(wc, flowTokensDeducted, t),
+		)
+		m.returned[wc] = metric.NewCounter(
+			annotateMetricTemplateWithWorkClassAndType(wc, flowTokensReturned, t),
+		)
+		m.unaccounted[wc] = metric.NewCounter(
+			annotateMetricTemplateWithWorkClassAndType(wc, flowTokensUnaccounted, t),
+		)
+	}
+	return m
+}
+
+func (m *tokenCounterMetrics) onTokenAdjustment(adjustment tokensPerWorkClass) {
+	if adjustment.regular < 0 {
+		m.deducted[regular].Inc(-int64(adjustment.regular))
+	} else if adjustment.regular > 0 {
+		m.returned[regular].Inc(int64(adjustment.regular))
+	}
+	if adjustment.elastic < 0 {
+		m.deducted[elastic].Inc(-int64(adjustment.elastic))
+	} else if adjustment.elastic > 0 {
+		m.returned[elastic].Inc(int64(adjustment.elastic))
+	}
+}
+
+func (m *tokenCounterMetrics) onUnaccounted(unaccounted tokensPerWorkClass) {
+	m.unaccounted[regular].Inc(int64(unaccounted.regular))
+	m.unaccounted[elastic].Inc(int64(unaccounted.elastic))
+}
+
+type tokenStreamMetrics struct {
+	count           [admissionpb.NumWorkClasses]*metric.Gauge
+	blockedCount    [admissionpb.NumWorkClasses]*metric.Gauge
+	tokensAvailable [admissionpb.NumWorkClasses]*metric.Gauge
+}
+
+func newTokenStreamMetrics(t flowControlMetricType) *tokenStreamMetrics {
+	m := &tokenStreamMetrics{}
+	for _, wc := range []admissionpb.WorkClass{
+		admissionpb.RegularWorkClass,
+		admissionpb.ElasticWorkClass,
+	} {
+		m.count[wc] = metric.NewGauge(
+			annotateMetricTemplateWithWorkClassAndType(wc, totalStreamCount, t),
+		)
+		m.blockedCount[wc] = metric.NewGauge(
+			annotateMetricTemplateWithWorkClassAndType(wc, blockedStreamCount, t),
+		)
+		m.tokensAvailable[wc] = metric.NewGauge(
+			annotateMetricTemplateWithWorkClassAndType(wc, flowTokensAvailable, t),
+		)
+	}
+	return m
+}

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -219,7 +219,7 @@ type voterStateForWaiters struct {
 	isLeader         bool
 	isLeaseHolder    bool
 	isStateReplicate bool
-	evalTokenCounter TokenCounter
+	evalTokenCounter *tokenCounter
 }
 
 type voterSet []voterStateForWaiters
@@ -456,7 +456,7 @@ type replicaState struct {
 	// is the identity that is used to deduct tokens or wait for tokens to be
 	// positive.
 	stream                             kvflowcontrol.Stream
-	evalTokenCounter, sendTokenCounter TokenCounter
+	evalTokenCounter, sendTokenCounter *tokenCounter
 	desc                               roachpb.ReplicaDescriptor
 
 	sendStream *replicaSendStream

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -370,7 +371,8 @@ func TestRangeController(t *testing.T) {
 	datadriven.Walk(t, datapathutils.TestDataPath(t, "range_controller"), func(t *testing.T, path string) {
 		settings := cluster.MakeTestingClusterSettings()
 		ranges := make(map[roachpb.RangeID]*testingRCRange)
-		ssTokenCounter := NewStreamTokenCounterProvider(settings)
+		ssTokenCounter := NewStreamTokenCounterProvider(settings, hlc.NewClockForTesting(nil))
+
 		// setTokenCounters is used to ensure that we only set the initial token
 		// counts once per counter.
 		setTokenCounters := make(map[kvflowcontrol.Stream]struct{})

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream.go
@@ -22,49 +22,31 @@ import (
 // for a given stream.
 //
 // TODO(kvoli): Add stream deletion upon decommissioning a store.
-// TODO(kvoli): Check mutex performance against syncutil.Map.
 type StreamTokenCounterProvider struct {
-	settings *cluster.Settings
-
-	mu struct {
-		syncutil.Mutex
-		sendCounters, evalCounters map[kvflowcontrol.Stream]TokenCounter
-	}
+	settings                   *cluster.Settings
+	sendCounters, evalCounters syncutil.Map[kvflowcontrol.Stream, tokenCounter]
 }
 
 // NewStreamTokenCounterProvider creates a new StreamTokenCounterProvider.
 func NewStreamTokenCounterProvider(settings *cluster.Settings) *StreamTokenCounterProvider {
-	p := StreamTokenCounterProvider{settings: settings}
-	p.mu.evalCounters = make(map[kvflowcontrol.Stream]TokenCounter)
-	p.mu.sendCounters = make(map[kvflowcontrol.Stream]TokenCounter)
-	return &p
+	return &StreamTokenCounterProvider{settings: settings}
 }
 
 // Eval returns the evaluation token counter for the given stream.
-func (p *StreamTokenCounterProvider) Eval(stream kvflowcontrol.Stream) TokenCounter {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	if t, ok := p.mu.evalCounters[stream]; ok {
+func (p *StreamTokenCounterProvider) Eval(stream kvflowcontrol.Stream) *tokenCounter {
+	if t, ok := p.evalCounters.Load(stream); ok {
 		return t
 	}
-
-	t := newTokenCounter(p.settings)
-	p.mu.evalCounters[stream] = t
+	t, _ := p.evalCounters.LoadOrStore(stream, newTokenCounter(p.settings))
 	return t
 }
 
 // Send returns the send token counter for the given stream.
-func (p *StreamTokenCounterProvider) Send(stream kvflowcontrol.Stream) TokenCounter {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	if t, ok := p.mu.sendCounters[stream]; ok {
+func (p *StreamTokenCounterProvider) Send(stream kvflowcontrol.Stream) *tokenCounter {
+	if t, ok := p.sendCounters.Load(stream); ok {
 		return t
 	}
-
-	t := newTokenCounter(p.settings)
-	p.mu.sendCounters[stream] = t
+	t, _ := p.sendCounters.LoadOrStore(stream, newTokenCounter(p.settings))
 	return t
 }
 
@@ -86,7 +68,7 @@ type SendTokenWatcher interface {
 	// call CancelHandle when tokens are no longer needed, or when the caller is
 	// done.
 	NotifyWhenAvailable(
-		TokenCounter,
+		*tokenCounter,
 		TokenGrantNotification,
 	) SendTokenWatcherHandleID
 	// CancelHandle cancels the given handle, stopping it from being notified

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
@@ -24,12 +26,20 @@ import (
 // TODO(kvoli): Add stream deletion upon decommissioning a store.
 type StreamTokenCounterProvider struct {
 	settings                   *cluster.Settings
+	clock                      *hlc.Clock
+	tokenMetrics               *tokenMetrics
 	sendCounters, evalCounters syncutil.Map[kvflowcontrol.Stream, tokenCounter]
 }
 
 // NewStreamTokenCounterProvider creates a new StreamTokenCounterProvider.
-func NewStreamTokenCounterProvider(settings *cluster.Settings) *StreamTokenCounterProvider {
-	return &StreamTokenCounterProvider{settings: settings}
+func NewStreamTokenCounterProvider(
+	settings *cluster.Settings, clock *hlc.Clock,
+) *StreamTokenCounterProvider {
+	return &StreamTokenCounterProvider{
+		settings:     settings,
+		clock:        clock,
+		tokenMetrics: newTokenMetrics(),
+	}
 }
 
 // Eval returns the evaluation token counter for the given stream.
@@ -37,7 +47,8 @@ func (p *StreamTokenCounterProvider) Eval(stream kvflowcontrol.Stream) *tokenCou
 	if t, ok := p.evalCounters.Load(stream); ok {
 		return t
 	}
-	t, _ := p.evalCounters.LoadOrStore(stream, newTokenCounter(p.settings))
+	t, _ := p.evalCounters.LoadOrStore(stream, newTokenCounter(
+		p.settings, p.clock, p.tokenMetrics.counterMetrics[flowControlEvalMetricType]))
 	return t
 }
 
@@ -46,8 +57,57 @@ func (p *StreamTokenCounterProvider) Send(stream kvflowcontrol.Stream) *tokenCou
 	if t, ok := p.sendCounters.Load(stream); ok {
 		return t
 	}
-	t, _ := p.sendCounters.LoadOrStore(stream, newTokenCounter(p.settings))
+	t, _ := p.sendCounters.LoadOrStore(stream, newTokenCounter(
+		p.settings, p.clock, p.tokenMetrics.counterMetrics[flowControlSendMetricType]))
 	return t
+}
+
+// UpdateMetricGauges updates the gauge token metrics.
+func (p *StreamTokenCounterProvider) UpdateMetricGauges() {
+	var (
+		count           [numFlowControlMetricTypes][admissionpb.NumWorkClasses]int64
+		blockedCount    [numFlowControlMetricTypes][admissionpb.NumWorkClasses]int64
+		tokensAvailable [numFlowControlMetricTypes][admissionpb.NumWorkClasses]int64
+	)
+	now := p.clock.PhysicalTime()
+
+	// First aggregate the metrics across all streams, by (eval|send) types and
+	// (regular|elastic) work classes, then using the aggregate update the
+	// gauges.
+	gaugeUpdateFn := func(metricType flowControlMetricType) func(
+		kvflowcontrol.Stream, *tokenCounter) bool {
+		return func(stream kvflowcontrol.Stream, t *tokenCounter) bool {
+			count[metricType][regular]++
+			count[metricType][elastic]++
+			tokensAvailable[metricType][regular] += int64(t.tokens(regular))
+			tokensAvailable[metricType][elastic] += int64(t.tokens(elastic))
+
+			regularStats, elasticStats := t.GetAndResetStats(now)
+			if regularStats.noTokenDuration > 0 {
+				blockedCount[metricType][regular]++
+			}
+			if elasticStats.noTokenDuration > 0 {
+				blockedCount[metricType][elastic]++
+			}
+			return true
+		}
+	}
+
+	p.evalCounters.Range(gaugeUpdateFn(flowControlEvalMetricType))
+	p.sendCounters.Range(gaugeUpdateFn(flowControlSendMetricType))
+	for _, typ := range []flowControlMetricType{
+		flowControlEvalMetricType,
+		flowControlSendMetricType,
+	} {
+		for _, wc := range []admissionpb.WorkClass{
+			admissionpb.RegularWorkClass,
+			admissionpb.ElasticWorkClass,
+		} {
+			p.tokenMetrics.streamMetrics[typ].count[wc].Update(count[typ][wc])
+			p.tokenMetrics.streamMetrics[typ].blockedCount[wc].Update(blockedCount[typ][wc])
+			p.tokenMetrics.streamMetrics[typ].tokensAvailable[wc].Update(tokensAvailable[typ][wc])
+		}
+	}
 }
 
 // SendTokenWatcherHandleID is a unique identifier for a handle that is

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/token_adjustment
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/token_adjustment
@@ -1,5 +1,20 @@
-init
+init stream=1
 ----
+
+metrics
+----
+kvflowcontrol.streams.eval.regular.total_count  : 1
+kvflowcontrol.streams.eval.regular.blocked_count: 0
+kvflowcontrol.tokens.eval.regular.available     : 16777216
+kvflowcontrol.tokens.eval.regular.deducted      : 0
+kvflowcontrol.tokens.eval.regular.returned      : 0
+kvflowcontrol.tokens.eval.regular.unaccounted   : 0
+kvflowcontrol.streams.eval.elastic.total_count  : 1
+kvflowcontrol.streams.eval.elastic.blocked_count: 0
+kvflowcontrol.tokens.eval.elastic.available     : 8388608
+kvflowcontrol.tokens.eval.elastic.deducted      : 0
+kvflowcontrol.tokens.eval.elastic.returned      : 0
+kvflowcontrol.tokens.eval.elastic.unaccounted   : 0
 
 adjust
 class=regular delta=-1MiB
@@ -36,8 +51,43 @@ history
  +2.0MiB elastic    +10MiB |  +2.0MiB
  +6.0MiB regular    +16MiB |  +8.0MiB
 
-init
+# Despite the elastic stream being unblocked by the time metrics is called, the
+# stream was blocked for a non-zero duration between metric calls so we expect
+# elastic.blocked_count=1.
+metrics
 ----
+kvflowcontrol.streams.eval.regular.total_count  : 1
+kvflowcontrol.streams.eval.regular.blocked_count: 0
+kvflowcontrol.tokens.eval.regular.available     : 16777216
+kvflowcontrol.tokens.eval.regular.deducted      : 16777216
+kvflowcontrol.tokens.eval.regular.returned      : 16777216
+kvflowcontrol.tokens.eval.regular.unaccounted   : 0
+kvflowcontrol.streams.eval.elastic.total_count  : 1
+kvflowcontrol.streams.eval.elastic.blocked_count: 1
+kvflowcontrol.tokens.eval.elastic.available     : 8388608
+kvflowcontrol.tokens.eval.elastic.deducted      : 18874368
+kvflowcontrol.tokens.eval.elastic.returned      : 18874368
+kvflowcontrol.tokens.eval.elastic.unaccounted   : 0
+
+init stream=2
+----
+
+# There should now be two streams in the metrics, double the available tokens
+# for each work class.
+metrics
+----
+kvflowcontrol.streams.eval.regular.total_count  : 2
+kvflowcontrol.streams.eval.regular.blocked_count: 0
+kvflowcontrol.tokens.eval.regular.available     : 33554432
+kvflowcontrol.tokens.eval.regular.deducted      : 16777216
+kvflowcontrol.tokens.eval.regular.returned      : 16777216
+kvflowcontrol.tokens.eval.regular.unaccounted   : 0
+kvflowcontrol.streams.eval.elastic.total_count  : 2
+kvflowcontrol.streams.eval.elastic.blocked_count: 0
+kvflowcontrol.tokens.eval.elastic.available     : 16777216
+kvflowcontrol.tokens.eval.elastic.deducted      : 18874368
+kvflowcontrol.tokens.eval.elastic.returned      : 18874368
+kvflowcontrol.tokens.eval.elastic.unaccounted   : 0
 
 adjust
 class=elastic delta=-7MiB
@@ -47,8 +97,10 @@ class=regular delta=-1MiB
 class=regular delta=-6MiB
 class=regular delta=+6MiB
 class=regular delta=-9MiB
-class=regular delta=+16MiB
+class=regular delta=+17MiB
+class=elastic delta=+1MiB
 ----
+
 
 history
 ----
@@ -62,4 +114,20 @@ history
  -6.0MiB regular   +2.0MiB |  -7.0MiB (elastic blocked)
  +6.0MiB regular   +8.0MiB |  -1.0MiB (elastic blocked)
  -9.0MiB regular   -1.0MiB |   -10MiB (regular and elastic blocked)
-  +16MiB regular    +15MiB |  +6.0MiB
+  +17MiB regular    +16MiB |  +7.0MiB
+ +1.0MiB elastic    +16MiB |  +8.0MiB
+
+metrics
+----
+kvflowcontrol.streams.eval.regular.total_count  : 2
+kvflowcontrol.streams.eval.regular.blocked_count: 1
+kvflowcontrol.tokens.eval.regular.available     : 33554432
+kvflowcontrol.tokens.eval.regular.deducted      : 40894464
+kvflowcontrol.tokens.eval.regular.returned      : 40894464
+kvflowcontrol.tokens.eval.regular.unaccounted   : 0
+kvflowcontrol.streams.eval.elastic.total_count  : 2
+kvflowcontrol.streams.eval.elastic.blocked_count: 1
+kvflowcontrol.tokens.eval.elastic.available     : 16777216
+kvflowcontrol.tokens.eval.elastic.deducted      : 50331648
+kvflowcontrol.tokens.eval.elastic.returned      : 50331648
+kvflowcontrol.tokens.eval.elastic.unaccounted   : 0

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter.go
@@ -14,11 +14,13 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
@@ -80,50 +82,67 @@ type tokenCounterPerWorkClass struct {
 	// needs to schedule the goroutine that got the entry for it to unblock
 	// another.
 	signalCh chan struct{}
+	stats    struct {
+		deltaStats
+		noTokenStartTime time.Time
+	}
+}
+
+type deltaStats struct {
+	noTokenDuration                time.Duration
+	tokensDeducted, tokensReturned kvflowcontrol.Tokens
 }
 
 func makeTokenCounterPerWorkClass(
-	wc admissionpb.WorkClass, limit kvflowcontrol.Tokens,
+	wc admissionpb.WorkClass, limit kvflowcontrol.Tokens, now time.Time,
 ) tokenCounterPerWorkClass {
-	return tokenCounterPerWorkClass{
+	twc := tokenCounterPerWorkClass{
 		wc:       wc,
 		tokens:   limit,
 		limit:    limit,
 		signalCh: make(chan struct{}, 1),
 	}
+	twc.stats.noTokenStartTime = now
+	return twc
 }
 
 // adjustTokensLocked adjusts the tokens for the given work class by delta.
 func (twc *tokenCounterPerWorkClass) adjustTokensLocked(
-	ctx context.Context, delta kvflowcontrol.Tokens,
-) {
-	var unaccounted kvflowcontrol.Tokens
+	ctx context.Context, delta kvflowcontrol.Tokens, now time.Time,
+) (adjustment, unaccounted kvflowcontrol.Tokens) {
 	before := twc.tokens
 	twc.tokens += delta
-
-	if delta <= 0 {
-		// Nothing left to do, since we know tokens didn't increase.
-		return
-	}
-	if twc.tokens > twc.limit {
-		unaccounted = twc.tokens - twc.limit
-		twc.tokens = twc.limit
-	}
-	if before <= 0 && twc.tokens > 0 {
-		twc.signal()
+	if delta > 0 {
+		twc.stats.tokensReturned += delta
+		if twc.tokens > twc.limit {
+			unaccounted = twc.tokens - twc.limit
+			twc.tokens = twc.limit
+		}
+		if before <= 0 && twc.tokens > 0 {
+			twc.signal()
+			twc.stats.noTokenDuration += now.Sub(twc.stats.noTokenStartTime)
+		}
+	} else {
+		twc.stats.tokensDeducted -= delta
+		if before > 0 && twc.tokens <= 0 {
+			twc.stats.noTokenStartTime = now
+		}
 	}
 	if buildutil.CrdbTestBuild && unaccounted != 0 {
 		log.Fatalf(ctx, "unaccounted[%s]=%d delta=%d limit=%d",
 			twc.wc, unaccounted, delta, twc.limit)
 	}
+
+	adjustment = twc.tokens - before
+	return adjustment, unaccounted
 }
 
 func (twc *tokenCounterPerWorkClass) setLimitLocked(
-	ctx context.Context, limit kvflowcontrol.Tokens,
+	ctx context.Context, limit kvflowcontrol.Tokens, now time.Time,
 ) {
 	before := twc.limit
 	twc.limit = limit
-	twc.adjustTokensLocked(ctx, twc.limit-before)
+	twc.adjustTokensLocked(ctx, twc.limit-before, now)
 }
 
 func (twc *tokenCounterPerWorkClass) signal() {
@@ -132,6 +151,18 @@ func (twc *tokenCounterPerWorkClass) signal() {
 	case twc.signalCh <- struct{}{}:
 	default:
 	}
+}
+
+func (twc *tokenCounterPerWorkClass) getAndResetStats(now time.Time) deltaStats {
+	stats := twc.stats.deltaStats
+	if twc.tokens <= 0 {
+		stats.noTokenDuration += now.Sub(twc.stats.noTokenStartTime)
+	}
+	twc.stats.deltaStats = deltaStats{}
+	// Doesn't matter if bwc.tokens is actually > 0 since in that case we won't
+	// use this value.
+	twc.stats.noTokenStartTime = now
+	return stats
 }
 
 type tokensPerWorkClass struct {
@@ -143,6 +174,8 @@ type tokensPerWorkClass struct {
 // returning and waiting for flow tokens.
 type tokenCounter struct {
 	settings *cluster.Settings
+	clock    *hlc.Clock
+	metrics  *tokenCounterMetrics
 
 	mu struct {
 		syncutil.RWMutex
@@ -152,27 +185,34 @@ type tokenCounter struct {
 }
 
 // newTokenCounter creates a new TokenCounter.
-func newTokenCounter(settings *cluster.Settings) *tokenCounter {
+func newTokenCounter(
+	settings *cluster.Settings, clock *hlc.Clock, metrics *tokenCounterMetrics,
+) *tokenCounter {
 	t := &tokenCounter{
 		settings: settings,
+		clock:    clock,
+		metrics:  metrics,
 	}
 	limit := tokensPerWorkClass{
 		regular: kvflowcontrol.Tokens(kvflowcontrol.RegularTokensPerStream.Get(&settings.SV)),
 		elastic: kvflowcontrol.Tokens(kvflowcontrol.ElasticTokensPerStream.Get(&settings.SV)),
 	}
+	now := clock.PhysicalTime()
+
 	t.mu.counters[admissionpb.RegularWorkClass] = makeTokenCounterPerWorkClass(
-		admissionpb.RegularWorkClass, limit.regular)
+		admissionpb.RegularWorkClass, limit.regular, now)
 	t.mu.counters[admissionpb.ElasticWorkClass] = makeTokenCounterPerWorkClass(
-		admissionpb.ElasticWorkClass, limit.elastic)
+		admissionpb.ElasticWorkClass, limit.elastic, now)
 
 	onChangeFunc := func(ctx context.Context) {
+		now := t.clock.PhysicalTime()
 		t.mu.Lock()
 		defer t.mu.Unlock()
 
 		t.mu.counters[admissionpb.RegularWorkClass].setLimitLocked(
-			ctx, kvflowcontrol.Tokens(kvflowcontrol.RegularTokensPerStream.Get(&settings.SV)))
+			ctx, kvflowcontrol.Tokens(kvflowcontrol.RegularTokensPerStream.Get(&settings.SV)), now)
 		t.mu.counters[admissionpb.ElasticWorkClass].setLimitLocked(
-			ctx, kvflowcontrol.Tokens(kvflowcontrol.ElasticTokensPerStream.Get(&settings.SV)))
+			ctx, kvflowcontrol.Tokens(kvflowcontrol.ElasticTokensPerStream.Get(&settings.SV)), now)
 	}
 
 	kvflowcontrol.RegularTokensPerStream.SetOnChange(&settings.SV, onChangeFunc)
@@ -224,6 +264,7 @@ func (t *tokenCounter) TokensAvailable(
 func (t *tokenCounter) TryDeduct(
 	ctx context.Context, wc admissionpb.WorkClass, tokens kvflowcontrol.Tokens,
 ) kvflowcontrol.Tokens {
+	now := t.clock.PhysicalTime()
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -233,7 +274,7 @@ func (t *tokenCounter) TryDeduct(
 	}
 
 	adjust := min(tokensAvailable, tokens)
-	t.adjustLocked(ctx, wc, -adjust)
+	t.adjustLocked(ctx, wc, -adjust, now)
 	return adjust
 }
 
@@ -414,23 +455,38 @@ func WaitForEval(
 func (t *tokenCounter) adjust(
 	ctx context.Context, class admissionpb.WorkClass, delta kvflowcontrol.Tokens,
 ) {
+	now := t.clock.PhysicalTime()
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	t.adjustLocked(ctx, class, delta)
+	t.adjustLocked(ctx, class, delta, now)
 }
 
 func (t *tokenCounter) adjustLocked(
-	ctx context.Context, class admissionpb.WorkClass, delta kvflowcontrol.Tokens,
+	ctx context.Context, class admissionpb.WorkClass, delta kvflowcontrol.Tokens, now time.Time,
 ) {
+	var adjustment, unaccounted tokensPerWorkClass
 	switch class {
 	case admissionpb.RegularWorkClass:
-		t.mu.counters[admissionpb.RegularWorkClass].adjustTokensLocked(ctx, delta)
-		// Regular {deductions,returns} also affect elastic flow tokens.
-		t.mu.counters[admissionpb.ElasticWorkClass].adjustTokensLocked(ctx, delta)
+		adjustment.regular, unaccounted.regular =
+			t.mu.counters[admissionpb.RegularWorkClass].adjustTokensLocked(ctx, delta, now)
+			// Regular {deductions,returns} also affect elastic flow tokens.
+		adjustment.elastic, unaccounted.elastic =
+			t.mu.counters[admissionpb.ElasticWorkClass].adjustTokensLocked(ctx, delta, now)
+
 	case admissionpb.ElasticWorkClass:
 		// Elastic {deductions,returns} only affect elastic flow tokens.
-		t.mu.counters[admissionpb.ElasticWorkClass].adjustTokensLocked(ctx, delta)
+		adjustment.elastic, unaccounted.elastic =
+			t.mu.counters[admissionpb.ElasticWorkClass].adjustTokensLocked(ctx, delta, now)
+	}
+
+	// Adjust metrics if any tokens were actually adjusted or unaccounted for
+	// tokens were detected.
+	if adjustment.regular != 0 || adjustment.elastic != 0 {
+		t.metrics.onTokenAdjustment(adjustment)
+	}
+	if unaccounted.regular != 0 || unaccounted.elastic != 0 {
+		t.metrics.onUnaccounted(unaccounted)
 	}
 }
 
@@ -441,5 +497,16 @@ func (t *tokenCounter) testingSetTokens(
 ) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.mu.counters[wc].adjustTokensLocked(ctx, tokens-t.mu.counters[wc].tokens)
+
+	t.mu.counters[wc].adjustTokensLocked(ctx,
+		tokens-t.mu.counters[wc].tokens, t.clock.PhysicalTime())
+}
+
+func (t *tokenCounter) GetAndResetStats(now time.Time) (regularStats, elasticStats deltaStats) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	regularStats = t.mu.counters[admissionpb.RegularWorkClass].getAndResetStats(now)
+	elasticStats = t.mu.counters[admissionpb.ElasticWorkClass].getAndResetStats(now)
+	return regularStats, elasticStats
 }


### PR DESCRIPTION
This commit introduces metrics related to stream eval tokens and stream
send tokens. Hooking up these metrics to the registry will be in a
subsequent commit.

There are two separate metric structs used:

1. `tokenCounterMetrics`, which only contains counter and is shared
   among all `tokenCounter`s on the same node. Each `tokenCounter`
   updates the shared counters after `adjust` is called.
2. `tokenStreamMetrics`, which is updated periodically by calling
   `UpdateMetricGauges` via the `StreamTokenCounterProvider`, which is
   one per node.

Metrics related to `WaitForEval` (as well as blocked stream logging) are
also deferred to a subsequent commit.

Part of: https://github.com/cockroachdb/cockroach/issues/128031
Release note: None