### PR TITLE
release-23.1: licenseccl: rename usage to environment

### DIFF
--- a/pkg/ccl/utilccl/licenseccl/license.proto
+++ b/pkg/ccl/utilccl/licenseccl/license.proto
@@ -19,7 +19,7 @@ message License {
     int64 valid_until_unix_sec = 2;
 
     enum Type {
-      NonCommercial = 0;
+      NonCommercial = 0 [deprecated = true];
       Enterprise = 1;
       Evaluation = 2;
       Free = 3;


### PR DESCRIPTION
Backport 1/1 commits from #130161.

/cc @cockroachdb/release

---

This renames the usage field in the license protobuf to environment and deprecates the NonCommercial type. 

_Note: the usage field does not exist in version 23.1, so this deviates from the original PR and only serves to deprecate the NonCommercial type._

Epic: CRDB-39988
Informs: CRDB-40069
Release note: none
Release justification: This work is part of the CockroachDB core deprecation.