### PR TITLE
crosscluster/logical: hide key_value_bytes column in dlq

### DIFF
--- a/pkg/ccl/crosscluster/logical/dead_letter_queue.go
+++ b/pkg/ccl/crosscluster/logical/dead_letter_queue.go
@@ -37,7 +37,7 @@ const (
 			dlq_timestamp     	TIMESTAMPTZ NOT NULL DEFAULT now():::TIMESTAMPTZ,
   		dlq_reason					STRING NOT NULL,
 			mutation_type				%s.%s.mutation_type,       
-  		key_value_bytes			BYTES NOT NULL,
+  		key_value_bytes			BYTES NOT NULL NOT VISIBLE,
 			incoming_row     		JSONB,
   		-- PK should be unique based on the ID, job ID and timestamp at which the 
   		-- row was written to the table.


### PR DESCRIPTION
The key_value_bytes column can really only be used for internal debugging, so might as well hide it from users running SELECT *.

Epic: none

Release note: none