### PR TITLE
ccl/sqlproxyccl: add proxy.sql.routing_method_count metric

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
         "//pkg/util/httputil",
         "//pkg/util/log",
         "//pkg/util/metric",
+        "//pkg/util/metric/aggmetric",
         "//pkg/util/netutil/addr",
         "//pkg/util/randutil",
         "//pkg/util/retry",

--- a/pkg/ccl/sqlproxyccl/metrics.go
+++ b/pkg/ccl/sqlproxyccl/metrics.go
@@ -11,6 +11,7 @@ package sqlproxyccl
 import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/metric/aggmetric"
 )
 
 // metrics contains pointers to the metrics for monitoring proxy operations.
@@ -45,6 +46,11 @@ type metrics struct {
 	QueryCancelSuccessful     *metric.Counter
 
 	AccessControlFileErrorCount *metric.Gauge
+
+	RoutingMethodCount              *aggmetric.AggCounter
+	SNIRoutingMethodCount           *aggmetric.Counter
+	DatabaseRoutingMethodCount      *aggmetric.Counter
+	ClusterOptionRoutingMethodCount *aggmetric.Counter
 }
 
 // MetricStruct implements the metrics.Struct interface.
@@ -212,18 +218,23 @@ var (
 		Measurement: "Query Cancel Requests",
 		Unit:        metric.Unit_COUNT,
 	}
-	accessControlFileErrorCount = metric.Metadata{
+	metaAccessControlFileErrorCount = metric.Metadata{
 		Name:        "proxy.access_control.errors",
 		Help:        "Numbers of access control list files that are currently having errors",
 		Measurement: "Access Control File Errors",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaRoutingMethodCount = metric.Metadata{
+		Name:        "proxy.sql.routing_method_count",
+		Help:        "Number of occurrences of each proxy routing method",
+		Measurement: "Number of occurrences",
 		Unit:        metric.Unit_COUNT,
 	}
 )
 
 // makeProxyMetrics instantiates the metrics holder for proxy monitoring.
 func makeProxyMetrics() metrics {
-
-	return metrics{
+	m := &metrics{
 		BackendDisconnectCount: metric.NewCounter(metaBackendDisconnectCount),
 		IdleDisconnectCount:    metric.NewCounter(metaIdleDisconnectCount),
 		BackendDownCount:       metric.NewCounter(metaBackendDownCount),
@@ -273,8 +284,14 @@ func makeProxyMetrics() metrics {
 		QueryCancelForwarded:      metric.NewCounter(metaQueryCancelForwarded),
 		QueryCancelSuccessful:     metric.NewCounter(metaQueryCancelSuccessful),
 
-		AccessControlFileErrorCount: metric.NewGauge(accessControlFileErrorCount),
+		AccessControlFileErrorCount: metric.NewGauge(metaAccessControlFileErrorCount),
+
+		RoutingMethodCount: aggmetric.NewCounter(metaRoutingMethodCount, "method"),
 	}
+	m.SNIRoutingMethodCount = m.RoutingMethodCount.AddChild("sni")
+	m.DatabaseRoutingMethodCount = m.RoutingMethodCount.AddChild("database")
+	m.ClusterOptionRoutingMethodCount = m.RoutingMethodCount.AddChild("cluster_option")
+	return *m
 }
 
 // updateForError updates the metrics relevant for the type of the error


### PR DESCRIPTION
Previously, it was not possible to determine the distribution of users
connecting to the proxy via SNI, database, or cluster option (via the options
parameter). This commit introduces a `proxy.sql.routing_method_count`
metric to record the number of occurrences of each proxy routing method. Only
successful parsing will be recorded; if a user provides invalid input, it will
not be tracked. This enhancement allows us to monitor and understand which
method was used by the proxy to retrieve the cluster identifier.

Epic: [CC-6926](https://cockroachlabs.atlassian.net/browse/CC-6926)

Release note: None