### PR TITLE
roachtest: disable journaling in dmsetupDiskStaller

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
     deps = [
         "//pkg/cmd/roachtest/cluster",
         "//pkg/cmd/roachtest/option",
+        "//pkg/cmd/roachtest/spec",
         "//pkg/cmd/roachtest/test",
         "//pkg/kv/kvpb",
         "//pkg/roachprod/config",


### PR DESCRIPTION
The journaling kernel threads can interfere with the `dmsetup create`
call.

See https://github.com/cockroachdb/cockroach/issues/129619#issuecomment-2316147244.

Fixes #129619.

Epic: none
Release note: None
