### PR TITLE
release-23.1: sqlproxyccl: add ServerlessOnly test helper

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -85,6 +85,7 @@ go_test(
         "//pkg/ccl/sqlproxyccl/tenant",
         "//pkg/ccl/sqlproxyccl/tenantdirsvr",
         "//pkg/ccl/sqlproxyccl/throttler",
+        "//pkg/ccl/testutilsccl",
         "//pkg/roachpb",
         "//pkg/security/certnames",
         "//pkg/security/securityassets",

--- a/pkg/ccl/sqlproxyccl/acl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/acl/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
     deps = [
         "//pkg/ccl/sqlproxyccl/tenant",
         "//pkg/ccl/sqlproxyccl/tenantdirsvr",
+        "//pkg/ccl/testutilsccl",
         "//pkg/roachpb",
         "//pkg/testutils",
         "//pkg/util/leaktest",

--- a/pkg/ccl/sqlproxyccl/acl/cidr_ranges_test.go
+++ b/pkg/ccl/sqlproxyccl/acl/cidr_ranges_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/acl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant"
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/errors"
@@ -22,6 +23,7 @@ import (
 
 func TestCIDRRanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	ctx := context.Background()
 
 	tenantID := roachpb.MustMakeTenantID(42)

--- a/pkg/ccl/sqlproxyccl/acl/file_test.go
+++ b/pkg/ccl/sqlproxyccl/acl/file_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -30,6 +31,9 @@ import (
 
 func TestDenyListFileParsing(t *testing.T) {
 	t.Run("test custom marshal code", func(t *testing.T) {
+		defer leaktest.AfterTest(t)()
+		testutilsccl.ServerlessOnly(t)
+
 		cases := []struct {
 			t        DenyType
 			expected string
@@ -45,6 +49,9 @@ func TestDenyListFileParsing(t *testing.T) {
 	})
 
 	t.Run("test DenyType custom unmarshal code", func(t *testing.T) {
+		defer leaktest.AfterTest(t)()
+		testutilsccl.ServerlessOnly(t)
+
 		cases := []struct {
 			raw      string
 			expected DenyType
@@ -67,6 +74,8 @@ func TestDenyListFileParsing(t *testing.T) {
 
 	t.Run("end to end testing of DenylistFile parsing", func(t *testing.T) {
 		defer leaktest.AfterTest(t)()
+		testutilsccl.ServerlessOnly(t)
+
 		expirationTimeString := "2021-01-01T15:20:39Z"
 		expirationTime := time.Date(2021, 1, 1, 15, 20, 39, 0, time.UTC)
 
@@ -130,6 +139,9 @@ denylist:
 	})
 
 	t.Run("test Ser/De of File", func(t *testing.T) {
+		defer leaktest.AfterTest(t)()
+		testutilsccl.ServerlessOnly(t)
+
 		file := DenylistFile{
 			Seq: 72,
 			Denylist: []*DenyEntry{
@@ -156,6 +168,7 @@ denylist:
 
 func TestDenylistLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	startTime := time.Date(2021, 1, 1, 15, 20, 39, 0, time.UTC)
 	longExpirationTimeString := "2030-01-01T15:30:39Z"
@@ -314,6 +327,9 @@ func parseIPNet(cidr string) *net.IPNet {
 func TestAllowListFileParsing(t *testing.T) {
 
 	t.Run("test AllowEntry custom unmarshal code", func(t *testing.T) {
+		defer leaktest.AfterTest(t)()
+		testutilsccl.ServerlessOnly(t)
+
 		cases := []struct {
 			raw      string
 			expected AllowEntry
@@ -367,6 +383,7 @@ func TestAllowListFileParsing(t *testing.T) {
 
 	t.Run("end to end testing of AllowlistFile parsing", func(t *testing.T) {
 		defer leaktest.AfterTest(t)()
+		testutilsccl.ServerlessOnly(t)
 
 		testCases := []struct {
 			input    string
@@ -441,6 +458,7 @@ allowlist:
 
 func TestAllowlistLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	type allowIOSpec struct {
 		connection ConnectionTags
@@ -491,6 +509,9 @@ allowlist:
 }
 
 func TestParsingErrorHandling(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
+
 	// Use cancel to prevent leaked goroutines from file watches.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/ccl/sqlproxyccl/acl/private_endpoints_test.go
+++ b/pkg/ccl/sqlproxyccl/acl/private_endpoints_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/acl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant"
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/errors"
@@ -25,6 +26,7 @@ import (
 
 func TestPrivateEndpoints(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	ctx := context.Background()
 
 	makeConn := func(endpoint string) acl.ConnectionTags {
@@ -114,6 +116,7 @@ func TestPrivateEndpoints(t *testing.T) {
 
 func TestFindPrivateEndpointID(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	newHeader := func(t *testing.T, tlvs []proxyproto.TLV) *proxyproto.Header {
 		t.Helper()

--- a/pkg/ccl/sqlproxyccl/acl/watcher_test.go
+++ b/pkg/ccl/sqlproxyccl/acl/watcher_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenantdirsvr"
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -68,6 +69,7 @@ func cidrRanges(fn lookupTenantFunc) *CIDRRanges {
 
 func TestACLWatcher(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	ctx := context.Background()
 	stopper := stop.NewStopper()

--- a/pkg/ccl/sqlproxyccl/authentication_test.go
+++ b/pkg/ccl/sqlproxyccl/authentication_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/throttler"
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/jackc/pgproto3/v2"
@@ -26,6 +27,7 @@ var nilThrottleHook = func(state throttler.AttemptStatus) error {
 
 func TestAuthenticateOK(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	cli, srv := net.Pipe()
 	be := pgproto3.NewBackend(pgproto3.NewChunkReader(srv), srv)
@@ -55,6 +57,7 @@ func TestAuthenticateOK(t *testing.T) {
 
 func TestAuthenticateClearText(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	cli, srv := net.Pipe()
 	be := pgproto3.NewBackend(pgproto3.NewChunkReader(srv), srv)
@@ -98,6 +101,7 @@ func TestAuthenticateClearText(t *testing.T) {
 
 func TestAuthenticateThrottled(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	server := func(t *testing.T, be *pgproto3.Backend) {
 		require.NoError(t, be.Send(&pgproto3.AuthenticationCleartextPassword{}))
@@ -153,6 +157,7 @@ func TestAuthenticateThrottled(t *testing.T) {
 
 func TestErrorFollowingAuthenticateNotThrottled(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	server := func(t *testing.T, be *pgproto3.Backend) {
 		require.NoError(t, be.Send(&pgproto3.AuthenticationCleartextPassword{}))
@@ -208,6 +213,7 @@ func TestErrorFollowingAuthenticateNotThrottled(t *testing.T) {
 
 func TestAuthenticateError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	cli, srv := net.Pipe()
 	be := pgproto3.NewBackend(pgproto3.NewChunkReader(srv), srv)
@@ -228,6 +234,7 @@ func TestAuthenticateError(t *testing.T) {
 
 func TestAuthenticateUnexpectedMessage(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	cli, srv := net.Pipe()
 	be := pgproto3.NewBackend(pgproto3.NewChunkReader(srv), srv)
@@ -250,6 +257,7 @@ func TestAuthenticateUnexpectedMessage(t *testing.T) {
 
 func TestReadTokenAuthResult(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	t.Run("unexpected message", func(t *testing.T) {
 		cli, srv := net.Pipe()

--- a/pkg/ccl/sqlproxyccl/backend_dialer_test.go
+++ b/pkg/ccl/sqlproxyccl/backend_dialer_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/certnames"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
@@ -28,6 +29,7 @@ import (
 
 func TestBackendDialTLSInsecure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -44,6 +46,7 @@ func TestBackendDialTLSInsecure(t *testing.T) {
 
 func TestBackendDialTLS(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	startupMsg := &pgproto3.StartupMessage{ProtocolVersion: pgproto3.ProtocolVersionNumber}

--- a/pkg/ccl/sqlproxyccl/balancer/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/balancer/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
     embed = [":balancer"],
     deps = [
         "//pkg/ccl/sqlproxyccl/tenant",
+        "//pkg/ccl/testutilsccl",
         "//pkg/roachpb",
         "//pkg/testutils",
         "//pkg/util/leaktest",

--- a/pkg/ccl/sqlproxyccl/balancer/assignment_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/assignment_test.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -20,6 +21,7 @@ import (
 
 func TestServerAssignment(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	ctx := context.Background()
 	stopper := stop.NewStopper()

--- a/pkg/ccl/sqlproxyccl/balancer/balancer_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/balancer_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant"
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -32,6 +33,7 @@ import (
 
 func TestBalancer_SelectTenantPod(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	ctx := context.Background()
 	stopper := stop.NewStopper()
@@ -64,6 +66,7 @@ func TestBalancer_SelectTenantPod(t *testing.T) {
 
 func TestRebalancer_processQueue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	ctx := context.Background()
 	stopper := stop.NewStopper()
@@ -243,6 +246,7 @@ func TestRebalancer_processQueue(t *testing.T) {
 // the manual timer is difficult to get it right (and often flaky).
 func TestRebalancer_rebalanceLoop(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	ctx := context.Background()
 	stopper := stop.NewStopper()
@@ -345,6 +349,7 @@ func TestRebalancer_rebalanceLoop(t *testing.T) {
 
 func TestRebalancer_rebalance(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -718,6 +723,7 @@ func TestRebalancer_rebalance(t *testing.T) {
 
 func TestBalancer_RebalanceTenant_WithRebalancingDisabled(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -793,6 +799,7 @@ func TestBalancer_RebalanceTenant_WithRebalancingDisabled(t *testing.T) {
 
 func TestBalancer_RebalanceTenant_WithDefaultDelay(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -896,6 +903,7 @@ func TestBalancer_RebalanceTenant_WithDefaultDelay(t *testing.T) {
 
 func TestEnqueueRebalanceRequests(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	baseCtx := context.Background()
 	stopper := stop.NewStopper()
@@ -937,6 +945,7 @@ func TestEnqueueRebalanceRequests(t *testing.T) {
 
 func TestCollectRunningPodAssignments(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	// Use a deterministic behavior in tests.
 	defer func(
@@ -1101,6 +1110,7 @@ func TestCollectRunningPodAssignments(t *testing.T) {
 
 func TestCollectDrainingPodAssignments(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	t.Run("no pods", func(t *testing.T) {
 		set := collectDrainingPodAssignments(
@@ -1150,6 +1160,7 @@ func TestCollectDrainingPodAssignments(t *testing.T) {
 
 func TestPartitionNRandom(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	generateSrc := func(count int) []*ServerAssignment {
 		var partition []*ServerAssignment
@@ -1227,6 +1238,7 @@ func TestPartitionNRandom(t *testing.T) {
 
 func TestRebalancerQueue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1300,6 +1312,7 @@ func TestRebalancerQueue(t *testing.T) {
 // dequeue.
 func TestRebalancerQueueBlocking(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/ccl/sqlproxyccl/balancer/conn_tracker_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn_tracker_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -28,6 +29,7 @@ import (
 
 func TestConnTracker(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -110,6 +112,7 @@ func TestConnTracker(t *testing.T) {
 
 func TestConnTracker_GetConnsMap(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -174,6 +177,7 @@ func TestConnTracker_GetConnsMap(t *testing.T) {
 
 func TestConnTrackerPartitionsRefresh(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	ctx := context.Background()
 	stopper := stop.NewStopper()
@@ -230,6 +234,7 @@ func TestConnTrackerPartitionsRefresh(t *testing.T) {
 
 func TestTenantEntry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	entry := newTenantEntry()
 
@@ -293,6 +298,7 @@ func TestTenantEntry(t *testing.T) {
 
 func TestTenantEntry_refreshPartitions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	entry := newTenantEntry()
 

--- a/pkg/ccl/sqlproxyccl/balancer/pod_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/pod_test.go
@@ -13,12 +13,14 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant"
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSelectTenantPods(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	t.Run("no pods", func(t *testing.T) {
 		require.Nil(t, selectTenantPod(nil, newTenantEntry()))

--- a/pkg/ccl/sqlproxyccl/conn_migration_test.go
+++ b/pkg/ccl/sqlproxyccl/conn_migration_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/balancer"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/interceptor"
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -28,6 +29,7 @@ import (
 
 func TestTransferContext(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	t.Run("new_context", func(t *testing.T) {
 		ctx, cancel := newTransferContext(context.Background())
@@ -57,6 +59,7 @@ func TestTransferContext(t *testing.T) {
 
 func TestForwarder_tryBeginTransfer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	t.Run("not_initialized", func(t *testing.T) {
 		defer testutils.TestingHook(&isSafeTransferPointLocked,
@@ -122,6 +125,7 @@ func TestForwarder_tryBeginTransfer(t *testing.T) {
 
 func TestTransferConnection(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	p1, p2 := net.Pipe()
 	defer p1.Close()
@@ -442,6 +446,7 @@ func TestTransferConnection(t *testing.T) {
 
 func TestIsSafeTransferPointLocked(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	makeProc := func(typ byte, transferredAt int) *processor {
 		p := &processor{}
@@ -489,6 +494,7 @@ func TestIsSafeTransferPointLocked(t *testing.T) {
 
 func TestRunShowTransferState(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	t.Run("successful", func(t *testing.T) {
 		buf := new(bytes.Buffer)
@@ -511,6 +517,7 @@ func TestRunShowTransferState(t *testing.T) {
 
 func TestWaitForShowTransferState(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	ctx := context.Background()
 
 	t.Run("context_cancelled", func(t *testing.T) {
@@ -836,6 +843,7 @@ func TestWaitForShowTransferState(t *testing.T) {
 
 func TestRunAndWaitForDeserializeSession(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	ctx := context.Background()
 
 	t.Run("write_failed", func(t *testing.T) {
@@ -1012,6 +1020,7 @@ func TestRunAndWaitForDeserializeSession(t *testing.T) {
 
 func TestWaitForSmallRowDescription(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	ctx := context.Background()
 
 	t.Run("context_cancelled", func(t *testing.T) {
@@ -1109,6 +1118,7 @@ func TestWaitForSmallRowDescription(t *testing.T) {
 
 func TestExpectDataRow(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	ctx := context.Background()
 
 	falseValidateFn := func(m *pgproto3.DataRow, s int) bool { return false }
@@ -1181,6 +1191,7 @@ func TestExpectDataRow(t *testing.T) {
 
 func TestExpectCommandComplete(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	ctx := context.Background()
 
 	t.Run("context_cancelled", func(t *testing.T) {
@@ -1242,6 +1253,7 @@ func TestExpectCommandComplete(t *testing.T) {
 
 func TestExpectReadyForQuery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	ctx := context.Background()
 
 	t.Run("context_cancelled", func(t *testing.T) {

--- a/pkg/ccl/sqlproxyccl/connector_test.go
+++ b/pkg/ccl/sqlproxyccl/connector_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/balancer"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/throttler"
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -35,6 +36,7 @@ import (
 
 func TestConnector_OpenTenantConnWithToken(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	const token = "foobarbaz"
 	ctx := context.Background()
@@ -172,6 +174,7 @@ func TestConnector_OpenTenantConnWithToken(t *testing.T) {
 
 func TestConnector_OpenTenantConnWithAuth(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	ctx := context.Background()
 	dummyHook := func(throttler.AttemptStatus) error {
@@ -327,6 +330,7 @@ func TestConnector_OpenTenantConnWithAuth(t *testing.T) {
 
 func TestConnector_dialTenantCluster(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	bgCtx := context.Background()
 
@@ -654,6 +658,7 @@ func TestConnector_dialTenantCluster(t *testing.T) {
 
 func TestConnector_lookupAddr(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	ctx := context.Background()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
@@ -771,6 +776,7 @@ func TestConnector_lookupAddr(t *testing.T) {
 
 func TestConnector_dialSQLServer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	ctx := context.Background()
 	stopper := stop.NewStopper()
@@ -903,6 +909,7 @@ func TestConnector_dialSQLServer(t *testing.T) {
 
 func TestRetriableConnectorError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	err := errors.New("foobar")
 	require.False(t, isRetriableConnectorError(err))
@@ -913,6 +920,7 @@ func TestRetriableConnectorError(t *testing.T) {
 
 func TestTenantTLSConfig(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	makeChains := func(commonName string, org string) [][]*x509.Certificate {
 		cert := &x509.Certificate{}

--- a/pkg/ccl/sqlproxyccl/error_source_test.go
+++ b/pkg/ccl/sqlproxyccl/error_source_test.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
@@ -34,6 +35,7 @@ func (conn *fakeConn) Write(_ []byte) (n int, err error) {
 
 func TestWrapConnectionError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	type testCase struct {
 		marker error
 		code   errorCode
@@ -53,6 +55,7 @@ func TestWrapConnectionError(t *testing.T) {
 
 func TestErrorSourceConn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	newConn := func(size int, readError error, writeError error) net.Conn {
 		return &errorSourceConn{
 			Conn: &fakeConn{

--- a/pkg/ccl/sqlproxyccl/forwarder_test.go
+++ b/pkg/ccl/sqlproxyccl/forwarder_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/interceptor"
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -32,6 +33,7 @@ import (
 
 func TestForward(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	bgCtx := context.Background()
 
@@ -328,6 +330,7 @@ func TestForward(t *testing.T) {
 
 func TestForwarder_Context(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	ctx := logtags.AddTag(context.Background(), "foo", "bar")
 	f := newForwarder(ctx, nil /* connector */, nil /* metrics */, nil /* timeSource */)
@@ -341,6 +344,7 @@ func TestForwarder_Context(t *testing.T) {
 
 func TestForwarder_Close(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	ctx := context.Background()
 	for _, withRun := range []bool{true, false} {
@@ -363,6 +367,7 @@ func TestForwarder_Close(t *testing.T) {
 
 func TestForwarder_tryReportError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	ctx := context.Background()
 	p1, p2 := net.Pipe()
@@ -398,6 +403,7 @@ func TestForwarder_tryReportError(t *testing.T) {
 
 func TestForwarder_replaceServerConn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	ctx := context.Background()
 	clientProxy, client := net.Pipe()
@@ -440,6 +446,7 @@ func TestForwarder_replaceServerConn(t *testing.T) {
 
 func TestWrapClientToServerError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	for _, tc := range []struct {
 		input  error
@@ -473,6 +480,7 @@ func TestWrapClientToServerError(t *testing.T) {
 
 func TestWrapServerToClientError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	for _, tc := range []struct {
 		input  error
@@ -506,6 +514,7 @@ func TestWrapServerToClientError(t *testing.T) {
 
 func TestMakeLogicalClockFn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	clockFn := makeLogicalClockFn()
 
@@ -532,6 +541,7 @@ func TestMakeLogicalClockFn(t *testing.T) {
 
 func TestSuspendResumeProcessor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	t.Run("context_cancelled", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/ccl/sqlproxyccl/frontend_admitter_test.go
+++ b/pkg/ccl/sqlproxyccl/frontend_admitter_test.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -37,6 +38,7 @@ func tlsConfig() (*tls.Config, error) {
 
 func TestFrontendAdmitWithNoBytes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	cli, srv := net.Pipe()
 	require.NoError(t, srv.SetReadDeadline(timeutil.Now().Add(3e9)))
@@ -53,6 +55,7 @@ func TestFrontendAdmitWithNoBytes(t *testing.T) {
 
 func TestFrontendAdmitWithClientSSLDisableAndCustomParam(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	cli, srv := net.Pipe()
 	require.NoError(t, srv.SetReadDeadline(timeutil.Now().Add(3e9)))
@@ -87,6 +90,7 @@ func TestFrontendAdmitWithClientSSLDisableAndCustomParam(t *testing.T) {
 
 func TestFrontendAdmitWithClientSSLRequire(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	cli, srv := net.Pipe()
 	require.NoError(t, srv.SetReadDeadline(timeutil.Now().Add(3e9)))
@@ -124,6 +128,7 @@ func TestFrontendAdmitWithClientSSLRequire(t *testing.T) {
 // expected.
 func TestFrontendAdmitRequireEncryption(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	cli, srv := net.Pipe()
 	require.NoError(t, srv.SetReadDeadline(timeutil.Now().Add(3e9)))
@@ -151,6 +156,7 @@ func TestFrontendAdmitRequireEncryption(t *testing.T) {
 // TestFrontendAdmitWithCancel sends CancelRequest.
 func TestFrontendAdmitWithCancel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	cli, srvPipe := net.Pipe()
 	srv := &fakeTCPConn{
@@ -177,6 +183,7 @@ func TestFrontendAdmitWithCancel(t *testing.T) {
 // TestFrontendAdmitWithSSLAndCancel sends SSLRequest followed by CancelRequest.
 func TestFrontendAdmitWithSSLAndCancel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	cli, srvPipe := net.Pipe()
 	srv := &fakeTCPConn{
@@ -212,6 +219,7 @@ func TestFrontendAdmitWithSSLAndCancel(t *testing.T) {
 
 func TestFrontendAdmitSessionRevivalToken(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	cli, srv := net.Pipe()
 	require.NoError(t, srv.SetReadDeadline(timeutil.Now().Add(3e9)))

--- a/pkg/ccl/sqlproxyccl/interceptor/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/interceptor/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
     args = ["-test.timeout=295s"],
     embed = [":interceptor"],
     deps = [
+        "//pkg/ccl/testutilsccl",
         "//pkg/sql/pgwire/pgwirebase",
         "//pkg/util/leaktest",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/ccl/sqlproxyccl/interceptor/backend_conn_test.go
+++ b/pkg/ccl/sqlproxyccl/interceptor/backend_conn_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/interceptor"
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/jackc/pgproto3/v2"
@@ -24,6 +25,7 @@ import (
 // For detailed ones, see the tests for the internal interceptor in base_test.go.
 func TestBackendConn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	q := (&pgproto3.Query{String: "SELECT 1"}).Encode(nil)
 

--- a/pkg/ccl/sqlproxyccl/interceptor/base_test.go
+++ b/pkg/ccl/sqlproxyccl/interceptor/base_test.go
@@ -17,6 +17,7 @@ import (
 	"testing/iotest"
 	"unsafe"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/errors"
@@ -26,6 +27,7 @@ import (
 
 func TestNewPgInterceptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	reader, _ := io.Pipe()
 
@@ -47,6 +49,7 @@ func TestNewPgInterceptor(t *testing.T) {
 
 func TestPGInterceptor_PeekMsg(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	t.Run("read_error", func(t *testing.T) {
 		r := iotest.ErrReader(errors.New("read error"))
@@ -147,6 +150,7 @@ func TestPGInterceptor_PeekMsg(t *testing.T) {
 
 func TestPGInterceptor_ReadMsg(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	t.Run("read_error/msg_fits", func(t *testing.T) {
 		buf := buildSrc(t, 1)
@@ -262,6 +266,7 @@ func TestPGInterceptor_ReadMsg(t *testing.T) {
 
 func TestPGInterceptor_ForwardMsg(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	t.Run("write_error/fully_buffered", func(t *testing.T) {
 		src := buildSrc(t, 1)
@@ -352,6 +357,7 @@ func TestPGInterceptor_ForwardMsg(t *testing.T) {
 
 func TestPGInterceptor_readSize(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	buf := bytes.NewBufferString("foobarbazz")
 	pgi := newPgInterceptor(iotest.OneByteReader(buf), 10 /* bufSize */)
@@ -370,6 +376,7 @@ func TestPGInterceptor_readSize(t *testing.T) {
 
 func TestPGInterceptor_writeSize(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	buf := bytes.NewBufferString("foobarbazz")
 	pgi := newPgInterceptor(iotest.OneByteReader(buf), 10 /* bufSize */)
@@ -388,6 +395,7 @@ func TestPGInterceptor_writeSize(t *testing.T) {
 
 func TestPGInterceptor_ensureNextNBytes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	t.Run("invalid n", func(t *testing.T) {
 		pgi := newPgInterceptor(nil /* src */, 8 /* bufSize */)

--- a/pkg/ccl/sqlproxyccl/interceptor/chunkreader_test.go
+++ b/pkg/ccl/sqlproxyccl/interceptor/chunkreader_test.go
@@ -12,10 +12,15 @@ import (
 	"io"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/require"
 )
 
 func TestChunkReader(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
+
 	cr := newChunkReader([]byte("foo bar baz hello world"))
 
 	buf, err := cr.Next(11)

--- a/pkg/ccl/sqlproxyccl/interceptor/frontend_conn_test.go
+++ b/pkg/ccl/sqlproxyccl/interceptor/frontend_conn_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/interceptor"
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/jackc/pgproto3/v2"
@@ -24,6 +25,7 @@ import (
 // For detailed ones, see the tests for the internal interceptor in base_test.go.
 func TestFrontendConn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	q := (&pgproto3.ReadyForQuery{TxStatus: 'I'}).Encode(nil)
 

--- a/pkg/ccl/sqlproxyccl/interceptor/interceptor_test.go
+++ b/pkg/ccl/sqlproxyccl/interceptor/interceptor_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/interceptor"
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/jackc/pgproto3/v2"
@@ -25,6 +26,7 @@ import (
 // used as a proxy.
 func TestSimpleProxy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	t.Run("client to server", func(t *testing.T) {
 		// These represents connections for client<->proxy and proxy<->server.

--- a/pkg/ccl/sqlproxyccl/interceptor/pg_conn_test.go
+++ b/pkg/ccl/sqlproxyccl/interceptor/pg_conn_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/interceptor"
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/jackc/pgproto3/v2"
 	"github.com/stretchr/testify/require"
@@ -23,6 +24,7 @@ import (
 // the internal interceptor in base_test.go.
 func TestPGConn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	q := (&pgproto3.Query{String: "SELECT 1"}).Encode(nil)
 
@@ -62,6 +64,7 @@ func TestPGConn(t *testing.T) {
 
 func TestPGConn_ToFrontendConn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	q := (&pgproto3.ReadyForQuery{TxStatus: 'I'}).Encode(nil)
 
@@ -81,6 +84,7 @@ func TestPGConn_ToFrontendConn(t *testing.T) {
 
 func TestPGConn_ToBackendConn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	q := (&pgproto3.Query{String: "SELECT 1"}).Encode(nil)
 

--- a/pkg/ccl/sqlproxyccl/metrics_test.go
+++ b/pkg/ccl/sqlproxyccl/metrics_test.go
@@ -11,6 +11,7 @@ package sqlproxyccl
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/errors"
@@ -19,6 +20,7 @@ import (
 
 func TestMetricsUpdateForError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	m := makeProxyMetrics()
 	type testCase struct {
 		code     errorCode

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenantdirsvr"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/throttler"
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -75,6 +76,7 @@ type serverAddresses struct {
 
 func TestProxyHandler_ValidateConnection(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -137,6 +139,7 @@ func TestProxyHandler_ValidateConnection(t *testing.T) {
 
 func TestProxyProtocol(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -294,6 +297,7 @@ func TestProxyProtocol(t *testing.T) {
 
 func TestPrivateEndpointsACL(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -471,6 +475,7 @@ func TestPrivateEndpointsACL(t *testing.T) {
 
 func TestAllowedCIDRRangesACL(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -592,6 +597,7 @@ func TestAllowedCIDRRangesACL(t *testing.T) {
 
 func TestLongDBName(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -621,6 +627,7 @@ func TestLongDBName(t *testing.T) {
 // deleted.
 func TestBackendDownRetry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -656,6 +663,7 @@ func TestBackendDownRetry(t *testing.T) {
 
 func TestFailedConnection(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -707,6 +715,7 @@ func TestFailedConnection(t *testing.T) {
 
 func TestUnexpectedError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -744,6 +753,7 @@ func TestUnexpectedError(t *testing.T) {
 
 func TestProxyAgainstSecureCRDB(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -862,6 +872,7 @@ func TestProxyAgainstSecureCRDB(t *testing.T) {
 
 func TestProxyTLSConf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	t.Run("insecure", func(t *testing.T) {
@@ -943,6 +954,7 @@ func TestProxyTLSConf(t *testing.T) {
 
 func TestProxyTLSClose(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 	// NB: The leaktest call is an important part of this test. We're
 	// verifying that no goroutines are leaked, despite calling Close an
@@ -1003,6 +1015,7 @@ func TestProxyTLSClose(t *testing.T) {
 
 func TestProxyModifyRequestParams(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -1067,6 +1080,7 @@ func TestProxyModifyRequestParams(t *testing.T) {
 
 func TestInsecureProxy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -1118,6 +1132,7 @@ func TestInsecureProxy(t *testing.T) {
 
 func TestErroneousFrontend(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -1144,6 +1159,7 @@ func TestErroneousFrontend(t *testing.T) {
 
 func TestErrorHint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -1176,6 +1192,7 @@ func TestErrorHint(t *testing.T) {
 
 func TestErroneousBackend(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -1202,6 +1219,7 @@ func TestErroneousBackend(t *testing.T) {
 
 func TestProxyRefuseConn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -1229,6 +1247,7 @@ func TestProxyRefuseConn(t *testing.T) {
 
 func TestProxyHandler_handle(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -1249,6 +1268,7 @@ func TestProxyHandler_handle(t *testing.T) {
 
 func TestDenylistUpdate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -1364,6 +1384,7 @@ func TestDenylistUpdate(t *testing.T) {
 
 func TestDirectoryConnect(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -1479,6 +1500,7 @@ func TestDirectoryConnect(t *testing.T) {
 
 func TestConnectionRebalancingDisabled(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	ctx := context.Background()
 	defer log.Scope(t).Close(t)
 
@@ -1566,6 +1588,7 @@ func TestConnectionRebalancingDisabled(t *testing.T) {
 
 func TestCancelQuery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	ctx := context.Background()
 	defer log.Scope(t).Close(t)
 
@@ -1912,6 +1935,7 @@ func TestCancelQuery(t *testing.T) {
 
 func TestPodWatcher(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	ctx := context.Background()
 	defer log.Scope(t).Close(t)
 
@@ -2010,6 +2034,7 @@ func TestPodWatcher(t *testing.T) {
 
 func TestConnectionMigration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	ctx := context.Background()
 	defer log.Scope(t).Close(t)
 
@@ -2402,6 +2427,7 @@ func TestConnectionMigration(t *testing.T) {
 // (both failed and successful ones).
 func TestAcceptedConnCountMetric(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -2492,6 +2518,7 @@ func TestAcceptedConnCountMetric(t *testing.T) {
 // decremented whenever the connections were closed due to a goroutine leak.
 func TestCurConnCountMetric(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
@@ -2558,6 +2585,7 @@ func TestCurConnCountMetric(t *testing.T) {
 
 func TestClusterNameAndTenantFromParams(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()

--- a/pkg/ccl/sqlproxyccl/server_test.go
+++ b/pkg/ccl/sqlproxyccl/server_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -24,6 +25,7 @@ import (
 
 func TestHandleHealth(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	ctx := context.Background()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
@@ -45,6 +47,7 @@ func TestHandleHealth(t *testing.T) {
 
 func TestHandleVars(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	ctx := context.Background()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
@@ -68,6 +71,7 @@ func TestHandleVars(t *testing.T) {
 
 func TestAwaitNoConnections(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	ctx := context.Background()
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)

--- a/pkg/ccl/sqlproxyccl/tenant/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/tenant/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
         "//pkg/base",
         "//pkg/ccl",
         "//pkg/ccl/sqlproxyccl/tenantdirsvr",
+        "//pkg/ccl/testutilsccl",
         "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenantdirsvr"
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -36,6 +37,7 @@ import (
 
 func TestDirectoryErrors(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.ScopeWithoutShowLogs(t).Close(t)
 
 	ctx := context.Background()
@@ -66,6 +68,7 @@ func TestDirectoryErrors(t *testing.T) {
 
 func TestWatchTenants(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
@@ -260,6 +263,7 @@ func TestWatchTenants(t *testing.T) {
 
 func TestWatchPods(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
@@ -393,6 +397,7 @@ func TestWatchPods(t *testing.T) {
 
 func TestCancelLookups(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.ScopeWithoutShowLogs(t).Close(t)
 
 	tenantID := roachpb.MustMakeTenantID(20)
@@ -427,6 +432,7 @@ func TestCancelLookups(t *testing.T) {
 
 func TestResume(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.ScopeWithoutShowLogs(t).Close(t)
 
 	tenantID := roachpb.MustMakeTenantID(40)
@@ -474,6 +480,7 @@ func TestResume(t *testing.T) {
 
 func TestDeleteTenant(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.ScopeWithoutShowLogs(t).Close(t)
 
 	// Create the directory.
@@ -539,6 +546,7 @@ func TestDeleteTenant(t *testing.T) {
 // TestRefreshThrottling checks that throttling works.
 func TestRefreshThrottling(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 	defer log.ScopeWithoutShowLogs(t).Close(t)
 	skip.UnderDeadlockWithIssue(t, 71365)
 

--- a/pkg/ccl/sqlproxyccl/tenant/entry_test.go
+++ b/pkg/ccl/sqlproxyccl/tenant/entry_test.go
@@ -11,12 +11,14 @@ package tenant
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/require"
 )
 
 func TestHasRunningPod(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	for _, tc := range []struct {
 		name     string
@@ -57,6 +59,7 @@ func TestHasRunningPod(t *testing.T) {
 
 func TestTenantMetadataUpdate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
 
 	e := &tenantEntry{}
 	require.False(t, e.IsValid())

--- a/pkg/ccl/sqlproxyccl/throttler/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/throttler/BUILD.bazel
@@ -26,6 +26,8 @@ go_test(
     args = ["-test.timeout=295s"],
     embed = [":throttler"],
     deps = [
+        "//pkg/ccl/testutilsccl",
+        "//pkg/util/leaktest",
         "//pkg/util/timeutil",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/ccl/sqlproxyccl/throttler/local_test.go
+++ b/pkg/ccl/sqlproxyccl/throttler/local_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
@@ -68,6 +70,9 @@ func countGuesses(
 }
 
 func TestThrottleLimitsCredentialGuesses(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
+
 	throttle := newTestLocalService(WithBaseDelay(time.Second))
 	ip1Tenant1 := ConnectionTags{IP: "1.1.1.1", TenantID: "1"}
 	ip1Tenant2 := ConnectionTags{IP: "1.1.1.1", TenantID: "2"}
@@ -90,6 +95,9 @@ func TestThrottleLimitsCredentialGuesses(t *testing.T) {
 }
 
 func TestReportSuccessDisablesLimiter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
+
 	throttle := newTestLocalService()
 	tenant1 := ConnectionTags{IP: "1.1.1.1", TenantID: "1"}
 	tenant2 := ConnectionTags{IP: "1.1.1.1", TenantID: "2"}
@@ -112,6 +120,9 @@ func TestReportSuccessDisablesLimiter(t *testing.T) {
 }
 
 func TestRacingRequests(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
+
 	throttle := newTestLocalService()
 	connection := ConnectionTags{IP: "1.1.1.1", TenantID: "1"}
 

--- a/pkg/ccl/sqlproxyccl/throttler/throttle_test.go
+++ b/pkg/ccl/sqlproxyccl/throttler/throttle_test.go
@@ -12,11 +12,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTriggerThrottle(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
+
 	type testCase struct {
 		backoffBefore time.Duration
 		backoffAfter  time.Duration
@@ -69,6 +74,9 @@ func TestTriggerThrottle(t *testing.T) {
 }
 
 func TestIsThrottled(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
+
 	now := timeutil.Now()
 
 	l := newThrottle(time.Second)
@@ -105,6 +113,9 @@ func TestIsThrottled(t *testing.T) {
 }
 
 func TestDisableThrottle(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testutilsccl.ServerlessOnly(t)
+
 	now := timeutil.Now()
 	l := newThrottle(time.Second)
 

--- a/pkg/ccl/testutilsccl/BUILD.bazel
+++ b/pkg/ccl/testutilsccl/BUILD.bazel
@@ -2,7 +2,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "testutilsccl",
-    srcs = ["alter_primary_key.go"],
+    testonly = 1,
+    srcs = [
+        "alter_primary_key.go",
+        "serverless_only.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl",
     visibility = ["//visibility:public"],
     deps = [
@@ -14,6 +18,7 @@ go_library(
         "//pkg/sql/sqltestutils",
         "//pkg/sql/tests",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/util",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/ccl/testutilsccl/serverless_only.go
+++ b/pkg/ccl/testutilsccl/serverless_only.go
@@ -1,0 +1,19 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package testutilsccl
+
+import "github.com/cockroachdb/cockroach/pkg/testutils/skip"
+
+// ServerlessOnly is called in tests to mark them as testing functionality that
+// is Serverless specific. This is changed from a no-op to a test skip once a
+// version is no longer used by Serverless in production.
+func ServerlessOnly(t skip.SkippableTest) {
+	// Uncomment in release branches that no longer support serverless.
+	// skip.IgnoreLint(t, "version is not used by serverless in production")
+}


### PR DESCRIPTION
Backport of #130442

----

This change updates every sql proxy test so that it calls the new ServerlessOnly test helper. Serverless supports fewer versions than traditional CRDB. Once a version of CRDB no longer supports Serverless, the ServerlessOnly helper will be updated to skip the tests. The purpose of this helper is to avoid unnecessary test triaging and limit the number of versions test fixes must be backported to.

Most of this change was generated by the following commands:
```
fastmod -F 'AfterTest(t)()' 'AfterTest(t)(); testutilsccl.ServerlessOnly()'
go fmt ./...
goimports -w .
```

Release Justification: test only change

Part of: https://github.com/cockroachdb/cockroach/issues/130441