### PR TITLE
ops: limit size of sql stats sent in diagnostic bundle

### DIFF
--- a/pkg/server/application_api/stats_test.go
+++ b/pkg/server/application_api/stats_test.go
@@ -222,7 +222,7 @@ func TestSQLStatCollection(t *testing.T) {
 	sqlServer.GetSQLStatsController().ResetLocalSQLStats(ctx)
 
 	// Query the reported statistics.
-	stats, err = sqlServer.GetScrubbedReportingStats(ctx)
+	stats, err = sqlServer.GetScrubbedReportingStats(ctx, 1000 /* limit */)
 	require.NoError(t, err)
 
 	foundStat = false
@@ -280,7 +280,7 @@ func TestSQLStatCollection(t *testing.T) {
 	sqlServer.GetSQLStatsController().ResetLocalSQLStats(ctx)
 
 	// Find our statement stat from the reported stats pool.
-	stats, err = sqlServer.GetScrubbedReportingStats(ctx)
+	stats, err = sqlServer.GetScrubbedReportingStats(ctx, 1000 /* limit */)
 	require.NoError(t, err)
 
 	foundStat = false
@@ -389,4 +389,40 @@ func TestClusterResetSQLStats(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestScrubbedReportingStatsLimit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+
+	sqlRunner := sqlutils.MakeSQLRunner(sqlDB)
+	sqlServer := srv.ApplicationLayer().SQLServer().(*sql.Server)
+	// Flush stats at the beginning of the test.
+	sqlServer.GetSQLStatsController().ResetLocalSQLStats(ctx)
+	sqlServer.GetReportedSQLStatsController().ResetLocalSQLStats(ctx)
+
+	hashedAppName := "hashed app name"
+	sqlRunner.Exec(t, `SET application_name = $1;`, hashedAppName)
+	sqlRunner.Exec(t, `CREATE DATABASE t`)
+	sqlRunner.Exec(t, `CREATE TABLE t.test (x INT PRIMARY KEY);`)
+	sqlRunner.Exec(t, `INSERT INTO t.test VALUES (1);`)
+	sqlRunner.Exec(t, `UPDATE t.test SET x=5 WHERE x=1`)
+	sqlRunner.Exec(t, `SELECT * FROM t.test`)
+	sqlRunner.Exec(t, `DELETE FROM t.test WHERE x=5`)
+
+	// verify that with low limit, number of stats is within that limit
+	sqlServer.GetSQLStatsController().ResetLocalSQLStats(ctx)
+	stats, err := sqlServer.GetScrubbedReportingStats(ctx, 5 /* limit */)
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(stats), 5)
+
+	// verify that with high limit, the number of	queries is as much as the above
+	sqlServer.GetSQLStatsController().ResetLocalSQLStats(ctx)
+	stats, err = sqlServer.GetScrubbedReportingStats(ctx, 1000 /* limit */)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(stats), 7)
 }

--- a/pkg/server/diagnostics/reporter.go
+++ b/pkg/server/diagnostics/reporter.go
@@ -278,7 +278,7 @@ func (r *Reporter) CreateReport(
 		}
 	}
 
-	info.SqlStats, err = r.SQLServer.GetScrubbedReportingStats(ctx)
+	info.SqlStats, err = r.SQLServer.GetScrubbedReportingStats(ctx, 100 /* limit */)
 	if err != nil {
 		if log.V(2 /* level */) {
 			log.Warningf(ctx, "unexpected error encountered when getting scrubbed reporting stats: %s", err)


### PR DESCRIPTION
ops: limit size of sql stats sent in diagnostic bundle

With the introduction of centralized telemetry collection, cockroach clusters will begin exporting some set of diagnostic information to CRL. Currently, the code which generates the diagnostic bundle ships all relevant statement stats to the registration server, which can be quite voluminous. This change limits the number of statement stats exported to 100 per report.

Epic: CRDB-40209
Fixes: CRDB-41233

Release note: None