### PR TITLE
kvserver: don't use windowed incremental disk stats for cumulative me…

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -3955,17 +3955,26 @@ func (sm *StoreMetrics) updateEnvStats(stats fs.EnvStats) {
 	sm.EncryptionAlgorithm.Update(int64(stats.EncryptionType))
 }
 
-func (sm *StoreMetrics) updateDiskStats(rollingStats disk.StatsWindow) {
-	cumulativeStats := rollingStats.Latest()
-	sm.DiskReadCount.Update(int64(cumulativeStats.ReadsCount))
-	sm.DiskReadBytes.Update(int64(cumulativeStats.BytesRead()))
-	sm.DiskReadTime.Update(int64(cumulativeStats.ReadsDuration))
-	sm.DiskWriteCount.Update(int64(cumulativeStats.WritesCount))
-	sm.DiskWriteBytes.Update(int64(cumulativeStats.BytesWritten()))
-	sm.DiskWriteTime.Update(int64(cumulativeStats.WritesDuration))
-	sm.DiskIOTime.Update(int64(cumulativeStats.CumulativeDuration))
-	sm.DiskWeightedIOTime.Update(int64(cumulativeStats.WeightedIODuration))
-	sm.DiskIopsInProgress.Update(int64(cumulativeStats.InProgressCount))
+func (sm *StoreMetrics) updateDiskStats(
+	ctx context.Context,
+	rollingStats disk.StatsWindow,
+	cumulativeStats disk.Stats,
+	cumulativeStatsErr error,
+) {
+	if cumulativeStatsErr == nil {
+		sm.DiskReadCount.Update(int64(cumulativeStats.ReadsCount))
+		sm.DiskReadBytes.Update(int64(cumulativeStats.BytesRead()))
+		sm.DiskReadTime.Update(int64(cumulativeStats.ReadsDuration))
+		sm.DiskWriteCount.Update(int64(cumulativeStats.WritesCount))
+		sm.DiskWriteBytes.Update(int64(cumulativeStats.BytesWritten()))
+		sm.DiskWriteTime.Update(int64(cumulativeStats.WritesDuration))
+		sm.DiskIOTime.Update(int64(cumulativeStats.CumulativeDuration))
+		sm.DiskWeightedIOTime.Update(int64(cumulativeStats.WeightedIODuration))
+		sm.DiskIopsInProgress.Update(int64(cumulativeStats.InProgressCount))
+	} else {
+		// Don't update cumulative stats to the useless zero value.
+		log.Errorf(ctx, "not updating cumulative stats due to %s", cumulativeStatsErr)
+	}
 	maxRollingStats := rollingStats.Max()
 	// maxRollingStats is computed as the change in stats every 100ms, so we
 	// scale them to represent the change in stats every 1s.

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3587,8 +3587,18 @@ func (s *Store) ComputeMetricsPeriodically(
 
 	// Get disk stats for the disk associated with this store.
 	if s.diskMonitor != nil {
+		// IncrementalStats returns the stats captured in the tracer since the
+		// last call to incremental stats. These are useful for computing
+		// functions like max over an interval. We could use rollingStats.Latest()
+		// for cumulative stats, but there is no guarantee that slowness in
+		// capturing traces or other timing issues will not cause rollingStats to
+		// be empty, in which case rollingStats.Latest() will be empty. For the
+		// real cumulative stats we use Monitor.CumulativeStats which is robust to
+		// such slowness (since it will return the latest value even if it is the
+		// same as the last call).
 		rollingStats := s.diskMonitor.IncrementalStats()
-		s.metrics.updateDiskStats(rollingStats)
+		cumulativeStats, cumulativeStatsErr := s.diskMonitor.CumulativeStats()
+		s.metrics.updateDiskStats(ctx, rollingStats, cumulativeStats, cumulativeStatsErr)
 	}
 
 	wt := m.Flush.WriteThroughput


### PR DESCRIPTION
…trics

They don't guarantee monotonicity. We now use disk.Monitor.CumulativeStats.

Fixes #129991

Epic: none

Release note: None