### PR TITLE
crosscluster: use fully qualified table names as targets

### DIFF
--- a/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
@@ -1430,7 +1430,12 @@ func TestShowLogicalReplicationJobs(t *testing.T) {
 		expectedJobID := jobIDs[rowIdx]
 		require.Equal(t, expectedJobID, jobID)
 		require.Equal(t, jobs.StatusRunning, jobs.Status(status))
-		require.Equal(t, pq.StringArray{"tab"}, targets)
+
+		if expectedJobID == jobAID {
+			require.Equal(t, pq.StringArray{"b.public.tab"}, targets)
+		} else if expectedJobID == jobBID {
+			require.Equal(t, pq.StringArray{"a.public.tab"}, targets)
+		}
 
 		// `SHOW LOGICAL REPLICATION JOBS` query runs after the job query in `jobutils.GetJobProgress()`,
 		// `LogicalReplicationProgress.ReplicatedTime` could have advanced by the time we run

--- a/pkg/sql/delegate/show_logical_replication_jobs.go
+++ b/pkg/sql/delegate/show_logical_replication_jobs.go
@@ -19,16 +19,32 @@ import (
 
 const (
 	baseSelectClause = `
+WITH table_names AS (
+	SELECT
+		t.job_id,
+		array_agg(t.table_name) AS targets
+	FROM (
+		SELECT
+			id AS job_id,
+			crdb_internal.get_fully_qualified_table_name(jsonb_array_elements(crdb_internal.pb_to_json(
+			 	 			'cockroach.sql.jobs.jobspb.Payload', 
+			 	 			payload)->'logicalReplicationDetails'->'replicationPairs')['srcDescriptorId']::INT) AS table_name
+		FROM crdb_internal.system_jobs 
+		WHERE job_type = 'LOGICAL REPLICATION'
+	) AS t
+	GROUP BY t.job_id
+)
+
 SELECT
-	id AS job_id, 
-	status, 
-	jsonb_array_to_string_array(crdb_internal.pb_to_json(
-			'cockroach.sql.jobs.jobspb.Payload', 
-			payload)->'logicalReplicationDetails'->'tableNames') AS targets, 
+	job_info.id AS job_id, 
+	job_info.status, 
+	table_names.targets AS targets,
 	hlc_to_timestamp((crdb_internal.pb_to_json(
 	  	'cockroach.sql.jobs.jobspb.Progress',
-	  	progress)->'LogicalReplication'->'replicatedTime'->>'wallTime')::DECIMAL) AS replicated_time%s
-FROM crdb_internal.system_jobs 
+	  	job_info.progress)->'LogicalReplication'->'replicatedTime'->>'wallTime')::DECIMAL) AS replicated_time%s
+FROM crdb_internal.system_jobs AS job_info
+LEFT JOIN table_names
+ON job_info.id = table_names.job_id
 WHERE job_type = 'LOGICAL REPLICATION'
 `
 


### PR DESCRIPTION
This PR updates the `targets` column returned by SHOW LDR jobs commands. `targets` should now show fully qualified table names.

Example output:
```
demo@127.0.0.1:26257/demoapp/b> SHOW LOGICAL REPLICATION JOBS;
        job_id       | status  |    targets     | replicated_time
---------------------+---------+----------------+------------------
  998783553025802241 | running | {a.public.tab} | NULL
  998783553070432257 | running | {b.public.tab} | NULL
(2 rows)

Time: 22ms total (execution 21ms / network 1ms)

demo@127.0.0.1:26257/demoapp/b> SHOW LOGICAL REPLICATION JOBS WITH DETAILS;
        job_id       | status  |    targets     |        replicated_time        |    replication_start_time     | conflict_resolution_type |                                                                                             description
---------------------+---------+----------------+-------------------------------+-------------------------------+--------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  998783553025802241 | running | {a.public.tab} | 2024-08-28 19:55:51.091169+00 | 2024-08-28 19:55:51.091169+00 | DLQ                      | LOGICAL REPLICATION STREAM into a.public.tab from postgresql://demo:redacted@127.0.0.1:26257/b?options=-ccluster%3Ddemoapp&sslmode=require&sslrootcert=%2FUsers%2Fannezhu%2F.cockroach-demo%2Fca.crt
  998783553070432257 | running | {b.public.tab} | 2024-08-28 19:55:51.105285+00 | 2024-08-28 19:55:51.105285+00 | DLQ                      | LOGICAL REPLICATION STREAM into b.public.tab from postgresql://demo:redacted@127.0.0.1:26257/a?options=-ccluster%3Ddemoapp&sslmode=require&sslrootcert=%2FUsers%2Fannezhu%2F.cockroach-demo%2Fca.crt
(2 rows)

Time: 16ms total (execution 16ms / network 1ms)
```

Epic: none
Informs: https://github.com/cockroachdb/cockroach/issues/128960
Release note: none