### PR TITLE
cmd/drt-run: check in drt-chaos.yaml file

### DIFF
--- a/pkg/cmd/drt-run/config.go
+++ b/pkg/cmd/drt-run/config.go
@@ -35,7 +35,6 @@ type config struct {
 	CockroachBinary string `yaml:"cockroach_binary"`
 	WorkloadBinary  string `yaml:"workload_binary"`
 	RoachtestBinary string `yaml:"roachtest_binary"`
-	Duration        time.Duration
 	Workloads       []workloadConfig
 
 	Operations struct {

--- a/pkg/cmd/drt-run/config/drt-chaos.yaml
+++ b/pkg/cmd/drt-run/config/drt-chaos.yaml
@@ -1,0 +1,50 @@
+workloads:
+  - name: tpcc-main
+    kind: tpcc
+    steps:
+      - command: run
+        args:
+          - --warehouses 12000
+          - --active-warehouses 1700
+          - --db cct_tpcc
+          - --secure
+          - --ramp 10m
+          - --display-every 5s
+          - --duration 12h
+          - --prometheus-port 2112
+          - --user cct_tpcc_user
+          - --tolerate-errors
+          - --password tpcc
+  - name: kv-main
+    kind: kv
+    steps:
+      - command: run
+        args:
+          - --concurrency 8
+          - --histograms kv/stats.json
+          - --db kv
+          - --splits 500
+          - --read-percent 50
+          - --cycle-length 100000
+          - --min-block-bytes 100
+          - --max-block-bytes 1000
+          - --max-rate 120
+          - --secure
+          - --prometheus-port 2114
+          - --ramp 10m
+          - --display-every 5s
+          - --duration 12h
+          - --tolerate-errors
+          - --enum
+operations:
+  parallelism: 3
+  sets:
+    - filter: .*
+      cadence: 5m
+cloud: gce
+cluster:
+  nodecount: 6
+cluster_name: drt-chaos
+certs: ./certs
+roachtest_binary: ./roachtest
+workload_binary: ./workload

--- a/pkg/cmd/drt-run/workloads.go
+++ b/pkg/cmd/drt-run/workloads.go
@@ -63,12 +63,6 @@ func (w *workloadRunner) runWorkloadStep(
 	}
 	args = append(args, pgUrl...)
 	args = append(args, step.Args...)
-	if strings.HasPrefix(step.Command, "run") {
-		// Add prometheus port, starting from 2112. This matches the expected behaviour
-		// from prometheus/datadog scrape configs when multiple workloads are running on
-		// one host.
-		args = append(args, fmt.Sprintf("--prometheus-port=%d", 2112+workloadIdx))
-	}
 
 	fmt.Printf("running command %s %s\n", w.config.WorkloadBinary, strings.Join(args, " "))
 	cmd := exec.CommandContext(ctx, w.config.WorkloadBinary, args...)


### PR DESCRIPTION
This file checks in a drt-chaos.yaml file for use
with drt-run to run operations and workloads on the drt-chaos cluster.

Epic: none

Release note: None