### PR TITLE
workload/schemachange: add unique constraint hits duplicate key errors

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -400,6 +400,11 @@ func (og *operationGenerator) addUniqueConstraint(ctx context.Context, tx pgx.Tx
 
 	if !canApplyConstraint {
 		og.candidateExpectedCommitErrors.add(pgcode.UniqueViolation)
+	} else {
+		// Otherwise there is still a possibility for an error,
+		// so add it in the potential set, since our validation query
+		// above isn't exhaustive enough.
+		og.potentialCommitErrors.add(pgcode.UniqueViolation)
 	}
 
 	stmt.sql = fmt.Sprintf(


### PR DESCRIPTION
Previously, the ALTER TABLE ADD UNIQUE CONSTRAINT operation could encounter duplicate key errors. This would occur because our scan query was not exhaustive enough. To address this and to help stabilize the workload, we will allow unique violations to be potential commit errors.

Fixes: #129909

Release note: None