### PR TITLE
crosscluster: store LDR job IDs in table descriptor

### DIFF
--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -1219,7 +1219,9 @@ message TableDescriptor {
   // stored outside the span of the object.
   optional ExternalRowData external = 61 [(gogoproto.nullable) = true];
 
-  // Next ID: 62
+  repeated int64 ldr_job_ids = 62 [(gogoproto.nullable) = false, (gogoproto.customname) = "LDRJobIDs"];
+
+  // Next ID: 63
 }
 
 // ExternalRowData indicates that the row data for this object is stored outside

--- a/pkg/sql/catalog/tabledesc/table_desc_test.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_test.go
@@ -151,6 +151,39 @@ func TestStripDanglingBackReferencesAndRoles(t *testing.T) {
 			strippedNonExistentRoles:       true,
 		},
 		{
+			name: "LDR job IDs",
+			input: descpb.TableDescriptor{
+				Name: "foo",
+				ID:   104,
+				MutationJobs: []descpb.TableDescriptor_MutationJob{
+					{JobID: 111222333444, MutationID: 1},
+				},
+				Mutations: []descpb.DescriptorMutation{
+					{MutationID: 1},
+					{MutationID: 2},
+				},
+				LDRJobIDs:  []int64{1, 2, 3},
+				Privileges: goodPrivilege,
+			},
+			expectedOutput: descpb.TableDescriptor{
+				Name: "foo",
+				ID:   104,
+				MutationJobs: []descpb.TableDescriptor_MutationJob{
+					{JobID: 111222333444, MutationID: 1},
+				},
+				Mutations: []descpb.DescriptorMutation{
+					{MutationID: 1},
+					{MutationID: 2},
+				},
+				LDRJobIDs:  []int64{},
+				Privileges: goodPrivilege,
+			},
+			validDescIDs:                   catalog.MakeDescriptorIDSet(100, 101, 104, 105),
+			validJobIDs:                    map[jobspb.JobID]struct{}{111222333444: {}},
+			strippedDanglingBackReferences: true,
+			strippedNonExistentRoles:       false,
+		},
+		{
 			name: "missing owner",
 			input: descpb.TableDescriptor{
 				Name: "foo",

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -142,6 +142,8 @@ var validationMap = []struct {
 			"ImportType":                    {status: thisFieldReferencesNoObjects},
 			"External": {status: todoIAmKnowinglyAddingTechDebt,
 				reason: "TODO(features): add validation that TableID is sane within the same tenant"},
+			// LDRJobIDs is checked in StripDanglingBackreferences.
+			"LDRJobIDs": {status: iSolemnlySwearThisFieldIsValidated},
 		},
 	},
 	{


### PR DESCRIPTION
This adds a new field to table descriptors that will keep track of LDR
jobs that are referencing this table as a destination.

This slice will be used in a future change to block schema changes on
this table if the slice is non-empty.

fixes https://github.com/cockroachdb/cockroach/issues/129728
Release note: None