### PR TITLE
release-24.2.1-rc: roachtest: don't run SQL against the draining node

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -549,7 +549,7 @@ func registerKVGracefulDraining(r registry.Registry) {
 
 			// TODO(baptist): Remove setting once #129427 is addressed.
 			if _, err := dbs[0].ExecContext(ctx, "SET CLUSTER SETTING kv.store_gossip.max_frequency = '0s'"); err != nil {
-				t.Fatalf("failed to disable load based splitting: %v", err)
+				t.Fatalf("failed to update gossip max frequency: %v", err)
 			}
 
 			t.Status("initializing workload")

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -541,6 +541,7 @@ func registerKVGracefulDraining(r registry.Registry) {
 			dbs := make([]*gosql.DB, nodes-1)
 			for i := range dbs {
 				dbs[i] = c.Conn(ctx, t.L(), i+1)
+				defer dbs[i].Close()
 			}
 
 			err := WaitFor3XReplication(ctx, t, t.L(), dbs[0])

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -573,9 +573,10 @@ func registerKVGracefulDraining(r registry.Registry) {
 			// Three iterations, each iteration has a 3-minute duration.
 			desiredRunDuration := 10 * time.Minute
 			m.Go(func(ctx context.Context) error {
+				// Don't connect to the node we are going to shut down.
 				cmd := fmt.Sprintf(
 					"./cockroach workload run kv --duration=%s --read-percent=50 --follower-read-percent=50 --concurrency=200 --max-rate=%d {pgurl%s}",
-					desiredRunDuration, specifiedQPS, c.CRDBNodes())
+					desiredRunDuration, specifiedQPS, c.Range(1, nodes-1))
 				t.WorkerStatus(cmd)
 				defer func() {
 					t.WorkerStatus("workload command completed")

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -623,37 +623,11 @@ func registerKVGracefulDraining(r registry.Registry) {
 					t.Status("letting workload run with all nodes")
 					select {
 					case <-ctx.Done():
-						return
+						t.Fatalf("context cancelled while waiting")
 					case <-time.After(2 * time.Minute):
 					}
 				}
-				// Graceful drain and allow it to complete. The liveness record is
-				// updated at the beginning of the drain process, so by time the drain
-				// completes in ~5s all other nodes should "know" it is draining.
-				cmd := fmt.Sprintf("./cockroach node drain --certs-dir=%s --port={pgport%s} --self", install.CockroachNodeCertsDir, restartNode)
-				c.Run(ctx, option.WithNodes(restartNode), cmd)
-				// Simulate a hard network drop to this node prior to shutting it down.
-				// This is what we see in some customer environments. As an example, a
-				// docker container shutdown will also disappear from the network and
-				// drop all packets in both directions.
-				// TODO(baptist): Convert this to use a network partitioning
-				// utility function.
-				if !c.IsLocal() {
-					c.Run(ctx, option.WithNodes(restartNode), `sudo iptables -A INPUT -p tcp --dport 26257 -j DROP`)
-					c.Run(ctx, option.WithNodes(restartNode), `sudo iptables -A OUTPUT -p tcp --dport 26257 -j DROP`)
-				}
-				c.Stop(ctx, t.L(), option.DefaultStopOpts(), restartNode)
-				t.Status("letting workload run with one node down")
-				select {
-				case <-ctx.Done():
-					return
-				case <-time.After(1 * time.Minute):
-				}
-				// Clean up the iptables rule before restarting.
-				if !c.IsLocal() {
-					c.Run(ctx, option.WithNodes(restartNode), `sudo iptables -F`)
-				}
-				c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), restartNode)
+				drainWithIpTables(ctx, restartNode, c, t)
 				m.ResetDeaths()
 			}
 
@@ -673,6 +647,40 @@ func registerKVGracefulDraining(r registry.Registry) {
 			m.Wait()
 		},
 	})
+}
+
+// drainWithIpTables does a graceful drain and allows it to complete. The
+// liveness record is updated at the beginning of the drain process, so by time
+// the drain completes in ~5s all other nodes should "know" it is draining.
+func drainWithIpTables(
+	ctx context.Context, restartNode option.NodeListOption, c cluster.Cluster, t test.Test,
+) {
+	cmd := fmt.Sprintf("./cockroach node drain --certs-dir=%s --port={pgport%s} --self", install.CockroachNodeCertsDir, restartNode)
+	c.Run(ctx, option.WithNodes(restartNode), cmd)
+
+	// Simulate a hard network drop to this node prior to shutting it down. This
+	// is what we see in some customer environments. As an example, a docker
+	// container shutdown will also disappear from the network and drop all
+	// packets in both directions.
+	// TODO(baptist): Convert this to use a network partitioning utility.
+	if !c.IsLocal() {
+		c.Run(ctx, option.WithNodes(restartNode), `sudo iptables -A INPUT -p tcp --dport 26257 -j DROP`)
+		c.Run(ctx, option.WithNodes(restartNode), `sudo iptables -A OUTPUT -p tcp --dport 26257 -j DROP`)
+		// NB: We don't use the original context as it might be cancelled.
+		defer c.Run(context.Background(), option.WithNodes(restartNode), `sudo iptables -F`)
+	}
+	c.Stop(ctx, t.L(), option.DefaultStopOpts(), restartNode)
+
+	t.Status("letting workload run with one node down")
+	select {
+	case <-ctx.Done():
+		t.Fatalf("context cancelled while waiting")
+	case <-time.After(1 * time.Minute):
+	}
+
+	startOpts := option.DefaultStartOpts()
+	startOpts.RoachprodOpts.SkipInit = true
+	c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), restartNode)
 }
 
 func registerKVSplits(r registry.Registry) {

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -547,6 +547,11 @@ func registerKVGracefulDraining(r registry.Registry) {
 			err := WaitFor3XReplication(ctx, t, t.L(), dbs[0])
 			require.NoError(t, err)
 
+			// TODO(baptist): Remove setting once #129427 is addressed.
+			if _, err := dbs[0].ExecContext(ctx, "SET CLUSTER SETTING kv.store_gossip.max_frequency = '0s'"); err != nil {
+				t.Fatalf("failed to disable load based splitting: %v", err)
+			}
+
 			t.Status("initializing workload")
 
 			// Initialize the database with a lot of ranges so that there are


### PR DESCRIPTION
Backport 4/4 commits from #129416.

/cc @cockroachdb/release

---

After #126506 the test incorrectly included the draining node as part of the nodes the workload were run against. This caused the statistics to be off by a factor of 5/6.

Note there is a separate issue related to the QPS dropping as part of the drain which is a different issue that is masked by this issue.

Epic: none

Fixes: #129027
Fixes: #128439
Fixes: #128168
Fixes: #126986
Fixes: #125731

Release note: None

Release Justification: This is a test only change to fix a failing roachtest.
