### PR TITLE
rac2: make reads of RangeController state shared

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -215,7 +215,7 @@ type rangeController struct {
 	leaseholder roachpb.ReplicaID
 
 	mu struct {
-		syncutil.Mutex
+		syncutil.RWMutex
 
 		// State for waiters. When anything in voterSets or nonVoterSets changes,
 		// waiterSetRefreshCh is closed, and replaced with a new channel. The
@@ -284,11 +284,11 @@ func (rc *rangeController) WaitForEval(
 	start := rc.opts.Clock.PhysicalTime()
 retry:
 	// Snapshot the waiter sets and the refresh channel.
-	rc.mu.Lock()
+	rc.mu.RLock()
 	vss := rc.mu.voterSets
 	nvs := rc.mu.nonVoterSet
 	refreshCh := rc.mu.waiterSetRefreshCh
-	rc.mu.Unlock()
+	rc.mu.RUnlock()
 
 	if refreshCh == nil {
 		// RangeControllerImpl is closed.
@@ -449,6 +449,7 @@ func (rc *rangeController) CloseRaftMuLocked(ctx context.Context) {
 	defer rc.mu.Unlock()
 
 	rc.mu.voterSets = nil
+	rc.mu.nonVoterSet = nil
 	close(rc.mu.waiterSetRefreshCh)
 	rc.mu.waiterSetRefreshCh = nil
 }


### PR DESCRIPTION
There can be many parallel `WaitForEval` readers trying to access the `RangeController`. Make the mutex an `RWMutex`, and lock it only for read in `WaitForEval`.

Epic: none
Release note: none