### PR TITLE
changefeedccl: add network metrics for the pubsub sinks

### DIFF
--- a/pkg/ccl/changefeedccl/sink_pubsub.go
+++ b/pkg/ccl/changefeedccl/sink_pubsub.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"encoding/json"
 	"hash/crc32"
+	"net"
 	"net/url"
 
 	"cloud.google.com/go/pubsub"
@@ -22,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/api/option"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -74,7 +76,8 @@ type deprecatedGcpPubsubClient struct {
 		topics          map[string]*pubsub.Topic
 	}
 
-	knobs *TestingKnobs
+	knobs   *TestingKnobs
+	metrics metricsRecorder
 }
 
 type deprecatedPubsubSink struct {
@@ -114,7 +117,7 @@ func makeDeprecatedPubsubSink(
 	mb metricsRecorderBuilder,
 	knobs *TestingKnobs,
 ) (Sink, error) {
-
+	m := mb(requiresResourceAccounting)
 	pubsubURL := sinkURL{URL: u, q: u.Query()}
 	pubsubTopicName := pubsubURL.consumeParam(changefeedbase.SinkParamTopicName)
 
@@ -142,7 +145,7 @@ func makeDeprecatedPubsubSink(
 		numWorkers:  numOfWorkers,
 		exitWorkers: cancel,
 		format:      formatType,
-		metrics:     mb(requiresResourceAccounting),
+		metrics:     m,
 	}
 
 	// creates custom pubsub object based on scheme
@@ -177,6 +180,7 @@ func makeDeprecatedPubsubSink(
 			endpoint:   endpoint,
 			url:        pubsubURL,
 			knobs:      knobs,
+			metrics:    m,
 		}
 		p.client = g
 		p.topicNamer = tn
@@ -457,15 +461,21 @@ func (p *deprecatedGcpPubsubClient) init() error {
 	if err != nil {
 		return err
 	}
+
+	// Set up the network metrics for tracking bytes in/out.
+	dialContext := p.metrics.netMetrics().Wrap((&net.Dialer{}).DialContext, "pubsub")
+	dial := func(ctx context.Context, target string) (net.Conn, error) {
+		return dialContext(ctx, "tcp", target)
+	}
+
 	// Sending messages to the same region ensures they are received in order
 	// even when multiple publishers are used.
 	// region can be changed from query parameter to config option
-
 	client, err = pubsub.NewClient(
 		p.ctx,
 		p.projectID,
 		creds,
-		option.WithEndpoint(p.endpoint),
+		option.WithEndpoint(p.endpoint), option.WithGRPCDialOption(grpc.WithContextDialer(dial)),
 	)
 
 	if err != nil {

--- a/pkg/ccl/changefeedccl/sink_pubsub_v2.go
+++ b/pkg/ccl/changefeedccl/sink_pubsub_v2.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net"
 	"net/url"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
+	"github.com/cockroachdb/cockroach/pkg/util/cidr"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -82,6 +84,7 @@ func makePubsubSinkClient(
 	unordered bool,
 	withTableNameAttribute bool,
 	knobs *TestingKnobs,
+	m metricsRecorder,
 ) (SinkClient, error) {
 	if u.Scheme != GcpScheme {
 		return nil, errors.Errorf("unknown scheme: %s", u.Scheme)
@@ -118,7 +121,7 @@ func makePubsubSinkClient(
 	// In unit tests the publisherClient gets set immediately after initializing
 	// the sink object via knobs.WrapSink.
 	if knobs == nil || !knobs.PubsubClientSkipClientCreation {
-		publisherClient, err = makePublisherClient(ctx, pubsubURL, unordered)
+		publisherClient, err = makePublisherClient(ctx, pubsubURL, unordered, m.netMetrics())
 		if err != nil {
 			return nil, err
 		}
@@ -296,7 +299,7 @@ func (pe *pubsubSinkClient) Close() error {
 }
 
 func makePublisherClient(
-	ctx context.Context, url sinkURL, unordered bool,
+	ctx context.Context, url sinkURL, unordered bool, nm *cidr.NetMetrics,
 ) (*pubsub.PublisherClient, error) {
 	const regionParam = "region"
 	region := url.consumeParam(regionParam)
@@ -318,7 +321,12 @@ func makePublisherClient(
 		return nil, err
 	}
 
-	opts := []option.ClientOption{creds, option.WithEndpoint(endpoint)}
+	// Set up the network metrics for tracking bytes in/out.
+	dialContext := nm.Wrap((&net.Dialer{}).DialContext, "pubsub")
+	dial := func(ctx context.Context, target string) (net.Conn, error) {
+		return dialContext(ctx, "tcp", target)
+	}
+	opts := []option.ClientOption{creds, option.WithEndpoint(endpoint), option.WithGRPCDialOption(grpc.WithContextDialer(dial))}
 
 	// See https://pkg.go.dev/cloud.google.com/go/pubsub#hdr-Emulator for emulator information.
 	if addr, _ := envutil.ExternalEnvString("PUBSUB_EMULATOR_HOST", 1); addr != "" {
@@ -428,6 +436,8 @@ func makePubsubSink(
 	settings *cluster.Settings,
 	knobs *TestingKnobs,
 ) (Sink, error) {
+	m := mb(requiresResourceAccounting)
+
 	batchCfg, retryOpts, err := getSinkConfigFromJson(jsonConfig, sinkJSONConfig{
 		// GCPubsub library defaults
 		Flush: sinkBatchConfig{
@@ -447,7 +457,7 @@ func makePubsubSink(
 		return nil, err
 	}
 	sinkClient, err := makePubsubSinkClient(ctx, u, encodingOpts, targets, batchCfg, unordered,
-		includeTableNameAttribute, knobs)
+		includeTableNameAttribute, knobs, m)
 	if err != nil {
 		return nil, err
 	}
@@ -468,7 +478,7 @@ func makePubsubSink(
 		topicNamer,
 		pacerFactory,
 		source,
-		mb(requiresResourceAccounting),
+		m,
 		settings,
 	), nil
 }


### PR DESCRIPTION
Add support for the cidr network metrics to the pubsub sinks.

Part of: #130097

Release note (enterprise change): Added network metrics to the pubsub sinks.
