### PR TITLE
storage: add additional trace statements for GC; fix counting

### DIFF
--- a/pkg/kv/kvserver/client_protectedts_test.go
+++ b/pkg/kv/kvserver/client_protectedts_test.go
@@ -208,7 +208,7 @@ ORDER BY raw_start_key ASC LIMIT 1`)
 	// timestamp of our record at the latest.
 	trace, _, err = s.Enqueue(ctx, "mvccGC", repl, true /* skipShouldQueue */, false /* async */)
 	require.NoError(t, err)
-	require.Regexp(t, "(?s)done with GC evaluation for 0 keys", trace.String())
+	require.Regexp(t, "(?s)handled \\d+ incoming point keys; deleted \\d+", trace.String())
 	thresh := thresholdFromTrace(trace)
 	require.Truef(t, thresh.Less(ptsRec.Timestamp), "threshold: %v, protected %v %q", thresh, ptsRec.Timestamp, trace)
 

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -598,7 +598,7 @@ func (r *replicaGCer) template() kvpb.GCRequest {
 
 func (r *replicaGCer) send(ctx context.Context, req kvpb.GCRequest) error {
 	n := atomic.AddInt32(&r.count, 1)
-	log.Eventf(ctx, "sending batch %d (%d keys)", n, len(req.Keys))
+	log.Eventf(ctx, "sending batch %d (%d keys, %d rangekeys)", n, len(req.Keys), len(req.RangeKeys))
 
 	ba := &kvpb.BatchRequest{}
 	// Technically not needed since we're talking directly to the Replica.

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -6283,12 +6283,15 @@ func MVCCGarbageCollect(
 	ms *enginepb.MVCCStats,
 	keys []kvpb.GCRequest_GCKey,
 	timestamp hlc.Timestamp,
-) error {
+) (retE error) {
 
 	var count int64
 	defer func(begin time.Time) {
-		log.Eventf(ctx, "done with GC evaluation for %d keys at %.2f keys/sec. Deleted %d entries",
-			len(keys), float64(len(keys))*1e9/float64(timeutil.Since(begin)), count)
+		log.Eventf(ctx, "handled %d incoming point keys; deleted %d in %s",
+			len(keys), count, timeutil.Since(begin))
+		if retE != nil {
+			log.Eventf(ctx, "err: %s", retE)
+		}
 	}(timeutil.Now())
 
 	// If there are no keys then there is no work.
@@ -6589,16 +6592,16 @@ type CollectableGCRangeKey struct {
 // not performed correctly by the level above.
 func MVCCGarbageCollectRangeKeys(
 	ctx context.Context, rw ReadWriter, ms *enginepb.MVCCStats, rks []CollectableGCRangeKey,
-) error {
+) (retE error) {
 
 	var count int64
 	defer func(begin time.Time) {
-		// TODO(oleg): this could be misleading if GC fails, but this function still
-		// reports how many keys were GC'd. The approach is identical to what point
-		// key GC does for consistency, but both places could be improved.
 		log.Eventf(ctx,
-			"done with GC evaluation for %d range keys at %.2f keys/sec. Deleted %d entries",
-			len(rks), float64(len(rks))*1e9/float64(timeutil.Since(begin)), count)
+			"handled %d incoming range keys; deleted %d fragments in %s",
+			len(rks), count, timeutil.Since(begin))
+		if retE != nil {
+			log.Eventf(ctx, "err: %s", retE)
+		}
 	}(timeutil.Now())
 
 	if len(rks) == 0 {
@@ -6707,9 +6710,12 @@ func MVCCGarbageCollectRangeKeys(
 				if !v.Timestamp.LessEq(gcKey.Timestamp) {
 					break
 				}
-				if err := rw.ClearMVCCRangeKey(rangeKeys.AsRangeKey(v)); err != nil {
+				k := rangeKeys.AsRangeKey(v)
+				log.Eventf(ctx, "clearing rangekey fragment: %s", k)
+				if err := rw.ClearMVCCRangeKey(k); err != nil {
 					return err
 				}
+				count++
 				if ms != nil {
 					ms.Add(updateStatsOnRangeKeyClearVersion(rangeKeys, v))
 				}


### PR DESCRIPTION
Currently, when performing a GC of point or range keys, we log a trace statement at completion of the method. If an error is encountered, it would be useful to surface it.

Update the  point and range key GC methods to print any error encountered during the GC.

Improve the trace statements for both the point and range key methods, indicating the number of incoming point / range keys, and the number of resulting point / range keys that were removed, along with the time taken to perform the GC.

Add additional trace statements for the range key method, logging the range key fragments that were removed.

Fix the `count` in `MVCCGarbageCollectRangeKeys`, capturing the count of range key fragments that were GC'd.

Fix #129419.

Release note: None.

Epic: None.