### PR TITLE
rac2: send-queue tracking in push mode

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
@@ -283,6 +283,7 @@ type testingRCRange struct {
 	// snapshots contain snapshots of the tracker state for different replicas,
 	// at various points in time. It is used in TestUsingSimulation.
 	snapshots []testingTrackerSnapshot
+	entries   []raftpb.Entry
 
 	mu struct {
 		syncutil.Mutex
@@ -559,6 +560,112 @@ func parsePriority(t *testing.T, input string) admissionpb.WorkPriority {
 	}
 }
 
+type testingEntryRange struct {
+	fromIndex, toIndex uint64
+}
+
+type testingRaftEvent struct {
+	rangeID           roachpb.RangeID
+	entries           []entryInfo
+	sendingEntryRange map[roachpb.ReplicaID]testingEntryRange
+}
+
+func parseRaftEvents(t *testing.T, input string) []testingRaftEvent {
+	var eventBuf []testingRaftEvent
+	n := 0
+	for _, line := range strings.Split(input, "\n") {
+		var (
+			rangeID, term, index              int
+			replicaID, fromIndex, toIndexExcl int
+			size                              int64
+			err                               error
+			pri                               admissionpb.WorkPriority
+		)
+
+		parts := strings.Fields(line)
+		parts[0] = strings.TrimSpace(parts[0])
+		switch {
+		case strings.HasPrefix(parts[0], "range_id="):
+			parts[0] = strings.TrimPrefix(strings.TrimSpace(parts[0]), "range_id=")
+			rangeID, err = strconv.Atoi(parts[0])
+			require.NoError(t, err)
+			eventBuf = append(eventBuf, testingRaftEvent{
+				rangeID: roachpb.RangeID(rangeID),
+			})
+			n++
+		case strings.HasPrefix(parts[0], "entries"):
+			// Skip the first line, which is the header.
+			eventBuf[n-1].entries = make([]entryInfo, 0)
+			continue
+		case strings.HasPrefix(parts[0], "term="):
+			require.True(t, strings.HasPrefix(parts[0], "term="))
+			parts[0] = strings.TrimPrefix(strings.TrimSpace(parts[0]), "term=")
+			term, err = strconv.Atoi(parts[0])
+			require.NoError(t, err)
+
+			parts[1] = strings.TrimSpace(parts[1])
+			require.True(t, strings.HasPrefix(parts[1], "index="))
+			parts[1] = strings.TrimPrefix(strings.TrimSpace(parts[1]), "index=")
+			index, err = strconv.Atoi(parts[1])
+			require.NoError(t, err)
+
+			parts[2] = strings.TrimSpace(parts[2])
+			require.True(t, strings.HasPrefix(parts[2], "pri="))
+			parts[2] = strings.TrimPrefix(strings.TrimSpace(parts[2]), "pri=")
+			pri = parsePriority(t, parts[2])
+
+			parts[3] = strings.TrimSpace(parts[3])
+			require.True(t, strings.HasPrefix(parts[3], "size="))
+			parts[3] = strings.TrimPrefix(strings.TrimSpace(parts[3]), "size=")
+			size, err = humanizeutil.ParseBytes(parts[3])
+			require.NoError(t, err)
+
+			eventBuf[n-1].entries = append(eventBuf[n-1].entries, entryInfo{
+				term:   uint64(term),
+				index:  uint64(index),
+				enc:    raftlog.EntryEncodingStandardWithACAndPriority,
+				tokens: kvflowcontrol.Tokens(size),
+				pri:    AdmissionToRaftPriority(pri),
+			})
+		case strings.HasPrefix(parts[0], "sending"):
+			// Skip the first line, which is the header.
+			eventBuf[n-1].sendingEntryRange = make(map[roachpb.ReplicaID]testingEntryRange)
+			continue
+		case strings.HasPrefix(parts[0], "replica_id="):
+			require.True(t, strings.HasPrefix(parts[0], "replica_id="))
+			parts[0] = strings.TrimPrefix(strings.TrimSpace(parts[0]), "replica_id=")
+			replicaID, err = strconv.Atoi(parts[0])
+			require.NoError(t, err)
+
+			// Line has format: [%d,%d) corresponding to [from,to).
+			parts[1] = strings.TrimSpace(parts[1])
+			bounds := strings.Split(parts[1], ",")
+			require.Len(t, bounds, 2)
+
+			bounds[0] = strings.TrimSpace(bounds[0])
+			require.True(t, strings.HasPrefix(bounds[0], "["))
+			bounds[0] = strings.TrimPrefix(strings.TrimSpace(bounds[0]), "[")
+			fromIndex, err = strconv.Atoi(bounds[0])
+			require.NoError(t, err)
+
+			bounds[1] = strings.TrimSpace(bounds[1])
+			require.True(t, strings.HasSuffix(bounds[1], ")"))
+			bounds[1] = strings.TrimSuffix(strings.TrimSpace(bounds[1]), ")")
+			toIndexExcl, err = strconv.Atoi(bounds[1])
+			require.NoError(t, err)
+
+			eventBuf[n-1].sendingEntryRange[roachpb.ReplicaID(replicaID)] = testingEntryRange{
+				fromIndex: uint64(fromIndex),
+				// Subtract 1 to make the range exclusive.
+				toIndex: uint64(toIndexExcl - 1),
+			}
+		default:
+			require.Failf(t, "unknown line", "%v", line)
+		}
+	}
+	return eventBuf
+}
+
 type entryInfo struct {
 	term   uint64
 	index  uint64
@@ -680,7 +787,12 @@ func (t *testingProbeToCloseTimerScheduler) ScheduleSendStreamCloseRaftMuLocked(
 //   - raft_event: Simulates a raft event on the given range, calling
 //     HandleRaftEvent.
 //     range_id=<range_id>
+//     entries
 //     term=<term> index=<index> pri=<pri> size=<size>
+//     ...
+//     sending
+//     replica_id=<replica_id> [from,to)
+//     ...
 //     ...
 //
 //   - stream_state: Prints the state of the stream(s) for the given range's
@@ -713,8 +825,10 @@ func TestRangeController(t *testing.T) {
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "init":
-				var regularInitString, elasticInitString string
-				var regularLimitString, elasticLimitString string
+				var (
+					regularInitString, elasticInitString   string
+					regularLimitString, elasticLimitString string
+				)
 				d.MaybeScanArgs(t, "regular_init", &regularInitString)
 				d.MaybeScanArgs(t, "elastic_init", &elasticInitString)
 				d.MaybeScanArgs(t, "regular_limit", &regularLimitString)
@@ -909,110 +1023,66 @@ func TestRangeController(t *testing.T) {
 				return state.tokenCountsString()
 
 			case "raft_event":
-				var lastRangeID roachpb.RangeID
-				init := false
-				var buf []entryInfo
-
-				propRangeEntries := func() {
-					event := RaftEvent{
-						Entries: make([]raftpb.Entry, len(buf)),
+				for _, event := range parseRaftEvents(t, d.Input) {
+					raftEvent := RaftEvent{
+						Entries:           make([]raftpb.Entry, len(event.entries)),
+						MsgApps:           map[roachpb.ReplicaID][]raftpb.Message{},
+						ReplicasStateInfo: state.ranges[event.rangeID].replicasStateInfo(),
 					}
-					for i, state := range buf {
-						event.Entries[i] = testingCreateEntry(t, state)
+					for i, entry := range event.entries {
+						raftEvent.Entries[i] = testingCreateEntry(t, entry)
 					}
-					// TODO(sumeer): all replicas are getting MsgApps for all the new
-					// entries, which does not sufficiently test the code paths. Enhance
-					// the test to include a prefix of the new entries, and entries that
-					// were appended previously.
 					msgApp := raftpb.Message{
-						Type:    raftpb.MsgApp,
-						To:      0,
-						Entries: event.Entries,
+						Type: raftpb.MsgApp,
+						To:   0,
+						// We will selectively include a prefix of the new entries, and a
+						// suffix of entries that were previously appended, down below.
+						Entries: nil,
 					}
-					msgApps := map[roachpb.ReplicaID][]raftpb.Message{}
-					testRC := state.ranges[lastRangeID]
+					testRC := state.ranges[event.rangeID]
+					testRC.entries = append(testRC.entries, raftEvent.Entries...)
 					func() {
 						testRC.mu.Lock()
 						defer testRC.mu.Unlock()
-						for k, testR := range testRC.mu.r.replicaSet {
-							msgApp.To = raftpb.PeerID(k)
-							msgApps[k] = append([]raftpb.Message(nil), msgApp)
-							if n := len(event.Entries); n > 0 {
-								testR.info.Next = event.Entries[n-1].Index + 1
-								testRC.mu.r.replicaSet[k] = testR
+
+						for replicaID, testR := range testRC.mu.r.replicaSet {
+							msgApp.Entries = nil
+							msgApp.To = raftpb.PeerID(replicaID)
+							if event.sendingEntryRange == nil ||
+								testingFirst(0, event.sendingEntryRange[replicaID]) == nil {
+								// When sendingEntryRange is not specified, include all
+								// entries for this replica.
+								msgApp.Entries = raftEvent.Entries
+							} else {
+								fromIndex := event.sendingEntryRange[replicaID].fromIndex
+								toIndex := event.sendingEntryRange[replicaID].toIndex
+								for _, entry := range testRC.entries {
+									if entry.Index >= fromIndex && entry.Index <= toIndex {
+										msgApp.Entries = append(msgApp.Entries, entry)
+									}
+								}
+							}
+							raftEvent.MsgApps[replicaID] = append([]raftpb.Message(nil), msgApp)
+							if len(msgApp.Entries) > 0 {
+								// Bump the Next and Index fields for replicas that have
+								// MsgApps being sent to them. The Match index is only updated
+								// if it increases.
+								testR.info.Match = max(msgApp.Entries[0].Index-1, testR.info.Match)
+								testR.info.Next = msgApp.Entries[len(msgApp.Entries)-1].Index + 1
+								testRC.mu.r.replicaSet[replicaID] = testR
 							}
 						}
 					}()
-					event.MsgApps = msgApps
-					event.ReplicasStateInfo = testRC.replicasStateInfo()
-					err := testRC.rc.HandleRaftEventRaftMuLocked(ctx, event)
-					require.NoError(t, err)
-				}
-
-				for _, line := range strings.Split(d.Input, "\n") {
-					var (
-						rangeID, term, index int
-						size                 int64
-						err                  error
-						pri                  admissionpb.WorkPriority
-					)
-
-					parts := strings.Fields(line)
-					parts[0] = strings.TrimSpace(parts[0])
-					if strings.HasPrefix(parts[0], "range_id=") {
-						if init {
-							// We are moving to another range, if a previous range has entries
-							// created then create the raft event and call handle raft ready
-							// using all the entries added so far.
-							propRangeEntries()
-							init = false
-						}
-
-						parts[0] = strings.TrimPrefix(strings.TrimSpace(parts[0]), "range_id=")
-						rangeID, err = strconv.Atoi(parts[0])
-						require.NoError(t, err)
-						lastRangeID = roachpb.RangeID(rangeID)
-					} else {
-						require.True(t, strings.HasPrefix(parts[0], "term="))
-						parts[0] = strings.TrimPrefix(strings.TrimSpace(parts[0]), "term=")
-						term, err = strconv.Atoi(parts[0])
-						require.NoError(t, err)
-
-						parts[1] = strings.TrimSpace(parts[1])
-						require.True(t, strings.HasPrefix(parts[1], "index="))
-						parts[1] = strings.TrimPrefix(strings.TrimSpace(parts[1]), "index=")
-						index, err = strconv.Atoi(parts[1])
-						require.NoError(t, err)
-
-						parts[2] = strings.TrimSpace(parts[2])
-						require.True(t, strings.HasPrefix(parts[2], "pri="))
-						parts[2] = strings.TrimPrefix(strings.TrimSpace(parts[2]), "pri=")
-						pri = parsePriority(t, parts[2])
-
-						parts[3] = strings.TrimSpace(parts[3])
-						require.True(t, strings.HasPrefix(parts[3], "size="))
-						parts[3] = strings.TrimPrefix(strings.TrimSpace(parts[3]), "size=")
-						size, err = humanizeutil.ParseBytes(parts[3])
-						require.NoError(t, err)
-
-						init = true
-						buf = append(buf, entryInfo{
-							term:   uint64(term),
-							index:  uint64(index),
-							enc:    raftlog.EntryEncodingStandardWithACAndPriority,
-							tokens: kvflowcontrol.Tokens(size),
-							pri:    AdmissionToRaftPriority(pri),
-						})
-					}
-				}
-				if init {
-					propRangeEntries()
+					raftEvent.ReplicasStateInfo = testRC.replicasStateInfo()
+					require.NoError(t, testRC.rc.HandleRaftEventRaftMuLocked(ctx, raftEvent))
 				}
 				return state.tokenCountsString()
 
 			case "stream_state":
 				var rangeID int
 				d.ScanArgs(t, "range_id", &rangeID)
+				// Sleep for a bit to allow any timers to fire.
+				time.Sleep(20 * time.Millisecond)
 				return state.sendStreamString(roachpb.RangeID(rangeID))
 
 			case "metrics":

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
@@ -241,6 +241,7 @@ func (s *testingRCState) getOrInitRange(t *testing.T, r testingRange) *testingRC
 			TenantID:            r.tenantID,
 			LocalReplicaID:      r.localReplicaID,
 			SSTokenCounter:      s.ssTokenCounter,
+			RaftInterface:       testRC,
 			Clock:               s.clock,
 			CloseTimerScheduler: s.probeToCloseScheduler,
 			EvalWaitMetrics:     s.evalMetrics,
@@ -248,8 +249,9 @@ func (s *testingRCState) getOrInitRange(t *testing.T, r testingRange) *testingRC
 		}
 
 		init := RangeControllerInitState{
-			ReplicaSet:  r.replicas(),
-			Leaseholder: r.localReplicaID,
+			ReplicaSet:    r.replicas(),
+			Leaseholder:   r.localReplicaID,
+			NextRaftIndex: r.nextRaftIndex,
 		}
 		testRC.rc = NewRangeController(s.testCtx, options, init)
 		s.ranges[r.rangeID] = testRC
@@ -353,9 +355,11 @@ type testingRange struct {
 	rangeID        roachpb.RangeID
 	tenantID       roachpb.TenantID
 	localReplicaID roachpb.ReplicaID
+	nextRaftIndex  uint64
 	replicaSet     map[roachpb.ReplicaID]testingReplica
 }
 
+// Used by simulation test.
 func makeSingleVoterTestingRange(
 	rangeID roachpb.RangeID,
 	tenantID roachpb.TenantID,
@@ -366,6 +370,8 @@ func makeSingleVoterTestingRange(
 		rangeID:        rangeID,
 		tenantID:       tenantID,
 		localReplicaID: 1,
+		// Set to 1, since simulation test starts appending at index 1.
+		nextRaftIndex: 1,
 		replicaSet: map[roachpb.ReplicaID]testingReplica{
 			1: {
 				desc: roachpb.ReplicaDescriptor{
@@ -403,7 +409,7 @@ func scanRanges(t *testing.T, input string) []testingRange {
 		if strings.HasPrefix(parts[0], "range_id=") {
 			// Create a new range, any replicas which follow until the next range_id
 			// line will be added to this replica set.
-			var rangeID, tenantID, localReplicaID int
+			var rangeID, tenantID, localReplicaID, nextRaftIndex int
 			var err error
 
 			require.True(t, strings.HasPrefix(parts[0], "range_id="))
@@ -423,10 +429,17 @@ func scanRanges(t *testing.T, input string) []testingRange {
 			localReplicaID, err = strconv.Atoi(parts[2])
 			require.NoError(t, err)
 
+			parts[3] = strings.TrimSpace(parts[3])
+			require.True(t, strings.HasPrefix(parts[3], "next_raft_index="))
+			parts[3] = strings.TrimPrefix(strings.TrimSpace(parts[3]), "next_raft_index=")
+			nextRaftIndex, err = strconv.Atoi(parts[2])
+			require.NoError(t, err)
+
 			replicas = append(replicas, testingRange{
 				rangeID:        roachpb.RangeID(rangeID),
 				tenantID:       roachpb.MustMakeTenantID(uint64(tenantID)),
 				localReplicaID: roachpb.ReplicaID(localReplicaID),
+				nextRaftIndex:  uint64(nextRaftIndex),
 				replicaSet:     make(map[roachpb.ReplicaID]testingReplica),
 			})
 		} else {
@@ -482,10 +495,12 @@ func scanReplica(t *testing.T, line string) testingReplica {
 		panic("unknown replica type")
 	}
 
+	next := uint64(0)
 	// The fourth field is optional, if set it contains the tracker state of the
 	// replica on the leader replica (localReplicaID). The valid states are
 	// Probe, Replicate, and Snapshot.
 	if len(parts) > 3 {
+		require.Equal(t, 5, len(parts))
 		parts[3] = strings.TrimSpace(parts[3])
 		require.True(t, strings.HasPrefix(parts[3], "state="))
 		parts[3] = strings.TrimPrefix(strings.TrimSpace(parts[3]), "state=")
@@ -499,6 +514,12 @@ func scanReplica(t *testing.T, line string) testingReplica {
 		default:
 			panic("unknown replica state")
 		}
+		parts[4] = strings.TrimSpace(parts[4])
+		require.True(t, strings.HasPrefix(parts[4], "next="))
+		parts[4] = strings.TrimPrefix(strings.TrimSpace(parts[4]), "next=")
+		nextInt, err := strconv.Atoi(parts[4])
+		require.NoError(t, err)
+		next = uint64(nextInt)
 	}
 
 	return testingReplica{
@@ -508,7 +529,7 @@ func scanReplica(t *testing.T, line string) testingReplica {
 			ReplicaID: roachpb.ReplicaID(replicaID),
 			Type:      replicaType,
 		},
-		info: ReplicaStateInfo{State: state},
+		info: ReplicaStateInfo{State: state, Next: next},
 	}
 }
 
@@ -882,13 +903,37 @@ func TestRangeController(t *testing.T) {
 
 				propRangeEntries := func() {
 					event := RaftEvent{
-						Entries:           make([]raftpb.Entry, len(buf)),
-						ReplicasStateInfo: state.ranges[lastRangeID].replicasStateInfo(),
+						Entries: make([]raftpb.Entry, len(buf)),
 					}
 					for i, state := range buf {
 						event.Entries[i] = testingCreateEntry(t, state)
 					}
-					err := state.ranges[lastRangeID].rc.HandleRaftEventRaftMuLocked(ctx, event)
+					// TODO(sumeer): all replicas are getting MsgApps for all the new
+					// entries, which does not sufficiently test the code paths. Enhance
+					// the test to include a prefix of the new entries, and entries that
+					// were appended previously.
+					msgApp := raftpb.Message{
+						Type:    raftpb.MsgApp,
+						To:      0,
+						Entries: event.Entries,
+					}
+					msgApps := map[roachpb.ReplicaID][]raftpb.Message{}
+					testRC := state.ranges[lastRangeID]
+					func() {
+						testRC.mu.Lock()
+						defer testRC.mu.Unlock()
+						for k, testR := range testRC.mu.r.replicaSet {
+							msgApp.To = raftpb.PeerID(k)
+							msgApps[k] = append([]raftpb.Message(nil), msgApp)
+							if n := len(event.Entries); n > 0 {
+								testR.info.Next = event.Entries[n-1].Index + 1
+								testRC.mu.r.replicaSet[k] = testR
+							}
+						}
+					}()
+					event.MsgApps = msgApps
+					event.ReplicasStateInfo = testRC.replicasStateInfo()
+					err := testRC.rc.HandleRaftEventRaftMuLocked(ctx, event)
 					require.NoError(t, err)
 				}
 

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/simulation_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/simulation_test.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
@@ -76,8 +75,7 @@ import (
 //     adjust={+,-}<bytes>/s rate=<int>/s [stream=t<int>/s<int>] \
 //     [deduction-delay=<duration>]                                          (B)
 //     ....
-//     t=<duration> handle=<string> op=connect stream=t<int>/s<int> \
-//     log-position=<int>/<int>                                              (C)
+//     t=<duration> handle=<string> op=connect stream=t<int>/s<int>          (C)
 //     ....
 //     t=<duration> handle=<string> op=disconnect stream=t<int>/s<int>       (D)
 //     ....
@@ -271,19 +269,6 @@ func TestUsingSimulation(t *testing.T) {
 							require.True(t, arg == "connect" || arg == "disconnect" ||
 								arg == "close" || arg == "snapshot")
 							tl.rcOp = arg
-
-						case strings.HasPrefix(parts[i], "log-position="):
-							// Parse log-position=<int>/<int>.
-							inner := strings.Split(arg, "/")
-							require.Len(t, inner, 2)
-							term, err := strconv.Atoi(inner[0])
-							require.NoError(t, err)
-							index, err := strconv.Atoi(inner[1])
-							require.NoError(t, err)
-							tl.position = kvflowcontrolpb.RaftLogPosition{
-								Term:  uint64(term),
-								Index: uint64(index),
-							}
 
 						default:
 							t.Fatalf("unrecognized prefix: %s", parts[i])
@@ -546,7 +531,6 @@ func (s *simulator) timeline(tl timeline) {
 		if tl.rcOp == "connect" {
 			// Form C.
 			require.NotZero(s.state.t, tl.stream)
-			require.NotZero(s.state.t, tl.position)
 		}
 		if tl.rcOp == "disconnect" {
 			// Form D.
@@ -554,12 +538,11 @@ func (s *simulator) timeline(tl timeline) {
 		}
 
 		s.ticker = append(s.ticker, &rcOpTicker{
-			t:        s.state.t,
-			tstart:   tl.tstart,
-			handle:   tl.handle,
-			op:       tl.rcOp,
-			stream:   tl.stream,
-			position: tl.position,
+			t:      s.state.t,
+			tstart: tl.tstart,
+			handle: tl.handle,
+			op:     tl.rcOp,
+			stream: tl.stream,
 		})
 		return
 	}
@@ -570,7 +553,6 @@ func (s *simulator) timeline(tl timeline) {
 	}
 
 	require.NotZero(s.state.t, tl.tend)
-	require.Zero(s.state.t, tl.position)
 	s.ticker = append(s.ticker, &rcTicker{
 		t: s.state.t,
 
@@ -651,9 +633,6 @@ type timeline struct {
 	// The specific operation to run on a RangeController. Only applicable to
 	// forms C-E.
 	rcOp string
-	// The log position at which we start issuing writes/deducting tokens (form
-	// B) or the position at which we connect a given stream (form C).
-	position kvflowcontrolpb.RaftLogPosition
 }
 
 type ticker interface {
@@ -924,12 +903,11 @@ func (w *waitingRCRequest) remove(i int) {
 // simulate timed operations on a RangeController (taking snapshots,
 // connecting/disconnected replica streams, closing it entirely).
 type rcOpTicker struct {
-	t        *testing.T
-	tstart   time.Time
-	handle   *testingRCRange
-	position kvflowcontrolpb.RaftLogPosition
-	stream   kvflowcontrol.Stream
-	op       string
+	t      *testing.T
+	tstart time.Time
+	handle *testingRCRange
+	stream kvflowcontrol.Stream
+	op     string
 
 	done bool
 }
@@ -948,7 +926,7 @@ func (rot *rcOpTicker) tick(ctx context.Context, t time.Time) {
 	case "disconnect":
 		rot.handle.testingDisconnectStream(rot.t, ctx, rot.stream)
 	case "connect":
-		rot.handle.testingConnectStream(rot.t, ctx, rot.stream, rot.position)
+		rot.handle.testingConnectStream(rot.t, ctx, rot.stream)
 	case "snapshot":
 		var data string
 		rid := rot.handle.testingFindReplStreamOrFatal(ctx, rot.stream)
@@ -1108,17 +1086,30 @@ func (r *testingRCRange) testingDeductTokens(
 		log.Fatal(ctx, "operating on a closed RangeController")
 	}
 	r.mu.quorumPosition.Index++
-
+	entry := testingCreateEntry(t, entryInfo{
+		term:   r.mu.quorumPosition.Term,
+		index:  r.mu.quorumPosition.Index,
+		enc:    raftlog.EntryEncodingStandardWithACAndPriority,
+		tokens: tokens,
+		pri:    AdmissionToRaftPriority(pri),
+	})
+	msgApps := map[roachpb.ReplicaID][]raftpb.Message{}
+	msgApp := raftpb.Message{
+		Type:    raftpb.MsgApp,
+		To:      0,
+		Entries: []raftpb.Entry{entry},
+	}
+	for k, testR := range r.mu.r.replicaSet {
+		msgApp.To = raftpb.PeerID(k)
+		msgApps[k] = append([]raftpb.Message(nil), msgApp)
+		testR.info.Next = r.mu.quorumPosition.Index + 1
+		r.mu.r.replicaSet[k] = testR
+	}
 	require.NoError(t, r.rc.HandleRaftEventRaftMuLocked(ctx, RaftEvent{
 		ReplicasStateInfo: r.replicasStateInfo(),
 		Term:              r.mu.quorumPosition.Term,
-		Entries: []raftpb.Entry{testingCreateEntry(t, entryInfo{
-			term:   r.mu.quorumPosition.Term,
-			index:  r.mu.quorumPosition.Index,
-			enc:    raftlog.EntryEncodingStandardWithACAndPriority,
-			tokens: tokens,
-			pri:    AdmissionToRaftPriority(pri),
-		})},
+		Entries:           []raftpb.Entry{entry},
+		MsgApps:           msgApps,
 	}))
 }
 
@@ -1182,15 +1173,11 @@ func (r *testingRCRange) testingFindReplStreamOrFatal(
 // thereby connecting a replication stream. If a voter for the given stream
 // already exists, it is overwritten and forced to StateReplicate.
 func (r *testingRCRange) testingConnectStream(
-	t *testing.T,
-	ctx context.Context,
-	stream kvflowcontrol.Stream,
-	position kvflowcontrolpb.RaftLogPosition,
+	t *testing.T, ctx context.Context, stream kvflowcontrol.Stream,
 ) {
 	if r.rc == nil {
 		log.Fatal(ctx, "operating on a closed RangeController")
 	}
-	r.mu.quorumPosition = position
 	r.mu.r.replicaSet[roachpb.ReplicaID(stream.StoreID)] = testingReplica{
 		desc: roachpb.ReplicaDescriptor{
 			// We aren't testing multiple stores per node.
@@ -1201,8 +1188,8 @@ func (r *testingRCRange) testingConnectStream(
 		},
 		info: ReplicaStateInfo{
 			State: tracker.StateReplicate,
-			Match: position.Index,
-			Next:  position.Index + 1,
+			Match: r.mu.quorumPosition.Index,
+			Next:  r.mu.quorumPosition.Index + 1,
 		},
 	}
 	// Send an empty raft event in order to trigger any state changes.

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/close
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/close
@@ -8,18 +8,21 @@ range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
   store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
-t1/s1: reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
-t1/s2: reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
-t1/s3: reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s1: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s2: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s3: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
 
 # There should be no tracked entries for the range.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false
+(n1,s1):1: state=replicate closed=false inflight=[1,1) send_queue=[1,1)
 ++++
-(n2,s2):2: state=replicate closed=false
+(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,1)
 ++++
-(n3,s3):3: state=replicate closed=false
+(n3,s3):3: state=replicate closed=false inflight=[1,1) send_queue=[1,1)
 ++++
 
 
@@ -31,25 +34,28 @@ range_id=1
   term=1 index=2 pri=NormalPri size=1MiB
   term=1 index=3 pri=NormalPri size=1MiB
 ----
-t1/s1: reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
-t1/s2: reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
-t1/s3: reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+t1/s1: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+       send reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+t1/s2: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+       send reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+       send reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false
+(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false
+(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
@@ -61,9 +67,12 @@ range_id=1
   store_id=1 term=1 to_index=2 pri=NormalPri
   store_id=2 term=1 to_index=1 pri=NormalPri
 ----
-t1/s1: reg=+15 MiB/+16 MiB ela=+7.0 MiB/+8.0 MiB
-t1/s2: reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
-t1/s3: reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+t1/s1: eval reg=+15 MiB/+16 MiB ela=+7.0 MiB/+8.0 MiB
+       send reg=+15 MiB/+16 MiB ela=+7.0 MiB/+8.0 MiB
+t1/s2: eval reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
+       send reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
+t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+       send reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
 
 # Change s3 to StateSnapshot. This should close the send stream and return the
 # tracked deductions for entries in [1,3].
@@ -77,11 +86,11 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
 NormalPri:
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false
+(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
 NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
@@ -92,9 +101,12 @@ NormalPri:
 adjust_tokens
   store_id=1 pri=HighPri tokens=0
 ----
-t1/s1: reg=+15 MiB/+16 MiB ela=+7.0 MiB/+8.0 MiB
-t1/s2: reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
-t1/s3: reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s1: eval reg=+15 MiB/+16 MiB ela=+7.0 MiB/+8.0 MiB
+       send reg=+15 MiB/+16 MiB ela=+7.0 MiB/+8.0 MiB
+t1/s2: eval reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
+       send reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
+t1/s3: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
 
 # Close the range controller. This should return the tracked deductions for
 # entry 3 on s1 and [2,3] on s2.
@@ -107,6 +119,9 @@ range_id=1 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=1 pri=HighPri tokens=0
 ----
-t1/s1: reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
-t1/s2: reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
-t1/s3: reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s1: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s2: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s3: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/close
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/close
@@ -2,10 +2,10 @@
 # state to StateSnapshot causes all tracked token deductions to be returned to
 # the underlying stream token counts.
 init
-range_id=1 tenant_id=1 local_replica_id=1
-  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate
-  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate
-  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 t1/s1: reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
@@ -68,10 +68,10 @@ t1/s3: reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
 # Change s3 to StateSnapshot. This should close the send stream and return the
 # tracked deductions for entries in [1,3].
 set_replicas
-range_id=1 tenant_id=1 local_replica_id=1
-  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate
-  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate
-  store_id=3 replica_id=3 type=VOTER_FULL state=StateSnapshot
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=4
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=4
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=4
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateSnapshot next=4
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/handle_raft_event
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/handle_raft_event
@@ -7,18 +7,21 @@ range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
   store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
-t1/s1: reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
-t1/s2: reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
-t1/s3: reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s1: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s2: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s3: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
 
 # There should be no tracked entries for the range.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false
+(n1,s1):1: state=replicate closed=false inflight=[1,1) send_queue=[1,1)
 ++++
-(n2,s2):2: state=replicate closed=false
+(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,1)
 ++++
-(n3,s3):3: state=replicate closed=false
+(n3,s3):3: state=replicate closed=false inflight=[1,1) send_queue=[1,1)
 ++++
 
 # Simulate a call to `HandleRaftEventRaftMuLocked` on s1 (leader/local
@@ -31,27 +34,30 @@ range_id=1
   term=1 index=2 pri=NormalPri size=1MiB
   term=1 index=3 pri=NormalPri size=1MiB
 ----
-t1/s1: reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
-t1/s2: reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
-t1/s3: reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+t1/s1: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+       send reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+t1/s2: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+       send reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+       send reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
 
 # The tracker should be tracking the three entries at indices 1..3, for each
 # replica stream (1,2,3).
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false
+(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false
+(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
@@ -66,17 +72,20 @@ range_id=1
   store_id=1 term=1 to_index=3 pri=NormalPri
   store_id=2 term=1 to_index=3 pri=NormalPri
 ----
-t1/s1: reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
-t1/s2: reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
-t1/s3: reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+t1/s1: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s2: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+       send reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false
+(n1,s1):1: state=replicate closed=false inflight=[4,4) send_queue=[4,4)
 ++++
-(n2,s2):2: state=replicate closed=false
+(n2,s2):2: state=replicate closed=false inflight=[4,4) send_queue=[4,4)
 ++++
-(n3,s3):3: state=replicate closed=false
+(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
@@ -103,11 +112,11 @@ now=500ms
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
 ++++
-(n2,s2):2: state=replicate closed=false
+(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
 ++++
-(n3,s3):3: state=probeRecentlyReplicate closed=false
+(n3,s3):3: state=probeRecentlyReplicate closed=false inflight=[1,4) send_queue=[4,4)
 ++++
 
 # Tick the clock by the remaining probe to close delay, the stream should now
@@ -118,9 +127,9 @@ now=1s
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
 ++++
-(n2,s2):2: state=replicate closed=false
+(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
 ++++
 (n3,s3):3: closed
 
@@ -131,9 +140,12 @@ raft_event
 range_id=1
   term=1 index=4 pri=NormalPri size=16MiB
 ----
-t1/s1: reg=+0 B/+16 MiB ela=-8.0 MiB/+8.0 MiB
-t1/s2: reg=+0 B/+16 MiB ela=-8.0 MiB/+8.0 MiB
-t1/s3: reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s1: eval reg=+0 B/+16 MiB ela=-8.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-8.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-8.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-8.0 MiB/+8.0 MiB
+t1/s3: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
 
 wait_for_eval name=a range_id=1 pri=LowPri
 ----
@@ -144,9 +156,12 @@ admit
 range_id=1
   store_id=1 term=1 to_index=4 pri=NormalPri
 ----
-t1/s1: reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
-t1/s2: reg=+0 B/+16 MiB ela=-8.0 MiB/+8.0 MiB
-t1/s3: reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s1: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-8.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-8.0 MiB/+8.0 MiB
+t1/s3: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
 
 # The operation should still be waiting, as it requires all replicas which are
 # in state replicate to have tokens available, s1 does but s2 doesn't.
@@ -172,9 +187,12 @@ range_id=1
   term=1 index=6 pri=NormalPri size=1MiB
   term=1 index=7 pri=NormalPri size=1MiB
 ----
-t1/s1: reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
-t1/s2: reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
-t1/s3: reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+t1/s1: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+       send reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+t1/s2: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+       send reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
 
 # The operation should now be done and have waited for s1 and s3.
 check_state

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/handle_raft_event
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/handle_raft_event
@@ -1,10 +1,10 @@
 # Intialize a range with voters on s1,s2 and s3. The local replica and
 # leaseholder will be s1. The leaseholder is denoted by the '*' suffix.
 init
-range_id=1 tenant_id=1 local_replica_id=1
-  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate
-  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate
-  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 t1/s1: reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
@@ -87,10 +87,10 @@ NormalPri:
 # return for s3 and untracking all entries and closing the stream after a 1s
 # delay.
 set_replicas
-range_id=1 tenant_id=1 local_replica_id=1
-  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate
-  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate
-  store_id=3 replica_id=3 type=VOTER_FULL state=StateProbe
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=4
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=4
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=4
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateProbe next=4
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 
@@ -159,10 +159,10 @@ range_id=1 tenant_id={1} local_replica_id=1
 # trigger the operation to refresh, ignore s2 now that it is in StateProbe and
 # check s3 for available tokens as it is now in StateReplicate.
 set_replicas
-range_id=1 tenant_id=1 local_replica_id=1
-  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate
-  store_id=2 replica_id=2 type=VOTER_FULL state=StateSnapshot
-  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=5
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=5
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateSnapshot next=4
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=5
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/handle_raft_event_partial_msg_app
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/handle_raft_event_partial_msg_app
@@ -1,0 +1,178 @@
+# This test creates raft events which have different (partial) MsgApps for each
+# replica. This test is meant to exercise send queue tracking while in push
+# mode, as opposed to pulling entries from Raft.
+init
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
+t1/s1: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s2: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s3: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+
+# Create MsgApps with different entries for each replica.
+raft_event
+range_id=1
+  entries
+    term=1 index=1 pri=NormalPri size=1MiB
+    term=1 index=2 pri=NormalPri size=1MiB
+    term=1 index=3 pri=NormalPri size=1MiB
+  sending
+    replica_id=1 [1,4)
+    replica_id=2 [1,3)
+    replica_id=3 [1,2)
+----
+t1/s1: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+       send reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+t1/s2: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+       send reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
+t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+       send reg=+15 MiB/+16 MiB ela=+7.0 MiB/+8.0 MiB
+
+# Note how r1 tracks all the entries, as its MsgApp contains all the entries,
+# while r2 and r3 have partial entry tracking.
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4)
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,4)
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+
+# Send another event, this time r2 and r3 will recreate the send queue state
+# because the sending entries contain a regression. r2 is being sent a MsgApp
+# with entries [2,5) intersecting than the last send range [1,3), so it will
+# recreate the send stream and additionally track the new entry (4). r3
+# recreates the send stream as well, for the same reason, as indexToSend (2) !=
+# the first MsgApp index [1,4). r3 doesn't track entry (3) because it's not in
+# entries added here.
+raft_event
+range_id=1
+  entries
+    term=1 index=4 pri=NormalPri size=1MiB
+    term=1 index=5 pri=NormalPri size=1MiB
+  sending
+    replica_id=1 [4,6)
+    replica_id=2 [2,5)
+    replica_id=3 [1,4)
+----
+t1/s1: eval reg=+11 MiB/+16 MiB ela=+3.0 MiB/+8.0 MiB
+       send reg=+11 MiB/+16 MiB ela=+3.0 MiB/+8.0 MiB
+t1/s2: eval reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
+       send reg=+15 MiB/+16 MiB ela=+7.0 MiB/+8.0 MiB
+t1/s3: eval reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[4,6) send_queue=[6,6)
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
+  term=1 index=4  tokens=1048576
+  term=1 index=5  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[2,5) send_queue=[5,6)
+NormalPri:
+  term=1 index=4  tokens=1048576
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,6)
+++++
+
+# Partially admit the entries, with r3 lagging by one entry. Expect to see the
+# corresponding tracked deductions returned up to each replica's respective
+# to_index.
+admit
+range_id=1
+  store_id=1 term=1 to_index=4 pri=NormalPri
+  store_id=2 term=1 to_index=4 pri=NormalPri
+  store_id=3 term=1 to_index=3 pri=NormalPri
+----
+t1/s1: eval reg=+15 MiB/+16 MiB ela=+7.0 MiB/+8.0 MiB
+       send reg=+15 MiB/+16 MiB ela=+7.0 MiB/+8.0 MiB
+t1/s2: eval reg=+15 MiB/+16 MiB ela=+7.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s3: eval reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[5,6) send_queue=[6,6)
+NormalPri:
+  term=1 index=5  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[5,5) send_queue=[5,6)
+++++
+(n3,s3):3: state=replicate closed=false inflight=[4,4) send_queue=[4,6)
+++++
+
+# Send a raft_event that contains the unsent entries for each replica, in
+# addition to the next entry added here. No replicas should recreate their send
+# stream.
+raft_event
+range_id=1
+    term=1 index=6 pri=NormalPri size=1MiB
+  sending
+    replica_id=1 [6,7)
+    replica_id=2 [5,7)
+    replica_id=3 [4,7)
+----
+t1/s1: eval reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
+       send reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
+t1/s2: eval reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
+       send reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
+t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+       send reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[6,7) send_queue=[7,7)
+NormalPri:
+  term=1 index=5  tokens=1048576
+  term=1 index=6  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[5,7) send_queue=[7,7)
+NormalPri:
+  term=1 index=5  tokens=1048576
+  term=1 index=6  tokens=1048576
+++++
+(n3,s3):3: state=replicate closed=false inflight=[4,7) send_queue=[7,7)
+NormalPri:
+  term=1 index=4  tokens=1048576
+  term=1 index=5  tokens=1048576
+  term=1 index=6  tokens=1048576
+++++
+
+# Lastly, admit all the entries. We should have all tokens returned.
+admit
+range_id=1
+  store_id=1 term=1 to_index=6 pri=NormalPri
+  store_id=2 term=1 to_index=6 pri=NormalPri
+  store_id=3 term=1 to_index=6 pri=NormalPri
+----
+t1/s1: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s2: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s3: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+
+close_rcs
+----
+range_id=1 tenant_id={1} local_replica_id=1

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/inspect
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/inspect
@@ -3,7 +3,8 @@ range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
   store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
 ----
 r1: [(n1,s1):1*]
-t1/s1: reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s1: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
 
 inspect range_id=1
 ----
@@ -94,9 +95,12 @@ range_id=1
   term=1 index=2 pri=NormalPri size=3MiB
   term=1 index=3 pri=NormalPri size=2MiB
 ----
-t1/s1: reg=+8.0 MiB/+16 MiB ela=+0 B/+8.0 MiB
-t1/s2: reg=+8.0 MiB/+16 MiB ela=+0 B/+8.0 MiB
-t1/s3: reg=+8.0 MiB/+16 MiB ela=+0 B/+8.0 MiB
+t1/s1: eval reg=+8.0 MiB/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+8.0 MiB/+16 MiB ela=+0 B/+8.0 MiB
+t1/s2: eval reg=+8.0 MiB/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+8.0 MiB/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=+8.0 MiB/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+8.0 MiB/+16 MiB ela=+0 B/+8.0 MiB
 
 inspect range_id=1
 ----
@@ -322,9 +326,12 @@ range_id=1
   store_id=1 term=1 to_index=1 pri=NormalPri
   store_id=2 term=1 to_index=2 pri=NormalPri
 ----
-t1/s1: reg=+11 MiB/+16 MiB ela=+3.0 MiB/+8.0 MiB
-t1/s2: reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
-t1/s3: reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s1: eval reg=+11 MiB/+16 MiB ela=+3.0 MiB/+8.0 MiB
+       send reg=+11 MiB/+16 MiB ela=+3.0 MiB/+8.0 MiB
+t1/s2: eval reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
+       send reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
+t1/s3: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
 
 inspect range_id=1
 ----

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/inspect
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/inspect
@@ -1,6 +1,6 @@
 init
-range_id=1 tenant_id=1 local_replica_id=1
-  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
 ----
 r1: [(n1,s1):1*]
 t1/s1: reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
@@ -30,10 +30,10 @@ inspect range_id=1
 # Add two other replicas, these new streams should show up and have the initial
 # tokens set.
 set_replicas
-range_id=1 tenant_id=1 local_replica_id=1
-  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate
-  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate
-  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 
@@ -223,10 +223,10 @@ inspect range_id=1
 # Change the replica on s3 to StateSnapshot. This should untrack all entries
 # and result in the stream token counts being updated accordingly.
 set_replicas
-range_id=1 tenant_id=1 local_replica_id=1
-  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate
-  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate
-  store_id=3 replica_id=3 type=VOTER_FULL state=StateSnapshot
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=4
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=4
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=4
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateSnapshot next=4
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval
@@ -3,10 +3,10 @@
 # set all streams to initially have 0 tokens and a limit of 1 token to simplify
 # the test, as evaluation requests only wait for positive tokens.
 init regular_limit=1 regular_init=0 elastic_limit=1 elastic_init=0
-range_id=1 tenant_id=1 local_replica_id=1
-  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate
-  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate
-  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 t1/s1: reg=+0 B/+1 B ela=+0 B/+1 B
@@ -87,10 +87,10 @@ range_id=1 tenant_id={1} local_replica_id=1
 
 # Change the replica set: replace replica 3 with a new replica 4.
 set_replicas
-range_id=1 tenant_id=1 local_replica_id=1
-  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate
-  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate
-  store_id=4 replica_id=4 type=VOTER_FULL state=StateReplicate
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
+  store_id=4 replica_id=4 type=VOTER_FULL state=StateReplicate next=1
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n4,s4):4]
 
@@ -130,11 +130,11 @@ range_id=1 tenant_id={1} local_replica_id=1
 
 # Test behavior with a non-voter replica.
 set_replicas
-range_id=1 tenant_id=1 local_replica_id=1
-  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate
-  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate
-  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate
-  store_id=4 replica_id=4 type=NON_VOTER state=StateReplicate
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
+  store_id=4 replica_id=4 type=NON_VOTER state=StateReplicate next=1
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4NON_VOTER]
 
@@ -249,14 +249,14 @@ range_id=1 tenant_id={1} local_replica_id=1
 # complete until all streams have tokens, whereas the high priority evaluation
 # on the second range will complete once a quorum has available tokens.
 set_replicas
-range_id=1 tenant_id=1 local_replica_id=1
-  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate
-  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate
-  store_id=3 replica_id=5 type=VOTER_FULL state=StateReplicate
-range_id=2 tenant_id=1 local_replica_id=1
-  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate
-  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate
-  store_id=5 replica_id=5 type=VOTER_FULL state=StateReplicate
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
+  store_id=3 replica_id=5 type=VOTER_FULL state=StateReplicate next=1
+range_id=2 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
+  store_id=5 replica_id=5 type=VOTER_FULL state=StateReplicate next=1
 ----
 r1: [(n1,s1):1,(n2,s2):2*,(n3,s3):5]
 r2: [(n1,s1):1*,(n3,s3):3,(n5,s5):5]

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval
@@ -9,9 +9,12 @@ range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
   store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
-t1/s1: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s2: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s3: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s1: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s2: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
 
 metrics
 ----
@@ -44,9 +47,12 @@ range_id=1 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=1 pri=HighPri tokens=1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s3: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s2: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
 
 # Cancel the context for the high priority evaluation 'a'.
 cancel_context range_id=1 name=a
@@ -60,9 +66,12 @@ range_id=1 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=2 pri=HighPri tokens=1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
 
 check_state
 ----
@@ -75,9 +84,12 @@ range_id=1 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=3 pri=HighPri tokens=1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
 
 check_state
 ----
@@ -97,10 +109,14 @@ r1: [(n1,s1):1*,(n2,s2):2,(n4,s4):4]
 adjust_tokens
   store_id=1 pri=HighPri tokens=-1
 ----
-t1/s1: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s1: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s4: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
 
 # Start a new high priority evaluation 'c'. It should not complete due to lack
 # of quorum.
@@ -115,10 +131,14 @@ range_id=1 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=1 pri=HighPri tokens=1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s4: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
 
 # Check the state. The high priority evaluation 'c' should now complete.
 check_state
@@ -151,10 +171,14 @@ range_id=1 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=3 pri=HighPri tokens=-1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s4: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
 
 # Check the state. The high priority evaluation 'd' should complete despite the
 # non-voter replica lacking tokens.
@@ -182,10 +206,14 @@ range_id=1 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=3 pri=LowPri tokens=1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+0 B/+1 B ela=+1 B/+1 B
-t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: eval reg=+0 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s4: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
 
 check_state
 ----
@@ -201,10 +229,14 @@ range_id=1 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=4 pri=LowPri tokens=1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+0 B/+1 B ela=+1 B/+1 B
-t1/s4: reg=+0 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: eval reg=+0 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s4: eval reg=+0 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
 
 check_state
 ----
@@ -221,10 +253,14 @@ adjust_tokens
   store_id=3 pri=LowPri tokens=-1
   store_id=4 pri=LowPri tokens=-1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s4: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
 
 # Test behavior when changing leaseholder.
 set_leaseholder range_id=1 replica_id=2
@@ -294,11 +330,16 @@ range_id=2 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=5 pri=HighPri tokens=1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s4: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s5: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
 
 check_state
 ----
@@ -318,11 +359,16 @@ range_id=2 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=3 pri=LowPri tokens=1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+0 B/+1 B ela=+1 B/+1 B
-t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: eval reg=+0 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s4: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s5: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
 
 check_state
 ----
@@ -356,11 +402,16 @@ adjust_tokens
   store_id=3 pri=LowPri  tokens=-1
   store_id=1 pri=HighPri tokens=-1
 ----
-t1/s1: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s4: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s5: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
 
 set_leaseholder range_id=1 replica_id=5
 ----
@@ -388,11 +439,16 @@ range_id=2 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=3 pri=HighPri tokens=1
 ----
-t1/s1: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s4: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s5: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
 
 # Start another evaluation 'j' on r1, it should also not complete until the
 # leader (s1) has tokens, despite both the leaseholder (s3) and a quorum
@@ -416,11 +472,16 @@ range_id=2 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=1 pri=HighPri tokens=1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s4: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s5: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
 
 check_state
 ----
@@ -441,11 +502,16 @@ range_id=2 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=3 pri=HighPri tokens=-1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s3: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s4: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s5: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+0 B/+1 B ela=+0 B/+1 B
 
 # Start an evaluation 'k' on r1, that does not complete since the leaseholder
 # (s3) has tokens.

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval_joint_config
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval_joint_config
@@ -4,13 +4,13 @@
 # which should have no consequence for quorum or non-elastic evaluation
 # requests (non-voter requires tokens for elastic).
 init regular_limit=1 regular_init=1 elastic_limit=1 elastic_init=1
-range_id=1 tenant_id=1 local_replica_id=1
-  store_id=1 replica_id=1 type=VOTER_FULL              state=StateReplicate
-  store_id=2 replica_id=2 type=VOTER_FULL              state=StateReplicate
-  store_id=3 replica_id=3 type=VOTER_DEMOTING_LEARNER  state=StateReplicate
-  store_id=4 replica_id=4 type=VOTER_INCOMING          state=StateReplicate
-  store_id=5 replica_id=5 type=NON_VOTER               state=StateReplicate
-  store_id=6 replica_id=6 type=LEARNER                 state=StateReplicate
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL              state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL              state=StateReplicate next=1
+  store_id=3 replica_id=3 type=VOTER_DEMOTING_LEARNER  state=StateReplicate next=1
+  store_id=4 replica_id=4 type=VOTER_INCOMING          state=StateReplicate next=1
+  store_id=5 replica_id=5 type=NON_VOTER               state=StateReplicate next=1
+  store_id=6 replica_id=6 type=LEARNER                 state=StateReplicate next=1
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3VOTER_DEMOTING_LEARNER,(n4,s4):4VOTER_INCOMING,(n5,s5):5NON_VOTER,(n6,s6):6LEARNER]
 t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval_joint_config
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval_joint_config
@@ -13,12 +13,18 @@ range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
   store_id=6 replica_id=6 type=LEARNER                 state=StateReplicate next=1
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3VOTER_DEMOTING_LEARNER,(n4,s4):4VOTER_INCOMING,(n5,s5):5NON_VOTER,(n6,s6):6LEARNER]
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
 
 # Start a happy case normal priority evaluation 'a', all voters have tokens.
 wait_for_eval name=a range_id=1 pri=NormalPri
@@ -31,12 +37,18 @@ range_id=1 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=2 pri=HighPri tokens=-1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
 
 # Start another evaluation 'b'. The request should be done immediately, since
 # there is still a quorum of voters with tokens in both configurations.
@@ -52,12 +64,18 @@ range_id=1 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=4 pri=HighPri tokens=-1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
 
 wait_for_eval name=c range_id=1 pri=NormalPri
 ----
@@ -72,12 +90,18 @@ range_id=1 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=4 pri=HighPri tokens=1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
 
 check_state
 ----
@@ -90,12 +114,18 @@ range_id=1 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=3 pri=HighPri tokens=-1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s3: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
 
 wait_for_eval name=d range_id=1 pri=NormalPri
 ----
@@ -111,12 +141,18 @@ range_id=1 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=3 pri=HighPri tokens=1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
 
 check_state
 ----
@@ -133,12 +169,18 @@ adjust_tokens
   store_id=2 pri=HighPri tokens=1
   store_id=3 pri=LowPri  tokens=-1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+1 B/+1 B ela=+0 B/+1 B
-t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: eval reg=+1 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
 
 wait_for_eval name=e range_id=1 pri=LowPri
 ----
@@ -153,12 +195,18 @@ range_id=1 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=3 pri=LowPri tokens=1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
 
 check_state
 ----
@@ -173,12 +221,18 @@ range_id=1 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=4 pri=LowPri tokens=-1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s4: reg=+1 B/+1 B ela=+0 B/+1 B
-t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: eval reg=+1 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
 
 wait_for_eval name=f range_id=1 pri=LowPri
 ----
@@ -194,12 +248,18 @@ range_id=1 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=4 pri=LowPri tokens=1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
 
 check_state
 ----

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval_non_voters
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval_non_voters
@@ -5,10 +5,10 @@
 # non-voter, all in StateReplicate. All streams will start with positive (1)
 # tokens.
 init regular_limit=1 regular_init=1 elastic_limit=1 elastic_init=1
-range_id=1 tenant_id=1 local_replica_id=1
-  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate
-  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate
-  store_id=3 replica_id=3 type=NON_VOTER  state=StateReplicate
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
+  store_id=3 replica_id=3 type=NON_VOTER  state=StateReplicate next=1
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3NON_VOTER]
 t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
@@ -61,13 +61,13 @@ range_id=1 tenant_id={1} local_replica_id=1
 # StateSnapshot and therefore not required to wait on for elastic work class
 # requests.
 set_replicas
-range_id=1 tenant_id=1 local_replica_id=1
-  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate
-  store_id=2 replica_id=2 type=VOTER_FULL state=StateSnapshot
-  store_id=3 replica_id=3 type=VOTER_FULL state=StateSnapshot
-  store_id=4 replica_id=4 type=NON_VOTER  state=StateReplicate
-  store_id=5 replica_id=5 type=NON_VOTER  state=StateReplicate
-  store_id=6 replica_id=6 type=NON_VOTER  state=StateReplicate
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateSnapshot next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateSnapshot next=1
+  store_id=4 replica_id=4 type=NON_VOTER  state=StateReplicate next=1
+  store_id=5 replica_id=5 type=NON_VOTER  state=StateReplicate next=1
+  store_id=6 replica_id=6 type=NON_VOTER  state=StateReplicate next=1
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4NON_VOTER,(n5,s5):5NON_VOTER,(n6,s6):6NON_VOTER]
 
@@ -144,13 +144,13 @@ range_id=1 tenant_id={1} local_replica_id=1
 # evaluation 'c' should still not complete, because the switched voting replica
 # stream doesn't have tokens still.
 set_replicas
-range_id=1 tenant_id=1 local_replica_id=1
-  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate
-  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate
-  store_id=3 replica_id=3 type=VOTER_FULL state=StateSnapshot
-  store_id=4 replica_id=4 type=NON_VOTER  state=StateReplicate
-  store_id=5 replica_id=5 type=NON_VOTER  state=StateReplicate
-  store_id=6 replica_id=6 type=NON_VOTER  state=StateReplicate
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateSnapshot next=1
+  store_id=4 replica_id=4 type=NON_VOTER  state=StateReplicate next=1
+  store_id=5 replica_id=5 type=NON_VOTER  state=StateReplicate next=1
+  store_id=6 replica_id=6 type=NON_VOTER  state=StateReplicate next=1
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4NON_VOTER,(n5,s5):5NON_VOTER,(n6,s6):6NON_VOTER]
 

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval_non_voters
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval_non_voters
@@ -11,9 +11,12 @@ range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
   store_id=3 replica_id=3 type=NON_VOTER  state=StateReplicate next=1
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3NON_VOTER]
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
 
 # Start a low priority evaluation 'a'. This should complete immediately as all
 # replicas have tokens.
@@ -28,9 +31,12 @@ range_id=1 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=3 pri=LowPri tokens=-1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+1 B/+1 B ela=+0 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: eval reg=+1 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
 
 wait_for_eval name=b range_id=1 pri=LowPri
 ----
@@ -43,9 +49,12 @@ range_id=1 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=3 pri=LowPri tokens=1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
 
 check_state
 ----
@@ -80,12 +89,18 @@ adjust_tokens
   store_id=5 pri=LowPri tokens=-1
   store_id=6 pri=LowPri tokens=-1
 ----
-t1/s1: reg=+1 B/+1 B ela=+0 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+0 B/+1 B
-t1/s3: reg=+1 B/+1 B ela=+0 B/+1 B
-t1/s4: reg=+1 B/+1 B ela=+0 B/+1 B
-t1/s5: reg=+1 B/+1 B ela=+0 B/+1 B
-t1/s6: reg=+1 B/+1 B ela=+0 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: eval reg=+1 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: eval reg=+1 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: eval reg=+1 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: eval reg=+1 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
 
 # Start a low priority evaluation 'c'. This should not complete until: 
 # (1) The leader has elastic tokens (already true)
@@ -104,12 +119,18 @@ range_id=1 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=1 pri=LowPri tokens=1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+0 B/+1 B
-t1/s3: reg=+1 B/+1 B ela=+0 B/+1 B
-t1/s4: reg=+1 B/+1 B ela=+0 B/+1 B
-t1/s5: reg=+1 B/+1 B ela=+0 B/+1 B
-t1/s6: reg=+1 B/+1 B ela=+0 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: eval reg=+1 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: eval reg=+1 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: eval reg=+1 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: eval reg=+1 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
 
 check_state
 ----
@@ -126,12 +147,18 @@ adjust_tokens
   store_id=5 pri=LowPri tokens=1
   store_id=6 pri=LowPri tokens=1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+0 B/+1 B
-t1/s3: reg=+1 B/+1 B ela=+0 B/+1 B
-t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: eval reg=+1 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
 
 check_state
 ----
@@ -167,12 +194,18 @@ range_id=1 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=2 pri=LowPri tokens=1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s3: reg=+1 B/+1 B ela=+0 B/+1 B
-t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: eval reg=+1 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
 
 check_state
 ----
@@ -193,12 +226,18 @@ adjust_tokens
   store_id=5 pri=HighPri tokens=-1
   store_id=6 pri=HighPri tokens=-1
 ----
-t1/s1: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s2: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s3: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s5: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s6: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s1: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
 
 wait_for_eval name=d range_id=1 pri=HighPri
 ----
@@ -213,12 +252,18 @@ range_id=1 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=1 pri=HighPri tokens=1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s3: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s4: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s5: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s6: reg=+0 B/+1 B ela=+0 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
 
 check_state
 ----
@@ -236,12 +281,18 @@ adjust_tokens
   store_id=5 pri=HighPri tokens=1
   store_id=6 pri=HighPri tokens=1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s3: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
 
 check_state
 ----
@@ -257,12 +308,18 @@ range_id=1 tenant_id={1} local_replica_id=1
 adjust_tokens
   store_id=3 pri=HighPri tokens=1
 ----
-t1/s1: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s2: reg=+0 B/+1 B ela=+0 B/+1 B
-t1/s3: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s4: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s5: reg=+1 B/+1 B ela=+1 B/+1 B
-t1/s6: reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s1: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s2: eval reg=+0 B/+1 B ela=+0 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s3: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s4: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s5: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
+t1/s6: eval reg=+1 B/+1 B ela=+1 B/+1 B
+       send reg=+1 B/+1 B ela=+1 B/+1 B
 
 check_state
 ----

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/simulation/range_controller_overview
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/simulation/range_controller_overview
@@ -19,9 +19,9 @@ handle=h
 # - Start writing to the range again at t=[20s,21s) at 2MiB/s across 10 reqs/s. 
 # - At t=22s, close the handle. 
 timeline
-t=0s        handle=h op=connect    stream=t1/s1   log-position=4/0
-t=0s        handle=h op=connect    stream=t1/s2   log-position=4/0
-t=0s        handle=h op=connect    stream=t1/s3   log-position=4/0
+t=0s        handle=h op=connect    stream=t1/s1
+t=0s        handle=h op=connect    stream=t1/s2
+t=0s        handle=h op=connect    stream=t1/s3
 t=2s        handle=h op=snapshot   stream=t1/s1
 t=3s        handle=h op=snapshot   stream=t1/s1
 t=4s        handle=h op=disconnect stream=t1/s2
@@ -175,109 +175,109 @@ snapshots handle=h
 ----
 t=2s stream=t1/s1
  pri=normal-pri
-  tokens=205KiB log-position=4/1
-  tokens=205KiB log-position=4/2
-  tokens=205KiB log-position=4/3
-  tokens=205KiB log-position=4/4
-  tokens=205KiB log-position=4/5
-  tokens=205KiB log-position=4/6
-  tokens=205KiB log-position=4/7
-  tokens=205KiB log-position=4/8
-  tokens=205KiB log-position=4/9
-  tokens=205KiB log-position=4/10
-  tokens=205KiB log-position=4/11
-  tokens=205KiB log-position=4/12
-  tokens=205KiB log-position=4/13
-  tokens=205KiB log-position=4/14
-  tokens=205KiB log-position=4/15
-  tokens=205KiB log-position=4/16
-  tokens=205KiB log-position=4/17
-  tokens=205KiB log-position=4/18
-  tokens=205KiB log-position=4/19
-  tokens=205KiB log-position=4/20
+  tokens=205KiB log-position=1/1
+  tokens=205KiB log-position=1/2
+  tokens=205KiB log-position=1/3
+  tokens=205KiB log-position=1/4
+  tokens=205KiB log-position=1/5
+  tokens=205KiB log-position=1/6
+  tokens=205KiB log-position=1/7
+  tokens=205KiB log-position=1/8
+  tokens=205KiB log-position=1/9
+  tokens=205KiB log-position=1/10
+  tokens=205KiB log-position=1/11
+  tokens=205KiB log-position=1/12
+  tokens=205KiB log-position=1/13
+  tokens=205KiB log-position=1/14
+  tokens=205KiB log-position=1/15
+  tokens=205KiB log-position=1/16
+  tokens=205KiB log-position=1/17
+  tokens=205KiB log-position=1/18
+  tokens=205KiB log-position=1/19
+  tokens=205KiB log-position=1/20
 
 t=3s stream=t1/s1
  pri=normal-pri
-  tokens=205KiB log-position=4/1
-  tokens=205KiB log-position=4/2
-  tokens=205KiB log-position=4/3
-  tokens=205KiB log-position=4/4
-  tokens=205KiB log-position=4/5
-  tokens=205KiB log-position=4/6
-  tokens=205KiB log-position=4/7
-  tokens=205KiB log-position=4/8
-  tokens=205KiB log-position=4/9
-  tokens=205KiB log-position=4/10
-  tokens=205KiB log-position=4/11
-  tokens=205KiB log-position=4/12
-  tokens=205KiB log-position=4/13
-  tokens=205KiB log-position=4/14
-  tokens=205KiB log-position=4/15
-  tokens=205KiB log-position=4/16
-  tokens=205KiB log-position=4/17
-  tokens=205KiB log-position=4/18
-  tokens=205KiB log-position=4/19
-  tokens=205KiB log-position=4/20
-  tokens=205KiB log-position=4/21
-  tokens=205KiB log-position=4/22
-  tokens=205KiB log-position=4/23
-  tokens=205KiB log-position=4/24
-  tokens=205KiB log-position=4/25
-  tokens=205KiB log-position=4/26
-  tokens=205KiB log-position=4/27
-  tokens=205KiB log-position=4/28
-  tokens=205KiB log-position=4/29
-  tokens=205KiB log-position=4/30
+  tokens=205KiB log-position=1/1
+  tokens=205KiB log-position=1/2
+  tokens=205KiB log-position=1/3
+  tokens=205KiB log-position=1/4
+  tokens=205KiB log-position=1/5
+  tokens=205KiB log-position=1/6
+  tokens=205KiB log-position=1/7
+  tokens=205KiB log-position=1/8
+  tokens=205KiB log-position=1/9
+  tokens=205KiB log-position=1/10
+  tokens=205KiB log-position=1/11
+  tokens=205KiB log-position=1/12
+  tokens=205KiB log-position=1/13
+  tokens=205KiB log-position=1/14
+  tokens=205KiB log-position=1/15
+  tokens=205KiB log-position=1/16
+  tokens=205KiB log-position=1/17
+  tokens=205KiB log-position=1/18
+  tokens=205KiB log-position=1/19
+  tokens=205KiB log-position=1/20
+  tokens=205KiB log-position=1/21
+  tokens=205KiB log-position=1/22
+  tokens=205KiB log-position=1/23
+  tokens=205KiB log-position=1/24
+  tokens=205KiB log-position=1/25
+  tokens=205KiB log-position=1/26
+  tokens=205KiB log-position=1/27
+  tokens=205KiB log-position=1/28
+  tokens=205KiB log-position=1/29
+  tokens=205KiB log-position=1/30
 
 t=16s stream=t1/s1
  pri=normal-pri
-  tokens=205KiB log-position=4/62
-  tokens=205KiB log-position=4/63
-  tokens=205KiB log-position=4/64
-  tokens=205KiB log-position=4/65
-  tokens=205KiB log-position=4/66
-  tokens=205KiB log-position=4/67
-  tokens=205KiB log-position=4/68
-  tokens=205KiB log-position=4/69
-  tokens=205KiB log-position=4/70
-  tokens=205KiB log-position=4/71
-  tokens=205KiB log-position=4/72
-  tokens=205KiB log-position=4/73
-  tokens=205KiB log-position=4/74
-  tokens=205KiB log-position=4/75
-  tokens=205KiB log-position=4/76
-  tokens=205KiB log-position=4/77
-  tokens=205KiB log-position=4/78
-  tokens=205KiB log-position=4/79
-  tokens=205KiB log-position=4/80
+  tokens=205KiB log-position=1/62
+  tokens=205KiB log-position=1/63
+  tokens=205KiB log-position=1/64
+  tokens=205KiB log-position=1/65
+  tokens=205KiB log-position=1/66
+  tokens=205KiB log-position=1/67
+  tokens=205KiB log-position=1/68
+  tokens=205KiB log-position=1/69
+  tokens=205KiB log-position=1/70
+  tokens=205KiB log-position=1/71
+  tokens=205KiB log-position=1/72
+  tokens=205KiB log-position=1/73
+  tokens=205KiB log-position=1/74
+  tokens=205KiB log-position=1/75
+  tokens=205KiB log-position=1/76
+  tokens=205KiB log-position=1/77
+  tokens=205KiB log-position=1/78
+  tokens=205KiB log-position=1/79
+  tokens=205KiB log-position=1/80
 
 t=17s stream=t1/s1
  pri=normal-pri
-  tokens=205KiB log-position=4/72
-  tokens=205KiB log-position=4/73
-  tokens=205KiB log-position=4/74
-  tokens=205KiB log-position=4/75
-  tokens=205KiB log-position=4/76
-  tokens=205KiB log-position=4/77
-  tokens=205KiB log-position=4/78
-  tokens=205KiB log-position=4/79
-  tokens=205KiB log-position=4/80
+  tokens=205KiB log-position=1/72
+  tokens=205KiB log-position=1/73
+  tokens=205KiB log-position=1/74
+  tokens=205KiB log-position=1/75
+  tokens=205KiB log-position=1/76
+  tokens=205KiB log-position=1/77
+  tokens=205KiB log-position=1/78
+  tokens=205KiB log-position=1/79
+  tokens=205KiB log-position=1/80
 
 t=19s stream=t1/s1
  
 t=21s stream=t1/s1
  pri=normal-pri
-  tokens=205KiB log-position=4/81
-  tokens=205KiB log-position=4/82
-  tokens=205KiB log-position=4/83
-  tokens=205KiB log-position=4/84
-  tokens=205KiB log-position=4/85
-  tokens=205KiB log-position=4/86
-  tokens=205KiB log-position=4/87
-  tokens=205KiB log-position=4/88
-  tokens=205KiB log-position=4/89
-  tokens=205KiB log-position=4/90
-  tokens=205KiB log-position=4/91
+  tokens=205KiB log-position=1/81
+  tokens=205KiB log-position=1/82
+  tokens=205KiB log-position=1/83
+  tokens=205KiB log-position=1/84
+  tokens=205KiB log-position=1/85
+  tokens=205KiB log-position=1/86
+  tokens=205KiB log-position=1/87
+  tokens=205KiB log-position=1/88
+  tokens=205KiB log-position=1/89
+  tokens=205KiB log-position=1/90
+  tokens=205KiB log-position=1/91
 ----
 ----
 

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/simulation/range_controller_shared_stream
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/simulation/range_controller_shared_stream
@@ -8,8 +8,8 @@ handle=h2
 # Set up two handles that connect only to s1, and issue writes at 2MiB/s each.
 # Set up token returns for the stream at 1MiB/s. 
 timeline
-t=0s         handle=h1    op=connect    stream=t1/s1   log-position=4/0
-t=0s         handle=h2    op=connect    stream=t1/s1   log-position=4/0
+t=0s         handle=h1    op=connect    stream=t1/s1
+t=0s         handle=h2    op=connect    stream=t1/s1
 t=[0s,10s)   handle=h1    class=regular adjust=-2MiB/s rate=10/s
 t=[0s,10s)   handle=h2    class=regular adjust=-2MiB/s rate=10/s
 t=[0s,10s)   stream=t1/s1 class=regular adjust=+1MiB/s rate=200/s

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/simulation/range_controller_single_slow_stream
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/simulation/range_controller_single_slow_stream
@@ -10,9 +10,9 @@ handle=h
 # deducted (1MiB/s). For the third stream (s3), we return flow tokens at only
 # 0.5MiB/s.
 timeline
-t=0s         handle=h op=connect    stream=t1/s1   log-position=1/0
-t=0s         handle=h op=connect    stream=t1/s2   log-position=1/0
-t=0s         handle=h op=connect    stream=t1/s3   log-position=1/0
+t=0s         handle=h op=connect    stream=t1/s1
+t=0s         handle=h op=connect    stream=t1/s2
+t=0s         handle=h op=connect    stream=t1/s3
 t=[0s,50s)   handle=h class=regular adjust=-1MiB/s   rate=10/s
 t=[0.2s,50s) handle=h class=regular adjust=+1MiB/s   rate=10/s stream=t1/s1
 t=[0.2s,50s) handle=h class=regular adjust=+1MiB/s   rate=10/s stream=t1/s2

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/simulation/range_controller_stream_connection
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/simulation/range_controller_stream_connection
@@ -7,9 +7,9 @@ handle=h
 # t=5s. We issue writes at 1MiB/s and return tokens for each stream at the rate
 # of deduction, only 200ms later.
 timeline
-t=0s             handle=h op=connect    stream=t1/s1   log-position=4/0
-t=0s             handle=h op=connect    stream=t1/s2   log-position=4/0
-t=5s             handle=h op=connect    stream=t1/s3   log-position=4/50
+t=0s             handle=h op=connect    stream=t1/s1
+t=0s             handle=h op=connect    stream=t1/s2
+t=5s             handle=h op=connect    stream=t1/s3
 t=[0s,10s)       handle=h class=regular adjust=-1MiB/s   rate=10/s
 t=[0.2s,10.2s)   handle=h class=regular adjust=+1MiB/s   rate=10/s stream=t1/s1
 t=[0.2s,10.2s)   handle=h class=regular adjust=+1MiB/s   rate=10/s stream=t1/s2

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/simulation/range_controller_stream_disconnection
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/simulation/range_controller_stream_disconnection
@@ -12,9 +12,9 @@ handle=h
 # deducted (1MiB/s). For the third stream (s3), we return flow tokens at only
 # 0.5MiB/s. At t=35s, disconnect the slow stream.
 timeline
-t=0s       handle=h op=connect    stream=t1/s1     log-position=4/0
-t=0s       handle=h op=connect    stream=t1/s2     log-position=4/0
-t=0s       handle=h op=connect    stream=t1/s3     log-position=4/0
+t=0s       handle=h op=connect    stream=t1/s1
+t=0s       handle=h op=connect    stream=t1/s2
+t=0s       handle=h op=connect    stream=t1/s3
 t=[0s,50s) handle=h class=regular adjust=-1MiB/s   rate=10/s
 t=[0s,50s) handle=h class=regular adjust=+1MiB/s   rate=10/s stream=t1/s1
 t=[0s,50s) handle=h class=regular adjust=+1MiB/s   rate=10/s stream=t1/s2

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/token_tracker
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/token_tracker
@@ -112,14 +112,15 @@ HighPri:
   term=1 index=30 tokens=300
   term=3 index=60 tokens=600
 
-untrack term=2
+untrack term=2 eval-tokens-ge-index=40
 LowPri=45
 NormalPri=0
 HighPri=0
 ----
-returned: tokens=500  pri=LowPri
-returned: tokens=200  pri=NormalPri
-returned: tokens=300  pri=HighPri
+send returned: tokens=500  pri=LowPri
+send returned: tokens=200  pri=NormalPri
+send returned: tokens=300  pri=HighPri
+eval returned: tokens=400  pri=LowPri
 
 state
 ----
@@ -132,13 +133,15 @@ HighPri:
   term=3 index=60 tokens=600
 
 # Untrack with a higher term.
-untrack term=3
+untrack term=3 eval-tokens-ge-index=51
 NormalPri=60
 HighPri=60
 ----
-returned: tokens=400  pri=LowPri
-returned: tokens=500  pri=NormalPri
-returned: tokens=600  pri=HighPri
+send returned: tokens=400  pri=LowPri
+send returned: tokens=500  pri=NormalPri
+send returned: tokens=600  pri=HighPri
+eval returned: tokens=400  pri=LowPri
+eval returned: tokens=600  pri=HighPri
 
 state
 ----
@@ -157,15 +160,14 @@ inspect
   }
 }
 
-untrack_ge index=40
-----
-returned: tokens=700  pri=LowPri
-
 state
 ----
+LowPri:
+  term=3 index=70 tokens=700
 
 untrack_all
 ----
+send returned: tokens=700  pri=LowPri
 
 state
 ----
@@ -173,10 +175,12 @@ state
 # Test tracking and untracking with different terms
 track
 term=4 index=80 tokens=800 pri=NormalPri
+term=4 index=85 tokens=800 pri=NormalPri
 term=5 index=90 tokens=900 pri=NormalPri
 term=5 index=100 tokens=999 pri=HighPri
 ----
 tracked: term=4 index=80 tokens=800 pri=NormalPri
+tracked: term=4 index=85 tokens=800 pri=NormalPri
 tracked: term=5 index=90 tokens=900 pri=NormalPri
 tracked: term=5 index=100 tokens=999 pri=HighPri
 
@@ -184,15 +188,17 @@ state
 ----
 NormalPri:
   term=4 index=80 tokens=800
+  term=4 index=85 tokens=800
   term=5 index=90 tokens=900
 HighPri:
   term=5 index=100 tokens=999
 
-untrack term=4
+untrack term=4 eval-tokens-ge-index=80
 NormalPri=95
 HighPri=95
 ----
-returned: tokens=800  pri=NormalPri
+send returned: tokens=1600 pri=NormalPri
+eval returned: tokens=1600 pri=NormalPri
 
 state
 ----
@@ -203,8 +209,8 @@ HighPri:
 
 untrack_all
 ----
-returned: tokens=900  pri=NormalPri
-returned: tokens=999  pri=HighPri
+send returned: tokens=900  pri=NormalPri
+send returned: tokens=999  pri=HighPri
 
 state
 ----

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -1223,8 +1223,9 @@ func (f RangeControllerFactoryImpl) New(
 			Knobs:               f.knobs,
 		},
 		rac2.RangeControllerInitState{
-			ReplicaSet:  state.replicaSet,
-			Leaseholder: state.leaseholder,
+			ReplicaSet:    state.replicaSet,
+			Leaseholder:   state.leaseholder,
+			NextRaftIndex: state.nextRaftIndex,
 		},
 	)
 }


### PR DESCRIPTION
The new raftEventForReplica encapsulates all that is needed to handle the RaftEvent, including (re)creating a replicaSendStream. The complexity is encapsulated in the construction of this event, which also pays attention to regressions, jumps, and other anomalies, all of which cause the existing replicaSendStream (if any) to be recreated. The recreaton is a significant simplification from the prototype, which was doing unnecessarily complicated work in fixing up the state.

The send-queue tracking is simple, [indexToSend, nextRaftIndex). Since there is a send-queue, we separately track the eval.tokensDeducted counts. Tracker.UntrackGE is no longer needed, which is another simplification.

Epic: CRDB-37515

Informs #123509

Release note: None