### PR TITLE
raft: expose the cluster version to Raft

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -416,6 +416,7 @@ func newRaftConfig(
 
 		PreVote:     true,
 		CheckQuorum: storeCfg.RaftEnableCheckQuorum,
+		CRDBVersion: storeCfg.Settings.Version,
 	}
 }
 

--- a/pkg/raft/BUILD.bazel
+++ b/pkg/raft/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/raft",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/raft/confchange",
         "//pkg/raft/quorum",
         "//pkg/raft/raftpb",
@@ -56,6 +57,7 @@ go_test(
         "//pkg/raft/raftstoreliveness",
         "//pkg/raft/rafttest",
         "//pkg/raft/tracker",
+        "//pkg/settings/cluster",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/raft/node_test.go
+++ b/pkg/raft/node_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftstoreliveness"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -474,6 +475,7 @@ func TestNodeStart(t *testing.T) {
 		MaxSizePerMsg:   noLimit,
 		MaxInflightMsgs: 256,
 		StoreLiveness:   raftstoreliveness.AlwaysLive{},
+		CRDBVersion:     cluster.MakeTestingClusterSettings().Version,
 	}
 	StartNode(c, []Peer{{ID: 1}})
 	ctx, cancel, n := newNodeTestHarness(context.Background(), t, c, Peer{ID: 1})
@@ -548,6 +550,7 @@ func TestNodeRestart(t *testing.T) {
 		MaxSizePerMsg:   noLimit,
 		MaxInflightMsgs: 256,
 		StoreLiveness:   raftstoreliveness.AlwaysLive{},
+		CRDBVersion:     cluster.MakeTestingClusterSettings().Version,
 	}
 	n := RestartNode(c)
 	defer n.Stop()
@@ -597,6 +600,7 @@ func TestNodeRestartFromSnapshot(t *testing.T) {
 		MaxSizePerMsg:   noLimit,
 		MaxInflightMsgs: 256,
 		StoreLiveness:   raftstoreliveness.AlwaysLive{},
+		CRDBVersion:     cluster.MakeTestingClusterSettings().Version,
 	}
 	n := RestartNode(c)
 	defer n.Stop()
@@ -621,6 +625,7 @@ func TestNodeAdvance(t *testing.T) {
 		MaxSizePerMsg:   noLimit,
 		MaxInflightMsgs: 256,
 		StoreLiveness:   raftstoreliveness.AlwaysLive{},
+		CRDBVersion:     cluster.MakeTestingClusterSettings().Version,
 	}
 	ctx, cancel, n := newNodeTestHarness(context.Background(), t, c)
 	defer cancel()

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/raft/confchange"
 	"github.com/cockroachdb/cockroach/pkg/raft/quorum"
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
@@ -267,6 +268,10 @@ type Config struct {
 
 	// StoreLiveness is a reference to the store liveness fabric.
 	StoreLiveness raftstoreliveness.StoreLiveness
+
+	// CRDBVersion exposes the active version to Raft. This helps version-gating
+	// features.
+	CRDBVersion clusterversion.Handle
 }
 
 func (c *Config) validate() error {
@@ -408,6 +413,7 @@ type raft struct {
 
 	logger        Logger
 	storeLiveness raftstoreliveness.StoreLiveness
+	crdbVersion   clusterversion.Handle
 }
 
 func newRaft(c *Config) *raft {
@@ -438,6 +444,7 @@ func newRaft(c *Config) *raft {
 		disableConfChangeValidation: c.DisableConfChangeValidation,
 		stepDownOnRemoval:           c.StepDownOnRemoval,
 		storeLiveness:               c.StoreLiveness,
+		crdbVersion:                 c.CRDBVersion,
 	}
 	lastID := r.raftLog.lastEntryID()
 

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -27,6 +27,7 @@ import (
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftstoreliveness"
 	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -3961,6 +3962,7 @@ func newTestConfig(
 		MaxSizePerMsg:   noLimit,
 		MaxInflightMsgs: 256,
 		StoreLiveness:   storeLiveness,
+		CRDBVersion:     cluster.MakeTestingClusterSettings().Version,
 	}
 }
 

--- a/pkg/raft/raftpb/confstate.go
+++ b/pkg/raft/raftpb/confstate.go
@@ -45,3 +45,10 @@ func (cs ConfState) Equivalent(cs2 ConfState) error {
 	}
 	return nil
 }
+
+func (cs ConfState) Describe() string {
+	return fmt.Sprintf(
+		"Voters:%v VotersOutgoing:%v Learners:%v LearnersNext:%v AutoLeave:%v",
+		cs.Voters, cs.VotersOutgoing, cs.Learners, cs.LearnersNext, cs.AutoLeave,
+	)
+}

--- a/pkg/raft/rafttest/BUILD.bazel
+++ b/pkg/raft/rafttest/BUILD.bazel
@@ -34,10 +34,13 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/raft/rafttest",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/raft",
         "//pkg/raft/raftpb",
         "//pkg/raft/raftstoreliveness",
         "//pkg/raft/tracker",
+        "//pkg/roachpb",
+        "//pkg/settings/cluster",
         "//pkg/util/hlc",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/raft/rafttest/interaction_env_handler.go
+++ b/pkg/raft/rafttest/interaction_env_handler.go
@@ -47,7 +47,8 @@ func (env *InteractionEnv) Handle(t *testing.T, d datadriven.TestData) string {
 	case "add-nodes":
 		// Example:
 		//
-		// add-nodes <number-of-nodes-to-add> voters=(1 2 3) learners=(4 5) index=2 content=foo async-storage-writes=true
+		// add-nodes <number-of-nodes-to-add> voters=(1 2 3) learners=(4 5) index=2
+		// content=foo async-storage-writes=true crdb-version=24.3
 		err = env.handleAddNodes(t, d)
 	case "campaign":
 		// Example:

--- a/pkg/raft/rafttest/node.go
+++ b/pkg/raft/rafttest/node.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftstoreliveness"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 )
 
 type node struct {
@@ -54,6 +55,7 @@ func startNode(id raftpb.PeerID, peers []raft.Peer, iface iface) *node {
 		MaxInflightMsgs:           256,
 		MaxUncommittedEntriesSize: 1 << 30,
 		StoreLiveness:             raftstoreliveness.AlwaysLive{},
+		CRDBVersion:               cluster.MakeTestingClusterSettings().Version,
 	}
 	rn := raft.StartNode(c, peers)
 	n := &node{
@@ -145,6 +147,7 @@ func (n *node) restart() {
 		MaxInflightMsgs:           256,
 		MaxUncommittedEntriesSize: 1 << 30,
 		StoreLiveness:             raftstoreliveness.AlwaysLive{},
+		CRDBVersion:               cluster.MakeTestingClusterSettings().Version,
 	}
 	n.Node = raft.RestartNode(c)
 	n.start()

--- a/pkg/raft/util.go
+++ b/pkg/raft/util.go
@@ -97,16 +97,10 @@ func DescribeSoftState(ss SoftState) string {
 	return fmt.Sprintf("State:%s", ss.RaftState)
 }
 
-func DescribeConfState(state pb.ConfState) string {
-	return fmt.Sprintf(
-		"Voters:%v VotersOutgoing:%v Learners:%v LearnersNext:%v AutoLeave:%v",
-		state.Voters, state.VotersOutgoing, state.Learners, state.LearnersNext, state.AutoLeave,
-	)
-}
-
 func DescribeSnapshot(snap pb.Snapshot) string {
 	m := snap.Metadata
-	return fmt.Sprintf("Index:%d Term:%d ConfState:%s", m.Index, m.Term, DescribeConfState(m.ConfState))
+	return fmt.Sprintf("Index:%d Term:%d ConfState:%s",
+		m.Index, m.Term, m.ConfState.Describe())
 }
 
 func DescribeReady(rd Ready, f EntryFormatter) string {

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -75,7 +75,6 @@ go_test(
         "//pkg/keys",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/concurrency/lock",
-        "//pkg/raft",
         "//pkg/raft/confchange",
         "//pkg/raft/quorum",
         "//pkg/raft/raftpb",

--- a/pkg/roachpb/metadata_replicas_test.go
+++ b/pkg/roachpb/metadata_replicas_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/raft/confchange"
 	"github.com/cockroachdb/cockroach/pkg/raft/quorum"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
@@ -188,8 +187,8 @@ func TestReplicaDescriptorsConfState(t *testing.T) {
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
 			r := MakeReplicaSet(test.in)
-			cs := r.ConfState()
-			require.Equal(t, test.out, raft.DescribeConfState(cs))
+			cs := r.ConfState().Describe()
+			require.Equal(t, test.out, cs)
 		})
 	}
 }


### PR DESCRIPTION
This commit exposes the cluster version to Raft, allowing to version-gate features inside Raft.

Also, this commit removes a cyclic dependency between roachpb, raft, and raftpb.

This is very much inspired by #124648

References: #125266

Epic: None

Release note: None