### PR TITLE
roachtest: fix perf dir in perturbation tests

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -731,7 +731,8 @@ func (v variations) runTest(ctx context.Context, t test.Test, c cluster.Cluster)
 	t.Status("T5: validating results")
 	require.NoError(t, downloadProfiles(ctx, c, t.L(), t.ArtifactsDir()))
 
-	require.NoError(t, v.writePerfArtifacts(ctx, t.Name(), t.ArtifactsDir(), baselineStats, perturbationStats, afterStats))
+	require.NoError(t, v.writePerfArtifacts(ctx, t.Name(), t.PerfArtifactsDir(), baselineStats, perturbationStats,
+		afterStats))
 
 	t.L().Printf("validating stats during the perturbation")
 	duringOK := isAcceptableChange(t.L(), baselineStats, perturbationStats, v.acceptableChange)


### PR DESCRIPTION
The test runner generates a `stats.json` file it uploades to a cluster
node to be picked up by roachperf.

However, it attempted[^1] to use the *agent* artifacts directory as a
destination on the *cluster*. This wouldn't have shown up in roachperf,
but it also failed since the agent typically uses `/artifacts` and `/`
is not writable on the remote node.

As of this commit, the correct perf dir is used.

Fixes #130791.
Fixes #130773.
Fixes #130772.
Fixes #130771.
Fixes #130770.
Fixes #130769.
Fixes #130768.

[^1]: https://github.com/cockroachdb/cockroach/commit/942aaec0b9a1d05c0c83ba9f6470ddd649f8a481

Epic: none
Release note: None
