### PR TITLE
roachprod: allow opting out of cost estimates

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -47,6 +47,7 @@ var (
 	grafanaArch           string
 	grafanaDumpDir        string
 	jaegerConfigNodes     string
+	listCost              bool
 	listDetails           bool
 	listJSON              bool
 	listMine              bool
@@ -179,6 +180,10 @@ func initFlags() {
 	extendCmd.Flags().DurationVarP(&extendLifetime,
 		"lifetime", "l", 12*time.Hour, "Lifetime of the cluster")
 
+	listCmd.Flags().BoolVarP(&listCost,
+		"cost", "c", os.Getenv("ROACHPROD_NO_COST_ESTIMATES") != "true",
+		"Show cost estimates",
+	)
 	listCmd.Flags().BoolVarP(&listDetails,
 		"details", "d", false, "Show cluster details")
 	listCmd.Flags().BoolVar(&listJSON,

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -310,7 +310,7 @@ hosts file.
 		filteredCloud, err := roachprod.List(config.Logger, listMine, listPattern,
 			vm.ListOptions{
 				Username:             username,
-				ComputeEstimatedCost: true,
+				ComputeEstimatedCost: listCost,
 			})
 
 		if err != nil {

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -2838,7 +2838,8 @@ func populateCostPerHour(l *logger.Logger, vms vm.List) error {
 				}
 				series, cpus, memory, err := decodeCustomType()
 				if err != nil {
-					l.Errorf("Error estimating VM costs (will continue without): %v", err)
+					l.Errorf("Error estimating VM costs, "+
+						"continuing without (consider ROACHPROD_NO_COST_ESTIMATES=true): %v", err)
 					continue
 				}
 				workload.ComputeVmWorkload.MachineType = &cloudbilling.MachineType{


### PR DESCRIPTION
They slow down `roachprod list` and at least at the time of writing,
an endpoint this functionality hits is very slow and eventually errors
out with a 502 and a large HTML file which roachprod spits out many
times over in the course of listing clusters.

This commit retains the default of displaying the cost, but adds a flag
`--cost=false` as well as an env var `ROACHPROD_NO_COST_ESTIMATES` that
allows opting out.

Epic: none
Release note: None
