### PR TITLE
cloud/externalconn: show pg urls

### DIFF
--- a/pkg/ccl/crosscluster/physical/BUILD.bazel
+++ b/pkg/ccl/crosscluster/physical/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/ccl/crosscluster/streamclient",
         "//pkg/ccl/revertccl",
         "//pkg/ccl/utilccl",
+        "//pkg/cloud",
         "//pkg/cloud/externalconn",
         "//pkg/cloud/externalconn/connectionpb",
         "//pkg/jobs",

--- a/pkg/ccl/crosscluster/physical/external_connection.go
+++ b/pkg/ccl/crosscluster/physical/external_connection.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/crosscluster/streamclient"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/connectionpb"
 )
@@ -47,7 +48,7 @@ func init() {
 			connectionpb.ConnectionProvider_sql,
 			externalconn.SimpleURIFactory,
 		)
-
+		cloud.RegisterRedactedParams(cloud.RedactedParams(streamclient.SslInlineURLParam))
 		externalconn.RegisterDefaultValidation(scheme, validatePostgresConnectionURI)
 	}
 

--- a/pkg/ccl/crosscluster/streamclient/pgconn.go
+++ b/pkg/ccl/crosscluster/streamclient/pgconn.go
@@ -22,10 +22,10 @@ import (
 )
 
 const (
-	// sslInlineURLParam is a non-standard connection URL
+	// SslInlineURLParam is a non-standard connection URL
 	// parameter. When true, we assume that sslcert, sslkey, and
 	// sslrootcert contain URL-encoded data rather than paths.
-	sslInlineURLParam = "sslinline"
+	SslInlineURLParam = "sslinline"
 
 	sslModeURLParam     = "sslmode"
 	sslCertURLParam     = "sslcert"
@@ -82,7 +82,7 @@ type tlsCerts struct {
 // tlsCerts struct can be used to apply the certificate data to the
 // tls.Config produced by pgx.
 func uriWithInlineTLSCertsRemoved(remote *url.URL) (*url.URL, *tlsCerts, error) {
-	if remote.Query().Get(sslInlineURLParam) != "true" {
+	if remote.Query().Get(SslInlineURLParam) != "true" {
 		return remote, nil, nil
 	}
 
@@ -132,7 +132,7 @@ func uriWithInlineTLSCertsRemoved(remote *url.URL) (*url.URL, *tlsCerts, error) 
 	v.Del(sslCertURLParam)
 	v.Del(sslKeyURLParam)
 	v.Del(sslRootCertURLParam)
-	v.Del(sslInlineURLParam)
+	v.Del(SslInlineURLParam)
 	retURL.RawQuery = v.Encode()
 	return &retURL, tlsInfo, nil
 }

--- a/pkg/cloud/externalconn/record.go
+++ b/pkg/cloud/externalconn/record.go
@@ -197,6 +197,11 @@ func (e *MutableExternalConnection) RedactedConnectionURI() string {
 		if err == nil {
 			return redactedURI
 		}
+	case connectionpb.TypeForeignData.String():
+		redactedURI, err := cloud.SanitizeExternalStorageURI(unredactedURI, nil)
+		if err == nil {
+			return redactedURI
+		}
 	default:
 		err = fmt.Errorf("cannot redact URI for unknown connection type: %s", e.rec.ConnectionType)
 	}


### PR DESCRIPTION
Release note: none.
Epic: none.