### PR TITLE
server/license: fix race in concurrent test-server startup

### DIFF
--- a/pkg/server/license/BUILD.bazel
+++ b/pkg/server/license/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/util/envutil",
         "//pkg/util/log",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/server/license/enforcer_test.go
+++ b/pkg/server/license/enforcer_test.go
@@ -64,10 +64,10 @@ func TestGracePeriodInitTSCache(t *testing.T) {
 	enforcer := &license.Enforcer{}
 	ts2 := ts1.Add(1)
 	ts2End := ts2.Add(7 * 24 * time.Hour) // Calculate the end of the grace period
-	enforcer.TestingKnobs = &license.TestingKnobs{
+	enforcer.SetTestingKnobs(&license.TestingKnobs{
 		EnableGracePeriodInitTSWrite: true,
 		OverrideStartTime:            &ts2,
-	}
+	})
 	// Ensure request for the grace period init ts1 before start just returns the start
 	// time used when the enforcer was created.
 	require.Equal(t, ts2End, enforcer.GetClusterInitGracePeriodEndTS())
@@ -149,12 +149,11 @@ func TestThrottle(t *testing.T) {
 		{OverTxnThreshold, license.LicTypeEvaluation, t0, t0, t15d, t46d, "License expired"},
 	} {
 		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
-			e := license.Enforcer{
-				TestingKnobs: &license.TestingKnobs{
-					OverrideStartTime:         &tc.gracePeriodInit,
-					OverrideThrottleCheckTime: &tc.checkTs,
-				},
-			}
+			e := license.Enforcer{}
+			e.SetTestingKnobs(&license.TestingKnobs{
+				OverrideStartTime:         &tc.gracePeriodInit,
+				OverrideThrottleCheckTime: &tc.checkTs,
+			})
 			e.SetTelemetryStatusReporter(&mockTelemetryStatusReporter{
 				lastPingTime: tc.lastTelemetryPingTime,
 			})

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1921,7 +1921,7 @@ func (s *SQLServer) startLicenseEnforcer(
 	// is shared to provide access to the values cached from the KV read.
 	if s.execCfg.Codec.ForSystemTenant() {
 		if knobs.Server != nil {
-			s.execCfg.LicenseEnforcer.TestingKnobs = &knobs.Server.(*TestingKnobs).LicenseTestingKnobs
+			s.execCfg.LicenseEnforcer.SetTestingKnobs(&knobs.Server.(*TestingKnobs).LicenseTestingKnobs)
 		}
 		// TODO(spilchen): we need to tell the license enforcer about the
 		// diagnostics reporter. This will be handled in CRDB-39991


### PR DESCRIPTION
The ccl/crosscluster package has tests that start multiple test servers in parallel. On older release branches this is failing with a race condition because two different threads are writing to the testing hooks.

Release note: None
Epic: none