### PR TITLE
kvserver: kvserver: mark "needs lease, not adding" as benign error

### DIFF
--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -1079,7 +1079,9 @@ func (bq *baseQueue) replicaCanBeProcessed(
 			st := repl.CurrentLeaseStatus(ctx)
 			if st.IsValid() && !st.OwnedBy(repl.StoreID()) {
 				log.VEventf(ctx, 1, "needs lease; not adding: %v", st.Lease)
-				return nil, errors.Newf("needs lease, not adding: %v", st.Lease)
+				// NB: this is an expected error, so make sure it doesn't get
+				// logged loudly.
+				return nil, benignerror.New(errors.Newf("needs lease, not adding: %v", st.Lease))
 			}
 		}
 	}

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -915,7 +915,6 @@ func (bq *baseQueue) processOneAsyncAndReleaseSem(
 	// it is no longer processable, return immediately.
 	if _, err := bq.replicaCanBeProcessed(ctx, repl, false /*acquireLeaseIfNeeded */); err != nil {
 		bq.finishProcessingReplica(ctx, stopper, repl, err)
-		log.Infof(ctx, "%s: skipping %d since replica can't be processed %v", taskName, repl.ReplicaID(), err)
 		<-bq.processSem
 		return
 	}


### PR DESCRIPTION
This prevents it from being logged loudly in `finishProcessingReplica`[^1].
Also downgrade a `log.Infof` with a similar error that was similarly
spurious. Serious (e.g. non-benign) errors are still logged.

[^1]: https://github.com/cockroachdb/cockroach/blob/382eacc3626b7ff2359ab3322b4f85e2e4bca8ea/pkg/kv/kvserver/queue.go#L1204-L1207

Noticed by @dt[^1].

[^1]: https://cockroachlabs.slack.com/archives/C0KB9Q03D/p1724180202398559

Epic: none
Release note (bug fix): a spurious error log from queue.go involving "

