### PR TITLE
schemachanger: refactor deprecated call in mustRetrieveIndexNameElem

### DIFF
--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -581,23 +581,6 @@ func mustRetrieveKeyIndexColumns(
 	return keyIndexCols
 }
 
-func mustRetrieveIndexNameElem(
-	b BuildCtx, tableID catid.DescID, indexID catid.IndexID,
-) (indexNameElem *scpb.IndexName) {
-	scpb.ForEachIndexName(b.QueryByID(tableID), func(
-		current scpb.Status, target scpb.TargetStatus, e *scpb.IndexName,
-	) {
-		if e.IndexID == indexID {
-			indexNameElem = e
-		}
-	})
-	if indexNameElem == nil {
-		panic(errors.AssertionFailedf("programming error: cannot find an index name element "+
-			"with ID %v from table %v", indexID, tableID))
-	}
-	return indexNameElem
-}
-
 func mustRetrieveConstraintWithoutIndexNameElem(
 	b BuildCtx, tableID catid.DescID, constraintID catid.ConstraintID,
 ) (constraintWithoutIndexName *scpb.ConstraintWithoutIndexName) {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -1719,3 +1719,14 @@ func mustRetrievePhysicalTableElem(b BuildCtx, descID catid.DescID) scpb.Element
 		return false
 	}).MustGetOneElement()
 }
+
+// mustRetrieveIndexNameElem will resolve a tableID and indexID to an index name
+// element.
+func mustRetrieveIndexNameElem(
+	b BuildCtx, tableID catid.DescID, indexID catid.IndexID,
+) (indexNameElem *scpb.IndexName) {
+	return b.QueryByID(tableID).FilterIndexName().
+		Filter(func(current scpb.Status, target scpb.TargetStatus, e *scpb.IndexName) bool {
+			return e.IndexID == indexID
+		}).MustGetOneElement()
+}


### PR DESCRIPTION
This patch refactors `mustRetrieveIndexNameElem` to be more aligned with how we get elems in the DSC today; we also move this in the `helpers.go` file as zone config partitions code uses it to support `ALTER PARTITION ... OF TABLE`.

Informs: #129889
Release note: None