### PR TITLE
sql: log cheap statement info to runtime trace

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -16,6 +16,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"runtime/pprof"
+	"runtime/trace"
 	"strings"
 	"time"
 
@@ -3418,6 +3419,13 @@ func (ex *connExecutor) execWithProfiling(
 	prepared *PreparedStatement,
 	op func(context.Context) error,
 ) error {
+	if trace.IsEnabled() {
+		defer trace.StartRegion(ctx, "SQLStatement").End()
+		// Go execution trace logging. Low-allocation only, please.
+		trace.Log(ctx, "sqlappname", ex.sessionData().ApplicationName)
+		trace.Log(ctx, "sqldb", ex.sessionData().Database)
+		trace.Log(ctx, "sqlstmttag", ast.StatementTag())
+	}
 	var err error
 	if ex.server.cfg.Settings.CPUProfileType() == cluster.CPUProfileWithLabels {
 		remoteAddr := "internal"


### PR DESCRIPTION
An instance of `pgwire.(*Server).serveImpl.func4`[^1] is a goroutine
doing work on behalf of a SQL client and as such it is one that tends
to be of interest when we look at Go execution traces.

This commit adds, while execution tracing is active, a few cheap pieces
of information about each statement that begins executing. This can
potentially help line up statement bundles and Go execution traces.

It would be interesting to log the statement fingerprint into the
execution trace, but the fingerprint isn't cheaply available here
and so this is left for a future change.

[^1]: https://github.com/cockroachdb/cockroach/blob/1b0a374fd2a101cebcfb24cff4b3b57795ad1df6/pkg/sql/pgwire/server.go#L1133-L1145

Epic: none
Release note: None
