### PR TITLE
crosscluster/physical: add support for reader tenant creation

### DIFF
--- a/pkg/ccl/crosscluster/replicationtestutils/testutils.go
+++ b/pkg/ccl/crosscluster/replicationtestutils/testutils.go
@@ -71,6 +71,7 @@ type TenantStreamingClustersArgs struct {
 	DestClusterSettings            map[string]string
 	DestClusterTestRegions         []string
 	RetentionTTLSeconds            int
+	EnableReaderTenant             bool
 	TestingKnobs                   *sql.StreamingTestingKnobs
 	TenantCapabilitiesTestingKnobs *tenantcapabilities.TestingKnobs
 
@@ -328,6 +329,13 @@ func (c *TenantStreamingClusters) BuildCreateTenantQuery(externalConnection stri
 		sourceURI)
 	if c.Args.RetentionTTLSeconds > 0 {
 		streamReplStmt = fmt.Sprintf("%s WITH RETENTION = '%ds'", streamReplStmt, c.Args.RetentionTTLSeconds)
+	}
+	if c.Args.EnableReaderTenant {
+		if c.Args.RetentionTTLSeconds == 0 {
+			streamReplStmt = fmt.Sprintf("%s WITH READ CAPABILITIES", streamReplStmt)
+		} else {
+			streamReplStmt = fmt.Sprintf("%s, READ CAPABILITIES", streamReplStmt)
+		}
 	}
 	return streamReplStmt
 }

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -132,7 +132,12 @@ message StreamIngestionDetails {
     (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID",
     (gogoproto.customname) = "SourceClusterID"];
 
+  // If ReaderTenantID is non-zero, this ID is associated with the reader tenant
+  // from which users can run read queries.
+  roachpb.TenantID read_tenant_id = 15 [(gogoproto.customname) = "ReadTenantID", (gogoproto.nullable) = false];
+
   reserved 5, 6;
+  // Next ID: 16.
 }
 
 message StreamIngestionCheckpoint {

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4826,6 +4826,10 @@ replication_options:
   {
       $$.val = &tree.TenantReplicationOptions{ExpirationWindow: $4.expr()}
   }
+| READ CAPABILITIES
+  {
+    $$.val = &tree.TenantReplicationOptions{EnableReaderTenant: tree.MakeDBool(true)}
+  }
 
 // %Help: CREATE SCHEDULE
 // %Category: Group

--- a/pkg/sql/parser/testdata/create_virtual_cluster
+++ b/pkg/sql/parser/testdata/create_virtual_cluster
@@ -71,6 +71,22 @@ CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" 
 CREATE VIRTUAL CLUSTER _ FROM REPLICATION OF _ ON 'pgurl' WITH RETENTION = '36h' -- identifiers removed
 
 parse
+CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH READ CAPABILITIES
+----
+CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH READ CAPABILITIES
+CREATE VIRTUAL CLUSTER ("destination-hyphen") FROM REPLICATION OF ("source-hyphen") ON ('pgurl') WITH READ CAPABILITIES -- fully parenthesized
+CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON '_' WITH READ CAPABILITIES -- literals removed
+CREATE VIRTUAL CLUSTER _ FROM REPLICATION OF _ ON 'pgurl' WITH READ CAPABILITIES -- identifiers removed
+
+parse
+CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH OPTIONS (READ CAPABILITIES)
+----
+CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH READ CAPABILITIES -- normalized!
+CREATE VIRTUAL CLUSTER ("destination-hyphen") FROM REPLICATION OF ("source-hyphen") ON ('pgurl') WITH READ CAPABILITIES -- fully parenthesized
+CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON '_' WITH READ CAPABILITIES -- literals removed
+CREATE VIRTUAL CLUSTER _ FROM REPLICATION OF _ ON 'pgurl' WITH READ CAPABILITIES -- identifiers removed
+
+parse
 CREATE VIRTUAL CLUSTER destination FROM REPLICATION OF ('a'||'b') ON ('pg'||'url')
 ----
 CREATE VIRTUAL CLUSTER destination FROM REPLICATION OF ('a' || 'b') ON ('pg' || 'url') -- normalized!


### PR DESCRIPTION
This adds the ability to create a 'reader' tenant when creating
a replicating tenant that is automatically activated by
the replication process when the initial scan completes. Users
can create a reader tenant by setting the option `READ CAPABILITIES`
to true when creating a replication job:

```
CREATE TENANT ... FROM REPLICATION OF ... ON ... WITH READ CAPABILITIES
```

This 'reader' tenant is responsible for what it does when activated. As
of writing, it does nothing special and thus this functionality is disabled
but future work is expected to adjust the bootstrap migrations run by the
tenant to cause it to configure itself to be a reader. This is out of scope
for this change however, which is solely focused on PCR's role in creating
and then activating this tenant.

Release note: none.
Epic: none.
Fixes: https://github.com/cockroachdb/cockroach/issues/130345