### PR TITLE
kvserver: misc rac2 logging and fixes

### DIFF
--- a/pkg/kv/kvserver/kvadmission/kvadmission.go
+++ b/pkg/kv/kvserver/kvadmission/kvadmission.go
@@ -353,6 +353,9 @@ func (n *controllerImpl) AdmitKVWork(
 				// and the point of deduction. That's ok, there's no strong
 				// synchronization needed between these two points.
 				ah.raftAdmissionMeta = &kvflowcontrolpb.RaftAdmissionMeta{
+					// TODO(sumeerbhola,kvoli): The priority needs to be converted to a
+					// raftpb.Priority when v2 encoding is enabled. e.g.,
+					// rac2.AdmissionToRaftPriority().
 					AdmissionPriority:   int32(admissionInfo.Priority),
 					AdmissionCreateTime: admissionInfo.CreateTime,
 					AdmissionOriginNode: n.nodeID.Get(),

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/log_tracker.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/log_tracker.go
@@ -51,6 +51,24 @@ func (av AdmittedVector) Merge(other AdmittedVector) AdmittedVector {
 	return av
 }
 
+func (av AdmittedVector) String() string {
+	return redact.StringWithoutMarkers(av)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (av AdmittedVector) SafeFormat(w redact.SafePrinter, _ rune) {
+	var buf redact.StringBuilder
+	buf.Printf("term:%d, admitted:[", av.Term)
+	for pri, index := range av.Admitted {
+		if pri > 0 {
+			buf.Printf(",")
+		}
+		buf.Printf("%s:%d", raftpb.Priority(pri), index)
+	}
+	buf.Printf("]")
+	w.Printf("%v", buf)
+}
+
 // LogTracker tracks the durable and logically admitted state of a raft log.
 //
 // Writes to a raft log are ordered by LogMark (term, index) where term is the

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream.go
@@ -61,7 +61,7 @@ func (p *StreamTokenCounterProvider) Eval(stream kvflowcontrol.Stream) *tokenCou
 		return t
 	}
 	t, _ := p.evalCounters.LoadOrStore(stream, newTokenCounter(
-		p.settings, p.clock, p.tokenMetrics.CounterMetrics[flowControlEvalMetricType]))
+		p.settings, p.clock, p.tokenMetrics.CounterMetrics[flowControlEvalMetricType], stream))
 	return t
 }
 
@@ -71,7 +71,7 @@ func (p *StreamTokenCounterProvider) Send(stream kvflowcontrol.Stream) *tokenCou
 		return t
 	}
 	t, _ := p.sendCounters.LoadOrStore(stream, newTokenCounter(
-		p.settings, p.clock, p.tokenMetrics.CounterMetrics[flowControlSendMetricType]))
+		p.settings, p.clock, p.tokenMetrics.CounterMetrics[flowControlSendMetricType], stream))
 	return t
 }
 

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter_test.go
@@ -203,6 +203,7 @@ func TestTokenCounter(t *testing.T) {
 		settings,
 		hlc.NewClockForTesting(nil),
 		newTokenCounterMetrics(flowControlEvalMetricType),
+		kvflowcontrol.Stream{},
 	)
 
 	assertStateReset := func(t *testing.T) {
@@ -378,6 +379,7 @@ func (ts *evalTestState) getOrCreateTC(stream string) *namedTokenCounter {
 				ts.settings,
 				hlc.NewClockForTesting(nil),
 				newTokenCounterMetrics(flowControlEvalMetricType),
+				kvflowcontrol.Stream{},
 			),
 			stream: stream,
 		}

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker.go
@@ -72,6 +72,10 @@ func (t *Tracker) Track(
 		term:   term,
 	})
 
+	if log.V(1) {
+		log.Infof(ctx, "tracking %v flow control tokens for pri=%s stream=%s log-position=%d/%d",
+			tokens, pri, t.stream, term, index)
+	}
 	return true
 }
 

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
@@ -407,7 +407,7 @@ HandleRaftReady:
  RaftNode.TermLocked() = 52
  Replica.MuUnlock
  RangeControllerFactory.New(replicaSet=[(n1,s2):5,(n11,s11):11], leaseholder=10, nextRaftIndex=28)
- RangeController.AdmitRaftMuLocked(5, {Term:52 Admitted:[26 26 26 26]})
+ RangeController.AdmitRaftMuLocked(5, term:52, admitted:[LowPri:26,NormalPri:26,AboveNormalPri:26,HighPri:26])
  RangeController.HandleRaftEventRaftMuLocked([28])
 .....
 AdmitRaftEntries:
@@ -496,7 +496,7 @@ HandleRaftReady:
  Replica.LeaseholderMuLocked
  RaftNode.TermLocked() = 52
  Replica.MuUnlock
- RangeController.AdmitRaftMuLocked(5, {Term:52 Admitted:[28 28 28 28]})
+ RangeController.AdmitRaftMuLocked(5, term:52, admitted:[LowPri:28,NormalPri:28,AboveNormalPri:28,HighPri:28])
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
 
@@ -512,7 +512,7 @@ enqueue-piggybacked-admitted from=25 to=5 term=52 index=25 pri=2
 process-piggybacked-admitted
 ----
  Replica.RaftMuAssertHeld
- RangeController.AdmitRaftMuLocked(25, {Term:52 Admitted:[24 0 25 0]})
+ RangeController.AdmitRaftMuLocked(25, term:52, admitted:[LowPri:24,NormalPri:0,AboveNormalPri:25,HighPri:0])
 
 # Noop.
 process-piggybacked-admitted
@@ -746,7 +746,7 @@ HandleRaftReady:
  Replica.LeaseholderMuLocked
  RaftNode.TermLocked() = 50
  Replica.MuUnlock
- RangeController.AdmitRaftMuLocked(5, {Term:50 Admitted:[26 26 26 26]})
+ RangeController.AdmitRaftMuLocked(5, term:50, admitted:[LowPri:26,NormalPri:26,AboveNormalPri:26,HighPri:26])
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
 
@@ -786,7 +786,7 @@ HandleRaftReady:
  Replica.LeaseholderMuLocked
  RaftNode.TermLocked() = 50
  Replica.MuUnlock
- RangeController.AdmitRaftMuLocked(5, {Term:50 Admitted:[27 27 27 27]})
+ RangeController.AdmitRaftMuLocked(5, term:50, admitted:[LowPri:27,NormalPri:27,AboveNormalPri:27,HighPri:27])
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
 

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -235,6 +235,7 @@ func newUninitializedReplicaWithoutRaftGroup(
 		RaftScheduler:          r.store.scheduler,
 		AdmittedPiggybacker:    r.store.cfg.KVFlowAdmittedPiggybacker,
 		ACWorkQueue:            r.store.cfg.KVAdmissionController,
+		Settings:               r.store.cfg.Settings,
 		EvalWaitMetrics:        r.store.cfg.KVFlowEvalWaitMetrics,
 		RangeControllerFactory: r.store.kvflowRangeControllerFactory,
 		EnabledWhenLeaderLevel: r.raftMu.flowControlLevel,


### PR DESCRIPTION
Logging and fixes picked up along the way to get v1 compatibility integration testing working for #130187.

---

rac2: introduce misc verbose logging

Previously, there was limited within the range controller and
sub-components. Introduce several V(Event|Info) logging statements:

```
rac2/range_controller.go:260  [T1,Vsystem,n1,s1,r70/1:/{Table/Max-Max},raft] r70 creating range controller
rac2/range_controller.go:376  [T1,Vsystem,n1] r70/1 admitted request (pri=normal-pri wait-duration=709ns wait-for-all=false)
rac2/range_controller.go:458  [T1,Vsystem,n1,s1,r70/1:/{Table/Max-Max},raft] r70 closing range controller
rac2/range_controller.go:646  [T1,Vsystem,n1,s1,r70/1:/{Table/Max-Max},raft] r70:(n1,s1):1 stream t1/s1 admit term:6, admitted:[LowPri:10,NormalPri:10,AboveNormalPri:10,HighPri:10]
rac2/range_controller.go:655  [T1,Vsystem,n1,s1,r70/1:/{Table/Max-Max},raft] creating send stream t1/s1 for replica (n1,s1):1
rac2/range_controller.go:772  [T1,Vsystem,n1,s1,r70/1:/{Table/Max-Max},raft] closing send stream t1/s1 for replica (n1,s1):1
rac2/token_counter.go:491     [T1,Vsystem,n1,s1,r70/1:/{Table/Max-Max},raft] adjusted flow tokens (wc=regular stream=t1/s1 delta=-1.0 MiB): regular=+15 MiB elastic=+7.0 MiB
rac2/token_tracker.go:76      [T1,Vsystem,n1,s1,r70/1:/{Table/Max-Max},raft] tracking +1.0 MiB flow control tokens for pri=NormalPri stream=t1/s2 log-position=6/22
````

Part of: https://github.com/cockroachdb/cockroach/issues/130187
Release note: None

---
replica_rac2: vlog when decoding raft admission meta

V(1) log the raft admission meta information when decoding an entry
below raft, as part of `AdmitRaftEntriesRaftMuLocked`.

Part of: https://github.com/cockroachdb/cockroach/issues/130187
Release note: None

---

kvserver: fix rac v2 replication handle lookup

When calling `LookupReplicationAdmissionHandle`, `storesForFlowControl`
would previously then call `Lookup`, which could only return a v1 replication
admission control handle.

Iterate over the stores calling the same method instead.

Part of: https://github.com/cockroachdb/cockroach/issues/130187
Release note: None

---

kvserver: pass settings when constructing rac2 processor

To avoid a nil ptr deref when using them in
`replica_rac2.processorImpl`.

Part of: https://github.com/cockroachdb/cockroach/issues/130187
Release note: None

---

kvadmission: add todo to handle raft admission meta prio

Part of: cockroachdb#130187
Release note: None
