### PR TITLE
roachtest: use latest versions for mixed-version import test

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_import.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_import.go
@@ -50,6 +50,8 @@ func runImportMixedVersions(ctx context.Context, t test.Test, c cluster.Cluster,
 		// the `workload fixtures import` command, which is only supported
 		// reliably multi-tenant mode starting from that version.
 		mixedversion.MinimumSupportedVersion("v23.2.0"),
+		// Only use the latest version of each release to work around #127029.
+		mixedversion.AlwaysUseLatestPredecessors,
 	)
 	runImport := func(ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper) error {
 		if err := h.Exec(r, "DROP DATABASE IF EXISTS tpcc CASCADE;"); err != nil {


### PR DESCRIPTION
Previously, the mixed import roachtest could use random versions of each release. This caused the test to flake due to #127029, so this commit prevents the flakes by making the test use the latest versions.

Fixes #129211

Release note: None