### PR TITLE
roachprod: grow in specific zones

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -36,6 +36,7 @@ var (
 	pprofOpts             roachprod.PprofOpts
 	numNodes              int
 	numRacks              int
+	growZones             []string
 	username              string
 	database              string
 	dryrun                bool
@@ -187,6 +188,9 @@ func initFlags() {
 		"mine", "m", false, "Show only clusters belonging to the current user")
 	listCmd.Flags().StringVar(&listPattern,
 		"pattern", "", "Show only clusters matching the regex pattern. Empty string matches everything.")
+
+	growCmd.Flags().StringSliceVar(&growZones,
+		"zones", nil, "existing zones to grow. If zones are formatted as AZ:N where N is an integer, the zone will be repeated N times.")
 
 	adminurlCmd.Flags().StringVar(&adminurlPath,
 		"path", "/", "Path to add to URL (e.g. to open a same page on each node)")

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -162,7 +162,11 @@ Cloud cluster has to be a managed cluster (i.e., a cluster created with the
 gce-managed flag). The new nodes will use the instance template that was used to
 create the cluster originally (Nodes will be created in the same zone as the
 existing nodes, or if the cluster is geographically distributed, the nodes will
-be fairly distributed across the zones of the cluster).
+be fairly distributed across the zones of the cluster, unless zones are specified).
+
+If zones are specified, new nodes will be distributed to the specified zones only.
+A weight can be specified for each zone to control the distribution of nodes across
+the zones.
 `,
 	Args: cobra.ExactArgs(2),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
@@ -170,7 +174,7 @@ be fairly distributed across the zones of the cluster).
 		if err != nil || count < 1 {
 			return errors.Wrapf(err, "invalid num-nodes argument")
 		}
-		return roachprod.Grow(context.Background(), config.Logger, args[0], isSecure, int(count))
+		return roachprod.Grow(context.Background(), config.Logger, args[0], isSecure, int(count), growZones)
 	}),
 }
 

--- a/pkg/cmd/roachtest/cluster/dynamic_cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/dynamic_cluster_interface.go
@@ -20,6 +20,6 @@ import (
 // operations that mutate the underlying cluster topology.
 type DynamicCluster interface {
 	Cluster
-	Grow(ctx context.Context, l *logger.Logger, nodeCount int) error
+	Grow(ctx context.Context, l *logger.Logger, nodeCount int, zones []string) error
 	Shrink(ctx context.Context, l *logger.Logger, nodeCount int) error
 }

--- a/pkg/cmd/roachtest/dynamic_cluster.go
+++ b/pkg/cmd/roachtest/dynamic_cluster.go
@@ -22,8 +22,10 @@ type dynamicClusterImpl struct {
 }
 
 // Grow adds nodes to the cluster.
-func (c *clusterImpl) Grow(ctx context.Context, l *logger.Logger, nodeCount int) error {
-	err := roachprod.Grow(ctx, l, c.name, c.IsSecure(), nodeCount)
+func (c *clusterImpl) Grow(
+	ctx context.Context, l *logger.Logger, nodeCount int, zones []string,
+) error {
+	err := roachprod.Grow(ctx, l, c.name, c.IsSecure(), nodeCount, zones)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/roachtest/operations/resize.go
+++ b/pkg/cmd/roachtest/operations/resize.go
@@ -73,7 +73,7 @@ func resizeCluster(
 
 	// Grow the cluster, but keep track of the original cluster size.
 	origClusterSize := c.Spec().NodeCount
-	err = dynamicCluster.Grow(ctx, o.L(), growCount)
+	err = dynamicCluster.Grow(ctx, o.L(), growCount, nil /* zones */)
 	if err != nil {
 		o.Fatal(err)
 	}

--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -362,7 +362,7 @@ func CreateCluster(l *logger.Logger, opts []*ClusterCreateOpts) error {
 }
 
 // GrowCluster adds new nodes to an existing cluster.
-func GrowCluster(l *logger.Logger, c *Cluster, numNodes int) error {
+func GrowCluster(l *logger.Logger, c *Cluster, numNodes int, zones []string) error {
 	names := make([]string, 0, numNodes)
 	offset := len(c.VMs) + 1
 	for i := offset; i < offset+numNodes; i++ {
@@ -380,7 +380,7 @@ func GrowCluster(l *logger.Logger, c *Cluster, numNodes int) error {
 		}
 	}
 	return vm.ForProvider(provider, func(p vm.Provider) error {
-		return p.Grow(l, c.VMs, c.Name, names)
+		return p.Grow(l, c.VMs, c.Name, names, zones)
 	})
 }
 

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1644,7 +1644,12 @@ func Create(
 }
 
 func Grow(
-	ctx context.Context, l *logger.Logger, clusterName string, secure bool, numNodes int,
+	ctx context.Context,
+	l *logger.Logger,
+	clusterName string,
+	secure bool,
+	numNodes int,
+	zones []string,
 ) error {
 	if numNodes <= 0 || numNodes >= 1000 {
 		// Upper limit is just for safety.
@@ -1656,7 +1661,7 @@ func Grow(
 		return err
 	}
 
-	err = cloud.GrowCluster(l, &c.Cluster, numNodes)
+	err = cloud.GrowCluster(l, &c.Cluster, numNodes, zones)
 	if err != nil {
 		return err
 	}

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -713,7 +713,7 @@ func (p *Provider) Create(
 	return p.waitForIPs(l, names, regions, providerOpts)
 }
 
-func (p *Provider) Grow(*logger.Logger, vm.List, string, []string) error {
+func (p *Provider) Grow(*logger.Logger, vm.List, string, []string, []string) error {
 	return vm.UnimplementedError
 }
 

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -156,7 +156,7 @@ func (p *Provider) AttachVolume(*logger.Logger, vm.Volume, *vm.VM) (string, erro
 	return "", vm.UnimplementedError
 }
 
-func (p *Provider) Grow(*logger.Logger, vm.List, string, []string) error {
+func (p *Provider) Grow(*logger.Logger, vm.List, string, []string, []string) error {
 	return vm.UnimplementedError
 }
 

--- a/pkg/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/roachprod/vm/flagstub/flagstub.go
@@ -124,7 +124,9 @@ func (p *provider) Create(
 }
 
 // Grow implements vm.Provider and returns Unimplemented.
-func (p *provider) Grow(l *logger.Logger, vms vm.List, clusterName string, names []string) error {
+func (p *provider) Grow(
+	l *logger.Logger, vms vm.List, clusterName string, names, zones []string,
+) error {
 	return errors.Newf("%s", p.unimplemented)
 }
 

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -279,7 +279,9 @@ func (p *Provider) Create(
 	return nil
 }
 
-func (p *Provider) Grow(l *logger.Logger, vms vm.List, clusterName string, names []string) error {
+func (p *Provider) Grow(
+	l *logger.Logger, vms vm.List, clusterName string, names, zones []string,
+) error {
 	now := timeutil.Now()
 	offset := p.clusters[clusterName].VMs.Len()
 	for i := range names {

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -476,7 +476,7 @@ type Provider interface {
 	// zones for the given provider.
 	ConfigSSH(l *logger.Logger, zones []string) error
 	Create(l *logger.Logger, names []string, opts CreateOpts, providerOpts ProviderOpts) error
-	Grow(l *logger.Logger, vms List, clusterName string, names []string) error
+	Grow(l *logger.Logger, vms List, clusterName string, names, zones []string) error
 	Shrink(l *logger.Logger, vmsToRemove List, clusterName string) error
 	Reset(l *logger.Logger, vms List) error
 	Delete(l *logger.Logger, vms List) error


### PR DESCRIPTION
Previously, the `roachprod grow` command would evenly grow a cluster if there are multiple zones. This change adds the ability to pass a `zones` flag to specify the distribution of new nodes across the existing zones in a cluster.

Epic: None
Release note: None