### PR TITLE
release-24.1: roachtest: delay verification of disagg-rebalance condition

### DIFF
--- a/pkg/cmd/roachtest/tests/disagg_rebalance.go
+++ b/pkg/cmd/roachtest/tests/disagg_rebalance.go
@@ -136,26 +136,29 @@ func registerDisaggRebalance(r registry.Registry) {
 				t.Fatalf("did not replicate to n4 quickly enough, only found %d replicas", count)
 			}
 
-			var bytesInRanges int64
-			if err := db.QueryRow(
-				"SELECT sum(used) "+
-					"FROM crdb_internal.kv_store_status WHERE node_id = $1 GROUP BY node_id LIMIT 1",
-				4,
-			).Scan(&bytesInRanges); err != nil {
-				t.Fatal(err)
-			}
-			var bytesSnapshotted int64
-			if err := db.QueryRow(
-				"SELECT metrics['range.snapshots.rcvd-bytes']::INT FROM crdb_internal.kv_store_status WHERE node_id = $1 LIMIT 1",
-				4,
-			).Scan(&bytesSnapshotted); err != nil {
-				t.Fatal(err)
-			}
+			testutils.SucceedsWithin(t, func() error {
+				var bytesInRanges int64
+				if err := db.QueryRow(
+					"SELECT sum(used) "+
+						"FROM crdb_internal.kv_store_status WHERE node_id = $1 GROUP BY node_id LIMIT 1",
+					4,
+				).Scan(&bytesInRanges); err != nil {
+					t.Fatal(err)
+				}
+				var bytesSnapshotted int64
+				if err := db.QueryRow(
+					"SELECT metrics['range.snapshots.rcvd-bytes']::INT FROM crdb_internal.kv_store_status WHERE node_id = $1 LIMIT 1",
+					4,
+				).Scan(&bytesSnapshotted); err != nil {
+					t.Fatal(err)
+				}
 
-			t.L().PrintfCtx(ctx, "got snapshot received bytes = %s, logical bytes in ranges = %s", humanize.IBytes(uint64(bytesSnapshotted)), humanize.IBytes(uint64(bytesInRanges)))
-			if bytesSnapshotted > bytesInRanges {
-				t.Fatalf("unexpected snapshot received bytes %d > bytes in all replicas on n4 %d, did not do a disaggregated rebalance?", bytesSnapshotted, bytesInRanges)
-			}
+				t.L().PrintfCtx(ctx, "got snapshot received bytes = %s, logical bytes in ranges = %s", humanize.IBytes(uint64(bytesSnapshotted)), humanize.IBytes(uint64(bytesInRanges)))
+				if bytesSnapshotted > bytesInRanges {
+					return errors.Errorf("unexpected snapshot received bytes %d > bytes in all replicas on n4 %d, did not do a disaggregated rebalance?", bytesSnapshotted, bytesInRanges)
+				}
+				return nil
+			}, 5*time.Minute)
 
 			t.Status("continue tpcc")
 


### PR DESCRIPTION
Backport 1/1 commits from #129882.

/cc @cockroachdb/release

Fixes #130068.

Release justification: Test-only change.

---

Previously, the disagg-rebalance roachtest can flake if the livebytes metric has not been updated with stats post snapshot application. This change throws this verification step behind a testutils.SucceedsWithin so we wait for an update for the number of bytes in a range, to be able to accurately determine if we did a fast rebalance or not.

Epic: none
Fixes: #128528

Release note: None
