### PR TITLE
tree: disallow creating partial index while table is used in LDR

### DIFF
--- a/pkg/sql/sem/tree/schema_helpers.go
+++ b/pkg/sql/sem/tree/schema_helpers.go
@@ -40,9 +40,9 @@ func IsSetOrResetSchemaLocked(n Statement) bool {
 func IsAllowedLDRSchemaChange(n Statement) bool {
 	switch s := n.(type) {
 	case *CreateIndex:
-		// Only allow non-unique indexes to be created. A unique index on a
-		// destination table could cause inserts to fail.
-		return !s.Unique
+		// Only allow non-unique and non-partial indexes to be created. A unique or
+		// partial index on a destination table could cause inserts to fail.
+		return !s.Unique && s.Predicate == nil
 	case *DropIndex:
 		return true
 	}

--- a/pkg/sql/sem/tree/schema_helpers_test.go
+++ b/pkg/sql/sem/tree/schema_helpers_test.go
@@ -36,6 +36,10 @@ func TestIsAllowedLDRSchemaChange(t *testing.T) {
 			isAllowed: false,
 		},
 		{
+			stmt:      "CREATE INDEX idx ON t (a) WHERE a > 10",
+			isAllowed: false,
+		},
+		{
 			stmt:      "DROP INDEX idx",
 			isAllowed: true,
 		},


### PR DESCRIPTION
Epic: CRDB-38974
Release note: None