### PR TITLE
rac2: add MsgApp pings to tickle admitted vectors

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
@@ -305,6 +305,10 @@ func (r *testingRCRange) FollowerStateRaftMuLocked(replicaID roachpb.ReplicaID) 
 	return replica.info
 }
 
+func (r *testingRCRange) SendPingRaftMuLocked(roachpb.ReplicaID) bool {
+	return false
+}
+
 func (r *testingRCRange) startWaitForEval(name string, pri admissionpb.WorkPriority) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker.go
@@ -45,6 +45,19 @@ func (dt *Tracker) Init(stream kvflowcontrol.Stream) {
 	}
 }
 
+func (t *Tracker) Empty() bool {
+	// TODO(pav-kv): can optimize this loop out if needed. We can maintain the
+	// total number of tokens held, and return whether it's zero. It's also
+	// possible to make it atomic and avoid locking the mutex in replicaSendStream
+	// when calling this.
+	for pri := range t.tracked {
+		if len(t.tracked[pri]) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // Track token deductions of the given priority with the given raft log index and term.
 func (t *Tracker) Track(
 	ctx context.Context, term uint64, index uint64, pri raftpb.Priority, tokens kvflowcontrol.Tokens,

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -377,6 +377,16 @@ type Processor interface {
 	// raftMu is held.
 	AdmitRaftMuLocked(context.Context, roachpb.ReplicaID, rac2.AdmittedVector)
 
+	// MaybeSendPingsRaftMuLocked sends a MsgApp ping to each raft peer whose
+	// admitted vector is lagging, and there wasn't a recent MsgApp to this peer.
+	// The messages are added to raft's message queue, and will be extracted from
+	// raft and sent during the next Ready processing.
+	//
+	// If the replica is not the leader, this call does nothing.
+	//
+	// raftMu is held.
+	MaybeSendPingsRaftMuLocked()
+
 	// AdmitForEval is called to admit work that wants to evaluate at the
 	// leaseholder.
 	//
@@ -1098,6 +1108,14 @@ func (p *processorImpl) AdmitRaftMuLocked(
 	// NB: rc is always updated while raftMu is held.
 	if rc := p.leader.rc; rc != nil {
 		rc.AdmitRaftMuLocked(ctx, replicaID, av)
+	}
+}
+
+// MaybeSendPingsRaftMuLocked implements Processor.
+func (p *processorImpl) MaybeSendPingsRaftMuLocked() {
+	p.opts.Replica.RaftMuAssertHeld()
+	if rc := p.leader.rc; rc != nil {
+		rc.MaybeSendPingsRaftMuLocked()
 	}
 }
 

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -142,6 +142,11 @@ func (rn *testRaftNode) FollowerStateRaftMuLocked(
 	return rac2.FollowerStateInfo{}
 }
 
+func (rn *testRaftNode) SendPingRaftMuLocked(to roachpb.ReplicaID) bool {
+	fmt.Fprintf(rn.b, " RaftNode.SendPingRaftMuLocked(%d)\n", to)
+	return true
+}
+
 func (rn *testRaftNode) setMark(t *testing.T, mark rac2.LogMark) {
 	require.True(t, mark.After(rn.mark))
 	rn.mark = mark
@@ -243,6 +248,10 @@ func (c *testRangeController) AdmitRaftMuLocked(
 	_ context.Context, replicaID roachpb.ReplicaID, av rac2.AdmittedVector,
 ) {
 	fmt.Fprintf(c.b, " RangeController.AdmitRaftMuLocked(%s, %+v)\n", replicaID, av)
+}
+
+func (c *testRangeController) MaybeSendPingsRaftMuLocked() {
+	fmt.Fprintf(c.b, " RangeController.MaybeSendPingsRaftMuLocked()\n")
 }
 
 func (c *testRangeController) SetReplicasRaftMuLocked(

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/raft_node.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/raft_node.go
@@ -58,3 +58,7 @@ func (rn raftNodeForRACv2) FollowerStateRaftMuLocked(
 
 	return rac2.FollowerStateInfo{State: tracker.StateProbe}
 }
+
+func (rn raftNodeForRACv2) SendPingRaftMuLocked(to roachpb.ReplicaID) bool {
+	return rn.RawNode.SendPing(raftpb.PeerID(to))
+}

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1375,6 +1375,8 @@ func (r *Replica) tick(
 	r.updatePausedFollowersLocked(ctx, ioThresholdMap)
 
 	leaseStatus := r.leaseStatusAtRLocked(ctx, r.store.Clock().NowAsClockTimestamp())
+	// TODO(pav-kv): modify the quiescence criterion so that we don't quiesce if
+	// RACv2 holds some send tokens.
 	if r.maybeQuiesceRaftMuLockedReplicaMuLocked(ctx, leaseStatus, livenessMap) {
 		return false, nil
 	}
@@ -1438,6 +1440,10 @@ func (r *Replica) tick(
 		// have been pending for 1 to 2 reproposal timeouts.
 		r.refreshProposalsLocked(ctx, refreshAtDelta, reasonTicks)
 	}
+
+	// NB: since we are returning true below, there will be a Ready handling
+	// immediately after this call, so any pings stashed in raft will be sent.
+	r.flowControlV2.MaybeSendPingsRaftMuLocked()
 	return true, nil
 }
 

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -481,6 +481,14 @@ func (rn *RawNode) NextUnstableIndex() uint64 {
 	return rn.raft.raftLog.unstable.entryInProgress + 1
 }
 
+// SendPing sends a MsgApp ping to the given peer, if it is in StateReplicate
+// and there was no recent MsgApp to this peer.
+//
+// Returns true if the ping was added to the message queue.
+func (rn *RawNode) SendPing(to pb.PeerID) bool {
+	return rn.raft.sendPing(to)
+}
+
 // Status returns the current status of the given group. This allocates, see
 // SparseStatus, BasicStatus and WithProgress for allocation-friendlier choices.
 func (rn *RawNode) Status() Status {


### PR DESCRIPTION
This commit adds another condition for sending `MsgApp` pings to peers, on top of existing `MsgApp` pings that raft leader sends if its knowledge about the follower's state (stable log index and commit index) hasn't converged to its own.

The additional condition is that the leader holds some RACv2 eval/flow tokens, meaning that the follower's storage hasn't admitted all the pending writes. Our knowledge may be lagging due to various reasons, e.g. the messages are dropped. We want to learn about admissions in a timely manner, so we send `MsgApp` pings that trigger `MsgAppResp` flow, which delivers the follower's current state to the leader. Eventually, the leader learns the follower's state and quiesces the pings.

We integrate with `MsgApp` pings for a couple of reasons:
 - simplicity
 - we don't want to send excessive amount of pings. If raft sends pings already (because its knowledge is lagging), RACv2 pings will not be sent in addition to that.

Part of #129508