### PR TITLE
release-23.1: changefeedccl: add more logging around core changefeed completion

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -227,8 +227,14 @@ func changefeedPlanHook(
 			logChangefeedCreateTelemetry(ctx, jr, changefeedStmt.Select != nil)
 
 			var err error
-			for r := getRetry(ctx); r.Next(); {
+			for r := getRetry(ctx); ; {
+				if !r.Next() {
+					log.Infof(ctx, "core changefeed retry loop exiting: %s", ctx.Err())
+					break
+				}
+
 				if err = distChangefeedFlow(ctx, p, 0 /* jobID */, details, progress, resultsCh); err == nil {
+					log.Infof(ctx, "core changefeed completed with no error")
 					return nil
 				}
 


### PR DESCRIPTION
Backport 1/1 commits from #129335.

/cc @cockroachdb/release

---

Epic: CRDB-37337

Release note: None

---

Release justification: adding useful logging
