### PR TITLE
roachtest/ruby-pg: mark connection timeout test as flaky

### DIFF
--- a/pkg/cmd/roachtest/tests/ruby_pg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg_blocklist.go
@@ -200,4 +200,5 @@ var rubyPGIgnorelist = blocklist{
 	`running with sync_* methods PG::Connection OS thread support Connection.new shouldn't block a second thread`:                                                                  "flaky",
 	`running with sync_* methods PG::Connection handles server close while asynchronous connect`:                                                                                   "flaky",
 	`running with sync_* methods PG::Connection multinationalization support respect and convert character encoding of input strings should convert error string to #put_copy_end`: "flaky",
+	`running with sync_* methods PG::Connection times out after connect_timeout seconds`:                                                                                           "flaky",
 }


### PR DESCRIPTION
Previously, the "PG::Connection times out after connect_timeout seconds" test could fail because of address in use errors. To address this, this patch adds the test on the ignore list.

Fixes: #129954

Release note: None