### PR TITLE
[wip] gossip: use ptp clock when configured

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -294,9 +294,10 @@ func New(
 	stopper *stop.Stopper,
 	registry *metric.Registry,
 	locality roachpb.Locality,
+	now func() int64,
 ) *Gossip {
 	g := &Gossip{
-		server:            newServer(ambient, clusterID, nodeID, stopper, registry),
+		server:            newServer(ambient, clusterID, nodeID, stopper, registry, now),
 		Connected:         make(chan struct{}),
 		outgoing:          makeNodeSet(minPeers, metric.NewGauge(MetaConnectionsOutgoingGauge)),
 		bootstrapping:     map[string]struct{}{},
@@ -339,7 +340,7 @@ func NewTestWithLocality(
 	n := &base.NodeIDContainer{}
 	var ac log.AmbientContext
 	ac.AddLogTag("n", n)
-	gossip := New(ac, c, n, stopper, registry, locality)
+	gossip := New(ac, c, n, stopper, registry, locality, func() int64 { return timeutil.Now().UnixNano() })
 	if nodeID != 0 {
 		n.Set(context.TODO(), nodeID)
 	}

--- a/pkg/gossip/server.go
+++ b/pkg/gossip/server.go
@@ -77,6 +77,7 @@ func newServer(
 	nodeID *base.NodeIDContainer,
 	stopper *stop.Stopper,
 	registry *metric.Registry,
+	now func() int64,
 ) *server {
 	s := &server{
 		AmbientContext: ambient,
@@ -88,7 +89,7 @@ func newServer(
 		serverMetrics:  makeMetrics(),
 	}
 
-	s.mu.is = newInfoStore(s.AmbientContext, nodeID, util.UnresolvedAddr{}, stopper, s.nodeMetrics)
+	s.mu.is = newInfoStore(s.AmbientContext, nodeID, util.UnresolvedAddr{}, stopper, s.nodeMetrics, now)
 	s.mu.incoming = makeNodeSet(minPeers, metric.NewGauge(MetaConnectionsIncomingGauge))
 	s.mu.nodeMap = make(map[util.UnresolvedAddr]serverInfo)
 	s.ready.Store(make(chan struct{}))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -316,14 +316,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 
 	nodeTombStorage, decommissionCheck := getPingCheckDecommissionFn(engines)
 
-	g := gossip.New(
-		cfg.AmbientCtx,
-		cfg.ClusterIDContainer,
-		nodeIDContainer,
-		stopper,
-		nodeRegistry,
-		cfg.Locality,
-	)
+	g := gossip.New(cfg.AmbientCtx, cfg.ClusterIDContainer, nodeIDContainer, stopper, nodeRegistry, cfg.Locality, clock.PhysicalNow)
 
 	tenantCapabilitiesTestingKnobs, _ := cfg.TestingKnobs.TenantCapabilitiesTestingKnobs.(*tenantcapabilities.TestingKnobs)
 	authorizer := tenantcapabilitiesauthorizer.New(cfg.Settings, tenantCapabilitiesTestingKnobs)

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -155,7 +155,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 
 	cfg.RPCContext.NodeID.Set(ctx, nodeID)
 	clusterID := cfg.RPCContext.StorageClusterID
-	ltc.Gossip = gossip.New(ambient, clusterID, nc, ltc.stopper, metric.NewRegistry(), roachpb.Locality{})
+	ltc.Gossip = gossip.New(ambient, clusterID, nc, ltc.stopper, metric.NewRegistry(), roachpb.Locality{}, ltc.Clock.PhysicalNow)
 	var err error
 	ltc.Eng, err = storage.Open(
 		ctx,


### PR DESCRIPTION
Before this commit we saw "info not fresh" errors related to gossip
while running the ptp roachtest introduced in #129123.  Since gossip
takes walltimes of the local clock and shoves them into HLC timestamps,
it's likely that there are places where we might end up comparing these
to timestamps sourced from a ptp clock, if the system is configured with
one. If these two clocks don't agree, this is problematic.
