### PR TITLE
kv: implement redact.SafeValue for storelivenesspb.Epoch

### DIFF
--- a/pkg/kv/kvserver/storeliveness/storelivenesspb/service.go
+++ b/pkg/kv/kvserver/storeliveness/storelivenesspb/service.go
@@ -15,3 +15,6 @@ package storelivenesspb
 // increment the epoch for which it requests support from another store (e.g.
 // after a restart).
 type Epoch int64
+
+// SafeValue implements the redact.SafeValue interface.
+func (e Epoch) SafeValue() {}

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -136,12 +136,15 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 					"github.com/cockroachdb/cockroach/pkg/kv/kvserver/split": {
 						"SplitObjective": {},
 					},
+					"github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness/storelivenesspb": {
+						"Epoch": {},
+					},
 					"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities": {
 						"ID": {},
 					},
 					"github.com/cockroachdb/cockroach/pkg/raft/raftpb": {
-						"PeerID": {},
 						"Epoch":  {},
+						"PeerID": {},
 					},
 					"github.com/cockroachdb/cockroach/pkg/repstream/streampb": {
 						"StreamID": {},


### PR DESCRIPTION
This commit implements `redact.SafeValue` for `storelivenesspb.Epoch` so that the value will show up in redacted logs.

Epic: None
Release note: None