### PR TITLE
sql, schemachanger: disallow ADD FK if referenced table is locked

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -462,6 +462,11 @@ func (n *alterTableNode) startExec(params runParams) error {
 				}
 				descriptorChanged = true
 				for _, updated := range affected {
+					// Disallow schema change if the FK references a table whose schema is
+					// locked.
+					if err := checkTableSchemaUnlocked(updated); err != nil {
+						return err
+					}
 					if err := params.p.writeSchemaChange(
 						params.ctx, updated, descpb.InvalidMutationID, tree.AsStringWithFQNames(n.n, params.Ann()),
 					); err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/schema_locked
+++ b/pkg/sql/logictest/testdata/logic_test/schema_locked
@@ -69,7 +69,7 @@ DROP TABLE t
 subtest disallow_schema_changes_when_schema_is_locked
 
 statement ok
-CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX idx (j)) WITH (schema_locked = t);
+CREATE TABLE t (i INT PRIMARY KEY, j INT, UNIQUE INDEX idx (j)) WITH (schema_locked = t);
 
 statement ok
 INSERT INTO t SELECT i, i+1 FROM generate_series(1,10) AS tmp(i);
@@ -99,8 +99,19 @@ statement error pgcode 57000 schema changes are disallowed on table "t" because 
 CREATE INDEX idx2 ON t(j);
 
 statement ok
+CREATE TABLE ref (a INT PRIMARY KEY, b INT)
+
+# Locked tables cannot be referenced by foreign keys.
+statement error pgcode 57000 schema changes are disallowed on table "t" because it is locked
+ALTER TABLE ref ADD CONSTRAINT fk FOREIGN KEY (b) REFERENCES t(j);
+
+# GRANT statements are allowed on the table, as they only affect the
+# table's privilege descriptor.
+statement ok
 GRANT DELETE ON TABLE t TO testuser WITH GRANT OPTION;
 
+# COMMENT statements are allowed on the table, as they don't actually
+# touch the descriptor.
 statement ok
 COMMENT ON TABLE t IS 't is a table';
 COMMENT ON INDEX t@idx IS 'idx is an index';

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_constraint.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_constraint.go
@@ -273,6 +273,8 @@ func alterTableAddForeignKey(
 		panic(scerrors.NotImplementedErrorf(t, "cross DB FK reference is a deprecated feature "+
 			"and is no longer supported."))
 	}
+	// Disallow schema change if the FK references a table whose schema is locked.
+	panicIfSchemaIsLocked(b.QueryByID(referencedTableID))
 
 	// 6. Check that temporary tables can only reference temporary tables, or,
 	// permanent tables can only reference permanent tables.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_index.go
@@ -101,6 +101,7 @@ func maybeDropIndex(
 	// We don't support handling zone config related properties for tables, so
 	// throw an unsupported error.
 	fallBackIfSubZoneConfigExists(b, nil, sie.TableID)
+	panicIfSchemaIsLocked(b.QueryByID(sie.TableID))
 	// Cannot drop the index if not CASCADE and a unique constraint depends on it.
 	if dropBehavior != tree.DropCascade && sie.IsUnique && !sie.IsCreatedExplicitly {
 		panic(errors.WithHint(
@@ -109,7 +110,6 @@ func maybeDropIndex(
 			"use CASCADE if you really want to drop it.",
 		))
 	}
-	panicIfSchemaIsLocked(b.QueryByID(sie.TableID))
 	dropSecondaryIndex(b, indexName, dropBehavior, sie)
 	return sie
 }


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/127019
Release note (bug fix): Fixed a bug where the schema_locked table parameter did not prevent a table from being referenced by a foreign key.