### PR TITLE
logical: skip TestLogicalJobResiliency under deadlock

### DIFF
--- a/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
@@ -833,6 +833,7 @@ func TestLogicalJobResiliency(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderRace(t, "multi cluster/node config exhausts hardware")
+	skip.UnderDeadlock(t, "Scattering prior to creating LDR job slows down ingestion")
 
 	clusterArgs := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
@@ -1002,7 +1003,7 @@ func CreateScatteredTable(t *testing.T, db *sqlutils.SQLRunner, numNodes int, db
 	// ranges, so if we write just a few ranges those might all be on a single
 	// server, which will cause the test to flake.
 	numRanges := 50
-	rowsPerRange := 40
+	rowsPerRange := 20
 	db.Exec(t, "INSERT INTO tab (pk) SELECT * FROM generate_series(1, $1)",
 		numRanges*rowsPerRange)
 	db.Exec(t, "ALTER TABLE tab SPLIT AT (SELECT * FROM generate_series($1::INT, $2::INT, $3::INT))",


### PR DESCRIPTION
This test is having issues with LDR under deadlock, probably due to
scattering the table prior to setting up LDR. The other unit tests
are fine due to deadlock because they scatter after creating the stream,
but that's not possible with this test.

Release note: none
Fixes: https://github.com/cockroachdb/cockroach/issues/128972