### PR TITLE
release-23.2.11-rc: ui: add license change notification to db console

### DIFF
--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -178,7 +178,8 @@ func (s *httpServer) setupRoutes(
 			}
 			return nil
 		},
-		Flags: flags,
+		Flags:    flags,
+		Settings: s.cfg.Settings,
 	})
 
 	// The authentication mux used here is created in "allow anonymous" mode so that the UI

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -757,7 +757,7 @@ Binary built without web UI.
 			respBytes, err = io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			expected := fmt.Sprintf(
-				`{"Insecure":true,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{"can_view_kv_metric_dashboards":true},"OIDCGenerateJWTAuthTokenEnabled":false}`,
+				`{"Insecure":true,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{"can_view_kv_metric_dashboards":true},"OIDCGenerateJWTAuthTokenEnabled":false,"LicenseType":"OSS","SecondsUntilLicenseExpiry":0}`,
 				build.GetInfo().Tag,
 				build.BinaryVersionPrefix(),
 				1,
@@ -785,7 +785,7 @@ Binary built without web UI.
 			{
 				loggedInClient,
 				fmt.Sprintf(
-					`{"Insecure":false,"LoggedInUser":"authentic_user","Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{"can_view_kv_metric_dashboards":true},"OIDCGenerateJWTAuthTokenEnabled":false}`,
+					`{"Insecure":false,"LoggedInUser":"authentic_user","Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{"can_view_kv_metric_dashboards":true},"OIDCGenerateJWTAuthTokenEnabled":false,"LicenseType":"OSS","SecondsUntilLicenseExpiry":0}`,
 					build.GetInfo().Tag,
 					build.BinaryVersionPrefix(),
 					1,
@@ -794,7 +794,7 @@ Binary built without web UI.
 			{
 				loggedOutClient,
 				fmt.Sprintf(
-					`{"Insecure":false,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{"can_view_kv_metric_dashboards":true},"OIDCGenerateJWTAuthTokenEnabled":false}`,
+					`{"Insecure":false,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{"can_view_kv_metric_dashboards":true},"OIDCGenerateJWTAuthTokenEnabled":false,"LicenseType":"OSS","SecondsUntilLicenseExpiry":0}`,
 					build.GetInfo().Tag,
 					build.BinaryVersionPrefix(),
 					1,

--- a/pkg/ui/BUILD.bazel
+++ b/pkg/ui/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/build",
         "//pkg/server/serverpb",
         "//pkg/settings",
+        "//pkg/settings/cluster",
         "//pkg/util/httputil",
         "//pkg/util/log",
     ],

--- a/pkg/ui/workspaces/cluster-ui/src/util/dataFromServer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/dataFromServer.ts
@@ -22,6 +22,8 @@ export interface DataFromServer {
   OIDCButtonText: string;
   OIDCGenerateJWTAuthTokenEnabled: boolean;
   FeatureFlags: FeatureFlags;
+  LicenseType: string;
+  SecondsUntilLicenseExpiry: number;
 }
 
 // Tell TypeScript about `window.dataFromServer`, which is set in a script

--- a/pkg/ui/workspaces/db-console/src/redux/alerts.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/alerts.ts
@@ -684,6 +684,78 @@ export const dataFromServerAlertSelector = createSelector(
   },
 );
 
+const licenseTypeNames = new Map<
+  string,
+  "Trial" | "Enterprise" | "Non-Commercial" | "None"
+>([
+  ["Evaluation", "Trial"],
+  ["Enterprise", "Enterprise"],
+  ["NonCommercial", "Non-Commercial"],
+  ["OSS", "None"],
+  ["BSD", "None"],
+]);
+
+// licenseTypeSelector returns user-friendly names of license types.
+export const licenseTypeSelector = createSelector(
+  getDataFromServer,
+  data => licenseTypeNames.get(data.LicenseType) || "None",
+);
+
+// daysUntilLicenseExpiresSelector returns number of days remaining before license expires.
+export const daysUntilLicenseExpiresSelector = createSelector(
+  getDataFromServer,
+  data => {
+    return Math.ceil(data.SecondsUntilLicenseExpiry / 86400); // seconds in 1 day
+  },
+);
+
+export const showLicenseTTLLocalSetting = new LocalSetting(
+  "show_license_ttl",
+  localSettingsSelector,
+  { show: true },
+);
+
+export const showLicenseTTLAlertSelector = createSelector(
+  showLicenseTTLLocalSetting.selector,
+  daysUntilLicenseExpiresSelector,
+  licenseTypeSelector,
+  (showLicenseTTL, daysUntilLicenseExpired, licenseType): Alert => {
+    if (!showLicenseTTL.show) {
+      return;
+    }
+    if (licenseType === "None") {
+      return;
+    }
+    const daysToShowAlert = 14;
+    let title: string;
+    let level: AlertLevel;
+
+    if (daysUntilLicenseExpired > daysToShowAlert) {
+      return;
+    } else if (daysUntilLicenseExpired < 0) {
+      title = `License expired ${Math.abs(daysUntilLicenseExpired)} days ago`;
+      level = AlertLevel.CRITICAL;
+    } else if (daysUntilLicenseExpired === 0) {
+      title = `License expired`;
+      level = AlertLevel.CRITICAL;
+    } else if (daysUntilLicenseExpired <= daysToShowAlert) {
+      title = `License expires in ${daysUntilLicenseExpired} days`;
+      level = AlertLevel.WARNING;
+    }
+    return {
+      level: level,
+      title: title,
+      showAsAlert: true,
+      autoClose: false,
+      closable: true,
+      dismiss: (dispatch: Dispatch<Action>) => {
+        dispatch(showLicenseTTLLocalSetting.set({ show: false }));
+        return Promise.resolve();
+      },
+    };
+  },
+);
+
 /**
  * Selector which returns an array of all active alerts which should be
  * displayed as a banner, which appears at the top of the page and overlaps
@@ -698,6 +770,7 @@ export const bannerAlertsSelector = createSelector(
   terminateSessionAlertSelector,
   terminateQueryAlertSelector,
   dataFromServerAlertSelector,
+  showLicenseTTLAlertSelector,
   (...alerts: Alert[]): Alert[] => {
     return _.without(alerts, null, undefined);
   },

--- a/pkg/ui/workspaces/db-console/src/redux/alerts.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/alerts.ts
@@ -21,6 +21,7 @@ import { ThunkAction } from "redux-thunk";
 
 import { LocalSetting } from "./localsettings";
 import {
+  LICENSE_UPDATE_DISMISSED_KEY,
   VERSION_DISMISSED_KEY,
   INSTRUCTIONS_BOX_COLLAPSED_KEY,
   saveUIData,
@@ -55,6 +56,7 @@ export enum AlertLevel {
   WARNING,
   CRITICAL,
   SUCCESS,
+  INFORMATION,
 }
 
 export interface AlertInfo {
@@ -631,20 +633,6 @@ export const upgradeNotFinalizedWarningSelector = createSelector(
 
 /**
  * Selector which returns an array of all active alerts which should be
- * displayed in the overview list page, these should be non-critical alerts.
- */
-
-export const overviewListAlertsSelector = createSelector(
-  staggeredVersionWarningSelector,
-  clusterPreserveDowngradeOptionOvertimeSelector,
-  upgradeNotFinalizedWarningSelector,
-  (...alerts: Alert[]): Alert[] => {
-    return _.without(alerts, null, undefined);
-  },
-);
-
-/**
- * Selector which returns an array of all active alerts which should be
  * displayed in the alerts panel, which is embedded within the cluster overview
  * page; currently, this includes all non-critical alerts.
  */
@@ -699,6 +687,104 @@ const licenseTypeNames = new Map<
 export const licenseTypeSelector = createSelector(
   getDataFromServer,
   data => licenseTypeNames.get(data.LicenseType) || "None",
+);
+
+export const licenseUpdateDismissedLocalSetting = new LocalSetting(
+  "license_update_dismissed",
+  localSettingsSelector,
+  moment(0),
+);
+
+const licenseUpdateDismissedPersistentLoadedSelector = createSelector(
+  (state: AdminUIState) => state.uiData,
+  uiData => uiData && Object.hasOwn(uiData, LICENSE_UPDATE_DISMISSED_KEY),
+);
+
+const licenseUpdateDismissedPersistentSelector = createSelector(
+  (state: AdminUIState) => state.uiData,
+  uiData => moment(uiData?.[LICENSE_UPDATE_DISMISSED_KEY]?.data ?? 0),
+);
+
+export const licenseUpdateNotificationSelector = createSelector(
+  licenseTypeSelector,
+  licenseUpdateDismissedLocalSetting.selector,
+  licenseUpdateDismissedPersistentSelector,
+  licenseUpdateDismissedPersistentLoadedSelector,
+  (
+    licenseType,
+    licenseUpdateDismissed,
+    licenseUpdateDismissedPersistent,
+    licenseUpdateDismissedPersistentLoaded,
+  ): Alert => {
+    // If customer has Enterprise license they don't need to worry about this.
+    if (licenseType === "Enterprise") {
+      return undefined;
+    }
+
+    // If the notification has been dismissed based on the session storage
+    // timestamp, don't show it.'
+    //
+    // Note: `licenseUpdateDismissed` is wrapped in `moment()` because
+    // the local storage selector won't convert it back from a string.
+    // We omit fixing that here since this change is being backported
+    // to many versions.
+    if (moment(licenseUpdateDismissed).isAfter(moment(0))) {
+      return undefined;
+    }
+
+    // If the notification has been dismissed based on the uiData
+    // storage in the cluster, don't show it. Note that this is
+    // different from how version upgrade notifications work, this one
+    // is dismissed forever and won't return even if you upgrade
+    // further or time passes.
+    if (
+      licenseUpdateDismissedPersistentLoaded &&
+      licenseUpdateDismissedPersistent &&
+      licenseUpdateDismissedPersistent.isAfter(moment(0))
+    ) {
+      return undefined;
+    }
+
+    return {
+      level: AlertLevel.INFORMATION,
+      title: "Coming November 18, 2024",
+      text: "Important changes to CockroachDB’s licensing model.",
+      link: docsURL.enterpriseLicenseUpdate,
+      dismiss: (dispatch: any) => {
+        const dismissedAt = moment();
+        // Note(davidh): I haven't been able to find historical context
+        // for why some alerts have both a "local" and a "persistent"
+        // dismissal. My thinking is that just the persistent dismissal
+        // should be adequate, but I'm preserving that behavior here to
+        // match the version upgrade notification.
+
+        // Dismiss locally.
+        dispatch(licenseUpdateDismissedLocalSetting.set(dismissedAt));
+        // Dismiss persistently.
+        return dispatch(
+          saveUIData({
+            key: LICENSE_UPDATE_DISMISSED_KEY,
+            value: dismissedAt.valueOf(),
+          }),
+        );
+      },
+    };
+  },
+);
+
+/**
+ * Selector which returns an array of all active alerts which should be
+ * displayed in the overview list page, these should be non-critical alerts.
+ */
+
+export const overviewListAlertsSelector = createSelector(
+  staggeredVersionWarningSelector,
+  clusterPreserveDowngradeOptionOvertimeSelector,
+  upgradeNotFinalizedWarningSelector,
+  licenseUpdateNotificationSelector,
+  (...alerts: Alert[]): Alert[] => {
+    return _.without(alerts, null, undefined);
+  },
 );
 
 // daysUntilLicenseExpiresSelector returns number of days remaining before license expires.
@@ -817,6 +903,7 @@ export function alertDataSync(store: Store<AdminUIState>) {
       const keysToMaybeLoad = [
         VERSION_DISMISSED_KEY,
         INSTRUCTIONS_BOX_COLLAPSED_KEY,
+        LICENSE_UPDATE_DISMISSED_KEY,
       ];
       const keysToLoad = _.filter(keysToMaybeLoad, key => {
         return !(_.has(uiData, key) || isInFlight(state, key));

--- a/pkg/ui/workspaces/db-console/src/redux/state.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/state.ts
@@ -66,6 +66,8 @@ const emptyDataFromServer: DataFromServer = {
   OIDCGenerateJWTAuthTokenEnabled: false,
   Tag: "",
   Version: "",
+  LicenseType: "OSS",
+  SecondsUntilLicenseExpiry: 0,
 };
 
 export const featureFlagSelector = createSelector(

--- a/pkg/ui/workspaces/db-console/src/redux/uiData.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/uiData.ts
@@ -56,6 +56,11 @@ export class OptInAttributes {
 // was last dismissed.
 export const VERSION_DISMISSED_KEY = "version_dismissed";
 
+// LICENSE_UPDATE_DISMISSED_KEY is the uiData key on the server that tracks when the licence
+// update banner was last dismissed. This banner notifies the user that we've changed our
+// licensing if they're deployed without an active license.
+export const LICENSE_UPDATE_DISMISSED_KEY = "license_update_dismissed";
+
 // INSTRUCTIONS_BOX_COLLAPSED_KEY is the uiData key on the server that tracks whether the
 // instructions box on the cluster viz has been collapsed or not.
 export const INSTRUCTIONS_BOX_COLLAPSED_KEY =

--- a/pkg/ui/workspaces/db-console/src/util/dataFromServer.ts
+++ b/pkg/ui/workspaces/db-console/src/util/dataFromServer.ts
@@ -22,6 +22,8 @@ export interface DataFromServer {
   OIDCButtonText: string;
   OIDCGenerateJWTAuthTokenEnabled: boolean;
   FeatureFlags: FeatureFlags;
+  LicenseType: string;
+  SecondsUntilLicenseExpiry: number;
 }
 // Tell TypeScript about `window.dataFromServer`, which is set in a script
 // tag in index.html, the contents of which are generated in a Go template

--- a/pkg/ui/workspaces/db-console/src/util/docs.ts
+++ b/pkg/ui/workspaces/db-console/src/util/docs.ts
@@ -62,6 +62,8 @@ export let sessionsTable: string;
 export let upgradeTroubleshooting: string;
 // Note that these explicitly don't use the current version, since we want to
 // link to the most up-to-date documentation available.
+export const enterpriseLicenseUpdate =
+  "https://www.cockroachlabs.com/enterprise-license-update/";
 export const upgradeCockroachVersion =
   "https://www.cockroachlabs.com/docs/stable/upgrade-cockroach-version.html";
 export const enterpriseLicensing =

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/alertBox/alertbox.styl
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/alertBox/alertbox.styl
@@ -46,6 +46,13 @@
     border-color $notification-info-border-color
     background-color $notification-info-fill-color
 
+  &--information
+    color $body-color
+    border-color $notification-info-border-color
+    background-color $notification-info-fill-color
+    path
+      fill $colors--primary-blue-3
+
   &--warning
     color $body-color
     border-color $notification-warning-border-color

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/alertBox/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/alertBox/index.tsx
@@ -18,6 +18,7 @@ import {
   warningIcon,
   notificationIcon,
   criticalIcon,
+  informationIcon,
 } from "src/views/shared/components/icons";
 import { trustIcon } from "src/util/trust";
 
@@ -27,6 +28,8 @@ function alertIcon(level: AlertLevel) {
       return trustIcon(criticalIcon);
     case AlertLevel.WARNING:
       return trustIcon(warningIcon);
+    case AlertLevel.INFORMATION:
+      return trustIcon(informationIcon);
     default:
       return trustIcon(notificationIcon);
   }
@@ -49,7 +52,7 @@ export class AlertBox extends React.Component<AlertBoxProps, {}> {
 
     const learnMore = this.props.link && (
       <a className="" href={this.props.link}>
-        Learn More.
+        Learn More
       </a>
     );
     content = (

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/icons/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/icons/index.tsx
@@ -98,7 +98,20 @@ export const warningIcon: string = `<svg width="21px" height="21px" viewBox="0 0
     </g>
 </svg>`;
 
-export const notificationIcon: string = `
+export const informationIcon = `
+<svg width="24" height="24" viewBox="0 0 24 24" fill="" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_11029_22094)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 12C0 5.37261 5.39028 0 12 0C18.6274 0 24 5.37261 24 12C24 18.6274 18.6274 24 12 24C5.37261 24 0 18.6274 0 12ZM11.1163 18.7865H12.8836V9.52586H11.1163V18.7865ZM11.1163 7.68786H12.8836V5.21364H11.1163V7.68786Z" fill="#394455"/>
+</g>
+<defs>
+<clipPath id="clip0_11029_22094">
+<rect width="24" height="24" fill="white" transform="matrix(1 0 0 -1 0 24)"/>
+</clipPath>
+</defs>
+</svg>
+`;
+
+export const notificationIcon = `
   <svg width="22px" height="22px" viewBox="0 0 38 38" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
     <!-- Generator: Sketch 3.3.3 (12081) - http://www.bohemiancoding.com/sketch -->
     <title>CL Mark</title>


### PR DESCRIPTION
Backport:
  * 1/1 commits from "server: include license expiration type and time into `uiconfig` response" (#120475)
  * 1/1 commits from "ui: show license expiration alert in Db Console" (#120490)
  * 1/1 commits from "ui: add license change notification to db console" (#129420)

Please see individual PRs for details.

/cc @cockroachdb/release

----

Note: This change requires two prerequisite PRs to expose license type information to the DB Console

Release justification: low-risk high-need change
