### PR TITLE
workload/schemachange: enable alter pk

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -4379,3 +4379,32 @@ public  roach_dwellings  ·
 public  testenum         ·
 
 subtest end
+
+subtest type_is_indexable
+
+# Indexable type (int4).
+query B
+SELECT crdb_internal.type_is_indexable(23);
+----
+true
+
+# Unindexable type (refcursor).
+query B
+SELECT crdb_internal.type_is_indexable(1790);
+----
+false
+
+statement ok
+CREATE TYPE foo_type AS ENUM ('v1', 'v2', 'v3');
+
+query B
+SELECT crdb_internal.type_is_indexable((SELECT oid FROM pg_type WHERE typname = 'foo_type'));
+----
+true
+
+query T
+SELECT crdb_internal.type_is_indexable(NULL);
+----
+NULL
+
+subtest end

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -61,6 +61,7 @@ go_library(
         "//pkg/sql/appstatspb",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catalogkeys",
+        "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/randgen/randgencfg",
         "//pkg/sql/colexecerror",

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/randgen/randgencfg"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
@@ -8844,6 +8845,27 @@ WHERE object_id = table_descriptor_id
 			Info:       `This function is used to get the fully qualified table name given a table descriptor ID`,
 			Volatility: volatility.Stable,
 			Language:   tree.RoutineLangSQL,
+		},
+	),
+	"crdb_internal.type_is_indexable": makeBuiltin(defProps(),
+		tree.Overload{
+			Types:      tree.ParamTypes{{Name: "oid", Typ: types.Oid}},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				oid := tree.MustBeDOid(args[0]).Oid
+				var typ *types.T
+				if resolvedTyp, ok := types.OidToType[oid]; ok {
+					typ = resolvedTyp
+				} else {
+					var err error
+					if typ, err = evalCtx.Planner.ResolveTypeByOID(ctx, oid); err != nil {
+						return nil, err
+					}
+				}
+				return tree.MakeDBool(tree.DBool(colinfo.ColumnTypeIsIndexable(typ))), nil
+			},
+			Info:       "Returns whether the given type OID is indexable.",
+			Volatility: volatility.Stable,
 		},
 	),
 }

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2608,6 +2608,7 @@ var builtinOidsArray = []string{
 	2640: `crdb_internal.clear_query_plan_cache() -> void`,
 	2641: `crdb_internal.clear_table_stats_cache() -> void`,
 	2642: `crdb_internal.get_fully_qualified_table_name(table_descriptor_id: int) -> string`,
+	2643: `crdb_internal.type_is_indexable(oid: oid) -> bool`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -3303,7 +3303,7 @@ func (og *operationGenerator) randColumn(
 	q := fmt.Sprintf(`
   SELECT column_name
     FROM [SHOW COLUMNS FROM %s]
-   WHERE column_name != 'rowid'
+   WHERE NOT is_hidden
 ORDER BY random()
    LIMIT 1;
 `, tableName.String())

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2571,12 +2571,20 @@ func (og *operationGenerator) alterTableAlterPrimaryKey(
 				AND index_columns.column_id = (columns.col->'id')::int8
 			)) AS is_in_inverted_index,
 			(EXISTS(
-				SELECT *
-				FROM crdb_internal.table_indexes
-				JOIN crdb_internal.index_columns USING (descriptor_id)
-				WHERE table_indexes.is_unique
-				AND table_indexes.descriptor_id = columns.table_id
-				AND index_columns.column_id = (columns.col->'id')::int8
+				SELECT 
+    tc.constraint_name, 
+    kcu.column_name
+		FROM 
+		    information_schema.table_constraints AS tc
+		JOIN 
+		    information_schema.key_column_usage AS kcu
+		ON 
+		    tc.constraint_name = kcu.constraint_name
+		WHERE 
+    tc.constraint_type = 'UNIQUE' 
+    AND kcu.column_name = col->>'name'
+		AND kcu.table_schema = quote_ident(schema_id::REGNAMESPACE::TEXT)
+    AND kcu.table_name = quote_ident(columns.table_name)
 			)) AS is_unique
 		FROM columns
 		WHERE NOT (

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -274,7 +274,7 @@ var opWeights = []int{
 	alterTableAddConstraintForeignKey: 1,
 	alterTableAddConstraintUnique:     1,
 	alterTableAlterColumnType:         0, // Disabled and tracked with #66662.
-	alterTableAlterPrimaryKey:         0, // Disabled and tracked with #128656.
+	alterTableAlterPrimaryKey:         1,
 	alterTableDropColumn:              1,
 	alterTableDropColumnDefault:       1,
 	alterTableDropConstraint:          1,


### PR DESCRIPTION
### workload/schemachange: avoid hidden columns in random column selection
This patch ensures that we avoid hidden columns during random column
selection. Prior to this, we would only filter out `rowid`, but columns
like those created from adding a hash-sharded-index should also be
excluded.

Release note: None

---

### builtins: add crdb_internal.type_is_indexable builtin
This patch adds the `crdb_internal.type_is_indexable`
builtin -- which determines whether or not a given
type oid is indexable.

This builtin is used to choose "proper" columns for
a primary key schema change.

Release note: None

---

### workload/schemachange: fix is_unique check for alter pk op
This patch uses a different query for determining whether or not
a column has a unique constraint. In particular, we want to distinguish
between a column with a unique constraint (this patch) vs a column that
is a part of a composite key with a unique constraint.

Fixes: https://github.com/cockroachdb/cockroach/issues/130196
Release note: None

---

### workload/schemachange: enable alterPK
This patch enables `ALTER TABLE ... ALTER PRIMARY KEY`
in the schemachange workload.

Fixes: #128656
Release note: None