### PR TITLE
server: be stricter about ignoring error on delegated drain

### DIFF
--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -259,7 +259,7 @@ func delegateDrain(
 			if err == io.EOF {
 				break
 			}
-			if grpcutil.IsClosedConnection(err) {
+			if req.Shutdown && grpcutil.IsClosedConnection(err) {
 				// If the drain request contained Shutdown==true, it's
 				// possible for the RPC connection to the target node to be
 				// shut down before a DrainResponse and EOF is


### PR DESCRIPTION
When we were draining another node, we would suppress certain errors
that could occur when the remote node shut down, but we were suppressing
them regardless of whether we actually _expected_ the remote node to
shut down.

In the decommission/drains[^1] roachtest, this led to a situation in
which the drain should have failed but didn't, but where this fact
was not reported to the `decommission` process.

With this commit, the roachtest would instead have received an error
from the decommission cli invocation (informing the test that the
drain step failed). This would have also failed the test, but in the
"proper" way. I don't know why the KV Put in the drain step failed
on a broken connection, but either way:

Closes #130914.

[^1]: https://github.com/cockroachdb/cockroach/issues/130914

Epic: none
Release note: None
