### PR TITLE
sql: support disabling read committed and enabling repeatable read

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -8079,7 +8079,7 @@ func genClusterLocksGenerator(
 				if curLock.LockHolder != nil {
 					txnIDDatum = tree.NewDUuid(tree.DUuid{UUID: curLock.LockHolder.ID})
 					tsDatum = eval.TimestampToInexactDTimestamp(curLock.LockHolder.WriteTimestamp)
-					isolationLevelDatum = tree.NewDString(tree.IsolationLevelFromKVTxnIsolationLevel(curLock.LockHolder.IsoLevel).String())
+					isolationLevelDatum = tree.NewDString(tree.FromKVIsoLevel(curLock.LockHolder.IsoLevel).String())
 					strengthDatum = tree.NewDString(curLock.LockStrength.String())
 					durationDatum = tree.NewDInterval(
 						duration.MakeDuration(curLock.HoldDuration.Nanoseconds(), 0 /* days */, 0 /* months */),
@@ -8092,7 +8092,7 @@ func genClusterLocksGenerator(
 				if waiter.WaitingTxn != nil {
 					txnIDDatum = tree.NewDUuid(tree.DUuid{UUID: waiter.WaitingTxn.ID})
 					tsDatum = eval.TimestampToInexactDTimestamp(waiter.WaitingTxn.WriteTimestamp)
-					isolationLevelDatum = tree.NewDString(tree.IsolationLevelFromKVTxnIsolationLevel(waiter.WaitingTxn.IsoLevel).String())
+					isolationLevelDatum = tree.NewDString(tree.FromKVIsoLevel(waiter.WaitingTxn.IsoLevel).String())
 				}
 				strengthDatum = tree.NewDString(waiter.Strength.String())
 				durationDatum = tree.NewDInterval(

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -327,8 +327,9 @@ serializable
 statement ok
 COMMIT
 
-# Since read_committed_isolation.enabled is false, setting isolation level
-# to READ COMMITTED should map to SERIALIZABLE.
+# Since read_committed_isolation.enabled and repeatable_read_isolation.enabled
+# are both false, setting isolation level to READ COMMITTED should map to
+# SERIALIZABLE.
 statement ok
 SET default_transaction_isolation = 'read committed'
 
@@ -345,10 +346,42 @@ SHOW DEFAULT_TRANSACTION_ISOLATION
 ----
 serializable
 
-# REPEATABLE READ can be used with a hidden cluster setting.
 statement ok
 SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = true
 
+# Since read_committed_isolation.enabled is false but repeatable_read_isolation.enabled
+# is true, setting isolation level to READ COMMITTED should map to REPEATABLE READ.
+statement ok
+SET default_transaction_isolation = 'read committed'
+
+onlyif config enterprise-configs
+query T
+SHOW default_transaction_isolation
+----
+snapshot
+
+skipif config enterprise-configs
+query T
+SHOW default_transaction_isolation
+----
+serializable
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED
+
+onlyif config enterprise-configs
+query T
+SHOW DEFAULT_TRANSACTION_ISOLATION
+----
+snapshot
+
+skipif config enterprise-configs
+query T
+SHOW DEFAULT_TRANSACTION_ISOLATION
+----
+serializable
+
+# Since repeatable_read_isolation.enabled is true, REPEATABLE READ can be used.
 statement ok
 BEGIN
 

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -608,8 +608,8 @@ func (ec *Context) GetClusterTimestamp() (*tree.DDecimal, error) {
 	// multiple timestamps. Prevent this with a gate at the SQL level and return
 	// a pgerror until we decide how this will officially behave. See #103245.
 	if ec.TxnIsoLevel.ToleratesWriteSkew() {
-		treeIso := tree.IsolationLevelFromKVTxnIsolationLevel(ec.TxnIsoLevel)
-		return nil, pgerror.Newf(pgcode.FeatureNotSupported, "unsupported in %s isolation", treeIso.String())
+		return nil, pgerror.Newf(pgcode.FeatureNotSupported,
+			"unsupported in %s isolation", tree.FromKVIsoLevel(ec.TxnIsoLevel).String())
 	}
 
 	ts, err := ec.Txn.CommitTimestamp()

--- a/pkg/sql/sem/tree/txn.go
+++ b/pkg/sql/sem/tree/txn.go
@@ -64,22 +64,74 @@ func (i IsolationLevel) String() string {
 	return isolationLevelNames[i]
 }
 
-// IsolationLevelFromKVTxnIsolationLevel converts a kv level isolation.Level to
-// its SQL semantic equivalent.
-func IsolationLevelFromKVTxnIsolationLevel(level isolation.Level) IsolationLevel {
-	var ret IsolationLevel
-	switch level {
-	case isolation.Serializable:
-		ret = SerializableIsolation
-	case isolation.ReadCommitted:
-		ret = ReadCommittedIsolation
-	case isolation.Snapshot:
-		ret = SnapshotIsolation
+// ToKVIsoLevel converts an IsolationLevel to its isolation.Level equivalent.
+func (i IsolationLevel) ToKVIsoLevel() isolation.Level {
+	switch i {
+	case ReadUncommittedIsolation, ReadCommittedIsolation:
+		return isolation.ReadCommitted
+	case RepeatableReadIsolation, SnapshotIsolation:
+		return isolation.Snapshot
+	case SerializableIsolation:
+		return isolation.Serializable
 	default:
-		panic("What to do here? Log is a banned import")
-		// log.Fatalf(context.Background(), "unknown isolation level: %s", level)
+		panic(fmt.Sprintf("unknown isolation level: %s", i))
 	}
-	return ret
+}
+
+// FromKVIsoLevel converts an isolation.Level to its SQL semantic equivalent.
+func FromKVIsoLevel(level isolation.Level) IsolationLevel {
+	switch level {
+	case isolation.ReadCommitted:
+		return ReadCommittedIsolation
+	case isolation.Snapshot:
+		return SnapshotIsolation
+	case isolation.Serializable:
+		return SerializableIsolation
+	default:
+		panic(fmt.Sprintf("unknown isolation level: %s", level))
+	}
+}
+
+// UpgradeToEnabledLevel upgrades the isolation level to the weakest enabled
+// isolation level that is stronger than or equal to the input level.
+func (i IsolationLevel) UpgradeToEnabledLevel(
+	allowReadCommitted, allowRepeatableRead, hasLicense bool,
+) (_ IsolationLevel, upgraded, upgradedDueToLicense bool) {
+	switch i {
+	case ReadUncommittedIsolation:
+		// READ UNCOMMITTED is mapped to READ COMMITTED. PostgreSQL also does
+		// this: https://www.postgresql.org/docs/current/transaction-iso.html.
+		upgraded = true
+		fallthrough
+	case ReadCommittedIsolation:
+		// READ COMMITTED is only allowed if the cluster setting is enabled and the
+		// cluster has a license. Otherwise, it is mapped to a stronger isolation
+		// level (REPEATABLE READ if enabled, SERIALIZABLE otherwise).
+		if allowReadCommitted && hasLicense {
+			return ReadCommittedIsolation, upgraded, upgradedDueToLicense
+		}
+		upgraded = true
+		if allowReadCommitted && !hasLicense {
+			upgradedDueToLicense = true
+		}
+		fallthrough
+	case RepeatableReadIsolation, SnapshotIsolation:
+		// REPEATABLE READ and SNAPSHOT are considered aliases. The isolation levels
+		// are only allowed if the cluster setting is enabled and the cluster has a
+		// license. Otherwise, they are mapped to SERIALIZABLE.
+		if allowRepeatableRead && hasLicense {
+			return SnapshotIsolation, upgraded, upgradedDueToLicense
+		}
+		upgraded = true
+		if allowRepeatableRead && !hasLicense {
+			upgradedDueToLicense = true
+		}
+		fallthrough
+	case SerializableIsolation:
+		return SerializableIsolation, upgraded, upgradedDueToLicense
+	default:
+		panic(fmt.Sprintf("unknown isolation level: %s", i))
+	}
 }
 
 // UserPriority holds the user priority for a transaction.

--- a/pkg/sql/testdata/telemetry/isolation_level
+++ b/pkg/sql/testdata/telemetry/isolation_level
@@ -112,7 +112,6 @@ feature-usage
 SET default_transaction_isolation = 'repeatable read'
 ----
 sql.txn.isolation.executed_at.read_committed
-sql.txn.isolation.upgraded_from.repeatable_read
 
 feature-usage
 SET default_transaction_isolation = 'snapshot'
@@ -134,7 +133,6 @@ feature-usage
 SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL REPEATABLE READ
 ----
 sql.txn.isolation.executed_at.read_committed
-sql.txn.isolation.upgraded_from.repeatable_read
 
 feature-usage
 SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SNAPSHOT
@@ -156,7 +154,6 @@ feature-usage
 BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ; COMMIT
 ----
 sql.txn.isolation.executed_at.snapshot
-sql.txn.isolation.upgraded_from.repeatable_read
 
 feature-usage
 BEGIN TRANSACTION ISOLATION LEVEL SNAPSHOT; COMMIT
@@ -180,7 +177,6 @@ feature-usage
 BEGIN; SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; COMMIT
 ----
 sql.txn.isolation.executed_at.snapshot
-sql.txn.isolation.upgraded_from.repeatable_read
 
 feature-usage
 BEGIN; SET TRANSACTION ISOLATION LEVEL SNAPSHOT; COMMIT

--- a/pkg/sql/testdata/telemetry_logging/logging/stmts_per_txn_limit
+++ b/pkg/sql/testdata/telemetry_logging/logging/stmts_per_txn_limit
@@ -228,4 +228,3 @@ BEGIN; SELECT 1; SELECT 2; SELECT 3; SELECT 4; COMMIT;
 	"TransactionFingerprintID": "2831371359051261045",
 	"User": "root"
 }
-

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -429,37 +429,12 @@ var varGen = map[string]sessionVar{
 				allowedValues = append(allowedValues, "read committed")
 			}
 			level, ok := tree.IsolationLevelMap[strings.ToLower(s)]
-			originalLevel := level
-			upgraded := false
-			upgradedDueToLicense := false
 			if !ok {
 				return newVarValueError(`default_transaction_isolation`, s, allowedValues...)
 			}
-			switch level {
-			case tree.ReadUncommittedIsolation:
-				upgraded = true
-				fallthrough
-			case tree.ReadCommittedIsolation:
-				level = tree.SerializableIsolation
-				if allowReadCommitted && hasLicense {
-					level = tree.ReadCommittedIsolation
-				} else {
-					upgraded = true
-					if allowReadCommitted && !hasLicense {
-						upgradedDueToLicense = true
-					}
-				}
-			case tree.RepeatableReadIsolation, tree.SnapshotIsolation:
-				level = tree.SerializableIsolation
-				if allowRepeatableRead && hasLicense {
-					level = tree.SnapshotIsolation
-				} else {
-					upgraded = true
-					if allowRepeatableRead && !hasLicense {
-						upgradedDueToLicense = true
-					}
-				}
-			}
+			originalLevel := level
+			level, upgraded, upgradedDueToLicense := level.UpgradeToEnabledLevel(
+				allowReadCommitted, allowRepeatableRead, hasLicense)
 			if f := m.upgradedIsolationLevel; upgraded && f != nil {
 				f(ctx, originalLevel, upgradedDueToLicense)
 			}
@@ -1605,7 +1580,7 @@ var varGen = map[string]sessionVar{
 	// See https://github.com/postgres/postgres/blob/REL_10_STABLE/src/backend/utils/misc/guc.c#L3401-L3409
 	`transaction_isolation`: {
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
-			level := tree.IsolationLevelFromKVTxnIsolationLevel(evalCtx.Txn.IsoLevel())
+			level := tree.FromKVIsoLevel(evalCtx.Txn.IsoLevel())
 			return strings.ToLower(level.String()), nil
 		},
 		RuntimeSet: func(ctx context.Context, evalCtx *extendedEvalContext, local bool, s string) error {


### PR DESCRIPTION
This commit fixes the isolation level upgrade logic to upgrade `READ UNCOMMITTED` and `READ COMMITTED` to `REPEATABLE READ` (i.e. `SNAPSHOT`) when read committed isolation is disabled but repeatable read is enabled. Previously, this combination would upgrade the isolation level all the way to `SERIALIZABLE` isolation.

Epic: None
Release note: None