### PR TITLE
release-24.1: roachtest: label randomized tests

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -332,6 +332,10 @@ func updateSpecForSelectiveTests(ctx context.Context, specs []registry.TestSpec)
 func testShouldBeSkipped(
 	testNamesToRun map[string]*testselector.TestDetails, test registry.TestSpec, suite string,
 ) bool {
+	if test.Randomized {
+		return false
+	}
+
 	for test.TestSelectionOptOutSuites.IsInitialized() && test.TestSelectionOptOutSuites.Contains(suite) {
 		// test should not be skipped for this suite
 		return false

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -168,6 +168,15 @@ type TestSpec struct {
 	// explaining why the test has been chosen for opting out of test selection.
 	TestSelectionOptOutSuites SuiteSet
 
+	// Randomized indicates if the test performs randomized
+	// actions. These tests are prioritized and not subject to test
+	// selection, as a passing run does not indicate that the same run
+	// will pass again due to the non-deterministic nature of the test.
+	// We have also seen cases where a randomized test takes a long time
+	// (sometimes months) to hit a bug, so running them consistently is
+	// important.
+	Randomized bool
+
 	// stats are populated by test selector based on previous execution data
 	stats *testStats
 }

--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -35,6 +35,7 @@ func registerAcceptance(r registry.Registry) {
 		encryptionSupport  registry.EncryptionSupport
 		defaultLeases      bool
 		requiresLicense    bool
+		randomized         bool
 		nativeLibs         []string
 		workloadNode       bool
 		incompatibleClouds registry.CloudSet
@@ -80,6 +81,7 @@ func registerAcceptance(r registry.Registry) {
 				fn:            runVersionUpgrade,
 				timeout:       2 * time.Hour, // actually lower in local runs; see `runVersionUpgrade`
 				defaultLeases: true,
+				randomized:    true,
 				nativeLibs:    registry.LibGEOS,
 			},
 		},
@@ -104,6 +106,7 @@ func registerAcceptance(r registry.Registry) {
 				fn:            runValidateSystemSchemaAfterVersionUpgrade,
 				timeout:       30 * time.Minute,
 				defaultLeases: true,
+				randomized:    true,
 				numNodes:      1,
 			},
 			{
@@ -151,6 +154,7 @@ func registerAcceptance(r registry.Registry) {
 				Timeout:           10 * time.Minute,
 				CompatibleClouds:  registry.AllClouds.Remove(tc.incompatibleClouds),
 				Suites:            registry.Suites(registry.Nightly, registry.Quick, registry.Acceptance),
+				Randomized:        tc.randomized,
 				RequiresLicense:   tc.requiresLicense,
 			}
 

--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -90,6 +90,7 @@ func registerBackupRestoreRoundTrip(r registry.Registry) {
 			CompatibleClouds:           registry.OnlyGCE,
 			Suites:                     registry.Suites(registry.Nightly),
 			TestSelectionOptOutSuites:  registry.Suites(registry.Nightly),
+			Randomized:                 true,
 			Skip:                       sp.skip,
 			RequiresDeprecatedWorkload: true, // uses schemachange
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/costfuzz.go
+++ b/pkg/cmd/roachtest/tests/costfuzz.go
@@ -55,6 +55,7 @@ func registerCostFuzz(r registry.Registry) {
 			Suites:           registry.Suites(registry.Nightly),
 			Leases:           registry.MetamorphicLeases,
 			NativeLibs:       registry.LibGEOS,
+			Randomized:       true,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				// When running in CI, only allow running workload-replay in the private roachtest,
 				// which has the required credentials.

--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -134,6 +134,7 @@ func registerFollowerReads(r registry.Registry) {
 		),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
+		Randomized:       true,
 		Run:              runFollowerReadsMixedVersionSingleRegionTest,
 	})
 
@@ -149,6 +150,7 @@ func registerFollowerReads(r registry.Registry) {
 		),
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
+		Randomized:       true,
 		Run:              runFollowerReadsMixedVersionGlobalTableTest,
 	})
 }

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2558,6 +2558,7 @@ func registerBackupMixedVersion(r registry.Registry) {
 		CompatibleClouds:          registry.Clouds(spec.GCE, spec.Local),
 		Suites:                    registry.Suites(registry.Nightly),
 		TestSelectionOptOutSuites: registry.Suites(registry.Nightly),
+		Randomized:                true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			mvt := mixedversion.NewTest(
 				ctx, t, t.L(), c, c.CRDBNodes(),

--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -76,6 +76,7 @@ func registerCDCMixedVersions(r registry.Registry) {
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		RequiresLicense:  true,
+		Randomized:       true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runCDCMixedVersions(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
@@ -35,6 +35,7 @@ func registerChangeReplicasMixedVersion(r registry.Registry) {
 		Cluster:          r.MakeClusterSpec(4),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
+		Randomized:       true,
 		Run:              runChangeReplicasMixedVersion,
 		Timeout:          60 * time.Minute,
 	})

--- a/pkg/cmd/roachtest/tests/mixed_version_import.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_import.go
@@ -30,6 +30,7 @@ func registerImportMixedVersions(r registry.Registry) {
 		Cluster:          r.MakeClusterSpec(4),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
+		Randomized:       true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			warehouses := 100
 			if c.IsLocal() {

--- a/pkg/cmd/roachtest/tests/mixed_version_multi_region.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_multi_region.go
@@ -66,6 +66,7 @@ func registerMultiRegionMixedVersion(r registry.Registry) {
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		CompatibleClouds:  registry.OnlyGCE,
 		Suites:            registry.Suites(registry.Weekly),
+		Randomized:        true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			partitionConfig := fmt.Sprintf(
 				"--regions=%s --partitions=%d",

--- a/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
@@ -34,6 +34,7 @@ func registerSchemaChangeMixedVersions(r registry.Registry) {
 		Cluster:                    r.MakeClusterSpec(4, spec.WorkloadNode()),
 		CompatibleClouds:           registry.AllExceptAWS,
 		Suites:                     registry.Suites(registry.Nightly),
+		Randomized:                 true,
 		NativeLibs:                 registry.LibGEOS,
 		RequiresDeprecatedWorkload: true, // uses schemachange
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -156,6 +156,7 @@ func registerRebalanceLoad(r registry.Registry) {
 			Cluster:          r.MakeClusterSpec(4), // the last node is just used to generate load
 			CompatibleClouds: registry.AllExceptAWS,
 			Suites:           registry.Suites(registry.Nightly),
+			Randomized:       true,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.IsLocal() {
 					concurrency = 32
@@ -191,6 +192,7 @@ func registerRebalanceLoad(r registry.Registry) {
 			Cluster:          r.MakeClusterSpec(7), // the last node is just used to generate load
 			CompatibleClouds: registry.AllExceptAWS,
 			Suites:           registry.Suites(registry.Nightly),
+			Randomized:       true,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.IsLocal() {
 					concurrency = 32

--- a/pkg/cmd/roachtest/tests/secondary_indexes.go
+++ b/pkg/cmd/roachtest/tests/secondary_indexes.go
@@ -148,6 +148,7 @@ func registerSecondaryIndexesMultiVersionCluster(r registry.Registry) {
 		Cluster:          r.MakeClusterSpec(3),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
+		Randomized:       true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runIndexUpgrade(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -341,6 +341,7 @@ WITH into_db = 'defaultdb', unsafe_restore_incompatible_version;
 			// https://github.com/cockroachdb/cockroach/issues/105968
 			CompatibleClouds: registry.Clouds(spec.GCE, spec.Local),
 			Suites:           registry.Suites(registry.Nightly),
+			Randomized:       true,
 			Leases:           registry.MetamorphicLeases,
 			NativeLibs:       registry.LibGEOS,
 			Timeout:          time.Minute * 20,

--- a/pkg/cmd/roachtest/tests/tlp.go
+++ b/pkg/cmd/roachtest/tests/tlp.go
@@ -43,6 +43,7 @@ func registerTLP(r registry.Registry) {
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		NativeLibs:       registry.LibGEOS,
+		Randomized:       true,
 		Run:              runTLP,
 		ExtraLabels:      []string{"O-rsg"},
 	})

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -577,6 +577,7 @@ func registerTPCC(r registry.Registry) {
 		Suites:            registry.Suites(registry.Nightly),
 		Cluster:           mixedHeadroomSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
+		Randomized:        true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCCMixedHeadroom(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/unoptimized_query_oracle.go
+++ b/pkg/cmd/roachtest/tests/unoptimized_query_oracle.go
@@ -61,6 +61,7 @@ func registerUnoptimizedQueryOracle(r registry.Registry) {
 				Cluster:          clusterSpec,
 				CompatibleClouds: registry.AllExceptAWS,
 				Suites:           registry.Suites(registry.Nightly),
+				Randomized:       true,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runQueryComparison(ctx, t, c, &queryComparisonTest{
 						name:      "unoptimized-query-oracle",


### PR DESCRIPTION
Backport 1/1 commits from #127974.

/cc @cockroachdb/release

---

This commit introduces a new field in the `TestSpec` to allow tests to be labeled as `Randomized`. Crucially, randomized tests are exempt from test selection.

We also update existing randomized tests to use the new field, including `mixedversion` tests, sqlsmith, tlp, and costfuzz.

Epic: none

Release note: None
Release justification: test engineering changes
