### PR TITLE
rpc: deflake TestClockOffsetInClientPingRequest

### DIFF
--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -235,8 +235,12 @@ func testClockOffsetInPingRequestInternal(t *testing.T, clientOnly bool) {
 	t.Logf("client dial")
 	// Dial: this causes the heartbeats to start.
 	remoteAddr := ln.Addr().String()
-	_, err = rpcCtxClient.GRPCDialNode(remoteAddr, 1, roachpb.Locality{}, SystemClass).Connect(ctx)
-	require.NoError(t, err)
+	testutils.SucceedsSoon(t, func() error {
+		_, err = rpcCtxClient.GRPCDialNode(
+			remoteAddr, 1, roachpb.Locality{}, SystemClass,
+		).Connect(ctx)
+		return err
+	})
 
 	// The first ping establishes the TCP+TLS connection and uses a blocking dialback,
 	// so it's usually pretty noisy in terms of detecting clock offsets. The second


### PR DESCRIPTION
Setting up the initial connection may time out under race. This commit wraps it in a `SucceedsSoon` so it can be retried.

Fixes: #130142

Release note: None