### PR TITLE
release-23.2: roachprod: stop forcefully after grace period

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -213,7 +213,7 @@ func initFlags() {
 	for _, stopProcessesCmd := range []*cobra.Command{stopCmd, stopInstanceCmd} {
 		stopProcessesCmd.Flags().IntVar(&sig, "sig", sig, "signal to pass to kill")
 		stopProcessesCmd.Flags().BoolVar(&waitFlag, "wait", waitFlag, "wait for processes to exit")
-		stopProcessesCmd.Flags().IntVar(&gracePeriod, "grace-period", gracePeriod, "approx number of seconds to wait for processes to exit")
+		stopProcessesCmd.Flags().IntVar(&gracePeriod, "grace-period", gracePeriod, "approx number of seconds to wait for processes to exit, before a forceful shutdown (SIGKILL) is performed")
 	}
 
 	syncCmd.Flags().BoolVar(&listOpts.IncludeVolumes, "include-volumes", false, "Include volumes when syncing")

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -60,7 +60,7 @@ var (
 	useTreeDist           = true
 	sig                   = 9
 	waitFlag              = false
-	maxWait               = 0
+	gracePeriod           = 0
 	createVMOpts          = vm.DefaultCreateOpts()
 	startOpts             = roachprod.DefaultStartOpts()
 	stageOS               string
@@ -213,7 +213,7 @@ func initFlags() {
 	for _, stopProcessesCmd := range []*cobra.Command{stopCmd, stopInstanceCmd} {
 		stopProcessesCmd.Flags().IntVar(&sig, "sig", sig, "signal to pass to kill")
 		stopProcessesCmd.Flags().BoolVar(&waitFlag, "wait", waitFlag, "wait for processes to exit")
-		stopProcessesCmd.Flags().IntVar(&maxWait, "max-wait", maxWait, "approx number of seconds to wait for processes to exit")
+		stopProcessesCmd.Flags().IntVar(&gracePeriod, "grace-period", gracePeriod, "approx number of seconds to wait for processes to exit")
 	}
 
 	syncCmd.Flags().BoolVar(&listOpts.IncludeVolumes, "include-volumes", false, "Include volumes when syncing")

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -524,7 +524,7 @@ SIGHUP), unless you also configure --max-wait.
 		if sig == 9 /* SIGKILL */ && !cmd.Flags().Changed("wait") {
 			wait = true
 		}
-		stopOpts := roachprod.StopOpts{Wait: wait, MaxWait: maxWait, ProcessTag: tag, Sig: sig}
+		stopOpts := roachprod.StopOpts{Wait: wait, GracePeriod: gracePeriod, ProcessTag: tag, Sig: sig}
 		return roachprod.Stop(context.Background(), config.Logger, args[0], stopOpts)
 	}),
 }
@@ -613,7 +613,7 @@ non-terminating signal (e.g. SIGHUP), unless you also configure --max-wait.
 		}
 		stopOpts := roachprod.StopOpts{
 			Wait:               wait,
-			MaxWait:            maxWait,
+			GracePeriod:        gracePeriod,
 			Sig:                sig,
 			VirtualClusterName: virtualClusterName,
 			SQLInstance:        sqlInstance,

--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -62,6 +62,7 @@ go_library(
         "@com_github_slack_go_slack//:slack",
         "@com_github_spf13_cobra//:cobra",
         "@org_golang_x_sync//errgroup",
+        "@org_golang_x_sys//unix",
     ],
 )
 

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -54,6 +54,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	_ "github.com/lib/pq"
+	"golang.org/x/sys/unix"
 )
 
 func init() {
@@ -2233,16 +2234,15 @@ func (c *clusterImpl) StopE(
 	c.setStatusForClusterOpt("stopping", stopOpts.RoachtestOpts.Worker, nodes...)
 	defer c.clearStatusForClusterOpt(stopOpts.RoachtestOpts.Worker)
 
-	if c.goCoverDir != "" && stopOpts.RoachprodOpts.Sig == 9 /* SIGKILL */ {
-		// If we are trying to collect coverage, we don't want to kill processes;
-		// use SIGUSR1 which dumps coverage data and exits. Note that Cockroach
-		// v23.1 and earlier ignore SIGUSR1, so we still want to send SIGKILL.
+	if c.goCoverDir != "" && stopOpts.RoachprodOpts.Sig == int(unix.SIGKILL) {
+		// If we are trying to collect coverage, we first send a SIGUSR1
+		// which dumps coverage data and exits. Note that Cockroach v23.1
+		// and earlier ignore SIGUSR1, so we still want to send SIGKILL,
+		// and that's the underlying behaviour of `Stop`.
 		l.Printf("coverage mode: first trying to stop using SIGUSR1")
-		opts := stopOpts.RoachprodOpts
-		opts.Sig = 10 // SIGUSR1
-		opts.Wait = true
-		opts.GracePeriod = 10
-		_ = roachprod.Stop(ctx, l, c.MakeNodes(nodes...), opts)
+		stopOpts.RoachprodOpts.Sig = 10 // SIGUSR1
+		stopOpts.RoachprodOpts.Wait = true
+		stopOpts.RoachprodOpts.GracePeriod = 10
 	}
 	return errors.Wrap(roachprod.Stop(ctx, l, c.MakeNodes(nodes...), stopOpts.RoachprodOpts), "cluster.StopE")
 }

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1050,27 +1050,6 @@ func (c *clusterImpl) setTest(t test.Test) {
 	c.l = t.L()
 }
 
-// StopCockroachGracefullyOnNode stops a running cockroach instance on the requested
-// node before a version upgrade.
-func (c *clusterImpl) StopCockroachGracefullyOnNode(
-	ctx context.Context, l *logger.Logger, node int,
-) error {
-	// A graceful shutdown is sending SIGTERM to the node, then waiting
-	// some reasonable amount of time, then sending a non-graceful SIGKILL.
-	gracefulOpts := option.DefaultStopOpts()
-	gracefulOpts.RoachprodOpts.Sig = 15 // SIGTERM
-	gracefulOpts.RoachprodOpts.Wait = true
-	gracefulOpts.RoachprodOpts.MaxWait = 60
-	if err := c.StopE(ctx, l, gracefulOpts, c.Node(node)); err != nil {
-		return err
-	}
-
-	// NB: we still call Stop to make sure the process is dead when we
-	// try to restart it (in case it takes longer than `MaxWait` for it
-	// to finish).
-	return c.StopE(ctx, l, option.DefaultStopOpts(), c.Node(node))
-}
-
 // Save marks the cluster as "saved" so that it doesn't get destroyed.
 func (c *clusterImpl) Save(ctx context.Context, msg string, l *logger.Logger) {
 	l.PrintfCtx(ctx, "saving cluster %s for debugging (--debug specified)", c)

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2241,7 +2241,7 @@ func (c *clusterImpl) StopE(
 		opts := stopOpts.RoachprodOpts
 		opts.Sig = 10 // SIGUSR1
 		opts.Wait = true
-		opts.MaxWait = 10
+		opts.GracePeriod = 10
 		_ = roachprod.Stop(ctx, l, c.MakeNodes(nodes...), opts)
 	}
 	return errors.Wrap(roachprod.Stop(ctx, l, c.MakeNodes(nodes...), stopOpts.RoachprodOpts), "cluster.StopE")

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -62,7 +62,6 @@ type Cluster interface {
 	Stop(ctx context.Context, l *logger.Logger, stopOpts option.StopOpts, opts ...option.Option)
 	SignalE(ctx context.Context, l *logger.Logger, sig int, opts ...option.Option) error
 	Signal(ctx context.Context, l *logger.Logger, sig int, opts ...option.Option)
-	StopCockroachGracefullyOnNode(ctx context.Context, l *logger.Logger, node int) error
 	NewMonitor(context.Context, ...option.Option) Monitor
 
 	// Starting virtual clusters.

--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -224,13 +224,13 @@ func NoBackupSchedule(opts interface{}) {
 }
 
 // Graceful performs a graceful stop of the cockroach process.
-func Graceful(maxWaitSeconds int) func(interface{}) {
+func Graceful(gracePeriodSeconds int) func(interface{}) {
 	return func(opts interface{}) {
 		switch opts := opts.(type) {
 		case *StopOpts:
 			opts.RoachprodOpts.Sig = 15 // SIGTERM
 			opts.RoachprodOpts.Wait = true
-			opts.RoachprodOpts.MaxWait = maxWaitSeconds
+			opts.RoachprodOpts.GracePeriod = gracePeriodSeconds
 		}
 	}
 }

--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -112,6 +112,18 @@ func DefaultStopOpts() StopOpts {
 	return StopOpts{RoachprodOpts: roachprod.DefaultStopOpts()}
 }
 
+// NewStopOpts returns a StopOpts populated with default values when
+// called with no options. Pass customization functions to change the
+// stop options.
+func NewStopOpts(opts ...StartStopOption) StopOpts {
+	stopOpts := StopOpts{RoachprodOpts: roachprod.DefaultStopOpts()}
+	for _, opt := range opts {
+		opt(&stopOpts)
+	}
+
+	return stopOpts
+}
+
 // StopSharedVirtualClusterOpts creates StopOpts that can be used to
 // stop the shared process virtual cluster with the given name.
 func StopSharedVirtualClusterOpts(virtualClusterName string) StopOpts {
@@ -208,5 +220,17 @@ func NoBackupSchedule(opts interface{}) {
 	switch opts := opts.(type) {
 	case *StartOpts:
 		opts.RoachprodOpts.ScheduleBackups = false
+	}
+}
+
+// Graceful performs a graceful stop of the cockroach process.
+func Graceful(maxWaitSeconds int) func(interface{}) {
+	return func(opts interface{}) {
+		switch opts := opts.(type) {
+		case *StopOpts:
+			opts.RoachprodOpts.Sig = 15 // SIGTERM
+			opts.RoachprodOpts.Wait = true
+			opts.RoachprodOpts.MaxWait = maxWaitSeconds
+		}
 	}
 }

--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -356,6 +356,8 @@ func RestartNodesWithNewBinary(
 	newVersion *Version,
 	settings ...install.ClusterSettingOption,
 ) error {
+	const maxWait = 300 // 5 minutes
+
 	// NB: We could technically stage the binary on all nodes before
 	// restarting each one, but on Unix it's invalid to write to an
 	// executable file while it is currently running. So we do the
@@ -376,7 +378,9 @@ func RestartNodesWithNewBinary(
 		// this upgraded node for DistSQL plans (see #87154 for more details).
 		// TODO(yuzefovich): ideally, we would also check that the drain was
 		// successful since if it wasn't, then we might see flakes too.
-		if err := c.StopCockroachGracefullyOnNode(ctx, l, node); err != nil {
+		if err := c.StopE(
+			ctx, l, option.NewStopOpts(option.Graceful(maxWait)), c.Node(node),
+		); err != nil {
 			return err
 		}
 

--- a/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
+++ b/pkg/cmd/roachtest/roachtestutil/clusterupgrade/clusterupgrade.go
@@ -356,7 +356,7 @@ func RestartNodesWithNewBinary(
 	newVersion *Version,
 	settings ...install.ClusterSettingOption,
 ) error {
-	const maxWait = 300 // 5 minutes
+	const gracePeriod = 300 // 5 minutes
 
 	// NB: We could technically stage the binary on all nodes before
 	// restarting each one, but on Unix it's invalid to write to an
@@ -379,7 +379,7 @@ func RestartNodesWithNewBinary(
 		// TODO(yuzefovich): ideally, we would also check that the drain was
 		// successful since if it wasn't, then we might see flakes too.
 		if err := c.StopE(
-			ctx, l, option.NewStopOpts(option.Graceful(maxWait)), c.Node(node),
+			ctx, l, option.NewStopOpts(option.Graceful(gracePeriod)), c.Node(node),
 		); err != nil {
 			return err
 		}

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -37,6 +37,10 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// shudownMaxWait is the default maximum duration (in seconds) that we
+// will wait for a graceful shutdown.
+const shutdownMaxWait = 300
+
 func registerDecommission(r registry.Registry) {
 	{
 		numNodes := 4
@@ -297,6 +301,8 @@ func runDecommission(
 		})
 	}
 
+	stopOpts := option.NewStopOpts(option.Graceful(shutdownMaxWait))
+
 	m.Go(func() error {
 		tBegin, whileDown := timeutil.Now(), true
 		node := nodes
@@ -322,7 +328,7 @@ func runDecommission(
 			}
 
 			if whileDown {
-				if err := c.StopCockroachGracefullyOnNode(ctx, t.L(), node); err != nil {
+				if err := c.StopE(ctx, t.L(), stopOpts, c.Node(node)); err != nil {
 					return err
 				}
 			}
@@ -347,7 +353,7 @@ func runDecommission(
 			}
 
 			if !whileDown {
-				if err := c.StopCockroachGracefullyOnNode(ctx, t.L(), node); err != nil {
+				if err := c.StopE(ctx, t.L(), stopOpts, c.Node(node)); err != nil {
 					return err
 				}
 			}

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -37,9 +37,9 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// shudownMaxWait is the default maximum duration (in seconds) that we
+// shudownGracePeriod is the default grace period (in seconds) that we
 // will wait for a graceful shutdown.
-const shutdownMaxWait = 300
+const shutdownGracePeriod = 300
 
 func registerDecommission(r registry.Registry) {
 	{
@@ -301,7 +301,7 @@ func runDecommission(
 		})
 	}
 
-	stopOpts := option.NewStopOpts(option.Graceful(shutdownMaxWait))
+	stopOpts := option.NewStopOpts(option.Graceful(shutdownGracePeriod))
 
 	m.Go(func() error {
 		tBegin, whileDown := timeutil.Now(), true

--- a/pkg/cmd/roachtest/tests/decommissionbench.go
+++ b/pkg/cmd/roachtest/tests/decommissionbench.go
@@ -878,7 +878,7 @@ func runSingleDecommission(
 	// stuck with replicas in purgatory, by pinning them to a node.
 
 	// We stop nodes gracefully when needed.
-	stopOpts := option.NewStopOpts(option.Graceful(shutdownMaxWait))
+	stopOpts := option.NewStopOpts(option.Graceful(shutdownGracePeriod))
 
 	// Gather metadata for logging purposes and wait for balance.
 	var bytesUsed, rangeCount, totalRanges int64

--- a/pkg/cmd/roachtest/tests/decommissionbench.go
+++ b/pkg/cmd/roachtest/tests/decommissionbench.go
@@ -877,6 +877,9 @@ func runSingleDecommission(
 	// TODO(sarkesian): Consider adding a future test for decommissions that get
 	// stuck with replicas in purgatory, by pinning them to a node.
 
+	// We stop nodes gracefully when needed.
+	stopOpts := option.NewStopOpts(option.Graceful(shutdownMaxWait))
+
 	// Gather metadata for logging purposes and wait for balance.
 	var bytesUsed, rangeCount, totalRanges int64
 	var candidateStores, avgBytesPerReplica int64
@@ -933,7 +936,7 @@ func runSingleDecommission(
 
 	if stopFirst {
 		h.t.Status(fmt.Sprintf("gracefully stopping node%d", target))
-		if err := h.c.StopCockroachGracefullyOnNode(ctx, h.t.L(), target); err != nil {
+		if err := h.c.StopE(ctx, h.t.L(), stopOpts, c.Node(target)); err != nil {
 			return err
 		}
 		// Wait after stopping the node to distinguish the impact of the node being
@@ -991,7 +994,7 @@ func runSingleDecommission(
 	if reuse {
 		if !stopFirst {
 			h.t.Status(fmt.Sprintf("gracefully stopping node%d", target))
-			if err := h.c.StopCockroachGracefullyOnNode(ctx, h.t.L(), target); err != nil {
+			if err := h.c.StopE(ctx, h.t.L(), stopOpts, c.Node(target)); err != nil {
 				return err
 			}
 		}

--- a/pkg/cmd/roachtest/tests/encryption.go
+++ b/pkg/cmd/roachtest/tests/encryption.go
@@ -42,9 +42,7 @@ func registerEncryption(r registry.Registry) {
 		}
 
 		for i := 1; i <= nodes; i++ {
-			if err := c.StopCockroachGracefullyOnNode(ctx, t.L(), i); err != nil {
-				t.Fatal(err)
-			}
+			c.Stop(ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownMaxWait)), c.Node(i))
 		}
 
 		// Restart node with encryption turned on to verify old key works.

--- a/pkg/cmd/roachtest/tests/encryption.go
+++ b/pkg/cmd/roachtest/tests/encryption.go
@@ -42,7 +42,7 @@ func registerEncryption(r registry.Registry) {
 		}
 
 		for i := 1; i <= nodes; i++ {
-			c.Stop(ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownMaxWait)), c.Node(i))
+			c.Stop(ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownGracePeriod)), c.Node(i))
 		}
 
 		// Restart node with encryption turned on to verify old key works.

--- a/pkg/cmd/roachtest/tests/jobs.go
+++ b/pkg/cmd/roachtest/tests/jobs.go
@@ -151,7 +151,7 @@ func executeNodeShutdown(
 		}
 	} else {
 		t.L().Printf(`stopping node gracefully %s`, target)
-		if err := c.StopCockroachGracefullyOnNode(ctx, t.L(), cfg.shutdownNode); err != nil {
+		if err := c.StopE(ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownMaxWait)), c.Node(cfg.shutdownNode)); err != nil {
 			return errors.Wrapf(err, "could not stop node %s", target)
 		}
 	}

--- a/pkg/cmd/roachtest/tests/jobs.go
+++ b/pkg/cmd/roachtest/tests/jobs.go
@@ -151,7 +151,7 @@ func executeNodeShutdown(
 		}
 	} else {
 		t.L().Printf(`stopping node gracefully %s`, target)
-		if err := c.StopE(ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownMaxWait)), c.Node(cfg.shutdownNode)); err != nil {
+		if err := c.StopE(ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownGracePeriod)), c.Node(cfg.shutdownNode)); err != nil {
 			return errors.Wrapf(err, "could not stop node %s", target)
 		}
 	}

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -494,13 +494,13 @@ func registerKVQuiescenceDead(r registry.Registry) {
 			})
 			// Graceful shut down third node.
 			m.ExpectDeath()
-			gracefulOpts := option.DefaultStopOpts()
-			gracefulOpts.RoachprodOpts.Sig = 15 // SIGTERM
-			gracefulOpts.RoachprodOpts.Wait = true
-			gracefulOpts.RoachprodOpts.MaxWait = 30
-			c.Stop(ctx, t.L(), gracefulOpts, c.Node(nodes))
-			// If graceful shutdown fails within 30 seconds, proceed with hard shutdown.
-			c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(nodes))
+			if err := c.StopE(
+				ctx, t.L(), option.NewStopOpts(option.Graceful(30)), c.Node(nodes),
+			); err != nil {
+				t.L().Printf("graceful shutdown failed: %v", err)
+				// If graceful shutdown fails within 30 seconds, proceed with hard shutdown.
+				c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(nodes))
+			}
 			// Measure qps with node down (i.e. without quiescence).
 			qpsOneDown := qps(func() {
 				// Use a different seed to make sure it's not just stepping into the

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -494,13 +494,9 @@ func registerKVQuiescenceDead(r registry.Registry) {
 			})
 			// Graceful shut down third node.
 			m.ExpectDeath()
-			if err := c.StopE(
+			c.Stop(
 				ctx, t.L(), option.NewStopOpts(option.Graceful(30)), c.Node(nodes),
-			); err != nil {
-				t.L().Printf("graceful shutdown failed: %v", err)
-				// If graceful shutdown fails within 30 seconds, proceed with hard shutdown.
-				c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(nodes))
-			}
+			)
 			// Measure qps with node down (i.e. without quiescence).
 			qpsOneDown := qps(func() {
 				// Use a different seed to make sure it's not just stepping into the

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -623,16 +623,11 @@ func registerKVGracefulDraining(r registry.Registry) {
 					case <-time.After(1 * time.Minute):
 					}
 				}
-				// Graceful drain: send SIGTERM, which should be sufficient
-				// to stop the node, followed by a non-graceful SIGKILL a
-				// bit later to clean up should the process have become
-				// stuck.
-				stopOpts := option.DefaultStopOpts()
-				stopOpts.RoachprodOpts.Sig = 15
-				stopOpts.RoachprodOpts.Wait = true
-				stopOpts.RoachprodOpts.MaxWait = 30
+				// Graceful drain: send SIGTERM, which should be sufficient to
+				// stop the node. It will be followed by a non-graceful
+				// SIGKILL a if the drain process does not finish within 30s
+				stopOpts := option.NewStopOpts(option.Graceful(shutdownGracePeriod))
 				c.Stop(ctx, t.L(), stopOpts, c.Node(nodes))
-				c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(nodes))
 				t.Status("letting workload run with one node down")
 				select {
 				case <-ctx.Done():

--- a/pkg/roachprod/BUILD.bazel
+++ b/pkg/roachprod/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
+        "@org_golang_x_sys//unix",
     ],
 )
 

--- a/pkg/roachprod/install/BUILD.bazel
+++ b/pkg/roachprod/install/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@org_golang_x_exp//maps",
         "@org_golang_x_sync//errgroup",
+        "@org_golang_x_sys//unix",
     ],
 )
 

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -391,14 +391,14 @@ func (c *SyncedCluster) newSession(
 // for shared-process configurations.)
 //
 // When Stop needs to kill a process without other flags, the signal
-// is 9 (SIGKILL) and wait is true. If maxWait is non-zero, Stop stops
-// waiting after that approximate number of seconds.
+// is 9 (SIGKILL) and wait is true. If gracePeriod is non-zero, Stop
+// stops waiting after that approximate number of seconds.
 func (c *SyncedCluster) Stop(
 	ctx context.Context,
 	l *logger.Logger,
 	sig int,
 	wait bool,
-	maxWait int,
+	gracePeriod int,
 	virtualClusterLabel string,
 ) error {
 	// virtualClusterDisplay includes information about the virtual
@@ -442,7 +442,7 @@ func (c *SyncedCluster) Stop(
 		if wait {
 			display += " and waiting"
 		}
-		return c.kill(ctx, l, "stop", display, sig, wait, maxWait, virtualClusterLabel)
+		return c.kill(ctx, l, "stop", display, sig, wait, gracePeriod, virtualClusterLabel)
 	} else {
 		res, err := c.ExecSQL(ctx, l, c.Nodes[:1], "", 0, []string{
 			"-e", fmt.Sprintf("ALTER TENANT '%s' STOP SERVICE", virtualClusterName),
@@ -462,20 +462,20 @@ func (c *SyncedCluster) Stop(
 // Signal sends a signal to the CockroachDB process.
 func (c *SyncedCluster) Signal(ctx context.Context, l *logger.Logger, sig int) error {
 	display := fmt.Sprintf("%s: sending signal %d", c.Name, sig)
-	return c.kill(ctx, l, "signal", display, sig, false /* wait */, 0 /* maxWait */, "")
+	return c.kill(ctx, l, "signal", display, sig, false /* wait */, 0 /* gracePeriod */, "")
 }
 
 // kill sends the signal sig to all nodes in the cluster using the kill command.
 // cmdName and display specify the roachprod subcommand and a status message,
 // for output/logging. If wait is true, the command will wait for the processes
-// to exit, up to maxWait seconds.
+// to exit, up to gracePeriod seconds.
 func (c *SyncedCluster) kill(
 	ctx context.Context,
 	l *logger.Logger,
 	cmdName, display string,
 	sig int,
 	wait bool,
-	maxWait int,
+	gracePeriod int,
 	virtualClusterLabel string,
 ) error {
 	const timedOutMessage = "timed out"
@@ -507,7 +507,7 @@ func (c *SyncedCluster) kill(
     echo "${pid}: dead" >> %[1]s/roachprod.log
   done`,
 					c.LogDir(node, "", 0), // [1]
-					maxWait,               // [2]
+					gracePeriod,           // [2]
 					timedOutMessage,       // [3]
 				)
 			}
@@ -551,7 +551,7 @@ fi`,
 			if wait && strings.Contains(res.CombinedOut, timedOutMessage) {
 				return res, fmt.Errorf(
 					"timed out after %ds waiting for n%d to drain and shutdown",
-					maxWait, node,
+					gracePeriod, node,
 				)
 			}
 
@@ -562,7 +562,7 @@ fi`,
 // Wipe TODO(peter): document
 func (c *SyncedCluster) Wipe(ctx context.Context, l *logger.Logger, preserveCerts bool) error {
 	display := fmt.Sprintf("%s: wiping", c.Name)
-	if err := c.Stop(ctx, l, 9, true /* wait */, 0 /* maxWait */, ""); err != nil {
+	if err := c.Stop(ctx, l, 9, true /* wait */, 0 /* gracePeriod */, ""); err != nil {
 		return err
 	}
 	return c.Parallel(ctx, l, OnNodes(c.Nodes).WithDisplay(display), func(ctx context.Context, node Node) (*RunResultDetails, error) {

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sys/unix"
 )
 
 // A SyncedCluster is created from the cluster metadata in the synced clusters
@@ -392,7 +393,8 @@ func (c *SyncedCluster) newSession(
 //
 // When Stop needs to kill a process without other flags, the signal
 // is 9 (SIGKILL) and wait is true. If gracePeriod is non-zero, Stop
-// stops waiting after that approximate number of seconds.
+// stops waiting after that approximate number of seconds, sending a
+// SIGKILL if the process is still running after that time.
 func (c *SyncedCluster) Stop(
 	ctx context.Context,
 	l *logger.Logger,
@@ -480,7 +482,7 @@ func (c *SyncedCluster) kill(
 ) error {
 	const timedOutMessage = "timed out"
 
-	if sig == 9 {
+	if sig == int(unix.SIGKILL) {
 		// `kill -9` without wait is never what a caller wants. See #77334.
 		wait = true
 	}
@@ -548,10 +550,13 @@ fi`,
 				return res, err
 			}
 
-			if wait && strings.Contains(res.CombinedOut, timedOutMessage) {
-				return res, fmt.Errorf(
-					"timed out after %ds waiting for n%d to drain and shutdown",
-					gracePeriod, node,
+			// If the process has not terminated after the grace period,
+			// perform a forceful termination.
+			if wait && sig != int(unix.SIGKILL) && strings.Contains(res.CombinedOut, timedOutMessage) {
+				l.Printf("n%d did not shutdown after %ds, performing a SIGKILL", node, gracePeriod)
+				return res, errors.Wrapf(
+					c.kill(ctx, l, cmdName, display, int(unix.SIGKILL), true, 0, virtualClusterLabel),
+					"failed to forcefully terminate n%d", node,
 				)
 			}
 
@@ -562,7 +567,7 @@ fi`,
 // Wipe TODO(peter): document
 func (c *SyncedCluster) Wipe(ctx context.Context, l *logger.Logger, preserveCerts bool) error {
 	display := fmt.Sprintf("%s: wiping", c.Name)
-	if err := c.Stop(ctx, l, 9, true /* wait */, 0 /* gracePeriod */, ""); err != nil {
+	if err := c.Stop(ctx, l, int(unix.SIGKILL), true /* wait */, 0 /* gracePeriod */, ""); err != nil {
 		return err
 	}
 	return c.Parallel(ctx, l, OnNodes(c.Nodes).WithDisplay(display), func(ctx context.Context, node Node) (*RunResultDetails, error) {

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -478,6 +478,8 @@ func (c *SyncedCluster) kill(
 	maxWait int,
 	virtualClusterLabel string,
 ) error {
+	const timedOutMessage = "timed out"
+
 	if sig == 9 {
 		// `kill -9` without wait is never what a caller wants. See #77334.
 		wait = true
@@ -493,6 +495,7 @@ func (c *SyncedCluster) kill(
     while kill -0 ${pid}; do
       if [ %[2]d -gt 0 -a $waitcnt -gt %[2]d ]; then
          echo "${pid}: max %[2]d attempts reached, aborting wait" >>%[1]s/roachprod.log
+         echo "%[3]s"
          break
       fi
       kill -0 ${pid} >> %[1]s/roachprod.log 2>&1
@@ -505,6 +508,7 @@ func (c *SyncedCluster) kill(
   done`,
 					c.LogDir(node, "", 0), // [1]
 					maxWait,               // [2]
+					timedOutMessage,       // [3]
 				)
 			}
 
@@ -539,7 +543,19 @@ fi`,
 				waitCmd,                   // [6]
 			)
 
-			return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("kill"))
+			res, err := c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("kill"))
+			if err != nil {
+				return res, err
+			}
+
+			if wait && strings.Contains(res.CombinedOut, timedOutMessage) {
+				return res, fmt.Errorf(
+					"timed out after %ds waiting for n%d to drain and shutdown",
+					maxWait, node,
+				)
+			}
+
+			return res, nil
 		})
 }
 

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -66,5 +66,5 @@ func StopServiceForVirtualCluster(
 	}
 
 	label := install.VirtualClusterLabel(stopOpts.VirtualClusterName, stopOpts.SQLInstance)
-	return c.Stop(ctx, l, stopOpts.Sig, stopOpts.Wait, stopOpts.MaxWait, label)
+	return c.Stop(ctx, l, stopOpts.Sig, stopOpts.Wait, stopOpts.GracePeriod, label)
 }

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -52,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
+	"golang.org/x/sys/unix"
 )
 
 // MalformedClusterNameError is returned when the cluster name passed to Create is invalid.
@@ -710,7 +711,8 @@ type StopOpts struct {
 	// process has terminated).
 	Wait bool // forced to true when Sig == 9
 	// GracePeriod is the mount of time (in seconds) roachprod will wait
-	// until the PID disappears.
+	// until the PID disappears. If the process is not terminated after
+	// that time, a hard stop (SIGKILL) is performed.
 	GracePeriod int
 
 	// Options that only apply to StopServiceForVirtualCluster
@@ -723,7 +725,7 @@ type StopOpts struct {
 func DefaultStopOpts() StopOpts {
 	return StopOpts{
 		ProcessTag:  "",
-		Sig:         9,
+		Sig:         int(unix.SIGKILL),
 		Wait:        false,
 		GracePeriod: 0,
 	}

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -709,9 +709,9 @@ type StopOpts struct {
 	// If Wait is set, roachprod waits until the PID disappears (i.e. the
 	// process has terminated).
 	Wait bool // forced to true when Sig == 9
-	// If MaxWait is set, roachprod waits that approximate number of seconds
+	// GracePeriod is the mount of time (in seconds) roachprod will wait
 	// until the PID disappears.
-	MaxWait int
+	GracePeriod int
 
 	// Options that only apply to StopServiceForVirtualCluster
 	VirtualClusterID   int
@@ -722,10 +722,10 @@ type StopOpts struct {
 // DefaultStopOpts returns StopOpts populated with the default values used by Stop.
 func DefaultStopOpts() StopOpts {
 	return StopOpts{
-		ProcessTag: "",
-		Sig:        9,
-		Wait:       false,
-		MaxWait:    0,
+		ProcessTag:  "",
+		Sig:         9,
+		Wait:        false,
+		GracePeriod: 0,
 	}
 }
 
@@ -735,7 +735,7 @@ func Stop(ctx context.Context, l *logger.Logger, clusterName string, opts StopOp
 	if err != nil {
 		return err
 	}
-	return c.Stop(ctx, l, opts.Sig, opts.Wait, opts.MaxWait, "")
+	return c.Stop(ctx, l, opts.Sig, opts.Wait, opts.GracePeriod, "")
 }
 
 // Signal sends a signal to nodes in the cluster.


### PR DESCRIPTION
Backport:
  * 1/1 commits from "roachtest: make graceful stop an option instead of a function" (#128849)
  * 2/2 commits from "roachprod: stop forcefully after grace period" (#129259)

Please see individual PRs for details.

/cc @cockroachdb/release

Epic: None

Release note: None

Release justification: test only changes.