### PR TITLE
roachprod: fail early on startup script errors and make them observable

### DIFF
--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -743,6 +743,8 @@ func (p *Provider) createVM(
 	startupArgs := azureStartupArgs{
 		RemoteUser:           remoteUser,
 		DisksInitializedFile: vm.DisksInitializedFile,
+		OSInitializedFile:    vm.OSInitializedFile,
+		StartupLogs:          vm.StartupLogs,
 	}
 	if !opts.SSDOpts.UseLocalSSD {
 		// We define lun42 explicitly in the data disk request below.

--- a/pkg/roachprod/vm/azure/utils.go
+++ b/pkg/roachprod/vm/azure/utils.go
@@ -25,12 +25,21 @@ type azureStartupArgs struct {
 	RemoteUser           string // The uname for /data* directories.
 	AttachedDiskLun      *int   // Use attached disk, with specified LUN; Use local ssd if nil.
 	DisksInitializedFile string // File to touch when disks are initialized.
+	OSInitializedFile    string // File to touch when OS is initialized.
+	StartupLogs          string // File to redirect startup script output logs.
 }
 
 const azureStartupTemplate = `#!/bin/bash
 
 # Script for setting up a Azure machine for roachprod use.
-set -xe
+# ensure any failure fails the entire script
+set -eux
+
+# Redirect output to stdout/err and a log file
+exec &> >(tee -a {{ .StartupLogs }})
+
+# Log the startup of the script with a timestamp
+echo "startup script starting: $(date -u)"
 mount_opts="defaults"
 
 {{if .AttachedDiskLun}}
@@ -113,6 +122,7 @@ sudo sed -i 's/#LoginGraceTime .*/LoginGraceTime 0/g' /etc/ssh/sshd_config
 sudo service ssh restart
 
 touch {{ .DisksInitializedFile }}
+touch {{ .OSInitializedFile }}
 `
 
 // evalStartupTemplate evaluates startup template defined above and returns

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -31,7 +31,17 @@ import (
 const gceDiskStartupScriptTemplate = `#!/usr/bin/env bash
 # Script for setting up a GCE machine for roachprod use.
 
-set -x
+# ensure any failure fails the entire script
+set -eux
+
+# Redirect output to stdout/err and a log file
+exec &> >(tee -a {{ .StartupLogs }})
+
+# Log the startup of the script with a timestamp
+echo "startup script starting: $(date -u)"
+
+sudo -u {{ .SharedUser }} bash -c "mkdir -p ~/.ssh && chmod 700 ~/.ssh"
+sudo -u {{ .SharedUser }} bash -c 'echo "{{ .PublicKey }}" >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys'
 
 function setup_disks() {
   first_setup=$1
@@ -73,14 +83,19 @@ function setup_disks() {
 
 	for l in ${local_or_persistent}; do
   d=$(readlink -f $l)
+  mounted="no"
   {{ if .Zfs }}
     # Check if the disk is already part of a zpool or mounted; skip if so.
-    (zpool list -v -P | grep ${d} > /dev/null) || (mount | grep ${d} > /dev/null)
+    if (zpool list -v -P | grep -q ${d}) || (mount | grep -q ${d}); then
+      mounted="yes"
+    fi
   {{ else }}
     # Skip already mounted disks.
-    mount | grep ${d} > /dev/null
+    if mount | grep -q ${d}; then
+      mounted="yes"
+    fi
   {{ end }}
-		if [ $? -ne 0 ]; then
+		if [ "$mounted" == "no" ]; then
 			disks+=("${d}")
 			echo "Disk ${d} not mounted, need to mount..."
 		else
@@ -163,7 +178,9 @@ fi
 setup_disks true
 
 # sshguard can prevent frequent ssh connections to the same host. Disable it.
-systemctl stop sshguard
+if systemctl is-active --quiet sshguard; then
+    systemctl stop sshguard
+fi
 systemctl mask sshguard
 # increase the number of concurrent unauthenticated connections to the sshd
 # daemon. See https://en.wikibooks.org/wiki/OpenSSH/Cookbook/Load_Balancing.
@@ -239,7 +256,9 @@ for timer in apt-daily-upgrade.timer apt-daily.timer e2scrub_all.timer fstrim.ti
 done
 
 for service in apport.service atd.service; do
-  systemctl stop $service
+	if systemctl is-active --quiet $service; then
+    systemctl stop $service
+	fi
   systemctl mask $service
 done
 
@@ -270,9 +289,6 @@ sysctl --system  # reload sysctl settings
 sudo ua enable fips --assume-yes
 {{ end }}
 
-sudo -u {{ .SharedUser }} bash -c "mkdir ~/.ssh && chmod 700 ~/.ssh"
-sudo -u {{ .SharedUser }} bash -c 'echo "{{ .PublicKey }}" >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys'
-
 sudo sed -i 's/#LoginGraceTime .*/LoginGraceTime 0/g' /etc/ssh/sshd_config
 sudo service ssh restart
 
@@ -298,6 +314,7 @@ func writeStartupScript(
 		EnableCron           bool
 		OSInitializedFile    string
 		DisksInitializedFile string
+		StartupLogs          string
 	}
 
 	publicKey, err := config.SSHPublicKey()
@@ -315,6 +332,7 @@ func writeStartupScript(
 		EnableCron:           enableCron,
 		OSInitializedFile:    vm.OSInitializedFile,
 		DisksInitializedFile: vm.DisksInitializedFile,
+		StartupLogs:          vm.StartupLogs,
 	}
 
 	tmpfile, err := os.CreateTemp("", "gce-startup-script")

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -60,6 +60,9 @@ const (
 	// need to be re-initialized on every start. The presence of this file
 	// automatically implies the presence of OSInitializedFile.
 	DisksInitializedFile = "/mnt/data1/" + InitializedFile
+	// StartupLogs is a log file that is created on a VM to redirect startup script
+	// output logs.
+	StartupLogs = "/var/log/roachprod_startup.log"
 )
 
 // UnimplementedError is returned when a method is not implemented by a


### PR DESCRIPTION
Previously, when a new VM was provisioned with roachprod a startup script was executed without `set -e` and failures if any weren't captured. This patch fixes these issues by executing the script using `set -eux` and redirecting failure outputs to a `/var/log/roachprod_startup.log`.

Epic: none
Fixes: #120007
Release note: None