### PR TITLE
server: wrap ctx err on cancelation when iterating over nodes

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -3248,7 +3248,7 @@ func iterateNodes[Client, Result any](
 				responseFn(res.nodeID, res.response)
 			}
 		case <-ctx.Done():
-			resultErr = errors.Errorf("request of %s canceled before completion", errorCtx)
+			resultErr = errors.Wrapf(ctx.Err(), "request of %s canceled before completion", errorCtx)
 		}
 		numNodes--
 	}


### PR DESCRIPTION
When iterating over all nodes, if the context is done causing the iteration to cancel, wrap the context error to include it for consumers of the error.

Epic: None
Fixes: #129531

Release note: None