### PR TITLE
workflows: disable cockroach-microbench-ci step for pull requests

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -347,6 +347,8 @@ jobs:
         if: always()
   cockroach-microbench-ci:
     runs-on: [ self-hosted, basic_runner_group ]
+    # TODO(sambhav-jain-16): enable this for pull requests also
+    if: ${{ github.event_name == 'push' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/build/github/cockroach-microbench-ci.sh
+++ b/build/github/cockroach-microbench-ci.sh
@@ -44,7 +44,7 @@ bazel test //pkg/sql/tests:tests_test \
   --test_sharding_strategy=disabled \
   --test_arg=-test.cpu --test_arg=1 \
   --test_arg=-test.v \
-  --test_arg=-test.count=4 \
+  --test_arg=-test.count=10 \
   --test_arg=-test.benchmem \
   --crdb_test_off \
   --test_output=all > "$log_output_file_path"


### PR DESCRIPTION
This change disbales the CI step for pull requests but this still runs for push step into the target branch. Also the count of the microbenchmarks are increased to get more robust results.

Epic: none

Release note: None