### PR TITLE
roachtest: schemachange/random-load failed

### DIFF
--- a/pkg/cmd/roachtest/tests/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/tests/schemachange_random_load.go
@@ -96,7 +96,12 @@ func runSchemaChangeRandomLoad(
 	c.Put(ctx, t.DeprecatedWorkload(), "./workload", loadNode)
 
 	t.Status("starting cockroach nodes")
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), roachNodes)
+
+	settings := install.MakeClusterSettings(install.ClusterSettingsOption{
+		"sql.log.all_statements.enabled": "true",
+	})
+
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, roachNodes)
 
 	c.Run(ctx, option.WithNodes(loadNode), "./workload init schemachange {pgurl:1}")
 


### PR DESCRIPTION
We are debugging this roachtest failure and are setting sql.log.all_statements.enabled to true to gather debug data.

Fixes: #129287

Release note: none