### PR TITLE
release-23.2: ui: use versioned crdb-protobuf-client

### DIFF
--- a/pkg/ui/pnpm-lock.yaml
+++ b/pkg/ui/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
         specifier: ^7.12.13
         version: 7.12.13
       '@cockroachlabs/crdb-protobuf-client':
-        specifier: workspace:../db-console/src/js
+        specifier: 24.2.1
         version: link:../db-console/src/js
       '@cockroachlabs/design-tokens':
         specifier: 0.4.5

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "24.2.0",
+  "version": "24.2.1",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",
@@ -33,7 +33,7 @@
   "dependencies": {
     "@ant-design/icons": "^5.3.6",
     "@babel/runtime": "^7.12.13",
-    "@cockroachlabs/crdb-protobuf-client": "workspace:../db-console/src/js",
+    "@cockroachlabs/crdb-protobuf-client": "24.2.1",
     "@cockroachlabs/design-tokens": "0.4.5",
     "@cockroachlabs/icons": "0.5.2",
     "@cockroachlabs/ui-components": "0.4.3",

--- a/pkg/ui/workspaces/db-console/src/js/package.json
+++ b/pkg/ui/workspaces/db-console/src/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/crdb-protobuf-client",
-  "version": "0.0.12",
+  "version": "24.2.1",
   "description": "Javascript client for use by CockroachDB UI",
   "main": "./protos.js",
   "types": "./protos.d.ts",


### PR DESCRIPTION
Previously `cluster-ui` was using a workspace link to the protobuf client that linked directly to the `src/js` directory in the `db- console` workspace that contained this library.

This made it difficult to import `cluster-ui` elsewhere as it wouldn't be able to find that dependency outside this project structure.

We've separately published a 24.2.1 version of the protobuf library which will enable it to be used outside of this repo.

Release note: None

---
Release justification: non-user-facing change to support `cluster-ui` lib