### PR TITLE
dev: also build `ts_project` for `eslint-plugin-crdb` in `gen js`

### DIFF
--- a/pkg/cmd/dev/generate.go
+++ b/pkg/cmd/dev/generate.go
@@ -309,7 +309,7 @@ func (d *dev) generateJs(cmd *cobra.Command) error {
 
 	args := []string{
 		"build",
-		"//pkg/ui/workspaces/eslint-plugin-crdb:eslint-plugin-crdb-lib",
+		"//pkg/ui/workspaces/eslint-plugin-crdb:ts_project",
 		"//pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client",
 		"//pkg/ui/workspaces/cluster-ui:ts_project",
 	}


### PR DESCRIPTION
Without this, generation can fail with an error like:

```
Rel: can't make  relative to /private/var/tmp/_bazel_davidh/d61affdd093572eb0c41c4220c20a747/execroot/com_github_cockroachdb_cockroach/bazel-out/darwin_arm64-fastbuild/bin/pkg/ui/workspaces/eslint-plugin-crdb/dist
```

It's unclear right now why this is happening. My suspicion is there is some sort of bug or deficiency in `rules_js` and/or `rules_ts` specifically on more recent Bazel versions and is probably related to Bazel 7 being more aggressive about rejecting using directories as output files.

Epic: none

Release note: None
Closes: #129369