### PR TITLE
docs-issue-generation: added fix for abrupt script failure 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -533,3 +533,4 @@ Zachary Smith <Zachary.smith@yodle.com> Zachary.smith <Zachary.smith@yodle.com>
 Zane Teh <zane@cockroachlabs.com>
 何羿宏 <heyihong.cn@gmail.com>
 智雅楠 <zac.zhiyanan@gmail.com>
+Mohini Pandey <mohini.pandey@cockroachlabs.com>

--- a/pkg/cmd/docs-issue-generation/jira.go
+++ b/pkg/cmd/docs-issue-generation/jira.go
@@ -78,7 +78,8 @@ func searchJiraDocsIssuesSingle(
 	for _, issue := range search.Issues {
 		prNumber, commitSha, err := extractPRNumberCommitFromDocsIssueBody(issue.RenderedFields.Description)
 		if err != nil {
-			return 0, 0, err
+			fmt.Printf("Error processing issue %s: %v", issue.Key, err)
+			continue // Skip this issue and continue with the next one
 		}
 		if prNumber != 0 && commitSha != "" {
 			_, ok := m[prNumber]


### PR DESCRIPTION
Description - We had an issue raised by Rich  where doc issues for few PR wasn't created because of abrupt failure in the script due to not finding SHA or pr number in the JIRA issue.

Fix - I have added a condition where even if SHA or PR number isn't found for one issue , it should still continue the execution for other PRs so that doc issues for them is created


Epic:none
Part of https://cockroachlabs.atlassian.net/browse/DOC-10884