### PR TITLE
sql: SHOW CREATE ALL SCHEMAS doesn't work with comment on

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -3602,12 +3602,21 @@ CREATE TABLE crdb_internal.create_schema_statements (
 							ExplicitSchema: true,
 						},
 					}
+
+					createStatement := tree.AsString(node)
+
+					comment, ok := p.Descriptors().GetSchemaComment(schemaDesc.GetID())
+					if ok {
+						commentOnSchema := tree.CommentOnSchema{Comment: &comment, Name: tree.ObjectNamePrefix{SchemaName: tree.Name(schemaDesc.GetName()), ExplicitSchema: true}}
+						createStatement += ";\n" + tree.AsString(&commentOnSchema)
+					}
+
 					if err := addRow(
 						tree.NewDInt(tree.DInt(db.GetID())),         // database_id
 						tree.NewDString(db.GetName()),               // database_name
 						tree.NewDString(schemaDesc.GetName()),       // schema_name
 						tree.NewDInt(tree.DInt(schemaDesc.GetID())), // descriptor_id (schema_id)
-						tree.NewDString(tree.AsString(node)),        // create_statement
+						tree.NewDString(createStatement),            // create_statement
 					); err != nil {
 						return err
 					}

--- a/pkg/sql/logictest/testdata/logic_test/show_create_all_schemas
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_all_schemas
@@ -41,6 +41,17 @@ create_statement
 CREATE SCHEMA public;
 CREATE SCHEMA test2;
 
+statement ok
+COMMENT ON SCHEMA public IS 'test comment';
+
+query T colnames,nosort
+SHOW CREATE ALL SCHEMAS
+----
+create_statement
+CREATE SCHEMA public;
+COMMENT ON SCHEMA public IS 'test comment';
+CREATE SCHEMA test2;
+
 # Make sure database names with hyphens work well.
 statement ok
 CREATE DATABASE "d-d";


### PR DESCRIPTION
  There was a bug where comments did not show up in
  the output of the show create all schemas command.
  The issue was that we did not have any code to get
   the comment and add it to the create schema
   descriptor.

  Fixes: #127979

  Release note (bug fix): SHOW CREATE ALL SCHEMAS
  now shows corresponding schema comments in it's output.