### PR TITLE
kvtenant: expose reader status  via connector

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -8029,3 +8029,52 @@ Support status: [reserved](#support-status)
 
 
 
+## ReadFromTenantInfo
+
+
+
+ReadFromTenantInfo returns the tenant from which the requesting tenant
+should read, if any.
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+ReadFromTenantInfoRequest requests info, if any, on which tenant the caller
+should read from.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| tenant_id | [cockroach.roachpb.TenantID](#cockroach.server.serverpb.ReadFromTenantInfoRequest-cockroach.roachpb.TenantID) |  | TenantID should always be the ID of the tenant making the request. This duplicates the ID in the auth context that is added implicitly, and must always match that ID when that ID is present, however that ID is absent in insecure test clusters which is why we also specify it explicitly here. | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+ReadFromTenantInfoResponse instructs a tenant as to which tenant, if any, it
+should configure itself to read from and the timestamp at which it should do
+so.
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| read_from | [cockroach.roachpb.TenantID](#cockroach.server.serverpb.ReadFromTenantInfoResponse-cockroach.roachpb.TenantID) |  |  | [reserved](#support-status) |
+| read_at | [cockroach.util.hlc.Timestamp](#cockroach.server.serverpb.ReadFromTenantInfoResponse-cockroach.util.hlc.Timestamp) |  |  | [reserved](#support-status) |
+
+
+
+
+
+
+

--- a/pkg/kv/kvclient/kvtenant/BUILD.bazel
+++ b/pkg/kv/kvclient/kvtenant/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/kv/kvclient/kvcoord",
         "//pkg/kv/kvclient/rangecache",
         "//pkg/kv/kvpb",
+        "//pkg/multitenant/mtinfo",
         "//pkg/multitenant/mtinfopb",
         "//pkg/multitenant/tenantcapabilities",
         "//pkg/multitenant/tenantcapabilities/tenantcapabilitiespb",

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangecache"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfo"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb"
@@ -75,6 +76,11 @@ type Connector interface {
 	// TenantInfo retrieves current metadata about the tenant record and
 	// an update channel to track changes
 	TenantInfo() (tenantcapabilities.Entry, <-chan struct{})
+
+	// ReadFromTenantInfoAccessor allows retrieving the other tenant, if any, from
+	// which the calling tenant should configure itself to read, along with the
+	// latest timestamp at which it should perform such reads at this time.
+	mtinfo.ReadFromTenantInfoAccessor
 
 	// NodeDescStore provides information on each of the KV nodes in the cluster
 	// in the form of NodeDescriptors and StoreDescriptors. This obviates the

--- a/pkg/multitenant/mtinfo/BUILD.bazel
+++ b/pkg/multitenant/mtinfo/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/multitenant/tenantcapabilities",
         "//pkg/roachpb",
         "//pkg/sql/sem/tree",
+        "//pkg/util/hlc",
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/multitenant/mtinfo/info.go
+++ b/pkg/multitenant/mtinfo/info.go
@@ -11,13 +11,20 @@
 package mtinfo
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 )
+
+type ReadFromTenantInfoAccessor interface {
+	ReadFromTenantInfo(context.Context) (roachpb.TenantID, hlc.Timestamp, error)
+}
 
 // GetTenantInfoFromSQLRow synthetizes a TenantInfo from a SQL row
 // extracted from system.tenants. The caller is responsible for

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -159,6 +159,12 @@ func (a tenantAuthorizer) authorize(
 		"/cockroach.blobs.Blob/PutStream":
 		return a.capabilitiesAuthorizer.HasNodelocalStorageCapability(ctx, tenID)
 
+	case "/cockroach.server.serverpb.Admin/ReadFromTenantInfo":
+		// NB: we don't check anything here as every tenant, even those who do not
+		// have HasCrossTenantRead, will call this even if only to learn that they
+		// are not a reader tenant.
+		return nil
+
 	default:
 		return authErrorf("unknown method %q", fullMethod)
 	}

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -24,6 +24,7 @@ import "kv/kvpb/api.proto";
 import "roachpb/metadata.proto";
 import "roachpb/data.proto";
 import "ts/catalog/chart_catalog.proto";
+import "util/hlc/timestamp.proto";
 import "util/metric/metric.proto";
 import "util/tracing/tracingpb/recorded_span.proto";
 import "gogoproto/gogo.proto";
@@ -1307,6 +1308,10 @@ service Admin {
       get: "/_admin/v1/tenants"
     };
   }
+
+  // ReadFromTenantInfo returns the tenant from which the requesting tenant
+  // should read, if any.
+  rpc ReadFromTenantInfo(ReadFromTenantInfoRequest) returns (ReadFromTenantInfoResponse) {}
 }
 
 message ListTenantsRequest{}
@@ -1320,6 +1325,24 @@ message Tenant {
   string tenant_name = 2;
   string sql_addr = 3;
   string rpc_addr = 4;
+}
+
+// ReadFromTenantInfoRequest requests info, if any, on which tenant the caller
+// should read from.
+message ReadFromTenantInfoRequest {
+  // TenantID should always be the ID of the tenant making the request. This
+  // duplicates the ID in the auth context that is added implicitly, and must
+  // always match that ID when that ID is present, however that ID is absent in
+  // insecure test clusters which is why we also specify it explicitly here.
+  roachpb.TenantID tenant_id = 1 [(gogoproto.nullable)=false, (gogoproto.customname) = "TenantID"];
+}
+
+// ReadFromTenantInfoResponse instructs a tenant as to which tenant, if any, it
+// should configure itself to read from and the timestamp at which it should do
+// so.
+message ReadFromTenantInfoResponse {
+  roachpb.TenantID read_from = 1 [(gogoproto.nullable)=false];
+  util.hlc.Timestamp read_at = 2 [(gogoproto.nullable)=false];
 }
 
 message ListTracingSnapshotsRequest {}


### PR DESCRIPTION
Tracking if a tenant is intended to be a reader of another tenant in the tenant record allows the system tenant to expose a new API in the tenant connector so that if a tenant intended to be a reader tenant calls the API, it can be informed of the tenant from which it should read and the timestamp -- fetched from the system tenant's PCR job for now -- at which it should do so. Actually configuring itself to be a reader and do so at that timestamp is left to the reader tenant's own devices, and is not included here; this change only adds the metadata to the tenant record and the API exposed to the tenant for fetching it.

Release note: none.
Epic: none.