### PR TITLE
db-console: update notification icon in alert box to use new cockroach logo

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/shared/components/alertBox/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/alertBox/index.tsx
@@ -8,14 +8,13 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+import { CockroachMarkLightFull } from "@cockroachlabs/icons";
 import classNames from "classnames";
 import React from "react";
 
 import { AlertInfo, AlertLevel } from "src/redux/alerts";
-import { trustIcon } from "src/util/trust";
 import {
   warningIcon,
-  notificationIcon,
   criticalIcon,
   informationIcon,
 } from "src/views/shared/components/icons";
@@ -25,13 +24,13 @@ import "./alertbox.styl";
 function alertIcon(level: AlertLevel) {
   switch (level) {
     case AlertLevel.CRITICAL:
-      return trustIcon(criticalIcon);
+      return criticalIcon;
     case AlertLevel.WARNING:
-      return trustIcon(warningIcon);
+      return warningIcon;
     case AlertLevel.INFORMATION:
-      return trustIcon(informationIcon);
+      return informationIcon;
     default:
-      return trustIcon(notificationIcon);
+      return <CockroachMarkLightFull />;
   }
 }
 
@@ -71,10 +70,7 @@ export class AlertBox extends React.Component<AlertBoxProps, {}> {
           `alert-box--${AlertLevel[this.props.level].toLowerCase()}`,
         )}
       >
-        <div
-          className="alert-box__icon"
-          dangerouslySetInnerHTML={alertIcon(this.props.level)}
-        />
+        <div className="alert-box__icon">{alertIcon(this.props.level)}</div>
         {content}
         <div className="alert-box__dismiss">
           <a className="alert-box__link" onClick={this.props.dismiss}>

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/icons/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/icons/index.tsx
@@ -9,26 +9,7 @@
 // licenses/APL.txt.
 
 // Exports icons as SVG strings.
-
-export const cockroachIcon = `<svg width="38px" height="38px" viewBox="0 0 38 38" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
-  <!-- Generator: Sketch 3.3.3 (12081) - http://www.bohemiancoding.com/sketch -->
-  <title>CL Mark</title>
-  <desc>Created with Sketch.</desc>
-  <g id="Update-6" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
-    <g id="Line-Chart-(v4)" sketch:type="MSArtboardGroup" transform="translate(-20.000000, -29.000000)">
-      <g id="Header" sketch:type="MSLayerGroup" transform="translate(-15.000000, -47.000000)">
-        <g id="CL-Mark" transform="translate(35.000000, 76.000000)">
-          <g id="Group-3">
-            <g id="Clip-2"></g>
-            <path d="M23.0622,10.88928 C21.72574,11.2024 20.3281,11.36466 18.89664,11.36466 C17.46518,11.36466 16.06754,11.2024 14.72538,10.88928 C15.84372,9.11696 17.25846,7.53996 18.89664,6.24302 C20.5352,7.54566 21.94386,9.11696 23.0622,10.88928 L23.0622,10.88928 Z M35.66034,0.68134 C33.97998,0.23294 32.2088,0 30.3867,0 C26.14058,0 22.18972,1.27718 18.89132,3.47396 C15.599,1.27718 11.64814,0 7.39632,0 C5.57384,0 3.80266,0.23294 2.1223,0.68134 C1.41322,0.86108 0.72504,1.08832 0.05244,1.34292 C0.00874,1.35926 -0.01216,1.41094 0.00722,1.4535 C0.30134,2.0919 0.62928,2.71054 0.98192,3.30942 C1.0013,3.34248 1.04158,3.35692 1.07768,3.344 C1.77878,3.09244 2.49622,2.87888 3.22962,2.70788 C4.56912,2.39552 5.96562,2.23668 7.39632,2.23668 C10.90448,2.23668 14.1854,3.2186 16.9898,4.91036 C15.21292,6.41478 13.69178,8.21408 12.50504,10.2296 C12.27248,10.6153 12.06234,11.00708 11.8579,11.40456 C11.72186,11.67132 11.59114,11.94378 11.4608,12.22764 C11.27346,12.65324 11.09182,13.07922 10.9326,13.51622 C10.09242,15.77 9.63262,18.21074 9.63262,20.74838 C9.63262,26.62356 12.09084,31.9371 16.0303,35.71772 C16.33696,36.01868 16.65502,36.30254 16.9898,36.5807 C17.25086,36.80756 17.51192,37.0177 17.78438,37.22214 C18.12752,37.4946 18.48662,37.74578 18.8461,37.98632 C18.87346,38.00494 18.90956,38.00456 18.93692,37.98594 C19.29602,37.74008 19.64942,37.4889 19.99256,37.22214 C20.27072,37.0177 20.53216,36.80756 20.79322,36.5807 C21.1223,36.30254 21.45176,36.01298 21.75804,35.71772 C25.69218,31.9371 28.15002,26.61786 28.15002,20.74838 C28.15002,18.21074 27.69022,15.7757 26.85004,13.52192 C26.6855,13.08492 26.50956,12.65324 26.31652,12.22764 C26.19188,11.94378 26.06116,11.67132 25.93044,11.40456 C25.72068,11.00708 25.51054,10.6153 25.2776,10.2296 C24.08554,8.21408 22.5701,6.41478 20.79322,4.91036 C23.59762,3.2186 26.87854,2.23668 30.3867,2.23668 C31.8174,2.23668 33.2139,2.39552 34.5534,2.70788 C35.28642,2.87888 36.00918,3.09244 36.70534,3.34362 C36.74144,3.35692 36.78172,3.34248 36.8011,3.30942 C37.15336,2.71054 37.47636,2.0919 37.77466,1.45388 C37.7948,1.41094 37.7739,1.35926 37.72944,1.34254 C37.05228,1.08832 36.3641,0.86108 35.66034,0.68134 L35.66034,0.68134 Z" id="Fill-1" fill="#151F34" sketch:type="MSShapeGroup"></path>
-          </g>
-          <path d="M25.91372,20.7499 C25.91372,25.65912 23.99396,30.12526 20.86086,33.4419 C20.31024,31.68174 20.0108,29.81404 20.0108,27.88212 C20.0108,22.97328 21.93056,18.49916 25.06366,15.1905 C25.61428,16.94648 25.91372,18.81418 25.91372,20.7499" id="Fill-4" fill="#348540" sketch:type="MSShapeGroup"></path>
-          <path d="M17.77184,27.88212 C17.77184,29.81404 17.4762,31.68174 16.9214,33.4419 C13.7883,30.12526 11.86854,25.65912 11.86854,20.7499 C11.86854,18.81418 12.17216,16.94648 12.72696,15.1905 C15.86006,18.49916 17.77184,22.97328 17.77184,27.88212" id="Fill-5" fill="#7DBC42" sketch:type="MSShapeGroup"></path>
-        </g>
-      </g>
-    </g>
-  </g>
-</svg>`;
+import React from "react";
 
 export const leftArrow = `<svg width="7px" height="10px" viewBox="0 0 7 10" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <!-- Generator: Sketch 41.2 (35397) - http://www.bohemiancoding.com/sketch -->
@@ -58,76 +39,131 @@ export const rightArrow = `<svg width="7px" height="10px" viewBox="0 0 7 10" ver
     </g>
 </svg>`;
 
-export const criticalIcon = `<svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 42 (36781) - http://www.bohemiancoding.com/sketch -->
+export const criticalIcon = (
+  <svg
+    width="20px"
+    height="20px"
+    viewBox="0 0 20 20"
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlnsXlink="http://www.w3.org/1999/xlink"
+  >
+    {/* Generator: Sketch 42 (36781) - http://www.bohemiancoding.com/sketch */}
     <title>Group 3</title>
     <desc>Created with Sketch.</desc>
     <defs></defs>
-    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Warning---Connection-Lost" transform="translate(-25.000000, -19.000000)">
-            <g id="Group-3">
-                <g transform="translate(25.000000, 19.000000)">
-                    <path d="M8.75139389,1.26729609 C9.24631171,0.277343549 10.0519669,0.283622947 10.5438615,1.26729609 L19.1995435,18.5766161 C19.4476073,19.0726851 19.1933971,19.4748284 18.6568996,19.4748284 L0.640505826,19.4748284 C0.092748094,19.4748284 -0.15156708,19.0753209 0.0977558747,18.5766161 L8.75139389,1.26729609 Z" id="Rectangle-4" fill="#F26969"></path>
-                    <g id="Group-2" transform="translate(8.000000, 3.000000)" font-size="14" font-family="SourceSansPro-Bold, SourceSansPro-Regular" fill="#FFFFFF" font-weight="bold">
-                        <text id="!">
-                            <tspan x="0" y="14">!</tspan>
-                        </text>
-                    </g>
-                </g>
+    <g
+      id="Symbols"
+      stroke="none"
+      strokeWidth="1"
+      fill="none"
+      fillRule="evenodd"
+    >
+      <g
+        id="Warning---Connection-Lost"
+        transform="translate(-25.000000, -19.000000)"
+      >
+        <g id="Group-3">
+          <g transform="translate(25.000000, 19.000000)">
+            <path
+              d="M8.75139389,1.26729609 C9.24631171,0.277343549 10.0519669,0.283622947 10.5438615,1.26729609 L19.1995435,18.5766161 C19.4476073,19.0726851 19.1933971,19.4748284 18.6568996,19.4748284 L0.640505826,19.4748284 C0.092748094,19.4748284 -0.15156708,19.0753209 0.0977558747,18.5766161 L8.75139389,1.26729609 Z"
+              id="Rectangle-4"
+              fill="#F26969"
+            ></path>
+            <g
+              id="Group-2"
+              transform="translate(8.000000, 3.000000)"
+              fontSize="14"
+              fontFamily="SourceSansPro-Bold, SourceSansPro-Regular"
+              fill="#FFFFFF"
+              fontWeight="bold"
+            >
+              <text id="!">
+                <tspan x="0" y="14">
+                  !
+                </tspan>
+              </text>
             </g>
+          </g>
         </g>
+      </g>
     </g>
-</svg>`;
+  </svg>
+);
 
-export const warningIcon = `<svg width="21px" height="21px" viewBox="0 0 21 21" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 41.2 (35397) - http://www.bohemiancoding.com/sketch -->
+export const warningIcon = (
+  <svg
+    width="21px"
+    height="21px"
+    viewBox="0 0 21 21"
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlnsXlink="http://www.w3.org/1999/xlink"
+  >
+    {/* Generator: Sketch 41.2 (35397) - http://www.bohemiancoding.com/sketch */}
     <title>Group 2</title>
     <desc>Created with Sketch.</desc>
     <defs></defs>
-    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Alert" transform="translate(-18.000000, -20.000000)">
-            <g id="Group-4">
-                <g id="Group-2" transform="translate(18.000000, 20.000000)">
-                    <circle id="Oval-5" fill="#FFCD02" cx="10.5" cy="10.5" r="10.5"></circle>
-                    <text id="!" font-family="SourceSansPro-Bold, SourceSansPro-Regular" font-size="14" font-weight="bold" fill="#FFFFFF">
-                        <tspan x="8" y="16">!</tspan>
-                    </text>
-                </g>
-            </g>
+    <g
+      id="Symbols"
+      stroke="none"
+      strokeWidth="1"
+      fill="none"
+      fillRule="evenodd"
+    >
+      <g id="Alert" transform="translate(-18.000000, -20.000000)">
+        <g id="Group-4">
+          <g id="Group-2" transform="translate(18.000000, 20.000000)">
+            <circle
+              id="Oval-5"
+              fill="#FFCD02"
+              cx="10.5"
+              cy="10.5"
+              r="10.5"
+            ></circle>
+            <text
+              id="!"
+              fontFamily="SourceSansPro-Bold, SourceSansPro-Regular"
+              fontSize="14"
+              fontWeight="bold"
+              fill="#FFFFFF"
+            >
+              <tspan x="8" y="16">
+                !
+              </tspan>
+            </text>
+          </g>
         </g>
+      </g>
     </g>
-</svg>`;
+  </svg>
+);
 
-export const informationIcon = `
-<svg width="24" height="24" viewBox="0 0 24 24" fill="" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_11029_22094)">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M0 12C0 5.37261 5.39028 0 12 0C18.6274 0 24 5.37261 24 12C24 18.6274 18.6274 24 12 24C5.37261 24 0 18.6274 0 12ZM11.1163 18.7865H12.8836V9.52586H11.1163V18.7865ZM11.1163 7.68786H12.8836V5.21364H11.1163V7.68786Z" fill="#394455"/>
-</g>
-<defs>
-<clipPath id="clip0_11029_22094">
-<rect width="24" height="24" fill="white" transform="matrix(1 0 0 -1 0 24)"/>
-</clipPath>
-</defs>
-</svg>
-`;
-
-export const notificationIcon = `
-  <svg width="22px" height="22px" viewBox="0 0 38 38" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
-    <!-- Generator: Sketch 3.3.3 (12081) - http://www.bohemiancoding.com/sketch -->
-    <title>CL Mark</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Update-6" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage" >
-        <g id="Line-Chart-(v4)" sketch:type="MSArtboardGroup" transform="translate(-20.000000, -29.000000)">
-            <g id="Header" sketch:type="MSLayerGroup" transform="translate(-15.000000, -47.000000)">
-                <g id="CL-Mark" transform="translate(35.000000, 76.000000)">
-                    <g id="Group-3">
-                        <g id="Clip-2"></g>
-                        <path d="M23.0622,10.88928 C21.72574,11.2024 20.3281,11.36466 18.89664,11.36466 C17.46518,11.36466 16.06754,11.2024 14.72538,10.88928 C15.84372,9.11696 17.25846,7.53996 18.89664,6.24302 C20.5352,7.54566 21.94386,9.11696 23.0622,10.88928 L23.0622,10.88928 Z M35.66034,0.68134 C33.97998,0.23294 32.2088,0 30.3867,0 C26.14058,0 22.18972,1.27718 18.89132,3.47396 C15.599,1.27718 11.64814,0 7.39632,0 C5.57384,0 3.80266,0.23294 2.1223,0.68134 C1.41322,0.86108 0.72504,1.08832 0.05244,1.34292 C0.00874,1.35926 -0.01216,1.41094 0.00722,1.4535 C0.30134,2.0919 0.62928,2.71054 0.98192,3.30942 C1.0013,3.34248 1.04158,3.35692 1.07768,3.344 C1.77878,3.09244 2.49622,2.87888 3.22962,2.70788 C4.56912,2.39552 5.96562,2.23668 7.39632,2.23668 C10.90448,2.23668 14.1854,3.2186 16.9898,4.91036 C15.21292,6.41478 13.69178,8.21408 12.50504,10.2296 C12.27248,10.6153 12.06234,11.00708 11.8579,11.40456 C11.72186,11.67132 11.59114,11.94378 11.4608,12.22764 C11.27346,12.65324 11.09182,13.07922 10.9326,13.51622 C10.09242,15.77 9.63262,18.21074 9.63262,20.74838 C9.63262,26.62356 12.09084,31.9371 16.0303,35.71772 C16.33696,36.01868 16.65502,36.30254 16.9898,36.5807 C17.25086,36.80756 17.51192,37.0177 17.78438,37.22214 C18.12752,37.4946 18.48662,37.74578 18.8461,37.98632 C18.87346,38.00494 18.90956,38.00456 18.93692,37.98594 C19.29602,37.74008 19.64942,37.4889 19.99256,37.22214 C20.27072,37.0177 20.53216,36.80756 20.79322,36.5807 C21.1223,36.30254 21.45176,36.01298 21.75804,35.71772 C25.69218,31.9371 28.15002,26.61786 28.15002,20.74838 C28.15002,18.21074 27.69022,15.7757 26.85004,13.52192 C26.6855,13.08492 26.50956,12.65324 26.31652,12.22764 C26.19188,11.94378 26.06116,11.67132 25.93044,11.40456 C25.72068,11.00708 25.51054,10.6153 25.2776,10.2296 C24.08554,8.21408 22.5701,6.41478 20.79322,4.91036 C23.59762,3.2186 26.87854,2.23668 30.3867,2.23668 C31.8174,2.23668 33.2139,2.39552 34.5534,2.70788 C35.28642,2.87888 36.00918,3.09244 36.70534,3.34362 C36.74144,3.35692 36.78172,3.34248 36.8011,3.30942 C37.15336,2.71054 37.47636,2.0919 37.77466,1.45388 C37.7948,1.41094 37.7739,1.35926 37.72944,1.34254 C37.05228,1.08832 36.3641,0.86108 35.66034,0.68134 L35.66034,0.68134 Z" id="Fill-1" fill="#152849" sketch:type="MSShapeGroup"></path>
-                    </g>
-                    <path d="M25.91372,20.7499 C25.91372,25.65912 23.99396,30.12526 20.86086,33.4419 C20.31024,31.68174 20.0108,29.81404 20.0108,27.88212 C20.0108,22.97328 21.93056,18.49916 25.06366,15.1905 C25.61428,16.94648 25.91372,18.81418 25.91372,20.7499" id="Fill-6" fill="#348540" sketch:type="MSShapeGroup"></path>
-                    <path d="M17.77184,27.88212 C17.77184,29.81404 17.4762,31.68174 16.9214,33.4419 C13.7883,30.12526 11.86854,25.65912 11.86854,20.7499 C11.86854,18.81418 12.17216,16.94648 12.72696,15.1905 C15.86006,18.49916 17.77184,22.97328 17.77184,27.88212" id="Fill-7" fill="#7DBC42" sketch:type="MSShapeGroup"></path>
-                </g>
-            </g>
-        </g>
+export const informationIcon = (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill=""
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <g clipPath="url(#clip0_11029_22094)">
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M0 12C0 5.37261 5.39028 0 12 0C18.6274 0 24 5.37261 24 12C24 18.6274 18.6274 24 12 24C5.37261 24 0 18.6274 0 12ZM11.1163 18.7865H12.8836V9.52586H11.1163V18.7865ZM11.1163 7.68786H12.8836V5.21364H11.1163V7.68786Z"
+        fill="#394455"
+      />
     </g>
-  </svg>`;
+    <defs>
+      <clipPath id="clip0_11029_22094">
+        <rect
+          width="24"
+          height="24"
+          fill="white"
+          transform="matrix(1 0 0 -1 0 24)"
+        />
+      </clipPath>
+    </defs>
+  </svg>
+);


### PR DESCRIPTION
The current icon for the notification alert is the outdated cockroach db logo. To make it consistent with the rest of the system, it needed to be updated. This change both removes the old logo from the codebase as well as uses the new one from our shared icon library.

Epic: none
Fixes: #127829

Release note (ui change): changes notification alert icon