### PR TITLE
roachtest: `validate-system-schema` works in shared-process deployments

### DIFF
--- a/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
+++ b/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
@@ -12,6 +12,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"sort"
 	"strings"
@@ -28,6 +29,57 @@ import (
 	"github.com/pmezard/go-difflib/difflib"
 )
 
+// validateSystemSchemaTenantVersion is the minimum version after
+// which we start ensuring that the schema for a tenant is the same
+// whether we upgraded to a version or bootstrapped in it. Prior to
+// this version, the check is expected to fail due to #129643.
+var validateSystemSchemaTenantVersion = clusterupgrade.MustParseVersion("v24.3.0-alpha.00000000")
+
+func diff(a, b string) error {
+	if a == b {
+		return nil
+	}
+
+	diffStr, diffErr := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:       difflib.SplitLines(a),
+		B:       difflib.SplitLines(b),
+		Context: 5,
+	})
+
+	if diffErr != nil {
+		return errors.Wrap(diffErr, "failed to produce diff")
+	}
+
+	return fmt.Errorf("diff:\n%s", diffStr)
+}
+
+type tenantSystemSchemaComparison struct {
+	name         string
+	bootstrapped string
+	upgraded     string
+}
+
+func newTenantSystemSchemaComparison(name string) *tenantSystemSchemaComparison {
+	return &tenantSystemSchemaComparison{name: name}
+}
+
+func (c tenantSystemSchemaComparison) Diff() error {
+	if err := diff(c.upgraded, c.bootstrapped); err != nil {
+		tenantDesc := "system"
+		if c.name != install.SystemInterfaceName {
+			tenantDesc = "non-system"
+		}
+
+		return errors.Newf(
+			"After upgrading, `USE system; SHOW CREATE ALL TABLES;` "+
+				"does not match expected output after version upgrade for %s tenant: %w",
+			tenantDesc, err,
+		)
+	}
+
+	return nil
+}
+
 // This test tests that, after bootstrapping a cluster from a previous
 // release's binary and upgrading it to the latest version, the `system`
 // database "contains the expected tables".
@@ -37,9 +89,13 @@ func runValidateSystemSchemaAfterVersionUpgrade(
 	ctx context.Context, t test.Test, c cluster.Cluster,
 ) {
 	// Obtain system table definitions with `SHOW CREATE ALL TABLES` in the SYSTEM db.
-	obtainSystemSchema := func(ctx context.Context, l *logger.Logger, c cluster.Cluster, node int) string {
+	obtainSystemSchema := func(
+		ctx context.Context, l *logger.Logger, c cluster.Cluster, node int, virtualCluster string,
+	) string {
 		// Create a connection to the database cluster.
-		db := c.Conn(ctx, l, node)
+		db := c.Conn(ctx, l, node, option.VirtualClusterName(virtualCluster))
+		defer db.Close()
+
 		sqlRunner := sqlutils.MakeSQLRunner(db)
 
 		// Prepare the SQL query.
@@ -60,27 +116,15 @@ func runValidateSystemSchemaAfterVersionUpgrade(
 		return sb.String()
 	}
 
-	// expected and actual output of `SHOW CREATE ALL TABLES;`.
-	var expected, actual string
-
-	// Start a cluster with the latest binary and get the system schema from the
-	// cluster.
-	if err := clusterupgrade.StartWithSettings(
-		ctx, t.L(), c, c.All(), option.DefaultStartOpts(), install.BinaryOption(test.DefaultCockroachPath),
-	); err != nil {
-		t.Fatal(err)
-	}
-	expected = obtainSystemSchema(ctx, t.L(), c, 1)
-	c.Wipe(ctx, c.All())
+	systemComparison := newTenantSystemSchemaComparison(install.SystemInterfaceName)
+	var tenantComparison *tenantSystemSchemaComparison
 
 	mvt := mixedversion.NewTest(ctx, t, t.L(), c, c.All(),
-		// Fixtures are generated on a version that's too old for this test.
-		mixedversion.NeverUseFixtures,
 		// We limit the number of upgrades since the test is not expected to work
 		// on versions older than 22.2.
-		mixedversion.MaxUpgrades(2),
-		// Multi-tenant deployments are currently unsupported. See #127378.
-		mixedversion.EnabledDeploymentModes(mixedversion.SystemOnlyDeployment),
+		mixedversion.MaxUpgrades(3),
+		// Fixtures are generated on a version that's too old for this test.
+		mixedversion.NeverUseFixtures,
 	)
 	mvt.AfterUpgradeFinalized(
 		"obtain system schema from the upgraded cluster",
@@ -91,24 +135,48 @@ func runValidateSystemSchemaAfterVersionUpgrade(
 				return nil
 			}
 
-			// Compare whether the two schemas are equal
-			actual = obtainSystemSchema(ctx, l, c, 1)
-			if expected != actual {
-				diff, diffErr := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
-					A:       difflib.SplitLines(expected),
-					B:       difflib.SplitLines(actual),
-					Context: 5,
-				})
-				if diffErr != nil {
-					return errors.Wrap(diffErr, "failed to produce diff")
-				}
-				return errors.Newf("After upgrading, `USE system; SHOW CREATE ALL TABLES;` "+
-					"does not match expected output after version upgrade."+
-					"\nDiff:\n%s", diff)
+			systemComparison.upgraded = obtainSystemSchema(ctx, l, c, 1, systemComparison.name)
+			if h.IsMultitenant() {
+				tenantComparison = newTenantSystemSchemaComparison(h.Tenant.Descriptor.Name)
+				tenantComparison.upgraded = obtainSystemSchema(ctx, l, c, 1, tenantComparison.name)
 			}
-			l.Printf("validating succeeded:\n%v", expected)
+
 			return nil
 		},
 	)
 	mvt.Run()
+
+	// Start a cluster with the latest binary and get the system schema
+	// from the cluster.
+	c.Wipe(ctx, c.All())
+	settings := install.MakeClusterSettings()
+
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), settings)
+	systemComparison.bootstrapped = obtainSystemSchema(ctx, t.L(), c, 1, systemComparison.name)
+
+	validateTenant := tenantComparison != nil && clusterupgrade.CurrentVersion().AtLeast(validateSystemSchemaTenantVersion)
+
+	if validateTenant {
+		t.L().Printf("creating shared-process tenant")
+		startOpts := option.StartSharedVirtualClusterOpts(tenantComparison.name)
+		c.StartServiceForVirtualCluster(ctx, t.L(), startOpts, settings)
+		tenantComparison.bootstrapped = obtainSystemSchema(ctx, t.L(), c, 1, tenantComparison.name)
+	}
+
+	if err := systemComparison.Diff(); err != nil {
+		t.Fatal(err)
+	}
+	t.L().Printf("validation succeeded for system tenant")
+
+	if validateTenant {
+		if err := tenantComparison.Diff(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := diff(systemComparison.upgraded, tenantComparison.upgraded); err != nil {
+			t.Fatal(fmt.Errorf("comparing system schema of system and tenant: %w", err))
+		}
+
+		t.L().Printf("validation succeeded for non-system tenant")
+	}
 }


### PR DESCRIPTION
This commit updates the
`acceptance/validate-system-schema-after-version-upgrade` roachtest so
that it can now work on multi-tenant (shared-process) deployments.

In multi-tenant deployments, we also capture the system schema on the
tenant and make the same assertion that the schema should match
whether we bootstrapped on a version or upgraded to it. In addition,
we also verify that the system schema is the same on the system and
non-system tenants.

Informs: #127378

Release note: None