### PR TITLE
release-23.1: roachtest: run unoptimized-query-oracle and costfuzz on a weekly basis

### DIFF
--- a/pkg/cmd/roachtest/tests/costfuzz.go
+++ b/pkg/cmd/roachtest/tests/costfuzz.go
@@ -42,7 +42,7 @@ func registerCostFuzz(r registry.Registry) {
 			RequiresLicense:  true,
 			Cluster:          clusterSpec,
 			CompatibleClouds: registry.AllExceptAWS,
-			Suites:           registry.Suites(registry.Nightly),
+			Suites:           registry.Suites(registry.Weekly),
 			Leases:           registry.MetamorphicLeases,
 			NativeLibs:       registry.LibGEOS,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/unoptimized_query_oracle.go
+++ b/pkg/cmd/roachtest/tests/unoptimized_query_oracle.go
@@ -58,7 +58,7 @@ func registerUnoptimizedQueryOracle(r registry.Registry) {
 				Timeout:          time.Hour * 1,
 				RequiresLicense:  true,
 				CompatibleClouds: registry.AllExceptAWS,
-				Suites:           registry.Suites(registry.Nightly),
+				Suites:           registry.Suites(registry.Weekly),
 				Cluster:          clusterSpec,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runQueryComparison(ctx, t, c, &queryComparisonTest{


### PR DESCRIPTION
Backport 1/1 commits from #129422.

/cc @cockroachdb/release

---

Informs #129043

Release note: None

---

Release justification: Test-only change