### PR TITLE
server: add `StoreIDs` to SpanStats response

### DIFF
--- a/pkg/roachpb/span_stats.proto
+++ b/pkg/roachpb/span_stats.proto
@@ -70,7 +70,11 @@ message SpanStats {
   // stale.
   cockroach.storage.enginepb.MVCCStats approximate_total_stats = 7 [(gogoproto.nullable) = false];
 
-  // NEXT ID: 8.
+
+  // Unique store ids for the requested span.
+  repeated int32 store_ids = 8 [(gogoproto.customname) = "StoreIDs", (gogoproto.casttype) = "StoreID"];
+
+  // NEXT ID: 9.
 }
 
 message SpanStatsResponse {


### PR DESCRIPTION
This commit adds a new response field to the
SpanStats rpc, `StoreIDs` which is a list of
unique store ids in ascending order that store
the requested span.

Fixes: https://github.com/cockroachdb/cockroach/issues/129060
Release note: None