### PR TITLE
roachtest: actually run backup-restore/mixed-version in shared-process

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2661,8 +2661,6 @@ func registerBackupMixedVersion(r registry.Registry) {
 					mixedversion.ClusterSettingMutator("storage.ingest_split.enabled"),
 					mixedversion.ClusterSettingMutator("storage.sstable.compression_algorithm"),
 				),
-				// Multi-tenant deployments are currently unsupported. See #127378.
-				mixedversion.EnabledDeploymentModes(mixedversion.SystemOnlyDeployment),
 			)
 			testRNG := mvt.RNG()
 


### PR DESCRIPTION
An egregious oversight.

Epic: none

Release note: None