### PR TITLE
roachtest: allow large max range size

### DIFF
--- a/pkg/cmd/roachtest/tests/split.go
+++ b/pkg/cmd/roachtest/tests/split.go
@@ -432,7 +432,12 @@ func runLoadSplits(ctx context.Context, t test.Test, c cluster.Cluster, params s
 		"--vmodule=split_queue=2,store_rebalancer=2,allocator=2,replicate_queue=2,"+
 			"decider=3,replica_split_load=1",
 	)
-	c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.CRDBNodes())
+	// This test sets a larger range size than allowed by the default settings.
+	settings := install.MakeClusterSettings()
+	if params.maxSize > 8<<30 {
+		settings.Env = append(settings.Env, fmt.Sprintf("COCKROACH_MAX_RANGE_MAX_BYTES=%d", params.maxSize))
+	}
+	c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
 
 	m := c.NewMonitor(ctx, c.CRDBNodes())
 	m.Go(func(ctx context.Context) error {
@@ -466,6 +471,13 @@ func runLoadSplits(ctx context.Context, t test.Test, c cluster.Cluster, params s
 			}
 		} else {
 			t.Fatal("no CPU or QPS split threshold set")
+		}
+
+		// The default for backpressureRangeHardCap is 8 GiB.
+		if params.maxSize > 8<<30 {
+			t.Status("allowing ranges up to ", params.maxSize*2, " bytes")
+			_, err := db.ExecContext(ctx, fmt.Sprintf("SET CLUSTER SETTING kv.range.range_size_hard_cap = '%d'", params.maxSize*2))
+			require.NoError(t, err)
 		}
 
 		t.Status("increasing range_max_bytes")
@@ -582,8 +594,16 @@ func runLargeRangeSplits(ctx context.Context, t test.Test, c cluster.Cluster, si
 	rows := size / rowEstimate
 	const minBytes = 16 << 20 // 16 MB
 
+	// Set the range max size to a multiple of what we expect the size of the
+	// bank table to be. This should result in the table fitting inside a single
+	// range.
+	rangeMaxSize := 10 * size
+
 	numNodes := c.Spec().NodeCount
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Node(1))
+	// This test sets a larger range size than allowed by the default settings.
+	settings := install.MakeClusterSettings()
+	settings.Env = append(settings.Env, fmt.Sprintf("COCKROACH_MAX_RANGE_MAX_BYTES=%d", rangeMaxSize))
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, c.Node(1))
 
 	db := c.Conn(ctx, t.L(), 1)
 	defer db.Close()
@@ -621,6 +641,11 @@ func runLargeRangeSplits(ctx context.Context, t test.Test, c cluster.Cluster, si
 			if err := disableLoadBasedSplitting(ctx, db); err != nil {
 				return err
 			}
+
+			// This effectively disables the hard cap.
+			if _, err := db.ExecContext(ctx, fmt.Sprintf("SET CLUSTER SETTING kv.range.range_size_hard_cap = '%d'", rangeMaxSize*2)); err != nil {
+				return err
+			}
 			if _, err := db.ExecContext(ctx, `SET CLUSTER SETTING kv.snapshot_rebalance.max_rate='512MiB'`); err != nil {
 				return err
 			}
@@ -629,10 +654,7 @@ func runLargeRangeSplits(ctx context.Context, t test.Test, c cluster.Cluster, si
 			if _, err := db.ExecContext(ctx, `SET CLUSTER SETTING kv.split.mvcc_stats_recomputation.enabled = 'false'`); err != nil {
 				return err
 			}
-			// Set the range size to a multiple of what we expect the size of the
-			// bank table to be. This should result in the table fitting
-			// inside a single range.
-			setRangeMaxBytes(t, db, minBytes, 10*size)
+			setRangeMaxBytes(t, db, minBytes, rangeMaxSize)
 
 			// NB: would probably be faster to use --data-loader=IMPORT here, but IMPORT
 			// will disregard our preference to keep things in a single range.
@@ -650,7 +672,7 @@ func runLargeRangeSplits(ctx context.Context, t test.Test, c cluster.Cluster, si
 	// Phase 2: add other nodes, wait for full replication of bank table.
 	t.Status("waiting for full replication")
 	{
-		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(2, numNodes))
+		c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, c.Range(2, numNodes))
 		m := c.NewMonitor(ctx, c.All())
 		// NB: we do a round-about thing of making sure that there's at least one
 		// range that has 3 replicas (rather than waiting that there are no ranges

--- a/pkg/config/zonepb/zone.go
+++ b/pkg/config/zonepb/zone.go
@@ -410,7 +410,7 @@ func (z *ZoneConfig) Validate() error {
 
 	if z.RangeMaxBytes != nil && *z.RangeMaxBytes > maxRangeMaxBytes {
 		return fmt.Errorf("RangeMaxBytes %d greater than maximum allowed %d",
-			*z.RangeMaxBytes, minRangeMaxBytes,
+			*z.RangeMaxBytes, maxRangeMaxBytes,
 		)
 	}
 

--- a/pkg/config/zonepb/zone_test.go
+++ b/pkg/config/zonepb/zone_test.go
@@ -67,7 +67,7 @@ func TestZoneConfigValidate(t *testing.T) {
 				NumReplicas:   proto.Int32(1),
 				RangeMaxBytes: proto.Int64(9 << 30 /* 9 GiB */),
 			},
-			"RangeMaxBytes 9663676416 greater than maximum allowed 67108864",
+			"RangeMaxBytes 9663676416 greater than maximum allowed 8589934592",
 		},
 		{
 			ZoneConfig{


### PR DESCRIPTION
After the introduction of #129450, there is a default max range size of 4GiB. This test explicitly attempts to set the ranges to 10GiB and fails during setup. This commit increases the max range size for this test.

Fixes: #129556
Fixes: #129552
Fixes: #129551
Fixes: #129544
Fixes: #129542
Fixes: #129540
Fixes: #129541
Fixes: #129539

Epic: none

Release note: None