### PR TITLE
replica_rac2: integrate admitted tracking on leader

### DIFF
--- a/pkg/kv/kvserver/flow_control_raft_transport_test.go
+++ b/pkg/kv/kvserver/flow_control_raft_transport_test.go
@@ -796,6 +796,6 @@ func TestFlowControlRaftTransportV2(t *testing.T) {
 type noopPiggybackedAdmittedResponseScheduler struct{}
 
 func (s noopPiggybackedAdmittedResponseScheduler) ScheduleAdmittedResponseForRangeRACv2(
-	ctx context.Context, msgs []kvflowcontrolpb.AdmittedResponseForRange,
+	context.Context, []kvflowcontrolpb.PiggybackedAdmittedState,
 ) {
 }

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -723,9 +723,6 @@ func (rss *replicaState) closeSendStream(ctx context.Context) {
 func (rss *replicaSendStream) makeConsistentInStateReplicate(
 	ctx context.Context,
 ) (shouldWaitChange bool) {
-	av := rss.parent.parent.opts.AdmittedTracker.GetAdmitted(rss.parent.desc.ReplicaID)
-	rss.admit(ctx, av)
-
 	// The leader is always in state replicate.
 	if rss.parent.parent.opts.LocalReplicaID == rss.parent.desc.ReplicaID {
 		if rss.mu.connectedState != replicate {

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -60,6 +60,12 @@ type RangeController interface {
 	//
 	// Requires replica.raftMu to be held.
 	HandleSchedulerEventRaftMuLocked(ctx context.Context) error
+	// AdmitRaftMuLocked handles the notification about the given replica's
+	// admitted vector change. No-op if the replica is not known, or the admitted
+	// vector is stale (either in Term, or the indices).
+	//
+	// Requires replica.raftMu to be held.
+	AdmitRaftMuLocked(context.Context, roachpb.ReplicaID, AdmittedVector)
 	// SetReplicasRaftMuLocked sets the replicas of the range. The caller will
 	// never mutate replicas, and neither should the callee.
 	//
@@ -375,6 +381,19 @@ func (rc *rangeController) HandleSchedulerEventRaftMuLocked(ctx context.Context)
 	panic("unimplemented")
 }
 
+// AdmitRaftMuLocked handles the notification about the given replica's
+// admitted vector change. No-op if the replica is not known, or the admitted
+// vector is stale (either in Term, or the indices).
+//
+// Requires replica.raftMu to be held.
+func (rc *rangeController) AdmitRaftMuLocked(
+	ctx context.Context, replicaID roachpb.ReplicaID, av AdmittedVector,
+) {
+	if rs, ok := rc.replicaMap[replicaID]; ok {
+		rs.admit(ctx, av)
+	}
+}
+
 // SetReplicasRaftMuLocked sets the replicas of the range. The caller will
 // never mutate replicas, and neither should the callee.
 //
@@ -530,6 +549,12 @@ func (rss *replicaSendStream) changeConnectedStateLocked(state connectedState, n
 	rss.mu.connectedStateStart = now
 }
 
+func (rss *replicaSendStream) admit(ctx context.Context, av AdmittedVector) {
+	rss.mu.Lock()
+	defer rss.mu.Unlock()
+	rss.returnTokens(ctx, rss.mu.tracker.Untrack(av.Term, av.Admitted))
+}
+
 func (rs *replicaState) createReplicaSendStream() {
 	// Must be in StateReplicate on creation.
 	rs.sendStream = &replicaSendStream{
@@ -676,6 +701,12 @@ func (rs *replicaState) handleReadyState(
 	return shouldWaitChange
 }
 
+func (rs *replicaState) admit(ctx context.Context, av AdmittedVector) {
+	if rss := rs.sendStream; rss != nil {
+		rss.admit(ctx, av)
+	}
+}
+
 func (rss *replicaState) closeSendStream(ctx context.Context) {
 	rss.sendStream.mu.Lock()
 	defer rss.sendStream.mu.Unlock()
@@ -693,9 +724,7 @@ func (rss *replicaSendStream) makeConsistentInStateReplicate(
 	ctx context.Context,
 ) (shouldWaitChange bool) {
 	av := rss.parent.parent.opts.AdmittedTracker.GetAdmitted(rss.parent.desc.ReplicaID)
-	rss.mu.Lock()
-	defer rss.mu.Unlock()
-	defer rss.returnTokens(ctx, rss.mu.tracker.Untrack(av.Term, av.Admitted))
+	rss.admit(ctx, av)
 
 	// The leader is always in state replicate.
 	if rss.parent.parent.opts.LocalReplicaID == rss.parent.desc.ReplicaID {

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -750,10 +750,10 @@ func (rss *replicaSendStream) returnTokens(
 	ctx context.Context, returned [raftpb.NumPriorities]kvflowcontrol.Tokens,
 ) {
 	for pri, tokens := range returned {
-		pri := raftpb.Priority(pri)
 		if tokens > 0 {
-			rss.parent.evalTokenCounter.Return(ctx, WorkClassFromRaftPriority(pri), tokens)
-			rss.parent.sendTokenCounter.Return(ctx, WorkClassFromRaftPriority(pri), tokens)
+			pri := WorkClassFromRaftPriority(raftpb.Priority(pri))
+			rss.parent.evalTokenCounter.Return(ctx, pri, tokens)
+			rss.parent.sendTokenCounter.Return(ctx, pri, tokens)
 		}
 	}
 }

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -106,17 +106,6 @@ type FollowerStateInfo struct {
 	Next  uint64
 }
 
-// AdmittedTracker is used to retrieve the latest admitted vector for a
-// replica (including the leader).
-type AdmittedTracker interface {
-	// GetAdmitted returns the latest AdmittedVector for replicaID. It returns
-	// an empty struct if the replicaID is not known. NB: the
-	// AdmittedVector.Admitted[i] value can transiently advance past
-	// FollowerStateInfo.Match, since the admitted tracking subsystem is
-	// separate from Raft.
-	GetAdmitted(replicaID roachpb.ReplicaID) AdmittedVector
-}
-
 // RaftEvent carries a RACv2-relevant subset of raft state sent to storage.
 type RaftEvent struct {
 	// Term is the leader term on whose behalf the entries or snapshot are
@@ -206,7 +195,6 @@ type RangeControllerOptions struct {
 	RaftInterface       RaftInterface
 	Clock               *hlc.Clock
 	CloseTimerScheduler ProbeToCloseTimerScheduler
-	AdmittedTracker     AdmittedTracker
 	EvalWaitMetrics     *EvalWaitMetrics
 }
 

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
@@ -239,7 +239,6 @@ func (s *testingRCState) getOrInitRange(r testingRange) *testingRCRange {
 			RaftInterface:       testRC,
 			Clock:               s.clock,
 			CloseTimerScheduler: s.probeToCloseScheduler,
-			AdmittedTracker:     testRC,
 			EvalWaitMetrics:     s.evalMetrics,
 		}
 
@@ -282,17 +281,6 @@ func (r *testingRCRange) FollowerStateRaftMuLocked(replicaID roachpb.ReplicaID) 
 		return FollowerStateInfo{}
 	}
 	return replica.info
-}
-
-func (r *testingRCRange) GetAdmitted(replicaID roachpb.ReplicaID) AdmittedVector {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	replica, ok := r.mu.r.replicaSet[replicaID]
-	if !ok {
-		return AdmittedVector{}
-	}
-	return replica.av
 }
 
 func (r *testingRCRange) startWaitForEval(name string, pri admissionpb.WorkPriority) {
@@ -350,7 +338,6 @@ const invalidTrackerState = tracker.StateSnapshot + 1
 type testingReplica struct {
 	desc roachpb.ReplicaDescriptor
 	info FollowerStateInfo
-	av   AdmittedVector
 }
 
 func scanRanges(t *testing.T, input string) []testingRange {

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -353,14 +353,13 @@ type Processor interface {
 	AdmitRaftEntriesRaftMuLocked(
 		ctx context.Context, event rac2.RaftEvent) bool
 
-	// EnqueuePiggybackedAdmittedAtLeader is called at the leader when
-	// receiving a piggybacked MsgAppResp that can advance a follower's
-	// admitted state. The caller is responsible for scheduling on the raft
-	// scheduler, such that ProcessPiggybackedAdmittedAtLeaderRaftMuLocked
-	// gets called soon.
-	EnqueuePiggybackedAdmittedAtLeader(msg raftpb.Message)
+	// EnqueuePiggybackedAdmittedAtLeader is called at the leader when receiving a
+	// piggybacked admitted vector that can advance the given follower's admitted
+	// state. The caller is responsible for scheduling on the raft scheduler, such
+	// that ProcessPiggybackedAdmittedAtLeaderRaftMuLocked gets called soon.
+	EnqueuePiggybackedAdmittedAtLeader(roachpb.ReplicaID, kvflowcontrolpb.AdmittedState)
 	// ProcessPiggybackedAdmittedAtLeaderRaftMuLocked is called to process
-	// previous enqueued piggybacked MsgAppResp. Returns true if
+	// previously enqueued piggybacked admitted vectors. Returns true if
 	// HandleRaftReadyRaftMuLocked should be called.
 	//
 	// raftMu is held.
@@ -389,6 +388,13 @@ type Processor interface {
 	)
 	// AdmittedState returns the vector of admitted log indices.
 	AdmittedState() rac2.AdmittedVector
+
+	// AdmitRaftMuLocked is called to notify RACv2 about the admitted vector
+	// update on the given peer replica. This releases the associated flow tokens
+	// if the replica is known and the admitted vector covers any.
+	//
+	// raftMu is held.
+	AdmitRaftMuLocked(context.Context, roachpb.ReplicaID, rac2.AdmittedVector)
 
 	// AdmitForEval is called to admit work that wants to evaluate at the
 	// leaseholder.
@@ -429,7 +435,14 @@ type processorImpl struct {
 		// State when leader, i.e., when leaderID == opts.ReplicaID, and v2
 		// protocol is enabled.
 		leader struct {
-			enqueuedPiggybackedResponses map[roachpb.ReplicaID]raftpb.Message
+			// pendingAdmitted contains recently delivered admitted vectors. When this
+			// map is not empty, the range is scheduled for applying these vectors to
+			// the corresponding streams / token trackers. The map is cleared when the
+			// admitted vectors are applied.
+			//
+			// Invariant: rc == nil ==> len(pendingAdmitted) == 0.
+			// Invariant: len(pendingAdmitted) != 0 ==> the processing is scheduled.
+			pendingAdmitted map[roachpb.ReplicaID]rac2.AdmittedVector
 			// Updating the rc reference requires both the enclosing mu and
 			// rcReferenceUpdateMu. Code paths that want to access this
 			// reference only need one of these mutexes. rcReferenceUpdateMu
@@ -676,7 +689,7 @@ func (p *processorImpl) closeLeaderStateRaftMuLockedProcLocked(ctx context.Conte
 		defer p.mu.leader.rcReferenceUpdateMu.Unlock()
 		p.mu.leader.rc = nil
 	}()
-	p.mu.leader.enqueuedPiggybackedResponses = nil
+	p.mu.leader.pendingAdmitted = nil
 	p.mu.leader.term = 0
 }
 
@@ -700,7 +713,7 @@ func (p *processorImpl) createLeaderStateRaftMuLockedProcLocked(
 		})
 	}()
 	p.mu.leader.term = term
-	p.mu.leader.enqueuedPiggybackedResponses = map[roachpb.ReplicaID]raftpb.Message{}
+	p.mu.leader.pendingAdmitted = map[roachpb.ReplicaID]rac2.AdmittedVector{}
 }
 
 // HandleRaftReadyRaftMuLocked implements Processor.
@@ -744,20 +757,23 @@ func (p *processorImpl) HandleRaftReadyRaftMuLocked(ctx context.Context, e rac2.
 		return
 	}
 
-	// Piggyback admitted index advancement, if any, to the message stream going
-	// to the leader node, if we are not the leader. At the leader node, the
-	// admitted vector is read directly from the log tracker.
-	if p.mu.leader.rc == nil && p.mu.leaderNodeID != 0 {
-		// TODO(pav-kv): must make sure the leader term is the same.
-		if admitted, dirty := p.logTracker.admitted(true /* sched */); dirty {
+	if av, dirty := p.logTracker.admitted(true /* sched */); dirty {
+		if rc := p.mu.leader.rc; rc != nil {
+			// If we are the leader, notify the RangeController about our replica's
+			// new admitted vector.
+			rc.AdmitRaftMuLocked(ctx, p.opts.ReplicaID, av)
+		} else if p.mu.leaderNodeID != 0 {
+			// If the leader is known, piggyback the updated admitted vector to the
+			// message stream going to the leader node.
+			// TODO(pav-kv): must make sure the leader term is the same.
 			p.opts.AdmittedPiggybacker.Add(p.mu.leaderNodeID, kvflowcontrolpb.PiggybackedAdmittedState{
 				RangeID:       p.opts.RangeID,
 				ToStoreID:     p.mu.leaderStoreID,
 				FromReplicaID: p.opts.ReplicaID,
 				ToReplicaID:   p.mu.leaderID,
 				Admitted: kvflowcontrolpb.AdmittedState{
-					Term:     admitted.Term,
-					Admitted: admitted.Admitted[:],
+					Term:     av.Term,
+					Admitted: av.Admitted[:],
 				}})
 		}
 	}
@@ -864,18 +880,20 @@ func (p *processorImpl) AdmitRaftEntriesRaftMuLocked(ctx context.Context, e rac2
 }
 
 // EnqueuePiggybackedAdmittedAtLeader implements Processor.
-func (p *processorImpl) EnqueuePiggybackedAdmittedAtLeader(msg raftpb.Message) {
-	if roachpb.ReplicaID(msg.To) != p.opts.ReplicaID {
-		// Ignore message to a stale ReplicaID.
-		return
-	}
+func (p *processorImpl) EnqueuePiggybackedAdmittedAtLeader(
+	from roachpb.ReplicaID, state kvflowcontrolpb.AdmittedState,
+) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.mu.leader.rc == nil {
 		return
 	}
-	// Only need to keep the latest message from a replica.
-	p.mu.leader.enqueuedPiggybackedResponses[roachpb.ReplicaID(msg.From)] = msg
+	var admitted [raftpb.NumPriorities]uint64
+	copy(admitted[:], state.Admitted)
+	// Merge in the received admitted vector. We are only interested in the
+	// highest admitted marks. Zero value always merges in favour of the new one.
+	p.mu.leader.pendingAdmitted[from] = p.mu.leader.pendingAdmitted[from].Merge(
+		rac2.AdmittedVector{Term: state.Term, Admitted: admitted})
 }
 
 // ProcessPiggybackedAdmittedAtLeaderRaftMuLocked implements Processor.
@@ -883,18 +901,13 @@ func (p *processorImpl) ProcessPiggybackedAdmittedAtLeaderRaftMuLocked(ctx conte
 	p.opts.Replica.RaftMuAssertHeld()
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if p.mu.destroyed || len(p.mu.leader.enqueuedPiggybackedResponses) == 0 || p.raftMu.raftNode == nil {
+	if p.mu.destroyed || len(p.mu.leader.pendingAdmitted) == 0 {
 		return false
 	}
-	p.opts.Replica.MuLock()
-	defer p.opts.Replica.MuUnlock()
-	for k, m := range p.mu.leader.enqueuedPiggybackedResponses {
-		err := p.raftMu.raftNode.StepMsgAppRespForAdmittedLocked(m)
-		if err != nil {
-			log.Errorf(ctx, "%s", err)
-		}
-		delete(p.mu.leader.enqueuedPiggybackedResponses, k)
+	for replicaID, state := range p.mu.leader.pendingAdmitted {
+		p.mu.leader.rc.AdmitRaftMuLocked(ctx, replicaID, state)
 	}
+	clear(p.mu.leader.pendingAdmitted)
 	return true
 }
 
@@ -952,6 +965,17 @@ func (p *processorImpl) AdmittedLogEntry(
 func (p *processorImpl) AdmittedState() rac2.AdmittedVector {
 	admitted, _ := p.logTracker.admitted(false /* sched */)
 	return admitted
+}
+
+// AdmitRaftMuLocked implements Processor.
+func (p *processorImpl) AdmitRaftMuLocked(
+	ctx context.Context, replicaID roachpb.ReplicaID, av rac2.AdmittedVector,
+) {
+	p.opts.Replica.RaftMuAssertHeld()
+	// NB: rc is always updated while raftMu is held.
+	if rc := p.mu.leader.rc; rc != nil {
+		rc.AdmitRaftMuLocked(ctx, replicaID, av)
+	}
 }
 
 // AdmitForEval implements Processor.

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -88,16 +88,8 @@ type RaftScheduler interface {
 // reads Raft state at various points while holding raftMu, and expects those
 // various reads to be mutually consistent.
 type RaftNode interface {
-	// EnablePingForAdmittedLaggingLocked is a one time behavioral change made
-	// to enable pinging for the admitted array when it is lagging match. Once
-	// changed, this will apply to current and future leadership roles at this
-	// replica.
-	EnablePingForAdmittedLaggingLocked()
-
-	// Read-only methods.
-
-	// rac2.RaftInterface is an interface that abstracts the raft.RawNode for use
-	// in the RangeController.
+	// RaftInterface is an interface that abstracts the raft.RawNode for use in
+	// the RangeController.
 	rac2.RaftInterface
 	// TermLocked returns the current term of this replica.
 	TermLocked() uint64
@@ -109,7 +101,6 @@ type RaftNode interface {
 	// guaranteed to be stablestorage, unless this method is called right after
 	// RawNode is initialized. Processor calls this only on initialization.
 	LogMarkLocked() rac2.LogMark
-
 	// NextUnstableIndexLocked returns the index of the next entry that will
 	// be sent to local storage. All entries < this index are either stored,
 	// or have been sent to storage.
@@ -117,12 +108,6 @@ type RaftNode interface {
 	// NB: NextUnstableIndex can regress when the node accepts appends or
 	// snapshots from a newer leader.
 	NextUnstableIndexLocked() uint64
-
-	// Mutating methods.
-
-	// StepMsgAppRespForAdmittedLocked steps a MsgAppResp on the leader, which
-	// may advance its knowledge of a follower's admitted state.
-	StepMsgAppRespForAdmittedLocked(raftpb.Message) error
 }
 
 // AdmittedPiggybacker is used to enqueue admitted vector messages addressed to

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -238,6 +238,12 @@ func (c *testRangeController) HandleSchedulerEventRaftMuLocked(ctx context.Conte
 	panic("HandleSchedulerEventRaftMuLocked should not be called when no send-queues")
 }
 
+func (c *testRangeController) AdmitRaftMuLocked(
+	_ context.Context, replicaID roachpb.ReplicaID, av rac2.AdmittedVector,
+) {
+	fmt.Fprintf(c.b, " RangeController.AdmitRaftMuLocked(%s, %+v)\n", replicaID, av)
+}
+
 func (c *testRangeController) SetReplicasRaftMuLocked(
 	ctx context.Context, replicas rac2.ReplicaSet,
 ) error {

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -104,11 +104,6 @@ type testRaftNode struct {
 	nextUnstableIndex uint64
 }
 
-func (rn *testRaftNode) EnablePingForAdmittedLaggingLocked() {
-	rn.r.mu.AssertHeld()
-	fmt.Fprintf(rn.b, " RaftNode.EnablePingForAdmittedLaggingLocked\n")
-}
-
 func (rn *testRaftNode) TermLocked() uint64 {
 	rn.r.mu.AssertHeld()
 	fmt.Fprintf(rn.b, " RaftNode.TermLocked() = %d\n", rn.term)
@@ -131,12 +126,6 @@ func (rn *testRaftNode) NextUnstableIndexLocked() uint64 {
 	rn.r.mu.AssertHeld()
 	fmt.Fprintf(rn.b, " RaftNode.NextUnstableIndexLocked() = %d\n", rn.nextUnstableIndex)
 	return rn.nextUnstableIndex
-}
-
-func (rn *testRaftNode) StepMsgAppRespForAdmittedLocked(msg raftpb.Message) error {
-	rn.r.mu.AssertHeld()
-	fmt.Fprintf(rn.b, " RaftNode.StepMsgAppRespForAdmittedLocked(%s)\n", msgString(msg))
-	return nil
 }
 
 func (rn *testRaftNode) FollowerStateRaftMuLocked(

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -155,10 +155,6 @@ func (rn *testRaftNode) print() {
 		rn.term, rn.leader, rn.r.leaseholder, rn.mark, rn.nextUnstableIndex)
 }
 
-func msgString(msg raftpb.Message) string {
-	return fmt.Sprintf("type: %s from: %d to: %d", msg.Type.String(), msg.From, msg.To)
-}
-
 type testAdmittedPiggybacker struct {
 	b *strings.Builder
 }
@@ -412,12 +408,9 @@ func TestProcessorBasic(t *testing.T) {
 				var from, to uint64
 				d.ScanArgs(t, "from", &from)
 				d.ScanArgs(t, "to", &to)
-				msg := raftpb.Message{
-					Type: raftpb.MsgAppResp,
-					To:   raftpb.PeerID(to),
-					From: raftpb.PeerID(from),
-				}
-				p.EnqueuePiggybackedAdmittedAtLeader(msg)
+				// TODO(pav-kv): parse the admitted vector.
+				p.EnqueuePiggybackedAdmittedAtLeader(
+					roachpb.ReplicaID(from), kvflowcontrolpb.AdmittedState{})
 				return builderStr()
 
 			case "process-piggybacked-admitted":

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/raft_node.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/raft_node.go
@@ -27,10 +27,6 @@ func NewRaftNode(rn *raft.RawNode) RaftNode {
 	return raftNodeForRACv2{RawNode: rn}
 }
 
-func (rn raftNodeForRACv2) EnablePingForAdmittedLaggingLocked() {
-	panic("TODO(pav-kv): implement")
-}
-
 func (rn raftNodeForRACv2) TermLocked() uint64 {
 	return rn.Term()
 }
@@ -45,19 +41,6 @@ func (rn raftNodeForRACv2) LogMarkLocked() rac2.LogMark {
 
 func (rn raftNodeForRACv2) NextUnstableIndexLocked() uint64 {
 	return rn.NextUnstableIndex()
-}
-
-func (rn raftNodeForRACv2) GetAdmittedLocked() [raftpb.NumPriorities]uint64 {
-	// TODO(pav-kv): implement.
-	return [raftpb.NumPriorities]uint64{}
-}
-
-func (rn raftNodeForRACv2) SetAdmittedLocked([raftpb.NumPriorities]uint64) raftpb.Message {
-	panic("TODO(pav-kv): implement")
-}
-
-func (rn raftNodeForRACv2) StepMsgAppRespForAdmittedLocked(m raftpb.Message) error {
-	return rn.RawNode.Step(m)
 }
 
 func (rn raftNodeForRACv2) FollowerStateRaftMuLocked(

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
@@ -122,7 +122,7 @@ HandleRaftReady:
 AdmitRaftEntries:
  ACWorkQueue.Admit({StoreID:2 TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false RangeID:3 ReplicaID:5 CallbackState:{Mark:{Term:50 Index:25} Priority:LowPri}}) = true
 destroyed-or-leader-using-v2: true
-LogTracker [+dirty]: mark:{Term:50 Index:25}, stable:23, admitted:[23 23 23 23]
+LogTracker: mark:{Term:50 Index:25}, stable:23, admitted:[23 23 23 23]
 LowPri: {Term:50 Index:25}
 
 # The leader has changed.
@@ -463,6 +463,7 @@ HandleRaftReady:
  Replica.LeaseholderMuLocked
  RaftNode.TermLocked() = 52
  Replica.MuUnlock
+ RangeController.AdmitRaftMuLocked(5, {Term:52 Admitted:[26 26 26 26]})
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
 
@@ -483,6 +484,7 @@ HandleRaftReady:
  Replica.LeaseholderMuLocked
  RaftNode.TermLocked() = 52
  Replica.MuUnlock
+ RangeController.AdmitRaftMuLocked(5, {Term:52 Admitted:[28 28 28 28]})
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
 
@@ -494,9 +496,7 @@ enqueue-piggybacked-admitted from=25 to=5
 process-piggybacked-admitted
 ----
  Replica.RaftMuAssertHeld
- Replica.MuLock
- RaftNode.StepMsgAppRespForAdmittedLocked(type: MsgAppResp from: 25 to: 5)
- Replica.MuUnlock
+ RangeController.AdmitRaftMuLocked(25, {Term:0 Admitted:[0 0 0 0]})
 
 # Noop.
 process-piggybacked-admitted
@@ -511,6 +511,7 @@ enqueue-piggybacked-admitted from=25 to=6
 process-piggybacked-admitted
 ----
  Replica.RaftMuAssertHeld
+ RangeController.AdmitRaftMuLocked(25, {Term:0 Admitted:[0 0 0 0]})
 
 # We are still the leader, now at a new term.
 set-raft-state term=53
@@ -739,6 +740,7 @@ HandleRaftReady:
  Replica.LeaseholderMuLocked
  RaftNode.TermLocked() = 50
  Replica.MuUnlock
+ RangeController.AdmitRaftMuLocked(5, {Term:50 Admitted:[26 26 26 26]})
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
 
@@ -761,7 +763,7 @@ HandleRaftReady:
 .....
 AdmitRaftEntries:
 destroyed-or-leader-using-v2: true
-LogTracker [+dirty]: mark:{Term:50 Index:27}, stable:26, admitted:[26 26 26 26]
+LogTracker: mark:{Term:50 Index:27}, stable:26, admitted:[26 26 26 26]
 
 # Everything up to 27 is admitted.
 synced-log term=50 index=27
@@ -778,6 +780,7 @@ HandleRaftReady:
  Replica.LeaseholderMuLocked
  RaftNode.TermLocked() = 50
  Replica.MuUnlock
+ RangeController.AdmitRaftMuLocked(5, {Term:50 Admitted:[27 27 27 27]})
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
 

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
@@ -360,7 +360,7 @@ HandleRaftReady:
 .....
 
 # Noop, since not the leader.
-enqueue-piggybacked-admitted from=25 to=5
+enqueue-piggybacked-admitted from=25 to=5 term=50 index=24 pri=0
 ----
 
 # Noop.
@@ -489,29 +489,23 @@ HandleRaftReady:
 .....
 
 # Enqueue piggybacked admitted vector.
-enqueue-piggybacked-admitted from=25 to=5
+enqueue-piggybacked-admitted from=25 to=5 term=52 index=24 pri=0
+----
+
+# Enqueue another piggybacked admitted vector, it merges into the previous one.
+enqueue-piggybacked-admitted from=25 to=5 term=52 index=25 pri=2
 ----
 
 # Process it.
 process-piggybacked-admitted
 ----
  Replica.RaftMuAssertHeld
- RangeController.AdmitRaftMuLocked(25, {Term:0 Admitted:[0 0 0 0]})
+ RangeController.AdmitRaftMuLocked(25, {Term:52 Admitted:[24 0 25 0]})
 
 # Noop.
 process-piggybacked-admitted
 ----
  Replica.RaftMuAssertHeld
-
-# Noop, since the replica id does not match.
-enqueue-piggybacked-admitted from=25 to=6
-----
-
-# Noop.
-process-piggybacked-admitted
-----
- Replica.RaftMuAssertHeld
- RangeController.AdmitRaftMuLocked(25, {Term:0 Admitted:[0 0 0 0]})
 
 # We are still the leader, now at a new term.
 set-raft-state term=53
@@ -578,7 +572,7 @@ get-enabled-level
 enabled-level: v1-encoding
 
 # Noop.
-enqueue-piggybacked-admitted from=25 to=5
+enqueue-piggybacked-admitted from=25 to=5 term=52 index=24 pri=0
 ----
 
 # Noop.

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/txt
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/txt
@@ -1,0 +1,1 @@
+bazel coverage --compilation_mode=fastbuild --@io_bazel_rules_go//go/config:cover_format=lcov --combined_report=lcov --instrumentation_filter="//pkg/kv/kvserver/kvflowcontrol/replica_rac2" --test_verbose_timeout_warnings --test_tmpdir=/tmp --sandbox_debug //pkg/kv/kvserver/kvflowcontrol/replica_rac2:small_tests


### PR DESCRIPTION
This PR plumbs the admitted vectors into the RACv2 `Processor`. Admitted vectors are applied to `replicaSendStream` and cause releasing the tokens held by the leader.

The admitted vectors are plumbed to `replicaSendStream` via 3 paths:
- The leader's own admitted vector is applied from `HandleRaftReadyRaftMuLocked`, calling into `RangeController.AdmitRaftMuLocked` directly.
- The followers' admitted vectors in most cases are received via annotated `RaftMessageRequest.AdmittedState`, which is dispatched from `stepRaftGroupRaftMuLocked` into the `Processor` via `Processor.AdmitRaftMuLocked` method.
- The followers' piggybacked admitted vectors from `RaftMessageRequestBatch` are queued on the `Processor` via `EnqueuePiggybackedAdmittedAtLeader` method, and later applied from `HandleRaftReadyRaftMuLocked`.

Part of #129508