### PR TITLE
roachtest: fix leaking goroutine in roachtest run-operation command.

### DIFF
--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -322,7 +322,11 @@ func CtrlC(ctx context.Context, l *logger.Logger, cancel func(), cr *clusterRegi
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, os.Interrupt)
 	go func() {
-		<-sig
+		select {
+		case <-sig:
+		case <-ctx.Done():
+			return
+		}
 		shout(ctx, l, os.Stderr,
 			"Signaled received. Canceling workers and waiting up to 5s for them.")
 		// Signal runner.Run() to stop.


### PR DESCRIPTION
Successful execution of the `roachtest run-operation` command prints a stack trace with a leaking goroutine. After analyzing the trace, the culprit is identified as the `CtrlC` function, which is leaking a goroutine.

The `CtrlC` function spawns a goroutine that waits for a SIGINT signal. During normal execution of the program, this goroutine remains dangling. This PR fixes the issue by ensuring the goroutine returns upon the completion of the context passed to it.

Epic: none

Release note: None