### PR TITLE
roachprod: fix typo in roachprod-gc yaml

### DIFF
--- a/pkg/roachprod/k8s/roachprod-gc.yaml
+++ b/pkg/roachprod/k8s/roachprod-gc.yaml
@@ -38,7 +38,7 @@ spec:
                 - --slack-token
                 - $(SLACK_TOKEN)
                 - --aws-account-ids=541263489771,337380398238
-                - --azure-subscription-names=e2e-adhoc,e2e-infra,Microsoft Azure Subscription
+                - --azure-subscription-names=e2e-adhoc,e2e-infra,Microsoft Azure Sponsorship
               env:
                 - name: SLACK_TOKEN
                   valueFrom:


### PR DESCRIPTION
The subscription name was accidentally specified as Microsoft Azure Subscription instead of Sponsorship.

Fixes: none
Epic: none
Release note: none