### PR TITLE
kvserver: misc bug rac2 bug fixes and integration testing setup

### DIFF
--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -671,8 +671,10 @@ func TestFlowControlCrashedNode(t *testing.T) {
 				Store: &kvserver.StoreTestingKnobs{
 					FlowControlTestingKnobs: &kvflowcontrol.TestingKnobs{
 						UseOnlyForScratchRanges: true,
-						MaintainStreamsForBrokenRaftTransport: func() bool {
-							return maintainStreamsForBrokenRaftTransport.Load()
+						V1: kvflowcontrol.TestingKnobsV1{
+							MaintainStreamsForBrokenRaftTransport: func() bool {
+								return maintainStreamsForBrokenRaftTransport.Load()
+							},
 						},
 					},
 				},
@@ -804,14 +806,16 @@ func TestFlowControlRaftSnapshot(t *testing.T) {
 							// deductions/returns.
 							return kvflowcontrol.Tokens(1 << 20 /* 1MiB */)
 						},
-						MaintainStreamsForBehindFollowers: func() bool {
-							return maintainStreamsForBehindFollowers.Load()
-						},
-						MaintainStreamsForInactiveFollowers: func() bool {
-							return maintainStreamsForInactiveFollowers.Load()
-						},
-						MaintainStreamsForBrokenRaftTransport: func() bool {
-							return maintainStreamsForBrokenRaftTransport.Load()
+						V1: kvflowcontrol.TestingKnobsV1{
+							MaintainStreamsForBehindFollowers: func() bool {
+								return maintainStreamsForBehindFollowers.Load()
+							},
+							MaintainStreamsForInactiveFollowers: func() bool {
+								return maintainStreamsForInactiveFollowers.Load()
+							},
+							MaintainStreamsForBrokenRaftTransport: func() bool {
+								return maintainStreamsForBrokenRaftTransport.Load()
+							},
 						},
 					},
 				},
@@ -1092,8 +1096,10 @@ func TestFlowControlRaftTransportBreak(t *testing.T) {
 				Store: &kvserver.StoreTestingKnobs{
 					FlowControlTestingKnobs: &kvflowcontrol.TestingKnobs{
 						UseOnlyForScratchRanges: true,
-						MaintainStreamsForInactiveFollowers: func() bool {
-							return maintainStreamsForInactiveFollowers.Load()
+						V1: kvflowcontrol.TestingKnobsV1{
+							MaintainStreamsForInactiveFollowers: func() bool {
+								return maintainStreamsForInactiveFollowers.Load()
+							},
 						},
 					},
 				},
@@ -1864,11 +1870,13 @@ func TestFlowControlUnquiescedRange(t *testing.T) {
 							return kvflowcontrol.Tokens(1 << 20 /* 1MiB */)
 						},
 						UseOnlyForScratchRanges: true,
-						MaintainStreamsForInactiveFollowers: func() bool {
-							// This test deals with quiesced ranges where
-							// followers have no activity. We don't want to
-							// disconnect streams due to this inactivity.
-							return true
+						V1: kvflowcontrol.TestingKnobsV1{
+							MaintainStreamsForInactiveFollowers: func() bool {
+								// This test deals with quiesced ranges where
+								// followers have no activity. We don't want to
+								// disconnect streams due to this inactivity.
+								return true
+							},
 						},
 					},
 				},
@@ -2228,14 +2236,6 @@ func TestFlowControlGranterAdmitOneByOne(t *testing.T) {
 				Store: &kvserver.StoreTestingKnobs{
 					FlowControlTestingKnobs: &kvflowcontrol.TestingKnobs{
 						UseOnlyForScratchRanges: true,
-						MaintainStreamsForBehindFollowers: func() bool {
-							// TODO(irfansharif): This test is flakey without
-							// this change -- we disconnect one stream or
-							// another because raft says we're no longer
-							// actively replicating through it. Why? Something
-							// to do with the many proposals we're issuing?
-							return true
-						},
 						OverrideTokenDeduction: func() kvflowcontrol.Tokens {
 							// This test asserts on the exact values of tracked
 							// tokens. In non-test code, the tokens deducted are
@@ -2243,6 +2243,16 @@ func TestFlowControlGranterAdmitOneByOne(t *testing.T) {
 							// the proposals. We don't care about such
 							// differences.
 							return kvflowcontrol.Tokens(1 << 10 /* 1KiB */)
+						},
+						V1: kvflowcontrol.TestingKnobsV1{
+							MaintainStreamsForBehindFollowers: func() bool {
+								// TODO(irfansharif): This test is flakey without
+								// this change -- we disconnect one stream or
+								// another because raft says we're no longer
+								// actively replicating through it. Why? Something
+								// to do with the many proposals we're issuing?
+								return true
+							},
 						},
 					},
 				},

--- a/pkg/kv/kvserver/flow_control_replica_integration.go
+++ b/pkg/kv/kvserver/flow_control_replica_integration.go
@@ -486,3 +486,8 @@ func (r *replicaForRACv2) MuRUnlock() {
 func (r *replicaForRACv2) LeaseholderMuRLocked() roachpb.ReplicaID {
 	return r.mu.state.Lease.Replica.ReplicaID
 }
+
+// IsScratchRange implements replica_rac2.Replica.
+func (r *replicaForRACv2) IsScratchRange() bool {
+	return (*Replica)(r).IsScratchRange()
+}

--- a/pkg/kv/kvserver/flow_control_replica_integration.go
+++ b/pkg/kv/kvserver/flow_control_replica_integration.go
@@ -226,7 +226,7 @@ func (f *replicaFlowControlIntegrationImpl) onRaftTransportDisconnected(
 		return // nothing to do
 	}
 
-	if fn := f.knobs.MaintainStreamsForBrokenRaftTransport; fn != nil && fn() {
+	if fn := f.knobs.V1.MaintainStreamsForBrokenRaftTransport; fn != nil && fn() {
 		return // nothing to do
 	}
 
@@ -311,12 +311,12 @@ func (f *replicaFlowControlIntegrationImpl) notActivelyReplicatingTo() []roachpb
 	inactiveFollowers := f.replicaForFlowControl.getInactiveFollowers()
 	disconnectedFollowers := f.replicaForFlowControl.getDisconnectedFollowers()
 
-	maintainStreamsForBrokenRaftTransport := f.knobs.MaintainStreamsForBrokenRaftTransport != nil &&
-		f.knobs.MaintainStreamsForBrokenRaftTransport()
-	maintainStreamsForInactiveFollowers := f.knobs.MaintainStreamsForInactiveFollowers != nil &&
-		f.knobs.MaintainStreamsForInactiveFollowers()
-	maintainStreamsForBehindFollowers := f.knobs.MaintainStreamsForBehindFollowers != nil &&
-		f.knobs.MaintainStreamsForBehindFollowers()
+	maintainStreamsForBrokenRaftTransport := f.knobs.V1.MaintainStreamsForBrokenRaftTransport != nil &&
+		f.knobs.V1.MaintainStreamsForBrokenRaftTransport()
+	maintainStreamsForInactiveFollowers := f.knobs.V1.MaintainStreamsForInactiveFollowers != nil &&
+		f.knobs.V1.MaintainStreamsForInactiveFollowers()
+	maintainStreamsForBehindFollowers := f.knobs.V1.MaintainStreamsForBehindFollowers != nil &&
+		f.knobs.V1.MaintainStreamsForBehindFollowers()
 
 	notActivelyReplicatingTo := make(map[roachpb.ReplicaDescriptor]struct{})
 	ourReplicaID := f.replicaForFlowControl.getReplicaID()

--- a/pkg/kv/kvserver/flow_control_stores.go
+++ b/pkg/kv/kvserver/flow_control_stores.go
@@ -368,6 +368,10 @@ func (ss *storesForRACv2) lookup(
 	if r == nil || r.replicaID != replicaID {
 		return nil
 	}
+	if flowTestKnobs := r.store.TestingKnobs().FlowControlTestingKnobs; flowTestKnobs != nil &&
+		flowTestKnobs.UseOnlyForScratchRanges && !r.IsScratchRange() {
+		return nil
+	}
 	return r.flowControlV2
 }
 

--- a/pkg/kv/kvserver/kvadmission/kvadmission.go
+++ b/pkg/kv/kvserver/kvadmission/kvadmission.go
@@ -353,9 +353,10 @@ func (n *controllerImpl) AdmitKVWork(
 				// and the point of deduction. That's ok, there's no strong
 				// synchronization needed between these two points.
 				ah.raftAdmissionMeta = &kvflowcontrolpb.RaftAdmissionMeta{
-					// TODO(sumeerbhola,kvoli): The priority needs to be converted to a
-					// raftpb.Priority when v2 encoding is enabled. e.g.,
-					// rac2.AdmissionToRaftPriority().
+					// NOTE: The priority is identical for v1 and v2, a
+					// admissionpb.WorkPriority,  until we encode the command in
+					// replica_raft, where if the range is using racv2 encoding we will
+					// convert the priority to a raftpb.Priority.
 					AdmissionPriority:   int32(admissionInfo.Priority),
 					AdmissionCreateTime: admissionInfo.CreateTime,
 					AdmissionOriginNode: n.nodeID.Get(),

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowhandle/kvflowhandle.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowhandle/kvflowhandle.go
@@ -162,8 +162,8 @@ func (h *Handle) deductTokensForInner(
 		return nil // unused return value in production code
 	}
 
-	if h.knobs.OverrideTokenDeduction != nil {
-		tokens = h.knobs.OverrideTokenDeduction()
+	if fn := h.knobs.OverrideTokenDeduction; fn != nil {
+		tokens = fn()
 	}
 
 	for _, c := range h.mu.connections {

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowtokentracker/tracker.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowtokentracker/tracker.go
@@ -154,7 +154,7 @@ func (dt *Tracker) Untrack(
 			break
 		}
 
-		if fn := dt.knobs.UntrackTokensInterceptor; fn != nil {
+		if fn := dt.knobs.V1.UntrackTokensInterceptor; fn != nil {
 			fn(deduction.tokens, deduction.position)
 		}
 

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowtokentracker/tracker_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowtokentracker/tracker_test.go
@@ -112,7 +112,7 @@ func TestTracker(t *testing.T) {
 				count := 0
 				var buf strings.Builder
 				buf.WriteString(fmt.Sprintf("pri=%s\n", pri))
-				knobs.UntrackTokensInterceptor = func(tokens kvflowcontrol.Tokens, position kvflowcontrolpb.RaftLogPosition) {
+				knobs.V1.UntrackTokensInterceptor = func(tokens kvflowcontrol.Tokens, position kvflowcontrolpb.RaftLogPosition) {
 					count += 1
 					buf.WriteString(fmt.Sprintf("  tokens=%s %s\n",
 						testingPrintTrimmedTokens(tokens), position))

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
@@ -245,6 +245,7 @@ func (s *testingRCState) getOrInitRange(t *testing.T, r testingRange) *testingRC
 			Clock:               s.clock,
 			CloseTimerScheduler: s.probeToCloseScheduler,
 			EvalWaitMetrics:     s.evalMetrics,
+			Knobs:               &kvflowcontrol.TestingKnobs{},
 		}
 
 		init := RangeControllerInitState{

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -86,6 +86,10 @@ func (r *testReplica) LeaseholderMuRLocked() roachpb.ReplicaID {
 	return r.leaseholder
 }
 
+func (r *testReplica) IsScratchRange() bool {
+	return true
+}
+
 type testRaftScheduler struct {
 	b *strings.Builder
 }

--- a/pkg/kv/kvserver/kvflowcontrol/testing_knobs.go
+++ b/pkg/kv/kvserver/kvflowcontrol/testing_knobs.go
@@ -18,12 +18,20 @@ import (
 // TestingKnobs provide fine-grained control over the various kvflowcontrol
 // components for testing.
 type TestingKnobs struct {
-	// UntrackTokensInterceptor is invoked whenever tokens are untracked, along
-	// with their corresponding log positions.
-	UntrackTokensInterceptor func(Tokens, kvflowcontrolpb.RaftLogPosition)
+	V1                      TestingKnobsV1
+	UseOnlyForScratchRanges bool
 	// OverrideTokenDeduction is used to override how many tokens are deducted
 	// post-evaluation.
 	OverrideTokenDeduction func() Tokens
+}
+
+// TestingKnobsV1 are the testing knobs that appply to replication flow control
+// v1, which is mostly contained in the kvflowcontroller, kvflowdispatch,
+// kvflowhandle and kvflowtokentracker packages.
+type TestingKnobsV1 struct {
+	// UntrackTokensInterceptor is invoked whenever tokens are untracked, along
+	// with their corresponding log positions.
+	UntrackTokensInterceptor func(Tokens, kvflowcontrolpb.RaftLogPosition)
 	// MaintainStreamsForBehindFollowers is used in tests to maintain
 	// replication streams for behind followers.
 	MaintainStreamsForBehindFollowers func() bool
@@ -34,9 +42,6 @@ type TestingKnobs struct {
 	// replication streams for followers we're no longer connected to via the
 	// RaftTransport.
 	MaintainStreamsForBrokenRaftTransport func() bool
-	// UseOnlyForScratchRanges enables the use of kvflowcontrol
-	// only for scratch ranges.
-	UseOnlyForScratchRanges bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -239,6 +239,7 @@ func newUninitializedReplicaWithoutRaftGroup(
 		EvalWaitMetrics:        r.store.cfg.KVFlowEvalWaitMetrics,
 		RangeControllerFactory: r.store.kvflowRangeControllerFactory,
 		EnabledWhenLeaderLevel: r.raftMu.flowControlLevel,
+		Knobs:                  r.store.TestingKnobs().FlowControlTestingKnobs,
 	})
 	return r
 }

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1923,11 +1923,12 @@ func (r *Replica) sendRaftMessage(ctx context.Context, msg raftpb.Message) {
 
 	req := newRaftMessageRequest()
 	*req = kvserverpb.RaftMessageRequest{
-		RangeID:       r.RangeID,
-		ToReplica:     toReplica,
-		FromReplica:   fromReplica,
-		Message:       msg,
-		RangeStartKey: startKey, // usually nil
+		RangeID:           r.RangeID,
+		ToReplica:         toReplica,
+		FromReplica:       fromReplica,
+		Message:           msg,
+		RangeStartKey:     startKey, // usually nil
+		UsingRac2Protocol: r.flowControlV2.GetEnabledWhenLeader() >= replica_rac2.EnabledWhenLeaderV1Encoding,
 	}
 	// For RACv2, annotate successful MsgAppResp messages with the vector of
 	// admitted log indices, by priority.

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -412,10 +413,19 @@ func (r *Replica) propose(
 	if !p.useReplicationAdmissionControl() {
 		raftAdmissionMeta = nil
 	}
+
+	encodePriority := r.encodePriorityForRACv2()
+	if encodePriority && raftAdmissionMeta != nil {
+		// AdmissionPriority is the same for both v1 and v2 replication flow control
+		// until we get here. If the v2 encoding is enabled, we need to convert the
+		// priority to the v2 encoding.
+		raftAdmissionMeta.AdmissionPriority = int32(rac2.AdmissionToRaftPriority(
+			admissionpb.WorkPriority(raftAdmissionMeta.AdmissionPriority)))
+	}
 	data, err := raftlog.EncodeCommand(ctx, p.command, p.idKey,
 		raftlog.EncodeOptions{
 			RaftAdmissionMeta: raftAdmissionMeta,
-			EncodePriority:    r.encodePriorityForRACv2(),
+			EncodePriority:    encodePriority,
 		})
 	if err != nil {
 		return kvpb.NewError(err)

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1560,6 +1560,7 @@ func NewStore(
 		s.cfg.KVFlowStreamTokenProvider,
 		replica_rac2.NewStreamCloseScheduler(
 			s.stopper, timeutil.DefaultTimeSource{}, s.scheduler),
+		s.TestingKnobs().FlowControlTestingKnobs,
 	)
 
 	// Run a log SyncWaiter loop for every 32 raft scheduler goroutines.


### PR DESCRIPTION
The `UsingRac2Protocol` in a `RaftMessageRequest` is used to notify
followers about the flow control protocol the range leader is using.
Populate the field so followers are informed and correctly admit work to
store queues.

---

Previously, we were not using the `raftpb.Priority` but
`admissionpb.WorkPriority` to encode commands. These priorities map to
different integers.

When the rac2 enablement level is
`replica_rac2.EnabledWhenLeaderV2Encoding`, convert the work priority to
a raft priority before encoding.

---

We wish to re-use some generally applicable testing knobs between v1 and
v2. Move the flow control v1 specific settings into
`kvflowcontrol.TestingKnobsV1`.

--- 

Thread `kvflowcontrol.TestingKnobs` through the `rac2` `Processor` and
`RangeController`. The two knobs supported allow only running
meaningful rac2 machinery against the scratch range and overwriting
token deduction amounts.

---

Part of: https://github.com/cockroachdb/cockroach/issues/130187
Release note: None