### PR TITLE
wip: opt: do not duplicate subqueries during filter push-down

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3862,6 +3862,10 @@ func (m *sessionDataMutator) SetOptimizerUseConditionalHoistFix(val bool) {
 	m.data.OptimizerUseConditionalHoistFix = val
 }
 
+func (m *sessionDataMutator) SetOptimizerAllowDuplicateSubquery(val bool) {
+	m.data.OptimizerAllowDuplicateSubquery = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -201,6 +201,7 @@ type Memo struct {
 	pushOffsetIntoIndexJoin                    bool
 	usePolymorphicParameterFix                 bool
 	useConditionalHoistFix                     bool
+	allowDuplicateSubquery                     bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -288,6 +289,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		pushOffsetIntoIndexJoin:                    evalCtx.SessionData().OptimizerPushOffsetIntoIndexJoin,
 		usePolymorphicParameterFix:                 evalCtx.SessionData().OptimizerUsePolymorphicParameterFix,
 		useConditionalHoistFix:                     evalCtx.SessionData().OptimizerUseConditionalHoistFix,
+		allowDuplicateSubquery:                     evalCtx.SessionData().OptimizerAllowDuplicateSubquery,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -453,6 +455,7 @@ func (m *Memo) IsStale(
 		m.pushOffsetIntoIndexJoin != evalCtx.SessionData().OptimizerPushOffsetIntoIndexJoin ||
 		m.usePolymorphicParameterFix != evalCtx.SessionData().OptimizerUsePolymorphicParameterFix ||
 		m.useConditionalHoistFix != evalCtx.SessionData().OptimizerUseConditionalHoistFix ||
+		m.allowDuplicateSubquery != evalCtx.SessionData().OptimizerAllowDuplicateSubquery ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -507,6 +507,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerUsePolymorphicParameterFix = false
 	notStale()
 
+	// Stale optimizer_allow_duplicate_subquery.
+	evalCtx.SessionData().OptimizerAllowDuplicateSubquery = true
+	stale()
+	evalCtx.SessionData().OptimizerAllowDuplicateSubquery = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -729,6 +729,22 @@ func (c *CustomFuncs) FilterHasCorrelatedSubquery(filters memo.FiltersExpr) bool
 	return false
 }
 
+// AllowDuplicateSubquery returns true the given filter does not contain a
+// subquery, or subquery push down is allowed by the
+// optimizer_prevent_subquery_duplication session setting.
+func (c *CustomFuncs) AllowDuplicateSubquery(f *memo.FiltersItem) bool {
+	if f.ScalarProps().HasSubquery {
+		return c.f.evalCtx.SessionData().OptimizerAllowDuplicateSubquery
+	}
+	return true
+}
+
+// FilterItemHasSubquery returns true if any of the filter conditions
+// contain a subquery.
+// func (c *CustomFuncs) FilterItemHasSubquery(f *memo.FiltersItem) bool {
+// 	return f.ScalarProps().HasSubquery
+// }
+
 // IsFilterFalse returns true if the filters always evaluate to false. The only
 // case that's checked is the fully normalized case, when the list contains a
 // single False condition.

--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -76,6 +76,7 @@
     $on:[
         ...
         $item:* &
+            (AllowDuplicateSubquery $item) &
             ^(FiltersItem (Eq (Variable) (Variable))) &
             (CanMapJoinOpFilter
                 $item
@@ -171,6 +172,11 @@
         $item:* &
             ^(FiltersItem (Eq (Variable) (Variable))) &
             ^(IsBoundBy $item $rightCols:(OutputCols $right)) &
+            ^(PossibleMapFilterCycle
+                $item
+                (OutputCols $left)
+                $rightCols
+            ) &
             (CanMapJoinOpFilter
                 $item
                 $rightCols

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -196,6 +196,7 @@ $input
     $filters:[
         ...
         $item:(FiltersItem $condition:*) &
+            (AllowDuplicateSubquery $item) &
             (IsBoundBy $item (OutputCols $left)) &
             (CanMapJoinOpFilter
                 $item

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -4175,20 +4175,7 @@ project
       │    │    │    ├── scan xy
       │    │    │    │    └── columns: y:9
       │    │    │    └── filters
-      │    │    │         ├── y:9 = 10 [outer=(9), constraints=(/9: [/10 - /10]; tight), fd=()-->(9)]
-      │    │    │         └── eq [subquery]
-      │    │    │              ├── subquery
-      │    │    │              │    └── limit
-      │    │    │              │         ├── columns: x:12!null
-      │    │    │              │         ├── cardinality: [0 - 1]
-      │    │    │              │         ├── key: ()
-      │    │    │              │         ├── fd: ()-->(12)
-      │    │    │              │         ├── scan xy
-      │    │    │              │         │    ├── columns: x:12!null
-      │    │    │              │         │    ├── key: (12)
-      │    │    │              │         │    └── limit hint: 1.00
-      │    │    │              │         └── 1
-      │    │    │              └── 100
+      │    │    │         └── y:9 = 10 [outer=(9), constraints=(/9: [/10 - /10]; tight), fd=()-->(9)]
       │    │    └── filters
       │    │         └── y:9 = k:1 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
       │    └── 1
@@ -4879,6 +4866,7 @@ select
 
 # The subquery should only be hoisted once to avoid creating an expression with
 # children that have intersecting columns. See #114703.
+# TODO: Would we still need this test and the corresponding session setting?
 norm expect=HoistSelectSubquery
 SELECT NULL
 FROM a AS t1
@@ -4890,6 +4878,7 @@ project
  ├── fd: ()-->(23)
  ├── inner-join (hash)
  │    ├── columns: t1.i:2!null t2.i:9!null "?column?":22!null
+ │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    ├── fd: ()-->(2,9,22), (2)==(9,22), (22)==(2,9), (9)==(2,22)
  │    ├── inner-join (hash)
  │    │    ├── columns: t1.i:2!null "?column?":22!null
@@ -4911,26 +4900,8 @@ project
  │    │    │              └── 0 [as="?column?":22]
  │    │    └── filters
  │    │         └── t1.i:2 = "?column?":22 [outer=(2,22), constraints=(/2: (/NULL - ]; /22: (/NULL - ]), fd=(2)==(22), (22)==(2)]
- │    ├── select
- │    │    ├── columns: t2.i:9!null
- │    │    ├── scan a [as=t2]
- │    │    │    └── columns: t2.i:9
- │    │    └── filters
- │    │         └── eq [outer=(9), subquery, constraints=(/9: (/NULL - ])]
- │    │              ├── t2.i:9
- │    │              └── subquery
- │    │                   └── max1-row
- │    │                        ├── columns: "?column?":22!null
- │    │                        ├── error: "more than one row returned by a subquery used as an expression"
- │    │                        ├── cardinality: [0 - 1]
- │    │                        ├── key: ()
- │    │                        ├── fd: ()-->(22)
- │    │                        └── project
- │    │                             ├── columns: "?column?":22!null
- │    │                             ├── fd: ()-->(22)
- │    │                             ├── scan a
- │    │                             └── projections
- │    │                                  └── 0 [as="?column?":22]
+ │    ├── scan a [as=t2]
+ │    │    └── columns: t2.i:9
  │    └── filters
  │         └── t1.i:2 = t2.i:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
  └── projections
@@ -4948,36 +4919,18 @@ project
  ├── fd: ()-->(31)
  ├── inner-join (hash)
  │    ├── columns: t1.i:2!null t2.i:9!null "?column?":22!null "?column?":30!null
- │    ├── fd: ()-->(2,9,22,30), (2)==(9,22,30), (30)==(2,9,22), (22)==(2,9,30), (9)==(2,22,30)
+ │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
+ │    ├── fd: ()-->(2,9,22,30), (2)==(9,22,30), (22)==(2,9,30), (30)==(2,9,22), (9)==(2,22,30)
  │    ├── inner-join (hash)
  │    │    ├── columns: t1.i:2!null "?column?":22!null "?column?":30!null
  │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │    │    ├── fd: ()-->(2,22,30), (2)==(22,30), (30)==(2,22), (22)==(2,30)
+ │    │    ├── fd: ()-->(2,22,30), (2)==(22,30), (22)==(2,30), (30)==(2,22)
  │    │    ├── inner-join (hash)
- │    │    │    ├── columns: t1.i:2!null "?column?":30!null
+ │    │    │    ├── columns: t1.i:2!null "?column?":22!null
  │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │    │    │    ├── fd: ()-->(2,30), (2)==(30), (30)==(2)
+ │    │    │    ├── fd: ()-->(2,22), (2)==(22), (22)==(2)
  │    │    │    ├── scan a [as=t1]
  │    │    │    │    └── columns: t1.i:2
- │    │    │    ├── max1-row
- │    │    │    │    ├── columns: "?column?":30!null
- │    │    │    │    ├── error: "more than one row returned by a subquery used as an expression"
- │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │    │    ├── key: ()
- │    │    │    │    ├── fd: ()-->(30)
- │    │    │    │    └── project
- │    │    │    │         ├── columns: "?column?":30!null
- │    │    │    │         ├── fd: ()-->(30)
- │    │    │    │         ├── scan a
- │    │    │    │         └── projections
- │    │    │    │              └── 0 [as="?column?":30]
- │    │    │    └── filters
- │    │    │         └── t1.i:2 = "?column?":30 [outer=(2,30), constraints=(/2: (/NULL - ]; /30: (/NULL - ]), fd=(2)==(30), (30)==(2)]
- │    │    ├── select
- │    │    │    ├── columns: "?column?":22!null
- │    │    │    ├── cardinality: [0 - 1]
- │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(22)
  │    │    │    ├── max1-row
  │    │    │    │    ├── columns: "?column?":22!null
  │    │    │    │    ├── error: "more than one row returned by a subquery used as an expression"
@@ -4991,58 +4944,23 @@ project
  │    │    │    │         └── projections
  │    │    │    │              └── 0 [as="?column?":22]
  │    │    │    └── filters
- │    │    │         └── eq [outer=(22), subquery, constraints=(/22: (/NULL - ])]
- │    │    │              ├── "?column?":22
- │    │    │              └── subquery
- │    │    │                   └── max1-row
- │    │    │                        ├── columns: "?column?":30!null
- │    │    │                        ├── error: "more than one row returned by a subquery used as an expression"
- │    │    │                        ├── cardinality: [0 - 1]
- │    │    │                        ├── key: ()
- │    │    │                        ├── fd: ()-->(30)
- │    │    │                        └── project
- │    │    │                             ├── columns: "?column?":30!null
- │    │    │                             ├── fd: ()-->(30)
- │    │    │                             ├── scan a
- │    │    │                             └── projections
- │    │    │                                  └── 0 [as="?column?":30]
+ │    │    │         └── t1.i:2 = "?column?":22 [outer=(2,22), constraints=(/2: (/NULL - ]; /22: (/NULL - ]), fd=(2)==(22), (22)==(2)]
+ │    │    ├── max1-row
+ │    │    │    ├── columns: "?column?":30!null
+ │    │    │    ├── error: "more than one row returned by a subquery used as an expression"
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(30)
+ │    │    │    └── project
+ │    │    │         ├── columns: "?column?":30!null
+ │    │    │         ├── fd: ()-->(30)
+ │    │    │         ├── scan a
+ │    │    │         └── projections
+ │    │    │              └── 0 [as="?column?":30]
  │    │    └── filters
- │    │         └── t1.i:2 = "?column?":22 [outer=(2,22), constraints=(/2: (/NULL - ]; /22: (/NULL - ]), fd=(2)==(22), (22)==(2)]
- │    ├── select
- │    │    ├── columns: t2.i:9!null
- │    │    ├── scan a [as=t2]
- │    │    │    └── columns: t2.i:9
- │    │    └── filters
- │    │         ├── eq [outer=(9), subquery, constraints=(/9: (/NULL - ])]
- │    │         │    ├── t2.i:9
- │    │         │    └── subquery
- │    │         │         └── max1-row
- │    │         │              ├── columns: "?column?":22!null
- │    │         │              ├── error: "more than one row returned by a subquery used as an expression"
- │    │         │              ├── cardinality: [0 - 1]
- │    │         │              ├── key: ()
- │    │         │              ├── fd: ()-->(22)
- │    │         │              └── project
- │    │         │                   ├── columns: "?column?":22!null
- │    │         │                   ├── fd: ()-->(22)
- │    │         │                   ├── scan a
- │    │         │                   └── projections
- │    │         │                        └── 0 [as="?column?":22]
- │    │         └── eq [outer=(9), subquery, constraints=(/9: (/NULL - ])]
- │    │              ├── t2.i:9
- │    │              └── subquery
- │    │                   └── max1-row
- │    │                        ├── columns: "?column?":30!null
- │    │                        ├── error: "more than one row returned by a subquery used as an expression"
- │    │                        ├── cardinality: [0 - 1]
- │    │                        ├── key: ()
- │    │                        ├── fd: ()-->(30)
- │    │                        └── project
- │    │                             ├── columns: "?column?":30!null
- │    │                             ├── fd: ()-->(30)
- │    │                             ├── scan a
- │    │                             └── projections
- │    │                                  └── 0 [as="?column?":30]
+ │    │         └── t1.i:2 = "?column?":30 [outer=(2,30), constraints=(/2: (/NULL - ]; /30: (/NULL - ]), fd=(2)==(30), (30)==(2)]
+ │    ├── scan a [as=t2]
+ │    │    └── columns: t2.i:9
  │    └── filters
  │         └── t1.i:2 = t2.i:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
  └── projections
@@ -5067,6 +4985,7 @@ project
  ├── fd: ()-->(19)
  ├── inner-join (hash)
  │    ├── columns: t1.i:2!null t2.i:9!null x:15!null
+ │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-more)
  │    ├── fd: ()-->(2,9,15), (2)==(9,15), (15)==(2,9), (9)==(2,15)
  │    ├── inner-join (hash)
  │    │    ├── columns: t1.i:2!null x:15!null
@@ -5086,24 +5005,8 @@ project
  │    │    │    └── 1
  │    │    └── filters
  │    │         └── t1.i:2 = x:15 [outer=(2,15), constraints=(/2: (/NULL - ]; /15: (/NULL - ]), fd=(2)==(15), (15)==(2)]
- │    ├── select
- │    │    ├── columns: t2.i:9!null
- │    │    ├── scan a [as=t2]
- │    │    │    └── columns: t2.i:9
- │    │    └── filters
- │    │         └── eq [outer=(9), subquery, constraints=(/9: (/NULL - ])]
- │    │              ├── t2.i:9
- │    │              └── subquery
- │    │                   └── limit
- │    │                        ├── columns: x:15!null
- │    │                        ├── cardinality: [0 - 1]
- │    │                        ├── key: ()
- │    │                        ├── fd: ()-->(15)
- │    │                        ├── scan xy
- │    │                        │    ├── columns: x:15!null
- │    │                        │    ├── key: (15)
- │    │                        │    └── limit hint: 1.00
- │    │                        └── 1
+ │    ├── scan a [as=t2]
+ │    │    └── columns: t2.i:9
  │    └── filters
  │         └── t1.i:2 = t2.i:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
  └── projections

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -1245,35 +1245,9 @@ project
  │    │    │    │              │         └── scan a
  │    │    │    │              │              └── columns: s:28
  │    │    │    │              └── 'foo'
- │    │    │    ├── select
- │    │    │    │    ├── scan uv
- │    │    │    │    └── filters
- │    │    │    │         └── eq [subquery]
- │    │    │    │              ├── subquery
- │    │    │    │              │    └── max1-row
- │    │    │    │              │         ├── columns: s:28
- │    │    │    │              │         ├── error: "more than one row returned by a subquery used as an expression"
- │    │    │    │              │         ├── cardinality: [0 - 1]
- │    │    │    │              │         ├── key: ()
- │    │    │    │              │         ├── fd: ()-->(28)
- │    │    │    │              │         └── scan a
- │    │    │    │              │              └── columns: s:28
- │    │    │    │              └── 'foo'
+ │    │    │    ├── scan uv
  │    │    │    └── filters (true)
- │    │    ├── select
- │    │    │    ├── scan b
- │    │    │    └── filters
- │    │    │         └── eq [subquery]
- │    │    │              ├── subquery
- │    │    │              │    └── max1-row
- │    │    │              │         ├── columns: s:28
- │    │    │              │         ├── error: "more than one row returned by a subquery used as an expression"
- │    │    │              │         ├── cardinality: [0 - 1]
- │    │    │              │         ├── key: ()
- │    │    │              │         ├── fd: ()-->(28)
- │    │    │              │         └── scan a
- │    │    │              │              └── columns: s:28
- │    │    │              └── 'foo'
+ │    │    ├── scan b
  │    │    └── filters (true)
  │    └── filters (true)
  └── projections
@@ -1506,6 +1480,116 @@ project
                 │    ├── columns: item.i_name:53
                 │    └── limit hint: 1.00
                 └── 1
+
+# Regression test for #116022. Do not push down a filter with a subquery.
+exec-ddl
+CREATE TABLE t116022a (
+  id INT PRIMARY KEY
+)
+----
+
+exec-ddl
+CREATE TABLE t116022b (
+  id INT PRIMARY KEY,
+  x INT
+)
+----
+
+exec-ddl
+CREATE TABLE t116022c (
+  id INT PRIMARY KEY,
+  x INT,
+  y INT
+)
+----
+
+exec-ddl
+CREATE TABLE t116022d (
+  id INT PRIMARY KEY,
+  x INT,
+  y INT
+)
+----
+
+# Explain why we use opt here.
+opt locality=(region=east) expect-not=PushFilterIntoJoinLeftAndRight
+SELECT a.id
+FROM t116022a AS a
+INNER JOIN t116022b AS b ON b.x = a.id
+INNER JOIN t116022c AS c ON c.y = b.id
+LEFT JOIN LATERAL (
+  SELECT d.id
+  FROM t116022d AS d
+  WHERE d.x = c.x
+  ORDER BY d.y
+  LIMIT 1
+) ON true
+WHERE b.id = (SELECT id FROM t116022b)
+----
+distribute
+ ├── columns: id:1!null
+ ├── fd: ()-->(1)
+ ├── distribution: east
+ ├── input distribution: 
+ └── project
+      ├── columns: a.id:1!null
+      ├── fd: ()-->(1)
+      └── distinct-on
+           ├── columns: a.id:1!null c.id:8!null
+           ├── grouping columns: c.id:8!null
+           ├── internal-ordering: +15 opt(1,4,5,10,18)
+           ├── key: (8)
+           ├── fd: ()-->(1)
+           ├── sort
+           │    ├── columns: a.id:1!null b.id:4!null b.x:5!null c.id:8!null c.x:9 c.y:10!null d.x:14 d.y:15 t116022b.id:18!null
+           │    ├── fd: ()-->(1,4,5,10,18), (4)==(10,18), (1)==(5), (5)==(1), (18)==(4,10), (8)-->(9), (10)==(4,18)
+           │    ├── ordering: +15 opt(1,4,5,10,18) [actual: +15]
+           │    └── right-join (hash)
+           │         ├── columns: a.id:1!null b.id:4!null b.x:5!null c.id:8!null c.x:9 c.y:10!null d.x:14 d.y:15 t116022b.id:18!null
+           │         ├── fd: ()-->(1,4,5,10,18), (4)==(10,18), (1)==(5), (5)==(1), (18)==(4,10), (8)-->(9), (10)==(4,18)
+           │         ├── scan t116022d [as=d]
+           │         │    └── columns: d.x:14 d.y:15
+           │         ├── inner-join (hash)
+           │         │    ├── columns: a.id:1!null b.id:4!null b.x:5!null c.id:8!null c.x:9 c.y:10!null t116022b.id:18!null
+           │         │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+           │         │    ├── key: (8)
+           │         │    ├── fd: ()-->(1,4,5,10,18), (4)==(10,18), (1)==(5), (5)==(1), (18)==(4,10), (8)-->(9), (10)==(4,18)
+           │         │    ├── scan t116022c [as=c]
+           │         │    │    ├── columns: c.id:8!null c.x:9 c.y:10
+           │         │    │    ├── key: (8)
+           │         │    │    └── fd: (8)-->(9,10)
+           │         │    ├── inner-join (lookup t116022a [as=a])
+           │         │    │    ├── columns: a.id:1!null b.id:4!null b.x:5!null t116022b.id:18!null
+           │         │    │    ├── key columns: [5] = [1]
+           │         │    │    ├── lookup columns are key
+           │         │    │    ├── cardinality: [0 - 1]
+           │         │    │    ├── key: ()
+           │         │    │    ├── fd: ()-->(1,4,5,18), (4)==(18), (1)==(5), (5)==(1), (18)==(4)
+           │         │    │    ├── inner-join (lookup t116022b [as=b])
+           │         │    │    │    ├── columns: b.id:4!null b.x:5 t116022b.id:18!null
+           │         │    │    │    ├── key columns: [18] = [4]
+           │         │    │    │    ├── lookup columns are key
+           │         │    │    │    ├── cardinality: [0 - 1]
+           │         │    │    │    ├── key: ()
+           │         │    │    │    ├── fd: ()-->(4,5,18), (18)==(4), (4)==(18)
+           │         │    │    │    ├── max1-row
+           │         │    │    │    │    ├── columns: t116022b.id:18!null
+           │         │    │    │    │    ├── error: "more than one row returned by a subquery used as an expression"
+           │         │    │    │    │    ├── cardinality: [0 - 1]
+           │         │    │    │    │    ├── key: ()
+           │         │    │    │    │    ├── fd: ()-->(18)
+           │         │    │    │    │    └── scan t116022b
+           │         │    │    │    │         ├── columns: t116022b.id:18!null
+           │         │    │    │    │         └── key: (18)
+           │         │    │    │    └── filters (true)
+           │         │    │    └── filters (true)
+           │         │    └── filters
+           │         │         └── c.y:10 = b.id:4 [outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ]), fd=(4)==(10), (10)==(4)]
+           │         └── filters
+           │              └── d.x:14 = c.x:9 [outer=(9,14), constraints=(/9: (/NULL - ]; /14: (/NULL - ]), fd=(9)==(14), (14)==(9)]
+           └── aggregations
+                └── const-agg [as=a.id:1, outer=(1)]
+                     └── a.id:1
 
 # ---------------------------------
 # MapEqualityIntoJoinLeftAndRight

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -810,24 +810,10 @@ inner-join (cross)
  │              │         ├── fd: ()-->(17)
  │              │         └── (true,)
  │              └── false
- ├── select
+ ├── scan a [as=a2]
  │    ├── columns: a2.k:8!null a2.i:9 a2.f:10 a2.s:11 a2.arr:12
  │    ├── key: (8)
- │    ├── fd: (8)-->(9-12)
- │    ├── scan a [as=a2]
- │    │    ├── columns: a2.k:8!null a2.i:9 a2.f:10 a2.s:11 a2.arr:12
- │    │    ├── key: (8)
- │    │    └── fd: (8)-->(9-12)
- │    └── filters
- │         └── coalesce [subquery]
- │              ├── subquery
- │              │    └── values
- │              │         ├── columns: column17:17!null
- │              │         ├── cardinality: [1 - 1]
- │              │         ├── key: ()
- │              │         ├── fd: ()-->(17)
- │              │         └── (true,)
- │              └── false
+ │    └── fd: (8)-->(9-12)
  └── filters (true)
 
 # Don't convert Exists if it is correlated.

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -545,6 +545,10 @@ message LocalOnlySessionData {
   // hoisting a volatile expression that is conditionally executed by a CASE,
   // COALESCE, or IFERR expression.
   bool optimizer_use_conditional_hoist_fix = 138;
+  // OptimizerAllowDuplicateSubquery, when true, allows the optimizer to
+  // duplicate references to subqueries in different scalar expressions within a
+  // memo. This is known to cause issues during optimization, see #116022.
+  bool optimizer_allow_duplicate_subquery = 139;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3488,6 +3488,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	// CockroachDB extension.
+	`optimizer_allow_duplicate_subquery`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_allow_duplicate_subquery`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_allow_duplicate_subquery", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerAllowDuplicateSubquery(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerAllowDuplicateSubquery), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
#### wip: opt: do not duplicate subqueries during filter push-down

This is a proposed fix for #116022. I'm currently exploring
alternatives, so I'm leaving this as a draft for now.

Release note (bug fix): A bug has been fixed that could cause queries to
result in an error "internal error: cannot overwrite ...".
