### PR TITLE
sql: support SECURITY DEFINER for routines

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
@@ -2721,3 +2721,14 @@ CREATE FUNCTION f(y ANYELEMENT) RETURNS ANYELEMENT AS $$
 $$ LANGUAGE PLpgSQL;
 
 subtest end
+
+subtest security_definer
+
+statement error pgcode 0A000 unimplemented: attempted to use a PL/pgSQL statement that is not yet supported
+CREATE FUNCTION create_secret_role() RETURNS VOID SECURITY DEFINER AS $$
+    BEGIN
+        EXECUTE 'CREATE ROLE secret_role';
+    END;
+$$ LANGUAGE plpgsql;
+
+subtest end

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2388,6 +2388,13 @@ func TestTenantLogic_udf_schema_change(
 	runLogicTest(t, "udf_schema_change")
 }
 
+func TestTenantLogic_udf_security(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_security")
+}
+
 func TestTenantLogic_udf_setof(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -2372,6 +2372,13 @@ func TestReadCommittedLogic_udf_schema_change(
 	runLogicTest(t, "udf_schema_change")
 }
 
+func TestReadCommittedLogic_udf_security(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_security")
+}
+
 func TestReadCommittedLogic_udf_setof(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
@@ -2365,6 +2365,13 @@ func TestRepeatableReadLogic_udf_schema_change(
 	runLogicTest(t, "udf_schema_change")
 }
 
+func TestRepeatableReadLogic_udf_security(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_security")
+}
+
 func TestRepeatableReadLogic_udf_setof(
 	t *testing.T,
 ) {

--- a/pkg/sql/catalog/funcdesc/func_desc.go
+++ b/pkg/sql/catalog/funcdesc/func_desc.go
@@ -831,6 +831,7 @@ func (desc *immutable) ToOverload() (ret *tree.Overload, err error) {
 	if desc.ReturnType.ReturnSet {
 		ret.Class = tree.GeneratorClass
 	}
+	ret.SecurityMode = desc.getCreateExprSecurity()
 
 	return ret, nil
 }

--- a/pkg/sql/delegate/show_all_cluster_settings.go
+++ b/pkg/sql/delegate/show_all_cluster_settings.go
@@ -22,7 +22,10 @@ func (d *delegator) delegateShowClusterSettingList(
 	hasModify := false
 	hasSqlModify := false
 	hasView := false
-	if err := d.catalog.CheckPrivilege(d.ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.MODIFYCLUSTERSETTING); err == nil {
+	cat := d.catalog
+	globalPrivObj := syntheticprivilege.GlobalPrivilegeObject
+	user := cat.GetCurrentUser()
+	if err := cat.CheckPrivilege(d.ctx, globalPrivObj, user, privilege.MODIFYCLUSTERSETTING); err == nil {
 		hasModify = true
 		hasSqlModify = true
 		hasView = true
@@ -30,7 +33,7 @@ func (d *delegator) delegateShowClusterSettingList(
 		return nil, err
 	}
 	if !hasSqlModify {
-		if err := d.catalog.CheckPrivilege(d.ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.MODIFYSQLCLUSTERSETTING); err == nil {
+		if err := cat.CheckPrivilege(d.ctx, globalPrivObj, user, privilege.MODIFYSQLCLUSTERSETTING); err == nil {
 			hasSqlModify = true
 			hasView = true
 		} else if pgerror.GetPGCode(err) != pgcode.InsufficientPrivilege {
@@ -38,7 +41,7 @@ func (d *delegator) delegateShowClusterSettingList(
 		}
 	}
 	if !hasView {
-		if err := d.catalog.CheckPrivilege(d.ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.VIEWCLUSTERSETTING); err == nil {
+		if err := cat.CheckPrivilege(d.ctx, globalPrivObj, user, privilege.VIEWCLUSTERSETTING); err == nil {
 			hasView = true
 		} else if pgerror.GetPGCode(err) != pgcode.InsufficientPrivilege {
 			return nil, err
@@ -47,7 +50,7 @@ func (d *delegator) delegateShowClusterSettingList(
 
 	// Fallback to role option if the user doesn't have the privilege.
 	if !hasModify {
-		ok, err := d.catalog.HasRoleOption(d.ctx, roleoption.MODIFYCLUSTERSETTING)
+		ok, err := cat.HasRoleOption(d.ctx, roleoption.MODIFYCLUSTERSETTING)
 		if err != nil {
 			return nil, err
 		}
@@ -56,7 +59,7 @@ func (d *delegator) delegateShowClusterSettingList(
 	}
 
 	if !hasView {
-		ok, err := d.catalog.HasRoleOption(d.ctx, roleoption.VIEWCLUSTERSETTING)
+		ok, err := cat.HasRoleOption(d.ctx, roleoption.VIEWCLUSTERSETTING)
 		if err != nil {
 			return nil, err
 		}
@@ -90,7 +93,7 @@ func (d *delegator) delegateShowTenantClusterSettingList(
 	// privileged operation than viewing local cluster settings. So we
 	// shouldn't be allowing with just the role option
 	// VIEWCLUSTERSETTINGS.
-	if err := d.catalog.CheckPrivilege(d.ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.VIEWCLUSTERMETADATA); err != nil {
+	if err := d.catalog.CheckPrivilege(d.ctx, syntheticprivilege.GlobalPrivilegeObject, d.catalog.GetCurrentUser(), privilege.VIEWCLUSTERMETADATA); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/delegate/show_default_session_variables_for_role.go
+++ b/pkg/sql/delegate/show_default_session_variables_for_role.go
@@ -15,7 +15,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
 )
 
-// delegateShowDefaultSessionVariablesForRole implements SHOW DEFAULT SESSION VARIABLES FOR ROLE <name> which returns all the default session variables for a user.
+// delegateShowDefaultSessionVariablesForRole implements SHOW DEFAULT SESSION VARIABLES FOR ROLE <name> which returns all the default session variables for a
+// user.
 // for the given role.
 // Privileges: None.
 func (d *delegator) delegateShowDefaultSessionVariablesForRole(
@@ -24,20 +25,23 @@ func (d *delegator) delegateShowDefaultSessionVariablesForRole(
 
 	// Check if user has at least one of CREATEROLE, MODIFYCLUSTERSETTING, or MODIFYSQLCLUSTERSETTING privileges
 	hasPrivilege := false
-	if err := d.catalog.CheckPrivilege(d.ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.CREATEROLE); err == nil {
+	cat := d.catalog
+	globalPrivObj := syntheticprivilege.GlobalPrivilegeObject
+	user := cat.GetCurrentUser()
+	if err := cat.CheckPrivilege(d.ctx, globalPrivObj, user, privilege.CREATEROLE); err == nil {
 		hasPrivilege = true
 	} else if pgerror.GetPGCode(err) != pgcode.InsufficientPrivilege {
 		return nil, err
 	}
 	if !hasPrivilege {
-		if err := d.catalog.CheckPrivilege(d.ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.MODIFYCLUSTERSETTING); err == nil {
+		if err := cat.CheckPrivilege(d.ctx, globalPrivObj, user, privilege.MODIFYCLUSTERSETTING); err == nil {
 			hasPrivilege = true
 		} else if pgerror.GetPGCode(err) != pgcode.InsufficientPrivilege {
 			return nil, err
 		}
 	}
 	if !hasPrivilege {
-		if err := d.catalog.CheckPrivilege(d.ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.MODIFYSQLCLUSTERSETTING); err == nil {
+		if err := cat.CheckPrivilege(d.ctx, globalPrivObj, user, privilege.MODIFYSQLCLUSTERSETTING); err == nil {
 			hasPrivilege = true
 		} else if pgerror.GetPGCode(err) != pgcode.InsufficientPrivilege {
 			return nil, err

--- a/pkg/sql/delegate/show_range_for_row.go
+++ b/pkg/sql/delegate/show_range_for_row.go
@@ -23,7 +23,7 @@ func (d *delegator) delegateShowRangeForRow(n *tree.ShowRangeForRow) (tree.State
 		return nil, err
 	}
 	// Basic requirement is SELECT privileges
-	if err = d.catalog.CheckPrivilege(d.ctx, idx.Table(), privilege.SELECT); err != nil {
+	if err = d.catalog.CheckPrivilege(d.ctx, idx.Table(), d.catalog.GetCurrentUser(), privilege.SELECT); err != nil {
 		return nil, err
 	}
 	if idx.Table().IsVirtualTable() {

--- a/pkg/sql/drop_function.go
+++ b/pkg/sql/drop_function.go
@@ -186,7 +186,7 @@ func (p *planner) canDropFunction(ctx context.Context, fnDesc catalog.FunctionDe
 		return err
 	}
 	if !hasOwernship {
-		return errors.Errorf("must be owner of function %s", fnDesc.GetName())
+		return pgerror.Newf(pgcode.InsufficientPrivilege, "must be owner of function %s", fnDesc.GetName())
 	}
 	return nil
 }

--- a/pkg/sql/logictest/testdata/logic_test/drop_function
+++ b/pkg/sql/logictest/testdata/logic_test/drop_function
@@ -325,6 +325,17 @@ DROP FUNCTION f_called_by_b2;
 DROP TABLE t1_with_b_2_ref;
 
 statement ok
+SET ROLE testuser;
+
+# Check to ensure ownership is validated properly during a drop. This is a
+# regression test to ensure we populate a proper pgcode for our error.
+statement error pgcode 42501 must be owner of function f_b
+DROP FUNCTION f_b();
+
+statement ok
+SET ROLE root;
+
+statement ok
 DROP FUNCTION f_b;
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/udf_security
+++ b/pkg/sql/logictest/testdata/logic_test/udf_security
@@ -1,0 +1,315 @@
+# LogicTest: !local-mixed-24.1 !local-mixed-24.2
+
+subtest basic_owner
+
+statement ok
+CREATE ROLE owner;
+CREATE ROLE invoker;
+
+statement ok
+CREATE TABLE top_secret_data (id INT, secret STRING);
+INSERT INTO top_secret_data VALUES (1, 'Top Secret');
+GRANT SELECT ON TABLE top_secret_data TO owner;
+
+statement ok
+SET ROLE owner;
+
+statement ok
+CREATE FUNCTION get_top_secret_data() RETURNS STRING LANGUAGE SQL SECURITY DEFINER AS $$
+    SELECT secret FROM top_secret_data;
+$$;
+
+statement ok
+SET ROLE invoker;
+
+# The invoker can execute the function, but not access the table directly.
+statement error pgcode 42501 user invoker does not have SELECT privilege on relation top_secret_data
+SELECT * FROM top_secret_data;
+
+query T
+SELECT get_top_secret_data();
+----
+Top Secret
+
+subtest end
+
+subtest alter_security
+
+# To change any invoker's ability to execute the function, we can alter the
+# function to be SECURITY INVOKER.
+statement ok
+SET ROLE owner;
+
+statement ok
+ALTER FUNCTION get_top_secret_data() SECURITY INVOKER;
+
+statement ok
+SET ROLE invoker;
+
+statement error pgcode 42501 user invoker does not have SELECT privilege on relation top_secret_data
+SELECT get_top_secret_data();
+
+subtest end
+
+subtest change_owner_privs
+
+# Ensure that the invoker inherits from the owner's privileges if the
+# privileges change.
+statement ok
+SET ROLE root;
+
+statement ok
+REVOKE SELECT ON TABLE top_secret_data FROM owner;
+
+statement ok
+ALTER FUNCTION get_top_secret_data() SECURITY DEFINER;
+
+statement ok
+SET ROLE invoker;
+
+statement error pgcode 42501 user owner does not have SELECT privilege on relation top_secret_data
+SELECT get_top_secret_data();
+
+subtest end
+
+subtest creator_owner
+
+statement ok
+SET ROLE owner;
+
+statement ok
+CREATE TABLE secret_data (id INT, secret STRING);
+INSERT INTO secret_data VALUES (1, 'Secret');
+
+statement ok
+CREATE FUNCTION get_secret_data() RETURNS STRING LANGUAGE SQL SECURITY DEFINER AS $$
+    SELECT secret FROM secret_data;
+$$;
+
+# The creator still has implicit privileges on the table. This deviates from
+# postgres, but we can change the ownership of the table.
+statement ok
+REVOKE ALL ON TABLE secret_data FROM owner;
+
+query TTTTTB colnames
+SELECT * FROM [SHOW GRANTS ON TABLE secret_data] WHERE grantee = 'owner';
+----
+database_name  schema_name  table_name   grantee  privilege_type  is_grantable
+test           public       secret_data  owner  ALL             true
+
+statement ok
+SET ROLE root;
+
+statement ok
+ALTER TABLE secret_data OWNER TO testuser;
+
+query TTTTTB colnames
+SELECT * FROM [SHOW GRANTS ON TABLE secret_data] WHERE grantee = 'owner';
+----
+database_name  schema_name  table_name   grantee  privilege_type  is_grantable
+
+statement ok
+SET ROLE invoker;
+
+statement error pgcode 42501 user owner does not have SELECT privilege on relation top_secret_data
+SELECT get_top_secret_data();
+
+subtest end
+
+subtest change_owner
+
+statement ok
+SET ROLE root;
+
+statement ok
+ALTER FUNCTION get_secret_data() OWNER TO testuser;
+GRANT SELECT ON secret_data TO testuser;
+SET ROLE invoker;
+
+query T
+SELECT get_secret_data();
+----
+Secret
+
+subtest end
+
+subtest revoke_execute
+
+# Despite SECURITY DEFINER being set, the invoker can't execute the function
+# if it does not have proper privileges.
+statement ok
+SET ROLE testuser;
+
+statement ok
+REVOKE ALL ON FUNCTION get_secret_data() FROM PUBLIC;
+SET ROLE invoker;
+
+statement error pgcode 42501 user invoker does not have EXECUTE privilege on function get_secret_data
+SELECT get_secret_data();
+
+subtest end
+
+subtest security_unsupported
+
+# We currently don't allow for routines to create roles. If we did, we would
+# likely want some createrole_self_grant session variable like postgres has.
+# https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-CREATEROLE-SELF-GRANT.
+statement error pgcode 0A000 unimplemented: CREATE ROLE usage inside a function definition
+CREATE FUNCTION create_secret_role() RETURNS VOID LANGUAGE SQL SECURITY DEFINER AS $$
+    CREATE ROLE secret_role;
+$$;
+
+statement error pgcode 0A000 unimplemented: SET usage inside a function definition
+CREATE FUNCTION create_secret_role() RETURNS VOID LANGUAGE SQL SECURITY DEFINER AS $$
+    SET ROLE testuser;
+$$;
+
+subtest end
+
+subtest nested_udfs
+
+statement ok
+SET ROLE root;
+
+statement ok
+CREATE ROLE owner1;
+
+statement ok
+CREATE TABLE t (id INT, secret STRING);
+INSERT INTO t VALUES (1, 'Confidential');
+GRANT SELECT ON TABLE t TO owner;
+
+# Owner creates a SECURITY DEFINER function accessing the table.
+statement ok
+SET ROLE owner;
+
+statement ok
+CREATE FUNCTION get_t() RETURNS STRING LANGUAGE SQL SECURITY DEFINER AS $$
+    SELECT secret FROM t;
+$$;
+
+statement ok
+SET ROLE owner1;
+
+# Another owner creates a SECURITY DEFINER function calling get_t.
+statement ok
+CREATE FUNCTION get_t_nested() RETURNS STRING LANGUAGE SQL SECURITY DEFINER AS $$
+    SELECT get_t();
+$$;
+
+statement ok
+SET ROLE invoker;
+
+# Invoker cannot directly access the table.
+statement error pgcode 42501 user invoker does not have SELECT privilege on relation t
+SELECT * FROM t;
+
+# Nested SECURITY DEFINER functions use the proper owner's privileges, allowing
+# the invoker to have special access of the table.
+query T
+SELECT get_t_nested();
+----
+Confidential
+
+# If we set get_t's security mode back to INVOKER...
+statement ok
+SET ROLE owner;
+
+statement ok
+ALTER FUNCTION get_t() SECURITY INVOKER;
+
+statement ok
+SET ROLE invoker;
+
+# ...the invoker can no longer access the table used in get_t.
+statement error pgcode 42501 user owner1 does not have SELECT privilege on relation t
+SELECT get_t_nested();
+
+statement ok
+SET ROLE owner;
+
+statement ok
+ALTER FUNCTION get_t() SECURITY DEFINER;
+
+statement ok
+SET ROLE root;
+
+# If we revoke owner1's access to get_t...
+statement ok
+REVOKE EXECUTE ON FUNCTION get_t FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION get_t TO invoker;
+
+statement ok
+SET ROLE invoker;
+
+# ...the invoker can no longer access get_t as well.
+statement error pgcode 42501 user owner1 does not have EXECUTE privilege on function get_t
+SELECT get_t_nested();
+
+query T
+SELECT get_t();
+----
+Confidential
+
+statement ok
+SET ROLE root;
+
+statement ok
+GRANT EXECUTE ON FUNCTION get_t TO owner1;
+
+statement ok
+SET ROLE invoker;
+
+# The invoker can access the nested function again. Issue a select to cache
+# this query plan.
+query T
+SELECT get_t_nested();
+----
+Confidential
+
+# Changing the ownership of get_t should invalidate our cached query plan and
+# reflect privileges properly.
+statement ok
+SET ROLE root;
+
+statement ok
+CREATE ROLE owner2;
+
+statement ok
+ALTER FUNCTION get_t() OWNER TO owner2;
+
+statement ok
+SET ROLE invoker;
+
+statement error pgcode 42501 user owner2 does not have SELECT privilege on relation t
+SELECT get_t_nested();
+
+subtest end
+
+subtest invoker_and_definer
+
+statement ok
+SET ROLE root;
+
+# Reset some privileges so that owner will be the owner of get_top_secret_data
+# with proper select privileges on secret_data again.
+statement ok
+GRANT SELECT ON TABLE secret_data TO owner;
+
+statement ok
+ALTER FUNCTION get_secret_data() OWNER TO owner;
+
+statement ok
+GRANT EXECUTE ON FUNCTION get_secret_data TO invoker;
+
+statement ok
+SET ROLE invoker;
+
+# Ensure that the user we perform privilege checks against is reset between
+# building.
+statement error pgcode 42501 user invoker does not have SELECT privilege on relation secret_data
+SELECT get_secret_data()
+UNION
+SELECT id FROM secret_data;
+
+subtest end

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -2341,6 +2341,13 @@ func TestLogic_udf_schema_change(
 	runLogicTest(t, "udf_schema_change")
 }
 
+func TestLogic_udf_security(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_security")
+}
+
 func TestLogic_udf_setof(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -2348,6 +2348,13 @@ func TestLogic_udf_schema_change(
 	runLogicTest(t, "udf_schema_change")
 }
 
+func TestLogic_udf_security(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_security")
+}
+
 func TestLogic_udf_setof(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -2362,6 +2362,13 @@ func TestLogic_udf_schema_change(
 	runLogicTest(t, "udf_schema_change")
 }
 
+func TestLogic_udf_security(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_security")
+}
+
 func TestLogic_udf_setof(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -2348,6 +2348,13 @@ func TestLogic_udf_schema_change(
 	runLogicTest(t, "udf_schema_change")
 }
 
+func TestLogic_udf_security(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_security")
+}
+
 func TestLogic_udf_setof(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -2376,6 +2376,13 @@ func TestLogic_udf_schema_change(
 	runLogicTest(t, "udf_schema_change")
 }
 
+func TestLogic_udf_security(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_security")
+}
+
 func TestLogic_udf_setof(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2600,6 +2600,13 @@ func TestLogic_udf_schema_change(
 	runLogicTest(t, "udf_schema_change")
 }
 
+func TestLogic_udf_security(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_security")
+}
+
 func TestLogic_udf_setof(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -209,4 +209,8 @@ type Catalog interface {
 
 	// GetCurrentUser returns the username.SQLUsername of the current session.
 	GetCurrentUser() username.SQLUsername
+
+	// GetRoutineOwner returns the username.SQLUsername of the routine's
+	// (specified by routineOid) owner.
+	GetRoutineOwner(ctx context.Context, routineOid oid.Oid) (username.SQLUsername, error)
 }

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -166,18 +166,18 @@ type Catalog interface {
 	// ResolveFunctionByOID resolves a function overload by OID.
 	ResolveFunctionByOID(ctx context.Context, oid oid.Oid) (*tree.RoutineName, *tree.Overload, error)
 
-	// CheckPrivilege verifies that the current user has the given privilege on
+	// CheckPrivilege verifies that the given user has the given privilege on
 	// the given catalog object. If not, then CheckPrivilege returns an error.
-	CheckPrivilege(ctx context.Context, o Object, priv privilege.Kind) error
+	CheckPrivilege(ctx context.Context, o Object, user username.SQLUsername, priv privilege.Kind) error
 
 	// CheckAnyPrivilege verifies that the current user has any privilege on
 	// the given catalog object. If not, then CheckAnyPrivilege returns an error.
 	CheckAnyPrivilege(ctx context.Context, o Object) error
 
-	// CheckExecutionPrivilege verifies that the current user has execution
+	// CheckExecutionPrivilege verifies that the given user has execution
 	// privileges for the UDF with the given OID. If not, then CheckPrivilege
 	// returns an error.
-	CheckExecutionPrivilege(ctx context.Context, oid oid.Oid) error
+	CheckExecutionPrivilege(ctx context.Context, oid oid.Oid, user username.SQLUsername) error
 
 	// HasAdminRole checks that the current user has admin privileges. If yes,
 	// returns true. Returns an error if query on the `system.users` table failed
@@ -206,4 +206,7 @@ type Catalog interface {
 	// Optimizer returns the query Optimizer used to optimize SQL statements
 	// referencing objects in this catalog, if any.
 	Optimizer() interface{}
+
+	// GetCurrentUser returns the username.SQLUsername of the current session.
+	GetCurrentUser() username.SQLUsername
 }

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/lib/pq/oid"
@@ -40,6 +41,11 @@ import (
 // prepends the database ID, since the same descriptor ID is reused across
 // databases.
 type StableID uint64
+
+// DefaultStableID is the uninitialized stable ID, used to represent an
+// invalid or default state for catalog objects. GlobalPrivilege objects
+// always return this value as their ID.
+const DefaultStableID = StableID(catid.InvalidDescID)
 
 // SchemaName is an alias for tree.ObjectNamePrefix, since it consists of the
 // catalog + schema name.

--- a/pkg/sql/opt/cat/object.go
+++ b/pkg/sql/opt/cat/object.go
@@ -13,10 +13,11 @@ type Object interface {
 	// StableID for more detail.
 	ID() StableID
 
-	// DescriptorID is the descriptor ID for this object. This can differ from the
-	// ID of this object in some cases. This is only important for reporting the
-	// Postgres-compatible identifiers for objects in the various object catalogs.
-	// In the vast majority of cases, you should use ID() instead.
+	// PostgresDescriptorID is the descriptor ID for this object. This can differ
+	// from the ID of this object in some cases. This is only important for
+	// reporting the Postgres-compatible identifiers for objects in the various
+	// object catalogs. In the vast majority of cases, you should use ID()
+	// instead.
 	PostgresDescriptorID() catid.DescID
 
 	// Equals returns true if this object is identical to the given Object.

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -682,7 +682,7 @@ func (u *unknownIndex) Column(i int) cat.IndexColumn {
 	var col cat.Column
 	col.Init(
 		i,
-		cat.StableID(0),
+		cat.DefaultStableID,
 		"?",
 		cat.Ordinary,
 		types.Int,

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -504,7 +504,7 @@ func (md *Metadata) CheckDependencies(
 		return false, err
 	}
 	for _, dep := range md.udfDeps {
-		if err := optCatalog.CheckExecutionPrivilege(ctx, dep.overload.Oid); err != nil {
+		if err := optCatalog.CheckExecutionPrivilege(ctx, dep.overload.Oid, optCatalog.GetCurrentUser()); err != nil {
 			return false, err
 		}
 	}
@@ -544,7 +544,7 @@ func (md *Metadata) checkDataSourcePrivileges(ctx context.Context, optCatalog ca
 			// privileges do not need to be checked). Ignore the "zero privilege".
 			priv := privilege.Kind(bits.TrailingZeros32(uint32(privs)))
 			if priv != 0 {
-				if err := optCatalog.CheckPrivilege(ctx, dataSource, priv); err != nil {
+				if err := optCatalog.CheckPrivilege(ctx, dataSource, optCatalog.GetCurrentUser(), priv); err != nil {
 					return err
 				}
 			}

--- a/pkg/sql/opt/optbuilder/BUILD.bazel
+++ b/pkg/sql/opt/optbuilder/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
         "//pkg/build",
         "//pkg/clusterversion",
         "//pkg/kv/kvserver/concurrency/isolation",
+        "//pkg/security/username",
         "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/sql/catalog/catpb",

--- a/pkg/sql/opt/optbuilder/alter_range.go
+++ b/pkg/sql/opt/optbuilder/alter_range.go
@@ -21,7 +21,7 @@ func (b *Builder) buildAlterRangeRelocate(
 	relocate *tree.RelocateRange, inScope *scope,
 ) (outScope *scope) {
 
-	if err := b.catalog.CheckPrivilege(b.ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.REPAIRCLUSTER); err != nil {
+	if err := b.catalog.CheckPrivilege(b.ctx, syntheticprivilege.GlobalPrivilegeObject, b.catalog.GetCurrentUser(), privilege.REPAIRCLUSTER); err != nil {
 		panic(err)
 	}
 

--- a/pkg/sql/opt/optbuilder/alter_table.go
+++ b/pkg/sql/opt/optbuilder/alter_table.go
@@ -29,7 +29,7 @@ func (b *Builder) buildAlterTableSplit(split *tree.Split, inScope *scope) (outSc
 		panic(err)
 	}
 	table := index.Table()
-	if err := b.catalog.CheckPrivilege(b.ctx, table, privilege.INSERT); err != nil {
+	if err := b.catalog.CheckPrivilege(b.ctx, table, b.catalog.GetCurrentUser(), privilege.INSERT); err != nil {
 		panic(err)
 	}
 
@@ -93,7 +93,7 @@ func (b *Builder) buildAlterTableUnsplit(unsplit *tree.Unsplit, inScope *scope) 
 		panic(err)
 	}
 	table := index.Table()
-	if err := b.catalog.CheckPrivilege(b.ctx, table, privilege.INSERT); err != nil {
+	if err := b.catalog.CheckPrivilege(b.ctx, table, b.catalog.GetCurrentUser(), privilege.INSERT); err != nil {
 		panic(err)
 	}
 
@@ -143,7 +143,7 @@ func (b *Builder) buildAlterTableRelocate(
 		panic(err)
 	}
 	table := index.Table()
-	if err := b.catalog.CheckPrivilege(b.ctx, table, privilege.INSERT); err != nil {
+	if err := b.catalog.CheckPrivilege(b.ctx, table, b.catalog.GetCurrentUser(), privilege.INSERT); err != nil {
 		panic(err)
 	}
 

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -50,7 +50,7 @@ func (b *Builder) buildUDF(
 	// Check for execution privileges for user-defined overloads. Built-in
 	// overloads do not need to be checked.
 	if o.Type == tree.UDFRoutine {
-		if err := b.catalog.CheckExecutionPrivilege(b.ctx, o.Oid); err != nil {
+		if err := b.catalog.CheckExecutionPrivilege(b.ctx, o.Oid, b.catalog.GetCurrentUser()); err != nil {
 			panic(err)
 		}
 	}
@@ -186,7 +186,7 @@ func (b *Builder) resolveProcedureDefinition(
 	}
 
 	// Check for execution privileges.
-	if err := b.catalog.CheckExecutionPrivilege(b.ctx, o.Oid); err != nil {
+	if err := b.catalog.CheckExecutionPrivilege(b.ctx, o.Oid, b.catalog.GetCurrentUser()); err != nil {
 		panic(err)
 	}
 	return f, def

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -8,6 +8,7 @@ package optbuilder
 import (
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
@@ -50,7 +51,7 @@ func (b *Builder) buildUDF(
 	// Check for execution privileges for user-defined overloads. Built-in
 	// overloads do not need to be checked.
 	if o.Type == tree.UDFRoutine {
-		if err := b.catalog.CheckExecutionPrivilege(b.ctx, o.Oid, b.catalog.GetCurrentUser()); err != nil {
+		if err := b.catalog.CheckExecutionPrivilege(b.ctx, o.Oid, b.checkPrivilegeUser); err != nil {
 			panic(err)
 		}
 	}
@@ -186,7 +187,7 @@ func (b *Builder) resolveProcedureDefinition(
 	}
 
 	// Check for execution privileges.
-	if err := b.catalog.CheckExecutionPrivilege(b.ctx, o.Oid, b.catalog.GetCurrentUser()); err != nil {
+	if err := b.catalog.CheckExecutionPrivilege(b.ctx, o.Oid, b.checkPrivilegeUser); err != nil {
 		panic(err)
 	}
 	return f, def
@@ -342,18 +343,34 @@ func (b *Builder) buildRoutine(
 	// for the schema changer we only need depth 1. Also keep track of when
 	// we have are executing inside a UDF, and whether the routine is used as a
 	// data source (this could be nested, so we need to track the previous state).
-	defer func(trackSchemaDeps, insideUDF, insideDataSource, insideSQLRoutine bool) {
+	defer func(
+		trackSchemaDeps,
+		insideUDF,
+		insideDataSource,
+		insideSQLRoutine bool,
+		checkPrivilegeUser username.SQLUsername,
+	) {
 		b.trackSchemaDeps = trackSchemaDeps
 		b.insideUDF = insideUDF
 		b.insideDataSource = insideDataSource
 		b.insideSQLRoutine = insideSQLRoutine
-	}(b.trackSchemaDeps, b.insideUDF, b.insideDataSource, b.insideSQLRoutine)
+		b.checkPrivilegeUser = checkPrivilegeUser
+	}(b.trackSchemaDeps, b.insideUDF, b.insideDataSource, b.insideSQLRoutine, b.checkPrivilegeUser)
 	oldInsideDataSource := b.insideDataSource
 	b.insideDataSource = false
 	b.trackSchemaDeps = false
 	b.insideUDF = true
 	b.insideSQLRoutine = o.Language == tree.RoutineLangSQL
 	isSetReturning := o.Class == tree.GeneratorClass
+	// If this is a user-defined routine that has a security mode of DEFINER, we
+	// need to override our checkPrivilegeUser to be the owner of the routine.
+	if o.Type != tree.BuiltinRoutine && o.SecurityMode == tree.RoutineDefiner {
+		checkPrivUser, err := b.catalog.GetRoutineOwner(b.ctx, o.Oid)
+		if err != nil {
+			panic(err)
+		}
+		b.checkPrivilegeUser = checkPrivUser
+	}
 
 	// Build an expression for each statement in the function body.
 	var body []memo.RelExpr

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -505,7 +505,7 @@ func (b *Builder) resolveSchemaForCreate(
 		panic(err)
 	}
 
-	if err := b.catalog.CheckPrivilege(b.ctx, sch, privilege.CREATE); err != nil {
+	if err := b.catalog.CheckPrivilege(b.ctx, sch, b.catalog.GetCurrentUser(), privilege.CREATE); err != nil {
 		panic(err)
 	}
 
@@ -705,7 +705,7 @@ func (b *Builder) resolveDataSourceRef(
 // of the memo.
 func (b *Builder) checkPrivilege(name opt.MDDepName, ds cat.DataSource, priv privilege.Kind) {
 	if !(priv == privilege.SELECT && b.skipSelectPrivilegeChecks) {
-		err := b.catalog.CheckPrivilege(b.ctx, ds, priv)
+		err := b.catalog.CheckPrivilege(b.ctx, ds, b.catalog.GetCurrentUser(), priv)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -705,7 +705,7 @@ func (b *Builder) resolveDataSourceRef(
 // of the memo.
 func (b *Builder) checkPrivilege(name opt.MDDepName, ds cat.DataSource, priv privilege.Kind) {
 	if !(priv == privilege.SELECT && b.skipSelectPrivilegeChecks) {
-		err := b.catalog.CheckPrivilege(b.ctx, ds, b.catalog.GetCurrentUser(), priv)
+		err := b.catalog.CheckPrivilege(b.ctx, ds, b.checkPrivilegeUser, priv)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -336,6 +336,13 @@ func (tc *Catalog) GetCurrentUser() username.SQLUsername {
 	return username.EmptyRoleName()
 }
 
+// GetRoutineOwner is part of the cat.Catalog interface.
+func (tc *Catalog) GetRoutineOwner(
+	ctx context.Context, routineOid oid.Oid,
+) (username.SQLUsername, error) {
+	return tc.GetCurrentUser(), nil
+}
+
 func (tc *Catalog) resolveSchema(toResolve *cat.SchemaName) (cat.Schema, cat.SchemaName, error) {
 	if string(toResolve.CatalogName) != testDB {
 		return nil, cat.SchemaName{}, pgerror.Newf(pgcode.InvalidSchemaName,

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -261,7 +261,9 @@ func (tc *Catalog) ResolveIndex(
 }
 
 // CheckPrivilege is part of the cat.Catalog interface.
-func (tc *Catalog) CheckPrivilege(ctx context.Context, o cat.Object, priv privilege.Kind) error {
+func (tc *Catalog) CheckPrivilege(
+	ctx context.Context, o cat.Object, user username.SQLUsername, priv privilege.Kind,
+) error {
 	return tc.CheckAnyPrivilege(ctx, o)
 }
 
@@ -293,7 +295,9 @@ func (tc *Catalog) CheckAnyPrivilege(ctx context.Context, o cat.Object) error {
 }
 
 // CheckExecutionPrivilege is part of the cat.Catalog interface.
-func (tc *Catalog) CheckExecutionPrivilege(ctx context.Context, oid oid.Oid) error {
+func (tc *Catalog) CheckExecutionPrivilege(
+	ctx context.Context, oid oid.Oid, user username.SQLUsername,
+) error {
 	if tc.revokedUDFOids.Contains(int(oid)) {
 		return pgerror.Newf(pgcode.InsufficientPrivilege, "user does not have privilege to execute function with OID %d", oid)
 	}
@@ -325,6 +329,11 @@ func (tc *Catalog) CheckRoleExists(ctx context.Context, role username.SQLUsernam
 // Optimizer is part of the cat.Catalog interface.
 func (tc *Catalog) Optimizer() interface{} {
 	return nil
+}
+
+// GetCurrentUser is part of the cat.Catalog interface.
+func (tc *Catalog) GetCurrentUser() username.SQLUsername {
+	return username.EmptyRoleName()
 }
 
 func (tc *Catalog) resolveSchema(toResolve *cat.SchemaName) (cat.Schema, cat.SchemaName, error) {

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -508,6 +508,17 @@ func (oc *optCatalog) GetCurrentUser() username.SQLUsername {
 	return oc.planner.User()
 }
 
+// GetRoutineOwner is part of the cat.Catalog interface.
+func (oc *optCatalog) GetRoutineOwner(
+	ctx context.Context, routineOid oid.Oid,
+) (username.SQLUsername, error) {
+	fnDesc, err := oc.planner.FunctionDesc(ctx, routineOid)
+	if err != nil {
+		return username.EmptyRoleName(), err
+	}
+	return fnDesc.FuncDesc().Privileges.Owner(), nil
+}
+
 // dataSourceForDesc returns a data source wrapper for the given descriptor.
 // The wrapper might come from the cache, or it may be created now.
 func (oc *optCatalog) dataSourceForDesc(

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -399,7 +399,7 @@ func getDescForDataSource(o cat.DataSource) (catalog.TableDescriptor, error) {
 
 // CheckPrivilege is part of the cat.Catalog interface.
 func (oc *optCatalog) CheckPrivilege(ctx context.Context, o cat.Object, priv privilege.Kind) error {
-	if o.ID() == 0 {
+	if o.ID() == cat.DefaultStableID {
 		return oc.planner.CheckPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, priv)
 	}
 	desc, err := getDescFromCatalogObjectForPermissions(o)

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -398,15 +398,17 @@ func getDescForDataSource(o cat.DataSource) (catalog.TableDescriptor, error) {
 }
 
 // CheckPrivilege is part of the cat.Catalog interface.
-func (oc *optCatalog) CheckPrivilege(ctx context.Context, o cat.Object, priv privilege.Kind) error {
+func (oc *optCatalog) CheckPrivilege(
+	ctx context.Context, o cat.Object, user username.SQLUsername, priv privilege.Kind,
+) error {
 	if o.ID() == cat.DefaultStableID {
-		return oc.planner.CheckPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, priv)
+		return oc.planner.CheckPrivilegeForUser(ctx, syntheticprivilege.GlobalPrivilegeObject, priv, user)
 	}
 	desc, err := getDescFromCatalogObjectForPermissions(o)
 	if err != nil {
 		return err
 	}
-	return oc.planner.CheckPrivilege(ctx, desc, priv)
+	return oc.planner.CheckPrivilegeForUser(ctx, desc, priv, user)
 }
 
 // CheckAnyPrivilege is part of the cat.Catalog interface.
@@ -419,12 +421,14 @@ func (oc *optCatalog) CheckAnyPrivilege(ctx context.Context, o cat.Object) error
 }
 
 // CheckExecutionPrivilege is part of the cat.Catalog interface.
-func (oc *optCatalog) CheckExecutionPrivilege(ctx context.Context, oid oid.Oid) error {
+func (oc *optCatalog) CheckExecutionPrivilege(
+	ctx context.Context, oid oid.Oid, user username.SQLUsername,
+) error {
 	desc, err := oc.planner.FunctionDesc(ctx, oid)
 	if err != nil {
 		return errors.WithAssertionFailure(err)
 	}
-	return oc.planner.CheckPrivilege(ctx, desc, privilege.EXECUTE)
+	return oc.planner.CheckPrivilegeForUser(ctx, desc, privilege.EXECUTE, user)
 }
 
 // HasAdminRole is part of the cat.Catalog interface.
@@ -497,6 +501,11 @@ func (oc *optCatalog) Optimizer() interface{} {
 	}
 	plannerInterface := eval.Planner(oc.planner)
 	return plannerInterface.Optimizer()
+}
+
+// GetCurrentUser is part of the cat.Catalog interface.
+func (oc *optCatalog) GetCurrentUser() username.SQLUsername {
+	return oc.planner.User()
 }
 
 // dataSourceForDesc returns a data source wrapper for the given descriptor.

--- a/pkg/sql/schemachanger/comparator_generated_test.go
+++ b/pkg/sql/schemachanger/comparator_generated_test.go
@@ -1998,6 +1998,11 @@ func TestSchemaChangeComparator_udf_schema_change(t *testing.T) {
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_schema_change"
 	runSchemaChangeComparatorTest(t, logicTestFile)
 }
+func TestSchemaChangeComparator_udf_security(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_security"
+	runSchemaChangeComparatorTest(t, logicTestFile)
+}
 func TestSchemaChangeComparator_udf_setof(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/udf_setof"

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -290,6 +290,11 @@ type Overload struct {
 	// UDFContainsOnlySignature is false, then DEFAULT expressions are included
 	// into RoutineParams.
 	DefaultExprs Exprs
+
+	// SecurityMode is true when privilege checks during function execution
+	// should be performed against the function owner rather than the invoking
+	// user.
+	SecurityMode RoutineSecurity
 }
 
 // params implements the overloadImpl interface.

--- a/pkg/sql/syntheticprivilege/global_privilege.go
+++ b/pkg/sql/syntheticprivilege/global_privilege.go
@@ -61,7 +61,7 @@ func (p *GlobalPrivilege) GetName() string {
 
 // ID implements the cat.Object interface.
 func (p *GlobalPrivilege) ID() cat.StableID {
-	return cat.StableID(descpb.InvalidID)
+	return cat.DefaultStableID
 }
 
 // PostgresDescriptorID implements the cat.Object interface.


### PR DESCRIPTION
### sql: correct error code

This patch assigns the pgcode (42501) to an ownership 
privilege check error. This aligns with postgres behavior.

```
postgres=> alter function testfn1(int) security definer;
ERROR:  42501: must be owner of function testfn1
LOCATION:  aclcheck_error, aclchk.c:3790
```

Release note: None

---

### opt/cat: add sentinel const for StableID

This patch adds the `DefaultStableID` constant
of 0 to describe an uninitialized stable ID for
catalog objects. GlobalPrivilege objects always
return this value as their ID.

Epic: none

Release note: None

---

### opt/cat: refactor priv checks to specify a user

This patch refactors privilege check methods of the `catalog`
interface to include a `username.SQLUsername`. This provides us
with the new API:

```
CheckPrivilege(ctx context.Context, o Object, user username.SQLUsername, priv privilege.Kind) error

CheckExecutionPrivilege(ctx context.Context, oid oid.Oid, user username.SQLUsername) error
```

Release note: None

---

### sql: support SECURITY DEFINER for routines

Epic: [CRDB-37477](https://cockroachlabs.atlassian.net/browse/CRDB-37477)
Fixes: https://github.com/cockroachdb/cockroach/issues/121514

Release note (sql change): Added support for `SECURITY DEFINER` in user defined
functions (UDFs) and stored procedures (SPs). When a UDF/SP (routine) is created
with `SECURITY DEFINER`, at execution, the privileges of the owner will be
checked.

Routines can now specify `[EXTERNAL] SECURITY INVOKER` (this is the
default -- privileges of the invoker are checked at execution) or
`[EXTERNAL] SECURITY DEFINER`. Note that the `EXTERNAL` keyword is
optional and solely exists for sql conformity.

In addition, altering a UDF's security "mode" is accomplished by:
`ALTER FUNCTION ... [EXTERNAL] SECURITY {INVOKER/DEFINER}`.