### PR TITLE
server: add more info to max-go-limit warning

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -744,8 +744,11 @@ func getDefaultGoMemLimit(ctx context.Context) int64 {
 		log.Ops.Shoutf(
 			ctx, severity.WARNING, "recommended default value of "+
 				"--max-go-memory (%s) was truncated to %s, consider reducing "+
-				"--max-sql-memory and / or --cache",
+				"--max-sql-memory (%s) and / or --cache (%s); total system/cgroup memory: %s.",
 			humanizeutil.IBytes(limit), humanizeutil.IBytes(maxGoMemLimit),
+			humanizeutil.IBytes(serverCfg.MemoryPoolSize),
+			humanizeutil.IBytes(serverCfg.CacheSize),
+			humanizeutil.IBytes(sysMem),
 		)
 		limit = maxGoMemLimit
 	}


### PR DESCRIPTION
Add the sql memory, cache size, and total memory to the warning issued
when `--max-go-memory` is clamped.

Fixes #130195