### PR TITLE
schemachanger: block zone config changes if schema_locked is set

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema_locked
+++ b/pkg/sql/logictest/testdata/logic_test/schema_locked
@@ -119,3 +119,13 @@ COMMENT ON COLUMN t.i IS 'i is a column';
 
 statement ok
 DROP TABLE t;
+
+subtest zone_config
+
+statement ok
+ALTER TABLE ref SET (schema_locked = true);
+
+statement error pgcode 57000 schema changes are disallowed on table "ref" because it is locked
+ALTER TABLE ref CONFIGURE ZONE USING num_replicas = 11;
+
+subtest end

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/configure_zone.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/configure_zone.go
@@ -124,6 +124,7 @@ func astToZoneConfigObject(b BuildCtx, n *tree.SetZoneConfig) (zoneConfigObject,
 	}
 	tblName := zs.TableOrIndex.Table.ToUnresolvedObjectName()
 	elems := b.ResolvePhysicalTable(tblName, ResolveParams{})
+	panicIfSchemaIsLocked(elems)
 	var tableID catid.DescID
 	elems.ForEach(func(_ scpb.Status, _ scpb.TargetStatus, e scpb.Element) {
 		switch e := e.(type) {


### PR DESCRIPTION
Fixes: #130668
Release note (bug fix): Fixed a bug where zone configuration changes issued by
the declarative schema changer were not blocked if a table had `schema_locked`
set. For more information about the declarative schema changer, see:
https://www.cockroachlabs.com/docs/stable/online-schema-changes#declarative-schema-changer/.