### PR TITLE
raft: bump proposal timeout for TestNodeProposeWaitDropped

### DIFF
--- a/pkg/raft/node_test.go
+++ b/pkg/raft/node_test.go
@@ -375,11 +375,7 @@ func TestNodeProposeWaitDropped(t *testing.T) {
 		}
 		n.Advance()
 	}
-	proposalTimeout := time.Millisecond * 100
-	ctx, cancel := context.WithTimeout(context.Background(), proposalTimeout)
-	// propose with cancel should be cancelled earyly if dropped
-	assert.Equal(t, ErrProposalDropped, n.Propose(ctx, droppingMsg))
-	cancel()
+	assert.Equal(t, ErrProposalDropped, n.Propose(context.Background(), droppingMsg))
 
 	n.Stop()
 	require.Empty(t, msgs)


### PR DESCRIPTION
In some rare cases, we see context cancellation race with the proposal being dropped (#129967, #128878). Up the context cancellation deadline 10x to hopefully prevent this, while still not causing the test to hang indefinitely.

closes https://github.com/cockroachdb/cockroach/issues/129967

Release note: None