### PR TITLE
release-24.1: roachprod: add ZFS option for AWS

### DIFF
--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1472,9 +1472,11 @@ func Create(
 	for _, o := range opts {
 		if o.CreateOpts.SSDOpts.FileSystem == vm.Zfs {
 			for _, provider := range o.CreateOpts.VMProviders {
-				if provider != gce.ProviderName {
+				// TODO(DarrylWong): support zfs on other providers, see: #123775.
+				// Once done, revisit all tests that set zfs to see if they can run on non GCE.
+				if !(provider == gce.ProviderName || provider == aws.ProviderName) {
 					return fmt.Errorf(
-						"creating a node with --filesystem=zfs is currently only supported on gce",
+						"creating a node with --filesystem=zfs is currently not supported in %q", provider,
 					)
 				}
 			}

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -1184,7 +1184,7 @@ func (p *Provider) runInstance(
 			extraMountOpts = "nobarrier"
 		}
 	}
-	filename, err := writeStartupScript(name, extraMountOpts, providerOpts.UseMultipleDisks, opts.Arch == string(vm.ArchFIPS))
+	filename, err := writeStartupScript(name, extraMountOpts, opts.SSDOpts.FileSystem, providerOpts.UseMultipleDisks, opts.Arch == string(vm.ArchFIPS))
 	if err != nil {
 		return errors.Wrapf(err, "could not write AWS startup script to temp file")
 	}

--- a/pkg/roachprod/vm/aws/support.go
+++ b/pkg/roachprod/vm/aws/support.go
@@ -45,8 +45,10 @@ fi
 sudo apt-get update
 sudo apt-get install -qy --no-install-recommends mdadm
 
-mount_opts="defaults"
+{{ if not .Zfs }}
+mount_opts="defaults,nofail"
 {{if .ExtraMountOpts}}mount_opts="${mount_opts},{{.ExtraMountOpts}}"{{end}}
+{{ end }}
 
 use_multiple_disks='{{if .UseMultipleDisks}}true{{end}}'
 
@@ -66,11 +68,22 @@ mount_prefix="/mnt/data"
 local_disks=()
 ebs_volumes=()
 
+{{ if .Zfs }}
+	apt-get update -q
+	apt-get install -yq zfsutils-linux
+{{ end }}
+
 # On different machine types, the drives are either called nvme... or xvdd.
 for d in $(ls /dev/nvme?n1 /dev/xvdd); do
-  if ! mount | grep ${d}; then
-		if udevadm info --query=property --name=${d} | grep "ID_MODEL=Amazon Elastic Block Store"; then
-			echo "EBS Volume ${d} identified!"
+{{ if .Zfs }}
+  # Check if the disk is already part of a zpool or mounted; skip if so.
+  (zpool list -v -P | grep ${d} > /dev/null) || (mount | grep ${d} > /dev/null)
+{{ else }}
+  # Skip already mounted disks.
+  mount | grep ${d} > /dev/null
+{{ end }}
+  if [ $? -ne 0 ]; then
+		if udevadm info --query=property --name=${d} | grep "ID_MODEL=Amazon Elastic Block Store">/dev/null; then
 			ebs_volumes+=("${d}")
 		else
 			local_disks+=("${d}")
@@ -84,8 +97,10 @@ done
 # use only EBS volumes if available and ignore EC2 NVMe Instance Storage
 disks=()
 if [ "${#ebs_volumes[@]}" -gt "0" ]; then
+  echo "Using only EBS disks: ${ebs_volumes[@]}"
 	disks=("${ebs_volumes[@]}")
 else
+	echo "Using only local disks: ${local_disks[@]}"
 	disks=("${local_disks[@]}")
 fi
 
@@ -102,28 +117,41 @@ elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
     disknum=$((disknum + 1 ))
     echo "Mounting ${disk} at ${mountpoint}"
     mkdir -p ${mountpoint}
+{{ if .Zfs }}
+    zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disk}
+    # NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+{{ else }}
     mkfs.ext4 -F ${disk}
     mount -o ${mount_opts} ${disk} ${mountpoint}
-    chmod 777 ${mountpoint}
     echo "${disk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
     tune2fs -m 0 ${disk}
+{{ end }}
+    chmod 777 ${mountpoint}
   done
 else
   mountpoint="${mount_prefix}1"
   echo "${#disks[@]} disks mounted, creating ${mountpoint} using RAID 0"
   mkdir -p ${mountpoint}
+{{ if .Zfs }}
+  zpool create -f $(basename $mountpoint) -m ${mountpoint} ${disks[@]}
+  # NOTE: we don't need an /etc/fstab entry for ZFS. It will handle this itself.
+{{ else }}
   raiddisk="/dev/md0"
   mdadm --create ${raiddisk} --level=0 --raid-devices=${#disks[@]} "${disks[@]}"
   mkfs.ext4 -F ${raiddisk}
   mount -o ${mount_opts} ${raiddisk} ${mountpoint}
-  chmod 777 ${mountpoint}
   echo "${raiddisk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
   tune2fs -m 0 ${raiddisk}
+{{ end }}
+  chmod 777 ${mountpoint}
 fi
 
 # Print the block device and FS usage output. This is useful for debugging.
 lsblk
 df -h
+{{ if .Zfs }}
+zpool list
+{{ end }}
 
 sudo apt-get install -qy chrony
 
@@ -218,12 +246,13 @@ sudo touch {{ .DisksInitializedFile }}
 // extraMountOpts, if not empty, is appended to the default mount options. It is
 // a comma-separated list of options for the "mount -o" flag.
 func writeStartupScript(
-	name string, extraMountOpts string, useMultiple bool, enableFips bool,
+	name string, extraMountOpts string, fileSystem string, useMultiple bool, enableFips bool,
 ) (string, error) {
 	type tmplParams struct {
 		VMName               string
 		ExtraMountOpts       string
 		UseMultipleDisks     bool
+		Zfs                  bool
 		EnableFIPS           bool
 		DisksInitializedFile string
 	}
@@ -232,6 +261,7 @@ func writeStartupScript(
 		VMName:               name,
 		ExtraMountOpts:       extraMountOpts,
 		UseMultipleDisks:     useMultiple,
+		Zfs:                  fileSystem == vm.Zfs,
 		EnableFIPS:           enableFips,
 		DisksInitializedFile: vm.DisksInitializedFile,
 	}

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -54,24 +54,10 @@ function setup_disks() {
 	{{ end }}
 	
 	use_multiple_disks='{{if .UseMultipleDisks}}true{{end}}'
-	
-	disks=()
+
 	mount_prefix="/mnt/data"
-	
-	{{ if .Zfs }}
-	apt-get update -q
-	apt-get install -yq zfsutils-linux
-	
-	# For zfs, we use the device names under /dev instead of the device
-	# links under /dev/disk/by-id/google-local* for local ssds, because
-	# there is an issue where the links for the zfs partitions which are
-	# created under /dev/disk/by-id/ when we run "zpool create ..." are
-	# inaccurate.
-	for d in $(ls /dev/nvme?n? /dev/disk/by-id/google-persistent-disk-[1-9]); do
-		zpool list -v -P | grep ${d} > /dev/null
-		if [ $? -ne 0 ]; then
-	{{ else }}
-	# if the use_multiple_disks is not set and there are more than 1 disk (excluding the boot disk),
+
+  # if the use_multiple_disks is not set and there are more than 1 disk (excluding the boot disk),
 	# then the disks will be selected for RAID'ing. If there are both Local SSDs and Persistent disks,
 	# RAID'ing in this case can cause performance differences. So, to avoid this, local SSDs are ignored.
 	# Scenarios:
@@ -80,24 +66,40 @@ function setup_disks() {
 	#   (local SSD >= 1, Persistent Disk = 1) - no RAID'ing and Persistent Disk mounted
 	#   (local SSD > 1, Persistent Disk = 0) - local SSDs selected for RAID'ing
 	#   (local SSD >= 0, Persistent Disk > 1) - network disks selected for RAID'ing
-	disk_list=()
-	if [ "$(ls /dev/disk/by-id/google-persistent-disk-[1-9]|wc -l)" -eq "0" ]; then
-		disk_list=$(ls /dev/disk/by-id/google-local-*)
+  local_or_persistent=()
+	disks=()
+
+	{{ if .Zfs }}
+	apt-get update -q
+	apt-get install -yq zfsutils-linux
+  {{ end }}
+
+  # N.B. we assume 0th disk is the boot disk.
+  if [ "$(ls /dev/disk/by-id/google-persistent-disk-[1-9]|wc -l)" -gt "0" ]; then
+    local_or_persistent=$(ls /dev/disk/by-id/google-persistent-disk-[1-9])
+    echo "Using only persistent disks: ${local_or_persistent[@]}"
 	else
-		echo "Only persistent disks are selected."
-		disk_list=$(ls /dev/disk/by-id/google-persistent-disk-[1-9])
+    local_or_persistent=$(ls /dev/disk/by-id/google-local-*)
+    echo "Using only local disks: ${local_or_persistent[@]}"
 	fi
-	for d in ${disk_list}; do
-		if ! mount | grep ${d}; then
-	{{ end }}
+
+	for l in ${local_or_persistent}; do
+  d=$(readlink -f $l)
+  {{ if .Zfs }}
+    # Check if the disk is already part of a zpool or mounted; skip if so.
+    (zpool list -v -P | grep ${d} > /dev/null) || (mount | grep ${d} > /dev/null)
+  {{ else }}
+    # Skip already mounted disks.
+    mount | grep ${d} > /dev/null
+  {{ end }}
+		if [ $? -ne 0 ]; then
 			disks+=("${d}")
 			echo "Disk ${d} not mounted, need to mount..."
 		else
 			echo "Disk ${d} already mounted, skipping..."
 		fi
 	done
-	
-	
+
 	if [ "${#disks[@]}" -eq "0" ]; then
 		mountpoint="${mount_prefix}1"
 		echo "No disks mounted, creating ${mountpoint}"


### PR DESCRIPTION
Backport 1/1 commits from #125175.

/cc @cockroachdb/release

---

Previously, onle GCE clusters supports ZFS. This PR
adds support for AWS. We also refactor GCE and AWS
startup scripts to make them closely resemble,
leaving the only diff wrt how local and persistent
drives are discovered.

Epic: none
Informs: #123775
Fixes: #129919

Release note: None
Release justification: test-only change