### PR TITLE
crosscluster/physical: defensively check errCh in span config event stream

### DIFF
--- a/pkg/ccl/crosscluster/producer/span_config_event_stream.go
+++ b/pkg/ccl/crosscluster/producer/span_config_event_stream.go
@@ -157,7 +157,12 @@ func (s *spanConfigEventStream) Next(ctx context.Context) (bool, error) {
 	case err := <-s.errCh:
 		return false, err
 	case s.data = <-s.streamCh:
-		return true, nil
+		select {
+		case err := <-s.errCh:
+			return false, err
+		default:
+			return true, nil
+		}
 	}
 }
 


### PR DESCRIPTION
Select does not choose which channel to read from based on some order, but the span config event stream must return as soon as there is an error. For this reason, this patch rechecks the errCh after select chooses to read from the data channel.

Informs #128865

Release note: none