### PR TITLE
sql: fix require_explicit_primary_keys setting to not block valid table

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -2058,13 +2058,6 @@ func NewTableDesc(
 		}
 	}
 
-	// If explicit primary keys are required, error out since a primary key was not supplied.
-	if desc.GetPrimaryIndex().NumKeyColumns() == 0 && desc.IsPhysicalTable() && evalCtx != nil &&
-		evalCtx.SessionData() != nil && evalCtx.SessionData().RequireExplicitPrimaryKeys {
-		return nil, errors.Errorf(
-			"no primary key specified for table %s (require_explicit_primary_keys = true)", desc.Name)
-	}
-
 	for i := range desc.Columns {
 		if _, ok := primaryIndexColumnSet[desc.Columns[i].Name]; ok {
 			desc.Columns[i].Nullable = false
@@ -2084,6 +2077,16 @@ func NewTableDesc(
 	}
 	if err := desc.AllocateIDs(ctx, version); err != nil {
 		return nil, err
+	}
+
+	// If explicit primary keys are required, error out if a primary key was not
+	// supplied.
+	if desc.IsPhysicalTable() &&
+		evalCtx != nil && evalCtx.SessionData() != nil &&
+		evalCtx.SessionData().RequireExplicitPrimaryKeys &&
+		desc.IsPrimaryIndexDefaultRowID() {
+		return nil, errors.Errorf(
+			"no primary key specified for table %s (require_explicit_primary_keys = true)", desc.Name)
 	}
 
 	for _, idx := range desc.PublicNonPrimaryIndexes() {

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -44,12 +44,18 @@ set require_explicit_primary_keys=true
 statement error pq: no primary key specified for table t \(require_explicit_primary_keys = true\)
 CREATE TABLE t (x INT, y INT)
 
+# Make sure the setting does not block a table that _does_ have a PK.
+statement ok
+CREATE TABLE t (x INT PRIMARY KEY, y INT)
+
 # Regression for #45496.
 statement ok
 reset require_explicit_primary_keys;
 
 statement ok
 DROP TABLE IF EXISTS t;
+
+statement ok
 CREATE TABLE t (rowid INT, rowid_1 INT, FAMILY (rowid, rowid_1))
 
 query T rowsort
@@ -657,8 +663,8 @@ FROM (
 LEFT JOIN pg_catalog.pg_depend r ON l.table_id = r.objid;
 ----
 table_id  name               state   refobjid
-161       test_serial_b_seq  PUBLIC  160
-160       test_serial        PUBLIC  NULL
+162       test_serial_b_seq  PUBLIC  161
+161       test_serial        PUBLIC  NULL
 
 statement ok
 DROP TABLE test_serial;
@@ -690,8 +696,8 @@ FROM (
 LEFT JOIN pg_catalog.pg_depend r ON l.table_id = r.objid;
 ----
 table_id  name               state   refobjid
-163       test_serial_b_seq  PUBLIC  162
-162       test_serial        PUBLIC  NULL
+164       test_serial_b_seq  PUBLIC  163
+163       test_serial        PUBLIC  NULL
 
 statement ok
 ALTER TABLE test_serial DROP COLUMN b;
@@ -706,7 +712,7 @@ FROM (
 LEFT JOIN pg_catalog.pg_depend r ON l.table_id = r.objid;
 ----
 table_id  name         state   refobjid
-162       test_serial  PUBLIC  NULL
+163       test_serial  PUBLIC  NULL
 
 statement ok
 DROP TABLE test_serial;


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/128462
Release note (bug fix): Fixed a bug where the
require_explicit_primary_keys session variable would overly aggressively prevent all CREATE TABLE statements from working.