### PR TITLE
*: update kv teams

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -44,10 +44,6 @@ cockroachdb/kv:
     cockroachdb/kv-prs: other
   triage_column_id: 14242655
   label: T-kv
-cockroachdb/replication:
-  aliases:
-    cockroachdb/repl-prs: other
-  label: T-kv-replication
 cockroachdb/spatial:
   triage_column_id: 9487269
   label: T-spatial

--- a/pkg/cmd/roachtest/registry/filter_test.go
+++ b/pkg/cmd/roachtest/registry/filter_test.go
@@ -22,9 +22,8 @@ import (
 
 func init() {
 	OverrideTeams(team.Map{
-		OwnerCDC.ToTeamAlias():         {},
-		OwnerKV.ToTeamAlias():          {},
-		OwnerReplication.ToTeamAlias(): {},
+		OwnerCDC.ToTeamAlias(): {},
+		OwnerKV.ToTeamAlias():  {},
 	})
 }
 

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -27,7 +27,6 @@ const (
 	OwnerCDC                Owner = `cdc`
 	OwnerDisasterRecovery   Owner = `disaster-recovery`
 	OwnerKV                 Owner = `kv`
-	OwnerReplication        Owner = `replication`
 	OwnerAdmissionControl   Owner = `admission-control`
 	OwnerObservability      Owner = `obs-prs`
 	OwnerObservabilityIndia Owner = `obs-india-prs`

--- a/pkg/cmd/roachtest/registry/testdata/filter/describe
+++ b/pkg/cmd/roachtest/registry/testdata/filter/describe
@@ -24,9 +24,9 @@ describe cloud=gce suite=nightly
 ----
 tests which are compatible with cloud "gce" and are part of the "nightly" suite
 
-describe cloud=local owner=replication benchmarks
+describe cloud=local owner=kv benchmarks
 ----
-benchmarks which are compatible with cloud "local" and have owner "replication"
+benchmarks which are compatible with cloud "local" and have owner "kv"
 
 describe cloud=gce suite=nightly
 foo

--- a/pkg/cmd/roachtest/registry/testdata/filter/errors
+++ b/pkg/cmd/roachtest/registry/testdata/filter/errors
@@ -23,10 +23,6 @@ filter suite=orm
 ----
 error: no tests in suite "orm"
 
-filter owner=replication
-----
-error: no tests with owner "replication"
-
 filter benchmarks
 component_blargle
 ----

--- a/pkg/cmd/roachtest/tests/inconsistency.go
+++ b/pkg/cmd/roachtest/tests/inconsistency.go
@@ -25,7 +25,7 @@ import (
 func registerInconsistency(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "inconsistency",
-		Owner:            registry.OwnerReplication,
+		Owner:            registry.OwnerKV,
 		Cluster:          r.MakeClusterSpec(3),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -438,7 +438,7 @@ func registerKVContention(r registry.Registry) {
 func registerKVQuiescenceDead(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:                "kv/quiescence/nodes=3",
-		Owner:               registry.OwnerReplication,
+		Owner:               registry.OwnerKV,
 		Cluster:             r.MakeClusterSpec(4, spec.WorkloadNode()),
 		CompatibleClouds:    registry.AllExceptAWS,
 		Suites:              registry.Suites(registry.Nightly),

--- a/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
+++ b/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
@@ -71,7 +71,7 @@ func registerLOQRecovery(r registry.Registry) {
 		testSpec := s
 		r.Add(registry.TestSpec{
 			Name:             s.testName(""),
-			Owner:            registry.OwnerReplication,
+			Owner:            registry.OwnerKV,
 			Benchmark:        true,
 			CompatibleClouds: registry.AllExceptAWS,
 			Suites:           registry.Suites(registry.Nightly),
@@ -86,7 +86,7 @@ func registerLOQRecovery(r registry.Registry) {
 		})
 		r.Add(registry.TestSpec{
 			Name:             s.testName("half-online"),
-			Owner:            registry.OwnerReplication,
+			Owner:            registry.OwnerKV,
 			Benchmark:        true,
 			CompatibleClouds: registry.AllExceptAWS,
 			Suites:           registry.Suites(registry.Nightly),

--- a/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
@@ -31,7 +31,7 @@ import (
 func registerChangeReplicasMixedVersion(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "change-replicas/mixed-version",
-		Owner:            registry.OwnerReplication,
+		Owner:            registry.OwnerKV,
 		Cluster:          r.MakeClusterSpec(4),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),

--- a/pkg/cmd/roachtest/tests/replicagc.go
+++ b/pkg/cmd/roachtest/tests/replicagc.go
@@ -31,7 +31,7 @@ func registerReplicaGC(r registry.Registry) {
 	for _, restart := range []bool{true, false} {
 		r.Add(registry.TestSpec{
 			Name:             fmt.Sprintf("replicagc-changed-peers/restart=%t", restart),
-			Owner:            registry.OwnerReplication,
+			Owner:            registry.OwnerKV,
 			Cluster:          r.MakeClusterSpec(6),
 			CompatibleClouds: registry.AllExceptAWS,
 			Suites:           registry.Suites(registry.Nightly),

--- a/pkg/internal/team/TEAMS.yaml
+++ b/pkg/internal/team/TEAMS.yaml
@@ -44,10 +44,6 @@ cockroachdb/kv:
     cockroachdb/kv-prs: other
   triage_column_id: 14242655
   label: T-kv
-cockroachdb/replication:
-  aliases:
-    cockroachdb/repl-prs: other
-  label: T-kv-replication
 cockroachdb/spatial:
   triage_column_id: 9487269
   label: T-spatial


### PR DESCRIPTION
**team: remove replication from teams.yaml**

The `replication` team was merged into `kv`.

Update the `TEAMS.yaml` files (parts `ii` and `iii` from [this doc][1]).

[1]: https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3692167169/Merging+teams+into+KV+-+2024-06#GitHub

---

**roachtest: move replication into kv; remove replication**

The Replication team was merged with KV.

Update the owners of various tests from `OwnerReplication` to `OwnerKV`.

Epic: CRDB-37617.