### PR TITLE
release-23.2: ui: fix release build, reference appropriate license expiry getter

### DIFF
--- a/pkg/ui/BUILD.bazel
+++ b/pkg/ui/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/util/httputil",
         "//pkg/util/log",
+        "//pkg/util/timeutil",
     ],
 )
 

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 const (
@@ -167,7 +168,7 @@ func Handler(cfg Config) http.Handler {
 		if err != nil {
 			log.Errorf(context.Background(), "unable to get license type: %+v", err)
 		}
-		licenseTTL := base.LicenseTTL.Value()
+		licenseTTL := base.GetLicenseTTL(r.Context(), cfg.Settings, timeutil.DefaultTimeSource{})
 		oidcConf := cfg.OIDC.GetOIDCConf()
 		args := indexHTMLArgs{
 			Insecure:         cfg.Insecure,


### PR DESCRIPTION
ui: fix release build, reference appropriate license expiry getter

A conflict between two recent changes broke the release build. The first added the license expiry to a web endpoint, the second modified the way license expiry was calculated. In isolation each of these changes worked, but together they caused a compilation error. This patch updates the web location where the license expiry is surfaced.

Epic: none
Fixes: #130610

Release note: None

Release justification: fixes build on release branch