### PR TITLE
cli: deflake TestZipQueryFallback test

### DIFF
--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -186,6 +186,12 @@ func TestZipQueryFallback(t *testing.T) {
 	skip.UnderRace(t, "test too slow under race")
 
 	existing := zipInternalTablesPerCluster["crdb_internal.transaction_contention_events"]
+
+	// Avoid leaking configuration changes after the tests end.
+	defer func() {
+		zipInternalTablesPerCluster["crdb_internal.transaction_contention_events"] = existing
+	}()
+
 	zipInternalTablesPerCluster["crdb_internal.transaction_contention_events"] = TableRegistryConfig{
 		nonSensitiveCols: existing.nonSensitiveCols,
 		// We want this to fail to trigger the fallback.


### PR DESCRIPTION
Previously, configuration from TestZipQueryFallback test was getting propagated to subsequent tests. This was causing undeterministic outcomes in test execution. This change resets the updated configuration post test execution run.

Fixes: #127457

Release note: None