### PR TITLE
backupccl: fix TestProtectedTimestampsFailDueToLimits

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -6450,7 +6450,7 @@ func TestProtectedTimestampsFailDueToLimits(t *testing.T) {
 	// Creating the protected timestamp record should fail because there are too
 	// many spans. Ensure that we get the appropriate error.
 	_, err := db.Exec(`BACKUP TABLE foo, bar TO 'nodelocal://1/foo/byte-limit'`)
-	require.EqualError(t, err, "pq: protectedts: limit exceeded: 0+30 > 1 bytes")
+	require.ErrorContains(t, err, "pq: protectedts: limit exceeded")
 
 	// TODO(adityamaru): Remove in 22.2 once no records protect spans.
 	t.Run("deprecated-spans-limit", func(t *testing.T) {


### PR DESCRIPTION
A Protected timestamp record contain a string representation of a job ID. The random generation used to construct job IDs is based on time and is now 1 character larger changing the size in this assertion.

As a follow-up, it is a bit odd that the backup/restore tests are testing this code rather than simply a test in the protectedts package. We should consider removing this test if the behaviour is tested elsewhere.

Fixes #129977
Release note: None