### PR TITLE
roachtest: don't run SQL against the draining node

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -540,6 +540,11 @@ func registerKVGracefulDraining(r registry.Registry) {
 			err := WaitFor3XReplication(ctx, t, t.L(), dbs[0])
 			require.NoError(t, err)
 
+			// TODO(baptist): Remove setting once #129427 is addressed.
+			if _, err := dbs[0].ExecContext(ctx, "SET CLUSTER SETTING kv.store_gossip.max_frequency = '0s'"); err != nil {
+				t.Fatalf("failed to disable load based splitting: %v", err)
+			}
+
 			t.Status("initializing workload")
 
 			// Initialize the database with a lot of ranges so that there are

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -566,9 +566,10 @@ func registerKVGracefulDraining(r registry.Registry) {
 			// Three iterations, each iteration has a 3-minute duration.
 			desiredRunDuration := 10 * time.Minute
 			m.Go(func(ctx context.Context) error {
+				// Don't connect to the node we are going to shut down.
 				cmd := fmt.Sprintf(
 					"./cockroach workload run kv --duration=%s --read-percent=50 --follower-read-percent=50 --concurrency=200 --max-rate=%d {pgurl%s}",
-					desiredRunDuration, specifiedQPS, c.CRDBNodes())
+					desiredRunDuration, specifiedQPS, c.Range(1, nodes-1))
 				t.WorkerStatus(cmd)
 				defer func() {
 					t.WorkerStatus("workload command completed")

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -534,6 +534,7 @@ func registerKVGracefulDraining(r registry.Registry) {
 			dbs := make([]*gosql.DB, nodes-1)
 			for i := range dbs {
 				dbs[i] = c.Conn(ctx, t.L(), i+1)
+				defer dbs[i].Close()
 			}
 
 			err := WaitFor3XReplication(ctx, t, t.L(), dbs[0])


### PR DESCRIPTION
After #126506 the test incorrectly included the draining node as part of the nodes the workload were run against. This caused the statistics to be off by a factor of 5/6.

Note there is a separate issue related to the QPS dropping as part of the drain which is a different issue that is masked by this issue.

Epic: none

Fixes: #129027
Fixes: #128439
Fixes: #128168
Fixes: #126986
Fixes: #125731

Release note: None