### PR TITLE
changefeedccl: add network metrics to sql sink

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -175,6 +175,7 @@ go_library(
         "@com_github_klauspost_compress//gzip",
         "@com_github_klauspost_compress//zstd",
         "@com_github_klauspost_pgzip//:pgzip",
+        "@com_github_lib_pq//:pq",
         "@com_github_linkedin_goavro_v2//:goavro",
         "@com_github_rcrowley_go_metrics//:go-metrics",
         "@com_github_twmb_franz_go//pkg/kerr",

--- a/pkg/util/cidr/BUILD.bazel
+++ b/pkg/util/cidr/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "@com_github_lib_pq//:pq",
     ],
 )
 


### PR DESCRIPTION
Add support for the cidr network metrics to the sql sink.

Part of: #130097

Release note (enterprise change): Added network metrics to the sql sink.
