### PR TITLE
workflow: increase test timeout in cockroach microbench ci

### DIFF
--- a/build/github/cockroach-microbench-ci.sh
+++ b/build/github/cockroach-microbench-ci.sh
@@ -33,7 +33,7 @@ mkdir -p "$output_dir"
 # Run benchmarks and clean output
 # running count=4 here because that's the minimum required for a comparison
 bazel test //pkg/sql/tests:tests_test \
-  --config=use_ci_timeouts \
+  --test_timeout=1800 \
   --strategy=TestRunner=sandboxed \
   --jobs 100 \
   --config=crosslinux \


### PR DESCRIPTION
The step started timing out after
https://github.com/cockroachdb/cockroach/pull/129390 because test.count was increased to 10 and the timeout used was 900 seconds. This change bumps it to 1800 seconds (i.e. 30 min)

Epic: none

Release note: None