### PR TITLE
server: create api for table metadata job status

### DIFF
--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1350,11 +1350,21 @@ message MVCCStatisticsJobProgress {
 
 message UpdateTableMetadataCacheDetails {}
 message UpdateTableMetadataCacheProgress {
+  enum Status {
+    NOT_RUNNING = 0;
+    RUNNING = 1;
+  }
   // The time at which the job last started a run.
-  google.protobuf.Timestamp last_run_time = 1 [
-    (gogoproto.nullable) = false,
+  google.protobuf.Timestamp last_start_time = 1 [
+    (gogoproto.nullable) = true,
     (gogoproto.stdtime) = true
   ];
+  // The time at which the job last completed a run.
+  google.protobuf.Timestamp last_completed_time = 2 [
+    (gogoproto.nullable) = true,
+    (gogoproto.stdtime) = true
+  ];
+  Status status = 3;
 }
 
 message ImportRollbackDetails {

--- a/pkg/server/api_v2.go
+++ b/pkg/server/api_v2.go
@@ -189,6 +189,7 @@ func registerRoutes(
 		{"sql/", a.execSQL, true, authserver.RegularRole, true},
 		{"database_metadata/", a.GetDBMetadata, true, authserver.RegularRole, true},
 		{"table_metadata/", a.GetTableMetadata, true, authserver.RegularRole, true},
+		{"table_metadata/updatejob/", a.TableMetadataJob, true, authserver.RegularRole, true},
 	}
 
 	// For all routes requiring authentication, have the outer mux (a.mux)

--- a/pkg/server/api_v2_databases_metadata_test.go
+++ b/pkg/server/api_v2_databases_metadata_test.go
@@ -495,6 +495,44 @@ func TestGetDBMetadata(t *testing.T) {
 	})
 }
 
+func TestGetTableMetadataUpdateJobStatus(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	testCluster := serverutils.StartCluster(t, 3, base.TestClusterArgs{})
+	ctx := context.Background()
+	defer testCluster.Stopper().Stop(ctx)
+	conn := testCluster.ServerConn(0)
+	defer conn.Close()
+
+	ts := testCluster.Server(0)
+
+	t.Run("authorization", func(t *testing.T) {
+		uri := "/api/v2/table_metadata/updatejob/"
+		sessionUsername := username.TestUserName()
+		userClient, _, err := ts.GetAuthenticatedHTTPClientAndCookie(sessionUsername, false, 1)
+		require.NoError(t, err)
+
+		failed := makeApiRequest[interface{}](t, userClient, ts.AdminURL().WithPath(uri).String())
+		require.Equal(t, http.StatusText(http.StatusNotFound), failed)
+
+		_, e := conn.Exec(fmt.Sprintf("GRANT CONNECT ON DATABASE defaultdb TO %s", sessionUsername.Normalized()))
+		require.NoError(t, e)
+
+		mdResp := makeApiRequest[tmUpdateJobStatusResponse](t, userClient, ts.AdminURL().WithPath(uri).String())
+		require.Equal(t, "NOT_RUNNING", mdResp.CurrentStatus)
+
+		_, e = conn.Exec(fmt.Sprintf("REVOKE CONNECT ON DATABASE defaultdb FROM %s", sessionUsername.Normalized()))
+		require.NoError(t, e)
+		failed = makeApiRequest[string](t, userClient, ts.AdminURL().WithPath(uri).String())
+		require.Equal(t, http.StatusText(http.StatusNotFound), failed)
+
+		_, e = conn.Exec(fmt.Sprintf("GRANT admin TO %s", sessionUsername.Normalized()))
+		require.NoError(t, e)
+		mdResp = makeApiRequest[tmUpdateJobStatusResponse](t, userClient, ts.AdminURL().WithPath(uri).String())
+		require.Equal(t, "NOT_RUNNING", mdResp.CurrentStatus)
+	})
+}
+
 func makeApiRequest[T any](t *testing.T, client http.Client, uri string) (mdResp T) {
 	req, err := http.NewRequest("GET", uri, nil)
 	require.NoError(t, err)

--- a/pkg/sql/tablemetadatacache/update_table_metadata_cache_job_test.go
+++ b/pkg/sql/tablemetadatacache/update_table_metadata_cache_job_test.go
@@ -84,8 +84,8 @@ WHERE id = $1 AND claim_instance_id IS NOT NULL`, jobs.UpdateTableMetadataCacheJ
 		}
 		var runningStatus string
 		require.NoError(t, row.Scan(&runningStatus))
-		if !strings.Contains(runningStatus, "last metadata update at") {
-			return errors.New("last run time not updated")
+		if !strings.Contains(runningStatus, "Job completed at") {
+			return errors.New("running_status not updated")
 		}
 		return nil
 	})


### PR DESCRIPTION
adds a new api v2 endpoint, GET /api/v2/table_metadata/updatejob.

This new API enables the ability to retrieve the status of the table metadata update job.

Resolves: https://github.com/cockroachdb/cockroach/issues/128896
Epic: [CRDB-37558](https://cockroachlabs.atlassian.net/browse/CRDB-37558)
Release note: None

Note: This PR is stacked on top of #129670, so only the last commit needs review