### PR TITLE
crosscluster/logical: use BulkPriority for LDR sql ingestion path

### DIFF
--- a/pkg/ccl/crosscluster/logical/lww_row_processor.go
+++ b/pkg/ccl/crosscluster/logical/lww_row_processor.go
@@ -321,7 +321,7 @@ var (
 		// We don't get any benefits from generating plan gists for internal
 		// queries, so we disable them.
 		DisablePlanGists: true,
-		QualityOfService: &sessiondatapb.UserLowQoS,
+		QualityOfService: &sessiondatapb.BulkLowQoS,
 	}
 )
 

--- a/pkg/sql/internal_test.go
+++ b/pkg/sql/internal_test.go
@@ -508,7 +508,7 @@ func TestInternalExecutorWithDefinedQoSOverrideDoesNotPanic(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	ie := s.InternalExecutor().(*sql.InternalExecutor)
-	qosLevel := sessiondatapb.TTLLow
+	qosLevel := sessiondatapb.BulkLow
 	_, err := ie.ExecEx(
 		ctx, "defined_quality_of_service_level_does_not_panic", nil,
 		sessiondata.InternalExecutorOverride{User: username.NodeUserName(), QualityOfService: &qosLevel},

--- a/pkg/sql/sessiondatapb/local_only_session_data.go
+++ b/pkg/sql/sessiondatapb/local_only_session_data.go
@@ -290,13 +290,10 @@ const (
 	// session default_transaction_quality_of_service value.
 	SystemLow = QoSLevel(admissionpb.LowPri)
 
-	// TTLStatsLow denotes a QoS level used internally by the TTL feature, which
-	// is not settable as a session default_transaction_quality_of_service value.
-	TTLStatsLow = QoSLevel(admissionpb.BulkLowPri)
-
-	// TTLLow denotes a QoS level used internally by the TTL feature, which is not
-	// settable as a session default_transaction_quality_of_service value.
-	TTLLow = QoSLevel(admissionpb.BulkLowPri)
+	// BulkLow denotes a QoS level used internally by the bulk operations (like
+	// LDR ingestion and TTL), which is not settable as a session
+	// default_transaction_quality_of_service value.
+	BulkLow = QoSLevel(admissionpb.BulkLowPri)
 
 	// UserLow denotes an end user QoS level lower than the default.
 	UserLow = QoSLevel(admissionpb.UserLowPri)
@@ -341,8 +338,8 @@ const (
 	// QoS level.
 	SystemLowName = "minimum"
 
-	// TTLLowName is the string value to display indicating a TTLLow QoS level.
-	TTLLowName = "ttl_low"
+	// BulkLowName is the string value to display indicating a BulkLow QoS level.
+	BulkLowName = "bulk_low"
 
 	// LockingNormalName is the string value to display indicating a
 	// LockingNormal QoS level.
@@ -359,13 +356,13 @@ const (
 // those cases.
 var (
 	SystemLowQoS = SystemLow
-	TTLLowQoS    = TTLLow
+	BulkLowQoS   = BulkLow
 	UserLowQoS   = UserLow
 )
 
 var qosLevelsDict = map[QoSLevel]string{
 	SystemLow:     SystemLowName,
-	TTLLow:        TTLLowName,
+	BulkLow:       BulkLowName,
 	UserLow:       UserLowName,
 	Normal:        NormalName,
 	LockingNormal: LockingNormalName,

--- a/pkg/sql/ttl/ttljob/ttljob_query_builder.go
+++ b/pkg/sql/ttl/ttljob/ttljob_query_builder.go
@@ -156,7 +156,7 @@ func (b *SelectQueryBuilder) Run(
 		ctx,
 		b.selectOpName,
 		nil, /* txn */
-		getInternalExecutorOverride(sessiondatapb.TTLLowQoS),
+		getInternalExecutorOverride(sessiondatapb.BulkLowQoS),
 		query,
 		b.cachedArgs...,
 	)
@@ -259,7 +259,7 @@ func (b *DeleteQueryBuilder) Run(
 		ctx,
 		b.deleteOpName,
 		txn.KV(),
-		getInternalExecutorOverride(sessiondatapb.TTLLowQoS),
+		getInternalExecutorOverride(sessiondatapb.BulkLowQoS),
 		query,
 		deleteArgs...,
 	)


### PR DESCRIPTION
When the sql path uses BulkPriority QoS, the elastic cpu limiter effectively
curtails the negative effect that sql based LDR ingestion had on the foreground
workload. Perf write up[ here](https://docs.google.com/document/d/1vr6G2z7Yo6_hStXxx3_2R1JOa3mdDMKGh1SC-aI0HwA/edit). 

Epic: none

Release note: none