### PR TITLE
release-24.1: roachtest: disable shared-process for follower-reads / rebalance-load

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -978,7 +978,10 @@ func runFollowerReadsMixedVersionSingleRegionTest(
 	ctx context.Context, t test.Test, c cluster.Cluster,
 ) {
 	topology := topologySpec{multiRegion: false}
-	runFollowerReadsMixedVersionTest(ctx, t, c, topology, exactStaleness)
+	runFollowerReadsMixedVersionTest(ctx, t, c, topology, exactStaleness,
+		// Test currently fails in shared-process deployments, see: #129167.
+		mixedversion.EnabledDeploymentModes(mixedversion.SystemOnlyDeployment),
+	)
 }
 
 // runFollowerReadsMixedVersionGlobalTableTest runs a multi-region follower-read
@@ -993,6 +996,8 @@ func runFollowerReadsMixedVersionGlobalTableTest(
 		survival:    region,
 	}
 	runFollowerReadsMixedVersionTest(ctx, t, c, topology, strong,
+		// Test currently fails in shared-process deployments, see: #129167.
+		mixedversion.EnabledDeploymentModes(mixedversion.SystemOnlyDeployment),
 		// Disable fixtures because we're using a 6-node, multi-region cluster.
 		mixedversion.NeverUseFixtures,
 		// Use a longer upgrade timeout to give the migrations enough time to finish

--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -98,6 +98,8 @@ func registerRebalanceLoad(r registry.Registry) {
 				mixedversion.ClusterSettingOption(
 					install.ClusterSettingsOption(settings.ClusterSettings),
 				),
+				// Test currently fails in shared-process deployments, see: #129389.
+				mixedversion.EnabledDeploymentModes(mixedversion.SystemOnlyDeployment),
 			)
 			mvt.OnStartup("maybe enable split/scatter on tenant",
 				func(ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper) error {


### PR DESCRIPTION
Epic: none

Release note: None

Release justification: test only changes