### PR TITLE
sql,server: unify sqlInstanceDialer initialization using instancereader-based dialer.

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -1988,14 +1988,14 @@ func (rpcCtx *Context) GRPCDialNode(
 	return rpcCtx.grpcDialNodeInternal(target, remoteNodeID, remoteLocality, class)
 }
 
-// GRPCDialPod wraps GRPCDialNode and treats the `remoteInstanceID`
+// GRPCDialInstance wraps GRPCDialNode and treats the `remoteInstanceID`
 // argument as a `NodeID` which it converts. This works because the
 // tenant gRPC server is initialized using the `InstanceID` so it
 // accepts our connection as matching the ID we're dialing.
 //
 // Since GRPCDialNode accepts a separate `target` and `NodeID` it
 // requires no further modification to work between pods.
-func (rpcCtx *Context) GRPCDialPod(
+func (rpcCtx *Context) GRPCDialInstance(
 	target string,
 	remoteInstanceID base.SQLInstanceID,
 	remoteLocality roachpb.Locality,

--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -202,9 +202,10 @@ func (n *Dialer) ConnHealth(nodeID roachpb.NodeID, class rpc.ConnectionClass) er
 	return n.rpcContext.ConnHealth(addr.String(), nodeID, class)
 }
 
-// ConnHealthTryDial returns nil if we have an open connection of the request
-// class to the given node that succeeded on its most recent heartbeat. If no
-// healthy connection is found, it will attempt to dial the node.
+// ConnHealthTryDial returns nil if we have an open connection of the
+// rpc.DefaultClass to the given sqlinstance that succeeded on its most recent
+// heartbeat. If no healthy connection is found, it will attempt to dial the
+// instance.
 //
 // This exists for components that do not themselves actively maintain RPC
 // connections to remote nodes, e.g. DistSQL. However, it can cause significant
@@ -217,27 +218,11 @@ func (n *Dialer) ConnHealth(nodeID roachpb.NodeID, class rpc.ConnectionClass) er
 // a connection attempt in the background if it doesn't and always return
 // immediately. It is only used today by DistSQL and it should probably be
 // removed and moved into that code. Also, as of #99191, we have stateful
-// circuit breakers that probe in the background and so whatever exactly it
-// is the caller really wants can likely be achieved by more direct means.
-func (n *Dialer) ConnHealthTryDial(nodeID roachpb.NodeID, class rpc.ConnectionClass) error {
-	err := n.ConnHealth(nodeID, class)
-	if err == nil {
-		return err
-	}
-	addr, locality, err := n.resolver(nodeID)
-	if err != nil {
-		return err
-	}
-	// NB: This will always return `ErrNotHeartbeated` since the heartbeat will
-	// not be done by the time `Health` is called since GRPCDialNode is async.
-	return n.rpcContext.GRPCDialNode(addr.String(), nodeID, locality, class).Health()
-}
-
-// ConnHealthTryDialInstance returns nil if we have an open connection of the
-// rpc.DefaultClass to the given sqlinstance that succeeded on its most recent
-// heartbeat. If no healthy connection is found, it will attempt to dial the
-// instance.
-func (n *Dialer) ConnHealthTryDialInstance(id base.SQLInstanceID, addr string) error {
+// circuit breakers that probe in the background and so whatever exactly it is
+// the caller really wants can likely be achieved by more direct means.
+func (n *Dialer) ConnHealthTryDial(
+	id base.SQLInstanceID, addr string, locality roachpb.Locality,
+) error {
 	if n == nil {
 		return errors.New("no node dialer configured")
 	}
@@ -245,7 +230,24 @@ func (n *Dialer) ConnHealthTryDialInstance(id base.SQLInstanceID, addr string) e
 		addr, roachpb.NodeID(id), rpc.DefaultClass); err == nil {
 		return nil
 	}
-	return n.rpcContext.GRPCDialInstance(addr, id, roachpb.Locality{}, rpc.DefaultClass).Health()
+	// NB: This will always return `ErrNotHeartbeated` since the heartbeat will
+	// not be done by the time `Health` is called since GRPCDialNode is async.
+	return n.rpcContext.GRPCDialInstance(addr, id, locality, rpc.DefaultClass).Health()
+}
+
+// ConnHealthTryDialWithResolve returns nil if we have an open connection of the
+// request class to the given node that succeeded on its most recent heartbeat.
+// If no healthy connection is found, it will attempt to dial the node.
+func (n *Dialer) ConnHealthTryDialWithResolve(id base.SQLInstanceID) error {
+	if n == nil || n.resolver == nil {
+		return errors.New("no node dialer configured")
+	}
+	addr, locality, err := n.resolver(roachpb.NodeID(id))
+	if err != nil {
+		return err
+	}
+
+	return n.ConnHealthTryDial(id, addr.String(), locality)
 }
 
 // GetCircuitBreaker retrieves the circuit breaker for connections to the

--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -245,7 +245,7 @@ func (n *Dialer) ConnHealthTryDialInstance(id base.SQLInstanceID, addr string) e
 		addr, roachpb.NodeID(id), rpc.DefaultClass); err == nil {
 		return nil
 	}
-	return n.rpcContext.GRPCDialPod(addr, id, roachpb.Locality{}, rpc.DefaultClass).Health()
+	return n.rpcContext.GRPCDialInstance(addr, id, roachpb.Locality{}, rpc.DefaultClass).Health()
 }
 
 // GetCircuitBreaker retrieves the circuit breaker for connections to the

--- a/pkg/rpc/nodedialer/nodedialer_test.go
+++ b/pkg/rpc/nodedialer/nodedialer_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -192,28 +193,28 @@ func TestConnHealthTryDial(t *testing.T) {
 	// When no connection exists, we expect ConnHealthTryDial to dial the node,
 	// which will return ErrNoHeartbeat at first but eventually succeed.
 	require.Eventually(t, func() bool {
-		return nd.ConnHealthTryDial(staticNodeID, rpc.DefaultClass) == nil
+		return nd.ConnHealthTryDialWithResolve(base.SQLInstanceID(staticNodeID)) == nil
 	}, time.Second, 10*time.Millisecond)
 
 	// But it should error for other node ID.
-	require.Error(t, nd.ConnHealthTryDial(9, rpc.DefaultClass))
+	require.Error(t, nd.ConnHealthTryDialWithResolve(base.SQLInstanceID(9)))
 
 	// When the heartbeat errors, ConnHealthTryDial should eventually error too.
 	hb.setErr(errors.New("boom"))
 	require.Eventually(t, func() bool {
-		return nd.ConnHealthTryDial(staticNodeID, rpc.DefaultClass) != nil
+		return nd.ConnHealthTryDialWithResolve(base.SQLInstanceID(staticNodeID)) == nil
 	}, time.Second, 10*time.Millisecond)
 
 	// When the heartbeat recovers, ConnHealthTryDial should too.
 	hb.setErr(nil)
 	require.Eventually(t, func() bool {
-		return nd.ConnHealthTryDial(staticNodeID, rpc.DefaultClass) == nil
+		return nd.ConnHealthTryDialWithResolve(base.SQLInstanceID(staticNodeID)) == nil
 	}, time.Second, 10*time.Millisecond)
 
 	// Closing the remote connection should eventually recover.
 	require.NoError(t, ln.popConn().Close())
 	require.Eventually(t, func() bool {
-		return nd.ConnHealthTryDial(staticNodeID, rpc.DefaultClass) == nil
+		return nd.ConnHealthTryDialWithResolve(base.SQLInstanceID(staticNodeID)) == nil
 	}, time.Second, 10*time.Millisecond)
 }
 

--- a/pkg/server/fanout_clients.go
+++ b/pkg/server/fanout_clients.go
@@ -145,7 +145,7 @@ func (t *tenantFanoutClient) dialNode(
 	if err != nil {
 		return nil, err
 	}
-	return t.rpcCtx.GRPCDialPod(instance.InstanceRPCAddr, id, instance.Locality, rpc.DefaultClass).Connect(ctx)
+	return t.rpcCtx.GRPCDialInstance(instance.InstanceRPCAddr, id, instance.Locality, rpc.DefaultClass).Connect(ctx)
 }
 
 func (t *tenantFanoutClient) getAllNodes(

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -606,26 +606,14 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		cfg.db,
 	)
 
-	// We can't use the nodeDialer as the sqlInstanceDialer unless we
-	// are serving the system tenant despite the fact that we've
-	// arranged for pod IDs and instance IDs to match since the
-	// secondary tenant gRPC servers currently live on a different
-	// port.
-	canUseNodeDialerAsSQLInstanceDialer := isMixedSQLAndKVNode && codec.ForSystemTenant()
-	if canUseNodeDialerAsSQLInstanceDialer {
-		cfg.sqlInstanceDialer = cfg.kvNodeDialer
-	} else {
-		// In a multi-tenant environment, use the sqlInstanceReader to resolve
-		// SQL pod addresses.
-		addressResolver := func(nodeID roachpb.NodeID) (net.Addr, roachpb.Locality, error) {
-			info, err := cfg.sqlInstanceReader.GetInstance(cfg.rpcContext.MasterCtx, base.SQLInstanceID(nodeID))
-			if err != nil {
-				return nil, roachpb.Locality{}, errors.Wrapf(err, "unable to look up descriptor for n%d", nodeID)
-			}
-			return &util.UnresolvedAddr{AddressField: info.InstanceRPCAddr}, info.Locality, nil
+	addressResolver := func(nodeID roachpb.NodeID) (net.Addr, roachpb.Locality, error) {
+		info, err := cfg.sqlInstanceReader.GetInstance(cfg.rpcContext.MasterCtx, base.SQLInstanceID(nodeID))
+		if err != nil {
+			return nil, roachpb.Locality{}, errors.Wrapf(err, "unable to look up descriptor for n%d", nodeID)
 		}
-		cfg.sqlInstanceDialer = nodedialer.New(cfg.rpcContext, addressResolver)
+		return &util.UnresolvedAddr{AddressField: info.InstanceRPCAddr}, info.Locality, nil
 	}
+	cfg.sqlInstanceDialer = nodedialer.New(cfg.rpcContext, addressResolver)
 
 	jobRegistry := cfg.circularJobRegistry
 	{
@@ -1027,8 +1015,6 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 			cfg.gossip,
 			cfg.stopper,
 			isAvailable,
-			cfg.kvNodeDialer.ConnHealthTryDial, // only used by system tenant
-			cfg.sqlInstanceDialer.ConnHealthTryDialInstance,
 			cfg.sqlInstanceDialer,
 			codec,
 			cfg.sqlInstanceReader,
@@ -1270,12 +1256,11 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 				DB:               cfg.db,
 			})
 		} else {
-			c = upgradecluster.NewTenantCluster(
-				upgradecluster.TenantClusterConfig{
-					Dialer:         cfg.sqlInstanceDialer,
-					InstanceReader: cfg.sqlInstanceReader,
-					DB:             cfg.db,
-				})
+			c = upgradecluster.NewTenantCluster(upgradecluster.TenantClusterConfig{
+				Dialer:         cfg.sqlInstanceDialer,
+				InstanceReader: cfg.sqlInstanceReader,
+				DB:             cfg.db,
+			})
 		}
 		systemDeps = upgrade.SystemDeps{
 			Cluster:       c,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -2581,7 +2581,7 @@ func (t *testTenant) RPCClientConn(
 func (t *testTenant) RPCClientConnE(user username.SQLUsername) (*grpc.ClientConn, error) {
 	ctx := context.Background()
 	rpcCtx := t.NewClientRPCContext(ctx, user)
-	return rpcCtx.GRPCDialPod(t.AdvRPCAddr(), t.SQLInstanceID(), t.Locality(), rpc.DefaultClass).Connect(ctx)
+	return rpcCtx.GRPCDialInstance(t.AdvRPCAddr(), t.SQLInstanceID(), t.Locality(), rpc.DefaultClass).Connect(ctx)
 }
 
 // GetAdminClient is part of the serverutils.ApplicationLayerInterface.

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -334,8 +334,6 @@ func startConnExecutor(
 			gw,
 			stopper,
 			func(base.SQLInstanceID) bool { return true }, // everybody is available
-			nil, /* connHealthCheckerSystem */
-			nil, /* instanceConnHealthChecker */
 			nil, /* sqlInstanceDialer */
 			keys.SystemSQLCodec,
 			nil, /* sqlAddressResolver */

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -176,8 +176,6 @@ func NewDistSQLPlanner(
 	gw gossip.OptionalGossip,
 	stopper *stop.Stopper,
 	isAvailable func(base.SQLInstanceID) bool,
-	connHealthCheckerSystem func(roachpb.NodeID, rpc.ConnectionClass) error, // will only be used by the system tenant
-	instanceConnHealthChecker func(base.SQLInstanceID, string) error,
 	sqlInstanceDialer *nodedialer.Dialer,
 	codec keys.SQLCodec,
 	sqlAddressResolver sqlinstance.AddressResolver,
@@ -191,10 +189,10 @@ func NewDistSQLPlanner(
 		gossip:               gw,
 		sqlInstanceDialer:    sqlInstanceDialer,
 		nodeHealth: distSQLNodeHealth{
-			gossip:             gw,
-			connHealthSystem:   connHealthCheckerSystem,
-			connHealthInstance: instanceConnHealthChecker,
-			isAvailable:        isAvailable,
+			gossip:                gw,
+			connHealth:            sqlInstanceDialer.ConnHealthTryDial,
+			connHealthWithResolve: sqlInstanceDialer.ConnHealthTryDialWithResolve,
+			isAvailable:           isAvailable,
 		},
 		distSender:         distSender,
 		nodeDescs:          nodeDescs,
@@ -1252,10 +1250,10 @@ func MakeSpanPartitionWithRangeCount(
 }
 
 type distSQLNodeHealth struct {
-	gossip             gossip.OptionalGossip
-	isAvailable        func(base.SQLInstanceID) bool
-	connHealthSystem   func(roachpb.NodeID, rpc.ConnectionClass) error
-	connHealthInstance func(base.SQLInstanceID, string) error
+	gossip                gossip.OptionalGossip
+	isAvailable           func(base.SQLInstanceID) bool
+	connHealth            func(id base.SQLInstanceID, addr string, locality roachpb.Locality) error
+	connHealthWithResolve func(base.SQLInstanceID) error
 }
 
 func (h *distSQLNodeHealth) checkSystem(
@@ -1269,7 +1267,7 @@ func (h *distSQLNodeHealth) checkSystem(
 		// artifact of rpcContext's reconnection mechanism at the time of
 		// writing). This is better than having it used in 100% of cases
 		// (until the liveness check below kicks in).
-		if err := h.connHealthSystem(roachpb.NodeID(sqlInstanceID), rpc.DefaultClass); err != nil {
+		if err := h.connHealthWithResolve(sqlInstanceID); err != nil {
 			// This host isn't known to be healthy. Don't use it (use the gateway
 			// instead). Note: this can never happen for our sqlInstanceID (which
 			// always has its address in the nodeMap).
@@ -1568,20 +1566,19 @@ func (dsp *DistSQLPlanner) deprecatedHealthySQLInstanceIDForKVNodeIDSystem(
 // checkInstanceHealth returns the instance health status by dialing the node.
 // It also caches the result to avoid redialing for a query.
 func (dsp *DistSQLPlanner) checkInstanceHealth(
-	instanceID base.SQLInstanceID,
-	instanceRPCAddr string,
-	isDraining bool,
-	nodeStatusesCache map[base.SQLInstanceID]NodeStatus,
+	instance *sqlinstance.InstanceInfo, nodeStatusesCache map[base.SQLInstanceID]NodeStatus,
 ) NodeStatus {
+	instanceID := instance.InstanceID
 	if nodeStatusesCache != nil {
 		if status, ok := nodeStatusesCache[instanceID]; ok {
 			return status
 		}
 	}
 	status := NodeOK
-	if isDraining {
+	if instance.IsDraining {
 		status = NodeDraining
-	} else if err := dsp.nodeHealth.connHealthInstance(instanceID, instanceRPCAddr); err != nil {
+	} else if err := dsp.nodeHealth.connHealth(
+		instanceID, instance.InstanceRPCAddr, instance.Locality); err != nil {
 		if errors.Is(err, rpc.ErrNotHeartbeated) {
 			// Consider ErrNotHeartbeated as a temporary error (see its description) and
 			// avoid caching its result, as it can resolve to a more accurate result soon.
@@ -1629,8 +1626,7 @@ func (dsp *DistSQLPlanner) healthySQLInstanceIDForKVNodeHostedInstanceResolver(
 	return func(nodeID roachpb.NodeID) (base.SQLInstanceID, SpanPartitionReason) {
 		sqlInstance := base.SQLInstanceID(nodeID)
 		if n, ok := instances[sqlInstance]; ok {
-			if status := dsp.checkInstanceHealth(
-				sqlInstance, n.InstanceRPCAddr, n.IsDraining, planCtx.nodeStatuses); status == NodeOK {
+			if status := dsp.checkInstanceHealth(&n, planCtx.nodeStatuses); status == NodeOK {
 				return sqlInstance, SpanPartitionReason_TARGET_HEALTHY
 			}
 		}
@@ -1694,8 +1690,7 @@ func (dsp *DistSQLPlanner) filterUnhealthyInstances(
 	for _, n := range instances {
 		// Gateway is always considered healthy
 		if n.InstanceID == dsp.gatewaySQLInstanceID ||
-			dsp.checkInstanceHealth(n.InstanceID, n.InstanceRPCAddr,
-				n.IsDraining, nodeStatusesCache) == NodeOK {
+			dsp.checkInstanceHealth(&n, nodeStatusesCache) == NodeOK {
 			instances[j] = n
 			j++
 		} else {

--- a/pkg/sql/flowinfra/cluster_test.go
+++ b/pkg/sql/flowinfra/cluster_test.go
@@ -304,7 +304,7 @@ func TestTenantClusterFlow(t *testing.T) {
 		})
 		defer podConns[i].Close()
 		pod := pods[i]
-		conn, err := pod.RPCContext().GRPCDialPod(pod.RPCAddr(), pod.SQLInstanceID(), pod.Locality(), rpc.DefaultClass).Connect(ctx)
+		conn, err := pod.RPCContext().GRPCDialInstance(pod.RPCAddr(), pod.SQLInstanceID(), pod.Locality(), rpc.DefaultClass).Connect(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Previously, sqlInstanceDialer initialization paths differed based on the
environment: single-tenant environments used kvNodeDialer, which relies on
gossip layer information to resolve addresses, while multi-tenant
environments used instancereader.

This change unifies the initialization paths by using instancereader for
both environments, leveraging the availability of instance information even
in single-tenant setups.

Release note: None
Informs: https://github.com/cockroachdb/cockroach/issues/125336