### PR TITLE
crosscluster/logical: check for empty DLQ and fingerprint in ldr roachtests

### DIFF
--- a/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
+	"github.com/cockroachdb/cockroach/pkg/ccl/crosscluster/replicationtestutils"
 	"github.com/cockroachdb/cockroach/pkg/ccl/crosscluster/replicationutils"
 	"github.com/cockroachdb/cockroach/pkg/ccl/crosscluster/streamclient"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/crosscluster/streamclient/randclient"
@@ -697,7 +698,7 @@ func TestRandomTables(t *testing.T) {
 	runnerB.QueryRow(t, streamStartStmt, dbAURL.String()).Scan(&jobBID)
 
 	WaitUntilReplicatedTime(t, s.Clock().Now(), runnerB, jobBID)
-
+	require.NoError(t, replicationtestutils.CheckEmptyDLQs(ctx, runnerB.DB, "b"))
 	compareReplicatedTables(t, s, "a", "b", tableName, runnerA, runnerB)
 }
 
@@ -829,7 +830,7 @@ func TestPreviouslyInterestingTables(t *testing.T) {
 				runnerA.Exec(t, fmt.Sprintf("DELETE FROM %s LIMIT 5", tableName))
 				WaitUntilReplicatedTime(t, s.Clock().Now(), runnerB, jobBID)
 			}
-
+			require.NoError(t, replicationtestutils.CheckEmptyDLQs(ctx, runnerB.DB, "b"))
 			compareReplicatedTables(t, s, "a", "b", tableName, runnerA, runnerB)
 		})
 	}

--- a/pkg/ccl/crosscluster/logical/udf_row_processor_test.go
+++ b/pkg/ccl/crosscluster/logical/udf_row_processor_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/crosscluster/replicationtestutils"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -103,7 +104,7 @@ func TestUDFWithRandomTables(t *testing.T) {
 	WaitUntilReplicatedTime(t, s.Clock().Now(), runnerB, jobBID)
 	runnerA.Exec(t, fmt.Sprintf("DELETE FROM %s LIMIT 5", tableName))
 	WaitUntilReplicatedTime(t, s.Clock().Now(), runnerB, jobBID)
-
+	require.NoError(t, replicationtestutils.CheckEmptyDLQs(ctx, runnerB.DB, "b"))
 	compareReplicatedTables(t, s, "a", "b", tableName, runnerA, runnerB)
 }
 

--- a/pkg/ccl/crosscluster/replicationtestutils/BUILD.bazel
+++ b/pkg/ccl/crosscluster/replicationtestutils/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     testonly = 1,
     srcs = [
         "encoding.go",
+        "logical.go",
         "replication_helpers.go",
         "span_config_helpers.go",
         "testutils.go",

--- a/pkg/ccl/crosscluster/replicationtestutils/logical.go
+++ b/pkg/ccl/crosscluster/replicationtestutils/logical.go
@@ -1,0 +1,44 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package replicationtestutils
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/errors"
+)
+
+func CheckEmptyDLQs(ctx context.Context, db sqlutils.DBHandle, dbName string) error {
+	dlqNameQuery := fmt.Sprintf("SELECT table_name FROM [SHOW TABLES FROM %s] where schema_name = 'crdb_replication'", dbName)
+	rows, err := db.QueryContext(ctx, dlqNameQuery)
+	if err != nil {
+		return errors.Wrapf(err, "failed to query dlq table name for database %s", dbName)
+	}
+	defer rows.Close()
+
+	var dlqTableName string
+	var dlqRowCount int
+	for rows.Next() {
+		if err := rows.Scan(&dlqTableName); err != nil {
+			return errors.Wrapf(err, "failed to scan dlq table name for database %s", dbName)
+		}
+		if err := db.QueryRowContext(ctx, fmt.Sprintf("SELECT count(*) FROM %s.crdb_replication.%s", dbName, dlqTableName)).Scan(&dlqRowCount); err != nil {
+			return err
+		}
+		if dlqRowCount != 0 {
+			return fmt.Errorf("expected DLQ to be empty, but found %d rows", dlqRowCount)
+		}
+	}
+	if dlqTableName == "" {
+		return errors.Newf("didn't find any any dlq tables in database %s", dbName)
+	}
+	return nil
+}

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -210,6 +210,7 @@ go_library(
         "//pkg/ccl/changefeedccl",
         "//pkg/ccl/changefeedccl/cdctest",
         "//pkg/ccl/changefeedccl/changefeedbase",
+        "//pkg/ccl/crosscluster/replicationtestutils",
         "//pkg/ccl/crosscluster/replicationutils",
         "//pkg/ccl/storageccl/engineccl/enginepbccl",
         "//pkg/cli",


### PR DESCRIPTION
Epic: none

Release note: none