### PR TITLE
sql: add get_fully_qualified_table_name builtin

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -3864,6 +3864,31 @@ select crdb_internal.job_payload_type('invalid'::BYTES);
 query error pgcode 22023 pq: crdb_internal.job_payload_type\(\): invalid type in job payload protocol message: Payload.Type called on a payload with an unknown details type: <nil>
 select crdb_internal.job_payload_type('');
 
+subtest crdb_internal.get_fully_qualified_table_name
+query T
+SELECT crdb_internal.get_fully_qualified_table_name(NULL)
+----
+NULL
+
+query T
+SELECT crdb_internal.get_fully_qualified_table_name((SELECT id FROM system.namespace WHERE name = 'foo'))
+----
+test.public.foo
+
+statement error unknown signature: crdb_internal.get_fully_qualified_table_name\(string\)
+SELECT crdb_internal.get_fully_qualified_table_name('')
+
+statement ok
+CREATE SCHEMA "testSchema"
+
+statement ok
+CREATE TABLE "testSchema"."testTable" (a INT)
+
+query T
+SELECT crdb_internal.get_fully_qualified_table_name((SELECT id FROM system.namespace WHERE name = 'testTable'))
+----
+test."testSchema"."testTable"
+
 subtest crdb_internal.redactable_sql_constants
 query T
 SELECT crdb_internal.redactable_sql_constants(NULL)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -8829,6 +8829,26 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 			Volatility: volatility.Volatile,
 		},
 	),
+	"crdb_internal.get_fully_qualified_table_name": makeBuiltin(
+		tree.FunctionProperties{Category: builtinconstants.CategorySystemInfo},
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "table_descriptor_id", Typ: types.Int},
+			},
+			ReturnType: tree.FixedReturnType(types.String),
+			Body: `
+SELECT quote_ident(db.name) || '.' || quote_ident(sc.name) || '.' || quote_ident(t.name)
+FROM system.namespace t
+JOIN system.namespace sc
+ON t."parentSchemaID" = sc.id
+JOIN system.namespace db on t."parentID" = db.id
+WHERE t.id = table_descriptor_id
+`,
+			Info:       `This function is used to get the fully qualified table name given a table descriptor ID`,
+			Volatility: volatility.Stable,
+			Language:   tree.RoutineLangSQL,
+		},
+	),
 }
 
 var lengthImpls = func(incBitOverload bool) builtinDefinition {

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2607,6 +2607,7 @@ var builtinOidsArray = []string{
 	2639: `crdb_internal.start_replication_stream_for_tables(req: bytes) -> bytes`,
 	2640: `crdb_internal.clear_query_plan_cache() -> void`,
 	2641: `crdb_internal.clear_table_stats_cache() -> void`,
+	2642: `crdb_internal.get_fully_qualified_table_name(table_descriptor_id: int) -> string`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid


### PR DESCRIPTION
This PR adds a SQL builtin function
`crdb_internal.get_fully_qualified_table_name()` that can be used to fetch a table's fully qualified name given a table descriptor id.

Example output:
```
demo@127.0.0.1:26257/demoapp/b> select crdb_internal.get_fully_qualified_table_names(116);
  crdb_internal.get_fully_qualified_table_names
-------------------------------------------------
  a.public.tab1
(1 row)

Time: 6ms total (execution 6ms / network 1ms)
```

Epic: none
Release note: none