### PR TITLE
storeliveness: SupportManager improvements and bug fixes

### DIFF
--- a/pkg/kv/kvserver/storeliveness/requester_state.go
+++ b/pkg/kv/kvserver/storeliveness/requester_state.go
@@ -358,8 +358,10 @@ func (rsfu *requesterStateForUpdate) handleHeartbeatResponse(msg *slpb.Message) 
 	from := msg.From
 	meta := rsfu.getMeta()
 	ss, ok := rsfu.getSupportFrom(from)
+	// If the store is not present in the map, ignore the heartbeat response;
+	// it is likely an old heartbeat response before the local store restarted.
 	if !ok {
-		ss = slpb.SupportState{Target: from}
+		return
 	}
 	metaNew, ssNew := handleHeartbeatResponse(meta, ss, msg)
 	if meta != metaNew {

--- a/pkg/kv/kvserver/storeliveness/requester_state.go
+++ b/pkg/kv/kvserver/storeliveness/requester_state.go
@@ -44,10 +44,28 @@ type requestedSupport struct {
 	// not updated as part of the support state and meta process; it updated in
 	// SupportFrom, so it's important that updating recentlyQueried doesn't lock
 	// requesterStateHandler.mu for writing. However, updating recentlyQueried
-	// needs to lock requesterStateHandler.mu for reading to ensure that the
-	// given store is not removed from the supportFrom map.
-	recentlyQueried atomic.Bool
+	// needs to lock requesterStateHandler.mu for reading to ensure that no new
+	// stores are added to the supportFrom map.
+	recentlyQueried atomic.Int32
 }
+
+// recentlyQueried transitions between three possible values to make sure stores
+// are not marked as idle prematurely. A store transitions from active to
+// inactive every IdleSupportFromInterval and back to active upon being queried
+// in a SupportFrom call. If another IdleSupportFromInterval expires after a
+// store was marked as inactive, it will be marked as idle and will not be sent
+// heartbeats until it transitions to active again.
+const (
+	// active indicates that the store has been queried in a SupportFrom call
+	// recently (within IdleSupportFromInterval).
+	active int32 = iota
+	// inactive indicates that the store has NOT been queried in a SupportFrom
+	// call recently (within IdleSupportFromInterval).
+	inactive
+	// idle indicates that it has been even longer since the store was queried
+	// in a SupportFrom (more than IdleSupportFromInterval).
+	idle
+)
 
 // requesterStateHandler is the main interface for handling support from other
 // stores. The typical interactions with requesterStateHandler are:
@@ -128,7 +146,7 @@ func (rsh *requesterStateHandler) getSupportFrom(id slpb.StoreIdent) (slpb.Suppo
 	if ok {
 		// If a store is present, set recentlyQueried to true. Otherwise, if
 		// this is a new store, recentlyQueried will be set to true in addStore.
-		rs.recentlyQueried.Store(true)
+		rs.recentlyQueried.Store(active)
 		supportState = rs.state
 	}
 	return supportState, ok
@@ -147,31 +165,27 @@ func (rsh *requesterStateHandler) addStore(id slpb.StoreIdent) {
 			state: slpb.SupportState{Target: id, Epoch: rsh.requesterState.meta.MaxEpoch},
 		}
 		// Adding a store is done in response to SupportFrom, so it's ok to set
-		// recentlyQueried to true here. This also ensures the store will not be
-		// removed immediately after adding.
-		rs.recentlyQueried.Store(true)
+		// recentlyQueried to active here. This also ensures the store will not
+		// be removed immediately after adding.
+		rs.recentlyQueried.Store(active)
 		rsh.requesterState.supportFrom[id] = &rs
 	}
 }
 
-// removeIdleStores removes all stores from the requesterState.supportFrom map
-// that have not appeared in a getSupportFrom call since the last time
-// removeIdleStores was called.
-func (rsh *requesterStateHandler) removeIdleStores() {
-	// Removing stores doesn't require persisting anything to disk, so it doesn't
+// markIdleStores marks all stores in the requesterState.supportFrom map as
+// idle if they have not appeared in a getSupportFrom call since the last time
+// markIdleStores was called.
+func (rsh *requesterStateHandler) markIdleStores() {
+	// Marking stores doesn't require persisting anything to disk, so it doesn't
 	// need to go through the full checkOut/checkIn process. However, we still
 	// check out the update to ensure that there are no concurrent updates.
 	defer rsh.checkInUpdate(rsh.checkOutUpdate())
-	// TODO(mira): If holding the write lock causes too much contention here,
-	// consider iterating through rsh.requesterState.supportFrom while holding a
-	// read lock to find all stores that need to be removed; then, iterate
-	// through that list of stores again while holding the write lock to
-	// actually remove them.
-	rsh.mu.Lock()
-	defer rsh.mu.Unlock()
-	for id, rs := range rsh.requesterState.supportFrom {
-		if !rs.recentlyQueried.Swap(false) {
-			delete(rsh.requesterState.supportFrom, id)
+
+	rsh.mu.RLock()
+	defer rsh.mu.RUnlock()
+	for _, rs := range rsh.requesterState.supportFrom {
+		if !rs.recentlyQueried.CompareAndSwap(active, inactive) {
+			rs.recentlyQueried.CompareAndSwap(inactive, idle)
 		}
 	}
 }
@@ -319,6 +333,10 @@ func (rsfu *requesterStateForUpdate) generateHeartbeats(from slpb.StoreIdent) []
 			"checkedIn.supportFrom while requesterStateForUpdate.inProgress.supportFrom is not empty",
 	)
 	for _, rs := range rsfu.checkedIn.supportFrom {
+		// Skip idle stores.
+		if rs.recentlyQueried.Load() == idle {
+			continue
+		}
 		heartbeat := slpb.Message{
 			Type:       slpb.MsgHeartbeat,
 			From:       from,

--- a/pkg/kv/kvserver/storeliveness/requester_state.go
+++ b/pkg/kv/kvserver/storeliveness/requester_state.go
@@ -75,9 +75,11 @@ const (
 //   - rsfu := checkOutUpdate()
 //     rsfu.getHeartbeatsToSend(now hlc.Timestamp, interval time.Duration)
 //     checkInUpdate(rsfu)
+//     finishUpdate(rsfu)
 //   - rsfu := checkOutUpdate()
 //     rsfu.handleHeartbeatResponse(msg slpb.Message)
 //     checkInUpdate(rsfu)
+//     finishUpdate(rsfu)
 //
 // Only one update can be in progress to ensure that multiple mutation methods
 // are not run concurrently. Adding or removing a store while an update is in
@@ -157,7 +159,7 @@ func (rsh *requesterStateHandler) addStore(id slpb.StoreIdent) {
 	// Adding a store doesn't require persisting anything to disk, so it doesn't
 	// need to go through the full checkOut/checkIn process. However, we still
 	// check out the update to ensure that there are no concurrent updates.
-	defer rsh.checkInUpdate(rsh.checkOutUpdate())
+	defer rsh.finishUpdate(rsh.checkOutUpdate())
 	rsh.mu.Lock()
 	defer rsh.mu.Unlock()
 	if _, ok := rsh.requesterState.supportFrom[id]; !ok {
@@ -179,7 +181,7 @@ func (rsh *requesterStateHandler) markIdleStores() {
 	// Marking stores doesn't require persisting anything to disk, so it doesn't
 	// need to go through the full checkOut/checkIn process. However, we still
 	// check out the update to ensure that there are no concurrent updates.
-	defer rsh.checkInUpdate(rsh.checkOutUpdate())
+	defer rsh.finishUpdate(rsh.checkOutUpdate())
 
 	rsh.mu.RLock()
 	defer rsh.mu.RUnlock()
@@ -281,10 +283,6 @@ func (rsh *requesterStateHandler) checkOutUpdate() *requesterStateForUpdate {
 // updates from the inProgress view. It clears the inProgress view, and swaps it
 // back in requesterStateHandler.update to be checked out by future updates.
 func (rsh *requesterStateHandler) checkInUpdate(rsfu *requesterStateForUpdate) {
-	defer func() {
-		rsfu.reset()
-		rsh.update.Swap(rsfu)
-	}()
 	if rsfu.inProgress.meta == (slpb.RequesterMeta{}) && len(rsfu.inProgress.supportFrom) == 0 {
 		return
 	}
@@ -297,6 +295,14 @@ func (rsh *requesterStateHandler) checkInUpdate(rsfu *requesterStateForUpdate) {
 	for storeID, rs := range rsfu.inProgress.supportFrom {
 		rsfu.checkedIn.supportFrom[storeID].state = rs.state
 	}
+}
+
+// finishUpdate performs cleanup after a successful or unsuccessful
+// checkInUpdate. It resets the requesterStateForUpdate in-progress state and
+// makes it available for future check out.
+func (rsh *requesterStateHandler) finishUpdate(rsfu *requesterStateForUpdate) {
+	rsfu.reset()
+	rsh.update.Swap(rsfu)
 }
 
 // Functions for generating heartbeats.

--- a/pkg/kv/kvserver/storeliveness/store_liveness_test.go
+++ b/pkg/kv/kvserver/storeliveness/store_liveness_test.go
@@ -53,8 +53,8 @@ func TestStoreLiveness(t *testing.T) {
 			datadriven.RunTest(
 				t, path, func(t *testing.T, d *datadriven.TestData) string {
 					switch d.Cmd {
-					case "remove-idle-stores":
-						sm.requesterStateHandler.removeIdleStores()
+					case "mark-idle-stores":
+						sm.requesterStateHandler.markIdleStores()
 						return ""
 
 					case "support-from":

--- a/pkg/kv/kvserver/storeliveness/store_liveness_test.go
+++ b/pkg/kv/kvserver/storeliveness/store_liveness_test.go
@@ -40,7 +40,7 @@ func TestStoreLiveness(t *testing.T) {
 		t, datapathutils.TestDataPath(t), func(t *testing.T, path string) {
 			ctx := context.Background()
 			storeID := slpb.StoreIdent{NodeID: roachpb.NodeID(1), StoreID: roachpb.StoreID(1)}
-			engine := storage.NewDefaultInMemForTesting()
+			engine := &testEngine{Engine: storage.NewDefaultInMemForTesting()}
 			defer engine.Close()
 			settings := clustersettings.MakeTestingClusterSettings()
 			stopper := stop.NewStopper()
@@ -108,6 +108,13 @@ func TestStoreLiveness(t *testing.T) {
 						manual.AdvanceTo(now.GoTime())
 						require.NoError(t, sm.onRestart(ctx))
 						return ""
+
+					case "error-on-write":
+						var errorOnWrite bool
+						d.ScanArgs(t, "on", &errorOnWrite)
+						engine.errorOnWrite = errorOnWrite
+						return ""
+
 					case "debug-requester-state":
 						var sortedSupportMap []string
 						for _, support := range sm.requesterStateHandler.requesterState.supportFrom {

--- a/pkg/kv/kvserver/storeliveness/support_manager.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager.go
@@ -192,6 +192,7 @@ func (sm *SupportManager) onRestart(ctx context.Context) error {
 	sm.minWithdrawalTS = sm.clock.Now().AddDuration(sm.options.SupportWithdrawalGracePeriod)
 	// Increment the current epoch.
 	rsfu := sm.requesterStateHandler.checkOutUpdate()
+	defer sm.requesterStateHandler.finishUpdate(rsfu)
 	rsfu.incrementMaxEpoch()
 	if err := rsfu.write(ctx, sm.engine); err != nil {
 		return err
@@ -262,6 +263,7 @@ func (sm *SupportManager) maybeAddStores() {
 // and sends the resulting messages via Transport.
 func (sm *SupportManager) sendHeartbeats(ctx context.Context) {
 	rsfu := sm.requesterStateHandler.checkOutUpdate()
+	defer sm.requesterStateHandler.finishUpdate(rsfu)
 	livenessInterval := sm.options.LivenessInterval
 	heartbeats := rsfu.getHeartbeatsToSend(sm.storeID, sm.clock.Now(), livenessInterval)
 	if err := rsfu.write(ctx, sm.engine); err != nil {
@@ -289,9 +291,18 @@ func (sm *SupportManager) withdrawSupport(ctx context.Context) {
 		return
 	}
 	ssfu := sm.supporterStateHandler.checkOutUpdate()
+	defer sm.supporterStateHandler.finishUpdate(ssfu)
 	ssfu.withdrawSupport(now)
-	if err := ssfu.write(ctx, sm.engine); err != nil {
-		log.Warningf(ctx, "failed to write supporter meta: %v", err)
+
+	batch := sm.engine.NewBatch()
+	defer batch.Close()
+	if err := ssfu.write(ctx, batch); err != nil {
+		log.Warningf(ctx, "failed to write supporter meta and state: %v", err)
+		return
+	}
+	if err := batch.Commit(true /* sync */); err != nil {
+		log.Warningf(ctx, "failed to commit supporter meta and state: %v", err)
+		return
 	}
 	log.VInfof(
 		ctx, 2, "store %d withdrew support from %d stores",
@@ -306,7 +317,9 @@ func (sm *SupportManager) withdrawSupport(ctx context.Context) {
 func (sm *SupportManager) handleMessages(ctx context.Context, msgs []*slpb.Message) {
 	log.VInfof(ctx, 2, "store %d drained receive queue of size %d", sm.storeID, len(msgs))
 	rsfu := sm.requesterStateHandler.checkOutUpdate()
+	defer sm.requesterStateHandler.finishUpdate(rsfu)
 	ssfu := sm.supporterStateHandler.checkOutUpdate()
+	defer sm.supporterStateHandler.finishUpdate(ssfu)
 	var responses []slpb.Message
 	for _, msg := range msgs {
 		switch msg.Type {
@@ -319,15 +332,15 @@ func (sm *SupportManager) handleMessages(ctx context.Context, msgs []*slpb.Messa
 		}
 	}
 
-	// TODO(mira): handle the errors below (and elsewhere in SupportManager)
-	// properly by resetting the update in progress.
 	batch := sm.engine.NewBatch()
 	defer batch.Close()
 	if err := rsfu.write(ctx, batch); err != nil {
 		log.Warningf(ctx, "failed to write requester meta: %v", err)
+		return
 	}
 	if err := ssfu.write(ctx, batch); err != nil {
 		log.Warningf(ctx, "failed to write supporter meta: %v", err)
+		return
 	}
 	if err := batch.Commit(true /* sync */); err != nil {
 		log.Warningf(ctx, "failed to sync supporter and requester state: %v", err)

--- a/pkg/kv/kvserver/storeliveness/support_manager.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager.go
@@ -237,7 +237,7 @@ func (sm *SupportManager) startLoop(ctx context.Context) {
 			sm.withdrawSupport(ctx)
 
 		case <-idleSupportFromTicker.C:
-			sm.requesterStateHandler.removeIdleStores()
+			sm.requesterStateHandler.markIdleStores()
 
 		case <-receiveQueueSig:
 			msgs := sm.receiveQueue.Drain()

--- a/pkg/kv/kvserver/storeliveness/supporter_state.go
+++ b/pkg/kv/kvserver/storeliveness/supporter_state.go
@@ -36,9 +36,11 @@ type supporterState struct {
 //   - ssfu := checkOutUpdate()
 //     ssfu.handleHeartbeat(msg slpb.Message)
 //     checkInUpdate(ssfu)
+//     finishUpdate(ssfu)
 //   - ssfu := checkOutUpdate()
 //     ssfu.withdrawSupport(now hlc.ClockTimestamp)
 //     checkInUpdate(ssfu)
+//     finishUpdate(ssfu)
 //
 // Only one update can be in progress to ensure that multiple mutation methods
 // are not run concurrently.
@@ -149,19 +151,20 @@ func (ssfu *supporterStateForUpdate) reset() {
 }
 
 // write writes the supporter meta and supportFor to disk if they changed in
-// this update.
-func (ssfu *supporterStateForUpdate) write(ctx context.Context, rw storage.ReadWriter) error {
+// this update. Accepts a batch to avoid potentially writing multiple support
+// states separately.
+func (ssfu *supporterStateForUpdate) write(ctx context.Context, b storage.Batch) error {
 	if ssfu.inProgress.meta == (slpb.SupporterMeta{}) && len(ssfu.inProgress.supportFor) == 0 {
 		return nil
 	}
 	if ssfu.inProgress.meta != (slpb.SupporterMeta{}) {
 		ssfu.assertMeta()
-		if err := writeSupporterMeta(ctx, rw, ssfu.inProgress.meta); err != nil {
+		if err := writeSupporterMeta(ctx, b, ssfu.inProgress.meta); err != nil {
 			return err
 		}
 	}
 	for _, ss := range ssfu.inProgress.supportFor {
-		if err := writeSupportForState(ctx, rw, ss); err != nil {
+		if err := writeSupportForState(ctx, b, ss); err != nil {
 			return err
 		}
 	}
@@ -204,10 +207,6 @@ func (ssh *supporterStateHandler) checkOutUpdate() *supporterStateForUpdate {
 // updates from the inProgress view. It clears the inProgress view, and swaps it
 // back in supporterStateHandler.update to be checked out by future updates.
 func (ssh *supporterStateHandler) checkInUpdate(ssfu *supporterStateForUpdate) {
-	defer func() {
-		ssfu.reset()
-		ssh.update.Swap(ssfu)
-	}()
 	if ssfu.inProgress.meta == (slpb.SupporterMeta{}) && len(ssfu.inProgress.supportFor) == 0 {
 		return
 	}
@@ -220,6 +219,14 @@ func (ssh *supporterStateHandler) checkInUpdate(ssfu *supporterStateForUpdate) {
 	for storeID, ss := range ssfu.inProgress.supportFor {
 		ssfu.checkedIn.supportFor[storeID] = ss
 	}
+}
+
+// finishUpdate performs cleanup after a successful or unsuccessful
+// checkInUpdate. It resets the supporterStateForUpdate in-progress state and
+// makes it available for future check out.
+func (ssh *supporterStateHandler) finishUpdate(ssfu *supporterStateForUpdate) {
+	ssfu.reset()
+	ssh.update.Swap(ssfu)
 }
 
 // Functions for handling heartbeats.

--- a/pkg/kv/kvserver/storeliveness/testdata/multi-store
+++ b/pkg/kv/kvserver/storeliveness/testdata/multi-store
@@ -75,3 +75,47 @@ support for:
 {Target:{NodeID:1 StoreID:2} Epoch:3 Expiration:0,0}
 {Target:{NodeID:2 StoreID:3} Epoch:4 Expiration:0,0}
 {Target:{NodeID:2 StoreID:4} Epoch:4 Expiration:104.000000000,0}
+
+
+# -------------------------------------------------------------
+# Store (n1, s1) processes some messages that require updating
+# both the requester and supporter states. The writes to disk
+# fail; both states are expected to be reset to the pre-update
+# values.
+# -------------------------------------------------------------
+
+error-on-write on=true
+----
+
+handle-messages
+  msg type=MsgHeartbeat from-node-id=2 from-store-id=3 epoch=4 expiration=200
+  msg type=MsgHeartbeatResp from-node-id=2 from-store-id=4 epoch=1 expiration=200
+----
+
+error-on-write on=false
+----
+
+debug-requester-state
+----
+meta:
+{MaxEpoch:2 MaxRequested:110.000000000,0}
+support from:
+{Target:{NodeID:1 StoreID:2} Epoch:1 Expiration:110.000000000,0}
+{Target:{NodeID:2 StoreID:3} Epoch:2 Expiration:0,0}
+{Target:{NodeID:2 StoreID:4} Epoch:1 Expiration:110.000000000,0}
+
+debug-supporter-state
+----
+meta:
+{MaxWithdrawn:103.000000000,0}
+support for:
+{Target:{NodeID:1 StoreID:2} Epoch:3 Expiration:0,0}
+{Target:{NodeID:2 StoreID:3} Epoch:4 Expiration:0,0}
+{Target:{NodeID:2 StoreID:4} Epoch:4 Expiration:104.000000000,0}
+
+send-heartbeats now=200 liveness-interval=10s
+----
+heartbeats:
+{Type:MsgHeartbeat From:{NodeID:1 StoreID:1} To:{NodeID:1 StoreID:2} Epoch:1 Expiration:210.000000000,0}
+{Type:MsgHeartbeat From:{NodeID:1 StoreID:1} To:{NodeID:2 StoreID:3} Epoch:2 Expiration:210.000000000,0}
+{Type:MsgHeartbeat From:{NodeID:1 StoreID:1} To:{NodeID:2 StoreID:4} Epoch:1 Expiration:210.000000000,0}

--- a/pkg/kv/kvserver/storeliveness/testdata/requester_state
+++ b/pkg/kv/kvserver/storeliveness/testdata/requester_state
@@ -148,11 +148,11 @@ support from:
 # to SupportFrom for (n2, s2).
 #
 # SupportFrom was already called above, so the first call to
-# remove-idle-stores will reset recentlyQueried, and the
-# second call to remove-idle-stores will remove (n2, s2).
+# mark-idle-stores will set recentlyQueried to inactive, and
+# the second call to mark-idle-stores will set it to idle.
 # -------------------------------------------------------------
 
-remove-idle-stores
+mark-idle-stores
 ----
 
 debug-requester-state
@@ -162,15 +162,30 @@ meta:
 support from:
 {Target:{NodeID:2 StoreID:2} Epoch:2 Expiration:410.000000000,0}
 
-remove-idle-stores
+send-heartbeats now=550 liveness-interval=10s
+----
+heartbeats:
+{Type:MsgHeartbeat From:{NodeID:1 StoreID:1} To:{NodeID:2 StoreID:2} Epoch:2 Expiration:560.000000000,0}
+
+mark-idle-stores
 ----
 
 debug-requester-state
 ----
 meta:
-{MaxEpoch:2 MaxRequested:510.000000000,0}
+{MaxEpoch:2 MaxRequested:560.000000000,0}
 support from:
+{Target:{NodeID:2 StoreID:2} Epoch:2 Expiration:410.000000000,0}
 
 send-heartbeats now=600 liveness-interval=10s
 ----
 heartbeats:
+
+support-from node-id=2 store-id=2
+----
+epoch: 2, expiration: 410.000000000,0, support provided: true
+
+send-heartbeats now=700 liveness-interval=10s
+----
+heartbeats:
+{Type:MsgHeartbeat From:{NodeID:1 StoreID:1} To:{NodeID:2 StoreID:2} Epoch:2 Expiration:710.000000000,0}

--- a/pkg/kv/kvserver/storeliveness/testdata/requester_state
+++ b/pkg/kv/kvserver/storeliveness/testdata/requester_state
@@ -189,3 +189,30 @@ send-heartbeats now=700 liveness-interval=10s
 ----
 heartbeats:
 {Type:MsgHeartbeat From:{NodeID:1 StoreID:1} To:{NodeID:2 StoreID:2} Epoch:2 Expiration:710.000000000,0}
+
+
+# -------------------------------------------------------------
+# Store (n1, s1) requests support but fails to write meta.
+# -------------------------------------------------------------
+
+error-on-write on=true
+----
+
+send-heartbeats now=800 liveness-interval=10s
+----
+heartbeats:
+
+debug-requester-state
+----
+meta:
+{MaxEpoch:2 MaxRequested:710.000000000,0}
+support from:
+{Target:{NodeID:2 StoreID:2} Epoch:2 Expiration:410.000000000,0}
+
+error-on-write on=false
+----
+
+send-heartbeats now=900 liveness-interval=10s
+----
+heartbeats:
+{Type:MsgHeartbeat From:{NodeID:1 StoreID:1} To:{NodeID:2 StoreID:2} Epoch:2 Expiration:910.000000000,0}

--- a/pkg/kv/kvserver/storeliveness/testdata/restart
+++ b/pkg/kv/kvserver/storeliveness/testdata/restart
@@ -74,6 +74,22 @@ support for:
 {Target:{NodeID:2 StoreID:2} Epoch:3 Expiration:300.000000000,0}
 
 # -------------------------------------------------------------
+# Store (n1, s1) receives an old heartbeat response from store
+# (n2, s2) after restarting. It's ignored
+# -------------------------------------------------------------
+
+handle-messages
+  msg type=MsgHeartbeatResp from-node-id=2 from-store-id=2 epoch=4 expiration=200
+----
+
+debug-requester-state
+----
+meta:
+{MaxEpoch:3 MaxRequested:110.000000000,0}
+support from:
+
+
+# -------------------------------------------------------------
 # Store (n1, s1) attempts to withdraw support before the grace
 # period has elapsed.
 # -------------------------------------------------------------

--- a/pkg/kv/kvserver/storeliveness/testdata/supporter_state
+++ b/pkg/kv/kvserver/storeliveness/testdata/supporter_state
@@ -102,3 +102,28 @@ responses:
 support-for node-id=2 store-id=2
 ----
 epoch: 2, support provided: true
+
+
+# -------------------------------------------------------------
+# Store (n1, s1) fails to write the support state.
+# -------------------------------------------------------------
+
+error-on-write on=true
+----
+
+handle-messages
+  msg type=MsgHeartbeat from-node-id=2 from-store-id=2 epoch=3 expiration=400
+----
+
+withdraw-support now=400
+----
+
+error-on-write on=false
+----
+
+debug-supporter-state
+----
+meta:
+{MaxWithdrawn:201.000000000,0}
+support for:
+{Target:{NodeID:2 StoreID:2} Epoch:2 Expiration:300.000000000,0}


### PR DESCRIPTION
This PR includes 3 commits: 2 of them fix a couple of `SupportManager` bugs, and the third one improves the process of stopping heartbeats for idle stores. See individual commits for more details.