### PR TITLE
roachtest: add roachperf stats

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -281,6 +281,7 @@ go_library(
         "//pkg/util/uuid",
         "//pkg/util/version",
         "//pkg/workload",
+        "//pkg/workload/cli",
         "//pkg/workload/debug",
         "//pkg/workload/histogram",
         "//pkg/workload/querybench",

--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -644,7 +644,7 @@ func (v variations) runTest(ctx context.Context, t test.Test, c cluster.Cluster)
 	t.Status(fmt.Sprintf("T2: running workload at stable rate of %d per node", stableRatePerNode))
 	var data *workloadData
 	cancelWorkload := m.GoWithCancel(func(ctx context.Context) error {
-		if data, err = v.workload.runWorkload(ctx, v, 0, stableRatePerNode); !errors.Is(err, context.Canceled) {
+		if data, err = v.workload.runWorkload(ctx, v, 0, stableRatePerNode); err != nil && !errors.Is(err, context.Canceled) {
 			return err
 		}
 		return nil
@@ -672,7 +672,7 @@ func (v variations) runTest(ctx context.Context, t test.Test, c cluster.Cluster)
 	t.L().Printf("Recovery interval     : %s", afterInterval)
 
 	cancelWorkload()
-	m.Wait()
+	require.NoError(t, m.WaitE())
 
 	baselineStats := data.worstStats(baselineInterval)
 	perturbationStats := data.worstStats(perturbationInterval)

--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -572,21 +572,24 @@ func (v variations) runTest(ctx context.Context, t test.Test, c cluster.Cluster)
 		})
 	})
 
+	// This is the computed stable rate for this cluster.
+	clusterMaxRate := make(chan int)
+	m.Go(func(ctx context.Context) error {
+		// Wait for the first 3/4 of the duration and then measure the QPS in
+		// the last 1/4.
+		waitDuration(ctx, v.fillDuration*3/4)
+		clusterMaxRate <- v.measureQPS(ctx, t.L(), v.fillDuration*1/4)
+		return nil
+	})
 	// Start filling the system without a rate.
 	t.Status("T1: filling at full rate")
 	require.NoError(t, v.workload.runWorkload(ctx, v, v.fillDuration, 0))
 
-	// Capture the max rate near the last 1/4 of the fill process.
-	sampleWindow := v.fillDuration / 4
-	ratioOfWrites := 0.5
-	fillStats := lm.worstStats(sampleWindow)
-	stableRate := int(float64(fillStats[`write`].count)*v.ratioOfMax/ratioOfWrites) / v.numWorkloadNodes
-
 	// Start the consistent workload and begin collecting profiles.
-	t.L().Printf("stable rate for this cluster is %d per node", stableRate)
-	t.Status("T2: running workload at stable rate")
+	stableRatePerNode := int(float64(<-clusterMaxRate) * v.ratioOfMax / float64(v.numWorkloadNodes))
+	t.Status(fmt.Sprintf("T2: running workload at stable rate of %d per node", stableRatePerNode))
 	cancelWorkload := m.GoWithCancel(func(ctx context.Context) error {
-		if err := v.workload.runWorkload(ctx, v, 0, stableRate); !errors.Is(err, context.Canceled) {
+		if err := v.workload.runWorkload(ctx, v, 0, stableRatePerNode); !errors.Is(err, context.Canceled) {
 			return err
 		}
 		return nil
@@ -625,7 +628,6 @@ func (v variations) runTest(ctx context.Context, t test.Test, c cluster.Cluster)
 	afterDuration := v.perturbation.endPerturbation(ctx, t.L(), v)
 	afterStats := lm.worstStats(afterDuration)
 
-	t.L().Printf("%s\n", prettyPrint("Fill stats", fillStats))
 	t.L().Printf("%s\n", prettyPrint("Baseline stats", baselineStats))
 	t.L().Printf("%s\n", prettyPrint("Perturbation stats", perturbationStats))
 	t.L().Printf("%s\n", prettyPrint("Recovery stats", afterStats))
@@ -700,7 +702,7 @@ func (lm *latencyMonitor) worstStats(window time.Duration) map[string]trackedSta
 	stats := make(map[string]trackedStat)
 	// startIndex is always between 0 and numOpsToTrack - 1.
 	startIndex := (lm.mu.index + numOpsToTrack - int(window.Seconds())) % numOpsToTrack
-	// endIndex is alwayss greater than startIndex.
+	// endIndex is always greater than startIndex.
 	endIndex := (lm.mu.index + numOpsToTrack) % numOpsToTrack
 	if endIndex < startIndex {
 		endIndex += numOpsToTrack
@@ -840,6 +842,55 @@ func (v variations) stableNodes() option.NodeListOption {
 // require multiple targets we could add multi-target support.
 func (v variations) targetNodes() option.NodeListOption {
 	return v.cluster.Node(v.numNodes)
+}
+
+// measureQPS will measure the approx QPS at the time this command is run. The
+// duration is the interval to measure over. Setting too short of an interval
+// can mean inaccuracy in results. Setting too long of an interval may mean the
+// impact is blurred out.
+func (v variations) measureQPS(ctx context.Context, l *logger.Logger, duration time.Duration) int {
+	stableNodes := v.stableNodes()
+
+	totalOpsCompleted := func() int {
+		// NB: We can't hold the connection open during the full duration.
+		var dbs []*gosql.DB
+		for _, nodeId := range stableNodes {
+			db := v.cluster.Conn(ctx, l, nodeId)
+			defer db.Close()
+			dbs = append(dbs, db)
+		}
+		rates := make(chan int, len(dbs))
+		// Count the inserts before sleeping.
+		for _, db := range dbs {
+			db := db
+			go func() {
+				var v float64
+				if err := db.QueryRowContext(
+					ctx, `SELECT sum(value) FROM crdb_internal.node_metrics WHERE name in ('sql.select.count', 'sql.insert.count')`,
+				).Scan(&v); err != nil {
+					panic(err)
+				}
+				rates <- int(v)
+			}()
+		}
+		var total int
+		for range dbs {
+			total += <-rates
+		}
+		return total
+	}
+
+	// Measure the current time and the QPS now.
+	startTime := timeutil.Now()
+	beforeOps := totalOpsCompleted()
+	// Wait for the duration minus the first query time.
+	select {
+	case <-ctx.Done():
+		return 0
+	case <-time.After(duration - timeutil.Since(startTime)):
+		afterOps := totalOpsCompleted()
+		return int(float64(afterOps-beforeOps) / duration.Seconds())
+	}
 }
 
 type workloadType interface {

--- a/pkg/cmd/roachtest/tests/util.go
+++ b/pkg/cmd/roachtest/tests/util.go
@@ -13,7 +13,6 @@ package tests
 import (
 	"context"
 	gosql "database/sql"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -27,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
-	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -362,22 +360,6 @@ func downloadProfiles(
 
 type IP struct {
 	Query string
-}
-
-// getListenAddr returns the public IP address of the machine running the test.
-func getListenAddr(ctx context.Context) (string, error) {
-	req, err := httputil.Get(ctx, "http://ip-api.com/json/")
-	if err != nil {
-		return "", err
-	}
-	defer req.Body.Close()
-
-	var ip IP
-	if err := json.NewDecoder(req.Body).Decode(&ip); err != nil {
-		return "", err
-	}
-
-	return ip.Query, nil
 }
 
 // EnvWorkloadDurationFlag - environment variable to override

--- a/pkg/workload/cli/format.go
+++ b/pkg/workload/cli/format.go
@@ -11,6 +11,8 @@
 package cli
 
 import (
+	"bufio"
+	"encoding/json"
 	"fmt"
 	"io"
 	"time"
@@ -148,3 +150,61 @@ func (f *jsonFormatter) outputTick(startElapsed time.Duration, t histogram.Tick)
 func (f *jsonFormatter) outputTotal(startElapsed time.Duration, t histogram.Tick) {}
 
 func (f *jsonFormatter) outputResult(startElapsed time.Duration, t histogram.Tick) {}
+
+type tickRaw struct {
+	Time time.Time
+	Errs int
+	Avgt float64
+	P50l float64
+	P95l float64
+	P99l float64
+	Maxl float64
+	Type string
+}
+
+type Tick struct {
+	Time       time.Time
+	Errs       int
+	Throughput float64
+	P50        time.Duration
+	P95        time.Duration
+	P99        time.Duration
+	PMax       time.Duration
+	Type       string
+}
+
+// fromJson parses a json string and returns a Tick struct.
+func fromJson(data string) (Tick, error) {
+	var tr tickRaw
+	if err := json.Unmarshal([]byte(data), &tr); err != nil {
+		return Tick{}, err
+	}
+	return Tick{
+		Time:       tr.Time,
+		Errs:       tr.Errs,
+		Throughput: tr.Avgt,
+		P50:        time.Duration(tr.P50l * float64(time.Millisecond)),
+		P95:        time.Duration(tr.P95l * float64(time.Millisecond)),
+		P99:        time.Duration(tr.P99l * float64(time.Millisecond)),
+		PMax:       time.Duration(tr.Maxl * float64(time.Millisecond)),
+		Type:       tr.Type,
+	}, nil
+}
+
+// ParseOutput reads the output of a workload run and returns the list of valid
+// Ticks it contains.
+// TODO(baptist): The output currently has a bunch of other garbage in it which
+// has accumulated over time. Ideally this should be removed from the original
+// output, but for now just ignore it.
+func ParseOutput(reader io.Reader) []Tick {
+	scanner := bufio.NewScanner(reader)
+	var ticks []Tick
+	for scanner.Scan() {
+		line := scanner.Text()
+		tick, err := fromJson(line)
+		if err == nil {
+			ticks = append(ticks, tick)
+		}
+	}
+	return ticks
+}

--- a/pkg/workload/cli/format_test.go
+++ b/pkg/workload/cli/format_test.go
@@ -12,7 +12,9 @@ package cli
 
 import (
 	"bytes"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -118,4 +120,41 @@ func TestJSONStructure(t *testing.T) {
 "type":"read"
 }`
 	require.JSONEq(t, expected, buf.String())
+}
+
+// TestParseJson ensures that all the fields in the JSON output can be parsed.
+func TestParseJSON(t *testing.T) {
+	// A line taken directly from a test run output.
+	jsonStr := `{"time":"2024-08-30T19:40:31.913393Z","errs":1,"avgt":4531.0,"avgl":1120.2,"p50l":2.4,"p95l":19.9,"p99l":37.7,"maxl":62.9,"type":"read"}`
+	tick, err := fromJson(jsonStr)
+	require.NoError(t, err)
+
+	expectedTick := Tick{
+		Time:       time.Date(2024, 8, 30, 19, 40, 31, 913393000, time.UTC),
+		Errs:       1,
+		Throughput: 4531.0,
+		P50:        2400 * time.Microsecond,
+		P95:        19900 * time.Microsecond,
+		P99:        37700 * time.Microsecond,
+		PMax:       62900 * time.Microsecond,
+		Type:       "read",
+	}
+	require.Equal(t, expectedTick, tick)
+}
+
+// TestParseOutput ensures that the valid json can be extracted from a file.
+// The output is an snippet from a test run output with associated non-JSON
+// garbage in the file.
+func TestParseOutput(t *testing.T) {
+	output := `
+	W240830 19:40:30.523513 3604 workload/pgx_helpers.go:240  [-] 4953  error preparing statement. name=kv-2 sql=SELECT k, v FROM kv AS OF SYSTEM TIME follower_read_timestamp() WHERE k IN ($1) ERROR: database "kv" does not exist (SQLSTATE 3D000)
+{"time":"2024-08-30T19:40:30.915598Z","errs":0,"avgt":242.1,"avgl":269.9,"p50l":13.6,"p95l":3758.1,"p99l":3892.3,"maxl":3892.3,"type":"follower-read"}
+{"time":"2024-08-30T19:40:30.915598Z","errs":0,"avgt":223.9,"avgl":249.7,"p50l":31.5,"p95l":3758.1,"p99l":3892.3,"maxl":3892.3,"type":"read"}
+Number of reads that didn't return any results: 40661.
+Write sequence could be resumed by passing --write-seq=R133867 to the next run.`
+	ticks := ParseOutput(strings.NewReader(output))
+	fmt.Println(ticks)
+	require.Equal(t, 2, len(ticks))
+	require.Equal(t, ticks[0].Type, "follower-read")
+	require.Equal(t, ticks[1].Type, "read")
 }


### PR DESCRIPTION
This commit adds the creation of a stats.json file after the run. This file is collected by the testing framework to make graphs on the roachperf dashboard.

Fixes: #128393

Epic: none

Release note: None