### PR TITLE
workload/schemachanger: ignore unique violation errors for CREATE INDEX

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1118,7 +1118,7 @@ func (og *operationGenerator) createIndex(ctx context.Context, tx pgx.Tx) (*opSt
 	// When an index exists, but `IF NOT EXISTS` is used, then
 	// the index will not be created and the op will complete without errors.
 	if !(indexExists && def.IfNotExists) {
-		stmt.potentialExecErrors.addAll(codesWithConditions{
+		og.potentialCommitErrors.addAll(codesWithConditions{
 			// If there is data in the table such that a unique index cannot be created,
 			// a pgcode.UniqueViolation will occur and will be wrapped in a
 			// pgcode.TransactionCommittedWithSchemaChangeFailure. The schemachange worker


### PR DESCRIPTION
Previously, the schema changer workload added logic to ignore potential unique violation errors during CREATE UNIQUE INDEX. This logic was for the statement phase, which is not when this error would be noticed, so it did not work correctly. To address this, this patch adds the logic to make unique violations error as  potential commit error for CREATE INDEX.

Fixes: #129366

Release note: None