### PR TITLE
cli: make haproxy a sql command

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -798,6 +798,7 @@ func init() {
 	sqlCmds = append(sqlCmds, nodeLocalCmds...)
 	sqlCmds = append(sqlCmds, importCmds...)
 	sqlCmds = append(sqlCmds, userFileCmds...)
+	sqlCmds = append(sqlCmds, genHAProxyCmd)
 	for _, cmd := range sqlCmds {
 		clientflags.AddSQLFlags(cmd, &cliCtx.clientOpts, sqlCtx,
 			cmd == sqlShellCmd, /* isShell */


### PR DESCRIPTION
This allows passing the `--user` flag, which is necessary when using
client certs for a non-root user.

As of this commit, work-arounds such as this[^1] are no longer
necessary.

[^1]: https://github.com/cockroachdb/cockroach/blob/4bcdf2167b9fb735d25794ee995b9d3df2cdf1d8/pkg/cmd/roachtest/tests/sysbench.go#L152-L165

Epic: none
Release note: None
