### PR TITLE
crosscluster/logical: use poller-collection for replicated time

### DIFF
--- a/pkg/jobs/metrics.go
+++ b/pkg/jobs/metrics.go
@@ -36,6 +36,9 @@ type Metrics struct {
 	// implementation of job specific metrics.
 	JobSpecificMetrics [jobspb.NumJobTypes]metric.Struct
 
+	// ResolvedMetrics are the per job type metrics for resolved timestamps.
+	ResolvedMetrics [jobspb.NumJobTypes]*metric.Gauge
+
 	// RunningNonIdleJobs is the total number of running jobs that are not idle.
 	RunningNonIdleJobs *metric.Gauge
 
@@ -288,8 +291,13 @@ func (m *Metrics) init(histogramWindowInterval time.Duration, lookup *cidr.Looku
 			ExpiredPTS:             metric.NewCounter(makeMetaExpiredPTS(typeStr)),
 			ProtectedAge:           metric.NewGauge(makeMetaProtectedAge(typeStr)),
 		}
-		if opts, ok := getRegisterOptions(jt); ok && opts.metrics != nil {
-			m.JobSpecificMetrics[jt] = opts.metrics
+		if opts, ok := getRegisterOptions(jt); ok {
+			if opts.metrics != nil {
+				m.JobSpecificMetrics[jt] = opts.metrics
+			}
+			if opts.resolvedMetric != nil {
+				m.ResolvedMetrics[jt] = opts.resolvedMetric
+			}
 		}
 	}
 }

--- a/pkg/jobs/metricspoller/job_statistics.go
+++ b/pkg/jobs/metricspoller/job_statistics.go
@@ -81,6 +81,48 @@ func updatePausedMetrics(ctx context.Context, execCtx sql.JobExecContext) error 
 	return nil
 }
 
+// lowTSForTypeQuery finds the lowest non-null ts for all jobs of a given type.
+// min() ignores nulls; jobs of the type that do not have a ts are not included
+// in the result, e.g. a new changefeed that is still in initial scan would not
+// change the result of the query, but if after its initial scan it was several
+// minutes behind and was the most lagged changefeed, that would be reflected.
+const lowTSForTypeQuery = `SELECT min(high_water_timestamp) FROM crdb_internal.jobs WHERE job_type = $1 AND status IN ` + jobs.NonTerminalStatusTupleString
+
+// updateTSMetrics updates the metrics for jobs that have registered for ts
+// tracking.
+func updateTSMetrics(ctx context.Context, execCtx sql.JobExecContext) error {
+	for _, typ := range jobspb.Type_value {
+		m := execCtx.ExecCfg().JobRegistry.MetricsStruct().ResolvedMetrics[typ]
+		// If this job type does not register a resolved TS metric, skip it.
+		if m == nil {
+			continue
+		}
+
+		var ts hlc.Timestamp
+		if err := execCtx.ExecCfg().InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			if err := txn.KV().SetUserPriority(roachpb.MinUserPriority); err != nil {
+				return err
+			}
+			row, err := txn.QueryRowEx(
+				ctx, "poll-jobs-metrics-ts", txn.KV(), sessiondata.NodeUserSessionDataOverride,
+				lowTSForTypeQuery, jobspb.Type(typ).String(),
+			)
+			// Feeding zero non-null rows to min() returns null; return and record
+			// a zero ts (i.e. no data.) in this case or an error case.
+			if err != nil || row == nil || row[0] == tree.DNull {
+				return err
+			}
+			d := *row[0].(*tree.DDecimal)
+			ts, err = hlc.DecimalToHLC(&d.Decimal)
+			return err
+		}); err != nil {
+			return errors.Wrap(err, "could not query jobs table")
+		}
+		m.Update(ts.GoTime().Unix())
+	}
+	return nil
+}
+
 type ptsStat struct {
 	numRecords int64
 	expired    int64

--- a/pkg/jobs/metricspoller/poller.go
+++ b/pkg/jobs/metricspoller/poller.go
@@ -94,6 +94,7 @@ type pollerMetrics struct {
 var metricPollerTasks = map[string]func(ctx context.Context, execCtx sql.JobExecContext) error{
 	"paused-jobs": updatePausedMetrics,
 	"manage-pts":  manageProtectedTimestamps,
+	"resolved-ts": updateTSMetrics,
 }
 
 func (m pollerMetrics) MetricStruct() {}

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1413,6 +1413,14 @@ func WithJobMetrics(m metric.Struct) RegisterOption {
 	}
 }
 
+// WithResolvedMetric registers a gauge metric that the poller will update to
+// reflect the minimum resolved timestamp of all the jobs of this type.
+func WithResolvedMetric(m *metric.Gauge) RegisterOption {
+	return func(opts *registerOptions) {
+		opts.resolvedMetric = m
+	}
+}
+
 // registerOptions are passed to RegisterConstructor and control how a job
 // resumer is created and configured.
 type registerOptions struct {
@@ -1427,6 +1435,9 @@ type registerOptions struct {
 
 	// metrics allow jobs to register job specific metrics.
 	metrics metric.Struct
+
+	// resolvedMetric, if set, is the metric to update using the min resolved ts.
+	resolvedMetric *metric.Gauge
 }
 
 // JobResultsReporter is an interface for reporting the results of the job execution.


### PR DESCRIPTION
    jobs/metricspoller: add optional 'highwater' metric from polled progress

    Many of our jobs maintain 'highwater' timestamps in their progress, reflecting the
    timestamp up to which they have processed. Many users of these jobs wish to monitor them
    via timeseries and exported metrics. However exporting these highwater timestamps via
    metrics has proven difficult to do directly from a running job for a few reasons, including
    the fact that many jobs may be running, so we need to reliably export the worst-case number
    and that each node exports its own number, so an aggregator will need to find the worst
    across those nodes. While this all is possible, an added complication is that if no node
    is executing a given job, its number is not moving and thus likely the most important to
    include in the worst-case, but when each job is responsible for pushing its number into the
    metric, this does not happen.

    This change instead extends our 'metrics poller' job that inspects the state of the jobs
    system to update certain metrics so that it can be asked to find the minimum timestamp
    across all jobs of a given type and update a metric for that type to the found number.

    Release note: none.
    Epic: none.