### PR TITLE
release-24.1: server: make telemetry timestamp atomic

### DIFF
--- a/pkg/ccl/serverccl/diagnosticsccl/reporter_test.go
+++ b/pkg/ccl/serverccl/diagnosticsccl/reporter_test.go
@@ -277,6 +277,68 @@ func TestServerReport(t *testing.T) {
 	}
 }
 
+func TestTelemetry_SuccessfulTelemetryPing(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	rt := startReporterTest(t, base.TestIsSpecificToStorageLayerAndNeedsASystemTenant)
+	defer rt.Close()
+
+	ctx := context.Background()
+	setupCluster(t, rt.serverDB)
+
+	for _, tc := range []struct {
+		name                  string
+		respError             error
+		respCode              int
+		expectTimestampUpdate bool
+	}{
+		{
+			name:                  "200 response",
+			respError:             nil,
+			respCode:              200,
+			expectTimestampUpdate: true,
+		},
+		{
+			name:                  "400 response",
+			respError:             nil,
+			respCode:              400,
+			expectTimestampUpdate: true,
+		},
+		{
+			name:                  "500 response",
+			respError:             nil,
+			respCode:              500,
+			expectTimestampUpdate: true,
+		},
+		{
+			name:                  "connection error",
+			respError:             errors.New("connection refused"),
+			expectTimestampUpdate: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer rt.diagServer.SetRespError(tc.respError)()
+			defer rt.diagServer.SetRespCode(tc.respCode)()
+
+			dr := rt.server.DiagnosticsReporter().(*diagnostics.Reporter)
+
+			before := timeutil.Now().Unix()
+			oldTimestamp := dr.LastSuccessfulTelemetryPing.Load()
+			require.LessOrEqual(t, dr.LastSuccessfulTelemetryPing.Load(), before)
+			dr.ReportDiagnostics(ctx)
+
+			if tc.expectTimestampUpdate {
+				require.GreaterOrEqual(t, dr.LastSuccessfulTelemetryPing.Load(), before)
+			} else {
+				require.Equal(t, oldTimestamp, dr.LastSuccessfulTelemetryPing.Load())
+			}
+		})
+	}
+
+}
+
 func TestUsageQuantization(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/server/diagnostics/reporter.go
+++ b/pkg/server/diagnostics/reporter.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -94,6 +95,13 @@ type Reporter struct {
 
 	// TestingKnobs is used for internal test controls only.
 	TestingKnobs *TestingKnobs
+
+	// LastSuccessfulTelemetryPing records the current timestamp in
+	// seconds since the Unix epoch whenever we successfully make contact
+	// with the registration server. This timestamp will be updated
+	// regardless of whether the response we get back is successful or
+	// not.
+	LastSuccessfulTelemetryPing atomic.Int64
 }
 
 // PeriodicallyReportDiagnostics starts a background worker that periodically
@@ -163,6 +171,17 @@ func (r *Reporter) ReportDiagnostics(ctx context.Context) {
 	if err != nil || res.StatusCode != http.StatusOK {
 		log.Warningf(ctx, "failed to report node usage metrics: status: %s, body: %s, "+
 			"error: %v", res.Status, b, err)
+		return
+	}
+
+	// If `err` == nil then we assume that we've made successful contact
+	// with the telemetry server and any further problems are not the
+	// customer's fault. We update the telemetry timestamp before moving
+	// on with other request handling.
+	r.LastSuccessfulTelemetryPing.Store(timeutil.Now().Unix())
+
+	if res.StatusCode != http.StatusOK {
+		log.Warningf(ctx, "failed to report node usage metrics: status: %s, body: %s", res.Status, b)
 		return
 	}
 	r.SQLServer.GetReportedSQLStatsController().ResetLocalSQLStats(ctx)


### PR DESCRIPTION
Backport 1/1 commits from #129423.

/cc @cockroachdb/release

---

Release justification: required telemetry changes for core modifications

Since the telemetry send timestamp will be accessed concurrently, we need to make it atomic.

Part of: CRDB-41231
Epic: CRDB-40209
Release note: None
