### PR TITLE
tree: fix walkStmt for SHOW EXPERIMENTAL_FINGERPRINTS

### DIFF
--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -1152,12 +1152,14 @@ func (n *ShowFingerprints) copyNode() *ShowFingerprints {
 // walkStmt is part of the walkableStmt interface.
 func (n *ShowFingerprints) walkStmt(v Visitor) Statement {
 	ret := n
-	ts, changed := walkTenantSpec(v, n.TenantSpec)
-	if changed {
-		if ret == n {
-			ret = n.copyNode()
+	if n.TenantSpec != nil {
+		ts, changed := walkTenantSpec(v, n.TenantSpec)
+		if changed {
+			if ret == n {
+				ret = n.copyNode()
+			}
+			ret.TenantSpec = ts
 		}
-		ret.TenantSpec = ts
 	}
 	if n.Options.StartTimestamp != nil {
 		e, changed := WalkExpr(v, n.Options.StartTimestamp)

--- a/pkg/testutils/sqlutils/pretty.go
+++ b/pkg/testutils/sqlutils/pretty.go
@@ -29,6 +29,15 @@ func VerifyStatementPrettyRoundtrip(t *testing.T, sql string) {
 	for i := range stmts {
 		origStmt := stmts[i].AST
 		verifyStatementPrettyRoundTrip(t, sql, origStmt, false /* plpgsql */)
+
+		// Verify that the AST can be walked.
+		if _, err := tree.SimpleStmtVisit(
+			origStmt,
+			func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) { return },
+		); err != nil {
+			t.Fatalf("cannot walk stmt %s %v", stmts[i].SQL, err)
+		}
+
 	}
 }
 


### PR DESCRIPTION
If SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE appeared in certain kinds of subqueries, the CRDB node could panic while walking the statement due to a missing nil check.

No release note since this only affected an experimental feature.

fixes https://github.com/cockroachdb/cockroach/issues/130822
Release note: None