### PR TITLE
server/license: disable write of grace period init timestamp

### DIFF
--- a/pkg/server/license/enforcer_test.go
+++ b/pkg/server/license/enforcer_test.go
@@ -39,7 +39,8 @@ func TestGracePeriodInitTSCache(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				LicenseTestingKnobs: license.TestingKnobs{
-					OverrideStartTime: &ts1,
+					EnableGracePeriodInitTSWrite: true,
+					OverrideStartTime:            &ts1,
 				},
 			},
 		},
@@ -51,7 +52,8 @@ func TestGracePeriodInitTSCache(t *testing.T) {
 	enforcer := &license.Enforcer{}
 	ts2 := ts1.Add(1)
 	enforcer.TestingKnobs = &license.TestingKnobs{
-		OverrideStartTime: &ts2,
+		EnableGracePeriodInitTSWrite: true,
+		OverrideStartTime:            &ts2,
 	}
 	// Ensure request for the grace period init ts1 before start just returns the start
 	// time used when the enforcer was created.


### PR DESCRIPTION
This follows up on commit 456521897e0, where we introduced a new grace period initialization timestamp written to the system key space for license enforcement. We were concerned that if we backported this change and released a patch update before the epic is done, customers might start the clock for the grace period without having the full license deprecation code in place. This could lead to immediate throttling once they do upgraded to a release with the complete code because they would have exhausted the grace period already. To mitigate this, we are making the writing of the grace period initialization timestamp opt-in and limited to testing scenarios. We will enable it by default once more of the core deprecation work is completed.

This change will be backported to 23.1, 23.2, 24.1 and 24.2.

Epic: CRDB-39988
Informs: CRDB-40064
Release note: None