### PR TITLE
multiregionccl: fix buglet in TestEnsureLocalReadsOnGlobalTables

### DIFF
--- a/pkg/ccl/multiregionccl/roundtrips_test.go
+++ b/pkg/ccl/multiregionccl/roundtrips_test.go
@@ -125,7 +125,7 @@ func TestEnsureLocalReadsOnGlobalTables(t *testing.T) {
 			cache := tc.Server(i).DistSenderI().(*kvcoord.DistSender).RangeDescriptorCache()
 			entry, err := cache.TestingGetCached(context.Background(), tablePrefix, false /* inverted */)
 			require.NoError(t, err)
-			require.NotNil(t, entry.Lease.Empty())
+			require.False(t, entry.Lease.Empty())
 
 			if expected, got := roachpb.LEAD_FOR_GLOBAL_READS, entry.ClosedTimestampPolicy; got != expected {
 				return errors.Newf("expected closedts policy %s, got %s", expected, got)


### PR DESCRIPTION
There was a check that couldn't fail.

Seen in https://github.com/cockroachdb/cockroach/issues/129783#issuecomment-2317086163.

Epic: none
Release note: None
