### PR TITLE
raft: integrate check quorum with leader fortification 

### DIFF
--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -1607,7 +1607,7 @@ func TestLeaderStepdownWhenQuorumActive(t *testing.T) {
 }
 
 func TestLeaderStepdownWhenQuorumLost(t *testing.T) {
-	sm := newTestRaft(1, 5, 1, newTestMemoryStorage(withPeers(1, 2, 3)))
+	sm := newTestRaft(1, 5, 1, newTestMemoryStorage(withPeers(1, 2, 3)), withFortificationDisabled())
 
 	sm.checkQuorum = true
 
@@ -2568,7 +2568,7 @@ func TestAddLearner(t *testing.T) {
 // TestAddNodeCheckQuorum tests that addNode does not trigger a leader election
 // immediately when checkQuorum is set.
 func TestAddNodeCheckQuorum(t *testing.T) {
-	r := newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1)))
+	r := newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1)), withFortificationDisabled())
 	r.checkQuorum = true
 
 	r.becomeCandidate()

--- a/pkg/raft/raftstoreliveness/store_liveness.go
+++ b/pkg/raft/raftstoreliveness/store_liveness.go
@@ -118,5 +118,5 @@ func (Disabled) SupportFromEnabled() bool {
 
 // SupportExpired implements the StoreLiveness interface.
 func (Disabled) SupportExpired(hlc.Timestamp) bool {
-	panic("unimplemented")
+	return true
 }

--- a/pkg/raft/rafttest/interaction_env_handler_raftstate.go
+++ b/pkg/raft/rafttest/interaction_env_handler_raftstate.go
@@ -48,8 +48,8 @@ func (env *InteractionEnv) handleRaftState() error {
 		} else {
 			voterStatus = "(Non-Voter)"
 		}
-		fmt.Fprintf(env.Output, "%d: %s %s Term:%d Lead:%d\n",
-			st.ID, st.RaftState, voterStatus, st.Term, st.Lead)
+		fmt.Fprintf(env.Output, "%d: %s %s Term:%d Lead:%d LeadEpoch:%d\n",
+			st.ID, st.RaftState, voterStatus, st.Term, st.Lead, st.LeadEpoch)
 	}
 	return nil
 }

--- a/pkg/raft/rafttest/interaction_env_handler_store_liveness.go
+++ b/pkg/raft/rafttest/interaction_env_handler_store_liveness.go
@@ -144,9 +144,15 @@ func (s *storeLiveness) SupportFromEnabled() bool {
 }
 
 // SupportExpired implements the StoreLiveness interface.
-func (s *storeLiveness) SupportExpired(hlc.Timestamp) bool {
-	// TODO(arul): we may need to implement this if we start injecting timestamps.
-	return false
+func (s *storeLiveness) SupportExpired(ts hlc.Timestamp) bool {
+	switch ts {
+	case hlc.Timestamp{}:
+		return true
+	case hlc.MaxTimestamp:
+		return false
+	default:
+		panic("unexpected timestamp")
+	}
 }
 
 // handleBumpEpoch handles the case where the epoch of a store is bumped and the

--- a/pkg/raft/testdata/checkquorum.txt
+++ b/pkg/raft/testdata/checkquorum.txt
@@ -59,10 +59,12 @@ stabilize
 # interval (see messages above).
 tick-election 1
 ----
-ok
+DEBUG 1 does not have store liveness support from a quorum of peers
 
 tick-election 1
 ----
+DEBUG 1 has not received messages from a quorum of peers in the last election timeout
+DEBUG 1 does not have store liveness support from a quorum of peers
 WARN 1 stepped down to follower since quorum is not active
 INFO 1 became follower at term 1
 

--- a/pkg/raft/testdata/confchange_v1_remove_leader.txt
+++ b/pkg/raft/testdata/confchange_v1_remove_leader.txt
@@ -23,9 +23,9 @@ ok
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
 
 # Start removing n1.
 propose-conf-change 1 v1=true
@@ -35,9 +35,9 @@ ok
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
 
 # Propose an extra entry which will be sent out together with the conf change.
 propose 1 foo
@@ -109,9 +109,9 @@ stabilize 1
 
 raft-state
 ----
-1: StateLeader (Non-Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Non-Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
 
 # n2 responds, n3 doesn't yet. Quorum for 'bar' should not be reached...
 stabilize 2
@@ -245,6 +245,6 @@ stabilize
 # Expected behavior: a new leader is elected after an election timeout.
 raft-state
 ----
-1: StateLeader (Non-Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Non-Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1

--- a/pkg/raft/testdata/confchange_v1_remove_leader_stepdown.txt
+++ b/pkg/raft/testdata/confchange_v1_remove_leader_stepdown.txt
@@ -24,9 +24,9 @@ ok
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
 
 # Start removing n1.
 propose-conf-change 1 v1=true
@@ -36,9 +36,9 @@ ok
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
 
 # Propose an extra entry which will be sent out together with the conf change.
 propose 1 foo
@@ -112,9 +112,9 @@ stabilize 1
 
 raft-state
 ----
-1: StateFollower (Non-Voter) Term:1 Lead:0
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateFollower (Non-Voter) Term:1 Lead:0 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
 
 # n2 responds, n3 doesn't yet. Quorum for 'bar' should not be reached...
 stabilize 2

--- a/pkg/raft/testdata/confchange_v2_replace_leader.txt
+++ b/pkg/raft/testdata/confchange_v2_replace_leader.txt
@@ -29,9 +29,9 @@ ok
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
 
 # create n4
 add-nodes 1
@@ -155,10 +155,10 @@ INFO 1 became follower at term 1
 # processed by the transfer target.
 raft-state
 ----
-1: StateFollower (Voter) Term:1 Lead:0
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
-4: StateFollower (Voter) Term:1 Lead:1
+1: StateFollower (Voter) Term:1 Lead:0 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+4: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:0
 
 # Leadership transfer is happening here.
 stabilize
@@ -322,10 +322,10 @@ stabilize
 # Leadership transfer succeeded.
 raft-state
 ----
-1: StateFollower (Voter) Term:2 Lead:4
-2: StateFollower (Voter) Term:2 Lead:4
-3: StateFollower (Voter) Term:2 Lead:4
-4: StateLeader (Voter) Term:2 Lead:4
+1: StateFollower (Voter) Term:2 Lead:4 LeadEpoch:1
+2: StateFollower (Voter) Term:2 Lead:4 LeadEpoch:1
+3: StateFollower (Voter) Term:2 Lead:4 LeadEpoch:1
+4: StateLeader (Voter) Term:2 Lead:4 LeadEpoch:1
 
 # n4 will propose a transition out of the joint config.
 propose-conf-change 4
@@ -420,10 +420,10 @@ stabilize
 # n1 is out of the configuration.
 raft-state
 ----
-1: StateFollower (Non-Voter) Term:2 Lead:4
-2: StateFollower (Voter) Term:2 Lead:4
-3: StateFollower (Voter) Term:2 Lead:4
-4: StateLeader (Voter) Term:2 Lead:4
+1: StateFollower (Non-Voter) Term:2 Lead:4 LeadEpoch:1
+2: StateFollower (Voter) Term:2 Lead:4 LeadEpoch:1
+3: StateFollower (Voter) Term:2 Lead:4 LeadEpoch:1
+4: StateLeader (Voter) Term:2 Lead:4 LeadEpoch:1
 
 # Make sure n1 cannot campaign to become leader.
 campaign 1

--- a/pkg/raft/testdata/confchange_v2_replace_leader_stepdown.txt
+++ b/pkg/raft/testdata/confchange_v2_replace_leader_stepdown.txt
@@ -30,9 +30,9 @@ ok
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
 
 # create n4
 add-nodes 1
@@ -54,10 +54,10 @@ ok
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
-4: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+4: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:0
 
 # n4 will propose a transition out of the joint config.
 propose-conf-change 4
@@ -162,10 +162,10 @@ stabilize
 # n1 is out of the configuration.
 raft-state
 ----
-1: StateFollower (Non-Voter) Term:1 Lead:0
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
-4: StateFollower (Voter) Term:1 Lead:1
+1: StateFollower (Non-Voter) Term:1 Lead:0 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+4: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:0
 
 # Make sure n1 cannot campaign to become leader.
 campaign 1
@@ -196,7 +196,7 @@ ok
 
 raft-state
 ----
-1: StateFollower (Non-Voter) Term:1 Lead:0
-2: StateLeader (Voter) Term:2 Lead:2
-3: StateFollower (Voter) Term:2 Lead:2
-4: StateFollower (Voter) Term:2 Lead:2
+1: StateFollower (Non-Voter) Term:1 Lead:0 LeadEpoch:1
+2: StateLeader (Voter) Term:2 Lead:2 LeadEpoch:1
+3: StateFollower (Voter) Term:2 Lead:2 LeadEpoch:1
+4: StateFollower (Voter) Term:2 Lead:2 LeadEpoch:1

--- a/pkg/raft/testdata/forget_leader.txt
+++ b/pkg/raft/testdata/forget_leader.txt
@@ -25,10 +25,10 @@ ok
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
-4: StateFollower (Non-Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+4: StateFollower (Non-Voter) Term:1 Lead:1 LeadEpoch:1
 
 # ForgetLeader is ignored if the follower is supporting the leader's store
 # liveness epoch.
@@ -52,10 +52,10 @@ INFO 2 forgetting leader 1 at term 1
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:0
-3: StateFollower (Voter) Term:1 Lead:1
-4: StateFollower (Non-Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:0 LeadEpoch:0
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+4: StateFollower (Non-Voter) Term:1 Lead:1 LeadEpoch:1
 
 forget-leader 2
 ----
@@ -63,10 +63,10 @@ INFO 2 no leader at term 1; dropping forget leader msg
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:0
-3: StateFollower (Voter) Term:1 Lead:1
-4: StateFollower (Non-Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:0 LeadEpoch:0
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+4: StateFollower (Non-Voter) Term:1 Lead:1 LeadEpoch:1
 
 # ForgetLeader also works on learners, but only if they are not supporting the
 # leader's store liveness epoch.
@@ -88,10 +88,10 @@ INFO 4 forgetting leader 1 at term 1
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:0
-3: StateFollower (Voter) Term:1 Lead:1
-4: StateFollower (Non-Voter) Term:1 Lead:0
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:0 LeadEpoch:0
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+4: StateFollower (Non-Voter) Term:1 Lead:0 LeadEpoch:0
 
 # When receiving a heartbeat from the leader, they revert to followers.
 tick-heartbeat 1
@@ -139,10 +139,10 @@ stabilize
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
-4: StateFollower (Non-Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:0
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+4: StateFollower (Non-Voter) Term:1 Lead:1 LeadEpoch:0
 
 withdraw-support 3 1
 ----
@@ -162,10 +162,10 @@ INFO 3 [logterm: 1, index: 11] sent MsgVote request to 2 at term 2
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateCandidate (Voter) Term:2 Lead:0
-4: StateFollower (Non-Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:0
+3: StateCandidate (Voter) Term:2 Lead:0 LeadEpoch:0
+4: StateFollower (Non-Voter) Term:1 Lead:1 LeadEpoch:0
 
 forget-leader 3
 ----
@@ -173,10 +173,10 @@ ok
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateCandidate (Voter) Term:2 Lead:0
-4: StateFollower (Non-Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:0
+3: StateCandidate (Voter) Term:2 Lead:0 LeadEpoch:0
+4: StateFollower (Non-Voter) Term:1 Lead:1 LeadEpoch:0
 
 stabilize log-level=none
 ----
@@ -184,10 +184,10 @@ ok
 
 raft-state
 ----
-1: StateFollower (Voter) Term:2 Lead:3
-2: StateFollower (Voter) Term:2 Lead:3
-3: StateLeader (Voter) Term:2 Lead:3
-4: StateFollower (Non-Voter) Term:2 Lead:3
+1: StateFollower (Voter) Term:2 Lead:3 LeadEpoch:1
+2: StateFollower (Voter) Term:2 Lead:3 LeadEpoch:1
+3: StateLeader (Voter) Term:2 Lead:3 LeadEpoch:1
+4: StateFollower (Non-Voter) Term:2 Lead:3 LeadEpoch:1
 
 # ForgetLeader shouldn't affect the election timeout: if a follower
 # forgets the leader 1 tick before the election timeout fires, it
@@ -258,7 +258,7 @@ ok
 
 raft-state
 ----
-1: StateFollower (Voter) Term:3 Lead:2
-2: StateLeader (Voter) Term:3 Lead:2
-3: StateFollower (Voter) Term:3 Lead:2
-4: StateFollower (Non-Voter) Term:3 Lead:2
+1: StateFollower (Voter) Term:3 Lead:2 LeadEpoch:1
+2: StateLeader (Voter) Term:3 Lead:2 LeadEpoch:1
+3: StateFollower (Voter) Term:3 Lead:2 LeadEpoch:1
+4: StateFollower (Non-Voter) Term:3 Lead:2 LeadEpoch:1

--- a/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
+++ b/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
@@ -90,9 +90,9 @@ stabilize
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:0
 
 # ForgetLeader is ignored if the follower is supporting the leader's store
 # liveness epoch.
@@ -115,9 +115,9 @@ INFO 2 forgetting leader 1 at term 1
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:0
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:0 LeadEpoch:0
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:0
 
 campaign 3
 ----
@@ -176,9 +176,9 @@ ok
 
 raft-state
 ----
-1: StateFollower (Voter) Term:2 Lead:3
-2: StateFollower (Voter) Term:2 Lead:3
-3: StateLeader (Voter) Term:2 Lead:3
+1: StateFollower (Voter) Term:2 Lead:3 LeadEpoch:1
+2: StateFollower (Voter) Term:2 Lead:3 LeadEpoch:1
+3: StateLeader (Voter) Term:2 Lead:3 LeadEpoch:1
 
 # Test that forgetting the leader still won't grant prevotes if the candidate
 # isn't up-to-date. We first replicate a proposal on 3 and 2.
@@ -268,6 +268,6 @@ ok
 
 raft-state
 ----
-1: StateFollower (Voter) Term:2 Lead:3
-2: StateFollower (Voter) Term:2 Lead:3
-3: StateLeader (Voter) Term:2 Lead:3
+1: StateFollower (Voter) Term:2 Lead:3 LeadEpoch:0
+2: StateFollower (Voter) Term:2 Lead:3 LeadEpoch:0
+3: StateLeader (Voter) Term:2 Lead:3 LeadEpoch:1

--- a/pkg/raft/testdata/fortification_checkquorum.txt
+++ b/pkg/raft/testdata/fortification_checkquorum.txt
@@ -1,0 +1,60 @@
+log-level none
+----
+ok
+
+add-nodes 3 voters=(1,2,3) index=10 checkquorum=true
+----
+ok
+
+campaign 1
+----
+ok
+
+stabilize
+----
+ok
+
+log-level debug
+----
+ok
+
+raft-state
+----
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+
+# Set the randomized election timeout to be worth 1 tick-election. This makes
+# the test deterministic. We then have to tick-election twice as the leader
+# heard from followers when it stabilized above; this trips the heartbeat lease
+# check quorum condition. However, the leader won't step down because it still
+# has StoreLiveness support.
+set-randomized-election-timeout 1 timeout=3
+----
+ok
+
+tick-election 1
+----
+ok
+
+tick-election 1
+----
+DEBUG 1 has not received messages from a quorum of peers in the last election timeout
+
+# Now, withdraw the StoreLiveness support for the leader's fortified epoch by
+# bumping it. This also shows that we won't break our LeadSupportUntil promise
+# to the leasing layer even if the heartbeat lease check quorum condition would
+# otherwise have caused the leader to step down.
+bump-epoch 1
+----
+  1 2 3
+1 2 1 1
+2 2 1 1
+3 2 1 1
+
+tick-election 1
+----
+DEBUG 1 has not received messages from a quorum of peers in the last election timeout
+DEBUG 1 does not have store liveness support from a quorum of peers
+WARN 1 stepped down to follower since quorum is not active
+INFO 1 became follower at term 1

--- a/pkg/raft/testdata/fortification_followers_dont_prevote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_prevote.txt
@@ -195,9 +195,9 @@ stabilize
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StatePreCandidate (Voter) Term:1 Lead:0
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StatePreCandidate (Voter) Term:1 Lead:0 LeadEpoch:0
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
 
 # However, once a quorum withdraws support for the fortified leader, 2 can then
 # be elected.
@@ -342,9 +342,9 @@ stabilize
 
 raft-state
 ----
-1: StateFollower (Voter) Term:2 Lead:2
-2: StateLeader (Voter) Term:2 Lead:2
-3: StateFollower (Voter) Term:2 Lead:2
+1: StateFollower (Voter) Term:2 Lead:2 LeadEpoch:1
+2: StateLeader (Voter) Term:2 Lead:2 LeadEpoch:1
+3: StateFollower (Voter) Term:2 Lead:2 LeadEpoch:1
 
 # Lastly, ensure that the leader is able to successfully campaign at a higher
 # term. We'll need to step down to set this up properly, as otherwise attempts
@@ -500,6 +500,6 @@ stabilize
 
 raft-state
 ----
-1: StateFollower (Voter) Term:3 Lead:2
-2: StateLeader (Voter) Term:3 Lead:2
-3: StateFollower (Voter) Term:3 Lead:2
+1: StateFollower (Voter) Term:3 Lead:2 LeadEpoch:1
+2: StateLeader (Voter) Term:3 Lead:2 LeadEpoch:1
+3: StateFollower (Voter) Term:3 Lead:2 LeadEpoch:1

--- a/pkg/raft/testdata/fortification_followers_dont_vote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_vote.txt
@@ -165,9 +165,9 @@ stabilize
 
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateCandidate (Voter) Term:2 Lead:0
-3: StateFollower (Voter) Term:1 Lead:1
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateCandidate (Voter) Term:2 Lead:0 LeadEpoch:0
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
 
 # However, once a quorum withdraws support for the fortified leader, 2 can then
 # be elected.
@@ -286,9 +286,9 @@ stabilize
 
 raft-state
 ----
-1: StateFollower (Voter) Term:3 Lead:2
-2: StateLeader (Voter) Term:3 Lead:2
-3: StateFollower (Voter) Term:3 Lead:2
+1: StateFollower (Voter) Term:3 Lead:2 LeadEpoch:1
+2: StateLeader (Voter) Term:3 Lead:2 LeadEpoch:1
+3: StateFollower (Voter) Term:3 Lead:2 LeadEpoch:1
 
 # Lastly, ensure that the leader is able to successfully campaign at a higher
 # term. We'll need to step down to set this up properly, as otherwise attempts
@@ -411,6 +411,6 @@ stabilize
 
 raft-state
 ----
-1: StateFollower (Voter) Term:4 Lead:2
-2: StateLeader (Voter) Term:4 Lead:2
-3: StateFollower (Voter) Term:4 Lead:2
+1: StateFollower (Voter) Term:4 Lead:2 LeadEpoch:1
+2: StateLeader (Voter) Term:4 Lead:2 LeadEpoch:1
+3: StateFollower (Voter) Term:4 Lead:2 LeadEpoch:1

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp_behind.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp_behind.txt
@@ -42,9 +42,9 @@ ok
 # is still at index 5, and has not received any MsgApp from the leader yet.
 raft-state
 ----
-1: StateLeader (Voter) Term:1 Lead:1
-2: StateFollower (Voter) Term:1 Lead:1
-3: StateFollower (Voter) Term:1 Lead:0
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+3: StateFollower (Voter) Term:1 Lead:0 LeadEpoch:0
 
 status 1
 ----

--- a/pkg/raft/tracker/supporttracker.go
+++ b/pkg/raft/tracker/supporttracker.go
@@ -81,6 +81,12 @@ func (st *SupportTracker) LeadSupportUntil() hlc.Timestamp {
 	return st.config.Voters.LeadSupportExpiration(supportExpMap)
 }
 
+// QuorumActive returns whether the leader is currently supported by a quorum or
+// not.
+func (st *SupportTracker) QuorumActive() bool {
+	return !st.storeLiveness.SupportExpired(st.LeadSupportUntil())
+}
+
 func (st *SupportTracker) String() string {
 	if len(st.support) == 0 {
 		return "empty"

--- a/pkg/raft/tracker/supporttracker_test.go
+++ b/pkg/raft/tracker/supporttracker_test.go
@@ -143,6 +143,137 @@ func TestLeadSupportUntil(t *testing.T) {
 	}
 }
 
+// TestQuorumActive ensures that we correctly determine whether a leader's
+// quorum is active or not.
+func TestQuorumActive(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ts := func(ts int64) hlc.Timestamp {
+		return hlc.Timestamp{
+			WallTime: ts,
+		}
+	}
+	mockLiveness := makeMockStoreLiveness(
+		map[pb.PeerID]mockLivenessEntry{
+			1: makeMockLivenessEntry(10, ts(10)),
+			2: makeMockLivenessEntry(20, ts(15)),
+			3: makeMockLivenessEntry(30, ts(20)),
+		},
+	)
+
+	testCases := []struct {
+		setup           func(tracker *SupportTracker)
+		curTS           hlc.Timestamp
+		expQuorumActive bool
+	}{
+		{
+			setup: func(supportTracker *SupportTracker) {
+				// No support recorded.
+			},
+			curTS:           ts(10),
+			expQuorumActive: false,
+		},
+		{
+			setup: func(supportTracker *SupportTracker) {
+				supportTracker.RecordSupport(1, 10)
+			},
+			curTS:           ts(10),
+			expQuorumActive: false,
+		},
+		{
+			setup: func(supportTracker *SupportTracker) {
+				supportTracker.RecordSupport(1, 10)
+				supportTracker.RecordSupport(3, 30)
+			},
+			curTS:           ts(9),
+			expQuorumActive: true,
+		},
+		{
+			setup: func(supportTracker *SupportTracker) {
+				supportTracker.RecordSupport(1, 10)
+				supportTracker.RecordSupport(3, 30)
+			},
+			curTS:           ts(14),
+			expQuorumActive: false,
+		},
+		{
+			setup: func(supportTracker *SupportTracker) {
+				supportTracker.RecordSupport(1, 10)
+				supportTracker.RecordSupport(3, 30)
+				supportTracker.RecordSupport(2, 20)
+			},
+			curTS:           ts(14),
+			expQuorumActive: true,
+		},
+		{
+			setup: func(supportTracker *SupportTracker) {
+				supportTracker.RecordSupport(1, 10)
+				supportTracker.RecordSupport(3, 30)
+				supportTracker.RecordSupport(2, 20)
+			},
+			curTS:           ts(16),
+			expQuorumActive: false,
+		},
+		{
+			setup: func(supportTracker *SupportTracker) {
+				// Record support at epochs at expired epochs.
+				supportTracker.RecordSupport(1, 9)
+				supportTracker.RecordSupport(3, 29)
+				supportTracker.RecordSupport(2, 19)
+			},
+			curTS:           ts(10),
+			expQuorumActive: false,
+		},
+		{
+			setup: func(supportTracker *SupportTracker) {
+				// Record support at newer epochs than what are present in
+				// StoreLiveness.
+				//
+				// NB: This is possible if there is a race between store liveness
+				// heartbeats updates and fortification responses.
+				supportTracker.RecordSupport(1, 11)
+				supportTracker.RecordSupport(3, 31)
+				supportTracker.RecordSupport(2, 21)
+			},
+			expQuorumActive: false,
+		},
+		{
+			setup: func(supportTracker *SupportTracker) {
+				// One of the epochs being supported is expired.
+				supportTracker.RecordSupport(1, 10)
+				supportTracker.RecordSupport(3, 29) // expired
+				supportTracker.RecordSupport(2, 20)
+			},
+			curTS:           ts(5),
+			expQuorumActive: true,
+		},
+		{
+			setup: func(supportTracker *SupportTracker) {
+				// Two of the epochs being supported is expired.
+				supportTracker.RecordSupport(1, 10)
+				supportTracker.RecordSupport(3, 29) // expired
+				supportTracker.RecordSupport(2, 19) // expired
+			},
+			curTS:           ts(10),
+			expQuorumActive: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		mockLiveness.curTS = tc.curTS
+		cfg := quorum.MakeEmptyConfig()
+
+		for _, id := range []pb.PeerID{1, 2, 3} {
+			cfg.Voters[0][id] = struct{}{}
+		}
+		supportTracker := MakeSupportTracker(&cfg, mockLiveness)
+
+		tc.setup(&supportTracker)
+		require.Equal(t, tc.expQuorumActive, supportTracker.QuorumActive(), "#%d %s %s", i, supportTracker.LeadSupportUntil(), tc.curTS)
+	}
+}
+
 type mockLivenessEntry struct {
 	epoch pb.Epoch
 	ts    hlc.Timestamp
@@ -157,6 +288,7 @@ func makeMockLivenessEntry(epoch pb.Epoch, ts hlc.Timestamp) mockLivenessEntry {
 
 type mockStoreLiveness struct {
 	liveness map[pb.PeerID]mockLivenessEntry
+	curTS    hlc.Timestamp
 }
 
 func makeMockStoreLiveness(liveness map[pb.PeerID]mockLivenessEntry) mockStoreLiveness {
@@ -182,6 +314,6 @@ func (mockStoreLiveness) SupportFromEnabled() bool {
 }
 
 // SupportExpired implements the raftstoreliveness.StoreLiveness interface.
-func (mockStoreLiveness) SupportExpired(hlc.Timestamp) bool {
-	panic("unimplemented")
+func (m mockStoreLiveness) SupportExpired(ts hlc.Timestamp) bool {
+	return ts.IsEmpty() || ts.Less(m.curTS)
 }


### PR DESCRIPTION
This commit ensures that a leader only steps down due to check quorum
if its LeadSupportUntil has expired.

closes https://github.com/cockroachdb/cockroach/issues/125353

Release note: None