### PR TITLE
restore: allow empty virtual sst in online restore

### DIFF
--- a/pkg/ccl/backupccl/backuprand/backup_rand_test.go
+++ b/pkg/ccl/backupccl/backuprand/backup_rand_test.go
@@ -166,9 +166,7 @@ database_name = 'rand' AND schema_name = 'public'`)
 	withOnlineRestore := func() string {
 		onlineRestoreExtension := ""
 		if rng.Intn(2) != 0 {
-			// TODO(msbutler): once this test is deflaked, add back the online restore
-			// variant of this test.
-			onlineRestoreExtension = ""
+			onlineRestoreExtension = ", experimental deferred copy"
 		}
 		return onlineRestoreExtension
 	}

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -882,21 +882,6 @@ func spansForAllRestoreTableIndexes(
 		})
 		return false
 	})
-
-	if forOnlineRestore {
-		spans, _ = roachpb.MergeSpans(&spans)
-		tableIDMap := make(map[uint32]struct{}, len(spans))
-		for _, sp := range spans {
-			_, tableID, err := codec.DecodeTablePrefix(sp.Key)
-			if err != nil {
-				return nil, err
-			}
-			if _, exists := tableIDMap[tableID]; exists {
-				return nil, errors.Newf("restore target contains two distinct spans with table id %d. Online restore cannot handle this as it may make an empty file span", tableID)
-			}
-			tableIDMap[tableID] = struct{}{}
-		}
-	}
 	return spans, nil
 }
 

--- a/pkg/ccl/backupccl/restore_online.go
+++ b/pkg/ccl/backupccl/restore_online.go
@@ -302,11 +302,6 @@ func sendAddRemoteSSTWorker(
 					)
 				}
 
-				// TODO(dt): remove when pebble supports empty (virtual) files.
-				if !file.BackupFileEntrySpan.Equal(restoringSubspan) {
-					return errors.AssertionFailedf("file span %s at path %s is not contained in restore span %s", file.BackupFileEntrySpan, file.Path, entry.Span)
-				}
-
 				restoringSubspan, err := rewriteSpan(&kr, restoringSubspan.Clone(), entry.ElidedPrefix)
 				if err != nil {
 					return err


### PR DESCRIPTION
Previously, only restore would fast fail if any backup spans were empty because
pebble could not read from an empty virtual sst. Pebble has gotten smarter, so
we can remove this check.

Fixes https://github.com/cockroachdb/cockroach/issues/129610

Release note: none