### PR TITLE
release-23.2: roachtest: disable shared-process on tpcc/mixed-headroom

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -381,6 +381,10 @@ func runTPCCMixedHeadroom(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 	mvt := mixedversion.NewTest(
 		ctx, t, t.L(), c, crdbNodes,
+		// We avoid multi-tenant deployments in 23.2 because this test
+		// uses the `workload fixtures import` command, which is only
+		// supported reliably multi-tenant mode starting on 23.2+.
+		mixedversion.EnabledDeploymentModes(mixedversion.SystemOnlyDeployment),
 	)
 
 	tenantFeaturesEnabled := make(chan struct{})


### PR DESCRIPTION
In #129642, we set the minimum supported version to `23.2` due to an `unimplemented` error that can happen when importing fixtures in multitenant mode in versions older than 23.2.

For that reason, we disable multi-tenancy entirely on the 23.2 branch.

Fixes: #130284

Release note: None

Release justification: test only changes.