### PR TITLE
admission: move user low above bulk normal

### DIFF
--- a/pkg/util/admission/admissionpb/admissionpb.go
+++ b/pkg/util/admission/admissionpb/admissionpb.go
@@ -29,11 +29,11 @@ const (
 	LowPri WorkPriority = math.MinInt8
 	// BulkLowPri is low priority work from internal bulk submissions.
 	BulkLowPri WorkPriority = -100
-	// UserLowPri is low priority work from user submissions (SQL).
-	UserLowPri WorkPriority = -50
 	// BulkNormalPri is bulk priority work from bulk jobs, which could be run due
 	// to user submissions or be automatic.
 	BulkNormalPri WorkPriority = -30
+	// UserLowPri is low priority work from user submissions (SQL).
+	UserLowPri WorkPriority = -10
 	// NormalPri is normal priority work.
 	NormalPri WorkPriority = 0
 	// LockingNormalPri is used for user normal priority transactions that are
@@ -105,8 +105,8 @@ func init() {
 	orderedPris := []WorkPriority{
 		LowPri,
 		BulkLowPri,
-		UserLowPri,
 		BulkNormalPri,
+		UserLowPri,
 		NormalPri,
 		LockingNormalPri,
 		UserHighPri,


### PR DESCRIPTION
This redefines User low priority to be -10, putting it above bulk normal.

Release note: none.
Epic: none.