### PR TITLE
raft: step down immediately on leader transfer

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -895,6 +895,8 @@ func (r *raft) appendEntry(es ...pb.Entry) (accepted bool) {
 
 // tickElection is run by followers and candidates after r.electionTimeout.
 func (r *raft) tickElection() {
+	assertTrue(r.state != StateLeader, "tickElection called by leader")
+
 	if r.leadEpoch != 0 {
 		if r.supportingFortifiedLeader() {
 			// There's a fortified leader and we're supporting it. Reset the
@@ -936,6 +938,8 @@ func (r *raft) tickElection() {
 
 // tickHeartbeat is run by leaders to send a MsgBeat after r.heartbeatTimeout.
 func (r *raft) tickHeartbeat() {
+	assertTrue(r.state == StateLeader, "tickHeartbeat called by non-leader")
+
 	r.heartbeatElapsed++
 	r.electionElapsed++
 

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1906,8 +1906,6 @@ func stepFollower(r *raft, m pb.Message) error {
 		//	r.logger.Infof("%x [term %d] ignored MsgTimeoutNow from %x due to leader fortification", r.id, r.Term, m.From)
 		//	return nil
 		//}
-		// TODO(nvanbenschoten): a MsgTimeoutNow is only valid to replace the
-		// leader in the term that sent it.
 		r.logger.Infof("%x [term %d] received MsgTimeoutNow from %x and starts an election to get leadership", r.id, r.Term, m.From)
 		// Leadership transfers never use pre-vote even if r.preVote is true; we
 		// know we are not recovering from a partition so there is no need for the

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -367,8 +367,28 @@ type raft struct {
 	//
 	// TODO(arul): This should be populated when responding to a MsgFortify.
 	leadEpoch pb.Epoch
-	// leadTransferee is id of the leader transfer target when its value is not zero.
-	// Follow the procedure defined in raft thesis 3.10.
+	// leadTransferee, if set, is the id of the leader transfer target during a
+	// pending leadership transfer. The value is set while the outgoing leader
+	// (this node) is catching the target up on its log. During this time, the
+	// leader will drop incoming proposals to give the transfer target time to
+	// catch up. Once the transfer target is caught up, the leader will send it
+	// a MsgTimeoutNow to encourage it to campaign immediately while bypassing
+	// pre-vote and leader support safeguards. As soon as the MsgTimeoutNow is
+	// sent, the leader will step down to a follower, as it has irrevocably
+	// compromised its leadership term by giving the target permission to
+	// overthrow it.
+	//
+	// For cases where the transfer target is already caught up on the log at the
+	// time that the leader receives a MsgTransferLeader, the MsgTimeoutNow will
+	// be sent immediately and the leader will step down to a follower without
+	// ever setting this field.
+	//
+	// In either case, if the transfer fails after the MsgTimeoutNow has been
+	// sent, the leader (who has stepped down to a follower) must call a new
+	// election at a new term in order to reestablish leadership.
+	//
+	// This roughly follows the procedure defined in the raft thesis, section
+	// 3.10: Leadership transfer extension.
 	leadTransferee pb.PeerID
 	// Only one conf change may be pending (in the log, but not yet
 	// applied) at a time. This is enforced via pendingConfIndex, which
@@ -1683,7 +1703,7 @@ func stepLeader(r *raft, m pb.Message) error {
 				// Transfer leadership is in progress.
 				if m.From == r.leadTransferee && pr.Match == r.raftLog.lastIndex() {
 					r.logger.Infof("%x sent MsgTimeoutNow to %x after received MsgAppResp", r.id, m.From)
-					r.sendTimeoutNow(m.From)
+					r.transferLeader(m.From)
 				}
 			}
 		}
@@ -1739,13 +1759,23 @@ func stepLeader(r *raft, m pb.Message) error {
 		}
 		// Transfer leadership to third party.
 		r.logger.Infof("%x [term %d] starts to transfer leadership to %x", r.id, r.Term, leadTransferee)
-		// Transfer leadership should be finished in one electionTimeout, so reset r.electionElapsed.
+		// Transfer leadership should be finished in one electionTimeout, so reset
+		// r.electionElapsed. If the transfer target is not caught up on its log by
+		// then, the transfer is aborted and the leader can resume normal operation.
+		// See raft.abortLeaderTransfer.
 		r.electionElapsed = 0
 		r.leadTransferee = leadTransferee
 		if pr.Match == r.raftLog.lastIndex() {
-			r.sendTimeoutNow(leadTransferee)
 			r.logger.Infof("%x sends MsgTimeoutNow to %x immediately as %x already has up-to-date log", r.id, leadTransferee, leadTransferee)
+			r.transferLeader(leadTransferee)
 		} else {
+			// If the transfer target is not initially caught up on its log, we don't
+			// send it a MsgTimeoutNow immediately. Instead, we eagerly try to catch
+			// it up on its log so that it will be able to win the election when it
+			// campaigns (recall that a candidate can only win an election if its log
+			// is up-to-date). If we are able to successfully catch it up in time,
+			// before the electionElapsed timeout fires, we call raft.transferLeader
+			// in response to receiving the final MsgAppResp.
 			pr.MsgAppProbesPaused = false
 			r.maybeSendAppend(leadTransferee)
 		}
@@ -1876,6 +1906,8 @@ func stepFollower(r *raft, m pb.Message) error {
 		//	r.logger.Infof("%x [term %d] ignored MsgTimeoutNow from %x due to leader fortification", r.id, r.Term, m.From)
 		//	return nil
 		//}
+		// TODO(nvanbenschoten): a MsgTimeoutNow is only valid to replace the
+		// leader in the term that sent it.
 		r.logger.Infof("%x [term %d] received MsgTimeoutNow from %x and starts an election to get leadership", r.id, r.Term, m.From)
 		// Leadership transfers never use pre-vote even if r.preVote is true; we
 		// know we are not recovering from a partition so there is no need for the
@@ -2278,11 +2310,17 @@ func (r *raft) resetRandomizedElectionTimeout() {
 	r.randomizedElectionTimeout = r.electionTimeout + globalRand.Intn(r.electionTimeout)
 }
 
-func (r *raft) sendTimeoutNow(to pb.PeerID) {
+func (r *raft) transferLeader(to pb.PeerID) {
+	assertTrue(r.state == StateLeader, "only the leader can transfer leadership")
 	r.send(pb.Message{To: to, Type: pb.MsgTimeoutNow})
+	r.becomeFollower(r.Term, r.lead)
 }
 
 func (r *raft) abortLeaderTransfer() {
+	// TODO(arul): we currently call this method regardless of whether we are the
+	// leader or not and regardless of whether there is an in-progress leadership
+	// transfer. We should consider limiting the cases where this can be called
+	// and adding the appropriate preconditions as assertions.
 	r.leadTransferee = None
 }
 

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -2747,8 +2747,9 @@ func TestCommitAfterRemoveNode(t *testing.T) {
 	require.Equal(t, []byte("hello"), ents[0].Data)
 }
 
-// TestLeaderTransferToUpToDateNode verifies transferring should succeed
-// if the transferee has the most up-to-date log entries when transfer starts.
+// TestLeaderTransferToUpToDateNode verifies transferring should start
+// immediately if the transferee has the most up-to-date log entries when
+// transfer is requested.
 func TestLeaderTransferToUpToDateNode(t *testing.T) {
 	nt := newNetwork(nil, nil, nil)
 	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgHup})
@@ -2770,11 +2771,11 @@ func TestLeaderTransferToUpToDateNode(t *testing.T) {
 	checkLeaderTransferState(t, lead, StateLeader, 1)
 }
 
-// TestLeaderTransferToUpToDateNodeFromFollower verifies transferring should succeed
-// if the transferee has the most up-to-date log entries when transfer starts.
-// Not like TestLeaderTransferToUpToDateNode, where the leader transfer message
-// is sent to the leader, in this test case every leader transfer message is sent
-// to the follower.
+// TestLeaderTransferToUpToDateNodeFromFollower verifies transferring should
+// start immediately if the transferee has the most up-to-date log entries when
+// transfer starts. Unlike TestLeaderTransferToUpToDateNode, where the leader
+// transfer message is sent to the leader, in this test case every leader
+// transfer message is sent to the follower and is redirected to the leader.
 func TestLeaderTransferToUpToDateNodeFromFollower(t *testing.T) {
 	nt := newNetwork(nil, nil, nil)
 	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgHup})
@@ -2796,8 +2797,47 @@ func TestLeaderTransferToUpToDateNodeFromFollower(t *testing.T) {
 	checkLeaderTransferState(t, lead, StateLeader, 1)
 }
 
+// TestLeaderTransferLeaderStepsDownImmediately verifies that the outgoing
+// leader steps down to a follower as soon as it sends a MsgTimeoutNow to the
+// transfer target, even before (and regardless of if) the target receives the
+// MsgTimeoutNow and campaigns.
+func TestLeaderTransferLeaderStepsDownImmediately(t *testing.T) {
+	nt := newNetwork(nil, nil, nil)
+	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgHup})
+
+	// Isolate node 3. It is up-to-date, so the leadership transfer will be
+	// initiated immediately, but node 3 will never receive the MsgTimeoutNow and
+	// call an election.
+	nt.isolate(3)
+
+	lead := nt.peers[1].(*raft)
+	require.Equal(t, uint64(1), lead.Term)
+	require.Equal(t, pb.PeerID(1), lead.lead)
+
+	// Transfer leadership to 3. The leader steps down immediately in the same
+	// term, waiting for the transfer target to call an election.
+	nt.send(pb.Message{From: 3, To: 1, Type: pb.MsgTransferLeader})
+
+	require.Equal(t, uint64(1), lead.Term)
+	checkLeaderTransferState(t, lead, StateFollower, 1)
+
+	// TODO(arul): a leader that steps down will currently never campaign due to
+	// the fortification promise that it made to itself. We'll need to fix this.
+	lead.deFortify(lead.lead, lead.Term)
+
+	// Eventually, the previous leader gives up on waiting and calls an election
+	// to reestablish leadership at the next term.
+	for i := 0; i < lead.randomizedElectionTimeout; i++ {
+		lead.tick()
+	}
+	nt.send(lead.readMessages()...)
+
+	require.Equal(t, uint64(2), lead.Term)
+	checkLeaderTransferState(t, lead, StateLeader, 1)
+}
+
 // TestLeaderTransferWithCheckQuorum ensures transferring leader still works
-// even the current leader is still under its leader lease
+// even the current leader is still under its leader lease.
 func TestLeaderTransferWithCheckQuorum(t *testing.T) {
 	nt := newNetwork(nil, nil, nil)
 	for i := 1; i < 4; i++ {
@@ -2832,18 +2872,23 @@ func TestLeaderTransferWithCheckQuorum(t *testing.T) {
 }
 
 func TestLeaderTransferToSlowFollower(t *testing.T) {
-	defaultLogger.EnableDebug()
 	nt := newNetwork(nil, nil, nil)
 	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgHup})
 
+	// Isolate node 3 and propose an entry on 1. This will cause node 3 to fall
+	// behind on its log, so that the leadership transfer won't be initiated
+	// immediately.
 	nt.isolate(3)
 	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{}}})
 
-	nt.recover()
 	lead := nt.peers[1].(*raft)
+	require.Equal(t, uint64(2), lead.trk.Progress(1).Match)
 	require.Equal(t, uint64(1), lead.trk.Progress(3).Match)
 
-	// Transfer leadership to 3 when node 3 is lack of log.
+	// Reconnect node 3 and initiate a transfer of leadership from node 1 to node
+	// 3. The leader (node 1) will catch it up on log entries using MsgApps before
+	// transferring it leadership using MsgTimeoutNow.
+	nt.recover()
 	nt.send(pb.Message{From: 3, To: 1, Type: pb.MsgTransferLeader})
 
 	checkLeaderTransferState(t, lead, StateFollower, 3)
@@ -2865,7 +2910,7 @@ func TestLeaderTransferAfterSnapshot(t *testing.T) {
 	require.Equal(t, uint64(1), lead.trk.Progress(3).Match)
 
 	filtered := pb.Message{}
-	// Snapshot needs to be applied before sending MsgAppResp
+	// Snapshot needs to be applied before sending MsgAppResp.
 	nt.msgHook = func(m pb.Message) bool {
 		if m.Type != pb.MsgAppResp || m.From != 3 || m.Reject {
 			return true
@@ -2873,12 +2918,12 @@ func TestLeaderTransferAfterSnapshot(t *testing.T) {
 		filtered = m
 		return false
 	}
-	// Transfer leadership to 3 when node 3 is lack of snapshot.
+	// Transfer leadership to 3 when node 3 is missing a snapshot.
 	nt.send(pb.Message{From: 3, To: 1, Type: pb.MsgTransferLeader})
 	require.Equal(t, StateLeader, lead.state)
 	require.NotEqual(t, pb.Message{}, filtered)
 
-	// Apply snapshot and resume progress
+	// Apply snapshot and resume progress.
 	follower := nt.peers[3].(*raft)
 	snap := follower.raftLog.nextUnstableSnapshot()
 	nt.storage[3].ApplySnapshot(*snap)
@@ -2914,7 +2959,11 @@ func TestLeaderTransferTimeout(t *testing.T) {
 	nt := newNetwork(nil, nil, nil)
 	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgHup})
 
+	// Isolate node 3 and propose an entry on 1. This will cause node 3 to fall
+	// behind on its log, so that the leadership transfer won't be initiated
+	// immediately. If it were, we couldn't test the timeout.
 	nt.isolate(3)
+	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{}}})
 
 	lead := nt.peers[1].(*raft)
 
@@ -2940,32 +2989,40 @@ func TestLeaderTransferIgnoreProposal(t *testing.T) {
 	nt := newNetwork(r, nil, nil)
 	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgHup})
 
+	// Isolate node 3 and propose an entry on 1. This will cause node 3 to fall
+	// behind on its log, so that the leadership transfer won't be initiated
+	// immediately.
 	nt.isolate(3)
+	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{}}})
 
-	lead := nt.peers[1].(*raft)
-
-	nextEnts(r, s) // handle empty entry
-
-	// Transfer leadership to isolated node to let transfer pending, then send proposal.
+	// Transfer leadership to the isolated, behind node. This will leave the
+	// transfer in a pending state as the leader tries to catch up the target.
 	nt.send(pb.Message{From: 3, To: 1, Type: pb.MsgTransferLeader})
+	lead := nt.peers[1].(*raft)
 	require.Equal(t, pb.PeerID(3), lead.leadTransferee)
 
-	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{}}})
+	// Then send proposal. This should be dropped.
 	err := lead.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{}}})
 	require.Equal(t, ErrProposalDropped, err)
+	require.Equal(t, pb.PeerID(3), lead.leadTransferee)
 
-	require.Equal(t, uint64(1), lead.trk.Progress(1).Match)
+	require.Equal(t, uint64(2), lead.trk.Progress(1).Match)
 }
 
 func TestLeaderTransferReceiveHigherTermVote(t *testing.T) {
 	nt := newNetworkWithConfig(fortificationDisabledConfig, nil, nil, nil)
 	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgHup})
 
+	// Isolate node 3 and propose an entry on 1. This will cause node 3 to fall
+	// behind on its log, so that the leadership transfer won't be initiated
+	// immediately.
 	nt.isolate(3)
+	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{}}})
 
 	lead := nt.peers[1].(*raft)
 
-	// Transfer leadership to isolated node to let transfer pending.
+	// Transfer leadership to the isolated, behind node. This will leave the
+	// transfer in a pending state as the leader tries to catch up the target.
 	nt.send(pb.Message{From: 3, To: 1, Type: pb.MsgTransferLeader})
 	require.Equal(t, pb.PeerID(3), lead.leadTransferee)
 
@@ -2978,11 +3035,15 @@ func TestLeaderTransferRemoveNode(t *testing.T) {
 	nt := newNetwork(nil, nil, nil)
 	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgHup})
 
-	nt.ignore(pb.MsgTimeoutNow)
+	// Isolate node 3 and propose an entry on 1. This will cause node 3 to fall
+	// behind on its log, so that the leadership transfer won't be initiated
+	// immediately.
+	nt.isolate(3)
+	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{}}})
 
 	lead := nt.peers[1].(*raft)
 
-	// The leadTransferee is removed when leadship transferring.
+	// The leadTransferee is removed with leadership transfer in progress.
 	nt.send(pb.Message{From: 3, To: 1, Type: pb.MsgTransferLeader})
 	require.Equal(t, pb.PeerID(3), lead.leadTransferee)
 
@@ -2995,11 +3056,15 @@ func TestLeaderTransferDemoteNode(t *testing.T) {
 	nt := newNetwork(nil, nil, nil)
 	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgHup})
 
-	nt.ignore(pb.MsgTimeoutNow)
+	// Isolate node 3 and propose an entry on 1. This will cause node 3 to fall
+	// behind on its log, so that the leadership transfer won't be initiated
+	// immediately.
+	nt.isolate(3)
+	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{}}})
 
 	lead := nt.peers[1].(*raft)
 
-	// The leadTransferee is demoted when leadship transferring.
+	// The leadTransferee is demoted with leadership transfer in progress.
 	nt.send(pb.Message{From: 3, To: 1, Type: pb.MsgTransferLeader})
 	require.Equal(t, pb.PeerID(3), lead.leadTransferee)
 
@@ -3021,12 +3086,17 @@ func TestLeaderTransferDemoteNode(t *testing.T) {
 	checkLeaderTransferState(t, lead, StateLeader, 1)
 }
 
-// TestLeaderTransferBack verifies leadership can transfer back to self when last transfer is pending.
+// TestLeaderTransferBack verifies leadership can transfer back to self when
+// last transfer is pending, which cancels the transfer attempt.
 func TestLeaderTransferBack(t *testing.T) {
 	nt := newNetwork(nil, nil, nil)
 	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgHup})
 
+	// Isolate node 3 and propose an entry on 1. This will cause node 3 to fall
+	// behind on its log, so that the leadership transfer won't be initiated
+	// immediately.
 	nt.isolate(3)
+	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{}}})
 
 	lead := nt.peers[1].(*raft)
 
@@ -3039,13 +3109,18 @@ func TestLeaderTransferBack(t *testing.T) {
 	checkLeaderTransferState(t, lead, StateLeader, 1)
 }
 
-// TestLeaderTransferSecondTransferToAnotherNode verifies leader can transfer to another node
-// when last transfer is pending.
+// TestLeaderTransferSecondTransferToAnotherNode verifies leader can transfer to
+// another node when last transfer is pending, which cancels the previous
+// transfer attempt and starts a new one.
 func TestLeaderTransferSecondTransferToAnotherNode(t *testing.T) {
 	nt := newNetwork(nil, nil, nil)
 	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgHup})
 
+	// Isolate node 3 and propose an entry on 1. This will cause node 3 to fall
+	// behind on its log, so that the leadership transfer won't be initiated
+	// immediately.
 	nt.isolate(3)
+	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{}}})
 
 	lead := nt.peers[1].(*raft)
 
@@ -3058,13 +3133,18 @@ func TestLeaderTransferSecondTransferToAnotherNode(t *testing.T) {
 	checkLeaderTransferState(t, lead, StateFollower, 2)
 }
 
-// TestLeaderTransferSecondTransferToSameNode verifies second transfer leader request
-// to the same node should not extend the timeout while the first one is pending.
+// TestLeaderTransferSecondTransferToSameNode verifies second transfer leader
+// request to the same node should not extend the timeout while the first one is
+// pending.
 func TestLeaderTransferSecondTransferToSameNode(t *testing.T) {
 	nt := newNetwork(nil, nil, nil)
 	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgHup})
 
+	// Isolate node 3 and propose an entry on 1. This will cause node 3 to fall
+	// behind on its log, so that the leadership transfer won't be initiated
+	// immediately.
 	nt.isolate(3)
+	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{}}})
 
 	lead := nt.peers[1].(*raft)
 
@@ -3439,29 +3519,34 @@ func testConfChangeCheckBeforeCampaign(t *testing.T, v2 bool) {
 
 	// Transfer leadership to peer 2.
 	nt.send(pb.Message{From: 2, To: 1, Type: pb.MsgTransferLeader})
-	assert.Equal(t, StateLeader, n1.state)
-	// It's still follower because committed conf change is not applied.
+	// The outgoing leader steps down immediately.
+	assert.Equal(t, StateFollower, n1.state)
+	// The transfer target does not campaign immediately because the committed
+	// conf change is not applied.
 	assert.Equal(t, StateFollower, n2.state)
 
-	// Abort transfer leader
-	for i := 0; i < n1.electionTimeout; i++ {
+	// TODO(arul): a leader that steps down will currently never campaign due to
+	// the fortification promise that it made to itself. We'll need to fix this.
+	n1.deFortify(n1.lead, n1.Term)
+
+	// Advance apply on node 1 and re-establish leadership.
+	nextEnts(n1, nt.storage[1])
+	for i := 0; i < n1.randomizedElectionTimeout; i++ {
 		n1.tick()
 	}
+	nt.send(n1.readMessages()...)
+	assert.Equal(t, StateLeader, n1.state)
 
-	// Advance apply
+	// Advance apply on node 2.
 	nextEnts(n2, nt.storage[2])
 
 	// Transfer leadership to peer 2 again.
 	nt.send(pb.Message{From: 2, To: 1, Type: pb.MsgTransferLeader})
+	// The outgoing leader steps down immediately.
 	assert.Equal(t, StateFollower, n1.state)
+	// The transfer target campaigns immediately now that the committed conf
+	// change is applied.
 	assert.Equal(t, StateLeader, n2.state)
-
-	nextEnts(n1, nt.storage[1])
-	// Trigger campaign in node 2
-	for i := 0; i < n1.randomizedElectionTimeout; i++ {
-		n1.tick()
-	}
-	assert.Equal(t, StateCandidate, n1.state)
 }
 
 // TestConfChangeCheckBeforeCampaign tests if unapplied ConfChange is checked before campaign.

--- a/pkg/raft/testdata/confchange_v2_replace_leader.txt
+++ b/pkg/raft/testdata/confchange_v2_replace_leader.txt
@@ -149,11 +149,13 @@ transfer-leadership from=1 to=4
 ----
 INFO 1 [term 1] starts to transfer leadership to 4
 INFO 1 sends MsgTimeoutNow to 4 immediately as 4 already has up-to-date log
+INFO 1 became follower at term 1
 
-# Leadership transfer wasn't processed yet.
+# Leadership transfer was initiated by the outgoing leader, but not yet
+# processed by the transfer target.
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
+1: StateFollower (Voter) Term:1 Lead:0
 2: StateFollower (Voter) Term:1 Lead:1
 3: StateFollower (Voter) Term:1 Lead:1
 4: StateFollower (Voter) Term:1 Lead:1
@@ -163,6 +165,7 @@ stabilize
 ----
 > 1 handling Ready
   Ready MustSync=false:
+  State:StateFollower
   Messages:
   1->4 MsgTimeoutNow Term:1 Log:0/0
 > 4 receiving messages
@@ -200,7 +203,6 @@ stabilize
   INFO 3 [logterm: 1, index: 4, vote: 0] cast MsgVote for 4 [logterm: 1, index: 4] at term 2
 > 1 handling Ready
   Ready MustSync=true:
-  State:StateFollower
   HardState Term:2 Vote:4 Commit:4 Lead:0 LeadEpoch:0
   Messages:
   1->4 MsgVoteResp Term:2 Log:0/0


### PR DESCRIPTION
Part of #129807.

This commit updates the handling of raft leadership transfers to have the outgoing leader step down immediately after the MsgTimeoutNow is sent. We retain the `leadTransferee` field because there is still a "pending", reversible transfer state while the leader is catching the follower up on its log. However, once the catch up is complete, the leader now steps down, as it has irrevocably compromised its leadership term by giving the target permission to overthrow it.

If the transfer fails after the MsgTimeoutNow has been sent, the leader (who has stepped down to a follower) must call a new election at a new term in order to reestablish leadership.

Release note: None