### PR TITLE
cluster-ui: new db page components

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databasesV2/databaseTypes.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesV2/databaseTypes.ts
@@ -1,0 +1,20 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export type DatabaseRow = {
+  name: string;
+  id: number;
+  approximateDiskSizeMiB: number;
+  tableCount: number;
+  rangeCount: number;
+  nodesByRegion: Record<string, number[]>;
+  schemaInsightsCount: number;
+  key: string;
+};

--- a/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
@@ -1,0 +1,168 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { Space } from "antd";
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+import Select, { OptionsType } from "react-select";
+
+import { PageLayout, PageSection } from "src/layouts";
+import { PageConfig, PageConfigItem } from "src/pageConfig";
+import PageCount from "src/sharedFromCloud/pageCount";
+import { PageHeader } from "src/sharedFromCloud/pageHeader";
+import { Search } from "src/sharedFromCloud/search";
+import { ReactSelectOption } from "src/types/selectTypes";
+
+import { Table, TableColumnProps } from "../sharedFromCloud/table";
+import useTable from "../sharedFromCloud/useTable";
+import { Bytes, EncodeDatabaseUri } from "../util";
+
+import { DatabaseRow } from "./databaseTypes";
+
+const mockRegionOptions = [
+  { label: "US East (N. Virginia)", value: "us-east-1" },
+  { label: "US East (Ohio)", value: "us-east-2" },
+];
+
+const mockData: DatabaseRow[] = new Array(20).fill(1).map((_, i) => ({
+  name: `myDB-${i}`,
+  id: i,
+  approximateDiskSizeMiB: i * 100,
+  tableCount: i,
+  rangeCount: i,
+  nodesByRegion: {
+    [mockRegionOptions[0].value]: [1, 2],
+    [mockRegionOptions[1].value]: [3],
+  },
+  schemaInsightsCount: i,
+  key: i.toString(),
+}));
+
+const filters = {};
+
+const initialParams = {
+  filters,
+  pagination: {
+    page: 1,
+    pageSize: 10,
+  },
+  search: "",
+  sort: {
+    field: "name",
+    order: "asc" as const,
+  },
+};
+
+const columns: TableColumnProps<DatabaseRow>[] = [
+  {
+    title: "Name",
+    sorter: true,
+    render: (db: DatabaseRow) => {
+      const encodedDBPath = EncodeDatabaseUri(db.name);
+      // TODO (xzhang: For CC we have to use `${location.pathname}/${db.name}`
+      return <Link to={encodedDBPath}>{db.name}</Link>;
+    },
+  },
+  {
+    title: "Size",
+    sorter: true,
+    render: (db: DatabaseRow) => {
+      return Bytes(db.approximateDiskSizeMiB);
+    },
+  },
+  {
+    title: "Tables",
+    sorter: true,
+    render: (db: DatabaseRow) => {
+      return db.tableCount;
+    },
+  },
+  {
+    title: "Ranges",
+    sorter: true,
+    render: (db: DatabaseRow) => {
+      return db.rangeCount;
+    },
+  },
+  {
+    title: "Regions / Nodes",
+    render: (db: DatabaseRow) => (
+      <Space direction="vertical">
+        {db.nodesByRegion &&
+          Object.keys(db.nodesByRegion).map(
+            region => `${region}: ${db.nodesByRegion[region].length}`,
+          )}
+      </Space>
+    ),
+  },
+  {
+    title: "Schema insights",
+    render: (db: DatabaseRow) => {
+      return db.schemaInsightsCount;
+    },
+  },
+];
+
+export const DatabasesPageV2 = () => {
+  const { setSearch } = useTable({
+    initial: initialParams,
+  });
+  const data = mockData;
+
+  const [nodeRegions, setNodeRegions] = useState<ReactSelectOption[]>([]);
+  const onNodeRegionsChange = (selected: OptionsType<ReactSelectOption>) => {
+    setNodeRegions((selected ?? []).map(v => v));
+  };
+
+  return (
+    <PageLayout>
+      <PageHeader title="Databases" />
+      <PageSection>
+        <PageConfig>
+          <PageConfigItem>
+            <Search placeholder="Search databases" onSubmit={setSearch} />
+          </PageConfigItem>
+          <PageConfigItem minWidth={"200px"}>
+            <Select
+              placeholder={"Regions"}
+              name="nodeRegions"
+              options={mockRegionOptions}
+              clearable={true}
+              isMulti
+              value={nodeRegions}
+              onChange={onNodeRegionsChange}
+            />
+          </PageConfigItem>
+        </PageConfig>
+      </PageSection>
+      <PageSection>
+        <PageCount
+          page={1}
+          pageSize={10}
+          total={data.length}
+          entity="databases"
+        />
+        <Table
+          columns={columns}
+          dataSource={data}
+          pagination={{
+            size: "small",
+            current: 1,
+            pageSize: 10,
+            showSizeChanger: false,
+            position: ["bottomCenter"],
+            total: data.length,
+          }}
+          onChange={(_pagination, _sorter) => {}}
+        />
+      </PageSection>
+    </PageLayout>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/index.ts
@@ -57,6 +57,7 @@ export * from "./contexts";
 export * from "./timestamp";
 export * from "./databases";
 export * from "./antdTheme";
+export * from "./databasesV2";
 // Reexport ConfigProvider instance from cluster-ui as exact instance
 // required in Db Console to apply Antd theme in Db Console.
 // TODO (koorosh): is it possible to define antd pacakge as peerDependency

--- a/pkg/ui/workspaces/cluster-ui/src/layouts/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/layouts/index.ts
@@ -1,0 +1,12 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export * from "./pageSection";
+export * from "./pageLayout";

--- a/pkg/ui/workspaces/cluster-ui/src/layouts/pageLayout.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/layouts/pageLayout.module.scss
@@ -1,0 +1,7 @@
+@import "src/core/index.module";
+
+.page-layout {
+  flex-grow: 0;
+  width: 100%;
+  padding-right: 16px;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/layouts/pageLayout.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/layouts/pageLayout.tsx
@@ -1,0 +1,20 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import classNames from "classnames/bind";
+import React from "react";
+
+import styles from "./pageLayout.module.scss";
+
+const cx = classNames.bind(styles);
+
+export const PageLayout: React.FC = ({ children }) => {
+  return <div className={cx("page-layout")}>{children}</div>;
+};

--- a/pkg/ui/workspaces/cluster-ui/src/layouts/pageSection.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/layouts/pageSection.module.scss
@@ -1,0 +1,6 @@
+@import "src/core/index.module";
+
+.page-section {
+  margin-bottom: 16px;
+}
+

--- a/pkg/ui/workspaces/cluster-ui/src/layouts/pageSection.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/layouts/pageSection.tsx
@@ -1,0 +1,45 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import classNames from "classnames/bind";
+import React, { ReactNode } from "react";
+
+import styles from "./pageSection.module.scss";
+const cx = classNames.bind(styles);
+
+type PageSectionProps = {
+  heading?: string | ReactNode;
+  children: ReactNode;
+  className?: string;
+  childrenClassname?: string;
+};
+
+export const PageSection: React.FC<PageSectionProps> = ({
+  heading,
+  children,
+  className,
+  childrenClassname,
+}) => {
+  const headingEl =
+    heading && typeof heading === "string" ? (
+      <h2 className={cx("page-section__heading")}>{heading}</h2>
+    ) : (
+      heading
+    );
+
+  return (
+    <div className={cx("page-section", className)}>
+      {headingEl}
+      <div className={cx("page-section__content", childrenClassname)}>
+        {children}
+      </div>
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/pageConfig/pageConfig.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/pageConfig/pageConfig.tsx
@@ -46,11 +46,20 @@ export function PageConfig(props: PageConfigProps): React.ReactElement {
 export interface PageConfigItemProps {
   children?: React.ReactNode;
   className?: string;
+  minWidth?: string;
 }
 
 export function PageConfigItem(props: PageConfigItemProps): React.ReactElement {
+  const minWidth = props.minWidth;
+  const itemStyles = React.useMemo(
+    () => ({
+      minWidth: minWidth || undefined,
+    }),
+    [minWidth],
+  );
+
   return (
-    <li className={`${cx("page-config__item")} ${props.className}`}>
+    <li className={cx("page-config__item", props.className)} style={itemStyles}>
       {props.children}
     </li>
   );

--- a/pkg/ui/workspaces/cluster-ui/src/types/selectTypes.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/types/selectTypes.ts
@@ -1,0 +1,17 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// This is temporary. We'll remove this when we can access the shared
+// component library from the console. In the meantime this just removes
+// some type pollution from new components using react-select.
+export type ReactSelectOption = {
+  label: string;
+  value: string;
+};

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -12,6 +12,7 @@ import {
   CockroachCloudContext,
   crlTheme,
   ConfigProvider as ClusterUIConfigProvider,
+  DatabasesPageV2,
 } from "@cockroachlabs/cluster-ui";
 import { ConfigProvider } from "antd";
 import { ConnectedRouter } from "connected-react-router";
@@ -205,6 +206,11 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                         />
 
                         {/* databases */}
+                        <Route
+                          exact
+                          path={"/v2/databases"}
+                          component={DatabasesPageV2}
+                        />
                         <Route
                           exact
                           path="/databases"


### PR DESCRIPTION
Only the latest 2 commits should be reviewed.

-------------------------
cluster-ui: add layouts dir with some base layout components

This commit adds shared layout components to align spacing
within new db console pages.

Components to start off:
- PageLayout - page content wrapper
- PageSection - page section wrapper

Epic: [CRDB-37558](https://cockroachlabs.atlassian.net/browse/CRDB-37558)
Release note: None

-----------------------------

cluster-ui: new db page components

This commit adds the new db page, with components under
the `databasesv2` dir. The page currently uses mocked data
and does not support pagination or sorting.

The page is available for preview under the new route,
`/v2/databases`. We'll eventually replace the existing
db routes with the new components.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/130674
Release note: None