### PR TITLE
replica_rac2: integrate LogTracker

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb/kvflowcontrol.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb/kvflowcontrol.go
@@ -67,7 +67,7 @@ func (a AdmittedState) String() string {
 }
 
 func (a AdmittedState) SafeFormat(w redact.SafePrinter, _ rune) {
-	w.Printf("admitted=t%d/%s", a.Term, a.Admitted)
+	w.Printf("admitted=t%d/%v", a.Term, a.Admitted)
 }
 
 func (a PiggybackedAdmittedState) String() string {

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "admission.go",
         "close_scheduler.go",
         "doc.go",
+        "log_tracker.go",
         "processor.go",
         "raft_node.go",
     ],

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/log_tracker.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/log_tracker.go
@@ -1,0 +1,131 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package replica_rac2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/rac2"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// logTracker wraps rac2.LogTracker with a mutex and state that helps track
+// admitted vector changes and schedule their delivery to the leader. The
+// semantics and requirements for all the methods is equivalent to the
+// corresponding methods of rac2.LogTracker.
+//
+// The logTracker has its own mutex in order to avoid interference with objects
+// that use wider mutexes such as raftMu.
+type logTracker struct {
+	syncutil.Mutex
+	lt rac2.LogTracker
+	// dirty is true when the admitted vector has changed and should be sent to
+	// the leader.
+	dirty bool
+	// scheduled is true when the admitted vector change has been scheduled for
+	// processing by raft Ready.
+	scheduled bool
+}
+
+func (l *logTracker) init(stable rac2.LogMark) {
+	l.Lock()
+	defer l.Unlock()
+	l.lt = rac2.NewLogTracker(stable)
+}
+
+// admitted returns the current admitted vector, and a bool indicating whether
+// this is the first call observing this particular admitted vector. The caller
+// may decide not to send this vector to the leader if it is not new (since it
+// has already been sent).
+//
+// The passed-in bool indicates whether this call is made from the Ready
+// handler. In this case the scheduled flag is reset, which allows the next
+// logAdmitted call to return true and allow scheduling a Ready iteration again.
+// This flow avoids unnecessary Ready scheduling events.
+func (l *logTracker) admitted(sched bool) (av rac2.AdmittedVector, dirty bool) {
+	l.Lock()
+	defer l.Unlock()
+	dirty, l.dirty = l.dirty, false
+	if sched {
+		l.scheduled = false
+	}
+	av = l.lt.Admitted()
+	return av, dirty
+}
+
+func (l *logTracker) append(ctx context.Context, after uint64, to rac2.LogMark) {
+	l.Lock()
+	defer l.Unlock()
+	if l.lt.Append(ctx, after, to) {
+		l.dirty = true
+	}
+}
+
+func (l *logTracker) register(ctx context.Context, at rac2.LogMark, pri raftpb.Priority) {
+	l.Lock()
+	defer l.Unlock()
+	l.lt.Register(ctx, at, pri)
+}
+
+func (l *logTracker) logSynced(ctx context.Context, stable rac2.LogMark) {
+	l.Lock()
+	defer l.Unlock()
+	if l.lt.LogSynced(ctx, stable) {
+		l.dirty = true
+	}
+}
+
+// logAdmitted returns true if the admitted vector has advanced and must be
+// scheduled for delivery to the leader. At the moment, this schedules a Ready
+// handling cycle.
+//
+// The returned bool helps to avoid scheduling Ready many times in a row, in
+// situations when there are many consecutive logAdmitted calls. The next
+// scheduling event will be allowed after the next admitted(true) call.
+func (l *logTracker) logAdmitted(ctx context.Context, at rac2.LogMark, pri raftpb.Priority) bool {
+	l.Lock()
+	defer l.Unlock()
+	if !l.lt.LogAdmitted(ctx, at, pri) {
+		return false
+	}
+	l.dirty = true
+	if !l.scheduled {
+		l.scheduled = true
+		return true
+	}
+	return false
+}
+
+func (l *logTracker) snapSynced(ctx context.Context, mark rac2.LogMark) {
+	l.Lock()
+	defer l.Unlock()
+	if l.lt.SnapSynced(ctx, mark) {
+		l.dirty = true
+	}
+}
+
+func (l *logTracker) debugString() string {
+	l.Lock()
+	defer l.Unlock()
+	var flags string
+	if l.dirty {
+		flags += "+dirty"
+	}
+	if l.scheduled {
+		flags += "+sched"
+	}
+	if len(flags) != 0 {
+		flags = " [" + flags + "]"
+	}
+	return fmt.Sprintf("LogTracker%s: %s", flags, l.lt.DebugString())
+}

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -105,10 +105,11 @@ type RaftNode interface {
 	// past the group membership state, so the leader returned here may not be
 	// known as a current group member.
 	LeaderLocked() roachpb.ReplicaID
+	// LogMarkLocked returns the current log mark of the raft log. It is not
+	// guaranteed to be stablestorage, unless this method is called right after
+	// RawNode is initialized. Processor calls this only on initialization.
+	LogMarkLocked() rac2.LogMark
 
-	// StableIndexLocked is the (inclusive) highest index that is known to be
-	// successfully persisted in local storage.
-	StableIndexLocked() uint64
 	// NextUnstableIndexLocked returns the index of the next entry that will
 	// be sent to local storage. All entries < this index are either stored,
 	// or have been sent to storage.
@@ -116,15 +117,9 @@ type RaftNode interface {
 	// NB: NextUnstableIndex can regress when the node accepts appends or
 	// snapshots from a newer leader.
 	NextUnstableIndexLocked() uint64
-	// GetAdmittedLocked returns the current value of the admitted array.
-	GetAdmittedLocked() [raftpb.NumPriorities]uint64
 
 	// Mutating methods.
 
-	// SetAdmittedLocked sets a new value for the admitted array. It is the
-	// caller's responsibility to ensure that it is not regressing admitted,
-	// and it is not advancing admitted beyond the stable index.
-	SetAdmittedLocked([raftpb.NumPriorities]uint64) raftpb.Message
 	// StepMsgAppRespForAdmittedLocked steps a MsgAppResp on the leader, which
 	// may advance its knowledge of a follower's admitted state.
 	StepMsgAppRespForAdmittedLocked(raftpb.Message) error
@@ -398,11 +393,18 @@ type Processor interface {
 		info SideChannelInfoUsingRaftMessageRequest,
 	)
 
+	// SyncedLogStorage is called when the log storage is synced, after writing a
+	// snapshot or log entries batch. It can be called synchronously from
+	// OnLogSync or OnSnapSync handlers if the write batch is blocking, or
+	// asynchronously from OnLogSync.
+	SyncedLogStorage(ctx context.Context, mark rac2.LogMark, snap bool)
 	// AdmittedLogEntry is called when an entry is admitted. It can be called
 	// synchronously from within ACWorkQueue.Admit if admission is immediate.
 	AdmittedLogEntry(
 		ctx context.Context, state EntryForAdmissionCallbackState,
 	)
+	// AdmittedState returns the vector of admitted log indices.
+	AdmittedState() rac2.AdmittedVector
 
 	// AdmitForEval is called to admit work that wants to evaluate at the
 	// leaseholder.
@@ -416,6 +418,9 @@ type Processor interface {
 
 type processorImpl struct {
 	opts ProcessorOptions
+
+	// State for tracking and advancing the log's admitted vector.
+	logTracker logTracker
 
 	// The fields below are accessed while holding the mutex. Lock ordering:
 	// Replica.raftMu < this.mu < Replica.mu.
@@ -432,10 +437,6 @@ type processorImpl struct {
 		leaderNodeID  roachpb.NodeID
 		leaderStoreID roachpb.StoreID
 		leaseholderID roachpb.ReplicaID
-		// State for advancing admitted.
-		lastObservedStableIndex     uint64
-		scheduledAdmittedProcessing bool
-		waitingForAdmissionState    waitingForAdmissionState
 		// State at a follower.
 		follower struct {
 			isLeaderUsingV2Protocol bool
@@ -510,7 +511,7 @@ func (p *processorImpl) InitRaftLocked(ctx context.Context, rn RaftNode) {
 		log.Fatalf(ctx, "initializing RaftNode after replica is initialized")
 	}
 	p.raftMu.raftNode = rn
-	// TODO(pav-kv): initialize the LogTracker from RaftNode state.
+	p.logTracker.init(p.raftMu.raftNode.LogMarkLocked())
 }
 
 // OnDestroyRaftMuLocked implements Processor.
@@ -523,7 +524,6 @@ func (p *processorImpl) OnDestroyRaftMuLocked(ctx context.Context) {
 	p.closeLeaderStateRaftMuLockedProcLocked(ctx)
 
 	// Release some memory.
-	p.mu.waitingForAdmissionState = waitingForAdmissionState{}
 	p.mu.follower.lowPriOverrideState = lowPriOverrideState{}
 }
 
@@ -740,18 +740,15 @@ func (p *processorImpl) HandleRaftReadyRaftMuLocked(ctx context.Context, e rac2.
 	// leader may switch to v2.
 
 	// Grab the state we need in one shot after acquiring Replica mu.
-	var nextUnstableIndex, stableIndex uint64
+	var nextUnstableIndex uint64
 	var leaderID, leaseholderID roachpb.ReplicaID
-	var admitted [raftpb.NumPriorities]uint64
 	var myLeaderTerm uint64
 	func() {
 		p.opts.Replica.MuLock()
 		defer p.opts.Replica.MuUnlock()
 		nextUnstableIndex = p.raftMu.raftNode.NextUnstableIndexLocked()
-		stableIndex = p.raftMu.raftNode.StableIndexLocked()
 		leaderID = p.raftMu.raftNode.LeaderLocked()
 		leaseholderID = p.opts.Replica.LeaseholderMuLocked()
-		admitted = p.raftMu.raftNode.GetAdmittedLocked()
 		if leaderID == p.opts.ReplicaID {
 			myLeaderTerm = p.raftMu.raftNode.TermLocked()
 		}
@@ -759,37 +756,31 @@ func (p *processorImpl) HandleRaftReadyRaftMuLocked(ctx context.Context, e rac2.
 	if len(e.Entries) > 0 {
 		nextUnstableIndex = e.Entries[0].Index
 	}
-	p.mu.lastObservedStableIndex = stableIndex
-	p.mu.scheduledAdmittedProcessing = false
 	p.makeStateConsistentRaftMuLockedProcLocked(
 		ctx, nextUnstableIndex, leaderID, leaseholderID, myLeaderTerm)
 
 	if !p.isLeaderUsingV2ProcLocked() {
 		return
 	}
-	// If there was a recent MsgStoreAppendResp that triggered this Ready
-	// processing, it has already been stepped, so the stable index would have
-	// advanced. So this is an opportune place to do Admitted processing.
-	nextAdmitted := p.mu.waitingForAdmissionState.computeAdmitted(stableIndex)
-	if admittedIncreased(admitted, nextAdmitted) {
-		p.opts.Replica.MuLock()
-		msgResp := p.raftMu.raftNode.SetAdmittedLocked(nextAdmitted)
-		p.opts.Replica.MuUnlock()
-		if p.mu.leader.rc == nil && p.mu.leaderNodeID != 0 {
-			// Follower, and know leaderNodeID, leaderStoreID.
-			// TODO(pav-kv): populate the message correctly.
+
+	// Piggyback admitted index advancement, if any, to the message stream going
+	// to the leader node, if we are not the leader. At the leader node, the
+	// admitted vector is read directly from the log tracker.
+	if p.mu.leader.rc == nil && p.mu.leaderNodeID != 0 {
+		// TODO(pav-kv): must make sure the leader term is the same.
+		if admitted, dirty := p.logTracker.admitted(true /* sched */); dirty {
 			p.opts.AdmittedPiggybacker.Add(p.mu.leaderNodeID, kvflowcontrolpb.PiggybackedAdmittedState{
 				RangeID:       p.opts.RangeID,
 				ToStoreID:     p.mu.leaderStoreID,
 				FromReplicaID: p.opts.ReplicaID,
-				ToReplicaID:   roachpb.ReplicaID(msgResp.To),
-				Admitted:      kvflowcontrolpb.AdmittedState{},
-			})
+				ToReplicaID:   p.mu.leaderID,
+				Admitted: kvflowcontrolpb.AdmittedState{
+					Term:     admitted.Term,
+					Admitted: admitted.Admitted[:],
+				}})
 		}
-		// Else if the local replica is the leader, we have already told it
-		// about the update by calling SetAdmittedLocked. If the leader is not
-		// known, we simply drop the message.
 	}
+
 	if p.mu.leader.rc != nil {
 		if err := p.mu.leader.rc.HandleRaftEventRaftMuLocked(ctx, e); err != nil {
 			log.Errorf(ctx, "error handling raft event: %v", err)
@@ -797,8 +788,22 @@ func (p *processorImpl) HandleRaftReadyRaftMuLocked(ctx context.Context, e rac2.
 	}
 }
 
+func (p *processorImpl) registerLogAppend(ctx context.Context, e rac2.RaftEvent) {
+	if len(e.Entries) == 0 {
+		return
+	}
+	after := e.Entries[0].Index - 1
+	to := rac2.LogMark{Term: e.Term, Index: e.Entries[len(e.Entries)-1].Index}
+	p.logTracker.append(ctx, after, to)
+}
+
 // AdmitRaftEntriesRaftMuLocked implements Processor.
 func (p *processorImpl) AdmitRaftEntriesRaftMuLocked(ctx context.Context, e rac2.RaftEvent) bool {
+	// Register all log appends without exception. If the replica is being
+	// destroyed, this should be a no-op, but there is no harm in registering the
+	// write just in case.
+	p.registerLogAppend(ctx, e)
+
 	// Return false only if we're not destroyed and not using V2.
 	if destroyed, usingV2 := func() (bool, bool) {
 		p.mu.Lock()
@@ -807,6 +812,8 @@ func (p *processorImpl) AdmitRaftEntriesRaftMuLocked(ctx context.Context, e rac2
 	}(); destroyed || !usingV2 {
 		return destroyed
 	}
+	// NB: destroyed and "using v2" status does not change below since we are
+	// holding raftMu.
 
 	for _, entry := range e.Entries {
 		typ, priBits, err := raftlog.EncodingOf(entry)
@@ -833,7 +840,6 @@ func (p *processorImpl) AdmitRaftEntriesRaftMuLocked(ctx context.Context, e rac2
 				p.mu.Lock()
 				defer p.mu.Unlock()
 				raftPri = p.mu.follower.lowPriOverrideState.getEffectivePriority(entry.Index, raftPri)
-				p.mu.waitingForAdmissionState.add(mark.Term, mark.Index, raftPri)
 			}()
 		} else {
 			raftPri = raftpb.LowPri
@@ -843,19 +849,16 @@ func (p *processorImpl) AdmitRaftEntriesRaftMuLocked(ctx context.Context, e rac2
 					"do not use RACv1 for pri %s, which is regular work",
 					admissionpb.WorkPriority(meta.AdmissionPriority))
 			}
-			func() {
-				p.mu.Lock()
-				defer p.mu.Unlock()
-				p.mu.waitingForAdmissionState.add(mark.Term, mark.Index, raftPri)
-			}()
 		}
-		admissionPri := rac2.RaftToAdmissionPriority(raftPri)
-		// NB: cannot hold mu when calling Admit since the callback may
-		// execute from inside Admit, when the entry is immediately admitted.
+		// Register all entries subject to AC with the log tracker.
+		p.logTracker.register(ctx, mark, raftPri)
+
+		// NB: cannot hold mu when calling Admit since the callback may execute from
+		// inside Admit, when the entry is immediately admitted.
 		submitted := p.opts.ACWorkQueue.Admit(ctx, EntryForAdmission{
 			StoreID:        p.opts.StoreID,
 			TenantID:       p.raftMu.tenantID,
-			Priority:       admissionPri,
+			Priority:       rac2.RaftToAdmissionPriority(raftPri),
 			CreateTime:     meta.AdmissionCreateTime,
 			RequestedCount: int64(len(entry.Data)),
 			Ingested:       typ.IsSideloaded(),
@@ -866,13 +869,14 @@ func (p *processorImpl) AdmitRaftEntriesRaftMuLocked(ctx context.Context, e rac2
 				Priority: raftPri,
 			},
 		})
+		// Failure is very rare and likely does not happen, e.g. store is not found.
+		// TODO(pav-kv): audit failure scenarios and minimize/eliminate them.
 		if !submitted {
-			// Very rare. e.g. store was not found.
-			func() {
-				p.mu.Lock()
-				defer p.mu.Unlock()
-				p.mu.waitingForAdmissionState.remove(mark.Term, mark.Index, raftPri)
-			}()
+			// NB: this also admits all previously registered entries.
+			// TODO(pav-kv): consider not registering this entry in the first place,
+			// instead of falsely admitting a prefix of the log. We don't want false
+			// admissions to reach the leader.
+			p.logTracker.logAdmitted(ctx, mark, raftPri)
 		}
 	}
 	return true
@@ -941,28 +945,32 @@ func (p *processorImpl) SideChannelForPriorityOverrideAtFollowerRaftMuLocked(
 	}
 }
 
+// SyncedLogStorage implements Processor.
+func (p *processorImpl) SyncedLogStorage(ctx context.Context, mark rac2.LogMark, snap bool) {
+	if snap {
+		p.logTracker.snapSynced(ctx, mark)
+	} else {
+		p.logTracker.logSynced(ctx, mark)
+	}
+	// NB: storage syncs will trigger raft Ready processing, so we don't need to
+	// explicitly schedule it here like in AdmittedLogEntry.
+}
+
 // AdmittedLogEntry implements Processor.
 func (p *processorImpl) AdmittedLogEntry(
 	ctx context.Context, state EntryForAdmissionCallbackState,
 ) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if p.mu.destroyed {
-		return
-	}
-	admittedMayAdvance :=
-		p.mu.waitingForAdmissionState.remove(state.Mark.Term, state.Mark.Index, state.Priority)
-	if !admittedMayAdvance || state.Mark.Index > p.mu.lastObservedStableIndex ||
-		!p.isLeaderUsingV2ProcLocked() {
-		return
-	}
-	// The lastObservedStableIndex has moved at or ahead of state.Index. This
-	// will happen when admission is not immediate. In this case we need to
-	// schedule processing.
-	if !p.mu.scheduledAdmittedProcessing {
-		p.mu.scheduledAdmittedProcessing = true
+	if p.logTracker.logAdmitted(ctx, state.Mark, state.Priority) {
+		// Schedule a raft Ready cycle that will send the updated admitted vector to
+		// the leader via AdmittedPiggybacker if it hasn't been sent by then.
 		p.opts.RaftScheduler.EnqueueRaftReady(p.opts.RangeID)
 	}
+}
+
+// AdmittedState implements Processor.
+func (p *processorImpl) AdmittedState() rac2.AdmittedVector {
+	admitted, _ := p.logTracker.admitted(false /* sched */)
+	return admitted
 }
 
 // AdmitForEval implements Processor.
@@ -989,15 +997,6 @@ func (p *processorImpl) AdmitForEval(
 		return false, nil
 	}
 	return p.mu.leader.rc.WaitForEval(ctx, pri)
-}
-
-func admittedIncreased(prev, next [raftpb.NumPriorities]uint64) bool {
-	for i := range prev {
-		if prev[i] < next[i] {
-			return true
-		}
-	}
-	return false
 }
 
 // GetAdmitted implements rac2.AdmittedTracker.

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -407,6 +407,15 @@ func TestProcessorBasic(t *testing.T) {
 				r.raftNode.print()
 				return builderStr()
 
+			case "synced-log":
+				var mark rac2.LogMark
+				d.ScanArgs(t, "term", &mark.Term)
+				d.ScanArgs(t, "index", &mark.Index)
+				// TODO(pav-kv): mark.Term should also be respected for correctness.
+				r.raftNode.stableIndex = mark.Index
+				r.raftNode.print()
+				return builderStr()
+
 			case "on-destroy":
 				p.OnDestroyRaftMuLocked(ctx)
 				return builderStr()

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -57,11 +57,7 @@ func (r *testReplica) initRaft(stable rac2.LogMark) {
 		b: r.b, r: r,
 		term:              stable.Term,
 		mark:              stable,
-		stableIndex:       stable.Index,
 		nextUnstableIndex: stable.Index + 1,
-	}
-	for pri := range r.raftNode.admitted {
-		r.raftNode.admitted[pri] = stable.Index
 	}
 }
 
@@ -105,9 +101,7 @@ type testRaftNode struct {
 	leader roachpb.ReplicaID
 
 	mark              rac2.LogMark
-	stableIndex       uint64
 	nextUnstableIndex uint64
-	admitted          [raftpb.NumPriorities]uint64
 }
 
 func (rn *testRaftNode) EnablePingForAdmittedLaggingLocked() {
@@ -127,34 +121,16 @@ func (rn *testRaftNode) LeaderLocked() roachpb.ReplicaID {
 	return rn.leader
 }
 
-func (rn *testRaftNode) StableIndexLocked() uint64 {
+func (rn *testRaftNode) LogMarkLocked() rac2.LogMark {
 	rn.r.mu.AssertHeld()
-	fmt.Fprintf(rn.b, " RaftNode.StableIndexLocked() = %d\n", rn.stableIndex)
-	return rn.stableIndex
+	fmt.Fprintf(rn.b, " RaftNode.LogMarkLocked() = %+v\n", rn.mark)
+	return rn.mark
 }
 
 func (rn *testRaftNode) NextUnstableIndexLocked() uint64 {
 	rn.r.mu.AssertHeld()
 	fmt.Fprintf(rn.b, " RaftNode.NextUnstableIndexLocked() = %d\n", rn.nextUnstableIndex)
 	return rn.nextUnstableIndex
-}
-
-func (rn *testRaftNode) GetAdmittedLocked() [raftpb.NumPriorities]uint64 {
-	rn.r.mu.AssertHeld()
-	fmt.Fprintf(rn.b, " RaftNode.GetAdmittedLocked = %s\n", admittedString(rn.admitted))
-	return rn.admitted
-}
-
-func (rn *testRaftNode) SetAdmittedLocked(admitted [raftpb.NumPriorities]uint64) raftpb.Message {
-	rn.r.mu.AssertHeld()
-	// TODO(sumeer): set more fields.
-	msg := raftpb.Message{
-		Type: raftpb.MsgAppResp,
-	}
-	fmt.Fprintf(rn.b, " RaftNode.SetAdmittedLocked(%s) = %s\n",
-		admittedString(admitted), msgString(msg))
-	rn.admitted = admitted
-	return msg
 }
 
 func (rn *testRaftNode) StepMsgAppRespForAdmittedLocked(msg raftpb.Message) error {
@@ -182,22 +158,12 @@ func (rn *testRaftNode) check(t *testing.T) {
 		return
 	}
 	require.LessOrEqual(t, rn.mark.Term, rn.term)
-	require.LessOrEqual(t, rn.stableIndex, rn.mark.Index)
-	require.Greater(t, rn.nextUnstableIndex, rn.stableIndex)
 	require.LessOrEqual(t, rn.nextUnstableIndex, rn.mark.Index+1)
-	for _, index := range rn.admitted {
-		require.LessOrEqual(t, index, rn.stableIndex)
-	}
 }
 
 func (rn *testRaftNode) print() {
-	fmt.Fprintf(rn.b, "Raft: term: %d leader: %d leaseholder: %d mark: %+v stable: %d next-unstable: %d admitted: %s",
-		rn.term, rn.leader, rn.r.leaseholder, rn.mark, rn.stableIndex, rn.nextUnstableIndex,
-		admittedString(rn.admitted))
-}
-
-func admittedString(admitted [raftpb.NumPriorities]uint64) string {
-	return fmt.Sprintf("[%d, %d, %d, %d]", admitted[0], admitted[1], admitted[2], admitted[3])
+	fmt.Fprintf(rn.b, "Raft: term: %d leader: %d leaseholder: %d mark: %+v next-unstable: %d",
+		rn.term, rn.leader, rn.r.leaseholder, rn.mark, rn.nextUnstableIndex)
 }
 
 func msgString(msg raftpb.Message) string {
@@ -211,7 +177,7 @@ type testAdmittedPiggybacker struct {
 func (p *testAdmittedPiggybacker) Add(
 	n roachpb.NodeID, m kvflowcontrolpb.PiggybackedAdmittedState,
 ) {
-	fmt.Fprintf(p.b, " Piggybacker.Add(n%s, %s)\n", n, m)
+	fmt.Fprintf(p.b, " Piggybacker.Add(n%d, %v)\n", n, m)
 }
 
 type testACWorkQueue struct {
@@ -346,6 +312,9 @@ func TestProcessorBasic(t *testing.T) {
 		b.Reset()
 		return str
 	}
+	printLogTracker := func() {
+		fmt.Fprint(&b, p.logTracker.debugString())
+	}
 	datadriven.RunTest(t, datapathutils.TestDataPath(t, "processor"),
 		func(t *testing.T, d *datadriven.TestData) string {
 			defer func() { r.raftNode.check(t) }()
@@ -367,21 +336,10 @@ func TestProcessorBasic(t *testing.T) {
 				return builderStr()
 
 			case "set-raft-state":
-				if d.HasArg("admitted") {
-					var arg string
-					d.ScanArgs(t, "admitted", &arg)
-					admitted := parseAdmitted(t, arg)
-					r.raftNode.admitted = admitted
-				}
 				if d.HasArg("leader") {
 					var leaderID int
 					d.ScanArgs(t, "leader", &leaderID)
 					r.raftNode.leader = roachpb.ReplicaID(leaderID)
-				}
-				if d.HasArg("stable-index") {
-					var stableIndex uint64
-					d.ScanArgs(t, "stable-index", &stableIndex)
-					r.raftNode.stableIndex = stableIndex
 				}
 				if d.HasArg("next-unstable-index") {
 					var nextUnstableIndex uint64
@@ -411,9 +369,8 @@ func TestProcessorBasic(t *testing.T) {
 				var mark rac2.LogMark
 				d.ScanArgs(t, "term", &mark.Term)
 				d.ScanArgs(t, "index", &mark.Index)
-				// TODO(pav-kv): mark.Term should also be respected for correctness.
-				r.raftNode.stableIndex = mark.Index
-				r.raftNode.print()
+				p.SyncedLogStorage(ctx, mark, false /* snap */)
+				printLogTracker()
 				return builderStr()
 
 			case "on-destroy":
@@ -452,6 +409,7 @@ func TestProcessorBasic(t *testing.T) {
 					fmt.Fprintf(&b, "AdmitRaftEntries:\n")
 					destroyedOrV2 := p.AdmitRaftEntriesRaftMuLocked(ctx, event)
 					fmt.Fprintf(&b, "destroyed-or-leader-using-v2: %t\n", destroyedOrV2)
+					printLogTracker()
 				}
 				return builderStr()
 
@@ -503,6 +461,7 @@ func TestProcessorBasic(t *testing.T) {
 				d.ScanArgs(t, "pri", &pri)
 				cb.Priority = raftpb.Priority(pri)
 				p.AdmittedLogEntry(ctx, cb)
+				printLogTracker()
 				return builderStr()
 
 			case "set-flow-control-mode":
@@ -589,22 +548,6 @@ func enabledLevelString(enabledLevel EnabledWhenLeaderLevel) string {
 		return "v2-encoding"
 	}
 	return "unknown-level"
-}
-
-func parseAdmitted(t *testing.T, arg string) [raftpb.NumPriorities]uint64 {
-	n := len(arg)
-	require.LessOrEqual(t, 2, n)
-	require.Equal(t, uint8('['), arg[0])
-	require.Equal(t, uint8(']'), arg[n-1])
-	parts := strings.Split(arg[1:n-1], ",")
-	require.Equal(t, 4, len(parts))
-	var admitted [raftpb.NumPriorities]uint64
-	for i, part := range parts {
-		val, err := strconv.Atoi(strings.TrimSpace(part))
-		require.NoError(t, err)
-		admitted[i] = uint64(val)
-	}
-	return admitted
 }
 
 func parseRangeDescriptor(t *testing.T, td *datadriven.TestData) roachpb.RangeDescriptor {

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -88,11 +88,12 @@ type testRaftNode struct {
 	b *strings.Builder
 	r *testReplica
 
-	admitted          [raftpb.NumPriorities]uint64
-	leader            roachpb.ReplicaID
+	term   uint64
+	leader roachpb.ReplicaID
+
 	stableIndex       uint64
 	nextUnstableIndex uint64
-	term              uint64
+	admitted          [raftpb.NumPriorities]uint64
 }
 
 func (rn *testRaftNode) EnablePingForAdmittedLaggingLocked() {
@@ -155,6 +156,12 @@ func (rn *testRaftNode) FollowerStateRaftMuLocked(
 	fmt.Fprintf(rn.b, " RaftNode.FollowerStateRaftMuLocked(%v)\n", replicaID)
 	// TODO(kvoli,sumeerbhola): implement.
 	return rac2.FollowerStateInfo{}
+}
+
+func (rn *testRaftNode) print() {
+	fmt.Fprintf(rn.b, "Raft: term: %d leader: %d leaseholder: %d stable: %d next-unstable: %d admitted: %s",
+		rn.term, rn.leader, rn.r.leaseholder, rn.stableIndex, rn.nextUnstableIndex,
+		admittedString(rn.admitted))
 }
 
 func admittedString(admitted [raftpb.NumPriorities]uint64) string {
@@ -307,11 +314,6 @@ func TestProcessorBasic(t *testing.T) {
 		b.Reset()
 		return str
 	}
-	printRaftState := func() {
-		fmt.Fprintf(&b, "Raft: leader: %d leaseholder: %d stable: %d next-unstable: %d term: %d admitted: %s",
-			r.raftNode.leader, r.leaseholder, r.raftNode.stableIndex, r.raftNode.nextUnstableIndex,
-			r.raftNode.term, admittedString(r.raftNode.admitted))
-	}
 	datadriven.RunTest(t, datapathutils.TestDataPath(t, "processor"),
 		func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
@@ -350,17 +352,17 @@ func TestProcessorBasic(t *testing.T) {
 					d.ScanArgs(t, "next-unstable-index", &nextUnstableIndex)
 					r.raftNode.nextUnstableIndex = nextUnstableIndex
 				}
-				if d.HasArg("my-leader-term") {
-					var myLeaderTerm uint64
-					d.ScanArgs(t, "my-leader-term", &myLeaderTerm)
-					r.raftNode.term = myLeaderTerm
+				if d.HasArg("term") {
+					var term uint64
+					d.ScanArgs(t, "term", &term)
+					r.raftNode.term = term
 				}
 				if d.HasArg("leaseholder") {
 					var leaseholder int
 					d.ScanArgs(t, "leaseholder", &leaseholder)
 					r.leaseholder = roachpb.ReplicaID(leaseholder)
 				}
-				printRaftState()
+				r.raftNode.print()
 				return builderStr()
 
 			case "on-destroy":

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/raft_node.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/raft_node.go
@@ -39,9 +39,8 @@ func (rn raftNodeForRACv2) LeaderLocked() roachpb.ReplicaID {
 	return roachpb.ReplicaID(rn.Lead())
 }
 
-func (rn raftNodeForRACv2) StableIndexLocked() uint64 {
-	// TODO(pav-kv): implement.
-	return 0
+func (rn raftNodeForRACv2) LogMarkLocked() rac2.LogMark {
+	return rn.LogMark()
 }
 
 func (rn raftNodeForRACv2) NextUnstableIndexLocked() uint64 {

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
@@ -55,11 +55,12 @@ init-raft log-term=40 log-index=23
  Replica.MuLock
  Replica.RaftMuAssertHeld
  Replica.MuAssertHeld
+ RaftNode.LogMarkLocked() = {Term:40 Index:23}
  Replica.MuUnlock
 
 set-raft-state term=50 leader=10 leaseholder=10
 ----
-Raft: term: 50 leader: 10 leaseholder: 10 mark: {Term:40 Index:23} stable: 23 next-unstable: 24 admitted: [23, 23, 23, 23]
+Raft: term: 50 leader: 10 leaseholder: 10 mark: {Term:40 Index:23} next-unstable: 24
 
 # The processor has never been given a range-descriptor, so it will do nothing.
 handle-raft-ready-and-admit
@@ -76,9 +77,9 @@ on-desc-changed  replicas=n11/s11/11
  Replica.MuAssertHeld
 
 # Raft is about to send us a newly appended entry 24.
-set-raft-state term=50 log-term=50 log-index=24 next-unstable-index=25
+set-raft-state log-term=50 log-index=24 next-unstable-index=25
 ----
-Raft: term: 50 leader: 10 leaseholder: 10 mark: {Term:50 Index:24} stable: 23 next-unstable: 25 admitted: [23, 23, 23, 23]
+Raft: term: 50 leader: 10 leaseholder: 10 mark: {Term:50 Index:24} next-unstable: 25
 
 # handleRaftReady. It thinks the leader is using v1, so there is no
 # advancement of admitted, or submission of this entry for admission.
@@ -88,19 +89,18 @@ HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 25
- RaftNode.StableIndexLocked() = 23
  RaftNode.LeaderLocked() = 10
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [23, 23, 23, 23]
  Replica.MuUnlock
 .....
 AdmitRaftEntries:
 destroyed-or-leader-using-v2: false
+LogTracker [+dirty]: mark:{Term:50 Index:24}, stable:23, admitted:[23 23 23 23]
 
-# A new entry 25 appended to raft by the new leader at term 50.
+# A new entry 25 appended to raft by the leader at term 50.
 set-raft-state log-term=50 log-index=25 next-unstable-index=26
 ----
-Raft: term: 50 leader: 10 leaseholder: 10 mark: {Term:50 Index:25} stable: 23 next-unstable: 26 admitted: [23, 23, 23, 23]
+Raft: term: 50 leader: 10 leaseholder: 10 mark: {Term:50 Index:25} next-unstable: 26
 
 # Told that the leader is using v2. And that [25,25] has no low-pri override.
 side-channel v2 leader-term=50 first=25 last=25
@@ -108,58 +108,55 @@ side-channel v2 leader-term=50 first=25 last=25
  Replica.RaftMuAssertHeld
 
 # The index 25 entry is v1 encoded, so by default it is low-pri. Admitted vector
-# does not advance.
+# does not advance, but its initial value is sent to the new leader.
 handle-raft-ready-and-admit entries=v1/i25/t45/pri0/time2/len100 leader-term=50
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 26
- RaftNode.StableIndexLocked() = 23
  RaftNode.LeaderLocked() = 10
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [23, 23, 23, 23]
  Replica.MuUnlock
 .....
 AdmitRaftEntries:
  ACWorkQueue.Admit({StoreID:2 TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false RangeID:3 ReplicaID:5 CallbackState:{Mark:{Term:50 Index:25} Priority:LowPri}}) = true
 destroyed-or-leader-using-v2: true
+LogTracker [+dirty]: mark:{Term:50 Index:25}, stable:23, admitted:[23 23 23 23]
+LowPri: {Term:50 Index:25}
 
 # The leader has changed.
 # TODO(pav-kv): the leader can't have changed without bumping the term.
 set-raft-state leader=11
 ----
-Raft: term: 50 leader: 11 leaseholder: 10 mark: {Term:50 Index:25} stable: 23 next-unstable: 26 admitted: [23, 23, 23, 23]
+Raft: term: 50 leader: 11 leaseholder: 10 mark: {Term:50 Index:25} next-unstable: 26
 
-# Stable index is advanced to 25.
+# Stable index is advanced to 25, and the admitted vector is updated. The
+# low-pri admitted index is 24 since there is an entry at 25 that is not
+# admitted.
 synced-log term=50 index=25
 ----
-Raft: term: 50 leader: 11 leaseholder: 10 mark: {Term:50 Index:25} stable: 25 next-unstable: 26 admitted: [23, 23, 23, 23]
+LogTracker [+dirty]: mark:{Term:50 Index:25}, stable:25, admitted:[24 25 25 25]
+LowPri: {Term:50 Index:25}
 
-# handleRaftReady with no entries. Since the leader is using v2, admitted is
-# advanced. admitted[low-pri] is 24 since there is an entry at 25 that is not
-# admitted. The new admitted vector is handed to the piggybacker.
+# handleRaftReady with no entries. Since the leader is using v2, and the
+# admitted vector was updated, the new vector is handed to the piggybacker.
 handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 26
- RaftNode.StableIndexLocked() = 25
  RaftNode.LeaderLocked() = 11
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [23, 23, 23, 23]
  Replica.MuUnlock
- Replica.MuLock
- RaftNode.SetAdmittedLocked([24, 25, 25, 25]) = type: MsgAppResp from: 0 to: 0
- Replica.MuUnlock
- Piggybacker.Add(n11, [r3,s11,5->0] admitted=t0/[])
+ Piggybacker.Add(n11, [r3,s11,5->11] admitted=t50/[24 25 25 25])
 .....
 
 # A new entry 26 appended to raft by the same leader at term 50.
 set-raft-state log-term=50 log-index=26 next-unstable-index=27
 ----
-Raft: term: 50 leader: 11 leaseholder: 10 mark: {Term:50 Index:26} stable: 25 next-unstable: 27 admitted: [24, 25, 25, 25]
+Raft: term: 50 leader: 11 leaseholder: 10 mark: {Term:50 Index:26} next-unstable: 27
 
 # Side channel for entries [26, 26] with no low-pri override.
 side-channel v2 leader-term=50 first=26 last=26
@@ -173,15 +170,16 @@ HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 27
- RaftNode.StableIndexLocked() = 25
  RaftNode.LeaderLocked() = 11
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [24, 25, 25, 25]
  Replica.MuUnlock
 .....
 AdmitRaftEntries:
  ACWorkQueue.Admit({StoreID:2 TenantID:4 Priority:user-high-pri CreateTime:2 RequestedCount:100 Ingested:false RangeID:3 ReplicaID:5 CallbackState:{Mark:{Term:50 Index:26} Priority:AboveNormalPri}}) = true
 destroyed-or-leader-using-v2: true
+LogTracker: mark:{Term:50 Index:26}, stable:25, admitted:[24 25 25 25]
+LowPri: {Term:50 Index:25}
+AboveNormalPri: {Term:50 Index:26}
 
 # handleRaftReady is a noop.
 handle-raft-ready-and-admit
@@ -190,66 +188,59 @@ HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 27
- RaftNode.StableIndexLocked() = 25
  RaftNode.LeaderLocked() = 11
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [24, 25, 25, 25]
  Replica.MuUnlock
 .....
 
 # Stable index is advanced, which should allow some priorities to advance
-# admitted, which will happen in the next handleRaftReady.
+# admitted, which will be piggybacked in the next handleRaftReady.
 synced-log term=50 index=26
 ----
-Raft: term: 50 leader: 11 leaseholder: 10 mark: {Term:50 Index:26} stable: 26 next-unstable: 27 admitted: [24, 25, 25, 25]
+LogTracker [+dirty]: mark:{Term:50 Index:26}, stable:26, admitted:[24 26 25 26]
+LowPri: {Term:50 Index:25}
+AboveNormalPri: {Term:50 Index:26}
 
 # Some admitted indices are advanced, but LowPri and AboveNormalPri cannot
 # advance past the index 25 and index 26 entries respectively, that are
-# waiting for admission.
+# waiting for admission. The new admitted vector is piggybacked.
 handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 27
- RaftNode.StableIndexLocked() = 26
  RaftNode.LeaderLocked() = 11
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [24, 25, 25, 25]
  Replica.MuUnlock
- Replica.MuLock
- RaftNode.SetAdmittedLocked([24, 26, 25, 26]) = type: MsgAppResp from: 0 to: 0
- Replica.MuUnlock
- Piggybacker.Add(n11, [r3,s11,5->0] admitted=t0/[])
+ Piggybacker.Add(n11, [r3,s11,5->11] admitted=t50/[24 26 25 26])
 .....
 
-# Callback is accurate and index 25 is admitted.
+# Callback is accurate and index 25 is admitted. The admitted index advances for
+# AboveNormalPri.
 admitted-log-entry leader-term=50 index=25 pri=0
 ----
  RaftScheduler.EnqueueRaftReady(rangeID=3)
+LogTracker [+dirty+sched]: mark:{Term:50 Index:26}, stable:26, admitted:[26 26 25 26]
+AboveNormalPri: {Term:50 Index:26}
 
-# admitted advances for AboveNormalPri.
+# The new admitted vector is piggybacked.
 handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 27
- RaftNode.StableIndexLocked() = 26
  RaftNode.LeaderLocked() = 11
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [24, 26, 25, 26]
  Replica.MuUnlock
- Replica.MuLock
- RaftNode.SetAdmittedLocked([26, 26, 25, 26]) = type: MsgAppResp from: 0 to: 0
- Replica.MuUnlock
- Piggybacker.Add(n11, [r3,s11,5->0] admitted=t0/[])
+ Piggybacker.Add(n11, [r3,s11,5->11] admitted=t50/[26 26 25 26])
 .....
 
 # Entry 27 is appended to raft.
 set-raft-state log-term=50 log-index=27 next-unstable-index=28
 ----
-Raft: term: 50 leader: 11 leaseholder: 10 mark: {Term:50 Index:27} stable: 26 next-unstable: 28 admitted: [26, 26, 25, 26]
+Raft: term: 50 leader: 11 leaseholder: 10 mark: {Term:50 Index:27} next-unstable: 28
 
 # Side channel for entries [27,27] indicate a low-pri override.
 side-channel v2 leader-term=50 first=27 last=27 low-pri
@@ -263,22 +254,28 @@ HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 28
- RaftNode.StableIndexLocked() = 26
  RaftNode.LeaderLocked() = 11
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [26, 26, 25, 26]
  Replica.MuUnlock
 .....
 AdmitRaftEntries:
  ACWorkQueue.Admit({StoreID:2 TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false RangeID:3 ReplicaID:5 CallbackState:{Mark:{Term:50 Index:27} Priority:LowPri}}) = true
 destroyed-or-leader-using-v2: true
+LogTracker: mark:{Term:50 Index:27}, stable:26, admitted:[26 26 25 26]
+LowPri: {Term:50 Index:27}
+AboveNormalPri: {Term:50 Index:26}
 
 admitted-log-entry leader-term=50 index=27 pri=3
 ----
+LogTracker: mark:{Term:50 Index:27}, stable:26, admitted:[26 26 25 26]
+LowPri: {Term:50 Index:27}
+AboveNormalPri: {Term:50 Index:26}
 
 admitted-log-entry leader-term=50 index=26 pri=2
 ----
  RaftScheduler.EnqueueRaftReady(rangeID=3)
+LogTracker [+dirty+sched]: mark:{Term:50 Index:27}, stable:26, admitted:[26 26 26 26]
+LowPri: {Term:50 Index:27}
 
 handle-raft-ready-and-admit
 ----
@@ -286,16 +283,16 @@ HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 28
- RaftNode.StableIndexLocked() = 26
  RaftNode.LeaderLocked() = 11
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [26, 26, 25, 26]
  Replica.MuUnlock
- Replica.MuLock
- RaftNode.SetAdmittedLocked([26, 26, 26, 26]) = type: MsgAppResp from: 0 to: 0
- Replica.MuUnlock
- Piggybacker.Add(n11, [r3,s11,5->0] admitted=t0/[])
+ Piggybacker.Add(n11, [r3,s11,5->11] admitted=t50/[26 26 26 26])
 .....
+
+# Switch to a new leader.
+set-raft-state term=51
+----
+Raft: term: 51 leader: 11 leaseholder: 10 mark: {Term:50 Index:27} next-unstable: 28
 
 # index 27 is still waiting for admission, but we switch to a new leader that
 # is using the v1 protocol. NB: in practice, we will never have the v1
@@ -305,10 +302,11 @@ side-channel v1 leader-term=51 first=27 last=27
 ----
  Replica.RaftMuAssertHeld
 
-# Stable index advanced to 27
+# Stable index advanced to 27, as well as all admitted indices except LowPri.
 synced-log term=50 index=27
 ----
-Raft: term: 50 leader: 11 leaseholder: 10 mark: {Term:50 Index:27} stable: 27 next-unstable: 28 admitted: [26, 26, 26, 26]
+LogTracker [+dirty]: mark:{Term:50 Index:27}, stable:27, admitted:[26 27 27 27]
+LowPri: {Term:50 Index:27}
 
 # Noop.
 handle-raft-ready-and-admit
@@ -317,55 +315,48 @@ HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 28
- RaftNode.StableIndexLocked() = 27
  RaftNode.LeaderLocked() = 11
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [26, 26, 26, 26]
  Replica.MuUnlock
 .....
 
-# A new entry at index 27 overwrites the previous one.
-# TODO(pav-kv): it should regress the stable and admitted indices.
+# A new entry at index 27 overwrites the previous one, and regresses the stable
+# and admitted indices.
 handle-raft-ready-and-admit entries=v1/i27/t46/pri0/time2/len100 leader-term=51
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 28
- RaftNode.StableIndexLocked() = 27
  RaftNode.LeaderLocked() = 11
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [26, 26, 26, 26]
  Replica.MuUnlock
 .....
 AdmitRaftEntries:
 destroyed-or-leader-using-v2: false
+LogTracker [+dirty]: mark:{Term:51 Index:27}, stable:26, admitted:[26 26 26 26]
 
 # Noop. Stale entry admission.
 admitted-log-entry leader-term=50 index=27 pri=0
 ----
+LogTracker [+dirty]: mark:{Term:51 Index:27}, stable:26, admitted:[26 26 26 26]
 
 # Same leader switches to v2.
 side-channel v2 leader-term=51 first=27 last=27
 ----
  Replica.RaftMuAssertHeld
 
-# Admitted advances.
+# Admitted vector is now sent to the leader.
 handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 28
- RaftNode.StableIndexLocked() = 27
  RaftNode.LeaderLocked() = 11
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [26, 26, 26, 26]
  Replica.MuUnlock
- Replica.MuLock
- RaftNode.SetAdmittedLocked([27, 27, 27, 27]) = type: MsgAppResp from: 0 to: 0
- Replica.MuUnlock
- Piggybacker.Add(n11, [r3,s11,5->0] admitted=t0/[])
+ Piggybacker.Add(n11, [r3,s11,5->11] admitted=t51/[26 26 26 26])
 .....
 
 # Noop, since not the leader.
@@ -380,7 +371,7 @@ process-piggybacked-admitted
 # Local replica is becoming the leader.
 set-raft-state term=52 leader=5
 ----
-Raft: term: 52 leader: 5 leaseholder: 10 mark: {Term:50 Index:27} stable: 27 next-unstable: 28 admitted: [27, 27, 27, 27]
+Raft: term: 52 leader: 5 leaseholder: 10 mark: {Term:50 Index:27} next-unstable: 28
 
 on-desc-changed  replicas=n11/s11/11,n1/s2/5
 ----
@@ -388,9 +379,9 @@ on-desc-changed  replicas=n11/s11/11,n1/s2/5
  Replica.MuAssertHeld
  RaftScheduler.EnqueueRaftReady(rangeID=3)
 
-set-raft-state log-term=52 log-index=28 next-unstable-index=29
+set-raft-state log-term=51 log-index=28 next-unstable-index=29
 ----
-Raft: term: 52 leader: 5 leaseholder: 10 mark: {Term:52 Index:28} stable: 27 next-unstable: 29 admitted: [27, 27, 27, 27]
+Raft: term: 52 leader: 5 leaseholder: 10 mark: {Term:51 Index:28} next-unstable: 29
 
 # RangeController is created.
 handle-raft-ready-and-admit entries=v1/i28/t46/pri0/time2/len100 leader-term=52
@@ -399,10 +390,8 @@ HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 29
- RaftNode.StableIndexLocked() = 27
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [27, 27, 27, 27]
  RaftNode.TermLocked() = 52
  Replica.MuUnlock
  RangeControllerFactory.New(replicaSet=[(n1,s2):5,(n11,s11):11], leaseholder=10, nextRaftIndex=28)
@@ -411,6 +400,8 @@ HandleRaftReady:
 AdmitRaftEntries:
  ACWorkQueue.Admit({StoreID:2 TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false RangeID:3 ReplicaID:5 CallbackState:{Mark:{Term:52 Index:28} Priority:LowPri}}) = true
 destroyed-or-leader-using-v2: true
+LogTracker [+dirty]: mark:{Term:52 Index:28}, stable:26, admitted:[26 26 26 26]
+LowPri: {Term:52 Index:28}
 
 # AdmitForEval returns true since there is a RangeController which admitted.
 admit-for-eval pri=low-pri
@@ -455,9 +446,11 @@ admit-for-eval pri=normal-pri
  RangeController.WaitForEval(pri=normal-pri) = (waited=false err=rc-was-closed)
 admitted: false err: rc-was-closed
 
-# Entry at index 28 is admitted, but stable index is 27.
+# Entry at index 28 is admitted, but stable index is still 26, so the admitted
+# vector is not changed since the last time.
 admitted-log-entry leader-term=52 index=28 pri=0
 ----
+LogTracker [+dirty]: mark:{Term:52 Index:28}, stable:26, admitted:[26 26 26 26]
 
 # Noop.
 handle-raft-ready-and-admit
@@ -466,41 +459,34 @@ HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 29
- RaftNode.StableIndexLocked() = 27
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [27, 27, 27, 27]
  RaftNode.TermLocked() = 52
  Replica.MuUnlock
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
 
-# Stable index advances to 28.
+# Stable index advances to 28, as well as all admitted indices.
 synced-log term=52 index=28
 ----
-Raft: term: 52 leader: 5 leaseholder: 10 mark: {Term:52 Index:28} stable: 28 next-unstable: 29 admitted: [27, 27, 27, 27]
+LogTracker [+dirty]: mark:{Term:52 Index:28}, stable:28, admitted:[28 28 28 28]
 
-# Admitted is advanced. Since the leader is local, no need to piggyback the
-# admitted vector.
+# Admitted is advanced, but since the leader is local, the new vector is not
+# piggybacked.
 handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 29
- RaftNode.StableIndexLocked() = 28
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [27, 27, 27, 27]
  RaftNode.TermLocked() = 52
- Replica.MuUnlock
- Replica.MuLock
- RaftNode.SetAdmittedLocked([28, 28, 28, 28]) = type: MsgAppResp from: 0 to: 0
  Replica.MuUnlock
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
 
-# Enqueue piggybacked MsgAppResp.
+# Enqueue piggybacked admitted vector.
 enqueue-piggybacked-admitted from=25 to=5
 ----
 
@@ -529,7 +515,7 @@ process-piggybacked-admitted
 # We are still the leader, now at a new term.
 set-raft-state term=53
 ----
-Raft: term: 53 leader: 5 leaseholder: 10 mark: {Term:52 Index:28} stable: 28 next-unstable: 29 admitted: [28, 28, 28, 28]
+Raft: term: 53 leader: 5 leaseholder: 10 mark: {Term:51 Index:28} next-unstable: 29
 
 # RangeController is recreated.
 handle-raft-ready-and-admit
@@ -538,10 +524,8 @@ HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 29
- RaftNode.StableIndexLocked() = 28
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [28, 28, 28, 28]
  RaftNode.TermLocked() = 53
  Replica.MuUnlock
  RangeController.CloseRaftMuLocked
@@ -561,10 +545,8 @@ HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 29
- RaftNode.StableIndexLocked() = 28
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [28, 28, 28, 28]
  RaftNode.TermLocked() = 53
  Replica.MuUnlock
  RangeController.SetReplicasRaftMuLocked([(n1,s2):5,(n11,s11):11,(n13,s13):13])
@@ -616,10 +598,12 @@ HandleRaftReady:
 .....
 AdmitRaftEntries:
 destroyed-or-leader-using-v2: true
+LogTracker [+dirty]: mark:{Term:53 Index:29}, stable:28, admitted:[28 28 28 28]
 
 # Noop.
 admitted-log-entry leader-term=52 index=28 pri=0
 ----
+LogTracker [+dirty]: mark:{Term:53 Index:29}, stable:28, admitted:[28 28 28 28]
 
 # Test transitioning to v2 protocol after becoming leader.
 reset
@@ -635,11 +619,12 @@ init-raft log-term=50 log-index=24
  Replica.MuLock
  Replica.RaftMuAssertHeld
  Replica.MuAssertHeld
+ RaftNode.LogMarkLocked() = {Term:50 Index:24}
  Replica.MuUnlock
 
 set-raft-state term=50 leader=5 leaseholder=5
 ----
-Raft: term: 50 leader: 5 leaseholder: 5 mark: {Term:50 Index:24} stable: 24 next-unstable: 25 admitted: [24, 24, 24, 24]
+Raft: term: 50 leader: 5 leaseholder: 5 mark: {Term:50 Index:24} next-unstable: 25
 
 # Noop, since don't know the descriptor.
 handle-raft-ready-and-admit
@@ -660,17 +645,15 @@ HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 25
- RaftNode.StableIndexLocked() = 24
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [24, 24, 24, 24]
  RaftNode.TermLocked() = 50
  Replica.MuUnlock
 .....
 
 set-raft-state log-term=50 log-index=25 next-unstable-index=26
 ----
-Raft: term: 50 leader: 5 leaseholder: 5 mark: {Term:50 Index:25} stable: 24 next-unstable: 26 admitted: [24, 24, 24, 24]
+Raft: term: 50 leader: 5 leaseholder: 5 mark: {Term:50 Index:25} next-unstable: 26
 
 # v1 protocol, so does not do anything.
 handle-raft-ready-and-admit entries=v1/i25/t45/pri0/time2/len100 leader-term=50
@@ -679,15 +662,14 @@ HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 26
- RaftNode.StableIndexLocked() = 24
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [24, 24, 24, 24]
  RaftNode.TermLocked() = 50
  Replica.MuUnlock
 .....
 AdmitRaftEntries:
 destroyed-or-leader-using-v2: false
+LogTracker: mark:{Term:50 Index:25}, stable:24, admitted:[24 24 24 24]
 
 # RangeController is created.
 set-enabled-level enabled-level=v1-encoding
@@ -702,7 +684,7 @@ set-enabled-level enabled-level=v1-encoding
 
 set-raft-state log-term=50 log-index=26 next-unstable-index=27
 ----
-Raft: term: 50 leader: 5 leaseholder: 5 mark: {Term:50 Index:26} stable: 24 next-unstable: 27 admitted: [24, 24, 24, 24]
+Raft: term: 50 leader: 5 leaseholder: 5 mark: {Term:50 Index:26} next-unstable: 27
 
 # Index 26 entry is sent to AC.
 handle-raft-ready-and-admit entries=v1/i26/t45/pri0/time2/len100 leader-term=50
@@ -711,10 +693,8 @@ HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 27
- RaftNode.StableIndexLocked() = 24
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [24, 24, 24, 24]
  RaftNode.TermLocked() = 50
  Replica.MuUnlock
  RangeController.HandleRaftEventRaftMuLocked([26])
@@ -722,53 +702,49 @@ HandleRaftReady:
 AdmitRaftEntries:
  ACWorkQueue.Admit({StoreID:2 TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false RangeID:3 ReplicaID:5 CallbackState:{Mark:{Term:50 Index:26} Priority:LowPri}}) = true
 destroyed-or-leader-using-v2: true
+LogTracker: mark:{Term:50 Index:26}, stable:24, admitted:[24 24 24 24]
+LowPri: {Term:50 Index:26}
 
 # Entry is admitted.
 admitted-log-entry leader-term=50 index=26 pri=0
 ----
+LogTracker: mark:{Term:50 Index:26}, stable:24, admitted:[24 24 24 24]
 
-# Noop, since stable index is still 20.
+# Noop, since stable index is still 24.
 handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 27
- RaftNode.StableIndexLocked() = 24
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [24, 24, 24, 24]
  RaftNode.TermLocked() = 50
  Replica.MuUnlock
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
 
+# Everything up to 26 is admitted.
 synced-log term=50 index=26
 ----
-Raft: term: 50 leader: 5 leaseholder: 5 mark: {Term:50 Index:26} stable: 26 next-unstable: 27 admitted: [24, 24, 24, 24]
+LogTracker [+dirty]: mark:{Term:50 Index:26}, stable:26, admitted:[26 26 26 26]
 
-# Everything up to 26 is admitted.
 handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 27
- RaftNode.StableIndexLocked() = 26
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [24, 24, 24, 24]
  RaftNode.TermLocked() = 50
- Replica.MuUnlock
- Replica.MuLock
- RaftNode.SetAdmittedLocked([26, 26, 26, 26]) = type: MsgAppResp from: 0 to: 0
  Replica.MuUnlock
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
 
 set-raft-state log-term=50 log-index=27 next-unstable-index=28
 ----
-Raft: term: 50 leader: 5 leaseholder: 5 mark: {Term:50 Index:27} stable: 26 next-unstable: 28 admitted: [26, 26, 26, 26]
+Raft: term: 50 leader: 5 leaseholder: 5 mark: {Term:50 Index:27} next-unstable: 28
 
 # Index 27 entry is not subject to AC.
 handle-raft-ready-and-admit entries=none/i27/t45/pri0/time2/len100 leader-term=50
@@ -777,36 +753,30 @@ HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 28
- RaftNode.StableIndexLocked() = 26
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [26, 26, 26, 26]
  RaftNode.TermLocked() = 50
  Replica.MuUnlock
  RangeController.HandleRaftEventRaftMuLocked([27])
 .....
 AdmitRaftEntries:
 destroyed-or-leader-using-v2: true
-
-synced-log term=50 index=27
-----
-Raft: term: 50 leader: 5 leaseholder: 5 mark: {Term:50 Index:27} stable: 27 next-unstable: 28 admitted: [26, 26, 26, 26]
+LogTracker [+dirty]: mark:{Term:50 Index:27}, stable:26, admitted:[26 26 26 26]
 
 # Everything up to 27 is admitted.
+synced-log term=50 index=27
+----
+LogTracker [+dirty]: mark:{Term:50 Index:27}, stable:27, admitted:[27 27 27 27]
+
 handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 28
- RaftNode.StableIndexLocked() = 27
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [26, 26, 26, 26]
  RaftNode.TermLocked() = 50
- Replica.MuUnlock
- Replica.MuLock
- RaftNode.SetAdmittedLocked([27, 27, 27, 27]) = type: MsgAppResp from: 0 to: 0
  Replica.MuUnlock
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
@@ -814,7 +784,7 @@ HandleRaftReady:
 # Transition to follower. In this case, the leader is not even known.
 set-raft-state term=51 leader=0
 ----
-Raft: term: 51 leader: 0 leaseholder: 5 mark: {Term:50 Index:27} stable: 27 next-unstable: 28 admitted: [27, 27, 27, 27]
+Raft: term: 51 leader: 0 leaseholder: 5 mark: {Term:50 Index:27} next-unstable: 28
 
 handle-raft-ready-and-admit
 ----
@@ -822,10 +792,8 @@ HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 28
- RaftNode.StableIndexLocked() = 27
  RaftNode.LeaderLocked() = 0
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [27, 27, 27, 27]
  Replica.MuUnlock
  RangeController.CloseRaftMuLocked
 .....

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
@@ -125,9 +125,14 @@ AdmitRaftEntries:
  ACWorkQueue.Admit({StoreID:2 TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false RangeID:3 ReplicaID:5 CallbackState:{Mark:{Term:50 Index:25} Priority:LowPri}}) = true
 destroyed-or-leader-using-v2: true
 
-# Stable index is advanced to 25, and the leader has changed.
+# The leader has changed.
 # TODO(pav-kv): the leader can't have changed without bumping the term.
-set-raft-state stable-index=25 leader=11
+set-raft-state leader=11
+----
+Raft: term: 50 leader: 11 leaseholder: 10 mark: {Term:50 Index:25} stable: 23 next-unstable: 26 admitted: [23, 23, 23, 23]
+
+# Stable index is advanced to 25.
+synced-log term=50 index=25
 ----
 Raft: term: 50 leader: 11 leaseholder: 10 mark: {Term:50 Index:25} stable: 25 next-unstable: 26 admitted: [23, 23, 23, 23]
 
@@ -194,7 +199,7 @@ HandleRaftReady:
 
 # Stable index is advanced, which should allow some priorities to advance
 # admitted, which will happen in the next handleRaftReady.
-set-raft-state stable-index=26
+synced-log term=50 index=26
 ----
 Raft: term: 50 leader: 11 leaseholder: 10 mark: {Term:50 Index:26} stable: 26 next-unstable: 27 admitted: [24, 25, 25, 25]
 
@@ -301,7 +306,7 @@ side-channel v1 leader-term=51 first=27 last=27
  Replica.RaftMuAssertHeld
 
 # Stable index advanced to 27
-set-raft-state stable-index=27
+synced-log term=50 index=27
 ----
 Raft: term: 50 leader: 11 leaseholder: 10 mark: {Term:50 Index:27} stable: 27 next-unstable: 28 admitted: [26, 26, 26, 26]
 
@@ -471,7 +476,7 @@ HandleRaftReady:
 .....
 
 # Stable index advances to 28.
-set-raft-state stable-index=28
+synced-log term=52 index=28
 ----
 Raft: term: 52 leader: 5 leaseholder: 10 mark: {Term:52 Index:28} stable: 28 next-unstable: 29 admitted: [27, 27, 27, 27]
 
@@ -738,7 +743,7 @@ HandleRaftReady:
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
 
-set-raft-state stable-index=26
+synced-log term=50 index=26
 ----
 Raft: term: 50 leader: 5 leaseholder: 5 mark: {Term:50 Index:26} stable: 26 next-unstable: 27 admitted: [24, 24, 24, 24]
 
@@ -783,7 +788,7 @@ HandleRaftReady:
 AdmitRaftEntries:
 destroyed-or-leader-using-v2: true
 
-set-raft-state stable-index=27
+synced-log term=50 index=27
 ----
 Raft: term: 50 leader: 5 leaseholder: 5 mark: {Term:50 Index:27} stable: 27 next-unstable: 28 admitted: [26, 26, 26, 26]
 

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
@@ -58,7 +58,7 @@ init-raft log-term=0 log-index=20
 # leaseholder are both on replica-id 10.
 set-raft-state leader=10 stable-index=20 next-unstable-index=25 leaseholder=10 admitted=[15,20,15,20]
 ----
-Raft: leader: 10 leaseholder: 10 stable: 20 next-unstable: 25 term: 0 admitted: [15, 20, 15, 20]
+Raft: term: 0 leader: 10 leaseholder: 10 stable: 20 next-unstable: 25 admitted: [15, 20, 15, 20]
 
 # The processor has never been given a range-descriptor, so it will do nothing.
 handle-raft-ready-and-admit
@@ -98,7 +98,7 @@ side-channel v2 leader-term=50 first=25 last=25
 
 set-raft-state next-unstable-index=26
 ----
-Raft: leader: 10 leaseholder: 10 stable: 20 next-unstable: 26 term: 0 admitted: [15, 20, 15, 20]
+Raft: term: 0 leader: 10 leaseholder: 10 stable: 20 next-unstable: 26 admitted: [15, 20, 15, 20]
 
 # The index 25 entry is v1 encoded, so by default it is low-pri. Admitted is
 # advanced to the stable-index, and this entry is submitted for admission.
@@ -124,7 +124,7 @@ destroyed-or-leader-using-v2: true
 # Stable index is advanced to 25.
 set-raft-state stable-index=25 leader=11
 ----
-Raft: leader: 11 leaseholder: 10 stable: 25 next-unstable: 26 term: 0 admitted: [20, 20, 20, 20]
+Raft: term: 0 leader: 11 leaseholder: 10 stable: 25 next-unstable: 26 admitted: [20, 20, 20, 20]
 
 # handleRaftReady with no entries. Since the leader is using v2, admitted is
 # advanced. admitted[low-pri] is 24 since there is an entry at 25 that is not
@@ -153,7 +153,7 @@ side-channel v2 leader-term=50 first=26 last=26
 
 set-raft-state next-unstable-index=27
 ----
-Raft: leader: 11 leaseholder: 10 stable: 25 next-unstable: 27 term: 0 admitted: [24, 25, 25, 25]
+Raft: term: 0 leader: 11 leaseholder: 10 stable: 25 next-unstable: 27 admitted: [24, 25, 25, 25]
 
 # The index 26 entry uses v2 and is using pri=2, which is AboveNormalPri.
 handle-raft-ready-and-admit entries=v2/i26/t45/pri2/time2/len100 leader-term=50
@@ -190,7 +190,7 @@ HandleRaftReady:
 # admitted, which will happen in the next handleRaftReady.
 set-raft-state stable-index=26
 ----
-Raft: leader: 11 leaseholder: 10 stable: 26 next-unstable: 27 term: 0 admitted: [24, 25, 25, 25]
+Raft: term: 0 leader: 11 leaseholder: 10 stable: 26 next-unstable: 27 admitted: [24, 25, 25, 25]
 
 # Some admitted indices are advanced, but LowPri and AboveNormalPri cannot
 # advance past the index 25 and index 26 entries respectively, that are
@@ -242,7 +242,7 @@ side-channel v2 leader-term=50 first=27 last=27 low-pri
 
 set-raft-state next-unstable-index=28
 ----
-Raft: leader: 11 leaseholder: 10 stable: 26 next-unstable: 28 term: 0 admitted: [26, 26, 25, 26]
+Raft: term: 0 leader: 11 leaseholder: 10 stable: 26 next-unstable: 28 admitted: [26, 26, 25, 26]
 
 # The index 27 entry is marked AboveNormalPri, but will be treated as LowPri.
 handle-raft-ready-and-admit entries=v2/i27/t45/pri2/time2/len100 leader-term=50
@@ -296,7 +296,7 @@ side-channel v1 leader-term=51 first=27 last=27
 # Stable index advanced to 27
 set-raft-state stable-index=27
 ----
-Raft: leader: 11 leaseholder: 10 stable: 27 next-unstable: 28 term: 0 admitted: [26, 26, 26, 26]
+Raft: term: 0 leader: 11 leaseholder: 10 stable: 27 next-unstable: 28 admitted: [26, 26, 26, 26]
 
 # Noop.
 handle-raft-ready-and-admit
@@ -365,9 +365,9 @@ process-piggybacked-admitted
  Replica.RaftMuAssertHeld
 
 # Local replica is becoming the leader.
-set-raft-state leader=5 my-leader-term=52
+set-raft-state term=52 leader=5
 ----
-Raft: leader: 5 leaseholder: 10 stable: 27 next-unstable: 28 term: 52 admitted: [27, 27, 27, 27]
+Raft: term: 52 leader: 5 leaseholder: 10 stable: 27 next-unstable: 28 admitted: [27, 27, 27, 27]
 
 on-desc-changed  replicas=n11/s11/11,n1/s2/5
 ----
@@ -377,7 +377,7 @@ on-desc-changed  replicas=n11/s11/11,n1/s2/5
 
 set-raft-state next-unstable-index=29
 ----
-Raft: leader: 5 leaseholder: 10 stable: 27 next-unstable: 29 term: 52 admitted: [27, 27, 27, 27]
+Raft: term: 52 leader: 5 leaseholder: 10 stable: 27 next-unstable: 29 admitted: [27, 27, 27, 27]
 
 # RangeController is created.
 handle-raft-ready-and-admit entries=v1/i28/t45/pri0/time2/len100 leader-term=52
@@ -465,7 +465,7 @@ HandleRaftReady:
 # Stable index advances to 28.
 set-raft-state stable-index=28
 ----
-Raft: leader: 5 leaseholder: 10 stable: 28 next-unstable: 29 term: 52 admitted: [27, 27, 27, 27]
+Raft: term: 52 leader: 5 leaseholder: 10 stable: 28 next-unstable: 29 admitted: [27, 27, 27, 27]
 
 # Admitted is advanced. Since the leader is local, no need to piggyback MsgAppResp.
 handle-raft-ready-and-admit
@@ -513,9 +513,9 @@ process-piggybacked-admitted
  Replica.RaftMuAssertHeld
 
 # My leader-term advances.
-set-raft-state my-leader-term=53
+set-raft-state term=53
 ----
-Raft: leader: 5 leaseholder: 10 stable: 28 next-unstable: 29 term: 53 admitted: [28, 28, 28, 28]
+Raft: term: 53 leader: 5 leaseholder: 10 stable: 28 next-unstable: 29 admitted: [28, 28, 28, 28]
 
 # RangeController is recreated.
 handle-raft-ready-and-admit
@@ -621,9 +621,9 @@ init-raft log-term=0 log-index=20
  Replica.RaftMuAssertHeld
  Replica.MuAssertHeld
 
-set-raft-state leader=5 my-leader-term=50 leaseholder=5 stable-index=20 next-unstable-index=25 admitted=[15,20,15,20]
+set-raft-state term=50 leader=5 leaseholder=5 stable-index=20 next-unstable-index=25 admitted=[15,20,15,20]
 ----
-Raft: leader: 5 leaseholder: 5 stable: 20 next-unstable: 25 term: 50 admitted: [15, 20, 15, 20]
+Raft: term: 50 leader: 5 leaseholder: 5 stable: 20 next-unstable: 25 admitted: [15, 20, 15, 20]
 
 # Noop, since don't know the descriptor.
 handle-raft-ready-and-admit
@@ -654,7 +654,7 @@ HandleRaftReady:
 
 set-raft-state next-unstable-index=26
 ----
-Raft: leader: 5 leaseholder: 5 stable: 20 next-unstable: 26 term: 50 admitted: [15, 20, 15, 20]
+Raft: term: 50 leader: 5 leaseholder: 5 stable: 20 next-unstable: 26 admitted: [15, 20, 15, 20]
 
 # v1 protocol, so does not do anything.
 handle-raft-ready-and-admit entries=v1/i25/t45/pri0/time2/len100 leader-term=50
@@ -686,7 +686,7 @@ set-enabled-level enabled-level=v1-encoding
 
 set-raft-state next-unstable-index=27
 ----
-Raft: leader: 5 leaseholder: 5 stable: 20 next-unstable: 27 term: 50 admitted: [15, 20, 15, 20]
+Raft: term: 50 leader: 5 leaseholder: 5 stable: 20 next-unstable: 27 admitted: [15, 20, 15, 20]
 
 # Index 26 entry is sent to AC.
 handle-raft-ready-and-admit entries=v1/i26/t45/pri0/time2/len100 leader-term=50
@@ -732,7 +732,7 @@ HandleRaftReady:
 
 set-raft-state stable-index=26
 ----
-Raft: leader: 5 leaseholder: 5 stable: 26 next-unstable: 27 term: 50 admitted: [20, 20, 20, 20]
+Raft: term: 50 leader: 5 leaseholder: 5 stable: 26 next-unstable: 27 admitted: [20, 20, 20, 20]
 
 # Everything up to 26 is admitted.
 handle-raft-ready-and-admit
@@ -755,7 +755,7 @@ HandleRaftReady:
 
 set-raft-state next-unstable-index=28
 ----
-Raft: leader: 5 leaseholder: 5 stable: 26 next-unstable: 28 term: 50 admitted: [26, 26, 26, 26]
+Raft: term: 50 leader: 5 leaseholder: 5 stable: 26 next-unstable: 28 admitted: [26, 26, 26, 26]
 
 # Index 27 entry is not subject to AC.
 handle-raft-ready-and-admit entries=none/i27/t45/pri0/time2/len100 leader-term=50
@@ -777,7 +777,7 @@ destroyed-or-leader-using-v2: true
 
 set-raft-state stable-index=27
 ----
-Raft: leader: 5 leaseholder: 5 stable: 27 next-unstable: 28 term: 50 admitted: [26, 26, 26, 26]
+Raft: term: 50 leader: 5 leaseholder: 5 stable: 27 next-unstable: 28 admitted: [26, 26, 26, 26]
 
 # Everything up to 27 is admitted.
 handle-raft-ready-and-admit
@@ -801,7 +801,7 @@ HandleRaftReady:
 # Transition to follower. In this case, the leader is not even known.
 set-raft-state leader=0
 ----
-Raft: leader: 0 leaseholder: 5 stable: 27 next-unstable: 28 term: 50 admitted: [27, 27, 27, 27]
+Raft: term: 50 leader: 0 leaseholder: 5 stable: 27 next-unstable: 28 admitted: [27, 27, 27, 27]
 
 handle-raft-ready-and-admit
 ----

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
@@ -48,17 +48,18 @@ get-enabled-level
 ----
 enabled-level: v1-encoding
 
-# TODO(pav-kv): initialize to a correct state.
-init-raft log-term=0 log-index=20
+# When replica is initialized, stable index and admitted indices are at the tip
+# of the log. The leader and leaseholder are both on replica-id 10.
+init-raft log-term=40 log-index=23
 ----
+ Replica.MuLock
  Replica.RaftMuAssertHeld
  Replica.MuAssertHeld
+ Replica.MuUnlock
 
-# Since stable-index is 20, admitted is slightly behind. The leader and
-# leaseholder are both on replica-id 10.
-set-raft-state leader=10 stable-index=20 next-unstable-index=25 leaseholder=10 admitted=[15,20,15,20]
+set-raft-state term=50 leader=10 leaseholder=10
 ----
-Raft: term: 0 leader: 10 leaseholder: 10 stable: 20 next-unstable: 25 admitted: [15, 20, 15, 20]
+Raft: term: 50 leader: 10 leaseholder: 10 mark: {Term:40 Index:23} stable: 23 next-unstable: 24 admitted: [23, 23, 23, 23]
 
 # The processor has never been given a range-descriptor, so it will do nothing.
 handle-raft-ready-and-admit
@@ -74,61 +75,65 @@ on-desc-changed  replicas=n11/s11/11
  Replica.RaftMuAssertHeld
  Replica.MuAssertHeld
 
+# Raft is about to send us a newly appended entry 24.
+set-raft-state term=50 log-term=50 log-index=24 next-unstable-index=25
+----
+Raft: term: 50 leader: 10 leaseholder: 10 mark: {Term:50 Index:24} stable: 23 next-unstable: 25 admitted: [23, 23, 23, 23]
+
 # handleRaftReady. It thinks the leader is using v1, so there is no
 # advancement of admitted, or submission of this entry for admission.
-handle-raft-ready-and-admit entries=v1/i25/t45/pri0/time2/len100 leader-term=50
+handle-raft-ready-and-admit entries=v1/i24/t45/pri0/time2/len100 leader-term=50
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 25
- RaftNode.StableIndexLocked() = 20
+ RaftNode.StableIndexLocked() = 23
  RaftNode.LeaderLocked() = 10
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [15, 20, 15, 20]
+ RaftNode.GetAdmittedLocked = [23, 23, 23, 23]
  Replica.MuUnlock
 .....
 AdmitRaftEntries:
 destroyed-or-leader-using-v2: false
+
+# A new entry 25 appended to raft by the new leader at term 50.
+set-raft-state log-term=50 log-index=25 next-unstable-index=26
+----
+Raft: term: 50 leader: 10 leaseholder: 10 mark: {Term:50 Index:25} stable: 23 next-unstable: 26 admitted: [23, 23, 23, 23]
 
 # Told that the leader is using v2. And that [25,25] has no low-pri override.
 side-channel v2 leader-term=50 first=25 last=25
 ----
  Replica.RaftMuAssertHeld
 
-set-raft-state next-unstable-index=26
-----
-Raft: term: 0 leader: 10 leaseholder: 10 stable: 20 next-unstable: 26 admitted: [15, 20, 15, 20]
-
-# The index 25 entry is v1 encoded, so by default it is low-pri. Admitted is
-# advanced to the stable-index, and this entry is submitted for admission.
+# The index 25 entry is v1 encoded, so by default it is low-pri. Admitted vector
+# does not advance.
 handle-raft-ready-and-admit entries=v1/i25/t45/pri0/time2/len100 leader-term=50
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 26
- RaftNode.StableIndexLocked() = 20
+ RaftNode.StableIndexLocked() = 23
  RaftNode.LeaderLocked() = 10
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [15, 20, 15, 20]
- Replica.MuUnlock
- Replica.MuLock
- RaftNode.SetAdmittedLocked([20, 20, 20, 20]) = type: MsgAppResp from: 0 to: 0
+ RaftNode.GetAdmittedLocked = [23, 23, 23, 23]
  Replica.MuUnlock
 .....
 AdmitRaftEntries:
  ACWorkQueue.Admit({StoreID:2 TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false RangeID:3 ReplicaID:5 CallbackState:{Mark:{Term:50 Index:25} Priority:LowPri}}) = true
 destroyed-or-leader-using-v2: true
 
-# Stable index is advanced to 25.
+# Stable index is advanced to 25, and the leader has changed.
+# TODO(pav-kv): the leader can't have changed without bumping the term.
 set-raft-state stable-index=25 leader=11
 ----
-Raft: term: 0 leader: 11 leaseholder: 10 stable: 25 next-unstable: 26 admitted: [20, 20, 20, 20]
+Raft: term: 50 leader: 11 leaseholder: 10 mark: {Term:50 Index:25} stable: 25 next-unstable: 26 admitted: [23, 23, 23, 23]
 
 # handleRaftReady with no entries. Since the leader is using v2, admitted is
 # advanced. admitted[low-pri] is 24 since there is an entry at 25 that is not
-# admitted. A MsgAppResp is handed to the piggybacker.
+# admitted. The new admitted vector is handed to the piggybacker.
 handle-raft-ready-and-admit
 ----
 HandleRaftReady:
@@ -138,7 +143,7 @@ HandleRaftReady:
  RaftNode.StableIndexLocked() = 25
  RaftNode.LeaderLocked() = 11
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [20, 20, 20, 20]
+ RaftNode.GetAdmittedLocked = [23, 23, 23, 23]
  Replica.MuUnlock
  Replica.MuLock
  RaftNode.SetAdmittedLocked([24, 25, 25, 25]) = type: MsgAppResp from: 0 to: 0
@@ -146,14 +151,15 @@ HandleRaftReady:
  Piggybacker.Add(n11, [r3,s11,5->0] admitted=t0/[])
 .....
 
+# A new entry 26 appended to raft by the same leader at term 50.
+set-raft-state log-term=50 log-index=26 next-unstable-index=27
+----
+Raft: term: 50 leader: 11 leaseholder: 10 mark: {Term:50 Index:26} stable: 25 next-unstable: 27 admitted: [24, 25, 25, 25]
+
 # Side channel for entries [26, 26] with no low-pri override.
 side-channel v2 leader-term=50 first=26 last=26
 ----
  Replica.RaftMuAssertHeld
-
-set-raft-state next-unstable-index=27
-----
-Raft: term: 0 leader: 11 leaseholder: 10 stable: 25 next-unstable: 27 admitted: [24, 25, 25, 25]
 
 # The index 26 entry uses v2 and is using pri=2, which is AboveNormalPri.
 handle-raft-ready-and-admit entries=v2/i26/t45/pri2/time2/len100 leader-term=50
@@ -190,7 +196,7 @@ HandleRaftReady:
 # admitted, which will happen in the next handleRaftReady.
 set-raft-state stable-index=26
 ----
-Raft: term: 0 leader: 11 leaseholder: 10 stable: 26 next-unstable: 27 admitted: [24, 25, 25, 25]
+Raft: term: 50 leader: 11 leaseholder: 10 mark: {Term:50 Index:26} stable: 26 next-unstable: 27 admitted: [24, 25, 25, 25]
 
 # Some admitted indices are advanced, but LowPri and AboveNormalPri cannot
 # advance past the index 25 and index 26 entries respectively, that are
@@ -235,14 +241,15 @@ HandleRaftReady:
  Piggybacker.Add(n11, [r3,s11,5->0] admitted=t0/[])
 .....
 
+# Entry 27 is appended to raft.
+set-raft-state log-term=50 log-index=27 next-unstable-index=28
+----
+Raft: term: 50 leader: 11 leaseholder: 10 mark: {Term:50 Index:27} stable: 26 next-unstable: 28 admitted: [26, 26, 25, 26]
+
 # Side channel for entries [27,27] indicate a low-pri override.
 side-channel v2 leader-term=50 first=27 last=27 low-pri
 ----
  Replica.RaftMuAssertHeld
-
-set-raft-state next-unstable-index=28
-----
-Raft: term: 0 leader: 11 leaseholder: 10 stable: 26 next-unstable: 28 admitted: [26, 26, 25, 26]
 
 # The index 27 entry is marked AboveNormalPri, but will be treated as LowPri.
 handle-raft-ready-and-admit entries=v2/i27/t45/pri2/time2/len100 leader-term=50
@@ -296,7 +303,7 @@ side-channel v1 leader-term=51 first=27 last=27
 # Stable index advanced to 27
 set-raft-state stable-index=27
 ----
-Raft: term: 0 leader: 11 leaseholder: 10 stable: 27 next-unstable: 28 admitted: [26, 26, 26, 26]
+Raft: term: 50 leader: 11 leaseholder: 10 mark: {Term:50 Index:27} stable: 27 next-unstable: 28 admitted: [26, 26, 26, 26]
 
 # Noop.
 handle-raft-ready-and-admit
@@ -312,8 +319,9 @@ HandleRaftReady:
  Replica.MuUnlock
 .....
 
-# Noop.
-handle-raft-ready-and-admit entries=v1/i27/t45/pri0/time2/len100 leader-term=51
+# A new entry at index 27 overwrites the previous one.
+# TODO(pav-kv): it should regress the stable and admitted indices.
+handle-raft-ready-and-admit entries=v1/i27/t46/pri0/time2/len100 leader-term=51
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
@@ -328,7 +336,7 @@ HandleRaftReady:
 AdmitRaftEntries:
 destroyed-or-leader-using-v2: false
 
-# Noop.
+# Noop. Stale entry admission.
 admitted-log-entry leader-term=50 index=27 pri=0
 ----
 
@@ -367,7 +375,7 @@ process-piggybacked-admitted
 # Local replica is becoming the leader.
 set-raft-state term=52 leader=5
 ----
-Raft: term: 52 leader: 5 leaseholder: 10 stable: 27 next-unstable: 28 admitted: [27, 27, 27, 27]
+Raft: term: 52 leader: 5 leaseholder: 10 mark: {Term:50 Index:27} stable: 27 next-unstable: 28 admitted: [27, 27, 27, 27]
 
 on-desc-changed  replicas=n11/s11/11,n1/s2/5
 ----
@@ -375,12 +383,12 @@ on-desc-changed  replicas=n11/s11/11,n1/s2/5
  Replica.MuAssertHeld
  RaftScheduler.EnqueueRaftReady(rangeID=3)
 
-set-raft-state next-unstable-index=29
+set-raft-state log-term=52 log-index=28 next-unstable-index=29
 ----
-Raft: term: 52 leader: 5 leaseholder: 10 stable: 27 next-unstable: 29 admitted: [27, 27, 27, 27]
+Raft: term: 52 leader: 5 leaseholder: 10 mark: {Term:52 Index:28} stable: 27 next-unstable: 29 admitted: [27, 27, 27, 27]
 
 # RangeController is created.
-handle-raft-ready-and-admit entries=v1/i28/t45/pri0/time2/len100 leader-term=52
+handle-raft-ready-and-admit entries=v1/i28/t46/pri0/time2/len100 leader-term=52
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
@@ -465,9 +473,10 @@ HandleRaftReady:
 # Stable index advances to 28.
 set-raft-state stable-index=28
 ----
-Raft: term: 52 leader: 5 leaseholder: 10 stable: 28 next-unstable: 29 admitted: [27, 27, 27, 27]
+Raft: term: 52 leader: 5 leaseholder: 10 mark: {Term:52 Index:28} stable: 28 next-unstable: 29 admitted: [27, 27, 27, 27]
 
-# Admitted is advanced. Since the leader is local, no need to piggyback MsgAppResp.
+# Admitted is advanced. Since the leader is local, no need to piggyback the
+# admitted vector.
 handle-raft-ready-and-admit
 ----
 HandleRaftReady:
@@ -512,10 +521,10 @@ process-piggybacked-admitted
 ----
  Replica.RaftMuAssertHeld
 
-# My leader-term advances.
+# We are still the leader, now at a new term.
 set-raft-state term=53
 ----
-Raft: term: 53 leader: 5 leaseholder: 10 stable: 28 next-unstable: 29 admitted: [28, 28, 28, 28]
+Raft: term: 53 leader: 5 leaseholder: 10 mark: {Term:52 Index:28} stable: 28 next-unstable: 29 admitted: [28, 28, 28, 28]
 
 # RangeController is recreated.
 handle-raft-ready-and-admit
@@ -616,14 +625,16 @@ get-enabled-level
 ----
 enabled-level: not-enabled
 
-init-raft log-term=0 log-index=20
+init-raft log-term=50 log-index=24
 ----
+ Replica.MuLock
  Replica.RaftMuAssertHeld
  Replica.MuAssertHeld
+ Replica.MuUnlock
 
-set-raft-state term=50 leader=5 leaseholder=5 stable-index=20 next-unstable-index=25 admitted=[15,20,15,20]
+set-raft-state term=50 leader=5 leaseholder=5
 ----
-Raft: term: 50 leader: 5 leaseholder: 5 stable: 20 next-unstable: 25 admitted: [15, 20, 15, 20]
+Raft: term: 50 leader: 5 leaseholder: 5 mark: {Term:50 Index:24} stable: 24 next-unstable: 25 admitted: [24, 24, 24, 24]
 
 # Noop, since don't know the descriptor.
 handle-raft-ready-and-admit
@@ -644,17 +655,17 @@ HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 25
- RaftNode.StableIndexLocked() = 20
+ RaftNode.StableIndexLocked() = 24
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [15, 20, 15, 20]
+ RaftNode.GetAdmittedLocked = [24, 24, 24, 24]
  RaftNode.TermLocked() = 50
  Replica.MuUnlock
 .....
 
-set-raft-state next-unstable-index=26
+set-raft-state log-term=50 log-index=25 next-unstable-index=26
 ----
-Raft: term: 50 leader: 5 leaseholder: 5 stable: 20 next-unstable: 26 admitted: [15, 20, 15, 20]
+Raft: term: 50 leader: 5 leaseholder: 5 mark: {Term:50 Index:25} stable: 24 next-unstable: 26 admitted: [24, 24, 24, 24]
 
 # v1 protocol, so does not do anything.
 handle-raft-ready-and-admit entries=v1/i25/t45/pri0/time2/len100 leader-term=50
@@ -663,10 +674,10 @@ HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 26
- RaftNode.StableIndexLocked() = 20
+ RaftNode.StableIndexLocked() = 24
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [15, 20, 15, 20]
+ RaftNode.GetAdmittedLocked = [24, 24, 24, 24]
  RaftNode.TermLocked() = 50
  Replica.MuUnlock
 .....
@@ -684,9 +695,9 @@ set-enabled-level enabled-level=v1-encoding
  Replica.MuUnlock
  RangeControllerFactory.New(replicaSet=[(n11,s11):11,(n13,s13):13], leaseholder=5, nextRaftIndex=26)
 
-set-raft-state next-unstable-index=27
+set-raft-state log-term=50 log-index=26 next-unstable-index=27
 ----
-Raft: term: 50 leader: 5 leaseholder: 5 stable: 20 next-unstable: 27 admitted: [15, 20, 15, 20]
+Raft: term: 50 leader: 5 leaseholder: 5 mark: {Term:50 Index:26} stable: 24 next-unstable: 27 admitted: [24, 24, 24, 24]
 
 # Index 26 entry is sent to AC.
 handle-raft-ready-and-admit entries=v1/i26/t45/pri0/time2/len100 leader-term=50
@@ -695,14 +706,11 @@ HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 27
- RaftNode.StableIndexLocked() = 20
+ RaftNode.StableIndexLocked() = 24
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [15, 20, 15, 20]
+ RaftNode.GetAdmittedLocked = [24, 24, 24, 24]
  RaftNode.TermLocked() = 50
- Replica.MuUnlock
- Replica.MuLock
- RaftNode.SetAdmittedLocked([20, 20, 20, 20]) = type: MsgAppResp from: 0 to: 0
  Replica.MuUnlock
  RangeController.HandleRaftEventRaftMuLocked([26])
 .....
@@ -721,10 +729,10 @@ HandleRaftReady:
  Replica.RaftMuAssertHeld
  Replica.MuLock
  RaftNode.NextUnstableIndexLocked() = 27
- RaftNode.StableIndexLocked() = 20
+ RaftNode.StableIndexLocked() = 24
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [20, 20, 20, 20]
+ RaftNode.GetAdmittedLocked = [24, 24, 24, 24]
  RaftNode.TermLocked() = 50
  Replica.MuUnlock
  RangeController.HandleRaftEventRaftMuLocked([])
@@ -732,7 +740,7 @@ HandleRaftReady:
 
 set-raft-state stable-index=26
 ----
-Raft: term: 50 leader: 5 leaseholder: 5 stable: 26 next-unstable: 27 admitted: [20, 20, 20, 20]
+Raft: term: 50 leader: 5 leaseholder: 5 mark: {Term:50 Index:26} stable: 26 next-unstable: 27 admitted: [24, 24, 24, 24]
 
 # Everything up to 26 is admitted.
 handle-raft-ready-and-admit
@@ -744,7 +752,7 @@ HandleRaftReady:
  RaftNode.StableIndexLocked() = 26
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuLocked
- RaftNode.GetAdmittedLocked = [20, 20, 20, 20]
+ RaftNode.GetAdmittedLocked = [24, 24, 24, 24]
  RaftNode.TermLocked() = 50
  Replica.MuUnlock
  Replica.MuLock
@@ -753,9 +761,9 @@ HandleRaftReady:
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
 
-set-raft-state next-unstable-index=28
+set-raft-state log-term=50 log-index=27 next-unstable-index=28
 ----
-Raft: term: 50 leader: 5 leaseholder: 5 stable: 26 next-unstable: 28 admitted: [26, 26, 26, 26]
+Raft: term: 50 leader: 5 leaseholder: 5 mark: {Term:50 Index:27} stable: 26 next-unstable: 28 admitted: [26, 26, 26, 26]
 
 # Index 27 entry is not subject to AC.
 handle-raft-ready-and-admit entries=none/i27/t45/pri0/time2/len100 leader-term=50
@@ -777,7 +785,7 @@ destroyed-or-leader-using-v2: true
 
 set-raft-state stable-index=27
 ----
-Raft: term: 50 leader: 5 leaseholder: 5 stable: 27 next-unstable: 28 admitted: [26, 26, 26, 26]
+Raft: term: 50 leader: 5 leaseholder: 5 mark: {Term:50 Index:27} stable: 27 next-unstable: 28 admitted: [26, 26, 26, 26]
 
 # Everything up to 27 is admitted.
 handle-raft-ready-and-admit
@@ -799,9 +807,9 @@ HandleRaftReady:
 .....
 
 # Transition to follower. In this case, the leader is not even known.
-set-raft-state leader=0
+set-raft-state term=51 leader=0
 ----
-Raft: term: 50 leader: 0 leaseholder: 5 stable: 27 next-unstable: 28 admitted: [27, 27, 27, 27]
+Raft: term: 51 leader: 0 leaseholder: 5 mark: {Term:50 Index:27} stable: 27 next-unstable: 28 admitted: [27, 27, 27, 27]
 
 handle-raft-ready-and-admit
 ----

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -170,8 +170,11 @@ type LogStore struct {
 }
 
 // SyncCallback is a callback that is notified when a raft log write has been
-// durably committed to disk. The function is handed the response messages that
-// are associated with the MsgStorageAppend that triggered the fsync.
+// durably committed to disk.
+//
+// The function is handed the struct containing messages that are associated
+// with the MsgStorageAppend that triggered the fsync.
+//
 // commitStats is populated iff this was a non-blocking sync.
 type SyncCallback interface {
 	OnLogSync(context.Context, MsgStorageAppendDone, storage.BatchCommitStats)

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/poison"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvadmission"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/rac2"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/replica_rac2"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
@@ -1107,6 +1108,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 				DisableSyncLogWriteToss: buildutil.CrdbTestBuild &&
 					r.store.TestingKnobs().DisableSyncLogWriteToss,
 			}
+			// TODO(pav-kv): make this branch unconditional.
 			if r.IsInitialized() && r.store.cfg.KVAdmissionController != nil {
 				// Enqueue raft log entries into admission queues. This is
 				// non-blocking; actual admission happens asynchronously.
@@ -1668,6 +1670,11 @@ func (r *replicaSyncCallback) OnLogSync(
 	ctx context.Context, done logstore.MsgStorageAppendDone, commitStats storage.BatchCommitStats,
 ) {
 	repl := (*Replica)(r)
+	// The log mark is non-empty only if this was a non-empty log append that
+	// updated the stable log mark.
+	if mark := done.Mark(); mark.Term != 0 {
+		repl.flowControlV2.SyncedLogStorage(ctx, mark, false /* snap */)
+	}
 	// Block sending the responses back to raft, if a test needs to.
 	if fn := repl.store.TestingKnobs().TestingAfterRaftLogSync; fn != nil {
 		fn(repl.ID())
@@ -1681,6 +1688,8 @@ func (r *replicaSyncCallback) OnLogSync(
 
 func (r *replicaSyncCallback) OnSnapSync(ctx context.Context, done logstore.MsgStorageAppendDone) {
 	repl := (*Replica)(r)
+	// NB: when storing snapshot, done always contains a non-zero log mark.
+	repl.flowControlV2.SyncedLogStorage(ctx, done.Mark(), true /* snap */)
 	repl.sendRaftMessages(ctx, done.Responses(), nil /* blocked */, true /* willDeliverLocal */)
 }
 
@@ -1915,6 +1924,20 @@ func (r *Replica) sendRaftMessage(ctx context.Context, msg raftpb.Message) {
 		FromReplica:   fromReplica,
 		Message:       msg,
 		RangeStartKey: startKey, // usually nil
+	}
+	// For RACv2, annotate successful MsgAppResp messages with the vector of
+	// admitted log indices, by priority.
+	if msg.Type == raftpb.MsgAppResp && !msg.Reject {
+		admitted := r.flowControlV2.AdmittedState()
+		// The admitted state must be in the coordinate system of the leader's log.
+		if admitted.Term == msg.Term && false {
+			// TODO(pav-kv): enable this annotation when it is covered with tests, and
+			// the leader knows how to handle it.
+			req.AdmittedState = kvflowcontrolpb.AdmittedState{
+				Term:     admitted.Term,
+				Admitted: admitted.Admitted[:],
+			}
+		}
 	}
 	if !r.sendRaftMessageRequest(ctx, req) {
 		r.mu.Lock()

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -464,6 +464,13 @@ func (rn *RawNode) Lead() pb.PeerID {
 	return rn.raft.lead
 }
 
+// LogMark returns the current log mark of the raft log. It is not guaranteed to
+// be in stable storage, unless this method is called right after RawNode is
+// initialized (in which case its state reflects the stable storage).
+func (rn *RawNode) LogMark() LogMark {
+	return rn.raft.raftLog.unstable.mark()
+}
+
 // NextUnstableIndex returns the index of the next entry that will be sent to
 // local storage, if there are any. All entries < this index are either stored,
 // or have been sent to storage.


### PR DESCRIPTION
This PR integrates the `LogTracker` into RACv2 `Processor`. The design sketch is below.

- `LogTracker` is created when `raft.RawNode` is initialized. It reads the initial stable state from `RawNode.LogMark()`, and initializes the stable and admitted indices to match this mark.
- `LogTracker` observes all log storage appends in `handleRaftReady`, and all log and snapshot syncs in `OnLogSync` and `OnSnapSync` handlers. This guarantees that the stable mark in `LogTracker` is always accurate.
- `LogTracker` observes all entries subject to admission control, and their corresponding admissions. This allows updating the admitted vector accurately.

The admitted vector is sent to the leader from two places:

- In `sendRaftMessage`, any successful `MsgAppResp` message is intercepted, and the corresponding `RaftMessageRequest` is annotated with the admitted vector if it is in the coordinate system of the receiver, i.e. has the same leader term. This flow supports the fast path when logical admission happens without delays: by the time the `MsgAppResp` is sent, the entries are already admitted, and the admitted vector has advanced.
- In `handleRaftReady`, the admitted vector is sent to the `Piggybacker`, which then attaches them to any `RaftMessageRequestBatch` going to the same node as the receiver replica. This serves cases when admission is lagging the log syncs, and there might be no `MsgAppResp` to attach the vector to. Such admissions are batched into one `Ready` cycle for efficiency reasons.

Part of #129508