### PR TITLE
roachprod: use NVMe when provisioning clusters on Azure.

### DIFF
--- a/pkg/cmd/roachtest/spec/machine_type.go
+++ b/pkg/cmd/roachtest/spec/machine_type.go
@@ -214,6 +214,7 @@ func SelectGCEMachineType(cpus int, mem MemPerCPU, arch vm.CPUArch) (string, vm.
 // N.B. cpus is expected to be an even number; validation is deferred to a specific cloud provider.
 //
 // See ExampleSelectAzureMachineType for an exhaustive list of selected machine types.
+// TODO: Add Ebsv5 machine type to leverage NVMe
 func SelectAzureMachineType(cpus int, mem MemPerCPU, arch vm.CPUArch) (string, vm.CPUArch, error) {
 	series := "Ddsv5" // 4 GB RAM per CPU
 	selectedArch := vm.ArchAMD64


### PR DESCRIPTION
 Currently, when provisioning clusters on Azure, we interface with the
 data disk via SCSI (the default). For improved performance and
 uniformity with other clouds use NVMe.

 Azure support DiskControllerType NVMe for `E Series v5` VM family.
 OS disk and network disks are interfaced with NVMe.
 Local storage are interfaced via SCSI, NVMe is not supported for
 local disk.

 Changes as part of this PR:
  - For `E Series v5` VM family enabled NVMe.

Epic: none
Fixes: #129009

Release note: None