### PR TITLE
sql: deflake TestValidationWithProtectedTS

### DIFF
--- a/pkg/sql/backfill_protected_timestamp_test.go
+++ b/pkg/sql/backfill_protected_timestamp_test.go
@@ -61,6 +61,9 @@ func TestValidationWithProtectedTS(t *testing.T) {
 			SQLEvalContext: &eval.TestingKnobs{
 				ForceProductionValues: true,
 			},
+			Store: &kvserver.StoreTestingKnobs{
+				DisableSplitQueue: true,
+			},
 			SQLExecutor: &sql.ExecutorTestingKnobs{
 				BeforeExecute: func(ctx context.Context, sql string, descriptors *descs.Collection) {
 					if indexScanQuery.MatchString(sql) {


### PR DESCRIPTION
This test does not work if ranges get split, so we disable the split queue.

fixes https://github.com/cockroachdb/cockroach/issues/130715
Release note: None