### PR TITLE
roachtest: randomize gce default zones using cluster name

### DIFF
--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -261,6 +261,8 @@ func getGCEOpts(
 	}
 	if len(zones) != 0 {
 		opts.Zones = zones
+	} else {
+		opts.UseSameDefaultZonesOrdering = true
 	}
 	opts.SSDCount = localSSDCount
 	if localSSD && localSSDCount > 0 {


### PR DESCRIPTION
Previously we randomized the default zones for gce when unspecified to avoid zone exhaustion errors. However, this ran into an issue with workload nodes which are created seperately from the main cluster, as a different default zone would return for each.

This change adds the ability to randomize the default zones based off of the cluster name. This ensures that the same ordering is returned for both the workload node and CRDB cluster.

Fixes: #129997
Release note: none
Epic: none