### PR TITLE
opt: add NOWAIT to unlocked scans below NOWAIT

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/select_for_update_read_committed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/select_for_update_read_committed
@@ -562,7 +562,7 @@ user root
 
 awaitquery q18
 
-subtest skip_locked
+subtest skip_locked_nowait
 
 statement ok
 CREATE TABLE xyz (x INT PRIMARY KEY, y INT, z INT, INDEX (y), FAMILY (x, y, z))
@@ -603,8 +603,8 @@ COMMIT;
 ----
 2  10  200
 
-# The unlocked reads in SKIP LOCKED should not block on locks, either, even
-# under serializable isolation.
+# Any unlocked reads underneath SKIP LOCKED or NOWAIT should not block on locks,
+# either, even under serializable isolation.
 
 statement ok
 SET optimizer_use_lock_op_for_serializable = true
@@ -616,6 +616,9 @@ query III
 SELECT * FROM xyz WHERE z = 100 ORDER BY x FOR UPDATE SKIP LOCKED
 ----
 3  30  100
+
+query error pgcode 55P03 could not obtain lock on row \(x\)=\(1\) in xyz@xyz_pkey
+SELECT * FROM xyz WHERE z = 100 ORDER BY x FOR UPDATE NOWAIT
 
 user testuser
 

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update
@@ -471,6 +471,27 @@ BEGIN; SELECT * FROM t FOR UPDATE NOWAIT
 statement ok
 ROLLBACK
 
+statement ok
+SET optimizer_use_lock_op_for_serializable = on
+
+query error pgcode 55P03 could not obtain lock on row \(k\)=\(1\) in t@t_pkey
+SELECT * FROM t FOR UPDATE NOWAIT
+
+query error pgcode 55P03 could not obtain lock on row \(k\)=\(1\) in t@t_pkey
+SELECT * FROM t FOR SHARE FOR UPDATE OF t NOWAIT
+
+query error pgcode 55P03 could not obtain lock on row \(k\)=\(1\) in t@t_pkey
+SELECT * FROM t FOR SHARE NOWAIT FOR UPDATE OF t
+
+query error pgcode 55P03 could not obtain lock on row \(k\)=\(1\) in t@t_pkey
+BEGIN; SELECT * FROM t FOR UPDATE NOWAIT
+
+statement ok
+ROLLBACK
+
+statement ok
+RESET optimizer_use_lock_op_for_serializable
+
 user root
 
 statement ok
@@ -676,3 +697,56 @@ user testuser
 
 statement ok
 COMMIT
+
+user root
+
+# Regression test for #121917 and #129145: ensure SKIP LOCKED and NOWAIT both
+# work when locking comes after the initial scan, due to
+# optimizer_use_lock_op_for_serializable.
+
+statement ok
+CREATE TABLE t129145 (a INT NOT NULL PRIMARY KEY, b INT NOT NULL, FAMILY (a, b))
+
+statement ok
+INSERT INTO t129145 VALUES (1, 1)
+
+statement ok
+GRANT SELECT ON t129145 TO testuser
+
+statement ok
+GRANT UPDATE ON t129145 TO testuser
+
+statement ok
+SET enable_durable_locking_for_serializable = true
+
+statement ok
+BEGIN; SELECT * FROM t129145 WHERE a = 1 FOR UPDATE
+
+user testuser
+
+statement ok
+SET optimizer_use_lock_op_for_serializable = on
+
+statement ok
+SET enable_durable_locking_for_serializable = true
+
+query II
+SELECT * FROM t129145 WHERE b = 1 FOR UPDATE SKIP LOCKED
+----
+
+query error pgcode 55P03 could not obtain lock on row \(a\)=\(1\) in t129145@t129145_pkey
+SELECT * FROM t129145 WHERE b = 1 FOR UPDATE NOWAIT
+
+statement ok
+RESET optimizer_use_lock_op_for_serializable
+
+statement ok
+RESET enable_durable_locking_for_serializable
+
+user root
+
+statement ok
+ROLLBACK
+
+statement ok
+RESET enable_durable_locking_for_serializable

--- a/pkg/sql/opt/locking.go
+++ b/pkg/sql/opt/locking.go
@@ -91,9 +91,10 @@ func (l Locking) IsLocking() bool {
 // IsNoOp returns true if none of the locking properties are set. It differs
 // from IsLocking in that it considers all of the locking properties, instead of
 // only Strength. Currently, the only locking property that can be set when
-// Strength=ForNone is WaitPolicy=LockWaitSkipLocked. So we can say: IsNoOp
-// returns false if IsLocking returns true OR the SKIP LOCKED wait policy is in
-// effect.
+// Strength=ForNone is WaitPolicy=LockWaitSkipLocked or
+// WaitPolicy=LockWaitError. So we can say: IsNoOp returns false if IsLocking
+// returns true OR the SKIP LOCKED wait policy is in effect OR the NOWAIT wait
+// policy is in effect.
 func (l Locking) IsNoOp() bool {
 	return l == Locking{}
 }

--- a/pkg/sql/opt/optbuilder/locking.go
+++ b/pkg/sql/opt/optbuilder/locking.go
@@ -374,6 +374,43 @@ func (b *Builder) shouldBuildLockOp() bool {
 		b.evalCtx.SessionData().OptimizerUseLockOpForSerializable
 }
 
+// lockingSpecForTableScan adjusts the lockingSpec for a Scan depending on
+// whether locking will be implemented by a Lock operator, and also creates
+// lockBuilders as a side-effect.
+func (b *Builder) lockingSpecForTableScan(locking lockingSpec, tabMeta *opt.TableMeta) lockingSpec {
+	if locking.isSet() {
+		lb := newLockBuilder(tabMeta)
+		for _, item := range locking {
+			item.builders = append(item.builders, lb)
+		}
+	}
+	if b.shouldBuildLockOp() {
+		// If we're implementing FOR UPDATE / FOR SHARE with a Lock operator on top
+		// of the plan, then this can be an unlocked scan. But if the locking uses
+		// SKIP LOCKED or NOWAIT then we still need this unlocked scan to use SKIP
+		// LOCKED or NOWAIT behavior, respectively, even if it does not take any
+		// locks itself.
+		if waitPolicy := locking.get().WaitPolicy; waitPolicy != tree.LockWaitBlock &&
+			// In isolation levels weaker than Serializable, unlocked scans read
+			// underneath locks without blocking. For these weaker isolation levels we
+			// do not strictly need unlocked scans to use SKIP LOCKED or NOWAIT
+			// behavior. We keep the SKIP LOCKED behavior anyway as an optimization,
+			// but avoid NOWAIT in order to prevent false positive locking errors.
+			(b.evalCtx.TxnIsoLevel == isolation.Serializable ||
+				waitPolicy == tree.LockWaitSkipLocked) {
+			// Create a dummy lockingSpec to get just the lock wait behavior.
+			locking = lockingSpec{&lockingItem{
+				item: &tree.LockingItem{
+					WaitPolicy: waitPolicy,
+				},
+			}}
+		} else {
+			locking = nil
+		}
+	}
+	return locking
+}
+
 // buildLocking constructs one Lock operator for each data source that this
 // lockingItem applied to.
 func (b *Builder) buildLocking(item *lockingItem, inScope *scope) {

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -160,29 +160,7 @@ func (b *Builder) buildDataSource(
 		switch t := ds.(type) {
 		case cat.Table:
 			tabMeta := b.addTable(t, &resName)
-			locking := lockCtx.locking
-			if locking.isSet() {
-				lb := newLockBuilder(tabMeta)
-				for _, item := range locking {
-					item.builders = append(item.builders, lb)
-				}
-			}
-			if b.shouldBuildLockOp() {
-				// If we're implementing FOR UPDATE / FOR SHARE with a Lock operator on
-				// top of the plan, then this can be an unlocked scan. But if the
-				// locking uses SKIP LOCKED then we still need this scan to skip over
-				// locks even if it does not take any locks itself.
-				if locking.get().WaitPolicy == tree.LockWaitSkipLocked {
-					// Create a dummy lockingSpec to get just the skip locked behavior.
-					locking = lockingSpec{&lockingItem{
-						item: &tree.LockingItem{
-							WaitPolicy: tree.LockWaitSkipLocked,
-						},
-					}}
-				} else {
-					locking = nil
-				}
-			}
+			locking := b.lockingSpecForTableScan(lockCtx.locking, tabMeta)
 			return b.buildScan(
 				tabMeta,
 				tableOrdinals(t, columnKinds{
@@ -510,28 +488,7 @@ func (b *Builder) buildScanFromTableRef(
 
 	tn := tree.MakeUnqualifiedTableName(tab.Name())
 	tabMeta := b.addTable(tab, &tn)
-	if locking.isSet() {
-		lb := newLockBuilder(tabMeta)
-		for _, item := range locking {
-			item.builders = append(item.builders, lb)
-		}
-	}
-	if b.shouldBuildLockOp() {
-		// If we're implementing FOR UPDATE / FOR SHARE with a Lock operator on top
-		// of the plan, then this can be an unlocked scan. But if the locking uses
-		// SKIP LOCKED then we still need this scan to skip over locks even if it
-		// does not take any locks itself.
-		if locking.get().WaitPolicy == tree.LockWaitSkipLocked {
-			// Create a dummy lockingSpec to get just the skip locked behavior.
-			locking = lockingSpec{&lockingItem{
-				item: &tree.LockingItem{
-					WaitPolicy: tree.LockWaitSkipLocked,
-				},
-			}}
-		} else {
-			locking = nil
-		}
-	}
+	locking = b.lockingSpecForTableScan(locking, tabMeta)
 	return b.buildScan(
 		tabMeta, ordinals, indexFlags, locking, inScope, false, /* disableNotVisibleIndex */
 	)

--- a/pkg/sql/opt/optbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/optbuilder/testdata/select_for_update
@@ -2820,7 +2820,8 @@ lock t
  └── project
       ├── columns: a:1!null b:2
       └── scan t
-           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           └── locking: none,nowait
 
 build
 SELECT * FROM t FOR NO KEY UPDATE NOWAIT
@@ -2840,7 +2841,8 @@ lock t
  └── project
       ├── columns: a:1!null b:2
       └── scan t
-           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           └── locking: none,nowait
 
 build
 SELECT * FROM t FOR SHARE NOWAIT
@@ -2860,7 +2862,8 @@ lock t
  └── project
       ├── columns: a:1!null b:2
       └── scan t
-           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           └── locking: none,nowait
 
 build
 SELECT * FROM t FOR KEY SHARE NOWAIT
@@ -2880,7 +2883,8 @@ lock t
  └── project
       ├── columns: a:1!null b:2
       └── scan t
-           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           └── locking: none,nowait
 
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT
@@ -2903,7 +2907,8 @@ lock t
       └── project
            ├── columns: a:1!null b:2
            └── scan t
-                └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+                ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+                └── locking: none,nowait
 
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE
@@ -2929,7 +2934,8 @@ lock t
            └── project
                 ├── columns: a:1!null b:2
                 └── scan t
-                     └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+                     ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+                     └── locking: none,nowait
 
 build
 SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE FOR UPDATE NOWAIT
@@ -2958,7 +2964,8 @@ lock t
                 └── project
                      ├── columns: a:1!null b:2
                      └── scan t
-                          └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+                          ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+                          └── locking: none,nowait
 
 build
 SELECT * FROM t FOR UPDATE OF t NOWAIT
@@ -2978,7 +2985,8 @@ lock t
  └── project
       ├── columns: a:1!null b:2
       └── scan t
-           └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           └── locking: none,nowait
 
 build
 SELECT * FROM t FOR UPDATE OF t2 NOWAIT
@@ -3010,7 +3018,8 @@ lock t
  └── project
       ├── columns: "?column?":5!null a:1!null
       ├── scan t
-      │    └── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      │    ├── columns: a:1!null b:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+      │    └── locking: none,nowait
       └── projections
            └── 1 [as="?column?":5]
 


### PR DESCRIPTION
(This is follow-up from #127718, basically a refinement of commit e74202ce65f5c454ee9bcfb0971b38f637955c3a.)

When using the new Lock operator to implement FOR UPDATE and FOR SHARE, we build unlocked scans that are then followed by a final Lock operator. If the Lock operator uses NOWAIT, however, similar to SKIP LOCKED, these unlocked scans still need to have the NOWAIT behavior to avoid blocking, even if they do not take locks themselves.

Unlike SKIP LOCKED, however, we do _not_ keep the NOWAIT behavior on unlocked scans under weaker isolation levels. This is because NOWAIT false positives produce false positive locking errors, whereas SKIP LOCKED false positives are benign (and in fact a minor performance optimization in some cases).

For example, consider the following scenario:

```sql
CREATE TABLE xy (x INT PRIMARY KEY, y INT);
INSERT INTO xy VALUES (1, 1), (2, 2);

-- lock the x=1 row in the first session
BEGIN;
SELECT * FROM xy WHERE x = 1 FOR UPDATE;

-- try to lock the y=2 row in the second session
BEGIN;
SELECT * FROM xy WHERE y = 2 FOR UPDATE NOWAIT;
```

Under serializable isolation, the final SELECT FOR UPDATE NOWAIT statement uses NOWAIT behavior in its initial full-table scan. This full-table scan first encounters the lock on x=1 which is a "false positive" in the sense that it is not the intended row to lock. This causes the statement to fail immediately. This might seem surprising, but under serializable isolation our only alternative is to instead block on the x=1 lock until the first transaction finishes. We choose to fail immediately (the NOWAIT behavior) instead of blocking because (a) it matches our behavior before this change, (b) it conceptually fits with the read-lock semantics of serializable isolation, in which we consider every read to acquire a shared lock, and (c) it preserves the expected serializable behavior in case the first transaction updates the x=1 row to have y=2.

Under weaker isolation levels we do not use NOWAIT in the initial full-table scan to avoid this false positive error, instead reading "underneath" the lock and only trying to lock the y=2 row.

If, instead of NOWAIT, we consider the final statement to use SKIP LOCKED, we can see that it doesn't hurt anything for us to always use the SKIP LOCKED behavior in the initial full table scan, even under weaker isolation levels. And sometimes it helps.

Fixes: #129145

Release note (bug fix): Fix a bug in which some SELECT FOR UPDATE or SELECT FOR SHARE queries using NOWAIT could still block on locked rows when using `optimizer_use_lock_op_for_serializable` under Serializable isolation. This bug was present when `optimizer_use_lock_op_for_serializable` was introduced in v23.2.0.