### PR TITLE
kvserver: acquire raft mu before calling RaftMuLocked method

### DIFF
--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -303,8 +303,8 @@ func (tc *testContext) addBogusReplicaToRangeDesc(
 		return roachpb.ReplicaDescriptor{}, err
 	}
 
-	tc.repl.setDescRaftMuLocked(ctx, &newDesc)
 	tc.repl.raftMu.Lock()
+	tc.repl.setDescRaftMuLocked(ctx, &newDesc)
 	tc.repl.mu.RLock()
 	tc.repl.assertStateRaftMuLockedReplicaMuRLocked(ctx, tc.engine)
 	tc.repl.mu.RUnlock()


### PR DESCRIPTION
`testContext.addBogusReplicaToRangeDesc()` is used to add a fake replica to the range descriptor for testing.
`setDescRaftMuLocked` is called to update the range descriptor but previously didn't acquire the `raftMu` before doing so.

Acquire the `raftMu` before calling `setDescRaftMuLocked` to avoid inconsistent locking.

Fixes: #130406
Release note: None