### PR TITLE
release-24.1: roachtest: don't run SQL against the draining node

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -551,9 +551,10 @@ func registerKVGracefulDraining(r registry.Registry) {
 			workloadStartTime := timeutil.Now()
 			desiredRunDuration := 5 * time.Minute
 			m.Go(func(ctx context.Context) error {
+				// Don't connect to the node we are going to shut down.
 				cmd := fmt.Sprintf(
 					"./cockroach workload run kv --duration=%s --read-percent=0 --concurrency=100 --max-rate=%d {pgurl%s}",
-					desiredRunDuration, specifiedQPS, c.CRDBNodes())
+					desiredRunDuration, specifiedQPS, c.Range(1, nodes-1))
 				t.WorkerStatus(cmd)
 				defer func() {
 					t.WorkerStatus("workload command completed")

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -551,9 +551,10 @@ func registerKVGracefulDraining(r registry.Registry) {
 			workloadStartTime := timeutil.Now()
 			desiredRunDuration := 5 * time.Minute
 			m.Go(func(ctx context.Context) error {
+				// TODO(baptist): Remove --tolerate-errors once #129427 is addressed.
 				// Don't connect to the node we are going to shut down.
 				cmd := fmt.Sprintf(
-					"./cockroach workload run kv --duration=%s --read-percent=0 --concurrency=100 --max-rate=%d {pgurl%s}",
+					"./cockroach workload run kv --tolerate-errors --duration=%s --read-percent=0 --concurrency=100 --max-rate=%d {pgurl%s}",
 					desiredRunDuration, specifiedQPS, c.Range(1, nodes-1))
 				t.WorkerStatus(cmd)
 				defer func() {


### PR DESCRIPTION
Backport 1/4 commits from #129416.

/cc @cockroachdb/release

---

After #126506 the test incorrectly included the draining node as part of the nodes the workload were run against. This caused the statistics to be off by a factor of 5/6.

Note there is a separate issue related to the QPS dropping as part of the drain which is a different issue that is masked by this issue.

Epic: none

Fixes: #129027
Fixes: #128439
Fixes: #128168
Fixes: #126986
Fixes: #125731

Release note: None

Release Justification: This is a test only change to fix a failing roachtest.
