### PR TITLE
sql: handle dropped descriptors  when waiting for schema changes

### DIFF
--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -163,6 +163,8 @@ func (p *planner) waitForDescriptorSchemaChanges(
 			blockingJobIDs = desc.ConcurrentSchemaChangeJobIDs()
 			return nil
 		}); err != nil {
+			log.Infof(ctx, "done schema change wait on concurrent jobs due"+
+				" to error on descriptor (%d): %s", descID, err)
 			return err
 		}
 		if !isBlocked {


### PR DESCRIPTION
Previously, when waiting for concurrent schema changes inside: waitForDescriptorSchemaChanges, if the descriptor was dropped we would end up returning that error via the txnStateTransitionsApplyWrapper. This would lead to the connection being dropped, which was causing flakes in TestConcurrentSchemaChanges. To address this, this patch forces schema changes with missing or dropped descriptors to retry, which should cause the correct error to bubble to the user.

Fixes: #130116

Release note (bug fix): If a connection was attempting a schema change while the same schema objects were being dropped, it was possible for the connection to be incorrectly dropped.