### PR TITLE
release-24.1: opt: add PushLimitIntoProjectFilteredScan

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3838,6 +3838,10 @@ func (m *sessionDataMutator) SetPlanCacheMode(val sessiondatapb.PlanCacheMode) {
 	m.data.PlanCacheMode = val
 }
 
+func (m *sessionDataMutator) SetOptimizerPushLimitIntoProjectFilteredScan(val bool) {
+	m.data.OptimizerPushLimitIntoProjectFilteredScan = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -6171,6 +6171,7 @@ optimizer_apply_full_scan_penalty_to_virtual_tables        off
 optimizer_hoist_uncorrelated_equality_subqueries           on
 optimizer_merge_joins_enabled                              on
 optimizer_prove_implication_with_virtual_computed_columns  off
+optimizer_push_limit_into_project_filtered_scan            off
 optimizer_push_offset_into_index_join                      on
 optimizer_use_forecasts                                    on
 optimizer_use_histograms                                   on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2890,6 +2890,7 @@ optimizer_apply_full_scan_penalty_to_virtual_tables        off                 N
 optimizer_hoist_uncorrelated_equality_subqueries           on                  NULL      NULL        NULL        string
 optimizer_merge_joins_enabled                              on                  NULL      NULL        NULL        string
 optimizer_prove_implication_with_virtual_computed_columns  off                 NULL      NULL        NULL        string
+optimizer_push_limit_into_project_filtered_scan            off                 NULL      NULL        NULL        string
 optimizer_push_offset_into_index_join                      on                  NULL      NULL        NULL        string
 optimizer_use_forecasts                                    on                  NULL      NULL        NULL        string
 optimizer_use_histograms                                   on                  NULL      NULL        NULL        string
@@ -3077,6 +3078,7 @@ optimizer_apply_full_scan_penalty_to_virtual_tables        off                 N
 optimizer_hoist_uncorrelated_equality_subqueries           on                  NULL  user     NULL      on                  on
 optimizer_merge_joins_enabled                              on                  NULL  user     NULL      on                  on
 optimizer_prove_implication_with_virtual_computed_columns  off                 NULL  user     NULL      off                 off
+optimizer_push_limit_into_project_filtered_scan            off                 NULL  user     NULL      off                 off
 optimizer_push_offset_into_index_join                      on                  NULL  user     NULL      on                  on
 optimizer_use_forecasts                                    on                  NULL  user     NULL      on                  on
 optimizer_use_histograms                                   on                  NULL  user     NULL      on                  on
@@ -3263,6 +3265,7 @@ optimizer_apply_full_scan_penalty_to_virtual_tables        NULL    NULL     NULL
 optimizer_hoist_uncorrelated_equality_subqueries           NULL    NULL     NULL     NULL        NULL
 optimizer_merge_joins_enabled                              NULL    NULL     NULL     NULL        NULL
 optimizer_prove_implication_with_virtual_computed_columns  NULL    NULL     NULL     NULL        NULL
+optimizer_push_limit_into_project_filtered_scan            NULL    NULL     NULL     NULL        NULL
 optimizer_push_offset_into_index_join                      NULL    NULL     NULL     NULL        NULL
 optimizer_use_forecasts                                    NULL    NULL     NULL     NULL        NULL
 optimizer_use_histograms                                   NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -127,6 +127,7 @@ optimizer_apply_full_scan_penalty_to_virtual_tables        off
 optimizer_hoist_uncorrelated_equality_subqueries           on
 optimizer_merge_joins_enabled                              on
 optimizer_prove_implication_with_virtual_computed_columns  off
+optimizer_push_limit_into_project_filtered_scan            off
 optimizer_push_offset_into_index_join                      on
 optimizer_use_forecasts                                    on
 optimizer_use_histograms                                   on

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -199,6 +199,7 @@ type Memo struct {
 	useImprovedMultiColumnSelectivityEstimate  bool
 	proveImplicationWithVirtualComputedCols    bool
 	pushOffsetIntoIndexJoin                    bool
+	pushLimitIntoProjectFilteredScan           bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -284,6 +285,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		useImprovedMultiColumnSelectivityEstimate:  evalCtx.SessionData().OptimizerUseImprovedMultiColumnSelectivityEstimate,
 		proveImplicationWithVirtualComputedCols:    evalCtx.SessionData().OptimizerProveImplicationWithVirtualComputedColumns,
 		pushOffsetIntoIndexJoin:                    evalCtx.SessionData().OptimizerPushOffsetIntoIndexJoin,
+		pushLimitIntoProjectFilteredScan:           evalCtx.SessionData().OptimizerPushLimitIntoProjectFilteredScan,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -447,6 +449,7 @@ func (m *Memo) IsStale(
 		m.useImprovedMultiColumnSelectivityEstimate != evalCtx.SessionData().OptimizerUseImprovedMultiColumnSelectivityEstimate ||
 		m.proveImplicationWithVirtualComputedCols != evalCtx.SessionData().OptimizerProveImplicationWithVirtualComputedColumns ||
 		m.pushOffsetIntoIndexJoin != evalCtx.SessionData().OptimizerPushOffsetIntoIndexJoin ||
+		m.pushLimitIntoProjectFilteredScan != evalCtx.SessionData().OptimizerPushLimitIntoProjectFilteredScan ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -502,6 +502,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerPushOffsetIntoIndexJoin = false
 	notStale()
 
+	// Stale optimizer_push_limit_into_project_filtered_scan.
+	evalCtx.SessionData().OptimizerPushLimitIntoProjectFilteredScan = true
+	stale()
+	evalCtx.SessionData().OptimizerPushLimitIntoProjectFilteredScan = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/xform/limit_funcs.go
+++ b/pkg/sql/opt/xform/limit_funcs.go
@@ -74,6 +74,12 @@ func (c *CustomFuncs) CanLimitFilteredScan(
 	return ok
 }
 
+// PushLimitIntoProjectFilteredScanEnabled returns true if its eponymous rule is
+// enabled via its session setting.
+func (c *CustomFuncs) PushLimitIntoProjectFilteredScanEnabled() bool {
+	return c.e.evalCtx.SessionData().OptimizerPushLimitIntoProjectFilteredScan
+}
+
 // GenerateLimitedScans enumerates all non-inverted and non-partial secondary
 // indexes on the Scan operator's table and tries to create new limited Scan
 // operators from them. Since this only needs to be done once per table,

--- a/pkg/sql/opt/xform/rules/limit.opt
+++ b/pkg/sql/opt/xform/rules/limit.opt
@@ -35,6 +35,59 @@
 =>
 (Scan (LimitScanPrivate $scanPrivate $limit $ordering))
 
+# PushLimitIntoProjectFilteredScan is similar to PushLimitIntoFilteredScan, but
+# matches when there is a Project expression between the Limit and the filtered
+# Scan.
+#
+# This rule is useful when GenerateConstrainedScans generates a Project above a
+# partial index Scan that produces a column(s) held constant by the partial
+# index predicate. For example, consider the schema and query:
+#
+#   CREATE TABLE t (a INT PRIMARY KEY, b INT, INDEX a_b_idx (a) WHERE b = 1)
+#   SELECT * FROM t WHERE a > 0 AND b = 1 LIMIT 1
+#
+# After GenerateConstrainedScans fires the memo will contain an expression tree
+# like:
+#
+#   limit
+#    ├── columns: a:1 b:2
+#    ├── project
+#    │    ├── columns: a:1 b:2 a:1
+#    │    ├── scan t@a_b_idx,partial
+#    │    │    ├── columns: a:1
+#    │    │    └── constraint: /1: [/1 - ]
+#    │    └── projections
+#    │         └── 1 [as=b:2]
+#    └── 5
+#
+# While the Project producing b:2 is beneficial because it eliminates the need
+# for an IndexJoin, it also prevents PushLimitIntoFilteredScan from pushing the
+# limit into the scan. PushLimitIntoProjectFilteredScan matches this specific
+# pattern to solve the issue.
+#
+# This rule is similar to the PushLimitIntoProject normalization rule.
+# Unfortunately, that rule does not apply here because normalization rules
+# cannot not fire on parent expressions when alternative expressions are
+# generated for their child groups during exploration. So, an exploration rule
+# with similar behavior is necessary.
+[PushLimitIntoProjectFilteredScan, Explore]
+(Limit
+    (Project
+            (Scan $scanPrivate:*)
+            $projections:*
+            $passthrough:*
+        ) &
+        (PushLimitIntoProjectFilteredScanEnabled)
+    (Const $limit:* & (IsPositiveInt $limit))
+    $ordering:* & (CanLimitFilteredScan $scanPrivate $ordering)
+)
+=>
+(Project
+    (Scan (LimitScanPrivate $scanPrivate $limit $ordering))
+    $projections
+    $passthrough
+)
+
 # PushLimitIntoIndexJoin pushes a limit through an index join. Since index
 # lookup can be expensive, it's always better to discard rows beforehand.
 [PushLimitIntoIndexJoin, Explore]

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -65,6 +65,17 @@ CREATE TABLE partial_index_tab
 )
 ----
 
+exec-ddl
+CREATE TABLE partial_index_const
+(
+    a INT,
+    b INT,
+    c INT,
+    INDEX (a) STORING (c) WHERE b = 1,
+    INDEX (a) STORING (c) WHERE b IS NULL
+)
+----
+
 # Insert statistics for index_tab. Histogram buckets are included for the
 # latitude column in order to make the optimizer choose specific plans for
 # SplitLimitedScanIntoUnionScans tests.
@@ -272,6 +283,193 @@ scan a@s_idx
  ├── volatile
  ├── key: ()
  └── fd: ()-->(4)
+
+# --------------------------------------------------
+# PushLimitIntoProjectFilteredScan
+# --------------------------------------------------
+
+opt set=(optimizer_push_limit_into_project_filtered_scan=on) expect=PushLimitIntoProjectFilteredScan
+SELECT * FROM partial_index_const WHERE a > 0 AND b = 1 LIMIT 5
+----
+project
+ ├── columns: a:1!null b:2!null c:3
+ ├── cardinality: [0 - 5]
+ ├── fd: ()-->(2)
+ ├── scan partial_index_const@partial_index_const_a_idx,partial
+ │    ├── columns: a:1!null c:3
+ │    ├── constraint: /1/4: [/1 - ]
+ │    └── limit: 5
+ └── projections
+      └── 1 [as=b:2]
+
+opt set=(optimizer_push_limit_into_project_filtered_scan=on) expect=PushLimitIntoProjectFilteredScan
+SELECT * FROM partial_index_const WHERE a > 0 AND b IS NULL LIMIT 5
+----
+project
+ ├── columns: a:1!null b:2 c:3
+ ├── cardinality: [0 - 5]
+ ├── fd: ()-->(2)
+ ├── scan partial_index_const@partial_index_const_a_idx1,partial
+ │    ├── columns: a:1!null c:3
+ │    ├── constraint: /1/4: [/1 - ]
+ │    └── limit: 5
+ └── projections
+      └── CAST(NULL AS INT8) [as=b:2]
+
+opt set=(optimizer_push_limit_into_project_filtered_scan=on) expect=PushLimitIntoProjectFilteredScan
+SELECT * FROM partial_index_const WHERE a > 0 AND b = 1 LIMIT 5 OFFSET 10
+----
+offset
+ ├── columns: a:1!null b:2!null c:3
+ ├── cardinality: [0 - 5]
+ ├── fd: ()-->(2)
+ ├── project
+ │    ├── columns: b:2!null a:1!null c:3
+ │    ├── cardinality: [0 - 15]
+ │    ├── fd: ()-->(2)
+ │    ├── scan partial_index_const@partial_index_const_a_idx,partial
+ │    │    ├── columns: a:1!null c:3
+ │    │    ├── constraint: /1/4: [/1 - ]
+ │    │    └── limit: 15
+ │    └── projections
+ │         └── 1 [as=b:2]
+ └── 10
+
+# PushLimitIntoProjectFilteredScan propagates row-level locking information.
+opt set=(optimizer_push_limit_into_project_filtered_scan=on) expect=PushLimitIntoProjectFilteredScan
+SELECT * FROM partial_index_const WHERE a > 0 AND b = 1 LIMIT 5 FOR UPDATE
+----
+project
+ ├── columns: a:1!null b:2!null c:3
+ ├── cardinality: [0 - 5]
+ ├── volatile
+ ├── fd: ()-->(2)
+ ├── scan partial_index_const@partial_index_const_a_idx,partial
+ │    ├── columns: a:1!null c:3
+ │    ├── constraint: /1/4: [/1 - ]
+ │    ├── limit: 5
+ │    ├── locking: for-update
+ │    └── volatile
+ └── projections
+      └── 1 [as=b:2]
+
+opt set=(optimizer_push_limit_into_project_filtered_scan=on,optimizer_use_lock_op_for_serializable=true) expect=PushLimitIntoProjectFilteredScan
+SELECT * FROM partial_index_const WHERE a > 0 AND b = 1 LIMIT 5 FOR UPDATE
+----
+lock partial_index_const
+ ├── columns: a:1!null b:2!null c:3  [hidden: rowid:4!null]
+ ├── locking: for-update
+ ├── cardinality: [0 - 5]
+ ├── volatile, mutations
+ ├── key: (4)
+ ├── fd: ()-->(2), (4)-->(1,3)
+ └── project
+      ├── columns: b:2!null a:1!null c:3 rowid:4!null
+      ├── cardinality: [0 - 5]
+      ├── key: (4)
+      ├── fd: ()-->(2), (4)-->(1,3)
+      ├── scan partial_index_const@partial_index_const_a_idx,partial
+      │    ├── columns: a:1!null c:3 rowid:4!null
+      │    ├── constraint: /1/4: [/1 - ]
+      │    ├── limit: 5
+      │    ├── key: (4)
+      │    └── fd: (4)-->(1,3)
+      └── projections
+           └── 1 [as=b:2]
+
+opt set=(optimizer_push_limit_into_project_filtered_scan=off) expect-not=PushLimitIntoProjectFilteredScan
+SELECT * FROM partial_index_const WHERE a > 0 AND b = 1 LIMIT 5
+----
+limit
+ ├── columns: a:1!null b:2!null c:3
+ ├── cardinality: [0 - 5]
+ ├── fd: ()-->(2)
+ ├── project
+ │    ├── columns: b:2!null a:1!null c:3
+ │    ├── fd: ()-->(2)
+ │    ├── limit hint: 5.00
+ │    ├── scan partial_index_const@partial_index_const_a_idx,partial
+ │    │    ├── columns: a:1!null c:3
+ │    │    ├── constraint: /1/4: [/1 - ]
+ │    │    └── limit hint: 5.00
+ │    └── projections
+ │         └── 1 [as=b:2]
+ └── 5
+
+# The rule does not apply when the limit is non-positive.
+opt set=(optimizer_push_limit_into_project_filtered_scan=on) expect-not=PushLimitIntoProjectFilteredScan
+SELECT * FROM partial_index_const WHERE a > 0 AND b = 1 LIMIT -5
+----
+limit
+ ├── columns: a:1!null b:2!null c:3
+ ├── cardinality: [0 - 0]
+ ├── immutable
+ ├── key: ()
+ ├── fd: ()-->(1-3)
+ ├── project
+ │    ├── columns: b:2!null a:1!null c:3
+ │    ├── fd: ()-->(2)
+ │    ├── limit hint: 1.00
+ │    ├── scan partial_index_const@partial_index_const_a_idx,partial
+ │    │    ├── columns: a:1!null c:3
+ │    │    ├── constraint: /1/4: [/1 - ]
+ │    │    └── limit hint: 1.00
+ │    └── projections
+ │         └── 1 [as=b:2]
+ └── -5
+
+# The rule does not apply to non-filtered scans.
+opt disable=PushLimitIntoProject set=(optimizer_push_limit_into_project_filtered_scan=on) expect-not=PushLimitIntoProjectFilteredScan
+SELECT a, b, a+1 FROM partial_index_const LIMIT 5
+----
+limit
+ ├── columns: a:1 b:2 "?column?":7
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── fd: (1)-->(7)
+ ├── project
+ │    ├── columns: "?column?":7 a:1 b:2
+ │    ├── immutable
+ │    ├── fd: (1)-->(7)
+ │    ├── limit hint: 5.00
+ │    ├── scan partial_index_const
+ │    │    ├── columns: a:1 b:2
+ │    │    ├── partial index predicates
+ │    │    │    ├── partial_index_const_a_idx: filters
+ │    │    │    │    └── b:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+ │    │    │    └── partial_index_const_a_idx1: filters
+ │    │    │         └── b:2 IS NULL [outer=(2), constraints=(/2: [/NULL - /NULL]; tight), fd=()-->(2)]
+ │    │    └── limit hint: 5.00
+ │    └── projections
+ │         └── a:1 + 1 [as="?column?":7, outer=(1), immutable]
+ └── 5
+
+# The rule does not apply to filtered scans that cannot provide the desired
+# ordering.
+opt disable=GenerateTopK set=(optimizer_push_limit_into_project_filtered_scan=on) expect-not=PushLimitIntoProjectFilteredScan
+SELECT * FROM partial_index_const WHERE a > 0 AND b = 1 ORDER BY c LIMIT 5
+----
+limit
+ ├── columns: a:1!null b:2!null c:3
+ ├── internal-ordering: +3 opt(2)
+ ├── cardinality: [0 - 5]
+ ├── fd: ()-->(2)
+ ├── ordering: +3 opt(2) [actual: +3]
+ ├── project
+ │    ├── columns: b:2!null a:1!null c:3
+ │    ├── fd: ()-->(2)
+ │    ├── ordering: +3 opt(2) [actual: +3]
+ │    ├── limit hint: 5.00
+ │    ├── sort
+ │    │    ├── columns: a:1!null c:3
+ │    │    ├── ordering: +3
+ │    │    ├── limit hint: 5.00
+ │    │    └── scan partial_index_const@partial_index_const_a_idx,partial
+ │    │         ├── columns: a:1!null c:3
+ │    │         └── constraint: /1/4: [/1 - ]
+ │    └── projections
+ │         └── 1 [as=b:2]
+ └── 5
 
 # --------------------------------------------------
 # PushLimitIntoIndexJoin

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -526,6 +526,9 @@ message LocalOnlySessionData {
   // PlanCacheMode indicates the method that the optimizer should use to choose
   // between a custom and generic query plan.
   PlanCacheMode plan_cache_mode = 133;
+  // OptimizerPushLimitIntoProjectFilteredScan, when true, indicates that the
+  // optimizer should push limit expressions into projects of filtered scans.
+  bool optimizer_push_limit_into_project_filtered_scan = 139;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3426,6 +3426,23 @@ var varGen = map[string]sessionVar{
 			return sessiondatapb.PlanCacheModeForceCustom.String()
 		},
 	},
+
+	// CockroachDB extension.
+	`optimizer_push_limit_into_project_filtered_scan`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_push_limit_into_project_filtered_scan`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_push_limit_into_project_filtered_scan", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerPushLimitIntoProjectFilteredScan(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerPushLimitIntoProjectFilteredScan), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
Backport 1/1 commits from #129901.

/cc @cockroachdb/release

---

The `PushLimitIntoProjectFilteredScan` exploration rule has been added
which allows the optimizer to produce partial index scans with hard
limits in more cases. See the rule's description for more details.

The rule is disabled by default, but can be enabled by setting the
`optimizer_push_limit_into_project_filtered_scan` to `on`.

Fixes #129893

Release note (performance improvement): The query optimizer now plans
limited, partial index scans in more cases when the new session setting,
`optimizer_push_limit_into_project_filtered_scan` is set to `on`.

---

Release justification: Low-risk performance improvement gated behind
a session setting.