### PR TITLE
util: publish cidr metrics for tenants

### DIFF
--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -420,6 +420,13 @@ func newTenantServer(
 		}
 	}
 
+	// NB: On a shared process tenant, we start cidr once per tenant.
+	// Potentially we could share this across tenants, but this breaks the
+	// tenant separation model. For a small number of tenants this is OK, but if
+	// we have a large number of tenants in shared process mode this could be a
+	// problem from a memory and network perspective.
+	baseCfg.CidrLookup.Start(ctx, stopper)
+
 	// Instantiate the SQL server proper.
 	sqlServer, err := newSQLServer(ctx, args)
 	if err != nil {


### PR DESCRIPTION
Previously the cidr metrics were only started for the system tenant. This was problematic for SQL tenants since the mapping wouldn't be updated.

Fixes: #130708

Release note: None