### PR TITLE
cluster-ui: add region and nodes label component 

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/components/regionNodesLabel/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/components/regionNodesLabel/index.ts
@@ -1,0 +1,11 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export * from "./regionNodesLabel";

--- a/pkg/ui/workspaces/cluster-ui/src/components/regionNodesLabel/regionNodesLabel.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/components/regionNodesLabel/regionNodesLabel.module.scss
@@ -1,0 +1,33 @@
+@import "src/core/index.module.scss";
+
+.container {
+  margin: 0.5rem;
+  width: fit-content;
+}
+
+
+.label-body {
+  background-color: $colors--neutral-3;
+  padding: 0.1rem 0.5rem;
+  border-radius: 0.375rem;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  column-gap: 0.5rem;
+}
+
+.badge {
+  :global(.ant-badge-count) {
+    background-color: $colors--neutral-1;
+    font-size: 12px;
+    height: 20px;
+    line-height: 20px;
+    padding: 0 6px;
+    border-radius: 10px;
+    min-width: 20px;
+    color: inherit;
+  }
+}
+
+

--- a/pkg/ui/workspaces/cluster-ui/src/components/regionNodesLabel/regionNodesLabel.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/components/regionNodesLabel/regionNodesLabel.tsx
@@ -1,0 +1,46 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { Tooltip, Badge, Typography } from "antd";
+import React from "react";
+
+import { NodeID, Region } from "src/types/clusterTypes";
+
+import styles from "./regionNodesLabel.module.scss";
+
+const { Text } = Typography;
+
+type RegionNodesLabelProps = {
+  nodes: NodeID[];
+  region: Region;
+  showCode?: boolean;
+};
+
+// TODO(xinhaoz): We may also be unable to show a flag for regions in SH.
+export const RegionNodesLabel: React.FC<RegionNodesLabelProps> = ({
+  nodes = [],
+  region,
+  // TODO (xinhaoz): Investigate if we can determine labels for regions in SH.
+  showCode = false,
+}) => {
+  return (
+    <div className={styles.container}>
+      <Tooltip placement="top" title={nodes.map(nid => "n" + nid).join(", ")}>
+        <div className={styles["label-body"]}>
+          <Text strong>{region.label}</Text>
+          {showCode && <Text>({region.code})</Text>}
+          <div>
+            <Badge count={nodes.length} className={styles.badge} />
+          </div>
+        </div>
+      </Tooltip>
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/databasesV2/databasesTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesV2/databasesTable.tsx
@@ -1,0 +1,94 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { Table } from "antd";
+import { ColumnsType } from "antd/es/table";
+import React from "react";
+import { Link } from "react-router-dom";
+
+import { RegionNodesLabel } from "src/components/regionNodesLabel";
+
+import { EncodeDatabaseUri } from "../util";
+
+import { DatabaseRow } from "./databaseTypes";
+
+const columns: ColumnsType<DatabaseRow> = [
+  {
+    title: "Name",
+    key: "name",
+    sorter: true,
+    render: (_, db: DatabaseRow) => {
+      const encodedDBPath = EncodeDatabaseUri(db.name);
+      // TODO (xzhang: For CC we have to use `${location.pathname}/${db.name}`
+      return <Link to={encodedDBPath}>{db.name}</Link>;
+    },
+  },
+  {
+    title: "Size",
+    dataIndex: "approximateDiskSizeMiB",
+    key: "size",
+    sorter: true,
+  },
+  {
+    title: "Tables",
+    dataIndex: "tableCount",
+    key: "tables",
+    sorter: true,
+  },
+  {
+    title: "Ranges",
+    dataIndex: "rangeCount",
+    key: "ranges",
+    sorter: true,
+  },
+  {
+    title: "Regions / Nodes",
+    key: "regions",
+    render: (db: DatabaseRow) => (
+      <div>
+        {Object.entries(db.nodesByRegion ?? []).map(([region, nodes]) => (
+          <RegionNodesLabel
+            key={region}
+            nodes={nodes}
+            region={{ label: region, code: region }}
+          />
+        ))}
+      </div>
+    ),
+  },
+  {
+    title: "Schema insights",
+    dataIndex: "schemaInsightsCount",
+    key: "schemaInsights",
+  },
+];
+
+type DatabasesTableProps = {
+  data: DatabaseRow[];
+};
+
+export const DatabasesTable: React.FC<DatabasesTableProps> = ({
+  data = [],
+}) => {
+  return (
+    <Table
+      columns={columns}
+      dataSource={data}
+      pagination={{
+        size: "small",
+        current: 1,
+        pageSize: 10,
+        showSizeChanger: false,
+        position: ["bottomCenter"],
+        total: data.length,
+      }}
+    />
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
@@ -8,11 +8,11 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { Space } from "antd";
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import Select, { OptionsType } from "react-select";
 
+import { RegionNodesLabel } from "src/components/regionNodesLabel";
 import { PageLayout, PageSection } from "src/layouts";
 import { PageConfig, PageConfigItem } from "src/pageConfig";
 import PageCount from "src/sharedFromCloud/pageCount";
@@ -37,10 +37,13 @@ const mockData: DatabaseRow[] = new Array(20).fill(1).map((_, i) => ({
   approximateDiskSizeMiB: i * 100,
   tableCount: i,
   rangeCount: i,
-  nodesByRegion: {
-    [mockRegionOptions[0].value]: [1, 2],
-    [mockRegionOptions[1].value]: [3],
-  },
+  nodesByRegion:
+    i % 2 === 0
+      ? {
+          [mockRegionOptions[0].value]: [1, 2],
+          [mockRegionOptions[1].value]: [3],
+        }
+      : null,
   schemaInsightsCount: i,
   key: i.toString(),
 }));
@@ -94,12 +97,15 @@ const columns: TableColumnProps<DatabaseRow>[] = [
   {
     title: "Regions / Nodes",
     render: (db: DatabaseRow) => (
-      <Space direction="vertical">
-        {db.nodesByRegion &&
-          Object.keys(db.nodesByRegion).map(
-            region => `${region}: ${db.nodesByRegion[region].length}`,
-          )}
-      </Space>
+      <div>
+        {Object.entries(db.nodesByRegion ?? {}).map(([region, nodes]) => (
+          <RegionNodesLabel
+            key={region}
+            nodes={nodes}
+            region={{ label: region, code: region }}
+          />
+        ))}
+      </div>
     ),
   },
   {

--- a/pkg/ui/workspaces/cluster-ui/src/types/clusterTypes.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/types/clusterTypes.ts
@@ -1,0 +1,18 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// This explicit typing helps us differentiate between
+// node ids and store ids.
+export type NodeID = number;
+
+export type Region = {
+  code: string; // e.g. us-east-1
+  label: string;
+};


### PR DESCRIPTION
Only the latest commit in this PR should be reviewed.
Previous: https://github.com/cockroachdb/cockroach/pull/130693

---------------------------------------------
This commit adds a component displaying a region and
its nodes. The component shows the region code, e.g.
`us-east-1` followed by a count of the number of nodes
in the region. On hover, the component shows the list
of nodes in the region.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/130674


<img width="1125" alt="image" src="https://github.com/user-attachments/assets/b52b420c-0716-4150-b8fe-7028c26400cb">
<img width="154" alt="image" src="https://github.com/user-attachments/assets/83d5c670-a8b5-474d-838b-853c9a0e109d">
