### PR TITLE
builtins: handle unavailable ranges in `crdb_internal.{lease_holder, range_stats}`

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -4440,7 +4440,8 @@ func listColumnNames(cols colinfo.ResultColumns) string {
 	return buf.String()
 }
 
-// crdbInternalRangesView exposes system ranges.
+// crdbInternalRangesView enhances crdb_internal.ranges_no_leases with
+// additional metadata about leaseholder and range size.
 var crdbInternalRangesView = virtualSchemaView{
 	schema: `
 CREATE VIEW crdb_internal.ranges AS SELECT ` +
@@ -4451,7 +4452,8 @@ CREATE VIEW crdb_internal.ranges AS SELECT ` +
 		colinfo.RangesExtraRenders +
 		`FROM crdb_internal.ranges_no_leases`,
 	resultColumns: colinfo.Ranges,
-	comment:       "ranges is a view which queries ranges_no_leases for system ranges",
+	comment: "ranges is like ranges_no_leases but with extra metadata about leaseholder " +
+		"and range size. The additional metadata may be NULL if the range is unavailable.",
 }
 
 // descriptorsByType is a utility function that iterates through a slice of

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5843,14 +5843,19 @@ SELECT
 						Key: key,
 					},
 				})
-				if err := evalCtx.Txn.Run(ctx, b); err != nil {
-					return nil, pgerror.Wrap(err, pgcode.InvalidParameterValue, "error fetching leaseholder")
+				if err := evalCtx.Txn.DB().Run(ctx, b); err != nil {
+					// Return NULL instead of an error to ensure the entire
+					// query to crdb_internal.lease_holder doesn't fail;
+					// instead, it will return partial results.
+					log.Errorf(ctx, "fetching leaseholder: %v", err)
+					return tree.DNull, nil //nolint:returnerrcheck
+				} else {
+					resp := b.RawResponse().Responses[0].GetInner().(*kvpb.LeaseInfoResponse)
+					return tree.NewDInt(tree.DInt(resp.Lease.Replica.StoreID)), nil
 				}
-				resp := b.RawResponse().Responses[0].GetInner().(*kvpb.LeaseInfoResponse)
-
-				return tree.NewDInt(tree.DInt(resp.Lease.Replica.StoreID)), nil
 			},
-			Info:       "This function is used to fetch the leaseholder corresponding to a request key",
+			Info: "This function is used to fetch the leaseholder corresponding to a request key. " +
+				"If an error is encountered (e.g. replica unavailability), NULL is returned.",
 			Volatility: volatility.Volatile,
 		},
 	),
@@ -6142,10 +6147,13 @@ SELECT
 				if args[0] == tree.DNull {
 					return tree.DNull, nil
 				}
+				// Ignore errors to ensure the entire query to
+				// crdb_internal.range_stats doesn't fail; instead, it will
+				// return partial results.
 				resps, err := evalCtx.RangeStatsFetcher.RangeStats(ctx,
 					roachpb.Key(tree.MustBeDBytes(args[0])))
 				if err != nil {
-					return nil, pgerror.Wrap(err, pgcode.InvalidParameterValue, "error fetching range stats")
+					log.Errorf(ctx, "fetching stats: %v", err)
 				}
 				jsonStr, err := gojson.Marshal(&resps[0].MVCCStats)
 				if err != nil {
@@ -6157,7 +6165,8 @@ SELECT
 				}
 				return jsonDatum, nil
 			},
-			Info:       "This function is used to retrieve range statistics information as a JSON object.",
+			Info: "This function is used to retrieve range statistics information as a JSON object. " +
+				"If an error is encountered (e.g. replica unavailability), empty stats are returned.",
 			Volatility: volatility.Volatile,
 		},
 	),


### PR DESCRIPTION
Previously, when querying `crdb_internal.{lease_holder, range_stats}` (e.g. as part of querying `crdb_internal.ranges`), a single unavailable range would result in the entire query failing. This is problematic when investigating clusters with unavailable ranges as it fails to show information even for the available ranges.

This commit changes the behavior of `crdb_internal.{lease_holder, range_stats}` to return `NULL` instead of an error if
the query hits an unavailable range. The exact error is logged but not displayed to the user.

Fixes: [#128088](https://github.com/cockroachdb/cockroach/issues/128088)

Release note (sql change): The values of `crdb_internal.ranges.lease_holder` and `crdb_internal.ranges.range_size` may be `NULL` if the query encounters an unavailable range; previously, the entire query would fail instead.

----
This is what the output looks like with some unavailable ranges on cockroach demo.

<img width="744" alt="Screenshot 2024-09-16 at 10 15 01 AM" src="https://github.com/user-attachments/assets/da2046ab-47f2-4193-808b-f53b891d4981">

----
Cons of this approach:
- The query to `crdb_internal.ranges` runs for a long time (e.g. a few min) if there are unavailable ranges (e.g. the query in the screenshot took 200s). This might be because some circuit breakers haven't tripped yet, so it would be slow only the first time an unavailable range is encountered.
- The range stats requests are batched and the batch fails when it hits the first unavailable range. It's an improvement over erroring out the entire `crdb_internal.ranges` query, but it still skips results for some available ranges.
- The actual error (e.g. replica unavailability) is logged but not exposed to the user.