### PR TITLE
kv: synchronize between leader lease acquisition and leadership transfers

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -2538,8 +2538,10 @@ func (r *Replica) maybeTransferRaftLeadershipToLeaseholderLocked(
 	if r.store.TestingKnobs().DisableLeaderFollowsLeaseholder {
 		return
 	}
+	raftStatus := r.mu.internalRaftGroup.SparseStatus()
+	leaseAcquisitionPending := r.mu.pendingLeaseRequest.AcquisitionInProgress()
 	ok := shouldTransferRaftLeadershipToLeaseholderLocked(
-		r.mu.internalRaftGroup.SparseStatus(), leaseStatus, r.StoreID(), r.store.IsDraining())
+		raftStatus, leaseStatus, leaseAcquisitionPending, r.StoreID(), r.store.IsDraining())
 	if ok {
 		lhReplicaID := raftpb.PeerID(leaseStatus.Lease.Replica.ReplicaID)
 		log.VEventf(ctx, 1, "transferring raft leadership to replica ID %v", lhReplicaID)
@@ -2551,6 +2553,7 @@ func (r *Replica) maybeTransferRaftLeadershipToLeaseholderLocked(
 func shouldTransferRaftLeadershipToLeaseholderLocked(
 	raftStatus raft.SparseStatus,
 	leaseStatus kvserverpb.LeaseStatus,
+	leaseAcquisitionPending bool,
 	storeID roachpb.StoreID,
 	draining bool,
 ) bool {
@@ -2562,6 +2565,30 @@ func shouldTransferRaftLeadershipToLeaseholderLocked(
 	// The status is invalid or its owned locally, there's nothing to do.
 	// Otherwise, the lease is valid and owned by another store.
 	if !leaseStatus.IsValid() || leaseStatus.OwnedBy(storeID) {
+		return false
+	}
+
+	// If there is an attempt to acquire the lease in progress, we don't want to
+	// transfer leadership away. This is more than just an optimization. If we
+	// were to transfer away leadership while a lease request was in progress, we
+	// may end up acquiring a leader lease after leadership has been transferred
+	// away. Or worse, the leader lease acquisition may succeed and then at some
+	// later point, the leadership transfer could succeed, leading to leadership
+	// being stolen out from under the leader lease. This second case could lead
+	// to a lease expiration regression, as the leadership term would end before
+	// lead support had expired.
+	//
+	// This same form of race is not possible if the lease is transferred to us as
+	// raft leader, because lease transfers always send targets expiration-based
+	// leases and never leader leases.
+	//
+	// NOTE: this check may be redundant with the lease validity check above, as a
+	// replica will not attempt to acquire a valid lease. We include it anyway for
+	// defense-in-depth and so that the proper synchronization between leader
+	// leases and leadership transfer makes fewer assumptions. A leader holding
+	// a leader lease must never transfer leadership away before transferring the
+	// lease away first.
+	if leaseAcquisitionPending {
 		return false
 	}
 

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -228,8 +228,8 @@ type pendingLeaseRequest struct {
 	// All accesses require repl.mu to be exclusively locked.
 	llHandles map[*leaseRequestHandle]struct{}
 	// nextLease is the pending RequestLease request, if any. It can be used to
-	// figure out if we're in the process of extending our own lease, or
-	// transferring it to another replica.
+	// figure out if we're in the process of acquiring our own lease, extending
+	// our own lease, or transferring it to another replica.
 	nextLease roachpb.Lease
 }
 
@@ -240,12 +240,47 @@ func makePendingLeaseRequest(repl *Replica) pendingLeaseRequest {
 	}
 }
 
-// RequestPending returns the pending Lease, if one is in progress.
-// The second return val is true if a lease request is pending.
+// RequestPending returns the pending Lease, if one is in the process of being
+// acquired, extended, or transferred. The second return val is true if a lease
+// request is pending.
 //
 // Requires repl.mu is read locked.
 func (p *pendingLeaseRequest) RequestPending() (roachpb.Lease, bool) {
 	return p.nextLease, p.nextLease != roachpb.Lease{}
+}
+
+// AcquisitionInProgress returns whether the replica is in the process of
+// acquiring a range lease for itself. Lease extensions do not count as
+// acquisitions.
+//
+// Requires repl.mu is read locked.
+func (p *pendingLeaseRequest) AcquisitionInProgress() bool {
+	if nextLease, ok := p.RequestPending(); ok {
+		// Is the lease being acquired? (as opposed to extended or transferred)
+		prevLocal := p.repl.ReplicaID() == p.repl.mu.state.Lease.Replica.ReplicaID
+		nextLocal := p.repl.ReplicaID() == nextLease.Replica.ReplicaID
+		return !prevLocal && nextLocal
+	}
+	return false
+}
+
+// TransferInProgress returns whether the replica is in the process of
+// transferring away its range lease. Note that the return values are
+// best-effort and shouldn't be relied upon for correctness: if a previous
+// transfer has returned an error, TransferInProgress will return `false`, but
+// that doesn't necessarily mean that the transfer cannot still apply (see
+// replica.mu.minLeaseProposedTS).
+//
+// It is assumed that the replica owning this pendingLeaseRequest owns the
+// lease.
+//
+// Requires repl.mu is read locked.
+func (p *pendingLeaseRequest) TransferInProgress() bool {
+	if nextLease, ok := p.RequestPending(); ok {
+		// Is the lease being transferred? (as opposed to just extended)
+		return p.repl.ReplicaID() != nextLease.Replica.ReplicaID
+	}
+	return false
 }
 
 // InitOrJoinRequest executes a RequestLease command asynchronously and returns a
@@ -622,25 +657,6 @@ func (p *pendingLeaseRequest) JoinRequest() *leaseRequestHandle {
 	}
 	p.llHandles[llHandle] = struct{}{}
 	return llHandle
-}
-
-// TransferInProgress returns whether the replica is in the process of
-// transferring away its range lease. Note that the return values are
-// best-effort and shouldn't be relied upon for correctness: if a previous
-// transfer has returned an error, TransferInProgress will return `false`, but
-// that doesn't necessarily mean that the transfer cannot still apply (see
-// replica.mu.minLeaseProposedTS).
-//
-// It is assumed that the replica owning this pendingLeaseRequest owns the
-// lease.
-//
-// Requires repl.mu is read locked.
-func (p *pendingLeaseRequest) TransferInProgress() bool {
-	if nextLease, ok := p.RequestPending(); ok {
-		// Is the lease being transferred? (as opposed to just extended)
-		return p.repl.ReplicaID() != nextLease.Replica.ReplicaID
-	}
-	return false
 }
 
 // newHandle creates a new leaseRequestHandle referencing the pending lease

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -715,12 +715,7 @@ func TestBehaviorDuringLeaseTransfer(t *testing.T) {
 		<-transferSem
 		// Check that a transfer is indeed on-going.
 		tc.repl.mu.Lock()
-		repDesc, err := tc.repl.getReplicaDescriptorRLocked()
-		if err != nil {
-			tc.repl.mu.Unlock()
-			t.Fatal(err)
-		}
-		pending := tc.repl.mu.pendingLeaseRequest.TransferInProgress(repDesc.ReplicaID)
+		pending := tc.repl.mu.pendingLeaseRequest.TransferInProgress()
 		tc.repl.mu.Unlock()
 		if !pending {
 			t.Fatalf("expected transfer to be in progress, and it wasn't")
@@ -761,7 +756,7 @@ func TestBehaviorDuringLeaseTransfer(t *testing.T) {
 		testutils.SucceedsSoon(t, func() error {
 			tc.repl.mu.Lock()
 			defer tc.repl.mu.Unlock()
-			pending := tc.repl.mu.pendingLeaseRequest.TransferInProgress(repDesc.ReplicaID)
+			pending := tc.repl.mu.pendingLeaseRequest.TransferInProgress()
 			if pending {
 				return errors.New("transfer pending")
 			}


### PR DESCRIPTION
Fixes #129807.

This commit adds synchronization between leader lease acquisition and leadership transfers, ensuring that a raft leader holding a leader lease will never transfer leadership away. Doing so could lead to a lease expiration regression, as the leadership term would end before lead support had expired.

This property is built on top of two new restrictions:
1. a raft leader will never begin to acquire (or promote to) a leader lease if is in the process of transferring away raft leadership.
2. a raft leader will never begin to transfer away raft leadership if it is in the process of acquire a lease.

Release note: None