### PR TITLE
logical: Improve shutdown logic in resiliency roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/logical_data_replication.go
+++ b/pkg/cmd/roachtest/tests/logical_data_replication.go
@@ -176,7 +176,7 @@ func TestLDRBasic(ctx context.Context, t test.Test, c cluster.Cluster, setup mul
 		tableName: "kv",
 	}
 
-	leftJobID, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload)
+	leftJobID, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload, true)
 
 	// Setup latency verifiers
 	maxExpectedLatency := 2 * time.Minute
@@ -240,7 +240,7 @@ func TestLDRUpdateHeavy(
 		tableName: "usertable",
 	}
 
-	leftJobID, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload)
+	leftJobID, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload, true)
 
 	// Setup latency verifiers
 	maxExpectedLatency := 3 * time.Minute
@@ -304,7 +304,16 @@ func TestLDROnNodeShutdown(
 		tableName: "kv",
 	}
 
-	leftJobID, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload)
+	var (
+		leftJobID, rightJobID int
+	)
+
+	rng, _ := randutil.NewPseudoRand()
+	if rng.Intn(2) == 0 {
+		leftJobID, rightJobID = setupLDR(ctx, t, c, setup, ldrWorkload, true)
+	} else {
+		leftJobID, rightJobID = setupLDR(ctx, t, c, setup, ldrWorkload, false)
+	}
 
 	// Setup latency verifiers, remembering to account for latency spike from killing a node
 	maxExpectedLatency := 5 * time.Minute
@@ -315,6 +324,37 @@ func TestLDROnNodeShutdown(
 	rlv := makeLatencyVerifier("ldr-right", 0, maxExpectedLatency, t.L(),
 		getLogicalDataReplicationJobInfo, t.Status, false /* tolerateErrors */)
 	defer rlv.maybeLogLatencyHist()
+
+	findNewConn := func(nodes option.NodeListOption, avoidNode int) (*gosql.DB, *sqlutils.SQLRunner) {
+		for {
+			anotherNode := nodes.SeededRandNode(setup.rng)[0]
+			if anotherNode != avoidNode {
+				db := c.Conn(ctx, t.L(), anotherNode)
+				sqlRunner := sqlutils.MakeSQLRunner(db)
+				return db, sqlRunner
+			}
+		}
+	}
+
+	t.L().Printf("Finding node to stop Left")
+	nodeToStopL := setup.left.nodes.SeededRandNode(setup.rng)[0]
+	t.L().Printf("Finding node to stop right")
+	nodeToStopR := setup.right.nodes.SeededRandNode(setup.rng)[0]
+
+	// Shutting down the gateway node will cause the latency verifier to fail unless a new SQL DB
+	// connection is provided, so find another node and get a connection to it. Cleanup will handle
+	// the old connection
+	if nodeToStopL == setup.left.gatewayNodes[0] {
+		newDB, newRunners := findNewConn(setup.left.nodes, nodeToStopL)
+		setup.left.db, setup.left.sysSQL = newDB, newRunners
+		defer newDB.Close()
+	}
+
+	if nodeToStopR == setup.right.gatewayNodes[0] {
+		newDB, newRunners := findNewConn(setup.right.nodes, nodeToStopR)
+		setup.right.db, setup.right.sysSQL = newDB, newRunners
+		defer newDB.Close()
+	}
 
 	workloadDoneCh := make(chan struct{})
 	debugZipFetcher := &sync.Once{}
@@ -340,35 +380,33 @@ func TestLDROnNodeShutdown(
 		return c.RunE(ctx, option.WithNodes(setup.workloadNode), ldrWorkload.workload.sourceRunCmd("system", setup.CRDBNodes()))
 	})
 
-	// Let workload run for a bit before we kill a node
-	time.Sleep(ldrWorkload.workload.(replicateKV).debugRunDuration / 10)
+	// Pick a random amount of minutes to wait before resuming
+	minutes := rand.Intn(int(ldrWorkload.workload.(replicateKV).debugRunDuration.Minutes()))
+	sleepDuration := time.Duration(minutes) * time.Minute
+	t.L().Printf("Sleeping for %d minutes", minutes)
+	time.Sleep(sleepDuration)
 
-	findNodeToStop := func(info *clusterInfo, rng *rand.Rand) int {
-		for {
-			anotherNode := info.nodes.SeededRandNode(rng)[0]
-			if anotherNode != info.gatewayNodes[0] {
-				return anotherNode
-			}
+	getStopOpts := func() option.StopOpts {
+		if rng.Intn(2) == 0 {
+			// Graceful stop
+			return option.NewStopOpts(option.Graceful(shutdownGracePeriod))
 		}
+		// Standard SIGKILL
+		return option.DefaultStopOpts()
 	}
 
-	t.L().Printf("Finding node to stop Left")
-	nodeToStopL := findNodeToStop(setup.left, setup.rng)
-	t.L().Printf("Finding node to stop right")
-	nodeToStopR := findNodeToStop(setup.right, setup.rng)
-
-	// Graceful shutdown on both nodes
-	// TODO(naveen.setlur): maybe switch this to a less graceful shutdown via SIGKILL
-	stopOpts := option.NewStopOpts(option.Graceful(shutdownGracePeriod))
 	t.L().Printf("Shutting down node-left: %d", nodeToStopL)
 	monitor.ExpectDeath()
-	if err := c.StopE(ctx, t.L(), stopOpts, c.Node(nodeToStopL)); err != nil {
+	if err := c.StopE(ctx, t.L(), getStopOpts(), c.Node(nodeToStopL)); err != nil {
 		t.Fatalf("Unable to shutdown node: %s", err)
 	}
 
+	// Sleep to stagger shutdown
+	time.Sleep(ldrWorkload.workload.(replicateKV).debugRunDuration / 20)
+
 	t.L().Printf("Shutting down node-right: %d", nodeToStopR)
 	monitor.ExpectDeath()
-	if err := c.StopE(ctx, t.L(), stopOpts, c.Node(nodeToStopR)); err != nil {
+	if err := c.StopE(ctx, t.L(), getStopOpts(), c.Node(nodeToStopR)); err != nil {
 		t.Fatalf("Unable to shutdown node: %s", err)
 	}
 
@@ -399,7 +437,7 @@ func TestLDROnNetworkPartition(
 		tableName: "kv",
 	}
 
-	leftJobID, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload)
+	leftJobID, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload, true)
 
 	monitor := c.NewMonitor(ctx, setup.CRDBNodes())
 	monitor.Go(func(ctx context.Context) error {
@@ -578,6 +616,7 @@ func setupLDR(
 	c cluster.Cluster,
 	setup multiClusterSetup,
 	ldrWorkload LDRWorkload,
+	waitForInitialScan bool,
 ) (int, int) {
 	c.Run(ctx,
 		option.WithNodes(setup.workloadNode),
@@ -607,12 +646,15 @@ func setupLDR(
 	leftJobID := startLDR(setup.left.sysSQL, setup.right.PgURLForDatabase(dbName))
 	rightJobID := startLDR(setup.right.sysSQL, setup.left.PgURLForDatabase(dbName))
 
-	// TODO(ssd): We wait for the replicated time to
-	// avoid starting the workload here until we
-	// have the behaviour around initial scans
-	// sorted out.
-	waitForReplicatedTime(t, leftJobID, setup.left.db, getLogicalDataReplicationJobInfo, 2*time.Minute)
-	waitForReplicatedTime(t, rightJobID, setup.right.db, getLogicalDataReplicationJobInfo, 2*time.Minute)
+	if waitForInitialScan {
+		// TODO(ssd): We wait for the replicated time to
+		// avoid starting the workload here until we
+		// have the behaviour around initial scans
+		// sorted out.
+		t.L().Printf("Waiting for initial scan to complete")
+		waitForReplicatedTime(t, leftJobID, setup.left.db, getLogicalDataReplicationJobInfo, 2*time.Minute)
+		waitForReplicatedTime(t, rightJobID, setup.right.db, getLogicalDataReplicationJobInfo, 2*time.Minute)
+	}
 
 	t.L().Printf("LDR Setup complete")
 	return leftJobID, rightJobID


### PR DESCRIPTION
Previously this roachtest avoided shutting down the coordinator as that would kill the LDR
ingestion job. With new changes that store client addresses in the job progress, this
restriction is no longer needed. The node will now also be sometimes killed by SIGKILL
rather than gracefully and shutdowns are staggered

Epic: none
Release note: none