### PR TITLE
release-23.2: sqlliveness: handle AmbiguousResultError gracefully on insert

### DIFF
--- a/pkg/sql/sqlliveness/slinstance/BUILD.bazel
+++ b/pkg/sql/sqlliveness/slinstance/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slinstance",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/kv/kvpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/enum",

--- a/pkg/sql/sqlliveness/slinstance/slinstance.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/enum"
@@ -215,14 +216,6 @@ func (l *Instance) createSession(ctx context.Context) (*session, error) {
 	if l.currentRegion != nil {
 		region = l.currentRegion
 	}
-	id, err := slstorage.MakeSessionID(region, uuid.MakeV4())
-	if err != nil {
-		return nil, err
-	}
-
-	s := &session{
-		id: id,
-	}
 
 	opts := retry.Options{
 		InitialBackoff: 10 * time.Millisecond,
@@ -230,7 +223,17 @@ func (l *Instance) createSession(ctx context.Context) (*session, error) {
 		Multiplier:     1.5,
 	}
 	everySecond := log.Every(time.Second)
+	var err error
+	s := &session{}
 	for i, r := 0, retry.StartWithCtx(ctx, opts); r.Next(); {
+		// Allocate a new session ID initially or if we hit
+		// an ambiguous result error.
+		if len(s.id) == 0 {
+			s.id, err = slstorage.MakeSessionID(region, uuid.MakeV4())
+			if err != nil {
+				return nil, err
+			}
+		}
 		// If we fail to insert the session, then reset the start time
 		// and expiration, since otherwise there is a danger of inserting
 		// an expired session.
@@ -251,6 +254,14 @@ func (l *Instance) createSession(ctx context.Context) (*session, error) {
 			// of retrying.
 			if grpcutil.IsAuthError(err) {
 				break
+			}
+			// Previous insert was ambiguous, so select a new session ID,
+			// since there may be a row that exists.
+			if errors.HasType(err, (*kvpb.AmbiguousResultError)(nil)) {
+				log.Infof(ctx,
+					"failed to create a session due to an ambiguous result error: %s",
+					s.ID().String())
+				s.id = ""
 			}
 			continue
 		}

--- a/pkg/sql/sqlliveness/slinstance/slinstance_test.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance_test.go
@@ -59,6 +59,7 @@ func TestSQLInstance(t *testing.T) {
 		numRetries       int
 		initialTimestamp hlc.Timestamp
 		nextTimestamp    hlc.Timestamp
+		lastSessionID    sqlliveness.SessionID
 	}
 	fakeStorage.SetInjectedFailure(func(sid sqlliveness.SessionID, expiration hlc.Timestamp) error {
 		failureMu.Lock()
@@ -67,23 +68,35 @@ func TestSQLInstance(t *testing.T) {
 		if failureMu.numRetries == 1 {
 			failureMu.initialTimestamp = expiration
 			return kvpb.NewReplicaUnavailableError(errors.Newf("fake injected error"), &roachpb.RangeDescriptor{}, roachpb.ReplicaDescriptor{})
+		} else if failureMu.numRetries == 2 {
+			failureMu.lastSessionID = sid
+			return kvpb.NewAmbiguousResultError(errors.Newf("fake injected error"))
 		}
 		failureMu.nextTimestamp = expiration
 		return nil
 	})
 	sqlInstance.Start(ctx, nil)
-	// We expect two attempts to insert, since we inject a replica unavailable
-	// error on the first attempt.
+	// We expect three attempts to insert, since we inject a replica unavailable
+	// error on the first attempt. On the second attempt we will inject an ambiguous
+	// result error. The third and final attempt will be successful.
 	testutils.SucceedsSoon(t, func() error {
 		failureMu.Lock()
 		defer failureMu.Unlock()
-		if failureMu.numRetries < 2 {
+		if failureMu.numRetries < 3 {
 			return errors.AssertionFailedf("unexpected number of retries on session insertion, "+
 				"expected at least 2, got %d", failureMu.numRetries)
 		}
 		if !failureMu.nextTimestamp.After(failureMu.initialTimestamp) {
 			return errors.AssertionFailedf("timestamp should move forward on each retry, "+
 				"got %s. Previous timestamp was: %s", failureMu.nextTimestamp, failureMu.initialTimestamp)
+		}
+		session, err := sqlInstance.Session(ctx)
+		if err != nil {
+			return err
+		}
+		if session.ID() == failureMu.lastSessionID || len(failureMu.lastSessionID) == 0 {
+			return errors.AssertionFailedf("new session ID should have been assigned after an ambiguous"+
+				" result error. Current: %s  Previous: %s", session.ID(), failureMu.lastSessionID)
 		}
 		return nil
 	})


### PR DESCRIPTION
Backport 1/1 commits from #128902.

/cc @cockroachdb/release

---

Previously, when inserting a new SQL liveness session, we extended the expiry between each InitPut to ensure that an expired session was never inserted. This worked well, but if an ambiguous result error was encountered, the row could already exist in the table with the old timestamp leading to a condition failed error.  To address this, this patch will also assign a new session ID if we encounter an ambiguous result error. This will ensure that we do not collide with the old session ID.

Fixes: #127301
Release note (bug fix): Starting up nodes could fail with: "could not insert session ...: unexpected value", if an ambigous result error was hit inserting into the sqlliveness table.
Release justification: low risk fix for a problem that can prevent nodes to start up during KV availability issues
