### PR TITLE
release-23.1: licenseccl: new license types

### DIFF
--- a/pkg/ccl/utilccl/license_check_test.go
+++ b/pkg/ccl/utilccl/license_check_test.go
@@ -85,6 +85,8 @@ func TestGetLicenseTypePresent(t *testing.T) {
 		{licenseccl.License_NonCommercial, "NonCommercial"},
 		{licenseccl.License_Enterprise, "Enterprise"},
 		{licenseccl.License_Evaluation, "Evaluation"},
+		{licenseccl.License_Trial, "Trial"},
+		{licenseccl.License_Free, "Free"},
 	} {
 		st := cluster.MakeTestingClusterSettings()
 		updater := st.MakeUpdater()
@@ -154,13 +156,13 @@ func TestTimeToEnterpriseLicenseExpiry(t *testing.T) {
 
 	lic0M, _ := (&licenseccl.License{
 		ClusterID:         []uuid.UUID{id},
-		Type:              licenseccl.License_Evaluation,
+		Type:              licenseccl.License_Free,
 		ValidUntilUnixSec: t0.AddDate(0, 0, 0).Unix(),
 	}).Encode()
 
 	licExpired, _ := (&licenseccl.License{
 		ClusterID:         []uuid.UUID{id},
-		Type:              licenseccl.License_Evaluation,
+		Type:              licenseccl.License_Trial,
 		ValidUntilUnixSec: t0.AddDate(0, -1, 0).Unix(),
 	}).Encode()
 

--- a/pkg/ccl/utilccl/licenseccl/license.proto
+++ b/pkg/ccl/utilccl/licenseccl/license.proto
@@ -22,9 +22,18 @@ message License {
       NonCommercial = 0;
       Enterprise = 1;
       Evaluation = 2;
+      Free = 3;
+      Trial = 4;
     }
 
     Type type = 3;
 
     string organization_name = 4;
+
+    // Two UUIDs uniquely identify this license and the associated organization.
+    // They are stored as bytes to align with the server's typical usage. We
+    // avoided using the custom UUID type normally used in protobufs to minimize
+    // dependencies, as the generated code is also used in other repositories.
+    bytes license_id = 6;
+    bytes organization_id = 7;
 }


### PR DESCRIPTION
Backport 1/1 commits from #129474.

/cc @cockroachdb/release

---

Epic: CRDB-39988
Closes: CRDB-40069
Release note: none

Release justification: This work is part of the CockroachDB core deprecation.