### PR TITLE
rac2,kvserver: add RaftEvent.MsgApps to maintain send-queue state

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -329,6 +329,9 @@ type Replica struct {
 		bytesAccount logstore.BytesAccount
 
 		flowControlLevel replica_rac2.EnabledWhenLeaderLevel
+
+		// Scratch for populating RaftEvent for flowControlV2.
+		msgAppScratchForFlowControl map[roachpb.ReplicaID][]raftpb.Message
 	}
 
 	// localMsgs contains a collection of raftpb.Message that target the local

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -225,6 +225,7 @@ func newUninitializedReplicaWithoutRaftGroup(
 		r.store.TestingKnobs().FlowControlTestingKnobs,
 	)
 	r.raftMu.flowControlLevel = racV2EnabledWhenLeaderLevel(r.raftCtx, store.cfg.Settings)
+	r.raftMu.msgAppScratchForFlowControl = map[roachpb.ReplicaID][]raftpb.Message{}
 	r.flowControlV2 = replica_rac2.NewProcessor(replica_rac2.ProcessorOptions{
 		NodeID:                 store.NodeID(),
 		StoreID:                r.StoreID(),

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -922,7 +922,8 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	}
 	// Even if we don't have a Ready, or entries in Ready,
 	// replica_rac2.Processor may need to do some work.
-	raftEvent := rac2.RaftEventFromMsgStorageAppend(msgStorageAppend)
+	raftEvent := rac2.RaftEventFromMsgStorageAppendAndMsgApps(
+		r.ReplicaID(), msgStorageAppend, outboundMsgs, r.raftMu.msgAppScratchForFlowControl)
 	r.flowControlV2.HandleRaftReadyRaftMuLocked(ctx, raftEvent)
 	if !hasReady {
 		// We must update the proposal quota even if we don't have a ready.


### PR DESCRIPTION
It is populated, but not yet used by RangeController.

Epic: CRDB-37515

Release note: None