### PR TITLE
kvserver: provide tenant id to Processor in OnDescChangedLocked

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -252,6 +252,7 @@ func TestProcessorBasic(t *testing.T) {
 	var q testACWorkQueue
 	var rcFactory testRangeControllerFactory
 	var p *processorImpl
+	tenantID := roachpb.MustMakeTenantID(4)
 	reset := func(enabled EnabledWhenLeaderLevel) {
 		b.Reset()
 		r = newTestReplica(&b)
@@ -263,7 +264,6 @@ func TestProcessorBasic(t *testing.T) {
 			NodeID:                 1,
 			StoreID:                2,
 			RangeID:                3,
-			TenantID:               roachpb.MustMakeTenantID(4),
 			ReplicaID:              5,
 			Replica:                r,
 			RaftScheduler:          &sched,
@@ -273,7 +273,7 @@ func TestProcessorBasic(t *testing.T) {
 			EnabledWhenLeaderLevel: enabled,
 		}).(*processorImpl)
 		fmt.Fprintf(&b, "n%s,s%s,r%s: replica=%s, tenant=%s, enabled-level=%s\n",
-			p.opts.NodeID, p.opts.StoreID, p.opts.RangeID, p.opts.ReplicaID, p.opts.TenantID,
+			p.opts.NodeID, p.opts.StoreID, p.opts.RangeID, p.opts.ReplicaID, tenantID,
 			enabledLevelString(p.mu.enabledWhenLeader))
 	}
 	builderStr := func() string {
@@ -346,7 +346,7 @@ func TestProcessorBasic(t *testing.T) {
 
 			case "on-desc-changed":
 				desc := parseRangeDescriptor(t, d)
-				p.OnDescChangedLocked(ctx, &desc)
+				p.OnDescChangedLocked(ctx, &desc, tenantID)
 				return builderStr()
 
 			case "handle-raft-ready-and-admit":

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -225,11 +225,9 @@ func newUninitializedReplicaWithoutRaftGroup(
 	)
 	r.raftMu.flowControlLevel = racV2EnabledWhenLeaderLevel(r.raftCtx, store.cfg.Settings)
 	r.flowControlV2 = replica_rac2.NewProcessor(replica_rac2.ProcessorOptions{
-		NodeID:  store.NodeID(),
-		StoreID: r.StoreID(),
-		RangeID: r.RangeID,
-		// TODO(sumeer): TenantID is not known yet. Fix.
-		TenantID:               roachpb.TenantID{},
+		NodeID:                 store.NodeID(),
+		StoreID:                r.StoreID(),
+		RangeID:                r.RangeID,
 		ReplicaID:              r.replicaID,
 		Replica:                (*replicaForRACv2)(r),
 		RaftScheduler:          r.store.scheduler,
@@ -433,7 +431,7 @@ func (r *Replica) setDescLockedRaftMuLocked(ctx context.Context, desc *roachpb.R
 	r.concMgr.OnRangeDescUpdated(desc)
 	r.mu.state.Desc = desc
 	r.mu.replicaFlowControlIntegration.onDescChanged(ctx)
-	r.flowControlV2.OnDescChangedLocked(ctx, desc)
+	r.flowControlV2.OnDescChangedLocked(ctx, desc, r.mu.tenantID)
 
 	// Give the liveness and meta ranges high priority in the Raft scheduler, to
 	// avoid head-of-line blocking and high scheduling latency.

--- a/pkg/kv/kvserver/replica_init_test.go
+++ b/pkg/kv/kvserver/replica_init_test.go
@@ -86,4 +86,7 @@ type noopProcessor struct {
 	replica_rac2.Processor
 }
 
-func (p noopProcessor) OnDescChangedLocked(ctx context.Context, desc *roachpb.RangeDescriptor) {}
+func (p noopProcessor) OnDescChangedLocked(
+	ctx context.Context, desc *roachpb.RangeDescriptor, tenantID roachpb.TenantID,
+) {
+}


### PR DESCRIPTION

The tenant id is known at the time when the RangeDescriptor is first set.
We simply pass the tenant id with every call to OnDescChangedLocked.

Informs #129129

Epic: CRDB-37515

Release note: None

