### PR TITLE
release-23.2.12-rc: kvserver: compact liveness range periodically

### DIFF
--- a/pkg/kv/kvserver/liveness/client_test.go
+++ b/pkg/kv/kvserver/liveness/client_test.go
@@ -370,3 +370,52 @@ func TestGetActiveNodes(t *testing.T) {
 	})
 	require.Equal(t, []roachpb.NodeID{1, 2, 3, 4}, getActiveNodes(nl1))
 }
+
+// TestLivenessRangeGetsPeriodicallyCompacted tests that the liveness range
+// gets compacted when we set the liveness range compaction interval.
+func TestLivenessRangeGetsPeriodicallyCompacted(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	// Enable the liveness range compaction and set the interval to 1s to speed
+	// up the test.
+	c := tc.Server(0).SystemLayer().SQLConn(t)
+	_, err := c.ExecContext(ctx, "set cluster setting kv.liveness_range_compact.interval='1s'")
+	require.NoError(t, err)
+
+	// Get the original file number of the sstable for the liveness range. We
+	// expect to see this file number change as the liveness range gets compacted.
+	livenessFileNumberQuery := "WITH replicas(n) AS (SELECT unnest(replicas) FROM " +
+		"crdb_internal.ranges_no_leases WHERE range_id = 2), sstables AS (SELECT " +
+		"(crdb_internal.sstable_metrics(n, n, start_key, end_key)).* " +
+		"FROM crdb_internal.ranges_no_leases, replicas WHERE range_id = 2) " +
+		"SELECT file_num FROM sstables"
+
+	sqlDB := tc.ApplicationLayer(0).SQLConn(t)
+	var original_file_num string
+	testutils.SucceedsSoon(t, func() error {
+		rows := sqlDB.QueryRow(livenessFileNumberQuery)
+		if err := rows.Scan(&original_file_num); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	// Expect that the liveness file number changes.
+	testutils.SucceedsSoon(t, func() error {
+		var current_file_num string
+		rows := sqlDB.QueryRow(livenessFileNumberQuery)
+		if err := rows.Scan(&current_file_num); err != nil {
+			return err
+		}
+		if current_file_num == original_file_num {
+			return errors.Errorf("Liveness compaction hasn't happened yet")
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
Backport 1/1 commits from #129827.

/cc @cockroachdb/release

---

This commit adds a cluster setting (turned off by default) that sets the period at which manual liveness range compactions are done.

This is done in a goroutine rather than in MVCC GC queue because:

1) This is meant to be a stop gap as this in not needed in 24.3 onwards. Therefore, a simple change like this should achieve the goal.

2) The MVCC GC queue runs against leaseholder replicas only. This means that we need to send a compaction request to the other liveness replicas.

Fixes: #128968

Epic: None

Release note: None

Release justification: Help reduce point tombstone accumulation on the liveness range
