### PR TITLE
kv: extract should transfer leader predicate, add test

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -2361,40 +2361,6 @@ func (r *Replica) maybeWatchForMergeLocked(ctx context.Context) (bool, error) {
 	return true, err
 }
 
-// maybeTransferRaftLeadershipToLeaseholderLocked attempts to transfer the
-// leadership away from this node to the leaseholder, if this node is the
-// current raft leader but not the leaseholder. We don't attempt to transfer
-// leadership if the leaseholder is behind on applying the log.
-//
-// We like it when leases and raft leadership are collocated because that
-// facilitates quick command application (requests generally need to make it to
-// both the lease holder and the raft leader before being applied by other
-// replicas).
-func (r *Replica) maybeTransferRaftLeadershipToLeaseholderLocked(
-	ctx context.Context, status kvserverpb.LeaseStatus,
-) {
-	if r.store.TestingKnobs().DisableLeaderFollowsLeaseholder {
-		return
-	}
-	if !r.isRaftLeaderRLocked() { // fast path
-		return
-	}
-	if !status.IsValid() || status.OwnedBy(r.StoreID()) {
-		return
-	}
-	raftStatus := r.raftSparseStatusRLocked()
-	if raftStatus == nil || raftStatus.RaftState != raft.StateLeader {
-		return
-	}
-	lhReplicaID := raftpb.PeerID(status.Lease.Replica.ReplicaID)
-	lhProgress, ok := raftStatus.Progress[lhReplicaID]
-	if (ok && lhProgress.Match >= raftStatus.Commit) || r.store.IsDraining() {
-		log.VEventf(ctx, 1, "transferring raft leadership to replica ID %v", lhReplicaID)
-		r.store.metrics.RangeRaftLeaderTransfers.Inc(1)
-		r.mu.internalRaftGroup.TransferLeader(lhReplicaID)
-	}
-}
-
 func (r *Replica) getReplicaDescriptorByIDRLocked(
 	replicaID roachpb.ReplicaID, fallback roachpb.ReplicaDescriptor,
 ) (roachpb.ReplicaDescriptor, error) {


### PR DESCRIPTION
This commit extracts a `shouldTransferRaftLeadershipToLeaseholderLocked` function from `Replica.maybeTransferRaftLeadershipToLeaseholderLocked` and wraps a unit test around it. This follows the lead of the other `shouldXYZ` functions in replica_raft.go.

It will allow us to confidently modify the logic in a future commit.

One note to reviewers is that now that `RawNode.SparseStatus` is cheap enough on Followers that we no longer need the `isRaftLeaderRLocked` fast-path.

Epic: None
Release note: None