### PR TITLE
release-24.2.1-rc: roachtest: disable shared-process for follower-reads test

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -980,7 +980,10 @@ func runFollowerReadsMixedVersionSingleRegionTest(
 	ctx context.Context, t test.Test, c cluster.Cluster,
 ) {
 	topology := topologySpec{multiRegion: false}
-	runFollowerReadsMixedVersionTest(ctx, t, c, topology, exactStaleness)
+	runFollowerReadsMixedVersionTest(ctx, t, c, topology, exactStaleness,
+		// Test currently fails in shared-process deployments, see: #129167.
+		mixedversion.EnabledDeploymentModes(mixedversion.SystemOnlyDeployment),
+	)
 }
 
 // runFollowerReadsMixedVersionGlobalTableTest runs a multi-region follower-read
@@ -995,6 +998,8 @@ func runFollowerReadsMixedVersionGlobalTableTest(
 		survival:    region,
 	}
 	runFollowerReadsMixedVersionTest(ctx, t, c, topology, strong,
+		// Test currently fails in shared-process deployments, see: #129167.
+		mixedversion.EnabledDeploymentModes(mixedversion.SystemOnlyDeployment),
 		// Disable fixtures because we're using a 6-node, multi-region cluster.
 		mixedversion.NeverUseFixtures,
 		// Use a longer upgrade timeout to give the migrations enough time to finish


### PR DESCRIPTION
Epic: none

Release note: None

Release justification: test only changes.