### PR TITLE
replica_rac2: move raft write registering

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/log_tracker
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/log_tracker
@@ -47,6 +47,35 @@ append term=2 after=5 to=10
 ----
 [upd] mark:{Term:2 Index:10}, stable:5, admitted:[5 5 5 5]
 
+register term=2 index=6 pri=LowPri
+----
+mark:{Term:2 Index:10}, stable:5, admitted:[5 5 5 5]
+LowPri: {Term:2 Index:6}
+
+# A snapshot at the same term does not admit all the previous entries, and
+# retains the stable index. The index will move when the snapshot is synced.
+snap term=2 index=20
+----
+mark:{Term:2 Index:20}, stable:5, admitted:[5 5 5 5]
+LowPri: {Term:2 Index:6}
+
+# Same does a snapshot at a new term and index higher than previous marks. It
+# only updates the term of the marks.
+snap term=3 index=10
+----
+[upd] mark:{Term:3 Index:10}, stable:5, admitted:[5 5 5 5]
+LowPri: {Term:2 Index:6}
+
+# A snapshot at a low index regresses the stable index, and admitted state and
+# queue.
+snap term=4 index=3
+----
+[upd] mark:{Term:4 Index:3}, stable:3, admitted:[3 3 3 3]
+
+sync term=4 index=3
+----
+mark:{Term:4 Index:3}, stable:3, admitted:[3 3 3 3]
+
 # ------------------------------------------------------------------------------
 # Test stable index advancement racing with admission.
 

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/log_tracker.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/log_tracker.go
@@ -63,6 +63,14 @@ func (l *logTracker) admitted(sched bool) (av rac2.AdmittedVector, dirty bool) {
 	return av, dirty
 }
 
+func (l *logTracker) snap(ctx context.Context, mark rac2.LogMark) {
+	l.Lock()
+	defer l.Unlock()
+	if l.lt.Snap(ctx, mark) {
+		l.dirty = true
+	}
+}
+
 func (l *logTracker) append(ctx context.Context, after uint64, to rac2.LogMark) {
 	l.Lock()
 	defer l.Unlock()
@@ -104,14 +112,6 @@ func (l *logTracker) logAdmitted(ctx context.Context, at rac2.LogMark, pri raftp
 		return true
 	}
 	return false
-}
-
-func (l *logTracker) snapSynced(ctx context.Context, mark rac2.LogMark) {
-	l.Lock()
-	defer l.Unlock()
-	if l.lt.SnapSynced(ctx, mark) {
-		l.dirty = true
-	}
 }
 
 func (l *logTracker) debugString() string {

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -366,7 +366,7 @@ func TestProcessorBasic(t *testing.T) {
 				var mark rac2.LogMark
 				d.ScanArgs(t, "term", &mark.Term)
 				d.ScanArgs(t, "index", &mark.Index)
-				p.SyncedLogStorage(ctx, mark, false /* snap */)
+				p.SyncedLogStorage(ctx, mark)
 				printLogTracker()
 				return builderStr()
 

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
@@ -407,12 +407,13 @@ HandleRaftReady:
  RaftNode.TermLocked() = 52
  Replica.MuUnlock
  RangeControllerFactory.New(replicaSet=[(n1,s2):5,(n11,s11):11], leaseholder=10, nextRaftIndex=28)
+ RangeController.AdmitRaftMuLocked(5, {Term:52 Admitted:[26 26 26 26]})
  RangeController.HandleRaftEventRaftMuLocked([28])
 .....
 AdmitRaftEntries:
  ACWorkQueue.Admit({StoreID:2 TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false RangeID:3 ReplicaID:5 CallbackState:{Mark:{Term:52 Index:28} Priority:LowPri}}) = true
 destroyed-or-leader-using-v2: true
-LogTracker [+dirty]: mark:{Term:52 Index:28}, stable:26, admitted:[26 26 26 26]
+LogTracker: mark:{Term:52 Index:28}, stable:26, admitted:[26 26 26 26]
 LowPri: {Term:52 Index:28}
 
 # AdmitForEval returns true since there is a RangeController which admitted.
@@ -462,7 +463,7 @@ admitted: false err: rc-was-closed
 # vector is not changed since the last time.
 admitted-log-entry leader-term=52 index=28 pri=0
 ----
-LogTracker [+dirty]: mark:{Term:52 Index:28}, stable:26, admitted:[26 26 26 26]
+LogTracker: mark:{Term:52 Index:28}, stable:26, admitted:[26 26 26 26]
 
 # Noop.
 handle-raft-ready-and-admit
@@ -475,7 +476,6 @@ HandleRaftReady:
  Replica.LeaseholderMuLocked
  RaftNode.TermLocked() = 52
  Replica.MuUnlock
- RangeController.AdmitRaftMuLocked(5, {Term:52 Admitted:[26 26 26 26]})
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
 

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1676,7 +1676,7 @@ func (r *replicaSyncCallback) OnLogSync(
 	// The log mark is non-empty only if this was a non-empty log append that
 	// updated the stable log mark.
 	if mark := done.Mark(); mark.Term != 0 {
-		repl.flowControlV2.SyncedLogStorage(ctx, mark, false /* snap */)
+		repl.flowControlV2.SyncedLogStorage(ctx, mark)
 	}
 	// Block sending the responses back to raft, if a test needs to.
 	if fn := repl.store.TestingKnobs().TestingAfterRaftLogSync; fn != nil {
@@ -1692,7 +1692,7 @@ func (r *replicaSyncCallback) OnLogSync(
 func (r *replicaSyncCallback) OnSnapSync(ctx context.Context, done logstore.MsgStorageAppendDone) {
 	repl := (*Replica)(r)
 	// NB: when storing snapshot, done always contains a non-zero log mark.
-	repl.flowControlV2.SyncedLogStorage(ctx, done.Mark(), true /* snap */)
+	repl.flowControlV2.SyncedLogStorage(ctx, done.Mark())
 	repl.sendRaftMessages(ctx, done.Responses(), nil /* blocked */, true /* willDeliverLocal */)
 }
 


### PR DESCRIPTION
This commit moves registering all raft log/snapshot writes for RACv2 into `HandleRaftReadyRaftMuLocked`, so that `maybeSendAdmittedRaftMuLocked` call always happens after registering the latest write.

This way, the admitted vector in `logTracker` carries the latest leader term we have observed from raft, and `maybeSendAdmittedRaftMuLocked` won't skip it when the term changes.

Part of #129508