### PR TITLE
crosscluster: fix descriptor id in show ldr jobs

### DIFF
--- a/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
@@ -1483,9 +1483,9 @@ func TestShowLogicalReplicationJobs(t *testing.T) {
 		require.Equal(t, jobs.StatusRunning, jobs.Status(status))
 
 		if expectedJobID == jobAID {
-			require.Equal(t, pq.StringArray{"b.public.tab"}, targets)
-		} else if expectedJobID == jobBID {
 			require.Equal(t, pq.StringArray{"a.public.tab"}, targets)
+		} else if expectedJobID == jobBID {
+			require.Equal(t, pq.StringArray{"b.public.tab"}, targets)
 		}
 
 		// `SHOW LOGICAL REPLICATION JOBS` query runs after the job query in `jobutils.GetJobProgress()`,

--- a/pkg/sql/delegate/show_logical_replication_jobs.go
+++ b/pkg/sql/delegate/show_logical_replication_jobs.go
@@ -28,7 +28,7 @@ WITH table_names AS (
 			id AS job_id,
 			crdb_internal.get_fully_qualified_table_name(jsonb_array_elements(crdb_internal.pb_to_json(
 			 	 			'cockroach.sql.jobs.jobspb.Payload', 
-			 	 			payload)->'logicalReplicationDetails'->'replicationPairs')['srcDescriptorId']::INT) AS table_name
+			 	 			payload)->'logicalReplicationDetails'->'replicationPairs')['dstDescriptorId']::INT) AS table_name
 		FROM crdb_internal.system_jobs 
 		WHERE job_type = 'LOGICAL REPLICATION'
 	) AS t


### PR DESCRIPTION
Use `dstDescriptorID` instead of `srcDescriptorID`.

Epic: none
Release note: none