### PR TITLE
release-24.2: roachprod: stop forcefully after grace period

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -268,7 +268,7 @@ func initFlags() {
 		}
 		stopProcessesCmd.Flags().IntVar(sigPtr, "sig", *sigPtr, "signal to pass to kill")
 		stopProcessesCmd.Flags().BoolVar(waitPtr, "wait", *waitPtr, "wait for processes to exit")
-		stopProcessesCmd.Flags().IntVar(gracePeriodPtr, "grace-period", *gracePeriodPtr, "approx number of seconds to wait for processes to exit")
+		stopProcessesCmd.Flags().IntVar(gracePeriodPtr, "grace-period", *gracePeriodPtr, "approx number of seconds to wait for processes to exit, before a forceful shutdown (SIGKILL) is performed")
 	}
 	deployCmd.Flags().DurationVar(&pause, "pause", pause, "duration to pause between node restarts")
 

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -68,10 +68,10 @@ var (
 	useTreeDist           = true
 	sig                   = 9
 	waitFlag              = false
-	maxWait               = 0
+	gracePeriod           = 0
 	deploySig             = 15
 	deployWaitFlag        = true
-	deployMaxWait         = 300
+	deployGracePeriod     = 300
 	pause                 = time.Duration(0)
 	createVMOpts          = vm.DefaultCreateOpts()
 	startOpts             = roachprod.DefaultStartOpts()
@@ -258,17 +258,17 @@ func initFlags() {
 		// See: https://github.com/spf13/cobra/issues/1398
 		sigPtr := &sig
 		waitPtr := &waitFlag
-		maxWaitPtr := &maxWait
+		gracePeriodPtr := &gracePeriod
 		// deployCmd is a special case, because it is used to stop processes in a
 		// rolling restart, and we want to drain the nodes by default.
 		if stopProcessesCmd == deployCmd {
 			sigPtr = &deploySig
 			waitPtr = &deployWaitFlag
-			maxWaitPtr = &deployMaxWait
+			gracePeriodPtr = &deployGracePeriod
 		}
 		stopProcessesCmd.Flags().IntVar(sigPtr, "sig", *sigPtr, "signal to pass to kill")
 		stopProcessesCmd.Flags().BoolVar(waitPtr, "wait", *waitPtr, "wait for processes to exit")
-		stopProcessesCmd.Flags().IntVar(maxWaitPtr, "max-wait", *maxWaitPtr, "approx number of seconds to wait for processes to exit")
+		stopProcessesCmd.Flags().IntVar(gracePeriodPtr, "grace-period", *gracePeriodPtr, "approx number of seconds to wait for processes to exit")
 	}
 	deployCmd.Flags().DurationVar(&pause, "pause", pause, "duration to pause between node restarts")
 

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -676,7 +676,7 @@ SIGHUP), unless you also configure --max-wait.
 		if sig == 9 /* SIGKILL */ && !cmd.Flags().Changed("wait") {
 			wait = true
 		}
-		stopOpts := roachprod.StopOpts{Wait: wait, MaxWait: maxWait, ProcessTag: tag, Sig: sig}
+		stopOpts := roachprod.StopOpts{Wait: wait, GracePeriod: gracePeriod, ProcessTag: tag, Sig: sig}
 		return roachprod.Stop(context.Background(), config.Logger, args[0], stopOpts)
 	}),
 }
@@ -764,7 +764,7 @@ non-terminating signal (e.g. SIGHUP), unless you also configure --max-wait.
 		}
 		stopOpts := roachprod.StopOpts{
 			Wait:               wait,
-			MaxWait:            maxWait,
+			GracePeriod:        gracePeriod,
 			Sig:                sig,
 			VirtualClusterName: virtualClusterName,
 			SQLInstance:        sqlInstance,
@@ -808,7 +808,7 @@ Currently available application options are:
 			versionArg = args[2]
 		}
 		return roachprod.Deploy(context.Background(), config.Logger, args[0], args[1],
-			versionArg, pause, deploySig, deployWaitFlag, deployMaxWait, secure)
+			versionArg, pause, deploySig, deployWaitFlag, deployGracePeriod, secure)
 	}),
 }
 

--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -70,6 +70,7 @@ go_library(
         "@com_github_slack_go_slack//:slack",
         "@com_github_spf13_cobra//:cobra",
         "@org_golang_x_sync//errgroup",
+        "@org_golang_x_sys//unix",
     ],
 )
 

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2331,7 +2331,7 @@ func (c *clusterImpl) StopE(
 		opts := stopOpts.RoachprodOpts
 		opts.Sig = 10 // SIGUSR1
 		opts.Wait = true
-		opts.MaxWait = 10
+		opts.GracePeriod = 10
 		_ = roachprod.Stop(ctx, l, c.MakeNodes(nodes...), opts)
 	}
 	return errors.Wrap(roachprod.Stop(ctx, l, c.MakeNodes(nodes...), stopOpts.RoachprodOpts), "cluster.StopE")

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1070,27 +1070,6 @@ func (c *clusterImpl) setTest(t test.Test) {
 	c.l = t.L()
 }
 
-// StopCockroachGracefullyOnNode stops a running cockroach instance on the requested
-// node before a version upgrade.
-func (c *clusterImpl) StopCockroachGracefullyOnNode(
-	ctx context.Context, l *logger.Logger, node int,
-) error {
-	// A graceful shutdown is sending SIGTERM to the node, then waiting
-	// some reasonable amount of time, then sending a non-graceful SIGKILL.
-	gracefulOpts := option.DefaultStopOpts()
-	gracefulOpts.RoachprodOpts.Sig = 15 // SIGTERM
-	gracefulOpts.RoachprodOpts.Wait = true
-	gracefulOpts.RoachprodOpts.MaxWait = 60
-	if err := c.StopE(ctx, l, gracefulOpts, c.Node(node)); err != nil {
-		return err
-	}
-
-	// NB: we still call Stop to make sure the process is dead when we
-	// try to restart it (in case it takes longer than `MaxWait` for it
-	// to finish).
-	return c.StopE(ctx, l, option.DefaultStopOpts(), c.Node(node))
-}
-
 // Save marks the cluster as "saved" so that it doesn't get destroyed.
 func (c *clusterImpl) Save(ctx context.Context, msg string, l *logger.Logger) {
 	l.PrintfCtx(ctx, "saving cluster %s for debugging (--debug specified)", c)

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -57,6 +57,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	_ "github.com/lib/pq"
+	"golang.org/x/sys/unix"
 )
 
 func init() {
@@ -2323,16 +2324,15 @@ func (c *clusterImpl) StopE(
 	c.setStatusForClusterOpt("stopping", stopOpts.RoachtestOpts.Worker, nodes...)
 	defer c.clearStatusForClusterOpt(stopOpts.RoachtestOpts.Worker)
 
-	if c.goCoverDir != "" && stopOpts.RoachprodOpts.Sig == 9 /* SIGKILL */ {
-		// If we are trying to collect coverage, we don't want to kill processes;
-		// use SIGUSR1 which dumps coverage data and exits. Note that Cockroach
-		// v23.1 and earlier ignore SIGUSR1, so we still want to send SIGKILL.
+	if c.goCoverDir != "" && stopOpts.RoachprodOpts.Sig == int(unix.SIGKILL) {
+		// If we are trying to collect coverage, we first send a SIGUSR1
+		// which dumps coverage data and exits. Note that Cockroach v23.1
+		// and earlier ignore SIGUSR1, so we still want to send SIGKILL,
+		// and that's the underlying behaviour of `Stop`.
 		l.Printf("coverage mode: first trying to stop using SIGUSR1")
-		opts := stopOpts.RoachprodOpts
-		opts.Sig = 10 // SIGUSR1
-		opts.Wait = true
-		opts.GracePeriod = 10
-		_ = roachprod.Stop(ctx, l, c.MakeNodes(nodes...), opts)
+		stopOpts.RoachprodOpts.Sig = 10 // SIGUSR1
+		stopOpts.RoachprodOpts.Wait = true
+		stopOpts.RoachprodOpts.GracePeriod = 10
 	}
 	return errors.Wrap(roachprod.Stop(ctx, l, c.MakeNodes(nodes...), stopOpts.RoachprodOpts), "cluster.StopE")
 }

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -65,7 +65,6 @@ type Cluster interface {
 	Stop(ctx context.Context, l *logger.Logger, stopOpts option.StopOpts, opts ...option.Option)
 	SignalE(ctx context.Context, l *logger.Logger, sig int, opts ...option.Option) error
 	Signal(ctx context.Context, l *logger.Logger, sig int, opts ...option.Option)
-	StopCockroachGracefullyOnNode(ctx context.Context, l *logger.Logger, node int) error
 	NewMonitor(context.Context, ...option.Option) Monitor
 
 	// Starting virtual clusters.

--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -112,6 +112,18 @@ func DefaultStopOpts() StopOpts {
 	return StopOpts{RoachprodOpts: roachprod.DefaultStopOpts()}
 }
 
+// NewStopOpts returns a StopOpts populated with default values when
+// called with no options. Pass customization functions to change the
+// stop options.
+func NewStopOpts(opts ...StartStopOption) StopOpts {
+	stopOpts := StopOpts{RoachprodOpts: roachprod.DefaultStopOpts()}
+	for _, opt := range opts {
+		opt(&stopOpts)
+	}
+
+	return stopOpts
+}
+
 // StopSharedVirtualClusterOpts creates StopOpts that can be used to
 // stop the shared process virtual cluster with the given name.
 func StopSharedVirtualClusterOpts(virtualClusterName string) StopOpts {
@@ -208,6 +220,18 @@ func NoBackupSchedule(opts interface{}) {
 	switch opts := opts.(type) {
 	case *StartOpts:
 		opts.RoachprodOpts.ScheduleBackups = false
+	}
+}
+
+// Graceful performs a graceful stop of the cockroach process.
+func Graceful(maxWaitSeconds int) func(interface{}) {
+	return func(opts interface{}) {
+		switch opts := opts.(type) {
+		case *StopOpts:
+			opts.RoachprodOpts.Sig = 15 // SIGTERM
+			opts.RoachprodOpts.Wait = true
+			opts.RoachprodOpts.MaxWait = maxWaitSeconds
+		}
 	}
 }
 

--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -224,13 +224,13 @@ func NoBackupSchedule(opts interface{}) {
 }
 
 // Graceful performs a graceful stop of the cockroach process.
-func Graceful(maxWaitSeconds int) func(interface{}) {
+func Graceful(gracePeriodSeconds int) func(interface{}) {
 	return func(opts interface{}) {
 		switch opts := opts.(type) {
 		case *StopOpts:
 			opts.RoachprodOpts.Sig = 15 // SIGTERM
 			opts.RoachprodOpts.Wait = true
-			opts.RoachprodOpts.MaxWait = maxWaitSeconds
+			opts.RoachprodOpts.GracePeriod = gracePeriodSeconds
 		}
 	}
 }

--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -356,6 +356,8 @@ func RestartNodesWithNewBinary(
 	newVersion *Version,
 	settings ...install.ClusterSettingOption,
 ) error {
+	const maxWait = 300 // 5 minutes
+
 	// NB: We could technically stage the binary on all nodes before
 	// restarting each one, but on Unix it's invalid to write to an
 	// executable file while it is currently running. So we do the
@@ -376,7 +378,9 @@ func RestartNodesWithNewBinary(
 		// this upgraded node for DistSQL plans (see #87154 for more details).
 		// TODO(yuzefovich): ideally, we would also check that the drain was
 		// successful since if it wasn't, then we might see flakes too.
-		if err := c.StopCockroachGracefullyOnNode(ctx, l, node); err != nil {
+		if err := c.StopE(
+			ctx, l, option.NewStopOpts(option.Graceful(maxWait)), c.Node(node),
+		); err != nil {
 			return err
 		}
 

--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -356,7 +356,7 @@ func RestartNodesWithNewBinary(
 	newVersion *Version,
 	settings ...install.ClusterSettingOption,
 ) error {
-	const maxWait = 300 // 5 minutes
+	const gracePeriod = 300 // 5 minutes
 
 	// NB: We could technically stage the binary on all nodes before
 	// restarting each one, but on Unix it's invalid to write to an
@@ -379,7 +379,7 @@ func RestartNodesWithNewBinary(
 		// TODO(yuzefovich): ideally, we would also check that the drain was
 		// successful since if it wasn't, then we might see flakes too.
 		if err := c.StopE(
-			ctx, l, option.NewStopOpts(option.Graceful(maxWait)), c.Node(node),
+			ctx, l, option.NewStopOpts(option.Graceful(gracePeriod)), c.Node(node),
 		); err != nil {
 			return err
 		}

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -37,6 +37,10 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// shudownMaxWait is the default maximum duration (in seconds) that we
+// will wait for a graceful shutdown.
+const shutdownMaxWait = 300
+
 func registerDecommission(r registry.Registry) {
 	{
 		numNodes := 4
@@ -296,6 +300,8 @@ func runDecommission(
 		})
 	}
 
+	stopOpts := option.NewStopOpts(option.Graceful(shutdownMaxWait))
+
 	m.Go(func() error {
 		tBegin, whileDown := timeutil.Now(), true
 		node := nodes
@@ -321,7 +327,7 @@ func runDecommission(
 			}
 
 			if whileDown {
-				if err := c.StopCockroachGracefullyOnNode(ctx, t.L(), node); err != nil {
+				if err := c.StopE(ctx, t.L(), stopOpts, c.Node(node)); err != nil {
 					return err
 				}
 			}
@@ -346,7 +352,7 @@ func runDecommission(
 			}
 
 			if !whileDown {
-				if err := c.StopCockroachGracefullyOnNode(ctx, t.L(), node); err != nil {
+				if err := c.StopE(ctx, t.L(), stopOpts, c.Node(node)); err != nil {
 					return err
 				}
 			}

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -37,9 +37,9 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// shudownMaxWait is the default maximum duration (in seconds) that we
+// shudownGracePeriod is the default grace period (in seconds) that we
 // will wait for a graceful shutdown.
-const shutdownMaxWait = 300
+const shutdownGracePeriod = 300
 
 func registerDecommission(r registry.Registry) {
 	{
@@ -300,7 +300,7 @@ func runDecommission(
 		})
 	}
 
-	stopOpts := option.NewStopOpts(option.Graceful(shutdownMaxWait))
+	stopOpts := option.NewStopOpts(option.Graceful(shutdownGracePeriod))
 
 	m.Go(func() error {
 		tBegin, whileDown := timeutil.Now(), true

--- a/pkg/cmd/roachtest/tests/decommissionbench.go
+++ b/pkg/cmd/roachtest/tests/decommissionbench.go
@@ -884,7 +884,7 @@ func runSingleDecommission(
 	// stuck with replicas in purgatory, by pinning them to a node.
 
 	// We stop nodes gracefully when needed.
-	stopOpts := option.NewStopOpts(option.Graceful(shutdownMaxWait))
+	stopOpts := option.NewStopOpts(option.Graceful(shutdownGracePeriod))
 
 	// Gather metadata for logging purposes and wait for balance.
 	var bytesUsed, rangeCount, totalRanges int64

--- a/pkg/cmd/roachtest/tests/decommissionbench.go
+++ b/pkg/cmd/roachtest/tests/decommissionbench.go
@@ -883,6 +883,9 @@ func runSingleDecommission(
 	// TODO(sarkesian): Consider adding a future test for decommissions that get
 	// stuck with replicas in purgatory, by pinning them to a node.
 
+	// We stop nodes gracefully when needed.
+	stopOpts := option.NewStopOpts(option.Graceful(shutdownMaxWait))
+
 	// Gather metadata for logging purposes and wait for balance.
 	var bytesUsed, rangeCount, totalRanges int64
 	var candidateStores, avgBytesPerReplica int64
@@ -939,7 +942,7 @@ func runSingleDecommission(
 
 	if stopFirst {
 		h.t.Status(fmt.Sprintf("gracefully stopping node%d", target))
-		if err := h.c.StopCockroachGracefullyOnNode(ctx, h.t.L(), target); err != nil {
+		if err := h.c.StopE(ctx, h.t.L(), stopOpts, c.Node(target)); err != nil {
 			return err
 		}
 		// Wait after stopping the node to distinguish the impact of the node being
@@ -997,7 +1000,7 @@ func runSingleDecommission(
 	if reuse {
 		if !stopFirst {
 			h.t.Status(fmt.Sprintf("gracefully stopping node%d", target))
-			if err := h.c.StopCockroachGracefullyOnNode(ctx, h.t.L(), target); err != nil {
+			if err := h.c.StopE(ctx, h.t.L(), stopOpts, c.Node(target)); err != nil {
 				return err
 			}
 		}

--- a/pkg/cmd/roachtest/tests/encryption.go
+++ b/pkg/cmd/roachtest/tests/encryption.go
@@ -85,7 +85,7 @@ func registerEncryption(r registry.Registry) {
 			}
 
 			for i := 1; i <= nodes; i++ {
-				c.Stop(ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownMaxWait)), c.Node(i))
+				c.Stop(ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownGracePeriod)), c.Node(i))
 			}
 		}
 	}

--- a/pkg/cmd/roachtest/tests/encryption.go
+++ b/pkg/cmd/roachtest/tests/encryption.go
@@ -85,9 +85,7 @@ func registerEncryption(r registry.Registry) {
 			}
 
 			for i := 1; i <= nodes; i++ {
-				if err := c.StopCockroachGracefullyOnNode(ctx, t.L(), i); err != nil {
-					t.Fatal(err)
-				}
+				c.Stop(ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownMaxWait)), c.Node(i))
 			}
 		}
 	}

--- a/pkg/cmd/roachtest/tests/jobs_util.go
+++ b/pkg/cmd/roachtest/tests/jobs_util.go
@@ -152,7 +152,7 @@ func executeNodeShutdown(
 	} else {
 		t.L().Printf(`stopping node gracefully %s`, target)
 		if err := c.StopE(
-			ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownMaxWait)), c.Node(cfg.shutdownNode),
+			ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownGracePeriod)), c.Node(cfg.shutdownNode),
 		); err != nil {
 			return errors.Wrapf(err, "could not stop node %s", target)
 		}

--- a/pkg/cmd/roachtest/tests/jobs_util.go
+++ b/pkg/cmd/roachtest/tests/jobs_util.go
@@ -151,7 +151,9 @@ func executeNodeShutdown(
 		}
 	} else {
 		t.L().Printf(`stopping node gracefully %s`, target)
-		if err := c.StopCockroachGracefullyOnNode(ctx, t.L(), cfg.shutdownNode); err != nil {
+		if err := c.StopE(
+			ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownMaxWait)), c.Node(cfg.shutdownNode),
+		); err != nil {
 			return errors.Wrapf(err, "could not stop node %s", target)
 		}
 	}

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -495,13 +495,9 @@ func registerKVQuiescenceDead(r registry.Registry) {
 			})
 			// Graceful shut down third node.
 			m.ExpectDeath()
-			if err := c.StopE(
+			c.Stop(
 				ctx, t.L(), option.NewStopOpts(option.Graceful(30)), c.Node(len(c.CRDBNodes())),
-			); err != nil {
-				t.L().Printf("graceful shutdown failed: %v", err)
-				// If graceful shutdown fails within 30 seconds, proceed with hard shutdown.
-				c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(len(c.CRDBNodes())))
-			}
+			)
 			// Measure qps with node down (i.e. without quiescence).
 			qpsOneDown := qps(func() {
 				// Use a different seed to make sure it's not just stepping into the

--- a/pkg/cmd/roachtest/tests/multi_region_system_database.go
+++ b/pkg/cmd/roachtest/tests/multi_region_system_database.go
@@ -67,7 +67,7 @@ func registerMultiRegionSystemDatabase(r registry.Registry) {
 			// Perform rolling restart to propagate region information to non-primary nodes
 			for i := 2; i <= nodes; i++ {
 				t.WorkerStatus("stop")
-				c.Stop(ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownMaxWait)), c.Node(i))
+				c.Stop(ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownGracePeriod)), c.Node(i))
 				t.WorkerStatus("start")
 				startOpts := option.DefaultStartOpts()
 				c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SecureOption(false)), c.Node(i))

--- a/pkg/cmd/roachtest/tests/multi_region_system_database.go
+++ b/pkg/cmd/roachtest/tests/multi_region_system_database.go
@@ -67,10 +67,7 @@ func registerMultiRegionSystemDatabase(r registry.Registry) {
 			// Perform rolling restart to propagate region information to non-primary nodes
 			for i := 2; i <= nodes; i++ {
 				t.WorkerStatus("stop")
-				err := c.StopCockroachGracefullyOnNode(ctx, t.L(), i)
-				if err != nil {
-					return
-				}
+				c.Stop(ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownMaxWait)), c.Node(i))
 				t.WorkerStatus("start")
 				startOpts := option.DefaultStartOpts()
 				c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SecureOption(false)), c.Node(i))

--- a/pkg/roachprod/install/BUILD.bazel
+++ b/pkg/roachprod/install/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@org_golang_x_exp//maps",
         "@org_golang_x_sync//errgroup",
+        "@org_golang_x_sys//unix",
     ],
 )
 

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -391,14 +391,14 @@ func (c *SyncedCluster) newSession(
 // for shared-process configurations.)
 //
 // When Stop needs to kill a process without other flags, the signal
-// is 9 (SIGKILL) and wait is true. If maxWait is non-zero, Stop stops
-// waiting after that approximate number of seconds.
+// is 9 (SIGKILL) and wait is true. If gracePeriod is non-zero, Stop
+// stops waiting after that approximate number of seconds.
 func (c *SyncedCluster) Stop(
 	ctx context.Context,
 	l *logger.Logger,
 	sig int,
 	wait bool,
-	maxWait int,
+	gracePeriod int,
 	virtualClusterLabel string,
 ) error {
 	// virtualClusterDisplay includes information about the virtual
@@ -442,7 +442,7 @@ func (c *SyncedCluster) Stop(
 		if wait {
 			display += " and waiting"
 		}
-		return c.kill(ctx, l, "stop", display, sig, wait, maxWait, virtualClusterLabel)
+		return c.kill(ctx, l, "stop", display, sig, wait, gracePeriod, virtualClusterLabel)
 	} else {
 		cmd := fmt.Sprintf("ALTER TENANT '%s' STOP SERVICE", virtualClusterName)
 		res, err := c.ExecSQL(ctx, l, c.Nodes[:1], "", 0, DefaultAuthMode(), "", /* database */
@@ -462,20 +462,20 @@ func (c *SyncedCluster) Stop(
 // Signal sends a signal to the CockroachDB process.
 func (c *SyncedCluster) Signal(ctx context.Context, l *logger.Logger, sig int) error {
 	display := fmt.Sprintf("%s: sending signal %d", c.Name, sig)
-	return c.kill(ctx, l, "signal", display, sig, false /* wait */, 0 /* maxWait */, "")
+	return c.kill(ctx, l, "signal", display, sig, false /* wait */, 0 /* gracePeriod */, "")
 }
 
 // kill sends the signal sig to all nodes in the cluster using the kill command.
 // cmdName and display specify the roachprod subcommand and a status message,
 // for output/logging. If wait is true, the command will wait for the processes
-// to exit, up to maxWait seconds.
+// to exit, up to gracePeriod seconds.
 func (c *SyncedCluster) kill(
 	ctx context.Context,
 	l *logger.Logger,
 	cmdName, display string,
 	sig int,
 	wait bool,
-	maxWait int,
+	gracePeriod int,
 	virtualClusterLabel string,
 ) error {
 	const timedOutMessage = "timed out"
@@ -507,7 +507,7 @@ func (c *SyncedCluster) kill(
     echo "${pid}: dead" >> %[1]s/roachprod.log
   done`,
 					c.LogDir(node, "", 0), // [1]
-					maxWait,               // [2]
+					gracePeriod,           // [2]
 					timedOutMessage,       // [3]
 				)
 			}
@@ -551,7 +551,7 @@ fi`,
 			if wait && strings.Contains(res.CombinedOut, timedOutMessage) {
 				return res, fmt.Errorf(
 					"timed out after %ds waiting for n%d to drain and shutdown",
-					maxWait, node,
+					gracePeriod, node,
 				)
 			}
 
@@ -562,7 +562,7 @@ fi`,
 // Wipe TODO(peter): document
 func (c *SyncedCluster) Wipe(ctx context.Context, l *logger.Logger, preserveCerts bool) error {
 	display := fmt.Sprintf("%s: wiping", c.Name)
-	if err := c.Stop(ctx, l, 9, true /* wait */, 0 /* maxWait */, ""); err != nil {
+	if err := c.Stop(ctx, l, 9, true /* wait */, 0 /* gracePeriod */, ""); err != nil {
 		return err
 	}
 	return c.Parallel(ctx, l, WithNodes(c.Nodes).WithDisplay(display), func(ctx context.Context, node Node) (*RunResultDetails, error) {

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -478,6 +478,8 @@ func (c *SyncedCluster) kill(
 	maxWait int,
 	virtualClusterLabel string,
 ) error {
+	const timedOutMessage = "timed out"
+
 	if sig == 9 {
 		// `kill -9` without wait is never what a caller wants. See #77334.
 		wait = true
@@ -493,6 +495,7 @@ func (c *SyncedCluster) kill(
     while kill -0 ${pid}; do
       if [ %[2]d -gt 0 -a $waitcnt -gt %[2]d ]; then
          echo "${pid}: max %[2]d attempts reached, aborting wait" >>%[1]s/roachprod.log
+         echo "%[3]s"
          break
       fi
       kill -0 ${pid} >> %[1]s/roachprod.log 2>&1
@@ -505,6 +508,7 @@ func (c *SyncedCluster) kill(
   done`,
 					c.LogDir(node, "", 0), // [1]
 					maxWait,               // [2]
+					timedOutMessage,       // [3]
 				)
 			}
 
@@ -539,7 +543,19 @@ fi`,
 				waitCmd,                   // [6]
 			)
 
-			return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("kill"))
+			res, err := c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("kill"))
+			if err != nil {
+				return res, err
+			}
+
+			if wait && strings.Contains(res.CombinedOut, timedOutMessage) {
+				return res, fmt.Errorf(
+					"timed out after %ds waiting for n%d to drain and shutdown",
+					maxWait, node,
+				)
+			}
+
+			return res, nil
 		})
 }
 

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -66,5 +66,5 @@ func StopServiceForVirtualCluster(
 	}
 
 	label := install.VirtualClusterLabel(stopOpts.VirtualClusterName, stopOpts.SQLInstance)
-	return c.Stop(ctx, l, stopOpts.Sig, stopOpts.Wait, stopOpts.MaxWait, label)
+	return c.Stop(ctx, l, stopOpts.Sig, stopOpts.Wait, stopOpts.GracePeriod, label)
 }

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -871,9 +871,9 @@ type StopOpts struct {
 	// If Wait is set, roachprod waits until the PID disappears (i.e. the
 	// process has terminated).
 	Wait bool // forced to true when Sig == 9
-	// If MaxWait is set, roachprod waits that approximate number of seconds
+	// GracePeriod is the mount of time (in seconds) roachprod will wait
 	// until the PID disappears.
-	MaxWait int
+	GracePeriod int
 
 	// Options that only apply to StopServiceForVirtualCluster
 	VirtualClusterID   int
@@ -884,10 +884,10 @@ type StopOpts struct {
 // DefaultStopOpts returns StopOpts populated with the default values used by Stop.
 func DefaultStopOpts() StopOpts {
 	return StopOpts{
-		ProcessTag: "",
-		Sig:        9,
-		Wait:       false,
-		MaxWait:    0,
+		ProcessTag:  "",
+		Sig:         9,
+		Wait:        false,
+		GracePeriod: 0,
 	}
 }
 
@@ -898,7 +898,7 @@ func Stop(ctx context.Context, l *logger.Logger, clusterName string, opts StopOp
 		return err
 	}
 
-	return c.Stop(ctx, l, opts.Sig, opts.Wait, opts.MaxWait, "")
+	return c.Stop(ctx, l, opts.Sig, opts.Wait, opts.GracePeriod, "")
 }
 
 // Signal sends a signal to nodes in the cluster.
@@ -2698,7 +2698,7 @@ func Deploy(
 	pauseDuration time.Duration,
 	sig int,
 	wait bool,
-	maxWait int,
+	gracePeriod int,
 	secure bool,
 ) error {
 	// Stage supports `workload` as well, so it needs to be excluded here. This
@@ -2727,7 +2727,7 @@ func Deploy(
 	for _, node := range c.TargetNodes() {
 		curNode := []install.Node{node}
 
-		err = c.WithNodes(curNode).Stop(ctx, l, sig, wait, maxWait, "")
+		err = c.WithNodes(curNode).Stop(ctx, l, sig, wait, gracePeriod, "")
 		if err != nil {
 			return err
 		}

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -872,7 +872,8 @@ type StopOpts struct {
 	// process has terminated).
 	Wait bool // forced to true when Sig == 9
 	// GracePeriod is the mount of time (in seconds) roachprod will wait
-	// until the PID disappears.
+	// until the PID disappears. If the process is not terminated after
+	// that time, a hard stop (SIGKILL) is performed.
 	GracePeriod int
 
 	// Options that only apply to StopServiceForVirtualCluster
@@ -885,7 +886,7 @@ type StopOpts struct {
 func DefaultStopOpts() StopOpts {
 	return StopOpts{
 		ProcessTag:  "",
-		Sig:         9,
+		Sig:         int(unix.SIGKILL),
 		Wait:        false,
 		GracePeriod: 0,
 	}


### PR DESCRIPTION
Backport:
  * 1/1 commits from "roachtest: make graceful stop an option instead of a function" (#128849)
  * 2/2 commits from "roachprod: stop forcefully after grace period" (#129259)

Please see individual PRs for details.

/cc @cockroachdb/release

Epic: None

Release note: None

Release justification: test only changes.