### PR TITLE
roachprod: enable sync command to accept cloud provider

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -273,6 +273,8 @@ func initFlags() {
 	deployCmd.Flags().DurationVar(&pause, "pause", pause, "duration to pause between node restarts")
 
 	syncCmd.Flags().BoolVar(&listOpts.IncludeVolumes, "include-volumes", false, "Include volumes when syncing")
+	syncCmd.Flags().StringArrayVarP(&listOpts.IncludeProviders, "clouds", "c",
+		make([]string, 0), "Specify the cloud providers when syncing. Important: Use this flag only if you are certain that you want to sync with a specific cloud. All DNS host entries for other clouds will be erased from the DNS zone.")
 
 	wipeCmd.Flags().BoolVar(&wipePreserveCerts, "preserve-certs", false, "do not wipe certificates")
 

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -463,12 +463,12 @@ var bashCompletion = os.ExpandEnv("$HOME/.roachprod/bash-completion.sh")
 // a side-effect. If you don't care about the list output, just "roachprod list
 // &>/dev/null".
 var syncCmd = &cobra.Command{
-	Use:   "sync",
+	Use:   "sync [flags]",
 	Short: "sync ssh keys/config and hosts files",
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		_, err := roachprod.Sync(config.Logger, vm.ListOptions{IncludeVolumes: listOpts.IncludeVolumes})
+		_, err := roachprod.Sync(config.Logger, listOpts)
 		_ = rootCmd.GenBashCompletionFile(bashCompletion)
 		return err
 	}),


### PR DESCRIPTION
"roachprod sync" command allows us to sync all th clusters and the dns entries. Currently, the command overwrites the dns entries for all the clouds and there is no way I can select a specific cloud to sync.
This becomes an issue for projects like cockroach-drt, where we are interested in syncing only gce cloud.
This PR introduces a flag as "clouds", which enables us to sync a specific cloud provider.

Informs: #126926
Epic: none