### PR TITLE
kvserver/kvadmission: add bulk low pri that is always subject to elastic

### DIFF
--- a/docs/generated/metrics/metrics.html
+++ b/docs/generated/metrics/metrics.html
@@ -12,8 +12,8 @@
 <tr><td>STORAGE</td><td>admission.admitted.elastic-cpu.bulk-normal-pri</td><td>Number of requests admitted</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>admission.admitted.elastic-cpu.normal-pri</td><td>Number of requests admitted</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>admission.admitted.elastic-stores</td><td>Number of requests admitted</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
+<tr><td>STORAGE</td><td>admission.admitted.elastic-stores.bulk-low-pri</td><td>Number of requests admitted</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>admission.admitted.elastic-stores.bulk-normal-pri</td><td>Number of requests admitted</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
-<tr><td>STORAGE</td><td>admission.admitted.elastic-stores.ttl-low-pri</td><td>Number of requests admitted</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>admission.admitted.kv</td><td>Number of requests admitted</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>admission.admitted.kv-stores</td><td>Number of requests admitted</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>admission.admitted.kv-stores.high-pri</td><td>Number of requests admitted</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
@@ -47,8 +47,8 @@
 <tr><td>STORAGE</td><td>admission.errored.elastic-cpu.bulk-normal-pri</td><td>Number of requests not admitted due to error</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>admission.errored.elastic-cpu.normal-pri</td><td>Number of requests not admitted due to error</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>admission.errored.elastic-stores</td><td>Number of requests not admitted due to error</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
+<tr><td>STORAGE</td><td>admission.errored.elastic-stores.bulk-low-pri</td><td>Number of requests not admitted due to error</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>admission.errored.elastic-stores.bulk-normal-pri</td><td>Number of requests not admitted due to error</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
-<tr><td>STORAGE</td><td>admission.errored.elastic-stores.ttl-low-pri</td><td>Number of requests not admitted due to error</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>admission.errored.kv</td><td>Number of requests not admitted due to error</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>admission.errored.kv-stores</td><td>Number of requests not admitted due to error</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>admission.errored.kv-stores.high-pri</td><td>Number of requests not admitted due to error</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
@@ -94,8 +94,8 @@
 <tr><td>STORAGE</td><td>admission.requested.elastic-cpu.bulk-normal-pri</td><td>Number of requests</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>admission.requested.elastic-cpu.normal-pri</td><td>Number of requests</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>admission.requested.elastic-stores</td><td>Number of requests</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
+<tr><td>STORAGE</td><td>admission.requested.elastic-stores.bulk-low-pri</td><td>Number of requests</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>admission.requested.elastic-stores.bulk-normal-pri</td><td>Number of requests</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
-<tr><td>STORAGE</td><td>admission.requested.elastic-stores.ttl-low-pri</td><td>Number of requests</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>admission.requested.kv</td><td>Number of requests</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>admission.requested.kv-stores</td><td>Number of requests</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>admission.requested.kv-stores.high-pri</td><td>Number of requests</td><td>Requests</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
@@ -121,8 +121,8 @@
 <tr><td>STORAGE</td><td>admission.wait_durations.elastic-cpu.bulk-normal-pri</td><td>Wait time durations for requests that waited</td><td>Wait time Duration</td><td>HISTOGRAM</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>admission.wait_durations.elastic-cpu.normal-pri</td><td>Wait time durations for requests that waited</td><td>Wait time Duration</td><td>HISTOGRAM</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>admission.wait_durations.elastic-stores</td><td>Wait time durations for requests that waited</td><td>Wait time Duration</td><td>HISTOGRAM</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
+<tr><td>STORAGE</td><td>admission.wait_durations.elastic-stores.bulk-low-pri</td><td>Wait time durations for requests that waited</td><td>Wait time Duration</td><td>HISTOGRAM</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>admission.wait_durations.elastic-stores.bulk-normal-pri</td><td>Wait time durations for requests that waited</td><td>Wait time Duration</td><td>HISTOGRAM</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
-<tr><td>STORAGE</td><td>admission.wait_durations.elastic-stores.ttl-low-pri</td><td>Wait time durations for requests that waited</td><td>Wait time Duration</td><td>HISTOGRAM</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>admission.wait_durations.kv</td><td>Wait time durations for requests that waited</td><td>Wait time Duration</td><td>HISTOGRAM</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>admission.wait_durations.kv-stores</td><td>Wait time durations for requests that waited</td><td>Wait time Duration</td><td>HISTOGRAM</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>admission.wait_durations.kv-stores.high-pri</td><td>Wait time durations for requests that waited</td><td>Wait time Duration</td><td>HISTOGRAM</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
@@ -147,8 +147,8 @@
 <tr><td>STORAGE</td><td>admission.wait_queue_length.elastic-cpu.bulk-normal-pri</td><td>Length of wait queue</td><td>Requests</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>admission.wait_queue_length.elastic-cpu.normal-pri</td><td>Length of wait queue</td><td>Requests</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>admission.wait_queue_length.elastic-stores</td><td>Length of wait queue</td><td>Requests</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
+<tr><td>STORAGE</td><td>admission.wait_queue_length.elastic-stores.bulk-low-pri</td><td>Length of wait queue</td><td>Requests</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>admission.wait_queue_length.elastic-stores.bulk-normal-pri</td><td>Length of wait queue</td><td>Requests</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
-<tr><td>STORAGE</td><td>admission.wait_queue_length.elastic-stores.ttl-low-pri</td><td>Length of wait queue</td><td>Requests</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>admission.wait_queue_length.kv</td><td>Length of wait queue</td><td>Requests</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>admission.wait_queue_length.kv-stores</td><td>Length of wait queue</td><td>Requests</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>admission.wait_queue_length.kv-stores.high-pri</td><td>Length of wait queue</td><td>Requests</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>

--- a/pkg/ccl/crosscluster/logical/lww_kv_processor.go
+++ b/pkg/ccl/crosscluster/logical/lww_kv_processor.go
@@ -147,7 +147,7 @@ func (p *kvRowProcessor) processParsedRow(
 	makeBatch := func(txn *kv.Txn) *kv.Batch {
 		b := txn.NewBatch()
 		b.Header.WriteOptions = originID1Options
-		b.AdmissionHeader.Priority = int32(admissionpb.BulkNormalPri)
+		b.AdmissionHeader.Priority = int32(admissionpb.BulkLowPri)
 		b.AdmissionHeader.Source = kvpb.AdmissionHeader_FROM_SQL
 		return b
 	}

--- a/pkg/sql/sessiondatapb/local_only_session_data.go
+++ b/pkg/sql/sessiondatapb/local_only_session_data.go
@@ -292,11 +292,11 @@ const (
 
 	// TTLStatsLow denotes a QoS level used internally by the TTL feature, which
 	// is not settable as a session default_transaction_quality_of_service value.
-	TTLStatsLow = QoSLevel(admissionpb.TTLLowPri)
+	TTLStatsLow = QoSLevel(admissionpb.BulkLowPri)
 
 	// TTLLow denotes a QoS level used internally by the TTL feature, which is not
 	// settable as a session default_transaction_quality_of_service value.
-	TTLLow = QoSLevel(admissionpb.TTLLowPri)
+	TTLLow = QoSLevel(admissionpb.BulkLowPri)
 
 	// UserLow denotes an end user QoS level lower than the default.
 	UserLow = QoSLevel(admissionpb.UserLowPri)

--- a/pkg/sql/ttl/ttljob/ttljob_processor.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor.go
@@ -370,7 +370,7 @@ func (t *ttlProcessor) runTTLOnQueryBounds(
 				return nil
 			}
 			if err := serverCfg.DB.Txn(
-				ctx, do, isql.SteppingEnabled(), isql.WithPriority(admissionpb.TTLLowPri),
+				ctx, do, isql.SteppingEnabled(), isql.WithPriority(admissionpb.BulkLowPri),
 			); err != nil {
 				return spanRowCount, errors.Wrapf(err, "error during row deletion")
 			}

--- a/pkg/util/admission/admissionpb/admissionpb.go
+++ b/pkg/util/admission/admissionpb/admissionpb.go
@@ -27,8 +27,8 @@ type WorkPriority int8
 const (
 	// LowPri is low priority work.
 	LowPri WorkPriority = math.MinInt8
-	// TTLLowPri is low priority work from TTL internal submissions.
-	TTLLowPri WorkPriority = -100
+	// BulkLowPri is low priority work from internal bulk submissions.
+	BulkLowPri WorkPriority = -100
 	// UserLowPri is low priority work from user submissions (SQL).
 	UserLowPri WorkPriority = -50
 	// BulkNormalPri is bulk priority work from bulk jobs, which could be run due
@@ -67,7 +67,7 @@ func (w WorkPriority) SafeFormat(p redact.SafePrinter, verb rune) {
 // name is used as the suffix on exported work queue metrics.
 var WorkPriorityDict = map[WorkPriority]string{
 	LowPri:           "low-pri",
-	TTLLowPri:        "ttl-low-pri",
+	BulkLowPri:       "bulk-low-pri",
 	UserLowPri:       "user-low-pri",
 	BulkNormalPri:    "bulk-normal-pri",
 	NormalPri:        "normal-pri",
@@ -104,7 +104,7 @@ func init() {
 
 	orderedPris := []WorkPriority{
 		LowPri,
-		TTLLowPri,
+		BulkLowPri,
 		UserLowPri,
 		BulkNormalPri,
 		NormalPri,
@@ -216,7 +216,7 @@ func (w WorkClass) SafeFormat(p redact.SafePrinter, verb rune) {
 
 // Prevent the linter from emitting unused warnings.
 var _ = LowPri
-var _ = TTLLowPri
+var _ = BulkLowPri
 var _ = UserLowPri
 var _ = NormalPri
 var _ = UserHighPri

--- a/pkg/util/admission/grant_coordinator.go
+++ b/pkg/util/admission/grant_coordinator.go
@@ -457,7 +457,7 @@ func makeStoresGrantCoordinators(
 			admissionpb.NormalPri, admissionpb.LockingNormalPri)
 	elasticStoreWorkQueueMetrics :=
 		makeWorkQueueMetrics(fmt.Sprintf("%s-stores", admissionpb.ElasticWorkClass), registry,
-			admissionpb.TTLLowPri, admissionpb.BulkNormalPri)
+			admissionpb.BulkLowPri, admissionpb.BulkNormalPri)
 	storeWorkQueueMetrics := [admissionpb.NumWorkClasses]*WorkQueueMetrics{
 		regularStoreWorkQueueMetrics, elasticStoreWorkQueueMetrics,
 	}


### PR DESCRIPTION
This new priority is above TTL but below bulk normal and user low. All KV requests at or below this new level are subjected to elastic limiting.

Release note: none.

Epic: none.