### PR TITLE
ui: add AlertBar component

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.module.styl
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.module.styl
@@ -1,0 +1,27 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+@require '~src/components/core/index.styl'
+
+.alert-bar
+  padding 12px
+  text-align center
+
+.alert--alert
+  background-color $colors--alert
+  color $colors--white
+  a
+    color $colors--white
+
+.alert--warning
+  background-color $colors--warning
+  color $colors--neutral-9
+  a
+    color $colors--neutral-9

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.stories.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.stories.tsx
@@ -1,0 +1,94 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { storiesOf } from "@storybook/react";
+import moment from "moment";
+import React from "react";
+
+import { styledWrapper } from "src/util/decorators";
+
+import { AlertBar } from "./alertBar";
+
+storiesOf("AlertBar", module)
+  .addDecorator(
+    styledWrapper({ padding: "24px", fontFamily: "SourceSansPro-Regular" }),
+  )
+  .add(`3.4.1 [pre-license] license key required by <date>`, () => (
+    <AlertBar
+      license={"None"}
+      numNodes={3}
+      throttled={false}
+      telemetrySuccessful={true}
+      throttleDate={moment("2025-01-04")}
+    />
+  ))
+  .add(`3.4.2 [pre-license] license key required, cluster throttled`, () => (
+    <AlertBar
+      license={"None"}
+      numNodes={3}
+      throttled={true}
+      telemetrySuccessful={true}
+      throttleDate={moment("2023-01-04")}
+    />
+  ))
+  .add(
+    `3.4.5 [license expiring] license key expired on <date>, cluster will be throttled on <date>`,
+    () => (
+      <AlertBar
+        license={"Free"}
+        numNodes={3}
+        throttled={false}
+        telemetrySuccessful={true}
+        licenseExpiryDate={moment().subtract(1, "month")}
+        throttleDate={moment().add(3, "day")}
+      />
+    ),
+  )
+  .add(
+    `3.4.6 + 3.4.7 [license expired] license key expired on <date>, cluster throttled`,
+    () => (
+      <AlertBar
+        license={"Free"}
+        numNodes={3}
+        throttled={true}
+        telemetrySuccessful={true}
+        licenseExpiryDate={moment().subtract(1, "month")}
+        throttleDate={moment().subtract(1, "day")}
+      />
+    ),
+  )
+  .add(
+    `3.4.8 [telemetry disabled] telemetry not received since <date>, cluster will be throttled on <date>`,
+    () => (
+      <AlertBar
+        license={"Free"}
+        numNodes={3}
+        throttled={false}
+        telemetrySuccessful={false}
+        licenseExpiryDate={moment().add(6, "month")}
+        lastSuccessfulTelemetryDate={moment().subtract(3, "day")}
+        throttleDate={moment().add(3, "day")}
+      />
+    ),
+  )
+  .add(
+    `3.4.9 [telemetry disabled] telemetry not received since <date>, cluster throttled on <date>`,
+    () => (
+      <AlertBar
+        license={"Free"}
+        numNodes={3}
+        throttled={true}
+        telemetrySuccessful={false}
+        licenseExpiryDate={moment().add(6, "month")}
+        lastSuccessfulTelemetryDate={moment().subtract(1, "month")}
+        throttleDate={moment().subtract(3, "day")}
+      />
+    ),
+  );

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.tsx
@@ -1,0 +1,113 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import classNames from "classnames/bind";
+import moment from "moment";
+import React from "react";
+
+import { enterpriseLicenseUpdate } from "src/util/docs";
+
+import styles from "./alertBar.module.styl";
+
+type License = "Enterprise" | "Free" | "None";
+
+interface AlertBarProps {
+  license: License;
+  numNodes: number;
+  throttled: boolean;
+  telemetrySuccessful: boolean;
+  licenseExpiryDate?: moment.Moment;
+  lastSuccessfulTelemetryDate?: moment.Moment;
+  throttleDate?: moment.Moment;
+  nodesMissingTelemetry?: [number];
+}
+
+const cx = classNames.bind(styles);
+
+export const AlertBar = ({
+  license,
+  numNodes,
+  throttled,
+  telemetrySuccessful,
+  licenseExpiryDate,
+  lastSuccessfulTelemetryDate,
+  throttleDate,
+}: AlertBarProps) => {
+  if (license === "Enterprise" || numNodes < 2) {
+    return null; // No matter what, an enterprise license is never throttled.
+  }
+
+  if (license === "Free") {
+    // If license is expired, we throttle.
+    if (licenseExpiryDate.isBefore(moment())) {
+      if (throttled) {
+        return (
+          <div className={cx("alert-bar", "alert--alert")}>
+            Your license key expired on{" "}
+            {licenseExpiryDate.format("MMMM Do, YYYY")} and the cluster was
+            throttled. Please add a license key to continue using this cluster.{" "}
+            <a href={enterpriseLicenseUpdate}>Learn more</a>
+          </div>
+        );
+      } else {
+        return (
+          <div className={cx("alert-bar", "alert--warning")}>
+            Your license key expired on{" "}
+            {licenseExpiryDate.format("MMMM Do, YYYY")}. The cluster will be
+            throttled on {throttleDate.format("MMMM Do, YYYY")} unless the
+            license is renewed. <a href={enterpriseLicenseUpdate}>Learn more</a>
+          </div>
+        );
+      }
+    }
+    if (!telemetrySuccessful) {
+      if (throttled) {
+        return (
+          <div className={cx("alert-bar", "alert--alert")}>
+            Telemetry has not been received from some nodes in this cluster
+            since {lastSuccessfulTelemetryDate.format("MMMM Do, YYYY")}. These
+            nodes were throttled on {throttleDate.format("MMMM Do, YYYY")}.{" "}
+            <a href={enterpriseLicenseUpdate}>Learn more</a>
+          </div>
+        );
+      } else {
+        return (
+          <div className={cx("alert-bar", "alert--warning")}>
+            Telemetry has not been received from some nodes in this cluster
+            since {lastSuccessfulTelemetryDate.format("MMMM Do, YYYY")}. These
+            nodes will be throttled on {throttleDate.format("MMMM Do, YYYY")}{" "}
+            unless telemetry is received.{" "}
+            <a href={enterpriseLicenseUpdate}>Learn more</a>
+          </div>
+        );
+      }
+    }
+  }
+
+  if (license === "None") {
+    if (throttled) {
+      return (
+        <div className={cx("alert-bar", "alert--alert")}>
+          This cluster was throttled because it requires a license key. Please
+          add a license key to continue using this cluster.{" "}
+          <a href={enterpriseLicenseUpdate}>Learn more</a>
+        </div>
+      );
+    } else {
+      return (
+        <div className={cx("alert-bar", "alert--warning")}>
+          This cluster will require a license key by{" "}
+          {throttleDate.format("MMMM Do, YYYY")} or the cluster will be
+          throttled. <a href={enterpriseLicenseUpdate}>Learn more</a>
+        </div>
+      );
+    }
+  }
+};


### PR DESCRIPTION
This component will be used to signal throttling notifications for free and unlicensed clusters.

This commit introduces the component and provides some configurability for rendering a few different kinds of messages that are reflected in the storybook examples.

It's likely the props interface will change once the backend API becomes available.

Resolves: CRDB-40935
Release Note: None