### PR TITLE
kvcoord: avoid missing updates to cached closedts policy

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2475,13 +2475,6 @@ const slowDistSenderRangeThreshold = time.Minute
 // to a single replica.
 const slowDistSenderReplicaThreshold = 10 * time.Second
 
-// defaultSendClosedTimestampPolicy is used when the closed timestamp policy
-// is not known by the range cache. This choice prevents sending batch requests
-// to only voters when a perfectly good non-voter may exist in the local
-// region. It's defined as a constant here to ensure that we use the same
-// value when populating the batch header.
-const defaultSendClosedTimestampPolicy = roachpb.LEAD_FOR_GLOBAL_READS
-
 // sendToReplicas sends a batch to the replicas of a range. Replicas are tried one
 // at a time (generally the leaseholder first). The result of this call is
 // either a BatchResponse or an error. In the former case, the BatchResponse
@@ -2520,7 +2513,7 @@ func (ds *DistSender) sendToReplicas(
 	if ba.RoutingPolicy == kvpb.RoutingPolicy_LEASEHOLDER &&
 		CanSendToFollower(
 			ctx, ds.st, ds.clock,
-			routing.ClosedTimestampPolicy(defaultSendClosedTimestampPolicy), ba,
+			routing.ClosedTimestampPolicy(roachpb.LEAD_FOR_GLOBAL_READS), ba,
 		) {
 		ba = ba.ShallowCopy()
 		ba.RoutingPolicy = kvpb.RoutingPolicy_NEAREST


### PR DESCRIPTION
Because we were previously defaulting the closedts policy to
`LEAD_FOR_GLOBAL_READS`, in cases where the policy was the
only stale portion of DistSender's view of the `RangeInfo`,
we could end up never learning the correct policy.

Instead of migrating the enum to one that contains a wire-encodable
"unknown" state, this PR takes the approach of zeroing out the lease
sequence instead. This has the desired effect of prompting a cache
update.

TODO would need a test. First want eyes on the approach & see if anything breaks.

See https://github.com/cockroachdb/cockroach/issues/129783#issuecomment-2317216498.

Speculatively:
Fixes https://github.com/cockroachdb/cockroach/issues/129783.

Epic: none
Release note: None
