### PR TITLE
server: make telemetry timestamp atomic

### DIFF
--- a/pkg/ccl/serverccl/diagnosticsccl/reporter_test.go
+++ b/pkg/ccl/serverccl/diagnosticsccl/reporter_test.go
@@ -325,15 +325,15 @@ func TestTelemetry_SuccessfulTelemetryPing(t *testing.T) {
 
 			dr := rt.server.DiagnosticsReporter().(*diagnostics.Reporter)
 
-			before := timeutil.Now()
-			oldTimestamp := dr.LastSuccessfulTelemetryPing
-			require.LessOrEqual(t, dr.LastSuccessfulTelemetryPing, before)
+			before := timeutil.Now().Unix()
+			oldTimestamp := dr.LastSuccessfulTelemetryPing.Load()
+			require.LessOrEqual(t, dr.LastSuccessfulTelemetryPing.Load(), before)
 			dr.ReportDiagnostics(ctx)
 
 			if tc.expectTimestampUpdate {
-				require.GreaterOrEqual(t, dr.LastSuccessfulTelemetryPing, before)
+				require.GreaterOrEqual(t, dr.LastSuccessfulTelemetryPing.Load(), before)
 			} else {
-				require.Equal(t, oldTimestamp, dr.LastSuccessfulTelemetryPing)
+				require.Equal(t, oldTimestamp, dr.LastSuccessfulTelemetryPing.Load())
 			}
 		})
 	}


### PR DESCRIPTION
Since the telemetry send timestamp will be accessed concurrently, we need to make it atomic.

Part of: CRDB-41231
Epic: CRDB-40209
Release note: None