### PR TITLE
rac2: ensure consistent lock ordering in controller test

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/priority_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/priority_test.go
@@ -15,10 +15,15 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPriority(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	var lastRaftPriority raftpb.Priority
 	lastConvertedBackPriority := admissionpb.LowPri
 	for i := int(admissionpb.LowPri); i < admissionpb.OneAboveHighPri; i++ {

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter_test.go
@@ -462,6 +462,9 @@ func (ts *evalTestState) evalStatesString() string {
 //   - refresh <name>
 //     name: the name of the WaitForEval operation to refresh.
 func TestWaitForEval(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	ts := newTestState()
 	datadriven.RunTest(t, "testdata/wait_for_eval", func(t *testing.T, d *datadriven.TestData) string {
 		switch d.Cmd {

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/datadriven"
 	"github.com/stretchr/testify/require"
 )
@@ -50,6 +51,7 @@ func formatUntracked(untracked [raftpb.NumPriorities]kvflowcontrol.Tokens) strin
 
 func TestTokenTracker(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	tracker := &Tracker{}


### PR DESCRIPTION
Previously, the `TestRangeControllerWaitForEval` test would acquire locks in iteration order over a map. This led to inconsistent lock ordering between different test range mutexes. Acquire the locks after first sorting the ranges, by `RangeID`, ensuring consistent acquisition ordering within the test.

Note that these mutexes are only used for test state synchronization, not within the `RangeController` implementation being tested.

Fixes: #129466
Release note: None