### PR TITLE
release-23.2: roachtest/mixedversion: improvements for multiple clusters

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -1052,12 +1052,22 @@ func newSingleStep(context *Context, impl singleStepProtocol, rng *rand.Rand) *s
 }
 
 // prefixedLogger returns a logger instance off of the given `l`
-// parameter, and adds a prefix to everything logged by the retured
-// logger.
+// parameter. The path and prefix are the same.
 func prefixedLogger(l *logger.Logger, prefix string) (*logger.Logger, error) {
-	fileName := strings.ReplaceAll(prefix, " ", "-")
-	formattedPrefix := fmt.Sprintf("[%s] ", fileName)
-	return l.ChildLogger(fileName, logger.LogPrefix(formattedPrefix))
+	filename := sanitizePath(prefix)
+	return prefixedLoggerWithFilename(l, filename, filename)
+}
+
+// prefixedLoggerWithFilename returns a logger instance with the given
+// prefix. The logger will write to a file on the given `path`,
+// relative to the logger `l`'s location.
+func prefixedLoggerWithFilename(l *logger.Logger, prefix, path string) (*logger.Logger, error) {
+	formattedPrefix := fmt.Sprintf("[%s] ", prefix)
+	return l.ChildLogger(path, logger.LogPrefix(formattedPrefix))
+}
+
+func sanitizePath(s string) string {
+	return strings.ReplaceAll(s, " ", "-")
 }
 
 func (h hooks) Filter(testContext Context) hooks {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
@@ -189,11 +189,19 @@ func (tr *testRunner) run() (retErr error) {
 	stepsErr := make(chan error)
 	defer func() { tr.teardown(stepsErr, retErr != nil) }()
 	defer func() {
-		// If the test failed an we haven't run any user hooks up to this
-		// point, redirect the failure to Test Eng, as this indicates a
-		// setup problem that should be investigated separately.
-		if retErr != nil && !tr.ranUserHooks.Load() {
-			retErr = registry.ErrorWithOwner(registry.OwnerTestEng, retErr)
+		if retErr != nil {
+			// If the test failed an we haven't run any user hooks up to this
+			// point, redirect the failure to Test Eng, as this indicates a
+			// setup problem that should be investigated separately.
+			if !tr.ranUserHooks.Load() {
+				retErr = registry.ErrorWithOwner(registry.OwnerTestEng, retErr)
+			}
+
+			// If this test run had a tag assigned, wrap the error with that
+			// tag to make it more immediately clear which run failed.
+			if tr.tag != "" {
+				retErr = errors.Wrapf(retErr, "%s", tr.tag)
+			}
 		}
 	}()
 
@@ -513,9 +521,7 @@ func (tr *testRunner) loggerFor(step *singleStep) (*logger.Logger, error) {
 	name = fmt.Sprintf("%d_%s", step.ID, name)
 	prefix := filepath.Join(tr.tag, logPrefix, name)
 
-	// Use the root logger here as the `prefix` passed will already
-	// include the full path from the root, including the tag.
-	return prefixedLogger(tr.logger.RootLogger(), prefix)
+	return prefixedLoggerWithFilename(tr.logger, prefix, filepath.Join(logPrefix, name))
 }
 
 // refreshBinaryVersions updates the `binaryVersions` field for every


### PR DESCRIPTION
Backport 1/2 commits from #130106.

/cc @cockroachdb/release

---

Specifically:

* we include the `tag`, if any, in the error message returned by a
test, making it easier to understand which upgrade failed.
* improve the logging setup: if there are two mixedversion test
instances, say `A` and `B`, the log files `A/mixed-version-test.log`
will contain all the output for A's upgrade steps (similarly for B).

Release justification: test only changes.
