### PR TITLE
changefeedccl: fix oob in TestGetCheckPointSpans

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors_test.go
@@ -222,7 +222,7 @@ func TestGetCheckpointSpans(t *testing.T) {
 	j := 0
 	for _, s := range spans {
 		catchupFromHWM += s.ts.GoTime().Sub(hwm.GoTime())
-		if cpSpans[j].Equal(s.span) {
+		if j < len(cpSpans) && cpSpans[j].Equal(s.span) {
 			catchupFromCheckpoint += s.ts.GoTime().Sub(cpTS.GoTime())
 			j++
 		}


### PR DESCRIPTION
`TestGetCheckPointSpans` (added in #129530) could panic with an out of
bounds error, depending on how the testing spans were shuffled, before
being handed to `getCheckpointSpans`, as the returned spans may not
always be the same length as the input.

Check the length while iterating to avoid an out of index panic.

Fixes: #130176
Release note: None