### PR TITLE
internal: update TEAMS.yaml

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -65,9 +65,9 @@ cockroachdb/test-eng-prs:
   triage_column_id: 14041337
   label: T-testeng
 cockroachdb/security:
-  label: T-cross-product-security
+  label: T-security-engineering
 cockroachdb/prodsec:
-  label: T-cross-product-security
+  label: T-security-engineering
 cockroachdb/product-security:
   label: T-product-security
 cockroachdb/disaster-recovery:

--- a/pkg/internal/team/TEAMS.yaml
+++ b/pkg/internal/team/TEAMS.yaml
@@ -65,9 +65,9 @@ cockroachdb/test-eng-prs:
   triage_column_id: 14041337
   label: T-testeng
 cockroachdb/security:
-  label: T-cross-product-security
+  label: T-security-engineering
 cockroachdb/prodsec:
-  label: T-cross-product-security
+  label: T-security-engineering
 cockroachdb/product-security:
   label: T-product-security
 cockroachdb/disaster-recovery:


### PR DESCRIPTION
Previously, the `TEAMS.yaml` file referenced a label for the T-cross-product-security team. This change updates the reference to the newly created T-security-engineering label.

Epic: none

Release note: None