### PR TITLE
scripts: allow secure clusters in pprof-loop

### DIFF
--- a/scripts/pprof-loop.sh
+++ b/scripts/pprof-loop.sh
@@ -8,6 +8,12 @@ block, fetches at 1s intervals.
 
 See https://pkg.go.dev/runtime/pprof for details.
 
+For secure clusters, invoke this script with an auth cookie in the
+PPROF_LOOP_COOKIE env var. A cookie can be obtained via:
+
+  cockroach auth-session login root \
+    --certs-dir=certs --only-cookie --expire-after 24h
+
 Usage:
 
 $0 'http://localhost:8080/debug/pprof/allocs'
@@ -48,7 +54,7 @@ while true; do
 	# Be resilient to spurious pprof failures but make sure
 	# to bail eagerly on first time since probably the URL
 	# is just wrong etc.
-	if ! curl --no-progress-meter "${1}" > "${f}"; then
+	if ! curl -k --cookie "${PPROF_LOOP_COOKIE-}" --no-progress-meter "${1}" > "${f}"; then
 		if [ $first -eq 1 ]; then
 			exit 1
 		fi


### PR DESCRIPTION
Epic: none
Release note: None
