### PR TITLE
sql: add sys DB  version accessor to isql.txn

### DIFF
--- a/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
+++ b/pkg/kv/kvserver/protectedts/ptstorage/storage_test.go
@@ -821,6 +821,12 @@ func (txn *wrappedInternalTxn) SessionData() *sessiondata.SessionData {
 	return txn.wrapped.SessionData()
 }
 
+func (txn *wrappedInternalTxn) GetSystemSchemaVersion(
+	ctx context.Context,
+) (roachpb.Version, error) {
+	return txn.wrapped.GetSystemSchemaVersion(ctx)
+}
+
 func wrapTxn(txn isql.Txn, errFunc func(statement string) error) *wrappedInternalTxn {
 	return &wrappedInternalTxn{wrapped: txn, errFunc: errFunc}
 }

--- a/pkg/sql/isql/BUILD.bazel
+++ b/pkg/sql/isql/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/kv",
+        "//pkg/roachpb",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/parser/statements",

--- a/pkg/sql/isql/isql_db.go
+++ b/pkg/sql/isql/isql_db.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser/statements"
@@ -50,6 +51,9 @@ type Txn interface {
 
 	// SessionData returns the transaction's SessionData.
 	SessionData() *sessiondata.SessionData
+
+	// GetSystemSchemaVersion exposes the schema version from the system db desc.
+	GetSystemSchemaVersion(context.Context) (roachpb.Version, error)
 
 	// Executor allows the user to execute transactional SQL statements.
 	Executor


### PR DESCRIPTION
Prior work added a 'version' to the system db desc that could be used to determine the verison of the system schema a txn should use via a leased db desc. However this version field, while maintained by migrations and tested, was not exposed to most users of internal txns without manually interacting with the lease manager and correctly handling its deadlines and expirations.

This adds a getter via the internal txn's descs collection that already correctly mediates descriptor accesses, making usage relatively simple.

Release note: none.
Epic: none.