### PR TITLE
raft: remove commit index advancement dependence on heartbeats

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -397,4 +397,4 @@ trace.snapshot.rate	duration	0s	if non-zero, interval at which background trace 
 trace.span_registry.enabled	boolean	true	if set, ongoing traces can be seen at https://<ui>/#/debug/tracez	application
 trace.zipkin.collector	string		the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.	application
 ui.display_timezone	enumeration	etc/utc	the timezone used to format timestamps in the ui [etc/utc = 0, america/new_york = 1]	application
-version	version	1000024.2-upgrading-to-1000024.3-step-010	set the active cluster version in the format '<major>.<minor>'	application
+version	version	1000024.2-upgrading-to-1000024.3-step-012	set the active cluster version in the format '<major>.<minor>'	application

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -354,6 +354,6 @@
 <tr><td><div id="setting-trace-span-registry-enabled" class="anchored"><code>trace.span_registry.enabled</code></div></td><td>boolean</td><td><code>true</code></td><td>if set, ongoing traces can be seen at https://&lt;ui&gt;/#/debug/tracez</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
 <tr><td><div id="setting-trace-zipkin-collector" class="anchored"><code>trace.zipkin.collector</code></div></td><td>string</td><td><code></code></td><td>the address of a Zipkin instance to receive traces, as &lt;host&gt;:&lt;port&gt;. If no port is specified, 9411 will be used.</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
 <tr><td><div id="setting-ui-display-timezone" class="anchored"><code>ui.display_timezone</code></div></td><td>enumeration</td><td><code>etc/utc</code></td><td>the timezone used to format timestamps in the ui [etc/utc = 0, america/new_york = 1]</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
-<tr><td><div id="setting-version" class="anchored"><code>version</code></div></td><td>version</td><td><code>1000024.2-upgrading-to-1000024.3-step-010</code></td><td>set the active cluster version in the format &#39;&lt;major&gt;.&lt;minor&gt;&#39;</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
+<tr><td><div id="setting-version" class="anchored"><code>version</code></div></td><td>version</td><td><code>1000024.2-upgrading-to-1000024.3-step-012</code></td><td>set the active cluster version in the format &#39;&lt;major&gt;.&lt;minor&gt;&#39;</td><td>Serverless/Dedicated/Self-Hosted</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -233,6 +233,10 @@ const (
 	// TTL to mirror the behaviour on the system tenant.
 	V24_3_TenantExcludeDataFromBackup
 
+	// V24_3_AdvanceCommitIndexViaMsgApps is the version that makes the commit
+	// index advancement using MsgApps only, and not MsgHeartbeat.
+	V24_3_AdvanceCommitIndexViaMsgApps
+
 	// *************************************************
 	// Step (1) Add new versions above this comment.
 	// Do not add new versions to a patch release.
@@ -281,10 +285,11 @@ var versionTable = [numKeys]roachpb.Version{
 	// v24.3 versions. Internal versions must be even.
 	V24_3_Start: {Major: 24, Minor: 2, Internal: 2},
 
-	V24_3_StoreLivenessEnabled:        {Major: 24, Minor: 2, Internal: 4},
-	V24_3_AddTimeseriesZoneConfig:     {Major: 24, Minor: 2, Internal: 6},
-	V24_3_TableMetadata:               {Major: 24, Minor: 2, Internal: 8},
-	V24_3_TenantExcludeDataFromBackup: {Major: 24, Minor: 2, Internal: 10},
+	V24_3_StoreLivenessEnabled:         {Major: 24, Minor: 2, Internal: 4},
+	V24_3_AddTimeseriesZoneConfig:      {Major: 24, Minor: 2, Internal: 6},
+	V24_3_TableMetadata:                {Major: 24, Minor: 2, Internal: 8},
+	V24_3_TenantExcludeDataFromBackup:  {Major: 24, Minor: 2, Internal: 10},
+	V24_3_AdvanceCommitIndexViaMsgApps: {Major: 24, Minor: 2, Internal: 12},
 
 	// *************************************************
 	// Step (2): Add new versions above this comment.

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -1134,7 +1134,7 @@ func TestHandleMsgApp(t *testing.T) {
 	}
 }
 
-// TestHandleHeartbeat ensures that the follower commits to the commit in the message.
+// TestHandleHeartbeat ensures that the follower handles heartbeats properly.
 func TestHandleHeartbeat(t *testing.T) {
 	commit := uint64(2)
 	tests := []struct {
@@ -1161,7 +1161,6 @@ func TestHandleHeartbeat(t *testing.T) {
 		sm.becomeFollower(init.term, 2)
 		sm.raftLog.commitTo(LogMark{Term: init.term, Index: commit})
 		sm.handleHeartbeat(tt.m)
-		assert.Equal(t, tt.wCommit, sm.raftLog.committed, "#%d", i)
 		m := sm.readMessages()
 		require.Len(t, m, 1, "#%d", i)
 		assert.Equal(t, pb.MsgHeartbeatResp, m[0].Type, "#%d", i)
@@ -1192,9 +1191,10 @@ func TestHandleHeartbeatResp(t *testing.T) {
 
 	// Once we have an MsgAppResp, heartbeats no longer send MsgApp.
 	sm.Step(pb.Message{
-		From:  2,
-		Type:  pb.MsgAppResp,
-		Index: msgs[0].Index + uint64(len(msgs[0].Entries)),
+		From:   2,
+		Type:   pb.MsgAppResp,
+		Index:  msgs[0].Index + uint64(len(msgs[0].Entries)),
+		Commit: sm.raftLog.lastIndex(),
 	})
 	// Consume the message sent in response to MsgAppResp
 	sm.readMessages()
@@ -2007,20 +2007,10 @@ func TestBcastBeat(t *testing.T) {
 	msgs := sm.readMessages()
 	require.Len(t, msgs, 2)
 
-	wantCommitMap := map[pb.PeerID]uint64{
-		2: min(sm.raftLog.committed, sm.trk.Progress(2).Match),
-		3: min(sm.raftLog.committed, sm.trk.Progress(3).Match),
-	}
 	for i, m := range msgs {
 		require.Equal(t, pb.MsgHeartbeat, m.Type, "#%d", i)
 		require.Zero(t, m.Index, "#%d", i)
 		require.Zero(t, m.LogTerm, "#%d", i)
-
-		commit, ok := wantCommitMap[m.To]
-		require.True(t, ok, "#%d", i)
-		require.Equal(t, commit, m.Commit, "#%d", i)
-		delete(wantCommitMap, m.To)
-
 		require.Empty(t, m.Entries, "#%d", i)
 	}
 }

--- a/pkg/raft/rawnode_test.go
+++ b/pkg/raft/rawnode_test.go
@@ -770,11 +770,13 @@ func TestRawNodeCommitPaginationAfterRestart(t *testing.T) {
 		highestApplied = rd.CommittedEntries[n-1].Index
 		rawNode.Advance(rd)
 		rawNode.Step(pb.Message{
-			Type:   pb.MsgHeartbeat,
-			To:     1,
-			From:   2, // illegal, but we get away with it
-			Term:   1,
-			Commit: 11,
+			Type:    pb.MsgApp,
+			To:      1,
+			From:    2, // illegal, but we get away with it
+			Term:    1,
+			LogTerm: 1,
+			Index:   11,
+			Commit:  11,
 		})
 	}
 }

--- a/pkg/raft/testdata/checkquorum.txt
+++ b/pkg/raft/testdata/checkquorum.txt
@@ -74,28 +74,28 @@ stabilize
   Ready MustSync=false:
   State:StateFollower
   Messages:
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
 > 2 receiving messages
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->2 MsgHeartbeat Term:1 Log:0/0
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
 > 2 handling Ready
   Ready MustSync=false:
   Messages:

--- a/pkg/raft/testdata/confchange_v1_remove_leader.txt
+++ b/pkg/raft/testdata/confchange_v1_remove_leader.txt
@@ -223,12 +223,12 @@ stabilize
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:6
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:6
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
 > 2 receiving messages
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:6
+  1->2 MsgHeartbeat Term:1 Log:0/0
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:6
+  1->3 MsgHeartbeat Term:1 Log:0/0
 > 2 handling Ready
   Ready MustSync=false:
   Messages:

--- a/pkg/raft/testdata/forget_leader.txt
+++ b/pkg/raft/testdata/forget_leader.txt
@@ -103,9 +103,9 @@ stabilize
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->4 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
+  1->4 MsgHeartbeat Term:1 Log:0/0
 > 2 handling Ready
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:11 Lead:0 LeadEpoch:0
@@ -113,11 +113,11 @@ stabilize
   Ready MustSync=true:
   HardState Term:1 Commit:11 Lead:0 LeadEpoch:0
 > 2 receiving messages
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:1 Log:0/0
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:1 Log:0/0
 > 4 receiving messages
-  1->4 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->4 MsgHeartbeat Term:1 Log:0/0
 > 2 handling Ready
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:0

--- a/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
+++ b/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
@@ -67,12 +67,12 @@ stabilize
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
 > 2 receiving messages
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:1 Log:0/0
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:1 Log:0/0
   INFO 3 became follower at term 1
 > 2 handling Ready
   Ready MustSync=false:

--- a/pkg/raft/testdata/heartbeat_resp_recovers_from_probing.txt
+++ b/pkg/raft/testdata/heartbeat_resp_recovers_from_probing.txt
@@ -53,12 +53,12 @@ stabilize
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
 > 2 receiving messages
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:1 Log:0/0
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:1 Log:0/0
 > 2 handling Ready
   Ready MustSync=false:
   Messages:

--- a/pkg/raft/testdata/msg_app_commit_index.txt
+++ b/pkg/raft/testdata/msg_app_commit_index.txt
@@ -1,5 +1,5 @@
-# This test demonstrates the effect of delayed commit on a follower node after a
-# network hiccup between the leader and this follower.
+# This test demonstrates that the leader tracks the followers' commit index
+# and tries to advance it if it's stale.
 
 # Skip logging the boilerplate. Set up a raft group of 3 nodes, and elect node 1
 # as the leader. Nodes 2 and 3 are the followers.
@@ -7,7 +7,7 @@ log-level none
 ----
 ok
 
-add-nodes 3 voters=(1,2,3) index=10
+add-nodes 3 voters=(1, 2, 3) index=10
 ----
 ok
 
@@ -54,13 +54,6 @@ Messages:
 3->1 MsgAppResp Term:1 Log:0/12 Commit:11
 3->1 MsgAppResp Term:1 Log:0/13 Commit:11
 
-# Suppose there is a network blip which prevents the leader learning that the
-# follower 3 has appended the proposed entries to the log.
-deliver-msgs drop=(1)
-----
-dropped: 3->1 MsgAppResp Term:1 Log:0/12 Commit:11
-dropped: 3->1 MsgAppResp Term:1 Log:0/13 Commit:11
-
 # In the meantime, the entries are committed, and the leader sends the commit
 # index to all the followers.
 stabilize 1 2
@@ -74,6 +67,8 @@ stabilize 1 2
   2->1 MsgAppResp Term:1 Log:0/12 Commit:11
   2->1 MsgAppResp Term:1 Log:0/13 Commit:11
 > 1 receiving messages
+  3->1 MsgAppResp Term:1 Log:0/12 Commit:11
+  3->1 MsgAppResp Term:1 Log:0/13 Commit:11
   2->1 MsgAppResp Term:1 Log:0/12 Commit:11
   2->1 MsgAppResp Term:1 Log:0/13 Commit:11
 > 1 handling Ready
@@ -116,19 +111,13 @@ status 1
 ----
 1: StateReplicate match=13 next=14
 2: StateReplicate match=13 next=14
-3: StateReplicate match=11 next=14 inflight=2
+3: StateReplicate match=13 next=14
 
-# The leader still observes that the entries are in-flight to the follower 3,
-# since it hasn't heard from it. Nothing triggers updating the follower's
-# commit index, so we have to wait up to the full heartbeat interval before
-# the leader sends the commit index.
+# Wait for the next heartbeat response.
 tick-heartbeat 1
 ----
 ok
 
-# However, the leader does not push the real commit index to the follower 3. It
-# cuts the commit index at the Progress.Match mark, because it thinks that it is
-# unsafe to send a commit index higher than that.
 process-ready 1
 ----
 Ready MustSync=false:
@@ -136,25 +125,25 @@ Messages:
 1->2 MsgHeartbeat Term:1 Log:0/0
 1->3 MsgHeartbeat Term:1 Log:0/0
 
-# Since the heartbeat message does not bump the follower's commit index, it will
-# take another roundtrip with the leader to update it. As such, the total time
-# it takes for the follower to learn the commit index is:
-#
-#   delay = HeartbeatInterval + 3/2 * RTT
-#
-# This is suboptimal. It could have taken HeartbeatInterval + 1/2 * RTT, if the
-# leader sent the up-to-date commit index in the heartbeat message.
-#
-# See https://github.com/etcd-io/raft/issues/138 which aims to fix this.
-stabilize 1 3
+# On the next MsgApp sent to follower 3, the leader will include that the
+# commit index is 13. Notice that the leader doesn't send MsgApp to follower 2
+# because it knows that it has the latest commit index.
+stabilize 1 2 3
 ----
+> 2 receiving messages
+  1->2 MsgHeartbeat Term:1 Log:0/0
 > 3 receiving messages
   1->3 MsgHeartbeat Term:1 Log:0/0
+> 2 handling Ready
+  Ready MustSync=false:
+  Messages:
+  2->1 MsgHeartbeatResp Term:1 Log:0/0
 > 3 handling Ready
   Ready MustSync=false:
   Messages:
   3->1 MsgHeartbeatResp Term:1 Log:0/0
 > 1 receiving messages
+  2->1 MsgHeartbeatResp Term:1 Log:0/0
   3->1 MsgHeartbeatResp Term:1 Log:0/0
 > 1 handling Ready
   Ready MustSync=false:
@@ -172,3 +161,31 @@ stabilize 1 3
   3->1 MsgAppResp Term:1 Log:0/13 Commit:13
 > 1 receiving messages
   3->1 MsgAppResp Term:1 Log:0/13 Commit:13
+
+# If the commit index is up-to-date, no MsgApp will be sent.
+tick-heartbeat 1
+----
+ok
+
+stabilize 1 2 3
+----
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
+> 2 receiving messages
+  1->2 MsgHeartbeat Term:1 Log:0/0
+> 3 receiving messages
+  1->3 MsgHeartbeat Term:1 Log:0/0
+> 2 handling Ready
+  Ready MustSync=false:
+  Messages:
+  2->1 MsgHeartbeatResp Term:1 Log:0/0
+> 3 handling Ready
+  Ready MustSync=false:
+  Messages:
+  3->1 MsgHeartbeatResp Term:1 Log:0/0
+> 1 receiving messages
+  2->1 MsgHeartbeatResp Term:1 Log:0/0
+  3->1 MsgHeartbeatResp Term:1 Log:0/0

--- a/pkg/raft/testdata/msg_app_commit_index_leader_old_version.txt
+++ b/pkg/raft/testdata/msg_app_commit_index_leader_old_version.txt
@@ -1,13 +1,25 @@
-# This test demonstrates the effect of delayed commit on a follower node after a
-# network hiccup between the leader and this follower.
+# This test demonstrates the case where the new commit index advancement logic
+# via MsgApp landed on some nodes, but not the leader. In this case,
+# heartbeats will continue advancing the commit index normally.
 
 # Skip logging the boilerplate. Set up a raft group of 3 nodes, and elect node 1
 # as the leader. Nodes 2 and 3 are the followers.
+
+# TODO(ibrahim): Remove this test on versions >= 25.1 as it would no longer be
+# possible to have a leader with an old version with commit index advancement
+# MsgHeartbeat dependency.
+
 log-level none
 ----
 ok
 
-add-nodes 3 voters=(1,2,3) index=10
+# Add one node that will become the leader and set its CRDB version to be old.
+add-nodes 1 voters=(1, 2, 3) index=10 crdb-version=24.2
+----
+ok
+
+# Add two nodes with the new CRDB version.
+add-nodes 2 voters=(1, 2, 3) index=10 crdb-version=24.3
 ----
 ok
 
@@ -54,13 +66,6 @@ Messages:
 3->1 MsgAppResp Term:1 Log:0/12 Commit:11
 3->1 MsgAppResp Term:1 Log:0/13 Commit:11
 
-# Suppose there is a network blip which prevents the leader learning that the
-# follower 3 has appended the proposed entries to the log.
-deliver-msgs drop=(1)
-----
-dropped: 3->1 MsgAppResp Term:1 Log:0/12 Commit:11
-dropped: 3->1 MsgAppResp Term:1 Log:0/13 Commit:11
-
 # In the meantime, the entries are committed, and the leader sends the commit
 # index to all the followers.
 stabilize 1 2
@@ -74,6 +79,8 @@ stabilize 1 2
   2->1 MsgAppResp Term:1 Log:0/12 Commit:11
   2->1 MsgAppResp Term:1 Log:0/13 Commit:11
 > 1 receiving messages
+  3->1 MsgAppResp Term:1 Log:0/12 Commit:11
+  3->1 MsgAppResp Term:1 Log:0/13 Commit:11
   2->1 MsgAppResp Term:1 Log:0/12 Commit:11
   2->1 MsgAppResp Term:1 Log:0/13 Commit:11
 > 1 handling Ready
@@ -110,58 +117,35 @@ deliver-msgs drop=(3)
 dropped: 1->3 MsgApp Term:1 Log:1/13 Commit:12
 dropped: 1->3 MsgApp Term:1 Log:1/13 Commit:13
 
-# The network blip ends here.
-
 status 1
 ----
 1: StateReplicate match=13 next=14
 2: StateReplicate match=13 next=14
-3: StateReplicate match=11 next=14 inflight=2
+3: StateReplicate match=13 next=14
 
-# The leader still observes that the entries are in-flight to the follower 3,
-# since it hasn't heard from it. Nothing triggers updating the follower's
-# commit index, so we have to wait up to the full heartbeat interval before
-# the leader sends the commit index.
+# Wait for the next heartbeat response.
 tick-heartbeat 1
 ----
 ok
 
-# However, the leader does not push the real commit index to the follower 3. It
-# cuts the commit index at the Progress.Match mark, because it thinks that it is
-# unsafe to send a commit index higher than that.
 process-ready 1
 ----
 Ready MustSync=false:
 Messages:
-1->2 MsgHeartbeat Term:1 Log:0/0
-1->3 MsgHeartbeat Term:1 Log:0/0
+1->2 MsgHeartbeat Term:1 Log:0/0 Commit:13
+1->3 MsgHeartbeat Term:1 Log:0/0 Commit:13
 
-# Since the heartbeat message does not bump the follower's commit index, it will
-# take another roundtrip with the leader to update it. As such, the total time
-# it takes for the follower to learn the commit index is:
-#
-#   delay = HeartbeatInterval + 3/2 * RTT
-#
-# This is suboptimal. It could have taken HeartbeatInterval + 1/2 * RTT, if the
-# leader sent the up-to-date commit index in the heartbeat message.
-#
-# See https://github.com/etcd-io/raft/issues/138 which aims to fix this.
-stabilize 1 3
+# No MsgApp will be sent since the leader sent the latest commit index.
+stabilize 1 2 3
 ----
+> 2 receiving messages
+  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:13
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0
-> 3 handling Ready
+  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:13
+> 2 handling Ready
   Ready MustSync=false:
   Messages:
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
-> 1 receiving messages
-  3->1 MsgHeartbeatResp Term:1 Log:0/0
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->3 MsgApp Term:1 Log:1/13 Commit:13
-> 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/13 Commit:13
+  2->1 MsgHeartbeatResp Term:1 Log:0/0
 > 3 handling Ready
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:1
@@ -169,6 +153,7 @@ stabilize 1 3
   1/12 EntryNormal "data1"
   1/13 EntryNormal "data2"
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/13 Commit:13
+  3->1 MsgHeartbeatResp Term:1 Log:0/0
 > 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:0/13 Commit:13
+  2->1 MsgHeartbeatResp Term:1 Log:0/0
+  3->1 MsgHeartbeatResp Term:1 Log:0/0

--- a/pkg/raft/testdata/replicate_pause.txt
+++ b/pkg/raft/testdata/replicate_pause.txt
@@ -131,15 +131,15 @@ stabilize 1
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:17
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
 
 stabilize 2 3
 ----
 > 2 receiving messages
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:17
+  1->2 MsgHeartbeat Term:1 Log:0/0
 > 3 receiving messages
-  1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->3 MsgHeartbeat Term:1 Log:0/0
 > 2 handling Ready
   Ready MustSync=false:
   Messages:

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
@@ -63,7 +63,7 @@ process-ready 1
 ----
 Ready MustSync=false:
 Messages:
-1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
+1->2 MsgHeartbeat Term:1 Log:0/0
 1->3 MsgHeartbeat Term:1 Log:0/0
 
 # Iterate until no more work is done by the new peer. It receives the heartbeat
@@ -137,7 +137,7 @@ status 1
 stabilize
 ----
 > 2 receiving messages
-  1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
+  1->2 MsgHeartbeat Term:1 Log:0/0
 > 2 handling Ready
   Ready MustSync=false:
   Messages:

--- a/pkg/raft/tracker/progress.go
+++ b/pkg/raft/tracker/progress.go
@@ -56,6 +56,10 @@ type Progress struct {
 	// In StateSnapshot, sentCommit == PendingSnapshot == Next-1.
 	sentCommit uint64
 
+	// matchCommit is the commit index at which the follower is known to match the
+	// leader. It is durable on the follower.
+	matchCommit uint64
+
 	// State defines how the leader should interact with the follower.
 	//
 	// When in StateProbe, leader sends at most one replication message
@@ -196,6 +200,14 @@ func (pr *Progress) CanBumpCommit(index uint64) bool {
 	return index > pr.sentCommit && pr.sentCommit < pr.Next-1
 }
 
+// IsFollowerCommitStale returns true if the follower's commit index it less
+// than index.
+// If the follower's commit index+1 is pr.Next, it means that sending a larger
+// commit index won't change anything, therefore we don't send it.
+func (pr *Progress) IsFollowerCommitStale(index uint64) bool {
+	return index > pr.matchCommit && pr.matchCommit+1 < pr.Next
+}
+
 // SentCommit updates the sentCommit.
 func (pr *Progress) SentCommit(commit uint64) {
 	pr.sentCommit = commit
@@ -211,6 +223,14 @@ func (pr *Progress) MaybeUpdate(n uint64) bool {
 	pr.Match = n
 	pr.Next = max(pr.Next, n+1) // invariant: Match < Next
 	return true
+}
+
+// MaybeUpdateMatchCommit updates the match commit from a follower if it's
+// larger than the previous received commit.
+func (pr *Progress) MaybeUpdateMatchCommit(commit uint64) {
+	if commit > pr.matchCommit {
+		pr.matchCommit = commit
+	}
 }
 
 // MaybeDecrTo adjusts the Progress to the receipt of a MsgApp rejection. The
@@ -295,7 +315,11 @@ func (pr *Progress) IsPaused() bool {
 // to guarantee that eventually the flow is either accepted or rejected.
 //
 // In StateSnapshot, we do not send append messages.
-func (pr *Progress) ShouldSendMsgApp(last, commit uint64) bool {
+//
+// If advanceCommit is true, it means that MsgApp owns the responsibility of
+// closing the followers' commit index gap even if some MsgApp messages gets
+// dropped. If it's false, it means that the responsibility is on MsgHeartbeat.
+func (pr *Progress) ShouldSendMsgApp(last, commit uint64, advanceCommit bool) bool {
 	switch pr.State {
 	case StateProbe:
 		return !pr.MsgAppProbesPaused
@@ -320,7 +344,26 @@ func (pr *Progress) ShouldSendMsgApp(last, commit uint64) bool {
 		//	- our commit index exceeds the in-flight commit index, and
 		//	- sending it can commit at least one of the follower's entries
 		//	  (including the ones still in flight to it).
-		return pr.CanBumpCommit(commit)
+		if pr.CanBumpCommit(commit) {
+			return true
+		}
+
+		// Send an empty MsgApp containing the latest commit index if we know that
+		// the follower's commit index is stale and we haven't recently sent a
+		// MsgApp (according to the MsgAppProbesPaused flag).
+
+		// NOTE: This is a different condition than the one above because we only
+		// send this message if pr.MsgAppProbesPaused is false. After this message,
+		// pr.MsgAppProbesPaused will be set to true until we receive a heartbeat
+		// response from the follower. In contrast, the condition above can keep
+		// sending empty MsgApps eagerly until we have sent the latest commit index
+		// to the follower.
+		// TODO(iskettaneh): Remove the dependency on MsgAppProbesPaused to send
+		// MsgApps.
+		if advanceCommit {
+			return pr.IsFollowerCommitStale(commit) && !pr.MsgAppProbesPaused
+		}
+		return false
 
 	case StateSnapshot:
 		return false


### PR DESCRIPTION
This commit removes the commit index advancement's dependence on
heartbeats. It does so by making sure that the leader sends an empty
MsgApp request if it knows that the follower's commit index is stale.

Backward compatability arguments:

1) Followers can accept commit index advancement using both paths:
Heartbeats & MsgApps.

2) If the leader's point of view of the cluster version is old, it
uses the old path of advancing the followrs' commit index using
heartbeats.

3) If the leader's point of view of the cluster version is new, it
means that all nodes in the cluster (including all followers) have the
latest binary for sure. At that moment, the leader uses the new logic
of advancing the commit index using MsgApp rather than heartbeats.

Fixes: https://github.com/cockroachdb/cockroach/issues/125266

Epic: None

Release note: None