### PR TITLE
plpgsql: add support for integer-range FOR loops

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
@@ -2720,6 +2720,543 @@ CREATE FUNCTION f(y ANYELEMENT) RETURNS ANYELEMENT AS $$
   END
 $$ LANGUAGE PLpgSQL;
 
+# Testing integer-range FOR loops.
+subtest integer_loop
+
+statement ok
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN 1..3 LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RAISE NOTICE 'DONE';
+    RETURN 0;
+  END
+$$;
+
+query T noticetrace
+SELECT f();
+----
+NOTICE: i: 1
+NOTICE: i: 2
+NOTICE: i: 3
+NOTICE: DONE
+
+# EXIT and CONTINUE statements are allowed. The counter is incremented even
+# after a CONTINUE.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN 1..10 LOOP
+      IF i = 3 THEN
+        CONTINUE;
+      ELSIF i = 5 THEN
+        EXIT;
+      END IF;
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RAISE NOTICE 'DONE';
+    RETURN 0;
+  END
+$$;
+
+query T noticetrace
+SELECT f();
+----
+NOTICE: i: 1
+NOTICE: i: 2
+NOTICE: i: 4
+NOTICE: DONE
+
+# Exception handling is allowed.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN 1..3 LOOP
+      BEGIN
+        IF i = 2 THEN
+          RAISE division_by_zero;
+        END IF;
+        RAISE NOTICE 'i: %', i;
+      EXCEPTION WHEN division_by_zero THEN
+        RAISE NOTICE 'i: %: caught division by zero', i;
+      END;
+    END LOOP;
+    RAISE NOTICE 'DONE';
+    RETURN 0;
+  END
+$$;
+
+query T noticetrace
+SELECT f();
+----
+NOTICE: i: 1
+NOTICE: i: 2: caught division by zero
+NOTICE: i: 3
+NOTICE: DONE
+
+# Exception handling outside the loop.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN 1..3 LOOP
+        IF i = 2 THEN
+          RAISE division_by_zero;
+        END IF;
+        RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RAISE NOTICE 'DONE';
+    RETURN 0;
+  EXCEPTION WHEN division_by_zero THEN
+    RAISE NOTICE 'caught division by zero';
+    RETURN 1;
+  END
+$$;
+
+query T noticetrace
+SELECT f();
+----
+NOTICE: i: 1
+NOTICE: caught division by zero
+
+# Modifications to the loop variable are local to that iteration, and do not
+# affect the loop or future iterations.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN 1..3 LOOP
+      i := i * 100;
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RAISE NOTICE 'DONE';
+    RETURN 0;
+  END
+$$;
+
+query T noticetrace
+SELECT f();
+----
+NOTICE: i: 100
+NOTICE: i: 200
+NOTICE: i: 300
+NOTICE: DONE
+
+# BY syntax allows changing the step size.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN 1..3 BY 2 LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RAISE NOTICE 'DONE';
+    RETURN 0;
+  END
+$$;
+
+query T noticetrace
+SELECT f();
+----
+NOTICE: i: 1
+NOTICE: i: 3
+NOTICE: DONE
+
+# Case with larger step than the distance between the bounds.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN 1..3 BY 5 LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RAISE NOTICE 'DONE';
+    RETURN 0;
+  END
+$$;
+
+query T noticetrace
+SELECT f();
+----
+NOTICE: i: 1
+NOTICE: DONE
+
+# Negative bounds are allowed.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN -3..3 LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RAISE NOTICE 'DONE';
+    RETURN 0;
+  END
+$$;
+
+query T noticetrace
+SELECT f();
+----
+NOTICE: i: -3
+NOTICE: i: -2
+NOTICE: i: -1
+NOTICE: i: 0
+NOTICE: i: 1
+NOTICE: i: 2
+NOTICE: i: 3
+NOTICE: DONE
+
+# The loop iterates one time for equal bounds.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN 1..1 LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RAISE NOTICE 'DONE';
+    RETURN 0;
+  END
+$$;
+
+query T noticetrace
+SELECT f();
+----
+NOTICE: i: 1
+NOTICE: DONE
+
+# The loop iterates zero times for reversed bounds.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN 2..1 LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RAISE NOTICE 'DONE';
+    RETURN 0;
+  END
+$$;
+
+query T noticetrace
+SELECT f();
+----
+NOTICE: DONE
+
+# REVERSE syntax allows changing the direction of the loop.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN REVERSE 3..1 LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RAISE NOTICE 'DONE';
+    RETURN 0;
+  END
+$$;
+
+query T noticetrace
+SELECT f();
+----
+NOTICE: i: 3
+NOTICE: i: 2
+NOTICE: i: 1
+NOTICE: DONE
+
+# Reverse iteration with an explicit step.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN REVERSE 5..1 BY 2 LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RAISE NOTICE 'DONE';
+    RETURN 0;
+  END
+$$;
+
+query T noticetrace
+SELECT f();
+----
+NOTICE: i: 5
+NOTICE: i: 3
+NOTICE: i: 1
+NOTICE: DONE
+
+# Reverse iteration with a negative bound.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN REVERSE 3..-3 LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RAISE NOTICE 'DONE';
+    RETURN 0;
+  END
+$$;
+
+query T noticetrace
+SELECT f();
+----
+NOTICE: i: 3
+NOTICE: i: 2
+NOTICE: i: 1
+NOTICE: i: 0
+NOTICE: i: -1
+NOTICE: i: -2
+NOTICE: i: -3
+NOTICE: DONE
+
+# Reverse iteration with ascending bounds.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN REVERSE 1..3 LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RAISE NOTICE 'DONE';
+    RETURN 0;
+  END
+$$;
+
+query T noticetrace
+SELECT f();
+----
+NOTICE: DONE
+
+# Modifications to an existing variable persist after the loop finishes.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    a INT := 1;
+    b INT := 2;
+  BEGIN
+    FOR i IN 1..3 LOOP
+      RAISE NOTICE 'i: %', i;
+      a := a + a;
+      b := b * b;
+    END LOOP;
+    RAISE NOTICE 'DONE a: % b: %', a, b;
+    RETURN 0;
+  END
+$$;
+
+query T noticetrace
+SELECT f();
+----
+NOTICE: i: 1
+NOTICE: i: 2
+NOTICE: i: 3
+NOTICE: DONE a: 8 b: 256
+
+# The bounds can be complex expressions rather than INT constants.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN (SELECT min(x) FROM xy)..(1 + (SELECT max(x) FROM xy)) LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RAISE NOTICE 'DONE';
+    RETURN 0;
+  END
+$$;
+
+query T noticetrace
+SELECT f();
+----
+NOTICE: i: 1
+NOTICE: i: 2
+NOTICE: i: 3
+NOTICE: i: 4
+NOTICE: DONE
+
+statement ok
+DROP FUNCTION f;
+
+# The loop variable is no longer in scope after the loop.
+statement error pgcode 42703 pq: column "i" does not exist
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN 1..3 LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RETURN i;
+  END
+$$;
+
+# The loop variable shadows a variable of the same name.
+statement error pgcode 0A000 pq: unimplemented: variable shadowing is not yet implemented
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    i INT;
+  BEGIN
+    FOR i IN 1..3 LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RETURN i;
+  END
+$$;
+
+# The loop variable cannot be referenced in the bounds.
+statement error pgcode 42703 pq: column "i" does not exist
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN 1..i+1 LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RETURN 0;
+  END
+$$;
+
+# The loop variable cannot be referenced in the step.
+statement error pgcode 42703 pq: column "i" does not exist
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN 1..3 BY i LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RETURN 0;
+  END
+$$;
+
+statement error pgcode 42601 pq: integer FOR loop must have only one target variable
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i, j IN 1..3 LOOP
+      RAISE NOTICE 'i: % j: %', i, j;
+    END LOOP;
+    RETURN 0;
+  END
+$$;
+
+# Bounds (and step, if specified), must be non-NULL.
+statement ok
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN NULL..3 LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RETURN 0;
+  END
+$$;
+
+statement error pgcode 22004 pq: lower bound of FOR loop cannot be null
+SELECT f();
+
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN 1..NULL LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RETURN 0;
+  END
+$$;
+
+statement error pgcode 22004 pq: upper bound of FOR loop cannot be null
+SELECT f();
+
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN 1..3 BY NULL LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RETURN 0;
+  END
+$$;
+
+statement error pgcode 22004 pq: BY value of FOR loop cannot be null
+SELECT f();
+
+# The step must be greater than zero.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN 1..3 BY 0 LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RETURN 0;
+  END
+$$;
+
+statement error pgcode 22023 pq: BY value of FOR loop must be greater than zero
+SELECT f();
+
+# The bounds/step must be coercible to an integer.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN 1.1..3 LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RETURN 0;
+  END
+$$;
+
+query T noticetrace
+SELECT f();
+----
+NOTICE: i: 1
+NOTICE: i: 2
+NOTICE: i: 3
+
+statement error pgcode 22P02 pq: could not parse \"foo\" as type int: strconv.ParseInt: parsing \"foo\": invalid syntax
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN 1..'foo' LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RETURN 0;
+  END
+$$;
+
+# Case with parameterized bounds and step size.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f(lower INT, upper INT, step INT) RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN lower..upper BY step LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RETURN 0;
+  END
+$$;
+
+query T noticetrace
+SELECT f(-1, 5, 2);
+----
+NOTICE: i: -1
+NOTICE: i: 1
+NOTICE: i: 3
+NOTICE: i: 5
+
+statement error pgcode 22004 pq: lower bound of FOR loop cannot be null
+SELECT f(NULL, 5, 2);
+
+statement error pgcode 22004 pq: upper bound of FOR loop cannot be null
+SELECT f(1, NULL, 2);
+
+statement error pgcode 22004 pq: BY value of FOR loop cannot be null
+SELECT f(1, 5, NULL);
+
+statement error pgcode 22023 pq: BY value of FOR loop must be greater than zero
+SELECT f(5, 1, -2);
+
 subtest end
 
 subtest security_definer

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -676,6 +676,20 @@ func (s *scope) findFuncArgCol(idx tree.PlaceholderIdx) *scopeColumn {
 	return nil
 }
 
+// findAnonymousColumnWithMetadataName returns the first anonymous column that
+// has the given name in the query metadata.
+func (s *scope) findAnonymousColumnWithMetadataName(metadataName string) *scopeColumn {
+	for ; s != nil; s = s.parent {
+		for i := range s.cols {
+			col := &s.cols[i]
+			if col.name.refName == "" && col.name.metadataName == metadataName {
+				return col
+			}
+		}
+	}
+	return nil
+}
+
 // startAggFunc is called when the builder starts building an aggregate
 // function. It is used to disallow nested aggregates and ensure that a
 // grouping error is not called on the aggregate arguments. For example:

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -6899,3 +6899,161 @@ project-set
                           │    └── variable: "_stmt_raise_1":9
                           └── column-access: 1 [as=column11:11]
                                └── variable: "_stmt_raise_1":9
+
+# Integer-range FOR loop.
+exec-ddl
+CREATE OR REPLACE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    FOR i IN 1..3 LOOP
+      RAISE NOTICE 'i: %', i;
+    END LOOP;
+    RAISE NOTICE 'DONE';
+    RETURN 0;
+  END
+$$;
+----
+
+# Use "norm" so it's easier to see the structure of the loop.
+norm format=show-scalars
+SELECT f();
+----
+values
+ ├── columns: f:40
+ └── tuple
+      └── udf: f
+           └── body
+                └── project
+                     ├── columns: stmt_loop_6:39
+                     ├── barrier
+                     │    ├── columns: "_loop_lower":4!null "_loop_upper":5!null "_loop_step":6!null "_loop_counter":8!null i:9!null
+                     │    └── project
+                     │         ├── columns: i:9!null "_loop_counter":8!null "_loop_lower":4!null "_loop_upper":5!null "_loop_step":6!null
+                     │         ├── barrier
+                     │         │    ├── columns: "_loop_lower":4!null "_loop_upper":5!null "_loop_step":6!null "_plpgsql_runtime_check_5":7
+                     │         │    └── values
+                     │         │         ├── columns: "_loop_lower":4!null "_loop_upper":5!null "_loop_step":6!null "_plpgsql_runtime_check_5":7
+                     │         │         └── tuple
+                     │         │              ├── const: 1
+                     │         │              ├── const: 3
+                     │         │              ├── const: 1
+                     │         │              └── null
+                     │         └── projections
+                     │              ├── variable: "_loop_lower":4 [as=i:9]
+                     │              └── variable: "_loop_lower":4 [as="_loop_counter":8]
+                     └── projections
+                          └── udf: stmt_loop_6 [as=stmt_loop_6:39]
+                               ├── tail-call
+                               ├── args
+                               │    ├── variable: i:9
+                               │    ├── variable: "_loop_lower":4
+                               │    ├── variable: "_loop_upper":5
+                               │    ├── variable: "_loop_step":6
+                               │    └── variable: "_loop_counter":8
+                               ├── params: i:10 "_loop_lower":11 "_loop_upper":12 "_loop_step":13 "_loop_counter":14
+                               └── body
+                                    └── values
+                                         ├── columns: stmt_if_11:35
+                                         └── tuple
+                                              └── case
+                                                   ├── true
+                                                   ├── when
+                                                   │    ├── le
+                                                   │    │    ├── variable: "_loop_counter":14
+                                                   │    │    └── variable: "_loop_upper":12
+                                                   │    └── subquery
+                                                   │         └── values
+                                                   │              ├── columns: "_stmt_raise_9":33
+                                                   │              └── tuple
+                                                   │                   └── udf: _stmt_raise_9
+                                                   │                        ├── tail-call
+                                                   │                        ├── args
+                                                   │                        │    ├── variable: i:10
+                                                   │                        │    ├── variable: "_loop_lower":11
+                                                   │                        │    ├── variable: "_loop_upper":12
+                                                   │                        │    ├── variable: "_loop_step":13
+                                                   │                        │    └── variable: "_loop_counter":14
+                                                   │                        ├── params: i:26 "_loop_lower":27 "_loop_upper":28 "_loop_step":29 "_loop_counter":30
+                                                   │                        └── body
+                                                   │                             ├── values
+                                                   │                             │    ├── columns: stmt_raise_10:31
+                                                   │                             │    └── tuple
+                                                   │                             │         └── function: crdb_internal.plpgsql_raise
+                                                   │                             │              ├── const: 'NOTICE'
+                                                   │                             │              ├── concat
+                                                   │                             │              │    ├── concat
+                                                   │                             │              │    │    ├── const: 'i: '
+                                                   │                             │              │    │    └── coalesce
+                                                   │                             │              │    │         ├── cast: STRING
+                                                   │                             │              │    │         │    └── variable: i:26
+                                                   │                             │              │    │         └── const: '<NULL>'
+                                                   │                             │              │    └── const: ''
+                                                   │                             │              ├── const: ''
+                                                   │                             │              ├── const: ''
+                                                   │                             │              └── const: '00000'
+                                                   │                             └── values
+                                                   │                                  ├── columns: stmt_if_8:32
+                                                   │                                  └── tuple
+                                                   │                                       └── subquery
+                                                   │                                            └── values
+                                                   │                                                 ├── columns: stmt_loop_inc_7:25
+                                                   │                                                 └── tuple
+                                                   │                                                      └── udf: stmt_loop_inc_7
+                                                   │                                                           ├── tail-call
+                                                   │                                                           ├── args
+                                                   │                                                           │    ├── variable: i:26
+                                                   │                                                           │    ├── variable: "_loop_lower":27
+                                                   │                                                           │    ├── variable: "_loop_upper":28
+                                                   │                                                           │    ├── variable: "_loop_step":29
+                                                   │                                                           │    └── variable: "_loop_counter":30
+                                                   │                                                           ├── params: i:15 "_loop_lower":16 "_loop_upper":17 "_loop_step":18 "_loop_counter":19
+                                                   │                                                           └── body
+                                                   │                                                                └── project
+                                                   │                                                                     ├── columns: stmt_loop_6:38
+                                                   │                                                                     ├── barrier
+                                                   │                                                                     │    ├── columns: "_loop_counter":36 i:37
+                                                   │                                                                     │    └── project
+                                                   │                                                                     │         ├── columns: i:37 "_loop_counter":36
+                                                   │                                                                     │         ├── values
+                                                   │                                                                     │         │    ├── columns: "_loop_counter":36
+                                                   │                                                                     │         │    └── tuple
+                                                   │                                                                     │         │         └── plus
+                                                   │                                                                     │         │              ├── variable: "_loop_counter":19
+                                                   │                                                                     │         │              └── variable: "_loop_step":18
+                                                   │                                                                     │         └── projections
+                                                   │                                                                     │              └── variable: "_loop_counter":36 [as=i:37]
+                                                   │                                                                     └── projections
+                                                   │                                                                          └── udf: stmt_loop_6 [as=stmt_loop_6:38]
+                                                   │                                                                               ├── tail-call
+                                                   │                                                                               ├── args
+                                                   │                                                                               │    ├── variable: i:37
+                                                   │                                                                               │    ├── variable: "_loop_lower":16
+                                                   │                                                                               │    ├── variable: "_loop_upper":17
+                                                   │                                                                               │    ├── variable: "_loop_step":18
+                                                   │                                                                               │    └── variable: "_loop_counter":36
+                                                   │                                                                               └── recursive-call
+                                                   └── subquery
+                                                        └── values
+                                                             ├── columns: loop_exit_1:34
+                                                             └── tuple
+                                                                  └── udf: loop_exit_1
+                                                                       ├── tail-call
+                                                                       └── body
+                                                                            └── values
+                                                                                 ├── columns: "_stmt_raise_2":3
+                                                                                 └── tuple
+                                                                                      └── udf: _stmt_raise_2
+                                                                                           ├── tail-call
+                                                                                           └── body
+                                                                                                ├── values
+                                                                                                │    ├── columns: stmt_raise_3:1
+                                                                                                │    └── tuple
+                                                                                                │         └── function: crdb_internal.plpgsql_raise
+                                                                                                │              ├── const: 'NOTICE'
+                                                                                                │              ├── const: 'DONE'
+                                                                                                │              ├── const: ''
+                                                                                                │              ├── const: ''
+                                                                                                │              └── const: '00000'
+                                                                                                └── values
+                                                                                                     ├── columns: stmt_return_4:2!null
+                                                                                                     └── tuple
+                                                                                                          └── const: 0

--- a/pkg/sql/plpgsql/parser/lexer.go
+++ b/pkg/sql/plpgsql/parser/lexer.go
@@ -156,19 +156,10 @@ func (l *lexer) MakeExecSqlStmt() (*plpgsqltree.Execute, error) {
 				pos++
 			}
 			// Read in one or more comma-separated variables as the INTO target.
-			for ; pos < endPos; pos += 2 {
-				tok = l.tokens[pos]
-				if tok.id != IDENT {
-					return nil, errors.Newf("\"%s\" is not a scalar variable", tok.str)
-				}
-				variable := plpgsqltree.Variable(strings.TrimSpace(l.getStr(pos, pos+1)))
-				target = append(target, variable)
-				if pos+1 == endPos || l.tokens[pos+1].id != ',' {
-					// This is the end of the target list.
-					break
-				}
+			target, intoEndPos, err = l.readTarget(pos, endPos)
+			if err != nil {
+				return nil, err
 			}
-			intoEndPos = pos + 1
 		}
 	}
 
@@ -252,6 +243,176 @@ func (l *lexer) MakeDynamicExecuteStmt() (*plpgsqltree.DynamicExecute, error) {
 	return ret, nil
 }
 
+func (l *lexer) MakeFetchOrMoveStmt(isMove bool) (plpgsqltree.Statement, error) {
+	if l.parser.Lookahead() != -1 {
+		// Push back the lookahead token so that it can be included.
+		l.PushBack(1)
+	}
+	prefix := "FETCH "
+	if isMove {
+		prefix = "MOVE "
+	}
+	sqlStr, terminator, err := l.ReadSqlStatement(INTO, ';')
+	if err != nil {
+		return nil, err
+	}
+	sqlStr = prefix + sqlStr
+	sqlStmt, err := parser.ParseOne(sqlStr)
+	if err != nil {
+		return nil, err
+	}
+	var cursor tree.CursorStmt
+	switch t := sqlStmt.AST.(type) {
+	case *tree.FetchCursor:
+		cursor = t.CursorStmt
+	case *tree.MoveCursor:
+		cursor = t.CursorStmt
+	default:
+		return nil, errors.Newf("invalid FETCH or MOVE syntax")
+	}
+	var target []plpgsqltree.Variable
+	if !isMove {
+		if terminator != INTO {
+			return nil, errors.Newf("invalid syntax for FETCH")
+		}
+		// Read past the INTO.
+		l.lastPos++
+		startPos, endPos, _, err := l.readSQLConstruct(true /* isExpr */, false /* allowEmpty */, ';')
+		if err != nil {
+			return nil, err
+		}
+		var targetEnd int
+		target, targetEnd, err = l.readTarget(startPos, endPos)
+		if err != nil {
+			return nil, err
+		}
+		if targetEnd != endPos {
+			return nil, errors.Newf("expected INTO target to be a comma-separated list")
+		}
+		if len(target) == 0 {
+			return nil, errors.Newf("expected INTO target")
+		}
+	}
+	// Move past the semicolon.
+	l.lastPos++
+	return &plpgsqltree.Fetch{
+		Cursor: cursor,
+		Target: target,
+		IsMove: isMove,
+	}, nil
+}
+
+// ReadIntegerForLoopControl reads a loop control statement that uses integer
+// bounds. Syntax:
+//
+//	[ REVERSE ] expression .. expression [ BY expression ] LOOP
+func (l *lexer) ReadIntegerForLoopControl() (plpgsqltree.ForLoopControl, error) {
+	if l.parser.Lookahead() != -1 {
+		// Push back the lookahead token so that it can be included.
+		l.PushBack(1)
+	}
+	var reverse bool
+	var byExprStr string
+	if l.Peek().id == REVERSE {
+		reverse = true
+		l.lastPos++
+	}
+	lowerBoundStr, _, err := l.ReadSqlExpr(DOT_DOT)
+	if err != nil {
+		return nil, err
+	}
+	l.lastPos++
+	upperBoundStr, terminator, err := l.ReadSqlExpr(LOOP, BY)
+	if err != nil {
+		return nil, err
+	}
+	l.lastPos++
+	if terminator == BY {
+		byExprStr, terminator, err = l.ReadSqlExpr(LOOP)
+		if err != nil {
+			return nil, err
+		}
+		l.lastPos++
+	}
+	if terminator == 0 {
+		return nil, errors.New("missing LOOP keyword")
+	}
+	var lowerBound, upperBound, byExpr plpgsqltree.Expr
+	lowerBound, err = l.ParseExpr(lowerBoundStr)
+	if err != nil {
+		return nil, err
+	}
+	upperBound, err = l.ParseExpr(upperBoundStr)
+	if err != nil {
+		return nil, err
+	}
+	if byExprStr != "" {
+		byExpr, err = l.ParseExpr(byExprStr)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &plpgsqltree.IntForLoopControl{
+		Reverse: reverse,
+		Lower:   lowerBound,
+		Upper:   upperBound,
+		Step:    byExpr,
+	}, err
+}
+
+func (l *lexer) ReadSqlExpr(
+	terminator1 int, terminators ...int,
+) (sqlStr string, terminatorMet int, err error) {
+	var startPos, endPos int
+	startPos, endPos, terminatorMet, err = l.readSQLConstruct(
+		true /* isExpr */, false /* allowEmpty */, terminator1, terminators...,
+	)
+	return l.getStr(startPos, endPos), terminatorMet, err
+}
+
+// ReadReturnExpr handles reading the expression for a RETURN statement, which
+// can be nonexistent.
+func (l *lexer) ReadReturnExpr() (sqlStr string, err error) {
+	var startPos, endPos int
+	startPos, endPos, _, err = l.readSQLConstruct(true /* isExpr */, true /* allowEmpty */, ';')
+	if err != nil || startPos == endPos {
+		return "", err
+	}
+	return l.getStr(startPos, endPos), err
+}
+
+func (l *lexer) ReadSqlStatement(
+	terminator1 int, terminators ...int,
+) (sqlStr string, terminatorMet int, err error) {
+	var startPos, endPos int
+	startPos, endPos, terminatorMet, err = l.readSQLConstruct(
+		false /* isExpr */, false /* allowEmpty */, terminator1, terminators...,
+	)
+	return l.getStr(startPos, endPos), terminatorMet, err
+}
+
+// findFirstOccurrence searches from the current position for occurrences of the
+// supplied tokens, returning the first one found. The cursor is not advanced
+// unless there is an error. If the given terminators are not found, the
+// function returns 0.
+func (l *lexer) findFirstOccurrence(
+	terminator1 int, terminators ...int,
+) (foundToken int, err error) {
+	if l.parser.Lookahead() != -1 {
+		// Push back the lookahead token so that it can be included.
+		l.PushBack(1)
+	}
+	originalPos := l.lastPos
+	_, _, terminatorMet, err := l.readSQLConstruct(
+		true /* isExpr */, true /* allowEmpty */, terminator1, terminators...,
+	)
+	if err == nil {
+		// Restore the original position.
+		l.lastPos = originalPos
+	}
+	return terminatorMet, err
+}
+
 func (l *lexer) readSQLConstruct(
 	isExpr, allowEmpty bool, terminator1 int, terminators ...int,
 ) (startPos, endPos, terminatorMet int, err error) {
@@ -305,99 +466,6 @@ func (l *lexer) readSQLConstruct(
 		}
 	}
 	return startPos, endPos, terminatorMet, nil
-}
-
-func (l *lexer) MakeFetchOrMoveStmt(isMove bool) (plpgsqltree.Statement, error) {
-	if l.parser.Lookahead() != -1 {
-		// Push back the lookahead token so that it can be included.
-		l.PushBack(1)
-	}
-	prefix := "FETCH "
-	if isMove {
-		prefix = "MOVE "
-	}
-	sqlStr, terminator, err := l.ReadSqlStatement(INTO, ';')
-	if err != nil {
-		return nil, err
-	}
-	sqlStr = prefix + sqlStr
-	sqlStmt, err := parser.ParseOne(sqlStr)
-	if err != nil {
-		return nil, err
-	}
-	var cursor tree.CursorStmt
-	switch t := sqlStmt.AST.(type) {
-	case *tree.FetchCursor:
-		cursor = t.CursorStmt
-	case *tree.MoveCursor:
-		cursor = t.CursorStmt
-	default:
-		return nil, errors.Newf("invalid FETCH or MOVE syntax")
-	}
-	var target []plpgsqltree.Variable
-	if !isMove {
-		if terminator != INTO {
-			return nil, errors.Newf("invalid syntax for FETCH")
-		}
-		// Read past the INTO.
-		l.lastPos++
-		startPos, endPos, _, err := l.readSQLConstruct(true /* isExpr */, false /* allowEmpty */, ';')
-		if err != nil {
-			return nil, err
-		}
-		for pos := startPos; pos < endPos; pos += 2 {
-			tok := l.tokens[pos]
-			if tok.id != IDENT {
-				return nil, errors.Newf("\"%s\" is not a scalar variable", tok.str)
-			}
-			if pos+1 != endPos && l.tokens[pos+1].id != ',' {
-				return nil, errors.Newf("expected INTO target to be a comma-separated list")
-			}
-			variable := plpgsqltree.Variable(strings.TrimSpace(l.getStr(pos, pos+1)))
-			target = append(target, variable)
-		}
-		if len(target) == 0 {
-			return nil, errors.Newf("expected INTO target")
-		}
-	}
-	// Move past the semicolon.
-	l.lastPos++
-	return &plpgsqltree.Fetch{
-		Cursor: cursor,
-		Target: target,
-		IsMove: isMove,
-	}, nil
-}
-
-func (l *lexer) ReadSqlExpr(
-	terminator1 int, terminators ...int,
-) (sqlStr string, terminatorMet int, err error) {
-	var startPos, endPos int
-	startPos, endPos, terminatorMet, err = l.readSQLConstruct(
-		true /* isExpr */, false /* allowEmpty */, terminator1, terminators...,
-	)
-	return l.getStr(startPos, endPos), terminatorMet, err
-}
-
-// ReadReturnExpr handles reading the expression for a RETURN statement, which
-// can be nonexistent.
-func (l *lexer) ReadReturnExpr() (sqlStr string, err error) {
-	var startPos, endPos int
-	startPos, endPos, _, err = l.readSQLConstruct(true /* isExpr */, true /* allowEmpty */, ';')
-	if err != nil || startPos == endPos {
-		return "", err
-	}
-	return l.getStr(startPos, endPos), err
-}
-
-func (l *lexer) ReadSqlStatement(
-	terminator1 int, terminators ...int,
-) (sqlStr string, terminatorMet int, err error) {
-	var startPos, endPos int
-	startPos, endPos, terminatorMet, err = l.readSQLConstruct(
-		false /* isExpr */, false /* allowEmpty */, terminator1, terminators...,
-	)
-	return l.getStr(startPos, endPos), terminatorMet, err
 }
 
 func (l *lexer) getStr(startPos, endPos int) string {
@@ -495,6 +563,36 @@ func (l *lexer) ParseExpr(sqlStr string) (plpgsqltree.Expr, error) {
 		return nil, pgerror.Newf(pgcode.Syntax, "query returned %d columns", len(exprs))
 	}
 	return exprs[0], nil
+}
+
+// ReadTarget reads a comma-separated list of target variables from the current
+// position.
+func (l *lexer) ReadTarget() ([]plpgsqltree.Variable, error) {
+	startPos, endPos := l.lastPos+1, len(l.tokens)
+	target, targetEnd, err := l.readTarget(startPos, endPos)
+	l.lastPos = targetEnd - 1
+	return target, err
+}
+
+// readTarget reads a comma-separated list of target variables from the given
+// start position to the given end position. It returns the target list and its
+// end position.
+func (l *lexer) readTarget(
+	pos, endPos int,
+) (target []plpgsqltree.Variable, targetEnd int, err error) {
+	for ; pos < endPos; pos += 2 {
+		tok := l.tokens[pos]
+		if tok.id != IDENT {
+			return nil, 0, errors.Newf("\"%s\" is not a scalar variable", tok.str)
+		}
+		variable := plpgsqltree.Variable(strings.TrimSpace(l.getStr(pos, pos+1)))
+		target = append(target, variable)
+		if pos+1 == endPos || l.tokens[pos+1].id != ',' {
+			// This is the end of the target list.
+			break
+		}
+	}
+	return target, pos + 1, nil
 }
 
 func checkLoopLabels(start, end string) error {

--- a/pkg/sql/plpgsql/parser/plpgsql.y
+++ b/pkg/sql/plpgsql/parser/plpgsql.y
@@ -171,6 +171,14 @@ func (u *plpgsqlSymUnion) sqlStatement() tree.Statement {
     return u.val.(tree.Statement)
 }
 
+func (u *plpgsqlSymUnion) variables() []plpgsqltree.Variable {
+		return u.val.([]plpgsqltree.Variable)
+}
+
+func (u *plpgsqlSymUnion) forLoopControl() plpgsqltree.ForLoopControl {
+		return u.val.(plpgsqltree.ForLoopControl)
+}
+
 %}
 /*
  * Basic non-keyword token types.  These are hard-wired into the core lexer.
@@ -325,9 +333,9 @@ func (u *plpgsqlSymUnion) sqlStatement() tree.Statement {
 %type <str>	expr_until_then expr_until_loop opt_expr_until_when
 %type <plpgsqltree.Expr>	opt_exitcond
 
-%type <forvariable>	for_variable
-%type <*tree.NumVal>	foreach_slice
-%type <plpgsqltree.Statement>	for_control
+%type <[]plpgsqltree.Variable> for_target
+%type <*tree.NumVal> foreach_slice
+%type <plpgsqltree.ForLoopControl> for_control
 
 %type <str> any_identifier opt_block_label opt_loop_label opt_label query_options
 %type <str> opt_error_level option_type
@@ -996,7 +1004,7 @@ stmt_loop: opt_loop_label LOOP loop_body opt_label ';'
       return setErr(plpgsqllex, err)
     }
     $$.val = &plpgsqltree.Loop{
-      Label: $1,
+      Label: loopLabel,
       Body: $3.statements(),
     }
   }
@@ -1013,51 +1021,61 @@ stmt_while: opt_loop_label WHILE expr_until_loop LOOP loop_body opt_label ';'
       return setErr(plpgsqllex, err)
     }
     $$.val = &plpgsqltree.While{
-      Label: $1,
+      Label: loopLabel,
       Condition: cond,
       Body: $5.statements(),
     }
   }
 ;
 
-stmt_for: opt_loop_label FOR for_control loop_body
+stmt_for: opt_loop_label FOR for_target IN for_control loop_body opt_label ';'
   {
-    return unimplemented(plpgsqllex, "for loop")
+    loopLabel, loopEndLabel := $1, $7
+    if err := checkLoopLabels(loopLabel, loopEndLabel); err != nil {
+      return setErr(plpgsqllex, err)
+    }
+    $$.val = &plpgsqltree.ForLoop{
+			Label: loopLabel,
+			Target: $3.variables(),
+			Control: $5.forLoopControl(),
+			Body: $6.statements(),
+		}
   }
 ;
 
-for_control: for_variable IN
-  // TODO(drewk) need to parse the sql expression here.
+for_control:
   {
-    return unimplemented(plpgsqllex, "for loop")
+	  foundToken, err := plpgsqllex.(*lexer).findFirstOccurrence(DOT_DOT, LOOP)
+	  if err != nil {
+	    return setErr(plpgsqllex, err)
+	  }
+	  switch foundToken {
+	  case DOT_DOT:
+	    // This is an iteration over an integer range.
+	    forLoopControl, err := plpgsqllex.(*lexer).ReadIntegerForLoopControl()
+	    if err != nil {
+	      return setErr(plpgsqllex, err)
+	    }
+	    $$.val = forLoopControl
+	  case LOOP:
+	    return unimplemented(plpgsqllex, "for loop over query or cursor")
+	  default:
+	    return setErr(plpgsqllex, errors.New("unterminated FOR loop definition"))
+	  }
   }
 ;
 
-/*
- * Processing the for_variable is tricky because we don't yet know if the
- * FOR is an integer FOR loop or a loop over query results.  In the former
- * case, the variable is just a name that we must instantiate as a loop
- * local variable, regardless of any other definition it might have.
- * Therefore, we always save the actual identifier into $$.name where it
- * can be used for that case.  We also save the outer-variable definition,
- * if any, because that's what we need for the loop-over-query case.  Note
- * that we must NOT apply check_assignable() or any other semantic check
- * until we know what's what.
- *
- * However, if we see a comma-separated list of names, we know that it
- * can't be an integer FOR loop and so it's OK to check the variables
- * immediately.  In particular, for T_WORD followed by comma, we should
- * complain that the name is not known rather than say it's a syntax error.
- * Note that the non-error result of this case sets *both* $$.scalar and
- * $$.row; see the for_control production.
- */
-for_variable: any_identifier
+for_target:
   {
-    return unimplemented(plpgsqllex, "for loop")
+    target, err := plpgsqllex.(*lexer).ReadTarget()
+    if err != nil {
+      return setErr(plpgsqllex, err)
+    }
+    $$.val = target
   }
 ;
 
-stmt_foreach_a: opt_loop_label FOREACH for_variable foreach_slice IN ARRAY expr_until_loop loop_body
+stmt_foreach_a: opt_loop_label FOREACH
   {
     return unimplemented(plpgsqllex, "for each loop")
   }

--- a/pkg/sql/plpgsql/parser/testdata/stmt_for
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_for
@@ -1,49 +1,297 @@
-error
+parse
 DECLARE
 BEGIN
 FOR counter IN 1..5 LOOP
-  EXECUTE 'any command';
+  RAISE NOTICE 'The counter is %', counter;
 END LOOP;
 END
 ----
-----
-at or near "counter": syntax error: unimplemented: this syntax
-DETAIL: source SQL:
 DECLARE
 BEGIN
 FOR counter IN 1..5 LOOP
-    ^
-HINT: You have attempted to use a feature that is not yet implemented.
+RAISE NOTICE 'The counter is %', counter;
+END LOOP;
+END;
+ -- normalized!
+DECLARE
+BEGIN
+FOR counter IN (1)..(5) LOOP
+RAISE NOTICE 'The counter is %', (counter);
+END LOOP;
+END;
+ -- fully parenthesized
+DECLARE
+BEGIN
+FOR counter IN _.._ LOOP
+RAISE NOTICE '_', counter;
+END LOOP;
+END;
+ -- literals removed
+DECLARE
+BEGIN
+FOR _ IN 1..5 LOOP
+RAISE NOTICE 'The counter is %', _;
+END LOOP;
+END;
+ -- identifiers removed
 
-Please check the public issue tracker to check whether this problem is
-already tracked. If you cannot find it there, please report the error
-with details by creating a new issue.
-
-If you would rather not post publicly, please contact us directly
-using the support form.
-
-We appreciate your feedback.
-----
-----
-
-
-error
+# Make sure labels work correctly.
+parse
 DECLARE
 BEGIN
 <<for_loop>>
 FOR counter IN 1..5 LOOP
-  EXECUTE 'any command';
+  RAISE NOTICE 'The counter is %', counter;
 END LOOP for_loop;
 END
 ----
-----
-at or near "counter": syntax error: unimplemented: this syntax
-DETAIL: source SQL:
 DECLARE
 BEGIN
 <<for_loop>>
 FOR counter IN 1..5 LOOP
-    ^
+RAISE NOTICE 'The counter is %', counter;
+END LOOP for_loop;
+END;
+ -- normalized!
+DECLARE
+BEGIN
+<<for_loop>>
+FOR counter IN (1)..(5) LOOP
+RAISE NOTICE 'The counter is %', (counter);
+END LOOP for_loop;
+END;
+ -- fully parenthesized
+DECLARE
+BEGIN
+<<for_loop>>
+FOR counter IN _.._ LOOP
+RAISE NOTICE '_', counter;
+END LOOP for_loop;
+END;
+ -- literals removed
+DECLARE
+BEGIN
+<<_>>
+FOR _ IN 1..5 LOOP
+RAISE NOTICE 'The counter is %', _;
+END LOOP _;
+END;
+ -- identifiers removed
+
+# The bounds can be arbitrary expressions.
+parse
+DECLARE
+BEGIN
+FOR counter IN (SELECT min(x) FROM xy)..(SELECT max(x) FROM xy) LOOP
+  RAISE NOTICE 'The counter is %', counter;
+END LOOP;
+END
+----
+DECLARE
+BEGIN
+FOR counter IN (SELECT min(x) FROM xy)..(SELECT max(x) FROM xy) LOOP
+RAISE NOTICE 'The counter is %', counter;
+END LOOP;
+END;
+ -- normalized!
+DECLARE
+BEGIN
+FOR counter IN ((SELECT (min((x))) FROM xy))..((SELECT (max((x))) FROM xy)) LOOP
+RAISE NOTICE 'The counter is %', (counter);
+END LOOP;
+END;
+ -- fully parenthesized
+DECLARE
+BEGIN
+FOR counter IN (SELECT min(x) FROM xy)..(SELECT max(x) FROM xy) LOOP
+RAISE NOTICE '_', counter;
+END LOOP;
+END;
+ -- literals removed
+DECLARE
+BEGIN
+FOR _ IN (SELECT _(_) FROM _)..(SELECT _(_) FROM _) LOOP
+RAISE NOTICE 'The counter is %', _;
+END LOOP;
+END;
+ -- identifiers removed
+
+# An extra dot here is interpreted as a decimal point.
+parse
+DECLARE
+BEGIN
+FOR counter IN 1...5 LOOP
+  RAISE NOTICE 'The counter is %', counter;
+END LOOP;
+END
+----
+DECLARE
+BEGIN
+FOR counter IN 1...5 LOOP
+RAISE NOTICE 'The counter is %', counter;
+END LOOP;
+END;
+ -- normalized!
+DECLARE
+BEGIN
+FOR counter IN (1)..(.5) LOOP
+RAISE NOTICE 'The counter is %', (counter);
+END LOOP;
+END;
+ -- fully parenthesized
+DECLARE
+BEGIN
+FOR counter IN _.._ LOOP
+RAISE NOTICE '_', counter;
+END LOOP;
+END;
+ -- literals removed
+DECLARE
+BEGIN
+FOR _ IN 1...5 LOOP
+RAISE NOTICE 'The counter is %', _;
+END LOOP;
+END;
+ -- identifiers removed
+
+# The step length can be specified.
+parse
+DECLARE
+BEGIN
+FOR counter IN 1..5 BY 2 LOOP
+  RAISE NOTICE 'The counter is %', counter;
+END LOOP;
+END
+----
+DECLARE
+BEGIN
+FOR counter IN 1..5 BY 2 LOOP
+RAISE NOTICE 'The counter is %', counter;
+END LOOP;
+END;
+ -- normalized!
+DECLARE
+BEGIN
+FOR counter IN (1)..(5) BY (2) LOOP
+RAISE NOTICE 'The counter is %', (counter);
+END LOOP;
+END;
+ -- fully parenthesized
+DECLARE
+BEGIN
+FOR counter IN _.._ BY _ LOOP
+RAISE NOTICE '_', counter;
+END LOOP;
+END;
+ -- literals removed
+DECLARE
+BEGIN
+FOR _ IN 1..5 BY 2 LOOP
+RAISE NOTICE 'The counter is %', _;
+END LOOP;
+END;
+ -- identifiers removed
+
+# Invalid syntax in first expression.
+error
+DECLARE
+BEGIN
+FOR counter IN (SELEC 1)..5 LOOP
+  RAISE NOTICE 'The counter is %', counter;
+END LOOP;
+END
+----
+at or near "loop": at or near "1": syntax error
+DETAIL: source SQL:
+SET ROW ((SELEC 1))
+                ^
+--
+source SQL:
+DECLARE
+BEGIN
+FOR counter IN (SELEC 1)..5 LOOP
+                            ^
+HINT: try \h SET SESSION
+
+# Invalid syntax in second expression.
+error
+DECLARE
+BEGIN
+FOR counter IN 1..(SELEC 5) LOOP
+  RAISE NOTICE 'The counter is %', counter;
+END LOOP;
+END
+----
+at or near "loop": at or near "5": syntax error
+DETAIL: source SQL:
+SET ROW ((SELEC 5) )
+                ^
+--
+source SQL:
+DECLARE
+BEGIN
+FOR counter IN 1..(SELEC 5) LOOP
+                            ^
+HINT: try \h SET SESSION
+
+# Invalid syntax in step length.
+error
+DECLARE
+BEGIN
+FOR counter IN 1..5 BY (SELEC 2) LOOP
+  RAISE NOTICE 'The counter is %', counter;
+END LOOP;
+END
+----
+at or near "loop": at or near "2": syntax error
+DETAIL: source SQL:
+SET ROW ((SELEC 2) )
+                ^
+--
+source SQL:
+DECLARE
+BEGIN
+FOR counter IN 1..5 BY (SELEC 2) LOOP
+                                 ^
+HINT: try \h SET SESSION
+
+# Extra range bound.
+error
+DECLARE
+BEGIN
+FOR counter IN 1..5..10 LOOP
+  RAISE NOTICE 'The counter is %', counter;
+END LOOP;
+END
+----
+at or near "loop": at or near ".": syntax error
+DETAIL: source SQL:
+SET ROW (5..10 )
+          ^
+--
+source SQL:
+DECLARE
+BEGIN
+FOR counter IN 1..5..10 LOOP
+                        ^
+HINT: try \h SET SESSION
+
+# Too few dots, so the parser expects cursor or query loop.
+error
+DECLARE
+BEGIN
+FOR counter IN 1.5 LOOP
+  RAISE NOTICE 'The counter is %', counter;
+END LOOP;
+END
+----
+----
+at or near "in": syntax error: unimplemented: this syntax
+DETAIL: source SQL:
+DECLARE
+BEGIN
+FOR counter IN 1.5 LOOP
+            ^
 HINT: You have attempted to use a feature that is not yet implemented.
 
 Please check the public issue tracker to check whether this problem is
@@ -57,21 +305,23 @@ We appreciate your feedback.
 ----
 ----
 
+# Nesting the dots should cause the parser to expect a cursor or query loop
+# instead.
 error
 DECLARE
 BEGIN
-FOR counter IN 1..5 LOOP
-  EXECUTE 'any command';
+FOR counter IN SELECT (1...5) LOOP
+  RAISE NOTICE 'The counter is %', counter;
 END LOOP;
 END
 ----
 ----
-at or near "counter": syntax error: unimplemented: this syntax
+at or near "in": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 DECLARE
 BEGIN
-FOR counter IN 1..5 LOOP
-    ^
+FOR counter IN SELECT (1...5) LOOP
+            ^
 HINT: You have attempted to use a feature that is not yet implemented.
 
 Please check the public issue tracker to check whether this problem is
@@ -95,12 +345,12 @@ END LOOP;
 RETURN;
 ----
 ----
-at or near "yr": syntax error: unimplemented: this syntax
+at or near "in": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 DECLARE
 BEGIN
 FOR yr IN SELECT * FROM generate_series(1,10,1) AS y_(y)
-    ^
+       ^
 HINT: You have attempted to use a feature that is not yet implemented.
 
 Please check the public issue tracker to check whether this problem is

--- a/pkg/sql/plpgsql/parser/testdata/stmt_foreach_a
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_foreach_a
@@ -11,14 +11,14 @@ BEGIN
 END
 ----
 ----
-at or near "x": syntax error: unimplemented: this syntax
+at or near "foreach": syntax error: unimplemented: this syntax
 DETAIL: source SQL:
 DECLARE
   s int8 := 0;
   x int;
 BEGIN
   FOREACH x IN ARRAY $1
-          ^
+  ^
 HINT: You have attempted to use a feature that is not yet implemented.
 
 Please check the public issue tracker to check whether this problem is


### PR DESCRIPTION
#### plpgsql: add parser support for integer FOR loops

This commit adds support in the PL/pgSQL parser for integer FOR loops,
which iterate a counter over a user-defined integer range.

Informs #105246

Release note: None

#### plpgsql: support integer range FOR loops

This commit adds support for integer FOR loops in PL/pgSQL. This allows
users to iterate over a range of integer values using the following syntax:
```
FOR target IN [ REVERSE ] expr .. expr [ BY expr ] LOOP ...
```

Informs #105246

Release note (sql change): Added support for PL/pgSQL integer FOR loops,
which iterate over a range of integer values.