### PR TITLE
build: allow roachtest defaults to be overwritten

### DIFF
--- a/build/teamcity/util/roachtest_util.sh
+++ b/build/teamcity/util/roachtest_util.sh
@@ -91,6 +91,6 @@ function upload_all {
 trap upload_all EXIT
 
 # Set up the parameters for the roachtest invocation.
-PARALLELISM=16
-CPUQUOTA=1024
+PARALLELISM="${PARALLELISM-16}"
+CPUQUOTA="${CPUQUOTA-1024}"
 TESTS="${TESTS-}"


### PR DESCRIPTION
This allows the `PARALLELISM` and `CPUQUOTA` defaults to be overwritten when running experiments on TeamCity.

Epic: none

Release note: None