### PR TITLE
storeliveness: intergrate with store and server

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -748,6 +748,14 @@ func (cfg RaftConfig) NodeLivenessDurations() (livenessActive, livenessRenewal t
 	return
 }
 
+// StoreLivenessDurations computes durations for store liveness heartbeat
+// interval and liveness interval.
+func (cfg RaftConfig) StoreLivenessDurations() (livenessInterval, heartbeatInterval time.Duration) {
+	livenessInterval = cfg.RangeLeaseDuration
+	heartbeatInterval = time.Duration(float64(livenessInterval) * livenessRenewalFraction)
+	return
+}
+
 // SentinelGossipTTL is time-to-live for the gossip sentinel. The sentinel
 // informs a node whether or not it's connected to the primary gossip network
 // and not just a partition. As such it must expire fairly quickly and be

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -443,6 +443,7 @@ go_test(
         "//pkg/kv/kvserver/spanset",
         "//pkg/kv/kvserver/split",
         "//pkg/kv/kvserver/stateloader",
+        "//pkg/kv/kvserver/storeliveness",
         "//pkg/kv/kvserver/tenantrate",
         "//pkg/kv/kvserver/tscache",
         "//pkg/kv/kvserver/txnwait",

--- a/pkg/kv/kvserver/replica_store_liveness.go
+++ b/pkg/kv/kvserver/replica_store_liveness.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"hash/fnv"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	slpb "github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness/storelivenesspb"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftstoreliveness"
@@ -94,12 +93,7 @@ func (r *replicaRLockedStoreLiveness) SupportFrom(
 
 // SupportFromEnabled implements the raftstoreliveness.StoreLiveness interface.
 func (r *replicaRLockedStoreLiveness) SupportFromEnabled() bool {
-	// TODO(mira): this version check is incorrect. For one, it doesn't belong
-	// here. Instead, the version should be checked when deciding to enable
-	// StoreLiveness or not. Then, the check here should only check whether store
-	// liveness is enabled.
-	storeLivenessEnabled := r.store.ClusterSettings().Version.IsActive(context.TODO(), clusterversion.V24_3_StoreLivenessEnabled)
-	if !storeLivenessEnabled {
+	if !r.store.storeLiveness.SupportFromEnabled(context.TODO()) {
 		return false
 	}
 	fracEnabled := raftLeaderFortificationFractionEnabled.Get(&r.store.ClusterSettings().SV)

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -56,6 +56,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness"
+	slpb "github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness/storelivenesspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/tenantrate"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/tscache"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/txnrecovery"
@@ -1154,17 +1155,18 @@ type StoreConfig struct {
 	AmbientCtx log.AmbientContext
 	base.RaftConfig
 
-	DefaultSpanConfig    roachpb.SpanConfig
-	Settings             *cluster.Settings
-	Clock                *hlc.Clock
-	Gossip               *gossip.Gossip
-	DB                   *kv.DB
-	NodeLiveness         *liveness.NodeLiveness
-	StorePool            *storepool.StorePool
-	Transport            *RaftTransport
-	NodeDialer           *nodedialer.Dialer
-	RPCContext           *rpc.Context
-	RangeDescriptorCache *rangecache.RangeCache
+	DefaultSpanConfig      roachpb.SpanConfig
+	Settings               *cluster.Settings
+	Clock                  *hlc.Clock
+	Gossip                 *gossip.Gossip
+	DB                     *kv.DB
+	NodeLiveness           *liveness.NodeLiveness
+	StorePool              *storepool.StorePool
+	Transport              *RaftTransport
+	StoreLivenessTransport *storeliveness.Transport
+	NodeDialer             *nodedialer.Dialer
+	RPCContext             *rpc.Context
+	RangeDescriptorCache   *rangecache.RangeCache
 
 	ClosedTimestampSender   *sidetransport.Sender
 	ClosedTimestampReceiver sidetransportReceiver
@@ -2174,8 +2176,18 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	)
 	s.metrics.registry.AddMetricStruct(s.recoveryMgr.Metrics())
 
-	// TODO(mira): create the store liveness support manager here.
-	// s.storeLiveness = ...
+	heartbeatInterval, livenessInterval := s.cfg.StoreLivenessDurations()
+	supportGracePeriod := s.cfg.RPCContext.StoreLivenessWithdrawalGracePeriod()
+	options := storeliveness.NewOptions(heartbeatInterval, livenessInterval, supportGracePeriod)
+	sm := storeliveness.NewSupportManager(
+		slpb.StoreIdent{NodeID: s.nodeDesc.NodeID}, s.StateEngine(), options,
+		s.cfg.Settings, s.stopper, s.cfg.Clock, s.cfg.StoreLivenessTransport,
+	)
+	s.cfg.StoreLivenessTransport.ListenMessages(s.StoreID(), sm)
+	s.storeLiveness = sm
+	if err = sm.Start(ctx); err != nil {
+		return errors.Wrap(err, "starting store liveness")
+	}
 
 	s.rangeIDAlloc = idAlloc
 

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer"
 	"github.com/cockroachdb/cockroach/pkg/raft"
@@ -247,6 +248,9 @@ func createTestStoreWithoutStart(
 		(*node_rac2.AdmittedPiggybacker)(nil),
 		nil, /* PiggybackedAdmittedResponseScheduler */
 		nil, /* knobs */
+	)
+	cfg.StoreLivenessTransport = storeliveness.NewTransport(
+		cfg.AmbientCtx, stopper, cfg.Clock, cfg.NodeDialer, server,
 	)
 
 	stores := NewStores(cfg.AmbientCtx, cfg.Clock)

--- a/pkg/kv/kvserver/storeliveness/BUILD.bazel
+++ b/pkg/kv/kvserver/storeliveness/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "storeliveness",
     srcs = [
+        "config.go",
         "fabric.go",
         "persist.go",
         "requester_state.go",

--- a/pkg/kv/kvserver/storeliveness/config.go
+++ b/pkg/kv/kvserver/storeliveness/config.go
@@ -1,0 +1,46 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package storeliveness
+
+import "time"
+
+// Options includes all Store Liveness durations needed by the SupportManager.
+type Options struct {
+	// HeartbeatInterval determines how often Store Liveness sends heartbeats.
+	HeartbeatInterval time.Duration
+	// LivenessInterval determines the Store Liveness support expiration time.
+	LivenessInterval time.Duration
+	// SupportExpiryInterval determines how often Store Liveness checks if support
+	// should be withdrawn.
+	SupportExpiryInterval time.Duration
+	// IdleSupportFromInterval determines how ofter Store Liveness checks if any
+	// stores have not appeared in a SupportFrom call recently.
+	IdleSupportFromInterval time.Duration
+	// SupportWithdrawalGracePeriod determines how long Store Liveness should
+	// wait after restart before withdrawing support. It helps prevent support
+	// churn until the first heartbeats are delivered.
+	SupportWithdrawalGracePeriod time.Duration
+}
+
+// NewOptions instantiates the Store Liveness Options.
+func NewOptions(
+	heartbeatInterval time.Duration,
+	livenessInterval time.Duration,
+	supportWithdrawalGracePeriod time.Duration,
+) Options {
+	return Options{
+		HeartbeatInterval:            heartbeatInterval,
+		LivenessInterval:             livenessInterval,
+		SupportExpiryInterval:        1 * time.Second,
+		IdleSupportFromInterval:      1 * time.Minute,
+		SupportWithdrawalGracePeriod: supportWithdrawalGracePeriod,
+	}
+}

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -288,6 +288,16 @@ func (c *Context) SetLoopbackDialer(loopbackDialFn func(context.Context) (net.Co
 	c.loopbackDialFn = loopbackDialFn
 }
 
+// StoreLivenessGracePeriod computes the grace period after a store restarts before which it will
+// not withdraw support from other stores.
+func (c *Context) StoreLivenessWithdrawalGracePeriod() time.Duration {
+	// RPCHeartbeatInterval and RPCHeartbeatTimeout ensure the remote store
+	// probes the RPC connection to the local store. DialTimeout ensures the
+	// remote store has enough time to dial the local store, and NetworkTimeout
+	// ensures the remote store's heartbeat is received by the local store.
+	return c.RPCHeartbeatInterval + c.RPCHeartbeatTimeout + base.DialTimeout + base.NetworkTimeout
+}
+
 // ContextOptions are passed to NewContext to set up a new *Context.
 // All pointer fields and TenantID are required.
 type ContextOptions struct {

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -146,6 +146,7 @@ go_library(
         "//pkg/kv/kvserver/rangefeed",
         "//pkg/kv/kvserver/rangelog",
         "//pkg/kv/kvserver/reports",
+        "//pkg/kv/kvserver/storeliveness",
         "//pkg/multitenant",
         "//pkg/multitenant/mtinfopb",
         "//pkg/multitenant/multitenantcpu",

--- a/pkg/testutils/localtestcluster/BUILD.bazel
+++ b/pkg/testutils/localtestcluster/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/kv/kvserver/closedts/sidetransport",
         "//pkg/kv/kvserver/kvstorage",
         "//pkg/kv/kvserver/liveness",
+        "//pkg/kv/kvserver/storeliveness",
         "//pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer",
         "//pkg/roachpb",
         "//pkg/rpc",


### PR DESCRIPTION
This commit initializes the Store Liveness `Transport` upon starting the server, initializes the Store Liveness `SupportManager`, and sets up the store's `SupportManager` as a message handler in the node's `Transport`.

The `SupportManager` does not start heartbeating other stores until support from them is requested via `SupportFrom`.

Fixes: #125064

Release note: None