### PR TITLE
opt: make invalid isolation error more readable in tests

### DIFF
--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -1164,7 +1164,7 @@ func (f *Flags) Set(arg datadriven.CmdArg) error {
 		level, ok := isolation.Level_value[arg.Vals[0]]
 		if !ok {
 			return fmt.Errorf(
-				"invalid isolation level (must be found in %v): %v", isolation.Level_value, arg.Vals[0],
+				"invalid isolation level %q, must be one of %s", arg.Vals[0], isolation.Levels(),
 			)
 		}
 		f.TxnIsoLevel = isolation.Level(level)


### PR DESCRIPTION
The error message when using an invalid `isolation` option in an opt
test now prints a more readable message. It previously read:

    invalid isolation level (must be found in map[ReadCommitted:2 Serializable:0 Snapshot:1]): foo

And it now reads:

    invalid isolation level "foo", must be one of [Serializable Snapshot ReadCommitted]

Release note: None
