### PR TITLE
replica_rac2: fix unprotected RangeController ref

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -988,7 +988,7 @@ func (p *processorImpl) AdmitForEval(
 		p.opts.EvalWaitMetrics.OnBypassed(workClass, 0 /* duration */)
 		return false, nil
 	}
-	return p.mu.leader.rc.WaitForEval(ctx, pri)
+	return rc.WaitForEval(ctx, pri)
 }
 
 func admittedIncreased(prev, next [raftpb.NumPriorities]uint64) bool {


### PR DESCRIPTION
The `p.mu.leader.rc` field can not be accessed without holding one of the mutexes protecting it. Use the cached `rd` variable.

Epic: none
Release note: none