### PR TITLE
kvserver: wire up replica_rac range controller factory 

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/buildutil",
+        "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/stop",
         "//pkg/util/syncutil",

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -160,6 +160,15 @@ func (rn *testRaftNode) StepMsgAppRespForAdmittedLocked(msg raftpb.Message) erro
 	return nil
 }
 
+func (rn *testRaftNode) FollowerStateRaftMuLocked(
+	replicaID roachpb.ReplicaID,
+) rac2.FollowerStateInfo {
+	rn.r.mu.AssertHeld()
+	fmt.Fprintf(rn.b, " RaftNode.FollowerStateRaftMuLocked(%v)\n", replicaID)
+	// TODO(kvoli,sumeerbhola): implement.
+	return rac2.FollowerStateInfo{}
+}
+
 func admittedString(admitted [raftpb.NumPriorities]uint64) string {
 	return fmt.Sprintf("[%d, %d, %d, %d]", admitted[0], admitted[1], admitted[2], admitted[3])
 }

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -226,18 +226,16 @@ func newUninitializedReplicaWithoutRaftGroup(
 	)
 	r.raftMu.flowControlLevel = racV2EnabledWhenLeaderLevel(r.raftCtx, store.cfg.Settings)
 	r.flowControlV2 = replica_rac2.NewProcessor(replica_rac2.ProcessorOptions{
-		NodeID:              store.NodeID(),
-		StoreID:             r.StoreID(),
-		RangeID:             r.RangeID,
-		ReplicaID:           r.replicaID,
-		Replica:             (*replicaForRACv2)(r),
-		RaftScheduler:       r.store.scheduler,
-		AdmittedPiggybacker: r.store.cfg.KVFlowAdmittedPiggybacker,
-		ACWorkQueue:         r.store.cfg.KVAdmissionController,
-		EvalWaitMetrics:     r.store.cfg.KVFlowEvalWaitMetrics,
-		RangeControllerFactory: replica_rac2.NewRangeControllerFactoryImpl(
-			r.store.cfg.KVFlowEvalWaitMetrics,
-			r.store.cfg.KVFlowStreamTokenProvider),
+		NodeID:                 store.NodeID(),
+		StoreID:                r.StoreID(),
+		RangeID:                r.RangeID,
+		ReplicaID:              r.replicaID,
+		Replica:                (*replicaForRACv2)(r),
+		RaftScheduler:          r.store.scheduler,
+		AdmittedPiggybacker:    r.store.cfg.KVFlowAdmittedPiggybacker,
+		ACWorkQueue:            r.store.cfg.KVAdmissionController,
+		EvalWaitMetrics:        r.store.cfg.KVFlowEvalWaitMetrics,
+		RangeControllerFactory: r.store.kvflowRangeControllerFactory,
 		EnabledWhenLeaderLevel: r.raftMu.flowControlLevel,
 	})
 	return r


### PR DESCRIPTION
RangeControllerFactory` is used to create new `RangeController`s when a
replica becomes the raft leader. Add the missing required fields in
`RangeControllerFactory` and wire up the factory to sit on the `Store`.

The `RangeControllerFactory` is one per-store, with callers providing
range specific information when asking for a new `RangeController`, and
the factory retaining one per-node or per-store controller dependencies.

Resolves: https://github.com/cockroachdb/cockroach/issues/130185
Release note: None