### PR TITLE
workflows: use env variable in place of set-output command

### DIFF
--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -371,7 +371,7 @@ jobs:
           echo "Latest commit on target branch ($TARGET_BRANCH): $LATEST_COMMIT"
           
           # Set the latest commit hash as an output variable
-          echo "::set-output name=latest_commit::$LATEST_COMMIT"
+          echo "latest_commit=$LATEST_COMMIT" >> $GITHUB_OUTPUT
         if: ${{ github.event_name != 'push' }}
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
In `cockroach-microbench-ci`, we use `set-output` to emit the latest commit of the target branch. However, it is being deprecated by github https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/. Therefore this change aims to use env variable instead.

Epic: none

Release note: None