### PR TITLE
sql/logictest: fix incorrect operator in test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -747,7 +747,7 @@ SELECT status,
 failed  ALTER TABLE test.public.customers ADD COLUMN i INT8 DEFAULT … ers (n)
 
 query BT
-SELECT status % '(running)|(succeeded)',
+SELECT status ~ '(running)|(succeeded)',
        regexp_replace(description, 'ROLL BACK JOB \d+.*', 'ROLL BACK JOB') as descr
   FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE GC' AND description LIKE 'GC for ROLL%' ORDER BY job_id DESC LIMIT 1
 ----


### PR DESCRIPTION
This is a follow-up to #129013 which changes the incorrectly used
similarity operator, `%`, to the regex match operator, `~`.

Epic: None

Release note: None
