### PR TITLE
raft: introduce LogSnapshot API

### DIFF
--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -214,6 +214,27 @@ func (r *Replica) GetFirstIndex() kvpb.RaftIndex {
 	return r.raftFirstIndexRLocked()
 }
 
+// LogSnapshot returns an immutable point-in-time snapshot of the log storage.
+func (r *replicaRaftStorage) LogSnapshot() raft.LogStorageSnapshot {
+	r.raftMu.AssertHeld()
+	r.mu.AssertRHeld()
+	// TODO(pav-kv): return a wrapper which, in all methods, checks that the log
+	// storage hasn't been written to. A more relaxed version of it should assert
+	// that only the relevant part of the log hasn't been overwritten, e.g. a new
+	// term leader hasn't appended a log slice that truncated the log, or the log
+	// hasn't been wiped.
+	//
+	// This would require auditing and integrating with the write paths. Today,
+	// this type implements only reads, and writes are in various places like the
+	// logstore.LogStore type, or the code in the split handler which creates an
+	// empty range state.
+	//
+	// We don't need a fully fledged Pebble snapshot here. For our purposes, we
+	// can also make sure that raftMu is held for the entire period of using the
+	// LogSnapshot - this should guarantee its immutability.
+	return r
+}
+
 // GetLeaseAppliedIndex returns the lease index of the last applied command.
 func (r *Replica) GetLeaseAppliedIndex() kvpb.LeaseAppliedIndex {
 	r.mu.RLock()

--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -706,7 +706,7 @@ func TestIsOutOfBounds(t *testing.T) {
 					require.True(t, tt.wpanic)
 				}
 			}()
-			err := l.mustCheckOutOfBounds(tt.lo, tt.hi)
+			err := l.snap(l.storage).mustCheckOutOfBounds(tt.lo, tt.hi)
 			require.False(t, tt.wpanic)
 			require.False(t, tt.wErrCompacted && err != ErrCompacted)
 			require.False(t, !tt.wErrCompacted && err != nil)


### PR DESCRIPTION
The API allows reading from raft log while `RawNode` continues making progress. Practically, this means we can unlock `Replica.mu` after having obtained the log snapshot, and can safely read from it while only holding `Replica.raftMu`.

To be used for:
- Fetching committed entries in `Ready` handler while only holding `raftMu` (instead of both `mu` and `raftMu`).
- Building leader->follower `MsgApp` messages on demand, driven by RACv2. Today these messages can be constructed (and incur IO) eagerly on any `Step` while holding `mu`.

Part of #128779
Part of #130955