### PR TITLE
changefeedccl: only update pts if behind checkpoint

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/testfeed.go
+++ b/pkg/ccl/changefeedccl/cdctest/testfeed.go
@@ -84,6 +84,8 @@ type EnterpriseTestFeed interface {
 	FetchRunningStatus() (string, error)
 	// Details returns changefeed details for this feed.
 	Details() (*jobspb.ChangefeedDetails, error)
+	// Progress returns the changefeed progress for this feed.
+	Progress() (*jobspb.ChangefeedProgress, error)
 	// HighWaterMark returns feed highwatermark.
 	HighWaterMark() (hlc.Timestamp, error)
 	// TickHighWaterMark waits until job highwatermark progresses beyond specified threshold.

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1714,10 +1714,10 @@ func (cf *changeFrontier) manageProtectedTimestamps(
 	ctx context.Context, txn isql.Txn, progress *jobspb.ChangefeedProgress,
 ) error {
 	ptsUpdateInterval := changefeedbase.ProtectTimestampInterval.Get(&cf.FlowCtx.Cfg.Settings.SV)
+	ptsUpdateLag := changefeedbase.ProtectTimestampLag.Get(&cf.FlowCtx.Cfg.Settings.SV)
 	if timeutil.Since(cf.lastProtectedTimestampUpdate) < ptsUpdateInterval {
 		return nil
 	}
-	cf.lastProtectedTimestampUpdate = timeutil.Now()
 
 	pts := cf.FlowCtx.Cfg.ProtectedTimestampProvider.WithTxn(txn)
 
@@ -1732,10 +1732,9 @@ func (cf *changeFrontier) manageProtectedTimestamps(
 			ctx, cf.FlowCtx.Codec(), cf.spec.JobID, AllTargets(cf.spec.Feed), highWater,
 		)
 		progress.ProtectedTimestampRecord = ptr.ID.GetUUID()
+		cf.lastProtectedTimestampUpdate = timeutil.Now()
 		return pts.Protect(ctx, ptr)
 	}
-
-	log.VEventf(ctx, 2, "updating protected timestamp %v at %v", progress.ProtectedTimestampRecord, highWater)
 
 	rec, err := pts.GetRecord(ctx, progress.ProtectedTimestampRecord)
 	if err != nil {
@@ -1743,6 +1742,16 @@ func (cf *changeFrontier) manageProtectedTimestamps(
 	}
 
 	if rec.Target != nil {
+		// Only update the PTS timestamp if it is lagging behind the high
+		// watermark. This is to prevent a rush of updates to the PTS if the
+		// changefeed restarts, which can cause contention and second order effects
+		// on system tables.
+		if !rec.Timestamp.AddDuration(ptsUpdateLag).Less(highWater) {
+			return nil
+		}
+
+		log.VEventf(ctx, 2, "updating protected timestamp %v at %v", progress.ProtectedTimestampRecord, highWater)
+		cf.lastProtectedTimestampUpdate = timeutil.Now()
 		return pts.UpdateTimestamp(ctx, progress.ProtectedTimestampRecord, highWater)
 	}
 
@@ -1766,6 +1775,7 @@ func (cf *changeFrontier) manageProtectedTimestamps(
 			progress.ProtectedTimestampRecord, prevRecordId, highWater)
 	}
 
+	cf.lastProtectedTimestampUpdate = timeutil.Now()
 	return nil
 }
 

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -9426,3 +9426,74 @@ func TestChangefeedAvroDecimalColumnWithDiff(t *testing.T) {
 
 	cdcTest(t, testFn, feedTestForceSink("kafka"))
 }
+
+func TestChangefeedProtectedTimestampUpdate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		// Checkpoint and trigger potential protected timestamp updates frequently.
+		// Make the protected timestamp lag long enough that it shouldn't be
+		// immediately updated after a restart.
+		changefeedbase.FrontierCheckpointFrequency.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 10*time.Millisecond)
+		changefeedbase.ProtectTimestampInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 10*time.Millisecond)
+		changefeedbase.ProtectTimestampLag.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 10*time.Hour)
+
+		sqlDB.Exec(t, `CREATE TABLE foo (id INT)`)
+
+		createStmt := `CREATE CHANGEFEED FOR foo WITH resolved='10ms', no_initial_scan`
+		testFeed := feed(t, f, createStmt)
+		defer closeFeed(t, testFeed)
+
+		eFeed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+		require.True(t, ok)
+
+		// Wait for the changefeed to checkpoint.
+		var lastHWM hlc.Timestamp
+		checkHWM := func() error {
+			hwm, err := eFeed.HighWaterMark()
+			if err == nil && !hwm.IsEmpty() && lastHWM.Less(hwm) {
+				lastHWM = hwm
+				return nil
+			}
+			return errors.New("waiting for high watermark to advance")
+		}
+		testutils.SucceedsSoon(t, checkHWM)
+
+		// Get the PTS of this feed.
+		p, err := eFeed.Progress()
+		require.NoError(t, err)
+
+		ptsQry := fmt.Sprintf(`SELECT ts FROM system.protected_ts_records WHERE id = '%s'`, p.ProtectedTimestampRecord)
+		var ts, ts2 string
+		sqlDB.QueryRow(t, ptsQry).Scan(&ts)
+		require.NoError(t, err)
+
+		// Force the changefeed to restart.
+		require.NoError(t, eFeed.Pause())
+		require.NoError(t, eFeed.Resume())
+
+		// Wait for a new checkpoint.
+		testutils.SucceedsSoon(t, checkHWM)
+
+		// Check that the PTS was not updated after the resume.
+		sqlDB.QueryRow(t, ptsQry).Scan(&ts2)
+		require.NoError(t, err)
+		require.Equal(t, ts, ts2)
+
+		// Lower the PTS lag and check that it has been updated.
+		changefeedbase.ProtectTimestampLag.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 10*time.Millisecond)
+
+		testutils.SucceedsSoon(t, checkHWM)
+
+		sqlDB.QueryRow(t, ptsQry).Scan(&ts2)
+		require.NoError(t, err)
+		require.Less(t, ts, ts2)
+	}
+
+	cdcTest(t, testFn, feedTestForceSink("kafka"))
+}

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -203,6 +203,14 @@ var ProtectTimestampInterval = settings.RegisterDurationSetting(
 	settings.PositiveDuration,
 	settings.WithPublic)
 
+// ProtectTimestampLag controls how much the protected timestamp record should lag behind the high watermark
+var ProtectTimestampLag = settings.RegisterDurationSetting(
+	settings.ApplicationLevel,
+	"changefeed.protect_timestamp.lag",
+	"controls how far behind the checkpoint the changefeed's protected timestamp is",
+	10*time.Minute,
+	settings.PositiveDuration)
+
 // MaxProtectedTimestampAge controls the frequency of protected timestamp record updates
 var MaxProtectedTimestampAge = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,

--- a/pkg/ccl/changefeedccl/protected_timestamps_test.go
+++ b/pkg/ccl/changefeedccl/protected_timestamps_test.go
@@ -61,6 +61,8 @@ func TestChangefeedUpdateProtectedTimestamp(t *testing.T) {
 		ptsInterval := 50 * time.Millisecond
 		changefeedbase.ProtectTimestampInterval.Override(
 			context.Background(), &s.Server.ClusterSettings().SV, ptsInterval)
+		changefeedbase.ProtectTimestampLag.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, ptsInterval)
 
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
 		sysDB := sqlutils.MakeSQLRunner(s.SystemServer.SQLConn(t))
@@ -254,6 +256,8 @@ func TestChangefeedProtectedTimestamps(t *testing.T) {
 			Scan(&tableID)
 
 		changefeedbase.ProtectTimestampInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, 100*time.Millisecond)
+		changefeedbase.ProtectTimestampLag.Override(
 			context.Background(), &s.Server.ClusterSettings().SV, 100*time.Millisecond)
 
 		ptp := s.Server.DistSQLServer().(*distsql.ServerImpl).ServerConfig.ProtectedTimestampProvider
@@ -501,6 +505,8 @@ func TestChangefeedMigratesProtectedTimestamps(t *testing.T) {
 
 		ptsInterval := 50 * time.Millisecond
 		changefeedbase.ProtectTimestampInterval.Override(
+			context.Background(), &s.Server.ClusterSettings().SV, ptsInterval)
+		changefeedbase.ProtectTimestampLag.Override(
 			context.Background(), &s.Server.ClusterSettings().SV, ptsInterval)
 
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -493,6 +493,19 @@ func (f *jobFeed) Details() (*jobspb.ChangefeedDetails, error) {
 	return payload.GetChangefeed(), nil
 }
 
+// Progress implements FeedJob interface.
+func (f *jobFeed) Progress() (*jobspb.ChangefeedProgress, error) {
+	var details []byte
+	if err := f.db.QueryRow(jobutils.JobProgressByIDQuery, f.jobID).Scan(&details); err != nil {
+		return nil, errors.Wrapf(err, "Progress for job %d", f.jobID)
+	}
+	var progress jobspb.Progress
+	if err := protoutil.Unmarshal(details, &progress); err != nil {
+		return nil, err
+	}
+	return progress.GetChangefeed(), nil
+}
+
 // HighWaterMark implements FeedJob interface.
 func (f *jobFeed) HighWaterMark() (hlc.Timestamp, error) {
 	var details []byte


### PR DESCRIPTION
A changefeed updates its PTS if a checkpoint happens and the time interval changefeed.protect_timestamp_interval has passed. However, whenever the changefeed restarts the interval is lost. Previously, we would conservatively update the PTS, but this could lead to overwhelming the PTS and other system tables.

This PR introduces a cluster setting `changefeed.protect_timestamp.lag`, which controls how much the changefeed PTS should lag behind the high watermark. Before updating the PTS, the changefeed reads the PTS record and if the old PTS is within `changefeed.protect_timestamp.lag` it skips updating the PTS record. If more than `changefeed.protect_timestamp.lag` has passed between the old PTS and the high watermark, the PTS is updated.

Epic: None
Fixes: #129509

Release note (enterprise change): Only update the PTS if `changefeed.protect_timestamp.lag` has passed between the last PTS and the changefeed high watermark.