### PR TITLE
changefeedccl: set debugUseAfterFinish option in a test

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -621,7 +621,11 @@ type TestTenantArgs struct {
 	// determine the tenant's HTTP port.
 	StartingHTTPPort int
 
-	// TracingDefault controls whether the tracing will be on or off by default.
+	// Tracer, if set, will be used by the Server for creating Spans.
+	Tracer *tracing.Tracer
+
+	// TracingDefault controls whether the tracing will be on or off by default,
+	// if Tracer is not set.
 	TracingDefault tracing.TracingMode
 
 	// GoroutineDumpDirName is used to initialize the same named field on the

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -346,6 +346,7 @@ go_test(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/timeutil/pgdate",
+        "//pkg/util/tracing",
         "//pkg/util/uuid",
         "//pkg/workload/bank",
         "//pkg/workload/ledger",

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -817,7 +817,7 @@ func TestTableNameCollision(t *testing.T) {
 		})
 	}
 
-	cdcTest(t, testFn, feedTestForceSink("kafka"), feedTestUseRootUserConnection)
+	cdcTest(t, testFn, feedTestForceSink("kafka"), feedTestUseRootUserConnection, withDebugUseAfterFinish)
 }
 
 func TestAvroMigrateToUnsupportedColumn(t *testing.T) {

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 	"github.com/lib/pq"
@@ -413,6 +414,10 @@ func startTestFullServer(
 		Settings:          options.settings,
 	}
 
+	if options.debugUseAfterFinish {
+		args.Tracer = tracing.NewTracerWithOpt(context.Background(), tracing.WithUseAfterFinishOpt(true, true))
+	}
+
 	if options.argsFn != nil {
 		options.argsFn(&args)
 	}
@@ -523,6 +528,10 @@ func startTestTenant(
 		Settings:      options.settings,
 	}
 
+	if options.debugUseAfterFinish {
+		tenantArgs.Tracer = tracing.NewTracerWithOpt(context.Background(), tracing.WithUseAfterFinishOpt(true, true))
+	}
+
 	tenantServer, tenantDB := serverutils.StartTenant(t, systemServer, tenantArgs)
 	// Re-run setup on the tenant as well
 	tenantRunner := sqlutils.MakeSQLRunner(tenantDB)
@@ -552,6 +561,7 @@ type feedTestOptions struct {
 	disabledSinkTypes            []string
 	settings                     *cluster.Settings
 	additionalSystemPrivs        []string
+	debugUseAfterFinish          bool
 }
 
 type feedTestOption func(opts *feedTestOptions)
@@ -616,6 +626,10 @@ func withKnobsFn(fn updateKnobsFn) feedTestOption {
 
 // Silence the linter.
 var _ = withKnobsFn(nil /* fn */)
+
+var withDebugUseAfterFinish feedTestOption = func(opts *feedTestOptions) {
+	opts.debugUseAfterFinish = true
+}
 
 func newTestOptions() feedTestOptions {
 	// percentTenant is the percentage of tests that will be run against

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1644,7 +1644,11 @@ func (ts *testServer) StartTenant(
 	if stopper == nil {
 		// We don't share the stopper with the server because we want their Tracers
 		// to be different, to simulate them being different processes.
-		tr := tracing.NewTracerWithOpt(ctx, tracing.WithClusterSettings(&st.SV), tracing.WithTracingMode(params.TracingDefault))
+		tr := params.Tracer
+		if tr == nil {
+			tr = tracing.NewTracerWithOpt(ctx, tracing.WithClusterSettings(&st.SV), tracing.WithTracingMode(params.TracingDefault))
+		}
+
 		stopper = stop.NewStopper(stop.WithTracer(tr))
 		// The server's stopper stops the tenant, for convenience.
 		// Use main server quiesce as a signal to stop tenants stopper. In the
@@ -1663,7 +1667,10 @@ func (ts *testServer) StartTenant(
 			return nil, err
 		}
 	} else if stopper.Tracer() == nil {
-		tr := tracing.NewTracerWithOpt(ctx, tracing.WithClusterSettings(&st.SV), tracing.WithTracingMode(params.TracingDefault))
+		tr := params.Tracer
+		if tr == nil {
+			tr = tracing.NewTracerWithOpt(ctx, tracing.WithClusterSettings(&st.SV), tracing.WithTracingMode(params.TracingDefault))
+		}
 		stopper.SetTracer(tr)
 	}
 


### PR DESCRIPTION
Adds the ability for tests to set the debugUseAfterFinish option on the
tracer, and sets it in the TestTableNameCollision test, for debugging.

Part of #128868

Release note: none
