### PR TITLE
kvserver: wiring of RACv2 to eval, and v1 => v2 transition code

### DIFF
--- a/pkg/kv/kvserver/flow_control_replica_integration.go
+++ b/pkg/kv/kvserver/flow_control_replica_integration.go
@@ -442,6 +442,22 @@ func (f *replicaFlowControlIntegrationImpl) clearState(ctx context.Context) {
 	f.disconnectedStreams = nil
 }
 
+type noopReplicaFlowControlIntegration struct{}
+
+func (n noopReplicaFlowControlIntegration) onBecameLeader(context.Context)    {}
+func (n noopReplicaFlowControlIntegration) onBecameFollower(context.Context)  {}
+func (n noopReplicaFlowControlIntegration) onDescChanged(context.Context)     {}
+func (n noopReplicaFlowControlIntegration) onFollowersPaused(context.Context) {}
+func (n noopReplicaFlowControlIntegration) onRaftTransportDisconnected(
+	context.Context, ...roachpb.StoreID,
+) {
+}
+func (n noopReplicaFlowControlIntegration) onRaftTicked(context.Context) {}
+func (n noopReplicaFlowControlIntegration) onDestroyed(context.Context)  {}
+func (n noopReplicaFlowControlIntegration) handle() (kvflowcontrol.Handle, bool) {
+	return nil, false
+}
+
 type replicaForRACv2 Replica
 
 var _ replica_rac2.Replica = &replicaForRACv2{}

--- a/pkg/kv/kvserver/flow_control_stores.go
+++ b/pkg/kv/kvserver/flow_control_stores.go
@@ -12,6 +12,7 @@ package kvserver
 
 import (
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb"
@@ -19,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/replica_rac2"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
@@ -51,6 +53,14 @@ func (sh *storesForFlowControl) Lookup(
 		return nil, false
 	}
 	return handle, found
+}
+
+// LookupReplicationAdmissionHandle is part of the StoresForFlowControl
+// interface.
+func (sh *storesForFlowControl) LookupReplicationAdmissionHandle(
+	rangeID roachpb.RangeID,
+) (kvflowcontrol.ReplicationAdmissionHandle, bool) {
+	return sh.Lookup(rangeID)
 }
 
 // Inspect is part of the StoresForFlowControl interface.
@@ -110,21 +120,57 @@ func makeStoreForFlowControl(store *Store) *storeForFlowControl {
 func (sh *storeForFlowControl) Lookup(
 	rangeID roachpb.RangeID,
 ) (_ kvflowcontrol.Handle, found bool) {
-	s := (*Store)(sh)
-	repl := s.GetReplicaIfExists(rangeID)
+	repl := sh.lookupReplica(rangeID)
 	if repl == nil {
 		return nil, false
 	}
-
-	if knobs := s.TestingKnobs().FlowControlTestingKnobs; knobs != nil &&
-		knobs.UseOnlyForScratchRanges &&
-		!repl.IsScratchRange() {
-		return nil, false
-	}
-
 	repl.mu.Lock()
 	defer repl.mu.Unlock()
 	return repl.mu.replicaFlowControlIntegration.handle()
+}
+
+// LookupReplicationAdmissionHandle is part of the StoresForFlowControl
+// interface.
+func (sh *storeForFlowControl) LookupReplicationAdmissionHandle(
+	rangeID roachpb.RangeID,
+) (kvflowcontrol.ReplicationAdmissionHandle, bool) {
+	repl := sh.lookupReplica(rangeID)
+	if repl == nil {
+		return nil, false
+	}
+	// NB: Admit is called soon after this lookup.
+	level := repl.flowControlV2.GetEnabledWhenLeader()
+	useV1 := level == replica_rac2.NotEnabledWhenLeader
+	var v1Handle kvflowcontrol.ReplicationAdmissionHandle
+	if useV1 {
+		repl.mu.Lock()
+		var found bool
+		v1Handle, found = repl.mu.replicaFlowControlIntegration.handle()
+		repl.mu.Unlock()
+		if !found {
+			return nil, found
+		}
+	}
+	// INVARIANT: useV1 => v1Handle was found.
+	return admissionDemuxHandle{
+		v1Handle: v1Handle,
+		r:        repl,
+		useV1:    useV1,
+	}, true
+}
+
+func (sh *storeForFlowControl) lookupReplica(rangeID roachpb.RangeID) *Replica {
+	s := (*Store)(sh)
+	repl := s.GetReplicaIfExists(rangeID)
+	if repl == nil {
+		return nil
+	}
+	if knobs := s.TestingKnobs().FlowControlTestingKnobs; knobs != nil &&
+		knobs.UseOnlyForScratchRanges &&
+		!repl.IsScratchRange() {
+		return nil
+	}
+	return repl
 }
 
 // ResetStreams is part of the StoresForFlowControl interface.
@@ -206,6 +252,14 @@ var _ StoresForFlowControl = NoopStoresFlowControlIntegration{}
 // Lookup is part of the StoresForFlowControl interface.
 func (l NoopStoresFlowControlIntegration) Lookup(roachpb.RangeID) (kvflowcontrol.Handle, bool) {
 	return nil, false
+}
+
+// LookupReplicationAdmissionHandle is part of the StoresForFlowControl
+// interface.
+func (l NoopStoresFlowControlIntegration) LookupReplicationAdmissionHandle(
+	rangeID roachpb.RangeID,
+) (kvflowcontrol.ReplicationAdmissionHandle, bool) {
+	return l.Lookup(rangeID)
 }
 
 // ResetStreams is part of the StoresForFlowControl interface.
@@ -297,4 +351,36 @@ func (ss *storesForRACv2) ScheduleAdmittedResponseForRangeRACv2(
 		repl.flowControlV2.EnqueuePiggybackedAdmittedAtLeader(m.Msg)
 		s.scheduler.EnqueueRACv2PiggybackAdmitted(m.RangeID)
 	}
+}
+
+type admissionDemuxHandle struct {
+	v1Handle kvflowcontrol.ReplicationAdmissionHandle
+	r        *Replica
+	useV1    bool
+}
+
+// Admit implements kvflowcontrol.ReplicationAdmissionHandle.
+func (h admissionDemuxHandle) Admit(
+	ctx context.Context, pri admissionpb.WorkPriority, ct time.Time,
+) (admitted bool, err error) {
+	if h.useV1 {
+		admitted, err = h.v1Handle.Admit(ctx, pri, ct)
+		if err != nil {
+			return admitted, err
+		}
+		// It is possible a transition from v1 => v2 happened while waiting, which
+		// can cause either value of admitted. See the comment in
+		// ReplicationAdmissionHandle.
+		level := h.r.flowControlV2.GetEnabledWhenLeader()
+		if level == replica_rac2.NotEnabledWhenLeader {
+			return admitted, err
+		}
+		// Transition from v1 => v2 happened while waiting. Fall through to wait
+		// on v2, since it is possible that nothing was waited on, or the
+		// overloaded stream was not waited on. This double wait is acceptable
+		// since during the transition from v1 => v2 only elastic work should be
+		// subject to replication AC, and we would like to err towards not
+		// overloading.
+	}
+	return h.r.flowControlV2.AdmitForEval(ctx, pri, ct)
 }

--- a/pkg/kv/kvserver/kvadmission/kvadmission.go
+++ b/pkg/kv/kvserver/kvadmission/kvadmission.go
@@ -338,7 +338,7 @@ func (n *controllerImpl) AdmitKVWork(
 		var admitted bool
 		attemptFlowControl := kvflowcontrol.Enabled.Get(&n.settings.SV)
 		if attemptFlowControl && !bypassAdmission {
-			kvflowHandle, found := n.kvflowHandles.Lookup(ba.RangeID)
+			kvflowHandle, found := n.kvflowHandles.LookupReplicationAdmissionHandle(ba.RangeID)
 			if !found {
 				return Handle{}, nil
 			}

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowdispatch/kvflowdispatch_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowdispatch/kvflowdispatch_test.go
@@ -226,6 +226,12 @@ func (d dummyHandles) Lookup(id roachpb.RangeID) (kvflowcontrol.Handle, bool) {
 	return nil, false
 }
 
+func (d dummyHandles) LookupReplicationAdmissionHandle(
+	rangeID roachpb.RangeID,
+) (kvflowcontrol.ReplicationAdmissionHandle, bool) {
+	return d.Lookup(rangeID)
+}
+
 func (d dummyHandles) ResetStreams(ctx context.Context) {}
 
 func (d dummyHandles) Inspect() []roachpb.RangeID {

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -389,6 +389,15 @@ type Processor interface {
 	AdmittedLogEntry(
 		ctx context.Context, state EntryForAdmissionCallbackState,
 	)
+
+	// AdmitForEval is called to admit work that wants to evaluate at the
+	// leaseholder.
+	//
+	// If the callee decided not to admit because replication admission
+	// control is disabled, or for any other reason, admitted will be false
+	// and error will be nil.
+	AdmitForEval(
+		ctx context.Context, pri admissionpb.WorkPriority, ct time.Time) (admitted bool, err error)
 }
 
 type processorImpl struct {
@@ -886,6 +895,14 @@ func (p *processorImpl) AdmittedLogEntry(
 		p.mu.scheduledAdmittedProcessing = true
 		p.opts.RaftScheduler.EnqueueRaftReady(p.opts.RangeID)
 	}
+}
+
+// AdmitForEval implements Processor.
+func (p *processorImpl) AdmitForEval(
+	ctx context.Context, pri admissionpb.WorkPriority, ct time.Time,
+) (admitted bool, err error) {
+	// TODO(sumeer):
+	return false, nil
 }
 
 func admittedIncreased(prev, next [raftpb.NumPriorities]uint64) bool {

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -871,6 +871,10 @@ type Replica struct {
 		// both the leaseholder and raft leader.
 		//
 		// Accessing it requires Replica.mu to be held, exclusively.
+		//
+		// There is a one-way transition from RACv1 => RACv2 that causes the
+		// existing real implementation to be destroyed and replaced with a real
+		// implementation.
 		replicaFlowControlIntegration replicaFlowControlIntegration
 	}
 


### PR DESCRIPTION
The replicaFlowControlIntegration object for v1, which is a member of Replica.mu, is destroyed and replaced by a noop implementation.

The admissionDemuxHandle implements the new ReplicationAdmissionHandle and handles a switch from v1 to v2 during the wait.

At raft log entry encoding time, for the entries that were subject to replication admission control, we look at the latest value of the EnabledWhenLeaderLevel to decide whether we can use the v2 encoding.

Fixes #129129
Fixes #128756

Epic: CRDB-37515

Release note: None