### PR TITLE
sql/sql_test: fix timeout in TestRaceWithBackfill

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -606,6 +607,11 @@ func TestRaceWithBackfill(t *testing.T) {
 				notifyBackfill()
 				return nil
 			},
+		},
+		SQLEvalContext: &eval.TestingKnobs{
+			// This prevents using a small kv-batch-size, which is suspected
+			// of causing the test to time out when run with race detection enabled.
+			ForceProductionValues: true,
 		},
 	}
 


### PR DESCRIPTION
We have seen test flakes with the TestRaceWithBackfill timing out when run with race detection enabled. This will ensure the kv batch size is a reasonable value by forcing production values, overridding any metamorphic constants that may be in use.

Epic: None
Closes #130013
Release note: None