### PR TITLE
kvserver: check whether we need to backpressure writes below latching 

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -2212,6 +2212,13 @@ not occurring.
 		Measurement: "Writes",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaBackpressuredBelowLatching = metric.Metadata{
+		Name: "requests.backpressure.below_latching",
+		Help: `Number of backpressured writes that we decided to backpressure below latching.
+`,
+		Measurement: "Writes",
+		Unit:        metric.Unit_COUNT,
+	}
 
 	// AddSSTable metrics.
 	metaAddSSTableProposals = metric.Metadata{
@@ -2885,6 +2892,7 @@ type StoreMetrics struct {
 
 	// Backpressure counts.
 	BackpressuredOnSplitRequests *metric.Gauge
+	BackpressuredBelowLatching   *metric.Counter
 
 	// AddSSTable stats: how many AddSSTable commands were proposed and how many
 	// were applied? How many applications required writing a copy?
@@ -3648,6 +3656,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 
 		// Backpressure counters.
 		BackpressuredOnSplitRequests: metric.NewGauge(metaBackpressuredOnSplitRequests),
+		BackpressuredBelowLatching:   metric.NewCounter(metaBackpressuredBelowLatching),
 
 		// AddSSTable proposal + applications counters.
 		AddSSTableProposals:           metric.NewCounter(metaAddSSTableProposals),

--- a/pkg/kv/kvserver/replica_backpressure.go
+++ b/pkg/kv/kvserver/replica_backpressure.go
@@ -43,7 +43,7 @@ var backpressureRangeSizeMultiplier = settings.RegisterFloatSetting(
 // size where backpressure would kick in by more than this quantity will
 // immediately avoid backpressure. This approach is a bit risky because a
 // command larger than this value would effectively disable backpressure
-// altogether. Another downside of this approach is that if the range size
+// altogether[1]. Another downside of this approach is that if the range size
 // is reduced by roughly exactly the multiplier then we'd potentially have
 // lots of ranges in this state.
 //
@@ -60,13 +60,17 @@ var backpressureRangeSizeMultiplier = settings.RegisterFloatSetting(
 //  2. We assign a higher priority in the snapshot queue to ranges which are
 //     currently backpressuring than ranges which are larger but are not
 //     applying backpressure.
+//
+// [1] As such, the default value of this setting is configured to match the
+// default value of MaxCommandSize. This prevents a single raft command from
+// effectively disabling batching in the default case.
 var backpressureByteTolerance = settings.RegisterByteSizeSetting(
 	settings.SystemOnly,
 	"kv.range.backpressure_byte_tolerance",
 	"defines the number of bytes above the product of "+
 		"backpressure_range_size_multiplier and the range_max_size at which "+
 		"backpressure will not apply",
-	32<<20 /* 32 MiB */)
+	64<<20 /* 64 MiB */)
 
 // backpressureBelowLatchingEnabled dictates whether write requests check
 // whether they need to bail evaluating and backpressure instead after acquiring


### PR DESCRIPTION
Previously, we would only check whether a write request needed to be
backpressured by checking against the range size above latching. This
meant if the range grew over the permissible size while a request was
waiting on locks/latches, it would still be able to evaluate.

This patch adds a cheap check for whether a batch must backpressure or
not below latching itself. Notably, unlike the above latching check, we
don't attempt to wait for any concurrent splits, as we're holding
latches at this point. The logic here is gated behind a enabled by
default cluster setting called
`kv.range.backpressure_below_latching.enabled`.

Closes https://github.com/cockroachdb/cockroach/issues/128082

Release note: None