### PR TITLE
security,jwtauthccl: Fix test failures due to leaked goroutines

### DIFF
--- a/pkg/util/leaktest/leaktest.go
+++ b/pkg/util/leaktest/leaktest.go
@@ -64,6 +64,10 @@ func interestingGoroutines() map[int64]string {
 			strings.Contains(stack, "github.com/jackc/pgconn/internal/ctxwatch.(*ContextWatcher).Watch.func1") ||
 			// Ignore pq goroutine that watches for context cancellation.
 			strings.Contains(stack, "github.com/lib/pq.(*conn).watchCancel") ||
+			// Ignore TLS handshake related goroutine.
+			// TODO(pritesh-lahoti): Revisit this once Go is updated to 1.23, as this seems to have been
+			// fixed: https://github.com/golang/go/pull/62227.
+			strings.Contains(stack, "net/http.(*persistConn).addTLS") ||
 			// Seems to be gccgo specific.
 			(runtime.Compiler == "gccgo" && strings.Contains(stack, "testing.T.Parallel")) ||
 			// Ignore intentionally long-running logging goroutines that live for the


### PR DESCRIPTION
We have been seeing intermittent test failures for `TestUseCerts` and `TestJWTAuthWithCustomCACert`.
These failures have been due to a leaked goroutine that establishes a TLS handshake.
The change is to ignore this goroutine while checking for leaked goroutines.
Added a TODO to revisit this once we update Go to 1.23, as this seems to
have been fixed: https://github.com/golang/go/pull/62227.

Epic: CRDB-36214, CRDB-40867
Fixes: #119052, #128214

Release note: None