### PR TITLE
raft: mark supporting followers as recently active

### DIFF
--- a/pkg/raft/testdata/fortification_checkquorum.txt
+++ b/pkg/raft/testdata/fortification_checkquorum.txt
@@ -37,9 +37,24 @@ tick-election 1
 ----
 ok
 
+print-fortification-state 1
+----
+1 : 1
+2 : 1
+3 : 1
+
+# Even if we haven't received any messages from the follower since last tick,
+# we are still okay because the follower is fortifying us which means that it's
+# active.
 tick-election 1
 ----
-DEBUG 1 has not received messages from a quorum of peers in the last election timeout
+ok
+
+status 1
+----
+1: StateReplicate match=11 next=12 sentCommit=10 matchCommit=10
+2: StateReplicate match=11 next=12 sentCommit=11 matchCommit=11
+3: StateReplicate match=11 next=12 sentCommit=11 matchCommit=11
 
 # Now, withdraw the StoreLiveness support for the leader's fortified epoch by
 # bumping it. This also shows that we won't break our LeadSupportUntil promise
@@ -51,6 +66,10 @@ bump-epoch 1
 1 2 1 1
 2 2 1 1
 3 2 1 1
+
+tick-election 1
+----
+DEBUG 1 does not have store liveness support from a quorum of peers
 
 tick-election 1
 ----

--- a/pkg/raft/tracker/progress.go
+++ b/pkg/raft/tracker/progress.go
@@ -101,8 +101,10 @@ type Progress struct {
 	// case the follower does not erroneously remain in StateSnapshot.
 	PendingSnapshot uint64
 
-	// RecentActive is true if the progress is recently active. Receiving any messages
-	// from the corresponding follower indicates the progress is active.
+	// RecentActive is true if the progress is recently active. Receiving any
+	// messages from the corresponding follower indicates the progress is active.
+	// Also, it's set to true on every heartbeat timeout if the follower is
+	// fortifying the leader.
 	// RecentActive can be reset to false after an election timeout.
 	// This is always true on the leader.
 	RecentActive bool


### PR DESCRIPTION
This commit marks followers who support the current leader as recently active. This is very important because if we stop heartbeats, we might not send any MsgApp to the followers because there is nothing new to append. This means that we will mark the followers as inactive, even though that they are technically active and supporting the leader.

Epic: None

Release note: None