### PR TITLE
server: periodically nudge decommissioning repls behind setting

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -508,7 +508,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	stores := kvserver.NewStores(cfg.AmbientCtx, clock)
 
 	decomNodeMap := &decommissioningNodeMap{
-		nodes: make(map[roachpb.NodeID]interface{}),
+		stopper: stopper,
+		sv:      &st.SV,
+		nodes:   make(map[roachpb.NodeID]DecommissioningNodeInfo),
 	}
 	nodeLiveness := liveness.NewNodeLiveness(liveness.NodeLivenessOptions{
 		AmbientCtx:              cfg.AmbientCtx,

--- a/pkg/server/storage_api/BUILD.bazel
+++ b/pkg/server/storage_api/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "//pkg/server/serverpb",
         "//pkg/server/srvtestutils",
         "//pkg/server/status/statuspb",
+        "//pkg/settings/cluster",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",


### PR DESCRIPTION
When `server.decommissioning.periodic_nudge_interval` is set to a non-zero value, each node will periodically nudge the ranges with a decommissioning replica the node holds a lease for.

When there are no ranges remaining on the decommissioning node, which are leased on a node, the nudger will stop.

Resolves: #130085
Release note: None