### PR TITLE
release-23.2: licenseccl: rename usage to environment

### DIFF
--- a/pkg/ccl/utilccl/license_check.go
+++ b/pkg/ccl/utilccl/license_check.go
@@ -263,15 +263,15 @@ func GetLicenseType(st *cluster.Settings) (string, error) {
 	return license.Type.String(), nil
 }
 
-// GetLicenseUsage returns the license usage.
-func GetLicenseUsage(st *cluster.Settings) (string, error) {
+// GetLicenseEnvironment returns the license environment.
+func GetLicenseEnvironment(st *cluster.Settings) (string, error) {
 	license, err := getLicense(st)
 	if err != nil {
 		return "", err
 	} else if license == nil {
 		return "", nil
 	}
-	return license.Usage.String(), nil
+	return license.Environment.String(), nil
 }
 
 // decode attempts to read a base64 encoded License.

--- a/pkg/ccl/utilccl/license_check_test.go
+++ b/pkg/ccl/utilccl/license_check_test.go
@@ -66,10 +66,10 @@ func TestSettingAndCheckingLicense(t *testing.T) {
 func TestGetLicenseTypePresent(t *testing.T) {
 	ctx := context.Background()
 	for _, tc := range []struct {
-		typ           licenseccl.License_Type
-		expectedType  string
-		usage         licenseccl.License_Usage
-		expectedUsage string
+		typ                 licenseccl.License_Type
+		expectedType        string
+		environment         licenseccl.License_Environment
+		expectedEnvironment string
 	}{
 		{licenseccl.License_NonCommercial, "NonCommercial", licenseccl.PreProduction, "pre-production"},
 		{licenseccl.License_Enterprise, "Enterprise", licenseccl.Production, "production"},
@@ -83,7 +83,7 @@ func TestGetLicenseTypePresent(t *testing.T) {
 		lic, _ := (&licenseccl.License{
 			Type:              tc.typ,
 			ValidUntilUnixSec: 0,
-			Usage:             tc.usage,
+			Environment:       tc.environment,
 		}).Encode()
 		if err := setLicense(ctx, updater, lic); err != nil {
 			t.Fatal(err)
@@ -95,19 +95,19 @@ func TestGetLicenseTypePresent(t *testing.T) {
 		if actualType != tc.expectedType {
 			t.Fatalf("expected license type %s, got %s", tc.expectedType, actualType)
 		}
-		actualUsage, err := GetLicenseUsage(st)
+		actualEnvironment, err := GetLicenseEnvironment(st)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if actualUsage != tc.expectedUsage {
-			t.Fatalf("expected license usage %s, got %s", tc.expectedUsage, actualUsage)
+		if actualEnvironment != tc.expectedEnvironment {
+			t.Fatalf("expected license environment %s, got %s", tc.expectedEnvironment, actualEnvironment)
 		}
 	}
 }
 
-func TestUnknownUsageEnum(t *testing.T) {
-	// This literal was generated with an enum value of 100 for usage, to show
-	// what happens if we add more usages later and then try to apply one to an
+func TestUnknownEnvironmentEnum(t *testing.T) {
+	// This literal was generated with an enum value of 100 for environment, to show
+	// what happens if we add more environments later and then try to apply one to an
 	// older node which does not include it.
 	l, err := decode(`crl-0-GAIoZA`)
 	if err != nil {
@@ -116,8 +116,8 @@ func TestUnknownUsageEnum(t *testing.T) {
 	if expected, got := "Evaluation", l.Type.String(); got != expected {
 		t.Fatalf("expected license type %s, got %s", expected, got)
 	}
-	if expected, got := "other", l.Usage.String(); got != expected {
-		t.Fatalf("expected license usage %q, got %q", expected, got)
+	if expected, got := "other", l.Environment.String(); got != expected {
+		t.Fatalf("expected license environment %q, got %q", expected, got)
 	}
 }
 

--- a/pkg/ccl/utilccl/licenseccl/license.go
+++ b/pkg/ccl/utilccl/licenseccl/license.go
@@ -48,7 +48,7 @@ func Decode(s string) (*License, error) {
 	return &lic, nil
 }
 
-func (u License_Usage) String() string {
+func (u License_Environment) String() string {
 	switch u {
 	case Unspecified:
 		return ""

--- a/pkg/ccl/utilccl/licenseccl/license.proto
+++ b/pkg/ccl/utilccl/licenseccl/license.proto
@@ -17,7 +17,7 @@ message License {
     int64 valid_until_unix_sec = 2;
 
     enum Type {
-      NonCommercial = 0;
+      NonCommercial = 0 [deprecated = true];
       Enterprise = 1;
       Evaluation = 2;
       Free = 3;
@@ -28,7 +28,7 @@ message License {
 
     string organization_name = 4;
 
-    enum Usage {
+    enum Environment {
       option (gogoproto.goproto_enum_prefix) = false;
       option (gogoproto.goproto_enum_stringer) = false;
 
@@ -38,7 +38,7 @@ message License {
       Development = 3;
     }
 
-    Usage usage = 5;
+    Environment environment = 5;
 
     // Two UUIDs uniquely identify this license and the associated organization.
     // They are stored as bytes to align with the server's typical usage. We


### PR DESCRIPTION
Backport 1/1 commits from #130161.

/cc @cockroachdb/release

---

This renames the usage field in the license protobuf to environment and deprecates the NonCommercial type.

Epic: CRDB-39988
Informs: CRDB-40069
Release note: none
Release justification: This work is part of the CockroachDB core deprecation.