### PR TITLE
roachtest: fix bug in `option.Apply`

### DIFF
--- a/pkg/cmd/roachtest/option/cluster_options_test.go
+++ b/pkg/cmd/roachtest/option/cluster_options_test.go
@@ -74,6 +74,12 @@ func TestApply(t *testing.T) {
 			},
 		},
 		{
+			name:          "using VirtualClusterOptions directly",
+			optionsStruct: "virtual_cluster_options",
+			options:       []OptionFunc{VirtualClusterName("app")},
+			expected:      VirtualClusterOptions{VirtualClusterName: "app"},
+		},
+		{
 			name:          "setting a non-applicable option",
 			optionsStruct: "valid_container",
 			options:       []OptionFunc{User("user")},
@@ -100,6 +106,10 @@ func TestApply(t *testing.T) {
 			switch tc.optionsStruct {
 			case "valid_container":
 				var c validContainer
+				err = Apply(&c, tc.options...)
+				container = c
+			case "virtual_cluster_options":
+				var c VirtualClusterOptions
 				err = Apply(&c, tc.options...)
 				container = c
 			case "wrong_type":


### PR DESCRIPTION
This commit fixes a bug in the recently introduced `option.Apply` function: the `GlobalOptions` struct embeds a `VirtualClusterOptions` struct, allowing several functions to reuse this struct if they can be applied on a specific virtual cluster.

However, the `reflect.VisibleFields` API used in `option.Apply` returns the `StructField` both for the embedded `VirtualClusterOptions` field, as well as for each of the fields of that struct itself.

When validating and applying options, we are only interested in the "flattened" view of the options -- embedded structs can be skipped.

Prior to this commit, trying to use `VirtualClusterOptions` as the container for the options for a function would lead to an error, since `VirtualClusterOptions` does not itself have a `VirtualClusterOptions` field.

Epic: none

Release note: None