### PR TITLE
release: update_versions: continue on other repos if one repo attempt fails

### DIFF
--- a/pkg/cmd/release/update_versions.go
+++ b/pkg/cmd/release/update_versions.go
@@ -12,6 +12,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"log"
@@ -102,6 +103,8 @@ type prRepo struct {
 	githubUsername string
 	prBranch       string
 	fn             func(gitDir string) error
+	// workOnRepoError is set to workOnRepo() result
+	workOnRepoError error
 }
 
 func (r prRepo) String() string {
@@ -282,27 +285,21 @@ func updateVersions(_ *cobra.Command, _ []string) error {
 	// This way we can fail early and avoid unnecessary work closing the PRs we were able to create.
 	log.Printf("repos to work on: %s\n", reposToWorkOn)
 	var prs []string
+	var workOnRepoErrors []error
 	for _, repo := range reposToWorkOn {
-		log.Printf("Cloning repo %s", repo.name())
-		if err := repo.clone(); err != nil {
-			return fmt.Errorf("cannot clone %s: %w", repo.name(), err)
-		}
-		log.Printf("Branching repo %s", repo.name())
-		if err := repo.checkout(); err != nil {
-			return fmt.Errorf("cannot create branch %s: %w", repo.name(), err)
-		}
-		log.Printf("Munging repo %s", repo.name())
-		if err := repo.apply(); err != nil {
-			return fmt.Errorf("cannot mutate repo %s: %w", repo.name(), err)
-		}
-		log.Printf("commiting changes to repo %s", repo.name())
-		if err := repo.commit(); err != nil {
-			return fmt.Errorf("cannot commit changes in repo %s: %w", repo.name(), err)
+		repo.workOnRepoError = workOnRepo(repo)
+		if repo.workOnRepoError != nil {
+			log.Printf("workOnRepo: error occurred while working on %s: %s", repo.name(), repo.workOnRepoError)
+			workOnRepoErrors = append(workOnRepoErrors, repo.workOnRepoError)
 		}
 	}
 
 	// Now that our local changes are staged, we can try and publish them.
 	for _, repo := range reposToWorkOn {
+		if repo.workOnRepoError != nil {
+			log.Printf("PR creation skipped due to previous errors while working on %s: %s", repo.name(), repo.workOnRepoError)
+			continue
+		}
 		dest := path.Join(globalWorkDir, repo.checkoutDir())
 		// We avoid creating duplicated PRs to allow this command to be
 		// run multiple times.
@@ -329,6 +326,9 @@ func updateVersions(_ *cobra.Command, _ []string) error {
 
 	if err := sendPrReport(releasedVersion, prs, smtpPassword); err != nil {
 		return fmt.Errorf("cannot send email: %w", err)
+	}
+	if len(workOnRepoErrors) > 0 {
+		return errors.Join(workOnRepoErrors...)
 	}
 	return nil
 }
@@ -550,6 +550,27 @@ func generateRepoList(
 		reposToWorkOn = append(reposToWorkOn, repo)
 	}
 	return reposToWorkOn, nil
+}
+
+func workOnRepo(repo prRepo) error {
+	log.Printf("Cloning repo %s", repo.name())
+	if err := repo.clone(); err != nil {
+		return fmt.Errorf("cannot clone %s: %w", repo.name(), err)
+	}
+	log.Printf("Branching repo %s", repo.name())
+	if err := repo.checkout(); err != nil {
+		return fmt.Errorf("cannot create branch %s: %w", repo.name(), err)
+	}
+	log.Printf("Munging repo %s", repo.name())
+	if err := repo.apply(); err != nil {
+		return fmt.Errorf("cannot mutate repo %s: %w", repo.name(), err)
+	}
+	log.Printf("commiting changes to repo %s", repo.name())
+	if err := repo.commit(); err != nil {
+		return fmt.Errorf("cannot commit changes in repo %s: %w", repo.name(), err)
+	}
+
+	return nil
 }
 
 func isLatestStableBranch(version *semver.Version) (bool, error) {


### PR DESCRIPTION
In "Create version update PRs" for v24.1.4", the whole TC job fails if "work on repo X" fails for any repo.

This PR continues to work on the other repos, should any one repo fail.

Release note: None
Epic: None
Release justification: release-infra only change.