### PR TITLE
crosscluster: redact url for LDR jobs

### DIFF
--- a/pkg/ccl/crosscluster/logical/BUILD.bazel
+++ b/pkg/ccl/crosscluster/logical/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/ccl/crosscluster/physical",
         "//pkg/ccl/crosscluster/streamclient",
         "//pkg/ccl/utilccl",
+        "//pkg/cloud",
         "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",

--- a/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/crosscluster"
 	"github.com/cockroachdb/cockroach/pkg/ccl/crosscluster/streamclient"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -195,6 +196,11 @@ func createLogicalReplicationStreamPlanHook(
 		}
 		streamAddress = crosscluster.StreamAddress(streamURL.String())
 
+		cleanedURI, err := cloud.SanitizeExternalStorageURI(from, nil)
+		if err != nil {
+			return err
+		}
+
 		client, err := streamclient.NewStreamClient(ctx, streamAddress, p.ExecCfg().InternalDB, streamclient.WithLogical())
 		if err != nil {
 			return err
@@ -240,7 +246,7 @@ func createLogicalReplicationStreamPlanHook(
 
 		jr := jobs.Record{
 			JobID:       p.ExecCfg().JobRegistry.MakeJobID(),
-			Description: fmt.Sprintf("LOGICAL REPLICATION STREAM into %s from %s", targetsDescription, streamAddress),
+			Description: fmt.Sprintf("LOGICAL REPLICATION STREAM into %s from %s", targetsDescription, cleanedURI),
 			Username:    p.User(),
 			Details: jobspb.LogicalReplicationDetails{
 				StreamID:                  uint64(spec.StreamID),

--- a/pkg/sql/delegate/show_logical_replication_jobs.go
+++ b/pkg/sql/delegate/show_logical_replication_jobs.go
@@ -39,8 +39,10 @@ WHERE job_type = 'LOGICAL REPLICATION'
 		payload)->'logicalReplicationDetails'->'replicationStartTime'->>'wallTime')::DECIMAL) AS replication_start_time,
 	IFNULL(crdb_internal.pb_to_json(
 		'cockroach.sql.jobs.jobspb.Payload',
-		payload)->'logicalReplicationDetails'->'defaultConflictResolution'->>'conflictResolutionType', 'LWW') AS conflict_resolution_type
-`
+		payload)->'logicalReplicationDetails'->'defaultConflictResolution'->>'conflictResolutionType', 'LWW') AS conflict_resolution_type,
+	crdb_internal.pb_to_json(
+		'cockroach.sql.jobs.jobspb.Payload',
+		payload)->>'description' AS description`
 )
 
 func (d *delegator) delegateShowLogicalReplicationJobs(


### PR DESCRIPTION
Redact sensitive information from URLs in job descriptions. This PR also adds a `description` column with redacted URLs to rows returned by `SHOW LOGICAL REPLICATION JOBS WITH DETAILS`

Example output of updated `SHOW LOGICAL REPLICATION JOBS WITH DETAILS` command:
```
demo@127.0.0.1:26257/demoapp/b> SHOW LOGICAL REPLICATION JOBS WITH DETAILS;
        job_id       | status  | targets | replicated_time |    replication_start_time     | conflict_resolution_type |                                                                                           description
---------------------+---------+---------+-----------------+-------------------------------+--------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  998275879939801089 | running | {tab1}  | NULL            | 2024-08-27 00:53:41.560452+00 | DLQ                      | LOGICAL REPLICATION STREAM into a.public.tab1 from postgresql://redacted@127.0.0.1:26257/b?options=-ccluster%3Ddemoapp&sslmode=require&sslrootcert=%2FUsers%2Fannezhu%2F.cockroach-demo%2Fca.crt
  998275879987052545 | running | {tab1}  | NULL            | 2024-08-27 00:53:41.575131+00 | LWW                      | LOGICAL REPLICATION STREAM into b.public.tab1 from postgresql://redacted@127.0.0.1:26257/a?options=-ccluster%3Ddemoapp&sslmode=require&sslrootcert=%2FUsers%2Fannezhu%2F.cockroach-demo%2Fca.crt
(2 rows)

Time: 13ms total (execution 12ms / network 0ms)
```

Epic: none
Informs: https://github.com/cockroachdb/cockroach/issues/128960
Release note: none