### PR TITLE
master: cockroach_releases.yaml (wait until v24.2.2 is published to mark v24.2.1 as withdrawn)

### DIFF
--- a/pkg/testutils/release/cockroach_releases.yaml
+++ b/pkg/testutils/release/cockroach_releases.yaml
@@ -26,6 +26,8 @@
   predecessor: "23.2"
 "24.2":
   latest: 24.2.1
+  withdrawn:
+  - 24.2.1
   predecessor: "24.1"
 "24.3":
   predecessor: "24.2"


### PR DESCRIPTION
Update pkg/testutils/release/cockroach_releases.yaml with recent values.

Epic: None
Release note: None
Release justification: test-only updates