### PR TITLE
roachtest: runOperation emit event to datadog fix.

### DIFF
--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -514,7 +514,7 @@ func maybeEmitDatadogEvent(
 	_, _, _ = datadogEventsAPI.CreateEvent(ctx, datadogV1.EventCreateRequest{
 		AggregationKey: datadog.PtrString(fmt.Sprintf("operation-%d", operationID)),
 		AlertType:      &alertType,
-		DateHappened:   datadog.PtrInt64(timeutil.Now().UnixNano()),
+		DateHappened:   datadog.PtrInt64(timeutil.Now().Unix()),
 		Host:           &hostname,
 		SourceTypeName: datadog.PtrString("roachtest"),
 		Tags: append(datadogTags,
@@ -677,7 +677,7 @@ func runOperation(register func(registry.Registry), filter string, clusterName s
 	}
 	op.spec = opSpec
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	// Cancel this context if we get an interrupt.
 	CtrlC(ctx, l, cancel, nil /* registry */)


### PR DESCRIPTION
`roachtest run-operation` command emits operation related event to datadog. Function `maybeEmitDatadogEvent` is broken because of two reasons:
1. Datadog context is getting overwritten to empty context in `runOperation` function.
2. The value of `DateHappened` in `datadogV1.EventCreateRequest` was set to Nanoseconds which is throwing error `Event too far in the future`.

This PR addresses the above issue.

Epic: none

Release note: None