### PR TITLE
changefeedccl: add decimals to parquet unit test

### DIFF
--- a/pkg/ccl/changefeedccl/parquet_test.go
+++ b/pkg/ccl/changefeedccl/parquet_test.go
@@ -15,6 +15,7 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
@@ -61,12 +62,48 @@ func TestParquetRows(t *testing.T) {
 	sqlDB := sqlutils.MakeSQLRunner(db)
 	sqlDB.Exec(t, "SET CLUSTER SETTING kv.rangefeed.enabled = true")
 
+	newDecimal := func(s string) *tree.DDecimal {
+		d, _, _ := apd.NewFromString(s)
+		return &tree.DDecimal{Decimal: *d}
+	}
+
 	for _, tc := range []struct {
 		testName          string
 		createTable       string
 		stmts             []string
 		expectedDatumRows [][]tree.Datum
 	}{
+		{
+			testName: "decimal",
+			createTable: `
+				CREATE TABLE foo (
+				i INT PRIMARY KEY,
+				d DECIMAL(18,9)
+				)
+				`,
+			stmts: []string{
+				`INSERT INTO foo VALUES (0, 0)`,
+				`DELETE FROM foo WHERE d = 0.0`,
+				`INSERT INTO foo VALUES (1, 1.000000000)`,
+				`UPDATE foo SET d = 2.000000000 WHERE d = 1.000000000`,
+				`INSERT INTO foo VALUES (2, 3.14)`,
+				`INSERT INTO foo VALUES (3, 1.234567890123456789)`,
+				`INSERT INTO foo VALUES (4, '-Inf'::DECIMAL)`,
+				`INSERT INTO foo VALUES (5, 'Inf'::DECIMAL)`,
+				`INSERT INTO foo VALUES (6, 'NaN'::DECIMAL)`,
+			},
+			expectedDatumRows: [][]tree.Datum{
+				{tree.NewDInt(0), newDecimal("0.000000000"), parquetEventTypeDatumStringMap[parquetEventInsert]},
+				{tree.NewDInt(0), tree.DNull, parquetEventTypeDatumStringMap[parquetEventDelete]},
+				{tree.NewDInt(1), newDecimal("1.000000000"), parquetEventTypeDatumStringMap[parquetEventInsert]},
+				{tree.NewDInt(1), newDecimal("2.000000000"), parquetEventTypeDatumStringMap[parquetEventUpdate]},
+				{tree.NewDInt(2), newDecimal("3.140000000"), parquetEventTypeDatumStringMap[parquetEventInsert]},
+				{tree.NewDInt(3), newDecimal("1.234567890"), parquetEventTypeDatumStringMap[parquetEventInsert]},
+				{tree.NewDInt(4), tree.DNegInfDecimal, parquetEventTypeDatumStringMap[parquetEventInsert]},
+				{tree.NewDInt(5), tree.DPosInfDecimal, parquetEventTypeDatumStringMap[parquetEventInsert]},
+				{tree.NewDInt(6), tree.DNaNDecimal, parquetEventTypeDatumStringMap[parquetEventInsert]},
+			},
+		},
 		{
 			testName: "mixed",
 			createTable: `
@@ -203,9 +240,6 @@ func TestParquetRows(t *testing.T) {
 
 			err = writer.close()
 			require.NoError(t, err)
-
-			// We inserted 18 updates, but may get dupes from rangefeeds.
-			require.GreaterOrEqual(t, numRows, 18)
 
 			meta, readDatums, err := parquet.ReadFile(f.Name())
 			require.NoError(t, err)

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1108,11 +1108,14 @@ var (
 	// DZeroDecimal is the decimal constant '0'.
 	DZeroDecimal = &DDecimal{Decimal: apd.Decimal{}}
 
-	// dNaNDecimal is the decimal constant 'NaN'.
-	dNaNDecimal = &DDecimal{Decimal: apd.Decimal{Form: apd.NaN}}
+	// DNaNDecimal is the decimal constant 'NaN'.
+	DNaNDecimal = &DDecimal{Decimal: apd.Decimal{Form: apd.NaN}}
 
-	// dPosInfDecimal is the decimal constant 'inf'.
-	dPosInfDecimal = &DDecimal{Decimal: apd.Decimal{Form: apd.Infinite, Negative: false}}
+	// DPosInfDecimal is the decimal constant 'inf'.
+	DPosInfDecimal = &DDecimal{Decimal: apd.Decimal{Form: apd.Infinite, Negative: false}}
+
+	// DNegInfDecimal is the decimal constant '-inf'.
+	DNegInfDecimal = &DDecimal{Decimal: apd.Decimal{Form: apd.Infinite, Negative: true}}
 )
 
 // IsMax implements the Datum interface.
@@ -1127,12 +1130,12 @@ func (d *DDecimal) IsMin(ctx context.Context, cmpCtx CompareContext) bool {
 
 // Max implements the Datum interface.
 func (d *DDecimal) Max(ctx context.Context, cmpCtx CompareContext) (Datum, bool) {
-	return dPosInfDecimal, true
+	return DPosInfDecimal, true
 }
 
 // Min implements the Datum interface.
 func (d *DDecimal) Min(ctx context.Context, cmpCtx CompareContext) (Datum, bool) {
-	return dNaNDecimal, true
+	return DNaNDecimal, true
 }
 
 // AmbiguousFormat implements the Datum interface.


### PR DESCRIPTION
This PR adds coverage for decimals to the parquet encoder unit test.

Epic: none
Informs: #130909

Release note: None