### PR TITLE
schemachanger: support partition zone config

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -528,7 +528,7 @@ statement ok
 ALTER partition "us-east-1" of index regional_by_row@regional_by_row_pkey CONFIGURE ZONE USING num_replicas = 10;
 
 statement ok
-SET override_multi_region_zone_config = false
+SET override_multi_region_zone_config = false;
 
 query TTT
 SELECT ZONE_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row]

--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -1300,3 +1300,21 @@ DATABASE foo  ALTER DATABASE foo CONFIGURE ZONE USING
                 lease_preferences = '[]'
 
 subtest end
+
+subtest bad_partition
+
+statement ok
+CREATE TABLE fooba(pk INT PRIMARY KEY, i INT)
+
+statement ok
+ALTER TABLE fooba PARTITION BY LIST (pk) (PARTITION "one" VALUES IN (1), PARTITION "rest" VALUES IN (DEFAULT));
+
+# Configure the zone of a partition that does not exist.
+statement error partition "cadr" does not exist on index "fooba_pkey"
+ALTER PARTITION cadr OF INDEX fooba@fooba_pkey CONFIGURE ZONE USING num_replicas = 1;
+
+# Configure the zone of a partition on an index that does not exist.
+statement error index "nonexistent" (?:not found in relation "fooba"|does not exist)
+ALTER PARTITION rest OF INDEX fooba@nonexistent CONFIGURE ZONE USING num_replicas = 1;
+
+subtest end

--- a/pkg/ccl/schemachangerccl/ccl_generated_test.go
+++ b/pkg/ccl/schemachangerccl/ccl_generated_test.go
@@ -29,6 +29,20 @@ func TestBackupRollbacks_ccl_alter_index_configure_zone_multiple(t *testing.T) {
 	sctest.BackupRollbacks(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestBackupRollbacks_ccl_alter_partition_configure_zone(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone"
+	sctest.BackupRollbacks(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestBackupRollbacks_ccl_alter_partition_configure_zone_multiple(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple"
+	sctest.BackupRollbacks(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestBackupRollbacks_ccl_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -68,6 +82,20 @@ func TestBackupRollbacksMixedVersion_ccl_alter_index_configure_zone_multiple(t *
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_index_configure_zone_multiple"
+	sctest.BackupRollbacksMixedVersion(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_ccl_alter_partition_configure_zone(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone"
+	sctest.BackupRollbacksMixedVersion(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_ccl_alter_partition_configure_zone_multiple(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple"
 	sctest.BackupRollbacksMixedVersion(t, path, MultiRegionTestClusterFactory{})
 }
 
@@ -113,6 +141,20 @@ func TestBackupSuccess_ccl_alter_index_configure_zone_multiple(t *testing.T) {
 	sctest.BackupSuccess(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestBackupSuccess_ccl_alter_partition_configure_zone(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone"
+	sctest.BackupSuccess(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestBackupSuccess_ccl_alter_partition_configure_zone_multiple(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple"
+	sctest.BackupSuccess(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestBackupSuccess_ccl_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -152,6 +194,20 @@ func TestBackupSuccessMixedVersion_ccl_alter_index_configure_zone_multiple(t *te
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_index_configure_zone_multiple"
+	sctest.BackupSuccessMixedVersion(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_ccl_alter_partition_configure_zone(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone"
+	sctest.BackupSuccessMixedVersion(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_ccl_alter_partition_configure_zone_multiple(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple"
 	sctest.BackupSuccessMixedVersion(t, path, MultiRegionTestClusterFactory{})
 }
 
@@ -197,6 +253,20 @@ func TestEndToEndSideEffects_ccl_alter_index_configure_zone_multiple(t *testing.
 	sctest.EndToEndSideEffects(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_ccl_alter_partition_configure_zone(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone"
+	sctest.EndToEndSideEffects(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestEndToEndSideEffects_ccl_alter_partition_configure_zone_multiple(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple"
+	sctest.EndToEndSideEffects(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_ccl_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -236,6 +306,20 @@ func TestExecuteWithDMLInjection_ccl_alter_index_configure_zone_multiple(t *test
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_index_configure_zone_multiple"
+	sctest.ExecuteWithDMLInjection(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_ccl_alter_partition_configure_zone(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone"
+	sctest.ExecuteWithDMLInjection(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_ccl_alter_partition_configure_zone_multiple(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple"
 	sctest.ExecuteWithDMLInjection(t, path, MultiRegionTestClusterFactory{})
 }
 
@@ -281,6 +365,20 @@ func TestGenerateSchemaChangeCorpus_ccl_alter_index_configure_zone_multiple(t *t
 	sctest.GenerateSchemaChangeCorpus(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_ccl_alter_partition_configure_zone(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone"
+	sctest.GenerateSchemaChangeCorpus(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestGenerateSchemaChangeCorpus_ccl_alter_partition_configure_zone_multiple(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple"
+	sctest.GenerateSchemaChangeCorpus(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_ccl_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -320,6 +418,20 @@ func TestPause_ccl_alter_index_configure_zone_multiple(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_index_configure_zone_multiple"
+	sctest.Pause(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestPause_ccl_alter_partition_configure_zone(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone"
+	sctest.Pause(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestPause_ccl_alter_partition_configure_zone_multiple(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple"
 	sctest.Pause(t, path, MultiRegionTestClusterFactory{})
 }
 
@@ -365,6 +477,20 @@ func TestPauseMixedVersion_ccl_alter_index_configure_zone_multiple(t *testing.T)
 	sctest.PauseMixedVersion(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_ccl_alter_partition_configure_zone(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone"
+	sctest.PauseMixedVersion(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestPauseMixedVersion_ccl_alter_partition_configure_zone_multiple(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple"
+	sctest.PauseMixedVersion(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_ccl_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -404,6 +530,20 @@ func TestRollback_ccl_alter_index_configure_zone_multiple(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_index_configure_zone_multiple"
+	sctest.Rollback(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestRollback_ccl_alter_partition_configure_zone(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone"
+	sctest.Rollback(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestRollback_ccl_alter_partition_configure_zone_multiple(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple"
 	sctest.Rollback(t, path, MultiRegionTestClusterFactory{})
 }
 

--- a/pkg/ccl/schemachangerccl/testdata/decomp/multiregion
+++ b/pkg/ccl/schemachangerccl/testdata/decomp/multiregion
@@ -1062,7 +1062,6 @@ ElementState:
   Status: PUBLIC
 - IndexZoneConfig:
     indexId: 1
-    partitionName: us-east1
     seqNum: 0
     subzone:
       config:
@@ -1096,7 +1095,6 @@ ElementState:
   Status: PUBLIC
 - IndexZoneConfig:
     indexId: 1
-    partitionName: us-east2
     seqNum: 0
     subzone:
       config:
@@ -1130,7 +1128,6 @@ ElementState:
   Status: PUBLIC
 - IndexZoneConfig:
     indexId: 1
-    partitionName: us-east3
     seqNum: 0
     subzone:
       config:
@@ -1171,6 +1168,108 @@ ElementState:
 - Owner:
     descriptorId: 108
     owner: root
+  Status: PUBLIC
+- PartitionZoneConfig:
+    indexId: 1
+    partitionName: us-east1
+    seqNum: 0
+    subzone:
+      config:
+        constraints: []
+        gc: null
+        globalReads: null
+        inheritedConstraints: true
+        inheritedLeasePreferences: false
+        leasePreferences:
+        - constraints:
+          - key: region
+            type: REQUIRED
+            value: us-east1
+        nullVoterConstraintsIsEmpty: true
+        numReplicas: null
+        numVoters: 5
+        rangeMaxBytes: null
+        rangeMinBytes: null
+        subzoneSpans: []
+        subzones: []
+        voterConstraints:
+        - constraints:
+          - key: region
+            type: REQUIRED
+            value: us-east1
+          numReplicas: 2
+      indexId: 1
+      partitionName: us-east1
+    subzoneSpans: []
+    tableId: 108
+  Status: PUBLIC
+- PartitionZoneConfig:
+    indexId: 1
+    partitionName: us-east2
+    seqNum: 0
+    subzone:
+      config:
+        constraints: []
+        gc: null
+        globalReads: null
+        inheritedConstraints: true
+        inheritedLeasePreferences: false
+        leasePreferences:
+        - constraints:
+          - key: region
+            type: REQUIRED
+            value: us-east2
+        nullVoterConstraintsIsEmpty: true
+        numReplicas: null
+        numVoters: 5
+        rangeMaxBytes: null
+        rangeMinBytes: null
+        subzoneSpans: []
+        subzones: []
+        voterConstraints:
+        - constraints:
+          - key: region
+            type: REQUIRED
+            value: us-east2
+          numReplicas: 2
+      indexId: 1
+      partitionName: us-east2
+    subzoneSpans: []
+    tableId: 108
+  Status: PUBLIC
+- PartitionZoneConfig:
+    indexId: 1
+    partitionName: us-east3
+    seqNum: 0
+    subzone:
+      config:
+        constraints: []
+        gc: null
+        globalReads: null
+        inheritedConstraints: true
+        inheritedLeasePreferences: false
+        leasePreferences:
+        - constraints:
+          - key: region
+            type: REQUIRED
+            value: us-east3
+        nullVoterConstraintsIsEmpty: true
+        numReplicas: null
+        numVoters: 5
+        rangeMaxBytes: null
+        rangeMinBytes: null
+        subzoneSpans: []
+        subzones: []
+        voterConstraints:
+        - constraints:
+          - key: region
+            type: REQUIRED
+            value: us-east3
+          numReplicas: 2
+      indexId: 1
+      partitionName: us-east3
+    subzoneSpans: []
+    tableId: 108
   Status: PUBLIC
 - PrimaryIndex:
     constraintId: 1

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone/alter_partition_configure_zone.definition
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone/alter_partition_configure_zone.definition
@@ -1,0 +1,13 @@
+setup
+CREATE TABLE t (
+    id INT PRIMARY KEY,
+    data STRING
+) PARTITION BY LIST (id) (
+    PARTITION p1 VALUES IN (1, 2, 3),
+    PARTITION p2 VALUES IN (4, 5, 6)
+);
+----
+
+test
+ALTER PARTITION p1 OF INDEX t@t_pkey CONFIGURE ZONE USING num_replicas = 7, gc.ttlseconds = 10000;
+----

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone/alter_partition_configure_zone.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone/alter_partition_configure_zone.explain
@@ -1,0 +1,30 @@
+/* setup */
+CREATE TABLE t (
+    id INT PRIMARY KEY,
+    data STRING
+) PARTITION BY LIST (id) (
+    PARTITION p1 VALUES IN (1, 2, 3),
+    PARTITION p2 VALUES IN (4, 5, 6)
+);
+
+/* test */
+EXPLAIN (DDL) ALTER PARTITION p1 OF INDEX t@t_pkey CONFIGURE ZONE USING num_replicas = 7, gc.ttlseconds = 10000;
+----
+Schema change plan for ALTER PARTITION ‹p1› OF INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹num_replicas› = ‹7›, ‹"gc.ttlseconds"› = ‹10000›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 1, PartitionName: "p1"}
+ │         └── 1 Mutation operation
+ │              └── AddPartitionZoneConfig {"TableID":104}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── PUBLIC → ABSENT PartitionZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 1, PartitionName: "p1"}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 1 element transitioning toward PUBLIC
+           │    └── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 1, PartitionName: "p1"}
+           └── 1 Mutation operation
+                └── AddPartitionZoneConfig {"TableID":104}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone/alter_partition_configure_zone.explain_shape
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone/alter_partition_configure_zone.explain_shape
@@ -1,0 +1,14 @@
+/* setup */
+CREATE TABLE t (
+    id INT PRIMARY KEY,
+    data STRING
+) PARTITION BY LIST (id) (
+    PARTITION p1 VALUES IN (1, 2, 3),
+    PARTITION p2 VALUES IN (4, 5, 6)
+);
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER PARTITION p1 OF INDEX t@t_pkey CONFIGURE ZONE USING num_replicas = 7, gc.ttlseconds = 10000;
+----
+Schema change plan for ALTER PARTITION ‹p1› OF INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹num_replicas› = ‹7›, ‹"gc.ttlseconds"› = ‹10000›;
+ └── execute 1 system table mutations transaction

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone/alter_partition_configure_zone.side_effects
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone/alter_partition_configure_zone.side_effects
@@ -1,0 +1,38 @@
+/* setup */
+CREATE TABLE t (
+    id INT PRIMARY KEY,
+    data STRING
+) PARTITION BY LIST (id) (
+    PARTITION p1 VALUES IN (1, 2, 3),
+    PARTITION p2 VALUES IN (4, 5, 6)
+);
+----
+...
++object {100 101 t} -> 104
+
+/* test */
+ALTER PARTITION p1 OF INDEX t@t_pkey CONFIGURE ZONE USING num_replicas = 7, gc.ttlseconds = 10000;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: CONFIGURE ZONE
+write *eventpb.AlterTable to event log:
+  mutationId: 1
+  sql:
+    descriptorId: 104
+    statement: ALTER PARTITION ‹p1› OF INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹num_replicas› = ‹7›, ‹"gc.ttlseconds"› = ‹10000›
+    tag: CONFIGURE ZONE
+    user: root
+  tableName: defaultdb.public.t
+## StatementPhase stage 1 of 1 with 1 MutationType op
+upsert zone config for #104
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 1 MutationType op
+upsert zone config for #104
+persist all catalog changes to storage
+# end PreCommitPhase
+commit transaction #1

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple/alter_partition_configure_zone_multiple.definition
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple/alter_partition_configure_zone_multiple.definition
@@ -1,0 +1,20 @@
+setup
+CREATE TABLE t (
+    id INT PRIMARY KEY,
+    data INT,
+    INDEX idx (data) PARTITION BY LIST (data) (
+        PARTITION p1 VALUES IN (10, 20, 30),
+        PARTITION p2 VALUES IN (40, 50, 60)
+    )
+) PARTITION BY LIST (id) (
+    PARTITION p3 VALUES IN (1, 2, 3),
+    PARTITION p4 VALUES IN (4, 5, 6)
+);
+----
+
+test
+ALTER PARTITION p3 OF INDEX t@t_pkey CONFIGURE ZONE USING num_replicas = 7;
+ALTER PARTITION p3 OF INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 10000;
+ALTER PARTITION p1 OF INDEX t@idx CONFIGURE ZONE USING gc.ttlseconds = 12000;
+ALTER PARTITION p3 OF INDEX t@t_pkey CONFIGURE ZONE USING num_replicas = 10;
+----

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple/alter_partition_configure_zone_multiple.side_effects
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple/alter_partition_configure_zone_multiple.side_effects
@@ -1,0 +1,78 @@
+/* setup */
+CREATE TABLE t (
+    id INT PRIMARY KEY,
+    data INT,
+    INDEX idx (data) PARTITION BY LIST (data) (
+        PARTITION p1 VALUES IN (10, 20, 30),
+        PARTITION p2 VALUES IN (40, 50, 60)
+    )
+) PARTITION BY LIST (id) (
+    PARTITION p3 VALUES IN (1, 2, 3),
+    PARTITION p4 VALUES IN (4, 5, 6)
+);
+----
+...
++object {100 101 t} -> 104
+
+/* test */
+ALTER PARTITION p3 OF INDEX t@t_pkey CONFIGURE ZONE USING num_replicas = 7;
+ALTER PARTITION p3 OF INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 10000;
+ALTER PARTITION p1 OF INDEX t@idx CONFIGURE ZONE USING gc.ttlseconds = 12000;
+ALTER PARTITION p3 OF INDEX t@t_pkey CONFIGURE ZONE USING num_replicas = 10;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: CONFIGURE ZONE
+write *eventpb.AlterTable to event log:
+  mutationId: 1
+  sql:
+    descriptorId: 104
+    statement: ALTER PARTITION ‹p3› OF INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹num_replicas› = ‹7›
+    tag: CONFIGURE ZONE
+    user: root
+  tableName: defaultdb.public.t
+## StatementPhase stage 1 of 1 with 1 MutationType op
+upsert zone config for #104
+checking for feature: CONFIGURE ZONE
+write *eventpb.AlterTable to event log:
+  mutationId: 1
+  sql:
+    descriptorId: 104
+    statement: ALTER PARTITION ‹p3› OF INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹10000›
+    tag: CONFIGURE ZONE
+    user: root
+  tableName: defaultdb.public.t
+## StatementPhase stage 1 of 1 with 1 MutationType op
+upsert zone config for #104
+checking for feature: CONFIGURE ZONE
+write *eventpb.AlterTable to event log:
+  mutationId: 1
+  sql:
+    descriptorId: 104
+    statement: ALTER PARTITION ‹p1› OF INDEX ‹defaultdb›.‹public›.‹t›@‹idx› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹12000›
+    tag: CONFIGURE ZONE
+    user: root
+  tableName: defaultdb.public.t
+## StatementPhase stage 1 of 1 with 1 MutationType op
+upsert zone config for #104
+checking for feature: CONFIGURE ZONE
+write *eventpb.AlterTable to event log:
+  mutationId: 1
+  sql:
+    descriptorId: 104
+    statement: ALTER PARTITION ‹p3› OF INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹num_replicas› = ‹10›
+    tag: CONFIGURE ZONE
+    user: root
+  tableName: defaultdb.public.t
+## StatementPhase stage 1 of 1 with 1 MutationType op
+upsert zone config for #104
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 4 MutationType ops
+upsert zone config for #104
+persist all catalog changes to storage
+# end PreCommitPhase
+commit transaction #1

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple/alter_partition_configure_zone_multiple__statement_1_of_4.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple/alter_partition_configure_zone_multiple__statement_1_of_4.explain
@@ -1,0 +1,34 @@
+/* setup */
+CREATE TABLE t (
+    id INT PRIMARY KEY,
+    data INT,
+    INDEX idx (data) PARTITION BY LIST (data) (
+        PARTITION p1 VALUES IN (10, 20, 30),
+        PARTITION p2 VALUES IN (40, 50, 60)
+    )
+) PARTITION BY LIST (id) (
+    PARTITION p3 VALUES IN (1, 2, 3),
+    PARTITION p4 VALUES IN (4, 5, 6)
+);
+
+/* test */
+EXPLAIN (DDL) ALTER PARTITION p3 OF INDEX t@t_pkey CONFIGURE ZONE USING num_replicas = 7;
+----
+Schema change plan for ALTER PARTITION ‹p3› OF INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹num_replicas› = ‹7›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 1, PartitionName: "p3"}
+ │         └── 1 Mutation operation
+ │              └── AddPartitionZoneConfig {"TableID":104}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── PUBLIC → ABSENT PartitionZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 1, PartitionName: "p3"}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 1 element transitioning toward PUBLIC
+           │    └── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 1, PartitionName: "p3"}
+           └── 1 Mutation operation
+                └── AddPartitionZoneConfig {"TableID":104}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple/alter_partition_configure_zone_multiple__statement_1_of_4.explain_shape
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple/alter_partition_configure_zone_multiple__statement_1_of_4.explain_shape
@@ -1,0 +1,18 @@
+/* setup */
+CREATE TABLE t (
+    id INT PRIMARY KEY,
+    data INT,
+    INDEX idx (data) PARTITION BY LIST (data) (
+        PARTITION p1 VALUES IN (10, 20, 30),
+        PARTITION p2 VALUES IN (40, 50, 60)
+    )
+) PARTITION BY LIST (id) (
+    PARTITION p3 VALUES IN (1, 2, 3),
+    PARTITION p4 VALUES IN (4, 5, 6)
+);
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER PARTITION p3 OF INDEX t@t_pkey CONFIGURE ZONE USING num_replicas = 7;
+----
+Schema change plan for ALTER PARTITION ‹p3› OF INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹num_replicas› = ‹7›;
+ └── execute 1 system table mutations transaction

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple/alter_partition_configure_zone_multiple__statement_2_of_4.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple/alter_partition_configure_zone_multiple__statement_2_of_4.explain
@@ -1,0 +1,38 @@
+/* setup */
+CREATE TABLE t (
+    id INT PRIMARY KEY,
+    data INT,
+    INDEX idx (data) PARTITION BY LIST (data) (
+        PARTITION p1 VALUES IN (10, 20, 30),
+        PARTITION p2 VALUES IN (40, 50, 60)
+    )
+) PARTITION BY LIST (id) (
+    PARTITION p3 VALUES IN (1, 2, 3),
+    PARTITION p4 VALUES IN (4, 5, 6)
+);
+
+/* test */
+ALTER PARTITION p3 OF INDEX t@t_pkey CONFIGURE ZONE USING num_replicas = 7;
+EXPLAIN (DDL) ALTER PARTITION p3 OF INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 10000;
+----
+Schema change plan for ALTER PARTITION ‹p3› OF INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹10000›; following ALTER PARTITION ‹p3› OF INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹num_replicas› = ‹7›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 2, PartitionName: "p3"}
+ │         └── 1 Mutation operation
+ │              └── AddPartitionZoneConfig {"TableID":104}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── PUBLIC → ABSENT PartitionZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 1, PartitionName: "p3"}
+      │    │    └── PUBLIC → ABSENT PartitionZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 2, PartitionName: "p3"}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 2 elements transitioning toward PUBLIC
+           │    ├── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 1, PartitionName: "p3"}
+           │    └── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 2, PartitionName: "p3"}
+           └── 2 Mutation operations
+                ├── AddPartitionZoneConfig {"TableID":104}
+                └── AddPartitionZoneConfig {"TableID":104}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple/alter_partition_configure_zone_multiple__statement_2_of_4.explain_shape
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple/alter_partition_configure_zone_multiple__statement_2_of_4.explain_shape
@@ -1,0 +1,19 @@
+/* setup */
+CREATE TABLE t (
+    id INT PRIMARY KEY,
+    data INT,
+    INDEX idx (data) PARTITION BY LIST (data) (
+        PARTITION p1 VALUES IN (10, 20, 30),
+        PARTITION p2 VALUES IN (40, 50, 60)
+    )
+) PARTITION BY LIST (id) (
+    PARTITION p3 VALUES IN (1, 2, 3),
+    PARTITION p4 VALUES IN (4, 5, 6)
+);
+
+/* test */
+ALTER PARTITION p3 OF INDEX t@t_pkey CONFIGURE ZONE USING num_replicas = 7;
+EXPLAIN (DDL, SHAPE) ALTER PARTITION p3 OF INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 10000;
+----
+Schema change plan for ALTER PARTITION ‹p3› OF INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹10000›; following ALTER PARTITION ‹p3› OF INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹num_replicas› = ‹7›;
+ └── execute 1 system table mutations transaction

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple/alter_partition_configure_zone_multiple__statement_3_of_4.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple/alter_partition_configure_zone_multiple__statement_3_of_4.explain
@@ -1,0 +1,42 @@
+/* setup */
+CREATE TABLE t (
+    id INT PRIMARY KEY,
+    data INT,
+    INDEX idx (data) PARTITION BY LIST (data) (
+        PARTITION p1 VALUES IN (10, 20, 30),
+        PARTITION p2 VALUES IN (40, 50, 60)
+    )
+) PARTITION BY LIST (id) (
+    PARTITION p3 VALUES IN (1, 2, 3),
+    PARTITION p4 VALUES IN (4, 5, 6)
+);
+
+/* test */
+ALTER PARTITION p3 OF INDEX t@t_pkey CONFIGURE ZONE USING num_replicas = 7;
+ALTER PARTITION p3 OF INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 10000;
+EXPLAIN (DDL) ALTER PARTITION p1 OF INDEX t@idx CONFIGURE ZONE USING gc.ttlseconds = 12000;
+----
+Schema change plan for ALTER PARTITION ‹p1› OF INDEX ‹defaultdb›.‹public›.‹t›@‹idx› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹12000›; following ALTER PARTITION ‹p3› OF INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹num_replicas› = ‹7›; ALTER PARTITION ‹p3› OF INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹10000›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (t), IndexID: 2 (idx), SeqNum: 1, PartitionName: "p1"}
+ │         └── 1 Mutation operation
+ │              └── AddPartitionZoneConfig {"TableID":104}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── PUBLIC → ABSENT PartitionZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 1, PartitionName: "p3"}
+      │    │    ├── PUBLIC → ABSENT PartitionZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 2, PartitionName: "p3"}
+      │    │    └── PUBLIC → ABSENT PartitionZoneConfig:{DescID: 104 (t), IndexID: 2 (idx), SeqNum: 1, PartitionName: "p1"}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 3 elements transitioning toward PUBLIC
+           │    ├── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 1, PartitionName: "p3"}
+           │    ├── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 2, PartitionName: "p3"}
+           │    └── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (t), IndexID: 2 (idx), SeqNum: 1, PartitionName: "p1"}
+           └── 3 Mutation operations
+                ├── AddPartitionZoneConfig {"TableID":104}
+                ├── AddPartitionZoneConfig {"TableID":104}
+                └── AddPartitionZoneConfig {"TableID":104}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple/alter_partition_configure_zone_multiple__statement_3_of_4.explain_shape
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple/alter_partition_configure_zone_multiple__statement_3_of_4.explain_shape
@@ -1,0 +1,20 @@
+/* setup */
+CREATE TABLE t (
+    id INT PRIMARY KEY,
+    data INT,
+    INDEX idx (data) PARTITION BY LIST (data) (
+        PARTITION p1 VALUES IN (10, 20, 30),
+        PARTITION p2 VALUES IN (40, 50, 60)
+    )
+) PARTITION BY LIST (id) (
+    PARTITION p3 VALUES IN (1, 2, 3),
+    PARTITION p4 VALUES IN (4, 5, 6)
+);
+
+/* test */
+ALTER PARTITION p3 OF INDEX t@t_pkey CONFIGURE ZONE USING num_replicas = 7;
+ALTER PARTITION p3 OF INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 10000;
+EXPLAIN (DDL, SHAPE) ALTER PARTITION p1 OF INDEX t@idx CONFIGURE ZONE USING gc.ttlseconds = 12000;
+----
+Schema change plan for ALTER PARTITION ‹p1› OF INDEX ‹defaultdb›.‹public›.‹t›@‹idx› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹12000›; following ALTER PARTITION ‹p3› OF INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹num_replicas› = ‹7›; ALTER PARTITION ‹p3› OF INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹10000›;
+ └── execute 1 system table mutations transaction

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple/alter_partition_configure_zone_multiple__statement_4_of_4.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple/alter_partition_configure_zone_multiple__statement_4_of_4.explain
@@ -1,0 +1,46 @@
+/* setup */
+CREATE TABLE t (
+    id INT PRIMARY KEY,
+    data INT,
+    INDEX idx (data) PARTITION BY LIST (data) (
+        PARTITION p1 VALUES IN (10, 20, 30),
+        PARTITION p2 VALUES IN (40, 50, 60)
+    )
+) PARTITION BY LIST (id) (
+    PARTITION p3 VALUES IN (1, 2, 3),
+    PARTITION p4 VALUES IN (4, 5, 6)
+);
+
+/* test */
+ALTER PARTITION p3 OF INDEX t@t_pkey CONFIGURE ZONE USING num_replicas = 7;
+ALTER PARTITION p3 OF INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 10000;
+ALTER PARTITION p1 OF INDEX t@idx CONFIGURE ZONE USING gc.ttlseconds = 12000;
+EXPLAIN (DDL) ALTER PARTITION p3 OF INDEX t@t_pkey CONFIGURE ZONE USING num_replicas = 10;
+----
+Schema change plan for ALTER PARTITION ‹p3› OF INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹num_replicas› = ‹10›; following ALTER PARTITION ‹p3› OF INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹num_replicas› = ‹7›; ALTER PARTITION ‹p3› OF INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹10000›; ALTER PARTITION ‹p1› OF INDEX ‹defaultdb›.‹public›.‹t›@‹idx› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹12000›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 3, PartitionName: "p3"}
+ │         └── 1 Mutation operation
+ │              └── AddPartitionZoneConfig {"TableID":104}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── PUBLIC → ABSENT PartitionZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 1, PartitionName: "p3"}
+      │    │    ├── PUBLIC → ABSENT PartitionZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 2, PartitionName: "p3"}
+      │    │    ├── PUBLIC → ABSENT PartitionZoneConfig:{DescID: 104 (t), IndexID: 2 (idx), SeqNum: 1, PartitionName: "p1"}
+      │    │    └── PUBLIC → ABSENT PartitionZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 3, PartitionName: "p3"}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 4 elements transitioning toward PUBLIC
+           │    ├── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 1, PartitionName: "p3"}
+           │    ├── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 2, PartitionName: "p3"}
+           │    ├── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (t), IndexID: 2 (idx), SeqNum: 1, PartitionName: "p1"}
+           │    └── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 3, PartitionName: "p3"}
+           └── 4 Mutation operations
+                ├── AddPartitionZoneConfig {"TableID":104}
+                ├── AddPartitionZoneConfig {"TableID":104}
+                ├── AddPartitionZoneConfig {"TableID":104}
+                └── AddPartitionZoneConfig {"TableID":104}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple/alter_partition_configure_zone_multiple__statement_4_of_4.explain_shape
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple/alter_partition_configure_zone_multiple__statement_4_of_4.explain_shape
@@ -1,0 +1,21 @@
+/* setup */
+CREATE TABLE t (
+    id INT PRIMARY KEY,
+    data INT,
+    INDEX idx (data) PARTITION BY LIST (data) (
+        PARTITION p1 VALUES IN (10, 20, 30),
+        PARTITION p2 VALUES IN (40, 50, 60)
+    )
+) PARTITION BY LIST (id) (
+    PARTITION p3 VALUES IN (1, 2, 3),
+    PARTITION p4 VALUES IN (4, 5, 6)
+);
+
+/* test */
+ALTER PARTITION p3 OF INDEX t@t_pkey CONFIGURE ZONE USING num_replicas = 7;
+ALTER PARTITION p3 OF INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 10000;
+ALTER PARTITION p1 OF INDEX t@idx CONFIGURE ZONE USING gc.ttlseconds = 12000;
+EXPLAIN (DDL, SHAPE) ALTER PARTITION p3 OF INDEX t@t_pkey CONFIGURE ZONE USING num_replicas = 10;
+----
+Schema change plan for ALTER PARTITION ‹p3› OF INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹num_replicas› = ‹10›; following ALTER PARTITION ‹p3› OF INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹num_replicas› = ‹7›; ALTER PARTITION ‹p3› OF INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹10000›; ALTER PARTITION ‹p1› OF INDEX ‹defaultdb›.‹public›.‹t›@‹idx› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹12000›;
+ └── execute 1 system table mutations transaction

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partitions
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partitions
@@ -193,7 +193,7 @@ translate database=db table=partition_by_list
 
 exec-sql
 CREATE TABLE db.test(i INT PRIMARY KEY, j INT) PARTITION BY LIST (i) (
-  PARTITION one_and_five    VALUES IN (1, 5)
+  PARTITION one_and_five VALUES IN (1, 5)
 );
 ----
 
@@ -218,3 +218,38 @@ translate database=db table=test
 /Table/110/1/{5-6}                         ttl_seconds=3 num_replicas=4
 /Table/110/{1/6-2}                         num_replicas=4
 /Table/11{0/2-1}                           range default
+
+exec-sql
+CREATE TABLE db.part (
+    id INT PRIMARY KEY,
+    data INT,
+    INDEX idx (data) PARTITION BY LIST (data) (
+        PARTITION p1 VALUES IN (10, 20, 30),
+        PARTITION p2 VALUES IN (40, 50, 60)
+    )
+);
+----
+
+exec-sql
+ALTER PARTITION p1 OF index db.part@idx CONFIGURE ZONE USING num_replicas = 10;
+----
+
+exec-sql
+ALTER PARTITION p2 OF index db.part@idx CONFIGURE ZONE USING num_replicas = 11;
+----
+
+translate database=db table=part
+----
+/Table/111{-/2/10}                         range default
+/Table/111/2/1{0-1}                        num_replicas=10
+/Table/111/2/{11-20}                       range default
+/Table/111/2/2{0-1}                        num_replicas=10
+/Table/111/2/{21-30}                       range default
+/Table/111/2/3{0-1}                        num_replicas=10
+/Table/111/2/{31-40}                       range default
+/Table/111/2/4{0-1}                        num_replicas=11
+/Table/111/2/{41-50}                       range default
+/Table/111/2/5{0-1}                        num_replicas=11
+/Table/111/2/{51-60}                       range default
+/Table/111/2/6{0-1}                        num_replicas=11
+/Table/11{1/2/61-2}                        range default

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "drop_view.go",
         "helpers.go",
         "index_zone_config.go",
+        "partition_zone_config.go",
         "process.go",
         "statement_control.go",
         "table_zone_config.go",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/configure_zone.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/configure_zone.go
@@ -25,6 +25,13 @@ func SetZoneConfig(b BuildCtx, n *tree.SetZoneConfig) {
 		panic(err)
 	}
 
+	// Fall back to the legacy schema changer if this is a YAML config (deprecated).
+	// Block from using YAML config unless we are discarding a YAML config.
+	if n.YAMLConfig != nil && !n.Discard {
+		panic(scerrors.NotImplementedErrorf(n,
+			"YAML config is deprecated and not supported in the declarative schema changer"))
+	}
+
 	// TODO(annie): implement complete support for CONFIGURE ZONE. This currently
 	// Supports:
 	// - Database
@@ -38,14 +45,8 @@ func SetZoneConfig(b BuildCtx, n *tree.SetZoneConfig) {
 		panic(err)
 	}
 
-	// Fall back to the legacy schema changer if this is a YAML config (deprecated).
-	// Block from using YAML config unless we are discarding a YAML config.
-	if n.YAMLConfig != nil && !n.Discard {
-		panic(scerrors.NotImplementedErrorf(n,
-			"YAML config is deprecated and not supported in the declarative schema changer"))
-	}
-
 	zs := n.ZoneSpecifier
+
 	if err := zco.checkPrivilegeForSetZoneConfig(b, zs); err != nil {
 		panic(err)
 	}
@@ -117,6 +118,7 @@ func astToZoneConfigObject(b BuildCtx, n *tree.SetZoneConfig) (zoneConfigObject,
 		return nil, scerrors.NotImplementedErrorf(n, "zone configurations on partitions "+
 			"and system ranges are not supported in the DSC")
 	}
+
 	tblName := zs.TableOrIndex.Table.ToUnresolvedObjectName()
 	elems := b.ResolvePhysicalTable(tblName, ResolveParams{})
 	panicIfSchemaChangeIsDisallowed(elems, n)
@@ -143,9 +145,12 @@ func astToZoneConfigObject(b BuildCtx, n *tree.SetZoneConfig) (zoneConfigObject,
 		return &tzo, nil
 	}
 
-	// We are an index object.
-	if targetsIndex {
-		return &indexZoneConfigObj{tableZoneConfigObj: tzo}, nil
+	izo := indexZoneConfigObj{tableZoneConfigObj: tzo}
+	// We are an index object. Determine the index ID and fill this
+	// information out in our zoneConfigObject.
+	izo.fillIndexFromZoneSpecifier(b, n.ZoneSpecifier)
+	if targetsIndex && !n.TargetsPartition() {
+		return &izo, nil
 	}
 
 	return nil, errors.AssertionFailedf("unexpected zone config object")

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/database_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/database_zone_config.go
@@ -98,9 +98,10 @@ func (dzo *databaseZoneConfigObj) retrievePartialZoneConfig(b BuildCtx) *zonepb.
 	sameDB := func(e *scpb.DatabaseZoneConfig) bool {
 		return e.DatabaseID == dzo.getTargetID()
 	}
-	mostRecentElem := findMostRecentZoneConfig(dzo, func(id catid.DescID) *scpb.ElementCollection[*scpb.DatabaseZoneConfig] {
-		return b.QueryByID(id).FilterDatabaseZoneConfig()
-	}, sameDB)
+	mostRecentElem := findMostRecentZoneConfig(dzo,
+		func(id catid.DescID) *scpb.ElementCollection[*scpb.DatabaseZoneConfig] {
+			return b.QueryByID(id).FilterDatabaseZoneConfig()
+		}, sameDB)
 
 	if mostRecentElem != nil {
 		dzo.zoneConfig = mostRecentElem.ZoneConfig

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -1734,7 +1734,7 @@ func mustRetrieveIndexNameElem(
 	b BuildCtx, tableID catid.DescID, indexID catid.IndexID,
 ) (indexNameElem *scpb.IndexName) {
 	return b.QueryByID(tableID).FilterIndexName().
-		Filter(func(current scpb.Status, target scpb.TargetStatus, e *scpb.IndexName) bool {
+		Filter(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.IndexName) bool {
 			return e.IndexID == indexID
 		}).MustGetOneElement()
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -1732,9 +1733,26 @@ func mustRetrievePhysicalTableElem(b BuildCtx, descID catid.DescID) scpb.Element
 // element.
 func mustRetrieveIndexNameElem(
 	b BuildCtx, tableID catid.DescID, indexID catid.IndexID,
-) (indexNameElem *scpb.IndexName) {
+) *scpb.IndexName {
 	return b.QueryByID(tableID).FilterIndexName().
 		Filter(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.IndexName) bool {
 			return e.IndexID == indexID
 		}).MustGetOneElement()
+}
+
+// mustRetrievePartitioningFromIndexPartitioning retrieves the partitioning
+// from the index partitioning element associated with the given tableID
+// and indexID.
+func mustRetrievePartitioningFromIndexPartitioning(
+	b BuildCtx, tableID catid.DescID, indexID catid.IndexID,
+) catalog.Partitioning {
+	idxPart := b.QueryByID(tableID).FilterIndexPartitioning().
+		Filter(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.IndexPartitioning) bool {
+			return e.IndexID == indexID
+		}).MustGetZeroOrOneElement()
+	partition := tabledesc.NewPartitioning(nil)
+	if idxPart != nil {
+		partition = tabledesc.NewPartitioning(&idxPart.PartitioningDescriptor)
+	}
+	return partition
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/index_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/index_zone_config.go
@@ -63,9 +63,10 @@ func (izo *indexZoneConfigObj) retrievePartialZoneConfig(b BuildCtx) *zonepb.Zon
 	sameIdx := func(e *scpb.IndexZoneConfig) bool {
 		return e.TableID == izo.getTargetID() && e.IndexID == izo.indexID
 	}
-	mostRecentElem := findMostRecentZoneConfig(izo, func(id catid.DescID) *scpb.ElementCollection[*scpb.IndexZoneConfig] {
-		return b.QueryByID(id).FilterIndexZoneConfig()
-	}, sameIdx)
+	mostRecentElem := findMostRecentZoneConfig(izo,
+		func(id catid.DescID) *scpb.ElementCollection[*scpb.IndexZoneConfig] {
+			return b.QueryByID(id).FilterIndexZoneConfig()
+		}, sameIdx)
 
 	// Since we will be performing a subzone config update, we need to retrieve
 	// its parent's (table's) zone config for later use. This is because we need
@@ -113,8 +114,6 @@ func (izo *indexZoneConfigObj) retrieveCompleteZoneConfig(
 	var subzone *zonepb.Subzone
 	indexID := izo.indexID
 	if placeholder != nil {
-		// TODO(annie): once we support partitions, we will need to pass in the
-		// actual partition name here.
 		if subzone = placeholder.GetSubzone(uint32(indexID), ""); subzone != nil {
 			if indexSubzone := placeholder.GetSubzone(uint32(indexID), ""); indexSubzone != nil {
 				subzone.Config.InheritFromParent(&indexSubzone.Config)
@@ -138,6 +137,7 @@ func (izo *indexZoneConfigObj) setZoneConfigToWrite(zone *zonepb.ZoneConfig) {
 	for _, subzone := range zone.Subzones {
 		if subzone.IndexID == uint32(izo.indexID) && len(subzone.PartitionName) == 0 {
 			subzoneToWrite = &subzone
+			break
 		}
 	}
 	izo.indexSubzone = subzoneToWrite

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/partition_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/partition_zone_config.go
@@ -7,13 +7,16 @@ package scbuildstmt
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -26,13 +29,266 @@ type partitionZoneConfigObj struct {
 	seqNum           uint32
 }
 
+var _ zoneConfigObject = &partitionZoneConfigObj{}
+
+func (pzo *partitionZoneConfigObj) getTableZoneConfig() *zonepb.ZoneConfig {
+	return pzo.tableZoneConfigObj.zoneConfig
+}
+
+func (pzo *partitionZoneConfigObj) addZoneConfigToBuildCtx(b BuildCtx) scpb.Element {
+	pzo.seqNum += 1
+	subzones := []zonepb.Subzone{*pzo.partitionSubzone}
+
+	// Merge the new subzones with the old subzones so that we can generate
+	// accurate subzone spans.
+	parentZoneConfig := pzo.getTableZoneConfig()
+	if parentZoneConfig != nil {
+		parentZoneConfig.SetSubzone(*pzo.partitionSubzone)
+		subzones = parentZoneConfig.Subzones
+	}
+
+	ss, err := generateSubzoneSpans(b, pzo.tableID, subzones)
+	if err != nil {
+		panic(err)
+	}
+
+	elem := &scpb.PartitionZoneConfig{
+		TableID:       pzo.tableID,
+		IndexID:       pzo.indexID,
+		PartitionName: pzo.partitionName,
+		Subzone:       *pzo.partitionSubzone,
+		SubzoneSpans:  ss,
+		SeqNum:        pzo.seqNum,
+	}
+	b.Add(elem)
+	return elem
+}
+
+func (pzo *partitionZoneConfigObj) retrievePartialZoneConfig(b BuildCtx) *zonepb.ZoneConfig {
+	samePartition := func(e *scpb.PartitionZoneConfig) bool {
+		return e.TableID == pzo.getTargetID() && e.IndexID == pzo.indexID &&
+			e.PartitionName == pzo.partitionName
+	}
+	mostRecentElem := findMostRecentZoneConfig(pzo,
+		func(id catid.DescID) *scpb.ElementCollection[*scpb.PartitionZoneConfig] {
+			return b.QueryByID(id).FilterPartitionZoneConfig()
+		}, samePartition)
+
+	// Set the table zone config for generating proper subzone spans later on.
+	_ = pzo.tableZoneConfigObj.retrievePartialZoneConfig(b)
+
+	var partialZone *zonepb.ZoneConfig
+	if mostRecentElem != nil {
+		// Construct a zone config placeholder with the correct subzone. This
+		// will be what we return.
+		partialZone = zonepb.NewZoneConfig()
+		partialZone.DeleteTableConfig()
+		partialZone.Subzones = []zonepb.Subzone{mostRecentElem.Subzone}
+		pzo.partitionSubzone = &mostRecentElem.Subzone
+		pzo.seqNum = mostRecentElem.SeqNum
+	}
+
+	return pzo.zoneConfig
+}
+
+func (pzo *partitionZoneConfigObj) retrieveCompleteZoneConfig(
+	b BuildCtx, getInheritedDefault bool,
+) (*zonepb.ZoneConfig, *zonepb.Subzone, error) {
+	var placeholder *zonepb.ZoneConfig
+	var err error
+	zc := &zonepb.ZoneConfig{}
+	if getInheritedDefault {
+		zc, err = pzo.getInheritedDefaultZoneConfig(b)
+	} else {
+		//zc, err = pzo.tableZoneConfigObj.getZoneConfig(b, false /* inheritDefaultRange */)
+		//if err != nil {
+		//	return nil, nil, err
+		//}
+		placeholder, err = pzo.getZoneConfig(b, false /* inheritDefaultRange */)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	completeZc := *zc
+	if err = pzo.completeZoneConfig(b, &completeZc); err != nil {
+		return nil, nil, err
+	}
+
+	var subzone *zonepb.Subzone
+	indexID := pzo.indexID
+	partName := pzo.partitionName
+	if placeholder != nil {
+		if subzone = placeholder.GetSubzone(uint32(indexID), partName); subzone != nil {
+			if indexSubzone := placeholder.GetSubzone(uint32(indexID), partName); indexSubzone != nil {
+				subzone.Config.InheritFromParent(&indexSubzone.Config)
+			}
+			subzone.Config.InheritFromParent(zc)
+			return placeholder, subzone, nil
+		}
+	} else {
+		if subzone = zc.GetSubzone(uint32(indexID), pzo.partitionName); subzone != nil {
+			if indexSubzone := zc.GetSubzone(uint32(indexID), pzo.partitionName); indexSubzone != nil {
+				subzone.Config.InheritFromParent(&indexSubzone.Config)
+			}
+			subzone.Config.InheritFromParent(zc)
+		}
+	}
+	return zc, subzone, nil
+}
+
+func (pzo *partitionZoneConfigObj) setZoneConfigToWrite(zone *zonepb.ZoneConfig) {
+	var subzoneToWrite *zonepb.Subzone
+	for _, subzone := range zone.Subzones {
+		if subzone.IndexID == uint32(pzo.indexID) && subzone.PartitionName == pzo.partitionName {
+			subzoneToWrite = &subzone
+			break
+		}
+	}
+	pzo.partitionSubzone = subzoneToWrite
+}
+
+// getInheritedFieldsForPartialSubzone returns the set of inherited fields for
+// a partial subzone based off of its parent zone.
+func (pzo *partitionZoneConfigObj) getInheritedFieldsForPartialSubzone(
+	b BuildCtx, partialZone *zonepb.ZoneConfig,
+) (*zonepb.ZoneConfig, error) {
+	// We are operating on a subZone and need to inherit all remaining
+	// unset fields in its parent zone, which is partialZone.
+	zoneInheritedFields := *partialZone
+	if err := pzo.completeZoneConfig(b, &zoneInheritedFields); err != nil {
+		return nil, err
+	}
+	// Since we have just a partition, we should copy from the inherited
+	// zone's fields (whether that was the table or database).
+	return &zoneInheritedFields, nil
+}
+
+func (pzo *partitionZoneConfigObj) applyZoneConfig(
+	b BuildCtx,
+	n *tree.SetZoneConfig,
+	copyFromParentList []tree.Name,
+	setters []func(c *zonepb.ZoneConfig),
+) error {
+	// TODO(annie): once we allow configuring zones for named zones/system ranges,
+	// we will need to guard against secondary tenants from configuring such
+	// ranges.
+
+	// We are configuring a partition. Determine the index ID and fill this
+	// information out in our zoneConfigObject.
+	pzo.panicIfNoPartitionExistsOnIdx(b, n)
+	pzo.panicIfBadPartitionReference(b, n)
+	indexID := pzo.indexID
+	tempIndexID := mustRetrieveIndexElement(b, pzo.getTargetID(), indexID).TemporaryIndexID
+
+	// Retrieve the partial zone configuration
+	partialZone := pzo.retrievePartialZoneConfig(b)
+
+	subzonePlaceholder := false
+	// No zone was found. Possibly a SubzonePlaceholder depending on the index.
+	if partialZone == nil {
+		partialZone = zonepb.NewZoneConfig()
+		subzonePlaceholder = true
+	}
+	currentZone := protoutil.Clone(partialZone).(*zonepb.ZoneConfig)
+
+	var partialSubzone *zonepb.Subzone
+	partialSubzone = partialZone.GetSubzoneExact(uint32(indexID), pzo.partitionName)
+	if partialSubzone == nil {
+		partialSubzone = &zonepb.Subzone{Config: *zonepb.NewZoneConfig()}
+	}
+
+	// Retrieve the zone configuration.
+	//
+	// If the statement was USING DEFAULT, we want to ignore the zone
+	// config that exists on targetID and instead skip to the inherited
+	// default (whichever applies -- a database if targetID is a table, default
+	// if targetID is a database, etc.). For this, we use the last parameter
+	// getInheritedDefault to retrieveCompleteZoneConfig().
+	// These zones are only used for validations. The merged zone will not
+	// be written.
+	completeZone, completeSubZone, err := pzo.retrieveCompleteZoneConfig(b,
+		n.SetDefault /* getInheritedDefault */)
+	if err != nil {
+		return err
+	}
+
+	// We need to inherit zone configuration information from the correct zone,
+	// not completeZone.
+	{
+		zoneInheritedFields, err := pzo.getInheritedFieldsForPartialSubzone(b, partialZone)
+		if err != nil {
+			return err
+		}
+		partialSubzone.Config.CopyFromZone(*zoneInheritedFields, copyFromParentList)
+	}
+
+	// Determine where to load the configuration.
+	newZone := *completeZone
+	if completeSubZone != nil {
+		newZone = completeSubZone.Config
+	}
+
+	// If an existing subzone is being modified, finalZone is overridden.
+	finalZone := partialSubzone.Config
+
+	if n.SetDefault {
+		finalZone = *zonepb.NewZoneConfig()
+	}
+
+	// Fill in our zone configs with var = val assignments.
+	if err := loadSettingsToZoneConfigs(setters, &newZone, &finalZone); err != nil {
+		return err
+	}
+
+	// Validate that there are no conflicts in the zone setup.
+	if err := zonepb.ValidateNoRepeatKeysInZone(&newZone); err != nil {
+		return err
+	}
+
+	if err := validateZoneAttrsAndLocalities(b, currentZone, &newZone); err != nil {
+		return err
+	}
+
+	// Fill in the final zone config with subzones.
+	fillZoneConfigsForSubzones(indexID, pzo.partitionName, tempIndexID, subzonePlaceholder, completeZone,
+		partialZone, newZone, finalZone)
+
+	// Finally, revalidate everything. Validate only the completeZone config.
+	if err := completeZone.Validate(); err != nil {
+		return pgerror.Wrap(err, pgcode.CheckViolation, "could not validate zone config")
+	}
+
+	// Finally, check for the extra protection partial zone configs would
+	// require from changes made to parent zones. The extra protections are:
+	//
+	// RangeMinBytes and RangeMaxBytes must be set together
+	// LeasePreferences cannot be set unless Constraints/VoterConstraints are
+	// explicitly set
+	// Per-replica constraints cannot be set unless num_replicas is explicitly
+	// set
+	// Per-voter constraints cannot be set unless num_voters is explicitly set
+	if err := finalZone.ValidateTandemFields(); err != nil {
+		err = errors.Wrap(err, "could not validate zone config")
+		err = pgerror.WithCandidateCode(err, pgcode.InvalidParameterValue)
+		err = errors.WithHint(err,
+			"try ALTER ... CONFIGURE ZONE USING <field_name> = COPY FROM PARENT [, ...] to "+
+				"populate the field")
+		return err
+	}
+	pzo.setZoneConfigToWrite(partialZone)
+	return err
+}
+
 // panicIfNoPartitionExistsOnIdx panics if the partition referenced in a
 // ALTER PARTITION ... OF TABLE does not exist on the provided index.
 func (pzo *partitionZoneConfigObj) panicIfNoPartitionExistsOnIdx(
 	b BuildCtx, n *tree.SetZoneConfig,
 ) {
 	zs := n.ZoneSpecifier
-	if zs.TargetsPartition() && len(zs.TableOrIndex.Index) != 0 && !n.AllIndexes {
+	// If we allow StarIndex to be set in the DSC, we will have to guard against
+	// that here as well.
+	if zs.TargetsPartition() && len(zs.TableOrIndex.Index) != 0 {
 		partitionName := string(zs.Partition)
 		var indexes []scpb.IndexPartitioning
 		idxPart := b.QueryByID(pzo.tableID).FilterIndexPartitioning()
@@ -69,19 +325,21 @@ func (pzo *partitionZoneConfigObj) panicIfBadPartitionReference(b BuildCtx, n *t
 	zs := &n.ZoneSpecifier
 	// Backward compatibility for ALTER PARTITION ... OF TABLE. Determine which
 	// index has the specified partition.
-	if zs.TargetsPartition() && len(zs.TableOrIndex.Index) == 0 && !n.AllIndexes {
+	//
+	// If we allow StarIndex to be set in the DSC, we will have to guard against
+	// that here as well.
+	if zs.TargetsPartition() && len(zs.TableOrIndex.Index) == 0 {
 		partitionName := string(zs.Partition)
 
-		// TODO(before merge): [reviewer callout] can we guarantee that this will
-		// be in the same order as NonDropIndexes()? Mainly for case 2 in the switch
-		// case below. My understanding is yes, but I want to confirm.
 		var indexes []scpb.IndexPartitioning
 		idxPart := b.QueryByID(pzo.tableID).FilterIndexPartitioning()
-		idxPart.ForEach(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.IndexPartitioning) {
-			partition := tabledesc.NewPartitioning(&e.PartitioningDescriptor)
-			partition = partition.FindPartitionByName(partitionName)
-			if partition != nil {
-				indexes = append(indexes, *e)
+		idxPart.ForEach(func(s scpb.Status, ts scpb.TargetStatus, e *scpb.IndexPartitioning) {
+			if s != scpb.Status_DROPPED && ts != scpb.ToAbsent {
+				partition := tabledesc.NewPartitioning(&e.PartitioningDescriptor)
+				partition = partition.FindPartitionByName(partitionName)
+				if partition != nil {
+					indexes = append(indexes, *e)
+				}
 			}
 		})
 
@@ -90,24 +348,37 @@ func (pzo *partitionZoneConfigObj) panicIfBadPartitionReference(b BuildCtx, n *t
 		case 0:
 			panic(fmt.Errorf("partition %q does not exist on table %q", partitionName, tableName))
 		case 1:
-			// We found the partition on a single index. Fill this index out in our
-			// AST.
+			// We found the partition on a single index. Fill this index out in
+			// our AST.
 			idx := indexes[0]
 			idxName := mustRetrieveIndexNameElem(b, pzo.tableID, idx.IndexID)
 			zs.TableOrIndex.Index = tree.UnrestrictedName(idxName.Name)
+			// Our index name has changed -- find the corresponding indexID
+			// and fill that out.
+			pzo.fillIndexFromZoneSpecifier(b, n.ZoneSpecifier)
 		case 2:
-			// Perhaps our target index is a part of a backfill. In this case, we
-			// temporary indexes created during backfill should always share the same
-			// zone configs as the corresponding new index.
+			// Sort our indexes to guarantee proper ordering; in the case of a
+			// backfill, we want to ensure that the temporary index is always
+			// the second element.
+			sort.Slice(indexes, func(i, j int) bool {
+				return indexes[i].IndexID < indexes[j].IndexID
+			})
+
+			// Perhaps our target index is a part of a backfill. In this case,
+			// temporary indexes created during backfill should always share the
+			// same zone configs as the corresponding new index.
 			idx := indexes[0]
 			maybeTempIdx := indexes[1]
 			if isCorrespondingTemporaryIndex(b, pzo.tableID, maybeTempIdx.IndexID, idx.IndexID) {
 				idxName := mustRetrieveIndexNameElem(b, pzo.tableID, idx.IndexID)
 				zs.TableOrIndex.Index = tree.UnrestrictedName(idxName.Name)
+				// Our index name has changed -- find the corresponding indexID
+				// and fill that out.
+				pzo.fillIndexFromZoneSpecifier(b, n.ZoneSpecifier)
 				break
 			}
-			// We are not in a backfill case -- the partition we are referencing is on
-			// multiple indexes. Fallthrough.
+			// We are not in a backfill case -- the partition we are referencing
+			// is on multiple indexes. Fallthrough.
 			fallthrough
 		default:
 			err := fmt.Errorf(

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/partition_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/partition_zone_config.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/errors"
@@ -54,6 +56,65 @@ func (pzo *partitionZoneConfigObj) panicIfNoPartitionExistsOnIdx(
 		default:
 			panic(errors.AssertionFailedf("partition %q exists multiple times on index %q",
 				partitionName, indexName))
+		}
+	}
+}
+
+// panicIfBadPartitionReference panics if the partition referenced in a
+// ALTER PARTITION ... OF TABLE does not exist or if it exists on multiple
+// indexes. Otherwise, we find the existing index and save in to our AST.
+// In cases where we find the partition existing on two indexes, we check
+// to ensure that we are not in a backfill case before panicking.
+func (pzo *partitionZoneConfigObj) panicIfBadPartitionReference(b BuildCtx, n *tree.SetZoneConfig) {
+	zs := &n.ZoneSpecifier
+	// Backward compatibility for ALTER PARTITION ... OF TABLE. Determine which
+	// index has the specified partition.
+	if zs.TargetsPartition() && len(zs.TableOrIndex.Index) == 0 && !n.AllIndexes {
+		partitionName := string(zs.Partition)
+
+		// TODO(before merge): [reviewer callout] can we guarantee that this will
+		// be in the same order as NonDropIndexes()? Mainly for case 2 in the switch
+		// case below. My understanding is yes, but I want to confirm.
+		var indexes []scpb.IndexPartitioning
+		idxPart := b.QueryByID(pzo.tableID).FilterIndexPartitioning()
+		idxPart.ForEach(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.IndexPartitioning) {
+			partition := tabledesc.NewPartitioning(&e.PartitioningDescriptor)
+			partition = partition.FindPartitionByName(partitionName)
+			if partition != nil {
+				indexes = append(indexes, *e)
+			}
+		})
+
+		tableName := n.TableOrIndex.Table.String()
+		switch len(indexes) {
+		case 0:
+			panic(fmt.Errorf("partition %q does not exist on table %q", partitionName, tableName))
+		case 1:
+			// We found the partition on a single index. Fill this index out in our
+			// AST.
+			idx := indexes[0]
+			idxName := mustRetrieveIndexNameElem(b, pzo.tableID, idx.IndexID)
+			zs.TableOrIndex.Index = tree.UnrestrictedName(idxName.Name)
+		case 2:
+			// Perhaps our target index is a part of a backfill. In this case, we
+			// temporary indexes created during backfill should always share the same
+			// zone configs as the corresponding new index.
+			idx := indexes[0]
+			maybeTempIdx := indexes[1]
+			if isCorrespondingTemporaryIndex(b, pzo.tableID, maybeTempIdx.IndexID, idx.IndexID) {
+				idxName := mustRetrieveIndexNameElem(b, pzo.tableID, idx.IndexID)
+				zs.TableOrIndex.Index = tree.UnrestrictedName(idxName.Name)
+				break
+			}
+			// We are not in a backfill case -- the partition we are referencing is on
+			// multiple indexes. Fallthrough.
+			fallthrough
+		default:
+			err := fmt.Errorf(
+				"partition %q exists on multiple indexes of table %q", partitionName, tableName)
+			err = pgerror.WithCandidateCode(err, pgcode.InvalidParameterValue)
+			err = errors.WithHint(err, "try ALTER PARTITION ... OF INDEX ...")
+			panic(err)
 		}
 	}
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/partition_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/partition_zone_config.go
@@ -1,0 +1,59 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package scbuildstmt
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
+)
+
+// partitionZoneConfigObj is used to represent a table-specific zone configuration
+// object.
+type partitionZoneConfigObj struct {
+	indexZoneConfigObj
+	partitionSubzone *zonepb.Subzone
+	partitionName    string
+	seqNum           uint32
+}
+
+// panicIfNoPartitionExistsOnIdx panics if the partition referenced in a
+// ALTER PARTITION ... OF TABLE does not exist on the provided index.
+func (pzo *partitionZoneConfigObj) panicIfNoPartitionExistsOnIdx(
+	b BuildCtx, n *tree.SetZoneConfig,
+) {
+	zs := n.ZoneSpecifier
+	if zs.TargetsPartition() && len(zs.TableOrIndex.Index) != 0 && !n.AllIndexes {
+		partitionName := string(zs.Partition)
+		var indexes []scpb.IndexPartitioning
+		idxPart := b.QueryByID(pzo.tableID).FilterIndexPartitioning()
+		idxPart.ForEach(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.IndexPartitioning) {
+			if e.IndexID != pzo.indexID {
+				return
+			}
+			partition := tabledesc.NewPartitioning(&e.PartitioningDescriptor)
+			partition = partition.FindPartitionByName(partitionName)
+			if partition != nil {
+				indexes = append(indexes, *e)
+			}
+		})
+
+		indexName := string(zs.TableOrIndex.Index)
+		switch len(indexes) {
+		case 0:
+			panic(fmt.Errorf("partition %q does not exist on index %q", partitionName, indexName))
+		case 1:
+			return
+		default:
+			panic(errors.AssertionFailedf("partition %q exists multiple times on index %q",
+				partitionName, indexName))
+		}
+	}
+}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/table_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/table_zone_config.go
@@ -102,9 +102,10 @@ func (tzo *tableZoneConfigObj) retrievePartialZoneConfig(b BuildCtx) *zonepb.Zon
 	sameTbl := func(e *scpb.TableZoneConfig) bool {
 		return e.TableID == tzo.getTargetID()
 	}
-	mostRecentElem := findMostRecentZoneConfig(tzo, func(id catid.DescID) *scpb.ElementCollection[*scpb.TableZoneConfig] {
-		return b.QueryByID(id).FilterTableZoneConfig()
-	}, sameTbl)
+	mostRecentElem := findMostRecentZoneConfig(tzo,
+		func(id catid.DescID) *scpb.ElementCollection[*scpb.TableZoneConfig] {
+			return b.QueryByID(id).FilterTableZoneConfig()
+		}, sameTbl)
 
 	if mostRecentElem != nil {
 		tzo.zoneConfig = mostRecentElem.ZoneConfig

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/fetchpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/zone"
 	"github.com/cockroachdb/cockroach/pkg/sql/covering"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -662,16 +661,10 @@ func generateSubzoneSpans(
 	// pretty sane. Dropped elements may refer to dropped types and we aren't
 	// necessarily in a position to deal with those dropped types. Add a special
 	// case to avoid generating any subzone spans in the face of being dropped.
-	isDroppedTable := false
-	b.QueryByID(tableID).FilterTable().
-		ForEach(func(current scpb.Status, target scpb.TargetStatus, e *scpb.Table) {
-			if e.TableID == tableID {
-				if current == scpb.Status_DROPPED || target == scpb.ToAbsent {
-					isDroppedTable = true
-				}
-			}
-		})
-	if isDroppedTable {
+	droppedTable := b.QueryByID(tableID).FilterTable().Filter(func(current scpb.Status, target scpb.TargetStatus, e *scpb.Table) bool {
+		return e.TableID == tableID && (current == scpb.Status_DROPPED || target == scpb.ToAbsent)
+	})
+	if droppedTable.Size() != 0 {
 		return nil, nil
 	}
 
@@ -685,14 +678,37 @@ func generateSubzoneSpans(
 		}
 	}
 
+	a := &tree.DatumAlloc{}
 	var indexCovering covering.Covering
 	var partitionCoverings []covering.Covering
-	b.QueryByID(tableID).FilterIndexName().ForEach(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.IndexName) {
-		newIndexCovering, newPartitionCoverings := getCoverings(b, subzoneIndexByIndexID,
-			subzoneIndexByPartition, tableID, e.IndexID, "")
-		indexCovering = append(indexCovering, newIndexCovering...)
-		partitionCoverings = append(partitionCoverings, newPartitionCoverings...)
-	})
+	var err error
+	b.QueryByID(tableID).FilterIndexName().NotToAbsent().ForEach(
+		func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.IndexName) {
+			_, indexSubzoneExists := subzoneIndexByIndexID[e.IndexID]
+			if indexSubzoneExists {
+				prefix := roachpb.Key(rowenc.MakeIndexKeyPrefix(b.Codec(), tableID, e.IndexID))
+				idxSpan := roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()}
+				// Each index starts with a unique prefix, so (from a precedence
+				// perspective) it's safe to append them all together.
+				indexCovering = append(indexCovering, covering.Range{
+					Start: idxSpan.Key, End: idxSpan.EndKey,
+					Payload: zonepb.Subzone{IndexID: uint32(e.IndexID)},
+				})
+			}
+			var emptyPrefix []tree.Datum
+			index := mustRetrieveIndexColumnElements(b, tableID, e.IndexID)
+			partitioning := mustRetrievePartitioningFromIndexPartitioning(b, tableID, e.IndexID)
+			var indexPartitionCoverings []covering.Covering
+			indexPartitionCoverings, err = indexCoveringsForPartitioning(
+				b, a, tableID, e.IndexID, index, partitioning, subzoneIndexByPartition, emptyPrefix)
+			if err != nil {
+				return
+			}
+			partitionCoverings = append(partitionCoverings, indexPartitionCoverings...)
+		})
+	if err != nil {
+		return nil, err
+	}
 
 	// OverlapCoveringMerge returns the payloads for any coverings that overlap
 	// in the same order they were input. So, we require that they be ordered
@@ -731,55 +747,6 @@ func generateSubzoneSpans(
 	return subzoneSpans, nil
 }
 
-func getCoverings(
-	b BuildCtx,
-	subzoneIndexByIndexID map[descpb.IndexID]int32,
-	subzoneIndexByPartition map[string]int32,
-	tableID catid.DescID,
-	indexID catid.IndexID,
-	partitionName string,
-) (covering.Covering, []covering.Covering) {
-	var indexCovering covering.Covering
-	var partitionCoverings []covering.Covering
-	a := &tree.DatumAlloc{}
-	idxCols := mustRetrieveIndexColumnElements(b, tableID, indexID)
-
-	for _, idxCol := range idxCols {
-		_, indexSubzoneExists := subzoneIndexByIndexID[idxCol.IndexID]
-		if indexSubzoneExists {
-			prefix := roachpb.Key(rowenc.MakeIndexKeyPrefix(b.Codec(), tableID, idxCol.IndexID))
-			idxSpan := roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()}
-			// Each index starts with a unique prefix, so (from a precedence
-			// perspective) it's safe to append them all together.
-			indexCovering = append(indexCovering, covering.Range{
-				Start: idxSpan.Key, End: idxSpan.EndKey,
-				Payload: zonepb.Subzone{IndexID: uint32(idxCol.IndexID)},
-			})
-		}
-		var emptyPrefix []tree.Datum
-		idxPart := b.QueryByID(tableID).FilterIndexPartitioning().
-			Filter(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.IndexPartitioning) bool {
-				return e.IndexID == indexID
-			}).MustGetZeroOrOneElement()
-		partition := tabledesc.NewPartitioning(nil)
-		if idxPart != nil {
-			partition = tabledesc.NewPartitioning(&idxPart.PartitioningDescriptor)
-			partition = partition.FindPartitionByName(partitionName)
-		}
-		indexPartitionCoverings, err := indexCoveringsForPartitioning(
-			b, a, tableID, idxCols, partition, subzoneIndexByPartition, emptyPrefix)
-		if err != nil {
-			panic(err)
-		}
-		// The returned indexPartitionCoverings are sorted with highest
-		// precedence first. They all start with the index prefix, so cannot
-		// overlap with the partition coverings for any other index, so (from a
-		// precedence perspective) it's safe to append them all together.
-		partitionCoverings = append(partitionCoverings, indexPartitionCoverings...)
-	}
-	return indexCovering, partitionCoverings
-}
-
 // indexCoveringsForPartitioning returns span coverings representing the
 // partitions in partDesc (including subpartitions). They are sorted with
 // highest precedence first and the interval.Range payloads are each a
@@ -788,12 +755,13 @@ func indexCoveringsForPartitioning(
 	b BuildCtx,
 	a *tree.DatumAlloc,
 	tableID catid.DescID,
-	idxs []*scpb.IndexColumn,
+	indexID catid.IndexID,
+	index []*scpb.IndexColumn,
 	part catalog.Partitioning,
 	relevantPartitions map[string]int32,
 	prefixDatums []tree.Datum,
 ) ([]covering.Covering, error) {
-	if part == nil || part.NumColumns() == 0 {
+	if part.NumColumns() == 0 {
 		return nil, nil
 	}
 
@@ -812,7 +780,7 @@ func indexCoveringsForPartitioning(
 		err := part.ForEachList(func(name string, values [][]byte, subPartitioning catalog.Partitioning) error {
 			for _, valueEncBuf := range values {
 				t, keyPrefix, err := decodePartitionTuple(
-					b, a, tableID, idxs, part, valueEncBuf, prefixDatums)
+					b, a, tableID, indexID, index, part, valueEncBuf, prefixDatums)
 				if err != nil {
 					return err
 				}
@@ -824,7 +792,7 @@ func indexCoveringsForPartitioning(
 				}
 				newPrefixDatums := append(prefixDatums, t.Datums...)
 				subpartitionCoverings, err := indexCoveringsForPartitioning(
-					b, a, tableID, idxs, subPartitioning, relevantPartitions, newPrefixDatums)
+					b, a, tableID, indexID, index, subPartitioning, relevantPartitions, newPrefixDatums)
 				if err != nil {
 					return err
 				}
@@ -848,12 +816,12 @@ func indexCoveringsForPartitioning(
 				return nil
 			}
 			_, fromKey, err := decodePartitionTuple(
-				b, a, tableID, idxs, part, from, prefixDatums)
+				b, a, tableID, indexID, index, part, from, prefixDatums)
 			if err != nil {
 				return err
 			}
 			_, toKey, err := decodePartitionTuple(
-				b, a, tableID, idxs, part, to, prefixDatums)
+				b, a, tableID, indexID, index, part, to, prefixDatums)
 			if err != nil {
 				return err
 			}
@@ -907,6 +875,7 @@ func decodePartitionTuple(
 	b BuildCtx,
 	a *tree.DatumAlloc,
 	tableID catid.DescID,
+	indexID catid.IndexID,
 	index []*scpb.IndexColumn,
 	part catalog.Partitioning,
 	valueEncBuf []byte,
@@ -914,7 +883,7 @@ func decodePartitionTuple(
 ) (*rowenc.PartitionTuple, []byte, error) {
 	keyColumns := b.QueryByID(tableID).FilterIndexColumn().
 		Filter(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.IndexColumn) bool {
-			return e.Kind == scpb.IndexColumn_KEY
+			return e.IndexID == indexID && e.Kind == scpb.IndexColumn_KEY
 		})
 	if len(prefixDatums)+part.NumColumns() > keyColumns.Size() {
 		return nil, nil, fmt.Errorf("not enough columns in index for this partitioning")
@@ -1155,7 +1124,7 @@ func isCorrespondingTemporaryIndex(
 ) bool {
 	maybeCorresponding := b.QueryByID(tableID).FilterTemporaryIndex().
 		Filter(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.TemporaryIndex) bool {
-			return idx+1 == e.IndexID && e.IndexID == otherIdx
+			return idx == e.TemporaryIndexID && e.TemporaryIndexID == otherIdx+1
 		}).MustGetZeroOrOneElement()
 	return maybeCorresponding != nil
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
@@ -371,26 +371,6 @@ func loadSettingsToZoneConfigs(
 	return nil
 }
 
-// fillIndexAndPartitionFromZoneSpecifier fills out the index id in the zone
-// specifier for a indexZoneConfigObj.
-func fillIndexAndPartitionFromZoneSpecifier(
-	b BuildCtx, zs tree.ZoneSpecifier, idxObj *indexZoneConfigObj,
-) {
-	tableID := idxObj.getTargetID()
-
-	indexName := string(zs.TableOrIndex.Index)
-	var indexID catid.IndexID
-	if indexName == "" {
-		// Use the primary index if index name is unspecified.
-		primaryIndexElem := mustRetrieveCurrentPrimaryIndexElement(b, tableID)
-		indexID = primaryIndexElem.IndexID
-	} else {
-		indexElems := b.ResolveIndex(tableID, tree.Name(indexName), ResolveParams{})
-		indexID = indexElems.FilterIndexName().MustGetOneElement().IndexID
-	}
-	idxObj.indexID = indexID
-}
-
 // lookUpSystemZonesTable attempts to look up the zone config in `system.zones`
 // table by `targetID`.
 // If `targetID` is not found, a nil `zone` is returned.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
@@ -759,7 +759,7 @@ func getCoverings(
 		var emptyPrefix []tree.Datum
 		idxPart := b.QueryByID(tableID).FilterIndexPartitioning().
 			Filter(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.IndexPartitioning) bool {
-				return e.TableID == tableID && e.IndexID == indexID
+				return e.IndexID == indexID
 			}).MustGetZeroOrOneElement()
 		partition := tabledesc.NewPartitioning(nil)
 		if idxPart != nil {
@@ -1144,4 +1144,18 @@ func prepareZoneConfig(
 		return nil, err
 	}
 	return partialZone, nil
+}
+
+// isCorrespondingTemporaryIndex returns true iff idx is a temporary index
+// created during a backfill and is the corresponding temporary index for
+// otherIdx. It assumes that idx and otherIdx are both indexes from the same
+// table.
+func isCorrespondingTemporaryIndex(
+	b BuildCtx, tableID catid.DescID, idx catid.IndexID, otherIdx catid.IndexID,
+) bool {
+	maybeCorresponding := b.QueryByID(tableID).FilterTemporaryIndex().
+		Filter(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.TemporaryIndex) bool {
+			return idx+1 == e.IndexID && e.IndexID == otherIdx
+		}).MustGetZeroOrOneElement()
+	return maybeCorresponding != nil
 }

--- a/pkg/sql/schemachanger/scdecomp/decomp.go
+++ b/pkg/sql/schemachanger/scdecomp/decomp.go
@@ -434,10 +434,19 @@ func (w *walkCtx) walkRelation(tbl catalog.TableDescriptor) {
 			for _, subZoneCfg := range zoneCfg.ZoneConfigProto().Subzones {
 				w.ev(scpb.Status_PUBLIC,
 					&scpb.IndexZoneConfig{
+						TableID: tbl.GetID(),
+						IndexID: catid.IndexID(subZoneCfg.IndexID),
+						Subzone: subZoneCfg,
+						SeqNum:  0,
+					})
+			}
+			for _, subZoneCfg := range zoneCfg.ZoneConfigProto().Subzones {
+				w.ev(scpb.Status_PUBLIC,
+					&scpb.PartitionZoneConfig{
 						TableID:       tbl.GetID(),
 						IndexID:       catid.IndexID(subZoneCfg.IndexID),
-						Subzone:       subZoneCfg,
 						PartitionName: subZoneCfg.PartitionName,
+						Subzone:       subZoneCfg,
 						SeqNum:        0,
 					})
 			}

--- a/pkg/sql/schemachanger/scexec/scmutationexec/index.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/index.go
@@ -493,8 +493,13 @@ func (m *deferredVisitor) MaybeAddSplitForIndex(
 	return nil
 }
 
-func (i *immediateVisitor) AddIndexZoneConfig(
-	ctx context.Context, op scop.AddIndexZoneConfig,
+func (i *immediateVisitor) AddIndexZoneConfig(_ context.Context, op scop.AddIndexZoneConfig) error {
+	i.ImmediateMutationStateUpdater.UpdateSubzoneConfig(op.TableID, op.Subzone, op.SubzoneSpans)
+	return nil
+}
+
+func (i *immediateVisitor) AddPartitionZoneConfig(
+	_ context.Context, op scop.AddPartitionZoneConfig,
 ) error {
 	i.ImmediateMutationStateUpdater.UpdateSubzoneConfig(op.TableID, op.Subzone, op.SubzoneSpans)
 	return nil

--- a/pkg/sql/schemachanger/scop/immediate_mutation.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation.go
@@ -922,3 +922,11 @@ type AddIndexZoneConfig struct {
 	Subzone      zonepb.Subzone
 	SubzoneSpans []zonepb.SubzoneSpan
 }
+
+// AddPartitionZoneConfig adds a zone config to a partition.
+type AddPartitionZoneConfig struct {
+	immediateMutationOp
+	TableID      descpb.ID
+	Subzone      zonepb.Subzone
+	SubzoneSpans []zonepb.SubzoneSpan
+}

--- a/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
@@ -135,6 +135,7 @@ type ImmediateMutationVisitor interface {
 	AddDatabaseZoneConfig(context.Context, AddDatabaseZoneConfig) error
 	AddTableZoneConfig(context.Context, AddTableZoneConfig) error
 	AddIndexZoneConfig(context.Context, AddIndexZoneConfig) error
+	AddPartitionZoneConfig(context.Context, AddPartitionZoneConfig) error
 }
 
 // Visit is part of the ImmediateMutationOp interface.
@@ -725,4 +726,9 @@ func (op AddTableZoneConfig) Visit(ctx context.Context, v ImmediateMutationVisit
 // Visit is part of the ImmediateMutationOp interface.
 func (op AddIndexZoneConfig) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
 	return v.AddIndexZoneConfig(ctx, op)
+}
+
+// Visit is part of the ImmediateMutationOp interface.
+func (op AddPartitionZoneConfig) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
+	return v.AddPartitionZoneConfig(ctx, op)
 }

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -79,6 +79,7 @@ message ElementProto {
     TablePartitioning table_partitioning = 132 [(gogoproto.customname) = "TablePartitioning", (gogoproto.moretags) = "parent:\"Table\""];
     TableSchemaLocked table_schema_locked = 133 [(gogoproto.customname) = "TableSchemaLocked", (gogoproto.moretags) = "parent:\"Table\""];
     LDRJobIDs ldr_job_ids = 134 [(gogoproto.customname) = "LDRJobIDs", (gogoproto.moretags) = "parent:\"Table\""];
+    PartitionZoneConfig partition_zone_config = 135 [(gogoproto.moretags) = "parent:\"TablePartitioning\""];
 
     // Multi-region elements.
     TableLocalityGlobal table_locality_global = 110 [(gogoproto.moretags) = "parent:\"Table\""];
@@ -678,15 +679,29 @@ message TableZoneConfig {
 message IndexZoneConfig {
   uint32 table_id = 1 [(gogoproto.customname) = "TableID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
   uint32 index_id = 2 [(gogoproto.customname) = "IndexID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.IndexID"];
+  cockroach.config.zonepb.Subzone subzone = 3 [(gogoproto.nullable) = false];
+  // `subzone_spans` is used solely for zone config writes. These spans are
+  // recreated for the table zone config during each configuration change.
+  repeated cockroach.config.zonepb.SubzoneSpan subzone_spans = 4 [(gogoproto.nullable) = false];
+  // `seq_num` is used to differentiate different subzone config elements tied
+  // to the same index. E.g. If we attempt to update an index subzone config,
+  // our solution is to drop the existing element and add a new element, with
+  // different `seq_num`.
+  uint32 seq_num = 5;
+}
+
+message PartitionZoneConfig {
+  uint32 table_id = 1 [(gogoproto.customname) = "TableID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
+  uint32 index_id = 2 [(gogoproto.customname) = "IndexID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.IndexID"];
   string partition_name = 3;
   cockroach.config.zonepb.Subzone subzone = 4 [(gogoproto.nullable) = false];
   // `subzone_spans` is used solely for zone config writes. These spans are
   // recreated for the table zone config during each configuration change.
   repeated cockroach.config.zonepb.SubzoneSpan subzone_spans = 5 [(gogoproto.nullable) = false];
   // `seq_num` is used to differentiate different subzone config elements tied
-  // to the same index/partition. E.g. If we attempt to update a(n)
-  // index/partition's subzone config, our solution is to drop the existing
-  // element and add a new element, with different `seq_num`.
+  // to the same partition. E.g. If we attempt to update a partition's subzone
+  // config, our solution is to drop the existing element and add a new element,
+  // with different `seq_num`.
   uint32 seq_num = 6;
 }
 

--- a/pkg/sql/schemachanger/scpb/elements_generated.go
+++ b/pkg/sql/schemachanger/scpb/elements_generated.go
@@ -1601,6 +1601,43 @@ func (c *ElementCollection[E]) FilterOwner() *ElementCollection[*Owner] {
 	return (*ElementCollection[*Owner])(ret)
 }
 
+func (e PartitionZoneConfig) element() {}
+
+// Element implements ElementGetter.
+func (e * ElementProto_PartitionZoneConfig) Element() Element {
+	return e.PartitionZoneConfig
+}
+
+// ForEachPartitionZoneConfig iterates over elements of type PartitionZoneConfig.
+// Deprecated
+func ForEachPartitionZoneConfig(
+	c *ElementCollection[Element], fn func(current Status, target TargetStatus, e *PartitionZoneConfig),
+) {
+  c.FilterPartitionZoneConfig().ForEach(fn)
+}
+
+// FindPartitionZoneConfig finds the first element of type PartitionZoneConfig.
+// Deprecated
+func FindPartitionZoneConfig(
+	c *ElementCollection[Element],
+) (current Status, target TargetStatus, element *PartitionZoneConfig) {
+	if tc := c.FilterPartitionZoneConfig(); !tc.IsEmpty() {
+		var e Element
+		current, target, e = tc.Get(0)
+		element = e.(*PartitionZoneConfig)
+	}
+	return current, target, element
+}
+
+// PartitionZoneConfigElements filters elements of type PartitionZoneConfig.
+func (c *ElementCollection[E]) FilterPartitionZoneConfig() *ElementCollection[*PartitionZoneConfig] {
+	ret := c.genericFilter(func(_ Status, _ TargetStatus, e Element) bool {
+		_, ok := e.(*PartitionZoneConfig)
+		return ok
+	})
+	return (*ElementCollection[*PartitionZoneConfig])(ret)
+}
+
 func (e PrimaryIndex) element() {}
 
 // Element implements ElementGetter.
@@ -2691,6 +2728,8 @@ func (e* ElementProto) SetElement(element Element) {
 			e.ElementOneOf = &ElementProto_Namespace{ Namespace: t}
 		case *Owner:
 			e.ElementOneOf = &ElementProto_Owner{ Owner: t}
+		case *PartitionZoneConfig:
+			e.ElementOneOf = &ElementProto_PartitionZoneConfig{ PartitionZoneConfig: t}
 		case *PrimaryIndex:
 			e.ElementOneOf = &ElementProto_PrimaryIndex{ PrimaryIndex: t}
 		case *RowLevelTTL:
@@ -2794,6 +2833,7 @@ func GetElementOneOfProtos() []interface{} {
 	((*ElementProto_LDRJobIDs)(nil)),
 	((*ElementProto_Namespace)(nil)),
 	((*ElementProto_Owner)(nil)),
+	((*ElementProto_PartitionZoneConfig)(nil)),
 	((*ElementProto_PrimaryIndex)(nil)),
 	((*ElementProto_RowLevelTTL)(nil)),
 	((*ElementProto_Schema)(nil)),
@@ -2871,6 +2911,7 @@ func GetElementTypes() []interface{} {
 	((*LDRJobIDs)(nil)),
 	((*Namespace)(nil)),
 	((*Owner)(nil)),
+	((*PartitionZoneConfig)(nil)),
 	((*PrimaryIndex)(nil)),
 	((*RowLevelTTL)(nil)),
 	((*Schema)(nil)),

--- a/pkg/sql/schemachanger/scpb/state.go
+++ b/pkg/sql/schemachanger/scpb/state.go
@@ -150,6 +150,7 @@ type ZoneConfigElement interface {
 var _ ZoneConfigElement = &DatabaseZoneConfig{}
 var _ ZoneConfigElement = &TableZoneConfig{}
 var _ ZoneConfigElement = &IndexZoneConfig{}
+var _ ZoneConfigElement = &PartitionZoneConfig{}
 
 func (e *DatabaseZoneConfig) GetSeqNum() uint32 {
 	return e.SeqNum
@@ -172,6 +173,14 @@ func (e *IndexZoneConfig) GetSeqNum() uint32 {
 }
 
 func (e *IndexZoneConfig) GetTargetID() catid.DescID {
+	return e.TableID
+}
+
+func (e *PartitionZoneConfig) GetSeqNum() uint32 {
+	return e.SeqNum
+}
+
+func (e *PartitionZoneConfig) GetTargetID() catid.DescID {
 	return e.TableID
 }
 

--- a/pkg/sql/schemachanger/scpb/uml/table.puml
+++ b/pkg/sql/schemachanger/scpb/uml/table.puml
@@ -258,7 +258,6 @@ object IndexZoneConfig
 
 IndexZoneConfig :  TableID
 IndexZoneConfig :  IndexID
-IndexZoneConfig :  PartitionName
 IndexZoneConfig :  Subzone
 IndexZoneConfig : []SubzoneSpans
 IndexZoneConfig :  SeqNum
@@ -279,6 +278,15 @@ object Owner
 
 Owner :  DescriptorID
 Owner :  Owner
+
+object PartitionZoneConfig
+
+PartitionZoneConfig :  TableID
+PartitionZoneConfig :  IndexID
+PartitionZoneConfig :  PartitionName
+PartitionZoneConfig :  Subzone
+PartitionZoneConfig : []SubzoneSpans
+PartitionZoneConfig :  SeqNum
 
 object PrimaryIndex
 
@@ -498,6 +506,7 @@ Database <|-- Owner
 Schema <|-- Owner
 AliasType <|-- Owner
 EnumType <|-- Owner
+TablePartitioning <|-- PartitionZoneConfig
 Table <|-- PrimaryIndex
 View <|-- PrimaryIndex
 Table <|-- RowLevelTTL

--- a/pkg/sql/schemachanger/scplan/internal/opgen/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "opgen_ldr_job_ids.go",
         "opgen_namespace.go",
         "opgen_owner.go",
+        "opgen_partition_zone_config.go",
         "opgen_primary_index.go",
         "opgen_row_level_ttl.go",
         "opgen_schema.go",

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_partition_zone_config.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_partition_zone_config.go
@@ -16,7 +16,6 @@ func init() {
 			scpb.Status_ABSENT,
 			to(scpb.Status_PUBLIC,
 				emit(func(this *scpb.PartitionZoneConfig) *scop.AddPartitionZoneConfig {
-
 					return &scop.AddPartitionZoneConfig{
 						TableID:      this.TableID,
 						Subzone:      this.Subzone,

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_partition_zone_config.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_partition_zone_config.go
@@ -1,0 +1,37 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package opgen
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+)
+
+func init() {
+	opRegistry.register((*scpb.PartitionZoneConfig)(nil),
+		toPublic(
+			scpb.Status_ABSENT,
+			to(scpb.Status_PUBLIC,
+				emit(func(this *scpb.PartitionZoneConfig) *scop.AddPartitionZoneConfig {
+
+					return &scop.AddPartitionZoneConfig{
+						TableID:      this.TableID,
+						Subzone:      this.Subzone,
+						SubzoneSpans: this.SubzoneSpans,
+					}
+				}),
+			),
+		),
+		toAbsent(
+			scpb.Status_PUBLIC,
+			to(scpb.Status_ABSENT,
+				emit(func(this *scpb.PartitionZoneConfig) *scop.NotImplementedForPublicObjects {
+					return notImplementedForPublicObjects(this)
+				}),
+			),
+		),
+	)
+}

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/helpers.go
@@ -231,7 +231,7 @@ func isIndexDependent(e scpb.Element) bool {
 	case *scpb.IndexName, *scpb.IndexComment, *scpb.IndexColumn,
 		*scpb.IndexZoneConfig:
 		return true
-	case *scpb.IndexPartitioning, *scpb.SecondaryIndexPartial:
+	case *scpb.IndexPartitioning, *scpb.PartitionZoneConfig, *scpb.SecondaryIndexPartial:
 		return true
 	}
 	return false

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -2891,7 +2891,7 @@ deprules
   kind: Precedence
   to: relation-Node
   query:
-    - $dependent[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.Column', '*scpb.ColumnComment', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseZoneConfig', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionSecurity', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.LDRJobIDs', '*scpb.Namespace', '*scpb.Owner', '*scpb.PrimaryIndex', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndex', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOption', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TemporaryIndex', '*scpb.TypeComment', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
+    - $dependent[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.Column', '*scpb.ColumnComment', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseZoneConfig', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionSecurity', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.LDRJobIDs', '*scpb.Namespace', '*scpb.Owner', '*scpb.PartitionZoneConfig', '*scpb.PrimaryIndex', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndex', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOption', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TemporaryIndex', '*scpb.TypeComment', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
     - $relation[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - joinOnDescID($dependent, $relation, $relation-id)
     - ToPublicOrTransient($dependent-Target, $relation-Target)
@@ -3012,7 +3012,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.PartitionZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - toAbsent($dependent-Target, $index-Target)
@@ -3025,7 +3025,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.PartitionZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - transient($dependent-Target, $index-Target)
@@ -3038,7 +3038,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.PartitionZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - $dependent-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -3052,7 +3052,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.PartitionZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - $dependent-Target[TargetStatus] = ABSENT
@@ -3135,7 +3135,7 @@ deprules
   to: referencing-via-attr-Node
   query:
     - $referenced-descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
-    - $referencing-via-attr[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnComment', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseZoneConfig', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionSecurity', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.LDRJobIDs', '*scpb.Namespace', '*scpb.Owner', '*scpb.RowLevelTTL', '*scpb.SchemaComment', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOption', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TypeComment', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
+    - $referencing-via-attr[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnComment', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseZoneConfig', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionSecurity', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.LDRJobIDs', '*scpb.Namespace', '*scpb.Owner', '*scpb.PartitionZoneConfig', '*scpb.RowLevelTTL', '*scpb.SchemaComment', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOption', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TypeComment', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
     - joinReferencedDescID($referencing-via-attr, $referenced-descriptor, $desc-id)
     - toAbsent($referenced-descriptor-Target, $referencing-via-attr-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
@@ -3191,7 +3191,7 @@ deprules
   to: dependent-Node
   query:
     - $descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
-    - $dependent[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnComment', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseZoneConfig', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionSecurity', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.LDRJobIDs', '*scpb.Namespace', '*scpb.Owner', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOption', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TypeComment', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
+    - $dependent[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnComment', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseZoneConfig', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionSecurity', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.LDRJobIDs', '*scpb.Namespace', '*scpb.Owner', '*scpb.PartitionZoneConfig', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOption', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TypeComment', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
     - joinOnDescID($descriptor, $dependent, $desc-id)
     - toAbsent($descriptor-Target, $dependent-Target)
     - $descriptor-Node[CurrentStatus] = DROPPED
@@ -3230,7 +3230,7 @@ deprules
   to: dependent-Node
   query:
     - $relation[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
-    - $dependent[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.Column', '*scpb.ColumnComment', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseData', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseZoneConfig', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionSecurity', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexData', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.LDRJobIDs', '*scpb.Namespace', '*scpb.Owner', '*scpb.PrimaryIndex', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndex', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOption', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableData', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TemporaryIndex', '*scpb.TypeComment', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
+    - $dependent[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.Column', '*scpb.ColumnComment', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseData', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseZoneConfig', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionSecurity', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexData', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.LDRJobIDs', '*scpb.Namespace', '*scpb.Owner', '*scpb.PartitionZoneConfig', '*scpb.PrimaryIndex', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndex', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOption', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableData', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TemporaryIndex', '*scpb.TypeComment', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
     - joinOnDescID($relation, $dependent, $relation-id)
     - ToPublicOrTransient($relation-Target, $dependent-Target)
     - $relation-Node[CurrentStatus] = DESCRIPTOR_ADDED
@@ -3297,7 +3297,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.PartitionZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - ToPublicOrTransient($dependent-Target, $index-Target)
@@ -3365,7 +3365,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.PartitionZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - ToPublicOrTransient($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = BACKFILL_ONLY
@@ -3409,7 +3409,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
+    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.PartitionZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - toAbsent($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = VALIDATED
@@ -3422,7 +3422,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
+    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.PartitionZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - transient($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = TRANSIENT_VALIDATED
@@ -3435,7 +3435,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
+    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.PartitionZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - $index-Target[TargetStatus] = TRANSIENT_ABSENT
     - $index-Node[CurrentStatus] = TRANSIENT_VALIDATED
@@ -3449,7 +3449,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
+    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.PartitionZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - $index-Target[TargetStatus] = ABSENT
     - $index-Node[CurrentStatus] = VALIDATED
@@ -3671,7 +3671,7 @@ deprules
   kind: Precedence
   to: descriptor-Node
   query:
-    - $dependent[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.Column', '*scpb.ColumnComment', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseZoneConfig', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionSecurity', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.LDRJobIDs', '*scpb.Namespace', '*scpb.Owner', '*scpb.PrimaryIndex', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndex', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOption', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TemporaryIndex', '*scpb.TypeComment', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
+    - $dependent[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.Column', '*scpb.ColumnComment', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseZoneConfig', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionSecurity', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.LDRJobIDs', '*scpb.Namespace', '*scpb.Owner', '*scpb.PartitionZoneConfig', '*scpb.PrimaryIndex', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndex', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOption', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TemporaryIndex', '*scpb.TypeComment', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
     - $descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - joinOnDescID($dependent, $descriptor, $desc-id)
     - toAbsent($dependent-Target, $descriptor-Target)
@@ -4350,7 +4350,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] = '*scpb.TemporaryIndex'
-    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.PartitionZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - ToPublicOrTransient($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = DELETE_ONLY
@@ -7267,7 +7267,7 @@ deprules
   kind: Precedence
   to: relation-Node
   query:
-    - $dependent[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.Column', '*scpb.ColumnComment', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseZoneConfig', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionSecurity', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.LDRJobIDs', '*scpb.Namespace', '*scpb.Owner', '*scpb.PrimaryIndex', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndex', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOption', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TemporaryIndex', '*scpb.TypeComment', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
+    - $dependent[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.Column', '*scpb.ColumnComment', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseZoneConfig', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionSecurity', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.LDRJobIDs', '*scpb.Namespace', '*scpb.Owner', '*scpb.PartitionZoneConfig', '*scpb.PrimaryIndex', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndex', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOption', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TemporaryIndex', '*scpb.TypeComment', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
     - $relation[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - joinOnDescID($dependent, $relation, $relation-id)
     - ToPublicOrTransient($dependent-Target, $relation-Target)
@@ -7388,7 +7388,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.PartitionZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - toAbsent($dependent-Target, $index-Target)
@@ -7401,7 +7401,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.PartitionZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - transient($dependent-Target, $index-Target)
@@ -7414,7 +7414,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.PartitionZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - $dependent-Target[TargetStatus] = TRANSIENT_ABSENT
@@ -7428,7 +7428,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.PartitionZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - $dependent-Target[TargetStatus] = ABSENT
@@ -7511,7 +7511,7 @@ deprules
   to: referencing-via-attr-Node
   query:
     - $referenced-descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
-    - $referencing-via-attr[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnComment', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseZoneConfig', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionSecurity', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.LDRJobIDs', '*scpb.Namespace', '*scpb.Owner', '*scpb.RowLevelTTL', '*scpb.SchemaComment', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOption', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TypeComment', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
+    - $referencing-via-attr[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnComment', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseZoneConfig', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionSecurity', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.LDRJobIDs', '*scpb.Namespace', '*scpb.Owner', '*scpb.PartitionZoneConfig', '*scpb.RowLevelTTL', '*scpb.SchemaComment', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOption', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TypeComment', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
     - joinReferencedDescID($referencing-via-attr, $referenced-descriptor, $desc-id)
     - toAbsent($referenced-descriptor-Target, $referencing-via-attr-Target)
     - $referenced-descriptor-Node[CurrentStatus] = DROPPED
@@ -7567,7 +7567,7 @@ deprules
   to: dependent-Node
   query:
     - $descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
-    - $dependent[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnComment', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseZoneConfig', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionSecurity', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.LDRJobIDs', '*scpb.Namespace', '*scpb.Owner', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOption', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TypeComment', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
+    - $dependent[Type] IN ['*scpb.CheckConstraintUnvalidated', '*scpb.ColumnComment', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseZoneConfig', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionSecurity', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.LDRJobIDs', '*scpb.Namespace', '*scpb.Owner', '*scpb.PartitionZoneConfig', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOption', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TypeComment', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
     - joinOnDescID($descriptor, $dependent, $desc-id)
     - toAbsent($descriptor-Target, $dependent-Target)
     - $descriptor-Node[CurrentStatus] = DROPPED
@@ -7606,7 +7606,7 @@ deprules
   to: dependent-Node
   query:
     - $relation[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
-    - $dependent[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.Column', '*scpb.ColumnComment', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseData', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseZoneConfig', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionSecurity', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexData', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.LDRJobIDs', '*scpb.Namespace', '*scpb.Owner', '*scpb.PrimaryIndex', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndex', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOption', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableData', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TemporaryIndex', '*scpb.TypeComment', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
+    - $dependent[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.Column', '*scpb.ColumnComment', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseData', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseZoneConfig', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionSecurity', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexData', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.LDRJobIDs', '*scpb.Namespace', '*scpb.Owner', '*scpb.PartitionZoneConfig', '*scpb.PrimaryIndex', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndex', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOption', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableData', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TemporaryIndex', '*scpb.TypeComment', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
     - joinOnDescID($relation, $dependent, $relation-id)
     - ToPublicOrTransient($relation-Target, $dependent-Target)
     - $relation-Node[CurrentStatus] = DESCRIPTOR_ADDED
@@ -7673,7 +7673,7 @@ deprules
   kind: Precedence
   to: index-Node
   query:
-    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.PartitionZoneConfig', '*scpb.SecondaryIndexPartial']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
     - ToPublicOrTransient($dependent-Target, $index-Target)
@@ -7741,7 +7741,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.PartitionZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - ToPublicOrTransient($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = BACKFILL_ONLY
@@ -7785,7 +7785,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
+    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.PartitionZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - toAbsent($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = VALIDATED
@@ -7798,7 +7798,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
+    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.PartitionZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - transient($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = TRANSIENT_VALIDATED
@@ -7811,7 +7811,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
+    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.PartitionZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - $index-Target[TargetStatus] = TRANSIENT_ABSENT
     - $index-Node[CurrentStatus] = TRANSIENT_VALIDATED
@@ -7825,7 +7825,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
-    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
+    - $dependent[Type] IN ['*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.PartitionZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - $index-Target[TargetStatus] = ABSENT
     - $index-Node[CurrentStatus] = VALIDATED
@@ -8047,7 +8047,7 @@ deprules
   kind: Precedence
   to: descriptor-Node
   query:
-    - $dependent[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.Column', '*scpb.ColumnComment', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseZoneConfig', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionSecurity', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.LDRJobIDs', '*scpb.Namespace', '*scpb.Owner', '*scpb.PrimaryIndex', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndex', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOption', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TemporaryIndex', '*scpb.TypeComment', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
+    - $dependent[Type] IN ['*scpb.CheckConstraint', '*scpb.CheckConstraintUnvalidated', '*scpb.Column', '*scpb.ColumnComment', '*scpb.ColumnComputeExpression', '*scpb.ColumnDefaultExpression', '*scpb.ColumnFamily', '*scpb.ColumnName', '*scpb.ColumnNotNull', '*scpb.ColumnOnUpdateExpression', '*scpb.ColumnType', '*scpb.CompositeTypeAttrName', '*scpb.CompositeTypeAttrType', '*scpb.ConstraintComment', '*scpb.ConstraintWithoutIndexName', '*scpb.DatabaseComment', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseZoneConfig', '*scpb.EnumTypeValue', '*scpb.ForeignKeyConstraint', '*scpb.ForeignKeyConstraintUnvalidated', '*scpb.FunctionBody', '*scpb.FunctionLeakProof', '*scpb.FunctionName', '*scpb.FunctionNullInputBehavior', '*scpb.FunctionSecurity', '*scpb.FunctionVolatility', '*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.LDRJobIDs', '*scpb.Namespace', '*scpb.Owner', '*scpb.PartitionZoneConfig', '*scpb.PrimaryIndex', '*scpb.RowLevelTTL', '*scpb.SchemaChild', '*scpb.SchemaComment', '*scpb.SchemaParent', '*scpb.SecondaryIndex', '*scpb.SecondaryIndexPartial', '*scpb.SequenceOption', '*scpb.SequenceOwner', '*scpb.TableComment', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.TableLocalitySecondaryRegion', '*scpb.TablePartitioning', '*scpb.TableSchemaLocked', '*scpb.TableZoneConfig', '*scpb.TemporaryIndex', '*scpb.TypeComment', '*scpb.UniqueWithoutIndexConstraint', '*scpb.UniqueWithoutIndexConstraintUnvalidated', '*scpb.UserPrivileges']
     - $descriptor[Type] IN ['*scpb.AliasType', '*scpb.CompositeType', '*scpb.Database', '*scpb.EnumType', '*scpb.Function', '*scpb.Schema', '*scpb.Sequence', '*scpb.Table', '*scpb.View']
     - joinOnDescID($dependent, $descriptor, $desc-id)
     - toAbsent($dependent-Target, $descriptor-Target)
@@ -8726,7 +8726,7 @@ deprules
   to: dependent-Node
   query:
     - $index[Type] = '*scpb.TemporaryIndex'
-    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.SecondaryIndexPartial']
+    - $dependent[Type] IN ['*scpb.IndexColumn', '*scpb.IndexComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.IndexZoneConfig', '*scpb.PartitionZoneConfig', '*scpb.SecondaryIndexPartial']
     - joinOnIndexID($index, $dependent, $table-id, $index-id)
     - ToPublicOrTransient($index-Target, $dependent-Target)
     - $index-Node[CurrentStatus] = DELETE_ONLY

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_24_1/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_24_1/helpers.go
@@ -226,7 +226,7 @@ func isIndexDependent(e scpb.Element) bool {
 	case *scpb.IndexName, *scpb.IndexComment, *scpb.IndexColumn,
 		*scpb.IndexZoneConfig:
 		return true
-	case *scpb.IndexPartitioning, *scpb.SecondaryIndexPartial:
+	case *scpb.IndexPartitioning, *scpb.PartitionZoneConfig, *scpb.SecondaryIndexPartial:
 		return true
 	}
 	return false

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_24_2/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_24_2/helpers.go
@@ -226,7 +226,7 @@ func isIndexDependent(e scpb.Element) bool {
 	case *scpb.IndexName, *scpb.IndexComment, *scpb.IndexColumn,
 		*scpb.IndexZoneConfig:
 		return true
-	case *scpb.IndexPartitioning, *scpb.SecondaryIndexPartial:
+	case *scpb.IndexPartitioning, *scpb.PartitionZoneConfig, *scpb.SecondaryIndexPartial:
 		return true
 	}
 	return false

--- a/pkg/sql/schemachanger/screl/attr.go
+++ b/pkg/sql/schemachanger/screl/attr.go
@@ -99,8 +99,10 @@ const (
 
 	// Expr corresponds to the string representation of a SQL expression for an element.
 	Expr
-	// SQL string name of the type.
+	// TypeName corresponds to the SQL string name of the type.
 	TypeName
+	// PartitionName corresponds to the name of a partition.
+	PartitionName
 
 	// AttrMax is the largest possible Attr value.
 	// Note: add any new enum values before TargetStatus, leave these at the end.
@@ -394,6 +396,12 @@ var elementSchemaOptions = []rel.SchemaOption{
 	rel.EntityMapping(t((*scpb.IndexZoneConfig)(nil)),
 		rel.EntityAttr(DescID, "TableID"),
 		rel.EntityAttr(IndexID, "IndexID"),
+		rel.EntityAttr(SeqNum, "SeqNum"),
+	),
+	rel.EntityMapping(t((*scpb.PartitionZoneConfig)(nil)),
+		rel.EntityAttr(DescID, "TableID"),
+		rel.EntityAttr(IndexID, "IndexID"),
+		rel.EntityAttr(PartitionName, "PartitionName"),
 		rel.EntityAttr(SeqNum, "SeqNum"),
 	),
 	rel.EntityMapping(t((*scpb.DatabaseData)(nil)),

--- a/pkg/sql/schemachanger/screl/attr_string.go
+++ b/pkg/sql/schemachanger/screl/attr_string.go
@@ -30,7 +30,8 @@ func _() {
 	_ = x[ReferencedColumnIDs-20]
 	_ = x[Expr-21]
 	_ = x[TypeName-22]
-	_ = x[AttrMax-22]
+	_ = x[PartitionName-23]
+	_ = x[AttrMax-23]
 }
 
 func (i Attr) String() string {
@@ -79,6 +80,8 @@ func (i Attr) String() string {
 		return "Expr"
 	case TypeName:
 		return "TypeName"
+	case PartitionName:
+		return "PartitionName"
 	default:
 		return "Attr(" + strconv.FormatInt(int64(i), 10) + ")"
 	}

--- a/pkg/sql/schemachanger/screl/scalars.go
+++ b/pkg/sql/schemachanger/screl/scalars.go
@@ -122,7 +122,8 @@ func VersionSupportsElementUse(el scpb.Element, version clusterversion.ClusterVe
 		return true
 	case *scpb.TypeComment, *scpb.DatabaseZoneConfig:
 		return version.IsActive(clusterversion.V24_2)
-	case *scpb.ColumnComputeExpression, *scpb.FunctionSecurity, *scpb.LDRJobIDs:
+	case *scpb.ColumnComputeExpression, *scpb.FunctionSecurity, *scpb.LDRJobIDs,
+		*scpb.PartitionZoneConfig:
 		return version.IsActive(clusterversion.V24_3)
 	default:
 		panic(errors.AssertionFailedf("unknown element %T", el))


### PR DESCRIPTION
### schemachanger: add PartitionZoneConfig element
This patch adds a new element, `PartitionZoneConfig`,
that will become relevant for supporting `ALTER PARTITION
... CONFIGURE ZONE` in the DSC.

Release note: None

---

### schemachanger: add opgen rule for partition zc
This patch adds an opgen rule to support our PartitionZoneConfig
element.

Release note: None

---

### schemachanger: panic if partition does not exist on index
This patch ensures that we panic if a partition does not
exist on the specified index in a `ALTER TABLE ... OF INDEX`.

Release note: None

---

### schemachanger: add support for ALTER PARTITION ... OF TABLE
This patch adds support for ALTER PARTITION ... OF TABLE in
the form of zone_config_helpers.

Release note: None

---

### schemachanger: support partition zone config
This patch adds the functionality to configure
a zone configuration on a partition.

Fixes: https://github.com/cockroachdb/cockroach/issues/129889
Release note: None

Epic: [CRDB-31473](https://cockroachlabs.atlassian.net/browse/CRDB-31473)