### PR TITLE
release-24.2.0-rc: fix ycsb roachtest regressions by giving workload node more cpu

### DIFF
--- a/pkg/cmd/roachtest/tests/ycsb.go
+++ b/pkg/cmd/roachtest/tests/ycsb.go
@@ -132,7 +132,7 @@ func registerYCSB(r registry.Registry) {
 					Name:      fmt.Sprintf("zfs/ycsb/%s/nodes=3/cpu=%d", wl, cpus),
 					Owner:     registry.OwnerStorage,
 					Benchmark: true,
-					Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus), spec.WorkloadNode(), spec.SetFileSystem(spec.Zfs)),
+					Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus), spec.WorkloadNode(), spec.WorkloadNodeCPU(cpus), spec.SetFileSystem(spec.Zfs)),
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						runYCSB(ctx, t, c, wl, cpus, ycsbOptions{})
 					},
@@ -146,7 +146,7 @@ func registerYCSB(r registry.Registry) {
 					Name:      fmt.Sprintf("%s/isolation-level=read-committed", name),
 					Owner:     registry.OwnerTestEng,
 					Benchmark: true,
-					Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus), spec.WorkloadNode()),
+					Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus), spec.WorkloadNode(), spec.WorkloadNodeCPU(cpus)),
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						runYCSB(ctx, t, c, wl, cpus, ycsbOptions{readCommitted: true})
 					},
@@ -160,7 +160,7 @@ func registerYCSB(r registry.Registry) {
 					Name:      fmt.Sprintf("%s/mvcc-range-keys=global", name),
 					Owner:     registry.OwnerTestEng,
 					Benchmark: true,
-					Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus), spec.WorkloadNode()),
+					Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus), spec.WorkloadNode(), spec.WorkloadNodeCPU(cpus)),
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						runYCSB(ctx, t, c, wl, cpus, ycsbOptions{rangeTombstone: true})
 					},
@@ -179,7 +179,7 @@ func registerYCSB(r registry.Registry) {
 					Name:      fmt.Sprintf("%s/uniform", name),
 					Owner:     registry.OwnerTestEng,
 					Benchmark: true,
-					Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus), spec.WorkloadNode()),
+					Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus), spec.WorkloadNode(), spec.WorkloadNodeCPU(cpus)),
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						runYCSB(ctx, t, c, wl, cpus, ycsbOptions{uniformDistribution: true})
 					},

--- a/pkg/cmd/roachtest/tests/ycsb.go
+++ b/pkg/cmd/roachtest/tests/ycsb.go
@@ -119,7 +119,7 @@ func registerYCSB(r registry.Registry) {
 				Name:      name,
 				Owner:     registry.OwnerTestEng,
 				Benchmark: true,
-				Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus), spec.WorkloadNode()),
+				Cluster:   r.MakeClusterSpec(4, spec.CPU(cpus), spec.WorkloadNode(), spec.WorkloadNodeCPU(cpus)),
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runYCSB(ctx, t, c, wl, cpus, ycsbOptions{})
 				},

--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -587,6 +587,8 @@ func runRun(gen workload.Generator, urls []string, dbName string) error {
 				}
 				continue
 			}
+			// Log the error so we get the stack trace.
+			log.Errorf(ctx, "%v", err)
 			return err
 
 		case <-ticker.C:


### PR DESCRIPTION
Backport:
  * 2/2 commits from "roachtest: fix ycsb regression by giving workload node more cpu" (#128334)
  * 1/1 commits from "roachtest: revert workload cpu change for all ycsb variants" (#128614)

Please see individual PRs for details.

/cc @cockroachdb/release

Fixes: https://github.com/cockroachdb/cockroach/issues/129543
Release note: none
Epic: none

Release Justification: test-only change