### PR TITLE
backupccl: clarify timeout error message

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -615,7 +615,7 @@ func runBackupProcessor(
 								if recording != nil {
 									log.Errorf(ctx, "failed export request for span %s\n trace:\n%s", span.span, recording)
 								}
-								return errors.Wrap(exportRequestErr, "export request timeout")
+								return errors.Wrap(exportRequestErr, "KV storage layer did not respond to BACKUP within timeout")
 							}
 							// BatchTimestampBeforeGCError is returned if the ExportRequest
 							// attempts to read below the range's GC threshold.


### PR DESCRIPTION
'ExportRequest' is internal jargon that while meaningful to CRL engineers is less useful to a cluster operator who just needs to know why the backup did not succeed. Instead, if backup is not getting responses from the KV layer, say as much so that an operator knows to look for unhealthy ranges or extreme cluster overload.

Release note: none.
Epic: none.