### PR TITLE
sql: move table metadata update job to new package

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -2280,6 +2280,7 @@ GO_TARGETS = [
     "//pkg/sql/syntheticprivilege:syntheticprivilege",
     "//pkg/sql/syntheticprivilege:syntheticprivilege_test",
     "//pkg/sql/syntheticprivilegecache:syntheticprivilegecache",
+    "//pkg/sql/tablemetadatacache:tablemetadatacache",
     "//pkg/sql/tests:tests",
     "//pkg/sql/tests:tests_test",
     "//pkg/sql/ttl/ttlbase:ttlbase",

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -277,7 +277,6 @@ go_library(
         "unsplit.go",
         "unsupported_vars.go",
         "update.go",
-        "update_table_metadata_cache_job.go",
         "upsert.go",
         "user.go",
         "values.go",

--- a/pkg/sql/tablemetadatacache/BUILD.bazel
+++ b/pkg/sql/tablemetadatacache/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "tablemetadatacache",
+    srcs = ["update_table_metadata_cache_job.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/tablemetadatacache",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/jobs",
+        "//pkg/jobs/jobspb",
+        "//pkg/settings/cluster",
+        "//pkg/util/log",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
+)

--- a/pkg/sql/tablemetadatacache/update_table_metadata_cache_job.go
+++ b/pkg/sql/tablemetadatacache/update_table_metadata_cache_job.go
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package sql
+package tablemetadatacache
 
 import (
 	"context"
@@ -41,7 +41,7 @@ func (j *tableMetadataUpdateJobResumer) OnFailOrCancel(
 ) error {
 	if jobs.HasErrJobCanceled(jobErr) {
 		err := errors.NewAssertionErrorWithWrappedErrf(
-			jobErr, "mvcc statistics update job is not cancelable",
+			jobErr, "update table metadata cache job is not cancelable",
 		)
 		log.Errorf(ctx, "%v", err)
 	}

--- a/pkg/upgrade/upgrades/BUILD.bazel
+++ b/pkg/upgrade/upgrades/BUILD.bazel
@@ -52,6 +52,7 @@ go_library(
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
+        "//pkg/sql/tablemetadatacache",
         "//pkg/upgrade",
         "//pkg/upgrade/upgradebase",
         "//pkg/util/envutil",

--- a/pkg/upgrade/upgrades/permanent_create_update_table_metadata_cache_job.go
+++ b/pkg/upgrade/upgrades/permanent_create_update_table_metadata_cache_job.go
@@ -16,9 +16,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	_ "github.com/cockroachdb/cockroach/pkg/jobs/metricspoller" // Ensure job implementation is linked.
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	_ "github.com/cockroachdb/cockroach/pkg/sql/tablemetadatacache" // Ensure job implementation is linked.
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
 )
 


### PR DESCRIPTION
This commit creates a new package tablemetadatacache and moves update_table_metadata_job.go to it.

Epic: none

Release note: None