### PR TITLE
server, util: fix failing TestServerController

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1135,7 +1135,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		node.storeCfg.KVFlowController,
 		node.storeCfg.KVFlowStreamTokenProvider,
 	)
-	cfg.CidrLookup.Start(ctx, stopper)
+	if err = cfg.CidrLookup.Start(ctx, stopper); err != nil {
+		return nil, err
+	}
 
 	// Instantiate the SQL server proper.
 	sqlServer, err := newSQLServer(ctx, sqlServerArgs{

--- a/pkg/server/server_controller_channel_orchestrator.go
+++ b/pkg/server/server_controller_channel_orchestrator.go
@@ -185,7 +185,7 @@ func (o *channelOrchestrator) startControlledServer(
 	// the server. Suggested use is for logging. To synchronize on the
 	// server's state, use the resulting serverState instead.
 	startErrorFn func(ctx context.Context, tenantName roachpb.TenantName, err error),
-	// serverStartedFn is called when the server has started
+	// startCompleteFn is called when the server has started
 	// successfully and is accepting clients. Suggested use is for
 	// logging. To synchronize on the server's state, use the
 	// resulting serverState instead.

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -425,7 +425,9 @@ func newTenantServer(
 	// tenant separation model. For a small number of tenants this is OK, but if
 	// we have a large number of tenants in shared process mode this could be a
 	// problem from a memory and network perspective.
-	baseCfg.CidrLookup.Start(ctx, stopper)
+	if err = baseCfg.CidrLookup.Start(ctx, stopper); err != nil {
+		return nil, err
+	}
 
 	// Instantiate the SQL server proper.
 	sqlServer, err := newSQLServer(ctx, args)

--- a/pkg/util/cidr/cidr.go
+++ b/pkg/util/cidr/cidr.go
@@ -113,7 +113,7 @@ func NewTestLookup() *Lookup {
 }
 
 // Start refreshes the lookup once and begins the CIDR lookup refresh task.
-func (c *Lookup) Start(ctx context.Context, stopper *stop.Stopper) (bool, *Lookup) {
+func (c *Lookup) Start(ctx context.Context, stopper *stop.Stopper) error {
 	getTickDuration := func() time.Duration {
 		tickDuration := cidrRefreshInterval.Get(c.st)
 		// If the tickDuration is 0, set to a year to avoid auto refreshing.
@@ -139,9 +139,10 @@ func (c *Lookup) Start(ctx context.Context, stopper *stop.Stopper) (bool, *Looku
 			}
 		}
 	}); err != nil {
-		log.Fatalf(ctx, "unable to start CIDR lookup refresh task: %v", err)
+		log.Errorf(ctx, "unable to start CIDR lookup refresh task: %v", err)
+		return err
 	}
-	return false, nil
+	return nil
 }
 
 // hexString returns a hex string representation of an IP address. The length of

--- a/pkg/util/cidr/cidr_test.go
+++ b/pkg/util/cidr/cidr_test.go
@@ -106,7 +106,7 @@ func TestInvalidCIDR(t *testing.T) {
 func TestEmptyLookup(t *testing.T) {
 	settings := cluster.MakeClusterSettings()
 	c := NewLookup(&settings.SV)
-	c.Start(context.Background(), stop.NewStopper())
+	require.NoError(t, c.Start(context.Background(), stop.NewStopper()))
 	c.LookupIP(net.ParseIP("127.0.0.1"))
 }
 
@@ -144,7 +144,7 @@ func TestRefresh(t *testing.T) {
 
 	st := cluster.MakeClusterSettings()
 	c := NewLookup(&st.SV)
-	c.Start(context.Background(), stopper)
+	require.NoError(t, c.Start(context.Background(), stopper))
 	// We haven't set the URL yet, so it should return an empty string.
 	require.Equal(t, "", c.LookupIP(net.ParseIP("127.0.0.1")))
 


### PR DESCRIPTION
The `TestServerController` test server stops quickly (due to deferred stop) after executing `CREATE TENANT hello` while the creation of the tenant is ongoing in `newTenantServer`. This causes `baseCfg.CidrLookup.Start` in `newTenantServer` to fail with `ErrUnavailable` because `s.runPrelude()` in `stopper.RunAsyncTask` returns true if a server is stopping: https://github.com/cockroachdb/cockroach/blob/3bf34dc3a192d7efeee8aa97e46bf73f817b2b9b/pkg/util/stop/stopper.go#L469-L471.

Fixes: #130757
Epic: CRDB-42208
Release note: None