### PR TITLE
rac2: wait for non-voters on elastic work priority

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -223,11 +223,13 @@ type rangeController struct {
 	mu struct {
 		syncutil.Mutex
 
-		// State for waiters. When anything in voterSets changes, voterSetRefreshCh
-		// is closed, and replaced with a new channel. The voterSets is
-		// copy-on-write, so waiters make a shallow copy.
-		voterSets         []voterSet
-		voterSetRefreshCh chan struct{}
+		// State for waiters. When anything in voterSets or nonVoterSets changes,
+		// waiterSetRefreshCh is closed, and replaced with a new channel. The
+		// voterSets and nonVoterSets is copy-on-write, so waiters make a shallow
+		// copy.
+		voterSets          []voterSet
+		nonVoterSet        []stateForWaiters
+		waiterSetRefreshCh chan struct{}
 	}
 
 	replicaMap map[roachpb.ReplicaID]*replicaState
@@ -236,9 +238,15 @@ type rangeController struct {
 // voterStateForWaiters informs whether WaitForEval is required to wait for
 // eval-tokens for a voter.
 type voterStateForWaiters struct {
+	stateForWaiters
+	isLeader      bool
+	isLeaseHolder bool
+}
+
+// stateForWaiters informs whether WaitForEval is required to wait for
+// eval-tokens for a replica.
+type stateForWaiters struct {
 	replicaID        roachpb.ReplicaID
-	isLeader         bool
-	isLeaseHolder    bool
 	isStateReplicate bool
 	evalTokenCounter *tokenCounter
 }
@@ -255,9 +263,9 @@ func NewRangeController(
 		leaseholder: init.Leaseholder,
 		replicaMap:  make(map[roachpb.ReplicaID]*replicaState),
 	}
-	rc.mu.voterSetRefreshCh = make(chan struct{})
+	rc.mu.waiterSetRefreshCh = make(chan struct{})
 	rc.updateReplicaSet(ctx, init.ReplicaSet)
-	rc.updateVoterSets()
+	rc.updateWaiterSets()
 	return rc
 }
 
@@ -281,29 +289,28 @@ func (rc *rangeController) WaitForEval(
 	rc.opts.EvalWaitMetrics.OnWaiting(wc)
 	start := rc.opts.Clock.PhysicalTime()
 retry:
-	// Snapshot the voterSets and voterSetRefreshCh.
+	// Snapshot the waiter sets and the refresh channel.
 	rc.mu.Lock()
 	vss := rc.mu.voterSets
-	vssRefreshCh := rc.mu.voterSetRefreshCh
+	nvs := rc.mu.nonVoterSet
+	refreshCh := rc.mu.waiterSetRefreshCh
 	rc.mu.Unlock()
 
-	if vssRefreshCh == nil {
+	if refreshCh == nil {
 		// RangeControllerImpl is closed.
-		// TODO(kvoli): We also need to do this in the replica_rac2.Processor,
-		// which will allow requests to bypass when a replica is not the leader and
-		// therefore the controller is closed.
 		rc.opts.EvalWaitMetrics.OnBypassed(wc, rc.opts.Clock.PhysicalTime().Sub(start))
 		return false, nil
 	}
 	for _, vs := range vss {
 		quorumCount := (len(vs) + 2) / 2
-		haveEvalTokensCount := 0
+		votersHaveEvalTokensCount := 0
 		handles = handles[:0]
 		requiredWait := false
+		// First check the voter set, which participate in quorum.
 		for _, v := range vs {
 			available, handle := v.evalTokenCounter.TokensAvailable(wc)
 			if available {
-				haveEvalTokensCount++
+				votersHaveEvalTokensCount++
 				continue
 			}
 
@@ -312,19 +319,48 @@ retry:
 				handle: handle,
 				requiredWait: v.isLeader || v.isLeaseHolder ||
 					(waitForAllReplicateHandles && v.isStateReplicate),
+				partOfQuorum: true,
 			}
 			handles = append(handles, handleInfo)
 			if !requiredWait && handleInfo.requiredWait {
 				requiredWait = true
 			}
 		}
-		remainingForQuorum := quorumCount - haveEvalTokensCount
+		// If we don't need to wait for all replicate handles, then we will never
+		// wait the non-voter streams having positive tokens, so we can skip
+		// checking them.
+		if waitForAllReplicateHandles {
+			for _, nv := range nvs {
+				available, handle := nv.evalTokenCounter.TokensAvailable(wc)
+				if available || !nv.isStateReplicate {
+					// Ignore non-voters without tokens which are not in StateReplicate,
+					// as we won't be waiting for them.
+					continue
+				}
+				// Don't have eval tokens, and have a handle for the non-voter.
+				handleInfo := tokenWaitingHandleInfo{
+					handle:       handle,
+					requiredWait: true,
+					partOfQuorum: false,
+				}
+				handles = append(handles, handleInfo)
+				if !requiredWait {
+					// NB: requiredWait won't always be true before here, because it is
+					// possible that the leaseholder and leader have tokens, but all
+					// other (non-)voters are not in StateReplicate or have tokens
+					// available.
+					requiredWait = true
+				}
+			}
+		}
+
+		remainingForQuorum := quorumCount - votersHaveEvalTokensCount
 		if remainingForQuorum < 0 {
 			remainingForQuorum = 0
 		}
 		if remainingForQuorum > 0 || requiredWait {
 			var state WaitEndState
-			state, scratch = WaitForEval(ctx, vssRefreshCh, handles, remainingForQuorum, scratch)
+			state, scratch = WaitForEval(ctx, refreshCh, handles, remainingForQuorum, scratch)
 			switch state {
 			case WaitSuccess:
 				continue
@@ -352,7 +388,7 @@ func (rc *rangeController) HandleRaftEventRaftMuLocked(ctx context.Context, e Ra
 	// If there was a quorum change, update the voter sets, triggering the
 	// refresh channel for any requests waiting for eval tokens.
 	if shouldWaitChange {
-		rc.updateVoterSets()
+		rc.updateWaiterSets()
 	}
 
 	// Compute the flow control state for each entry. We do this once here,
@@ -381,7 +417,7 @@ func (rc *rangeController) HandleSchedulerEventRaftMuLocked(ctx context.Context)
 // Requires replica.raftMu to be held.
 func (rc *rangeController) SetReplicasRaftMuLocked(ctx context.Context, replicas ReplicaSet) error {
 	rc.updateReplicaSet(ctx, replicas)
-	rc.updateVoterSets()
+	rc.updateWaiterSets()
 	return nil
 }
 
@@ -395,7 +431,7 @@ func (rc *rangeController) SetLeaseholderRaftMuLocked(
 		return
 	}
 	rc.leaseholder = replica
-	rc.updateVoterSets()
+	rc.updateWaiterSets()
 }
 
 // CloseRaftMuLocked closes the range controller.
@@ -406,8 +442,8 @@ func (rc *rangeController) CloseRaftMuLocked(ctx context.Context) {
 	defer rc.mu.Unlock()
 
 	rc.mu.voterSets = nil
-	close(rc.mu.voterSetRefreshCh)
-	rc.mu.voterSetRefreshCh = nil
+	close(rc.mu.waiterSetRefreshCh)
+	rc.mu.waiterSetRefreshCh = nil
 }
 
 func (rc *rangeController) updateReplicaSet(ctx context.Context, newSet ReplicaSet) {
@@ -432,7 +468,7 @@ func (rc *rangeController) updateReplicaSet(ctx context.Context, newSet ReplicaS
 	rc.replicaSet = newSet
 }
 
-func (rc *rangeController) updateVoterSets() {
+func (rc *rangeController) updateWaiterSets() {
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
 
@@ -449,23 +485,34 @@ func (rc *rangeController) updateVoterSets() {
 		}
 	}
 	var voterSets []voterSet
+	var nonVoterSet []stateForWaiters
 	for len(voterSets) < setCount {
 		voterSets = append(voterSets, voterSet{})
 	}
 	for _, r := range rc.replicaSet {
 		isOld := r.IsVoterOldConfig()
 		isNew := r.IsVoterNewConfig()
+
+		rs := rc.replicaMap[r.ReplicaID]
+		waiterState := stateForWaiters{
+			replicaID:        r.ReplicaID,
+			isStateReplicate: rs.isStateReplicate(),
+			evalTokenCounter: rs.evalTokenCounter,
+		}
+
+		if r.IsNonVoter() {
+			nonVoterSet = append(nonVoterSet, waiterState)
+		}
+
 		if !isOld && !isNew {
 			continue
 		}
+
 		// Is a voter.
-		rs := rc.replicaMap[r.ReplicaID]
 		vsfw := voterStateForWaiters{
-			replicaID:        r.ReplicaID,
-			isLeader:         r.ReplicaID == rc.opts.LocalReplicaID,
-			isLeaseHolder:    r.ReplicaID == rc.leaseholder,
-			isStateReplicate: rs.isStateReplicate(),
-			evalTokenCounter: rs.evalTokenCounter,
+			stateForWaiters: waiterState,
+			isLeader:        r.ReplicaID == rc.opts.LocalReplicaID,
+			isLeaseHolder:   r.ReplicaID == rc.leaseholder,
 		}
 		if isOld {
 			voterSets[0] = append(voterSets[0], vsfw)
@@ -475,8 +522,9 @@ func (rc *rangeController) updateVoterSets() {
 		}
 	}
 	rc.mu.voterSets = voterSets
-	close(rc.mu.voterSetRefreshCh)
-	rc.mu.voterSetRefreshCh = make(chan struct{})
+	rc.mu.nonVoterSet = nonVoterSet
+	close(rc.mu.waiterSetRefreshCh)
+	rc.mu.waiterSetRefreshCh = make(chan struct{})
 }
 
 type replicaState struct {

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval
@@ -166,6 +166,66 @@ range_id=1 tenant_id={1} local_replica_id=1
   name=c pri=high-pri done=true  waited=true  err=<nil>
   name=d pri=high-pri done=true  waited=true  err=<nil>
 
+# Start a low priority evaluation. This should wait for all replica streams,
+# including the non-voter stream to have tokens available.
+wait_for_eval name=e range_id=1 pri=LowPri
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=high-pri done=true  waited=false err=context canceled
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=high-pri done=true  waited=true  err=<nil>
+  name=d pri=high-pri done=true  waited=true  err=<nil>
+  name=e pri=low-pri  done=false waited=false err=<nil>
+
+# Add tokens to s3 (voter) stream. The low priority evaluation should stil not
+# complete, as the non-voter stream (s4) does not have tokens.
+adjust_tokens
+  store_id=3 pri=LowPri tokens=1
+----
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: reg=+0 B/+1 B ela=+1 B/+1 B
+t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
+
+check_state
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=high-pri done=true  waited=false err=context canceled
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=high-pri done=true  waited=true  err=<nil>
+  name=d pri=high-pri done=true  waited=true  err=<nil>
+  name=e pri=low-pri  done=false waited=false err=<nil>
+
+# Add tokens to s4 (non-voter) stream. The low priority evaluation should now
+# complete.
+adjust_tokens
+  store_id=4 pri=LowPri tokens=1
+----
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: reg=+0 B/+1 B ela=+1 B/+1 B
+t1/s4: reg=+0 B/+1 B ela=+1 B/+1 B
+
+check_state
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=high-pri done=true  waited=false err=context canceled
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=high-pri done=true  waited=true  err=<nil>
+  name=d pri=high-pri done=true  waited=true  err=<nil>
+  name=e pri=low-pri  done=true  waited=true  err=<nil>
+
+# Now remove the tokens we just added to end up back with s3/s4 not having
+# elastic (or regular) tokens.
+adjust_tokens
+  store_id=3 pri=LowPri tokens=-1
+  store_id=4 pri=LowPri tokens=-1
+----
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
+
 # Test behavior when changing leaseholder.
 set_leaseholder range_id=1 replica_id=2
 ----
@@ -174,14 +234,15 @@ r1: [(n1,s1):1,(n2,s2):2*,(n3,s3):3,(n4,s4):4NON_VOTER]
 # Start a new high priority evaluation 'e'. This evaluation completes
 # immediately because there are already sufficient tokens for the new
 # leaseholder.
-wait_for_eval name=e range_id=1 pri=HighPri
+wait_for_eval name=f range_id=1 pri=HighPri
 ----
 range_id=1 tenant_id={1} local_replica_id=1
   name=a pri=high-pri done=true  waited=false err=context canceled
   name=b pri=low-pri  done=true  waited=true  err=<nil>
   name=c pri=high-pri done=true  waited=true  err=<nil>
   name=d pri=high-pri done=true  waited=true  err=<nil>
-  name=e pri=high-pri done=true  waited=true  err=<nil>
+  name=e pri=low-pri  done=true  waited=true  err=<nil>
+  name=f pri=high-pri done=true  waited=true  err=<nil>
 
 # Start another evaluation on a new range, which will intersect some of the
 # stores of the first range. The evaluation on the first range will not
@@ -205,28 +266,30 @@ set_leaseholder range_id=1 replica_id=4
 r1: [(n1,s1):1,(n2,s2):2,(n3,s3):5]
 r2: [(n1,s1):1*,(n3,s3):3,(n5,s5):5]
 
-wait_for_eval name=f range_id=1 pri=LowPri
+wait_for_eval name=g range_id=1 pri=LowPri
 ----
 range_id=1 tenant_id={1} local_replica_id=1
   name=a pri=high-pri done=true  waited=false err=context canceled
   name=b pri=low-pri  done=true  waited=true  err=<nil>
   name=c pri=high-pri done=true  waited=true  err=<nil>
   name=d pri=high-pri done=true  waited=true  err=<nil>
-  name=e pri=high-pri done=true  waited=true  err=<nil>
-  name=f pri=low-pri  done=false waited=false err=<nil>
+  name=e pri=low-pri  done=true  waited=true  err=<nil>
+  name=f pri=high-pri done=true  waited=true  err=<nil>
+  name=g pri=low-pri  done=false waited=false err=<nil>
 range_id=2 tenant_id={1} local_replica_id=1
 
-wait_for_eval name=g range_id=2 pri=HighPri
+wait_for_eval name=h range_id=2 pri=HighPri
 ----
 range_id=1 tenant_id={1} local_replica_id=1
   name=a pri=high-pri done=true  waited=false err=context canceled
   name=b pri=low-pri  done=true  waited=true  err=<nil>
   name=c pri=high-pri done=true  waited=true  err=<nil>
   name=d pri=high-pri done=true  waited=true  err=<nil>
-  name=e pri=high-pri done=true  waited=true  err=<nil>
-  name=f pri=low-pri  done=false waited=false err=<nil>
+  name=e pri=low-pri  done=true  waited=true  err=<nil>
+  name=f pri=high-pri done=true  waited=true  err=<nil>
+  name=g pri=low-pri  done=false waited=false err=<nil>
 range_id=2 tenant_id={1} local_replica_id=1
-  name=g pri=high-pri done=false waited=false err=<nil>
+  name=h pri=high-pri done=false waited=false err=<nil>
 
 adjust_tokens
   store_id=5 pri=HighPri tokens=1
@@ -244,10 +307,11 @@ range_id=1 tenant_id={1} local_replica_id=1
   name=b pri=low-pri  done=true  waited=true  err=<nil>
   name=c pri=high-pri done=true  waited=true  err=<nil>
   name=d pri=high-pri done=true  waited=true  err=<nil>
-  name=e pri=high-pri done=true  waited=true  err=<nil>
-  name=f pri=low-pri  done=false waited=false err=<nil>
+  name=e pri=low-pri  done=true  waited=true  err=<nil>
+  name=f pri=high-pri done=true  waited=true  err=<nil>
+  name=g pri=low-pri  done=false waited=false err=<nil>
 range_id=2 tenant_id={1} local_replica_id=1
-  name=g pri=high-pri done=true  waited=true  err=<nil>
+  name=h pri=high-pri done=true  waited=true  err=<nil>
 
 # Adding elastic tokens to s3 should complete the low priority evaluation 'f',
 # as all stores now have elastic tokens available.
@@ -267,10 +331,11 @@ range_id=1 tenant_id={1} local_replica_id=1
   name=b pri=low-pri  done=true  waited=true  err=<nil>
   name=c pri=high-pri done=true  waited=true  err=<nil>
   name=d pri=high-pri done=true  waited=true  err=<nil>
-  name=e pri=high-pri done=true  waited=true  err=<nil>
-  name=f pri=low-pri  done=true  waited=true  err=<nil>
+  name=e pri=low-pri  done=true  waited=true  err=<nil>
+  name=f pri=high-pri done=true  waited=true  err=<nil>
+  name=g pri=low-pri  done=true  waited=true  err=<nil>
 range_id=2 tenant_id={1} local_replica_id=1
-  name=g pri=high-pri done=true  waited=true  err=<nil>
+  name=h pri=high-pri done=true  waited=true  err=<nil>
 
 metrics
 ----
@@ -280,10 +345,10 @@ kvflowcontrol.eval_wait.regular.requests.errored  : 1
 kvflowcontrol.eval_wait.regular.requests.bypassed : 0
 kvflowcontrol.eval_wait.regular.duration.count    : 5
 kvflowcontrol.eval_wait.elastic.requests.waiting  : 0
-kvflowcontrol.eval_wait.elastic.requests.admitted : 2
+kvflowcontrol.eval_wait.elastic.requests.admitted : 3
 kvflowcontrol.eval_wait.elastic.requests.errored  : 0
 kvflowcontrol.eval_wait.elastic.requests.bypassed : 0
-kvflowcontrol.eval_wait.elastic.duration.count    : 2
+kvflowcontrol.eval_wait.elastic.duration.count    : 3
 
 # Adjust the tokens so that r1 doesn't have tokens on s3 or s1, then transfer
 # s3 the lease for r1.
@@ -302,20 +367,21 @@ set_leaseholder range_id=1 replica_id=5
 r1: [(n1,s1):1,(n2,s2):2,(n3,s3):5*]
 r2: [(n1,s1):1*,(n3,s3):3,(n5,s5):5]
 
-# Start another evaluation 'h' on r1. It should not complete as the leaseholder
+# Start another evaluation 'i' on r1. It should not complete as the leaseholder
 # (s3) doesn't have available tokens and the leader (s1) doesn't have tokens.
-wait_for_eval name=h range_id=1 pri=HighPri
+wait_for_eval name=i range_id=1 pri=HighPri
 ----
 range_id=1 tenant_id={1} local_replica_id=1
   name=a pri=high-pri done=true  waited=false err=context canceled
   name=b pri=low-pri  done=true  waited=true  err=<nil>
   name=c pri=high-pri done=true  waited=true  err=<nil>
   name=d pri=high-pri done=true  waited=true  err=<nil>
-  name=e pri=high-pri done=true  waited=true  err=<nil>
-  name=f pri=low-pri  done=true  waited=true  err=<nil>
-  name=h pri=high-pri done=false waited=false err=<nil>
+  name=e pri=low-pri  done=true  waited=true  err=<nil>
+  name=f pri=high-pri done=true  waited=true  err=<nil>
+  name=g pri=low-pri  done=true  waited=true  err=<nil>
+  name=i pri=high-pri done=false waited=false err=<nil>
 range_id=2 tenant_id={1} local_replica_id=1
-  name=g pri=high-pri done=true  waited=true  err=<nil>
+  name=h pri=high-pri done=true  waited=true  err=<nil>
 
 # Add tokens to s3, this should not complete 'h' as the leader of r1 (s1) does
 # not have tokens.
@@ -328,22 +394,23 @@ t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
 t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
 t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
 
-# Start another evaluation 'i' on r1, it should also not complete until the
+# Start another evaluation 'j' on r1, it should also not complete until the
 # leader (s1) has tokens, despite both the leaseholder (s3) and a quorum
 # (s2,s3) having tokens available. Similar to above.
-wait_for_eval name=i range_id=1 pri=HighPri
+wait_for_eval name=j range_id=1 pri=HighPri
 ----
 range_id=1 tenant_id={1} local_replica_id=1
   name=a pri=high-pri done=true  waited=false err=context canceled
   name=b pri=low-pri  done=true  waited=true  err=<nil>
   name=c pri=high-pri done=true  waited=true  err=<nil>
   name=d pri=high-pri done=true  waited=true  err=<nil>
-  name=e pri=high-pri done=true  waited=true  err=<nil>
-  name=f pri=low-pri  done=true  waited=true  err=<nil>
-  name=h pri=high-pri done=false waited=false err=<nil>
+  name=e pri=low-pri  done=true  waited=true  err=<nil>
+  name=f pri=high-pri done=true  waited=true  err=<nil>
+  name=g pri=low-pri  done=true  waited=true  err=<nil>
   name=i pri=high-pri done=false waited=false err=<nil>
+  name=j pri=high-pri done=false waited=false err=<nil>
 range_id=2 tenant_id={1} local_replica_id=1
-  name=g pri=high-pri done=true  waited=true  err=<nil>
+  name=h pri=high-pri done=true  waited=true  err=<nil>
 
 # Finally, add tokens to s1 to complete both evaluations 'h' and 'i'.
 adjust_tokens
@@ -362,12 +429,13 @@ range_id=1 tenant_id={1} local_replica_id=1
   name=b pri=low-pri  done=true  waited=true  err=<nil>
   name=c pri=high-pri done=true  waited=true  err=<nil>
   name=d pri=high-pri done=true  waited=true  err=<nil>
-  name=e pri=high-pri done=true  waited=true  err=<nil>
-  name=f pri=low-pri  done=true  waited=true  err=<nil>
-  name=h pri=high-pri done=true  waited=true  err=<nil>
+  name=e pri=low-pri  done=true  waited=true  err=<nil>
+  name=f pri=high-pri done=true  waited=true  err=<nil>
+  name=g pri=low-pri  done=true  waited=true  err=<nil>
   name=i pri=high-pri done=true  waited=true  err=<nil>
+  name=j pri=high-pri done=true  waited=true  err=<nil>
 range_id=2 tenant_id={1} local_replica_id=1
-  name=g pri=high-pri done=true  waited=true  err=<nil>
+  name=h pri=high-pri done=true  waited=true  err=<nil>
 
 # No tokens on s3.
 adjust_tokens
@@ -379,22 +447,23 @@ t1/s3: reg=+0 B/+1 B ela=+0 B/+1 B
 t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
 t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
 
-# Start an evaluation 'j' on r1, that does not complete since the leaseholder
+# Start an evaluation 'k' on r1, that does not complete since the leaseholder
 # (s3) has tokens.
-wait_for_eval name=j range_id=1 pri=HighPri
+wait_for_eval name=k range_id=1 pri=HighPri
 ----
 range_id=1 tenant_id={1} local_replica_id=1
   name=a pri=high-pri done=true  waited=false err=context canceled
   name=b pri=low-pri  done=true  waited=true  err=<nil>
   name=c pri=high-pri done=true  waited=true  err=<nil>
   name=d pri=high-pri done=true  waited=true  err=<nil>
-  name=e pri=high-pri done=true  waited=true  err=<nil>
-  name=f pri=low-pri  done=true  waited=true  err=<nil>
-  name=h pri=high-pri done=true  waited=true  err=<nil>
+  name=e pri=low-pri  done=true  waited=true  err=<nil>
+  name=f pri=high-pri done=true  waited=true  err=<nil>
+  name=g pri=low-pri  done=true  waited=true  err=<nil>
   name=i pri=high-pri done=true  waited=true  err=<nil>
-  name=j pri=high-pri done=false waited=false err=<nil>
+  name=j pri=high-pri done=true  waited=true  err=<nil>
+  name=k pri=high-pri done=false waited=false err=<nil>
 range_id=2 tenant_id={1} local_replica_id=1
-  name=g pri=high-pri done=true  waited=true  err=<nil>
+  name=h pri=high-pri done=true  waited=true  err=<nil>
 
 # Close all the RangeControllers. Evaluation 'j' is done, but specifies waited
 # is false, and error is nil.
@@ -405,13 +474,14 @@ range_id=1 tenant_id={1} local_replica_id=1
   name=b pri=low-pri  done=true  waited=true  err=<nil>
   name=c pri=high-pri done=true  waited=true  err=<nil>
   name=d pri=high-pri done=true  waited=true  err=<nil>
-  name=e pri=high-pri done=true  waited=true  err=<nil>
-  name=f pri=low-pri  done=true  waited=true  err=<nil>
-  name=h pri=high-pri done=true  waited=true  err=<nil>
+  name=e pri=low-pri  done=true  waited=true  err=<nil>
+  name=f pri=high-pri done=true  waited=true  err=<nil>
+  name=g pri=low-pri  done=true  waited=true  err=<nil>
   name=i pri=high-pri done=true  waited=true  err=<nil>
-  name=j pri=high-pri done=true  waited=false err=<nil>
+  name=j pri=high-pri done=true  waited=true  err=<nil>
+  name=k pri=high-pri done=true  waited=false err=<nil>
 range_id=2 tenant_id={1} local_replica_id=1
-  name=g pri=high-pri done=true  waited=true  err=<nil>
+  name=h pri=high-pri done=true  waited=true  err=<nil>
 
 metrics
 ----
@@ -421,7 +491,7 @@ kvflowcontrol.eval_wait.regular.requests.errored  : 1
 kvflowcontrol.eval_wait.regular.requests.bypassed : 1
 kvflowcontrol.eval_wait.regular.duration.count    : 8
 kvflowcontrol.eval_wait.elastic.requests.waiting  : 0
-kvflowcontrol.eval_wait.elastic.requests.admitted : 2
+kvflowcontrol.eval_wait.elastic.requests.admitted : 3
 kvflowcontrol.eval_wait.elastic.requests.errored  : 0
 kvflowcontrol.eval_wait.elastic.requests.bypassed : 0
-kvflowcontrol.eval_wait.elastic.duration.count    : 2
+kvflowcontrol.eval_wait.elastic.duration.count    : 3

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval_joint_config
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval_joint_config
@@ -1,0 +1,222 @@
+# This test exercises WaitForEval when there is a joint configuration, with
+# incoming and outgoing voters. We require quorum of streams with available
+# tokens in both voting sets. A non-voter and learner replica are also added,
+# which should have no consequence for quorum or non-elastic evaluation
+# requests (non-voter requires tokens for elastic).
+init regular_limit=1 regular_init=1 elastic_limit=1 elastic_init=1
+range_id=1 tenant_id=1 local_replica_id=1
+  store_id=1 replica_id=1 type=VOTER_FULL              state=StateReplicate
+  store_id=2 replica_id=2 type=VOTER_FULL              state=StateReplicate
+  store_id=3 replica_id=3 type=VOTER_DEMOTING_LEARNER  state=StateReplicate
+  store_id=4 replica_id=4 type=VOTER_INCOMING          state=StateReplicate
+  store_id=5 replica_id=5 type=NON_VOTER               state=StateReplicate
+  store_id=6 replica_id=6 type=LEARNER                 state=StateReplicate
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3VOTER_DEMOTING_LEARNER,(n4,s4):4VOTER_INCOMING,(n5,s5):5NON_VOTER,(n6,s6):6LEARNER]
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+
+# Start a happy case normal priority evaluation 'a', all voters have tokens.
+wait_for_eval name=a range_id=1 pri=NormalPri
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=normal-pri done=true  waited=true  err=<nil>
+
+# Next, remove tokens from the non-leader/leaseholder voter which is in both
+# configurations (s2).
+adjust_tokens
+  store_id=2 pri=HighPri tokens=-1
+----
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+
+# Start another evaluation 'b'. The request should be done immediately, since
+# there is still a quorum of voters with tokens in both configurations.
+wait_for_eval name=b range_id=1 pri=NormalPri
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=normal-pri done=true  waited=true  err=<nil>
+  name=b pri=normal-pri done=true  waited=true  err=<nil>
+
+# Remove tokens from the incoming voter (s4). Despite the outgoing
+# configuration (s1,s2,s3) having a quorum (s1+s3), the incoming configuration
+# (s1,s2,s4) does not, so the evaluation request 'c' should be blocked.
+adjust_tokens
+  store_id=4 pri=HighPri tokens=-1
+----
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+
+wait_for_eval name=c range_id=1 pri=NormalPri
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=normal-pri done=true  waited=true  err=<nil>
+  name=b pri=normal-pri done=true  waited=true  err=<nil>
+  name=c pri=normal-pri done=false waited=false err=<nil>
+
+# Add tokens back to the incoming voter (s4). The incoming configuration now
+# has a quorum with available tokens. The evaluation request 'c' should be
+# done.
+adjust_tokens
+  store_id=4 pri=HighPri tokens=1
+----
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+
+check_state
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=normal-pri done=true  waited=true  err=<nil>
+  name=b pri=normal-pri done=true  waited=true  err=<nil>
+  name=c pri=normal-pri done=true  waited=true  err=<nil>
+
+# Now test the case where the outgoing configuration does not have a quorum.
+adjust_tokens
+  store_id=3 pri=HighPri tokens=-1
+----
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+
+wait_for_eval name=d range_id=1 pri=NormalPri
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=normal-pri done=true  waited=true  err=<nil>
+  name=b pri=normal-pri done=true  waited=true  err=<nil>
+  name=c pri=normal-pri done=true  waited=true  err=<nil>
+  name=d pri=normal-pri done=false waited=false err=<nil>
+
+# Add tokens back to the demoting learner (s3). The outgoing configuration now
+# has a quorum with available tokens. The evaluation request 'd' should be
+# done.
+adjust_tokens
+  store_id=3 pri=HighPri tokens=1
+----
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+
+check_state
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=normal-pri done=true  waited=true  err=<nil>
+  name=b pri=normal-pri done=true  waited=true  err=<nil>
+  name=c pri=normal-pri done=true  waited=true  err=<nil>
+  name=d pri=normal-pri done=true  waited=true  err=<nil>
+
+# Ensure that elastic (LowPri) requests block on all replicas, in both
+# configurations, having elastic tokens. Start with the outgoing voter (s3)
+# having no elastic tokens (also add back the tokens to s2 to reset).
+adjust_tokens
+  store_id=2 pri=HighPri tokens=1
+  store_id=3 pri=LowPri  tokens=-1
+----
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: reg=+1 B/+1 B ela=+0 B/+1 B
+t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+
+wait_for_eval name=e range_id=1 pri=LowPri
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=normal-pri done=true  waited=true  err=<nil>
+  name=b pri=normal-pri done=true  waited=true  err=<nil>
+  name=c pri=normal-pri done=true  waited=true  err=<nil>
+  name=d pri=normal-pri done=true  waited=true  err=<nil>
+  name=e pri=low-pri  done=false waited=false err=<nil>
+
+# Add tokens back to the outgoing voter (s3). 'e' should be done.
+adjust_tokens
+  store_id=3 pri=LowPri tokens=1
+----
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+
+check_state
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=normal-pri done=true  waited=true  err=<nil>
+  name=b pri=normal-pri done=true  waited=true  err=<nil>
+  name=c pri=normal-pri done=true  waited=true  err=<nil>
+  name=d pri=normal-pri done=true  waited=true  err=<nil>
+  name=e pri=low-pri  done=true  waited=true  err=<nil>
+
+# Do the same with the incoming voter (s4) having no elastic tokens.
+adjust_tokens
+  store_id=4 pri=LowPri tokens=-1
+----
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: reg=+1 B/+1 B ela=+0 B/+1 B
+t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+
+wait_for_eval name=f range_id=1 pri=LowPri
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=normal-pri done=true  waited=true  err=<nil>
+  name=b pri=normal-pri done=true  waited=true  err=<nil>
+  name=c pri=normal-pri done=true  waited=true  err=<nil>
+  name=d pri=normal-pri done=true  waited=true  err=<nil>
+  name=e pri=low-pri  done=true  waited=true  err=<nil>
+  name=f pri=low-pri  done=false waited=false err=<nil>
+
+# Add tokens back to the incoming voter (s4). 'f' should be done.
+adjust_tokens
+  store_id=4 pri=LowPri tokens=1
+----
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+
+check_state
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=normal-pri done=true  waited=true  err=<nil>
+  name=b pri=normal-pri done=true  waited=true  err=<nil>
+  name=c pri=normal-pri done=true  waited=true  err=<nil>
+  name=d pri=normal-pri done=true  waited=true  err=<nil>
+  name=e pri=low-pri  done=true  waited=true  err=<nil>
+  name=f pri=low-pri  done=true  waited=true  err=<nil>
+
+close_rcs
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=normal-pri done=true  waited=true  err=<nil>
+  name=b pri=normal-pri done=true  waited=true  err=<nil>
+  name=c pri=normal-pri done=true  waited=true  err=<nil>
+  name=d pri=normal-pri done=true  waited=true  err=<nil>
+  name=e pri=low-pri  done=true  waited=true  err=<nil>
+  name=f pri=low-pri  done=true  waited=true  err=<nil>

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval_non_voters
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval_non_voters
@@ -1,0 +1,281 @@
+# This test excercises calling WaitForEval with a variety of replica sets which
+# include non-voters in various states.
+#
+# Initialize the test state with a single range, holding two voters and one
+# non-voter, all in StateReplicate. All streams will start with positive (1)
+# tokens.
+init regular_limit=1 regular_init=1 elastic_limit=1 elastic_init=1
+range_id=1 tenant_id=1 local_replica_id=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate
+  store_id=3 replica_id=3 type=NON_VOTER  state=StateReplicate
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3NON_VOTER]
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
+
+# Start a low priority evaluation 'a'. This should complete immediately as all
+# replicas have tokens.
+wait_for_eval name=a range_id=1 pri=LowPri
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=low-pri  done=true  waited=true  err=<nil>
+
+# Next, remove the elastic tokens from the non-voter and start another low
+# priority evaluation 'b'. This should not complete until the non-voter has
+# available tokens.
+adjust_tokens
+  store_id=3 pri=LowPri tokens=-1
+----
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: reg=+1 B/+1 B ela=+0 B/+1 B
+
+wait_for_eval name=b range_id=1 pri=LowPri
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=low-pri  done=true  waited=true  err=<nil>
+  name=b pri=low-pri  done=false waited=false err=<nil>
+
+# Now, add the elastic tokens back to the non-voter, the evaluation 'b' should
+# complete.
+adjust_tokens
+  store_id=3 pri=LowPri tokens=1
+----
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
+
+check_state
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=low-pri  done=true  waited=true  err=<nil>
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+
+# Next, ensure that WaitForEval correctly waits for a quorum of voting replicas
+# to have tokens, non-voting replicas should not count towards the quourum. 
+#
+# Add three more replicas to have 3 voters {s1,s2,s3} and 3 non-voters
+# {s4,s5,s6}. The voters, aside from the local replica, will be in
+# StateSnapshot and therefore not required to wait on for elastic work class
+# requests.
+set_replicas
+range_id=1 tenant_id=1 local_replica_id=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateSnapshot
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateSnapshot
+  store_id=4 replica_id=4 type=NON_VOTER  state=StateReplicate
+  store_id=5 replica_id=5 type=NON_VOTER  state=StateReplicate
+  store_id=6 replica_id=6 type=NON_VOTER  state=StateReplicate
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4NON_VOTER,(n5,s5):5NON_VOTER,(n6,s6):6NON_VOTER]
+
+# Remove elastic tokens from all the replica streams.
+adjust_tokens
+  store_id=1 pri=LowPri tokens=-1
+  store_id=2 pri=LowPri tokens=-1
+  store_id=3 pri=LowPri tokens=-1
+  store_id=4 pri=LowPri tokens=-1
+  store_id=5 pri=LowPri tokens=-1
+  store_id=6 pri=LowPri tokens=-1
+----
+t1/s1: reg=+1 B/+1 B ela=+0 B/+1 B
+t1/s2: reg=+1 B/+1 B ela=+0 B/+1 B
+t1/s3: reg=+1 B/+1 B ela=+0 B/+1 B
+t1/s4: reg=+1 B/+1 B ela=+0 B/+1 B
+t1/s5: reg=+1 B/+1 B ela=+0 B/+1 B
+t1/s6: reg=+1 B/+1 B ela=+0 B/+1 B
+
+# Start a low priority evaluation 'c'. This should not complete until: 
+# (1) The leader has elastic tokens (already true)
+# (2) The leaseholder has elastic tokens (already true)
+# (3) A quorum of voting replicas have elastic tokens e.g., s1 + (s2|s3)
+# (4) All non-voting replicas in StateReplicate have elastic tokens
+wait_for_eval name=c range_id=1 pri=LowPri
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=low-pri  done=true  waited=true  err=<nil>
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=low-pri  done=false waited=false err=<nil>
+
+# Add the tokens back to the leader and leaseholder. This should not complete
+# the evaluation 'c'.
+adjust_tokens
+  store_id=1 pri=LowPri tokens=1
+----
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+1 B/+1 B ela=+0 B/+1 B
+t1/s3: reg=+1 B/+1 B ela=+0 B/+1 B
+t1/s4: reg=+1 B/+1 B ela=+0 B/+1 B
+t1/s5: reg=+1 B/+1 B ela=+0 B/+1 B
+t1/s6: reg=+1 B/+1 B ela=+0 B/+1 B
+
+check_state
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=low-pri  done=true  waited=true  err=<nil>
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=low-pri  done=false waited=false err=<nil>
+
+# Add tokens to the non-voting replicas. This shouldn't complete evaluation
+# 'c', because the range still lacks a quorum of voting replicas with available
+# tokens.
+adjust_tokens
+  store_id=4 pri=LowPri tokens=1
+  store_id=5 pri=LowPri tokens=1
+  store_id=6 pri=LowPri tokens=1
+----
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+1 B/+1 B ela=+0 B/+1 B
+t1/s3: reg=+1 B/+1 B ela=+0 B/+1 B
+t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+
+check_state
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=low-pri  done=true  waited=true  err=<nil>
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=low-pri  done=false waited=false err=<nil>
+
+# Switch one of non-leader/leaseholder voting replicas to StateReplicate. The
+# evaluation 'c' should still not complete, because the switched voting replica
+# stream doesn't have tokens still.
+set_replicas
+range_id=1 tenant_id=1 local_replica_id=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateSnapshot
+  store_id=4 replica_id=4 type=NON_VOTER  state=StateReplicate
+  store_id=5 replica_id=5 type=NON_VOTER  state=StateReplicate
+  store_id=6 replica_id=6 type=NON_VOTER  state=StateReplicate
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4NON_VOTER,(n5,s5):5NON_VOTER,(n6,s6):6NON_VOTER]
+
+check_state
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=low-pri  done=true  waited=true  err=<nil>
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=low-pri  done=false waited=false err=<nil>
+
+
+# Finally, add the tokens back to the voter and the evaluation 'c' should now
+# complete as there is a quorum of voting replicas with tokens.
+adjust_tokens
+  store_id=2 pri=LowPri tokens=1
+----
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: reg=+1 B/+1 B ela=+0 B/+1 B
+t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+
+check_state
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=low-pri  done=true  waited=true  err=<nil>
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=low-pri  done=true  waited=true  err=<nil>
+
+# Next, we check that non-elastic work class requests are not blocked by the
+# presence of non-voting replicas in any way. Remove all tokens and start a high priority
+# evaluation 'd'.
+adjust_tokens
+  store_id=1 pri=HighPri tokens=-1
+  store_id=2 pri=HighPri tokens=-1
+  store_id=3 pri=LowPri  tokens=1
+  store_id=3 pri=HighPri tokens=-1
+  store_id=4 pri=HighPri tokens=-1
+  store_id=5 pri=HighPri tokens=-1
+  store_id=6 pri=HighPri tokens=-1
+----
+t1/s1: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s2: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s5: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s6: reg=+0 B/+1 B ela=+0 B/+1 B
+
+wait_for_eval name=d range_id=1 pri=HighPri
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=low-pri  done=true  waited=true  err=<nil>
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=low-pri  done=true  waited=true  err=<nil>
+  name=d pri=high-pri done=false waited=false err=<nil>
+
+# Add the tokens back to the leader and leaseholder. This should not complete
+# the evaluation 'd'.
+adjust_tokens
+  store_id=1 pri=HighPri tokens=1
+----
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s5: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s6: reg=+0 B/+1 B ela=+0 B/+1 B
+
+check_state
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=low-pri  done=true  waited=true  err=<nil>
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=low-pri  done=true  waited=true  err=<nil>
+  name=d pri=high-pri done=false waited=false err=<nil>
+
+# Add tokens back to all of the non-voting replicas. This should not complete
+# the evaluation 'd' because the non-voting replicas don't count towards
+# quorum.
+adjust_tokens
+  store_id=4 pri=HighPri tokens=1
+  store_id=5 pri=HighPri tokens=1
+  store_id=6 pri=HighPri tokens=1
+----
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+
+check_state
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=low-pri  done=true  waited=true  err=<nil>
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=low-pri  done=true  waited=true  err=<nil>
+  name=d pri=high-pri done=false waited=false err=<nil>
+
+# Lastly, add tokens back the voting replica in StateSnapshot. Despite being in
+# StateSnapshot, the replica stream having tokens is sufficient to complete the
+# evaluation 'd', as it completes a quorum (s1+s3/3).
+adjust_tokens
+  store_id=3 pri=HighPri tokens=1
+----
+t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+
+check_state
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=low-pri  done=true  waited=true  err=<nil>
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=low-pri  done=true  waited=true  err=<nil>
+  name=d pri=high-pri done=true  waited=true  err=<nil>
+
+close_rcs
+----
+range_id=1 tenant_id={1} local_replica_id=1
+  name=a pri=low-pri  done=true  waited=true  err=<nil>
+  name=b pri=low-pri  done=true  waited=true  err=<nil>
+  name=c pri=low-pri  done=true  waited=true  err=<nil>
+  name=d pri=high-pri done=true  waited=true  err=<nil>

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter.go
@@ -340,10 +340,13 @@ func (wh waitHandle) ConfirmHaveTokensAndUnblockNextWaiter() (haveTokens bool) {
 
 type tokenWaitingHandleInfo struct {
 	handle TokenWaitingHandle
-	// For regular work, this will be set for the leaseholder and leader. For
-	// elastic work this will be set for the aforementioned, and all replicas
+	// requiredWait will be set for the leaseholder and leader for regular work.
+	// For elastic work this will be set for the aforementioned, and all replicas
 	// which are in StateReplicate.
 	requiredWait bool
+	// partOfQuorum will be set for all voting replicas which can contribute to
+	// quorum.
+	partOfQuorum bool
 }
 
 // WaitEndState is the state returned by WaitForEval and indicates the result
@@ -416,12 +419,12 @@ func WaitForEval(
 
 	// m is the current length of the scratch slice.
 	m := len(scratch)
-	signaledCount := 0
+	signaledQuorumCount := 0
 
-	// Wait for (1) at least a quorumCount of handles to be signaled and have
-	// available tokens; as well as (2) all of the required wait handles to be
-	// signaled and have tokens available.
-	for signaledCount < requiredQuorum || requiredWaitCount > 0 {
+	// Wait for (1) at least a quorumCount of partOfQuorum handles to be signaled
+	// and have available tokens; as well as (2) all of the required wait handles
+	// to be signaled and have tokens available.
+	for signaledQuorumCount < requiredQuorum || requiredWaitCount > 0 {
 		chosen, _, _ := reflect.Select(scratch)
 		switch chosen {
 		case 0:
@@ -436,7 +439,9 @@ func WaitForEval(
 				continue
 			}
 
-			signaledCount++
+			if handleInfo.partOfQuorum {
+				signaledQuorumCount++
+			}
 			if handleInfo.requiredWait {
 				requiredWaitCount--
 			}

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter_test.go
@@ -530,6 +530,7 @@ func TestWaitForEval(t *testing.T) {
 				handleInfo := tokenWaitingHandleInfo{
 					handle:       ts.getOrCreateTC(stream).testingHandle(),
 					requiredWait: required,
+					partOfQuorum: true,
 				}
 				handles = append(handles, handleInfo)
 			}


### PR DESCRIPTION
Previously, the `RangeController` would wait for all voters to have available elastic eval tokens before returning from `WaitForEval` (in the happy case). This didn't match the existing v1, or desired behavior of waiting for all replicas (excluding learners) to have eval tokens for elastic work priorities.

Update `RangeController` to wait for all voters+non-voters for elastic work priorities. A `nonVoterSet` is introduced, similar to the existing `voterSets` and is used determine which streams should be checked.

Resolves: #130287
Release note: None