### PR TITLE
jobs: remove unnecessary stack traces from logs

### DIFF
--- a/pkg/jobs/job_scheduler.go
+++ b/pkg/jobs/job_scheduler.go
@@ -432,7 +432,7 @@ func (s *jobScheduler) runDaemon(ctx context.Context, stopper *stop.Stopper) {
 				if err := whenDisabled.withCancelOnDisabled(ctx, &s.Settings.SV, func(ctx context.Context) error {
 					return s.executeSchedules(ctx, maxSchedules)
 				}); err != nil {
-					log.Errorf(ctx, "error executing schedules: %+v", err)
+					log.Errorf(ctx, "error executing schedules: %v", err)
 				}
 			}
 		}


### PR DESCRIPTION
Errors while executing scheduled jobs are logging lengthy stack traces in the log. Stack traces logged are not necessary for problem diagnosis and can be removed for log cleanliness.

Fixes: #119892
EPIC: CRDB-36371
Release note (general change): Avoid logging unnecessary stack traces while executing scheduled jobs.