### PR TITLE
sqlproxyccl: static directory server lists pods when watch starts

### DIFF
--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -1894,6 +1894,10 @@ func TestPodWatcher(t *testing.T) {
 	opts.testingKnobs.balancerOpts = []balancer.Option{
 		balancer.NoRebalanceLoop(),
 		balancer.RebalanceRate(1.0),
+		// Set a rebalance delay of zero. Rebalance is triggered on startup because
+		// the watch enumerates three existing pods. The delay of zero allows
+		// addition of the fourth pod to trigger rebalancing.
+		balancer.RebalanceDelay(0),
 	}
 	proxy, addrs := newSecureProxyServer(ctx, t, s.Stopper(), opts)
 	connectionString := fmt.Sprintf("postgres://testuser:hunter2@%s/?sslmode=require&options=--cluster=tenant-cluster-%s", addrs.listenAddr, tenantID)

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/util/grpcutil",
         "//pkg/util/log",
+        "//pkg/util/protoutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",


### PR DESCRIPTION
Previously, the static directory server only emitted pods that were added after the server starts. This doesn't match the production behavior (or the documentation) that all existing pods are emitted by the watch on startup. The lack of the initial scan means some tests had stale directory caches.

Fixes: #129146