### PR TITLE
release-23.1: changefeedccl: redact `client_key` in from SHOW JOBS output

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -165,7 +165,13 @@ func init() {
 	jobspb.ChangefeedDetailsMarshaler = func(m *jobspb.ChangefeedDetails, marshaller *jsonpb.Marshaler) ([]byte, error) {
 		if protoreflect.ShouldRedact(marshaller) {
 			var err error
-			m.SinkURI, err = cloud.SanitizeExternalStorageURI(m.SinkURI, nil)
+			// Redacts user sensitive information from sinkURI.
+			m.SinkURI, err = cloud.SanitizeExternalStorageURI(m.SinkURI, []string{
+				changefeedbase.SinkParamSASLPassword,
+				changefeedbase.SinkParamCACert,
+				changefeedbase.SinkParamClientKey,
+				changefeedbase.SinkParamClientCert,
+			})
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -944,10 +944,12 @@ func changefeedJobDescription(
 	sinkURI string,
 	opts changefeedbase.StatementOptions,
 ) (string, error) {
+	// Redacts user sensitive information from job description.
 	cleanedSinkURI, err := cloud.SanitizeExternalStorageURI(sinkURI, []string{
 		changefeedbase.SinkParamSASLPassword,
 		changefeedbase.SinkParamCACert,
 		changefeedbase.SinkParamClientCert,
+		changefeedbase.SinkParamClientKey,
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Backport 1/1 commits from #122529.

/cc @cockroachdb/release

---

Previously, SHOW CHANGEFEED JOB revealed sensitive user data like `client_key`.
This patch now redacts it in the job description and sinkURI output column.

Epic: none

Release note (enterprise change): SHOW CHANGEFEED JOB, SHOW CHANGEFEED JOBS,
and SHOW JOBS no longer expose user sensitive information like `client_key`.

---
Release justification: low risk bug fix to redact user-sensitive info for SQL output