### PR TITLE
sql: rename snapshot isolation enabled setting to favor "repeatable read"

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/read_committed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/read_committed
@@ -84,9 +84,9 @@ SELECT aisle FROM supermarket WHERE person = 'matilda' FOR UPDATE
 statement ok
 ROLLBACK
 
-# Use SELECT FOR UPDATE under snapshot isolation.
+# Use SELECT FOR UPDATE under repeatable read isolation.
 statement ok
-SET CLUSTER SETTING sql.txn.snapshot_isolation.enabled = true
+SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = true
 
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SNAPSHOT
@@ -100,7 +100,7 @@ statement ok
 ROLLBACK
 
 statement ok
-RESET CLUSTER SETTING sql.txn.snapshot_isolation.enabled
+RESET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled
 
 # Use SELECT FOR UPDATE in a subquery under read committed isolation.
 statement ok

--- a/pkg/cmd/roachtest/tests/ycsb.go
+++ b/pkg/cmd/roachtest/tests/ycsb.go
@@ -193,6 +193,8 @@ func enableIsolationLevels(ctx context.Context, t test.Test, db *gosql.DB) error
 		// master, we should keep these to ensure that the settings are configured
 		// properly in mixed-version roachtests.
 		`SET CLUSTER SETTING sql.txn.read_committed_isolation.enabled = 'true';`,
+		// NOTE: for a similar reason, we use the deprecated name for this setting
+		// to ensure that it is properly configured in mixed-version roachtests.
 		`SET CLUSTER SETTING sql.txn.snapshot_isolation.enabled = 'true';`,
 	} {
 		if _, err := db.ExecContext(ctx, cmd); err != nil {

--- a/pkg/settings/options.go
+++ b/pkg/settings/options.go
@@ -45,7 +45,7 @@ func WithName(name SettingName) SettingOption {
 }
 
 // WithRetiredName configures a previous user-visible name of the setting,
-// when that name was diferent from the key and is not in use any more.
+// when that name was different from the key and is not in use any more.
 func WithRetiredName(name SettingName) SettingOption {
 	return SettingOption{commonOpt: func(c *common) {
 		registerAlias(c.key, name, NameRetired)

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3529,13 +3529,16 @@ var allowReadCommittedIsolation = settings.RegisterBoolSetting(
 	settings.WithPublic,
 )
 
+// TODO(nvanbenschoten): rename this variable and update uses of it to favor
+// "repeatable read" over "snapshot".
 var allowSnapshotIsolation = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"sql.txn.snapshot_isolation.enabled",
-	"set to true to allow transactions to use the SNAPSHOT isolation level. At "+
-		"the time of writing, this setting is intended only for usage by "+
+	"set to true to allow transactions to use the REPEATABLE READ isolation "+
+		"level. At the time of writing, this setting is intended only for usage by "+
 		"CockroachDB developers.",
 	false,
+	settings.WithName("sql.txn.repeatable_read_isolation.enabled"),
 )
 
 var logIsolationLevelLimiter = log.Every(10 * time.Second)

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -428,7 +428,7 @@ func TestHalloweenProblemAvoidance(t *testing.T) {
 	defer s.Stopper().Stop(context.Background())
 
 	for _, s := range []string{
-		`SET CLUSTER SETTING sql.txn.snapshot_isolation.enabled = true;`,
+		`SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = true;`,
 		`CREATE DATABASE t;`,
 		`CREATE TABLE t.test (x FLOAT);`,
 	} {

--- a/pkg/sql/logictest/testdata/logic_test/cluster_locks
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_locks
@@ -355,7 +355,7 @@ SELECT count(*) FROM crdb_internal.cluster_locks WHERE table_name IN ('t','t2')
 # Test with different isolation levels.
 
 statement ok
-SET CLUSTER SETTING sql.txn.snapshot_isolation.enabled = true
+SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = true
 
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -341,9 +341,9 @@ SHOW DEFAULT_TRANSACTION_ISOLATION
 ----
 serializable
 
-# SNAPSHOT can be used with a hidden cluster setting
+# REPEATABLE READ can be used with a hidden cluster setting.
 statement ok
-SET CLUSTER SETTING sql.txn.snapshot_isolation.enabled = true
+SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = true
 
 statement ok
 BEGIN
@@ -411,7 +411,7 @@ statement ok
 COMMIT
 
 statement ok
-SET CLUSTER SETTING sql.txn.snapshot_isolation.enabled = false
+SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = false
 
 statement ok
 SET CLUSTER SETTING sql.txn.read_committed_isolation.enabled = true
@@ -759,7 +759,7 @@ statement ok
 COMMIT
 
 statement ok
-SET CLUSTER SETTING sql.txn.snapshot_isolation.enabled = true
+SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = true
 
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SNAPSHOT, PRIORITY LOW
@@ -791,7 +791,7 @@ high
 statement ok
 COMMIT
 
-# With the snapshot_isolation.enabled cluster setting set to true,
+# With the repeatable_read_isolation.enabled cluster setting set to true,
 # REPEATABLE READ gets mapped to SNAPSHOT if there is a valid license.
 onlyif config enterprise-configs
 query T noticetrace
@@ -820,7 +820,7 @@ SHOW DEFAULT_TRANSACTION_ISOLATION
 serializable
 
 statement ok
-SET CLUSTER SETTING sql.txn.snapshot_isolation.enabled = false
+SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = false
 
 statement ok
 SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
@@ -922,9 +922,9 @@ SHOW default_transaction_isolation
 serializable
 
 statement ok
-SET CLUSTER SETTING sql.txn.snapshot_isolation.enabled = true
+SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = true
 
-# Since snapshot_isolation.enabled is true, setting isolation level to
+# Since repeatable_read_isolation.enabled is true, setting isolation level to
 # REPEATABLE READ should map to SNAPSHOT.
 statement ok
 SET default_transaction_isolation = 'repeatable read'
@@ -957,10 +957,10 @@ SHOW default_transaction_isolation
 serializable
 
 statement ok
-SET CLUSTER SETTING sql.txn.snapshot_isolation.enabled = false
+SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = false
 
-# Since snapshot_isolation.enabled is false, setting isolation level to SNAPSHOT
-# should map to SERIALIZABLE.
+# Since repeatable_read_isolation.enabled is false, setting isolation level to
+# SNAPSHOT should map to SERIALIZABLE.
 statement ok
 SET default_transaction_isolation = 'repeatable read'
 

--- a/pkg/sql/testdata/telemetry/isolation_level
+++ b/pkg/sql/testdata/telemetry/isolation_level
@@ -3,7 +3,7 @@ SET CLUSTER SETTING sql.txn.read_committed_isolation.enabled = false
 ----
 
 exec
-SET CLUSTER SETTING sql.txn.snapshot_isolation.enabled = false
+SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = false
 ----
 
 feature-list
@@ -95,7 +95,7 @@ SET CLUSTER SETTING sql.txn.read_committed_isolation.enabled = true
 ----
 
 exec
-SET CLUSTER SETTING sql.txn.snapshot_isolation.enabled = true
+SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = true
 ----
 
 feature-usage

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -422,6 +422,7 @@ var varGen = map[string]sessionVar{
 			hasLicense := base.CCLDistributionAndEnterpriseEnabled(m.settings)
 			var allowedValues = []string{"serializable"}
 			if allowSnapshot {
+				// TODO(nvanbenschoten): switch to "repeatable read".
 				allowedValues = append(allowedValues, "snapshot")
 			}
 			if allowReadCommitted {
@@ -1615,6 +1616,7 @@ var varGen = map[string]sessionVar{
 			if !ok {
 				var allowedValues = []string{"serializable"}
 				if allowSnapshotIsolation.Get(&evalCtx.ExecCfg.Settings.SV) {
+					// TODO(nvanbenschoten): switch to "repeatable read".
 					allowedValues = append(allowedValues, "snapshot")
 				}
 				if allowReadCommittedIsolation.Get(&evalCtx.ExecCfg.Settings.SV) {


### PR DESCRIPTION
This commit renames the setting that enables snapshot/repeatable read isolation from `sql.txn.snapshot_isolation.enabled` to `sql.txn.repeatable_read_isolation.enabled`.

This is part of a larger change to favor the term "repeatable read" over "snapshot" at the SQL level.

Epic: None
Release note: None