### PR TITLE
release-24.1: roachprod: test selection - backport all changes

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -320,6 +320,10 @@ func updateSpecForSelectiveTests(ctx context.Context, specs []registry.TestSpec)
 		} else {
 			selectedTestsCount++
 		}
+		if td, ok := tdMap[specs[i].Name]; ok {
+			// populate the stats as obtained from the test selector
+			specs[i].SetStats(td.AvgDurationInMillis, td.LastFailureIsPreempt)
+		}
 	}
 	fmt.Printf("%d out of %d tests selected for the run!\n", selectedTestsCount, len(specs))
 }

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -29,6 +29,18 @@ var LibGEOS = []string{"libgeos", "libgeos_c"}
 // endpoint should use.
 var PrometheusNameSpace = "roachtest"
 
+// testStats is internally populated based on its previous runs and used for
+// deciding on the current execution approach. This includes decisions like
+// executing the test on spot VM vs ondemand VM.
+// The stats are populated if selective-tests is enabled.
+type testStats struct {
+	// AvgDurationInMillis is the average duration that the test takes to run
+	AvgDurationInMillis int64
+	// LastFailureIsPreempt indicates that the last run of the test failed
+	// due to VM preemption
+	LastFailureIsPreempt bool
+}
+
 // TestSpec is a spec for a roachtest.
 type TestSpec struct {
 	Skip string // if non-empty, test will be skipped
@@ -155,6 +167,22 @@ type TestSpec struct {
 	// Note that this flag needs to be set with a specific reason in the comment
 	// explaining why the test has been chosen for opting out of test selection.
 	TestSelectionOptOutSuites SuiteSet
+
+	// stats are populated by test selector based on previous execution data
+	stats *testStats
+}
+
+// SetStats sets the stats for the test
+func (ts *TestSpec) SetStats(avgDurationInMillis int64, lastFailureIsPreempt bool) {
+	ts.stats = &testStats{
+		AvgDurationInMillis:  avgDurationInMillis,
+		LastFailureIsPreempt: lastFailureIsPreempt,
+	}
+}
+
+// IsLastFailurePreempt returns true is the last failure of the test was due to VM preemption.
+func (ts *TestSpec) IsLastFailurePreempt() bool {
+	return ts.stats != nil && ts.stats.LastFailureIsPreempt
 }
 
 // PostValidation is a type of post-validation that runs after a test completes.

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -334,9 +334,9 @@ func (r *testRunner) Run(
 			//  TODO(bhaskar): remove this once we have more usage details
 			//  and more convinced about using spot VMs for all the runs.
 			if roachtestflags.Cloud == spec.GCE &&
-				tests[i].Benchmark &&
 				!tests[i].Suites.Contains(registry.Weekly) &&
-				rand.Float64() <= 0.5 {
+				!tests[i].IsLastFailurePreempt() &&
+				rand.Float64() <= 0.75 {
 				lopt.l.PrintfCtx(ctx, "using spot VMs to run test %s", tests[i].Name)
 				tests[i].Cluster.UseSpotVMs = true
 			}

--- a/pkg/cmd/roachtest/testselector/selector.go
+++ b/pkg/cmd/roachtest/testselector/selector.go
@@ -46,10 +46,10 @@ var suites = map[string]string{
 
 // TestDetails has the details of the test as fetched from snowflake
 type TestDetails struct {
-	Name                string // test name
-	Selected            bool   // whether a test is Selected or not
-	AvgDurationInMillis int64  // average duration of the test
-	TotalRuns           int    // total number of times the test has run successfully
+	Name                 string // test name
+	Selected             bool   // whether a test is Selected or not
+	AvgDurationInMillis  int64  // average duration of the test
+	LastFailureIsPreempt bool   // last failure is due to a VM preemption
 }
 
 // SelectTestsReq is the request for CategoriseTests
@@ -130,12 +130,12 @@ func CategoriseTests(ctx context.Context, req *SelectTestsReq) ([]*TestDetails, 
 		// 0. test name
 		// 1. whether a test is Selected or not
 		// 2. average duration of the test
-		// 3. total number of times the test has run successfully
+		// 3. last failure is due to an infra flake
 		testDetails := &TestDetails{
-			Name:                testInfos[0],
-			Selected:            testInfos[1] != "no",
-			AvgDurationInMillis: getDuration(testInfos[2]),
-			TotalRuns:           getTotalRuns(testInfos[3]),
+			Name:                 testInfos[0],
+			Selected:             testInfos[1] != "no",
+			AvgDurationInMillis:  getDuration(testInfos[2]),
+			LastFailureIsPreempt: testInfos[3] == "yes",
 		}
 		if testDetails.Selected {
 			// selected for running
@@ -162,12 +162,6 @@ func CategoriseTests(ctx context.Context, req *SelectTestsReq) ([]*TestDetails, 
 func getDuration(durationStr string) int64 {
 	duration, _ := strconv.ParseInt(durationStr, 10, 64)
 	return duration
-}
-
-// getTotalRuns extracts the total runs from the snowflake query total_runs field
-func getTotalRuns(totalRunsStr string) int {
-	totalRuns, _ := strconv.ParseInt(totalRunsStr, 10, 64)
-	return int(totalRuns)
 }
 
 // getConnect makes connection to snowflake and returns the connection.

--- a/pkg/cmd/roachtest/testselector/snowflake_query.sql
+++ b/pkg/cmd/roachtest/testselector/snowflake_query.sql
@@ -1,12 +1,14 @@
-with builds as (
+with ts as (
+  select current_date() as t -- this returns the current date
+), builds as (
   -- select all the build IDs in the last "forPastDays" days
   select
     ID as run_id,
     min(start_date) as first_run, -- get the first time the test was run
     max(start_date) as last_run, -- -- get the last time the test was run
-  from DATAMART_PROD.TEAMCITY.BUILDS
+  from DATAMART_PROD.TEAMCITY.BUILDS, ts
   where
-    start_date > dateadd(DAY, ?, current_date()) -- last "forPastDays" days
+    start_date > dateadd(DAY, ?, ts.t) -- last "forPastDays" days
     and lower(status) = 'success' -- consider only successful builds
     and branch_name = ? -- consider the builds from target branch
     and lower(name) like ? -- name is based on the suite and cloud e.g. '%roachtest nightly - gce%'
@@ -17,6 +19,11 @@ with builds as (
          count(case when status='SUCCESS' then test_name end) as total_successful_runs, -- all successful runs
          -- count the number of failed tests. tests failed due to preempted VMs are ignored.
          count(case when status='FAILURE' and details not like '%VMs preempted during the test run%' then test_name end) as failure_count,
+         -- record the latest details of the test. this is useful for identifying if the latest failure of
+         -- the test is due to infra failure
+         MAX_BY(details, b.last_run) as recent_details,
+         MAX_BY(ignore_details, b.last_run) as recent_ignore_details,
+         MAX_BY(status, b.last_run) as last_status,
          -- get the first_run and last_run only if the status is not UNKNOWN. This returns nil for runs that have never run
          min(case when status!='UNKNOWN' then b.first_run end) as first_run,
          max(case when status!='UNKNOWN' then b.last_run end) as last_run,
@@ -32,13 +39,27 @@ select
   test_name,
   case when
          -- mark as selected if
-         failure_count > 0 or -- the test has failed at least once in the past "forPastDays" days
-         first_run > dateadd(DAY, ?, current_date()) or -- recently added test - test has not run for more than "firstRunOn" days
-         last_run < dateadd(DAY, ?, current_date()) or -- the test has not been run for last "lastRunOn" days
-         last_run is null -- the test is always ignored till now or have never been run
+          -- the test has failed at least once in the past "forPastDays" days
+          -- recently added test - test has not run for more than "firstRunOn" days
+          -- the test has not been run for last "lastRunOn" days
+          -- the last failure was VM preemption
+         failure_count > 0 or
+         first_run > dateadd(DAY, ?, ts.t) or
+         last_run < dateadd(DAY, ?, ts.t) or
+         recent_details like '%VMs preempted during the test run%' or
+          -- last_status='UNKNOWN' can be for the following scenarios:
+           -- test is run in the past, but added to skip by the test writer
+            -- In this scenario, we want to select the test as we do not know when user may mark it to not skipped
+           -- test is not run due to incompatibility
+            -- here also, user can make it compatible at any point. So, we always select.
+           -- test is never run - we always select
+           -- test is not run by test selector in the last run
+            -- The test should not be selected by default in this case and should be selected based on the sorted unselected list
+         (last_status='UNKNOWN' and recent_ignore_details!='test selector')
          then 'yes' else 'no' end as selected,
   -- average duration - this is set to 0 if the test is never run (total_successful_runs=0)
   case when total_successful_runs > 0 then total_duration/total_successful_runs else 0 end as avg_duration,
-  total_successful_runs,
-from test_stats
-order by selected desc, total_successful_runs
+  -- indicates the last failure was due to infra flake
+  case when recent_details like '%VMs preempted during the test run%' then 'yes' else 'no' end as last_failure_is_preeempt,
+from test_stats, ts
+order by selected desc, last_run -- selected="yes" appears first. Rest of the tests are sorted by the last run.


### PR DESCRIPTION
Backport 1/1 commits from #127881.

/cc @cockroachdb/release

---
roachprod: fix the issue with test starvation in test selection

In the selective test run, there is a possibility of test starvation
in certain scenarios:
1. Decommissioned tests overshadow - If we have a number of tests
  that have stopped running, the run count for these tests will keep
  going down. So, these tests will keep getting selected by test
  selector, but, will not run. This overshadows all other test run
  counts.
2. Any failed test that ran successfully for the next 30 days - A
test that has failed once is run everyday for the next 30 days.
Now, when this 30 days period is over, the count for number of runs
is way higher than other tests run in intervals (14 vs 30).

The solution that is done here are:
1. sort the tests by the last run date instead of the number if times
  the test has run.
2. add an extra check on the tests and consider only the tests that have
  been ignored by test selector. This way we are dealing with tests that
  are previously considered under test selector to be ignored. Any other
  test not ignored by test selector are selected by default. If those tests
  are decommissioned, those tests will anyways not run.

There is one more change added to extract the way the current date is used.
This is done to ensure consistency in the query.

Also, changing the fallback time back to 7 days as this change should fix the
starvation.

Fixes: #127791
Epic: None

roachtest: rerun the test if failed due to VM preemption

We are considering all tests that have failed due to preemption as success.
But, if the test has failed due to a preemption, the test is run one more time
to ensure that the test is good. The test is run on an on-demand VM to ensure
that the test does not fail again due to preemption.

Without this change, the logic of running a test on demand will not work as we
consider preemption test failures as success, which get ignored the next run.
Because of the test getting ignored, the information of the last run being failed
due to a preemption is lost.

Fixes: #128450
Epic: none

roachtest/test-selector: capture infra flake information in query

In the current test selection categorization all the failures due to
spot VM failures are ignored. But, we do not have that information
if the test actually failure due to VM preemption. To avoid that test
to fail again due to VM preemption, we can ensure that we do not run
that test again in spot VMs.

This PR captures the information that the test has failed last time
due to a VM preemption and uses the information to not run the same
test in spot VM the next time. Also, the spot VM selection is increased
to 80% as:
1. we have an extra condition to not run the same test on spot.
2. we are running lesser tests due to selective tests and hence, the
spot VM usage is going down.

Informs: #119630
Epic: none

roachtest: use spot VM for all tests

Currently, we are using spot VMs only to run benchmark tests. The reason
for the low adoption of spot VM is because of the test failures due to
VM preemption.
But, with the recent changes, we have better control on VM preemption
changes where if there is a test failure due to preemption, the test is
run on an on-demand VM the next time.
Also, the current failed tests that are run on spot VM is 148 out of 1093 = 13.5%.
If I consider failure out of total tests run is 148 out of 2508 = 5.9%.

So, this PR removes the condition to use spot VMs only for benchmark tests and changes
the probability to 75%.

Fixes: #127236
Epic: None

Release justification: Test eng change to reduce cost