### PR TITLE
Adding Gemfile in the repository for Jekyll setup #129639

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'jekyll', '~> 4.3.3'
+gem 'bundler', '~> 2.5.17'
+


### PR DESCRIPTION
Resolves #129639
---

### **Added Gemfile for Jekyll Setup**

This PR resolves issue [#129639](https://github.com/cockroachdb/cockroach/issues/129639), where the repository was missing a `Gemfile` required for setting up Jekyll as per the instructions in the `CONTRIBUTOR.md` file.

**Changes:**
- Added a `Gemfile` with the following content:
  ```ruby
  source 'https://rubygems.org'

  gem 'jekyll', '~> 4.3.3'
  gem 'bundler', '~> 2.5.17'
  ```

**Expected behavior:**
- This `Gemfile` allows users to run `bundle install` and set up the environment for local development of the CockroachDB documentation using Jekyll.

**Environment:**
- Ubuntu 24.04 LTS
- Ruby version: [e.g. 2.x]
- Jekyll version: 4.3.3

Please review and let me know if any changes are needed.

