### PR TITLE
release-24.2: sqlproxyccl: skip TestFailedConnection under stress

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -100,6 +100,7 @@ go_test(
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -639,6 +640,11 @@ func TestBackendDownRetry(t *testing.T) {
 func TestFailedConnection(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// This test is asserting against specific counter values and error messages.
+	// The counter assertions make it difficult to insert retries and the test
+	// flakes once a month under stress.
+	skip.UnderStress(t)
 
 	ctx := context.Background()
 	te := newTester()


### PR DESCRIPTION
Backport 1/1 commits from #128796.

/cc @cockroachdb/release

---

This test occasionally flakes under stress. I've been unable to reproduce the flake. The nature of the test asserting on counters and error messages makes it difficult to make the test more robust by inserting retries.

Fixes: #125741

Release Justification: Test only change
