### PR TITLE
raft: export log mark type

### DIFF
--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -349,7 +349,7 @@ func (l *raftLog) lastIndex() uint64 {
 
 // commitTo bumps the commit index to the given value if it is higher than the
 // current commit index.
-func (l *raftLog) commitTo(mark logMark) {
+func (l *raftLog) commitTo(mark LogMark) {
 	// TODO(pav-kv): it is only safe to update the commit index if our log is
 	// consistent with the mark.term leader. If the mark.term leader sees the
 	// mark.index entry as committed, all future leaders have it in the log. It is
@@ -357,11 +357,11 @@ func (l *raftLog) commitTo(mark logMark) {
 	// accTerm >= mark.term. Do this once raftLog/unstable tracks the accTerm.
 
 	// never decrease commit
-	if l.committed < mark.index {
-		if l.lastIndex() < mark.index {
-			l.logger.Panicf("tocommit(%d) is out of range [lastIndex(%d)]. Was the raft log corrupted, truncated, or lost?", mark.index, l.lastIndex())
+	if l.committed < mark.Index {
+		if l.lastIndex() < mark.Index {
+			l.logger.Panicf("tocommit(%d) is out of range [lastIndex(%d)]. Was the raft log corrupted, truncated, or lost?", mark.Index, l.lastIndex())
 		}
-		l.committed = mark.index
+		l.committed = mark.Index
 	}
 }
 
@@ -400,7 +400,7 @@ func (l *raftLog) acceptApplying(i uint64, size entryEncodingSize, allowUnstable
 		i < l.maxAppliableIndex(allowUnstable)
 }
 
-func (l *raftLog) stableTo(mark logMark) { l.unstable.stableTo(mark) }
+func (l *raftLog) stableTo(mark LogMark) { l.unstable.stableTo(mark) }
 
 func (l *raftLog) stableSnapTo(i uint64) { l.unstable.stableSnapTo(i) }
 

--- a/pkg/raft/log_unstable.go
+++ b/pkg/raft/log_unstable.go
@@ -172,34 +172,34 @@ func (u *unstable) acceptInProgress() {
 //
 // The method makes sure the entries can not be overwritten by an in-progress
 // log append. See the related comment in newStorageAppendRespMsg.
-func (u *unstable) stableTo(mark logMark) {
-	if mark.term != u.term {
+func (u *unstable) stableTo(mark LogMark) {
+	if mark.Term != u.term {
 		// The last accepted term has changed. Ignore. This is possible if part or
 		// all of the unstable log was replaced between that time that a set of
 		// entries started to be written to stable storage and when they finished.
 		u.logger.Infof("mark (term,index)=(%d,%d) mismatched the last accepted "+
-			"term %d in unstable log; ignoring ", mark.term, mark.index, u.term)
+			"term %d in unstable log; ignoring ", mark.Term, mark.Index, u.term)
 		return
 	}
-	if u.snapshot != nil && mark.index == u.snapshot.Metadata.Index {
+	if u.snapshot != nil && mark.Index == u.snapshot.Metadata.Index {
 		// Index matched unstable snapshot, not unstable entry. Ignore.
-		u.logger.Infof("entry at index %d matched unstable snapshot; ignoring", mark.index)
+		u.logger.Infof("entry at index %d matched unstable snapshot; ignoring", mark.Index)
 		return
 	}
-	if mark.index <= u.prev.index || mark.index > u.lastIndex() {
+	if mark.Index <= u.prev.index || mark.Index > u.lastIndex() {
 		// Unstable entry missing. Ignore.
-		u.logger.Infof("entry at index %d missing from unstable log; ignoring", mark.index)
+		u.logger.Infof("entry at index %d missing from unstable log; ignoring", mark.Index)
 		return
 	}
 	if u.snapshot != nil {
 		u.logger.Panicf("mark %+v acked earlier than the snapshot(in-progress=%t): %s",
 			mark, u.snapshotInProgress, DescribeSnapshot(*u.snapshot))
 	}
-	u.logSlice = u.forward(mark.index)
+	u.logSlice = u.forward(mark.Index)
 	// TODO(pav-kv): why can mark.index overtake u.entryInProgress? Probably bugs
 	// in tests using the log writes incorrectly, e.g. TestLeaderStartReplication
 	// takes nextUnstableEnts() without acceptInProgress().
-	u.entryInProgress = max(u.entryInProgress, mark.index)
+	u.entryInProgress = max(u.entryInProgress, mark.Index)
 	u.shrinkEntriesArray()
 }
 

--- a/pkg/raft/log_unstable_test.go
+++ b/pkg/raft/log_unstable_test.go
@@ -472,7 +472,7 @@ func TestUnstableStableTo(t *testing.T) {
 				u.stableSnapTo(u.snapshot.Metadata.Index)
 			}
 			u.checkInvariants(t)
-			u.stableTo(logMark{term: tt.term, index: tt.index})
+			u.stableTo(LogMark{Term: tt.term, Index: tt.index})
 			u.checkInvariants(t)
 			require.Equal(t, tt.wprev, u.prev.index)
 			require.Equal(t, tt.wentryInProgress, u.entryInProgress)

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -1158,7 +1158,7 @@ func TestHandleHeartbeat(t *testing.T) {
 		require.NoError(t, storage.Append(init.entries))
 		sm := newTestRaft(1, 5, 1, storage)
 		sm.becomeFollower(init.term, 2)
-		sm.raftLog.commitTo(logMark{term: init.term, index: commit})
+		sm.raftLog.commitTo(LogMark{Term: init.term, Index: commit})
 		sm.handleHeartbeat(tt.m)
 		assert.Equal(t, tt.wCommit, sm.raftLog.committed, "#%d", i)
 		m := sm.readMessages()
@@ -1175,7 +1175,7 @@ func TestHandleHeartbeatResp(t *testing.T) {
 	sm := newTestRaft(1, 5, 1, storage)
 	sm.becomeCandidate()
 	sm.becomeLeader()
-	sm.raftLog.commitTo(logMark{term: 3, index: sm.raftLog.lastIndex()})
+	sm.raftLog.commitTo(LogMark{Term: 3, Index: sm.raftLog.lastIndex()})
 
 	// A heartbeat response from a node that is behind; re-send MsgApp
 	sm.Step(pb.Message{From: 2, Type: pb.MsgHeartbeatResp})
@@ -2359,7 +2359,7 @@ func TestRestoreIgnoreSnapshot(t *testing.T) {
 	storage := newTestMemoryStorage(withPeers(1, 2))
 	sm := newTestRaft(1, 10, 1, storage)
 	require.True(t, sm.raftLog.append(init))
-	sm.raftLog.commitTo(logMark{term: init.term, index: commit})
+	sm.raftLog.commitTo(LogMark{Term: init.term, Index: commit})
 
 	s := snapshot{
 		term: 1,

--- a/pkg/raft/types.go
+++ b/pkg/raft/types.go
@@ -38,21 +38,21 @@ func pbEntryID(entry *pb.Entry) entryID {
 	return entryID{term: entry.Term, index: entry.Index}
 }
 
-// logMark is a position in a log consistent with the leader at a specific term.
+// LogMark is a position in a log consistent with the leader at a specific term.
 //
 // This is different from entryID. The entryID ties an entry to the term of the
-// leader who proposed it, while the logMark identifies an entry in a particular
+// leader who proposed it, while the LogMark identifies an entry in a particular
 // leader's coordinate system. Different leaders can have different entries at a
 // particular index.
 //
 // Generally, all entries in raft form a tree (branching when a new leader
-// starts proposing entries at its term). A logMark identifies a position in a
+// starts proposing entries at its term). A LogMark identifies a position in a
 // particular branch of this tree.
-type logMark struct {
-	// term is the term of the leader whose log is considered.
-	term uint64
-	// index is the position in this leader's log.
-	index uint64
+type LogMark struct {
+	// Term is the term of the leader whose log is considered.
+	Term uint64
+	// Index is the position in this leader's log.
+	Index uint64
 }
 
 // logSlice describes a correct slice of a raft log.
@@ -108,9 +108,9 @@ func (s logSlice) lastEntryID() entryID {
 	return s.prev
 }
 
-// mark returns the logMark identifying the end of this logSlice.
-func (s logSlice) mark() logMark {
-	return logMark{term: s.term, index: s.lastIndex()}
+// mark returns the LogMark identifying the end of this logSlice.
+func (s logSlice) mark() LogMark {
+	return LogMark{Term: s.term, Index: s.lastIndex()}
 }
 
 // termAt returns the term of the entry at the given index.
@@ -153,7 +153,7 @@ func (s logSlice) valid() error {
 // observed this committed state.
 //
 // Semantically, from the log perspective, this type is equivalent to a logSlice
-// from 0 to lastEntryID(), plus a commit logMark. All leader logs at terms >=
+// from 0 to lastEntryID(), plus a commit LogMark. All leader logs at terms >=
 // snapshot.term contain all entries up to the lastEntryID(). At earlier terms,
 // logs may or may not be consistent with this snapshot, depending on whether
 // they contain the lastEntryID().
@@ -186,10 +186,10 @@ func (s snapshot) lastEntryID() entryID {
 	return entryID{term: s.snap.Metadata.Term, index: s.snap.Metadata.Index}
 }
 
-// mark returns committed logMark of this snapshot, in the coordinate system of
+// mark returns committed LogMark of this snapshot, in the coordinate system of
 // the leader who observes this committed state.
-func (s snapshot) mark() logMark {
-	return logMark{term: s.term, index: s.snap.Metadata.Index}
+func (s snapshot) mark() LogMark {
+	return LogMark{Term: s.term, Index: s.snap.Metadata.Index}
 }
 
 // valid returns nil iff the snapshot is well-formed.

--- a/pkg/raft/types_test.go
+++ b/pkg/raft/types_test.go
@@ -92,7 +92,7 @@ func TestLogSlice(t *testing.T) {
 			last := s.lastEntryID()
 			require.Equal(t, tt.last, last)
 			require.Equal(t, last.index, s.lastIndex())
-			require.Equal(t, logMark{term: tt.term, index: last.index}, s.mark())
+			require.Equal(t, LogMark{Term: tt.term, Index: last.index}, s.mark())
 
 			require.Equal(t, tt.prev.term, s.termAt(tt.prev.index))
 			for _, e := range tt.entries {
@@ -164,7 +164,7 @@ func TestSnapshot(t *testing.T) {
 			last := s.lastEntryID()
 			require.Equal(t, tt.last, last)
 			require.Equal(t, last.index, s.lastIndex())
-			require.Equal(t, logMark{term: tt.term, index: last.index}, s.mark())
+			require.Equal(t, LogMark{Term: tt.term, Index: last.index}, s.mark())
 		})
 	}
 }


### PR DESCRIPTION
The `LogMark` type will be used for log writes processing in the client code of `raft` package, instead of ad-hoc term/index pairs. The type documents the meaning of "leader term" and underlines the difference with the "entry term". Some raft APIs will be converted to expose this type too.

Epic: none
Release note: none