### PR TITLE
raft,logstore: add helpers for MsgStorageAppend

### DIFF
--- a/pkg/kv/kvserver/client_manual_proposal_test.go
+++ b/pkg/kv/kvserver/client_manual_proposal_test.go
@@ -261,7 +261,7 @@ LIMIT
 type wgSyncCallback sync.WaitGroup
 
 func (w *wgSyncCallback) OnLogSync(
-	ctx context.Context, messages []raftpb.Message, stats storage.BatchCommitStats,
+	context.Context, logstore.MsgStorageAppendDone, storage.BatchCommitStats,
 ) {
 	(*sync.WaitGroup)(w).Done()
 }

--- a/pkg/kv/kvserver/logstore/logstore_bench_test.go
+++ b/pkg/kv/kvserver/logstore/logstore_bench_test.go
@@ -38,7 +38,7 @@ func (b *discardBatch) Commit(bool) error {
 
 type noopSyncCallback struct{}
 
-func (noopSyncCallback) OnLogSync(context.Context, []raftpb.Message, storage.BatchCommitStats) {}
+func (noopSyncCallback) OnLogSync(context.Context, MsgStorageAppendDone, storage.BatchCommitStats) {}
 
 func BenchmarkLogStore_StoreEntries(b *testing.B) {
 	defer log.Scope(b).Close(b)

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1667,7 +1667,7 @@ func (r *Replica) maybeCoalesceHeartbeat(
 type replicaSyncCallback Replica
 
 func (r *replicaSyncCallback) OnLogSync(
-	ctx context.Context, msgs []raftpb.Message, commitStats storage.BatchCommitStats,
+	ctx context.Context, done logstore.MsgStorageAppendDone, commitStats storage.BatchCommitStats,
 ) {
 	repl := (*Replica)(r)
 	// Block sending the responses back to raft, if a test needs to.
@@ -1675,7 +1675,7 @@ func (r *replicaSyncCallback) OnLogSync(
 		fn(repl.ID())
 	}
 	// Send MsgStorageAppend's responses.
-	repl.sendRaftMessages(ctx, msgs, nil /* blocked */, false /* willDeliverLocal */)
+	repl.sendRaftMessages(ctx, done.Responses(), nil /* blocked */, false /* willDeliverLocal */)
 	if commitStats.TotalDuration > defaultReplicaRaftMuWarnThreshold {
 		log.Infof(repl.raftCtx, "slow non-blocking raft commit: %s", commitStats)
 	}

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -252,6 +252,9 @@ func newStorageAppendMsg(r *raft, rd Ready) pb.Message {
 	// handling to use a fast-path in r.raftLog.term() before the newly appended
 	// entries are removed from the unstable log.
 	m.Responses = r.msgsAfterAppend
+	// Warning: there is code outside raft package depending on the order of
+	// Responses, particularly MsgStorageAppendResp being last in this list.
+	// Change this with caution.
 	if needStorageAppendRespMsg(rd) {
 		m.Responses = append(m.Responses, newStorageAppendRespMsg(r, rd))
 	}

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -218,6 +218,7 @@ func newStorageAppendMsg(r *raft, rd Ready) pb.Message {
 		Entries: rd.Entries,
 	}
 	if ln := len(rd.Entries); ln != 0 {
+		// See comment in newStorageAppendRespMsg for why the accTerm is attached.
 		m.LogTerm = r.raftLog.accTerm()
 		m.Index = rd.Entries[ln-1].Index
 	}
@@ -238,6 +239,8 @@ func newStorageAppendMsg(r *raft, rd Ready) pb.Message {
 	if !IsEmptySnap(rd.Snapshot) {
 		snap := rd.Snapshot
 		m.Snapshot = &snap
+		// See comment in newStorageAppendRespMsg for why the accTerm is attached.
+		m.LogTerm = r.raftLog.accTerm()
 	}
 	// Attach all messages in msgsAfterAppend as responses to be delivered after
 	// the message is processed, along with a self-directed MsgStorageAppendResp
@@ -322,6 +325,7 @@ func newStorageAppendRespMsg(r *raft, rd Ready) pb.Message {
 	if !IsEmptySnap(rd.Snapshot) {
 		snap := rd.Snapshot
 		m.Snapshot = &snap
+		m.LogTerm = r.raftLog.accTerm()
 	}
 	return m
 }


### PR DESCRIPTION
This PR equips `MsgStorageAppend(Resp)` protocol messages with helpers useful for extracting the `LogMark`. To be used by the code outside `raft` package depending on the `LogMark` ordering of raft storage writes.

Part of #124440