### PR TITLE
release-24.1.5-rc: server/license: fix race in concurrent test-server startup

### DIFF
--- a/pkg/server/license/BUILD.bazel
+++ b/pkg/server/license/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/keys",
         "//pkg/sql/isql",
         "//pkg/util/log",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
     ],
 )

--- a/pkg/server/license/enforcer_test.go
+++ b/pkg/server/license/enforcer_test.go
@@ -51,10 +51,10 @@ func TestGracePeriodInitTSCache(t *testing.T) {
 	// timestamp that was already setup.
 	enforcer := &license.Enforcer{}
 	ts2 := ts1.Add(1)
-	enforcer.TestingKnobs = &license.TestingKnobs{
+	enforcer.SetTestingKnobs(&license.TestingKnobs{
 		EnableGracePeriodInitTSWrite: true,
 		OverrideStartTime:            &ts2,
-	}
+	})
 	// Ensure request for the grace period init ts1 before start just returns the start
 	// time used when the enforcer was created.
 	require.Equal(t, ts2, enforcer.GetGracePeriodInitTS())

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1852,7 +1852,7 @@ func (s *SQLServer) startLicenseEnforcer(ctx context.Context, knobs base.Testing
 	// is shared to provide access to the values cached from the KV read.
 	if s.execCfg.Codec.ForSystemTenant() {
 		if knobs.Server != nil {
-			s.execCfg.LicenseEnforcer.TestingKnobs = &knobs.Server.(*TestingKnobs).LicenseTestingKnobs
+			s.execCfg.LicenseEnforcer.SetTestingKnobs(&knobs.Server.(*TestingKnobs).LicenseTestingKnobs)
 		}
 		err := startup.RunIdempotentWithRetry(ctx, s.stopper.ShouldQuiesce(), "license enforcer start",
 			func(ctx context.Context) error {


### PR DESCRIPTION
Backport 1/1 commits from #130313.

/cc @cockroachdb/release

---

The ccl/crosscluster package has tests that start multiple test servers in parallel. On older release branches this is failing with a race condition because two different threads are writing to the testing hooks.

Release note: None
Epic: none
Release justification: This work is part of the CockroachDB core deprecation.

Closes: #130484 