### PR TITLE
storage: fix test crash caused by invalid key passed to builtin

### DIFF
--- a/pkg/sql/sem/builtins/generator_builtins_test.go
+++ b/pkg/sql/sem/builtins/generator_builtins_test.go
@@ -11,10 +11,13 @@
 package builtins
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -198,4 +201,40 @@ func TestGetSSTableMetricsSingleNode(t *testing.T) {
 		count++
 	}
 	require.GreaterOrEqual(t, count, 1)
+}
+
+func TestScanStorageInternalKeys(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	const numNodes = 3
+	tc := serverutils.StartCluster(t, numNodes, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+
+	sqlDB.Exec(t, `CREATE TABLE t(k INT PRIMARY KEY, v INT)`)
+	sqlDB.Exec(t, `INSERT INTO t SELECT i, i*10 FROM generate_series(1, 1000) AS g(i)`)
+	require.NoError(t, tc.WaitForFullReplication())
+
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	randKey := func() []byte {
+		k := make([]byte, 1+rng.Intn(5))
+		for i := range k {
+			k[i] = byte(rng.Intn(256))
+		}
+		return k
+	}
+	for i := 0; i < 10000; i++ {
+		a := randKey()
+		b := a
+		for bytes.Equal(a, b) {
+			b = randKey()
+		}
+		if bytes.Compare(a, b) < 0 {
+			a, b = b, a
+		}
+		n := 1 + rng.Intn(numNodes)
+		sqlDB.QueryStr(t, `SELECT crdb_internal.scan_storage_internal_keys($1, $2, $3, $4, 100)`, n, n, a, b)
+	}
 }

--- a/pkg/storage/engine_key.go
+++ b/pkg/storage/engine_key.go
@@ -213,6 +213,10 @@ func DecodeEngineKey(b []byte) (key EngineKey, ok bool) {
 	// Last byte is the version length + 1 when there is a version,
 	// else it is 0.
 	versionLen := int(b[len(b)-1])
+	if versionLen == 1 {
+		// The key encodes an empty version, which is not valid.
+		return EngineKey{}, false
+	}
 	// keyPartEnd points to the sentinel byte.
 	keyPartEnd := len(b) - 1 - versionLen
 	if keyPartEnd < 0 || b[keyPartEnd] != 0x00 {

--- a/pkg/storage/enginepb/decode.go
+++ b/pkg/storage/enginepb/decode.go
@@ -33,6 +33,10 @@ func SplitMVCCKey(mvccKey []byte) (key []byte, ts []byte, ok bool) {
 		return nil, nil, false
 	}
 	tsLen := int(mvccKey[len(mvccKey)-1])
+	if tsLen == 1 {
+		// We never encode an empty version.
+		return nil, nil, false
+	}
 	keyPartEnd := len(mvccKey) - 1 - tsLen
 	if keyPartEnd < 0 {
 		return nil, nil, false

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -413,7 +413,10 @@ func checkEngineKey(k []byte) {
 		panic(errors.AssertionFailedf("empty key"))
 	}
 	if int(k[len(k)-1]) >= len(k) {
-		panic(errors.AssertionFailedf("malformed key sentinel byte: %x", k))
+		panic(errors.AssertionFailedf("malformed key terminator byte: %x", k))
+	}
+	if k[len(k)-1] == 1 {
+		panic(errors.AssertionFailedf("invalid key terminator byte 1"))
 	}
 }
 


### PR DESCRIPTION
There are a few `crdb_internal` storage-related built-ins which take
keys as arguments: `compact_engine_span`, `sstable_metrics`,
`scan_storage_internal_keys`. Their implementations allow passing
either encoded keys or unencoded keys without a timestmap. If the
given key looks like a valid encoded key, we use it as-is.

There is a case where the key looks valid but later it trips up the
`EngineComparer`: when it has an encoded version which has zero length
(i.e. `foo<00><01>`). This commit makes the decoding code more strict
to error out for such keys.

Fixes #129952