### PR TITLE
replica_rac2: remove processorImpl mutex

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -182,7 +182,7 @@ type RangeControllerFactory interface {
 //
 // State transitions are NotEnabledWhenLeader => EnabledWhenLeaderV1Encoding
 // => EnabledWhenLeaderV2Encoding, i.e., the level will never regress.
-type EnabledWhenLeaderLevel uint8
+type EnabledWhenLeaderLevel = uint32
 
 const (
 	NotEnabledWhenLeader EnabledWhenLeaderLevel = iota
@@ -501,7 +501,7 @@ type processorImpl struct {
 	// enabledWhenLeader indicates the RACv2 mode of operation when this replica
 	// is the leader. Atomic value, for serving GetEnabledWhenLeader. Updated only
 	// while holding raftMu. Can be read non-atomically if raftMu is held.
-	enabledWhenLeader atomic.Uint32
+	enabledWhenLeader EnabledWhenLeaderLevel
 
 	v1EncodingPriorityMismatch log.EveryN
 }
@@ -509,10 +509,11 @@ type processorImpl struct {
 var _ Processor = &processorImpl{}
 
 func NewProcessor(opts ProcessorOptions) Processor {
-	p := &processorImpl{opts: opts}
-	p.enabledWhenLeader.Store(uint32(opts.EnabledWhenLeaderLevel))
-	p.v1EncodingPriorityMismatch = log.Every(time.Minute)
-	return p
+	return &processorImpl{
+		opts:                       opts,
+		enabledWhenLeader:          opts.EnabledWhenLeaderLevel,
+		v1EncodingPriorityMismatch: log.Every(time.Minute),
+	}
 }
 
 // isLeaderUsingV2RaftMuLocked returns true if the current leader uses the V2
@@ -548,10 +549,10 @@ func (p *processorImpl) SetEnabledWhenLeaderRaftMuLocked(
 	ctx context.Context, level EnabledWhenLeaderLevel,
 ) {
 	p.opts.Replica.RaftMuAssertHeld()
-	if p.destroyed || EnabledWhenLeaderLevel(p.enabledWhenLeader.Load()) >= level {
+	if p.destroyed || p.enabledWhenLeader >= level {
 		return
 	}
-	p.enabledWhenLeader.Store(uint32(level))
+	atomic.StoreUint32(&p.enabledWhenLeader, level)
 	if level != EnabledWhenLeaderV1Encoding || p.desc.replicas == nil {
 		return
 	}
@@ -575,7 +576,7 @@ func (p *processorImpl) SetEnabledWhenLeaderRaftMuLocked(
 
 // GetEnabledWhenLeader implements Processor.
 func (p *processorImpl) GetEnabledWhenLeader() EnabledWhenLeaderLevel {
-	return EnabledWhenLeaderLevel(p.enabledWhenLeader.Load())
+	return atomic.LoadUint32(&p.enabledWhenLeader)
 }
 
 func descToReplicaSet(desc *roachpb.RangeDescriptor) rac2.ReplicaSet {
@@ -677,7 +678,7 @@ func (p *processorImpl) makeStateConsistentRaftMuLocked(
 		return
 	}
 	// Is the leader.
-	if EnabledWhenLeaderLevel(p.enabledWhenLeader.Load()) == NotEnabledWhenLeader {
+	if p.enabledWhenLeader == NotEnabledWhenLeader {
 		return
 	}
 	if p.leader.rc != nil && myLeaderTerm > p.leader.term {

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -459,17 +459,26 @@ type processorImpl struct {
 		term uint64
 	}
 
-	// Fields below are accessed while holding Replica.raftMu. This
-	// peculiarity is only to handle the fact that OnDescChanged is called
-	// with Replica.mu held.
-	raftMu struct {
+	// replMu contains the fields that must be accessed while holding Replica.mu.
+	replMu struct {
+		// raftNode provides access to a subset of raft RawNode. The reference is
+		// updated while holding both Replica.raftMu and Replica.mu, so can be read
+		// with any of the two mutexes locked. When interacting with raftNode, the
+		// Replica.mu must be held. See RaftNode comments.
 		raftNode RaftNode
-		// replicasChanged is set to true when replicas has been updated. This
-		// is used to lazily update all the state under mu that needs to use
-		// the state in replicas.
+	}
+
+	// desc contains the data derived from OnDescChangedLocked calls. It is always
+	// updated with both Replica.raftMu and Replica.mu held, and is first set when
+	// Replica is initialized. The fields are grouped for informational purposes,
+	// processorImpl always accesses them under raftMu like other fields.
+	desc struct {
+		// replicasChanged is set to true when replicas has been updated. This is
+		// used to lazily update all the state under mu that needs to use the state
+		// in replicas.
 		replicas        rac2.ReplicaSet
 		replicasChanged bool
-		// Set once, in the first call to OnDescChanged.
+		// Set once, in the first call to OnDescChangedLocked.
 		tenantID roachpb.TenantID
 	}
 
@@ -503,11 +512,11 @@ func (p *processorImpl) isLeaderUsingV2ProcLocked() bool {
 func (p *processorImpl) InitRaftLocked(ctx context.Context, rn RaftNode) {
 	p.opts.Replica.RaftMuAssertHeld()
 	p.opts.Replica.MuAssertHeld()
-	if p.raftMu.replicas != nil {
+	if p.desc.replicas != nil {
 		log.Fatalf(ctx, "initializing RaftNode after replica is initialized")
 	}
-	p.raftMu.raftNode = rn
-	p.logTracker.init(p.raftMu.raftNode.LogMarkLocked())
+	p.replMu.raftNode = rn
+	p.logTracker.init(p.replMu.raftNode.LogMarkLocked())
 }
 
 // OnDestroyRaftMuLocked implements Processor.
@@ -528,7 +537,7 @@ func (p *processorImpl) SetEnabledWhenLeaderRaftMuLocked(
 		return
 	}
 	p.enabledWhenLeader.Store(uint32(level))
-	if level != EnabledWhenLeaderV1Encoding || p.raftMu.replicas == nil {
+	if level != EnabledWhenLeaderV1Encoding || p.desc.replicas == nil {
 		return
 	}
 	// May need to create RangeController.
@@ -538,10 +547,10 @@ func (p *processorImpl) SetEnabledWhenLeaderRaftMuLocked(
 	func() {
 		p.opts.Replica.MuLock()
 		defer p.opts.Replica.MuUnlock()
-		leaderID = p.raftMu.raftNode.LeaderLocked()
+		leaderID = p.replMu.raftNode.LeaderLocked()
 		if leaderID == p.opts.ReplicaID {
-			term = p.raftMu.raftNode.TermLocked()
-			nextUnstableIndex = p.raftMu.raftNode.NextUnstableIndexLocked()
+			term = p.replMu.raftNode.TermLocked()
+			nextUnstableIndex = p.replMu.raftNode.NextUnstableIndexLocked()
 		}
 	}()
 	if leaderID == p.opts.ReplicaID {
@@ -568,19 +577,19 @@ func (p *processorImpl) OnDescChangedLocked(
 ) {
 	p.opts.Replica.RaftMuAssertHeld()
 	p.opts.Replica.MuAssertHeld()
-	initialization := p.raftMu.replicas == nil
+	initialization := p.desc.replicas == nil
 	if initialization {
 		// Replica is initialized, in that we now have a descriptor.
-		if p.raftMu.raftNode == nil {
+		if p.replMu.raftNode == nil {
 			panic(errors.AssertionFailedf("RaftNode is not initialized"))
 		}
-		p.raftMu.tenantID = tenantID
-	} else if p.raftMu.tenantID != tenantID {
+		p.desc.tenantID = tenantID
+	} else if p.desc.tenantID != tenantID {
 		panic(errors.AssertionFailedf("tenantId was changed from %s to %s",
-			p.raftMu.tenantID, tenantID))
+			p.desc.tenantID, tenantID))
 	}
-	p.raftMu.replicas = descToReplicaSet(desc)
-	p.raftMu.replicasChanged = true
+	p.desc.replicas = descToReplicaSet(desc)
+	p.desc.replicasChanged = true
 	// We need to promptly return tokens if some replicas have been removed,
 	// since those tokens could be used by other ranges with replicas on the
 	// same store. Ensure that promptness by scheduling ready.
@@ -590,7 +599,7 @@ func (p *processorImpl) OnDescChangedLocked(
 }
 
 // makeStateConsistentRaftMuLockedProcLocked, uses the union of the latest
-// state retrieved from RaftNode, and the set of replica (in raftMu.replicas),
+// state retrieved from RaftNode, and the set of replica (in replMu.replicas),
 // to initialize or update the internal state of processorImpl.
 //
 // nextUnstableIndex is used to initialize the state of the send-queues if
@@ -603,9 +612,9 @@ func (p *processorImpl) makeStateConsistentRaftMuLockedProcLocked(
 	leaseholderID roachpb.ReplicaID,
 	myLeaderTerm uint64,
 ) {
-	replicasChanged := p.raftMu.replicasChanged
+	replicasChanged := p.desc.replicasChanged
 	if replicasChanged {
-		p.raftMu.replicasChanged = false
+		p.desc.replicasChanged = false
 	}
 	if !replicasChanged && leaderID == p.leaderID && leaseholderID == p.leaseholderID &&
 		(p.leader.rc == nil || p.leader.term == myLeaderTerm) {
@@ -621,7 +630,7 @@ func (p *processorImpl) makeStateConsistentRaftMuLockedProcLocked(
 		p.leaderNodeID = 0
 		p.leaderStoreID = 0
 	} else {
-		rd, ok := p.raftMu.replicas[leaderID]
+		rd, ok := p.desc.replicas[leaderID]
 		if !ok {
 			if leaderID == p.opts.ReplicaID {
 				// Is leader, but not in the set of replicas. We expect this
@@ -630,7 +639,7 @@ func (p *processorImpl) makeStateConsistentRaftMuLockedProcLocked(
 				// tolerate it.
 				log.Errorf(ctx,
 					"leader=%d is not in the set of replicas=%v",
-					leaderID, p.raftMu.replicas)
+					leaderID, p.desc.replicas)
 				p.leaderNodeID = p.opts.NodeID
 				p.leaderStoreID = p.opts.StoreID
 			} else {
@@ -666,7 +675,7 @@ func (p *processorImpl) makeStateConsistentRaftMuLockedProcLocked(
 	}
 	// Existing RangeController.
 	if replicasChanged {
-		if err := p.leader.rc.SetReplicasRaftMuLocked(ctx, p.raftMu.replicas); err != nil {
+		if err := p.leader.rc.SetReplicasRaftMuLocked(ctx, p.desc.replicas); err != nil {
 			log.Errorf(ctx, "error setting replicas: %v", err)
 		}
 	}
@@ -700,13 +709,13 @@ func (p *processorImpl) createLeaderStateRaftMuLockedProcLocked(
 	}
 	p.leader.term = term
 	rc := p.opts.RangeControllerFactory.New(ctx, rangeControllerInitState{
-		replicaSet:     p.raftMu.replicas,
+		replicaSet:     p.desc.replicas,
 		leaseholder:    p.leaseholderID,
 		nextRaftIndex:  nextUnstableIndex,
 		rangeID:        p.opts.RangeID,
-		tenantID:       p.raftMu.tenantID,
+		tenantID:       p.desc.tenantID,
 		localReplicaID: p.opts.ReplicaID,
-		raftInterface:  p.raftMu.raftNode,
+		raftInterface:  p.replMu.raftNode,
 	})
 
 	func() {
@@ -725,10 +734,10 @@ func (p *processorImpl) createLeaderStateRaftMuLockedProcLocked(
 func (p *processorImpl) HandleRaftReadyRaftMuLocked(ctx context.Context, e rac2.RaftEvent) {
 	p.opts.Replica.RaftMuAssertHeld()
 	// Skip if the replica is not initialized or already destroyed.
-	if p.raftMu.replicas == nil || p.destroyed {
+	if p.desc.replicas == nil || p.destroyed {
 		return
 	}
-	if p.raftMu.raftNode == nil {
+	if p.replMu.raftNode == nil {
 		log.Fatal(ctx, "RaftNode is not initialized")
 		return
 	}
@@ -743,11 +752,11 @@ func (p *processorImpl) HandleRaftReadyRaftMuLocked(ctx context.Context, e rac2.
 	func() {
 		p.opts.Replica.MuLock()
 		defer p.opts.Replica.MuUnlock()
-		nextUnstableIndex = p.raftMu.raftNode.NextUnstableIndexLocked()
-		leaderID = p.raftMu.raftNode.LeaderLocked()
+		nextUnstableIndex = p.replMu.raftNode.NextUnstableIndexLocked()
+		leaderID = p.replMu.raftNode.LeaderLocked()
 		leaseholderID = p.opts.Replica.LeaseholderMuLocked()
 		if leaderID == p.opts.ReplicaID {
-			myLeaderTerm = p.raftMu.raftNode.TermLocked()
+			myLeaderTerm = p.replMu.raftNode.TermLocked()
 		}
 	}()
 	if len(e.Entries) > 0 {
@@ -847,7 +856,7 @@ func (p *processorImpl) AdmitRaftEntriesRaftMuLocked(ctx context.Context, e rac2
 		// inside Admit, when the entry is immediately admitted.
 		submitted := p.opts.ACWorkQueue.Admit(ctx, EntryForAdmission{
 			StoreID:        p.opts.StoreID,
-			TenantID:       p.raftMu.tenantID,
+			TenantID:       p.desc.tenantID,
 			Priority:       rac2.RaftToAdmissionPriority(raftPri),
 			CreateTime:     meta.AdmissionCreateTime,
 			RequestedCount: int64(len(entry.Data)),

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -393,32 +393,44 @@ type Processor interface {
 //
 // All the fields in it are used with Replica.raftMu held, with only a few
 // exceptions commented explicitly.
-//
-// TODO(pav-kv): remove ProcLocked infix, processorImpl.mu mentions in comments.
 type processorImpl struct {
+	// opts is an immutable bag of constants and interfaces for interaction with
+	// the Replica and surrounding components. Set once upon construction.
 	opts ProcessorOptions
 
-	// State for tracking and advancing the log's admitted vector.
-	// Has its own mutex, can be used without raftMu for a subset of operations.
+	// logTracker contains state for tracking and advancing the log's stable index
+	// and admitted vector.
+	//
+	// Has its own mutex. Used without raftMu for a subset of operations, when
+	// registering storage notifications or reporting the admitted vector.
 	logTracker logTracker
 
-	// Transitions once from false => true when the Replica is destroyed.
+	// destroyed transitions once from false => true when the Replica is being
+	// destroyed.
 	destroyed bool
 
+	// leaderID is the ID of the current term leader. Can be zero if unknown.
 	leaderID roachpb.ReplicaID
-	// leaderNodeID, leaderStoreID are a function of leaderID and
-	// raftMu.replicas. They are set when leaderID is non-zero and replicas
-	// contains leaderID, else are 0.
+	// leaderNodeID and leaderStoreID are a function of leaderID and replicas
+	// fields. They are set when leaderID is non-zero and replicas contains
+	// leaderID, else are 0.
 	leaderNodeID  roachpb.NodeID
 	leaderStoreID roachpb.StoreID
+	// leaseholderID is the currently known leaseholder replica.
 	leaseholderID roachpb.ReplicaID
+
 	// State at a follower.
 	follower struct {
+		// isLeaderUsingV2Protocol is true when the leaderID indicated that it's
+		// using RACv2.
 		isLeaderUsingV2Protocol bool
-		lowPriOverrideState     lowPriOverrideState
+		// lowPriOverrideState records which raft log entries have their priority
+		// overridden to be raftpb.LowPri.
+		lowPriOverrideState lowPriOverrideState
 	}
-	// State when leader, i.e., when leaderID == opts.ReplicaID, and v2
-	// protocol is enabled.
+
+	// State when leader, i.e., when leaderID == opts.ReplicaID, and v2 protocol
+	// is enabled.
 	leader struct {
 		// pendingAdmittedMu contains recently delivered admitted vectors. When the
 		// updates map is not empty, the range is scheduled for applying these
@@ -446,16 +458,19 @@ type processorImpl struct {
 		// TODO(pav-kv): factor out pendingAdmittedMu and scratch into a type.
 		scratch map[roachpb.ReplicaID]rac2.AdmittedVector
 
-		// Updating the rc reference requires both the enclosing mu and
-		// rcReferenceUpdateMu. Code paths that want to access this
-		// reference only need one of these mutexes. rcReferenceUpdateMu
-		// is ordered after the enclosing mu.
+		// rcReferenceUpdateMu is a narrow mutex held when rc reference is updated.
+		// To access rc, the code must hold raftMu or rcReferenceUpdateMu.
+		// Locking order: raftMu < rcReferenceUpdateMu.
 		rcReferenceUpdateMu syncutil.RWMutex
-		rc                  rac2.RangeController
-		// Term is used to notice transitions out of leadership and back,
-		// to recreate rc. It is set when rc is created, and is not
-		// up-to-date if there is no rc (which can happen when using the
-		// v1 protocol).
+		// rc is not nil iff this replica is a leader of the term, and uses RACv2.
+		// rc is always updated while holding raftMu and rcReferenceUpdateMu. To
+		// access rc, the code must hold at least one of these mutexes.
+		rc rac2.RangeController
+		// term is used to notice transitions out of leadership and back, to
+		// recreate rc. It is set when rc is created, and is not up-to-date if there
+		// is no rc (which can happen when using the v1 protocol).
+		//
+		// TODO(pav-kv): move this next to leaderID, and always know the term.
 		term uint64
 	}
 
@@ -473,17 +488,19 @@ type processorImpl struct {
 	// Replica is initialized. The fields are grouped for informational purposes,
 	// processorImpl always accesses them under raftMu like other fields.
 	desc struct {
+		// replicas contains the current set of replicas.
+		replicas rac2.ReplicaSet
 		// replicasChanged is set to true when replicas has been updated. This is
-		// used to lazily update all the state under mu that needs to use the state
-		// in replicas.
-		replicas        rac2.ReplicaSet
+		// used to lazily update all the state that depends on replicas.
 		replicasChanged bool
-		// Set once, in the first call to OnDescChangedLocked.
+		// tenantID is the tenant owning the replica. Set once, in the first call to
+		// OnDescChanged.
 		tenantID roachpb.TenantID
 	}
 
-	// Is the RACv2 protocol enabled when this replica is the leader.
-	// Atomic value, for serving GetEnabledWhenLeader.
+	// enabledWhenLeader indicates the RACv2 mode of operation when this replica
+	// is the leader. Atomic value, for serving GetEnabledWhenLeader. Updated only
+	// while holding raftMu. Can be read non-atomically if raftMu is held.
 	enabledWhenLeader atomic.Uint32
 
 	v1EncodingPriorityMismatch log.EveryN
@@ -498,10 +515,8 @@ func NewProcessor(opts ProcessorOptions) Processor {
 	return p
 }
 
-// isLeaderUsingV2ProcLocked returns true if the current leader uses the V2
+// isLeaderUsingV2RaftMuLocked returns true if the current leader uses the V2
 // protocol.
-//
-// NB: the result of this method does not change while raftMu is held.
 func (p *processorImpl) isLeaderUsingV2ProcLocked() bool {
 	// We are the leader using V2, or a follower who learned that the leader is
 	// using the V2 protocol.
@@ -523,7 +538,7 @@ func (p *processorImpl) InitRaftLocked(ctx context.Context, rn RaftNode) {
 func (p *processorImpl) OnDestroyRaftMuLocked(ctx context.Context) {
 	p.opts.Replica.RaftMuAssertHeld()
 	p.destroyed = true
-	p.closeLeaderStateRaftMuLockedProcLocked(ctx)
+	p.closeLeaderStateRaftMuLocked(ctx)
 	// Release some memory.
 	p.follower.lowPriOverrideState = lowPriOverrideState{}
 }
@@ -554,7 +569,7 @@ func (p *processorImpl) SetEnabledWhenLeaderRaftMuLocked(
 		}
 	}()
 	if leaderID == p.opts.ReplicaID {
-		p.createLeaderStateRaftMuLockedProcLocked(ctx, term, nextUnstableIndex)
+		p.createLeaderStateRaftMuLocked(ctx, term, nextUnstableIndex)
 	}
 }
 
@@ -598,14 +613,14 @@ func (p *processorImpl) OnDescChangedLocked(
 	}
 }
 
-// makeStateConsistentRaftMuLockedProcLocked, uses the union of the latest
-// state retrieved from RaftNode, and the set of replica (in replMu.replicas),
-// to initialize or update the internal state of processorImpl.
+// makeStateConsistentRaftMuLocked uses the union of the latest state retrieved
+// from RaftNode and the p.replicas set to initialize or update the internal
+// state of processorImpl.
 //
 // nextUnstableIndex is used to initialize the state of the send-queues if
 // this replica is becoming the leader. This index must immediately precede
 // the entries provided to RangeController.
-func (p *processorImpl) makeStateConsistentRaftMuLockedProcLocked(
+func (p *processorImpl) makeStateConsistentRaftMuLocked(
 	ctx context.Context,
 	nextUnstableIndex uint64,
 	leaderID roachpb.ReplicaID,
@@ -657,7 +672,7 @@ func (p *processorImpl) makeStateConsistentRaftMuLockedProcLocked(
 	if p.leaderID != p.opts.ReplicaID {
 		if p.leader.rc != nil {
 			// Transition from leader to follower.
-			p.closeLeaderStateRaftMuLockedProcLocked(ctx)
+			p.closeLeaderStateRaftMuLocked(ctx)
 		}
 		return
 	}
@@ -667,10 +682,10 @@ func (p *processorImpl) makeStateConsistentRaftMuLockedProcLocked(
 	}
 	if p.leader.rc != nil && myLeaderTerm > p.leader.term {
 		// Need to recreate the RangeController.
-		p.closeLeaderStateRaftMuLockedProcLocked(ctx)
+		p.closeLeaderStateRaftMuLocked(ctx)
 	}
 	if p.leader.rc == nil {
-		p.createLeaderStateRaftMuLockedProcLocked(ctx, myLeaderTerm, nextUnstableIndex)
+		p.createLeaderStateRaftMuLocked(ctx, myLeaderTerm, nextUnstableIndex)
 		return
 	}
 	// Existing RangeController.
@@ -682,7 +697,7 @@ func (p *processorImpl) makeStateConsistentRaftMuLockedProcLocked(
 	p.leader.rc.SetLeaseholderRaftMuLocked(ctx, leaseholderID)
 }
 
-func (p *processorImpl) closeLeaderStateRaftMuLockedProcLocked(ctx context.Context) {
+func (p *processorImpl) closeLeaderStateRaftMuLocked(ctx context.Context) {
 	if p.leader.rc == nil {
 		return
 	}
@@ -701,7 +716,7 @@ func (p *processorImpl) closeLeaderStateRaftMuLockedProcLocked(ctx context.Conte
 	p.leader.rc = nil
 }
 
-func (p *processorImpl) createLeaderStateRaftMuLockedProcLocked(
+func (p *processorImpl) createLeaderStateRaftMuLocked(
 	ctx context.Context, term uint64, nextUnstableIndex uint64,
 ) {
 	if p.leader.rc != nil {
@@ -741,9 +756,9 @@ func (p *processorImpl) HandleRaftReadyRaftMuLocked(ctx context.Context, e rac2.
 		log.Fatal(ctx, "RaftNode is not initialized")
 		return
 	}
-	// NB: we need to call makeStateConsistentRaftMuLockedProcLocked even if
-	// NotEnabledWhenLeader, since this replica could be a follower and the
-	// leader may switch to v2.
+	// NB: we need to call makeStateConsistentRaftMuLocked even if
+	// NotEnabledWhenLeader, since this replica could be a follower and the leader
+	// may switch to v2.
 
 	// Grab the state we need in one shot after acquiring Replica mu.
 	var nextUnstableIndex uint64
@@ -762,7 +777,7 @@ func (p *processorImpl) HandleRaftReadyRaftMuLocked(ctx context.Context, e rac2.
 	if len(e.Entries) > 0 {
 		nextUnstableIndex = e.Entries[0].Index
 	}
-	p.makeStateConsistentRaftMuLockedProcLocked(
+	p.makeStateConsistentRaftMuLocked(
 		ctx, nextUnstableIndex, leaderID, leaseholderID, myLeaderTerm)
 
 	if !p.isLeaderUsingV2ProcLocked() {

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -296,7 +296,7 @@ func TestProcessorBasic(t *testing.T) {
 		}).(*processorImpl)
 		fmt.Fprintf(&b, "n%s,s%s,r%s: replica=%s, tenant=%s, enabled-level=%s\n",
 			p.opts.NodeID, p.opts.StoreID, p.opts.RangeID, p.opts.ReplicaID, tenantID,
-			enabledLevelString(EnabledWhenLeaderLevel(p.enabledWhenLeader.Load())))
+			enabledLevelString(p.GetEnabledWhenLeader()))
 	}
 	builderStr := func() string {
 		str := b.String()

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -296,7 +296,7 @@ func TestProcessorBasic(t *testing.T) {
 		}).(*processorImpl)
 		fmt.Fprintf(&b, "n%s,s%s,r%s: replica=%s, tenant=%s, enabled-level=%s\n",
 			p.opts.NodeID, p.opts.StoreID, p.opts.RangeID, p.opts.ReplicaID, tenantID,
-			enabledLevelString(p.mu.enabledWhenLeader))
+			enabledLevelString(EnabledWhenLeaderLevel(p.enabledWhenLeader.Load())))
 	}
 	builderStr := func() string {
 		str := b.String()


### PR DESCRIPTION
This PR removes the `processorImpl` mutex. Almost all `processorImpl` fields are used under `raftMu` (only by methods containing `RaftMuLocked` infix). Exceptions:

- `logTracker`. It has an internal mutex for interaction with log syncs/admissions out of band.
- `leader.rc` has `rcReferenceUpdateMu` for high-contention interaction with out-of-band `AdmitForEval`.
- `leader.pendingAdmittedMu` has a narrow mutex for quick interaction with appends from `RaftTransport`.
- `enabledWhenLeader` is an atomic and doesn't need a mutex.

Related to #129508