### PR TITLE
rac2,replica_rac2: implement Processor.AdmitForEval

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller_wait_for_eval
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller_wait_for_eval
@@ -16,14 +16,14 @@ t1/s3: reg=+0 B/+1 B ela=+0 B/+1 B
 wait_for_eval name=a range_id=1 pri=HighPri
 ----
 range_id=1 tenant_id={1} local_replica_id=1
-  name=a pri=high-pri done=false err=<nil>
+  name=a pri=high-pri done=false waited=false err=<nil>
 
 # Start a low priority evaluation. It should also not complete.
 wait_for_eval name=b range_id=1 pri=LowPri
 ----
 range_id=1 tenant_id={1} local_replica_id=1
-  name=a pri=high-pri done=false err=<nil>
-  name=b pri=low-pri  done=false err=<nil>
+  name=a pri=high-pri done=false waited=false err=<nil>
+  name=b pri=low-pri  done=false waited=false err=<nil>
 
 # Add high priority tokens to the first store. This is not enough for quorum.
 adjust_tokens
@@ -37,8 +37,8 @@ t1/s3: reg=+0 B/+1 B ela=+0 B/+1 B
 cancel_context range_id=1 name=a
 ----
 range_id=1 tenant_id={1} local_replica_id=1
-  name=a pri=high-pri done=true  err=context canceled
-  name=b pri=low-pri  done=false err=<nil>
+  name=a pri=high-pri done=true  waited=false err=context canceled
+  name=b pri=low-pri  done=false waited=false err=<nil>
 
 # Add high priority tokens to the second store. 'b' is elastic so it should not
 # complete despite having a quorum of streams with available tokens.
@@ -52,8 +52,8 @@ t1/s3: reg=+0 B/+1 B ela=+0 B/+1 B
 check_state
 ----
 range_id=1 tenant_id={1} local_replica_id=1
-  name=a pri=high-pri done=true  err=context canceled
-  name=b pri=low-pri  done=false err=<nil>
+  name=a pri=high-pri done=true  waited=false err=context canceled
+  name=b pri=low-pri  done=false waited=false err=<nil>
 
 # Add high priority tokens to the third store. Now all stores have positive
 # tokens and 'b' should complete.
@@ -67,8 +67,8 @@ t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
 check_state
 ----
 range_id=1 tenant_id={1} local_replica_id=1
-  name=a pri=high-pri done=true  err=context canceled
-  name=b pri=low-pri  done=true  err=<nil>
+  name=a pri=high-pri done=true  waited=false err=context canceled
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
 
 # Change the replica set: replace replica 3 with a new replica 4.
 set_replicas
@@ -92,9 +92,9 @@ t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
 wait_for_eval name=c range_id=1 pri=HighPri
 ----
 range_id=1 tenant_id={1} local_replica_id=1
-  name=a pri=high-pri done=true  err=context canceled
-  name=b pri=low-pri  done=true  err=<nil>
-  name=c pri=high-pri done=false err=<nil>
+  name=a pri=high-pri done=true  waited=false err=context canceled
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=high-pri done=false waited=false err=<nil>
 
 # Add high priority tokens back to the first store, restoring quorum.
 adjust_tokens
@@ -109,9 +109,9 @@ t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
 check_state
 ----
 range_id=1 tenant_id={1} local_replica_id=1
-  name=a pri=high-pri done=true  err=context canceled
-  name=b pri=low-pri  done=true  err=<nil>
-  name=c pri=high-pri done=true  err=<nil>
+  name=a pri=high-pri done=true  waited=false err=context canceled
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=high-pri done=true  waited=true  err=<nil>
 
 # Test behavior with a non-voter replica.
 set_replicas
@@ -127,10 +127,10 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4NON_VOTER]
 wait_for_eval name=d range_id=1 pri=HighPri
 ----
 range_id=1 tenant_id={1} local_replica_id=1
-  name=a pri=high-pri done=true  err=context canceled
-  name=b pri=low-pri  done=true  err=<nil>
-  name=c pri=high-pri done=true  err=<nil>
-  name=d pri=high-pri done=true  err=<nil>
+  name=a pri=high-pri done=true  waited=false err=context canceled
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=high-pri done=true  waited=true  err=<nil>
+  name=d pri=high-pri done=true  waited=true  err=<nil>
 
 # Remove tokens from s3, s1 and s2 have tokens which is enough for quorum.
 adjust_tokens
@@ -146,10 +146,10 @@ t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
 check_state
 ----
 range_id=1 tenant_id={1} local_replica_id=1
-  name=a pri=high-pri done=true  err=context canceled
-  name=b pri=low-pri  done=true  err=<nil>
-  name=c pri=high-pri done=true  err=<nil>
-  name=d pri=high-pri done=true  err=<nil>
+  name=a pri=high-pri done=true  waited=false err=context canceled
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=high-pri done=true  waited=true  err=<nil>
+  name=d pri=high-pri done=true  waited=true  err=<nil>
 
 # Test behavior when changing leaseholder.
 set_leaseholder range_id=1 replica_id=2
@@ -162,11 +162,11 @@ r1: [(n1,s1):1,(n2,s2):2*,(n3,s3):3,(n4,s4):4NON_VOTER]
 wait_for_eval name=e range_id=1 pri=HighPri
 ----
 range_id=1 tenant_id={1} local_replica_id=1
-  name=a pri=high-pri done=true  err=context canceled
-  name=b pri=low-pri  done=true  err=<nil>
-  name=c pri=high-pri done=true  err=<nil>
-  name=d pri=high-pri done=true  err=<nil>
-  name=e pri=high-pri done=true  err=<nil>
+  name=a pri=high-pri done=true  waited=false err=context canceled
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=high-pri done=true  waited=true  err=<nil>
+  name=d pri=high-pri done=true  waited=true  err=<nil>
+  name=e pri=high-pri done=true  waited=true  err=<nil>
 
 # Start another evaluation on a new range, which will intersect some of the
 # stores of the first range. The evaluation on the first range will not
@@ -193,25 +193,25 @@ r2: [(n1,s1):1*,(n3,s3):3,(n5,s5):5]
 wait_for_eval name=f range_id=1 pri=LowPri
 ----
 range_id=1 tenant_id={1} local_replica_id=1
-  name=a pri=high-pri done=true  err=context canceled
-  name=b pri=low-pri  done=true  err=<nil>
-  name=c pri=high-pri done=true  err=<nil>
-  name=d pri=high-pri done=true  err=<nil>
-  name=e pri=high-pri done=true  err=<nil>
-  name=f pri=low-pri  done=false err=<nil>
+  name=a pri=high-pri done=true  waited=false err=context canceled
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=high-pri done=true  waited=true  err=<nil>
+  name=d pri=high-pri done=true  waited=true  err=<nil>
+  name=e pri=high-pri done=true  waited=true  err=<nil>
+  name=f pri=low-pri  done=false waited=false err=<nil>
 range_id=2 tenant_id={1} local_replica_id=1
 
 wait_for_eval name=g range_id=2 pri=HighPri
 ----
 range_id=1 tenant_id={1} local_replica_id=1
-  name=a pri=high-pri done=true  err=context canceled
-  name=b pri=low-pri  done=true  err=<nil>
-  name=c pri=high-pri done=true  err=<nil>
-  name=d pri=high-pri done=true  err=<nil>
-  name=e pri=high-pri done=true  err=<nil>
-  name=f pri=low-pri  done=false err=<nil>
+  name=a pri=high-pri done=true  waited=false err=context canceled
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=high-pri done=true  waited=true  err=<nil>
+  name=d pri=high-pri done=true  waited=true  err=<nil>
+  name=e pri=high-pri done=true  waited=true  err=<nil>
+  name=f pri=low-pri  done=false waited=false err=<nil>
 range_id=2 tenant_id={1} local_replica_id=1
-  name=g pri=high-pri done=false err=<nil>
+  name=g pri=high-pri done=false waited=false err=<nil>
 
 adjust_tokens
   store_id=5 pri=HighPri tokens=1
@@ -225,14 +225,14 @@ t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
 check_state
 ----
 range_id=1 tenant_id={1} local_replica_id=1
-  name=a pri=high-pri done=true  err=context canceled
-  name=b pri=low-pri  done=true  err=<nil>
-  name=c pri=high-pri done=true  err=<nil>
-  name=d pri=high-pri done=true  err=<nil>
-  name=e pri=high-pri done=true  err=<nil>
-  name=f pri=low-pri  done=false err=<nil>
+  name=a pri=high-pri done=true  waited=false err=context canceled
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=high-pri done=true  waited=true  err=<nil>
+  name=d pri=high-pri done=true  waited=true  err=<nil>
+  name=e pri=high-pri done=true  waited=true  err=<nil>
+  name=f pri=low-pri  done=false waited=false err=<nil>
 range_id=2 tenant_id={1} local_replica_id=1
-  name=g pri=high-pri done=true  err=<nil>
+  name=g pri=high-pri done=true  waited=true  err=<nil>
 
 # Adding elastic tokens to s3 should complete the low priority evaluation 'f',
 # as all stores now have elastic tokens available.
@@ -248,14 +248,14 @@ t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
 check_state
 ----
 range_id=1 tenant_id={1} local_replica_id=1
-  name=a pri=high-pri done=true  err=context canceled
-  name=b pri=low-pri  done=true  err=<nil>
-  name=c pri=high-pri done=true  err=<nil>
-  name=d pri=high-pri done=true  err=<nil>
-  name=e pri=high-pri done=true  err=<nil>
-  name=f pri=low-pri  done=true  err=<nil>
+  name=a pri=high-pri done=true  waited=false err=context canceled
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=high-pri done=true  waited=true  err=<nil>
+  name=d pri=high-pri done=true  waited=true  err=<nil>
+  name=e pri=high-pri done=true  waited=true  err=<nil>
+  name=f pri=low-pri  done=true  waited=true  err=<nil>
 range_id=2 tenant_id={1} local_replica_id=1
-  name=g pri=high-pri done=true  err=<nil>
+  name=g pri=high-pri done=true  waited=true  err=<nil>
 
 # Adjust the tokens so that r1 doesn't have tokens on s3 or s1, then transfer
 # s3 the lease for r1.
@@ -279,15 +279,15 @@ r2: [(n1,s1):1*,(n3,s3):3,(n5,s5):5]
 wait_for_eval name=h range_id=1 pri=HighPri
 ----
 range_id=1 tenant_id={1} local_replica_id=1
-  name=a pri=high-pri done=true  err=context canceled
-  name=b pri=low-pri  done=true  err=<nil>
-  name=c pri=high-pri done=true  err=<nil>
-  name=d pri=high-pri done=true  err=<nil>
-  name=e pri=high-pri done=true  err=<nil>
-  name=f pri=low-pri  done=true  err=<nil>
-  name=h pri=high-pri done=false err=<nil>
+  name=a pri=high-pri done=true  waited=false err=context canceled
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=high-pri done=true  waited=true  err=<nil>
+  name=d pri=high-pri done=true  waited=true  err=<nil>
+  name=e pri=high-pri done=true  waited=true  err=<nil>
+  name=f pri=low-pri  done=true  waited=true  err=<nil>
+  name=h pri=high-pri done=false waited=false err=<nil>
 range_id=2 tenant_id={1} local_replica_id=1
-  name=g pri=high-pri done=true  err=<nil>
+  name=g pri=high-pri done=true  waited=true  err=<nil>
 
 # Add tokens to s3, this should not complete 'h' as the leader of r1 (s1) does
 # not have tokens.
@@ -306,16 +306,16 @@ t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
 wait_for_eval name=i range_id=1 pri=HighPri
 ----
 range_id=1 tenant_id={1} local_replica_id=1
-  name=a pri=high-pri done=true  err=context canceled
-  name=b pri=low-pri  done=true  err=<nil>
-  name=c pri=high-pri done=true  err=<nil>
-  name=d pri=high-pri done=true  err=<nil>
-  name=e pri=high-pri done=true  err=<nil>
-  name=f pri=low-pri  done=true  err=<nil>
-  name=h pri=high-pri done=false err=<nil>
-  name=i pri=high-pri done=false err=<nil>
+  name=a pri=high-pri done=true  waited=false err=context canceled
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=high-pri done=true  waited=true  err=<nil>
+  name=d pri=high-pri done=true  waited=true  err=<nil>
+  name=e pri=high-pri done=true  waited=true  err=<nil>
+  name=f pri=low-pri  done=true  waited=true  err=<nil>
+  name=h pri=high-pri done=false waited=false err=<nil>
+  name=i pri=high-pri done=false waited=false err=<nil>
 range_id=2 tenant_id={1} local_replica_id=1
-  name=g pri=high-pri done=true  err=<nil>
+  name=g pri=high-pri done=true  waited=true  err=<nil>
 
 # Finally, add tokens to s1 to complete both evaluations 'h' and 'i'.
 adjust_tokens
@@ -330,13 +330,57 @@ t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
 check_state
 ----
 range_id=1 tenant_id={1} local_replica_id=1
-  name=a pri=high-pri done=true  err=context canceled
-  name=b pri=low-pri  done=true  err=<nil>
-  name=c pri=high-pri done=true  err=<nil>
-  name=d pri=high-pri done=true  err=<nil>
-  name=e pri=high-pri done=true  err=<nil>
-  name=f pri=low-pri  done=true  err=<nil>
-  name=h pri=high-pri done=true  err=<nil>
-  name=i pri=high-pri done=true  err=<nil>
+  name=a pri=high-pri done=true  waited=false err=context canceled
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=high-pri done=true  waited=true  err=<nil>
+  name=d pri=high-pri done=true  waited=true  err=<nil>
+  name=e pri=high-pri done=true  waited=true  err=<nil>
+  name=f pri=low-pri  done=true  waited=true  err=<nil>
+  name=h pri=high-pri done=true  waited=true  err=<nil>
+  name=i pri=high-pri done=true  waited=true  err=<nil>
 range_id=2 tenant_id={1} local_replica_id=1
-  name=g pri=high-pri done=true  err=<nil>
+  name=g pri=high-pri done=true  waited=true  err=<nil>
+
+# No tokens on s3.
+adjust_tokens
+  store_id=3 pri=HighPri tokens=-1
+----
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
+
+# Start an evaluation 'j' on r1, that does not complete since the leaseholder
+# (s3) has tokens.
+wait_for_eval name=j range_id=1 pri=HighPri
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=high-pri done=true  waited=false err=context canceled
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=high-pri done=true  waited=true  err=<nil>
+  name=d pri=high-pri done=true  waited=true  err=<nil>
+  name=e pri=high-pri done=true  waited=true  err=<nil>
+  name=f pri=low-pri  done=true  waited=true  err=<nil>
+  name=h pri=high-pri done=true  waited=true  err=<nil>
+  name=i pri=high-pri done=true  waited=true  err=<nil>
+  name=j pri=high-pri done=false waited=false err=<nil>
+range_id=2 tenant_id={1} local_replica_id=1
+  name=g pri=high-pri done=true  waited=true  err=<nil>
+
+# Close all the RangeControllers. Evaluation 'j' is done, but specifies waited
+# is false, and error is nil.
+close_rcs
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=high-pri done=true  waited=false err=context canceled
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=high-pri done=true  waited=true  err=<nil>
+  name=d pri=high-pri done=true  waited=true  err=<nil>
+  name=e pri=high-pri done=true  waited=true  err=<nil>
+  name=f pri=low-pri  done=true  waited=true  err=<nil>
+  name=h pri=high-pri done=true  waited=true  err=<nil>
+  name=i pri=high-pri done=true  waited=true  err=<nil>
+  name=j pri=high-pri done=true  waited=false err=<nil>
+range_id=2 tenant_id={1} local_replica_id=1
+  name=g pri=high-pri done=true  waited=true  err=<nil>

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/BUILD.bazel
@@ -10,10 +10,12 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/replica_rac2",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/kv/kvserver/kvflowcontrol",
         "//pkg/kv/kvserver/kvflowcontrol/rac2",
         "//pkg/kv/kvserver/raftlog",
         "//pkg/raft/raftpb",
         "//pkg/roachpb",
+        "//pkg/settings/cluster",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/buildutil",
         "//pkg/util/log",
@@ -31,6 +33,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":replica_rac2"],
     deps = [
+        "//pkg/kv/kvserver/kvflowcontrol",
         "//pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb",
         "//pkg/kv/kvserver/kvflowcontrol/rac2",
         "//pkg/kv/kvserver/kvserverbase",
@@ -38,6 +41,7 @@ go_test(
         "//pkg/kv/kvserver/raftlog",
         "//pkg/raft/raftpb",
         "//pkg/roachpb",
+        "//pkg/settings/cluster",
         "//pkg/testutils/datapathutils",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/leaktest",
@@ -45,6 +49,7 @@ go_test(
         "//pkg/util/protoutil",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -16,7 +16,9 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/rac2"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
@@ -24,11 +26,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -185,21 +191,34 @@ func (q *testACWorkQueue) Admit(ctx context.Context, entry EntryForAdmission) bo
 }
 
 type testRangeControllerFactory struct {
-	b *strings.Builder
+	b   *strings.Builder
+	rcs []*testRangeController
 }
 
 func (f *testRangeControllerFactory) New(state rangeControllerInitState) rac2.RangeController {
 	fmt.Fprintf(f.b, " RangeControllerFactory.New(replicaSet=%s, leaseholder=%s, nextRaftIndex=%d)\n",
 		state.replicaSet, state.leaseholder, state.nextRaftIndex)
-	return &testRangeController{b: f.b}
+	rc := &testRangeController{b: f.b, waited: true}
+	f.rcs = append(f.rcs, rc)
+	return rc
 }
 
 type testRangeController struct {
-	b *strings.Builder
+	b              *strings.Builder
+	waited         bool
+	waitForEvalErr error
 }
 
-func (c *testRangeController) WaitForEval(ctx context.Context, pri admissionpb.WorkPriority) error {
-	panic("WaitForEval should not be called")
+func (c *testRangeController) WaitForEval(
+	ctx context.Context, pri admissionpb.WorkPriority,
+) (bool, error) {
+	errStr := "<nil>"
+	if c.waitForEvalErr != nil {
+		errStr = c.waitForEvalErr.Error()
+	}
+	fmt.Fprintf(c.b, " RangeController.WaitForEval(pri=%s) = (waited=%t err=%s)\n",
+		pri.String(), c.waited, errStr)
+	return c.waited, c.waitForEvalErr
 }
 
 func raftEventString(e rac2.RaftEvent) string {
@@ -245,12 +264,17 @@ func (c *testRangeController) CloseRaftMuLocked(ctx context.Context) {
 }
 
 func TestProcessorBasic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
 	var b strings.Builder
 	var r *testReplica
 	var sched testRaftScheduler
 	var piggybacker testAdmittedPiggybacker
 	var q testACWorkQueue
 	var rcFactory testRangeControllerFactory
+	var st *cluster.Settings
 	var p *processorImpl
 	tenantID := roachpb.MustMakeTenantID(4)
 	reset := func(enabled EnabledWhenLeaderLevel) {
@@ -260,6 +284,8 @@ func TestProcessorBasic(t *testing.T) {
 		piggybacker = testAdmittedPiggybacker{b: &b}
 		q = testACWorkQueue{b: &b}
 		rcFactory = testRangeControllerFactory{b: &b}
+		st = cluster.MakeTestingClusterSettings()
+		kvflowcontrol.Mode.Override(ctx, &st.SV, kvflowcontrol.ApplyToElastic)
 		p = NewProcessor(ProcessorOptions{
 			NodeID:                 1,
 			StoreID:                2,
@@ -270,6 +296,7 @@ func TestProcessorBasic(t *testing.T) {
 			AdmittedPiggybacker:    &piggybacker,
 			ACWorkQueue:            &q,
 			RangeControllerFactory: &rcFactory,
+			Settings:               st,
 			EnabledWhenLeaderLevel: enabled,
 		}).(*processorImpl)
 		fmt.Fprintf(&b, "n%s,s%s,r%s: replica=%s, tenant=%s, enabled-level=%s\n",
@@ -286,7 +313,6 @@ func TestProcessorBasic(t *testing.T) {
 			r.raftNode.leader, r.leaseholder, r.raftNode.stableIndex, r.raftNode.nextUnstableIndex,
 			r.raftNode.term, admittedString(r.raftNode.admitted))
 	}
-	ctx := context.Background()
 	datadriven.RunTest(t, datapathutils.TestDataPath(t, "processor"),
 		func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
@@ -428,10 +454,60 @@ func TestProcessorBasic(t *testing.T) {
 				p.AdmittedLogEntry(ctx, cb)
 				return builderStr()
 
+			case "set-flow-control-mode":
+				var mode string
+				d.ScanArgs(t, "mode", &mode)
+				var modeVal kvflowcontrol.ModeT
+				switch mode {
+				case "apply-to-all":
+					modeVal = kvflowcontrol.ApplyToAll
+				case "apply-to-elastic":
+					modeVal = kvflowcontrol.ApplyToElastic
+				default:
+					t.Fatalf("unknown mode: %s", mode)
+				}
+				kvflowcontrol.Mode.Override(ctx, &st.SV, modeVal)
+				return builderStr()
+
+			case "admit-for-eval":
+				pri := parseAdmissionPriority(t, d)
+				// The callee ignores the create time.
+				admitted, err := p.AdmitForEval(ctx, pri, time.Time{})
+				fmt.Fprintf(&b, "admitted: %t err: ", admitted)
+				if err == nil {
+					fmt.Fprintf(&b, "<nil>\n")
+				} else {
+					fmt.Fprintf(&b, "%s\n", err.Error())
+				}
+				return builderStr()
+
+			case "set-wait-for-eval-return-values":
+				rc := rcFactory.rcs[len(rcFactory.rcs)-1]
+				d.ScanArgs(t, "waited", &rc.waited)
+				rc.waitForEvalErr = nil
+				if d.HasArg("err") {
+					var errStr string
+					d.ScanArgs(t, "err", &errStr)
+					rc.waitForEvalErr = errors.Errorf("%s", errStr)
+				}
+				return builderStr()
+
 			default:
 				return fmt.Sprintf("unknown command: %s", d.Cmd)
 			}
 		})
+}
+
+func parseAdmissionPriority(t *testing.T, td *datadriven.TestData) admissionpb.WorkPriority {
+	var priStr string
+	td.ScanArgs(t, "pri", &priStr)
+	for k, v := range admissionpb.WorkPriorityDict {
+		if v == priStr {
+			return k
+		}
+	}
+	t.Fatalf("unknown priority %s", priStr)
+	return admissionpb.NormalPri
 }
 
 func parseEnabledLevel(t *testing.T, td *datadriven.TestData) EnabledWhenLeaderLevel {

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
@@ -14,6 +14,16 @@ on-destroy
 ----
  Replica.RaftMuAssertHeld
 
+# AdmitForEval returns false since there is no RangeController.
+admit-for-eval pri=low-pri
+----
+admitted: false err: <nil>
+
+# AdmitForEval returns false since there is no RangeController.
+admit-for-eval pri=normal-pri
+----
+admitted: false err: <nil>
+
 reset
 ----
 n1,s2,r3: replica=5, tenant=4, enabled-level=not-enabled
@@ -381,6 +391,49 @@ HandleRaftReady:
 AdmitRaftEntries:
  ACWorkQueue.Admit({TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false CallbackState:{StoreID:2 RangeID:3 ReplicaID:5 LeaderTerm:52 Index:28 Priority:LowPri}}) = true
 leader-using-v2: true
+
+# AdmitForEval returns true since there is a RangeController which admitted.
+admit-for-eval pri=low-pri
+----
+ RangeController.WaitForEval(pri=low-pri) = (waited=true err=<nil>)
+admitted: true err: <nil>
+
+# AdmitForEval returns false despite there being a RangeController since
+# normal-pri is not subject to replication AC. RangeController.WaitForEval was
+# not called.
+admit-for-eval pri=normal-pri
+----
+admitted: false err: <nil>
+
+# Subject normal-pri to replication AC.
+set-flow-control-mode mode=apply-to-all
+----
+
+# AdmitForEval for normal-pri returns true.
+admit-for-eval pri=normal-pri
+----
+ RangeController.WaitForEval(pri=normal-pri) = (waited=true err=<nil>)
+admitted: true err: <nil>
+
+# Change the return value from WaitForEval.
+set-wait-for-eval-return-values waited=false
+----
+
+# Plumbing to WaitForEval is correct.
+admit-for-eval pri=normal-pri
+----
+ RangeController.WaitForEval(pri=normal-pri) = (waited=false err=<nil>)
+admitted: false err: <nil>
+
+# Set WaitForEval to return an error.
+set-wait-for-eval-return-values waited=false err=rc-was-closed
+----
+
+# Plumbing to WaitForEval is correct.
+admit-for-eval pri=normal-pri
+----
+ RangeController.WaitForEval(pri=normal-pri) = (waited=false err=rc-was-closed)
+admitted: false err: rc-was-closed
 
 # Entry at index 28 is admitted, but stable index is 27.
 admitted-log-entry replica-id=5 leader-term=52 index=28 pri=0


### PR DESCRIPTION

- RangeController.WaitForEval is changed to additionally return a waited
  bool, so that it conforms to the callers expectation that (false, nil)
  will be returned when the RangeController is closed during waiting.
  This allows the caller to wait on the local store (before eval) and
  not completely bypass all AC.
- Processor.AdmitForEval consults the existing
  kvadmission.flow_control.mode cluster setting to decide whether a
  request should be subject to replication AC, and if yes, forwards to
  the RangeController.

Fixes #129522

Epic: CRDB-37515

Release note: None
