### PR TITLE
kvserver,rac2: add and plumb RaftEvent

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -147,6 +147,7 @@ go_library(
         "//pkg/kv/kvserver/kvflowcontrol/kvflowdispatch",
         "//pkg/kv/kvserver/kvflowcontrol/kvflowhandle",
         "//pkg/kv/kvserver/kvflowcontrol/node_rac2",
+        "//pkg/kv/kvserver/kvflowcontrol/rac2",
         "//pkg/kv/kvserver/kvflowcontrol/replica_rac2",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/kvserverpb",

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -338,28 +338,27 @@ type Processor interface {
 	// if there was no Ready, since it can be used to advance Admitted, and do
 	// other processing.
 	//
-	// The entries slice is Ready.Entries, i.e., represent MsgStorageAppend on
-	// all replicas. To stay consistent with the structure of
-	// Replica.handleRaftReadyRaftMuLocked, this method only does leader
-	// specific processing of entries.
-	// AdmitRaftEntriesFromMsgStorageAppendRaftMuLocked does the general
-	// replica processing for MsgStorageAppend.
+	// The RaftEvent represents MsgStorageAppend on all replicas. To stay
+	// consistent with the structure of Replica.handleRaftReadyRaftMuLocked, this
+	// method only does leader specific processing of entries.
+	// AdmitRaftEntriesFromMsgStorageAppendRaftMuLocked does the general replica
+	// processing for MsgStorageAppend.
 	//
 	// raftMu is held.
-	HandleRaftReadyRaftMuLocked(ctx context.Context, entries []raftpb.Entry)
-	// AdmitRaftEntriesFromMsgStorageAppendRaftMuLocked subjects entries to
-	// admission control on a replica (leader or follower). Like
-	// HandleRaftReadyRaftMuLocked, this is called from
-	// Replica.handleRaftReadyRaftMuLocked. It is split off from that function
-	// since it is natural to position the admission control processing when we
-	// are writing to the store in Replica.handleRaftReadyRaftMuLocked. This is
-	// a noop if the leader is not using the RACv2 protocol. Returns false if
-	// the leader is using RACv1, in which the caller should follow the RACv1
-	// admission pathway.
+	HandleRaftReadyRaftMuLocked(context.Context, rac2.RaftEvent)
+	// AdmitRaftEntriesRaftMuLocked subjects entries to admission control on a
+	// replica (leader or follower). Like HandleRaftReadyRaftMuLocked, this is
+	// called from Replica.handleRaftReadyRaftMuLocked.
+	//
+	// It is split off from that function since it is natural to position the
+	// admission control processing when we are writing to the store in
+	// Replica.handleRaftReadyRaftMuLocked. This is a noop if the leader is not
+	// using the RACv2 protocol. Returns false if the leader is using RACv1, in
+	// which the caller should follow the RACv1 admission pathway.
 	//
 	// raftMu is held.
-	AdmitRaftEntriesFromMsgStorageAppendRaftMuLocked(
-		ctx context.Context, leaderTerm uint64, entries []raftpb.Entry) bool
+	AdmitRaftEntriesRaftMuLocked(
+		ctx context.Context, event rac2.RaftEvent) bool
 
 	// EnqueuePiggybackedAdmittedAtLeader is called at the leader when
 	// receiving a piggybacked MsgAppResp that can advance a follower's
@@ -668,7 +667,7 @@ func (p *processorImpl) createLeaderStateRaftMuLockedProcLocked(
 }
 
 // HandleRaftReadyRaftMuLocked implements Processor.
-func (p *processorImpl) HandleRaftReadyRaftMuLocked(ctx context.Context, entries []raftpb.Entry) {
+func (p *processorImpl) HandleRaftReadyRaftMuLocked(ctx context.Context, e rac2.RaftEvent) {
 	p.opts.Replica.RaftMuAssertHeld()
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -677,7 +676,7 @@ func (p *processorImpl) HandleRaftReadyRaftMuLocked(ctx context.Context, entries
 	}
 	if p.raftMu.raftNode == nil {
 		if buildutil.CrdbTestBuild {
-			if len(entries) > 0 {
+			if len(e.Entries) > 0 {
 				panic(errors.AssertionFailedf("entries provided without raft node"))
 			}
 		}
@@ -704,8 +703,8 @@ func (p *processorImpl) HandleRaftReadyRaftMuLocked(ctx context.Context, entries
 			myLeaderTerm = p.raftMu.raftNode.TermLocked()
 		}
 	}()
-	if len(entries) > 0 {
-		nextUnstableIndex = entries[0].Index
+	if len(e.Entries) > 0 {
+		nextUnstableIndex = e.Entries[0].Index
 	}
 	p.mu.lastObservedStableIndex = stableIndex
 	p.mu.scheduledAdmittedProcessing = false
@@ -734,18 +733,14 @@ func (p *processorImpl) HandleRaftReadyRaftMuLocked(ctx context.Context, entries
 		// known, we simply drop the message.
 	}
 	if p.mu.leader.rc != nil {
-		if err := p.mu.leader.rc.HandleRaftEventRaftMuLocked(ctx, rac2.RaftEvent{
-			Entries: entries,
-		}); err != nil {
+		if err := p.mu.leader.rc.HandleRaftEventRaftMuLocked(ctx, e); err != nil {
 			log.Errorf(ctx, "error handling raft event: %v", err)
 		}
 	}
 }
 
-// AdmitRaftEntriesFromMsgStorageAppendRaftMuLocked implements Processor.
-func (p *processorImpl) AdmitRaftEntriesFromMsgStorageAppendRaftMuLocked(
-	ctx context.Context, leaderTerm uint64, entries []raftpb.Entry,
-) bool {
+// AdmitRaftEntriesRaftMuLocked implements Processor.
+func (p *processorImpl) AdmitRaftEntriesRaftMuLocked(ctx context.Context, e rac2.RaftEvent) bool {
 	// NB: the state being read here is only modified under raftMu, so it will
 	// not become stale during this method.
 	var isLeaderUsingV2Protocol bool
@@ -758,7 +753,7 @@ func (p *processorImpl) AdmitRaftEntriesFromMsgStorageAppendRaftMuLocked(
 	if !isLeaderUsingV2Protocol {
 		return false
 	}
-	for _, entry := range entries {
+	for _, entry := range e.Entries {
 		typ, priBits, err := raftlog.EncodingOf(entry)
 		if err != nil {
 			panic(errors.Wrap(err, "unable to determine raft command encoding"))
@@ -782,7 +777,7 @@ func (p *processorImpl) AdmitRaftEntriesFromMsgStorageAppendRaftMuLocked(
 				p.mu.Lock()
 				defer p.mu.Unlock()
 				raftPri = p.mu.follower.lowPriOverrideState.getEffectivePriority(entry.Index, raftPri)
-				p.mu.waitingForAdmissionState.add(leaderTerm, entry.Index, raftPri)
+				p.mu.waitingForAdmissionState.add(e.Term, entry.Index, raftPri)
 			}()
 		} else {
 			raftPri = raftpb.LowPri
@@ -795,7 +790,7 @@ func (p *processorImpl) AdmitRaftEntriesFromMsgStorageAppendRaftMuLocked(
 			func() {
 				p.mu.Lock()
 				defer p.mu.Unlock()
-				p.mu.waitingForAdmissionState.add(leaderTerm, entry.Index, raftPri)
+				p.mu.waitingForAdmissionState.add(e.Term, entry.Index, raftPri)
 			}()
 		}
 		admissionPri := rac2.RaftToAdmissionPriority(raftPri)
@@ -811,7 +806,7 @@ func (p *processorImpl) AdmitRaftEntriesFromMsgStorageAppendRaftMuLocked(
 				StoreID:    p.opts.StoreID,
 				RangeID:    p.opts.RangeID,
 				ReplicaID:  p.opts.ReplicaID,
-				LeaderTerm: leaderTerm,
+				LeaderTerm: e.Term,
 				Index:      entry.Index,
 				Priority:   raftPri,
 			},
@@ -821,7 +816,7 @@ func (p *processorImpl) AdmitRaftEntriesFromMsgStorageAppendRaftMuLocked(
 			func() {
 				p.mu.Lock()
 				defer p.mu.Unlock()
-				p.mu.waitingForAdmissionState.remove(leaderTerm, entry.Index, raftPri)
+				p.mu.waitingForAdmissionState.remove(e.Term, entry.Index, raftPri)
 			}()
 		}
 	}

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -350,20 +350,21 @@ func TestProcessorBasic(t *testing.T) {
 				return builderStr()
 
 			case "handle-raft-ready-and-admit":
-				var entries []raftpb.Entry
+				var event rac2.RaftEvent
 				if d.HasArg("entries") {
 					var arg string
 					d.ScanArgs(t, "entries", &arg)
-					entries = createEntries(t, parseEntryInfos(t, arg))
+					event.Entries = createEntries(t, parseEntryInfos(t, arg))
+				}
+				if len(event.Entries) > 0 {
+					d.ScanArgs(t, "leader-term", &event.Term)
 				}
 				fmt.Fprintf(&b, "HandleRaftReady:\n")
-				p.HandleRaftReadyRaftMuLocked(ctx, entries)
+				p.HandleRaftReadyRaftMuLocked(ctx, event)
 				fmt.Fprintf(&b, ".....\n")
-				if len(entries) > 0 {
-					var leaderTerm uint64
-					d.ScanArgs(t, "leader-term", &leaderTerm)
+				if len(event.Entries) > 0 {
 					fmt.Fprintf(&b, "AdmitRaftEntries:\n")
-					isV2 := p.AdmitRaftEntriesFromMsgStorageAppendRaftMuLocked(ctx, leaderTerm, entries)
+					isV2 := p.AdmitRaftEntriesRaftMuLocked(ctx, event)
 					fmt.Fprintf(&b, "leader-using-v2: %t\n", isV2)
 				}
 				return builderStr()


### PR DESCRIPTION
This change updates the `RaftEvent` structure to reflect the semantics of a raft storage write, and plumbs it into RACv2 code in a few places.

Part of #128019