### PR TITLE
sql,ccl: add auth behaviors for authorization

### DIFF
--- a/pkg/ccl/ldapccl/authorization_ldap.go
+++ b/pkg/ccl/ldapccl/authorization_ldap.go
@@ -61,17 +61,6 @@ func (authManager *ldapAuthManager) validateLDAPAuthZOptions() error {
 // contain sensitive information we do not want to send to sql clients but still
 // want to log it). We do not want to send any information back to client which
 // was not provided by the client.
-//
-//	 Example authorization example for obtaining LDAP groups for LDAP user:
-//	 if ldapGroups, detailedErrors, authError := ldapManager.m.FetchLDAPGroups(ctx, execCfg.Settings, externalUserDN, entry, identMap); authError != nil {
-//		errForLog := authError
-//		if detailedErrors != "" {
-//			errForLog = errors.Join(errForLog, errors.Newf("%s", detailedErrors))
-//		}
-//		  log.Warningf(ctx, "error retrieving ldap groups for authZ: %+v", errForLog)
-//	 } else {
-//		  log.Infof(ctx, "LDAP authorization: retrieved ldap groups are %+v", ldapGroups)
-//	 }
 func (authManager *ldapAuthManager) FetchLDAPGroups(
 	ctx context.Context,
 	st *cluster.Settings,

--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "auth_behaviors.go",
         "auth_methods.go",
         "authenticator.go",
+        "authorizer.go",
         "command_result.go",
         "conn.go",
         "hba_conf.go",

--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -975,7 +975,32 @@ func authLDAP(
 		}
 		return nil
 	})
-	// TODO(souravcrl): add authorizer auth behavior b.SetAuthorizer() for syncing LDAP groups
+
+	b.SetAuthorizer(func(ctx context.Context, user username.SQLUsername, clientConnection bool) ([]username.SQLUsername, error) {
+		c.LogAuthInfof(ctx, "LDAP authentication succeeded; attempting authorization")
+		if ldapGroups, detailedErrors, authError := ldapManager.m.FetchLDAPGroups(ctx, execCfg.Settings, ldapUserDN, user, entry, identMap); authError != nil {
+			errForLog := authError
+			if detailedErrors != "" {
+				errForLog = errors.Join(errForLog, errors.Newf("%s", detailedErrors))
+			}
+			log.Warningf(ctx, "LDAP authorization: error retrieving ldap groups for authorization: %+v", errForLog)
+			return nil, authError
+		} else {
+			log.Infof(ctx, "LDAP authorization sync succeeded; attempting to assign roles")
+			// parse and apply transformation to LDAP group DNs for roles granter.
+			sqlGroupRoles := make([]username.SQLUsername, len(ldapGroups))
+			for idx := range ldapGroups {
+				var err error
+				if sqlGroupRoles[idx], err = username.MakeSQLUsernameFromUserInput(ldapGroups[idx].String(), username.PurposeValidation); err != nil {
+					return nil, errors.Wrapf(err, "LDAP authorization: error creating group role for DN %s", ldapGroups[idx].String())
+				}
+			}
+			return sqlGroupRoles, nil
+		}
+	})
+	b.SetRoleGranter(func(ctx context.Context, user username.SQLUsername, sqlGroups []username.SQLUsername) error {
+		return nil
+	})
 
 	return b, nil
 }

--- a/pkg/sql/pgwire/authorizer.go
+++ b/pkg/sql/pgwire/authorizer.go
@@ -1,0 +1,45 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package pgwire
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+)
+
+// Authorizer is a component of an AuthMethod that adds additional system
+// privilege information for the client session, specifically when we want to
+// synchronize this information from some external authorization system (e.g.:
+// LDAP groups, JWT claims or X.509 SAN or other fields, etc). It returns list
+// of system identities which map to roles created specifically to assign the
+// privileges to the session and could be either the subject distinguished names
+// defined in role options or the role itself. Authorizer is intended to be used
+// with GrantRolesFn which assigns it to intended groups(roles).
+type Authorizer = func(
+	ctx context.Context,
+	systemIdentity username.SQLUsername,
+	clientConnection bool,
+) ([]username.SQLUsername, error)
+
+// RoleGranter defines a mechanism by which an AuthMethod associated with an
+// incoming connection may grant additional roles obtained from an external
+// authorization systems (e.g.: LDAP groups, JWT claims or X.509 SAN or other
+// fields, etc.) to a sql session. It is expected that at this point we have
+// created these groups(roles) with requisite privileges which are retrieved
+// during the granting process and assigned to the sql session identified by the
+// systemIdentity. Both Authorizer and RoleGranter are executed as part of
+// (*AuthBehaviors).MaybeAuthorize().
+type RoleGranter = func(
+	ctx context.Context,
+	systemIdentity username.SQLUsername,
+	sqlGroups []username.SQLUsername,
+) error


### PR DESCRIPTION
informs https://github.com/cockroachdb/cockroach/issues/125087
informs https://github.com/cockroachdb/cockroach/pull/128498
informs https://github.com/cockroachdb/cockroach/pull/129707
fixes CRDB-41622
Epic CRDB-33829

We currently lack auth behavior functions for authorization which can be
configured as part of AuthMethod itself. This PR adds these AuthBehaviors for
authorization, specifically:
1. Authorizer which retrieves authorization information from an external
authorization system and is a component of the AuthMethod for that auth system.
It also maps the information to sql identities like roles or subject role
option.
2. RolesGranter which defines how the mapped sql identities can be fetched as
sql group roles and be granted to the sql user session.

Release note: None