### PR TITLE
opt: do not plan uniqueness checks for partial, hash-sharded indexes

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
@@ -1446,3 +1446,121 @@ vectorized: true
                               columns: (column1, column2)
                               estimated row count: 1
                               label: buffer 1
+
+subtest regression_130334
+
+# Uniqueness constraint checks should not be planned on unique, hash-sharded,
+# partial indexes.
+statement ok
+CREATE TABLE t130334 (
+  a INT
+)
+
+statement ok
+CREATE UNIQUE INDEX ON t130334(a) USING HASH WHERE a IS NOT NULL
+
+query T
+EXPLAIN (VERBOSE)
+INSERT INTO t130334 VALUES (1)
+----
+distribution: local
+vectorized: true
+·
+• insert fast path
+  columns: ()
+  estimated row count: 0 (missing stats)
+  into: t130334(a, rowid, crdb_internal_a_shard_16)
+  auto commit
+  size: 5 columns, 1 row
+  row 0, expr 0: 1
+  row 0, expr 1: unique_rowid()
+  row 0, expr 2: 11
+  row 0, expr 3: true
+  row 0, expr 4: true
+
+query T
+EXPLAIN (VERBOSE)
+UPSERT INTO t130334 VALUES (1)
+----
+distribution: local
+vectorized: true
+·
+• upsert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: t130334(a, rowid, crdb_internal_a_shard_16)
+│ auto commit
+│ arbiter indexes: t130334_pkey
+│
+└── • project
+    │ columns: (column1, rowid_default, crdb_internal_a_shard_16_comp, a, rowid, crdb_internal_a_shard_16, column1, crdb_internal_a_shard_16_comp, rowid, check1, partial_index_put1, partial_index_del1)
+    │
+    └── • render
+        │ columns: (partial_index_put1, partial_index_del1, check1, column1, rowid_default, crdb_internal_a_shard_16_comp, a, rowid, crdb_internal_a_shard_16)
+        │ render partial_index_put1: column1 IS NOT NULL
+        │ render partial_index_del1: a IS NOT NULL
+        │ render check1: crdb_internal_a_shard_16_comp IN (0, 1, __more10_100__, 15)
+        │ render column1: column1
+        │ render rowid_default: rowid_default
+        │ render crdb_internal_a_shard_16_comp: crdb_internal_a_shard_16_comp
+        │ render a: a
+        │ render rowid: rowid
+        │ render crdb_internal_a_shard_16: crdb_internal_a_shard_16
+        │
+        └── • render
+            │ columns: (crdb_internal_a_shard_16, column1, rowid_default, crdb_internal_a_shard_16_comp, a, rowid)
+            │ render crdb_internal_a_shard_16: CASE rowid IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE mod(fnv32(md5(crdb_internal.datums_to_bytes(a))), 16) END
+            │ render column1: column1
+            │ render rowid_default: rowid_default
+            │ render crdb_internal_a_shard_16_comp: crdb_internal_a_shard_16_comp
+            │ render a: a
+            │ render rowid: rowid
+            │
+            └── • lookup join (left outer)
+                │ columns: (column1, rowid_default, crdb_internal_a_shard_16_comp, a, rowid)
+                │ estimated row count: 1 (missing stats)
+                │ table: t130334@t130334_pkey
+                │ equality: (rowid_default) = (rowid)
+                │ equality cols are key
+                │ locking strength: for update
+                │
+                └── • values
+                      columns: (column1, rowid_default, crdb_internal_a_shard_16_comp)
+                      size: 3 columns, 1 row
+                      row 0, expr 0: 1
+                      row 0, expr 1: unique_rowid()
+                      row 0, expr 2: 11
+
+query T
+EXPLAIN (VERBOSE)
+UPDATE t130334 SET a = 1 WHERE true
+----
+distribution: local
+vectorized: true
+·
+• update
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ table: t130334
+│ set: a, crdb_internal_a_shard_16
+│ auto commit
+│
+└── • render
+    │ columns: (a, rowid, crdb_internal_a_shard_16, a_new, crdb_internal_a_shard_16_comp, check1, partial_index_put1, partial_index_del1)
+    │ render partial_index_put1: true
+    │ render partial_index_del1: a IS NOT NULL
+    │ render check1: true
+    │ render crdb_internal_a_shard_16_comp: 11
+    │ render a_new: 1
+    │ render crdb_internal_a_shard_16: mod(fnv32(md5(crdb_internal.datums_to_bytes(a))), 16)
+    │ render a: a
+    │ render rowid: rowid
+    │
+    └── • scan
+          columns: (a, rowid)
+          estimated row count: 1,000 (missing stats)
+          table: t130334@t130334_pkey
+          spans: FULL SCAN
+          locking strength: for update
+
+subtest end


### PR DESCRIPTION
In #74235 we began synthesizing "unique without index" constraints for
tables with unique, hash-sharded indexes. This provides information to
the optimizer that is beneficial in planning, e.g., a unique,
hash-sharded index on the columns `(shard, col)` also holds `col` unique
and the "unique without index" constraint represents this. As a
side-effect, this also caused the optimizer to build uniqueness checks
to uphold these "unique without indexes".

In the case of a non-partial, unique, hash-sharded index, the optimizer
eliminates the post-query uniqueness checks. It builds a scan expression
and uses the functional dependencies derived via the hash-sharded index,
and the knowledge that the shard column is dependent on the index
columns to determine that the physical index guarantees uniqueness of
the "unique without index" (see `uniqueCheckHelper.init` for details).

However, the uniqueness check could not be eliminate for a partial,
unique, hash-sharded index even though they are upheld by the physical
hash-sharded indexes and thus are unnecessary. The checks remained in
the query plan because a scan's FDs cannot include any information
derived from a partial index—partial constraints only apply to a subset
of rows in the table, not the entire table (#67959 tracks one potential
solution for this).

These unnecessary checks added overhead to mutations on tables with
these types of indexes. Also, under read-committed isolation they caused
mutations to fail with the error "explicit unique checks are not yet
supported under read committed isolation" due to #110873.

This commit eliminates the uniqueness checks by using the existing
knowledge that the synthesized "unique without index" constraint is
upheld by a physical index, and simply not building the post-query
checks.

Fixes #130334

Release note (bug fix): A bug has been fixed that the optimizer to plan
unnecessary post-query uniqueness checks during `INSERT`, `UPSERT`, and
`UPDATE` statements on tables with partial, unique, hash-sharded
indexes. These unnecessary checks added overhead to execution of these
statements, and caused the statements to error when executed under
read-committed isolation.
