### PR TITLE
workflows: update trigger for merge queue event

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -1,5 +1,6 @@
 name: GitHub Actions Essential CI
 on:
+  merge_group:
   pull_request:
     types: [opened, reopened, synchronize]
     branches:
@@ -25,7 +26,6 @@ on:
       - "!staging-v23.2*"
   push:
     branches:
-      - "gh-readonly-queue/*"
       - "master"
       - "release-*"
       - "staging-*"


### PR DESCRIPTION
The trigger for the merge queue events for CI was not set up properly. This is the proper way it should be done according to the documentation.

Epic: none
Part of: DEVINF-1127
Release note: None
Release justification: Non-production code changes