### PR TITLE
replica_rac2: rm Ready scheduling on piggybacked

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1430,10 +1430,10 @@ func (r *Replica) tick(
 	return true, nil
 }
 
-func (r *Replica) processRACv2PiggybackedAdmitted(ctx context.Context) bool {
+func (r *Replica) processRACv2PiggybackedAdmitted(ctx context.Context) {
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()
-	return r.flowControlV2.ProcessPiggybackedAdmittedAtLeaderRaftMuLocked(ctx)
+	r.flowControlV2.ProcessPiggybackedAdmittedAtLeaderRaftMuLocked(ctx)
 }
 
 func (r *Replica) hasRaftReadyRLocked() bool {

--- a/pkg/kv/kvserver/scheduler.go
+++ b/pkg/kv/kvserver/scheduler.go
@@ -122,9 +122,9 @@ type raftProcessor interface {
 	// Process a raft tick for the specified range.
 	// Return true if the range should be queued for ready processing.
 	processTick(context.Context, roachpb.RangeID) bool
-	// Process a piggybacked raftpb.Message that advances admitted. Used for
-	// RACv2. Returns true if the range should be queued for ready processing.
-	processRACv2PiggybackedAdmitted(ctx context.Context, id roachpb.RangeID) bool
+	// Process piggybacked admitted vectors that may advance admitted state for
+	// the given range's peer replicas. Used for RACv2.
+	processRACv2PiggybackedAdmitted(ctx context.Context, id roachpb.RangeID)
 }
 
 type raftScheduleFlags int
@@ -414,14 +414,8 @@ func (ss *raftSchedulerShard) worker(
 			}
 		}
 		if state.flags&stateRACv2PiggybackedAdmitted != 0 {
-			// processRACv2PiggybackedAdmitted returns true if the range should
-			// perform ready processing. Do not reorder this below the call to
-			// processReady.
-			if processor.processRACv2PiggybackedAdmitted(ctx, id) {
-				state.flags |= stateRaftReady
-			}
+			processor.processRACv2PiggybackedAdmitted(ctx, id)
 		}
-
 		if state.flags&stateRaftReady != 0 {
 			processor.processReady(id)
 		}

--- a/pkg/kv/kvserver/scheduler_test.go
+++ b/pkg/kv/kvserver/scheduler_test.go
@@ -179,10 +179,7 @@ func (p *testProcessor) processTick(_ context.Context, rangeID roachpb.RangeID) 
 	return false
 }
 
-func (p *testProcessor) processRACv2PiggybackedAdmitted(
-	ctx context.Context, id roachpb.RangeID,
-) bool {
-	return false
+func (p *testProcessor) processRACv2PiggybackedAdmitted(_ context.Context, _ roachpb.RangeID) {
 }
 
 func (p *testProcessor) readyCount(rangeID roachpb.RangeID) int {

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -721,12 +721,10 @@ func (s *Store) processTick(_ context.Context, rangeID roachpb.RangeID) bool {
 	return exists // ready
 }
 
-func (s *Store) processRACv2PiggybackedAdmitted(ctx context.Context, rangeID roachpb.RangeID) bool {
-	r, ok := s.mu.replicasByRangeID.Load(rangeID)
-	if !ok {
-		return false
+func (s *Store) processRACv2PiggybackedAdmitted(ctx context.Context, rangeID roachpb.RangeID) {
+	if r, ok := s.mu.replicasByRangeID.Load(rangeID); ok {
+		r.processRACv2PiggybackedAdmitted(ctx)
 	}
-	return r.processRACv2PiggybackedAdmitted(ctx)
 }
 
 // nodeIsLiveCallback is invoked when a node transitions from non-live to live.


### PR DESCRIPTION
Since the piggybacked admitted vectors are applied immediately from within the method that clears the queued updates, we no longer need to schedule a Ready cycle. Previously the token release would happen subsequently in Ready handler.

Related to #129508