### PR TITLE
roachtest: set min supported version to 23.2 in tpcc/mixed-headroom

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -433,6 +433,10 @@ func runTPCCMixedHeadroom(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 	mvt := mixedversion.NewTest(
 		ctx, t, t.L(), c, c.CRDBNodes(),
+		// We test only upgrades from 23.2 in this test because it uses
+		// the `workload fixtures import` command, which is only supported
+		// reliably multi-tenant mode starting from that version.
+		mixedversion.MinimumSupportedVersion("v23.2.0"),
 		mixedversion.MaxUpgrades(3),
 	)
 


### PR DESCRIPTION
When trying to use `workload import fixtures`, we need to be in a 23.2 release. This command fails in a lot of 23.1 releases as it was not supported (unimplemented error).

Fixes: #129632

Release note: None