### PR TITLE
roachprod: fix `--gce-project`, plus other  minor fixes and cleanup

### DIFF
--- a/pkg/cmd/roachprod/README.md
+++ b/pkg/cmd/roachprod/README.md
@@ -29,7 +29,21 @@ installations (`gcloud components update`).
 * VMs have a default lifetime of 12 hours (changeable with the
   `--lifetime` flag).
 * Default settings create 4 VMs (`-n 4`) with 4 CPUs, 15GB memory
-  (`--machine-type=n1-standard-4`), and local SSDs (`--local-ssd`).
+  (`--machine-type=n2-standard-4`), Intel Ice Lake (`--min-cpu-platform Intel Ice Lake`)
+  and local SSDs (`--local-ssd`).
+
+### Global Overrides
+
+Many defaults can be globally affected via environment variables.
+E.g., `ROACHPROD_EMAIL_DOMAIN` determines email domain for authentication.
+When using a custom service account, it might be necessary to specify
+a different email domain.
+
+```
+export ROACHPROD_EMAIL_DOMAIN=developer.gserviceaccount.com
+```
+
+For a full list, see `config.go` and `flags.go`.
 
 ## Cluster quick-start using roachprod
 

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -120,6 +120,10 @@ func initFlags() {
 		term.IsTerminal(int(os.Stdout.Fd())), "enable fast DNS resolution via the standard Go net package")
 	rootCmd.PersistentFlags().StringVarP(&config.EmailDomain, "email-domain", "",
 		config.DefaultEmailDomain, "email domain for users")
+	rootCmd.PersistentFlags().BoolVar(&config.UseSharedUser,
+		"use-shared-user", true,
+		fmt.Sprintf("use the shared user %q for ssh rather than your user %q",
+			config.SharedUser, config.OSUser.Username))
 
 	createCmd.Flags().DurationVarP(&createVMOpts.Lifetime,
 		"lifetime", "l", 12*time.Hour, "Lifetime of the cluster")
@@ -157,9 +161,11 @@ func initFlags() {
 		if vm.Providers[providerName].Active() {
 			providerOptsContainer[providerName].ConfigureCreateFlags(createCmd.Flags())
 
-			for _, cmd := range []*cobra.Command{
-				destroyCmd, extendCmd, listCmd, syncCmd, gcCmd, setupSSHCmd, startCmd, pgurlCmd, adminurlCmd,
-			} {
+			for _, cmd := range rootCmd.Commands() {
+				if cmd == createCmd {
+					// createCmd is handled below
+					continue
+				}
 				providerOptsContainer[providerName].ConfigureClusterFlags(cmd.Flags(), vm.AcceptMultipleProjects)
 			}
 
@@ -298,9 +304,9 @@ func initFlags() {
 	logsCmd.Flags().StringVar(&logsFilter,
 		"filter", "", "re to filter log messages")
 	logsCmd.Flags().Var(flagutil.Time(&logsFrom),
-		"from", "time from which to stream logs")
+		"from", "time from which to stream logs (e.g., 2024-09-07T16:05:06Z)")
 	logsCmd.Flags().Var(flagutil.Time(&logsTo),
-		"to", "time to which to stream logs")
+		"to", "time to which to stream logs (e.g., 2024-09-07T17:05:06Z); if ommitted, command streams without returning")
 	logsCmd.Flags().DurationVar(&logsInterval,
 		"interval", 200*time.Millisecond, "interval to poll logs from host")
 	logsCmd.Flags().StringVar(&logsDir,
@@ -410,7 +416,7 @@ func initFlags() {
 		cmd.Flags().BoolVar(&urlOpen, "open", false, "Open the url in a browser")
 	}
 
-	for _, cmd := range []*cobra.Command{createCmd, listCmd, destroyCmd, extendCmd, logsCmd} {
+	for _, cmd := range []*cobra.Command{createCmd, listCmd, destroyCmd} {
 		cmd.Flags().StringVarP(&username, "username", "u", os.Getenv("ROACHPROD_USER"),
 			"Username to run under, detect if blank")
 	}

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -881,7 +881,7 @@ into a single stream.
 		} else {
 			dest = args[0] + ".logs"
 		}
-		return roachprod.Logs(config.Logger, args[0], dest, username, logsOpts)
+		return roachprod.Logs(config.Logger, args[0], dest, logsOpts)
 	}),
 }
 

--- a/pkg/roachprod/config/config.go
+++ b/pkg/roachprod/config/config.go
@@ -59,6 +59,10 @@ var (
 	// EmailDomain used to form fully qualified usernames for gcloud and slack.
 	EmailDomain string
 
+	// UseSharedUser is used to determine if config.SharedUser should be used for SSH.
+	// By default, this is true, otherwise config.OSUser will be used.
+	UseSharedUser = true
+
 	// DNSRequiredProviders is the list of cloud providers that must be active for
 	// DNS records to be synced when roachprod syncs its state.
 	DefaultDNSRequiredProviders = envOrDefaultStrings(

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1776,13 +1776,13 @@ type LogsOpts struct {
 }
 
 // Logs TODO
-func Logs(l *logger.Logger, clusterName, dest, username string, logsOpts LogsOpts) error {
+func Logs(l *logger.Logger, clusterName, dest string, logsOpts LogsOpts) error {
 	c, err := getClusterFromCache(l, clusterName)
 	if err != nil {
 		return err
 	}
 	return c.Logs(
-		l, logsOpts.Dir, dest, username, logsOpts.Filter, logsOpts.ProgramFilter,
+		l, logsOpts.Dir, dest, logsOpts.Filter, logsOpts.ProgramFilter,
 		logsOpts.Interval, logsOpts.From, logsOpts.To, logsOpts.Out,
 	)
 }

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -101,6 +101,7 @@ func Init() error {
 	providerInstance.Projects = []string{defaultDefaultProject}
 	projectFromEnv := os.Getenv("GCE_PROJECT")
 	if projectFromEnv != "" {
+		fmt.Printf("WARNING: `GCE_PROJECT` is deprecated; please, use `ROACHPROD_GCE_DEFAULT_PROJECT` instead")
 		providerInstance.Projects = []string{projectFromEnv}
 	}
 	providerInstance.ServiceAccount = os.Getenv("GCE_SERVICE_ACCOUNT")
@@ -218,7 +219,7 @@ func (jsonVM *jsonVM) toVM(
 	cpuPlatform := jsonVM.CPUPlatform
 	zone := lastComponent(jsonVM.Zone)
 	remoteUser := config.SharedUser
-	if !opts.useSharedUser {
+	if !config.UseSharedUser {
 		// N.B. gcloud uses the local username to log into instances rather
 		// than the username on the authenticated Google account but we set
 		// up the shared user at cluster creation time. Allow use of the
@@ -318,7 +319,6 @@ func DefaultProviderOpts() *ProviderOpts {
 		PDVolumeSize:         500,
 		TerminateOnMigration: false,
 		UseSpot:              false,
-		useSharedUser:        true,
 		preemptible:          false,
 	}
 }
@@ -356,9 +356,6 @@ type ProviderOpts struct {
 	// GCE allows two availability policies in case of a maintenance event (see --maintenance-policy via gcloud),
 	// 'TERMINATE' or 'MIGRATE'. The default is 'MIGRATE' which we denote by 'TerminateOnMigration == false'.
 	TerminateOnMigration bool
-	// useSharedUser indicates that the shared user rather than the personal
-	// user should be used to ssh into the remote machines.
-	useSharedUser bool
 	// use preemptible instances
 	preemptible bool
 }
@@ -1098,11 +1095,6 @@ func (o *ProviderOpts) ConfigureClusterFlags(flags *pflag.FlagSet, opt vm.Multip
 		},
 		ProviderName+"-project", /* name */
 		usage)
-
-	flags.BoolVar(&o.useSharedUser,
-		ProviderName+"-use-shared-user", true,
-		fmt.Sprintf("use the shared user %q for ssh rather than your user %q",
-			config.SharedUser, config.OSUser.Username))
 
 	// Flags about DNS override the default values in
 	// providerInstance.dnsProvider.


### PR DESCRIPTION
Previously, `--gce-project` was only enabled for a small subset of roachprod commands; effectively, it was broken. This caught users by surprise, and rightfully so since `README` implies it should be synonymous with setting the `GCE_PROJECT` environment variable.
This PR fixes it by ensuring _every_ (GCE) roachprod command sets it.

`--$provider-use-shared-user` was effectively broken, passed only into the `Create` command. This PR makes it a global flag (instead of per Provider), enabling _all_ commands to use it.

Remove defunct usecases of `--user`. The only remaining usecase is the `Create` command where this flag (equiv., `ROACHPROD_USER`) override the cluster name prefix.

Finally, fix `roachprod log` command and update its CLI doc. strings.

Epic: none

Release note: None