### PR TITLE
kv/gc: fix re-use of clearRangeEndKey

### DIFF
--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -171,6 +171,7 @@ func TestRunNewVsOld(t *testing.T) {
 // BenchmarkRun benchmarks the old and implementations of Run with different
 // data distributions.
 func BenchmarkRun(b *testing.B) {
+	defer log.Scope(b).Close(b)
 	ctx := context.Background()
 	runGC := func(eng storage.Engine, old bool, spec randomRunGCTestSpec) (Info, error) {
 		runGCFunc := Run

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -2299,7 +2299,7 @@ func TestGcKeyBatcher(t *testing.T) {
 				gcer:             &g,
 				info:             &Info{},
 				pointsBatches:    make([]pointsBatch, 1),
-				clearRangeEndKey: keys.MaxKey,
+				clearRangeEndKey: keys.MaxKey.Clone(),
 				prevWasNewest:    true,
 			}
 

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -20,6 +20,7 @@ import (
 	"hash/crc32"
 	"math"
 	"math/rand"
+	"slices"
 	"sort"
 	"strconv"
 	"sync"
@@ -181,7 +182,15 @@ func (k Key) Clone() Key {
 // take a shallow copy of the Key, so both the receiver and the return
 // value should be treated as immutable after.
 func (k Key) Next() Key {
-	return Key(encoding.BytesNext(k))
+	return encoding.BytesNext(k)
+}
+
+// ClonedNext is like Next, but is guaranteed to return a deep copy of the Key.
+//
+// The method is more efficient than calling Clone().Next() or Next().Clone()
+// because it will never re-allocate the key's underlying byte slice twice.
+func (k Key) ClonedNext() Key {
+	return slices.Clip(k).Next()
 }
 
 // Prevish returns a previous key in lexicographic sort order. It is impossible
@@ -196,7 +205,7 @@ func (k Key) Next() Key {
 // The method may only take a shallow copy of the Key, so both the receiver and
 // the return value should be treated as immutable after.
 func (k Key) Prevish(length int) Key {
-	return Key(encoding.BytesPrevish(k, length))
+	return encoding.BytesPrevish(k, length)
 }
 
 // IsPrev is a more efficient version of k.Next().Equal(m).
@@ -210,7 +219,7 @@ func (k Key) IsPrev(m Key) bool {
 // is added to the final byte and the carry propagated. The special
 // cases of nil and KeyMin always returns KeyMax.
 func (k Key) PrefixEnd() Key {
-	return Key(keysbase.PrefixEnd(k))
+	return keysbase.PrefixEnd(k)
 }
 
 // Equal returns whether two keys are identical.

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -7108,7 +7108,7 @@ func mvccMinSplitKey(it MVCCIterator, startKey roachpb.Key) (roachpb.Key, error)
 	if minSplitKey == nil {
 		// The first key in the range does not represent a row in a SQL table.
 		// Allow a split at any key that sorts after it.
-		minSplitKey = it.UnsafeKey().Key.Clone().Next()
+		minSplitKey = it.UnsafeKey().Key.ClonedNext()
 	}
 	return minSplitKey, nil
 }


### PR DESCRIPTION
In a customer workload that performs transactions containing 2 INSERTs and 4 UPDATEs (i.e. creates lots of garbage), we saw that **9.49%** of all heap allocations were in the MVCC GC queue:
```
      File: cockroach
Type: alloc_objects
Time: Aug 26, 2024 at 11:25pm (UTC)
Showing nodes accounting for 14767325388, 100% of 14767325388 total
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context
----------------------------------------------------------+-------------
                                        1401222694   100% |   github.com/cockroachdb/cockroach/pkg/kv/kvserver/gc.processReplicatedKeyRange.func1 github.com/cockroachdb/cockroach/pkg/kv/kvserver/gc/gc.go:515
1401222694  9.49%  9.49% 1401222694  9.49%                | github.com/cockroachdb/cockroach/pkg/kv/kvserver/gc.(*gcKeyBatcher).foundNonGCableData github.com/cockroachdb/cockroach/pkg/kv/kvserver/gc/gc.go:773
----------------------------------------------------------+-------------
```

This was due to the fact that the `clearRangeEndKey` slice was not being correctly re-used, so it was being re-allocated on every live MVCC version.

This commit fixes this logic so that we properly re-use the slice. The effect can be seen in microbenchmarks:
```
name                                                                                                                                                                  old time/op    new time/op    delta
Run/old=false/ts=[1,100],keySuffix=[2,6],valueLen=[1,1],versionsPerKey=[1,2],deleteFrac=0.000000,intentFrac=0.100000,oldIntentFrac=0.000000,rangeFrac=0.000000#03-10     314ns ± 2%     296ns ± 2%    -5.56%  (p=0.000 n=10+10)
Run/old=false/ts=[1,100],keySuffix=[2,6],valueLen=[1,1],versionsPerKey=[1,2],deleteFrac=0.000000,intentFrac=0.100000,oldIntentFrac=0.000000,rangeFrac=0.000000-10        319ns ± 4%     304ns ± 3%    -4.79%  (p=0.000 n=9+10)
Run/old=false/ts=[1,100],keySuffix=[2,6],valueLen=[1,1],versionsPerKey=[1,2],deleteFrac=0.000000,intentFrac=0.100000,oldIntentFrac=0.000000,rangeFrac=0.000000#01-10     316ns ± 3%     301ns ± 3%    -4.71%  (p=0.000 n=10+10)
Run/old=false/ts=[1,100],keySuffix=[2,6],valueLen=[1,1],versionsPerKey=[1,2],deleteFrac=0.000000,intentFrac=0.100000,oldIntentFrac=0.000000,rangeFrac=0.000000#04-10     310ns ± 4%     297ns ± 6%    -4.01%  (p=0.009 n=10+10)
Run/old=false/ts=[1,100],keySuffix=[2,6],valueLen=[1,1],versionsPerKey=[1,2],deleteFrac=0.000000,intentFrac=0.100000,oldIntentFrac=0.000000,rangeFrac=0.000000#02-10     312ns ± 2%     300ns ± 4%    -3.79%  (p=0.001 n=9+10)

name                                                                                                                                                                  old speed      new speed      delta
Run/old=false/ts=[1,100],keySuffix=[2,6],valueLen=[1,1],versionsPerKey=[1,2],deleteFrac=0.000000,intentFrac=0.100000,oldIntentFrac=0.000000,rangeFrac=0.000000#03-10  89.3MB/s ± 2%  94.5MB/s ± 2%    +5.88%  (p=0.000 n=10+10)
Run/old=false/ts=[1,100],keySuffix=[2,6],valueLen=[1,1],versionsPerKey=[1,2],deleteFrac=0.000000,intentFrac=0.100000,oldIntentFrac=0.000000,rangeFrac=0.000000-10     87.7MB/s ± 4%  92.1MB/s ± 3%    +5.02%  (p=0.000 n=9+10)
Run/old=false/ts=[1,100],keySuffix=[2,6],valueLen=[1,1],versionsPerKey=[1,2],deleteFrac=0.000000,intentFrac=0.100000,oldIntentFrac=0.000000,rangeFrac=0.000000#01-10  88.6MB/s ± 3%  93.0MB/s ± 3%    +4.95%  (p=0.000 n=10+10)
Run/old=false/ts=[1,100],keySuffix=[2,6],valueLen=[1,1],versionsPerKey=[1,2],deleteFrac=0.000000,intentFrac=0.100000,oldIntentFrac=0.000000,rangeFrac=0.000000#04-10  90.5MB/s ± 3%  94.3MB/s ± 6%    +4.25%  (p=0.009 n=10+10)
Run/old=false/ts=[1,100],keySuffix=[2,6],valueLen=[1,1],versionsPerKey=[1,2],deleteFrac=0.000000,intentFrac=0.100000,oldIntentFrac=0.000000,rangeFrac=0.000000#02-10  89.7MB/s ± 2%  93.3MB/s ± 4%    +3.96%  (p=0.001 n=9+10)

name                                                                                                                                                                  old alloc/op   new alloc/op   delta
Run/old=false/ts=[1,100],keySuffix=[2,6],valueLen=[1,1],versionsPerKey=[1,2],deleteFrac=0.000000,intentFrac=0.100000,oldIntentFrac=0.000000,rangeFrac=0.000000#03-10     28.0B ± 0%     19.0B ± 0%   -32.14%  (p=0.001 n=8+9)
Run/old=false/ts=[1,100],keySuffix=[2,6],valueLen=[1,1],versionsPerKey=[1,2],deleteFrac=0.000000,intentFrac=0.100000,oldIntentFrac=0.000000,rangeFrac=0.000000#04-10     28.2B ±35%     20.2B ±49%   -28.37%  (p=0.026 n=10+10)
Run/old=false/ts=[1,100],keySuffix=[2,6],valueLen=[1,1],versionsPerKey=[1,2],deleteFrac=0.000000,intentFrac=0.100000,oldIntentFrac=0.000000,rangeFrac=0.000000#02-10     40.0B ± 0%     31.6B ± 2%   -20.94%  (p=0.000 n=8+8)
Run/old=false/ts=[1,100],keySuffix=[2,6],valueLen=[1,1],versionsPerKey=[1,2],deleteFrac=0.000000,intentFrac=0.100000,oldIntentFrac=0.000000,rangeFrac=0.000000-10        93.2B ±11%     85.1B ±12%    -8.69%  (p=0.024 n=10+10)
Run/old=false/ts=[1,100],keySuffix=[2,6],valueLen=[1,1],versionsPerKey=[1,2],deleteFrac=0.000000,intentFrac=0.100000,oldIntentFrac=0.000000,rangeFrac=0.000000#01-10     60.0B ± 0%     56.2B ±17%      ~     (p=0.092 n=9+10)

name                                                                                                                                                                  old allocs/op  new allocs/op  delta
Run/old=false/ts=[1,100],keySuffix=[2,6],valueLen=[1,1],versionsPerKey=[1,2],deleteFrac=0.000000,intentFrac=0.100000,oldIntentFrac=0.000000,rangeFrac=0.000000-10         1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Run/old=false/ts=[1,100],keySuffix=[2,6],valueLen=[1,1],versionsPerKey=[1,2],deleteFrac=0.000000,intentFrac=0.100000,oldIntentFrac=0.000000,rangeFrac=0.000000#01-10      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Run/old=false/ts=[1,100],keySuffix=[2,6],valueLen=[1,1],versionsPerKey=[1,2],deleteFrac=0.000000,intentFrac=0.100000,oldIntentFrac=0.000000,rangeFrac=0.000000#02-10      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Run/old=false/ts=[1,100],keySuffix=[2,6],valueLen=[1,1],versionsPerKey=[1,2],deleteFrac=0.000000,intentFrac=0.100000,oldIntentFrac=0.000000,rangeFrac=0.000000#03-10      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Run/old=false/ts=[1,100],keySuffix=[2,6],valueLen=[1,1],versionsPerKey=[1,2],deleteFrac=0.000000,intentFrac=0.100000,oldIntentFrac=0.000000,rangeFrac=0.000000#04-10      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
```

Epic: None
Release note: None