### PR TITLE
opt/props: add MaxFrequency() function to props.Histogram

### DIFF
--- a/pkg/sql/opt/props/histogram.go
+++ b/pkg/sql/opt/props/histogram.go
@@ -182,6 +182,17 @@ func (h *Histogram) maxDistinctValuesCount() float64 {
 	return count
 }
 
+// MaxFrequency returns the maximum value of NumEq across all histogram buckets.
+func (h *Histogram) MaxFrequency() float64 {
+	var mf float64
+	for i := range h.buckets {
+		if numEq := h.numEq(i); numEq > mf {
+			mf = numEq
+		}
+	}
+	return mf
+}
+
 // maxDistinctValuesInRange returns the maximum number of distinct values in
 // the range (lowerBound, upperBound). It returns ok=false when it is not
 // possible to determine a finite value (which is the case for all types other

--- a/pkg/sql/opt/props/histogram_test.go
+++ b/pkg/sql/opt/props/histogram_test.go
@@ -139,27 +139,34 @@ func TestHistogram(t *testing.T) {
 	if distinct != expected {
 		t.Fatalf("expected %f but found %f", expected, distinct)
 	}
+	maxFrequency, expected := h.MaxFrequency(), float64(35)
+	if maxFrequency != expected {
+		t.Fatalf("expected %f but found %f", expected, maxFrequency)
+	}
 
 	testData := []struct {
-		constraint  string
-		buckets     []cat.HistogramBucket
-		count       float64
-		maxDistinct float64
-		distinct    float64
+		constraint   string
+		buckets      []cat.HistogramBucket
+		count        float64
+		maxDistinct  float64
+		distinct     float64
+		maxFrequency float64
 	}{
 		{
-			constraint:  "/1: [/0 - /0]",
-			buckets:     []cat.HistogramBucket{},
-			count:       0,
-			maxDistinct: 0,
-			distinct:    0,
+			constraint:   "/1: [/0 - /0]",
+			buckets:      []cat.HistogramBucket{},
+			count:        0,
+			maxDistinct:  0,
+			distinct:     0,
+			maxFrequency: 0,
 		},
 		{
-			constraint:  "/1: [/50 - /100]",
-			buckets:     []cat.HistogramBucket{},
-			count:       0,
-			maxDistinct: 0,
-			distinct:    0,
+			constraint:   "/1: [/50 - /100]",
+			buckets:      []cat.HistogramBucket{},
+			count:        0,
+			maxDistinct:  0,
+			distinct:     0,
+			maxFrequency: 0,
 		},
 		{
 			constraint: "/1: [ - /1] [/11 - /24] [/30 - /45]",
@@ -172,9 +179,10 @@ func TestHistogram(t *testing.T) {
 				{NumRange: 0, NumEq: 0, DistinctRange: 0, UpperBound: tree.NewDInt(30)},
 				{NumRange: 40, NumEq: 35, DistinctRange: 7, UpperBound: tree.NewDInt(42)},
 			},
-			count:       80,
-			maxDistinct: 17,
-			distinct:    11.14,
+			count:        80,
+			maxDistinct:  17,
+			distinct:     11.14,
+			maxFrequency: 35,
 		},
 		{
 			constraint: "/1: [/5 - /10] [/15 - /32] [/34 - /36] [/38 - ]",
@@ -192,9 +200,10 @@ func TestHistogram(t *testing.T) {
 				{NumRange: 0, NumEq: 0, DistinctRange: 0, UpperBound: tree.NewDInt(37)},
 				{NumRange: 14.55, NumEq: 35, DistinctRange: 2.55, UpperBound: tree.NewDInt(42)},
 			},
-			count:       80.46,
-			maxDistinct: 16.73,
-			distinct:    12.13,
+			count:        80.46,
+			maxDistinct:  16.73,
+			distinct:     12.13,
+			maxFrequency: 35,
 		},
 		{
 			constraint: "/1: [ - /41]",
@@ -207,9 +216,10 @@ func TestHistogram(t *testing.T) {
 				{NumRange: 0, NumEq: 0, DistinctRange: 0, UpperBound: tree.NewDInt(30)},
 				{NumRange: 36.36, NumEq: 3.64, DistinctRange: 6.36, UpperBound: tree.NewDInt(41)},
 			},
-			count:       56,
-			maxDistinct: 21,
-			distinct:    14.36,
+			count:        56,
+			maxDistinct:  21,
+			distinct:     14.36,
+			maxFrequency: 5,
 		},
 		{
 			constraint: "/1: [/1 - ]",
@@ -222,9 +232,10 @@ func TestHistogram(t *testing.T) {
 				{NumRange: 0, NumEq: 0, DistinctRange: 0, UpperBound: tree.NewDInt(30)},
 				{NumRange: 40, NumEq: 35, DistinctRange: 7, UpperBound: tree.NewDInt(42)},
 			},
-			count:       91,
-			maxDistinct: 22,
-			distinct:    15,
+			count:        91,
+			maxDistinct:  22,
+			distinct:     15,
+			maxFrequency: 35,
 		},
 		{
 			constraint: "/1: [/40 - /40]",
@@ -233,9 +244,10 @@ func TestHistogram(t *testing.T) {
 			buckets: []cat.HistogramBucket{
 				{NumRange: 0, NumEq: 5.71, DistinctRange: 0, UpperBound: tree.NewDInt(40)},
 			},
-			count:       5.71,
-			maxDistinct: 1,
-			distinct:    1,
+			count:        5.71,
+			maxDistinct:  1,
+			distinct:     1,
+			maxFrequency: 5.71,
 		},
 		{
 			constraint: "/1: [/0 - /100]",
@@ -248,9 +260,10 @@ func TestHistogram(t *testing.T) {
 				{NumRange: 0, DistinctRange: 0, NumEq: 0, UpperBound: tree.NewDInt(30)},
 				{NumRange: 40, DistinctRange: 7, NumEq: 35, UpperBound: tree.NewDInt(42)},
 			},
-			count:       91,
-			maxDistinct: 22,
-			distinct:    15,
+			count:        91,
+			maxDistinct:  22,
+			distinct:     15,
+			maxFrequency: 35,
 		},
 
 		// Tests with multiple columns.
@@ -265,9 +278,10 @@ func TestHistogram(t *testing.T) {
 				{NumRange: 0, NumEq: 0, DistinctRange: 0, UpperBound: tree.NewDInt(30)},
 				{NumRange: 40, NumEq: 35, DistinctRange: 7, UpperBound: tree.NewDInt(42)},
 			},
-			count:       80,
-			maxDistinct: 17,
-			distinct:    11.14,
+			count:        80,
+			maxDistinct:  17,
+			distinct:     11.14,
+			maxFrequency: 35,
 		},
 		{
 			constraint: "/2/1: [/3 - /3/1] [/3/11 - /3/24] [/3/30 - /3/45]",
@@ -280,9 +294,10 @@ func TestHistogram(t *testing.T) {
 				{NumRange: 0, NumEq: 0, DistinctRange: 0, UpperBound: tree.NewDInt(30)},
 				{NumRange: 40, NumEq: 35, DistinctRange: 7, UpperBound: tree.NewDInt(42)},
 			},
-			count:       80,
-			maxDistinct: 17,
-			distinct:    11.14,
+			count:        80,
+			maxDistinct:  17,
+			distinct:     11.14,
+			maxFrequency: 35,
 		},
 		{
 			constraint: "/2/1/3: [/1/40/2 - /1/40/3]",
@@ -291,9 +306,10 @@ func TestHistogram(t *testing.T) {
 			buckets: []cat.HistogramBucket{
 				{NumRange: 0, NumEq: 5.71, DistinctRange: 0, UpperBound: tree.NewDInt(40)},
 			},
-			count:       5.71,
-			maxDistinct: 1,
-			distinct:    1,
+			count:        5.71,
+			maxDistinct:  1,
+			distinct:     1,
+			maxFrequency: 5.71,
 		},
 		{
 			constraint: "/2/1/3: [/1/40/2 - /1/40/2] [/1/40/4 - /1/40/4] [/1/40/6 - /1/40/6]",
@@ -302,9 +318,10 @@ func TestHistogram(t *testing.T) {
 			buckets: []cat.HistogramBucket{
 				{NumRange: 0, NumEq: 5.71, DistinctRange: 0, UpperBound: tree.NewDInt(40)},
 			},
-			count:       5.71,
-			maxDistinct: 1,
-			distinct:    1,
+			count:        5.71,
+			maxDistinct:  1,
+			distinct:     1,
+			maxFrequency: 5.71,
 		},
 	}
 
@@ -329,6 +346,10 @@ func TestHistogram(t *testing.T) {
 			distinct := roundVal(filtered.DistinctValuesCount())
 			if testData[i].distinct != distinct {
 				t.Fatalf("expected %f but found %f", testData[i].distinct, distinct)
+			}
+			maxFrequency := roundVal(filtered.MaxFrequency())
+			if testData[i].maxFrequency != maxFrequency {
+				t.Fatalf("expected %f but found %f", testData[i].maxFrequency, maxFrequency)
 			}
 			roundHistogram(filtered)
 			if !reflect.DeepEqual(testData[i].buckets, filtered.buckets) {
@@ -1160,6 +1181,11 @@ func BenchmarkHistogram(b *testing.B) {
 					b.Run("DistinctValuesCount", func(b *testing.B) {
 						for i := 0; i < b.N; i++ {
 							h.DistinctValuesCount()
+						}
+					})
+					b.Run("MaxFrequency", func(b *testing.B) {
+						for i := 0; i < b.N; i++ {
+							h.MaxFrequency()
 						}
 					})
 					b.Run("Filter", func(b *testing.B) {


### PR DESCRIPTION
This commit adds a new function to `props.Histogram` called `MaxFrequency`, which returns the maximum value of `NumEq` across all histogram buckets.

This function will be useful to calculate an estimate for the upper bound of the row count for joins.

Epic: None
Release note: None
