### PR TITLE
raft: clean up defortification on incoming messages

### DIFF
--- a/pkg/raft/testdata/fortification_followers_dont_prevote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_prevote.txt
@@ -231,7 +231,8 @@ stabilize
   2->3 MsgPreVote Term:2 Log:1/11
   INFO 3 [logterm: 1, index: 11, vote: 1] cast MsgPreVote for 2 [logterm: 1, index: 11] at term 1
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:0
   Messages:
   3->2 MsgPreVoteResp Term:2 Log:0/0
 > 2 receiving messages
@@ -377,11 +378,13 @@ stabilize
   2->3 MsgPreVote Term:3 Log:2/12
   INFO 3 [logterm: 2, index: 12, vote: 2] cast MsgPreVote for 2 [logterm: 2, index: 12] at term 2
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
+  HardState Term:2 Commit:12 Lead:2 LeadEpoch:0
   Messages:
   1->2 MsgPreVoteResp Term:3 Log:0/0
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
+  HardState Term:2 Vote:2 Commit:12 Lead:2 LeadEpoch:0
   Messages:
   3->2 MsgPreVoteResp Term:3 Log:0/0
 > 2 receiving messages

--- a/pkg/raft/testdata/prevote.txt
+++ b/pkg/raft/testdata/prevote.txt
@@ -112,7 +112,7 @@ stabilize
 ----
 > 1 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:12 Lead:1 LeadEpoch:1
+  HardState Term:1 Vote:1 Commit:12 Lead:1 LeadEpoch:0
   CommittedEntries:
   1/12 EntryNormal "prop_1"
   Messages:
@@ -120,7 +120,8 @@ stabilize
   1->3 MsgApp Term:1 Log:1/12 Commit:12
   1->3 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:0
   Messages:
   2->3 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
 > 2 receiving messages
@@ -133,7 +134,7 @@ stabilize
   2->3 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:12 Lead:1 LeadEpoch:1
+  HardState Term:1 Vote:1 Commit:12 Lead:1 LeadEpoch:0
   CommittedEntries:
   1/12 EntryNormal "prop_1"
   Messages:

--- a/pkg/raft/util.go
+++ b/pkg/raft/util.go
@@ -52,6 +52,14 @@ var isResponseMsg = [...]bool{
 	pb.MsgFortifyLeaderResp: true,
 }
 
+var isMsgFromLeader = [...]bool{
+	pb.MsgApp:           true,
+	pb.MsgSnap:          true,
+	pb.MsgHeartbeat:     true,
+	pb.MsgFortifyLeader: true,
+	pb.MsgTimeoutNow:    true,
+}
+
 func isMsgInArray(msgt pb.MessageType, arr []bool) bool {
 	i := int(msgt)
 	return i < len(arr) && arr[i]
@@ -63,6 +71,10 @@ func IsLocalMsg(msgt pb.MessageType) bool {
 
 func IsResponseMsg(msgt pb.MessageType) bool {
 	return isMsgInArray(msgt, isResponseMsg[:])
+}
+
+func IsMsgFromLeader(msgt pb.MessageType) bool {
+	return isMsgInArray(msgt, isMsgFromLeader[:])
 }
 
 func IsLocalMsgTarget(id pb.PeerID) bool {

--- a/pkg/raft/util_test.go
+++ b/pkg/raft/util_test.go
@@ -147,6 +147,45 @@ func TestIsResponseMsg(t *testing.T) {
 	}
 }
 
+func TestMsgFromLeader(t *testing.T) {
+	tests := []struct {
+		msgt       pb.MessageType
+		isResponse bool
+	}{
+		{pb.MsgHup, false},
+		{pb.MsgBeat, false},
+		{pb.MsgUnreachable, false},
+		{pb.MsgSnapStatus, false},
+		{pb.MsgCheckQuorum, false},
+		{pb.MsgTransferLeader, false},
+		{pb.MsgProp, false},
+		{pb.MsgApp, true},
+		{pb.MsgAppResp, false},
+		{pb.MsgVote, false},
+		{pb.MsgVoteResp, false},
+		{pb.MsgSnap, true},
+		{pb.MsgHeartbeat, true},
+		{pb.MsgHeartbeatResp, false},
+		{pb.MsgTimeoutNow, true},
+		{pb.MsgPreVote, false},
+		{pb.MsgPreVoteResp, false},
+		{pb.MsgStorageAppend, false},
+		{pb.MsgStorageAppendResp, false},
+		{pb.MsgStorageApply, false},
+		{pb.MsgStorageApplyResp, false},
+		{pb.MsgForgetLeader, false},
+		{pb.MsgFortifyLeader, true},
+		{pb.MsgFortifyLeaderResp, false},
+	}
+
+	for i, tt := range tests {
+		got := IsMsgFromLeader(tt.msgt)
+		if got != tt.isResponse {
+			t.Errorf("#%d: got %v, want %v", i, got, tt.isResponse)
+		}
+	}
+}
+
 // TestPayloadSizeOfEmptyEntry ensures that payloadSize of empty entry is always zero.
 // This property is important because new leaders append an empty entry to their log,
 // and we don't want this to count towards the uncommitted log quota.


### PR DESCRIPTION
This commit cleans up the logic to defortify a follower when receiving a message, either from the leader or from a candidate. The only change in behavior is that followers now defortify on MsgPreVote messages when they are no longer supporting the leader, instead of waiting for the following MsgVote.

Epic: None
Release note: None