### PR TITLE
rpc,tenantcapabilities: add cross-tenant reads to 'all' capabilities

### DIFF
--- a/pkg/kv/kvserver/tenantrate/limiter_test.go
+++ b/pkg/kv/kvserver/tenantrate/limiter_test.go
@@ -667,6 +667,10 @@ func (ts *testState) BindReader(tenantcapabilities.Reader) {}
 
 var _ tenantcapabilities.Authorizer = &testState{}
 
+func (ts *testState) HasCrossTenantRead(tenID roachpb.TenantID) bool {
+	return false
+}
+
 func (ts *testState) HasProcessDebugCapability(ctx context.Context, tenID roachpb.TenantID) error {
 	if ts.capabilities[tenID].CanDebugProcess {
 		return nil
@@ -784,6 +788,10 @@ func parseStrings(t *testing.T, d *datadriven.TestData) []string {
 type fakeAuthorizer struct{}
 
 var _ tenantcapabilities.Authorizer = &fakeAuthorizer{}
+
+func (fakeAuthorizer) HasCrossTenantRead(tenID roachpb.TenantID) bool {
+	return false
+}
 
 func (fakeAuthorizer) HasNodeStatusCapability(_ context.Context, tenID roachpb.TenantID) error {
 	return nil

--- a/pkg/multitenant/tenantcapabilities/interfaces.go
+++ b/pkg/multitenant/tenantcapabilities/interfaces.go
@@ -41,6 +41,9 @@ type Reader interface {
 // signals other than just the tenant capability state. For example, request
 // usage pattern over a timespan.
 type Authorizer interface {
+	// HasCrossTenantRead returns true if a tenant can read other tenant spans.
+	HasCrossTenantRead(tenID roachpb.TenantID) bool
+
 	// HasCapabilityForBatch returns an error if a tenant, referenced by its ID,
 	// is not allowed to execute the supplied batch request given the capabilities
 	// it possesses.

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/allow_everything.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/allow_everything.go
@@ -29,6 +29,11 @@ func NewAllowEverythingAuthorizer() *AllowEverythingAuthorizer {
 	return &AllowEverythingAuthorizer{}
 }
 
+// HasCrossTenantRead returns true if a tenant can read from other tenants.
+func (n *AllowEverythingAuthorizer) HasCrossTenantRead(tenID roachpb.TenantID) bool {
+	return true
+}
+
 // HasCapabilityForBatch implements the tenantcapabilities.Authorizer interface.
 func (n *AllowEverythingAuthorizer) HasCapabilityForBatch(
 	context.Context, roachpb.TenantID, *kvpb.BatchRequest,

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/allow_nothing.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/allow_nothing.go
@@ -30,6 +30,11 @@ func NewAllowNothingAuthorizer() *AllowNothingAuthorizer {
 	return &AllowNothingAuthorizer{}
 }
 
+// HasCrossTenantRead returns true if a tenant can read from other tenants.
+func (n *AllowNothingAuthorizer) HasCrossTenantRead(tenID roachpb.TenantID) bool {
+	return false
+}
+
 // HasCapabilityForBatch implements the tenantcapabilities.Authorizer interface.
 func (n *AllowNothingAuthorizer) HasCapabilityForBatch(
 	context.Context, roachpb.TenantID, *kvpb.BatchRequest,

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer.go
@@ -97,6 +97,11 @@ func New(settings *cluster.Settings, knobs *tenantcapabilities.TestingKnobs) *Au
 	return a
 }
 
+// HasCrossTenantRead returns true if a tenant can read from other tenants.
+func (a *Authorizer) HasCrossTenantRead(tenID roachpb.TenantID) bool {
+	return tenID.IsSystem()
+}
+
 // HasCapabilityForBatch implements the tenantcapabilities.Authorizer interface.
 func (a *Authorizer) HasCapabilityForBatch(
 	ctx context.Context, tenID roachpb.TenantID, ba *kvpb.BatchRequest,


### PR DESCRIPTION
The allow-all capability check now also allows 'cross tenant reads', which are defined as read requests made by a non-system tenant to spans not contained by its tenant span. This is added to the capability authorizer API, but is not a defined capability and cannot be granted to tenants; it is only implicitly granted to tenants that are implicitly understood to have 'all' capabilities, such as in shared service.

Release note: none.
Epic: none.