### PR TITLE
rac2: log blocked replication stream

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
+        "@com_github_dustin_go_humanize//:go-humanize",
     ],
 )
 
@@ -39,6 +40,7 @@ go_test(
         "log_tracker_test.go",
         "priority_test.go",
         "range_controller_test.go",
+        "store_stream_test.go",
         "token_counter_test.go",
         "token_tracker_test.go",
     ],
@@ -62,6 +64,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/protoutil",
         "//pkg/util/syncutil",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_stretchr_testify//require",

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream.go
@@ -12,12 +12,18 @@ package rac2
 
 import (
 	"context"
+	"fmt"
+	"strings"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/redact"
+	"github.com/dustin/go-humanize"
 )
 
 // StreamTokenCounterProvider is the interface for retrieving token counters
@@ -28,6 +34,7 @@ type StreamTokenCounterProvider struct {
 	settings                   *cluster.Settings
 	clock                      *hlc.Clock
 	tokenMetrics               *tokenMetrics
+	sendLogger, evalLogger     *blockedStreamLogger
 	sendCounters, evalCounters syncutil.Map[kvflowcontrol.Stream, tokenCounter]
 }
 
@@ -39,6 +46,8 @@ func NewStreamTokenCounterProvider(
 		settings:     settings,
 		clock:        clock,
 		tokenMetrics: newTokenMetrics(),
+		sendLogger:   newBlockedStreamLogger(flowControlSendMetricType),
+		evalLogger:   newBlockedStreamLogger(flowControlEvalMetricType),
 	}
 }
 
@@ -62,7 +71,7 @@ func (p *StreamTokenCounterProvider) Send(stream kvflowcontrol.Stream) *tokenCou
 	return t
 }
 
-// UpdateMetricGauges updates the gauge token metrics.
+// UpdateMetricGauges updates the gauge token metrics and logs blocked streams.
 func (p *StreamTokenCounterProvider) UpdateMetricGauges() {
 	var (
 		count           [numFlowControlMetricTypes][admissionpb.NumWorkClasses]int64
@@ -77,18 +86,20 @@ func (p *StreamTokenCounterProvider) UpdateMetricGauges() {
 	gaugeUpdateFn := func(metricType flowControlMetricType) func(
 		kvflowcontrol.Stream, *tokenCounter) bool {
 		return func(stream kvflowcontrol.Stream, t *tokenCounter) bool {
+			regularTokens := t.tokens(admissionpb.RegularWorkClass)
+			elasticTokens := t.tokens(admissionpb.ElasticWorkClass)
 			count[metricType][regular]++
 			count[metricType][elastic]++
-			tokensAvailable[metricType][regular] += int64(t.tokens(regular))
-			tokensAvailable[metricType][elastic] += int64(t.tokens(elastic))
+			tokensAvailable[metricType][regular] += int64(regularTokens)
+			tokensAvailable[metricType][elastic] += int64(elasticTokens)
 
-			regularStats, elasticStats := t.GetAndResetStats(now)
-			if regularStats.noTokenDuration > 0 {
+			if regularTokens <= 0 {
 				blockedCount[metricType][regular]++
 			}
-			if elasticStats.noTokenDuration > 0 {
+			if elasticTokens <= 0 {
 				blockedCount[metricType][elastic]++
 			}
+
 			return true
 		}
 	}
@@ -108,6 +119,154 @@ func (p *StreamTokenCounterProvider) UpdateMetricGauges() {
 			p.tokenMetrics.streamMetrics[typ].tokensAvailable[wc].Update(tokensAvailable[typ][wc])
 		}
 	}
+
+	// Next, check if any of the blocked stream loggers are ready to log, if so
+	// we iterate over every (token|send) stream and observe the stream state.
+	// When vmodule=2, the logger is always ready.
+	logStreamFn := func(logger *blockedStreamLogger) func(
+		stream kvflowcontrol.Stream, t *tokenCounter) bool {
+		return func(stream kvflowcontrol.Stream, t *tokenCounter) bool {
+			// NB: We reset each stream's stats here. The stat returned will be the
+			// delta between the last stream observation and now.
+			regularStats, elasticStats := t.GetAndResetStats(now)
+			logger.observeStream(stream, now,
+				t.tokens(regular), t.tokens(elastic), regularStats, elasticStats)
+			return true
+		}
+	}
+	if p.evalLogger.willLog() {
+		p.evalCounters.Range(logStreamFn(p.evalLogger))
+		p.evalLogger.flushLogs()
+	}
+	if p.sendLogger.willLog() {
+		p.sendCounters.Range(logStreamFn(p.sendLogger))
+		p.sendLogger.flushLogs()
+	}
+}
+
+// TODO(kvoli): Consider adjusting these limits and making them configurable.
+const (
+	// streamStatsCountCap is the maximum number of streams to log verbose stats
+	// for. Streams are only logged if they were blocked at some point in the
+	// last metrics interval.
+	streamStatsCountCap = 20
+	// blockedStreamCountCap is the maximum number of streams to log (compactly)
+	// as currently blocked.
+	blockedStreamCountCap = 100
+	// blockedStreamLoggingInterval is the interval at which blocked streams are
+	// logged. This interval applies independently to both eval and send streams
+	// i.e., we log both eval and send streams at this interval, independent of
+	// each other.
+	blockedStreamLoggingInterval = 30 * time.Second
+)
+
+type blockedStreamLogger struct {
+	metricType flowControlMetricType
+	limiter    log.EveryN
+	// blockedCount is the total number of unique streams blocked in the last
+	// interval, regardless of the work class e.g., if 5 streams exist and all
+	// are blocked for both elastic and regular work classes, the counts would
+	// be:
+	//   blockedRegularCount=5
+	//   blockedElasticCount=5
+	//   blockedCount=5
+	blockedCount        int
+	blockedElasticCount int
+	blockedRegularCount int
+	elaBuf, regBuf      strings.Builder
+}
+
+func newBlockedStreamLogger(metricType flowControlMetricType) *blockedStreamLogger {
+	return &blockedStreamLogger{
+		metricType: metricType,
+		limiter:    log.Every(blockedStreamLoggingInterval),
+	}
+}
+
+func (b *blockedStreamLogger) willLog() bool {
+	return b.limiter.ShouldLog()
+}
+
+func (b *blockedStreamLogger) flushLogs() {
+	if b.blockedRegularCount > 0 {
+		log.Warningf(context.Background(), "%d blocked %s regular replication stream(s): %s",
+			b.blockedRegularCount, b.metricType, redact.SafeString(b.regBuf.String()))
+	}
+	if b.blockedElasticCount > 0 {
+		log.Warningf(context.Background(), "%d blocked %s elastic replication stream(s): %s",
+			b.blockedElasticCount, b.metricType, redact.SafeString(b.elaBuf.String()))
+	}
+	b.elaBuf.Reset()
+	b.regBuf.Reset()
+	b.blockedCount = 0
+	b.blockedRegularCount = 0
+	b.blockedElasticCount = 0
+}
+
+func (b *blockedStreamLogger) observeStream(
+	stream kvflowcontrol.Stream,
+	now time.Time,
+	regularTokens, elasticTokens kvflowcontrol.Tokens,
+	regularStats, elasticStats deltaStats,
+) {
+	// Log stats, which reflect both elastic and regular at the interval defined
+	// by blockedStreamLoggingInteval. If a high-enough log verbosity is
+	// specified, shouldLogBacked will always be true, but since this method
+	// executes at the frequency of scraping the metric, we will still log at a
+	// reasonable rate.
+	logBlockedStream := func(stream kvflowcontrol.Stream, blockedCount int, buf *strings.Builder) {
+		if blockedCount == 1 {
+			buf.WriteString(stream.String())
+		} else if blockedCount <= blockedStreamCountCap {
+			buf.WriteString(", ")
+			buf.WriteString(stream.String())
+		} else if blockedCount == blockedStreamCountCap+1 {
+			buf.WriteString(" omitted some due to overflow")
+		}
+	}
+
+	if regularTokens <= 0 {
+		b.blockedRegularCount++
+		logBlockedStream(stream, b.blockedRegularCount, &b.regBuf)
+	}
+	if elasticTokens <= 0 {
+		b.blockedElasticCount++
+		logBlockedStream(stream, b.blockedElasticCount, &b.elaBuf)
+	}
+	if regularStats.noTokenDuration == 0 && elasticStats.noTokenDuration == 0 {
+		return
+	}
+
+	b.blockedCount++
+	if b.blockedCount <= streamStatsCountCap {
+		var bb strings.Builder
+		fmt.Fprintf(&bb, "%v stream %s was blocked: durations:", b.metricType, stream.String())
+		if regularStats.noTokenDuration > 0 {
+			fmt.Fprintf(&bb, " regular %s", regularStats.noTokenDuration.String())
+		}
+		if elasticStats.noTokenDuration > 0 {
+			fmt.Fprintf(&bb, " elastic %s", elasticStats.noTokenDuration.String())
+		}
+		regularDelta := regularStats.tokensReturned - regularStats.tokensDeducted
+		elasticDelta := elasticStats.tokensReturned - elasticStats.tokensDeducted
+		fmt.Fprintf(&bb, " tokens delta: regular %s (%s - %s) elastic %s (%s - %s)",
+			pprintTokens(regularDelta),
+			pprintTokens(regularStats.tokensReturned),
+			pprintTokens(regularStats.tokensDeducted),
+			pprintTokens(elasticDelta),
+			pprintTokens(elasticStats.tokensReturned),
+			pprintTokens(elasticStats.tokensDeducted))
+		log.Infof(context.Background(), "%s", redact.SafeString(bb.String()))
+	} else if b.blockedCount == streamStatsCountCap+1 {
+		log.Infof(context.Background(), "skipped logging some streams that were blocked")
+	}
+}
+
+func pprintTokens(t kvflowcontrol.Tokens) string {
+	if t < 0 {
+		return fmt.Sprintf("-%s", humanize.IBytes(uint64(-t)))
+	}
+	return humanize.IBytes(uint64(t))
 }
 
 // SendTokenWatcherHandleID is a unique identifier for a handle that is

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream_test.go
@@ -1,0 +1,205 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rac2
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"regexp"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockedStreamLogging(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s := log.ScopeWithoutShowLogs(t)
+	// Causes every call to update the gauges to log.
+	prevVModule := log.GetVModule()
+	_ = log.SetVModule("store_stream=2")
+	defer func() { _ = log.SetVModule(prevVModule) }()
+	defer s.Close(t)
+
+	ctx := context.Background()
+	testStartTs := timeutil.Now()
+
+	makeStream := func(id uint64) kvflowcontrol.Stream {
+		return kvflowcontrol.Stream{
+			TenantID: roachpb.MustMakeTenantID(id),
+			StoreID:  roachpb.StoreID(id),
+		}
+	}
+
+	st := cluster.MakeTestingClusterSettings()
+	const numTokens = 1 << 20 /* 1 MiB */
+	kvflowcontrol.ElasticTokensPerStream.Override(ctx, &st.SV, numTokens)
+	kvflowcontrol.RegularTokensPerStream.Override(ctx, &st.SV, numTokens)
+	p := NewStreamTokenCounterProvider(st, hlc.NewClockForTesting(nil))
+
+	numBlocked := 0
+	createStreamAndExhaustTokens := func(id uint64, checkMetric bool) {
+		p.Eval(makeStream(id)).Deduct(ctx, admissionpb.RegularWorkClass, kvflowcontrol.Tokens(numTokens))
+		if checkMetric {
+			p.UpdateMetricGauges()
+			require.Equal(t, int64(numBlocked+1), p.tokenMetrics.streamMetrics[flowControlEvalMetricType].blockedCount[elastic].Value())
+			require.Equal(t, int64(numBlocked+1), p.tokenMetrics.streamMetrics[flowControlEvalMetricType].blockedCount[regular].Value())
+		}
+		numBlocked++
+	}
+	// 1 stream that is blocked.
+	id := uint64(1)
+	createStreamAndExhaustTokens(id, true)
+	// Total 24 streams are blocked.
+	for id++; id < 25; id++ {
+		createStreamAndExhaustTokens(id, false)
+	}
+	// 25th stream will also be blocked. The detailed stats will only cover an
+	// arbitrary subset of 20 streams.
+	log.Infof(ctx, "creating stream id %d", id)
+	createStreamAndExhaustTokens(id, true)
+
+	// Total 104 streams are blocked.
+	for id++; id < 105; id++ {
+		createStreamAndExhaustTokens(id, false)
+	}
+	// 105th stream will also be blocked. The blocked stream names will only
+	// list 100 streams.
+	log.Infof(ctx, "creating stream id %d", id)
+	createStreamAndExhaustTokens(id, true)
+
+	log.FlushFiles()
+	entries, err := log.FetchEntriesFromFiles(testStartTs.UnixNano(),
+		math.MaxInt64, 2000,
+		regexp.MustCompile(`store_stream\.go|store_stream_test\.go`),
+		log.WithMarkedSensitiveData)
+	require.NoError(t, err)
+
+	blockedStreamRegexp, err := regexp.Compile(
+		"eval stream .* was blocked: durations: regular .* elastic .* tokens delta: regular .* elastic .*")
+	require.NoError(t, err)
+	blockedStreamSkippedRegexp, err := regexp.Compile(
+		"skipped logging some streams that were blocked")
+	require.NoError(t, err)
+
+	const blockedCountElasticRegexp = "%d blocked eval elastic replication stream.*"
+	const blockedCountRegularRegexp = "%d blocked eval regular replication stream.*"
+	blocked1ElasticRegexp, err := regexp.Compile(fmt.Sprintf(blockedCountElasticRegexp, 1))
+	require.NoError(t, err)
+	blocked1RegularRegexp, err := regexp.Compile(fmt.Sprintf(blockedCountRegularRegexp, 1))
+	require.NoError(t, err)
+	blocked25ElasticRegexp, err := regexp.Compile(fmt.Sprintf(blockedCountElasticRegexp, 25))
+	require.NoError(t, err)
+	blocked25RegularRegexp, err := regexp.Compile(fmt.Sprintf(blockedCountRegularRegexp, 25))
+	require.NoError(t, err)
+	blocked105ElasticRegexp, err := regexp.Compile(
+		"105 blocked eval elastic replication stream.* omitted some due to overflow")
+	require.NoError(t, err)
+	blocked105RegularRegexp, err := regexp.Compile(
+		"105 blocked eval regular replication stream.* omitted some due to overflow")
+	require.NoError(t, err)
+
+	const creatingRegexp = "creating stream id %d"
+	creating25Regexp, err := regexp.Compile(fmt.Sprintf(creatingRegexp, 25))
+	require.NoError(t, err)
+	creating105Regexp, err := regexp.Compile(fmt.Sprintf(creatingRegexp, 105))
+	require.NoError(t, err)
+
+	blockedStreamCount := 0
+	foundBlockedElastic := false
+	foundBlockedRegular := false
+	foundBlockedStreamSkipped := false
+	// First section of the log where 1 stream blocked. Entries are in reverse
+	// chronological order.
+	index := len(entries) - 1
+	for ; index >= 0; index-- {
+		entry := entries[index]
+		if creating25Regexp.MatchString(entry.Message) {
+			break
+		}
+		if blockedStreamRegexp.MatchString(entry.Message) {
+			blockedStreamCount++
+		}
+		if blocked1ElasticRegexp.MatchString(entry.Message) {
+			foundBlockedElastic = true
+		}
+		if blocked1RegularRegexp.MatchString(entry.Message) {
+			foundBlockedRegular = true
+		}
+		if blockedStreamSkippedRegexp.MatchString(entry.Message) {
+			foundBlockedStreamSkipped = true
+		}
+	}
+	require.Equal(t, 1, blockedStreamCount)
+	require.True(t, foundBlockedElastic)
+	require.True(t, foundBlockedRegular)
+	require.False(t, foundBlockedStreamSkipped)
+
+	blockedStreamCount = 0
+	foundBlockedElastic = false
+	foundBlockedRegular = false
+	// Second section of the log where 25 streams are blocked and 20 are logged
+	// (streamStatsCountCap).
+	for ; index >= 0; index-- {
+		entry := entries[index]
+		if creating105Regexp.MatchString(entry.Message) {
+			break
+		}
+		if blockedStreamRegexp.MatchString(entry.Message) {
+			blockedStreamCount++
+		}
+		if blocked25ElasticRegexp.MatchString(entry.Message) {
+			foundBlockedElastic = true
+		}
+		if blocked25RegularRegexp.MatchString(entry.Message) {
+			foundBlockedRegular = true
+		}
+		if blockedStreamSkippedRegexp.MatchString(entry.Message) {
+			foundBlockedStreamSkipped = true
+		}
+	}
+	require.Equal(t, 20, blockedStreamCount)
+	require.True(t, foundBlockedElastic)
+	require.True(t, foundBlockedRegular)
+	require.True(t, foundBlockedStreamSkipped)
+
+	blockedStreamCount = 0
+	foundBlockedElastic = false
+	foundBlockedRegular = false
+	// Third section of the log where 105 streams blocked.
+	for ; index >= 0; index-- {
+		entry := entries[index]
+		if blockedStreamRegexp.MatchString(entry.Message) {
+			blockedStreamCount++
+		}
+		if blocked105ElasticRegexp.MatchString(entry.Message) {
+			foundBlockedElastic = true
+		}
+		if blocked105RegularRegexp.MatchString(entry.Message) {
+			foundBlockedRegular = true
+		}
+		if blockedStreamSkippedRegexp.MatchString(entry.Message) {
+			foundBlockedStreamSkipped = true
+		}
+	}
+	require.Equal(t, 20, blockedStreamCount)
+	require.True(t, foundBlockedElastic, "unable to find %v", blocked105ElasticRegexp)
+	require.True(t, foundBlockedRegular, "unable to find %v", blocked105RegularRegexp)
+	require.True(t, foundBlockedStreamSkipped, "unable to find %v", blockedStreamSkippedRegexp)
+}

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/token_adjustment
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/token_adjustment
@@ -63,7 +63,7 @@ kvflowcontrol.tokens.eval.regular.deducted      : 16777216
 kvflowcontrol.tokens.eval.regular.returned      : 16777216
 kvflowcontrol.tokens.eval.regular.unaccounted   : 0
 kvflowcontrol.streams.eval.elastic.total_count  : 1
-kvflowcontrol.streams.eval.elastic.blocked_count: 1
+kvflowcontrol.streams.eval.elastic.blocked_count: 0
 kvflowcontrol.tokens.eval.elastic.available     : 8388608
 kvflowcontrol.tokens.eval.elastic.deducted      : 18874368
 kvflowcontrol.tokens.eval.elastic.returned      : 18874368
@@ -120,14 +120,33 @@ history
 metrics
 ----
 kvflowcontrol.streams.eval.regular.total_count  : 2
-kvflowcontrol.streams.eval.regular.blocked_count: 1
+kvflowcontrol.streams.eval.regular.blocked_count: 0
 kvflowcontrol.tokens.eval.regular.available     : 33554432
 kvflowcontrol.tokens.eval.regular.deducted      : 40894464
 kvflowcontrol.tokens.eval.regular.returned      : 40894464
 kvflowcontrol.tokens.eval.regular.unaccounted   : 0
 kvflowcontrol.streams.eval.elastic.total_count  : 2
-kvflowcontrol.streams.eval.elastic.blocked_count: 1
+kvflowcontrol.streams.eval.elastic.blocked_count: 0
 kvflowcontrol.tokens.eval.elastic.available     : 16777216
 kvflowcontrol.tokens.eval.elastic.deducted      : 50331648
+kvflowcontrol.tokens.eval.elastic.returned      : 50331648
+kvflowcontrol.tokens.eval.elastic.unaccounted   : 0
+
+adjust
+class=regular delta=-16MiB
+----
+
+metrics
+----
+kvflowcontrol.streams.eval.regular.total_count  : 2
+kvflowcontrol.streams.eval.regular.blocked_count: 1
+kvflowcontrol.tokens.eval.regular.available     : 16777216
+kvflowcontrol.tokens.eval.regular.deducted      : 57671680
+kvflowcontrol.tokens.eval.regular.returned      : 40894464
+kvflowcontrol.tokens.eval.regular.unaccounted   : 0
+kvflowcontrol.streams.eval.elastic.total_count  : 2
+kvflowcontrol.streams.eval.elastic.blocked_count: 1
+kvflowcontrol.tokens.eval.elastic.available     : 0
+kvflowcontrol.tokens.eval.elastic.deducted      : 67108864
 kvflowcontrol.tokens.eval.elastic.returned      : 50331648
 kvflowcontrol.tokens.eval.elastic.unaccounted   : 0


### PR DESCRIPTION
When a stream has been blocked in the last metrics interval, log a
message that indicates the stream, token deltas and blocked duration,
separately for eval and send streams.

The logging is output is near identical to the v1 replication flow
control logging, also including whether the stream is for eval or send.

A sample output showing all possible log messages:

```
kv/kvserver/kvflowcontrol/rac2/store_stream.go:254 ⋮ [-] 24  eval stream t20/s20 was blocked: durations: regular 20.75µs elastic 20.75µs tokens delta: regular -1.0 MiB (0 B - 1.0 MiB) elastic -1.0 MiB (0 B - 1.0 MiB)
kv/kvserver/kvflowcontrol/rac2/store_stream.go:256 ⋮ [-] 25  skipped logging some streams that were blocked
kv/kvserver/kvflowcontrol/rac2/store_stream.go:181 ⋮ [-] 26  25 blocked eval regular replication stream(s): t14/s14, t22/s22, t1/s1, t2/s2, t3/s3, t9/s9, t13/s13, t24/s24, t25/s25, t5/s5, t10/s10, t11/s11, t18/s18, t19/s19, t23/s23, t6/s6, t7/s7, t15/s15, t17/s17, t20/s20, t4/s4, t8/s8, t12/s12, t16/s16, t21/s21
kv/kvserver/kvflowcontrol/rac2/store_stream.go:185 ⋮ [-] 27  25 blocked eval elastic replication stream(s): t14/s14, t22/s22, t1/s1, t2/s2, t3/s3, t9/s9, t13/s13, t24/s24, t25/s25, t5/s5, t10/s10, t11/s11, t18/s18, t19/s19, t23/s23, t6/s6, t7/s7, t15/s15, t17/s17, t20/s20, t4/s4, t8/s8, t12/s12, t16/s16, t21/s21
```

Resolves: https://github.com/cockroachdb/cockroach/issues/128913
Release note: None