### PR TITLE
kv,storage: add new OriginTimestamp option to ConditionalPut

### DIFF
--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -2553,3 +2553,12 @@ func (writeOptions *WriteOptions) GetOriginID() uint32 {
 	}
 	return writeOptions.OriginID
 }
+
+func (r *ConditionalPutRequest) Validate() error {
+	if !r.OriginTimestamp.IsEmpty() {
+		if r.AllowIfDoesNotExist {
+			return errors.AssertionFailedf("invalid ConditionalPutRequest: AllowIfDoesNotExist and non-empty OriginTimestamp are incompatible")
+		}
+	}
+	return nil
+}

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -382,6 +382,39 @@ message ConditionalPutRequest {
   // timestamp. This option should be used with care as it precludes
   // the use of this value with transactions.
   bool inline = 7;
+
+  // OriginTimestamp, if set, indicates that the ConditionalPut should
+  // only succeed if the provided timestamp is greater than the
+  // OriginTimestamp field in the MVCCValueHeader of the existing
+  // value (if the value has a non-zero OriginTimestamp) or the MVCC
+  // timestamp of the existing value. If there is no existing value,
+  // the timestamp check succeeds.
+  //
+  // The conditional put request will only succeed if this timestamp
+  // comparison is successful and the expected bytes matches the
+  // actual bytes.
+  //
+  // On success, this timestamp will also be stored in the
+  // OriginTimestamp field of the the MVCCValueHeader for the newly
+  // written value.
+  //
+  // In the proposed use case, the OriginTimestamp is the MVCC version
+  // timestamp of the row on the source cluster and the semantics lead
+  // to idempotent last-write-wins semantics against the "original
+  // MVCC timestamp" of the value on the destination, which is its
+  // MVCC timestamp or, if set, the OriginTimestamp (reflecting that
+  // this value originated from the source cluster).
+  //
+  // Used by logical data replication.
+  util.hlc.Timestamp origin_timestamp = 8 [(gogoproto.nullable) = false];
+
+  // ShouldWinOriginTimestampTie, if true, indicates that if the "comparison
+  // timestamp" (see comment on OriginTimestamp) and OriginTimestamp are equal,
+  // then the ConditionalPut should succeed (assuming the expected and actual
+  // bytes also match).
+  //
+  // This must only be used in conjunction with OriginTimestamp.
+  bool should_win_origin_timestamp_tie = 9;
 }
 
 // A ConditionalPutResponse is the return value from the
@@ -3213,7 +3246,7 @@ message RangeFeedRequest {
   // OmitInRangefeeds = true, the write will not be emitted on the rangefeed.
   // WithFiltering should NOT be set for system-table rangefeeds.
   bool with_filtering = 7;
-  
+
   // WithMatchingOriginIDs specifies if the rangefeed server should emit events
   // originating from specific clusters during Logical Data Replication. If this
   // field is empty, all events are emitted.

--- a/pkg/kv/kvpb/errors.go
+++ b/pkg/kv/kvpb/errors.go
@@ -1186,7 +1186,13 @@ func (e *ConditionFailedError) Error() string {
 }
 
 func (e *ConditionFailedError) SafeFormatError(p errors.Printer) (next error) {
-	p.Printf("unexpected value: %s", e.ActualValue)
+	if e.HadNewerOriginTimestamp {
+		p.Printf("higher OriginTimestamp but unexpected value: %s", e.ActualValue)
+	} else if e.OriginTimestampOlderThan.IsSet() {
+		p.Printf("OriginTimestamp older than %s", e.OriginTimestampOlderThan)
+	} else {
+		p.Printf("unexpected value: %s", e.ActualValue)
+	}
 	return nil
 }
 

--- a/pkg/kv/kvpb/errors.proto
+++ b/pkg/kv/kvpb/errors.proto
@@ -400,6 +400,20 @@ message OpRequiresTxnError {
 // contain the actual value found.
 message ConditionFailedError {
   optional roachpb.Value actual_value = 1;
+  // HadNewerOriginTimestamp is returned when an OriginTimestamp was
+  // sent in the conditional put, the origin timestamp was newer than
+  // the existing value's "comparison timestamp" (see comment for
+  // OriginTimestampOlderThan) but the expected value was
+  // mismatched. The caller may choose to try again using the returned
+  // ActualValue as the expected value.
+  optional bool had_newer_origin_timestamp = 2 [(gogoproto.nullable) = false];
+  // OriginTimestampOlderThan is returned when an OriginTimestamp was
+  // sent in the conditional put and it was older than the existing
+  // value's OriginTimestamp (if it exists) or MVCC timestamp.
+  //
+  // See the comment on the OriginTimestamp field of
+  // kvpb.ConditionalPutRequest for more details.
+  optional util.hlc.Timestamp origin_timestamp_older_than = 3 [(gogoproto.nullable) = false];
 }
 
 // A LeaseRejectedError indicates that the requested replica could
@@ -692,7 +706,7 @@ message RefreshFailedError {
 
   // The timestamp the key was last updated.
   optional util.hlc.Timestamp timestamp = 3 [(gogoproto.nullable) = false];
-  
+
   // The conflicting transaction's TxnMeta, if available. This field is used
   // when the refresh fails with REASON_INTENT and is bubbled up for
   // observability purposes to track the conflicting transaction. This field is

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -972,7 +972,7 @@ func runMVCCConditionalPut(
 	for i := 0; i < b.N; i++ {
 		key := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(i)))
 		ts := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
-		if _, err := MVCCConditionalPut(ctx, eng, key, ts, value, expected, CPutFailIfMissing, MVCCWriteOptions{}); err != nil {
+		if _, err := MVCCConditionalPut(ctx, eng, key, ts, value, expected, ConditionalPutWriteOptions{AllowIfDoesNotExist: CPutFailIfMissing}); err != nil {
 			b.Fatalf("failed put: %+v", err)
 		}
 	}
@@ -995,7 +995,7 @@ func runMVCCBlindConditionalPut(ctx context.Context, b *testing.B, emk engineMak
 		key := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(i)))
 		ts := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
 		if _, err := MVCCBlindConditionalPut(
-			ctx, eng, key, ts, value, nil, CPutFailIfMissing, MVCCWriteOptions{},
+			ctx, eng, key, ts, value, nil, ConditionalPutWriteOptions{AllowIfDoesNotExist: CPutFailIfMissing},
 		); err != nil {
 			b.Fatalf("failed put: %+v", err)
 		}

--- a/pkg/storage/enginepb/mvcc3.proto
+++ b/pkg/storage/enginepb/mvcc3.proto
@@ -150,7 +150,7 @@ message IgnoredSeqNumRange {
 //
 // NB: a shallow copy of this value has to equal a deep copy, i.e. there
 // must be (recursively) no pointers in this type. Should this need to
-// change, need to update mvccGetWithValueHeader.
+// change, need to update mvccGet.
 //
 // NB: ensure that this struct stays in sync with MVCCValueHeader{Pure,CrdbTest}.
 // See kvpb.RequestHeader for details on how they help us keep the KVNemesisSeq

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -239,7 +239,10 @@ func (m mvccCPutOp) run(ctx context.Context) string {
 	txn.Sequence++
 
 	_, err := storage.MVCCConditionalPut(ctx, writer, m.key,
-		txn.ReadTimestamp, m.value, m.expVal, true, storage.MVCCWriteOptions{Txn: txn})
+		txn.ReadTimestamp, m.value, m.expVal, storage.ConditionalPutWriteOptions{
+			MVCCWriteOptions:    storage.MVCCWriteOptions{Txn: txn},
+			AllowIfDoesNotExist: true,
+		})
 	if err != nil {
 		if writeTooOldErr := (*kvpb.WriteTooOldError)(nil); errors.As(err, &writeTooOldErr) {
 			txn.WriteTimestamp.Forward(writeTooOldErr.ActualTimestamp)

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -386,15 +386,15 @@ func (r MVCCRangeKeyValue) Clone() MVCCRangeKeyValue {
 	return r
 }
 
-// optionalValue represents an optional roachpb.Value. It is preferred
-// over a *roachpb.Value to avoid the forced heap allocation.
+// optionalValue represents an optional MVCCValue. It is preferred
+// over a *roachpb.Value or *MVCCValue to avoid the forced heap allocation.
 type optionalValue struct {
-	roachpb.Value
+	MVCCValue
 	exists bool
 }
 
-func makeOptionalValue(v roachpb.Value) optionalValue {
-	return optionalValue{Value: v, exists: true}
+func makeOptionalValue(v MVCCValue) optionalValue {
+	return optionalValue{MVCCValue: v, exists: true}
 }
 
 func (v *optionalValue) IsPresent() bool {
@@ -412,6 +412,21 @@ func (v *optionalValue) ToPointer() *roachpb.Value {
 	// Copy to prevent forcing receiver onto heap.
 	cpy := v.Value
 	return &cpy
+}
+
+func (v *optionalValue) isOriginTimestampWinner(
+	proposedTS hlc.Timestamp, inclusive bool,
+) (bool, hlc.Timestamp) {
+	if !v.exists {
+		return true, hlc.Timestamp{}
+	}
+
+	existTS := v.Value.Timestamp
+	if v.MVCCValueHeader.OriginTimestamp.IsSet() {
+		existTS = v.MVCCValueHeader.OriginTimestamp
+	}
+
+	return existTS.Less(proposedTS) || (inclusive && existTS.Equal(proposedTS)), existTS
 }
 
 // isSysLocal returns whether the key is system-local.
@@ -1406,11 +1421,11 @@ func MVCCGetForKnownTimestampWithNoIntent(
 		// recently, so may be in the memtable or L0. A Pebble Get will
 		// iteratively go down the levels and find the value in a higher level,
 		// which would avoid seeking all the levels. This will not need to handle
-		// rangekeys. We won't be able to use mvccGetWithValueHeader, that we are
-		// using below for convenience. We should also measure that the Get is
-		// performant enough to avoid the need to use a batch-only iterator for
-		// the valueInBatch case (though using the batch-only iterator allows us
-		// to assert that the value was indeed found in the batch).
+		// rangekeys. We won't be able to use mvccGet, that we are using below for
+		// convenience. We should also measure that the Get is performant enough
+		// to avoid the need to use a batch-only iterator for the valueInBatch
+		// case (though using the batch-only iterator allows us to assert that the
+		// value was indeed found in the batch).
 		iter, err = batch.NewMVCCIterator(ctx, MVCCKeyIterKind,
 			IterOptions{
 				KeyTypes: IterKeyTypePointsAndRanges, Prefix: true, ReadCategory: fs.RangefeedReadCategory})
@@ -1420,14 +1435,14 @@ func MVCCGetForKnownTimestampWithNoIntent(
 	}
 	defer iter.Close()
 
-	// Use mvccGetWithValueHeader, even though we know the exact timestamp,
-	// since it convenient.
+	// Use mvccGet, even though we know the exact timestamp, since it
+	// convenient.
 	//
-	// mvccGetWithValueHeader will expose a rangekey tombstone for key@timesamp,
-	// as a point, even though we know key@timestamp must be a point-key. We
-	// should stop using mvccGetWithValueHeader, which would allow us to assert
-	// on this expected behavior.
-	value, intent, vh, err := mvccGetWithValueHeader(
+	// mvccGet will expose a rangekey tombstone for key@timesamp, as a
+	// point, even though we know key@timestamp must be a point-key. We
+	// should stop using mvccGet, which would allow us to assert on this
+	// expected behavior.
+	value, intent, err := mvccGet(
 		ctx, iter, key, timestamp, MVCCGetOptions{Tombstones: true})
 	val := value.ToPointer()
 	if intent != nil {
@@ -1443,7 +1458,7 @@ func MVCCGetForKnownTimestampWithNoIntent(
 		return nil, enginepb.MVCCValueHeader{}, errors.Errorf(
 			"expected timestamp %v and found %v for key %v", timestamp, val.Timestamp, key)
 	}
-	return val, vh, err
+	return val, value.MVCCValueHeader, err
 }
 
 // MVCCGetWithValueHeader is like MVCCGet, but in addition returns the
@@ -1477,7 +1492,7 @@ func MVCCGetWithValueHeader(
 		return result, enginepb.MVCCValueHeader{}, err
 	}
 	defer iter.Close()
-	value, intent, vh, err := mvccGetWithValueHeader(ctx, iter, key, timestamp, opts)
+	value, intent, err := mvccGet(ctx, iter, key, timestamp, opts)
 	val := value.ToPointer()
 	if err == nil && val != nil {
 		// NB: This calculation is different from Scan, since Scan responses include
@@ -1494,10 +1509,13 @@ func MVCCGetWithValueHeader(
 	}
 	result.Value = val
 	result.Intent = intent
-	return result, vh, err
+	return result, value.MVCCValueHeader, err
 }
 
-// gcassert:inline
+// mvccGet returns an optionalValue containing the MVCCValue for the
+// given key (if it exists).
+//
+// The MVCCValueHeader is included in the returned MVCCValue.
 func mvccGet(
 	ctx context.Context,
 	iter MVCCIterator,
@@ -1505,28 +1523,17 @@ func mvccGet(
 	timestamp hlc.Timestamp,
 	opts MVCCGetOptions,
 ) (value optionalValue, intent *roachpb.Intent, err error) {
-	value, intent, _, err = mvccGetWithValueHeader(ctx, iter, key, timestamp, opts)
-	return value, intent, err
-}
-
-func mvccGetWithValueHeader(
-	ctx context.Context,
-	iter MVCCIterator,
-	key roachpb.Key,
-	timestamp hlc.Timestamp,
-	opts MVCCGetOptions,
-) (value optionalValue, intent *roachpb.Intent, vh enginepb.MVCCValueHeader, err error) {
 	if len(key) == 0 {
-		return optionalValue{}, nil, enginepb.MVCCValueHeader{}, emptyKeyError()
+		return optionalValue{}, nil, emptyKeyError()
 	}
 	if timestamp.WallTime < 0 {
-		return optionalValue{}, nil, enginepb.MVCCValueHeader{}, errors.Errorf("cannot write to %q at timestamp %s", key, timestamp)
+		return optionalValue{}, nil, errors.Errorf("cannot write to %q at timestamp %s", key, timestamp)
 	}
 	if util.RaceEnabled && !iter.IsPrefix() {
-		return optionalValue{}, nil, enginepb.MVCCValueHeader{}, errors.AssertionFailedf("mvccGet called with non-prefix iterator")
+		return optionalValue{}, nil, errors.AssertionFailedf("mvccGet called with non-prefix iterator")
 	}
 	if err := opts.validate(); err != nil {
-		return optionalValue{}, nil, enginepb.MVCCValueHeader{}, err
+		return optionalValue{}, nil, err
 	}
 
 	mvccScanner := pebbleMVCCScannerPool.Get().(*pebbleMVCCScanner)
@@ -1566,40 +1573,41 @@ func mvccGetWithValueHeader(
 	}
 
 	if mvccScanner.err != nil {
-		return optionalValue{}, nil, enginepb.MVCCValueHeader{}, mvccScanner.err
+		return optionalValue{}, nil, mvccScanner.err
 	}
 	intents, err := buildScanIntents(mvccScanner.intentsRepr())
 	if err != nil {
-		return optionalValue{}, nil, enginepb.MVCCValueHeader{}, err
+		return optionalValue{}, nil, err
 	}
 	if opts.errOnIntents() && len(intents) > 0 {
 		lcErr := &kvpb.LockConflictError{Locks: roachpb.AsLocks(intents)}
-		return optionalValue{}, nil, enginepb.MVCCValueHeader{}, lcErr
+		return optionalValue{}, nil, lcErr
 	}
 
 	if len(intents) > 1 {
-		return optionalValue{}, nil, enginepb.MVCCValueHeader{}, errors.Errorf("expected 0 or 1 intents, got %d", len(intents))
+		return optionalValue{}, nil, errors.Errorf("expected 0 or 1 intents, got %d", len(intents))
 	} else if len(intents) == 1 {
 		intent = &intents[0]
 	}
 
 	if len(results.repr) == 0 {
-		return optionalValue{}, intent, enginepb.MVCCValueHeader{}, nil
+		return optionalValue{}, intent, nil
 	}
 
 	mvccKey, rawValue, _, err := MVCCScanDecodeKeyValue(results.repr)
 	if err != nil {
-		return optionalValue{}, nil, enginepb.MVCCValueHeader{}, err
+		return optionalValue{}, nil, err
 	}
 
-	value = makeOptionalValue(roachpb.Value{
-		RawBytes:  rawValue,
-		Timestamp: mvccKey.Timestamp,
-	})
 	// NB: we may return MVCCValueHeader out of curUnsafeValue because that
 	// type does not contain any pointers. A comment on MVCCValueHeader ensures
 	// that this stays true.
-	return value, intent, mvccScanner.curUnsafeValue.MVCCValueHeader, nil
+	value = makeOptionalValue(MVCCValue{Value: roachpb.Value{
+		RawBytes:  rawValue,
+		Timestamp: mvccKey.Timestamp,
+	}, MVCCValueHeader: mvccScanner.curUnsafeValue.MVCCValueHeader})
+
+	return value, intent, nil
 }
 
 // MVCCGetAsTxn constructs a temporary transaction from the given transaction
@@ -2105,7 +2113,7 @@ func replayTransactionalWrite(
 			if err != nil {
 				return err
 			}
-			writtenValue = makeOptionalValue(intentVal.Value)
+			writtenValue = makeOptionalValue(intentVal)
 		}
 	}
 	if !writtenValue.exists {
@@ -2139,19 +2147,20 @@ func replayTransactionalWrite(
 			if err != nil {
 				return err
 			}
-			exVal = makeOptionalValue(prevIntentVal.Value)
+			exVal = makeOptionalValue(prevIntentVal)
 		} else {
 			// If the previous value at the key wasn't written by this
 			// transaction, or it was hidden by a rolled back seqnum, we look at
 			// last committed value on the key. Since we want the last committed
 			// value on the key, we read below our previous intents here.
 			metaTimestamp := meta.Timestamp.ToTimestamp()
-			exVal, _, err = mvccGet(ctx, iter, key, metaTimestamp.Prev(), MVCCGetOptions{
+			val, _, err := mvccGet(ctx, iter, key, metaTimestamp.Prev(), MVCCGetOptions{
 				Tombstones: true,
 			})
 			if err != nil {
 				return err
 			}
+			exVal = val
 		}
 
 		value, err = valueFn(exVal)
@@ -2163,9 +2172,9 @@ func replayTransactionalWrite(
 	// To ensure the transaction is idempotent, we must assert that the
 	// calculated value on this replay is the same as the one we've previously
 	// written.
-	if !bytes.Equal(value.RawBytes, writtenValue.RawBytes) {
+	if !bytes.Equal(value.RawBytes, writtenValue.Value.RawBytes) {
 		return errors.AssertionFailedf("transaction %s with sequence %d has a different value %+v after recomputing from what was written: %+v",
-			txn.ID, txn.Sequence, value.RawBytes, writtenValue.RawBytes)
+			txn.ID, txn.Sequence, value.RawBytes, writtenValue.Value.RawBytes)
 	}
 
 	// If ambiguous replay protection is enabled, a replay that changes the
@@ -2253,6 +2262,7 @@ func mvccPutInternal(
 	if !value.Timestamp.IsEmpty() {
 		return false, roachpb.LockAcquisition{}, errors.Errorf("cannot have timestamp set in value")
 	}
+
 	if err := opts.validate(); err != nil {
 		return false, roachpb.LockAcquisition{}, err
 	}
@@ -2267,6 +2277,7 @@ func mvccPutInternal(
 			return false, roachpb.LockAcquisition{}, errors.Errorf(
 				"ltScanner must be nil for putIsBlind %t, putIsInline %t", putIsBlind, putIsInline)
 		}
+
 	}
 
 	metaKey := MakeMVCCMetadataKey(key)
@@ -2334,7 +2345,7 @@ func mvccPutInternal(
 		if valueFn != nil {
 			var inlineVal optionalValue
 			if ok {
-				inlineVal = makeOptionalValue(roachpb.Value{RawBytes: meta.RawBytes})
+				inlineVal = makeOptionalValue(MVCCValue{Value: roachpb.Value{RawBytes: meta.RawBytes}})
 			}
 			if value, err = valueFn(inlineVal); err != nil {
 				return false, roachpb.LockAcquisition{}, err
@@ -2477,7 +2488,7 @@ func mvccPutInternal(
 					if err != nil {
 						return false, roachpb.LockAcquisition{}, err
 					}
-					exVal = makeOptionalValue(curIntentVal.Value)
+					exVal = makeOptionalValue(curIntentVal)
 				} else {
 					// Seqnum of last write was ignored. Try retrieving the value from the history.
 					prevIntent, prevIntentOk := meta.GetPrevIntentSeq(opts.Txn.Sequence, opts.Txn.IgnoredSeqNums)
@@ -2486,7 +2497,7 @@ func mvccPutInternal(
 						if err != nil {
 							return false, roachpb.LockAcquisition{}, err
 						}
-						exVal = makeOptionalValue(prevIntentVal.Value)
+						exVal = makeOptionalValue(prevIntentVal)
 					}
 				}
 			}
@@ -2498,13 +2509,14 @@ func mvccPutInternal(
 				//
 				// Since we want the last committed value on the key, we must
 				// read below our previous intents here.
-				exVal, _, err = mvccGet(ctx, iter, key, metaTimestamp.Prev(), MVCCGetOptions{
+				optVal, _, err := mvccGet(ctx, iter, key, metaTimestamp.Prev(), MVCCGetOptions{
 					Tombstones:   true,
 					ReadCategory: opts.Category,
 				})
 				if err != nil {
 					return false, roachpb.LockAcquisition{}, err
 				}
+				exVal = optVal
 			}
 
 			exReplaced = exVal.IsPresent()
@@ -2637,14 +2649,16 @@ func mvccPutInternal(
 			return false, roachpb.LockAcquisition{}, writeTooOldErr
 		} else /* meta.Txn == nil && metaTimestamp.Less(readTimestamp) */ {
 			// If a valueFn is specified, read the existing value using iter.
+			opts := MVCCGetOptions{
+				Tombstones:   true,
+				ReadCategory: opts.Category,
+			}
 			if valueFn != nil {
-				exVal, _, err := mvccGet(ctx, iter, key, readTimestamp, MVCCGetOptions{
-					Tombstones:   true,
-					ReadCategory: opts.Category,
-				})
+				exVal, _, err := mvccGet(ctx, iter, key, readTimestamp, opts)
 				if err != nil {
 					return false, roachpb.LockAcquisition{}, err
 				}
+
 				value, err = valueFn(exVal)
 				if err != nil {
 					return false, roachpb.LockAcquisition{}, err
@@ -2829,7 +2843,7 @@ func MVCCIncrement(
 	valueFn := func(value optionalValue) (roachpb.Value, error) {
 		if value.IsPresent() {
 			var err error
-			if int64Val, err = value.GetInt(); err != nil {
+			if int64Val, err = value.Value.GetInt(); err != nil {
 				return roachpb.Value{}, errors.Errorf("key %q does not contain an integer value", key)
 			}
 		}
@@ -2868,6 +2882,27 @@ const (
 	CPutFailIfMissing CPutMissingBehavior = false
 )
 
+// ConditionalPutWriteOptions bundles options for the
+// MVCCConditionalPut and MVCCBlindConditionalPut functions.
+type ConditionalPutWriteOptions struct {
+	MVCCWriteOptions
+
+	AllowIfDoesNotExist CPutMissingBehavior
+	// OriginTimestamp, if set, indicates that the caller wants to put the
+	// value only if any existing key is older than this timestamp.
+	//
+	// See the comment on the OriginTimestamp field of
+	// kvpb.ConditionalPutRequest for more details.
+	OriginTimestamp hlc.Timestamp
+	// ShouldWinOriginTimestampTie indicates whether the value should be
+	// accepted if the origin timestamp is the same as the
+	// origin_timestamp/mvcc_timestamp of the existing value.
+	//
+	// See the comment on the ShouldWinOriginTimestampTie field of
+	// kvpb.ConditionalPutRequest for more details.
+	ShouldWinOriginTimestampTie bool
+}
+
 // MVCCConditionalPut sets the value for a specified key only if the expected
 // value matches. If not, the return a ConditionFailedError containing the
 // actual value. An empty expVal signifies that the key is expected to not
@@ -2890,8 +2925,7 @@ func MVCCConditionalPut(
 	timestamp hlc.Timestamp,
 	value roachpb.Value,
 	expVal []byte,
-	allowIfDoesNotExist CPutMissingBehavior,
-	opts MVCCWriteOptions,
+	opts ConditionalPutWriteOptions,
 ) (roachpb.LockAcquisition, error) {
 	iter, err := newMVCCIterator(
 		ctx, rw, timestamp, false /* rangeKeyMasking */, true, /* noInterleavedIntents */
@@ -2917,7 +2951,7 @@ func MVCCConditionalPut(
 		defer ltScanner.close()
 	}
 	return mvccConditionalPutUsingIter(
-		ctx, rw, iter, ltScanner, key, timestamp, value, expVal, allowIfDoesNotExist, opts)
+		ctx, rw, iter, ltScanner, key, timestamp, value, expVal, opts)
 }
 
 // MVCCBlindConditionalPut is a fast-path of MVCCConditionalPut. See the
@@ -2936,11 +2970,33 @@ func MVCCBlindConditionalPut(
 	timestamp hlc.Timestamp,
 	value roachpb.Value,
 	expVal []byte,
-	allowIfDoesNotExist CPutMissingBehavior,
-	opts MVCCWriteOptions,
+	opts ConditionalPutWriteOptions,
 ) (roachpb.LockAcquisition, error) {
 	return mvccConditionalPutUsingIter(
-		ctx, writer, nil, nil, key, timestamp, value, expVal, allowIfDoesNotExist, opts)
+		ctx, writer, nil, nil, key, timestamp, value, expVal, opts)
+}
+
+// maybeConditionFailedError returns a non-nil ConditionFailedError if
+// the expBytes and actVal don't match. If allowNoExisting is true,
+// then a non-existent actual value is allowed even when
+// expected-value is non-empty.
+func maybeConditionFailedError(
+	expBytes []byte, actVal optionalValue, allowNoExisting bool,
+) *kvpb.ConditionFailedError {
+	expValPresent := len(expBytes) != 0
+	actValPresent := actVal.IsPresent()
+	if expValPresent && actValPresent {
+		if !bytes.Equal(expBytes, actVal.Value.TagAndDataBytes()) {
+			return &kvpb.ConditionFailedError{
+				ActualValue: actVal.ToPointer(),
+			}
+		}
+	} else if expValPresent != actValPresent && (actValPresent || !allowNoExisting) {
+		return &kvpb.ConditionFailedError{
+			ActualValue: actVal.ToPointer(),
+		}
+	}
+	return nil
 }
 
 func mvccConditionalPutUsingIter(
@@ -2952,24 +3008,56 @@ func mvccConditionalPutUsingIter(
 	timestamp hlc.Timestamp,
 	value roachpb.Value,
 	expBytes []byte,
-	allowNoExisting CPutMissingBehavior,
-	opts MVCCWriteOptions,
+	opts ConditionalPutWriteOptions,
 ) (roachpb.LockAcquisition, error) {
-	valueFn := func(existVal optionalValue) (roachpb.Value, error) {
-		if expValPresent, existValPresent := len(expBytes) != 0, existVal.IsPresent(); expValPresent && existValPresent {
-			if !bytes.Equal(expBytes, existVal.TagAndDataBytes()) {
+	if !opts.OriginTimestamp.IsEmpty() {
+		if bool(opts.AllowIfDoesNotExist) {
+			return roachpb.LockAcquisition{}, errors.AssertionFailedf("AllowIfDoesNotExist and non-zero OriginTimestamp are incompatible")
+		}
+		putIsInline := timestamp.IsEmpty()
+		if putIsInline {
+			return roachpb.LockAcquisition{}, errors.AssertionFailedf("inline put and non-zero OriginTimestamp are incompatible")
+		}
+	}
+
+	var valueFn func(existVal optionalValue) (roachpb.Value, error)
+	if opts.OriginTimestamp.IsEmpty() {
+		valueFn = func(actualValue optionalValue) (roachpb.Value, error) {
+			if err := maybeConditionFailedError(expBytes, actualValue, bool(opts.AllowIfDoesNotExist)); err != nil {
+				return roachpb.Value{}, err
+			}
+			return value, nil
+		}
+	} else {
+		valueFn = func(existVal optionalValue) (roachpb.Value, error) {
+			originTSWinner, existTS := existVal.isOriginTimestampWinner(opts.OriginTimestamp,
+				opts.ShouldWinOriginTimestampTie)
+			if !originTSWinner {
 				return roachpb.Value{}, &kvpb.ConditionFailedError{
-					ActualValue: existVal.ToPointer(),
+					OriginTimestampOlderThan: existTS,
 				}
 			}
-		} else if expValPresent != existValPresent && (existValPresent || !bool(allowNoExisting)) {
-			return roachpb.Value{}, &kvpb.ConditionFailedError{
-				ActualValue: existVal.ToPointer(),
+
+			// We are the OriginTimestamp comparison winner. We
+			// check the expected bytes because a mismatch implies
+			// that the caller may have produced other commands with
+			// outdated data.
+			if err := maybeConditionFailedError(expBytes, existVal, false); err != nil {
+				err.HadNewerOriginTimestamp = true
+				return roachpb.Value{}, err
 			}
+			return value, nil
 		}
-		return value, nil
+
+		// TODO(ssd): We set the OriginTimestamp on our write
+		// options to the originTimestamp passed to us. We
+		// don't assert they are the same yet because it is
+		// still unclear how exactly we want to manage this in
+		// the long run.
+		opts.MVCCWriteOptions.OriginTimestamp = opts.OriginTimestamp
 	}
-	return mvccPutUsingIter(ctx, writer, iter, ltScanner, key, timestamp, noValue, valueFn, opts)
+
+	return mvccPutUsingIter(ctx, writer, iter, ltScanner, key, timestamp, noValue, valueFn, opts.MVCCWriteOptions)
 }
 
 // MVCCInitPut sets the value for a specified key if the key doesn't exist. It
@@ -3056,7 +3144,7 @@ func mvccInitPutUsingIter(
 				ActualValue: existVal.ToPointer(),
 			}
 		}
-		if existVal.IsPresent() && !existVal.EqualTagAndData(value) {
+		if existVal.IsPresent() && !existVal.Value.EqualTagAndData(value) {
 			// The existing value does not match the supplied value.
 			return roachpb.Value{}, &kvpb.ConditionFailedError{
 				ActualValue: existVal.ToPointer(),

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -3023,7 +3023,8 @@ func TestMVCCConditionalPutOldTimestamp(t *testing.T) {
 		// Condition matches.
 		value2,
 	} {
-		_, err = MVCCConditionalPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, value3, expVal.TagAndDataBytes(), CPutFailIfMissing, MVCCWriteOptions{})
+		_, err = MVCCConditionalPut(ctx, engine, testKey1, hlc.Timestamp{WallTime: 2}, value3, expVal.TagAndDataBytes(),
+			ConditionalPutWriteOptions{AllowIfDoesNotExist: CPutFailIfMissing})
 		require.ErrorAs(t, err, new(*kvpb.WriteTooOldError))
 
 		// Either way, no new value is written.

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_with_origin_timestamps
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_with_origin_timestamps
@@ -1,0 +1,126 @@
+# CPut with non-tombstone values
+run ok
+cput k=k1 v=v ts=10
+----
+>> at end:
+data: "k1"/10.000000000,0 -> /BYTES/v
+
+### CPut with OriginTimestamp older than local write loses
+run error
+cput k=k1 v=v ts=12 origin_ts=9
+----
+>> at end:
+data: "k1"/10.000000000,0 -> /BYTES/v
+error: (*kvpb.ConditionFailedError:) OriginTimestamp older than 10.000000000,0
+
+### CPut with OriginTimestamp newer than local but out of date expectation gets an error
+run error
+cput k=k1 v=v ts=13 origin_ts=11 cond=not_v
+----
+>> at end:
+data: "k1"/10.000000000,0 -> /BYTES/v
+error: (*kvpb.ConditionFailedError:) higher OriginTimestamp but unexpected value: raw_bytes:"\000\000\000\000\003v" timestamp:<wall_time:10000000000 > 
+
+### CPut with OriginTimestamp newer than local write but with too old ts still fails
+run error
+cput k=k1 v=v ts=9 origin_ts=11 cond=v
+----
+>> at end:
+data: "k1"/10.000000000,0 -> /BYTES/v
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 9.000000000,0 too old; must write at or above 10.000000000,1
+
+### CPut with OriginTimestamp newer than local write wins
+run ok
+cput k=k1 v=v ts=13 origin_ts=11 cond=v
+----
+>> at end:
+data: "k1"/13.000000000,0 -> {originTs=11.000000000,0}/BYTES/v
+data: "k1"/10.000000000,0 -> /BYTES/v
+
+### CPut with OriginTimestamp older than existing OriginTimestamp loses
+run error
+cput k=k1 v=v2 ts=19 origin_ts=9 cond=v
+----
+>> at end:
+data: "k1"/13.000000000,0 -> {originTs=11.000000000,0}/BYTES/v
+data: "k1"/10.000000000,0 -> /BYTES/v
+error: (*kvpb.ConditionFailedError:) OriginTimestamp older than 11.000000000,0
+
+### CPut with OriginTimestamp newer than existing OriginTimestamp wins
+run ok
+cput k=k1 v=v2 ts=20 origin_ts=12 cond=v
+----
+>> at end:
+data: "k1"/20.000000000,0 -> {originTs=12.000000000,0}/BYTES/v2
+data: "k1"/13.000000000,0 -> {originTs=11.000000000,0}/BYTES/v
+data: "k1"/10.000000000,0 -> /BYTES/v
+
+# CPut with value on on non-existent key with OriginTimestamp set wins
+run ok
+cput k=k2 v=v ts=11 origin_ts=9
+----
+>> at end:
+data: "k1"/20.000000000,0 -> {originTs=12.000000000,0}/BYTES/v2
+data: "k1"/13.000000000,0 -> {originTs=11.000000000,0}/BYTES/v
+data: "k1"/10.000000000,0 -> /BYTES/v
+data: "k2"/11.000000000,0 -> {originTs=9.000000000,0}/BYTES/v
+
+run ok
+clear_range k=k1 end=z
+----
+>> at end:
+<no data>
+
+## Test CPut with no value for callers that want to use CPut in place of
+## Del.
+run ok
+del k=k1 ts=2
+----
+del: "k1": found key false
+>> at end:
+data: "k1"/2.000000000,0 -> /<empty>
+
+run ok
+cput k=k2 v=<tombstone> ts=3 origin_ts=2
+----
+>> at end:
+data: "k1"/2.000000000,0 -> /<empty>
+data: "k2"/3.000000000,0 -> {originTs=2.000000000,0}/<empty>
+
+## k1 is now a "normal" tombostone
+## k2 is still a "originTimestamp"'d tombstone
+
+# CPuts with too old origin timestamps fail with both kinds of tombstones
+
+run error
+cput k=k1 v=v1 ts=4 origin_ts=1
+----
+>> at end:
+data: "k1"/2.000000000,0 -> /<empty>
+data: "k2"/3.000000000,0 -> {originTs=2.000000000,0}/<empty>
+error: (*kvpb.ConditionFailedError:) OriginTimestamp older than 2.000000000,0
+
+run error
+cput k=k2 v=v1 ts=4 origin_ts=1
+----
+>> at end:
+data: "k1"/2.000000000,0 -> /<empty>
+data: "k2"/3.000000000,0 -> {originTs=2.000000000,0}/<empty>
+error: (*kvpb.ConditionFailedError:) OriginTimestamp older than 2.000000000,0
+
+run ok
+cput k=k1 v=v1 ts=3 origin_ts=4
+----
+>> at end:
+data: "k1"/3.000000000,0 -> {originTs=4.000000000,0}/BYTES/v1
+data: "k1"/2.000000000,0 -> /<empty>
+data: "k2"/3.000000000,0 -> {originTs=2.000000000,0}/<empty>
+
+run ok
+cput k=k2 v=v1 ts=4 origin_ts=5
+----
+>> at end:
+data: "k1"/3.000000000,0 -> {originTs=4.000000000,0}/BYTES/v1
+data: "k1"/2.000000000,0 -> /<empty>
+data: "k2"/4.000000000,0 -> {originTs=5.000000000,0}/BYTES/v1
+data: "k2"/3.000000000,0 -> {originTs=2.000000000,0}/<empty>


### PR DESCRIPTION
To improve the performance of the logical replication ingestion
processor, we would like to be able to manually generate KV batches
rather than writing via SQL.  However, we also only want to write an
ingested row if it is clearly newer than an existing row.

Two new ConditionaPutRequest parameters allow for this:

- `OriginTimestamp`: When set, any existing value must be older than
  this timestamp. The time comparison is made against the
  OriginTimestamp field in the values MVCCValueHeader if it is set or
  the keys MVCCTimestamp if it isn't.

- `ShouldWinOriginTimestampTie`: When true, indicates that the
  proposed value should be accepted even the inbound OriginTimestamp is
  exactly equal to the existing value's timestamp.

Additionally, two new error states have been added to
ConditionFailedError:

- `OriginTimestampOlderThan`: An error with this value set indicates
  that the ConditionalPutRequest failed because its OriginTimestamp was
  too old.

- `HadNewerOriginTimestamp`: When set, this indicates that while the
  expected value did not match the existing value, the provided origin
  timestamp was newer.

The expectation is that callers who receive an error with
OriginTimestampOlderThan may abort their transaction and not attempt a
retry because their proposed value is too old.

A caller who gets an error with HadNewerOriginTimestamp may choose to
abort their transaction but retry with the value provided in the
ActualValue field. Note a value expectation mismatch is likely for
our proposed caller who is constructing its expected values using
rangefeed events from another table.

Epic: none
Release note: None