### PR TITLE
server,admission: fix close and read race on DiskStatsMonitor

### DIFF
--- a/pkg/util/admission/grant_coordinator.go
+++ b/pkg/util/admission/grant_coordinator.go
@@ -66,10 +66,10 @@ type StoreGrantCoordinators struct {
 	// numStores is used to track the number of stores which have been added
 	// to the gcMap. This is used because the IntMap doesn't expose a size
 	// api.
-	numStores             int
-	pebbleMetricsProvider PebbleMetricsProvider
-	onLogEntryAdmitted    OnLogEntryAdmitted
-	closeCh               chan struct{}
+	numStores                      int
+	setPebbleMetricsProviderCalled bool
+	onLogEntryAdmitted             OnLogEntryAdmitted
+	closeCh                        chan struct{}
 
 	disableTickerForTesting bool // TODO(irfansharif): Fold into the testing knobs struct below.
 	knobs                   *TestingKnobs
@@ -80,12 +80,13 @@ type StoreGrantCoordinators struct {
 func (sgc *StoreGrantCoordinators) SetPebbleMetricsProvider(
 	startupCtx context.Context, pmp PebbleMetricsProvider, iotc IOThresholdConsumer,
 ) {
-	if sgc.pebbleMetricsProvider != nil {
+	if sgc.setPebbleMetricsProviderCalled {
 		panic(errors.AssertionFailedf("SetPebbleMetricsProvider called more than once"))
 	}
-	sgc.pebbleMetricsProvider = pmp
+	sgc.setPebbleMetricsProviderCalled = true
+	pebbleMetricsProvider := pmp
 	sgc.closeCh = make(chan struct{})
-	metrics := sgc.pebbleMetricsProvider.GetPebbleMetrics()
+	metrics := pebbleMetricsProvider.GetPebbleMetrics()
 	for _, m := range metrics {
 		gc := sgc.initGrantCoordinator(m.StoreID)
 		// Defensive call to LoadAndStore even though Store ought to be sufficient
@@ -115,7 +116,7 @@ func (sgc *StoreGrantCoordinators) SetPebbleMetricsProvider(
 			select {
 			default:
 				if remainingTicks == 0 {
-					metrics := sgc.pebbleMetricsProvider.GetPebbleMetrics()
+					metrics := pebbleMetricsProvider.GetPebbleMetrics()
 					if len(metrics) != sgc.numStores {
 						log.Warningf(ctx,
 							"expected %d store metrics and found %d metrics", sgc.numStores, len(metrics))
@@ -146,6 +147,7 @@ func (sgc *StoreGrantCoordinators) SetPebbleMetricsProvider(
 				})
 			case <-sgc.closeCh:
 				done = true
+				pebbleMetricsProvider.Close()
 			}
 		}
 		ticker.stop()

--- a/pkg/util/admission/granter.go
+++ b/pkg/util/admission/granter.go
@@ -648,6 +648,7 @@ func (sg *kvStoreTokenGranter) storeReplicatedWorkAdmittedLocked(
 // PebbleMetricsProvider provides the pebble.Metrics for all stores.
 type PebbleMetricsProvider interface {
 	GetPebbleMetrics() []StoreMetrics
+	Close()
 }
 
 // IOThresholdConsumer is informed about updated IOThresholds.

--- a/pkg/util/admission/granter_test.go
+++ b/pkg/util/admission/granter_test.go
@@ -487,6 +487,8 @@ func (m *testMetricsProvider) GetPebbleMetrics() []StoreMetrics {
 	return m.metrics
 }
 
+func (m *testMetricsProvider) Close() {}
+
 func (m *testMetricsProvider) UpdateIOThreshold(
 	id roachpb.StoreID, threshold *admissionpb.IOThreshold,
 ) {


### PR DESCRIPTION
The diskStatsMap owns its DiskStatsMonitors, but it is closed from a different path than the StoreGrantCoordinators which calls read methods on the diskStatsMap (via the PebbleMetricsProvider interface). This causes a rare shutdown race, which fails a unit test. This is fixed by adding a Close method on PebbleMetricsProvider, to align the usage and closing. The nodePebbleMetricsProvider implements this interface, instead of directly implementing it by Node.

There is some minor cleanup permitted by this. Node does not need a diskStatsMap member. StoreGrantCoordinators does not need a PebbleMetricsProvider member.

Fixes #128958

Epic: none

Release note: None