### PR TITLE
roachtest: perturbation/*/backfill tests work around bugs

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -318,6 +318,10 @@ func (b backfill) startTargetNode(ctx context.Context, t test.Test, v variations
 	_, err := db.ExecContext(ctx, cmd)
 	require.NoError(t, err)
 
+	// TODO(#130939): Allow the backfill to complete, without this it can hang indefinitely.
+	_, err = db.ExecContext(ctx, "SET CLUSTER SETTING bulkio.index_backfill.batch_size = 5000")
+	require.NoError(t, err)
+
 	t.L().Printf("waiting for replicas to be in place")
 	v.waitForRebalanceToStop(ctx, t)
 

--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -757,10 +757,6 @@ func (t trackedStat) merge(o trackedStat, c scoreCalculator) trackedStat {
 	}
 }
 
-// minAcceptableLatencyThreshold is the threshold below which we consider the
-// latency acceptable regardless of any relative change from the baseline.
-const minAcceptableLatencyThreshold = 10 * time.Millisecond
-
 // isAcceptableChange determines if a change from the baseline is acceptable.
 // It compares all the metrics rather than failing fast. Normally multiple
 // metrics will fail at once if a test is going to fail and it is helpful to see
@@ -778,7 +774,7 @@ func isAcceptableChange(
 		baseStat := baseline[name]
 		otherStat := other[name]
 		increase := float64(otherStat.score) / float64(baseStat.score)
-		if float64(otherStat.P99) > float64(minAcceptableLatencyThreshold) && increase > acceptableChange {
+		if increase > acceptableChange {
 			logger.Printf("FAILURE: %-15s: Increase %.4f > %.4f BASE: %v SCORE: %v\n", name, increase, acceptableChange, baseStat.score, otherStat.score)
 			allPassed = false
 		} else {

--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -151,6 +151,9 @@ func setupMetamorphic(p perturbation) variations {
 	v.partitionSite = rng.Intn(2) == 0
 	v.cleanRestart = rng.Intn(2) == 0
 	v.cloud = cloudSets[rng.Intn(len(cloudSets))]
+	// TODO(baptist): Temporarily disable the metamorphic tests on other clouds
+	// as they have limitations on configurations that can run.
+	v.cloud = registry.OnlyGCE
 	v.perturbation = p
 	return v
 }

--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -314,7 +314,7 @@ func (b backfill) startTargetNode(ctx context.Context, t test.Test, v variations
 	db := v.Conn(ctx, t.L(), 1)
 	defer db.Close()
 
-	cmd := fmt.Sprintf("ALTER DATABASE backfill CONFIGURE ZONE USING constraints = '[+node%d]', lease_preferences='[[-node%d]]'", target, target)
+	cmd := fmt.Sprintf(`ALTER DATABASE backfill CONFIGURE ZONE USING constraints='{"+node%d":1}', lease_preferences='[[-node%d]]', num_replicas=3`, target, target)
 	_, err := db.ExecContext(ctx, cmd)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Clean up the perturbation tests to have better success when they run.  The four commits work around various issues that have been found now that these tests are running regularly on nightly builds.

1) Fix the success criteria if there is a stall
2) Fix the issue with index backfill getting stuck (and file #130939 to track)
3) Fix the zone configuration for the backfill test.
4) Remove non-GCE clouds.

Informs: #130939

Epic: none

Release note: None