### PR TITLE
roachtest: find error ownership in the innermost error in the chain

### DIFF
--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -84,19 +84,19 @@ func generateHelpCommand(
 
 func failuresAsErrorWithOwnership(failures []failure) *registry.ErrorWithOwnership {
 	var transientError rperrors.TransientError
-	var err registry.ErrorWithOwnership
+	var errWithOwner registry.ErrorWithOwnership
 	if failuresMatchingError(failures, &transientError) {
-		err = registry.ErrorWithOwner(
+		errWithOwner = registry.ErrorWithOwner(
 			registry.OwnerTestEng, transientError,
 			registry.WithTitleOverride(transientError.Cause),
 			registry.InfraFlake,
 		)
 
-		return &err
+		return &errWithOwner
 	}
 
-	if errWithOwner := failuresSpecifyOwner(failures); errWithOwner != nil {
-		return errWithOwner
+	if failuresMatchingError(failures, &errWithOwner) {
+		return &errWithOwner
 	}
 
 	return nil

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -335,7 +335,28 @@ func TestCreatePostRequest(t *testing.T) {
 			expectedMessagePrefix: testName + " failed",
 			expectedLabels:        []string{"T-testeng", "X-infra-flake"},
 		},
-		// 12. Arbitrary transient failures lead to an issue assigned to
+		// 12. Nested ErrorWithOwnership -- assignment is based on innermost
+		// error in the chain.
+		{
+			nonReleaseBlocker: true,
+			failures: []failure{
+				createFailure(registry.ErrorWithOwner(
+					registry.OwnerSQLFoundations,
+					registry.ErrorWithOwner(
+						registry.OwnerTestEng,
+						errors.New("oops"),
+						registry.WithTitleOverride("monitor_failure"),
+						registry.InfraFlake,
+					),
+				)),
+			},
+			expectedPost:          true,
+			expectedTeam:          "@cockroachdb/test-eng",
+			expectedName:          "monitor_failure",
+			expectedMessagePrefix: testName + " failed",
+			expectedLabels:        []string{"T-testeng", "X-infra-flake"},
+		},
+		// 13. Arbitrary transient failures lead to an issue assigned to
 		// test eng with the corresponding title override.
 		{
 			nonReleaseBlocker: true,
@@ -348,7 +369,7 @@ func TestCreatePostRequest(t *testing.T) {
 			expectedMessagePrefix: testName + " failed",
 			expectedLabels:        []string{"T-testeng", "X-infra-flake"},
 		},
-		// 13. When a transient error happens as a result of *another*
+		// 14. When a transient error happens as a result of *another*
 		// transient error, the corresponding issue uses the first
 		// transient error in the chain.
 		{
@@ -363,7 +384,7 @@ func TestCreatePostRequest(t *testing.T) {
 			expectedMessagePrefix: testName + " failed",
 			expectedLabels:        []string{"T-testeng", "X-infra-flake"},
 		},
-		// 14. Verify hostError failure are routed to test-eng and marked as infra-flake, when the
+		// 15. Verify hostError failure are routed to test-eng and marked as infra-flake, when the
 		// first failure is a non-handled error.
 		{
 			nonReleaseBlocker:     true,
@@ -374,7 +395,7 @@ func TestCreatePostRequest(t *testing.T) {
 			expectedMessagePrefix: testName + " failed",
 			expectedLabels:        []string{"T-testeng", "X-infra-flake"},
 		},
-		// 15. Verify hostError failure are routed to test-eng and marked as infra-flake, when the only error is
+		// 16. Verify hostError failure are routed to test-eng and marked as infra-flake, when the only error is
 		// hostError failure
 		{
 			nonReleaseBlocker: true,
@@ -387,7 +408,7 @@ func TestCreatePostRequest(t *testing.T) {
 			expectedMessagePrefix: testName + " failed",
 			expectedLabels:        []string{"T-testeng", "X-infra-flake"},
 		},
-		// 16. Verify that a Side-Eye URL is rendered in the issue.
+		// 17. Verify that a Side-Eye URL is rendered in the issue.
 		{
 			nonReleaseBlocker: true,
 			failures: []failure{

--- a/pkg/cmd/roachtest/registry/errors.go
+++ b/pkg/cmd/roachtest/registry/errors.go
@@ -39,6 +39,10 @@ func (ewo ErrorWithOwnership) Is(target error) bool {
 	return errors.Is(ewo.Err, target)
 }
 
+func (ewo ErrorWithOwnership) Unwrap() error {
+	return ewo.Err
+}
+
 func (ewo ErrorWithOwnership) As(reference interface{}) bool {
 	return errors.As(ewo.Err, reference)
 }

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -542,26 +542,6 @@ func failuresMatchingError(failures []failure, refError any) bool {
 	return false
 }
 
-// failuresSpecifyOwner checks if any of the errors in any of the
-// given failures is a failure that is associated with an owner. If
-// such an error is found, it is returned; otherwise, nil is returned.
-func failuresSpecifyOwner(failures []failure) *registry.ErrorWithOwnership {
-	var ref registry.ErrorWithOwnership
-	for _, f := range failures {
-		for _, err := range f.errors {
-			if errors.As(err, &ref) {
-				return &ref
-			}
-		}
-
-		if errors.As(f.squashedErr, &ref) {
-			return &ref
-		}
-	}
-
-	return nil
-}
-
 func (t *testImpl) ArtifactsDir() string {
 	return t.artifactsDir
 }

--- a/pkg/cmd/roachtest/test_impl_test.go
+++ b/pkg/cmd/roachtest/test_impl_test.go
@@ -188,7 +188,7 @@ func Test_failureSpecifyOwnerAndAddFailureCombination(t *testing.T) {
 		l: nilLogger(),
 	}
 	ti.addFailure(0, "", vmPreemptionError("my_VM"))
-	errWithOwnership := failuresSpecifyOwner(ti.failures())
+	errWithOwnership := failuresAsErrorWithOwnership(ti.failures())
 
 	require.NotNil(t, errWithOwnership)
 	require.Equal(t, registry.OwnerTestEng, errWithOwnership.Owner)

--- a/pkg/cmd/roachtest/testdata/help_command_createpost_17.txt
+++ b/pkg/cmd/roachtest/testdata/help_command_createpost_17.txt
@@ -1,0 +1,17 @@
+echo
+----
+----
+
+
+See: [roachtest README](https://github.com/cockroachdb/cockroach/blob/master/pkg/cmd/roachtest/README.md)
+
+
+
+See: [How To Investigate \(internal\)](https://cockroachlabs.atlassian.net/l/c/SSSBr8c7)
+
+
+
+See: [Grafana](https://go.crdb.dev/roachtest-grafana//github-test/1689957243000/1689957853000)
+
+----
+----


### PR DESCRIPTION
This PR is very similar to #124403, but applying the same logic when finding `ErrorWithOwnership` instances (instead of `TransientErorr` instances). Specifically, we look for the innermost instance of an error with ownership to decide what ownership to apply. The idea is that ownership should be assigned based on the "first" error observed during the test.

Fixes: #130469

Release note: None