### PR TITLE
logstore: fix bug in getting LogMark from message

### DIFF
--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -109,6 +109,13 @@ func (m MsgStorageAppendDone) Mark() raft.LogMark {
 	// one in the list.
 	// TODO(pav-kv): this is an undocumented API quirk. Refactor the raft write
 	// API to be more digestible outside the package.
+	if buildutil.CrdbTestBuild {
+		for _, msg := range m[:len(m)-1] {
+			if msg.Type == raftpb.MsgStorageAppendResp {
+				panic("unexpected MsgStorageAppendResp not in last position")
+			}
+		}
+	}
 	if msg := m[len(m)-1]; msg.Type != raftpb.MsgStorageAppendResp {
 		return raft.LogMark{}
 	} else if msg.Index != 0 {

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -109,11 +109,9 @@ func (m MsgStorageAppendDone) Mark() raft.LogMark {
 	// one in the list.
 	// TODO(pav-kv): this is an undocumented API quirk. Refactor the raft write
 	// API to be more digestible outside the package.
-	msg := m[len(m)-1]
-	if msg.Type != raftpb.MsgStorageAppendResp {
+	if msg := m[len(m)-1]; msg.Type != raftpb.MsgStorageAppendResp {
 		return raft.LogMark{}
-	}
-	if len(msg.Entries) != 0 {
+	} else if msg.Index != 0 {
 		return raft.LogMark{Term: msg.LogTerm, Index: msg.Index}
 	} else if msg.Snapshot != nil {
 		return raft.LogMark{Term: msg.LogTerm, Index: msg.Snapshot.Metadata.Index}


### PR DESCRIPTION
The `Entries` field is not used in `MsgStorageAppendResp`. Instead, a non-zero `Index` field indicates that there has been at least one entry in the corresponding `MsgStorageAppend` message.

Related to #129508