### PR TITLE
stop: annotate tasks with `trace.Region`

### DIFF
--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -322,7 +322,18 @@ func (s *Stopper) RunTask(ctx context.Context, taskName string, f func(context.C
 	return nil
 }
 
-func (s *Stopper) startRegion(ctx context.Context, taskName string) *trace.Region {
+type region interface {
+	End()
+}
+
+type noopRegion struct{}
+
+func (n noopRegion) End() {}
+
+func (s *Stopper) startRegion(ctx context.Context, taskName string) region {
+	if !trace.IsEnabled() {
+		return noopRegion{}
+	}
 	return trace.StartRegion(ctx, taskName)
 }
 


### PR DESCRIPTION
From the docs[^1]:

> A region is for logging a time interval during a goroutine's
> execution. By definition, a region starts and ends in the same
> goroutine. Regions can be nested to represent subintervals.

`StartRegion` is a no-op when no execution trace is ongoing[^2]. It does
make one small allocation otherwise, which is a little silly since a
better API could have avoided it.

The result of this change is that execution traces are easier
to inspect visually, as many goroutines in the system will
now state their purpose (the task name) as opposed to looking
like yet another opaque "(*Stopper).RunAsyncTaskEx.func2".

![](https://github.com/user-attachments/assets/f6c20a1a-01da-4ef1-b0f8-edea3132e21c)



Sadly, goroutines that tagged their region before the execution
trace begins will not reflect their region. So, for example, a
`(*raftSchedulerShard).worker`, despite running inside of a task,
will not have a region attached to it (since the `StartRegion`
call happened at server start,  before the execution trace began).

[^1]: https://pkg.go.dev/runtime/trace#hdr-User_annotation
[^2]: https://cs.opensource.google/go/go/+/refs/tags/go1.23.1:src/runtime/trace/annotation.go;l=144-159

Epic: none
Release note: None
