### PR TITLE
server: Create new api for database metadata

### DIFF
--- a/pkg/server/api_v2.go
+++ b/pkg/server/api_v2.go
@@ -187,6 +187,7 @@ func registerRoutes(
 		{"rules/", a.listRules, false, authserver.RegularRole, true},
 
 		{"sql/", a.execSQL, true, authserver.RegularRole, true},
+		{"database_metadata/", a.GetDBMetadata, true, authserver.RegularRole, true},
 		{"table_metadata/", a.GetTableMetadata, true, authserver.RegularRole, true},
 	}
 

--- a/pkg/server/api_v2_databases_metadata.go
+++ b/pkg/server/api_v2_databases_metadata.go
@@ -279,7 +279,7 @@ func (a *apiV2Server) getTableMetadata(
 	if len(storeIds) > 0 {
 		query.Append("AND ( ")
 		for i, storeId := range storeIds {
-			query.Append("store_ids @> ARRAY[$] ", storeId)
+			query.Append("tbm.store_ids @> ARRAY[$] ", storeId)
 			if i < len(storeIds)-1 {
 				query.Append("OR ")
 			}
@@ -384,6 +384,279 @@ func (a *apiV2Server) getTableMetadata(
 	return tms, totalRowCount, nil
 }
 
+// GetDBMetadata returns a paginated response of database metadata and statistics. This is not a live view of
+// the database data but instead is cached data that had been precomputed at an earlier time.
+//
+// The user making the request will receive database metadata based on the CONNECT database grant and admin privilege.
+//
+// ---
+// parameters:
+//
+//   - name: name
+//     type: string
+//     description: a string which is used to match database name against.
+//     in: query
+//     required: false
+//
+//   - name: sortBy
+//     type: string
+//     description: Which column to sort by. This currently supports: "name", "size", "tableCount", and "lastUpdated".
+//     If a non supported value is provided, it will be ignored.
+//     in: query
+//     required: false
+//
+//   - name: sortOrder
+//     type: string
+//     description: The direction in which to order the sortBy column by. Supports either "asc" or "desc". If a non
+//     supported value is provided, it will be ignored.
+//     in: query
+//     required: false
+//
+//   - name: pageSize
+//     type: string
+//     description: The size of the page of the result set to return.
+//     in: query
+//     required: false
+//
+//   - name: pageNum
+//     type: string
+//     description: The page number of the result set to return.
+//     in: query
+//     required: false
+//
+//   - name: storeId
+//     type: integer
+//     description: The id of the store to filter databases by. If the database has at least one table in it that
+//     contains data in the store, it will be included in the result set. Multiple storeId query parameters are support.
+//     If multiple are provided, a database will be included in the result set if it contains >0 tables data in at least
+//     one of the stores.
+//     in: query
+//     required: false
+//
+// produces:
+// - application/json
+//
+// responses:
+//
+//	"200":
+//	  description: A paginated response of dbMetadata results.
+func (a *apiV2Server) GetDBMetadata(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	ctx = a.sqlServer.AnnotateCtx(ctx)
+	sqlUser := authserver.UserFromHTTPAuthInfoContext(ctx)
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	queryValues := r.URL.Query()
+
+	dbName := queryValues.Get(nameKey)
+	sortByQs := queryValues.Get(sortByKey)
+	sortOrderQs := queryValues.Get(sortOrderKey)
+	pageNum, err := apiutil.GetIntQueryStringVal(queryValues, pageNumKey)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("invalid query param value for: %s", pageNumKey),
+			http.StatusUnprocessableEntity)
+		return
+	}
+	pageSize, err := apiutil.GetIntQueryStringVal(queryValues, pageSizeKey)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("invalid query param value for: %s", pageSizeKey),
+			http.StatusUnprocessableEntity)
+		return
+	}
+
+	storeIds, err := apiutil.GetIntQueryStringVals(queryValues, storeIdKey)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("invalid query param value for: %s", storeIdKey),
+			http.StatusUnprocessableEntity)
+		return
+	}
+
+	if pageSize <= 0 {
+		pageSize = defaultPageSize
+	}
+
+	if pageNum <= 0 {
+		pageNum = defaultPageNum
+	}
+
+	offset := (pageNum - 1) * pageSize
+
+	var sortBy string
+	switch sortByQs {
+	case "name":
+		sortBy = "db_name"
+	case "size":
+		sortBy = "size_bytes"
+	case "tableCount":
+		sortBy = "table_count"
+	case "lastUpdated":
+		sortBy = "last_updated"
+	}
+
+	var sortOrder string
+	if sortByQs != "" {
+		sortOrder = "ASC"
+		if sortOrderQs == "desc" {
+			sortOrder = "DESC"
+		}
+	}
+
+	var dbNameFilter string
+	if dbName != "" {
+		dbNameFilter = fmt.Sprintf("%%%s%%", dbName)
+	}
+
+	dbm, totalRowCount, err := a.getDBMetadata(ctx, sqlUser, dbNameFilter, storeIds, sortBy, sortOrder, pageSize, offset)
+
+	if err != nil {
+		srverrors.APIV2InternalError(ctx, err, w)
+		return
+	}
+
+	resp := PaginatedResponse[[]dbMetadata]{
+		Results: dbm,
+		PaginationInfo: paginationInfo{
+			TotalResults: totalRowCount,
+			PageSize:     pageSize,
+			PageNum:      pageNum,
+		},
+	}
+	apiutil.WriteJSONResponse(ctx, w, 200, resp)
+
+}
+
+func (a *apiV2Server) getDBMetadata(
+	ctx context.Context,
+	sqlUser username.SQLUsername,
+	dbName string,
+	storeIds []int,
+	sortBy string,
+	sortOrder string,
+	limit int,
+	offset int,
+) (dbms []dbMetadata, totalRowCount int64, retErr error) {
+	sqlUserStr := sqlUser.Normalized()
+	dbms = make([]dbMetadata, 0)
+	query := safesql.NewQuery()
+
+	// Base query aggregates table metadata by db_id. It joins on a subquery which flattens
+	// and deduplicates all store ids for tables in a database into a single array. This query
+	// will only return databases that the provided sql user has CONNECT privileges to. If they
+	// are an admin, they have access to all databases.
+	query.Append(`SELECT
+		tbm.db_id,
+		tbm.db_name,
+		sum(tbm.replication_size_bytes):: INT as size_bytes,
+		count(tbm.table_id) as table_count,
+		max(tbm.last_updated) as last_updated,
+		s.store_ids,
+		count(*) OVER() as total_row_count
+		FROM system.table_metadata tbm
+		JOIN crdb_internal.databases dbs ON dbs.id = tbm.db_id
+		LEFT JOIN system.role_members rm ON rm.role = 'admin' AND member = $
+		JOIN (
+			SELECT db_id, array_agg(DISTINCT unnested_ids) as store_ids
+			FROM system.table_metadata, unnest(store_ids) as unnested_ids
+			GROUP BY db_id
+		) s ON s.db_id = tbm.db_id
+		WHERE (rm.role = 'admin' OR dbs.name in (
+			SELECT cdp.database_name
+			FROM "".crdb_internal.cluster_database_privileges cdp
+			WHERE grantee = $
+			AND privilege_type = 'CONNECT'
+		))
+`, sqlUserStr, sqlUserStr)
+
+	if dbName != "" {
+		query.Append("AND db_name ILIKE $ ", dbName)
+	}
+
+	// If store ids are provided, at least one of the store
+	// ids must exist in the store_ids array.
+	if len(storeIds) > 0 {
+		query.Append("AND ( ")
+		for i, storeId := range storeIds {
+			query.Append("tbm.store_ids @> ARRAY[$] ", storeId)
+			if i < len(storeIds)-1 {
+				query.Append("OR ")
+			}
+		}
+		query.Append(") ")
+	}
+
+	orderBy := ""
+	if sortBy != "" {
+		orderBy = fmt.Sprintf("%s %s,", sortBy, sortOrder)
+	}
+
+	query.Append("GROUP BY tbm.db_id, tbm.db_name, s.store_ids ")
+	query.Append(fmt.Sprintf("ORDER BY %s db_id %s ", orderBy, sortOrder))
+	query.Append("LIMIT $ ", limit)
+	query.Append("OFFSET $ ", offset)
+
+	it, err := a.admin.internalExecutor.QueryIteratorEx(
+		ctx, "get-database-metadata", nil, /* txn */
+		sessiondata.InternalExecutorOverride{},
+		query.String(), query.QueryArguments()...,
+	)
+
+	if err != nil {
+		return nil, totalRowCount, err
+	}
+
+	defer func(it isql.Rows) {
+		retErr = errors.CombineErrors(retErr, it.Close())
+	}(it)
+
+	ok, err := it.Next(ctx)
+	if err != nil {
+		return nil, totalRowCount, err
+	}
+
+	setTotalRowCount := true
+	if ok {
+		// If ok == false, the query returned 0 rows.
+		scanner := makeResultScanner(it.Types())
+		for ; ok; ok, err = it.Next(ctx) {
+			var dbm dbMetadata
+			row := it.Cur()
+			if setTotalRowCount {
+				if err := scanner.Scan(row, "total_row_count", &totalRowCount); err != nil {
+					return nil, totalRowCount, err
+				}
+				setTotalRowCount = false
+			}
+			if err := scanner.Scan(row, "db_id", &dbm.DbId); err != nil {
+				return nil, 0, err
+			}
+			if err := scanner.Scan(row, "db_name", &dbm.DbName); err != nil {
+				return nil, 0, err
+			}
+			if err := scanner.Scan(row, "size_bytes", &dbm.SizeBytes); err != nil {
+				return nil, 0, err
+			}
+			if err := scanner.Scan(row, "table_count", &dbm.TableCount); err != nil {
+				return nil, 0, err
+			}
+			if err := scanner.Scan(row, "store_ids", &dbm.StoreIds); err != nil {
+				return nil, totalRowCount, err
+			}
+			if err := scanner.Scan(row, "last_updated", &dbm.LastUpdated); err != nil {
+				return nil, 0, err
+			}
+			dbms = append(dbms, dbm)
+		}
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+
+	return dbms, totalRowCount, nil
+}
+
 type PaginatedResponse[T any] struct {
 	Results        T              `json:"results"`
 	PaginationInfo paginationInfo `json:"paginationInfo"`
@@ -411,4 +684,13 @@ type tableMetadata struct {
 	StoreIds             []int64   `json:"store_ids"`
 	LastUpdateError      string    `json:"last_update_error,omitempty"`
 	LastUpdated          time.Time `json:"last_updated"`
+}
+
+type dbMetadata struct {
+	DbId        int64     `json:"db_id,omitempty"`
+	DbName      string    `json:"db_name,omitempty"`
+	SizeBytes   int64     `json:"size_bytes,omitempty"`
+	TableCount  int64     `json:"table_count,omitempty"`
+	StoreIds    []int64   `json:"store_ids"`
+	LastUpdated time.Time `json:"last_updated"`
 }

--- a/pkg/server/api_v2_databases_metadata_test.go
+++ b/pkg/server/api_v2_databases_metadata_test.go
@@ -34,6 +34,8 @@ func defaultTMComparator(first, second tableMetadata) int {
 	return cmp.Compare(first.TableId, second.TableId)
 }
 
+func defaultDMComparator(first, second dbMetadata) int { return cmp.Compare(first.DbId, second.DbId) }
+
 func descendingComparator[T any](comparator func(first, second T) int) func(first, second T) int {
 	return func(f, s T) int {
 		return -1 * comparator(f, s)
@@ -300,6 +302,188 @@ func TestGetTableMetadata(t *testing.T) {
 		for _, tt := range unprocessableTest {
 			t.Run(tt.name, func(t *testing.T) {
 				uri := fmt.Sprintf("/api/v2/table_metadata/%s", tt.queryString)
+				req, err := http.NewRequest("GET", ts.AdminURL().WithPath(uri).String(), nil)
+				require.NoError(t, err)
+				resp, err := client.Do(req)
+				require.NoError(t, err)
+				defer resp.Body.Close()
+				require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+			})
+		}
+	})
+}
+
+func TestGetDBMetadata(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{})
+	ctx := context.Background()
+	defer testCluster.Stopper().Stop(ctx)
+	conn := testCluster.ServerConn(0)
+	defer conn.Close()
+	var (
+		db1Name = "new_test_db_1"
+		db2Name = "new_test_db_2"
+	)
+	db1Id, _ := setupTest(t, conn, db1Name, db2Name)
+
+	ts := testCluster.Server(0)
+	client, err := ts.GetAdminHTTPClient()
+	require.NoError(t, err)
+	t.Run("non GET method 405 error", func(t *testing.T) {})
+	t.Run("sorting", func(t *testing.T) {
+
+		nameComparator := func(first, second dbMetadata) int {
+			return cmp.Or(cmp.Compare(first.DbName, second.DbName), defaultDMComparator(first, second))
+		}
+		sizeComparator := func(first, second dbMetadata) int {
+			return cmp.Or(cmp.Compare(first.SizeBytes, second.SizeBytes), defaultDMComparator(first, second))
+		}
+		tableCountComparator := func(first, second dbMetadata) int {
+			return cmp.Or(cmp.Compare(first.TableCount, second.TableCount), defaultDMComparator(first, second))
+		}
+		lastUpdatedComparator := func(first, second dbMetadata) int {
+			return cmp.Or(first.LastUpdated.Compare(second.LastUpdated), defaultDMComparator(first, second))
+		}
+
+		var sortTests = []struct {
+			name        string
+			queryString string
+			comparator  func(first, second dbMetadata) int
+		}{
+			{"no sort", "", defaultDMComparator},
+			{"empty sort", "?sortBy=", defaultDMComparator},
+			{"non-sortable param", "?sortBy=asdfas", defaultDMComparator},
+			{"empty query string and set sort order", "?sortOrder=desc", defaultDMComparator},
+			{"sort by size", "?sortBy=name", nameComparator},
+			{"sort by size", "?sortBy=size", sizeComparator},
+			{"sort by table count", "?sortBy=tableCount", tableCountComparator},
+			{"sort by lastUpdated", "?sortBy=lastUpdated", lastUpdatedComparator},
+			{"sort by name descending", "?sortBy=name&sortOrder=desc", descendingComparator(nameComparator)},
+			{"sort by size descending", "?sortBy=size&sortOrder=desc", descendingComparator(sizeComparator)},
+			{"sort by table count descending", "?sortBy=tableCount&sortOrder=desc", descendingComparator(tableCountComparator)},
+			{"sort by last updated descending", "?sortBy=lastUpdated&sortOrder=desc", descendingComparator(lastUpdatedComparator)},
+		}
+		for _, tt := range sortTests {
+			t.Run(tt.name, func(t *testing.T) {
+				uri := fmt.Sprintf("/api/v2/database_metadata/%s", tt.queryString)
+				mdResp := makeApiRequest[PaginatedResponse[[]dbMetadata]](t, client, ts.AdminURL().WithPath(uri).String())
+				require.NotEmpty(t, mdResp.Results)
+				isSorted := slices.IsSortedFunc(mdResp.Results, tt.comparator)
+				require.True(t, isSorted)
+			})
+		}
+	})
+
+	t.Run("authorization", func(t *testing.T) {
+		sessionUsername := username.TestUserName()
+		userClient, _, err := ts.GetAuthenticatedHTTPClientAndCookie(sessionUsername, false, 1)
+		require.NoError(t, err)
+
+		// Assert that the test user gets an empty response for db 1
+		uri := "/api/v2/database_metadata/"
+		mdResp := makeApiRequest[PaginatedResponse[[]dbMetadata]](t, userClient, ts.AdminURL().WithPath(uri).String())
+
+		require.Empty(t, mdResp.Results)
+		require.Zero(t, mdResp.PaginationInfo.TotalResults)
+
+		// Grant connect access to DB 1
+		_, e := conn.Exec(fmt.Sprintf("GRANT CONNECT ON DATABASE %s TO %s", db1Name, sessionUsername.Normalized()))
+		require.NoError(t, e)
+		mdResp = makeApiRequest[PaginatedResponse[[]dbMetadata]](t, userClient, ts.AdminURL().WithPath(uri).String())
+
+		// Assert that user now see results for db1
+		require.Len(t, mdResp.Results, 1)
+		require.True(t, mdResp.Results[0].DbId == int64(db1Id))
+		require.True(t, slices.IsSortedFunc(mdResp.Results, defaultDMComparator))
+
+		// Revoke connect access from db1
+		_, e = conn.Exec(fmt.Sprintf("REVOKE CONNECT ON DATABASE %s FROM %s", db1Name, sessionUsername.Normalized()))
+		require.NoError(t, e)
+		mdResp = makeApiRequest[PaginatedResponse[[]dbMetadata]](t, userClient, ts.AdminURL().WithPath(uri).String())
+
+		// Assert that user no longer sees results from db1
+		require.Empty(t, mdResp.Results)
+
+		// Make user admin
+		_, e = conn.Exec(fmt.Sprintf("GRANT admin TO %s", sessionUsername.Normalized()))
+		require.NoError(t, e)
+		mdResp = makeApiRequest[PaginatedResponse[[]dbMetadata]](t, userClient, ts.AdminURL().WithPath(uri).String())
+
+		// Assert that user now see results for all dbs
+		require.Len(t, mdResp.Results, 2)
+		require.True(t, slices.IsSortedFunc(mdResp.Results, defaultDMComparator))
+
+	})
+	t.Run("pagination", func(t *testing.T) {
+		var pageTests = []struct {
+			name             string
+			queryString      string
+			expectedPageNum  int
+			expectedPageSize int
+		}{
+			{"no page size or page num", "?", defaultPageNum, defaultPageSize},
+			{"set page size", "?pageSize=1", defaultPageNum, 1},
+			{"set page size and page num", "?pageSize=1&pageNum=2", 2, 1},
+			{"invalid page size and num", "?pageSize=0&pageNum=0", defaultPageNum, defaultPageSize},
+		}
+		for _, tt := range pageTests {
+			t.Run(tt.name, func(t *testing.T) {
+				uri := fmt.Sprintf("/api/v2/database_metadata/%s", tt.queryString)
+				mdResp := makeApiRequest[PaginatedResponse[[]dbMetadata]](t, client, ts.AdminURL().WithPath(uri).String())
+				require.NotEmpty(t, mdResp.Results)
+				require.LessOrEqual(t, len(mdResp.Results), tt.expectedPageSize)
+				require.Equal(t, tt.expectedPageSize, mdResp.PaginationInfo.PageSize)
+				require.Equal(t, tt.expectedPageNum, mdResp.PaginationInfo.PageNum)
+			})
+		}
+	})
+	t.Run("db name filter", func(t *testing.T) {
+		var dbtableNameTests = []struct {
+			name          string
+			nameFilter    string
+			expectedCount int
+		}{
+			// matches database: new_test_db_1
+			{"with db name", db1Name, 1},
+			// matches database new_test_db_1
+			{"with db name non-matching case", strings.ToUpper(db1Name), 1},
+			// matches database new_test_db_1, new_test_db2
+			{"with partial database name", db1Name[0:4], 2},
+		}
+
+		for _, tt := range dbtableNameTests {
+			t.Run(tt.name, func(t *testing.T) {
+				uri := fmt.Sprintf("/api/v2/database_metadata/?name=%s", tt.nameFilter)
+				mdResp := makeApiRequest[PaginatedResponse[[]dbMetadata]](t, client, ts.AdminURL().WithPath(uri).String())
+
+				require.Equal(t, int64(tt.expectedCount), mdResp.PaginationInfo.TotalResults)
+			})
+		}
+	})
+	t.Run("filter store id", func(t *testing.T) {
+		storeIds := []int64{8, 9}
+		uri := fmt.Sprintf("/api/v2/database_metadata/?storeId=%d&storeId=%d", storeIds[0], storeIds[1])
+		mdResp := makeApiRequest[PaginatedResponse[[]dbMetadata]](t, client, ts.AdminURL().WithPath(uri).String())
+		for _, dmdr := range mdResp.Results {
+			require.Condition(t, func() (success bool) {
+				return slices.Contains(dmdr.StoreIds, storeIds[0]) || slices.Contains(dmdr.StoreIds, storeIds[1])
+			})
+		}
+	})
+	t.Run("422 unprocessable", func(t *testing.T) {
+		var unprocessableTest = []struct {
+			name        string
+			queryString string
+		}{
+			{"pageNum", "?pageNum=a"},
+			{"pageSize", "?pageSize=a"},
+			{"storeId", "?storeId=a"},
+			{"multiple storeIds", "?storeId=1&storeId=a"},
+		}
+		for _, tt := range unprocessableTest {
+			t.Run(tt.name, func(t *testing.T) {
+				uri := fmt.Sprintf("/api/v2/database_metadata/%s", tt.queryString)
 				req, err := http.NewRequest("GET", ts.AdminURL().WithPath(uri).String(), nil)
 				require.NoError(t, err)
 				resp, err := client.Do(req)


### PR DESCRIPTION
adds a new api v2 endpoint, /api/v2/database_metadata/.

This new API enables the ability to retrieve paginated table metadata aggregated at the database level

Resolves: https://github.com/cockroachdb/cockroach/issues/128895
Epic: [CRDB-37558](https://cockroachlabs.atlassian.net/browse/CRDB-37558)
Release note: None

Note: This PR is stacked on top of #128231, so only the last commit needs review