### PR TITLE
rpc,tenantcapabilities: allow cross tenant reads in shared service

### DIFF
--- a/pkg/kv/kvserver/tenantrate/limiter_test.go
+++ b/pkg/kv/kvserver/tenantrate/limiter_test.go
@@ -667,7 +667,7 @@ func (ts *testState) BindReader(tenantcapabilities.Reader) {}
 
 var _ tenantcapabilities.Authorizer = &testState{}
 
-func (ts *testState) HasCrossTenantRead(tenID roachpb.TenantID) bool {
+func (ts *testState) HasCrossTenantRead(ctx context.Context, tenID roachpb.TenantID) bool {
 	return false
 }
 
@@ -789,7 +789,7 @@ type fakeAuthorizer struct{}
 
 var _ tenantcapabilities.Authorizer = &fakeAuthorizer{}
 
-func (fakeAuthorizer) HasCrossTenantRead(tenID roachpb.TenantID) bool {
+func (fakeAuthorizer) HasCrossTenantRead(ctx context.Context, tenID roachpb.TenantID) bool {
 	return false
 }
 

--- a/pkg/multitenant/tenantcapabilities/interfaces.go
+++ b/pkg/multitenant/tenantcapabilities/interfaces.go
@@ -42,7 +42,7 @@ type Reader interface {
 // usage pattern over a timespan.
 type Authorizer interface {
 	// HasCrossTenantRead returns true if a tenant can read other tenant spans.
-	HasCrossTenantRead(tenID roachpb.TenantID) bool
+	HasCrossTenantRead(ctx context.Context, tenID roachpb.TenantID) bool
 
 	// HasCapabilityForBatch returns an error if a tenant, referenced by its ID,
 	// is not allowed to execute the supplied batch request given the capabilities

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/allow_everything.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/allow_everything.go
@@ -30,7 +30,9 @@ func NewAllowEverythingAuthorizer() *AllowEverythingAuthorizer {
 }
 
 // HasCrossTenantRead returns true if a tenant can read from other tenants.
-func (n *AllowEverythingAuthorizer) HasCrossTenantRead(tenID roachpb.TenantID) bool {
+func (n *AllowEverythingAuthorizer) HasCrossTenantRead(
+	ctx context.Context, tenID roachpb.TenantID,
+) bool {
 	return true
 }
 

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/allow_nothing.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/allow_nothing.go
@@ -31,7 +31,9 @@ func NewAllowNothingAuthorizer() *AllowNothingAuthorizer {
 }
 
 // HasCrossTenantRead returns true if a tenant can read from other tenants.
-func (n *AllowNothingAuthorizer) HasCrossTenantRead(tenID roachpb.TenantID) bool {
+func (n *AllowNothingAuthorizer) HasCrossTenantRead(
+	ctx context.Context, tenID roachpb.TenantID,
+) bool {
 	return false
 }
 

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/authorizer.go
@@ -98,8 +98,22 @@ func New(settings *cluster.Settings, knobs *tenantcapabilities.TestingKnobs) *Au
 }
 
 // HasCrossTenantRead returns true if a tenant can read from other tenants.
-func (a *Authorizer) HasCrossTenantRead(tenID roachpb.TenantID) bool {
-	return tenID.IsSystem()
+func (a *Authorizer) HasCrossTenantRead(ctx context.Context, tenID roachpb.TenantID) bool {
+	if tenID.IsSystem() {
+		// The system tenant has access to all request types.
+		return true
+	}
+	_, mode := a.getMode(ctx, tenID)
+	switch mode {
+	case authorizerModeOn, authorizerModeV222:
+		return false
+	case authorizerModeAllowAll:
+		return true
+	default:
+		err := errors.AssertionFailedf("unknown authorizer mode: %d", mode)
+		logcrash.ReportOrPanic(ctx, &a.settings.SV, "%v", err)
+		return false
+	}
 }
 
 // HasCapabilityForBatch implements the tenantcapabilities.Authorizer interface.

--- a/pkg/rpc/auth_test.go
+++ b/pkg/rpc/auth_test.go
@@ -1120,7 +1120,7 @@ func (m mockAuthorizer) HasProcessDebugCapability(
 	return errors.New("tenant does not have capability")
 }
 
-func (m mockAuthorizer) HasCrossTenantRead(tenID roachpb.TenantID) bool {
+func (m mockAuthorizer) HasCrossTenantRead(ctx context.Context, tenID roachpb.TenantID) bool {
 	return m.hasCrossTenantRead
 }
 


### PR DESCRIPTION
Previously, we added support for cross tenant reads, but these would only function from the system tenant. When running as a shared service tenant, we should also allow reading the spans of other tenants. To address this, this patch updates authorization logic to look at the authorization mode to determine if the cross tenant read check should be enforced, which will allow shared service tenants to exempt.

Fixes: #130182

Release note: None