### PR TITLE
sql/schemachanger: fix flake in TestConcurrentSchemaChanges

### DIFF
--- a/pkg/sql/schemachanger/schemachanger_test.go
+++ b/pkg/sql/schemachanger/schemachanger_test.go
@@ -666,8 +666,9 @@ func TestConcurrentSchemaChanges(t *testing.T) {
 		workerName string, workInterval time.Duration, work func(workConn *gosql.DB) error,
 	) func(context.Context) error {
 		return func(workerCtx context.Context) error {
+			// Previously, we would have a fixed connection limit, which could
+			// play badly if an error was hit
 			workConn := s.SQLConn(t)
-			workConn.SetMaxOpenConns(1)
 			for {
 				jitteredInterval := workInterval * time.Duration(0.8+0.4*rand.Float32())
 				select {


### PR DESCRIPTION
Previously, each worker thread in TestConcurrentSchemaChanges had its own SQL connection pool, but these pools were limited to a single connection. When running this test in CI, we encounter an internal error that causes the connection to fail on the client side (the exact location is unclear, but it's likely originating from the go PQ library). On the server side, the connection simply drops. Due to the connection pool limit, a new connection cannot be established, resulting in this workload encountering the "driver: bad connection" error. To resolve this, this patch removes the connection limit on the pool, allowing a new connection to replace a failed one in the event of a driver error.

Fixes: #130116

Release note: None