### PR TITLE
roachprod: respect ROACHPROD_USER in list, destroy

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -403,7 +403,7 @@ func initFlags() {
 		cmd.Flags().BoolVar(&urlOpen, "open", false, "Open the url in a browser")
 	}
 
-	for _, cmd := range []*cobra.Command{createCmd, destroyCmd, extendCmd, logsCmd} {
+	for _, cmd := range []*cobra.Command{createCmd, listCmd, destroyCmd, extendCmd, logsCmd} {
 		cmd.Flags().StringVarP(&username, "username", "u", os.Getenv("ROACHPROD_USER"),
 			"Username to run under, detect if blank")
 	}

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -230,7 +230,7 @@ directories inside ${HOME}/local directory are removed.
 `,
 	Args: cobra.ArbitraryArgs,
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Destroy(config.Logger, destroyAllMine, destroyAllLocal, args...)
+		return roachprod.Destroy(config.Logger, username, destroyAllMine, destroyAllLocal, args...)
 	}),
 }
 
@@ -307,7 +307,11 @@ hosts file.
 		if listJSON && listDetails {
 			return errors.New("'json' option cannot be combined with 'details' option")
 		}
-		filteredCloud, err := roachprod.List(config.Logger, listMine, listPattern, vm.ListOptions{ComputeEstimatedCost: true})
+		filteredCloud, err := roachprod.List(config.Logger, listMine, listPattern,
+			vm.ListOptions{
+				Username:             username,
+				ComputeEstimatedCost: true,
+			})
 
 		if err != nil {
 			return err

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1843,7 +1843,9 @@ func (c *clusterImpl) doDestroy(ctx context.Context, l *logger.Logger) <-chan st
 			// We use a non-cancelable context for running this command. Once we got
 			// here, the cluster cannot be destroyed again, so we really want this
 			// command to succeed.
-			if err := roachprod.Destroy(l, false /* destroyAllMine */, false /* destroyAllLocal */, c.name); err != nil {
+			if err := roachprod.Destroy(l, "" /* optionalUsername */, false, /* destroyAllMine */
+				false, /* destroyAllLocal */
+				c.name); err != nil {
 				l.ErrorfCtx(ctx, "error destroying cluster %s: %s", c, err)
 			} else {
 				l.PrintfCtx(ctx, "destroying cluster %s... done", c)

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -441,6 +441,7 @@ type VolumeCreateOpts struct {
 }
 
 type ListOptions struct {
+	Username             string // if set, <username>-.* clusters are detected as 'mine'
 	IncludeVolumes       bool
 	IncludeEmptyClusters bool
 	ComputeEstimatedCost bool


### PR DESCRIPTION
Ran into some trouble on my gceworker because list and destroy weren't
respecting ROACHPROD_USER and so clusters I created there weren't
visible: the GCE worker uses a service account, so the pattern roachprod
was looking for "my" clusters under was '983903724139-compute' from the
service account faux email address. Both of these commands needed to
start taking into account ROACHPROD_USER (corresponding to the
`--username` flag).

They now do and the following works:

```
roachprod create -n 1 tobias-test
roachprod list -m    # <-- shows it
roachprod destroy -m # <-- destroys it
```

Release note: None
Epic: None
