### PR TITLE
bazel,dev: fix staging behavior from non-default configurations

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -36,6 +36,7 @@ build --define gotags=bazel,gss
 build --experimental_proto_descriptor_sets_include_source_info
 build --incompatible_strict_action_env --incompatible_enable_cc_toolchain_resolution
 build --symlink_prefix=_bazel/
+build:dev --strip=never
 common --experimental_allow_tags_propagation
 test --config=test --experimental_ui_max_stdouterr_bytes=10485760
 build --ui_event_filters=-DEBUG

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -173,7 +173,6 @@ func (d *dev) build(cmd *cobra.Command, commandLine []string) error {
 	}
 	args = append(args, additionalBazelArgs...)
 	configArgs := getConfigArgs(args)
-	configArgs = append(configArgs, getConfigArgs(additionalBazelArgs)...)
 
 	if err := d.assertNoLinkedNpmDeps(buildTargets); err != nil {
 		return err
@@ -292,7 +291,7 @@ func (d *dev) stageArtifacts(
 			}
 			var geosDir string
 			if archived != "" {
-				execRoot, err := d.getExecutionRoot(ctx)
+				execRoot, err := d.getExecutionRoot(ctx, configArgs)
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -172,6 +172,8 @@ func (d *dev) build(cmd *cobra.Command, commandLine []string) error {
 		return err
 	}
 	args = append(args, additionalBazelArgs...)
+	configArgs := getConfigArgs(args)
+	configArgs = append(configArgs, getConfigArgs(additionalBazelArgs)...)
 
 	if err := d.assertNoLinkedNpmDeps(buildTargets); err != nil {
 		return err
@@ -189,7 +191,7 @@ func (d *dev) build(cmd *cobra.Command, commandLine []string) error {
 		if err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...); err != nil {
 			return err
 		}
-		return d.stageArtifacts(ctx, buildTargets)
+		return d.stageArtifacts(ctx, buildTargets, configArgs)
 	}
 	volume := mustGetFlagString(cmd, volumeFlag)
 	cross = "cross" + cross
@@ -258,7 +260,9 @@ func (d *dev) crossBuild(
 	return err
 }
 
-func (d *dev) stageArtifacts(ctx context.Context, targets []buildTarget) error {
+func (d *dev) stageArtifacts(
+	ctx context.Context, targets []buildTarget, configArgs []string,
+) error {
 	workspace, err := d.getWorkspace(ctx)
 	if err != nil {
 		return err
@@ -267,7 +271,7 @@ func (d *dev) stageArtifacts(ctx context.Context, targets []buildTarget) error {
 	if err = d.os.MkdirAll(path.Join(workspace, "bin")); err != nil {
 		return err
 	}
-	bazelBin, err := d.getBazelBin(ctx)
+	bazelBin, err := d.getBazelBin(ctx, configArgs)
 	if err != nil {
 		return err
 	}
@@ -459,11 +463,19 @@ func (d *dev) getBasicBuildArgs(
 	return args, buildTargets, nil
 }
 
-// Given a list of Bazel arguments, find the ones starting with --config= and
-// return them.
+// Given a list of Bazel arguments, find the ones that represent a "config"
+// (either --config or -c) and return all of these. This is used to find
+// the appropriate bazel-bin for any invocation.
 func getConfigArgs(args []string) (ret []string) {
+	var addNext bool
 	for _, arg := range args {
-		if strings.HasPrefix(arg, "--config=") {
+		if addNext {
+			ret = append(ret, arg)
+			addNext = false
+		} else if arg == "--config" || arg == "--compilation_mode" || arg == "-c" {
+			ret = append(ret, arg)
+			addNext = true
+		} else if strings.HasPrefix(arg, "--config=") || strings.HasPrefix(arg, "--compilation_mode=") {
 			ret = append(ret, arg)
 		}
 	}

--- a/pkg/cmd/dev/doctor.go
+++ b/pkg/cmd/dev/doctor.go
@@ -503,7 +503,7 @@ func (d *dev) doctor(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	bazelBin, err := d.getBazelBin(ctx)
+	bazelBin, err := d.getBazelBin(ctx, []string{})
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/dev/generate.go
+++ b/pkg/cmd/dev/generate.go
@@ -303,7 +303,7 @@ func (d *dev) generateJs(cmd *cobra.Command) error {
 		return fmt.Errorf("building JS development prerequisites: %w", err)
 	}
 
-	bazelBin, err := d.getBazelBin(ctx)
+	bazelBin, err := d.getBazelBin(ctx, []string{})
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/dev/roachprod_stress.go
+++ b/pkg/cmd/dev/roachprod_stress.go
@@ -120,7 +120,7 @@ func (d *dev) roachprodStress(cmd *cobra.Command, commandLine []string) error {
 	if _, err := d.exec.CommandContextSilent(ctx, "bazel", args...); err != nil {
 		return err
 	}
-	if err := d.stageArtifacts(ctx, roachprodStressTarget); err != nil {
+	if err := d.stageArtifacts(ctx, roachprodStressTarget, []string{}); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/dev/testdata/datadriven/dev-build
+++ b/pkg/cmd/dev/testdata/datadriven/dev-build
@@ -80,4 +80,4 @@ dev build tests
 bazel build //pkg:all_tests --config=test --build_event_binary_file=/tmp/path
 bazel info workspace --color=no
 mkdir crdb-checkout/bin
-bazel info bazel-bin --color=no
+bazel info bazel-bin --color=no --config=test

--- a/pkg/cmd/dev/testdata/recorderdriven/dev-build
+++ b/pkg/cmd/dev/testdata/recorderdriven/dev-build
@@ -4,7 +4,7 @@ bazel query pkg/roachpb:roachpb_test --output=label_kind
 bazel build //pkg/roachpb:roachpb_test --config=test --build_event_binary_file=/tmp/path
 bazel info workspace --color=no
 mkdir crdb-checkout/bin
-bazel info bazel-bin --color=no
+bazel info bazel-bin --color=no --config=test
 
 # TODO(irfansharif): This test case is skipped -- it's too verbose given it
 # scans through the sandbox for each generated file and copies them over

--- a/pkg/cmd/dev/testdata/recorderdriven/dev-build.rec
+++ b/pkg/cmd/dev/testdata/recorderdriven/dev-build.rec
@@ -8,3 +8,6 @@ bazel build //pkg/roachpb:roachpb_test --config=test --build_event_binary_file=/
 mkdir crdb-checkout/bin
 ----
 
+bazel info bazel-bin --color=no --config=test
+----
+/path/to/bazel/bin

--- a/pkg/cmd/dev/ui.go
+++ b/pkg/cmd/dev/ui.go
@@ -675,7 +675,7 @@ func makeUICleanCmd(d *dev) *cobra.Command {
 //
 // See https://github.com/bazelbuild/rules_nodejs/issues/2028
 func arrangeFilesForWatchers(d *dev, ossOnly bool) error {
-	bazelBin, err := d.getBazelBin(d.cli.Context())
+	bazelBin, err := d.getBazelBin(d.cli.Context(), []string{})
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -102,7 +102,7 @@ func mustGetFlagDuration(cmd *cobra.Command, name string) time.Duration {
 	return val
 }
 
-func (d *dev) getBazelInfo(ctx context.Context, key string) (string, error) {
+func (d *dev) getBazelInfo(ctx context.Context, key string, extraArgs []string) (string, error) {
 	args := []string{"info", key, "--color=no"}
 	out, err := d.exec.CommandContextSilent(ctx, "bazel", args...)
 	if err != nil {
@@ -117,15 +117,17 @@ func (d *dev) getWorkspace(ctx context.Context) (string, error) {
 		return os.Getwd()
 	}
 
-	return d.getBazelInfo(ctx, "workspace")
+	return d.getBazelInfo(ctx, "workspace", []string{})
 }
 
-func (d *dev) getBazelBin(ctx context.Context) (string, error) {
-	return d.getBazelInfo(ctx, "bazel-bin")
+// The second argument should be the relevant "config args", namely Bazel arguments
+// that are --config or --compilation_mode arguments (see getConfigArgs()).
+func (d *dev) getBazelBin(ctx context.Context, configArgs []string) (string, error) {
+	return d.getBazelInfo(ctx, "bazel-bin", configArgs)
 }
 
 func (d *dev) getExecutionRoot(ctx context.Context) (string, error) {
-	return d.getBazelInfo(ctx, "execution_root")
+	return d.getBazelInfo(ctx, "execution_root", []string{})
 }
 
 // getDevBin returns the path to the running dev executable.

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -104,6 +104,7 @@ func mustGetFlagDuration(cmd *cobra.Command, name string) time.Duration {
 
 func (d *dev) getBazelInfo(ctx context.Context, key string, extraArgs []string) (string, error) {
 	args := []string{"info", key, "--color=no"}
+	args = append(args, extraArgs...)
 	out, err := d.exec.CommandContextSilent(ctx, "bazel", args...)
 	if err != nil {
 		return "", err
@@ -126,8 +127,8 @@ func (d *dev) getBazelBin(ctx context.Context, configArgs []string) (string, err
 	return d.getBazelInfo(ctx, "bazel-bin", configArgs)
 }
 
-func (d *dev) getExecutionRoot(ctx context.Context) (string, error) {
-	return d.getBazelInfo(ctx, "execution_root", []string{})
+func (d *dev) getExecutionRoot(ctx context.Context, configArgs []string) (string, error) {
+	return d.getBazelInfo(ctx, "execution_root", configArgs)
 }
 
 // getDevBin returns the path to the running dev executable.


### PR DESCRIPTION
Backport:
  * 1/1 commits from "bazel,dev: in `dev`, handle different `--compilation_mode`s correctly..." (#106944)
  * 1/1 commits from "dev: fix staging behavior from non-default configurations" (#123241)

Please see individual PRs for details.

/cc @cockroachdb/release

Release note: None
Epic: None
Release justification: Non-production code changes
