### PR TITLE
raft: do not grant {,Pre}Vote when supporting fortified leader

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -804,8 +804,8 @@ func (r *raft) reset(term uint64) {
 		//
 		// [*] this case, and other cases where a state transition implies
 		// de-fortification.
-		assertTrue(!r.supportingFortifiedLeader(),
-			"should not be changing terms when supporting a fortified leader")
+		assertTrue(!r.supportingFortifiedLeader() || r.lead == r.id,
+			"should not be changing terms when supporting a fortified leader; leader exempted")
 		r.Term = term
 		r.Vote = None
 		r.lead = None
@@ -979,8 +979,9 @@ func (r *raft) becomePreCandidate() {
 	if r.state == StateLeader {
 		panic("invalid transition [leader -> pre-candidate]")
 	}
-	assertTrue(!r.supportingFortifiedLeader(),
-		"should not be supporting a fortified leader when becoming pre-candidate")
+	assertTrue(!r.supportingFortifiedLeader() || r.lead == r.id,
+		"should not be supporting a fortified leader when becoming pre-candidate; leader exempted",
+	)
 	// Becoming a pre-candidate changes our step functions and state,
 	// but doesn't change anything else. In particular it does not increase
 	// r.Term or change r.Vote.
@@ -1045,7 +1046,13 @@ func (r *raft) hup(t CampaignType) {
 		r.logger.Warningf("%x is unpromotable and can not campaign", r.id)
 		return
 	}
-	if r.supportingFortifiedLeader() {
+	// NB: The leader is allowed to bump its term by calling an election. Note that
+	// we must take care to ensure the leader's support expiration doesn't regress.
+	//
+	// TODO(arul): add special handling for the r.lead == r.id case with an
+	// assertion to ensure the LeaderSupportExpiration is in the past before
+	// campaigning.
+	if r.supportingFortifiedLeader() && r.lead != r.id {
 		r.logger.Debugf("%x ignoring MsgHup due to leader fortification", r.id)
 		return
 	}
@@ -1175,17 +1182,43 @@ func (r *raft) Step(m pb.Message) error {
 	case m.Term > r.Term:
 		if m.Type == pb.MsgVote || m.Type == pb.MsgPreVote {
 			force := bytes.Equal(m.Context, []byte(campaignTransfer))
-			inLease := r.checkQuorum && r.lead != None && r.electionElapsed < r.electionTimeout
-			if !force && inLease {
-				// If a server receives a RequestVote request within the minimum election timeout
-				// of hearing from a current leader, it does not update its term or grant its vote
-				last := r.raftLog.lastEntryID()
-				// TODO(pav-kv): it should be ok to simply print the %+v of the lastEntryID.
-				r.logger.Infof("%x [logterm: %d, index: %d, vote: %x] ignored %s from %x [logterm: %d, index: %d] at term %d: recently received communication from leader (remaining ticks: %d)",
-					r.id, last.term, last.index, r.Vote, m.Type, m.From, m.LogTerm, m.Index, r.Term, r.electionTimeout-r.electionElapsed)
-				return nil
+			inHeartbeatLease := r.checkQuorum && r.lead != None && r.electionElapsed < r.electionTimeout
+			// NB: A fortified leader is allowed to bump its term. It'll need to
+			// re-fortify once if it gets elected at the higher term though, so the
+			// leader must take care to not regress its supported expiration. However,
+			// at the follower, we grant the fortified leader our vote at the higher
+			// term.
+			inFortifyLease := r.supportingFortifiedLeader() && r.lead != m.From
+			if !force && (inHeartbeatLease || inFortifyLease) {
+				// If a server receives a Request{,Pre}Vote message but is still
+				// supporting a fortified leader, it does not update its term or grant
+				// its vote. Similarly, if a server receives a Request{,Pre}Vote message
+				// within the minimum election timeout of hearing from the current
+				// leader it does not update its term or grant its vote.
+				{
+					// Log why we're ignoring the Request{,Pre}Vote.
+					var inHeartbeatLeaseMsg string
+					var inFortifyLeaseMsg string
+					var sep string
+					if inHeartbeatLease {
+						inHeartbeatLeaseMsg = fmt.Sprintf("recently received communication from leader (remaining ticks: %d)", r.electionTimeout-r.electionElapsed)
+					}
+					if inFortifyLease {
+						inFortifyLeaseMsg = fmt.Sprintf("supporting fortified leader %d at epoch %d", r.lead, r.leadEpoch)
+					}
+					if inFortifyLease && inHeartbeatLease {
+						sep = " and "
+					}
+					last := r.raftLog.lastEntryID()
+					// TODO(pav-kv): it should be ok to simply print the %+v of the
+					// lastEntryID.
+					r.logger.Infof("%x [logterm: %d, index: %d, vote: %x] ignored %s from %x [logterm: %d, index: %d] at term %d: %s%s%s",
+						r.id, last.term, last.index, r.Vote, m.Type, m.From, m.LogTerm, m.Index, r.Term, inHeartbeatLeaseMsg, sep, inFortifyLeaseMsg)
+				}
+				return nil // don't update term/grant vote; early return
 			}
 		}
+
 		switch {
 		case m.Type == pb.MsgPreVote:
 			// Never change our term in response to a PreVote
@@ -1207,15 +1240,13 @@ func (r *raft) Step(m pb.Message) error {
 				r.becomeFollower(m.Term, m.From)
 			case pb.MsgVote:
 				force := bytes.Equal(m.Context, []byte(campaignTransfer))
-				if force {
-					// The leader has asked another follower to campaign. In doing so,
-					// the leader can be thought of as "defortifying".
+				if force || m.From == r.lead {
+					// The leader has asked another follower to campaign or is trying to
+					// bump its term knowing fully well it'll no longer be fortified at
+					// the higher term. Both these cases can be considered the leader
+					// explicitly "defortifying".
 					r.deFortify(r.lead, m.Term)
 				}
-				// TODO(arul): Once we start rejecting MsgVotes when we support a
-				// fortified leader we'll never get here. At that point, we can get
-				// rid of this hack.
-				r.deFortify(r.lead, m.Term)
 				r.becomeFollower(m.Term, None)
 			default:
 				r.becomeFollower(m.Term, None)
@@ -2277,4 +2308,12 @@ func (r *raft) reduceUncommittedSize(s entryPayloadSize) {
 	} else {
 		r.uncommittedSize -= s
 	}
+}
+
+func (r *raft) testingStepDown() error {
+	if r.lead != r.id {
+		return errors.New("cannot step down if not the leader")
+	}
+	r.becomeFollower(r.Term, r.id) // mirror the logic in how we step down when CheckQuorum fails
+	return nil
 }

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1181,7 +1181,7 @@ func (r *raft) Step(m pb.Message) error {
 				// of hearing from a current leader, it does not update its term or grant its vote
 				last := r.raftLog.lastEntryID()
 				// TODO(pav-kv): it should be ok to simply print the %+v of the lastEntryID.
-				r.logger.Infof("%x [logterm: %d, index: %d, vote: %x] ignored %s from %x [logterm: %d, index: %d] at term %d: lease is not expired (remaining ticks: %d)",
+				r.logger.Infof("%x [logterm: %d, index: %d, vote: %x] ignored %s from %x [logterm: %d, index: %d] at term %d: recently received communication from leader (remaining ticks: %d)",
 					r.id, last.term, last.index, r.Vote, m.Type, m.From, m.LogTerm, m.Index, r.Term, r.electionTimeout-r.electionElapsed)
 				return nil
 			}

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -739,9 +739,9 @@ func TestDuelingCandidates(t *testing.T) {
 	s1 := newTestMemoryStorage(withPeers(1, 2, 3))
 	s2 := newTestMemoryStorage(withPeers(1, 2, 3))
 	s3 := newTestMemoryStorage(withPeers(1, 2, 3))
-	a := newTestRaft(1, 10, 1, s1)
-	b := newTestRaft(2, 10, 1, s2)
-	c := newTestRaft(3, 10, 1, s3)
+	a := newTestRaft(1, 10, 1, s1, withFortificationDisabled())
+	b := newTestRaft(2, 10, 1, s2, withFortificationDisabled())
+	c := newTestRaft(3, 10, 1, s3, withFortificationDisabled())
 
 	nt := newNetwork(a, b, c)
 	nt.cut(1, 3)
@@ -784,9 +784,9 @@ func TestDuelingCandidates(t *testing.T) {
 }
 
 func TestDuelingPreCandidates(t *testing.T) {
-	cfgA := newTestConfig(1, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)))
-	cfgB := newTestConfig(2, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)))
-	cfgC := newTestConfig(3, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)))
+	cfgA := newTestConfig(1, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)), withFortificationDisabled())
+	cfgB := newTestConfig(2, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)), withFortificationDisabled())
+	cfgC := newTestConfig(3, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)), withFortificationDisabled())
 	cfgA.PreVote = true
 	cfgB.PreVote = true
 	cfgC.PreVote = true

--- a/pkg/raft/rafttest/interaction_env_handler.go
+++ b/pkg/raft/rafttest/interaction_env_handler.go
@@ -159,6 +159,13 @@ func (env *InteractionEnv) Handle(t *testing.T, d datadriven.TestData) string {
 		//
 		// Example: send-snapshot 1 3
 		env.handleSendSnapshot(t, d)
+	case "step-down":
+		// Steps down as the leader. No-op if not the leader.
+		//
+		// Example:
+		//
+		// step-down 1
+		err = env.handleStepDown(t, d)
 	case "propose":
 		// Propose an entry.
 		//

--- a/pkg/raft/rafttest/interaction_env_handler_forget_leader.go
+++ b/pkg/raft/rafttest/interaction_env_handler_forget_leader.go
@@ -1,3 +1,6 @@
+// This code has been modified from its original form by Cockroach Labs, Inc.
+// All modifications are Copyright 2024 Cockroach Labs, Inc.
+//
 // Copyright 2023 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,4 +32,9 @@ func (env *InteractionEnv) handleForgetLeader(t *testing.T, d datadriven.TestDat
 // ForgetLeader makes the follower at the given index forget its leader.
 func (env *InteractionEnv) ForgetLeader(idx int) {
 	env.Nodes[idx].ForgetLeader()
+}
+
+func (env *InteractionEnv) handleStepDown(t *testing.T, d datadriven.TestData) error {
+	idx := firstAsNodeIdx(t, d)
+	return env.Nodes[idx].TestingStepDown()
 }

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -533,3 +533,7 @@ func (rn *RawNode) TransferLeader(transferee pb.PeerID) {
 func (rn *RawNode) ForgetLeader() error {
 	return rn.raft.Step(pb.Message{Type: pb.MsgForgetLeader})
 }
+
+func (rn *RawNode) TestingStepDown() error {
+	return rn.raft.testingStepDown()
+}

--- a/pkg/raft/testdata/checkquorum.txt
+++ b/pkg/raft/testdata/checkquorum.txt
@@ -49,10 +49,10 @@ stabilize
   INFO 2 has received 1 MsgVoteResp votes and 0 vote rejections
 > 1 receiving messages
   2->1 MsgVote Term:2 Log:1/11
-  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 2 [logterm: 1, index: 11] at term 1: lease is not expired (remaining ticks: 3)
+  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 2 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3)
 > 3 receiving messages
   2->3 MsgVote Term:2 Log:1/11
-  INFO 3 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 2 [logterm: 1, index: 11] at term 1: lease is not expired (remaining ticks: 3)
+  INFO 3 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 2 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3)
 
 # Tick the leader without processing any messages from followers. We have to
 # tick 2 election timeouts, since the followers were active in the current
@@ -163,7 +163,7 @@ INFO 1 [logterm: 1, index: 11, vote: 0] cast MsgVote for 2 [logterm: 1, index: 1
 deliver-msgs 3
 ----
 2->3 MsgVote Term:3 Log:1/11
-INFO 3 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 2 [logterm: 1, index: 11] at term 1: lease is not expired (remaining ticks: 3)
+INFO 3 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 2 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3)
 
 stabilize
 ----

--- a/pkg/raft/testdata/forget_leader.txt
+++ b/pkg/raft/testdata/forget_leader.txt
@@ -219,6 +219,32 @@ forget-leader 2
 ----
 INFO 2 forgetting leader 3 at term 2
 
+# Withdraw support for 3 from all peers so that they vote for 2 when 2 calls an
+# election.
+withdraw-support 1 3
+----
+  1 2 3 4
+1 1 1 x 1
+2 x 1 x 1
+3 x 1 1 1
+4 x 1 1 1
+
+withdraw-support 3 3
+----
+  1 2 3 4
+1 1 1 x 1
+2 x 1 x 1
+3 x 1 x 1
+4 x 1 1 1
+
+withdraw-support 4 3
+----
+  1 2 3 4
+1 1 1 x 1
+2 x 1 x 1
+3 x 1 x 1
+4 x 1 x 1
+
 tick-heartbeat 2
 ----
 INFO 2 is starting a new election at term 2

--- a/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
+++ b/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
@@ -53,9 +53,9 @@ stabilize 3
 deliver-msgs 1 2
 ----
 3->1 MsgPreVote Term:2 Log:1/11
-INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3)
+INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3) and supporting fortified leader 1 at epoch 1
 3->2 MsgPreVote Term:2 Log:1/11
-INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3)
+INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3) and supporting fortified leader 1 at epoch 1
 
 # Make 1 assert leadership over 3 again.
 tick-heartbeat 1

--- a/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
+++ b/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
@@ -53,9 +53,9 @@ stabilize 3
 deliver-msgs 1 2
 ----
 3->1 MsgPreVote Term:2 Log:1/11
-INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 1, index: 11] at term 1: lease is not expired (remaining ticks: 3)
+INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3)
 3->2 MsgPreVote Term:2 Log:1/11
-INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 1, index: 11] at term 1: lease is not expired (remaining ticks: 3)
+INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3)
 
 # Make 1 assert leadership over 3 again.
 tick-heartbeat 1

--- a/pkg/raft/testdata/fortification_followers_dont_prevote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_prevote.txt
@@ -1,0 +1,502 @@
+# Test to ensure that a follower will not vote for another peer
+# if they're supporting a fortified leader. Pre-vote is turned on.
+
+log-level debug
+----
+ok
+
+add-nodes 3 voters=(1,2,3) index=10 prevote=true
+----
+INFO 1 switched to configuration voters=(1 2 3)
+INFO 1 became follower at term 0
+INFO newRaft 1 [peers: [1,2,3], term: 0, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
+INFO 2 switched to configuration voters=(1 2 3)
+INFO 2 became follower at term 0
+INFO newRaft 2 [peers: [1,2,3], term: 0, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
+INFO 3 switched to configuration voters=(1 2 3)
+INFO 3 became follower at term 0
+INFO newRaft 3 [peers: [1,2,3], term: 0, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
+
+campaign 1
+----
+INFO 1 is starting a new election at term 0
+INFO 1 became pre-candidate at term 0
+INFO 1 [logterm: 1, index: 10] sent MsgPreVote request to 2 at term 0
+INFO 1 [logterm: 1, index: 10] sent MsgPreVote request to 3 at term 0
+
+stabilize
+----
+> 1 handling Ready
+  Ready MustSync=false:
+  State:StatePreCandidate
+  Messages:
+  1->2 MsgPreVote Term:1 Log:1/10
+  1->3 MsgPreVote Term:1 Log:1/10
+  INFO 1 received MsgPreVoteResp from 1 at term 0
+  INFO 1 has received 1 MsgPreVoteResp votes and 0 vote rejections
+> 2 receiving messages
+  1->2 MsgPreVote Term:1 Log:1/10
+  INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgPreVote for 1 [logterm: 1, index: 10] at term 0
+> 3 receiving messages
+  1->3 MsgPreVote Term:1 Log:1/10
+  INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgPreVote for 1 [logterm: 1, index: 10] at term 0
+> 2 handling Ready
+  Ready MustSync=false:
+  Messages:
+  2->1 MsgPreVoteResp Term:1 Log:0/0
+> 3 handling Ready
+  Ready MustSync=false:
+  Messages:
+  3->1 MsgPreVoteResp Term:1 Log:0/0
+> 1 receiving messages
+  2->1 MsgPreVoteResp Term:1 Log:0/0
+  INFO 1 received MsgPreVoteResp from 2 at term 0
+  INFO 1 has received 2 MsgPreVoteResp votes and 0 vote rejections
+  INFO 1 became candidate at term 1
+  INFO 1 [logterm: 1, index: 10] sent MsgVote request to 2 at term 1
+  INFO 1 [logterm: 1, index: 10] sent MsgVote request to 3 at term 1
+  3->1 MsgPreVoteResp Term:1 Log:0/0
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  1->2 MsgVote Term:1 Log:1/10
+  1->3 MsgVote Term:1 Log:1/10
+  INFO 1 received MsgVoteResp from 1 at term 1
+  INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
+> 2 receiving messages
+  1->2 MsgVote Term:1 Log:1/10
+  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 2 became follower at term 1
+  INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
+> 3 receiving messages
+  1->3 MsgVote Term:1 Log:1/10
+  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 3 became follower at term 1
+  INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  2->1 MsgVoteResp Term:1 Log:0/0
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  3->1 MsgVoteResp Term:1 Log:0/0
+> 1 receiving messages
+  2->1 MsgVoteResp Term:1 Log:0/0
+  INFO 1 received MsgVoteResp from 2 at term 1
+  INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
+  INFO 1 became leader at term 1
+  3->1 MsgVoteResp Term:1 Log:0/0
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateLeader
+  HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
+  Entries:
+  1/11 EntryNormal ""
+  Messages:
+  1->2 MsgFortifyLeader Term:1 Log:0/0
+  1->3 MsgFortifyLeader Term:1 Log:0/0
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+  1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+> 2 receiving messages
+  1->2 MsgFortifyLeader Term:1 Log:0/0
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+> 3 receiving messages
+  1->3 MsgFortifyLeader Term:1 Log:0/0
+  1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
+  Entries:
+  1/11 EntryNormal ""
+  Messages:
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
+  Entries:
+  1/11 EntryNormal ""
+  Messages:
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:10
+> 1 receiving messages
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:10
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/11 EntryNormal ""
+  Messages:
+  1->2 MsgApp Term:1 Log:1/11 Commit:11
+  1->3 MsgApp Term:1 Log:1/11 Commit:11
+> 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/11 Commit:11
+> 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/11 Commit:11
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/11 EntryNormal ""
+  Messages:
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:11
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/11 EntryNormal ""
+  Messages:
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
+> 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:11
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
+
+withdraw-support 2 1
+----
+  1 2 3
+1 1 1 1
+2 x 1 1
+3 1 1 1
+
+# Ensure neither 1 or 3 vote for 2 as both of them are still
+# supporting the fortified leader (1).
+campaign 2
+----
+INFO 2 is starting a new election at term 1
+INFO 2 became pre-candidate at term 1
+INFO 2 [logterm: 1, index: 11] sent MsgPreVote request to 1 at term 1
+INFO 2 [logterm: 1, index: 11] sent MsgPreVote request to 3 at term 1
+
+stabilize
+----
+> 2 handling Ready
+  Ready MustSync=true:
+  State:StatePreCandidate
+  HardState Term:1 Vote:1 Commit:11 Lead:0 LeadEpoch:0
+  Messages:
+  2->1 MsgPreVote Term:2 Log:1/11
+  2->3 MsgPreVote Term:2 Log:1/11
+  INFO 2 received MsgPreVoteResp from 2 at term 1
+  INFO 2 has received 1 MsgPreVoteResp votes and 0 vote rejections
+> 1 receiving messages
+  2->1 MsgPreVote Term:2 Log:1/11
+  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 2 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
+> 3 receiving messages
+  2->3 MsgPreVote Term:2 Log:1/11
+  INFO 3 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 2 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
+
+raft-state
+----
+1: StateLeader (Voter) Term:1 Lead:1
+2: StatePreCandidate (Voter) Term:1 Lead:0
+3: StateFollower (Voter) Term:1 Lead:1
+
+# However, once a quorum withdraws support for the fortified leader, 2 can then
+# be elected.
+withdraw-support 3 1
+----
+  1 2 3
+1 1 1 1
+2 x 1 1
+3 x 1 1
+
+campaign 2
+----
+INFO 2 is starting a new election at term 1
+INFO 2 became pre-candidate at term 1
+INFO 2 [logterm: 1, index: 11] sent MsgPreVote request to 1 at term 1
+INFO 2 [logterm: 1, index: 11] sent MsgPreVote request to 3 at term 1
+
+stabilize
+----
+> 2 handling Ready
+  Ready MustSync=false:
+  Messages:
+  2->1 MsgPreVote Term:2 Log:1/11
+  2->3 MsgPreVote Term:2 Log:1/11
+  INFO 2 received MsgPreVoteResp from 2 at term 1
+  INFO 2 has received 1 MsgPreVoteResp votes and 0 vote rejections
+> 1 receiving messages
+  2->1 MsgPreVote Term:2 Log:1/11
+  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 2 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
+> 3 receiving messages
+  2->3 MsgPreVote Term:2 Log:1/11
+  INFO 3 [logterm: 1, index: 11, vote: 1] cast MsgPreVote for 2 [logterm: 1, index: 11] at term 1
+> 3 handling Ready
+  Ready MustSync=false:
+  Messages:
+  3->2 MsgPreVoteResp Term:2 Log:0/0
+> 2 receiving messages
+  3->2 MsgPreVoteResp Term:2 Log:0/0
+  INFO 2 received MsgPreVoteResp from 3 at term 1
+  INFO 2 has received 2 MsgPreVoteResp votes and 0 vote rejections
+  INFO 2 became candidate at term 2
+  INFO 2 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
+  INFO 2 [logterm: 1, index: 11] sent MsgVote request to 3 at term 2
+> 2 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:2 Vote:2 Commit:11 Lead:0 LeadEpoch:0
+  Messages:
+  2->1 MsgVote Term:2 Log:1/11
+  2->3 MsgVote Term:2 Log:1/11
+  INFO 2 received MsgVoteResp from 2 at term 2
+  INFO 2 has received 1 MsgVoteResp votes and 0 vote rejections
+> 1 receiving messages
+  2->1 MsgVote Term:2 Log:1/11
+  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 2 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
+> 3 receiving messages
+  2->3 MsgVote Term:2 Log:1/11
+  INFO 3 [term: 1] received a MsgVote message with higher term from 2 [term: 2]
+  INFO 3 became follower at term 2
+  INFO 3 [logterm: 1, index: 11, vote: 0] cast MsgVote for 2 [logterm: 1, index: 11] at term 2
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:2 Vote:2 Commit:11 Lead:0 LeadEpoch:0
+  Messages:
+  3->2 MsgVoteResp Term:2 Log:0/0
+> 2 receiving messages
+  3->2 MsgVoteResp Term:2 Log:0/0
+  INFO 2 received MsgVoteResp from 3 at term 2
+  INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
+  INFO 2 became leader at term 2
+> 2 handling Ready
+  Ready MustSync=true:
+  State:StateLeader
+  HardState Term:2 Vote:2 Commit:11 Lead:2 LeadEpoch:1
+  Entries:
+  2/12 EntryNormal ""
+  Messages:
+  2->1 MsgFortifyLeader Term:2 Log:0/0
+  2->3 MsgFortifyLeader Term:2 Log:0/0
+  2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
+  2->3 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
+> 1 receiving messages
+  2->1 MsgFortifyLeader Term:2 Log:0/0
+  INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 2 [term: 2]
+  INFO 1 became follower at term 2
+  2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
+> 3 receiving messages
+  2->3 MsgFortifyLeader Term:2 Log:0/0
+  2->3 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateFollower
+  HardState Term:2 Commit:11 Lead:2 LeadEpoch:1
+  Entries:
+  2/12 EntryNormal ""
+  Messages:
+  1->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
+  1->2 MsgAppResp Term:2 Log:0/12 Commit:11
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:2 Vote:2 Commit:11 Lead:2 LeadEpoch:1
+  Entries:
+  2/12 EntryNormal ""
+  Messages:
+  3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
+  3->2 MsgAppResp Term:2 Log:0/12 Commit:11
+> 2 receiving messages
+  1->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
+  1->2 MsgAppResp Term:2 Log:0/12 Commit:11
+  3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
+  3->2 MsgAppResp Term:2 Log:0/12 Commit:11
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:2 Vote:2 Commit:12 Lead:2 LeadEpoch:1
+  CommittedEntries:
+  2/12 EntryNormal ""
+  Messages:
+  2->1 MsgApp Term:2 Log:2/12 Commit:12
+  2->3 MsgApp Term:2 Log:2/12 Commit:12
+> 1 receiving messages
+  2->1 MsgApp Term:2 Log:2/12 Commit:12
+> 3 receiving messages
+  2->3 MsgApp Term:2 Log:2/12 Commit:12
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:2 Commit:12 Lead:2 LeadEpoch:1
+  CommittedEntries:
+  2/12 EntryNormal ""
+  Messages:
+  1->2 MsgAppResp Term:2 Log:0/12 Commit:12
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:2 Vote:2 Commit:12 Lead:2 LeadEpoch:1
+  CommittedEntries:
+  2/12 EntryNormal ""
+  Messages:
+  3->2 MsgAppResp Term:2 Log:0/12 Commit:12
+> 2 receiving messages
+  1->2 MsgAppResp Term:2 Log:0/12 Commit:12
+  3->2 MsgAppResp Term:2 Log:0/12 Commit:12
+
+raft-state
+----
+1: StateFollower (Voter) Term:2 Lead:2
+2: StateLeader (Voter) Term:2 Lead:2
+3: StateFollower (Voter) Term:2 Lead:2
+
+# Lastly, ensure that the leader is able to successfully campaign at a higher
+# term. We'll need to step down to set this up properly, as otherwise attempts
+# to campaign will no-op.
+step-down 2
+----
+INFO 2 became follower at term 2
+
+campaign 2
+----
+INFO 2 is starting a new election at term 2
+INFO 2 became pre-candidate at term 2
+INFO 2 [logterm: 2, index: 12] sent MsgPreVote request to 1 at term 2
+INFO 2 [logterm: 2, index: 12] sent MsgPreVote request to 3 at term 2
+
+stabilize
+----
+> 2 handling Ready
+  Ready MustSync=true:
+  State:StatePreCandidate
+  HardState Term:2 Vote:2 Commit:12 Lead:0 LeadEpoch:0
+  Messages:
+  2->1 MsgPreVote Term:3 Log:2/12
+  2->3 MsgPreVote Term:3 Log:2/12
+  INFO 2 received MsgPreVoteResp from 2 at term 2
+  INFO 2 has received 1 MsgPreVoteResp votes and 0 vote rejections
+> 1 receiving messages
+  2->1 MsgPreVote Term:3 Log:2/12
+  INFO 1 [logterm: 2, index: 12, vote: 0] cast MsgPreVote for 2 [logterm: 2, index: 12] at term 2
+> 3 receiving messages
+  2->3 MsgPreVote Term:3 Log:2/12
+  INFO 3 [logterm: 2, index: 12, vote: 2] cast MsgPreVote for 2 [logterm: 2, index: 12] at term 2
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->2 MsgPreVoteResp Term:3 Log:0/0
+> 3 handling Ready
+  Ready MustSync=false:
+  Messages:
+  3->2 MsgPreVoteResp Term:3 Log:0/0
+> 2 receiving messages
+  1->2 MsgPreVoteResp Term:3 Log:0/0
+  INFO 2 received MsgPreVoteResp from 1 at term 2
+  INFO 2 has received 2 MsgPreVoteResp votes and 0 vote rejections
+  INFO 2 became candidate at term 3
+  INFO 2 [logterm: 2, index: 12] sent MsgVote request to 1 at term 3
+  INFO 2 [logterm: 2, index: 12] sent MsgVote request to 3 at term 3
+  3->2 MsgPreVoteResp Term:3 Log:0/0
+> 2 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:3 Vote:2 Commit:12 Lead:0 LeadEpoch:0
+  Messages:
+  2->1 MsgVote Term:3 Log:2/12
+  2->3 MsgVote Term:3 Log:2/12
+  INFO 2 received MsgVoteResp from 2 at term 3
+  INFO 2 has received 1 MsgVoteResp votes and 0 vote rejections
+> 1 receiving messages
+  2->1 MsgVote Term:3 Log:2/12
+  INFO 1 [term: 2] received a MsgVote message with higher term from 2 [term: 3]
+  INFO 1 became follower at term 3
+  INFO 1 [logterm: 2, index: 12, vote: 0] cast MsgVote for 2 [logterm: 2, index: 12] at term 3
+> 3 receiving messages
+  2->3 MsgVote Term:3 Log:2/12
+  INFO 3 [term: 2] received a MsgVote message with higher term from 2 [term: 3]
+  INFO 3 became follower at term 3
+  INFO 3 [logterm: 2, index: 12, vote: 0] cast MsgVote for 2 [logterm: 2, index: 12] at term 3
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:3 Vote:2 Commit:12 Lead:0 LeadEpoch:0
+  Messages:
+  1->2 MsgVoteResp Term:3 Log:0/0
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:3 Vote:2 Commit:12 Lead:0 LeadEpoch:0
+  Messages:
+  3->2 MsgVoteResp Term:3 Log:0/0
+> 2 receiving messages
+  1->2 MsgVoteResp Term:3 Log:0/0
+  INFO 2 received MsgVoteResp from 1 at term 3
+  INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
+  INFO 2 became leader at term 3
+  3->2 MsgVoteResp Term:3 Log:0/0
+> 2 handling Ready
+  Ready MustSync=true:
+  State:StateLeader
+  HardState Term:3 Vote:2 Commit:12 Lead:2 LeadEpoch:1
+  Entries:
+  3/13 EntryNormal ""
+  Messages:
+  2->1 MsgFortifyLeader Term:3 Log:0/0
+  2->3 MsgFortifyLeader Term:3 Log:0/0
+  2->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
+  2->3 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
+> 1 receiving messages
+  2->1 MsgFortifyLeader Term:3 Log:0/0
+  2->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
+> 3 receiving messages
+  2->3 MsgFortifyLeader Term:3 Log:0/0
+  2->3 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:3 Vote:2 Commit:12 Lead:2 LeadEpoch:1
+  Entries:
+  3/13 EntryNormal ""
+  Messages:
+  1->2 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
+  1->2 MsgAppResp Term:3 Log:0/13 Commit:12
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:3 Vote:2 Commit:12 Lead:2 LeadEpoch:1
+  Entries:
+  3/13 EntryNormal ""
+  Messages:
+  3->2 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
+  3->2 MsgAppResp Term:3 Log:0/13 Commit:12
+> 2 receiving messages
+  1->2 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
+  1->2 MsgAppResp Term:3 Log:0/13 Commit:12
+  3->2 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
+  3->2 MsgAppResp Term:3 Log:0/13 Commit:12
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:3 Vote:2 Commit:13 Lead:2 LeadEpoch:1
+  CommittedEntries:
+  3/13 EntryNormal ""
+  Messages:
+  2->1 MsgApp Term:3 Log:3/13 Commit:13
+  2->3 MsgApp Term:3 Log:3/13 Commit:13
+> 1 receiving messages
+  2->1 MsgApp Term:3 Log:3/13 Commit:13
+> 3 receiving messages
+  2->3 MsgApp Term:3 Log:3/13 Commit:13
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:3 Vote:2 Commit:13 Lead:2 LeadEpoch:1
+  CommittedEntries:
+  3/13 EntryNormal ""
+  Messages:
+  1->2 MsgAppResp Term:3 Log:0/13 Commit:13
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:3 Vote:2 Commit:13 Lead:2 LeadEpoch:1
+  CommittedEntries:
+  3/13 EntryNormal ""
+  Messages:
+  3->2 MsgAppResp Term:3 Log:0/13 Commit:13
+> 2 receiving messages
+  1->2 MsgAppResp Term:3 Log:0/13 Commit:13
+  3->2 MsgAppResp Term:3 Log:0/13 Commit:13
+
+raft-state
+----
+1: StateFollower (Voter) Term:3 Lead:2
+2: StateLeader (Voter) Term:3 Lead:2
+3: StateFollower (Voter) Term:3 Lead:2

--- a/pkg/raft/testdata/fortification_followers_dont_vote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_vote.txt
@@ -1,0 +1,416 @@
+# Test to ensure that a follower will not vote for another peer
+# if they're supporting a fortified leader.
+
+log-level debug
+----
+ok
+
+add-nodes 3 voters=(1,2,3) index=10
+----
+INFO 1 switched to configuration voters=(1 2 3)
+INFO 1 became follower at term 0
+INFO newRaft 1 [peers: [1,2,3], term: 0, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
+INFO 2 switched to configuration voters=(1 2 3)
+INFO 2 became follower at term 0
+INFO newRaft 2 [peers: [1,2,3], term: 0, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
+INFO 3 switched to configuration voters=(1 2 3)
+INFO 3 became follower at term 0
+INFO newRaft 3 [peers: [1,2,3], term: 0, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
+
+campaign 1
+----
+INFO 1 is starting a new election at term 0
+INFO 1 became candidate at term 1
+INFO 1 [logterm: 1, index: 10] sent MsgVote request to 2 at term 1
+INFO 1 [logterm: 1, index: 10] sent MsgVote request to 3 at term 1
+
+stabilize
+----
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  1->2 MsgVote Term:1 Log:1/10
+  1->3 MsgVote Term:1 Log:1/10
+  INFO 1 received MsgVoteResp from 1 at term 1
+  INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
+> 2 receiving messages
+  1->2 MsgVote Term:1 Log:1/10
+  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 2 became follower at term 1
+  INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
+> 3 receiving messages
+  1->3 MsgVote Term:1 Log:1/10
+  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 3 became follower at term 1
+  INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  2->1 MsgVoteResp Term:1 Log:0/0
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  3->1 MsgVoteResp Term:1 Log:0/0
+> 1 receiving messages
+  2->1 MsgVoteResp Term:1 Log:0/0
+  INFO 1 received MsgVoteResp from 2 at term 1
+  INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
+  INFO 1 became leader at term 1
+  3->1 MsgVoteResp Term:1 Log:0/0
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateLeader
+  HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
+  Entries:
+  1/11 EntryNormal ""
+  Messages:
+  1->2 MsgFortifyLeader Term:1 Log:0/0
+  1->3 MsgFortifyLeader Term:1 Log:0/0
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+  1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+> 2 receiving messages
+  1->2 MsgFortifyLeader Term:1 Log:0/0
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+> 3 receiving messages
+  1->3 MsgFortifyLeader Term:1 Log:0/0
+  1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
+  Entries:
+  1/11 EntryNormal ""
+  Messages:
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
+  Entries:
+  1/11 EntryNormal ""
+  Messages:
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:10
+> 1 receiving messages
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:10
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/11 EntryNormal ""
+  Messages:
+  1->2 MsgApp Term:1 Log:1/11 Commit:11
+  1->3 MsgApp Term:1 Log:1/11 Commit:11
+> 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/11 Commit:11
+> 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/11 Commit:11
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/11 EntryNormal ""
+  Messages:
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:11
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/11 EntryNormal ""
+  Messages:
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
+> 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:11
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
+
+withdraw-support 2 1
+----
+  1 2 3
+1 1 1 1
+2 x 1 1
+3 1 1 1
+
+# Ensure neither 1 or 3 vote for 2 as both of them are still
+# supporting the fortified leader (1).
+campaign 2
+----
+INFO 2 is starting a new election at term 1
+INFO 2 became candidate at term 2
+INFO 2 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
+INFO 2 [logterm: 1, index: 11] sent MsgVote request to 3 at term 2
+
+stabilize
+----
+> 2 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:2 Vote:2 Commit:11 Lead:0 LeadEpoch:0
+  Messages:
+  2->1 MsgVote Term:2 Log:1/11
+  2->3 MsgVote Term:2 Log:1/11
+  INFO 2 received MsgVoteResp from 2 at term 2
+  INFO 2 has received 1 MsgVoteResp votes and 0 vote rejections
+> 1 receiving messages
+  2->1 MsgVote Term:2 Log:1/11
+  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 2 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
+> 3 receiving messages
+  2->3 MsgVote Term:2 Log:1/11
+  INFO 3 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 2 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
+
+raft-state
+----
+1: StateLeader (Voter) Term:1 Lead:1
+2: StateCandidate (Voter) Term:2 Lead:0
+3: StateFollower (Voter) Term:1 Lead:1
+
+# However, once a quorum withdraws support for the fortified leader, 2 can then
+# be elected.
+withdraw-support 3 1
+----
+  1 2 3
+1 1 1 1
+2 x 1 1
+3 x 1 1
+
+campaign 2
+----
+INFO 2 is starting a new election at term 2
+INFO 2 became candidate at term 3
+INFO 2 [logterm: 1, index: 11] sent MsgVote request to 1 at term 3
+INFO 2 [logterm: 1, index: 11] sent MsgVote request to 3 at term 3
+
+stabilize
+----
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:3 Vote:2 Commit:11 Lead:0 LeadEpoch:0
+  Messages:
+  2->1 MsgVote Term:3 Log:1/11
+  2->3 MsgVote Term:3 Log:1/11
+  INFO 2 received MsgVoteResp from 2 at term 3
+  INFO 2 has received 1 MsgVoteResp votes and 0 vote rejections
+> 1 receiving messages
+  2->1 MsgVote Term:3 Log:1/11
+  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 2 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
+> 3 receiving messages
+  2->3 MsgVote Term:3 Log:1/11
+  INFO 3 [term: 1] received a MsgVote message with higher term from 2 [term: 3]
+  INFO 3 became follower at term 3
+  INFO 3 [logterm: 1, index: 11, vote: 0] cast MsgVote for 2 [logterm: 1, index: 11] at term 3
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:3 Vote:2 Commit:11 Lead:0 LeadEpoch:0
+  Messages:
+  3->2 MsgVoteResp Term:3 Log:0/0
+> 2 receiving messages
+  3->2 MsgVoteResp Term:3 Log:0/0
+  INFO 2 received MsgVoteResp from 3 at term 3
+  INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
+  INFO 2 became leader at term 3
+> 2 handling Ready
+  Ready MustSync=true:
+  State:StateLeader
+  HardState Term:3 Vote:2 Commit:11 Lead:2 LeadEpoch:1
+  Entries:
+  3/12 EntryNormal ""
+  Messages:
+  2->1 MsgFortifyLeader Term:3 Log:0/0
+  2->3 MsgFortifyLeader Term:3 Log:0/0
+  2->1 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
+  2->3 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
+> 1 receiving messages
+  2->1 MsgFortifyLeader Term:3 Log:0/0
+  INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 2 [term: 3]
+  INFO 1 became follower at term 3
+  2->1 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
+> 3 receiving messages
+  2->3 MsgFortifyLeader Term:3 Log:0/0
+  2->3 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateFollower
+  HardState Term:3 Commit:11 Lead:2 LeadEpoch:1
+  Entries:
+  3/12 EntryNormal ""
+  Messages:
+  1->2 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
+  1->2 MsgAppResp Term:3 Log:0/12 Commit:11
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:3 Vote:2 Commit:11 Lead:2 LeadEpoch:1
+  Entries:
+  3/12 EntryNormal ""
+  Messages:
+  3->2 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
+  3->2 MsgAppResp Term:3 Log:0/12 Commit:11
+> 2 receiving messages
+  1->2 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
+  1->2 MsgAppResp Term:3 Log:0/12 Commit:11
+  3->2 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
+  3->2 MsgAppResp Term:3 Log:0/12 Commit:11
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:3 Vote:2 Commit:12 Lead:2 LeadEpoch:1
+  CommittedEntries:
+  3/12 EntryNormal ""
+  Messages:
+  2->1 MsgApp Term:3 Log:3/12 Commit:12
+  2->3 MsgApp Term:3 Log:3/12 Commit:12
+> 1 receiving messages
+  2->1 MsgApp Term:3 Log:3/12 Commit:12
+> 3 receiving messages
+  2->3 MsgApp Term:3 Log:3/12 Commit:12
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:3 Commit:12 Lead:2 LeadEpoch:1
+  CommittedEntries:
+  3/12 EntryNormal ""
+  Messages:
+  1->2 MsgAppResp Term:3 Log:0/12 Commit:12
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:3 Vote:2 Commit:12 Lead:2 LeadEpoch:1
+  CommittedEntries:
+  3/12 EntryNormal ""
+  Messages:
+  3->2 MsgAppResp Term:3 Log:0/12 Commit:12
+> 2 receiving messages
+  1->2 MsgAppResp Term:3 Log:0/12 Commit:12
+  3->2 MsgAppResp Term:3 Log:0/12 Commit:12
+
+raft-state
+----
+1: StateFollower (Voter) Term:3 Lead:2
+2: StateLeader (Voter) Term:3 Lead:2
+3: StateFollower (Voter) Term:3 Lead:2
+
+# Lastly, ensure that the leader is able to successfully campaign at a higher
+# term. We'll need to step down to set this up properly, as otherwise attempts
+# to campaign will no-op.
+step-down 2
+----
+INFO 2 became follower at term 3
+
+campaign 2
+----
+INFO 2 is starting a new election at term 3
+INFO 2 became candidate at term 4
+INFO 2 [logterm: 3, index: 12] sent MsgVote request to 1 at term 4
+INFO 2 [logterm: 3, index: 12] sent MsgVote request to 3 at term 4
+
+stabilize
+----
+> 2 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:4 Vote:2 Commit:12 Lead:0 LeadEpoch:0
+  Messages:
+  2->1 MsgVote Term:4 Log:3/12
+  2->3 MsgVote Term:4 Log:3/12
+  INFO 2 received MsgVoteResp from 2 at term 4
+  INFO 2 has received 1 MsgVoteResp votes and 0 vote rejections
+> 1 receiving messages
+  2->1 MsgVote Term:4 Log:3/12
+  INFO 1 [term: 3] received a MsgVote message with higher term from 2 [term: 4]
+  INFO 1 became follower at term 4
+  INFO 1 [logterm: 3, index: 12, vote: 0] cast MsgVote for 2 [logterm: 3, index: 12] at term 4
+> 3 receiving messages
+  2->3 MsgVote Term:4 Log:3/12
+  INFO 3 [term: 3] received a MsgVote message with higher term from 2 [term: 4]
+  INFO 3 became follower at term 4
+  INFO 3 [logterm: 3, index: 12, vote: 0] cast MsgVote for 2 [logterm: 3, index: 12] at term 4
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:4 Vote:2 Commit:12 Lead:0 LeadEpoch:0
+  Messages:
+  1->2 MsgVoteResp Term:4 Log:0/0
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:4 Vote:2 Commit:12 Lead:0 LeadEpoch:0
+  Messages:
+  3->2 MsgVoteResp Term:4 Log:0/0
+> 2 receiving messages
+  1->2 MsgVoteResp Term:4 Log:0/0
+  INFO 2 received MsgVoteResp from 1 at term 4
+  INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
+  INFO 2 became leader at term 4
+  3->2 MsgVoteResp Term:4 Log:0/0
+> 2 handling Ready
+  Ready MustSync=true:
+  State:StateLeader
+  HardState Term:4 Vote:2 Commit:12 Lead:2 LeadEpoch:1
+  Entries:
+  4/13 EntryNormal ""
+  Messages:
+  2->1 MsgFortifyLeader Term:4 Log:0/0
+  2->3 MsgFortifyLeader Term:4 Log:0/0
+  2->1 MsgApp Term:4 Log:3/12 Commit:12 Entries:[4/13 EntryNormal ""]
+  2->3 MsgApp Term:4 Log:3/12 Commit:12 Entries:[4/13 EntryNormal ""]
+> 1 receiving messages
+  2->1 MsgFortifyLeader Term:4 Log:0/0
+  2->1 MsgApp Term:4 Log:3/12 Commit:12 Entries:[4/13 EntryNormal ""]
+> 3 receiving messages
+  2->3 MsgFortifyLeader Term:4 Log:0/0
+  2->3 MsgApp Term:4 Log:3/12 Commit:12 Entries:[4/13 EntryNormal ""]
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:4 Vote:2 Commit:12 Lead:2 LeadEpoch:1
+  Entries:
+  4/13 EntryNormal ""
+  Messages:
+  1->2 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
+  1->2 MsgAppResp Term:4 Log:0/13 Commit:12
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:4 Vote:2 Commit:12 Lead:2 LeadEpoch:1
+  Entries:
+  4/13 EntryNormal ""
+  Messages:
+  3->2 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
+  3->2 MsgAppResp Term:4 Log:0/13 Commit:12
+> 2 receiving messages
+  1->2 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
+  1->2 MsgAppResp Term:4 Log:0/13 Commit:12
+  3->2 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
+  3->2 MsgAppResp Term:4 Log:0/13 Commit:12
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:4 Vote:2 Commit:13 Lead:2 LeadEpoch:1
+  CommittedEntries:
+  4/13 EntryNormal ""
+  Messages:
+  2->1 MsgApp Term:4 Log:4/13 Commit:13
+  2->3 MsgApp Term:4 Log:4/13 Commit:13
+> 1 receiving messages
+  2->1 MsgApp Term:4 Log:4/13 Commit:13
+> 3 receiving messages
+  2->3 MsgApp Term:4 Log:4/13 Commit:13
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:4 Vote:2 Commit:13 Lead:2 LeadEpoch:1
+  CommittedEntries:
+  4/13 EntryNormal ""
+  Messages:
+  1->2 MsgAppResp Term:4 Log:0/13 Commit:13
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:4 Vote:2 Commit:13 Lead:2 LeadEpoch:1
+  CommittedEntries:
+  4/13 EntryNormal ""
+  Messages:
+  3->2 MsgAppResp Term:4 Log:0/13 Commit:13
+> 2 receiving messages
+  1->2 MsgAppResp Term:4 Log:0/13 Commit:13
+  3->2 MsgAppResp Term:4 Log:0/13 Commit:13
+
+raft-state
+----
+1: StateFollower (Voter) Term:4 Lead:2
+2: StateLeader (Voter) Term:4 Lead:2
+3: StateFollower (Voter) Term:4 Lead:2

--- a/pkg/raft/testdata/prevote.txt
+++ b/pkg/raft/testdata/prevote.txt
@@ -63,6 +63,23 @@ withdraw-support 3 1
 2 1 1 1
 3 x 1 1
 
+# Withdraw support for 1 (the previous leader) before campaigning from both 1
+# and 2; otherwise, 1 and 2 would trivially reject the campaign (because they
+# support a fortified leader) without checking 3's log.
+withdraw-support 2 1
+----
+  1 2 3
+1 1 1 1
+2 x 1 1
+3 x 1 1
+
+withdraw-support 1 1
+----
+  1 2 3
+1 x 1 1
+2 x 1 1
+3 x 1 1
+
 campaign 3
 ----
 INFO 3 is starting a new election at term 1
@@ -80,6 +97,7 @@ Messages:
 3->2 MsgPreVote Term:2 Log:1/11
 INFO 3 received MsgPreVoteResp from 3 at term 1
 INFO 3 has received 1 MsgPreVoteResp votes and 0 vote rejections
+
 
 deliver-msgs 1 2
 ----
@@ -136,12 +154,6 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/12 Commit:11
   3->1 MsgAppResp Term:1 Log:0/12 Commit:12
 
-withdraw-support 2 1
-----
-  1 2 3
-1 1 1 1
-2 x 1 1
-3 x 1 1
 
 # Let 2 campaign. It should succeed, since it's up-to-date on the log.
 campaign 2

--- a/pkg/raft/testdata/prevote_checkquorum.txt
+++ b/pkg/raft/testdata/prevote_checkquorum.txt
@@ -51,10 +51,10 @@ stabilize
   INFO 2 has received 1 MsgPreVoteResp votes and 0 vote rejections
 > 1 receiving messages
   2->1 MsgPreVote Term:2 Log:1/11
-  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 2 [logterm: 1, index: 11] at term 1: lease is not expired (remaining ticks: 3)
+  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 2 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3)
 > 3 receiving messages
   2->3 MsgPreVote Term:2 Log:1/11
-  INFO 3 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 2 [logterm: 1, index: 11] at term 1: lease is not expired (remaining ticks: 3)
+  INFO 3 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 2 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3)
 
 # If 2 hasn't heard from the leader in the past election timeout, it should
 # grant prevotes, allowing 3 to hold an election.
@@ -106,7 +106,7 @@ stabilize
 ----
 > 1 receiving messages
   3->1 MsgPreVote Term:2 Log:1/11
-  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 1, index: 11] at term 1: lease is not expired (remaining ticks: 3)
+  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3)
 > 3 receiving messages
   2->3 MsgPreVoteResp Term:2 Log:0/0
   INFO 3 received MsgPreVoteResp from 2 at term 1
@@ -125,7 +125,7 @@ stabilize
   INFO 3 has received 1 MsgVoteResp votes and 0 vote rejections
 > 1 receiving messages
   3->1 MsgVote Term:2 Log:1/11
-  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 3 [logterm: 1, index: 11] at term 1: lease is not expired (remaining ticks: 3)
+  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 3 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3)
 > 2 receiving messages
   3->2 MsgVote Term:2 Log:1/11
   INFO 2 [term: 1] received a MsgVote message with higher term from 3 [term: 2]
@@ -248,10 +248,10 @@ stabilize
   INFO 1 has received 1 MsgPreVoteResp votes and 0 vote rejections
 > 2 receiving messages
   1->2 MsgPreVote Term:3 Log:2/12
-  INFO 2 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 1 [logterm: 2, index: 12] at term 2: lease is not expired (remaining ticks: 3)
+  INFO 2 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 1 [logterm: 2, index: 12] at term 2: recently received communication from leader (remaining ticks: 3)
 > 3 receiving messages
   1->3 MsgPreVote Term:3 Log:2/12
-  INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 1 [logterm: 2, index: 12] at term 2: lease is not expired (remaining ticks: 3)
+  INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 1 [logterm: 2, index: 12] at term 2: recently received communication from leader (remaining ticks: 3)
 
 withdraw-support 2 3
 ----
@@ -283,7 +283,7 @@ stabilize
   INFO 1 [logterm: 2, index: 12, vote: 0] cast MsgPreVote for 2 [logterm: 2, index: 12] at term 2
 > 3 receiving messages
   2->3 MsgPreVote Term:3 Log:2/12
-  INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 2 [logterm: 2, index: 12] at term 2: lease is not expired (remaining ticks: 3)
+  INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 2 [logterm: 2, index: 12] at term 2: recently received communication from leader (remaining ticks: 3)
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
@@ -311,7 +311,7 @@ stabilize
   INFO 1 [logterm: 2, index: 12, vote: 0] cast MsgVote for 2 [logterm: 2, index: 12] at term 3
 > 3 receiving messages
   2->3 MsgVote Term:3 Log:2/12
-  INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgVote from 2 [logterm: 2, index: 12] at term 2: lease is not expired (remaining ticks: 3)
+  INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgVote from 2 [logterm: 2, index: 12] at term 2: recently received communication from leader (remaining ticks: 3)
 > 1 handling Ready
   Ready MustSync=true:
   State:StateFollower

--- a/pkg/raft/testdata/prevote_checkquorum.txt
+++ b/pkg/raft/testdata/prevote_checkquorum.txt
@@ -51,10 +51,10 @@ stabilize
   INFO 2 has received 1 MsgPreVoteResp votes and 0 vote rejections
 > 1 receiving messages
   2->1 MsgPreVote Term:2 Log:1/11
-  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 2 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3)
+  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 2 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3) and supporting fortified leader 1 at epoch 1
 > 3 receiving messages
   2->3 MsgPreVote Term:2 Log:1/11
-  INFO 3 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 2 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3)
+  INFO 3 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 2 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3) and supporting fortified leader 1 at epoch 1
 
 # If 2 hasn't heard from the leader in the past election timeout, it should
 # grant prevotes, allowing 3 to hold an election.
@@ -106,7 +106,7 @@ stabilize
 ----
 > 1 receiving messages
   3->1 MsgPreVote Term:2 Log:1/11
-  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3)
+  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3) and supporting fortified leader 1 at epoch 1
 > 3 receiving messages
   2->3 MsgPreVoteResp Term:2 Log:0/0
   INFO 3 received MsgPreVoteResp from 2 at term 1
@@ -125,7 +125,7 @@ stabilize
   INFO 3 has received 1 MsgVoteResp votes and 0 vote rejections
 > 1 receiving messages
   3->1 MsgVote Term:2 Log:1/11
-  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 3 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3)
+  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 3 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3) and supporting fortified leader 1 at epoch 1
 > 2 receiving messages
   3->2 MsgVote Term:2 Log:1/11
   INFO 2 [term: 1] received a MsgVote message with higher term from 3 [term: 2]
@@ -248,10 +248,10 @@ stabilize
   INFO 1 has received 1 MsgPreVoteResp votes and 0 vote rejections
 > 2 receiving messages
   1->2 MsgPreVote Term:3 Log:2/12
-  INFO 2 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 1 [logterm: 2, index: 12] at term 2: recently received communication from leader (remaining ticks: 3)
+  INFO 2 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 1 [logterm: 2, index: 12] at term 2: recently received communication from leader (remaining ticks: 3) and supporting fortified leader 3 at epoch 1
 > 3 receiving messages
   1->3 MsgPreVote Term:3 Log:2/12
-  INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 1 [logterm: 2, index: 12] at term 2: recently received communication from leader (remaining ticks: 3)
+  INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 1 [logterm: 2, index: 12] at term 2: recently received communication from leader (remaining ticks: 3) and supporting fortified leader 3 at epoch 1
 
 withdraw-support 2 3
 ----
@@ -283,7 +283,7 @@ stabilize
   INFO 1 [logterm: 2, index: 12, vote: 0] cast MsgPreVote for 2 [logterm: 2, index: 12] at term 2
 > 3 receiving messages
   2->3 MsgPreVote Term:3 Log:2/12
-  INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 2 [logterm: 2, index: 12] at term 2: recently received communication from leader (remaining ticks: 3)
+  INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 2 [logterm: 2, index: 12] at term 2: recently received communication from leader (remaining ticks: 3) and supporting fortified leader 3 at epoch 1
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
@@ -311,7 +311,7 @@ stabilize
   INFO 1 [logterm: 2, index: 12, vote: 0] cast MsgVote for 2 [logterm: 2, index: 12] at term 3
 > 3 receiving messages
   2->3 MsgVote Term:3 Log:2/12
-  INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgVote from 2 [logterm: 2, index: 12] at term 2: recently received communication from leader (remaining ticks: 3)
+  INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgVote from 2 [logterm: 2, index: 12] at term 2: recently received communication from leader (remaining ticks: 3) and supporting fortified leader 3 at epoch 1
 > 1 handling Ready
   Ready MustSync=true:
   State:StateFollower

--- a/pkg/raft/testdata/probe_and_replicate.txt
+++ b/pkg/raft/testdata/probe_and_replicate.txt
@@ -140,6 +140,10 @@ deliver-msgs drop=(1,2,3,4,5,6,7)
 ----
 ok
 
+bump-epoch 7
+----
+ok
+
 ## Create term 4 entries.
 campaign 6
 ----
@@ -374,13 +378,13 @@ raft-log 7
 bump-epoch 5
 ----
   1 2 3 4 5 6 7
-1 2 2 1 2 3 2 1
-2 2 2 1 2 3 2 1
-3 2 2 1 2 3 2 1
-4 2 2 1 2 3 2 1
-5 2 2 1 2 3 2 1
-6 2 2 1 2 3 2 1
-7 2 2 1 2 3 2 1
+1 2 2 1 2 3 2 2
+2 2 2 1 2 3 2 2
+3 2 2 1 2 3 2 2
+4 2 2 1 2 3 2 2
+5 2 2 1 2 3 2 2
+6 2 2 1 2 3 2 2
+7 2 2 1 2 3 2 2
 
 # Elect node 1 as leader and stabilize.
 campaign 1


### PR DESCRIPTION
Raft peers that have promised fortification support to the leader and still support the leader in StoreLiveness should not grant votes or pre-votes to peers calling elections.

Closes https://github.com/cockroachdb/cockroach/issues/125351

Release note: None