### PR TITLE
changefeedccl: add network metrics to kafka v1 sink

### DIFF
--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"math"
+	"net"
 	"net/url"
 	"strings"
 	"sync"
@@ -31,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
+	"github.com/cockroachdb/cockroach/pkg/util/cidr"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -1227,6 +1229,7 @@ func buildKafkaConfig(
 	u sinkURL,
 	jsonStr changefeedbase.SinkSpecificJSONConfig,
 	kafkaThrottlingMetrics metrics.Histogram,
+	netMetrics *cidr.NetMetrics,
 ) (*sarama.Config, error) {
 	dialConfig, err := buildDialConfig(u)
 	if err != nil {
@@ -1313,6 +1316,16 @@ func buildKafkaConfig(
 			"failed to parse sarama config; check %s option", changefeedbase.OptKafkaSinkConfig)
 	}
 
+	// Leverage sarama's proxy support to slip in our net metrics
+	config.Net.Proxy.Enable = true
+	// This is how sarama constructs its Dialer. See (*Config).getDialer() in sarama.
+	dialer := &net.Dialer{
+		Timeout:   config.Net.DialTimeout,
+		KeepAlive: config.Net.KeepAlive,
+		LocalAddr: config.Net.LocalAddr,
+	}
+	config.Net.Proxy.Dialer = netMetrics.WrapDialer(dialer, "kafka")
+
 	// Note that the sarama.Config.Validate() below only logs an error in some
 	// cases, so we explicitly validate sarama config from our side.
 	if err := saramaCfg.Validate(); err != nil {
@@ -1347,7 +1360,7 @@ func makeKafkaSink(
 	}
 
 	m := mb(requiresResourceAccounting)
-	config, err := buildKafkaConfig(ctx, u, jsonStr, m.getKafkaThrottlingMetrics(settings))
+	config, err := buildKafkaConfig(ctx, u, jsonStr, m.getKafkaThrottlingMetrics(settings), m.netMetrics())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add support for the cidr network metrics to the kafka v1 sink.

Part of: https://github.com/cockroachdb/cockroach/issues/130097

Release note (enterprise change): Added network metrics to the kafka v1 sink.