### PR TITLE
changefeedccl: deflake TestChangefeedWithSimpleDistributionStrategy

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist_test.go
@@ -405,6 +405,12 @@ func newRangeDistributionTester(
 	systemDB.Exec(t, "SET CLUSTER SETTING kv.rangefeed.enabled = true")
 	if tc.StartedDefaultTestTenant() {
 		systemDB.Exec(t, `ALTER TENANT [$1] GRANT CAPABILITY can_admin_relocate_range=true`, serverutils.TestTenantID().ToUint64())
+		// Give 1,000,000 upfront tokens to the tenant, and keep the tokens per
+		// second rate to the default value of 10,000. This helps avoid throttling
+		// in the tests.
+		systemDB.Exec(t,
+			"SELECT crdb_internal.update_tenant_resource_limits($1::INT, 1000000, 10000, 0, now(), 0)",
+			serverutils.TestTenantID().ToUint64())
 	}
 
 	t.Logf("%s: creating and inserting rows into table", timeutil.Now().Format(time.DateTime))


### PR DESCRIPTION
This change: https://github.com/cockroachdb/cockroach/pull/125117 removed giving 1M upfront tokens to new tenants. This seems that have cause some throttling in this test. This commit re-adds the 1M upfront tokens for the affected tests.

Fixes: #125170

Epic: None

Release note: None