### PR TITLE
release-24.1: util: fix race in cidr startup

### DIFF
--- a/pkg/util/cidr/cidr.go
+++ b/pkg/util/cidr/cidr.go
@@ -76,20 +76,27 @@ func NewLookup(st *settings.Values) *Lookup {
 	byLength := make([]map[string]string, 0)
 	c.byLength.Store(&byLength)
 	c.lastUpdate.Store(time.Time{})
-	c.changed = make(chan time.Duration)
+	c.changed = make(chan time.Duration, 1)
 
 	cidrMappingUrl.SetOnChange(st, func(ctx context.Context) {
 		// Reset the lastUpdate time so that the URL is always reloaded even if
 		// the new file/URL has an older timestamp.
 		c.lastUpdate.Store(time.Time{})
-		c.changed <- cidrRefreshInterval.Get(c.st)
+		select {
+		case c.changed <- cidrRefreshInterval.Get(c.st):
+		default:
+		}
 	})
 	// We have to register this callback first. Otherwise we may run into
 	// an unlikely but possible scenario where we've started the ticker,
 	// and the setting is changed before we register the callback and the
 	// ticker will not be reset to the new value.
 	cidrRefreshInterval.SetOnChange(c.st, func(ctx context.Context) {
-		c.changed <- cidrRefreshInterval.Get(c.st)
+		log.Infof(ctx, "refresh interval changed to '%s'", cidrRefreshInterval.Get(c.st))
+		select {
+		case c.changed <- cidrRefreshInterval.Get(c.st):
+		default:
+		}
 	})
 	return c
 }


### PR DESCRIPTION
Backport 1/1 commits from #130590.

/cc @cockroachdb/release

---

Previously if the `server.cidr_mapping_url` was set and a node restarted, there was a race condition where `SetOnChange` for the setting could be called before the `Start` was called. This could result in it blocking while attempting to submit to the channel.

Fixes: #130589

Release note: None

Release Justification: Fixes a race in a newly introduced feature. Only applicable if the new setting is set.
