### PR TITLE
logictest: revert incorrect test assertion update

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
@@ -205,8 +205,8 @@ ORDER BY start_key
 /Table/106  14400
 /Table/107  14400
 /Table/110  90001
-/Table/111  90001
-/Table/112  14400
+/Table/111  1
+/Table/112  1
 
 subtest transactional_schemachanges
 


### PR DESCRIPTION
(Deja vu: this is #121556 all over again.)

103bd54 incorrectly updated the test expectations, likely because the `--rewrite` flag was used on an assertion that has the retry directive.

This commit undoes that change.

Fixes: #130405

Release note: None