### PR TITLE
roachprod-microbench: os volume for gcs temp files

### DIFF
--- a/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
+++ b/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
@@ -106,7 +106,7 @@ log_into_gcloud
   --gce-use-spot \
   --local-ssd=false \
   --gce-pd-volume-size=384 \
-  --os-volume-size=10
+  --os-volume-size=50
 
 # Stage binaries on the cluster
 for sha in "${build_sha_arr[@]}"; do


### PR DESCRIPTION
After a recent change to use PDs to stage the microbenchmark binaries, the OS volume was reduced. The google cloud storage util still copies the file to a temp directory on the OS volume first, hence we need at least enough space for a full binary before it is copied to the persistent disk.

Epic: None
Release note: None