### PR TITLE
sqlccl: use sqlutils.IsError instead of errors.Is for TestExplainGist

### DIFF
--- a/pkg/ccl/testccl/sqlccl/BUILD.bazel
+++ b/pkg/ccl/testccl/sqlccl/BUILD.bazel
@@ -39,7 +39,6 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/spanconfig",
         "//pkg/sql",
-        "//pkg/sql/catalog",
         "//pkg/sql/gcjob",
         "//pkg/sql/isql",
         "//pkg/sql/lexbase",

--- a/pkg/ccl/testccl/sqlccl/explain_test.go
+++ b/pkg/ccl/testccl/sqlccl/explain_test.go
@@ -16,10 +16,10 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -253,7 +253,7 @@ func TestExplainGist(t *testing.T) {
 			if err != nil {
 				// We might be still in the process of cancelling the previous
 				// DROP operation - ignore this particular error.
-				if !errors.Is(err, catalog.ErrDescriptorDropped) {
+				if !testutils.IsError(err, "descriptor is being dropped") {
 					t.Fatal(err)
 				}
 				continue


### PR DESCRIPTION
TestExplainGist ignores an uninformative `descriptor is being dropped` error. This commit changes the check for that error to use `sqlutils.IsError` instead of `errors.Is`, since `errors.Is` occasionally doesn't catch the error, for some reason.

Fixes #129445

Release note: None