### PR TITLE
opt: do not include virtual computed columns in lock columns

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/read_committed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/read_committed
@@ -536,3 +536,28 @@ user testuser
 
 statement ok
 COMMIT
+
+subtest regression_130661
+
+statement ok
+CREATE TABLE t130661 (
+	id INT PRIMARY KEY NOT NULL,
+	i INT NOT NULL,
+	v INT AS (i + 1) VIRTUAL NOT NULL,
+	FAMILY (id),
+	FAMILY (i)
+)
+
+statement ok
+INSERT INTO t130661 VALUES (1, 10)
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED
+
+statement ok
+SELECT * FROM t130661 WHERE id = 1 FOR UPDATE
+
+statement ok
+COMMIT
+
+subtest end

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update_read_committed
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update_read_committed
@@ -22,6 +22,8 @@ query T
 EXPLAIN (OPT) SELECT aisle FROM supermarket WHERE person = 'matilda' FOR UPDATE
 ----
 lock supermarket
+ ├── key columns: person
+ ├── lock columns: (7-10)
  ├── locking: for-update,durability-guaranteed
  └── scan supermarket
       └── constraint: /1: [/'matilda' - /'matilda']
@@ -57,6 +59,8 @@ update supermarket
            └── subquery
                 └── project
                      └── lock supermarket
+                          ├── key columns: person
+                          ├── lock columns: (19-22)
                           ├── locking: for-update,durability-guaranteed
                           └── scan supermarket
                                └── constraint: /13: [/'matilda' - /'matilda']
@@ -119,6 +123,8 @@ SELECT aisle + 1 FROM s
 with &1 (s)
  ├── project
  │    └── lock supermarket
+ │         ├── key columns: person
+ │         ├── lock columns: (7-10)
  │         ├── locking: for-update,durability-guaranteed
  │         └── scan supermarket
  │              └── constraint: /1: [/'matilda' - /'matilda']
@@ -182,6 +188,8 @@ with &1 (names)
  ├── values
  │    └── ('matilda',)
  └── lock supermarket
+      ├── key columns: supermarket.person
+      ├── lock columns: (9-12)
       ├── locking: for-update,durability-guaranteed
       └── project
            └── inner-join (lookup supermarket)
@@ -254,6 +262,8 @@ SELECT aisle
   FOR UPDATE
 ----
 lock supermarket
+ ├── key columns: person
+ ├── lock columns: (7-10)
  ├── locking: for-update,durability-guaranteed
  └── project
       └── index-join supermarket
@@ -309,6 +319,8 @@ SELECT aisle
   FOR UPDATE
 ----
 lock supermarket
+ ├── key columns: person
+ ├── lock columns: (7-10)
  ├── locking: for-update,durability-guaranteed
  └── project
       └── inner-join (lookup supermarket)

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -702,6 +702,8 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		}
 
 	case *LockExpr:
+		f.formatColList(tp, "key columns:", t.KeyCols, opt.ColSet{} /* notNullCols */)
+		tp.Childf("lock columns: %v", t.LockCols)
 		f.formatLocking(tp, t.Locking)
 
 	case *WithExpr:

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -1600,6 +1600,8 @@ SELECT * FROM abcde WHERE d IS NULL LIMIT 1 FOR UPDATE
 ----
 lock abcde
  ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ ├── key columns: a:1
+ ├── lock columns: (8-12)
  ├── locking: for-update
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
@@ -1621,6 +1623,8 @@ SELECT * FROM abcde WHERE d IS NULL OFFSET 1 FOR UPDATE
 ----
 lock abcde
  ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ ├── key columns: a:1
+ ├── lock columns: (8-12)
  ├── locking: for-update
  ├── volatile, mutations
  ├── key: (1)
@@ -1652,6 +1656,8 @@ limit
  ├── fd: ()-->(1-5)
  ├── lock abcde
  │    ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ │    ├── key columns: a:1
+ │    ├── lock columns: (8-12)
  │    ├── locking: for-update,skip-locked
  │    ├── volatile, mutations
  │    ├── key: (1)
@@ -1682,6 +1688,8 @@ offset
  ├── key: (1)
  ├── lock abcde
  │    ├── columns: a:1!null
+ │    ├── key columns: a:1
+ │    ├── lock columns: (8-12)
  │    ├── locking: for-update,skip-locked
  │    ├── volatile, mutations
  │    ├── key: (1)
@@ -1710,6 +1718,8 @@ SELECT * FROM abcde WHERE d IS NULL LIMIT 1 FOR UPDATE
 ----
 lock abcde
  ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ ├── key columns: a:1
+ ├── lock columns: (8-12)
  ├── locking: for-update,durability-guaranteed
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
@@ -1731,6 +1741,8 @@ SELECT * FROM abcde WHERE d IS NULL OFFSET 1 FOR UPDATE
 ----
 lock abcde
  ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ ├── key columns: a:1
+ ├── lock columns: (8-12)
  ├── locking: for-update,durability-guaranteed
  ├── volatile, mutations
  ├── key: (1)
@@ -1762,6 +1774,8 @@ limit
  ├── fd: ()-->(1-5)
  ├── lock abcde
  │    ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ │    ├── key columns: a:1
+ │    ├── lock columns: (8-12)
  │    ├── locking: for-update,skip-locked,durability-guaranteed
  │    ├── volatile, mutations
  │    ├── key: (1)
@@ -1793,6 +1807,8 @@ offset
  ├── fd: ()-->(4), (1)-->(2,3,5)
  ├── lock abcde
  │    ├── columns: a:1!null b:2 c:3!null d:4 e:5
+ │    ├── key columns: a:1
+ │    ├── lock columns: (8-12)
  │    ├── locking: for-update,skip-locked,durability-guaranteed
  │    ├── volatile, mutations
  │    ├── key: (1)

--- a/pkg/sql/opt/norm/testdata/rules/mutation
+++ b/pkg/sql/opt/norm/testdata/rules/mutation
@@ -359,6 +359,8 @@ SELECT a FROM t WHERE a = 1 FOR SHARE;
 ----
 lock t
  ├── columns: a:2!null  [hidden: k:1!null]
+ ├── key columns: k:1
+ ├── lock columns: (12-20)
  ├── locking: for-share
  ├── volatile, mutations
  ├── key: (1)

--- a/pkg/sql/opt/optbuilder/testdata/read-committed
+++ b/pkg/sql/opt/optbuilder/testdata/read-committed
@@ -1,0 +1,35 @@
+# Tests for read-committed isolation level.
+
+exec-ddl
+CREATE TABLE t130661 (
+	id INT PRIMARY KEY,
+	i INT NOT NULL,
+	v INT AS (i + 10) VIRTUAL NOT NULL
+)
+----
+
+# Regression test for #130661. The lock columns should not include virtual
+# computed columns (in this case the column with ID 8).
+build isolation=ReadCommitted
+SELECT * FROM t130661 WHERE id = 1 FOR UPDATE
+----
+lock t130661
+ ├── columns: id:1!null i:2!null v:3!null
+ ├── key columns: id:1
+ ├── lock columns: (6,7)
+ ├── locking: for-update,durability-guaranteed
+ └── project
+      ├── columns: id:1!null i:2!null v:3!null
+      └── select
+           ├── columns: id:1!null i:2!null v:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+           ├── project
+           │    ├── columns: v:3!null id:1!null i:2!null crdb_internal_mvcc_timestamp:4 tableoid:5
+           │    ├── scan t130661
+           │    │    ├── columns: id:1!null i:2!null crdb_internal_mvcc_timestamp:4 tableoid:5
+           │    │    └── computed column expressions
+           │    │         └── v:3
+           │    │              └── i:2 + 10
+           │    └── projections
+           │         └── i:2 + 10 [as=v:3]
+           └── filters
+                └── id:1 = 1

--- a/pkg/sql/opt/optbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/optbuilder/testdata/select_for_update
@@ -32,6 +32,8 @@ SELECT * FROM t FOR UPDATE
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null b:2
@@ -52,6 +54,8 @@ SELECT * FROM t FOR NO KEY UPDATE
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-no-key-update
  └── project
       ├── columns: a:1!null b:2
@@ -72,6 +76,8 @@ SELECT * FROM t FOR SHARE
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-share
  └── project
       ├── columns: a:1!null b:2
@@ -92,6 +98,8 @@ SELECT * FROM t FOR KEY SHARE
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-key-share
  └── project
       ├── columns: a:1!null b:2
@@ -112,9 +120,13 @@ SELECT * FROM t FOR KEY SHARE FOR SHARE
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (9,10)
  ├── locking: for-share
  └── lock t
       ├── columns: a:1!null b:2
+      ├── key columns: a:1
+      ├── lock columns: (5,6)
       ├── locking: for-key-share
       └── project
            ├── columns: a:1!null b:2
@@ -135,12 +147,18 @@ SELECT * FROM t FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (13,14)
  ├── locking: for-no-key-update
  └── lock t
       ├── columns: a:1!null b:2
+      ├── key columns: a:1
+      ├── lock columns: (9,10)
       ├── locking: for-share
       └── lock t
            ├── columns: a:1!null b:2
+           ├── key columns: a:1
+           ├── lock columns: (5,6)
            ├── locking: for-key-share
            └── project
                 ├── columns: a:1!null b:2
@@ -161,15 +179,23 @@ SELECT * FROM t FOR KEY SHARE FOR SHARE FOR NO KEY UPDATE FOR UPDATE
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (17,18)
  ├── locking: for-update
  └── lock t
       ├── columns: a:1!null b:2
+      ├── key columns: a:1
+      ├── lock columns: (13,14)
       ├── locking: for-no-key-update
       └── lock t
            ├── columns: a:1!null b:2
+           ├── key columns: a:1
+           ├── lock columns: (9,10)
            ├── locking: for-share
            └── lock t
                 ├── columns: a:1!null b:2
+                ├── key columns: a:1
+                ├── lock columns: (5,6)
                 ├── locking: for-key-share
                 └── project
                      ├── columns: a:1!null b:2
@@ -190,6 +216,8 @@ SELECT * FROM t FOR UPDATE OF t
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null b:2
@@ -222,6 +250,8 @@ SELECT 1 FROM t FOR UPDATE OF t
 ----
 lock t
  ├── columns: "?column?":5!null  [hidden: a:1!null]
+ ├── key columns: a:1
+ ├── lock columns: (6,7)
  ├── locking: for-update
  └── project
       ├── columns: "?column?":5!null a:1!null
@@ -248,6 +278,8 @@ SELECT * FROM t AS t2 FOR UPDATE
 ----
 lock t [as=t2]
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null b:2
@@ -278,6 +310,8 @@ SELECT * FROM t AS t2 FOR UPDATE OF t2
 ----
 lock t [as=t2]
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null b:2
@@ -303,6 +337,8 @@ SELECT * FROM [53 AS t] FOR UPDATE
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null b:2
@@ -323,6 +359,8 @@ SELECT * FROM [53 AS t] FOR UPDATE OF t
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null b:2
@@ -389,6 +427,8 @@ SELECT * FROM v FOR UPDATE
 ----
 lock t [as=t2]
  ├── columns: a:1!null
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null
@@ -409,6 +449,8 @@ SELECT * FROM v FOR UPDATE OF v
 ----
 lock t [as=t2]
  ├── columns: a:1!null
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null
@@ -463,6 +505,8 @@ SELECT * FROM v AS v2 FOR UPDATE
 ----
 lock t [as=t2]
  ├── columns: a:1!null
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null
@@ -493,6 +537,8 @@ SELECT * FROM v AS v2 FOR UPDATE OF v2
 ----
 lock t [as=t2]
  ├── columns: a:1!null
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null
@@ -521,6 +567,8 @@ SELECT * FROM (SELECT a FROM t) FOR UPDATE
 ----
 lock t
  ├── columns: a:1!null
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null
@@ -541,6 +589,8 @@ SELECT * FROM (SELECT a FROM t FOR UPDATE)
 ----
 lock t
  ├── columns: a:1!null
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null
@@ -561,9 +611,13 @@ SELECT * FROM (SELECT a FROM t FOR NO KEY UPDATE) FOR KEY SHARE
 ----
 lock t
  ├── columns: a:1!null
+ ├── key columns: a:1
+ ├── lock columns: (9,10)
  ├── locking: for-key-share
  └── lock t
       ├── columns: a:1!null
+      ├── key columns: a:1
+      ├── lock columns: (5,6)
       ├── locking: for-no-key-update
       └── project
            ├── columns: a:1!null
@@ -584,9 +638,13 @@ SELECT * FROM (SELECT a FROM t FOR KEY SHARE) FOR NO KEY UPDATE
 ----
 lock t
  ├── columns: a:1!null
+ ├── key columns: a:1
+ ├── lock columns: (9,10)
  ├── locking: for-no-key-update
  └── lock t
       ├── columns: a:1!null
+      ├── key columns: a:1
+      ├── lock columns: (5,6)
       ├── locking: for-key-share
       └── project
            ├── columns: a:1!null
@@ -617,6 +675,8 @@ SELECT * FROM (SELECT a FROM t FOR UPDATE OF t)
 ----
 lock t
  ├── columns: a:1!null
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null
@@ -637,6 +697,8 @@ SELECT * FROM (SELECT a FROM t) AS r FOR UPDATE
 ----
 lock t
  ├── columns: a:1!null
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null
@@ -657,6 +719,8 @@ SELECT * FROM (SELECT a FROM t FOR UPDATE) AS r
 ----
 lock t
  ├── columns: a:1!null
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null
@@ -687,6 +751,8 @@ SELECT * FROM (SELECT a FROM t FOR UPDATE OF t) AS r
 ----
 lock t
  ├── columns: a:1!null
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null
@@ -755,6 +821,8 @@ project
                 ├── columns: t.a:1!null
                 └── lock t
                      ├── columns: t.a:1!null
+                     ├── key columns: t.a:1
+                     ├── lock columns: (5,6)
                      ├── locking: for-update
                      └── project
                           ├── columns: t.a:1!null
@@ -801,6 +869,8 @@ project
                 ├── columns: t.a:1!null
                 └── lock t
                      ├── columns: t.a:1!null
+                     ├── key columns: t.a:1
+                     ├── lock columns: (5,6)
                      ├── locking: for-update
                      └── project
                           ├── columns: t.a:1!null
@@ -869,6 +939,8 @@ project
                 ├── columns: a:1!null
                 └── lock t
                      ├── columns: a:1!null
+                     ├── key columns: a:1
+                     ├── lock columns: (5,6)
                      ├── locking: for-update
                      └── project
                           ├── columns: a:1!null
@@ -915,6 +987,8 @@ project
                 ├── columns: a:1!null
                 └── lock t
                      ├── columns: a:1!null
+                     ├── key columns: a:1
+                     ├── lock columns: (5,6)
                      ├── locking: for-update
                      └── project
                           ├── columns: a:1!null
@@ -944,6 +1018,8 @@ SELECT * FROM t WHERE a IN (SELECT a FROM t) FOR UPDATE
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (9,10)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null b:2
@@ -990,6 +1066,8 @@ project
            └── any: eq
                 ├── lock t
                 │    ├── columns: a:5!null
+                │    ├── key columns: a:5
+                │    ├── lock columns: (9,10)
                 │    ├── locking: for-update
                 │    └── project
                 │         ├── columns: a:5!null
@@ -1020,6 +1098,8 @@ SELECT * FROM t WHERE a IN (SELECT a FROM t) FOR UPDATE OF t
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (9,10)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null b:2
@@ -1066,6 +1146,8 @@ project
            └── any: eq
                 ├── lock t
                 │    ├── columns: a:5!null
+                │    ├── key columns: a:5
+                │    ├── lock columns: (9,10)
                 │    ├── locking: for-update
                 │    └── project
                 │         ├── columns: a:5!null
@@ -1096,6 +1178,8 @@ SELECT * FROM t WHERE a IN (SELECT b FROM t) FOR UPDATE
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (9,10)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null b:2
@@ -1144,6 +1228,8 @@ project
                 │    ├── columns: b:6
                 │    └── lock t
                 │         ├── columns: a:5!null b:6
+                │         ├── key columns: a:5
+                │         ├── lock columns: (9,10)
                 │         ├── locking: for-update
                 │         └── project
                 │              ├── columns: a:5!null b:6
@@ -1174,6 +1260,8 @@ SELECT * FROM t WHERE a IN (SELECT b FROM t) FOR UPDATE OF t
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (9,10)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null b:2
@@ -1222,6 +1310,8 @@ project
                 │    ├── columns: b:6
                 │    └── lock t
                 │         ├── columns: a:5!null b:6
+                │         ├── key columns: a:5
+                │         ├── lock columns: (9,10)
                 │         ├── locking: for-update
                 │         └── project
                 │              ├── columns: a:5!null b:6
@@ -1315,6 +1405,8 @@ with &1
  ├── columns: a:9!null
  ├── lock t
  │    ├── columns: t.a:1!null
+ │    ├── key columns: t.a:1
+ │    ├── lock columns: (5,6)
  │    ├── locking: for-update
  │    └── project
  │         ├── columns: t.a:1!null
@@ -1347,6 +1439,8 @@ with &1 (cte)
  ├── columns: a:9!null
  ├── lock t
  │    ├── columns: t.a:1!null
+ │    ├── key columns: t.a:1
+ │    ├── lock columns: (5,6)
  │    ├── locking: for-update
  │    └── project
  │         ├── columns: t.a:1!null
@@ -1382,9 +1476,13 @@ SELECT * FROM t JOIN u USING (a) FOR UPDATE
 ----
 lock u
  ├── columns: a:1!null b:2 c:6  [hidden: u.a:5!null]
+ ├── key columns: u.a:5
+ ├── lock columns: (13,14)
  ├── locking: for-update
  └── lock t
       ├── columns: t.a:1!null b:2 u.a:5!null c:6
+      ├── key columns: t.a:1
+      ├── lock columns: (9,10)
       ├── locking: for-update
       └── project
            ├── columns: t.a:1!null b:2 u.a:5!null c:6
@@ -1417,6 +1515,8 @@ SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t
 ----
 lock t
  ├── columns: a:1!null b:2 c:6
+ ├── key columns: t.a:1
+ ├── lock columns: (9,10)
  ├── locking: for-update
  └── project
       ├── columns: t.a:1!null b:2 c:6
@@ -1449,6 +1549,8 @@ SELECT * FROM t JOIN u USING (a) FOR UPDATE OF u
 ----
 lock u
  ├── columns: a:1!null b:2 c:6  [hidden: u.a:5!null]
+ ├── key columns: u.a:5
+ ├── lock columns: (9,10)
  ├── locking: for-update
  └── project
       ├── columns: t.a:1!null b:2 u.a:5!null c:6
@@ -1482,9 +1584,13 @@ SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t, u
 ----
 lock u
  ├── columns: a:1!null b:2 c:6  [hidden: u.a:5!null]
+ ├── key columns: u.a:5
+ ├── lock columns: (13,14)
  ├── locking: for-update
  └── lock t
       ├── columns: t.a:1!null b:2 u.a:5!null c:6
+      ├── key columns: t.a:1
+      ├── lock columns: (9,10)
       ├── locking: for-update
       └── project
            ├── columns: t.a:1!null b:2 u.a:5!null c:6
@@ -1518,9 +1624,13 @@ SELECT * FROM t JOIN u USING (a) FOR UPDATE OF t FOR SHARE OF u
 ----
 lock u
  ├── columns: a:1!null b:2 c:6  [hidden: u.a:5!null]
+ ├── key columns: u.a:5
+ ├── lock columns: (13,14)
  ├── locking: for-share
  └── lock t
       ├── columns: t.a:1!null b:2 u.a:5!null c:6
+      ├── key columns: t.a:1
+      ├── lock columns: (9,10)
       ├── locking: for-update
       └── project
            ├── columns: t.a:1!null b:2 u.a:5!null c:6
@@ -1564,9 +1674,13 @@ SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2 FOR SHARE OF u2
 ----
 lock u [as=u2]
  ├── columns: a:1!null b:2 c:6  [hidden: u2.a:5!null]
+ ├── key columns: u2.a:5
+ ├── lock columns: (13,14)
  ├── locking: for-share
  └── lock t [as=t2]
       ├── columns: t2.a:1!null b:2 u2.a:5!null c:6
+      ├── key columns: t2.a:1
+      ├── lock columns: (9,10)
       ├── locking: for-update
       └── project
            ├── columns: t2.a:1!null b:2 u2.a:5!null c:6
@@ -1600,15 +1714,23 @@ SELECT * FROM t JOIN u USING (a) FOR KEY SHARE FOR UPDATE
 ----
 lock u
  ├── columns: a:1!null b:2 c:6  [hidden: u.a:5!null]
+ ├── key columns: u.a:5
+ ├── lock columns: (21,22)
  ├── locking: for-update
  └── lock t
       ├── columns: t.a:1!null b:2 u.a:5!null c:6
+      ├── key columns: t.a:1
+      ├── lock columns: (17,18)
       ├── locking: for-update
       └── lock u
            ├── columns: t.a:1!null b:2 u.a:5!null c:6
+           ├── key columns: u.a:5
+           ├── lock columns: (13,14)
            ├── locking: for-key-share
            └── lock t
                 ├── columns: t.a:1!null b:2 u.a:5!null c:6
+                ├── key columns: t.a:1
+                ├── lock columns: (9,10)
                 ├── locking: for-key-share
                 └── project
                      ├── columns: t.a:1!null b:2 u.a:5!null c:6
@@ -1642,12 +1764,18 @@ SELECT * FROM t JOIN u USING (a) FOR KEY SHARE FOR NO KEY UPDATE OF t
 ----
 lock t
  ├── columns: a:1!null b:2 c:6  [hidden: u.a:5!null]
+ ├── key columns: t.a:1
+ ├── lock columns: (17,18)
  ├── locking: for-no-key-update
  └── lock u
       ├── columns: t.a:1!null b:2 u.a:5!null c:6
+      ├── key columns: u.a:5
+      ├── lock columns: (13,14)
       ├── locking: for-key-share
       └── lock t
            ├── columns: t.a:1!null b:2 u.a:5!null c:6
+           ├── key columns: t.a:1
+           ├── lock columns: (9,10)
            ├── locking: for-key-share
            └── project
                 ├── columns: t.a:1!null b:2 u.a:5!null c:6
@@ -1681,15 +1809,23 @@ SELECT * FROM t JOIN u USING (a) FOR SHARE FOR NO KEY UPDATE OF t FOR UPDATE OF 
 ----
 lock u
  ├── columns: a:1!null b:2 c:6  [hidden: u.a:5!null]
+ ├── key columns: u.a:5
+ ├── lock columns: (21,22)
  ├── locking: for-update
  └── lock t
       ├── columns: t.a:1!null b:2 u.a:5!null c:6
+      ├── key columns: t.a:1
+      ├── lock columns: (17,18)
       ├── locking: for-no-key-update
       └── lock u
            ├── columns: t.a:1!null b:2 u.a:5!null c:6
+           ├── key columns: u.a:5
+           ├── lock columns: (13,14)
            ├── locking: for-share
            └── lock t
                 ├── columns: t.a:1!null b:2 u.a:5!null c:6
+                ├── key columns: t.a:1
+                ├── lock columns: (9,10)
                 ├── locking: for-share
                 └── project
                      ├── columns: t.a:1!null b:2 u.a:5!null c:6
@@ -1949,9 +2085,13 @@ SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE
 ----
 lock u [as=u2]
  ├── columns: a:1!null b:2 c:6  [hidden: u2.a:5!null]
+ ├── key columns: u2.a:5
+ ├── lock columns: (13,14)
  ├── locking: for-update
  └── lock t [as=t2]
       ├── columns: t2.a:1!null b:2 u2.a:5!null c:6
+      ├── key columns: t2.a:1
+      ├── lock columns: (9,10)
       ├── locking: for-update
       └── project
            ├── columns: t2.a:1!null b:2 u2.a:5!null c:6
@@ -2014,6 +2154,8 @@ SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2
 ----
 lock t [as=t2]
  ├── columns: a:1!null b:2 c:6
+ ├── key columns: t2.a:1
+ ├── lock columns: (9,10)
  ├── locking: for-update
  └── project
       ├── columns: t2.a:1!null b:2 c:6
@@ -2046,6 +2188,8 @@ SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF u2
 ----
 lock u [as=u2]
  ├── columns: a:1!null b:2 c:6  [hidden: u2.a:5!null]
+ ├── key columns: u2.a:5
+ ├── lock columns: (9,10)
  ├── locking: for-update
  └── project
       ├── columns: t2.a:1!null b:2 u2.a:5!null c:6
@@ -2084,9 +2228,13 @@ SELECT * FROM t AS t2 JOIN u AS u2 USING (a) FOR UPDATE OF t2, u2
 ----
 lock u [as=u2]
  ├── columns: a:1!null b:2 c:6  [hidden: u2.a:5!null]
+ ├── key columns: u2.a:5
+ ├── lock columns: (13,14)
  ├── locking: for-update
  └── lock t [as=t2]
       ├── columns: t2.a:1!null b:2 u2.a:5!null c:6
+      ├── key columns: t2.a:1
+      ├── lock columns: (9,10)
       ├── locking: for-update
       └── project
            ├── columns: t2.a:1!null b:2 u2.a:5!null c:6
@@ -2125,9 +2273,13 @@ SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE
 ----
 lock u [as=u2]
  ├── columns: a:1!null b:2 c:6  [hidden: u2.a:5!null]
+ ├── key columns: u2.a:5
+ ├── lock columns: (13,14)
  ├── locking: for-update
  └── lock t
       ├── columns: t.a:1!null b:2 u2.a:5!null c:6
+      ├── key columns: t.a:1
+      ├── lock columns: (9,10)
       ├── locking: for-update
       └── project
            ├── columns: t.a:1!null b:2 u2.a:5!null c:6
@@ -2191,9 +2343,13 @@ SELECT * FROM (t JOIN u AS u2 USING (a)) j FOR UPDATE OF j
 ----
 lock u [as=u2]
  ├── columns: a:1!null b:2 c:6  [hidden: u2.a:5!null]
+ ├── key columns: u2.a:5
+ ├── lock columns: (13,14)
  ├── locking: for-update
  └── lock t
       ├── columns: t.a:1!null b:2 u2.a:5!null c:6
+      ├── key columns: t.a:1
+      ├── lock columns: (9,10)
       ├── locking: for-update
       └── project
            ├── columns: t.a:1!null b:2 u2.a:5!null c:6
@@ -2230,9 +2386,13 @@ SELECT * FROM t, u FOR UPDATE
 ----
 lock u
  ├── columns: a:1!null b:2 a:5!null c:6
+ ├── key columns: u.a:5
+ ├── lock columns: (13,14)
  ├── locking: for-update
  └── lock t
       ├── columns: t.a:1!null b:2 u.a:5!null c:6
+      ├── key columns: t.a:1
+      ├── lock columns: (9,10)
       ├── locking: for-update
       └── project
            ├── columns: t.a:1!null b:2 u.a:5!null c:6
@@ -2263,6 +2423,8 @@ SELECT * FROM t, u FOR UPDATE OF t
 ----
 lock t
  ├── columns: a:1!null b:2 a:5!null c:6
+ ├── key columns: t.a:1
+ ├── lock columns: (9,10)
  ├── locking: for-update
  └── project
       ├── columns: t.a:1!null b:2 u.a:5!null c:6
@@ -2294,9 +2456,13 @@ SELECT * FROM t, u FOR SHARE OF t FOR UPDATE OF u
 ----
 lock u
  ├── columns: a:1!null b:2 a:5!null c:6
+ ├── key columns: u.a:5
+ ├── lock columns: (13,14)
  ├── locking: for-update
  └── lock t
       ├── columns: t.a:1!null b:2 u.a:5!null c:6
+      ├── key columns: t.a:1
+      ├── lock columns: (9,10)
       ├── locking: for-share
       └── project
            ├── columns: t.a:1!null b:2 u.a:5!null c:6
@@ -2330,9 +2496,13 @@ SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE
 ----
 lock u
  ├── columns: a:1!null b:2 a:5!null c:6
+ ├── key columns: u.a:5
+ ├── lock columns: (13,14)
  ├── locking: for-update
  └── lock t
       ├── columns: t.a:1!null b:2 u.a:5!null c:6
+      ├── key columns: t.a:1
+      ├── lock columns: (9,10)
       ├── locking: for-update
       └── project
            ├── columns: t.a:1!null b:2 u.a:5!null c:6
@@ -2377,6 +2547,8 @@ SELECT * FROM t, LATERAL (SELECT * FROM u) sub FOR UPDATE OF sub
 ----
 lock u
  ├── columns: a:1!null b:2 a:5!null c:6
+ ├── key columns: u.a:5
+ ├── lock columns: (9,10)
  ├── locking: for-update
  └── project
       ├── columns: t.a:1!null b:2 u.a:5!null c:6
@@ -2421,6 +2593,8 @@ SELECT * FROM indexed WHERE b = 2 FOR UPDATE
 ----
 lock indexed
  ├── columns: a:1!null b:2!null c:3
+ ├── key columns: a:1
+ ├── lock columns: (6-8)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null b:2!null c:3
@@ -2449,6 +2623,8 @@ SELECT * FROM indexed WHERE b BETWEEN 2 AND 10 FOR UPDATE
 ----
 lock indexed
  ├── columns: a:1!null b:2!null c:3
+ ├── key columns: a:1
+ ├── lock columns: (6-8)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null b:2!null c:3
@@ -2488,9 +2664,13 @@ SELECT c FROM t JOIN u ON t.b = u.a WHERE t.a = 2 FOR UPDATE
 ----
 lock u
  ├── columns: c:6  [hidden: t.a:1!null u.a:5!null]
+ ├── key columns: u.a:5
+ ├── lock columns: (13,14)
  ├── locking: for-update
  └── lock t
       ├── columns: t.a:1!null u.a:5!null c:6
+      ├── key columns: t.a:1
+      ├── lock columns: (9,10)
       ├── locking: for-update
       └── project
            ├── columns: t.a:1!null u.a:5!null c:6
@@ -2532,9 +2712,13 @@ SELECT c FROM t JOIN u ON t.b = u.a WHERE t.a BETWEEN 2 AND 10 FOR UPDATE
 ----
 lock u
  ├── columns: c:6  [hidden: t.a:1!null u.a:5!null]
+ ├── key columns: u.a:5
+ ├── lock columns: (13,14)
  ├── locking: for-update
  └── lock t
       ├── columns: t.a:1!null u.a:5!null c:6
+      ├── key columns: t.a:1
+      ├── lock columns: (9,10)
       ├── locking: for-update
       └── project
            ├── columns: t.a:1!null u.a:5!null c:6
@@ -2576,9 +2760,13 @@ SELECT * FROM t JOIN indexed ON t.b = indexed.b WHERE t.a = 2 FOR UPDATE
 ----
 lock indexed
  ├── columns: a:1!null b:2!null a:5!null b:6!null c:7
+ ├── key columns: indexed.a:5
+ ├── lock columns: (14-16)
  ├── locking: for-update
  └── lock t
       ├── columns: t.a:1!null t.b:2!null indexed.a:5!null indexed.b:6!null c:7
+      ├── key columns: t.a:1
+      ├── lock columns: (10,11)
       ├── locking: for-update
       └── project
            ├── columns: t.a:1!null t.b:2!null indexed.a:5!null indexed.b:6!null c:7
@@ -2626,6 +2814,8 @@ SELECT * FROM inverted WHERE b @> '{1, 2}' FOR UPDATE
 ----
 lock inverted
  ├── columns: a:1!null b:2!null c:3
+ ├── key columns: a:1
+ ├── lock columns: (7-9)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null b:2!null c:3
@@ -2654,6 +2844,8 @@ SELECT * FROM inverted WHERE b <@ '{1, 2}' FOR UPDATE
 ----
 lock inverted
  ├── columns: a:1!null b:2 c:3
+ ├── key columns: a:1
+ ├── lock columns: (7-9)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null b:2 c:3
@@ -2689,9 +2881,13 @@ SELECT * FROM inverted@b_inv AS i1, inverted AS i2 WHERE i1.b @> i2.b FOR UPDATE
 ----
 lock inverted [as=i2]
  ├── columns: a:1!null b:2 c:3 a:7!null b:8 c:9
+ ├── key columns: i2.a:7
+ ├── lock columns: (19-21)
  ├── locking: for-update
  └── lock inverted [as=i1]
       ├── columns: i1.a:1!null i1.b:2 i1.c:3 i2.a:7!null i2.b:8 i2.c:9
+      ├── key columns: i1.a:1
+      ├── lock columns: (13-15)
       ├── locking: for-update
       └── project
            ├── columns: i1.a:1!null i1.b:2 i1.c:3 i2.a:7!null i2.b:8 i2.c:9
@@ -2742,6 +2938,8 @@ SELECT a,b,c FROM zigzag WHERE b = 5 AND c = 6.0 FOR UPDATE
 ----
 lock zigzag
  ├── columns: a:1!null b:2!null c:3!null
+ ├── key columns: a:1
+ ├── lock columns: (8-11)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null b:2!null c:3!null
@@ -2770,6 +2968,8 @@ SELECT * from zigzag where d @> '{"a": {"b": "c"}, "f": "g"}' FOR UPDATE
 ----
 lock zigzag
  ├── columns: a:1!null b:2 c:3 d:4!null
+ ├── key columns: a:1
+ ├── lock columns: (8-11)
  ├── locking: for-update
  └── project
       ├── columns: a:1!null b:2 c:3 d:4!null
@@ -2794,6 +2994,8 @@ SELECT * FROM information_schema.columns FOR UPDATE
 ----
 lock columns
  ├── columns: table_catalog:2!null table_schema:3!null table_name:4!null column_name:5!null column_comment:6 ordinal_position:7!null column_default:8 is_nullable:9!null data_type:10!null character_maximum_length:11 character_octet_length:12 numeric_precision:13 numeric_precision_radix:14 numeric_scale:15 datetime_precision:16 interval_type:17 interval_precision:18 character_set_catalog:19 character_set_schema:20 character_set_name:21 collation_catalog:22 collation_schema:23 collation_name:24 domain_catalog:25 domain_schema:26 domain_name:27 udt_catalog:28 udt_schema:29 udt_name:30 scope_catalog:31 scope_schema:32 scope_name:33 maximum_cardinality:34 dtd_identifier:35 is_self_referencing:36 is_identity:37 identity_generation:38 identity_start:39 identity_increment:40 identity_maximum:41 identity_minimum:42 identity_cycle:43 is_generated:44 generation_expression:45 is_updatable:46 is_hidden:47!null crdb_sql_type:48!null  [hidden: crdb_internal_vtable_pk:1!null]
+ ├── key columns: crdb_internal_vtable_pk:1
+ ├── lock columns: (49-96)
  ├── locking: for-update
  └── scan columns
       └── columns: crdb_internal_vtable_pk:1!null table_catalog:2!null table_schema:3!null table_name:4!null column_name:5!null column_comment:6 ordinal_position:7!null column_default:8 is_nullable:9!null data_type:10!null character_maximum_length:11 character_octet_length:12 numeric_precision:13 numeric_precision_radix:14 numeric_scale:15 datetime_precision:16 interval_type:17 interval_precision:18 character_set_catalog:19 character_set_schema:20 character_set_name:21 collation_catalog:22 collation_schema:23 collation_name:24 domain_catalog:25 domain_schema:26 domain_name:27 udt_catalog:28 udt_schema:29 udt_name:30 scope_catalog:31 scope_schema:32 scope_name:33 maximum_cardinality:34 dtd_identifier:35 is_self_referencing:36 is_identity:37 identity_generation:38 identity_start:39 identity_increment:40 identity_maximum:41 identity_minimum:42 identity_cycle:43 is_generated:44 generation_expression:45 is_updatable:46 is_hidden:47!null crdb_sql_type:48!null
@@ -2816,6 +3018,8 @@ SELECT * FROM t FOR UPDATE NOWAIT
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-update,nowait
  └── project
       ├── columns: a:1!null b:2
@@ -2837,6 +3041,8 @@ SELECT * FROM t FOR NO KEY UPDATE NOWAIT
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-no-key-update,nowait
  └── project
       ├── columns: a:1!null b:2
@@ -2858,6 +3064,8 @@ SELECT * FROM t FOR SHARE NOWAIT
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-share,nowait
  └── project
       ├── columns: a:1!null b:2
@@ -2879,6 +3087,8 @@ SELECT * FROM t FOR KEY SHARE NOWAIT
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-key-share,nowait
  └── project
       ├── columns: a:1!null b:2
@@ -2900,9 +3110,13 @@ SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (9,10)
  ├── locking: for-share,nowait
  └── lock t
       ├── columns: a:1!null b:2
+      ├── key columns: a:1
+      ├── lock columns: (5,6)
       ├── locking: for-key-share
       └── project
            ├── columns: a:1!null b:2
@@ -2924,12 +3138,18 @@ SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (13,14)
  ├── locking: for-no-key-update
  └── lock t
       ├── columns: a:1!null b:2
+      ├── key columns: a:1
+      ├── lock columns: (9,10)
       ├── locking: for-share,nowait
       └── lock t
            ├── columns: a:1!null b:2
+           ├── key columns: a:1
+           ├── lock columns: (5,6)
            ├── locking: for-key-share
            └── project
                 ├── columns: a:1!null b:2
@@ -2951,15 +3171,23 @@ SELECT * FROM t FOR KEY SHARE FOR SHARE NOWAIT FOR NO KEY UPDATE FOR UPDATE NOWA
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (17,18)
  ├── locking: for-update,nowait
  └── lock t
       ├── columns: a:1!null b:2
+      ├── key columns: a:1
+      ├── lock columns: (13,14)
       ├── locking: for-no-key-update
       └── lock t
            ├── columns: a:1!null b:2
+           ├── key columns: a:1
+           ├── lock columns: (9,10)
            ├── locking: for-share,nowait
            └── lock t
                 ├── columns: a:1!null b:2
+                ├── key columns: a:1
+                ├── lock columns: (5,6)
                 ├── locking: for-key-share
                 └── project
                      ├── columns: a:1!null b:2
@@ -2981,6 +3209,8 @@ SELECT * FROM t FOR UPDATE OF t NOWAIT
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-update,nowait
  └── project
       ├── columns: a:1!null b:2
@@ -3014,6 +3244,8 @@ SELECT 1 FROM t FOR UPDATE OF t NOWAIT
 ----
 lock t
  ├── columns: "?column?":5!null  [hidden: a:1!null]
+ ├── key columns: a:1
+ ├── lock columns: (6,7)
  ├── locking: for-update,nowait
  └── project
       ├── columns: "?column?":5!null a:1!null
@@ -3041,6 +3273,8 @@ SELECT * FROM t FOR UPDATE SKIP LOCKED
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-update,skip-locked
  └── project
       ├── columns: a:1!null b:2
@@ -3062,6 +3296,8 @@ SELECT * FROM t FOR NO KEY UPDATE SKIP LOCKED
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-no-key-update,skip-locked
  └── project
       ├── columns: a:1!null b:2
@@ -3083,6 +3319,8 @@ SELECT * FROM t FOR SHARE SKIP LOCKED
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-share,skip-locked
  └── project
       ├── columns: a:1!null b:2
@@ -3104,6 +3342,8 @@ SELECT * FROM t FOR KEY SHARE SKIP LOCKED
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-key-share,skip-locked
  └── project
       ├── columns: a:1!null b:2
@@ -3125,9 +3365,13 @@ SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (9,10)
  ├── locking: for-share,skip-locked
  └── lock t
       ├── columns: a:1!null b:2
+      ├── key columns: a:1
+      ├── lock columns: (5,6)
       ├── locking: for-key-share
       └── project
            ├── columns: a:1!null b:2
@@ -3149,12 +3393,18 @@ SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED FOR NO KEY UPDATE
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (13,14)
  ├── locking: for-no-key-update
  └── lock t
       ├── columns: a:1!null b:2
+      ├── key columns: a:1
+      ├── lock columns: (9,10)
       ├── locking: for-share,skip-locked
       └── lock t
            ├── columns: a:1!null b:2
+           ├── key columns: a:1
+           ├── lock columns: (5,6)
            ├── locking: for-key-share
            └── project
                 ├── columns: a:1!null b:2
@@ -3176,15 +3426,23 @@ SELECT * FROM t FOR KEY SHARE FOR SHARE SKIP LOCKED FOR NO KEY UPDATE FOR UPDATE
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (17,18)
  ├── locking: for-update,skip-locked
  └── lock t
       ├── columns: a:1!null b:2
+      ├── key columns: a:1
+      ├── lock columns: (13,14)
       ├── locking: for-no-key-update
       └── lock t
            ├── columns: a:1!null b:2
+           ├── key columns: a:1
+           ├── lock columns: (9,10)
            ├── locking: for-share,skip-locked
            └── lock t
                 ├── columns: a:1!null b:2
+                ├── key columns: a:1
+                ├── lock columns: (5,6)
                 ├── locking: for-key-share
                 └── project
                      ├── columns: a:1!null b:2
@@ -3206,6 +3464,8 @@ SELECT * FROM t FOR UPDATE OF t SKIP LOCKED
 ----
 lock t
  ├── columns: a:1!null b:2
+ ├── key columns: a:1
+ ├── lock columns: (5,6)
  ├── locking: for-update,skip-locked
  └── project
       ├── columns: a:1!null b:2
@@ -3239,6 +3499,8 @@ SELECT 1 FROM t FOR UPDATE OF t SKIP LOCKED
 ----
 lock t
  ├── columns: "?column?":5!null  [hidden: a:1!null]
+ ├── key columns: a:1
+ ├── lock columns: (6,7)
  ├── locking: for-update,skip-locked
  └── project
       ├── columns: "?column?":5!null a:1!null

--- a/pkg/sql/opt/xform/testdata/external/tpcc-read-committed
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-read-committed
@@ -125,6 +125,8 @@ FOR UPDATE
 ----
 lock stock
  ├── columns: s_quantity:3 s_ytd:14 s_order_cnt:15 s_remote_cnt:16 s_data:17 s_dist_05:8  [hidden: s_i_id:1!null s_w_id:2!null]
+ ├── key columns: s_w_id:2 s_i_id:1
+ ├── lock columns: (20-36)
  ├── locking: for-update,durability-guaranteed
  ├── cardinality: [0 - 5]
  ├── volatile, mutations
@@ -823,6 +825,8 @@ FOR UPDATE
 ----
 lock new_order
  ├── columns: no_o_id:1!null  [hidden: no_d_id:2!null no_w_id:3!null]
+ ├── key columns: no_w_id:3 no_d_id:2 no_o_id:1
+ ├── lock columns: (6-8)
  ├── locking: for-update,durability-guaranteed
  ├── cardinality: [0 - 1]
  ├── volatile, mutations

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -358,6 +358,8 @@ SELECT * FROM partial_index_const WHERE a > 0 AND b = 1 LIMIT 5 FOR UPDATE
 ----
 lock partial_index_const
  ├── columns: a:1!null b:2!null c:3  [hidden: rowid:4!null]
+ ├── key columns: rowid:4
+ ├── lock columns: (7-10)
  ├── locking: for-update
  ├── cardinality: [0 - 5]
  ├── volatile, mutations


### PR DESCRIPTION
#### sql/logictest: do not round-trip unique, hash-sharded indexes

Prior to this commit, logic tests with `CREATE TABLE` statements that
had unique, hash-sharded indexes would always fail because they did not
round trip. This is because only unique hash-sharded indexes are
allowed, yet we format them as unique constraints. As a temporary fix,
we no longer attempt to round-trip them.

Release note: None

#### opt: format key and lock columns for LockExpr

Release note: None

#### opt: do not include virtual computed columns in lock columns

Virtual computed columns cannot be included in lock columns because
these columns are fetch from the primary index when the lock is
translated into a lookup join. The primary index does not actually store
virtual columns, so attempting to fetch `NOT NULL` virtual columns would
confuse the execution engine into thinking they should be present, and
cause errors with the message "internal error: Non-nullable column ...".

Fixes #130661

Release note (bug fix): A bug has been fixed which could cause errors
with the message "internal error: Non-nullable column ..." when
executing statements under read-committed isolation that involve tables
with `NOT NULL` virtual columns.
