### PR TITLE
kv: remove custom raftDescribeMessage

### DIFF
--- a/pkg/kv/kvserver/raft.go
+++ b/pkg/kv/kvserver/raft.go
@@ -181,38 +181,9 @@ func logRaftReady(ctx context.Context, ready raft.Ready) {
 	}
 	for i, m := range ready.Messages {
 		fmt.Fprintf(&buf, "  Outgoing Message[%d]: %.200s\n",
-			i, raftDescribeMessage(m, raftEntryFormatter))
+			i, raft.DescribeMessage(m, raftEntryFormatter))
 	}
 	log.Infof(ctx, "raft ready (must-sync=%t)\n%s", ready.MustSync, buf.String())
-}
-
-// This is a fork of raft.DescribeMessage with a tweak to avoid logging
-// snapshot data.
-func raftDescribeMessage(m raftpb.Message, f raft.EntryFormatter) string {
-	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "%x->%x %v Term:%d Log:%d/%d", m.From, m.To, m.Type, m.Term, m.LogTerm, m.Index)
-	if m.Reject {
-		fmt.Fprintf(&buf, " Rejected (Hint: %d)", m.RejectHint)
-	}
-	if m.Commit != 0 {
-		fmt.Fprintf(&buf, " Commit:%d", m.Commit)
-	}
-	if len(m.Entries) > 0 {
-		fmt.Fprintf(&buf, " Entries:[")
-		for i, e := range m.Entries {
-			if i != 0 {
-				buf.WriteString(", ")
-			}
-			buf.WriteString(raft.DescribeEntry(e, f))
-		}
-		fmt.Fprintf(&buf, "]")
-	}
-	if m.Snapshot != nil {
-		snap := *m.Snapshot
-		snap.Data = nil
-		fmt.Fprintf(&buf, " Snapshot:%v", snap)
-	}
-	return buf.String()
 }
 
 func raftEntryFormatter(data []byte) string {

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1838,7 +1838,7 @@ func (r *Replica) deliverLocalRaftMsgsRaftMuLockedReplicaMuLocked(
 	for i, m := range localMsgs {
 		if err := raftGroup.Step(m); err != nil {
 			log.Fatalf(ctx, "unexpected error stepping local raft message [%s]: %v",
-				raftDescribeMessage(m, raftEntryFormatter), err)
+				raft.DescribeMessage(m, raftEntryFormatter), err)
 		}
 		// NB: we can reset messages in the localMsgs.recycled slice without holding
 		// the localMsgs mutex because no-one ever writes to localMsgs.recycled and

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
+	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
@@ -377,7 +378,7 @@ func (s *Store) processRaftRequestWithReplica(
 	defer r.MeasureRaftCPUNanos(grunning.Time())
 
 	if verboseRaftLoggingEnabled() {
-		log.Infof(ctx, "incoming raft message:\n%s", raftDescribeMessage(req.Message, raftEntryFormatter))
+		log.Infof(ctx, "incoming raft message:\n%s", raft.DescribeMessage(req.Message, raftEntryFormatter))
 	}
 
 	if req.Message.Type == raftpb.MsgSnap {


### PR DESCRIPTION
`raftDescribeMessage` was introduced as a fork of `raft.DescribeMessage` with a tweak to avoid logging snapshot data. `raft.DescribeMessage` has not logged snapshot data since the introduction of `raft.DescribeSnapshot` in 07c1ab6c, so the fork is no longer needed.

This picks up some of the recent changes that we have made to `raft.DescribeMessage` for the purposes of leader fortification.

Epic: None
Release note: None