### PR TITLE
parser: fix formatting of ALTER PARTITION .. OF INDEX t@*

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2686,8 +2686,8 @@ alter_zone_partition_stmt:
     s.ZoneSpecifier = tree.ZoneSpecifier{
        TableOrIndex: tree.TableIndexName{Table: name},
        Partition: tree.Name($3),
+       StarIndex: true,
     }
-    s.AllIndexes = true
     $$.val = s
   }
 | ALTER PARTITION partition_name OF TABLE table_name '@' error

--- a/pkg/sql/parser/testdata/alter_index
+++ b/pkg/sql/parser/testdata/alter_index
@@ -223,6 +223,14 @@ EXPLAIN ALTER PARTITION p OF INDEX db.t@idx CONFIGURE ZONE = '_' -- literals rem
 EXPLAIN ALTER PARTITION _ OF INDEX _._@_ CONFIGURE ZONE = 'foo' -- identifiers removed
 
 parse
+ALTER PARTITION p1 OF INDEX foobar@* CONFIGURE ZONE USING num_replicas = 1;
+----
+ALTER PARTITION p1 OF INDEX foobar@* CONFIGURE ZONE USING num_replicas = 1 -- normalized!
+ALTER PARTITION p1 OF INDEX foobar@* CONFIGURE ZONE USING num_replicas = (1) -- fully parenthesized
+ALTER PARTITION p1 OF INDEX foobar@* CONFIGURE ZONE USING num_replicas = _ -- literals removed
+ALTER PARTITION _ OF INDEX _@* CONFIGURE ZONE USING _ = 1 -- identifiers removed
+
+parse
 ALTER INDEX db.t@i CONFIGURE ZONE USING foo = bar, baz = yay
 ----
 ALTER INDEX db.t@i CONFIGURE ZONE USING foo = bar, baz = yay

--- a/pkg/sql/sem/tree/zone.go
+++ b/pkg/sql/sem/tree/zone.go
@@ -21,6 +21,11 @@ type ZoneSpecifier struct {
 
 	// Partition is only respected when Table is set.
 	Partition Name
+
+	// StarIndex is true if the special `table@*` specifier is used. It indicates
+	// that the zone configuration should be applied across all of a table's
+	// indexes. (e.g., ALTER PARTITION ... OF INDEX <tablename>@*)
+	StarIndex bool
 }
 
 // TelemetryName returns a name fitting for telemetry purposes.
@@ -51,7 +56,7 @@ func (node ZoneSpecifier) TargetsTable() bool {
 
 // TargetsIndex returns whether the zone specifier targets an index.
 func (node ZoneSpecifier) TargetsIndex() bool {
-	return node.TargetsTable() && node.TableOrIndex.Index != ""
+	return node.TargetsTable() && (node.TableOrIndex.Index != "" || node.StarIndex)
 }
 
 // TargetsPartition returns whether the zone specifier targets a partition.
@@ -79,6 +84,9 @@ func (node *ZoneSpecifier) Format(ctx *FmtCtx) {
 			ctx.WriteString("TABLE ")
 		}
 		ctx.FormatNode(&node.TableOrIndex)
+		if node.StarIndex {
+			ctx.WriteString("@*")
+		}
 	}
 }
 
@@ -104,9 +112,6 @@ func (node *ShowZoneConfig) Format(ctx *FmtCtx) {
 // statement.
 type SetZoneConfig struct {
 	ZoneSpecifier
-	// AllIndexes indicates that the zone configuration should be applied across
-	// all of a tables indexes. (ALTER PARTITION ... OF INDEX <tablename>@*)
-	AllIndexes bool
 	ZoneConfigSettings
 }
 

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -165,7 +165,7 @@ func (p *planner) SetZoneConfig(ctx context.Context, n *tree.SetZoneConfig) (pla
 	return &setZoneConfigNode{
 		stmt:          n,
 		zoneSpecifier: n.ZoneSpecifier,
-		allIndexes:    n.AllIndexes,
+		allIndexes:    n.ZoneSpecifier.StarIndex,
 		yamlConfig:    yamlConfig,
 		options:       options,
 		setDefault:    n.SetDefault,


### PR DESCRIPTION
This statement was not being formatted correctly. Fixing it required tracking more state in the ZoneSpecifier AST node.

Epic: CRDB-41753
Release note: None