### PR TITLE
crosscluster/logical: sharpen metadata names

### DIFF
--- a/pkg/ccl/crosscluster/logical/dead_letter_queue.go
+++ b/pkg/ccl/crosscluster/logical/dead_letter_queue.go
@@ -179,7 +179,7 @@ func (dlq *deadLetterQueueClient) Log(
 	srcTableID := cdcEventRow.TableID
 	dstTableMeta, ok := dlq.srcTableIDToDestMeta[srcTableID]
 	if !ok {
-		return errors.Newf("failed to look up fully qualified name for table %d", dstTableMeta.tableID)
+		return errors.Newf("failed to look up fully qualified name for src table id %d", srcTableID)
 	}
 	dlqTableName := dstTableMeta.toDLQTableName()
 

--- a/pkg/ccl/crosscluster/logical/logical_replication_dist.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_dist.go
@@ -32,7 +32,7 @@ func constructLogicalReplicationWriterSpecs(
 	initialScanTimestamp hlc.Timestamp,
 	previousReplicatedTimestamp hlc.Timestamp,
 	checkpoint jobspb.StreamIngestionCheckpoint,
-	tableMd map[int32]execinfrapb.TableReplicationMetadata,
+	tableMetadataByDestID map[int32]execinfrapb.TableReplicationMetadata,
 	jobID jobspb.JobID,
 	streamID streampb.StreamID,
 	ignoreCDCIgnoredTTLDeletes bool,
@@ -46,7 +46,7 @@ func constructLogicalReplicationWriterSpecs(
 		InitialScanTimestamp:        initialScanTimestamp,
 		Checkpoint:                  checkpoint, // TODO: Only forward relevant checkpoint info
 		StreamAddress:               string(streamAddress),
-		TableMetadata:               tableMd,
+		TableMetadataByDestID:       tableMetadataByDestID,
 		IgnoreCDCIgnoredTTLDeletes:  ignoreCDCIgnoredTTLDeletes,
 		Mode:                        mode,
 	}

--- a/pkg/ccl/crosscluster/logical/logical_replication_job.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job.go
@@ -158,7 +158,7 @@ func (r *logicalReplicationResumer) ingest(
 	}
 
 	// TODO(azhu): add a flag to avoid recreating dlq tables during replanning
-	dlqClient := InitDeadLetterQueueClient(execCfg.InternalDB.Executor(), planInfo.srcTableIDsToDestMeta)
+	dlqClient := InitDeadLetterQueueClient(execCfg.InternalDB.Executor(), planInfo.destTableBySrcID)
 	if err := dlqClient.Create(ctx); err != nil {
 		return errors.Wrap(err, "failed to create dead letter queue")
 	}
@@ -292,9 +292,9 @@ type logicalReplicationPlanner struct {
 }
 
 type logicalReplicationPlanInfo struct {
-	sourceSpans           []roachpb.Span
-	streamAddress         []string
-	srcTableIDsToDestMeta map[descpb.ID]dstTableMetadata
+	sourceSpans      []roachpb.Span
+	streamAddress    []string
+	destTableBySrcID map[descpb.ID]dstTableMetadata
 }
 
 func makeLogicalReplicationPlanner(
@@ -331,7 +331,7 @@ func (p *logicalReplicationPlanner) generatePlanImpl(
 		progress = p.job.Progress().Details.(*jobspb.Progress_LogicalReplication).LogicalReplication
 		payload  = p.job.Payload().Details.(*jobspb.Payload_LogicalReplicationDetails).LogicalReplicationDetails
 		info     = logicalReplicationPlanInfo{
-			srcTableIDsToDestMeta: make(map[descpb.ID]dstTableMetadata),
+			destTableBySrcID: make(map[descpb.ID]dstTableMetadata),
 		}
 	)
 	asOf := progress.ReplicatedTime
@@ -357,7 +357,7 @@ func (p *logicalReplicationPlanner) generatePlanImpl(
 		defaultFnOID = catid.FuncIDToOID(catid.DescID(defaultFnID))
 	}
 
-	tablesMd := make(map[int32]execinfrapb.TableReplicationMetadata)
+	tableMetadataByDestID := make(map[int32]execinfrapb.TableReplicationMetadata)
 	if err := sql.DescsTxn(ctx, execCfg, func(ctx context.Context, txn isql.Txn, descriptors *descs.Collection) error {
 		for _, pair := range payload.ReplicationPairs {
 			srcTableDesc := plan.DescriptorMap[pair.SrcDescriptorID]
@@ -383,14 +383,14 @@ func (p *logicalReplicationPlanner) generatePlanImpl(
 				fnOID = defaultFnOID
 			}
 
-			tablesMd[pair.DstDescriptorID] = execinfrapb.TableReplicationMetadata{
+			tableMetadataByDestID[pair.DstDescriptorID] = execinfrapb.TableReplicationMetadata{
 				SourceDescriptor:              srcTableDesc,
 				DestinationParentDatabaseName: dbDesc.GetName(),
 				DestinationParentSchemaName:   scDesc.GetName(),
 				DestinationTableName:          dstTableDesc.GetName(),
 				DestinationFunctionOID:        uint32(fnOID),
 			}
-			info.srcTableIDsToDestMeta[descpb.ID(pair.SrcDescriptorID)] = dstTableMetadata{
+			info.destTableBySrcID[descpb.ID(pair.SrcDescriptorID)] = dstTableMetadata{
 				database: dbDesc.GetName(),
 				schema:   scDesc.GetName(),
 				table:    dstTableDesc.GetName(),
@@ -418,7 +418,7 @@ func (p *logicalReplicationPlanner) generatePlanImpl(
 		payload.ReplicationStartTime,
 		progress.ReplicatedTime,
 		progress.Checkpoint,
-		tablesMd,
+		tableMetadataByDestID,
 		p.job.ID(),
 		streampb.StreamID(payload.StreamID),
 		payload.IgnoreCDCIgnoredTTLDeletes,

--- a/pkg/ccl/crosscluster/logical/lww_kv_processor.go
+++ b/pkg/ccl/crosscluster/logical/lww_kv_processor.go
@@ -53,14 +53,14 @@ func newKVRowProcessor(
 	ctx context.Context,
 	cfg *execinfra.ServerConfig,
 	evalCtx *eval.Context,
-	srcTablesByDestID map[descpb.ID]sqlProcessorTableConfig,
+	procConfigByDestID map[descpb.ID]sqlProcessorTableConfig,
 	fallback *sqlRowProcessor,
 ) (*kvRowProcessor, error) {
 	cdcEventTargets := changefeedbase.Targets{}
-	srcTablesBySrcID := make(map[descpb.ID]catalog.TableDescriptor, len(srcTablesByDestID))
-	dstBySrc := make(map[descpb.ID]descpb.ID, len(srcTablesByDestID))
+	srcTablesBySrcID := make(map[descpb.ID]catalog.TableDescriptor, len(procConfigByDestID))
+	dstBySrc := make(map[descpb.ID]descpb.ID, len(procConfigByDestID))
 
-	for dstID, s := range srcTablesByDestID {
+	for dstID, s := range procConfigByDestID {
 		dstBySrc[s.srcDesc.GetID()] = dstID
 		srcTablesBySrcID[s.srcDesc.GetID()] = s.srcDesc
 		cdcEventTargets.Add(changefeedbase.Target{
@@ -82,7 +82,7 @@ func newKVRowProcessor(
 		cfg:      cfg,
 		evalCtx:  evalCtx,
 		dstBySrc: dstBySrc,
-		writers:  make(map[descpb.ID]*kvTableWriter, len(srcTablesByDestID)),
+		writers:  make(map[descpb.ID]*kvTableWriter, len(procConfigByDestID)),
 		decoder:  cdcevent.NewEventDecoderWithCache(ctx, rfCache, false, false),
 		alloc:    &tree.DatumAlloc{},
 		fallback: fallback,

--- a/pkg/ccl/crosscluster/logical/udf_row_processor.go
+++ b/pkg/ccl/crosscluster/logical/udf_row_processor.go
@@ -96,15 +96,15 @@ type applierQuerier struct {
 func makeApplierQuerier(
 	ctx context.Context,
 	settings *cluster.Settings,
-	tableConfigs map[descpb.ID]sqlProcessorTableConfig,
+	tableConfigByDestID map[descpb.ID]sqlProcessorTableConfig,
 	jobID jobspb.JobID,
 	ie isql.Executor,
 ) *applierQuerier {
 	return &applierQuerier{
 		queryBuffer: queryBuffer{
-			deleteQueries:  make(map[catid.DescID]queryBuilder, len(tableConfigs)),
-			insertQueries:  make(map[catid.DescID]map[catid.FamilyID]queryBuilder, len(tableConfigs)),
-			applierQueries: make(map[catid.DescID]map[catid.FamilyID]queryBuilder, len(tableConfigs)),
+			deleteQueries:  make(map[catid.DescID]queryBuilder, len(tableConfigByDestID)),
+			insertQueries:  make(map[catid.DescID]map[catid.FamilyID]queryBuilder, len(tableConfigByDestID)),
+			applierQueries: make(map[catid.DescID]map[catid.FamilyID]queryBuilder, len(tableConfigByDestID)),
 		},
 		settings:    settings,
 		ieoInsert:   getIEOverride(replicatedInsertOpName, jobID),

--- a/pkg/sql/execinfrapb/flow_diagram.go
+++ b/pkg/sql/execinfrapb/flow_diagram.go
@@ -568,7 +568,7 @@ func (s *LogicalReplicationWriterSpec) summary() (string, []string) {
 	const spanLimit = 9
 
 	tableNames := []string{}
-	for _, table := range s.TableMetadata {
+	for _, table := range s.TableMetadataByDestID {
 		tableNames = append(tableNames, table.SourceDescriptor.Name)
 	}
 

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -527,9 +527,10 @@ message LogicalReplicationWriterSpec {
     // Checkpoint stores a set of resolved spans denoting completed progress.
     optional jobs.jobspb.StreamIngestionCheckpoint checkpoint = 7 [(gogoproto.nullable) = false];
 
-    // TableReplicationMetadata is a map from destination table IDs to metadata
-    // containing source table descriptors and fully qualified destination table names.
-    map<int32, TableReplicationMetadata> table_metadata = 8 [(gogoproto.nullable) = false];
+    // TableMetadataByDestID is a map from destination table IDs to metadata
+    // containing source table descriptors and fully qualified destination table
+    // names.
+    map<int32, TableReplicationMetadata> table_metadata_by_dest_id = 8 [(gogoproto.nullable) = false, (gogoproto.customname) = "TableMetadataByDestID"];
 
     // IgnoreCDCIgnoredTTLDeletes is an option on whether to filter out 'OmitinRangefeed' events
     // when processing changes in LDR


### PR DESCRIPTION
Throughout the ldr codebase we throw around several objects indexed on src or
dest descriptor IDs or names. This patch attempts to name these maps a little
more clearly.

Epic: none

Release note: none
