### PR TITLE
crosscluster: add conflictResolutionType column

### DIFF
--- a/pkg/sql/delegate/show_logical_replication_jobs.go
+++ b/pkg/sql/delegate/show_logical_replication_jobs.go
@@ -36,7 +36,10 @@ WHERE job_type = 'LOGICAL REPLICATION'
 		, 
 	hlc_to_timestamp((crdb_internal.pb_to_json(
 		'cockroach.sql.jobs.jobspb.Payload',
-		payload)->'logicalReplicationDetails'->'replicationStartTime'->>'wallTime')::DECIMAL) AS replication_start_time
+		payload)->'logicalReplicationDetails'->'replicationStartTime'->>'wallTime')::DECIMAL) AS replication_start_time,
+	IFNULL(crdb_internal.pb_to_json(
+		'cockroach.sql.jobs.jobspb.Payload',
+		payload)->'logicalReplicationDetails'->'defaultConflictResolution'->>'conflictResolutionType', 'LWW') AS conflict_resolution_type
 `
 )
 


### PR DESCRIPTION
This PR adds a column named `conflict_resolution_type` to rows output by the `SHOW LOGICAL REPLICATION JOBS WITH DETAILS` command. `conflict_resolution_type` can be either one of the following string values:

- LWW
- UDF
- DLQ

Example output of `SHOW REPLICATION JOBS WITH DETAILS`:
```
demo@127.0.0.1:26257/demoapp/b> SHOW LOGICAL REPLICATION JOBS WITH DETAILS;
        job_id       | status  | targets |        replicated_time        |    replication_start_time     | conflict_resolution_type
---------------------+---------+---------+-------------------------------+-------------------------------+---------------------------
  997060849214881793 | running | {tab1}  | 2024-08-22 17:53:43.60986+00  | 2024-08-22 17:53:43.60986+00  | DLQ
  997060849254957057 | running | {tab1}  | 2024-08-22 17:53:43.622359+00 | 2024-08-22 17:53:43.622359+00 | LWW
(2 rows)

Time: 15ms total (execution 15ms / network 0ms)
```

Epic: CRDB-40869
Fixes: #128960
Release note: None