### PR TITLE
rac2: introduce log storage tracker

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "rac2",
     srcs = [
+        "log_tracker.go",
         "metrics.go",
         "priority.go",
         "range_controller.go",
@@ -16,6 +17,7 @@ go_library(
         "//pkg/base",
         "//pkg/kv/kvserver/kvflowcontrol",
         "//pkg/kv/kvserver/raftlog",
+        "//pkg/raft",
         "//pkg/raft/raftpb",
         "//pkg/raft/tracker",
         "//pkg/roachpb",
@@ -34,6 +36,7 @@ go_library(
 go_test(
     name = "rac2_test",
     srcs = [
+        "log_tracker_test.go",
         "priority_test.go",
         "range_controller_test.go",
         "token_counter_test.go",

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/log_tracker.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/log_tracker.go
@@ -1,0 +1,254 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rac2
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/raft"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+)
+
+// LogMark is a position in a log consistent with the leader at a specific term.
+type LogMark = raft.LogMark
+
+// AdmittedVector contains admitted log indices for each priority.
+type AdmittedVector struct {
+	// Term is the leader term to which the admitted log indices relate to.
+	Term uint64
+	// Admitted contains admitted indices in the Term's log.
+	Admitted [raftpb.NumPriorities]uint64
+}
+
+// LogTracker tracks the durable and logically admitted state of a raft log.
+//
+// Writes to a raft log are ordered by LogMark (term, index) where term is the
+// leader term on whose behalf entries are currently written, and index is the
+// entry position in the log as seen by this leader. The index can only regress
+// if term goes up, and a new leader overwrites a suffix of the log.
+//
+// Integration with storage guarantees that completion of a (term, index)
+// write/sync means that all writes made under lower terms, or same term and
+// lower log indices, have been completed. A similar guarantee comes for
+// admissions at each priority.
+type LogTracker struct {
+	// last is the latest log mark observed by the tracker.
+	last LogMark
+	// stable is the durable log index, in the last.Term log coordinate system.
+	// Entries in (stable, last.Index] are still in the write queue.
+	stable uint64
+	// waiting contains, for each priority, entries present in the last.Term log
+	// waiting for admission.
+	//
+	// Invariants:
+	//	- waiting[pri][i].Index <= last.Index
+	//	- waiting[pri][i].Term <= last.Term
+	//	- waiting[pri][i].Index < waiting[pri][i+1].Index
+	//	- waiting[pri][i].Term <= waiting[pri][i+1].Term
+	waiting [raftpb.NumPriorities][]LogMark
+}
+
+// NewLogTracker returns a LogTracker initialized to the given log mark. The
+// caller must make sure that the log mark is durable.
+func NewLogTracker(stable LogMark) LogTracker {
+	return LogTracker{last: stable, stable: stable.Index}
+}
+
+// Stable returns the currently observed stable log mark.
+func (l *LogTracker) Stable() LogMark {
+	return LogMark{Term: l.last.Term, Index: l.stable}
+}
+
+// Admitted returns the current admitted log state, tied to the latest observed
+// leader term.
+//
+// The admitted index for a priority is computed as one before the min entry
+// index in the waiting queue. The indices are capped at the stable log index,
+// and bumped to stable index for priorities which don't have any entries
+// waiting for admission.
+//
+// Guarantees:
+//   - the term never regresses,
+//   - admitted indices never regress if the term does not change,
+//   - indices converge to the stable index which converges to the last index.
+func (l *LogTracker) Admitted() AdmittedVector {
+	a := AdmittedVector{Term: l.last.Term}
+	for pri := range a.Admitted {
+		index := l.stable
+		if len(l.waiting[pri]) != 0 {
+			index = min(index, l.waiting[pri][0].Index-1)
+		}
+		a.Admitted[pri] = index
+	}
+	return a
+}
+
+// Append informs the tracker that log entries at indices (after, to.Index] are
+// about to be sent to stable storage, on behalf of the to.Term leader.
+//
+// All log storage writes must be registered with the Append call, ordered by
+// LogMark, with no gaps. Any entries in the (after, to.Index] batch, that are
+// subject to admission control, should be registered with the Register call
+// before the batch is sent to storage.
+func (l *LogTracker) Append(ctx context.Context, after uint64, to LogMark) {
+	// Fast path. We are at the same term. The log must be contiguous.
+	if to.Term == l.last.Term {
+		if after != l.last.Index {
+			l.errorf(ctx, "append (%d,%d]@%d out of order", after, to.Index, to.Term)
+			return
+		}
+		l.last.Index = to.Index
+		return
+	}
+	if to.Term < l.last.Term || after > l.last.Index {
+		// Does not happen. Log writes are always ordered by LogMark, and have no
+		// gaps. Gaps can only appear when the log is cleared in response to storing
+		// a snapshot, which is handled by the SnapSynced method.
+		l.errorf(ctx, "append (%d,%d]@%d out of order", after, to.Index, to.Term)
+		return
+	}
+	// Invariant: to.Term > l.last.Term && after <= l.last.Index.
+	l.last = to
+	// The effective stable and admitted indices can potentially regress here.
+	// This happens when a new leader overwrites a suffix of the log.
+	l.stable = min(l.stable, after)
+	// Entries at index > after.Index from previous terms are now obsolete.
+	for pri, marks := range l.waiting {
+		l.waiting[pri] = truncate(marks, after)
+	}
+}
+
+// Register informs the tracker that the entry at the given log mark is about to
+// be sent to admission queue with the given priority. Must be called in the
+// LogMark order, at most once for each entry.
+//
+// Typically, every batch of appended log entries should call Append once,
+// followed by a sequence of Register calls for individual entries that are
+// subject to admission control.
+func (l *LogTracker) Register(ctx context.Context, at LogMark, pri raftpb.Priority) {
+	if at.Term != l.last.Term || at.Index <= l.stable {
+		// Does not happen. Entries must be registered before being sent to storage,
+		// so an entry can't become stable before the Register call.
+		l.errorf(ctx, "admission register %+v [pri=%v] out of order", at, pri)
+		return
+	}
+	ln := len(l.waiting[pri])
+	if ln != 0 && at.Index <= l.waiting[pri][ln-1].Index {
+		l.errorf(ctx, "admission register %+v [pri=%v] out of order", at, pri)
+		return
+	}
+	l.waiting[pri] = append(l.waiting[pri], at)
+}
+
+// LogSynced informs the tracker that the log up to the given LogMark has been
+// persisted to stable storage.
+//
+// All writes are done in the LogMark order, but the corresponding LogSynced
+// calls can be skipped or invoked in any order, e.g. due to delivery
+// concurrency. The tracker keeps the latest (in the logical sense) stable mark.
+func (l *LogTracker) LogSynced(ctx context.Context, stable LogMark) {
+	if stable.After(l.last) {
+		// Does not happen. The write must have been registered with Append call.
+		l.errorf(ctx, "syncing mark %+v before appending it", stable)
+		return
+	}
+	// TODO(pav-kv): we can move the stable index up for a stale Term too, if we
+	// track leader term for each entry (see LogAdmitted), or forks of the log.
+	if stable.Term == l.last.Term && stable.Index > l.stable {
+		l.stable = stable.Index
+	}
+}
+
+// LogAdmitted informs the tracker that the log up to the given LogMark has been
+// logically admitted to storage, at the given priority.
+//
+// All writes are done in the LogMark order, but the corresponding LogAdmitted
+// calls can be skipped or invoked in any order, e.g. due to delivery
+// concurrency. The tracker accounts for the latest (in the logical sense)
+// admission.
+//
+// LogAdmitted and LogSynced for the same entry/mark can happen in any order
+// too, since the write and admission queues are decoupled from each other, and
+// there can be concurrency in the signal delivery. LogTracker dampens this by
+// capping admitted indices at stable index (see Admitted), so that admissions
+// appear to happen after log syncs.
+func (l *LogTracker) LogAdmitted(ctx context.Context, at LogMark, pri raftpb.Priority) {
+	if at.After(l.last) {
+		// Does not happen. The write must have been registered with Append call.
+		l.errorf(ctx, "admitting mark %+v before appending it", at)
+		return
+	}
+	waiting := l.waiting[pri]
+	// There is nothing to admit, or it's a stale admission.
+	if len(waiting) == 0 || at.Index < waiting[0].Index {
+		return
+	}
+	// Remove waiting entries preceding the admitted mark. Due to invariants, this
+	// is always a prefix of the queue.
+	for i, mark := range waiting {
+		if mark.After(at) {
+			l.waiting[pri] = waiting[i:]
+			return
+		}
+	}
+	// The entire queue is admitted, clear it.
+	l.waiting[pri] = waiting[len(waiting):]
+}
+
+// SnapSynced informs the tracker that a snapshot at the given log mark has been
+// stored/synced, and the log is cleared.
+func (l *LogTracker) SnapSynced(ctx context.Context, mark LogMark) {
+	if !mark.After(l.last) {
+		l.errorf(ctx, "syncing stale snapshot %+v", mark)
+		return
+	}
+	// Fake an append spanning the gap between the log and the snapshot. It will,
+	// if necessary, truncate the stable index and remove entries waiting for
+	// admission that became obsolete.
+	l.Append(ctx, min(l.last.Index, mark.Index), mark)
+	l.LogSynced(ctx, mark)
+}
+
+// String returns a string representation of the LogTracker.
+func (l *LogTracker) String() string {
+	return redact.StringWithoutMarkers(l)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (l *LogTracker) SafeFormat(w redact.SafePrinter, _ rune) {
+	admitted := l.Admitted().Admitted
+	w.Printf("mark:%+v, stable:%d, admitted:%v", l.last, l.stable, admitted)
+}
+
+func (l *LogTracker) errorf(ctx context.Context, format string, args ...any) {
+	format += "\n%s"
+	args = append(args, l.String())
+	if buildutil.CrdbTestBuild {
+		panic(errors.AssertionFailedf(format, args...))
+	} else {
+		log.Errorf(ctx, format, args...)
+	}
+}
+
+// truncate returns a prefix of the ordered log marks slice, with all marks at
+// index > after removed from it.
+func truncate(marks []LogMark, after uint64) []LogMark {
+	for i := len(marks); i > 0; i-- {
+		if marks[i-1].Index <= after {
+			return marks[:i]
+		}
+	}
+	return marks[:0]
+}

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/log_tracker_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/log_tracker_test.go
@@ -1,0 +1,271 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rac2
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/datadriven"
+	"github.com/stretchr/testify/require"
+)
+
+func mark(term, index uint64) LogMark {
+	return LogMark{Term: term, Index: index}
+}
+
+func (l *LogTracker) check(t *testing.T) {
+	require.LessOrEqual(t, l.stable, l.last.Index)
+	stable := l.Stable()
+	require.Equal(t, l.last.Term, stable.Term)
+	for _, waiting := range l.waiting {
+		if ln := len(waiting); ln != 0 {
+			require.LessOrEqual(t, waiting[ln-1].Index, l.last.Index)
+			require.LessOrEqual(t, waiting[ln-1].Term, l.last.Term)
+		}
+		for i, ln := 1, len(waiting); i < ln; i++ {
+			require.Less(t, waiting[i-1].Index, waiting[i].Index)
+			require.LessOrEqual(t, waiting[i-1].Term, waiting[i].Term)
+		}
+	}
+	a := l.Admitted()
+	require.Equal(t, stable.Term, a.Term)
+	for _, index := range a.Admitted {
+		require.LessOrEqual(t, index, stable.Index)
+	}
+}
+
+func TestLogTrackerAppend(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	for _, tt := range []struct {
+		last   LogMark
+		stable uint64
+
+		after uint64
+		to    LogMark
+		notOk bool
+		want  uint64 // stable index
+	}{
+		// Invalid appends. Writes with stale term or index gaps.
+		{last: mark(10, 100), after: 100, to: mark(9, 200), notOk: true},
+		{last: mark(10, 100), after: 200, to: mark(10, 300), notOk: true},
+		{last: mark(10, 100), after: 20, to: mark(10, 50), notOk: true},
+		// Valid appends.
+		{after: 0, to: mark(10, 100), want: 0},
+		{last: mark(10, 100), after: 100, to: mark(10, 150)},
+		{last: mark(10, 100), after: 100, to: mark(15, 150)},
+		{last: mark(10, 100), after: 50, to: mark(15, 150)},
+		// Stable index does not change.
+		{last: mark(10, 100), stable: 50, after: 100, to: mark(10, 150), want: 50},
+		{last: mark(10, 100), stable: 50, after: 100, to: mark(11, 150), want: 50},
+		{last: mark(10, 100), stable: 50, after: 70, to: mark(11, 150), want: 50},
+		// Stable index regresses.
+		{last: mark(10, 100), stable: 50, after: 30, to: mark(11, 150), want: 30},
+	} {
+		t.Run("", func(t *testing.T) {
+			defer func() {
+				failed := recover() != nil
+				require.Equal(t, tt.notOk, failed)
+			}()
+			l := NewLogTracker(tt.last)
+			l.stable = tt.stable
+			l.check(t)
+			l.Append(context.Background(), tt.after, tt.to)
+			l.check(t)
+			require.Equal(t, tt.to, l.last)
+			require.Equal(t, tt.want, l.Stable().Index)
+		})
+	}
+}
+
+func TestLogTrackerLogSynced(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	for _, tt := range []struct {
+		last   LogMark
+		stable uint64
+
+		sync  LogMark
+		notOk bool
+		want  uint64 // stable index
+	}{
+		// Invalid syncs.
+		{last: mark(5, 20), sync: mark(7, 10), notOk: true},
+		{last: mark(5, 20), sync: mark(5, 25), notOk: true},
+
+		// Valid syncs. The sync mark <= the latest observed mark.
+		{last: mark(5, 20), stable: 5, sync: mark(4, 10), want: 5},
+		{last: mark(5, 20), stable: 15, sync: mark(4, 10), want: 15},
+		{last: mark(5, 20), stable: 15, sync: mark(4, 100), want: 15},
+		{last: mark(5, 20), sync: mark(5, 10), want: 10},
+		{last: mark(5, 20), stable: 15, sync: mark(5, 10), want: 15},
+		{last: mark(5, 20), sync: mark(5, 20), want: 20},
+		{last: mark(5, 40), stable: 15, sync: mark(5, 30), want: 30},
+	} {
+		t.Run("", func(t *testing.T) {
+			defer func() {
+				failed := recover() != nil
+				require.Equal(t, tt.notOk, failed)
+			}()
+			l := NewLogTracker(tt.last)
+			l.stable = tt.stable
+			l.check(t)
+			l.LogSynced(context.Background(), tt.sync)
+			l.check(t)
+			require.Equal(t, tt.last, l.last)
+			require.Equal(t, tt.want, l.Stable().Index)
+		})
+	}
+}
+
+func TestLogTrackerSnapSynced(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	for _, tt := range []struct {
+		last   LogMark
+		stable uint64
+		snap   LogMark
+		notOk  bool
+	}{
+		// Invalid snapshots.
+		{last: mark(5, 20), snap: mark(4, 30), notOk: true},
+		{last: mark(5, 20), snap: mark(5, 10), notOk: true},
+		// Valid snapshots.
+		{last: mark(5, 20), snap: mark(5, 30)},
+		{last: mark(5, 20), snap: mark(6, 10)},
+		{last: mark(5, 20), snap: mark(6, 30)},
+	} {
+		t.Run("", func(t *testing.T) {
+			defer func() {
+				failed := recover() != nil
+				require.Equal(t, tt.notOk, failed)
+			}()
+			l := NewLogTracker(tt.last)
+			l.stable = tt.stable
+			l.check(t)
+			l.SnapSynced(context.Background(), tt.snap)
+			l.check(t)
+			require.Equal(t, tt.snap, l.last)
+			require.Equal(t, tt.snap.Index, l.Stable().Index)
+		})
+	}
+}
+
+func TestLogTracker(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	readPri := func(t *testing.T, d *datadriven.TestData) raftpb.Priority {
+		var s string
+		d.ScanArgs(t, "pri", &s)
+		pri := priFromString(s)
+		if pri == raftpb.NumPriorities {
+			t.Fatalf("unknown pri: %s", s)
+		}
+		return pri
+	}
+	readMark := func(t *testing.T, d *datadriven.TestData, idxName string) LogMark {
+		var mark LogMark
+		d.ScanArgs(t, "term", &mark.Term)
+		d.ScanArgs(t, idxName, &mark.Index)
+		return mark
+	}
+
+	var tracker LogTracker
+	state := func() string {
+		var b strings.Builder
+		fmt.Fprintln(&b, tracker.String())
+		for pri, marks := range tracker.waiting {
+			if len(marks) == 0 {
+				continue
+			}
+			fmt.Fprintf(&b, "%s:", raftpb.Priority(pri))
+			for _, mark := range marks {
+				fmt.Fprintf(&b, " %+v", mark)
+			}
+			fmt.Fprintf(&b, "\n")
+		}
+		return b.String()
+	}
+
+	ctx := context.Background()
+	run := func(t *testing.T, d *datadriven.TestData) (out string) {
+		defer func() {
+			if err := recover(); err != nil {
+				out = "error"
+			}
+		}()
+
+		switch d.Cmd {
+		case "reset": // Example: reset term=1 index=10
+			stable := readMark(t, d, "index")
+			tracker = NewLogTracker(stable)
+			return state()
+
+		case "append": // Example: append term=10 after=100 to=200
+			var after uint64
+			d.ScanArgs(t, "after", &after)
+			to := readMark(t, d, "to")
+			tracker.Append(ctx, after, to)
+			return state()
+
+		case "sync": // Example: sync term=10 index=100
+			mark := readMark(t, d, "index")
+			tracker.LogSynced(ctx, mark)
+			return state()
+
+		case "register": // Example: register term=10 index=100 pri=LowPri
+			mark := readMark(t, d, "index")
+			pri := readPri(t, d)
+			tracker.Register(ctx, mark, pri)
+			return state()
+
+		case "admit": // Example: admit term=10 index=100 pri=LowPri
+			mark := readMark(t, d, "index")
+			pri := readPri(t, d)
+			tracker.LogAdmitted(ctx, mark, pri)
+			return state()
+
+		default:
+			t.Fatalf("unknown command: %s", d.Cmd)
+			return ""
+		}
+	}
+
+	datadriven.RunTest(t, datapathutils.TestDataPath(t, "log_tracker"), run)
+}
+
+// priFromString converts a string to Priority.
+// TODO(pav-kv): move to the package next to Priority.
+func priFromString(s string) raftpb.Priority {
+	switch s {
+	case "LowPri":
+		return raftpb.LowPri
+	case "NormalPri":
+		return raftpb.NormalPri
+	case "AboveNormalPri":
+		return raftpb.AboveNormalPri
+	case "HighPri":
+		return raftpb.HighPri
+	default:
+		return raftpb.NumPriorities
+	}
+}

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/log_tracker
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/log_tracker
@@ -1,0 +1,256 @@
+# ------------------------------------------------------------------------------
+# Test basic operations.
+
+reset term=1 index=5
+----
+mark:{Term:1 Index:5}, stable:5, admitted:[5 5 5 5]
+
+append term=1 after=5 to=10
+----
+mark:{Term:1 Index:10}, stable:5, admitted:[5 5 5 5]
+
+register term=1 index=7 pri=LowPri
+----
+mark:{Term:1 Index:10}, stable:5, admitted:[5 5 5 5]
+LowPri: {Term:1 Index:7}
+
+sync term=1 index=10
+----
+mark:{Term:1 Index:10}, stable:10, admitted:[6 10 10 10]
+LowPri: {Term:1 Index:7}
+
+admit term=1 index=6 pri=LowPri
+----
+mark:{Term:1 Index:10}, stable:10, admitted:[6 10 10 10]
+LowPri: {Term:1 Index:7}
+
+admit term=1 index=7 pri=LowPri
+----
+mark:{Term:1 Index:10}, stable:10, admitted:[10 10 10 10]
+
+append term=1 after=10 to=12
+----
+mark:{Term:1 Index:12}, stable:10, admitted:[10 10 10 10]
+
+register term=1 index=11 pri=LowPri
+----
+mark:{Term:1 Index:12}, stable:10, admitted:[10 10 10 10]
+LowPri: {Term:1 Index:11}
+
+register term=1 index=12 pri=HighPri
+----
+mark:{Term:1 Index:12}, stable:10, admitted:[10 10 10 10]
+LowPri: {Term:1 Index:11}
+HighPri: {Term:1 Index:12}
+
+append term=2 after=5 to=10
+----
+mark:{Term:2 Index:10}, stable:5, admitted:[5 5 5 5]
+
+# ------------------------------------------------------------------------------
+# Test stable index advancement racing with admission.
+
+reset term=1 index=1
+----
+mark:{Term:1 Index:1}, stable:1, admitted:[1 1 1 1]
+
+append term=1 after=1 to=10
+----
+mark:{Term:1 Index:10}, stable:1, admitted:[1 1 1 1]
+
+register term=1 index=5 pri=HighPri
+----
+mark:{Term:1 Index:10}, stable:1, admitted:[1 1 1 1]
+HighPri: {Term:1 Index:5}
+
+admit term=1 index=5 pri=HighPri
+----
+mark:{Term:1 Index:10}, stable:1, admitted:[1 1 1 1]
+
+sync term=1 index=10
+----
+mark:{Term:1 Index:10}, stable:10, admitted:[10 10 10 10]
+
+# ------------------------------------------------------------------------------
+# Same race but sync completes first.
+
+reset term=1 index=1
+----
+mark:{Term:1 Index:1}, stable:1, admitted:[1 1 1 1]
+
+append term=1 after=1 to=10
+----
+mark:{Term:1 Index:10}, stable:1, admitted:[1 1 1 1]
+
+register term=1 index=5 pri=HighPri
+----
+mark:{Term:1 Index:10}, stable:1, admitted:[1 1 1 1]
+HighPri: {Term:1 Index:5}
+
+sync term=1 index=10
+----
+mark:{Term:1 Index:10}, stable:10, admitted:[10 10 10 4]
+HighPri: {Term:1 Index:5}
+
+admit term=1 index=5 pri=HighPri
+----
+mark:{Term:1 Index:10}, stable:10, admitted:[10 10 10 10]
+
+# ------------------------------------------------------------------------------
+# Port of waiting_for_admission_state test.
+
+reset term=3 index=1
+----
+mark:{Term:3 Index:1}, stable:1, admitted:[1 1 1 1]
+
+append term=3 after=1 to=7
+----
+mark:{Term:3 Index:7}, stable:1, admitted:[1 1 1 1]
+
+register term=3 index=5 pri=LowPri
+----
+mark:{Term:3 Index:7}, stable:1, admitted:[1 1 1 1]
+LowPri: {Term:3 Index:5}
+
+register term=3 index=6 pri=HighPri
+----
+mark:{Term:3 Index:7}, stable:1, admitted:[1 1 1 1]
+LowPri: {Term:3 Index:5}
+HighPri: {Term:3 Index:6}
+
+register term=3 index=7 pri=HighPri
+----
+mark:{Term:3 Index:7}, stable:1, admitted:[1 1 1 1]
+LowPri: {Term:3 Index:5}
+HighPri: {Term:3 Index:6} {Term:3 Index:7}
+
+# No-op, since the term is old.
+admit term=2 index=7 pri=HighPri
+----
+mark:{Term:3 Index:7}, stable:1, admitted:[1 1 1 1]
+LowPri: {Term:3 Index:5}
+HighPri: {Term:3 Index:6} {Term:3 Index:7}
+
+# Entry admitted, but the admitted index stays at 1 since the stable index is
+# still there.
+admit term=3 index=6 pri=HighPri
+----
+mark:{Term:3 Index:7}, stable:1, admitted:[1 1 1 1]
+LowPri: {Term:3 Index:5}
+HighPri: {Term:3 Index:7}
+
+# Stable index moves, and admitted indices move accordingly.
+sync term=3 index=7
+----
+mark:{Term:3 Index:7}, stable:7, admitted:[4 7 7 6]
+LowPri: {Term:3 Index:5}
+HighPri: {Term:3 Index:7}
+
+append term=3 after=7 to=8
+----
+mark:{Term:3 Index:8}, stable:7, admitted:[4 7 7 6]
+LowPri: {Term:3 Index:5}
+HighPri: {Term:3 Index:7}
+
+register term=3 index=8 pri=HighPri
+----
+mark:{Term:3 Index:8}, stable:7, admitted:[4 7 7 6]
+LowPri: {Term:3 Index:5}
+HighPri: {Term:3 Index:7} {Term:3 Index:8}
+
+# Admitted indices move up for priorities with no queue.
+sync term=3 index=8
+----
+mark:{Term:3 Index:8}, stable:8, admitted:[4 8 8 6]
+LowPri: {Term:3 Index:5}
+HighPri: {Term:3 Index:7} {Term:3 Index:8}
+
+# All HighPri entries are admitted.
+admit term=3 index=8 pri=HighPri
+----
+mark:{Term:3 Index:8}, stable:8, admitted:[4 8 8 8]
+LowPri: {Term:3 Index:5}
+
+append term=3 after=8 to=11
+----
+mark:{Term:3 Index:11}, stable:8, admitted:[4 8 8 8]
+LowPri: {Term:3 Index:5}
+
+register term=3 index=9 pri=LowPri
+----
+mark:{Term:3 Index:11}, stable:8, admitted:[4 8 8 8]
+LowPri: {Term:3 Index:5} {Term:3 Index:9}
+
+register term=3 index=11 pri=LowPri
+----
+mark:{Term:3 Index:11}, stable:8, admitted:[4 8 8 8]
+LowPri: {Term:3 Index:5} {Term:3 Index:9} {Term:3 Index:11}
+
+# New term, removes a suffix of the log.
+append term=4 after=9 to=10
+----
+mark:{Term:4 Index:10}, stable:8, admitted:[4 8 8 8]
+LowPri: {Term:3 Index:5} {Term:3 Index:9}
+
+register term=4 index=10 pri=LowPri
+----
+mark:{Term:4 Index:10}, stable:8, admitted:[4 8 8 8]
+LowPri: {Term:3 Index:5} {Term:3 Index:9} {Term:4 Index:10}
+
+# New term, again removes a suffix of the log.
+append term=5 after=8 to=9
+----
+mark:{Term:5 Index:9}, stable:8, admitted:[4 8 8 8]
+LowPri: {Term:3 Index:5}
+
+register term=5 index=9 pri=LowPri
+----
+mark:{Term:5 Index:9}, stable:8, admitted:[4 8 8 8]
+LowPri: {Term:3 Index:5} {Term:5 Index:9}
+
+# New term, again removes a suffix of the log.
+append term=6 after=6 to=7
+----
+mark:{Term:6 Index:7}, stable:6, admitted:[4 6 6 6]
+LowPri: {Term:3 Index:5}
+
+register term=6 index=7 pri=LowPri
+----
+mark:{Term:6 Index:7}, stable:6, admitted:[4 6 6 6]
+LowPri: {Term:3 Index:5} {Term:6 Index:7}
+
+# New term, no suffix is removed.
+append term=7 after=7 to=8
+----
+mark:{Term:7 Index:8}, stable:6, admitted:[4 6 6 6]
+LowPri: {Term:3 Index:5} {Term:6 Index:7}
+
+register term=7 index=8 pri=LowPri
+----
+mark:{Term:7 Index:8}, stable:6, admitted:[4 6 6 6]
+LowPri: {Term:3 Index:5} {Term:6 Index:7} {Term:7 Index:8}
+
+# Index not found, but a prefix of the queue is removed. Note: the term 6 entry
+# is removed due to being stale, even though its index is above the admitted.
+admit term=7 index=6 pri=LowPri
+----
+mark:{Term:7 Index:8}, stable:6, admitted:[6 6 6 6]
+LowPri: {Term:7 Index:8}
+
+# A stale admission, no-op.
+admit term=6 index=8 pri=LowPri
+----
+mark:{Term:7 Index:8}, stable:6, admitted:[6 6 6 6]
+LowPri: {Term:7 Index:8}
+
+sync term=7 index=8
+----
+mark:{Term:7 Index:8}, stable:8, admitted:[7 8 8 8]
+LowPri: {Term:7 Index:8}
+
+# Everything is persisted and admitted.
+admit term=7 index=8 pri=LowPri
+----
+mark:{Term:7 Index:8}, stable:8, admitted:[8 8 8 8]
+
+# ------------------------------------------------------------------------------

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -337,6 +337,8 @@ type Replica struct {
 	// - Replica.localMsgs must be held to append messages to active.
 	// - Replica.raftMu and Replica.localMsgs must both be held to switch slices.
 	// - Replica.raftMu < Replica.localMsgs
+	//
+	// TODO(pav-kv): replace these with log marks for the latest completed write.
 	localMsgs struct {
 		syncutil.Mutex
 		active, recycled []raftpb.Message

--- a/pkg/raft/types.go
+++ b/pkg/raft/types.go
@@ -55,6 +55,12 @@ type LogMark struct {
 	Index uint64
 }
 
+// After returns true if the log mark logically happens after the other mark.
+// This represents the order of log writes in raft.
+func (l LogMark) After(other LogMark) bool {
+	return l.Term > other.Term || l.Term == other.Term && l.Index > other.Index
+}
+
 // logSlice describes a correct slice of a raft log.
 //
 // Every log slice is considered in a context of a specific leader term. This

--- a/pkg/testutils/lint/passes/fmtsafe/functions.go
+++ b/pkg/testutils/lint/passes/fmtsafe/functions.go
@@ -125,6 +125,8 @@ var requireConstFmt = map[string]bool{
 	"(*github.com/cockroachdb/cockroach/pkg/kv/kvserver.raftLogger).Fatalf":   true,
 	"(*github.com/cockroachdb/cockroach/pkg/kv/kvserver.raftLogger).Panicf":   true,
 
+	"(*github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/rac2.LogTracker).errorf": true,
+
 	"(github.com/cockroachdb/cockroach/pkg/raft.Logger).Debugf":   true,
 	"(github.com/cockroachdb/cockroach/pkg/raft.Logger).Infof":    true,
 	"(github.com/cockroachdb/cockroach/pkg/raft.Logger).Warningf": true,


### PR DESCRIPTION
This PR introduces the data structure that observes all raft log storage writes, syncs and logical admissions, and tracks the stable/admitted log state correspondingly.

Log writes are ordered by leader term, then by index. Log writes have no gaps, except when a snapshot clears the log. All writes/syncs must be registered. Admissions can be registered selectively, for entries that are subject to RACv2.

Part of #129508