### PR TITLE
rac2: indicate admitted updates from LogTracker

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/log_tracker.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/log_tracker.go
@@ -12,6 +12,8 @@ package rac2
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
@@ -265,6 +267,22 @@ func (l *LogTracker) String() string {
 func (l *LogTracker) SafeFormat(w redact.SafePrinter, _ rune) {
 	admitted := l.Admitted().Admitted
 	w.Printf("mark:%+v, stable:%d, admitted:%v", l.last, l.stable, admitted)
+}
+
+// DebugString returns a debug string for this tracker.
+func (l *LogTracker) DebugString() string {
+	var b strings.Builder
+	fmt.Fprint(&b, l.String())
+	for pri, marks := range l.waiting {
+		if len(marks) == 0 {
+			continue
+		}
+		fmt.Fprintf(&b, "\n%s:", raftpb.Priority(pri))
+		for _, mark := range marks {
+			fmt.Fprintf(&b, " %+v", mark)
+		}
+	}
+	return b.String()
 }
 
 func (l *LogTracker) errorf(ctx context.Context, format string, args ...any) {

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/log_tracker.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/log_tracker.go
@@ -192,13 +192,13 @@ func (l *LogTracker) LogAdmitted(ctx context.Context, at LogMark, pri raftpb.Pri
 	}
 	waiting := l.waiting[pri]
 	// There is nothing to admit, or it's a stale admission.
-	if len(waiting) == 0 || at.Index < waiting[0].Index {
+	if len(waiting) == 0 || waiting[0].After(at) {
 		return
 	}
-	// Remove waiting entries preceding the admitted mark. Due to invariants, this
-	// is always a prefix of the queue.
-	for i, mark := range waiting {
-		if mark.After(at) {
+	// At least one waiting entry can be admitted. Remove all entries up to the
+	// admitted mark. Due to invariants, this is always a prefix of the queue.
+	for i, ln := 1, len(waiting); i < ln; i++ {
+		if waiting[i].After(at) {
 			l.waiting[pri] = waiting[i:]
 			return
 		}

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/log_tracker_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/log_tracker_test.go
@@ -190,8 +190,11 @@ func TestLogTracker(t *testing.T) {
 	}
 
 	var tracker LogTracker
-	state := func() string {
+	state := func(updated bool) string {
 		var b strings.Builder
+		if updated {
+			fmt.Fprint(&b, "[upd] ")
+		}
 		fmt.Fprintln(&b, tracker.String())
 		for pri, marks := range tracker.waiting {
 			if len(marks) == 0 {
@@ -218,31 +221,31 @@ func TestLogTracker(t *testing.T) {
 		case "reset": // Example: reset term=1 index=10
 			stable := readMark(t, d, "index")
 			tracker = NewLogTracker(stable)
-			return state()
+			return state(false)
 
 		case "append": // Example: append term=10 after=100 to=200
 			var after uint64
 			d.ScanArgs(t, "after", &after)
 			to := readMark(t, d, "to")
-			tracker.Append(ctx, after, to)
-			return state()
+			updated := tracker.Append(ctx, after, to)
+			return state(updated)
 
 		case "sync": // Example: sync term=10 index=100
 			mark := readMark(t, d, "index")
-			tracker.LogSynced(ctx, mark)
-			return state()
+			updated := tracker.LogSynced(ctx, mark)
+			return state(updated)
 
 		case "register": // Example: register term=10 index=100 pri=LowPri
 			mark := readMark(t, d, "index")
 			pri := readPri(t, d)
 			tracker.Register(ctx, mark, pri)
-			return state()
+			return state(false)
 
 		case "admit": // Example: admit term=10 index=100 pri=LowPri
 			mark := readMark(t, d, "index")
 			pri := readPri(t, d)
-			tracker.LogAdmitted(ctx, mark, pri)
-			return state()
+			updated := tracker.LogAdmitted(ctx, mark, pri)
+			return state(updated)
 
 		default:
 			t.Fatalf("unknown command: %s", d.Cmd)

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/log_tracker_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/log_tracker_test.go
@@ -12,8 +12,6 @@ package rac2
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
@@ -191,22 +189,11 @@ func TestLogTracker(t *testing.T) {
 
 	var tracker LogTracker
 	state := func(updated bool) string {
-		var b strings.Builder
+		var s string
 		if updated {
-			fmt.Fprint(&b, "[upd] ")
+			s += "[upd] "
 		}
-		fmt.Fprintln(&b, tracker.String())
-		for pri, marks := range tracker.waiting {
-			if len(marks) == 0 {
-				continue
-			}
-			fmt.Fprintf(&b, "%s:", raftpb.Priority(pri))
-			for _, mark := range marks {
-				fmt.Fprintf(&b, " %+v", mark)
-			}
-			fmt.Fprintf(&b, "\n")
-		}
-		return b.String()
+		return s + tracker.DebugString()
 	}
 
 	ctx := context.Background()

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/log_tracker
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/log_tracker
@@ -97,6 +97,33 @@ admit term=1 index=5 pri=HighPri
 mark:{Term:1 Index:10}, stable:10, admitted:[10 10 10 10]
 
 # ------------------------------------------------------------------------------
+# Regression test with admitting an entry missing in the queue.
+
+reset term=1 index=1
+----
+mark:{Term:1 Index:1}, stable:1, admitted:[1 1 1 1]
+
+append term=1 after=1 to=3
+----
+mark:{Term:1 Index:3}, stable:1, admitted:[1 1 1 1]
+
+register term=1 index=3 pri=LowPri
+----
+mark:{Term:1 Index:3}, stable:1, admitted:[1 1 1 1]
+LowPri: {Term:1 Index:3}
+
+append term=3 after=3 to=5
+----
+mark:{Term:3 Index:5}, stable:1, admitted:[1 1 1 1]
+LowPri: {Term:1 Index:3}
+
+# TODO(pav-kv): this should admit the term 1 LowPri entry.
+admit term=3 index=2 pri=LowPri
+----
+mark:{Term:3 Index:5}, stable:1, admitted:[1 1 1 1]
+LowPri: {Term:1 Index:3}
+
+# ------------------------------------------------------------------------------
 # Port of waiting_for_admission_state test.
 
 reset term=3 index=1

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/log_tracker
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/log_tracker
@@ -16,7 +16,7 @@ LowPri: {Term:1 Index:7}
 
 sync term=1 index=10
 ----
-mark:{Term:1 Index:10}, stable:10, admitted:[6 10 10 10]
+[upd] mark:{Term:1 Index:10}, stable:10, admitted:[6 10 10 10]
 LowPri: {Term:1 Index:7}
 
 admit term=1 index=6 pri=LowPri
@@ -26,7 +26,7 @@ LowPri: {Term:1 Index:7}
 
 admit term=1 index=7 pri=LowPri
 ----
-mark:{Term:1 Index:10}, stable:10, admitted:[10 10 10 10]
+[upd] mark:{Term:1 Index:10}, stable:10, admitted:[10 10 10 10]
 
 append term=1 after=10 to=12
 ----
@@ -45,7 +45,7 @@ HighPri: {Term:1 Index:12}
 
 append term=2 after=5 to=10
 ----
-mark:{Term:2 Index:10}, stable:5, admitted:[5 5 5 5]
+[upd] mark:{Term:2 Index:10}, stable:5, admitted:[5 5 5 5]
 
 # ------------------------------------------------------------------------------
 # Test stable index advancement racing with admission.
@@ -69,7 +69,7 @@ mark:{Term:1 Index:10}, stable:1, admitted:[1 1 1 1]
 
 sync term=1 index=10
 ----
-mark:{Term:1 Index:10}, stable:10, admitted:[10 10 10 10]
+[upd] mark:{Term:1 Index:10}, stable:10, admitted:[10 10 10 10]
 
 # ------------------------------------------------------------------------------
 # Same race but sync completes first.
@@ -89,12 +89,12 @@ HighPri: {Term:1 Index:5}
 
 sync term=1 index=10
 ----
-mark:{Term:1 Index:10}, stable:10, admitted:[10 10 10 4]
+[upd] mark:{Term:1 Index:10}, stable:10, admitted:[10 10 10 4]
 HighPri: {Term:1 Index:5}
 
 admit term=1 index=5 pri=HighPri
 ----
-mark:{Term:1 Index:10}, stable:10, admitted:[10 10 10 10]
+[upd] mark:{Term:1 Index:10}, stable:10, admitted:[10 10 10 10]
 
 # ------------------------------------------------------------------------------
 # Regression test with admitting an entry missing in the queue.
@@ -114,7 +114,7 @@ LowPri: {Term:1 Index:3}
 
 append term=3 after=3 to=5
 ----
-mark:{Term:3 Index:5}, stable:1, admitted:[1 1 1 1]
+[upd] mark:{Term:3 Index:5}, stable:1, admitted:[1 1 1 1]
 LowPri: {Term:1 Index:3}
 
 # The term 1 entry is admitted because the admission mark is at term 3.
@@ -168,7 +168,7 @@ HighPri: {Term:3 Index:7}
 # Stable index moves, and admitted indices move accordingly.
 sync term=3 index=7
 ----
-mark:{Term:3 Index:7}, stable:7, admitted:[4 7 7 6]
+[upd] mark:{Term:3 Index:7}, stable:7, admitted:[4 7 7 6]
 LowPri: {Term:3 Index:5}
 HighPri: {Term:3 Index:7}
 
@@ -187,14 +187,14 @@ HighPri: {Term:3 Index:7} {Term:3 Index:8}
 # Admitted indices move up for priorities with no queue.
 sync term=3 index=8
 ----
-mark:{Term:3 Index:8}, stable:8, admitted:[4 8 8 6]
+[upd] mark:{Term:3 Index:8}, stable:8, admitted:[4 8 8 6]
 LowPri: {Term:3 Index:5}
 HighPri: {Term:3 Index:7} {Term:3 Index:8}
 
 # All HighPri entries are admitted.
 admit term=3 index=8 pri=HighPri
 ----
-mark:{Term:3 Index:8}, stable:8, admitted:[4 8 8 8]
+[upd] mark:{Term:3 Index:8}, stable:8, admitted:[4 8 8 8]
 LowPri: {Term:3 Index:5}
 
 append term=3 after=8 to=11
@@ -215,7 +215,7 @@ LowPri: {Term:3 Index:5} {Term:3 Index:9} {Term:3 Index:11}
 # New term, removes a suffix of the log.
 append term=4 after=9 to=10
 ----
-mark:{Term:4 Index:10}, stable:8, admitted:[4 8 8 8]
+[upd] mark:{Term:4 Index:10}, stable:8, admitted:[4 8 8 8]
 LowPri: {Term:3 Index:5} {Term:3 Index:9}
 
 register term=4 index=10 pri=LowPri
@@ -226,7 +226,7 @@ LowPri: {Term:3 Index:5} {Term:3 Index:9} {Term:4 Index:10}
 # New term, again removes a suffix of the log.
 append term=5 after=8 to=9
 ----
-mark:{Term:5 Index:9}, stable:8, admitted:[4 8 8 8]
+[upd] mark:{Term:5 Index:9}, stable:8, admitted:[4 8 8 8]
 LowPri: {Term:3 Index:5}
 
 register term=5 index=9 pri=LowPri
@@ -237,7 +237,7 @@ LowPri: {Term:3 Index:5} {Term:5 Index:9}
 # New term, again removes a suffix of the log.
 append term=6 after=6 to=7
 ----
-mark:{Term:6 Index:7}, stable:6, admitted:[4 6 6 6]
+[upd] mark:{Term:6 Index:7}, stable:6, admitted:[4 6 6 6]
 LowPri: {Term:3 Index:5}
 
 register term=6 index=7 pri=LowPri
@@ -248,7 +248,7 @@ LowPri: {Term:3 Index:5} {Term:6 Index:7}
 # New term, no suffix is removed.
 append term=7 after=7 to=8
 ----
-mark:{Term:7 Index:8}, stable:6, admitted:[4 6 6 6]
+[upd] mark:{Term:7 Index:8}, stable:6, admitted:[4 6 6 6]
 LowPri: {Term:3 Index:5} {Term:6 Index:7}
 
 register term=7 index=8 pri=LowPri
@@ -260,7 +260,7 @@ LowPri: {Term:3 Index:5} {Term:6 Index:7} {Term:7 Index:8}
 # is removed due to being stale, even though its index is above the admitted.
 admit term=7 index=6 pri=LowPri
 ----
-mark:{Term:7 Index:8}, stable:6, admitted:[6 6 6 6]
+[upd] mark:{Term:7 Index:8}, stable:6, admitted:[6 6 6 6]
 LowPri: {Term:7 Index:8}
 
 # A stale admission, no-op.
@@ -271,12 +271,12 @@ LowPri: {Term:7 Index:8}
 
 sync term=7 index=8
 ----
-mark:{Term:7 Index:8}, stable:8, admitted:[7 8 8 8]
+[upd] mark:{Term:7 Index:8}, stable:8, admitted:[7 8 8 8]
 LowPri: {Term:7 Index:8}
 
 # Everything is persisted and admitted.
 admit term=7 index=8 pri=LowPri
 ----
-mark:{Term:7 Index:8}, stable:8, admitted:[8 8 8 8]
+[upd] mark:{Term:7 Index:8}, stable:8, admitted:[8 8 8 8]
 
 # ------------------------------------------------------------------------------

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/log_tracker
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/log_tracker
@@ -117,11 +117,10 @@ append term=3 after=3 to=5
 mark:{Term:3 Index:5}, stable:1, admitted:[1 1 1 1]
 LowPri: {Term:1 Index:3}
 
-# TODO(pav-kv): this should admit the term 1 LowPri entry.
+# The term 1 entry is admitted because the admission mark is at term 3.
 admit term=3 index=2 pri=LowPri
 ----
 mark:{Term:3 Index:5}, stable:1, admitted:[1 1 1 1]
-LowPri: {Term:1 Index:3}
 
 # ------------------------------------------------------------------------------
 # Port of waiting_for_admission_state test.


### PR DESCRIPTION
This PR makes `LogTracker` return a bit indicating when the `Admitted` vector has changed. The admitted vector is considered "changed" when its leader term goes up (and the admitted indices either stay intact or regress), or the term stays intact but the admitted index at any priority goes up.

Part of #129508