### PR TITLE
insights, server: fix race in ListExecutionInsights and insights pool

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -527,6 +527,7 @@ go_test(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlstats",
+        "//pkg/sql/sqlstats/insights",
         "//pkg/storage",
         "//pkg/storage/disk",
         "//pkg/storage/fs",

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -397,11 +397,12 @@ func (b *baseStatusServer) localExecutionInsights(
 			return
 		}
 
-		// Versions <=22.2.6 expects that Statement is not null when building the exec insights virtual table.
-		insightWithStmt := *insight
-		insightWithStmt.Statement = &insights.Statement{}
+		insightsCopy := *insight
+		// Copy statements slice - these insights objects can be read concurrently.
+		insightsCopy.Statements = make([]*insights.Statement, len(insight.Statements))
+		copy(insightsCopy.Statements, insight.Statements)
 
-		response.Insights = append(response.Insights, insightWithStmt)
+		response.Insights = append(response.Insights, insightsCopy)
 	})
 
 	return &response, nil

--- a/pkg/sql/sqlstats/insights/pool.go
+++ b/pkg/sql/sqlstats/insights/pool.go
@@ -26,10 +26,8 @@ var insightPool = sync.Pool{
 
 func makeInsight(sessionID clusterunique.ID, transaction *Transaction) *Insight {
 	insight := insightPool.Get().(*Insight)
-	*insight = Insight{
-		Session:     Session{ID: sessionID},
-		Transaction: transaction,
-	}
+	insight.Session = Session{ID: sessionID}
+	insight.Transaction = transaction
 	return insight
 }
 


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/pull/128400 we nil'd the entries in the Insight.Statements slice on
`releaseInsight`, which is called when evicting insights from the cache.
This caused a race leading to a nil pointer dereference:
The ListExecutionInsights status server grpc was making  shallow copies of the insights objects from the cache. After releasing the RLock we marshal the shallow copies into the grpc response. If insights are simultaneously getting evicted during that process, they clear the shared `Statements` slice leading to a nil pointer dereference in the marhsaling code.

We address this by creating a new slice for each insight when creating the grpc response. Additionally, Insights retrieved from the pool are modified so that it's reuses the Statements slice that was prepped during `releaseInsight`, something it was not previously doing.

Epic: none
Fixes: #130290
Fixes: #129936

Release note: None