### PR TITLE
kvserver/rangefeed: add node level buffered sender

### DIFF
--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -76,6 +76,7 @@ go_test(
         "scheduler_test.go",
         "sender_helper_test.go",
         "task_test.go",
+        "unbuffered_registration_test.go",
         "unbuffered_sender_test.go",
     ],
     embed = [":rangefeed"],

--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -63,6 +63,7 @@ go_test(
     srcs = [
         "bench_test.go",
         "budget_test.go",
+        "buffered_sender_test.go",
         "catchup_scan_bench_test.go",
         "catchup_scan_test.go",
         "event_size_test.go",

--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "task.go",
         "test_helpers.go",
         "testutil.go",
+        "unbuffered_registration.go",
         "unbuffered_sender.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed",

--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -69,6 +69,7 @@ go_test(
         "event_size_test.go",
         "processor_helpers_test.go",
         "processor_test.go",
+        "registry_helpers_test.go",
         "registry_test.go",
         "resolved_timestamp_test.go",
         "scheduler_test.go",

--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "buffered_sender.go",
         "buffered_stream.go",
         "catchup_scan.go",
+        "event_queue.go",
         "event_size.go",
         "filter.go",
         "metrics.go",

--- a/pkg/kv/kvserver/rangefeed/bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/bench_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 type benchmarkRangefeedOpts struct {
-	procType         procType
+	feedType         rangefeedTestType
 	opType           opType
 	numRegistrations int
 	budget           int64
@@ -46,13 +46,13 @@ const (
 // BenchmarkRangefeed benchmarks the processor and registrations, by submitting
 // a set of events and waiting until they are all emitted.
 func BenchmarkRangefeed(b *testing.B) {
-	for _, procType := range testTypes {
+	for _, feedType := range testTypes {
 		for _, opType := range []opType{writeOpType, commitOpType, closedTSOpType} {
 			for _, numRegistrations := range []int{1, 10, 100} {
-				name := fmt.Sprintf("procType=%s/opType=%s/numRegs=%d", procType, opType, numRegistrations)
+				name := fmt.Sprintf("rangefeedTestType=%s/opType=%s/numRegs=%d", feedType, opType, numRegistrations)
 				b.Run(name, func(b *testing.B) {
 					runBenchmarkRangefeed(b, benchmarkRangefeedOpts{
-						procType:         procType,
+						feedType:         feedType,
 						opType:           opType,
 						numRegistrations: numRegistrations,
 						budget:           math.MaxInt64,
@@ -95,7 +95,7 @@ func runBenchmarkRangefeed(b *testing.B, opts benchmarkRangefeedOpts) {
 	span := roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z")}
 
 	p, h, stopper := newTestProcessor(b, withSpan(span), withBudget(budget), withChanCap(b.N),
-		withEventTimeout(time.Hour), withProcType(opts.procType))
+		withEventTimeout(time.Hour), withRangefeedTestType(opts.feedType))
 	defer stopper.Stop(ctx)
 
 	// Add registrations.

--- a/pkg/kv/kvserver/rangefeed/buffered_sender.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_sender.go
@@ -12,12 +12,21 @@ package rangefeed
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
 )
+
+type sharedMuxEvent struct {
+	event *kvpb.MuxRangeFeedEvent
+	alloc *SharedBudgetAllocation
+}
 
 //	┌─────────────────────────────────────────┐                                      MuxRangefeedEvent
 //	│            Node.MuxRangeFeed            │◄──────────────────────────────────────────────────┐
@@ -54,6 +63,23 @@ import (
 // Refer to the comments above UnbufferedSender for more details on the role of
 // senders in the entire rangefeed architecture.
 type BufferedSender struct {
+	// taskCancel is a function to cancel BufferedSender.run spawned in the
+	// background. It is called by BufferedSender.Stop. It is expected to be
+	// called after BufferedSender.Start.
+	taskCancel context.CancelFunc
+
+	// wg is used to coordinate async tasks spawned by BufferedSender. Currently,
+	// there is only one task spawned by BufferedSender.Start
+	// (BufferedSender.run).
+	wg sync.WaitGroup
+
+	// errCh is used to signal errors from BufferedSender.run back to the caller.
+	// If non-empty, the BufferedSender.run is finished and error should be
+	// handled. Note that it is possible for BufferedSender.run to be finished
+	// without sending an error to errCh. Other goroutines are expected to receive
+	// the same shutdown signal in this case and handle error appropriately.
+	errCh chan error
+
 	// streamID -> context cancellation
 	streams syncutil.Map[int64, context.CancelFunc]
 
@@ -66,36 +92,52 @@ type BufferedSender struct {
 
 	// metrics is used to record rangefeed metrics for the node.
 	metrics RangefeedMetricsRecorder
+
+	queueMu struct {
+		syncutil.Mutex
+		stopped bool
+		buffer  *eventQueue
+	}
+
+	// Unblocking channel to notify the BufferedSender.run goroutine that there
+	// are events to send.
+	notifyDataC chan struct{}
 }
 
 func NewBufferedSender(
 	sender ServerStreamSender, metrics RangefeedMetricsRecorder,
 ) *BufferedSender {
-	return &BufferedSender{
+	bs := &BufferedSender{
 		sender:  sender,
 		metrics: metrics,
 	}
+	bs.queueMu.buffer = newEventQueue()
+	bs.notifyDataC = make(chan struct{}, 1)
+	return bs
 }
 
 // SendBuffered buffers the event before sending them to the underlying
-// ServerStreamSender. Currently, this function is only used for testing
-// purposes, so it just mimics the behavior we’d expect from BufferedSender when
-// an event is ready to be sent to the underlying gRPC stream. We plan to
-// implement this fully by buffering the event in a queue in the future.
+// ServerStreamSender.
+//
+// alloc.Release is nil-safe. SendBuffered will take the ownership of the alloc
+// and release it if the return error is non-nil. Note that it is safe to send
+// error events without being blocked for too long.
 func (bs *BufferedSender) SendBuffered(
 	ev *kvpb.MuxRangeFeedEvent, alloc *SharedBudgetAllocation,
-) error {
-	err := bs.sender.Send(ev)
-	alloc.Release(context.Background())
-	if ev.Error != nil {
-		// Add metrics here
-		if cleanUp, ok := bs.rangefeedCleanup.LoadAndDelete(ev.StreamID); ok {
-			// TODO(wenyihu6): add more observability metrics into how long the
-			// clean up call is taking
-			(*cleanUp)()
-		}
+) (err error) {
+	bs.queueMu.Lock()
+	defer bs.queueMu.Unlock()
+	if bs.queueMu.stopped {
+		log.Errorf(context.Background(), "stream sender is stopped")
+		return errors.New("stream sender is stopped")
 	}
-	return err
+	alloc.Use(context.Background())
+	bs.queueMu.buffer.pushBack(sharedMuxEvent{ev, alloc})
+	select {
+	case bs.notifyDataC <- struct{}{}:
+	default:
+	}
+	return nil
 }
 
 // SendUnbuffered bypasses the buffer and sends the event to the underlying
@@ -108,23 +150,44 @@ func (bs *BufferedSender) SendUnbuffered(event *kvpb.MuxRangeFeedEvent) error {
 	return bs.sender.Send(event)
 }
 
+func (bs *BufferedSender) waitForEmptyBuffer(ctx context.Context) error {
+	opts := retry.Options{
+		InitialBackoff: 5 * time.Millisecond,
+		Multiplier:     2,
+		MaxBackoff:     10 * time.Second,
+		MaxRetries:     50,
+	}
+	for re := retry.StartWithCtx(ctx, opts); re.Next(); {
+		bs.queueMu.Lock()
+		caughtUp := bs.queueMu.buffer.Len() == 0 // nolint:deferunlockcheck
+		bs.queueMu.Unlock()
+		if caughtUp {
+			return nil
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return errors.New("buffered sender failed to send in time")
+}
+
 func (bs *BufferedSender) SendBufferedError(ev *kvpb.MuxRangeFeedEvent) {
 	if ev.Error == nil {
 		log.Fatalf(context.Background(), "unexpected: SendWithoutBlocking called with non-error event")
 	}
-
 	if cancel, ok := bs.streams.LoadAndDelete(ev.StreamID); ok {
 		// Fine to skip nil checking here since that would be a programming error.
 		(*cancel)()
 		bs.metrics.UpdateMetricsOnRangefeedDisconnect()
-		// Ignore error since the stream is already disconnecting. There is nothing
-		// else that could be done. When SendBuffered is returning an error, a node
-		// level shutdown from node.MuxRangefeed is happening soon to let clients
-		// know that the rangefeed is shutting down.
-		log.Infof(context.Background(),
-			"failed to buffer rangefeed complete event for stream %d due to %s, "+
-				"but a node level shutdown should be happening", ev.StreamID, ev.Error)
-		_ = bs.SendBuffered(ev, nil)
+		if err := bs.SendBuffered(ev, nil); err != nil {
+			// Ignore error since the stream is already disconnecting. There is nothing
+			// else that could be done. When SendBuffered is returning an error, a node
+			// level shutdown from node.MuxRangefeed is happening soon to let clients
+			// know that the rangefeed is shutting down.
+			log.Infof(context.Background(),
+				"failed to buffer rangefeed complete event for stream %d due to %s, "+
+					"but a node level shutdown should be happening", ev.StreamID, ev.Error)
+		}
 	}
 }
 
@@ -144,7 +207,7 @@ func (bs *BufferedSender) RegisterRangefeedCleanUp(streamID int64, cleanUp func(
 }
 
 // disconnectAll disconnects all active streams and invokes all rangefeed clean
-// up callbacks. It is expected to be called during StreamMuxer.Stop.
+// up callbacks. It is expected to be called during BufferedSender.Stop.
 func (bs *BufferedSender) disconnectAll() {
 	bs.streams.Range(func(streamID int64, cancel *context.CancelFunc) bool {
 		(*cancel)()
@@ -168,29 +231,96 @@ func (bs *BufferedSender) AddStream(streamID int64, cancel context.CancelFunc) {
 	bs.metrics.UpdateMetricsOnRangefeedConnect()
 }
 
+// run forwards buffered events back to the client. run is expected to be called
+// in a goroutine and will block until the context is done or the stopper is
+// quiesced. BufferedSender will stop forwarding events after run completes. It
+// may still buffer more events in the buffer, but they will be cleaned up soon
+// during bs.Stop(), and there should be no new events buffered after that.
+func (bs *BufferedSender) run(ctx context.Context, stopper *stop.Stopper) error {
+	for {
+		select {
+		case <-ctx.Done():
+			// Top level goroutine will receive the context cancellation and handle
+			// ctx.Err().
+			return nil
+		case <-stopper.ShouldQuiesce():
+			// Top level goroutine will receive the stopper quiesce signal and handle
+			// error.
+			return nil
+		case <-bs.notifyDataC:
+			for {
+				e, success := bs.popFront()
+				if success {
+					err := bs.sender.Send(e.event)
+					e.alloc.Release(ctx)
+					if e.event.Error != nil {
+						// Add metrics here
+						if cleanUp, ok := bs.rangefeedCleanup.LoadAndDelete(e.event.StreamID); ok {
+							// TODO(wenyihu6): add more observability metrics into how long the
+							// clean up call is taking
+							(*cleanUp)()
+						}
+					}
+					if err != nil {
+						return err
+					}
+				} else {
+					break
+				}
+			}
+		}
+	}
+}
+
+func (bs *BufferedSender) popFront() (e sharedMuxEvent, success bool) {
+	bs.queueMu.Lock()
+	defer bs.queueMu.Unlock()
+	event, ok := bs.queueMu.buffer.popFront()
+	return event, ok
+}
+
 func (bs *BufferedSender) Start(ctx context.Context, stopper *stop.Stopper) error {
-	panic("unimplemented: buffered sender for rangefeed #126560")
+	bs.errCh = make(chan error, 1)
+	bs.wg.Add(1)
+	ctx, bs.taskCancel = context.WithCancel(ctx)
+	if err := stopper.RunAsyncTask(ctx, "buffered stream output", func(ctx context.Context) {
+		defer bs.wg.Done()
+		if err := bs.run(ctx, stopper); err != nil {
+			bs.errCh <- err
+		}
+	}); err != nil {
+		bs.taskCancel()
+		bs.wg.Done()
+		return err
+	}
+	return nil
 }
 
 // Stop cancels the BufferedSender.run task, waits for it to complete, and
 // handles any cleanups for active streams. It is expected to be called after
-// BufferedSender.Start. After this function returns, the caller is not expected
-// to call RegisterRangefeedCleanUp, assume that the registered cleanup callback
-// will be executed after calling SendBufferedError, or assume that
-// SendBufferedError would send an error back to the client.
+// BufferedSender.Start. After this function returns, BufferedSend will return
+// an error to avoid more being buffered afterwards. The caller is also not
+// expected to call RegisterRangefeedCleanUp after this function ends and assume
+// that the registered cleanup callback will be executed after calling
+// SendBufferedError, or assume that SendBufferedError would send an error back
+// to the client.
 // TODO(wenyihu6): add observability into when this goes wrong
-//
-// Note that Stop does not send any errors back to notify clients since the grpc
-// stream is being torn down, and the client will decide whether to restart all
-// rangefeeds again based on the returned error from grpc server stream.
-//
 // TODO(wenyihu6): add tests to make sure client treats node out of budget
 // errors as retryable and will restart all rangefeeds
 func (bs *BufferedSender) Stop() {
+	bs.taskCancel()
+	bs.wg.Wait()
 	bs.disconnectAll()
-	panic("unimplemented: buffered sender for rangefeed #126560")
+
+	bs.queueMu.Lock()
+	defer bs.queueMu.Unlock()
+	bs.queueMu.stopped = true
+	bs.queueMu.buffer.removeAll()
 }
 
 func (bs *BufferedSender) Error() chan error {
-	panic("unimplemented: buffered sender for rangefeed #126560")
+	if bs.errCh == nil {
+		log.Fatalf(context.Background(), "BufferedSender.Error called before BufferedSender.Start")
+	}
+	return bs.errCh
 }

--- a/pkg/kv/kvserver/rangefeed/buffered_sender.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_sender.go
@@ -12,16 +12,21 @@ package rangefeed
 
 import (
 	"context"
+	"math"
 	"sync"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 )
+
+var bufferedSenderCapacity = envutil.EnvOrDefaultInt64(
+	"COCKROACH_BUFFERED_STREAM_CAPACITY_PER_STREAM", math.MaxInt64)
 
 type sharedMuxEvent struct {
 	event *kvpb.MuxRangeFeedEvent
@@ -95,8 +100,10 @@ type BufferedSender struct {
 
 	queueMu struct {
 		syncutil.Mutex
-		stopped bool
-		buffer  *eventQueue
+		stopped  bool
+		capacity int64
+		buffer   *eventQueue
+		overflow bool
 	}
 
 	// Unblocking channel to notify the BufferedSender.run goroutine that there
@@ -112,6 +119,7 @@ func NewBufferedSender(
 		metrics: metrics,
 	}
 	bs.queueMu.buffer = newEventQueue()
+	bs.queueMu.capacity = bufferedSenderCapacity
 	bs.notifyDataC = make(chan struct{}, 1)
 	return bs
 }
@@ -130,6 +138,14 @@ func (bs *BufferedSender) SendBuffered(
 	if bs.queueMu.stopped {
 		log.Errorf(context.Background(), "stream sender is stopped")
 		return errors.New("stream sender is stopped")
+	}
+	if bs.queueMu.overflow {
+		log.Error(context.Background(), "buffer capacity exceeded")
+		return newRetryErrBufferCapacityExceeded()
+	}
+	if bs.queueMu.buffer.Len() >= bs.queueMu.capacity {
+		bs.queueMu.overflow = true
+		return newRetryErrBufferCapacityExceeded()
 	}
 	alloc.Use(context.Background())
 	bs.queueMu.buffer.pushBack(sharedMuxEvent{ev, alloc})
@@ -249,7 +265,7 @@ func (bs *BufferedSender) run(ctx context.Context, stopper *stop.Stopper) error 
 			return nil
 		case <-bs.notifyDataC:
 			for {
-				e, success := bs.popFront()
+				e, success, overflowed, remains := bs.popFront()
 				if success {
 					err := bs.sender.Send(e.event)
 					e.alloc.Release(ctx)
@@ -264,6 +280,9 @@ func (bs *BufferedSender) run(ctx context.Context, stopper *stop.Stopper) error 
 					if err != nil {
 						return err
 					}
+					if overflowed && remains == int64(0) {
+						return newRetryErrBufferCapacityExceeded()
+					}
 				} else {
 					break
 				}
@@ -272,11 +291,16 @@ func (bs *BufferedSender) run(ctx context.Context, stopper *stop.Stopper) error 
 	}
 }
 
-func (bs *BufferedSender) popFront() (e sharedMuxEvent, success bool) {
+func (bs *BufferedSender) popFront() (
+	e sharedMuxEvent,
+	success bool,
+	overflowed bool,
+	remains int64,
+) {
 	bs.queueMu.Lock()
 	defer bs.queueMu.Unlock()
 	event, ok := bs.queueMu.buffer.popFront()
-	return event, ok
+	return event, ok, bs.queueMu.overflow, bs.queueMu.buffer.Len()
 }
 
 func (bs *BufferedSender) Start(ctx context.Context, stopper *stop.Stopper) error {

--- a/pkg/kv/kvserver/rangefeed/buffered_sender.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_sender.go
@@ -14,7 +14,9 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
 //	┌─────────────────────────────────────────┐                                      MuxRangefeedEvent
@@ -52,6 +54,12 @@ import (
 // Refer to the comments above UnbufferedSender for more details on the role of
 // senders in the entire rangefeed architecture.
 type BufferedSender struct {
+	// streamID -> context cancellation
+	streams syncutil.Map[int64, context.CancelFunc]
+
+	// streamID -> cleanup callback
+	rangefeedCleanup syncutil.Map[int64, func()]
+
 	// Note that lockedMuxStream wraps the underlying grpc server stream, ensuring
 	// thread safety.
 	sender ServerStreamSender
@@ -70,37 +78,116 @@ func NewBufferedSender(
 }
 
 // SendBuffered buffers the event before sending them to the underlying
-// ServerStreamSender.
+// ServerStreamSender. Currently, this function is only used for testing
+// purposes, so it just mimics the behavior we’d expect from BufferedSender when
+// an event is ready to be sent to the underlying gRPC stream. We plan to
+// implement this fully by buffering the event in a queue in the future.
 func (bs *BufferedSender) SendBuffered(
-	event *kvpb.MuxRangeFeedEvent, alloc *SharedBudgetAllocation,
+	ev *kvpb.MuxRangeFeedEvent, alloc *SharedBudgetAllocation,
 ) error {
-	panic("unimplemented: buffered sender for rangefeed #126560")
+	err := bs.sender.Send(ev)
+	alloc.Release(context.Background())
+	if ev.Error != nil {
+		// Add metrics here
+		if cleanUp, ok := bs.rangefeedCleanup.LoadAndDelete(ev.StreamID); ok {
+			// TODO(wenyihu6): add more observability metrics into how long the
+			// clean up call is taking
+			(*cleanUp)()
+		}
+	}
+	return err
 }
 
 // SendUnbuffered bypasses the buffer and sends the event to the underlying
 // ServerStreamSender directly. Note that this can cause event re-ordering.
 // Caller is responsible for ensuring that events are sent in order.
-func (bs *BufferedSender) SendUnbuffered(
-	event *kvpb.MuxRangeFeedEvent, alloc *SharedBudgetAllocation,
-) error {
-	panic("unimplemented: buffered sender for rangefeed #126560")
+func (bs *BufferedSender) SendUnbuffered(event *kvpb.MuxRangeFeedEvent) error {
+	if event.Error != nil {
+		log.Fatalf(context.Background(), "unexpected: SendUnbuffered called with error event")
+	}
+	return bs.sender.Send(event)
 }
 
 func (bs *BufferedSender) SendBufferedError(ev *kvpb.MuxRangeFeedEvent) {
-	// Disconnect stream and cancel context. Then call SendBuffered with the error
-	// event.
-	panic("unimplemented: buffered sender for rangefeed #126560")
+	if ev.Error == nil {
+		log.Fatalf(context.Background(), "unexpected: SendWithoutBlocking called with non-error event")
+	}
+
+	if cancel, ok := bs.streams.LoadAndDelete(ev.StreamID); ok {
+		// Fine to skip nil checking here since that would be a programming error.
+		(*cancel)()
+		bs.metrics.UpdateMetricsOnRangefeedDisconnect()
+		// Ignore error since the stream is already disconnecting. There is nothing
+		// else that could be done. When SendBuffered is returning an error, a node
+		// level shutdown from node.MuxRangefeed is happening soon to let clients
+		// know that the rangefeed is shutting down.
+		log.Infof(context.Background(),
+			"failed to buffer rangefeed complete event for stream %d due to %s, "+
+				"but a node level shutdown should be happening", ev.StreamID, ev.Error)
+		_ = bs.SendBuffered(ev, nil)
+	}
+}
+
+// RegisterRangefeedCleanUp registers a cleanup callback for unbuffered
+// registrations The callback associated with the streamID will be invoked when
+// BufferedSender 1. receives an error event with the streamID from
+// SendBufferedError 2. the error event has been popped from the queue and is
+// about to be sent to grpc stream. Caller cannot expect immediate rangefeed
+// cleanup after SendBufferedError, and it may not be called if
+// BufferedSender.run stopped. It is not valid to RegisterRangefeedCleanUp on an
+// already disconnected stream and expect clean up to be invoked after
+// SendBufferedError. TODO(wenyihu6): check with Nathan and see if this is okay?
+// Shouldn't be possible since RegisterRangefeedCleanUp is blocking until
+// stores.Rangefeed returns.
+func (bs *BufferedSender) RegisterRangefeedCleanUp(streamID int64, cleanUp func()) {
+	bs.rangefeedCleanup.Store(streamID, &cleanUp)
+}
+
+// disconnectAll disconnects all active streams and invokes all rangefeed clean
+// up callbacks. It is expected to be called during StreamMuxer.Stop.
+func (bs *BufferedSender) disconnectAll() {
+	bs.streams.Range(func(streamID int64, cancel *context.CancelFunc) bool {
+		(*cancel)()
+		// Remove the stream from the activeStreams map.
+		bs.streams.Delete(streamID)
+		bs.metrics.UpdateMetricsOnRangefeedDisconnect()
+		return true
+	})
+
+	bs.rangefeedCleanup.Range(func(streamID int64, cleanUp *func()) bool {
+		(*cleanUp)()
+		bs.rangefeedCleanup.Delete(streamID)
+		return true
+	})
 }
 
 func (bs *BufferedSender) AddStream(streamID int64, cancel context.CancelFunc) {
-	panic("unimplemented: buffered sender for rangefeed #126560")
+	if _, loaded := bs.streams.LoadOrStore(streamID, &cancel); loaded {
+		log.Fatalf(context.Background(), "stream %d already exists", streamID)
+	}
+	bs.metrics.UpdateMetricsOnRangefeedConnect()
 }
 
 func (bs *BufferedSender) Start(ctx context.Context, stopper *stop.Stopper) error {
 	panic("unimplemented: buffered sender for rangefeed #126560")
 }
 
+// Stop cancels the BufferedSender.run task, waits for it to complete, and
+// handles any cleanups for active streams. It is expected to be called after
+// BufferedSender.Start. After this function returns, the caller is not expected
+// to call RegisterRangefeedCleanUp, assume that the registered cleanup callback
+// will be executed after calling SendBufferedError, or assume that
+// SendBufferedError would send an error back to the client.
+// TODO(wenyihu6): add observability into when this goes wrong
+//
+// Note that Stop does not send any errors back to notify clients since the grpc
+// stream is being torn down, and the client will decide whether to restart all
+// rangefeeds again based on the returned error from grpc server stream.
+//
+// TODO(wenyihu6): add tests to make sure client treats node out of budget
+// errors as retryable and will restart all rangefeeds
 func (bs *BufferedSender) Stop() {
+	bs.disconnectAll()
 	panic("unimplemented: buffered sender for rangefeed #126560")
 }
 

--- a/pkg/kv/kvserver/rangefeed/buffered_sender_test.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_sender_test.go
@@ -158,3 +158,57 @@ func TestBufferedSenderOnStop(t *testing.T) {
 	require.Equal(t, streamIdStart, int64(testServerStream.totalEventsSent()))
 	require.Equal(t, int32(streamIdEnd-streamIdStart), testRangefeedCounter.get())
 }
+
+// TODO(wenyihu6): add tests on kvclient/rangefeed to make sure this error is
+// properly decoded as a retry signal
+func TestBufferedSenderOnOverflow(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	testServerStream := newTestServerStream()
+	testRangefeedCounter := newTestRangefeedCounter()
+	bufferedSenderCapacity = 10
+	bs := NewBufferedSender(testServerStream, testRangefeedCounter)
+	cancel()
+
+	val1 := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 1}}
+	ev1 := new(kvpb.RangeFeedEvent)
+	ev1.MustSetValue(&kvpb.RangeFeedValue{Key: keyA, Value: val1})
+	muxEv := &kvpb.MuxRangeFeedEvent{RangeFeedEvent: *ev1, RangeID: 0, StreamID: 1}
+	require.NoError(t, bs.Start(ctx, stopper))
+	defer func() {
+		bs.Stop()
+		require.Equal(t, bs.queueMu.buffer.Len(), int64(0))
+		require.Equal(t, bs.SendBuffered(muxEv, nil).Error(),
+			errors.New("stream sender is stopped").Error())
+	}()
+
+	getLen := func() int64 {
+		bs.queueMu.Lock()
+		defer bs.queueMu.Unlock()
+		return bs.queueMu.buffer.Len()
+	}
+
+	for i := 0; i < 10; i++ {
+		require.NoError(t, bs.SendBuffered(muxEv, nil))
+	}
+	require.Equal(t, int64(10), getLen())
+	e, success, overflowed, remains := bs.popFront()
+	require.Equal(t, sharedMuxEvent{
+		event: muxEv,
+		alloc: nil,
+	}, e)
+	require.True(t, success)
+	require.False(t, overflowed)
+	require.Equal(t, int64(9), remains)
+	require.Equal(t, int64(9), getLen())
+	require.NoError(t, bs.SendBuffered(muxEv, nil))
+	require.Equal(t, int64(10), getLen())
+
+	// Overflow now.
+	require.Equal(t, bs.SendBuffered(muxEv, nil).Error(),
+		newRetryErrBufferCapacityExceeded().Error())
+}

--- a/pkg/kv/kvserver/rangefeed/buffered_sender_test.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_sender_test.go
@@ -1,0 +1,143 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rangefeed
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBufferedSenderWithDisconnect tests that BufferedSender can handle stream
+// disconnects properly including context canceled, metrics updates, rangefeed
+// cleanup after SendBufferedError.
+func TestBufferedSenderWithSendBufferedError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	testServerStream := newTestServerStream()
+	testRangefeedCounter := newTestRangefeedCounter()
+	bs := NewBufferedSender(testServerStream, testRangefeedCounter)
+	// TODO(wenyihu6): change disconnectAll to Stop later on.
+	defer bs.disconnectAll()
+
+	t.Run("basic operation", func(t *testing.T) {
+		const streamID = 0
+		var num atomic.Int32
+		streamCtx, cancel := context.WithCancel(context.Background())
+		bs.AddStream(int64(streamID), cancel)
+		bs.RegisterRangefeedCleanUp(int64(streamID), func() {
+			num.Add(1)
+		})
+		bs.SendBufferedError(makeMuxRangefeedErrorEvent(int64(streamID), 1, kvpb.NewError(nil)))
+		time.Sleep(10 * time.Millisecond)
+		// Ensure that the rangefeed clean up is called.
+		require.Equal(t, int32(1), num.Load())
+		// Ensure that the stream is properly disconnected.
+		require.Equal(t, context.Canceled, streamCtx.Err())
+		require.Equal(t, int32(0), testRangefeedCounter.get())
+	})
+	t.Run("cleanup map and active streams map out of sync", func(t *testing.T) {
+		const streamID = 0
+		var num atomic.Int32
+		streamCtx, cancel := context.WithCancel(context.Background())
+		bs.AddStream(int64(streamID), cancel)
+		require.Equal(t, int32(1), testRangefeedCounter.get())
+
+		// Disconnect stream without registering clean up should still work.
+		bs.SendBufferedError(makeMuxRangefeedErrorEvent(int64(streamID), 1, kvpb.NewError(nil)))
+		require.Equal(t, context.Canceled, streamCtx.Err())
+		require.Equal(t, int32(0), num.Load())
+		require.Equal(t, int32(0), testRangefeedCounter.get())
+	})
+
+	t.Run("multiple clean up should do nothing", func(t *testing.T) {
+		const streamID = 0
+		var num atomic.Int32
+		_, cancel := context.WithCancel(context.Background())
+		bs.AddStream(int64(streamID), cancel)
+		bs.RegisterRangefeedCleanUp(int64(streamID), func() {
+			num.Add(1)
+		})
+
+		bs.SendBufferedError(makeMuxRangefeedErrorEvent(int64(streamID), 1, kvpb.NewError(nil)))
+		time.Sleep(10 * time.Millisecond)
+		require.Equal(t, int32(1), num.Load())
+		require.Equal(t, int32(0), testRangefeedCounter.get())
+
+		// Disconnecting the stream again should do nothing.
+		bs.SendBufferedError(makeMuxRangefeedErrorEvent(int64(streamID), 1, kvpb.NewError(nil)))
+		time.Sleep(10 * time.Millisecond)
+		require.Equal(t, int32(1), num.Load())
+		require.Equal(t, int32(0), testRangefeedCounter.get())
+	})
+}
+
+func TestBufferedSenderOnStop(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	testServerStream := newTestServerStream()
+	testRangefeedCounter := newTestRangefeedCounter()
+	bs := NewBufferedSender(testServerStream, testRangefeedCounter)
+
+	rng, _ := randutil.NewTestRand()
+	var actualSum atomic.Int32
+
+	// [streamIdStart,streamIDEnd) are in the active streams. streamIdStart <=
+	// streamIDEnd. If streamIDStart == streamIDEnd, no elements yet. [0,
+	// streamIdStart) are disconnected.
+	streamIdStart := int64(0)
+	streamIdEnd := int64(0)
+
+	defer func() {
+		bs.disconnectAll()
+		// Ensure that all streams are disconnected and cleanups are properly
+		// called.
+		require.Equal(t, int32(0), testRangefeedCounter.get())
+		require.Equal(t, int32(streamIdEnd), actualSum.Load())
+		require.Equal(t, streamIdStart, int64(testServerStream.totalEventsSent()))
+	}()
+
+	for i := 0; i < 100000; i++ {
+		randBool := rng.Intn(2) == 0
+		require.LessOrEqualf(t, streamIdStart, streamIdEnd, "test programming error")
+		if randBool || streamIdStart == streamIdEnd {
+			_, cancel := context.WithCancel(context.Background())
+			bs.AddStream(streamIdEnd, cancel)
+			bs.RegisterRangefeedCleanUp(streamIdEnd, func() {
+				actualSum.Add(1)
+			})
+			streamIdEnd++
+		} else {
+			bs.SendBufferedError(makeMuxRangefeedErrorEvent(streamIdStart, 1, kvpb.NewError(nil)))
+			streamIdStart++
+		}
+	}
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, int32(streamIdStart), actualSum.Load())
+	require.Equal(t, streamIdStart, int64(testServerStream.totalEventsSent()))
+	require.Equal(t, int32(streamIdEnd-streamIdStart), testRangefeedCounter.get())
+}

--- a/pkg/kv/kvserver/rangefeed/event_queue.go
+++ b/pkg/kv/kvserver/rangefeed/event_queue.go
@@ -1,0 +1,120 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rangefeed
+
+import (
+	"context"
+	"sync"
+)
+
+const eventQueueChunkSize = 4096
+
+// idQueueChunk is a queue chunk of a fixed size which idQueue uses to extend
+// its storage. Chunks are kept in the pool to reduce allocations.
+type queueChunk struct {
+	data      [eventQueueChunkSize]sharedMuxEvent
+	nextChunk *queueChunk
+}
+
+var sharedQueueChunkSyncPool = sync.Pool{
+	New: func() interface{} {
+		return new(queueChunk)
+	},
+}
+
+func getPooledQueueChunk() *queueChunk {
+	return sharedQueueChunkSyncPool.Get().(*queueChunk)
+}
+
+func putPooledQueueChunk(e *queueChunk) {
+	*e = queueChunk{}
+	sharedQueueChunkSyncPool.Put(e)
+}
+
+// eventQueue stores buffered events. Internally events are stored in
+// eventQueueChunkSize sized arrays that are added as needed and discarded once
+// reader and writers finish working with it.
+//
+// eventQueue is like a queue but uses a fixed size for the chunked
+// linked list. Each chunk has a fixed size of 4096 elements. This
+// implementation uses sync.Pool to reduce the number of allocations. It should
+// be used when the queue is used to store a large number of elements.
+//
+// pushBack, popFront, len run in constant time. removeAll runs in linear time
+// with respect to the number of elements in the queue. This structure is not
+// safe for concurrent use.
+type eventQueue struct {
+	first, last *queueChunk
+	read, write int
+	size        int
+}
+
+func newEventQueue() *eventQueue {
+	chunk := getPooledQueueChunk()
+	return &eventQueue{
+		first: chunk,
+		last:  chunk,
+	}
+}
+
+func (q *eventQueue) pushBack(e sharedMuxEvent) {
+	if q.write == eventQueueChunkSize {
+		nexChunk := getPooledQueueChunk()
+		q.last.nextChunk = nexChunk
+		q.last = nexChunk
+		q.write = 0
+	}
+	q.last.data[q.write] = e
+	q.write++
+	q.size++
+}
+
+func (q *eventQueue) popFront() (sharedMuxEvent, bool) {
+	if q.size == 0 {
+		return sharedMuxEvent{}, false
+	}
+	if q.read == eventQueueChunkSize {
+		removed := q.first
+		q.first = q.first.nextChunk
+		putPooledQueueChunk(removed)
+		q.read = 0
+	}
+	res := q.first.data[q.read]
+	q.read++
+	q.size--
+	return res, true
+}
+
+func (q *eventQueue) removeAll() {
+	start := q.read
+	for chunk := q.first; chunk != nil; {
+		max := eventQueueChunkSize
+		if chunk.nextChunk == nil {
+			max = q.write
+		}
+		for i := start; i < max; i++ {
+			chunk.data[i].alloc.Release(context.Background())
+			chunk.data[i] = sharedMuxEvent{}
+		}
+		next := chunk.nextChunk
+		putPooledQueueChunk(chunk)
+		chunk = next
+		start = 0
+	}
+	q.first = q.last
+	q.read = 0
+	q.write = 0
+	q.size = 0
+}
+
+func (q *eventQueue) Len() int64 {
+	return int64(q.size)
+}

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -63,13 +63,15 @@ var (
 	)
 )
 
+func newRetryErrBufferCapacityExceeded() error {
+	return kvpb.NewRangeFeedRetryError(kvpb.RangeFeedRetryError_REASON_SLOW_CONSUMER)
+}
+
 // newErrBufferCapacityExceeded creates an error that is returned to subscribers
 // if the rangefeed processor is not able to keep up with the flow of incoming
 // events and is forced to drop events in order to not block.
 func newErrBufferCapacityExceeded() *kvpb.Error {
-	return kvpb.NewError(
-		kvpb.NewRangeFeedRetryError(kvpb.RangeFeedRetryError_REASON_SLOW_CONSUMER),
-	)
+	return kvpb.NewError(newRetryErrBufferCapacityExceeded())
 }
 
 // Config encompasses the configuration required to create a Processor.

--- a/pkg/kv/kvserver/rangefeed/registry_helpers_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_helpers_test.go
@@ -12,6 +12,8 @@ package rangefeed
 
 import (
 	"context"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"sync"
 	"testing"
 	"time"
@@ -36,6 +38,113 @@ var (
 	spAC = roachpb.Span{Key: keyA, EndKey: keyC}
 	spXY = roachpb.Span{Key: keyX, EndKey: keyY}
 )
+
+var txn1, txn2 = uuid.MakeV4(), uuid.MakeV4()
+
+var keyValues = []storage.MVCCKeyValue{
+	makeKV("a", "valA1", 10),
+	makeIntent("c", txn1, "txnKeyC", 15),
+	makeProvisionalKV("c", "txnKeyC", 15),
+	makeKV("c", "valC2", 11),
+	makeKV("c", "valC1", 9),
+	makeIntent("d", txn2, "txnKeyD", 21),
+	makeProvisionalKV("d", "txnKeyD", 21),
+	makeKV("d", "valD5", 20),
+	makeKV("d", "valD4", 19),
+	makeKV("d", "valD3", 16),
+	makeKV("d", "valD2", 3),
+	makeKV("d", "valD1", 1),
+	makeKV("e", "valE3", 6),
+	makeKV("e", "valE2", 5),
+	makeKV("e", "valE1", 4),
+	makeKV("f", "valF3", 7),
+	makeKV("f", "valF2", 6),
+	makeKV("f", "valF1", 5),
+	makeKV("h", "valH1", 15),
+	makeKV("m", "valM1", 1),
+	makeIntent("n", txn1, "txnKeyN", 12),
+	makeProvisionalKV("n", "txnKeyN", 12),
+	makeIntent("r", txn1, "txnKeyR", 19),
+	makeProvisionalKV("r", "txnKeyR", 19),
+	makeKV("r", "valR1", 4),
+	makeKV("s", "valS3", 21),
+	makeKVWithHeader("s", "valS2", 20, enginepb.MVCCValueHeader{OmitInRangefeeds: true}),
+	makeKV("s", "valS1", 19),
+	makeIntent("w", txn1, "txnKeyW", 3),
+	makeProvisionalKV("w", "txnKeyW", 3),
+	makeIntent("z", txn2, "txnKeyZ", 21),
+	makeProvisionalKV("z", "txnKeyZ", 21),
+	makeKV("z", "valZ1", 4),
+}
+
+func expEvents(filtering bool) (expEvents []*kvpb.RangeFeedEvent) {
+	// Compare the events sent on the registration's Stream to the expected events.
+	expEvents = []*kvpb.RangeFeedEvent{
+		rangeFeedValueWithPrev(
+			roachpb.Key("d"),
+			makeValWithTs("valD3", 16),
+			makeVal("valD2"),
+		),
+		rangeFeedValueWithPrev(
+			roachpb.Key("d"),
+			makeValWithTs("valD4", 19),
+			makeVal("valD3"),
+		),
+		rangeFeedValueWithPrev(
+			roachpb.Key("d"),
+			makeValWithTs("valD5", 20),
+			makeVal("valD4"),
+		),
+		rangeFeedValueWithPrev(
+			roachpb.Key("e"),
+			makeValWithTs("valE2", 5),
+			makeVal("valE1"),
+		),
+		rangeFeedValueWithPrev(
+			roachpb.Key("e"),
+			makeValWithTs("valE3", 6),
+			makeVal("valE2"),
+		),
+		rangeFeedValue(
+			roachpb.Key("f"),
+			makeValWithTs("valF1", 5),
+		),
+		rangeFeedValueWithPrev(
+			roachpb.Key("f"),
+			makeValWithTs("valF2", 6),
+			makeVal("valF1"),
+		),
+		rangeFeedValueWithPrev(
+			roachpb.Key("f"),
+			makeValWithTs("valF3", 7),
+			makeVal("valF2"),
+		),
+		rangeFeedValue(
+			roachpb.Key("h"),
+			makeValWithTs("valH1", 15),
+		),
+		rangeFeedValue(
+			roachpb.Key("s"),
+			makeValWithTs("valS1", 19),
+		),
+	}
+	if !filtering {
+		expEvents = append(expEvents,
+			rangeFeedValueWithPrev(
+				roachpb.Key("s"),
+				makeValWithTs("valS2", 20),
+				makeVal("valS1"),
+			))
+	}
+	expEvents = append(expEvents, rangeFeedValueWithPrev(
+		roachpb.Key("s"),
+		makeValWithTs("valS3", 21),
+		// Even though the event that wrote val2 is filtered out, we want to keep
+		// val2 as a previous value of the next event.
+		makeVal("valS2"),
+	))
+	return
+}
 
 type testStream struct {
 	ctx     context.Context

--- a/pkg/kv/kvserver/rangefeed/registry_helpers_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_helpers_test.go
@@ -57,10 +57,6 @@ func (s *testStream) Context() context.Context {
 	return s.ctx
 }
 
-func (s *testStream) Cancel() {
-	s.ctxDone()
-}
-
 func (s *testStream) SendUnbufferedIsThreadSafe() {}
 
 func (s *testStream) SendUnbuffered(e *kvpb.RangeFeedEvent) error {

--- a/pkg/kv/kvserver/rangefeed/registry_helpers_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_helpers_test.go
@@ -12,8 +12,6 @@ package rangefeed
 
 import (
 	"context"
-	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"sync"
 	"testing"
 	"time"
@@ -22,9 +20,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
 var (
@@ -204,6 +204,7 @@ func (s *testStream) BlockSend() func() {
 // by sending the error to the done channel.
 func (s *testStream) Disconnect(err *kvpb.Error) {
 	s.done <- err
+	s.ctxDone()
 }
 
 // Error returns the error that was sent to the done channel. It returns nil if
@@ -334,7 +335,7 @@ func newTestRegistration(s *testStream, opts ...registrationOption) registration
 
 	switch cfg.withRegistrationTestTypes {
 	case buffered:
-		newBufferedRegistration(
+		return newBufferedRegistration(
 			cfg.span,
 			cfg.ts,
 			makeCatchUpIterator(cfg.catchup, cfg.span, cfg.ts),

--- a/pkg/kv/kvserver/rangefeed/registry_helpers_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_helpers_test.go
@@ -205,7 +205,7 @@ func (t registrationType) String() string {
 	panic("unknown processor type")
 }
 
-var registrationTestTypes = []registrationType{buffered}
+var registrationTestTypes = []registrationType{buffered, unbuffered}
 
 type testRegistrationConfig struct {
 	span                      roachpb.Span
@@ -227,17 +227,35 @@ func newTestRegistration(s *testStream, opts ...registrationOption) registration
 		cfg.metrics = NewMetrics()
 	}
 
-	return newBufferedRegistration(
-		cfg.span,
-		cfg.ts,
-		makeCatchUpIterator(cfg.catchup, cfg.span, cfg.ts),
-		cfg.withDiff,
-		cfg.withFiltering,
-		cfg.withOmitRemote,
-		5,
-		false, /* blockWhenFull */
-		cfg.metrics,
-		s,
-		func() {},
-	)
+	switch cfg.withRegistrationTestTypes {
+	case buffered:
+		newBufferedRegistration(
+			cfg.span,
+			cfg.ts,
+			makeCatchUpIterator(cfg.catchup, cfg.span, cfg.ts),
+			cfg.withDiff,
+			cfg.withFiltering,
+			cfg.withOmitRemote,
+			5,
+			false, /* blockWhenFull */
+			cfg.metrics,
+			s,
+			func() {},
+		)
+	case unbuffered:
+		return newUnbufferedRegistration(
+			cfg.span,
+			cfg.ts,
+			makeCatchUpIterator(cfg.catchup, cfg.span, cfg.ts),
+			cfg.withDiff,
+			cfg.withFiltering,
+			cfg.withOmitRemote,
+			5,
+			cfg.metrics,
+			&testBufferedStream{Stream: s},
+			func() {},
+		)
+	default:
+		panic("unknown registration type")
+	}
 }

--- a/pkg/kv/kvserver/rangefeed/registry_helpers_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_helpers_test.go
@@ -1,0 +1,172 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rangefeed
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/cockroachdb/cockroach/pkg/keys" // hook up pretty printer
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+var (
+	keyA, keyB = roachpb.Key("a"), roachpb.Key("b")
+	keyC, keyD = roachpb.Key("c"), roachpb.Key("d")
+	keyX, keyY = roachpb.Key("x"), roachpb.Key("y")
+
+	spAB = roachpb.Span{Key: keyA, EndKey: keyB}
+	spBC = roachpb.Span{Key: keyB, EndKey: keyC}
+	spCD = roachpb.Span{Key: keyC, EndKey: keyD}
+	spAC = roachpb.Span{Key: keyA, EndKey: keyC}
+	spXY = roachpb.Span{Key: keyX, EndKey: keyY}
+)
+
+type testStream struct {
+	ctx     context.Context
+	ctxDone func()
+	done    chan *kvpb.Error
+	mu      struct {
+		syncutil.Mutex
+		sendErr error
+		events  []*kvpb.RangeFeedEvent
+	}
+}
+
+func newTestStream() *testStream {
+	ctx, done := context.WithCancel(context.Background())
+	return &testStream{ctx: ctx, ctxDone: done, done: make(chan *kvpb.Error, 1)}
+}
+
+func (s *testStream) Context() context.Context {
+	return s.ctx
+}
+
+func (s *testStream) Cancel() {
+	s.ctxDone()
+}
+
+func (s *testStream) SendUnbufferedIsThreadSafe() {}
+
+func (s *testStream) SendUnbuffered(e *kvpb.RangeFeedEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.mu.sendErr != nil {
+		return s.mu.sendErr
+	}
+	s.mu.events = append(s.mu.events, e)
+	return nil
+}
+
+func (s *testStream) SetSendErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mu.sendErr = err
+}
+
+func (s *testStream) Events() []*kvpb.RangeFeedEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	es := s.mu.events
+	s.mu.events = nil
+	return es
+}
+
+func (s *testStream) BlockSend() func() {
+	s.mu.Lock()
+	var once sync.Once
+	return func() {
+		once.Do(s.mu.Unlock) // safe to call multiple times, e.g. defer and explicit
+	}
+}
+
+// Disconnect implements the Stream interface. It mocks the disconnect behavior
+// by sending the error to the done channel.
+func (s *testStream) Disconnect(err *kvpb.Error) {
+	s.done <- err
+}
+
+// Error returns the error that was sent to the done channel. It returns nil if
+// no error was sent yet.
+func (s *testStream) Error() error {
+	select {
+	case err := <-s.done:
+		return err.GoError()
+	default:
+		return nil
+	}
+}
+
+// WaitForError waits for the rangefeed to complete and returns the error sent
+// to the done channel. It fails the test if rangefeed cannot complete within 30
+// seconds.
+func (s *testStream) WaitForError(t *testing.T) error {
+	select {
+	case err := <-s.done:
+		return err.GoError()
+	case <-time.After(testutils.DefaultSucceedsSoonDuration):
+		t.Fatalf("time out waiting for rangefeed completion")
+		return nil
+	}
+}
+
+type testRegistration struct {
+	*bufferedRegistration
+	*testStream
+}
+
+func makeCatchUpIterator(
+	iter storage.SimpleMVCCIterator, span roachpb.Span, startTime hlc.Timestamp,
+) *CatchUpIterator {
+	if iter == nil {
+		return nil
+	}
+	return &CatchUpIterator{
+		simpleCatchupIter: simpleCatchupIterAdapter{iter},
+		span:              span,
+		startTime:         startTime,
+	}
+}
+
+func newTestRegistration(
+	span roachpb.Span,
+	ts hlc.Timestamp,
+	catchup storage.SimpleMVCCIterator,
+	withDiff bool,
+	withFiltering bool,
+	withOmitRemote bool,
+) *testRegistration {
+	s := newTestStream()
+	r := newBufferedRegistration(
+		span,
+		ts,
+		makeCatchUpIterator(catchup, span, ts),
+		withDiff,
+		withFiltering,
+		withOmitRemote,
+		5,
+		false, /* blockWhenFull */
+		NewMetrics(),
+		s,
+		func() {},
+	)
+	return &testRegistration{
+		bufferedRegistration: r,
+		testStream:           s,
+	}
+}

--- a/pkg/kv/kvserver/rangefeed/registry_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_test.go
@@ -19,11 +19,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -155,43 +153,7 @@ func TestRegistrationCatchUpScan(t *testing.T) {
 		testutils.RunTrueAndFalse(t, "filtering", func(t *testing.T, filtering bool) {
 			// Run a catch-up scan for a registration over a test
 			// iterator with the following keys.
-			txn1, txn2 := uuid.MakeV4(), uuid.MakeV4()
-			iter := newTestIterator([]storage.MVCCKeyValue{
-				makeKV("a", "valA1", 10),
-				makeIntent("c", txn1, "txnKeyC", 15),
-				makeProvisionalKV("c", "txnKeyC", 15),
-				makeKV("c", "valC2", 11),
-				makeKV("c", "valC1", 9),
-				makeIntent("d", txn2, "txnKeyD", 21),
-				makeProvisionalKV("d", "txnKeyD", 21),
-				makeKV("d", "valD5", 20),
-				makeKV("d", "valD4", 19),
-				makeKV("d", "valD3", 16),
-				makeKV("d", "valD2", 3),
-				makeKV("d", "valD1", 1),
-				makeKV("e", "valE3", 6),
-				makeKV("e", "valE2", 5),
-				makeKV("e", "valE1", 4),
-				makeKV("f", "valF3", 7),
-				makeKV("f", "valF2", 6),
-				makeKV("f", "valF1", 5),
-				makeKV("h", "valH1", 15),
-				makeKV("m", "valM1", 1),
-				makeIntent("n", txn1, "txnKeyN", 12),
-				makeProvisionalKV("n", "txnKeyN", 12),
-				makeIntent("r", txn1, "txnKeyR", 19),
-				makeProvisionalKV("r", "txnKeyR", 19),
-				makeKV("r", "valR1", 4),
-				makeKV("s", "valS3", 21),
-				makeKVWithHeader("s", "valS2", 20, enginepb.MVCCValueHeader{OmitInRangefeeds: true}),
-				makeKV("s", "valS1", 19),
-				makeIntent("w", txn1, "txnKeyW", 3),
-				makeProvisionalKV("w", "txnKeyW", 3),
-				makeIntent("z", txn2, "txnKeyZ", 21),
-				makeProvisionalKV("z", "txnKeyZ", 21),
-				makeKV("z", "valZ1", 4),
-			}, roachpb.Key("w"))
-
+			iter := newTestIterator(keyValues, roachpb.Key("w"))
 			metrics := NewMetrics()
 			s := newTestStream()
 			r := newTestRegistration(s, withRSpan(roachpb.Span{
@@ -210,71 +172,7 @@ func TestRegistrationCatchUpScan(t *testing.T) {
 			require.NotZero(t, metrics.RangeFeedCatchUpScanNanos.Count())
 
 			// Compare the events sent on the registration's Stream to the expected events.
-			expEvents := []*kvpb.RangeFeedEvent{
-				rangeFeedValueWithPrev(
-					roachpb.Key("d"),
-					makeValWithTs("valD3", 16),
-					makeVal("valD2"),
-				),
-				rangeFeedValueWithPrev(
-					roachpb.Key("d"),
-					makeValWithTs("valD4", 19),
-					makeVal("valD3"),
-				),
-				rangeFeedValueWithPrev(
-					roachpb.Key("d"),
-					makeValWithTs("valD5", 20),
-					makeVal("valD4"),
-				),
-				rangeFeedValueWithPrev(
-					roachpb.Key("e"),
-					makeValWithTs("valE2", 5),
-					makeVal("valE1"),
-				),
-				rangeFeedValueWithPrev(
-					roachpb.Key("e"),
-					makeValWithTs("valE3", 6),
-					makeVal("valE2"),
-				),
-				rangeFeedValue(
-					roachpb.Key("f"),
-					makeValWithTs("valF1", 5),
-				),
-				rangeFeedValueWithPrev(
-					roachpb.Key("f"),
-					makeValWithTs("valF2", 6),
-					makeVal("valF1"),
-				),
-				rangeFeedValueWithPrev(
-					roachpb.Key("f"),
-					makeValWithTs("valF3", 7),
-					makeVal("valF2"),
-				),
-				rangeFeedValue(
-					roachpb.Key("h"),
-					makeValWithTs("valH1", 15),
-				),
-				rangeFeedValue(
-					roachpb.Key("s"),
-					makeValWithTs("valS1", 19),
-				),
-			}
-			if !filtering {
-				expEvents = append(expEvents,
-					rangeFeedValueWithPrev(
-						roachpb.Key("s"),
-						makeValWithTs("valS2", 20),
-						makeVal("valS1"),
-					))
-			}
-			expEvents = append(expEvents, rangeFeedValueWithPrev(
-				roachpb.Key("s"),
-				makeValWithTs("valS3", 21),
-				// Even though the event that wrote val2 is filtered out, we want to keep
-				// val2 as a previous value of the next event.
-				makeVal("valS2"),
-			))
-			require.Equal(t, expEvents, s.Events())
+			require.Equal(t, expEvents(filtering), s.Events())
 		})
 	})
 }

--- a/pkg/kv/kvserver/rangefeed/registry_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_test.go
@@ -13,9 +13,7 @@ package rangefeed
 import (
 	"context"
 	"fmt"
-	"sync"
 	"testing"
-	"time"
 
 	_ "github.com/cockroachdb/cockroach/pkg/keys" // hook up pretty printer
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -25,156 +23,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/stretchr/testify/require"
 )
-
-var (
-	keyA, keyB = roachpb.Key("a"), roachpb.Key("b")
-	keyC, keyD = roachpb.Key("c"), roachpb.Key("d")
-	keyX, keyY = roachpb.Key("x"), roachpb.Key("y")
-
-	spAB = roachpb.Span{Key: keyA, EndKey: keyB}
-	spBC = roachpb.Span{Key: keyB, EndKey: keyC}
-	spCD = roachpb.Span{Key: keyC, EndKey: keyD}
-	spAC = roachpb.Span{Key: keyA, EndKey: keyC}
-	spXY = roachpb.Span{Key: keyX, EndKey: keyY}
-)
-
-type testStream struct {
-	ctx     context.Context
-	ctxDone func()
-	done    chan *kvpb.Error
-	mu      struct {
-		syncutil.Mutex
-		sendErr error
-		events  []*kvpb.RangeFeedEvent
-	}
-}
-
-func newTestStream() *testStream {
-	ctx, done := context.WithCancel(context.Background())
-	return &testStream{ctx: ctx, ctxDone: done, done: make(chan *kvpb.Error, 1)}
-}
-
-func (s *testStream) Context() context.Context {
-	return s.ctx
-}
-
-func (s *testStream) Cancel() {
-	s.ctxDone()
-}
-
-func (s *testStream) SendUnbufferedIsThreadSafe() {}
-
-func (s *testStream) SendUnbuffered(e *kvpb.RangeFeedEvent) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.mu.sendErr != nil {
-		return s.mu.sendErr
-	}
-	s.mu.events = append(s.mu.events, e)
-	return nil
-}
-
-func (s *testStream) SetSendErr(err error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.mu.sendErr = err
-}
-
-func (s *testStream) Events() []*kvpb.RangeFeedEvent {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	es := s.mu.events
-	s.mu.events = nil
-	return es
-}
-
-func (s *testStream) BlockSend() func() {
-	s.mu.Lock()
-	var once sync.Once
-	return func() {
-		once.Do(s.mu.Unlock) // safe to call multiple times, e.g. defer and explicit
-	}
-}
-
-// Disconnect implements the Stream interface. It mocks the disconnect behavior
-// by sending the error to the done channel.
-func (s *testStream) Disconnect(err *kvpb.Error) {
-	s.done <- err
-}
-
-// Error returns the error that was sent to the done channel. It returns nil if
-// no error was sent yet.
-func (s *testStream) Error() error {
-	select {
-	case err := <-s.done:
-		return err.GoError()
-	default:
-		return nil
-	}
-}
-
-// WaitForError waits for the rangefeed to complete and returns the error sent
-// to the done channel. It fails the test if rangefeed cannot complete within 30
-// seconds.
-func (s *testStream) WaitForError(t *testing.T) error {
-	select {
-	case err := <-s.done:
-		return err.GoError()
-	case <-time.After(testutils.DefaultSucceedsSoonDuration):
-		t.Fatalf("time out waiting for rangefeed completion")
-		return nil
-	}
-}
-
-type testRegistration struct {
-	*bufferedRegistration
-	*testStream
-}
-
-func makeCatchUpIterator(
-	iter storage.SimpleMVCCIterator, span roachpb.Span, startTime hlc.Timestamp,
-) *CatchUpIterator {
-	if iter == nil {
-		return nil
-	}
-	return &CatchUpIterator{
-		simpleCatchupIter: simpleCatchupIterAdapter{iter},
-		span:              span,
-		startTime:         startTime,
-	}
-}
-
-func newTestRegistration(
-	span roachpb.Span,
-	ts hlc.Timestamp,
-	catchup storage.SimpleMVCCIterator,
-	withDiff bool,
-	withFiltering bool,
-	withOmitRemote bool,
-) *testRegistration {
-	s := newTestStream()
-	r := newBufferedRegistration(
-		span,
-		ts,
-		makeCatchUpIterator(catchup, span, ts),
-		withDiff,
-		withFiltering,
-		withOmitRemote,
-		5,
-		false, /* blockWhenFull */
-		NewMetrics(),
-		s,
-		func() {},
-	)
-	return &testRegistration{
-		bufferedRegistration: r,
-		testStream:           s,
-	}
-}
 
 func TestRegistrationBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/kv/kvserver/rangefeed/registry_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_test.go
@@ -36,206 +36,228 @@ func TestRegistrationBasic(t *testing.T) {
 	ev1.MustSetValue(&kvpb.RangeFeedValue{Key: keyA, Value: val})
 	ev2.MustSetValue(&kvpb.RangeFeedValue{Key: keyB, Value: val})
 
-	// Registration with no catchup scan specified.
-	noCatchupReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, /* catchup */
-		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
-	noCatchupReg.publish(ctx, ev1, nil /* alloc */)
-	noCatchupReg.publish(ctx, ev2, nil /* alloc */)
-	require.Equal(t, len(noCatchupReg.buf), 2)
-	go noCatchupReg.runOutputLoop(ctx, 0)
-	require.NoError(t, noCatchupReg.waitForCaughtUp(ctx))
-	require.Equal(t, []*kvpb.RangeFeedEvent{ev1, ev2}, noCatchupReg.Events())
-	noCatchupReg.disconnect(nil)
-
-	// Registration with catchup scan.
-	catchupReg := newTestRegistration(spBC, hlc.Timestamp{WallTime: 1},
-		newTestIterator([]storage.MVCCKeyValue{
-			makeKV("b", "val1", 10),
-			makeKV("bc", "val3", 11),
-			makeKV("bd", "val4", 9),
-		}, nil),
-		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
-	catchupReg.publish(ctx, ev1, nil /* alloc */)
-	catchupReg.publish(ctx, ev2, nil /* alloc */)
-	require.Equal(t, len(catchupReg.buf), 2)
-	go catchupReg.runOutputLoop(ctx, 0)
-	require.NoError(t, catchupReg.waitForCaughtUp(ctx))
-	events := catchupReg.Events()
-	require.Equal(t, 5, len(events))
-	require.Equal(t, []*kvpb.RangeFeedEvent{ev1, ev2}, events[3:])
-	catchupReg.disconnect(nil)
-
-	// EXIT CONDITIONS
-	// External Disconnect.
-	disconnectReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, /* catchup */
-		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
-	disconnectReg.publish(ctx, ev1, nil /* alloc */)
-	disconnectReg.publish(ctx, ev2, nil /* alloc */)
-	go disconnectReg.runOutputLoop(ctx, 0)
-	require.NoError(t, disconnectReg.waitForCaughtUp(ctx))
-	discErr := kvpb.NewError(fmt.Errorf("disconnection error"))
-	disconnectReg.disconnect(discErr)
-	require.Equal(t, discErr.GoError(), disconnectReg.WaitForError(t))
-	require.Equal(t, 2, len(disconnectReg.Events()))
-
-	// External Disconnect before output loop.
-	disconnectEarlyReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, /* catchup */
-		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
-	disconnectEarlyReg.publish(ctx, ev1, nil /* alloc */)
-	disconnectEarlyReg.publish(ctx, ev2, nil /* alloc */)
-	disconnectEarlyReg.disconnect(discErr)
-	go disconnectEarlyReg.runOutputLoop(ctx, 0)
-	require.Equal(t, discErr.GoError(), disconnectEarlyReg.WaitForError(t))
-	require.Equal(t, 0, len(disconnectEarlyReg.Events()))
-
-	// Overflow.
-	overflowReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, /* catchup */
-		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
-	for i := 0; i < cap(overflowReg.buf)+3; i++ {
-		overflowReg.publish(ctx, ev1, nil /* alloc */)
-	}
-	go overflowReg.runOutputLoop(ctx, 0)
-	require.Equal(t, newErrBufferCapacityExceeded().GoError(), overflowReg.WaitForError(t))
-	require.Equal(t, cap(overflowReg.buf), len(overflowReg.Events()))
-
-	// Stream Error.
-	streamErrReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, /* catchup */
-		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
-	streamErr := fmt.Errorf("stream error")
-	streamErrReg.SetSendErr(streamErr)
-	go streamErrReg.runOutputLoop(ctx, 0)
-	streamErrReg.publish(ctx, ev1, nil /* alloc */)
-	require.Equal(t, streamErr, streamErrReg.WaitForError(t))
-
-	// Stream Context Canceled.
-	streamCancelReg := newTestRegistration(spAB, hlc.Timestamp{}, nil, /* catchup */
-		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
-
-	streamCancelReg.Cancel()
-	go streamCancelReg.runOutputLoop(ctx, 0)
-	require.NoError(t, streamCancelReg.waitForCaughtUp(ctx))
-	require.Equal(t, streamCancelReg.stream.Context().Err(), streamCancelReg.WaitForError(t))
+	testutils.RunValues(t, "registration type=", registrationTestTypes, func(t *testing.T, rt registrationType) {
+		t.Run("registration with no catchup scan specified", func(t *testing.T) {
+			s := newTestStream()
+			noCatchupReg := newTestRegistration(s, withRSpan(spAB), withRegistrationType(rt))
+			noCatchupReg.publish(ctx, ev1, nil /* alloc */)
+			noCatchupReg.publish(ctx, ev2, nil /* alloc */)
+			if noCatchupReg, ok := noCatchupReg.(*bufferedRegistration); ok {
+				require.Equal(t, len(noCatchupReg.buf), 2)
+			}
+			go noCatchupReg.runOutputLoop(ctx, 0)
+			require.NoError(t, noCatchupReg.waitForCaughtUp(ctx))
+			require.Equal(t, []*kvpb.RangeFeedEvent{ev1, ev2}, s.Events())
+			noCatchupReg.disconnect(nil)
+		})
+		t.Run("registration with catchup scan", func(t *testing.T) {
+			s := newTestStream()
+			catchupReg := newTestRegistration(s, withRSpan(spBC),
+				withStartTs(hlc.Timestamp{WallTime: 1}),
+				withCatchUpIter(newTestIterator([]storage.MVCCKeyValue{
+					makeKV("b", "val1", 10),
+					makeKV("bc", "val3", 11),
+					makeKV("bd", "val4", 9),
+				}, nil)), withRegistrationType(rt))
+			catchupReg.publish(ctx, ev1, nil /* alloc */)
+			catchupReg.publish(ctx, ev2, nil /* alloc */)
+			if noCatchupReg, ok := catchupReg.(*bufferedRegistration); ok {
+				require.Equal(t, len(noCatchupReg.buf), 2)
+			}
+			go catchupReg.runOutputLoop(ctx, 0)
+			require.NoError(t, catchupReg.waitForCaughtUp(ctx))
+			events := s.Events()
+			require.Equal(t, 5, len(events))
+			require.Equal(t, []*kvpb.RangeFeedEvent{ev1, ev2}, events[3:])
+			catchupReg.disconnect(nil)
+		})
+		t.Run("external disconnect after output loop", func(t *testing.T) {
+			s := newTestStream()
+			disconnectReg := newTestRegistration(s, withRSpan(spAB), withRegistrationType(rt))
+			disconnectReg.publish(ctx, ev1, nil /* alloc */)
+			disconnectReg.publish(ctx, ev2, nil /* alloc */)
+			go disconnectReg.runOutputLoop(ctx, 0)
+			require.NoError(t, disconnectReg.waitForCaughtUp(ctx))
+			discErr := kvpb.NewError(fmt.Errorf("disconnection error"))
+			disconnectReg.disconnect(discErr)
+			require.Equal(t, discErr.GoError(), s.WaitForError(t))
+			require.Equal(t, 2, len(s.Events()))
+		})
+		t.Run("external disconnect before output loop", func(t *testing.T) {
+			s := newTestStream()
+			disconnectEarlyReg := newTestRegistration(s, withRSpan(spAB), withRegistrationType(rt))
+			disconnectEarlyReg.publish(ctx, ev1, nil /* alloc */)
+			disconnectEarlyReg.publish(ctx, ev2, nil /* alloc */)
+			discErr := kvpb.NewError(fmt.Errorf("disconnection error"))
+			disconnectEarlyReg.disconnect(discErr)
+			go disconnectEarlyReg.runOutputLoop(ctx, 0)
+			require.Equal(t, discErr.GoError(), s.WaitForError(t))
+			if rt == buffered {
+				require.Equal(t, 0, len(s.Events()))
+			}
+		})
+		t.Run("overflow", func(t *testing.T) {
+			s := newTestStream()
+			var capOfBuf int
+			var overflowReg registration
+			switch rt {
+			case buffered:
+				overflowReg = newTestRegistration(s, withRSpan(spAB), withRegistrationType(rt))
+				capOfBuf = cap(overflowReg.(*bufferedRegistration).buf)
+			}
+			for i := 0; i < capOfBuf+3; i++ {
+				overflowReg.publish(ctx, ev1, nil /* alloc */)
+			}
+			go overflowReg.runOutputLoop(ctx, 0)
+			require.Equal(t, kvpb.NewRangeFeedRetryError(kvpb.RangeFeedRetryError_REASON_SLOW_CONSUMER), s.WaitForError(t))
+			require.Equal(t, capOfBuf, len(s.Events()))
+		})
+		t.Run("stream error", func(t *testing.T) {
+			s := newTestStream()
+			streamErrReg := newTestRegistration(s, withRSpan(spAB), withRegistrationType(rt))
+			streamErr := fmt.Errorf("stream error")
+			s.SetSendErr(streamErr)
+			go streamErrReg.runOutputLoop(ctx, 0)
+			streamErrReg.publish(ctx, ev1, nil /* alloc */)
+			require.Equal(t, streamErr, s.WaitForError(t))
+		})
+		t.Run("stream context canceled", func(t *testing.T) {
+			s := newTestStream()
+			streamCancelReg := newTestRegistration(s, withRSpan(spAB), withRegistrationType(rt))
+			streamCancelReg.disconnect(kvpb.NewError(context.Canceled))
+			go streamCancelReg.runOutputLoop(ctx, 0)
+			require.NoError(t, streamCancelReg.waitForCaughtUp(ctx))
+			require.Equal(t, context.Canceled, s.WaitForError(t))
+		})
+	})
 }
 
 func TestRegistrationCatchUpScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	testutils.RunTrueAndFalse(t, "withFiltering", func(t *testing.T, withFiltering bool) {
-		// Run a catch-up scan for a registration over a test
-		// iterator with the following keys.
-		txn1, txn2 := uuid.MakeV4(), uuid.MakeV4()
-		iter := newTestIterator([]storage.MVCCKeyValue{
-			makeKV("a", "valA1", 10),
-			makeIntent("c", txn1, "txnKeyC", 15),
-			makeProvisionalKV("c", "txnKeyC", 15),
-			makeKV("c", "valC2", 11),
-			makeKV("c", "valC1", 9),
-			makeIntent("d", txn2, "txnKeyD", 21),
-			makeProvisionalKV("d", "txnKeyD", 21),
-			makeKV("d", "valD5", 20),
-			makeKV("d", "valD4", 19),
-			makeKV("d", "valD3", 16),
-			makeKV("d", "valD2", 3),
-			makeKV("d", "valD1", 1),
-			makeKV("e", "valE3", 6),
-			makeKV("e", "valE2", 5),
-			makeKV("e", "valE1", 4),
-			makeKV("f", "valF3", 7),
-			makeKV("f", "valF2", 6),
-			makeKV("f", "valF1", 5),
-			makeKV("h", "valH1", 15),
-			makeKV("m", "valM1", 1),
-			makeIntent("n", txn1, "txnKeyN", 12),
-			makeProvisionalKV("n", "txnKeyN", 12),
-			makeIntent("r", txn1, "txnKeyR", 19),
-			makeProvisionalKV("r", "txnKeyR", 19),
-			makeKV("r", "valR1", 4),
-			makeKV("s", "valS3", 21),
-			makeKVWithHeader("s", "valS2", 20, enginepb.MVCCValueHeader{OmitInRangefeeds: true}),
-			makeKV("s", "valS1", 19),
-			makeIntent("w", txn1, "txnKeyW", 3),
-			makeProvisionalKV("w", "txnKeyW", 3),
-			makeIntent("z", txn2, "txnKeyZ", 21),
-			makeProvisionalKV("z", "txnKeyZ", 21),
-			makeKV("z", "valZ1", 4),
-		}, roachpb.Key("w"))
+	testutils.RunValues(t, "registration type=", registrationTestTypes, func(t *testing.T, rt registrationType) {
+		testutils.RunTrueAndFalse(t, "filtering", func(t *testing.T, filtering bool) {
+			// Run a catch-up scan for a registration over a test
+			// iterator with the following keys.
+			txn1, txn2 := uuid.MakeV4(), uuid.MakeV4()
+			iter := newTestIterator([]storage.MVCCKeyValue{
+				makeKV("a", "valA1", 10),
+				makeIntent("c", txn1, "txnKeyC", 15),
+				makeProvisionalKV("c", "txnKeyC", 15),
+				makeKV("c", "valC2", 11),
+				makeKV("c", "valC1", 9),
+				makeIntent("d", txn2, "txnKeyD", 21),
+				makeProvisionalKV("d", "txnKeyD", 21),
+				makeKV("d", "valD5", 20),
+				makeKV("d", "valD4", 19),
+				makeKV("d", "valD3", 16),
+				makeKV("d", "valD2", 3),
+				makeKV("d", "valD1", 1),
+				makeKV("e", "valE3", 6),
+				makeKV("e", "valE2", 5),
+				makeKV("e", "valE1", 4),
+				makeKV("f", "valF3", 7),
+				makeKV("f", "valF2", 6),
+				makeKV("f", "valF1", 5),
+				makeKV("h", "valH1", 15),
+				makeKV("m", "valM1", 1),
+				makeIntent("n", txn1, "txnKeyN", 12),
+				makeProvisionalKV("n", "txnKeyN", 12),
+				makeIntent("r", txn1, "txnKeyR", 19),
+				makeProvisionalKV("r", "txnKeyR", 19),
+				makeKV("r", "valR1", 4),
+				makeKV("s", "valS3", 21),
+				makeKVWithHeader("s", "valS2", 20, enginepb.MVCCValueHeader{OmitInRangefeeds: true}),
+				makeKV("s", "valS1", 19),
+				makeIntent("w", txn1, "txnKeyW", 3),
+				makeProvisionalKV("w", "txnKeyW", 3),
+				makeIntent("z", txn2, "txnKeyZ", 21),
+				makeProvisionalKV("z", "txnKeyZ", 21),
+				makeKV("z", "valZ1", 4),
+			}, roachpb.Key("w"))
 
-		r := newTestRegistration(roachpb.Span{
-			Key:    roachpb.Key("d"),
-			EndKey: roachpb.Key("w"),
-		}, hlc.Timestamp{WallTime: 4}, iter, true /* withDiff */, withFiltering, false /* withOmitRemote */)
+			metrics := NewMetrics()
+			s := newTestStream()
+			r := newTestRegistration(s, withRSpan(roachpb.Span{
+				Key:    roachpb.Key("d"),
+				EndKey: roachpb.Key("w"),
+			}), withStartTs(hlc.Timestamp{WallTime: 4}), withCatchUpIter(iter), withDiff(true),
+				withFiltering(filtering), withRMetrics(metrics), withRegistrationType(rt))
+			require.Zero(t, metrics.RangeFeedCatchUpScanNanos.Count())
+			switch r := r.(type) {
+			case *bufferedRegistration:
+				require.NoError(t, r.maybeRunCatchUpScan(context.Background()))
+			}
+			require.True(t, iter.closed)
+			require.NotZero(t, metrics.RangeFeedCatchUpScanNanos.Count())
 
-		require.Zero(t, r.metrics.RangeFeedCatchUpScanNanos.Count())
-		require.NoError(t, r.maybeRunCatchUpScan(context.Background()))
-		require.True(t, iter.closed)
-		require.NotZero(t, r.metrics.RangeFeedCatchUpScanNanos.Count())
-
-		// Compare the events sent on the registration's Stream to the expected events.
-		expEvents := []*kvpb.RangeFeedEvent{
-			rangeFeedValueWithPrev(
-				roachpb.Key("d"),
-				makeValWithTs("valD3", 16),
-				makeVal("valD2"),
-			),
-			rangeFeedValueWithPrev(
-				roachpb.Key("d"),
-				makeValWithTs("valD4", 19),
-				makeVal("valD3"),
-			),
-			rangeFeedValueWithPrev(
-				roachpb.Key("d"),
-				makeValWithTs("valD5", 20),
-				makeVal("valD4"),
-			),
-			rangeFeedValueWithPrev(
-				roachpb.Key("e"),
-				makeValWithTs("valE2", 5),
-				makeVal("valE1"),
-			),
-			rangeFeedValueWithPrev(
-				roachpb.Key("e"),
-				makeValWithTs("valE3", 6),
-				makeVal("valE2"),
-			),
-			rangeFeedValue(
-				roachpb.Key("f"),
-				makeValWithTs("valF1", 5),
-			),
-			rangeFeedValueWithPrev(
-				roachpb.Key("f"),
-				makeValWithTs("valF2", 6),
-				makeVal("valF1"),
-			),
-			rangeFeedValueWithPrev(
-				roachpb.Key("f"),
-				makeValWithTs("valF3", 7),
-				makeVal("valF2"),
-			),
-			rangeFeedValue(
-				roachpb.Key("h"),
-				makeValWithTs("valH1", 15),
-			),
-			rangeFeedValue(
-				roachpb.Key("s"),
-				makeValWithTs("valS1", 19),
-			),
-		}
-		if !withFiltering {
-			expEvents = append(expEvents,
+			// Compare the events sent on the registration's Stream to the expected events.
+			expEvents := []*kvpb.RangeFeedEvent{
 				rangeFeedValueWithPrev(
+					roachpb.Key("d"),
+					makeValWithTs("valD3", 16),
+					makeVal("valD2"),
+				),
+				rangeFeedValueWithPrev(
+					roachpb.Key("d"),
+					makeValWithTs("valD4", 19),
+					makeVal("valD3"),
+				),
+				rangeFeedValueWithPrev(
+					roachpb.Key("d"),
+					makeValWithTs("valD5", 20),
+					makeVal("valD4"),
+				),
+				rangeFeedValueWithPrev(
+					roachpb.Key("e"),
+					makeValWithTs("valE2", 5),
+					makeVal("valE1"),
+				),
+				rangeFeedValueWithPrev(
+					roachpb.Key("e"),
+					makeValWithTs("valE3", 6),
+					makeVal("valE2"),
+				),
+				rangeFeedValue(
+					roachpb.Key("f"),
+					makeValWithTs("valF1", 5),
+				),
+				rangeFeedValueWithPrev(
+					roachpb.Key("f"),
+					makeValWithTs("valF2", 6),
+					makeVal("valF1"),
+				),
+				rangeFeedValueWithPrev(
+					roachpb.Key("f"),
+					makeValWithTs("valF3", 7),
+					makeVal("valF2"),
+				),
+				rangeFeedValue(
+					roachpb.Key("h"),
+					makeValWithTs("valH1", 15),
+				),
+				rangeFeedValue(
 					roachpb.Key("s"),
-					makeValWithTs("valS2", 20),
-					makeVal("valS1"),
-				))
-		}
-		expEvents = append(expEvents, rangeFeedValueWithPrev(
-			roachpb.Key("s"),
-			makeValWithTs("valS3", 21),
-			// Even though the event that wrote val2 is filtered out, we want to keep
-			// val2 as a previous value of the next event.
-			makeVal("valS2"),
-		))
-		require.Equal(t, expEvents, r.Events())
+					makeValWithTs("valS1", 19),
+				),
+			}
+			if !filtering {
+				expEvents = append(expEvents,
+					rangeFeedValueWithPrev(
+						roachpb.Key("s"),
+						makeValWithTs("valS2", 20),
+						makeVal("valS1"),
+					))
+			}
+			expEvents = append(expEvents, rangeFeedValueWithPrev(
+				roachpb.Key("s"),
+				makeValWithTs("valS3", 21),
+				// Even though the event that wrote val2 is filtered out, we want to keep
+				// val2 as a previous value of the next event.
+				makeVal("valS2"),
+			))
+			require.Equal(t, expEvents, s.Events())
+		})
 	})
 }
 
@@ -245,224 +267,239 @@ func TestRegistryWithOmitOrigin(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	noPrev := func(ev *kvpb.RangeFeedEvent) *kvpb.RangeFeedEvent {
-		ev = ev.ShallowCopy()
-		ev.GetValue().(*kvpb.RangeFeedValue).PrevValue = roachpb.Value{}
-		return ev
-	}
+	testutils.RunValues(t, "registration type=", registrationTestTypes, func(t *testing.T, rt registrationType) {
+		noPrev := func(ev *kvpb.RangeFeedEvent) *kvpb.RangeFeedEvent {
+			ev = ev.ShallowCopy()
+			ev.GetValue().(*kvpb.RangeFeedValue).PrevValue = roachpb.Value{}
+			return ev
+		}
 
-	val := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 1}}
-	ev1, ev2 := new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent)
-	ev1.MustSetValue(&kvpb.RangeFeedValue{Key: keyA, Value: val, PrevValue: val})
-	ev2.MustSetValue(&kvpb.RangeFeedValue{Key: keyB, Value: val, PrevValue: val})
+		val := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 1}}
+		ev1, ev2 := new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent)
+		ev1.MustSetValue(&kvpb.RangeFeedValue{Key: keyA, Value: val, PrevValue: val})
+		ev2.MustSetValue(&kvpb.RangeFeedValue{Key: keyB, Value: val, PrevValue: val})
 
-	reg := makeRegistry(NewMetrics())
-	rAC := newTestRegistration(spAC, hlc.Timestamp{}, nil, false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
-	originFiltering := newTestRegistration(spAC, hlc.Timestamp{}, nil, false /* withDiff */, false /* withFiltering */, true /* withOmitRemote */)
+		reg := makeRegistry(NewMetrics())
 
-	go rAC.runOutputLoop(ctx, 0)
-	go originFiltering.runOutputLoop(ctx, 0)
+		sAC := newTestStream()
+		rAC := newTestRegistration(sAC, withRSpan(spAC), withRegistrationType(rt))
+		originFilteringStream := newTestStream()
+		originFiltering := newTestRegistration(originFilteringStream, withRSpan(spAC),
+			withOmitRemote(true), withRegistrationType(rt))
 
-	defer rAC.disconnect(nil)
-	defer originFiltering.disconnect(nil)
+		go rAC.runOutputLoop(ctx, 0)
+		go originFiltering.runOutputLoop(ctx, 0)
 
-	reg.Register(ctx, rAC.bufferedRegistration)
-	reg.Register(ctx, originFiltering.bufferedRegistration)
+		defer rAC.disconnect(nil)
+		defer originFiltering.disconnect(nil)
 
-	reg.PublishToOverlapping(ctx, spAC, ev1, logicalOpMetadata{}, nil /* alloc */)
-	reg.PublishToOverlapping(ctx, spAC, ev2, logicalOpMetadata{originID: 1}, nil /* alloc */)
+		reg.Register(ctx, rAC)
+		reg.Register(ctx, originFiltering)
 
-	require.NoError(t, reg.waitForCaughtUp(ctx, all))
+		reg.PublishToOverlapping(ctx, spAC, ev1, logicalOpMetadata{}, nil /* alloc */)
+		reg.PublishToOverlapping(ctx, spAC, ev2, logicalOpMetadata{originID: 1}, nil /* alloc */)
 
-	require.Equal(t, []*kvpb.RangeFeedEvent{noPrev(ev1), noPrev(ev2)}, rAC.Events())
-	require.Equal(t, []*kvpb.RangeFeedEvent{noPrev(ev1)}, originFiltering.Events())
-	require.Nil(t, rAC.Error())
-	require.Nil(t, originFiltering.Error())
+		require.NoError(t, reg.waitForCaughtUp(ctx, all))
+
+		require.Equal(t, []*kvpb.RangeFeedEvent{noPrev(ev1), noPrev(ev2)}, sAC.Events())
+		require.Equal(t, []*kvpb.RangeFeedEvent{noPrev(ev1)}, originFilteringStream.Events())
+		require.Nil(t, sAC.Error())
+		require.Nil(t, originFilteringStream.Error())
+	})
 }
 
 func TestRegistryBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	val := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 1}}
-	ev1, ev2 := new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent)
-	ev3, ev4, ev5 := new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent)
-	ev1.MustSetValue(&kvpb.RangeFeedValue{Key: keyA, Value: val, PrevValue: val})
-	ev2.MustSetValue(&kvpb.RangeFeedValue{Key: keyB, Value: val, PrevValue: val})
-	ev3.MustSetValue(&kvpb.RangeFeedValue{Key: keyC, Value: val, PrevValue: val})
-	ev4.MustSetValue(&kvpb.RangeFeedValue{Key: keyD, Value: val, PrevValue: val})
-	ev5.MustSetValue(&kvpb.RangeFeedValue{Key: keyD, Value: val, PrevValue: val})
-	err1 := kvpb.NewErrorf("error1")
-	noPrev := func(ev *kvpb.RangeFeedEvent) *kvpb.RangeFeedEvent {
-		ev = ev.ShallowCopy()
-		ev.GetValue().(*kvpb.RangeFeedValue).PrevValue = roachpb.Value{}
-		return ev
-	}
+	testutils.RunValues(t, "registration type=", registrationTestTypes, func(t *testing.T, rt registrationType) {
+		val := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 1}}
+		ev1, ev2 := new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent)
+		ev3, ev4, ev5 := new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent)
+		ev1.MustSetValue(&kvpb.RangeFeedValue{Key: keyA, Value: val, PrevValue: val})
+		ev2.MustSetValue(&kvpb.RangeFeedValue{Key: keyB, Value: val, PrevValue: val})
+		ev3.MustSetValue(&kvpb.RangeFeedValue{Key: keyC, Value: val, PrevValue: val})
+		ev4.MustSetValue(&kvpb.RangeFeedValue{Key: keyD, Value: val, PrevValue: val})
+		ev5.MustSetValue(&kvpb.RangeFeedValue{Key: keyD, Value: val, PrevValue: val})
+		err1 := kvpb.NewErrorf("error1")
+		noPrev := func(ev *kvpb.RangeFeedEvent) *kvpb.RangeFeedEvent {
+			ev = ev.ShallowCopy()
+			ev.GetValue().(*kvpb.RangeFeedValue).PrevValue = roachpb.Value{}
+			return ev
+		}
 
-	reg := makeRegistry(NewMetrics())
-	require.Equal(t, 0, reg.Len())
-	reg.PublishToOverlapping(ctx, spAB, ev1, logicalOpMetadata{}, nil /* alloc */)
-	reg.Disconnect(ctx, spAB)
-	reg.DisconnectWithErr(ctx, spAB, err1)
+		reg := makeRegistry(NewMetrics())
+		require.Equal(t, 0, reg.Len())
+		reg.PublishToOverlapping(ctx, spAB, ev1, logicalOpMetadata{}, nil /* alloc */)
+		reg.Disconnect(ctx, spAB)
+		reg.DisconnectWithErr(ctx, spAB, err1)
 
-	rAB := newTestRegistration(spAB, hlc.Timestamp{}, nil, false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
-	rBC := newTestRegistration(spBC, hlc.Timestamp{}, nil, true /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
-	rCD := newTestRegistration(spCD, hlc.Timestamp{}, nil, true /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
-	rAC := newTestRegistration(spAC, hlc.Timestamp{}, nil, false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
-	rACFiltering := newTestRegistration(spAC, hlc.Timestamp{}, nil, false /* withDiff */, true /* withFiltering */, false /* withOmitRemote */)
-	go rAB.runOutputLoop(ctx, 0)
-	go rBC.runOutputLoop(ctx, 0)
-	go rCD.runOutputLoop(ctx, 0)
-	go rAC.runOutputLoop(ctx, 0)
-	go rACFiltering.runOutputLoop(ctx, 0)
-	defer rAB.disconnect(nil)
-	defer rBC.disconnect(nil)
-	defer rCD.disconnect(nil)
-	defer rAC.disconnect(nil)
-	defer rACFiltering.disconnect(nil)
+		sAB := newTestStream()
+		rAB := newTestRegistration(sAB, withRSpan(spAB), withRegistrationType(rt))
+		sBC := newTestStream()
+		rBC := newTestRegistration(sBC, withRSpan(spBC), withDiff(true), withRegistrationType(rt))
+		sCD := newTestStream()
+		rCD := newTestRegistration(sCD, withRSpan(spCD), withDiff(true), withRegistrationType(rt))
+		sAC := newTestStream()
+		rAC := newTestRegistration(sAC, withRSpan(spAC), withRegistrationType(rt))
+		sACFiltering := newTestStream()
+		rACFiltering := newTestRegistration(sACFiltering, withRSpan(spAC), withFiltering(true), withRegistrationType(rt))
+		go rAB.runOutputLoop(ctx, 0)
+		go rBC.runOutputLoop(ctx, 0)
+		go rCD.runOutputLoop(ctx, 0)
+		go rAC.runOutputLoop(ctx, 0)
+		go rACFiltering.runOutputLoop(ctx, 0)
+		defer rAB.disconnect(nil)
+		defer rBC.disconnect(nil)
+		defer rCD.disconnect(nil)
+		defer rAC.disconnect(nil)
+		defer rACFiltering.disconnect(nil)
 
-	// Register 6 registrations.
-	reg.Register(ctx, rAB.bufferedRegistration)
-	require.Equal(t, 1, reg.Len())
-	reg.Register(ctx, rBC.bufferedRegistration)
-	require.Equal(t, 2, reg.Len())
-	reg.Register(ctx, rCD.bufferedRegistration)
-	require.Equal(t, 3, reg.Len())
-	reg.Register(ctx, rAC.bufferedRegistration)
-	require.Equal(t, 4, reg.Len())
-	reg.Register(ctx, rACFiltering.bufferedRegistration)
-	require.Equal(t, 5, reg.Len())
+		// Register 6 registrations.
+		reg.Register(ctx, rAB)
+		require.Equal(t, 1, reg.Len())
+		reg.Register(ctx, rBC)
+		require.Equal(t, 2, reg.Len())
+		reg.Register(ctx, rCD)
+		require.Equal(t, 3, reg.Len())
+		reg.Register(ctx, rAC)
+		require.Equal(t, 4, reg.Len())
+		reg.Register(ctx, rACFiltering)
+		require.Equal(t, 5, reg.Len())
 
-	// Publish to different spans.
-	reg.PublishToOverlapping(ctx, spAB, ev1, logicalOpMetadata{}, nil /* alloc */)
-	reg.PublishToOverlapping(ctx, spBC, ev2, logicalOpMetadata{}, nil /* alloc */)
-	reg.PublishToOverlapping(ctx, spCD, ev3, logicalOpMetadata{}, nil /* alloc */)
-	reg.PublishToOverlapping(ctx, spAC, ev4, logicalOpMetadata{}, nil /* alloc */)
-	reg.PublishToOverlapping(ctx, spAC, ev5, logicalOpMetadata{omitInRangefeeds: true}, nil /* alloc */)
+		// Publish to different spans.
+		reg.PublishToOverlapping(ctx, spAB, ev1, logicalOpMetadata{}, nil /* alloc */)
+		reg.PublishToOverlapping(ctx, spBC, ev2, logicalOpMetadata{}, nil /* alloc */)
+		reg.PublishToOverlapping(ctx, spCD, ev3, logicalOpMetadata{}, nil /* alloc */)
+		reg.PublishToOverlapping(ctx, spAC, ev4, logicalOpMetadata{}, nil /* alloc */)
+		reg.PublishToOverlapping(ctx, spAC, ev5, logicalOpMetadata{omitInRangefeeds: true}, nil /* alloc */)
 
-	require.NoError(t, reg.waitForCaughtUp(ctx, all))
-	require.Equal(t, []*kvpb.RangeFeedEvent{noPrev(ev1), noPrev(ev4), noPrev(ev5)}, rAB.Events())
-	require.Equal(t, []*kvpb.RangeFeedEvent{ev2, ev4, ev5}, rBC.Events())
-	require.Equal(t, []*kvpb.RangeFeedEvent{ev3}, rCD.Events())
-	require.Equal(t, []*kvpb.RangeFeedEvent{noPrev(ev1), noPrev(ev2), noPrev(ev4), noPrev(ev5)}, rAC.Events())
-	// Registration rACFiltering doesn't receive ev5 because both withFiltering
-	// (for the registration) and OmitInRangefeeds (for the event) are true.
-	require.Equal(t, []*kvpb.RangeFeedEvent{noPrev(ev1), noPrev(ev2), noPrev(ev4)}, rACFiltering.Events())
-	require.Nil(t, rAB.Error())
-	require.Nil(t, rBC.Error())
-	require.Nil(t, rCD.Error())
-	require.Nil(t, rAC.Error())
-	require.Nil(t, rACFiltering.Error())
+		require.NoError(t, reg.waitForCaughtUp(ctx, all))
+		require.Equal(t, []*kvpb.RangeFeedEvent{noPrev(ev1), noPrev(ev4), noPrev(ev5)}, sAB.Events())
+		require.Equal(t, []*kvpb.RangeFeedEvent{ev2, ev4, ev5}, sBC.Events())
+		require.Equal(t, []*kvpb.RangeFeedEvent{ev3}, sCD.Events())
+		require.Equal(t, []*kvpb.RangeFeedEvent{noPrev(ev1), noPrev(ev2), noPrev(ev4), noPrev(ev5)}, sAC.Events())
+		// Registration rACFiltering doesn't receive ev5 because both withFiltering
+		// (for the registration) and OmitInRangefeeds (for the event) are true.
+		require.Equal(t, []*kvpb.RangeFeedEvent{noPrev(ev1), noPrev(ev2), noPrev(ev4)}, sACFiltering.Events())
+		require.Nil(t, sAB.Error())
+		require.Nil(t, sBC.Error())
+		require.Nil(t, sCD.Error())
+		require.Nil(t, sAC.Error())
+		require.Nil(t, sACFiltering.Error())
 
-	// Check the registry's operation filter.
-	f := reg.NewFilter()
-	// Testing NeedVal.
-	require.True(t, f.NeedVal(spAB))
-	require.True(t, f.NeedVal(spBC))
-	require.True(t, f.NeedVal(spCD))
-	require.True(t, f.NeedVal(spAC))
-	require.False(t, f.NeedVal(spXY))
-	require.True(t, f.NeedVal(roachpb.Span{Key: keyA}))
-	require.True(t, f.NeedVal(roachpb.Span{Key: keyB}))
-	require.True(t, f.NeedVal(roachpb.Span{Key: keyC}))
-	require.False(t, f.NeedVal(roachpb.Span{Key: keyX}))
-	// Testing NeedPrevVal.
-	require.False(t, f.NeedPrevVal(spAB))
-	require.True(t, f.NeedPrevVal(spBC))
-	require.True(t, f.NeedPrevVal(spCD))
-	require.True(t, f.NeedPrevVal(spAC))
-	require.False(t, f.NeedPrevVal(spXY))
-	require.False(t, f.NeedPrevVal(roachpb.Span{Key: keyA}))
-	require.True(t, f.NeedPrevVal(roachpb.Span{Key: keyB}))
-	require.True(t, f.NeedPrevVal(roachpb.Span{Key: keyC}))
-	require.False(t, f.NeedPrevVal(roachpb.Span{Key: keyX}))
+		// Check the registry's operation filter.
+		f := reg.NewFilter()
+		// Testing NeedVal.
+		require.True(t, f.NeedVal(spAB))
+		require.True(t, f.NeedVal(spBC))
+		require.True(t, f.NeedVal(spCD))
+		require.True(t, f.NeedVal(spAC))
+		require.False(t, f.NeedVal(spXY))
+		require.True(t, f.NeedVal(roachpb.Span{Key: keyA}))
+		require.True(t, f.NeedVal(roachpb.Span{Key: keyB}))
+		require.True(t, f.NeedVal(roachpb.Span{Key: keyC}))
+		require.False(t, f.NeedVal(roachpb.Span{Key: keyX}))
+		// Testing NeedPrevVal.
+		require.False(t, f.NeedPrevVal(spAB))
+		require.True(t, f.NeedPrevVal(spBC))
+		require.True(t, f.NeedPrevVal(spCD))
+		require.True(t, f.NeedPrevVal(spAC))
+		require.False(t, f.NeedPrevVal(spXY))
+		require.False(t, f.NeedPrevVal(roachpb.Span{Key: keyA}))
+		require.True(t, f.NeedPrevVal(roachpb.Span{Key: keyB}))
+		require.True(t, f.NeedPrevVal(roachpb.Span{Key: keyC}))
+		require.False(t, f.NeedPrevVal(roachpb.Span{Key: keyX}))
 
-	// Disconnect span that overlaps with rCD.
-	reg.DisconnectWithErr(ctx, spCD, err1)
-	require.Equal(t, 4, reg.Len())
-	require.Equal(t, err1.GoError(), rCD.WaitForError(t))
+		// Disconnect span that overlaps with rCD.
+		reg.DisconnectWithErr(ctx, spCD, err1)
+		require.Equal(t, 4, reg.Len())
+		require.Equal(t, err1.GoError(), sCD.WaitForError(t))
 
-	// Can still publish to rAB.
-	reg.PublishToOverlapping(ctx, spAB, ev4, logicalOpMetadata{}, nil /* alloc */)
-	reg.PublishToOverlapping(ctx, spBC, ev3, logicalOpMetadata{}, nil /* alloc */)
-	reg.PublishToOverlapping(ctx, spCD, ev2, logicalOpMetadata{}, nil /* alloc */)
-	reg.PublishToOverlapping(ctx, spAC, ev1, logicalOpMetadata{}, nil /* alloc */)
-	require.NoError(t, reg.waitForCaughtUp(ctx, all))
-	require.Equal(t, []*kvpb.RangeFeedEvent{noPrev(ev4), noPrev(ev1)}, rAB.Events())
+		// Can still publish to rAB.
+		reg.PublishToOverlapping(ctx, spAB, ev4, logicalOpMetadata{}, nil /* alloc */)
+		reg.PublishToOverlapping(ctx, spBC, ev3, logicalOpMetadata{}, nil /* alloc */)
+		reg.PublishToOverlapping(ctx, spCD, ev2, logicalOpMetadata{}, nil /* alloc */)
+		reg.PublishToOverlapping(ctx, spAC, ev1, logicalOpMetadata{}, nil /* alloc */)
+		require.NoError(t, reg.waitForCaughtUp(ctx, all))
+		require.Equal(t, []*kvpb.RangeFeedEvent{noPrev(ev4), noPrev(ev1)}, sAB.Events())
 
-	// Disconnect from rAB without error.
-	reg.Disconnect(ctx, spAB)
-	require.Nil(t, rAC.WaitForError(t))
-	require.Nil(t, rAB.WaitForError(t))
-	require.Equal(t, 1, reg.Len())
+		// Disconnect from rAB without error.
+		reg.Disconnect(ctx, spAB)
+		require.Nil(t, sAC.WaitForError(t))
+		require.Nil(t, sAB.WaitForError(t))
+		require.Equal(t, 1, reg.Len())
 
-	// Check the registry's operation filter again.
-	f = reg.NewFilter()
-	// Testing NeedVal.
-	require.False(t, f.NeedVal(spAB))
-	require.True(t, f.NeedVal(spBC))
-	require.False(t, f.NeedVal(spCD))
-	require.True(t, f.NeedVal(spAC))
-	require.False(t, f.NeedVal(spXY))
-	require.False(t, f.NeedVal(roachpb.Span{Key: keyA}))
-	require.True(t, f.NeedVal(roachpb.Span{Key: keyB}))
-	require.False(t, f.NeedVal(roachpb.Span{Key: keyC}))
-	require.False(t, f.NeedVal(roachpb.Span{Key: keyX}))
-	// Testing NeedPrevVal.
-	require.False(t, f.NeedPrevVal(spAB))
-	require.True(t, f.NeedPrevVal(spBC))
-	require.False(t, f.NeedPrevVal(spCD))
-	require.True(t, f.NeedPrevVal(spAC))
-	require.False(t, f.NeedPrevVal(spXY))
-	require.False(t, f.NeedPrevVal(roachpb.Span{Key: keyA}))
-	require.True(t, f.NeedPrevVal(roachpb.Span{Key: keyB}))
-	require.False(t, f.NeedPrevVal(roachpb.Span{Key: keyC}))
-	require.False(t, f.NeedPrevVal(roachpb.Span{Key: keyX}))
+		// Check the registry's operation filter again.
+		f = reg.NewFilter()
+		// Testing NeedVal.
+		require.False(t, f.NeedVal(spAB))
+		require.True(t, f.NeedVal(spBC))
+		require.False(t, f.NeedVal(spCD))
+		require.True(t, f.NeedVal(spAC))
+		require.False(t, f.NeedVal(spXY))
+		require.False(t, f.NeedVal(roachpb.Span{Key: keyA}))
+		require.True(t, f.NeedVal(roachpb.Span{Key: keyB}))
+		require.False(t, f.NeedVal(roachpb.Span{Key: keyC}))
+		require.False(t, f.NeedVal(roachpb.Span{Key: keyX}))
+		// Testing NeedPrevVal.
+		require.False(t, f.NeedPrevVal(spAB))
+		require.True(t, f.NeedPrevVal(spBC))
+		require.False(t, f.NeedPrevVal(spCD))
+		require.True(t, f.NeedPrevVal(spAC))
+		require.False(t, f.NeedPrevVal(spXY))
+		require.False(t, f.NeedPrevVal(roachpb.Span{Key: keyA}))
+		require.True(t, f.NeedPrevVal(roachpb.Span{Key: keyB}))
+		require.False(t, f.NeedPrevVal(roachpb.Span{Key: keyC}))
+		require.False(t, f.NeedPrevVal(roachpb.Span{Key: keyX}))
 
-	// Unregister the rBC registration.
-	reg.Unregister(ctx, rBC.bufferedRegistration)
-	require.Equal(t, 0, reg.Len())
+		// Unregister the rBC registration.
+		reg.Unregister(ctx, rBC)
+		require.Equal(t, 0, reg.Len())
+	})
 }
 
 func TestRegistryPublishBeneathStartTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
-	reg := makeRegistry(NewMetrics())
 
-	r := newTestRegistration(spAB, hlc.Timestamp{WallTime: 10}, nil, /* catchup */
-		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
-	go r.runOutputLoop(ctx, 0)
-	reg.Register(ctx, r.bufferedRegistration)
+	testutils.RunValues(t, "registration type=", registrationTestTypes, func(t *testing.T, rt registrationType) {
+		reg := makeRegistry(NewMetrics())
+		s := newTestStream()
+		r := newTestRegistration(s, withRSpan(spAB), withStartTs(hlc.Timestamp{WallTime: 10}), withRegistrationType(rt))
+		go r.runOutputLoop(ctx, 0)
+		reg.Register(ctx, r)
 
-	// Publish a value with a timestamp beneath the registration's start
-	// timestamp. Should be ignored.
-	ev := new(kvpb.RangeFeedEvent)
-	ev.MustSetValue(&kvpb.RangeFeedValue{
-		Value: roachpb.Value{Timestamp: hlc.Timestamp{WallTime: 5}},
+		// Publish a value with a timestamp beneath the registration's start
+		// timestamp. Should be ignored.
+		ev := new(kvpb.RangeFeedEvent)
+		ev.MustSetValue(&kvpb.RangeFeedValue{
+			Value: roachpb.Value{Timestamp: hlc.Timestamp{WallTime: 5}},
+		})
+		reg.PublishToOverlapping(ctx, spAB, ev, logicalOpMetadata{}, nil /* alloc */)
+		require.NoError(t, reg.waitForCaughtUp(ctx, all))
+		require.Nil(t, s.Events())
+
+		// Publish a value with a timestamp equal to the registration's start
+		// timestamp. Should be ignored.
+		ev.MustSetValue(&kvpb.RangeFeedValue{
+			Value: roachpb.Value{Timestamp: hlc.Timestamp{WallTime: 10}},
+		})
+		reg.PublishToOverlapping(ctx, spAB, ev, logicalOpMetadata{}, nil /* alloc */)
+		require.NoError(t, reg.waitForCaughtUp(ctx, all))
+		require.Nil(t, s.Events())
+
+		// Publish a checkpoint with a timestamp beneath the registration's. Should
+		// be delivered.
+		ev.MustSetValue(&kvpb.RangeFeedCheckpoint{
+			Span: spAB, ResolvedTS: hlc.Timestamp{WallTime: 5},
+		})
+		reg.PublishToOverlapping(ctx, spAB, ev, logicalOpMetadata{}, nil /* alloc */)
+		require.NoError(t, reg.waitForCaughtUp(ctx, all))
+		require.Equal(t, []*kvpb.RangeFeedEvent{ev}, s.Events())
+
+		r.disconnect(nil)
 	})
-	reg.PublishToOverlapping(ctx, spAB, ev, logicalOpMetadata{}, nil /* alloc */)
-	require.NoError(t, reg.waitForCaughtUp(ctx, all))
-	require.Nil(t, r.Events())
-
-	// Publish a value with a timestamp equal to the registration's start
-	// timestamp. Should be ignored.
-	ev.MustSetValue(&kvpb.RangeFeedValue{
-		Value: roachpb.Value{Timestamp: hlc.Timestamp{WallTime: 10}},
-	})
-	reg.PublishToOverlapping(ctx, spAB, ev, logicalOpMetadata{}, nil /* alloc */)
-	require.NoError(t, reg.waitForCaughtUp(ctx, all))
-	require.Nil(t, r.Events())
-
-	// Publish a checkpoint with a timestamp beneath the registration's. Should
-	// be delivered.
-	ev.MustSetValue(&kvpb.RangeFeedCheckpoint{
-		Span: spAB, ResolvedTS: hlc.Timestamp{WallTime: 5},
-	})
-	reg.PublishToOverlapping(ctx, spAB, ev, logicalOpMetadata{}, nil /* alloc */)
-	require.NoError(t, reg.waitForCaughtUp(ctx, all))
-	require.Equal(t, []*kvpb.RangeFeedEvent{ev}, r.Events())
-
-	r.disconnect(nil)
 }
 
 func TestRegistrationString(t *testing.T) {
@@ -508,32 +545,33 @@ func TestRegistrationString(t *testing.T) {
 func TestRegistryShutdownMetrics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
-	reg := makeRegistry(NewMetrics())
 
-	regDoneC := make(chan interface{})
-	r := newTestRegistration(spAB, hlc.Timestamp{WallTime: 10}, nil, /*catchup */
-		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
-	go func() {
-		r.runOutputLoop(ctx, 0)
-		close(regDoneC)
-	}()
-	reg.Register(ctx, r.bufferedRegistration)
+	testutils.RunValues(t, "registration type=", registrationTestTypes, func(t *testing.T, rt registrationType) {
+		reg := makeRegistry(NewMetrics())
+		regDoneC := make(chan interface{})
+		r := newTestRegistration(newTestStream(), withRSpan(spAB),
+			withStartTs(hlc.Timestamp{WallTime: 10}), withRegistrationType(rt))
+		go func() {
+			r.runOutputLoop(ctx, 0)
+			close(regDoneC)
+		}()
+		reg.Register(ctx, r)
 
-	reg.DisconnectAllOnShutdown(ctx, nil)
-	<-regDoneC
-	require.Zero(t, reg.metrics.RangeFeedRegistrations.Value(), "metric is not zero on stop")
+		reg.DisconnectAllOnShutdown(ctx, nil)
+		<-regDoneC
+		require.Zero(t, reg.metrics.RangeFeedRegistrations.Value(), "metric is not zero on stop")
+	})
 }
 
 // TestBaseRegistration tests base registration implementation methods.
 func TestBaseRegistration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	r := newTestRegistration(spAB, hlc.Timestamp{WallTime: 10}, nil, /*catchup */
-		true /* withDiff */, true /* withFiltering */, false /* withOmitRemote */)
+	r := newTestRegistration(newTestStream(), withRSpan(spAB), withStartTs(hlc.Timestamp{WallTime: 10}), withDiff(true), withFiltering(true))
 	require.Equal(t, spAB, r.getSpan())
 	require.Equal(t, hlc.Timestamp{WallTime: 10}, r.getCatchUpTimestamp())
 	r.setSpanAsKeys()
-	require.Equal(t, r.keys, spAB.AsRange())
-	require.Equal(t, r.keys, r.Range())
+	require.Equal(t, r.Range(), spAB.AsRange())
+	require.Equal(t, r.Range(), r.Range())
 	r.setID(10)
 	require.Equal(t, uintptr(10), r.ID())
 	require.True(t, r.getWithDiff())

--- a/pkg/kv/kvserver/rangefeed/registry_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_test.go
@@ -142,7 +142,7 @@ func TestRegistrationBasic(t *testing.T) {
 				overflowReg.publish(ctx, ev1, nil /* alloc */)
 			}
 			go overflowReg.runOutputLoop(ctx, 0)
-			require.Equal(t, kvpb.NewRangeFeedRetryError(kvpb.RangeFeedRetryError_REASON_SLOW_CONSUMER), s.WaitForError(t))
+			require.Equal(t, newRetryErrBufferCapacityExceeded(), s.WaitForError(t))
 			require.Equal(t, capOfBuf, len(s.Events()))
 			require.NoError(t, overflowReg.waitForCaughtUp(ctx))
 			if r, ok := overflowReg.(*unbufferedRegistration); ok {

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -348,6 +348,12 @@ func (p *ScheduledProcessor) Register(
 		// once they observe the first checkpoint event.
 		r.publish(ctx, p.newCheckpointEvent(), nil)
 
+		if bs, ok := stream.(BufferedStream); ok {
+			bs.RegisterRangefeedCleanUp(func() {
+				log.Fatalf(context.Background(), "unimplemented: see #126560")
+			})
+		}
+
 		// Run an output loop for the registry.
 		runOutputLoop := func(ctx context.Context) {
 			r.runOutputLoop(ctx, p.RangeID)

--- a/pkg/kv/kvserver/rangefeed/unbuffered_registration.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_registration.go
@@ -1,0 +1,482 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rangefeed
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+)
+
+// unbufferedRegistration is similar to bufferedRangefeed but uses
+// BufferedStream to buffer live raft updates instead of a using buf channel and
+// having a dedicated per-range per-registration goroutine to volley events to
+// underlying grpc stream. Instead, there is only one BufferedStream for each
+// incoming node.MuxRangefeed rpc call. BufferedStream is responsible for
+// buffering and sending its updates to the underlying grpc stream in a
+// dedicated goroutine O(node).
+//
+// Note that UnbufferedRegistration needs to ensure that events sent to
+// BufferedStream are in order and can be sent to the underlying stream
+// directly. To achieve this, events from catch-up scans bypass BufferedStream
+// buffers and are sent to underlying Stream directly. While catch-up scan is
+// ongoing, live updates are temporarily buffered in buf to hold them until
+// catch-up scan is complete. After catch-up scan is done, we know that catch-up
+// scan events have been sent to grpc stream successfully. Raft updates buffered
+// in the buf will then be sent to BufferedStream first and live updates will be
+// sent to BufferedStream directly from then on.
+//
+// Note that there will still be a short-lived dedicated goroutine for catch up
+// scan.
+//
+// Updates are delivered to the BufferedStream until
+// 1. unbufferedRegistration.disconnect is called which can happen when: a) A
+// SendBuffered to the BufferedStream returns an error (BufferedStream is
+// stopped or is full) b) catch-up scan fails or catch-up buffer overflows. c)
+// Registration is manually unregistered from processor d) client requests to
+// close rangefeed with a specific streamID.
+// 2. BufferedSender can disconnect all registrations when a node-level shutdown
+// is needed.
+//
+// unbufferedRegistration is responsible for allocating and draining memory
+// catch-up buffer while BufferedStream is responsible for allocating and
+// draining memory buffered in BufferedStream.
+type unbufferedRegistration struct {
+	// Input.
+	baseRegistration
+	metrics *Metrics
+
+	// Output.
+	// unbufferedRegistration chooses to bypass buffer and blocking send to the
+	// underlying stream directly for catch-up scans by calling
+	// stream.SendUnbuffered.
+	stream BufferedStream
+
+	// Internal.
+	mu struct {
+		// TODO(wenyihu6 during code reviews): ask why we are using Locker for
+		// registrations insted of Mutex
+		sync.Locker
+
+		// True if this registration catchUpBuf has overflowed, live raft events are
+		// dropped. This will cause the registration to disconnect with an error
+		// once catch-up scan is done and catchUpBuf is drained and published. Once
+		// set to true, cannot unset.
+		catchUpOverflowed bool
+
+		// It is set to nil if catchUpBuf has been drained (either catch-up scan
+		// succeeded or failed). Safe to send to BufferedStream if nil and
+		// disconnected is false. the case of error, disconnected flag is set. Once
+		// set, cannot unset.
+		//
+		// Note that it needs to be protected under mutex since it is shared between
+		// goroutines and set to nil after it's done.
+		//
+		// If no catch-up iter is provided, catchUpBuf will be nil since the
+		// initialization.
+		catchUpBuf chan *sharedEvent
+
+		// Fine to repeatedly cancel context. Management of the catch-up runOutput
+		// context goroutine.
+		catchUpScanCancelFn func()
+
+		// Once disconnected is set, it cannot be unset. This flag indicates that
+		// the registration is marked for disconnection, but it may still receive
+		// raft updates from publish until the actual p.reg.Unregister happens.
+		// Unregistration only happens when the callback registered via
+		// RegisterRangefeedCleanUp is invoked from BufferedStream. Since this could
+		// happen very late (when even is popped and ready to be sent to grpc
+		// stream), we check the disconnected flag during publish to prevent further
+		// raft events from being sent to BufferedStream. However, this doesn’t
+		// guarantee that no Raft updates will be sent after this flag is set.
+		// Catch-up scans and buffer may still send more updates, but this is fine.
+		// Rangefeed might still send a few events after signaling completion errors
+		// to the client, which should be handled by the client.
+		disconnected bool
+
+		// catchUpIter is created by replcia under raftMu lock when registration is
+		// created. It is detached by output loop for processing and closed. If
+		// runOutputLoop was not started and catchUpIter is non-nil at the time that
+		// disconnect is called, it is closed by disconnect. Otherwise,
+		// maybeRunCatchUpScan is responsible for detaching and closing it.
+		catchUpIter *CatchUpIterator
+
+		// Used for testing only. Boolean indicating if all events in catchUpBuf
+		// have been output to BufferedStream. Note that this does not mean that
+		// BufferedStream has been sent to underlying grpc Stream yet.
+		caughtUp bool
+	}
+}
+
+var _ registration = (*unbufferedRegistration)(nil)
+
+func newUnbufferedRegistration(
+	span roachpb.Span,
+	startTS hlc.Timestamp,
+	catchUpIter *CatchUpIterator,
+	withDiff bool,
+	withFiltering bool,
+	withOmitRemote bool,
+	bufferSz int,
+	metrics *Metrics,
+	stream BufferedStream,
+	unregisterFn func(),
+) *unbufferedRegistration {
+	br := &unbufferedRegistration{
+		baseRegistration: baseRegistration{
+			span:             span,
+			catchUpTimestamp: startTS,
+			withDiff:         withDiff,
+			withFiltering:    withFiltering,
+			withOmitRemote:   withOmitRemote,
+			unreg:            unregisterFn,
+		},
+		metrics: metrics,
+		stream:  stream,
+	}
+	br.mu.Locker = &syncutil.Mutex{}
+	br.mu.catchUpIter = catchUpIter
+	br.mu.caughtUp = true
+	if br.mu.catchUpIter != nil {
+		// Send to underlying stream directly if catch-up scan is not needed.
+		br.mu.catchUpBuf = make(chan *sharedEvent, bufferSz)
+	}
+	return br
+}
+
+// publish attempts to send a single event to catch-up buffer or directly to
+// BufferedStream. If registration is disconnected or catchUpOverflowed is set,
+// live events are dropped. Rangefeed clients will need a catchup-scan after
+// restarting rangefeeds. Note that publish is responsible for calling alloc.Use
+// and alloc.Release. If event is sent to catch-up buffer,
+// runOutputLoop is responsible for releasing it. If event is sent to
+// BufferedStream, the ownership of alloc is transferred to BufferedStream.
+// BufferedStream is responsible for allocating and releasing it.
+func (ubr *unbufferedRegistration) publish(
+	ctx context.Context, event *kvpb.RangeFeedEvent, alloc *SharedBudgetAllocation,
+) {
+	ubr.assertEvent(ctx, event)
+	strippedEvent := ubr.maybeStripEvent(ctx, event)
+	if shouldSendToStream := ubr.maybePutInCatchUpBuffer(ctx, strippedEvent, alloc); shouldSendToStream {
+		// We are caught up and can send to underlying stream directly.
+		if err := ubr.stream.SendBuffered(strippedEvent, alloc); err != nil {
+			// BufferedSender is full or has been stopped. A node level shutdown is
+			// happening, so BufferedSender should disconnect all streams soon. There
+			// is not anything else we can do here. Disconnect again just in case.
+			ubr.disconnect(kvpb.NewError(err))
+		}
+	}
+}
+
+// When a registration disconnects, the following clean-up must happen:
+// a ) Registration level clean-up: setDisconnectedIfNotWithLock
+// - catch-up iter needs to be closed if not detached already
+// - catchUpBuf needs to be drained. runOutputLoop goroutine is responsible for
+// watching the stream context cancellation and drain catch-up buffer.
+// b) Processor level clean-up: p.reg.Unregister
+// c) BufferedSender level clean-up: stream.Disconnect
+// - cancel stream context, metrics updates, send a disconnect error back to
+// rangefeed client
+//
+// There are two ways to disconnect a registration:
+// 1. ubr.disconnect is called
+// - a) happens here. b), c) happen during stream.Disconnect.
+// 2. BufferedSender invokes the callback registered via
+// RegisterRangefeedCleanUp.
+// - b), c) happen in BufferedSender and a happens via the callback
+//
+// Safe to run multiple times, but subsequent errors would be discarded.
+func (ubr *unbufferedRegistration) disconnect(pErr *kvpb.Error) {
+	ubr.mu.Lock()
+	defer ubr.mu.Unlock()
+	if alreadyDisconnected := ubr.setDisconnectedIfNotWithLock(); !alreadyDisconnected {
+		ubr.stream.Disconnect(pErr)
+	}
+}
+
+// runOutputLoop is run in a goroutine. It is short-lived and responsible for
+// 1. running catch-up scan
+// 2. publishing/discarding catch-up buffer after catch-up scan is done.
+//
+// The contract is that it will empty catch-up buffer and set it to nil when
+// this goroutine ends. Once set to nil, no more events should be put in
+// catch-up buffer.
+//
+// TODO(wenyihu6): check if it is ever possible for disconnect happens and
+// runOutputLoop to not start at all and no one is draining catch-up buffer
+// during reviews
+func (ubr *unbufferedRegistration) runOutputLoop(ctx context.Context, forStacks roachpb.RangeID) {
+	ubr.mu.Lock()
+	if ubr.mu.disconnected {
+		// already disconnected
+		ubr.discardCatchUpBufferWithLock(ctx)
+		ubr.mu.Unlock()
+		return
+	}
+
+	ctx, ubr.mu.catchUpScanCancelFn = context.WithCancel(ctx)
+	ubr.mu.Unlock()
+
+	if err := ubr.maybeRunCatchUpScan(ctx); err != nil {
+		ubr.disconnect(kvpb.NewError(errors.Wrap(err, "catch-up scan failed")))
+		// Important to disconnect before draining to avoid upstream to interpret
+		// nil catch-up buf as sending to underlying stream directly.
+		ubr.discardCatchUpBuffer(ctx)
+		return
+	}
+
+	if err := ubr.publishCatchUpBuffer(ctx); err != nil {
+		ubr.disconnect(kvpb.NewError(err))
+		// Important to disconnect before draining to avoid upstream to interpret
+		// nil catch-up buf as sending to underlying stream directly.
+		ubr.discardCatchUpBuffer(ctx)
+		return
+	}
+	// Success: publishCatchUpBuffer should have drained and set catchUpBuf to nil
+	// when it succeeds.
+}
+
+// Noop for unbuffered registration since events are not buffered in buf.
+// runOutputLoop is responsible for draining catchUpBuf.
+func (ubr *unbufferedRegistration) drainAllocations(ctx context.Context) {}
+
+// maybePutInCatchUpBuffer tries to put event in catch-up buffer and returns a
+// boolean indicating whether the caller should still try sending the event to
+// stream instead. If disconnected or catchUpOverflowed is already set, events
+// are simply ignored. If catchUpBuf is nil, the function return true,
+// signalling the event should be sent to stream instead. Otherwise, it
+// allocates for memory and sending to catch-up buffer. Caller is responsible
+// for draining buffer.
+//
+// Note that the caller is responsible for calling alloc.Use and alloc.Release if
+// shouldSendToStream is true. And caller does not need to call disconnect if
+// shouldSendToStream is false.
+func (ubr *unbufferedRegistration) maybePutInCatchUpBuffer(
+	ctx context.Context, event *kvpb.RangeFeedEvent, alloc *SharedBudgetAllocation,
+) (shouldSendToStream bool) {
+	ubr.mu.Lock()
+	defer ubr.mu.Unlock()
+	if ubr.mu.disconnected || ubr.mu.catchUpOverflowed {
+		// No memory is allocated yet. BufferedRegistration does not need to check
+		// for disconnected since it has a dedicated goroutine to watch for stream
+		// context cancellation and unregister from processor happens relatively
+		// fast. However, unbufferedRegistration does not have such luxury. It only
+		// unregisters from processor when callback registered via
+		// RegisterRangefeedCleanUp is called (which can happen late). Thus, we
+		// check for disconnected to sync here.
+		return false
+	}
+	// Disconnected or catchUpOverflowed is not set and catchUpBuf is nil -> Safe
+	// to send to underlying stream.
+	if ubr.mu.catchUpBuf == nil {
+		return true
+	}
+
+	e := getPooledSharedEvent(sharedEvent{event: event, alloc: alloc})
+	alloc.Use(ctx)
+	select {
+	case ubr.mu.catchUpBuf <- e:
+		ubr.mu.caughtUp = false
+		// Success.
+	default:
+		// catchUpBuf exceeded and we are dropping this event. Registration will
+		// need a catch-up scan after being disconnected.
+		ubr.mu.catchUpOverflowed = true
+		e.alloc.Release(ctx)
+		putPooledSharedEvent(e)
+	}
+	return false
+}
+
+// Wait for this registration to completely drain its catchUpBuf. Note that this
+// does not mean that BufferedStream has been sent to underlying grpc Stream
+// yet.
+func (ubr *unbufferedRegistration) waitForCaughtUp(ctx context.Context) error {
+	opts := retry.Options{
+		InitialBackoff: 5 * time.Millisecond,
+		Multiplier:     2,
+		MaxBackoff:     10 * time.Second,
+		MaxRetries:     50,
+	}
+	for re := retry.StartWithCtx(ctx, opts); re.Next(); {
+		ubr.mu.Lock()
+		caughtUp := len(ubr.mu.catchUpBuf) == 0 && ubr.mu.caughtUp
+		ubr.mu.Unlock()
+		if caughtUp {
+			return nil
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return errors.Errorf("unbufferedRegistration %v failed to empty in time", ubr.Range())
+}
+
+func (ubr *unbufferedRegistration) setDisconnectedIfNot() {
+	ubr.mu.Lock()
+	defer ubr.mu.Unlock()
+	ubr.setDisconnectedIfNotWithLock()
+}
+
+// setDisconnectedIfNotWithLock sets disconnected to true if it is not already
+// set. It handles registration level cleanup. It is called from BufferedSender
+// to disconnect registrations. It is no-op if ubr.disconnect already happens.
+//
+// Note it is called while holding ubr.mu.
+func (ubr *unbufferedRegistration) setDisconnectedIfNotWithLock() (alreadyDisconnected bool) {
+	// TODO(wenyihu6 during code reviews or later on): think about if we should
+	// just drain catchUpBuf here during reviews. We never publish anything in
+	// catch-up buf if disconnected. But this might take a long time and you are
+	// on a hot path.
+	if ubr.mu.disconnected {
+		return true
+	}
+	if ubr.mu.catchUpIter != nil {
+		// catch-up scan hasn't started yet.
+		ubr.mu.catchUpIter.Close()
+		ubr.mu.catchUpIter = nil
+	}
+	if ubr.mu.catchUpScanCancelFn != nil {
+		ubr.mu.catchUpScanCancelFn()
+	}
+	ubr.mu.disconnected = true
+	return false
+}
+
+// discardCatchUpBufferWithLock drains catchUpBuf and release all memory held by
+// the events in catch-up buffer without publishing them. It is safe to assume
+// that catch-up buffer is empty and nil after call.
+func (ubr *unbufferedRegistration) discardCatchUpBufferWithLock(ctx context.Context) {
+	func() {
+		for {
+			select {
+			case e := <-ubr.mu.catchUpBuf:
+				// TODO(wenyihu6): check if release with context.Background is fine
+				// during reviews
+				e.alloc.Release(ctx)
+				putPooledSharedEvent(e)
+			default:
+				// Done.
+				return
+			}
+		}
+	}()
+
+	ubr.mu.catchUpBuf = nil
+	ubr.mu.caughtUp = true
+}
+
+// publishCatchUpBuffer drains catchUpBuf and release all memory held by
+// the events in catch-up buffer while publishing them.
+//
+// Caller is responsible for draining it again if error is returned. If no
+// error, it is safe to assume that catch-up buffer is empty and nil after this
+// call.
+func (ubr *unbufferedRegistration) publishCatchUpBuffer(ctx context.Context) error {
+	ubr.mu.Lock()
+	defer ubr.mu.Unlock()
+
+	// TODO(wenyihu6): check if we can just drain without holding the lock first
+	// during reviews We shouldn't be reading from the buffer at the same time
+	publish := func() error {
+		for {
+			select {
+			case e := <-ubr.mu.catchUpBuf:
+				err := ubr.stream.SendBuffered(e.event, e.alloc)
+				e.alloc.Release(ctx)
+				putPooledSharedEvent(e)
+				if err != nil {
+					return err
+				}
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-ubr.stream.Context().Done():
+				return ubr.stream.Context().Err()
+			default:
+				// Done.
+				return nil
+			}
+		}
+	}
+
+	if err := publish(); err != nil {
+		return err
+	}
+
+	// Even if the catch-up buffer has overflowed, all events in it should still
+	// be published. But we should return an error here before setting catchUpBuf
+	// to nil. Doing so might be misinterpreted by publish as a successful
+	// catch-up scan, causing it to start sending to the underlying stream. Caller
+	// will be responsible for disconnecting first. Caller will drain catchUpBuf
+	// again after disconnect, but it will be no-op.
+	if ubr.mu.catchUpOverflowed {
+		// TODO(wenyihu6): refactor this to a var
+		return kvpb.NewRangeFeedRetryError(kvpb.RangeFeedRetryError_REASON_SLOW_CONSUMER)
+	}
+
+	// Success.
+	ubr.mu.catchUpBuf = nil
+	ubr.mu.caughtUp = true
+	return nil
+}
+
+// discardCatchUpBuffer discards all events in catch-up buffer without
+// publishing them. It is safe to assume that catch-up buffer is empty and nil
+// after this call. In case of error, caller should make sure to set
+// disconnected to true before this call to make sure publish doesn't treat nil
+// catchUpBuf as a successful catch-up scan.
+func (ubr *unbufferedRegistration) discardCatchUpBuffer(ctx context.Context) {
+	ubr.mu.Lock()
+	defer ubr.mu.Unlock()
+	// TODO(wenyihu6): Check if we can just discard without holding the lock first
+	// ? We shouldn't be reading from the buffer at the same time
+	ubr.discardCatchUpBufferWithLock(ctx)
+}
+
+// detachCatchUpIter detaches the catchUpIter that was previously attached.
+func (ubr *unbufferedRegistration) detachCatchUpIter() *CatchUpIterator {
+	ubr.mu.Lock()
+	defer ubr.mu.Unlock()
+	catchUpIter := ubr.mu.catchUpIter
+	ubr.mu.catchUpIter = nil
+	return catchUpIter
+}
+
+// maybeRunCatchUpScan runs the catch-up scan if catchUpIter is not nil. It
+// promises to close catchUpIter once detached. It returns an error if catch-up
+// scan fails. The caller should drain catchUpBuf and disconnects. Note that
+// catch up scan bypasses BufferedStream and are sent to underlying stream
+// directly.
+func (ubr *unbufferedRegistration) maybeRunCatchUpScan(ctx context.Context) error {
+	catchUpIter := ubr.detachCatchUpIter()
+	if catchUpIter == nil {
+		return nil
+	}
+	start := timeutil.Now()
+	defer func() {
+		catchUpIter.Close()
+		ubr.metrics.RangeFeedCatchUpScanNanos.Inc(timeutil.Since(start).Nanoseconds())
+	}()
+
+	// In the future, we might want a separate queue for catch up scans.
+	// TODO(wenyihu6): check if we should sent to BufferedStream instead during
+	// code reviews.
+	return catchUpIter.CatchUpScan(ctx, ubr.stream.SendUnbuffered, ubr.withDiff, ubr.withFiltering,
+		ubr.withOmitRemote)
+}

--- a/pkg/kv/kvserver/rangefeed/unbuffered_registration.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_registration.go
@@ -433,8 +433,7 @@ func (ubr *unbufferedRegistration) publishCatchUpBuffer(ctx context.Context) err
 	// will be responsible for disconnecting first. Caller will drain catchUpBuf
 	// again after disconnect, but it will be no-op.
 	if ubr.mu.catchUpOverflowed {
-		// TODO(wenyihu6): refactor this to a var
-		return kvpb.NewRangeFeedRetryError(kvpb.RangeFeedRetryError_REASON_SLOW_CONSUMER)
+		return newRetryErrBufferCapacityExceeded()
 	}
 
 	// Success.

--- a/pkg/kv/kvserver/rangefeed/unbuffered_registration.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_registration.go
@@ -419,6 +419,13 @@ func (ubr *unbufferedRegistration) publishCatchUpBuffer(ctx context.Context) err
 		return err
 	}
 
+	ubr.mu.Lock()
+	defer ubr.mu.Unlock()
+
+	if err := publish(); err != nil {
+		return err
+	}
+
 	// Even if the catch-up buffer has overflowed, all events in it should still
 	// be published. But we should return an error here before setting catchUpBuf
 	// to nil. Doing so might be misinterpreted by publish as a successful

--- a/pkg/kv/kvserver/rangefeed/unbuffered_registration_test.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_registration_test.go
@@ -43,8 +43,9 @@ func TestUnbufferedRegOnConcurrentDisconnect(t *testing.T) {
 	testServerStream := newTestServerStream()
 	testRangefeedCounter := newTestRangefeedCounter()
 	bs := NewBufferedSender(testServerStream, testRangefeedCounter)
+	require.NoError(t, bs.Start(ctx, stopper))
 	defer func() {
-		bs.disconnectAll()
+		bs.Stop()
 		require.Equal(t, 0, p.Len())
 	}()
 
@@ -132,7 +133,8 @@ func TestUnbufferedRegOnDisconnect(t *testing.T) {
 	testServerStream := newTestServerStream()
 	testRangefeedCounter := newTestRangefeedCounter()
 	bs := NewBufferedSender(testServerStream, testRangefeedCounter)
-	defer bs.disconnectAll()
+	require.NoError(t, bs.Start(ctx, stopper))
+	defer bs.Stop()
 
 	startTs := hlc.Timestamp{WallTime: 4}
 	span := roachpb.Span{

--- a/pkg/kv/kvserver/rangefeed/unbuffered_registration_test.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_registration_test.go
@@ -1,0 +1,366 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rangefeed
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/cockroachdb/cockroach/pkg/keys" // hook up pretty printer
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUnbufferedRegOnConcurrentDisconnect tests that BufferedSender can handle
+// concurrent stream disconnects.
+func TestUnbufferedRegOnConcurrentDisconnect(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	p, h, stopper := newTestProcessor(t, withRangefeedTestType(scheduledProcessorWithUnbufferedReg))
+	defer stopper.Stop(ctx)
+	testServerStream := newTestServerStream()
+	testRangefeedCounter := newTestRangefeedCounter()
+	bs := NewBufferedSender(testServerStream, testRangefeedCounter)
+	defer func() {
+		bs.disconnectAll()
+		require.Equal(t, 0, p.Len())
+	}()
+
+	p.ConsumeLogicalOps(ctx, writeValueOp(hlc.Timestamp{WallTime: 1}))
+	require.Equal(t, 0, testServerStream.totalEventsSent())
+
+	const r1 = 1
+	var wg sync.WaitGroup
+	for id := int64(0); id < 50; id++ {
+		wg.Add(1)
+		go func(id int64) {
+			defer wg.Done()
+			ctx, done := context.WithCancel(context.Background())
+			bs.AddStream(id, done)
+			p.Register(h.span, hlc.Timestamp{}, nil, /* catchUpIter */
+				false /* withDiff */, false /* withFiltering */, false, /* withOmitRemote */
+				NewBufferedPerRangeEventSink(ctx, r1, id, bs), func() {})
+		}(id)
+	}
+	wg.Wait()
+	require.Equal(t, int32(50), testRangefeedCounter.get())
+	require.Equal(t, 50, p.Len())
+
+	check := func(f func(e *kvpb.MuxRangeFeedEvent) bool, expected int, expectedEachStreamEventCount int, expectedTotal int) error {
+		if actual := testServerStream.totalEventsFilterBy(f); actual != expected {
+			return errors.Newf("expected %d events filtered, but got %v", expected, actual)
+		}
+		if actualTotal := testServerStream.totalEventsSent(); actualTotal != expectedTotal {
+			return errors.Newf("expected %d events sent, but got %v", expectedTotal, actualTotal)
+		}
+		var err error
+		testServerStream.iterateEvents(func(_ int64, events []*kvpb.MuxRangeFeedEvent) bool {
+			if len(events) != expectedEachStreamEventCount {
+				err = errors.Newf("expected %d events sent by every stream, but got %v for a stream", expectedEachStreamEventCount, len(events))
+				return false
+			}
+			return true
+		})
+		return err
+	}
+
+	// Make sure events consumed before p.Register are not sent.
+	testutils.SucceedsSoon(t, func() error {
+		f := func(e *kvpb.MuxRangeFeedEvent) bool {
+			return e.Checkpoint != nil
+		}
+		return check(f, 50, 1, 50)
+	})
+
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			p.ConsumeLogicalOps(ctx, writeValueOp(hlc.Timestamp{WallTime: 1}))
+		}()
+	}
+	testutils.SucceedsSoon(t, func() error {
+		f := func(e *kvpb.MuxRangeFeedEvent) bool {
+			return e.Val != nil
+		}
+		return check(f, 20*50, 21, 21*50)
+	})
+
+	for id := int64(0); id < 50; id++ {
+		wg.Add(1)
+		go func(id int64) {
+			defer wg.Done()
+			bs.SendBufferedError(makeMuxRangefeedErrorEvent(id, r1, kvpb.NewError(nil)))
+		}(id)
+	}
+	wg.Wait()
+	require.Equal(t, int32(0), testRangefeedCounter.get())
+}
+
+// TestUnbufferedRegOnDisconnect tests that BufferedSender can handle
+// disconnects properly and send events in the correct order.
+func TestUnbufferedRegOnDisconnect(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	p, h, stopper := newTestProcessor(t, withRangefeedTestType(scheduledProcessorWithUnbufferedReg))
+	defer stopper.Stop(ctx)
+	testServerStream := newTestServerStream()
+	testRangefeedCounter := newTestRangefeedCounter()
+	bs := NewBufferedSender(testServerStream, testRangefeedCounter)
+	defer bs.disconnectAll()
+
+	startTs := hlc.Timestamp{WallTime: 4}
+	span := roachpb.Span{
+		Key:    roachpb.Key("d"),
+		EndKey: roachpb.Key("w"),
+	}
+	catchUpIter := newTestIterator(keyValues, roachpb.Key("w"))
+	ctx, done := context.WithCancel(context.Background())
+	const r1 = 1
+	const s1 = 1
+
+	bs.AddStream(s1, done)
+	require.Equal(t, int32(1), testRangefeedCounter.get())
+	p.Register(h.span, startTs, makeCatchUpIterator(catchUpIter, span, startTs), /* catchUpIter */
+		true /* withDiff */, false /* withFiltering */, false, /* withOmitRemote */
+		NewBufferedPerRangeEventSink(ctx, r1, s1, bs), func() {})
+
+	key := roachpb.Key("d")
+	val1 := roachpb.Value{RawBytes: []byte("val1"), Timestamp: hlc.Timestamp{WallTime: 5}}
+	val2 := roachpb.Value{RawBytes: []byte("val2"), Timestamp: hlc.Timestamp{WallTime: 6}}
+	op1 := writeValueOpWithKV(key, val1.Timestamp, val1.RawBytes)
+	op2 := writeValueOpWithKV(key, val2.Timestamp, val2.RawBytes)
+	ev1, ev2 := new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent)
+	ev1.MustSetValue(&kvpb.RangeFeedValue{Key: key, Value: val1})
+	ev2.MustSetValue(&kvpb.RangeFeedValue{Key: key, Value: val2})
+
+	p.ConsumeLogicalOps(ctx, op1)
+	p.ConsumeLogicalOps(ctx, op2)
+	time.Sleep(1 * time.Second)
+	// Wait a bit before disconnecting to make sure events are sent.
+	discErr := kvpb.NewError(fmt.Errorf("disconnection error"))
+	p.DisconnectSpanWithErr(spBC, discErr)
+
+	catchUpEvents := expEvents(false)
+	expectedEvents := make([]*kvpb.RangeFeedEvent, len(catchUpEvents)+1+2+1)
+	copy(expectedEvents, catchUpEvents)
+	checkpointEvent := &kvpb.RangeFeedEvent{}
+	checkpointEvent.MustSetValue(&kvpb.RangeFeedCheckpoint{Span: roachpb.Span{
+		Key:    roachpb.Key("a"),
+		EndKey: roachpb.Key("z"),
+	}})
+	expectedEvents[len(catchUpEvents)] = checkpointEvent
+	expectedEvents[len(catchUpEvents)+1] = ev1
+	expectedEvents[len(catchUpEvents)+2] = ev2
+
+	evErr := &kvpb.RangeFeedEvent{}
+	evErr.MustSetValue(&kvpb.RangeFeedError{Error: *discErr})
+	expectedEvents[len(catchUpEvents)+3] = evErr
+
+	testutils.SucceedsSoon(t, func() error {
+		events := testServerStream.getEventsByStreamID(s1)
+		actualEvents := make([]*kvpb.RangeFeedEvent, len(events))
+		for i, ev := range events {
+			actualEvents[i] = &ev.RangeFeedEvent
+		}
+		if !reflect.DeepEqual(expectedEvents, actualEvents) {
+			return errors.Newf("expected %v \n, got %v", expectedEvents, actualEvents)
+		}
+		if p.Len() != 0 {
+			return errors.Newf("expected no registrations, got %d", p.Len())
+		}
+		return nil
+	})
+
+	require.Equal(t, int32(0), testRangefeedCounter.get())
+}
+
+// TODO(wenyihu6): add memory accounting tests here as well
+// TestCatchUpBufDrain tests that the catchUpBuf is drained after all events are
+// sent.
+func TestCatchUpBufDrain(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	rng, _ := randutil.NewTestRand()
+	ev1 := new(kvpb.RangeFeedEvent)
+	val := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 1}}
+	ev1.MustSetValue(&kvpb.RangeFeedValue{Key: keyA, Value: val})
+	numReg := rng.Intn(1000)
+	regs := make([]*unbufferedRegistration, numReg)
+
+	for i := 0; i < numReg; i++ {
+		s := newTestStream()
+		iter := newTestIterator(keyValues, roachpb.Key("w"))
+		catchUpReg := newTestRegistration(s, withRSpan(spAB), withRegistrationType(unbuffered), withDiff(false),
+			withCatchUpIter(iter)).(*unbufferedRegistration)
+		catchUpReg.publish(ctx, ev1, nil /* alloc */)
+		go catchUpReg.runOutputLoop(ctx, 0)
+		regs[i] = catchUpReg
+	}
+
+	// For each registration, publish events (higher chance) and disconnect
+	// randomly.
+	for j := 0; j < numReg; j++ {
+		if rng.Intn(5) != 4 {
+			for i := 0; i < 100; i++ {
+				regs[j].publish(ctx, ev1, nil /* alloc */)
+			}
+		} else {
+			regs[j].disconnect(kvpb.NewError(nil))
+		}
+	}
+
+	// Wait for all registrations to catch up and drain their catchUpBuf.
+	for _, reg := range regs {
+		testutils.SucceedsSoon(t, func() error {
+			if reg.waitForCaughtUp(ctx) != nil {
+				return errors.Newf("not caught up")
+			}
+			reg.mu.Lock()
+			defer reg.mu.Unlock()
+			if reg.mu.catchUpBuf != nil {
+				return errors.Newf("catchUpBuf not drained")
+			}
+			return nil
+		})
+	}
+}
+
+// A lot of tests are already covered in registry_test.go. This test is for
+// unbuffered registrations specifically.
+func TestUnbufferedRegistration(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	val1 := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 1}}
+	val2 := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 5}}
+	ev1, ev2, ev3, ev4, ev5 := new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent),
+		new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent)
+	ev1.MustSetValue(&kvpb.RangeFeedValue{Key: keyA, Value: val1})
+	ev2.MustSetValue(&kvpb.RangeFeedValue{Key: keyB, Value: val1})
+	ev3.MustSetValue(&kvpb.RangeFeedValue{Key: keyC, Value: val2})
+	ev4.MustSetValue(&kvpb.RangeFeedCheckpoint{
+		Span: roachpb.Span{
+			Key:    roachpb.Key("d"),
+			EndKey: roachpb.Key("w")},
+		ResolvedTS: hlc.Timestamp{WallTime: 5},
+	})
+	ev5.MustSetValue(&kvpb.RangeFeedDeleteRange{
+		Span: roachpb.Span{
+			Key:    roachpb.Key("d"),
+			EndKey: roachpb.Key("w")},
+		Timestamp: hlc.Timestamp{WallTime: 6},
+	})
+
+	t.Run("disconnect before catch up scan starts", func(t *testing.T) {
+		s := newTestStream()
+		iter := newTestIterator(keyValues, roachpb.Key("w"))
+		catchUpReg := newTestRegistration(s, withRSpan(spAB), withRegistrationType(unbuffered),
+			withCatchUpIter(iter)).(*unbufferedRegistration)
+		catchUpReg.publish(ctx, ev1, nil /* alloc */)
+		catchUpReg.disconnect(kvpb.NewError(nil))
+		require.Nil(t, catchUpReg.mu.catchUpIter)
+		// Catch up scan should not be initiated.
+		go catchUpReg.runOutputLoop(ctx, 0)
+		require.NoError(t, catchUpReg.waitForCaughtUp(ctx))
+		require.Nil(t, catchUpReg.mu.catchUpIter)
+		// No events should be sent since the registration has catch up buffer and
+		// is disconnected before catch up scan starts.
+		require.Nil(t, s.Events())
+		// Repeatedly disconnect should be fine.
+		catchUpReg.disconnect(kvpb.NewError(nil))
+	})
+	t.Run("disconnect before publishCatchUpBuffer", func(t *testing.T) {
+		s := newTestStream()
+		iter := newTestIterator(keyValues, roachpb.Key("w"))
+		catchUpReg := newTestRegistration(s, withRSpan(spAB), withRegistrationType(unbuffered),
+			withCatchUpIter(iter)).(*unbufferedRegistration)
+		for i := 0; i < 10000; i++ {
+			catchUpReg.publish(ctx, ev1, nil /* alloc */)
+		}
+		// No events should be sent since the registration has catch up buffer.
+		require.Nil(t, s.Events())
+		require.NoError(t, catchUpReg.maybeRunCatchUpScan(context.Background()))
+		// Disconnected before catch up overflowed.
+		catchUpReg.disconnect(kvpb.NewError(nil))
+		require.Equal(t, context.Canceled,
+			catchUpReg.publishCatchUpBuffer(context.Background()))
+		require.NotNil(t, catchUpReg.mu.catchUpBuf)
+		require.True(t, catchUpReg.mu.catchUpOverflowed)
+		catchUpReg.discardCatchUpBuffer(context.Background())
+		require.Nil(t, catchUpReg.mu.catchUpBuf)
+	})
+	t.Run("catch up scan + publish updates correctness testing", func(t *testing.T) {
+		// Run a catch-up scan for a registration over a test
+		// iterator with the following keys.
+		s := newTestStream()
+		iter := newTestIterator(keyValues, roachpb.Key("w"))
+		r := newTestRegistration(s, withRSpan(roachpb.Span{
+			Key:    roachpb.Key("d"),
+			EndKey: roachpb.Key("w"),
+		}), withStartTs(hlc.Timestamp{WallTime: 4}), withCatchUpIter(iter), withDiff(true),
+			withRegistrationType(unbuffered)).(*unbufferedRegistration)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r.runOutputLoop(ctx, 0)
+		}()
+		capOfBuf := cap(r.mu.catchUpBuf)
+		r.publish(ctx, ev1, nil /* alloc */)
+		r.publish(ctx, ev2, nil /* alloc */)
+		r.publish(ctx, ev3, nil /* alloc */)
+		r.publish(ctx, ev4, nil /* alloc */)
+		r.publish(ctx, ev5, nil /* alloc */)
+		catchUpEvents := expEvents(false)
+		testutils.SucceedsSoon(t, func() error {
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			if len(s.mu.events) < len(catchUpEvents) || !reflect.DeepEqual(catchUpEvents, s.mu.events[:len(catchUpEvents)]) {
+				return errors.Newf("expected %v in %v", catchUpEvents, s.mu.events)
+			}
+			return nil
+		})
+		wg.Wait()
+
+		func() {
+			r.mu.Lock()
+			defer r.mu.Unlock()
+			require.False(t, r.mu.catchUpOverflowed)
+			require.Nil(t, r.mu.catchUpBuf)
+		}()
+
+		func() {
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			require.Equal(t, capOfBuf+len(catchUpEvents), len(s.mu.events))
+			require.Equal(t, []*kvpb.RangeFeedEvent{ev1, ev2, ev3, ev4, ev5}, s.mu.events[len(catchUpEvents):])
+		}()
+	})
+}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1983,7 +1983,7 @@ func (n *Node) MuxRangeFeed(muxStream kvpb.Internal_MuxRangeFeedServer) error {
 	var sm streamManager
 	if kvserver.RangefeedUseBufferedSender.Get(&n.storeCfg.Settings.SV) {
 		sm = rangefeed.NewBufferedSender(lockedMuxStream, n.metrics)
-		log.Fatalf(ctx, "unimplemented: buffered sender for rangefeed #126560")
+		log.Infof(ctx, "using buffered sender for rangefeed")
 	} else {
 		sm = rangefeed.NewUnbufferedSender(lockedMuxStream, n.metrics)
 	}


### PR DESCRIPTION
**kvserver/rangefeed: add node level buffered sender**

This patch is the last step for reducing long-running O(ranges) goroutines in
kvserver/rangefeed. It changes the BufferedSender to use a queue to buffer
events before forwarding them to underlying grpc stream.

Closed: https://github.com/cockroachdb/cockroach/issues/129813
Release note: A new cluster setting
`kv.rangefeed.buffered_stream_sender.enabled` can now be used to allow rangefeed
to use buffered sender for all rangefeed feeds instead of buffering events
separately per client per range.

---

**kvserver/rangefeed: add capacity to node level buffered sender**

This patch adds capacity to node level buffered sender which will shut down all
registrations if the node level buffer had overflowed.

Part of: https://github.com/cockroachdb/cockroach/issues/129813
Release note: none

TODO: decide a good constant value for this, add a larger test at the kvclient side to make sure error returned here is treated as a restart signal
