### PR TITLE
backup,cdc: disallow backup, cdc on external tables

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -638,6 +638,15 @@ func backupPlanHook(
 			return errors.AssertionFailedf("unexpected descriptor coverage %v", backupStmt.Coverage())
 		}
 
+		for _, t := range targetDescs {
+			if tbl, ok := t.(catalog.TableDescriptor); ok && tbl.ExternalRowData() != nil {
+				if tbl.ExternalRowData().TenantID.IsSet() {
+					return errors.UnimplementedError(errors.IssueLink{}, "backing up from a replication target is not supported")
+				}
+				return errors.UnimplementedError(errors.IssueLink{}, "backing up from external tables is not supported")
+			}
+		}
+
 		// Check BACKUP privileges.
 		err = checkPrivilegesForBackup(ctx, backupStmt, p, targetDescs, to)
 		if err != nil {

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -466,6 +466,15 @@ func createChangefeedJobRecord(
 		return nil, err
 	}
 
+	for _, t := range targetDescs {
+		if tbl, ok := t.(catalog.TableDescriptor); ok && tbl.ExternalRowData() != nil {
+			if tbl.ExternalRowData().TenantID.IsSet() {
+				return nil, errors.UnimplementedError(errors.IssueLink{}, "changefeeds on a replication target are not supported")
+			}
+			return nil, errors.UnimplementedError(errors.IssueLink{}, "changefeeds on external tables are not supported")
+		}
+	}
+
 	targets, tables, err := getTargetsAndTables(ctx, p, targetDescs, changefeedStmt.Targets,
 		changefeedStmt.originalSpecs, opts.ShouldUseFullStatementTimeName(), sinkURI)
 


### PR DESCRIPTION
Release note: none.
Epic: none.