### PR TITLE
release-24.2: roachtest: use spot VM for all tests

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -336,10 +336,9 @@ func (r *testRunner) Run(
 			//  TODO(bhaskar): remove this once we have more usage details
 			//  and more convinced about using spot VMs for all the runs.
 			if roachtestflags.Cloud == spec.GCE &&
-				tests[i].Benchmark &&
 				!tests[i].Suites.Contains(registry.Weekly) &&
 				!tests[i].IsLastFailurePreempt() &&
-				rand.Float64() <= 0.8 {
+				rand.Float64() <= 0.75 {
 				lopt.l.PrintfCtx(ctx, "using spot VMs to run test %s", tests[i].Name)
 				tests[i].Cluster.UseSpotVMs = true
 			}


### PR DESCRIPTION
Backport 1/1 commits from #127896.

/cc @cockroachdb/release

---

Currently, we are using spot VMs only to run benchmark tests. The reason for the low adoption of spot VM is because of the test failures due to VM preemption.
But, with the recent changes, we have better control on VM preemption changes where if there is a test failure due to preemption, the test is run on an on-demand VM the next time.
Also, the current failed tests that are run on spot VM is 148 out of 1093 = 13.5%. If I consider failure out of total tests run is 148 out of 2508 = 5.9%.

So, this PR removes the condition to use spot VMs only for benchmark tests and changes the probability to 75%.

Fixes: #127236
Epic: None
release justification: test eng changes
