### PR TITLE
sql: reduce allocations related to aggregate functions

### DIFF
--- a/pkg/sql/colexec/colexecagg/aggregate_funcs.go
+++ b/pkg/sql/colexec/colexecagg/aggregate_funcs.go
@@ -604,9 +604,10 @@ func ProcessAggregations(
 	constructors = make([]execagg.AggregateConstructor, len(aggregations))
 	constArguments = make([]tree.Datums, len(aggregations))
 	outputTypes = make([]*types.T, len(aggregations))
+	pAlloc := execagg.MakeParamTypesAllocator(aggregations)
 	for i, aggFn := range aggregations {
 		constructors[i], constArguments[i], outputTypes[i], err = execagg.GetAggregateConstructor(
-			ctx, evalCtx, semaCtx, &aggFn, inputTypes,
+			ctx, evalCtx, semaCtx, &aggFn, inputTypes, &pAlloc,
 		)
 		if err != nil {
 			return

--- a/pkg/sql/execinfra/execagg/base.go
+++ b/pkg/sql/execinfra/execagg/base.go
@@ -32,27 +32,27 @@ type AggregateConstructor func(*eval.Context, tree.Datums) eval.AggregateFunc
 //
 // inputTypes cannot be mutated if aggregateConstructor will be used.
 func getAggregateInfo(
-	fn execinfrapb.AggregatorSpec_Func, inputTypes []*types.T,
+	fn execinfrapb.AggregatorSpec_Func, paramTypes []*types.T,
 ) (aggregateConstructor AggregateConstructor, returnType *types.T, err error) {
 	if fn == execinfrapb.AnyNotNull {
 		// The ANY_NOT_NULL builtin does not have a fixed return type;
 		// handle it separately.
-		if len(inputTypes) != 1 {
+		if len(paramTypes) != 1 {
 			return nil, nil, errors.Errorf("any_not_null aggregate needs 1 input")
 		}
-		return builtins.NewAnyNotNullAggregate, inputTypes[0], nil
+		return builtins.NewAnyNotNullAggregate, paramTypes[0], nil
 	}
 
 	_, builtins := builtinsregistry.GetBuiltinProperties(strings.ToLower(fn.String()))
 	for _, b := range builtins {
 		typs := b.Types.Types()
-		if len(typs) != len(inputTypes) {
+		if len(typs) != len(paramTypes) {
 			continue
 		}
 		match := true
 		for i, t := range typs {
-			if !inputTypes[i].Equivalent(t) {
-				if b.CalledOnNullInput && inputTypes[i].IsAmbiguous() {
+			if !paramTypes[i].Equivalent(t) {
+				if b.CalledOnNullInput && paramTypes[i].IsAmbiguous() {
 					continue
 				}
 				match = false
@@ -62,14 +62,14 @@ func getAggregateInfo(
 		if match {
 			// Found!
 			constructAgg := func(evalCtx *eval.Context, arguments tree.Datums) eval.AggregateFunc {
-				return b.AggregateFunc.(eval.AggregateOverload)(inputTypes, evalCtx, arguments)
+				return b.AggregateFunc.(eval.AggregateOverload)(paramTypes, evalCtx, arguments)
 			}
-			colTyp := b.InferReturnTypeFromInputArgTypes(inputTypes)
+			colTyp := b.InferReturnTypeFromInputArgTypes(paramTypes)
 			return constructAgg, colTyp, nil
 		}
 	}
 	return nil, nil, errors.Errorf(
-		"no builtin aggregate for %s on %+v", fn, inputTypes,
+		"no builtin aggregate for %s on %+v", fn, paramTypes,
 	)
 }
 
@@ -83,14 +83,18 @@ func GetAggregateConstructor(
 	semaCtx *tree.SemaContext,
 	aggInfo *execinfrapb.AggregatorSpec_Aggregation,
 	inputTypes []*types.T,
+	pAlloc *ParamTypesAllocator,
 ) (constructor AggregateConstructor, arguments tree.Datums, outputType *types.T, err error) {
-	argTypes := make([]*types.T, len(aggInfo.ColIdx)+len(aggInfo.Arguments))
+	paramTypes, err := pAlloc.alloc(len(aggInfo.ColIdx) + len(aggInfo.Arguments))
+	if err != nil {
+		return nil, nil, nil, err
+	}
 	for j, c := range aggInfo.ColIdx {
 		if c >= uint32(len(inputTypes)) {
 			err = errors.Errorf("ColIdx out of range (%d)", aggInfo.ColIdx)
 			return
 		}
-		argTypes[j] = inputTypes[c]
+		paramTypes[j] = inputTypes[c]
 	}
 	arguments = make(tree.Datums, len(aggInfo.Arguments))
 	var d tree.Datum
@@ -106,11 +110,44 @@ func GetAggregateConstructor(
 			err = errors.Wrapf(err, "%s", argument)
 			return
 		}
-		argTypes[len(aggInfo.ColIdx)+j] = d.ResolvedType()
+		paramTypes[len(aggInfo.ColIdx)+j] = d.ResolvedType()
 		arguments[j] = d
 	}
-	constructor, outputType, err = getAggregateInfo(aggInfo.Func, argTypes)
+	constructor, outputType, err = getAggregateInfo(aggInfo.Func, paramTypes)
 	return
+}
+
+// ParamTypesAllocator is a helper struct for batching allocations of aggregate
+// function parameter types.
+type ParamTypesAllocator struct {
+	typs []*types.T
+}
+
+// MakeParamTypesAllocator creates a new ParamTypesAllocator with enough space
+// to allocate slices of parameter types for all the given aggregate functions.
+func MakeParamTypesAllocator(
+	aggregations []execinfrapb.AggregatorSpec_Aggregation,
+) ParamTypesAllocator {
+	numParamTypes := 0
+	for _, aggFn := range aggregations {
+		numParamTypes += len(aggFn.ColIdx)
+		numParamTypes += len(aggFn.Arguments)
+	}
+	return ParamTypesAllocator{
+		typs: make([]*types.T, numParamTypes),
+	}
+}
+
+// alloc returns a slice of types.T of length n. It returns a slice of the
+// allocator's type slice and returns an error if the allocator's type slice is
+// not long enough.
+func (p *ParamTypesAllocator) alloc(n int) (_ []*types.T, err error) {
+	if len(p.typs) < n {
+		return nil, errors.AssertionFailedf("not enough types; requested %d, have %d", n, len(p.typs))
+	}
+	res := p.typs[:n:n]
+	p.typs = p.typs[n:]
+	return res, nil
 }
 
 // GetAggregateOutputType returns the output type for the given aggregate
@@ -118,9 +155,9 @@ func GetAggregateConstructor(
 //
 // inputTypes argument can be mutated by the caller.
 func GetAggregateOutputType(
-	fn execinfrapb.AggregatorSpec_Func, inputTypes []*types.T,
+	fn execinfrapb.AggregatorSpec_Func, paramTypes []*types.T,
 ) (outputType *types.T, err error) {
-	_, outputType, err = getAggregateInfo(fn, inputTypes)
+	_, outputType, err = getAggregateInfo(fn, paramTypes)
 	return outputType, err
 }
 

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -678,6 +678,11 @@ var queries = [...]benchQuery{
 		args:    []interface{}{},
 		cleanup: "TRUNCATE TABLE customer",
 	},
+	{
+		name:  "const-agg",
+		query: `SELECT * FROM k GROUP BY id HAVING sum(a) > 100`,
+		args:  []interface{}{},
+	},
 }
 
 func init() {

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -125,6 +125,7 @@ func (ag *aggregatorBase) init(
 	// the functions which need to be fed values.
 	ag.inputTypes = input.OutputTypes()
 	semaCtx := flowCtx.NewSemaContext(flowCtx.Txn)
+	pAlloc := execagg.MakeParamTypesAllocator(spec.Aggregations)
 	for i, aggInfo := range spec.Aggregations {
 		if aggInfo.FilterColIdx != nil {
 			col := *aggInfo.FilterColIdx
@@ -139,7 +140,7 @@ func (ag *aggregatorBase) init(
 			}
 		}
 		constructor, arguments, outputType, err := execagg.GetAggregateConstructor(
-			ctx, ag.evalCtx, semaCtx, &aggInfo, ag.inputTypes,
+			ctx, ag.evalCtx, semaCtx, &aggInfo, ag.inputTypes, &pAlloc,
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
#### opt: add vectorize on/off modes for end-to-end benchmarks

Release note: None

#### opt: add benchmark case for query with const-aggs

Release note: None

#### sql/rowexec: reduce allocations of `aggregateFuncHolder`

Prior to this commit, the row-by-row engine would perform an allocation
of an `aggregateFuncHolder` for every aggregate function in a query
plan. This was expensive for queries with many aggregate functions.

Release note (performance improvement): The initialization of the
execution engine for a query is now more efficient when the query plan
contains aggregate functions.

#### sql/execagg: reduce allocations of parameter type slices

The `execagg.ParamTypesAllocator` has been added which helps batch
allocations of aggregate function parameter types when setting up
row-by-row and vectorized execution.

Epic: None

Release note (performance improvement): The initialization of the
execution engine for a query is now more efficient when the query plan
contains aggregate functions.
