### PR TITLE
release-24.2: raft: fix flaky leader index in waitLeader function

### DIFF
--- a/pkg/raft/rafttest/BUILD.bazel
+++ b/pkg/raft/rafttest/BUILD.bazel
@@ -52,6 +52,5 @@ go_test(
     deps = [
         "//pkg/raft",
         "//pkg/raft/raftpb",
-        "//pkg/testutils/skip",
     ],
 )


### PR DESCRIPTION
Backport 1/1 commits from #130084.

Fixes #130244.

/cc @cockroachdb/release

---

Fixes #127413.

This commit bypasses the larger rebase in #122133 to pick up the test flake fix in https://github.com/etcd-io/raft/pull/188. There was some discussion in https://github.com/etcd-io/raft/issues/181 about alternatives for fixing this test. For now, we stick with a direct cherry-pick.

Release note: None

Release justification: test fix.