### PR TITLE
opt: fix SplitDisjunctionOfJoinTerms and SplitDisjunctionOfAntiJoinTerms

### DIFF
--- a/pkg/sql/opt/memo/check_expr.go
+++ b/pkg/sql/opt/memo/check_expr.go
@@ -93,7 +93,7 @@ func (m *Memo) CheckExpr(e opt.Expr) {
 		if !t.Passthrough.SubsetOf(t.Input.Relational().OutputCols) {
 			panic(errors.AssertionFailedf(
 				"projection passes through columns not in input: %v",
-				t.Input.Relational().OutputCols.Difference(t.Passthrough),
+				t.Passthrough.Difference(t.Input.Relational().OutputCols),
 			))
 		}
 		for _, item := range t.Projections {

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -1536,6 +1536,37 @@ func (c *CustomFuncs) makeFilteredSelectForJoin(
 	return newSelect
 }
 
+// CanSplitJoinWithDisjuncts returns true if the given join can be split into a
+// union of two joins. See SplitJoinWithDisjuncts for more details.
+func (c *CustomFuncs) CanSplitJoinWithDisjuncts(
+	joinRel memo.RelExpr, joinFilters memo.FiltersExpr,
+) bool {
+	leftInput := joinRel.Child(0).(memo.RelExpr)
+	rightInput := joinRel.Child(1).(memo.RelExpr)
+
+	switch joinRel.Op() {
+	case opt.InnerJoinOp, opt.SemiJoinOp, opt.AntiJoinOp:
+		// Do nothing
+	default:
+		panic(errors.AssertionFailedf("expected joinRel to be inner, semi, or anti-join"))
+	}
+
+	origLeftScan, _, ok := c.getfilteredCanonicalScan(leftInput)
+	if !ok {
+		return false
+	}
+
+	origRightScan, _, ok := c.getfilteredCanonicalScan(rightInput)
+	if !ok {
+		return false
+	}
+
+	// Look for a disjunction of equijoin predicates.
+	// TODO(mgartner): Make this more efficient.
+	_, _, _, ok = c.splitDisjunctionForJoin(joinRel, joinFilters, origLeftScan, origRightScan)
+	return ok
+}
+
 // SplitJoinWithDisjuncts checks a join relation for a disjunction of predicates
 // in an InnerJoin, SemiJoin or AntiJoin. If present, and the inputs to the join
 // are canonical scans, or Selects from canonical scans, it builds two new join
@@ -1562,20 +1593,10 @@ func (c *CustomFuncs) SplitJoinWithDisjuncts(
 	newRelationCols opt.ColSet,
 	aggCols opt.ColSet,
 	groupingCols opt.ColSet,
-	ok bool,
 ) {
-	notOkSplitJoin := func() (memo.RelExpr, memo.RelExpr, opt.ColSet, opt.ColSet, opt.ColSet, bool) {
-		emptyColSet := opt.ColSet{}
-		return nil, nil, emptyColSet, emptyColSet, emptyColSet, false
-	}
-
-	var joinPrivate *memo.JoinPrivate
-	var leftInput memo.RelExpr
-	var rightInput memo.RelExpr
-
-	joinPrivate = joinRel.Private().(*memo.JoinPrivate)
-	leftInput = joinRel.Child(0).(memo.RelExpr)
-	rightInput = joinRel.Child(1).(memo.RelExpr)
+	joinPrivate := joinRel.Private().(*memo.JoinPrivate)
+	leftInput := joinRel.Child(0).(memo.RelExpr)
+	rightInput := joinRel.Child(1).(memo.RelExpr)
 
 	switch joinRel.Op() {
 	case opt.InnerJoinOp, opt.SemiJoinOp, opt.AntiJoinOp:
@@ -1586,12 +1607,12 @@ func (c *CustomFuncs) SplitJoinWithDisjuncts(
 
 	origLeftScan, leftFilters, ok := c.getfilteredCanonicalScan(leftInput)
 	if !ok {
-		return notOkSplitJoin()
+		panic(errors.AssertionFailedf("expected join left input to have canonical scan"))
 	}
 	origLeftScanPrivate := &origLeftScan.ScanPrivate
 	origRightScan, rightFilters, ok := c.getfilteredCanonicalScan(rightInput)
 	if !ok {
-		return notOkSplitJoin()
+		panic(errors.AssertionFailedf("expected join right input to have canonical scan"))
 	}
 	origRightScanPrivate := &origRightScan.ScanPrivate
 
@@ -1599,7 +1620,7 @@ func (c *CustomFuncs) SplitJoinWithDisjuncts(
 	firstOnClause, secondOnClause, itemToReplace, ok :=
 		c.splitDisjunctionForJoin(joinRel, joinFilters, origLeftScan, origRightScan)
 	if !ok {
-		return notOkSplitJoin()
+		panic(errors.AssertionFailedf("expected join filters to have splitable disjunction"))
 	}
 
 	// Add in the primary key columns so the caller can group by them to
@@ -1736,7 +1757,7 @@ func (c *CustomFuncs) SplitJoinWithDisjuncts(
 		panic(errors.AssertionFailedf("Unexpected join type while splitting disjuncted join predicates: %v",
 			joinRel.Op()))
 	}
-	return firstJoin, secondJoin, newRelationCols, aggCols, groupingCols, true
+	return firstJoin, secondJoin, newRelationCols, aggCols, groupingCols
 }
 
 // getfilteredCanonicalScan looks at a *ScanExpr or *SelectExpr "relation" and

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -149,7 +149,16 @@
 (InnerJoin | SemiJoin
     *
     *
-    $on:* & (CanSplitJoinWithDisjuncts (Root) $on)
+    $on:* &
+        (Let
+            (
+                $firstOnClause
+                $secondOnClause
+                $itemToReplace
+                $ok
+            ):(CanSplitJoinWithDisjuncts (Root) $on)
+            $ok
+        )
     *
 )
 =>
@@ -163,7 +172,13 @@
                     $newRelationCols
                     $aggCols
                     $groupingCols
-                ):(SplitJoinWithDisjuncts (Root) $on)
+                ):(SplitJoinWithDisjuncts
+                    (Root)
+                    $on
+                    $firstOnClause
+                    $secondOnClause
+                    $itemToReplace
+                )
                 $firstJoin
             )
             $secondJoin
@@ -187,7 +202,20 @@
 # SplitDisjunctionOfJoinTerms, except the INTERSECT ALL set operation is used in
 # place of UNION ALL.
 [SplitDisjunctionOfAntiJoinTerms, Explore]
-(AntiJoin * * $on:* & (CanSplitJoinWithDisjuncts (Root) $on) *)
+(AntiJoin
+    *
+    *
+    $on:* &
+        (Let
+            (
+                $firstOnClause
+                $secondOnClause
+                $itemToReplace
+                $ok
+            ):(CanSplitJoinWithDisjuncts (Root) $on)
+            $ok
+        )
+)
 =>
 (Project
     (DistinctOn
@@ -199,7 +227,13 @@
                     $newRelationCols
                     $aggCols
                     $groupingCols
-                ):(SplitJoinWithDisjuncts (Root) $on)
+                ):(SplitJoinWithDisjuncts
+                    (Root)
+                    $on
+                    $firstOnClause
+                    $secondOnClause
+                    $itemToReplace
+                )
                 $firstJoin
             )
             $secondJoin

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -149,25 +149,23 @@
 (InnerJoin | SemiJoin
     *
     *
-    $on:* &
-        (Let
-            (
-                $firstJoin
-                $secondJoin
-                $newRelationCols
-                $aggCols
-                $groupingCols
-                $ok
-            ):(SplitJoinWithDisjuncts (Root) $on)
-            $ok
-        )
+    $on:* & (CanSplitJoinWithDisjuncts (Root) $on)
     *
 )
 =>
 (Project
     (DistinctOn
         (UnionAll
-            $firstJoin
+            (Let
+                (
+                    $firstJoin
+                    $secondJoin
+                    $newRelationCols
+                    $aggCols
+                    $groupingCols
+                ):(SplitJoinWithDisjuncts (Root) $on)
+                $firstJoin
+            )
             $secondJoin
             (MakeSetPrivate
                 $firstJoinCols:(OutputCols $firstJoin)
@@ -189,28 +187,21 @@
 # SplitDisjunctionOfJoinTerms, except the INTERSECT ALL set operation is used in
 # place of UNION ALL.
 [SplitDisjunctionOfAntiJoinTerms, Explore]
-(AntiJoin
-    *
-    *
-    $on:* &
-        (Let
-            (
-                $firstJoin
-                $secondJoin
-                $newRelationCols
-                $aggCols
-                $groupingCols
-                $ok
-            ):(SplitJoinWithDisjuncts (Root) $on)
-            $ok
-        )
-    *
-)
+(AntiJoin * * $on:* & (CanSplitJoinWithDisjuncts (Root) $on) *)
 =>
 (Project
     (DistinctOn
         (IntersectAll
-            $firstJoin
+            (Let
+                (
+                    $firstJoin
+                    $secondJoin
+                    $newRelationCols
+                    $aggCols
+                    $groupingCols
+                ):(SplitJoinWithDisjuncts (Root) $on)
+                $firstJoin
+            )
             $secondJoin
             (MakeSetPrivate
                 $firstJoinCols:(OutputCols $firstJoin)

--- a/pkg/sql/opt/xform/testdata/rules/disjunction_in_join
+++ b/pkg/sql/opt/xform/testdata/rules/disjunction_in_join
@@ -1,4 +1,4 @@
-# Test ORed ON clause predicates which may be split into unions or 
+# Test ORed ON clause predicates which may be split into unions or
 # intersections. The rewrite is cost-based, so may not always show up in the
 # query plan.
 # Use tables both with and without a primary key, to test when PK columns are


### PR DESCRIPTION
#### opt: fix test assertion message

A test-only assertion with the message "projection passes through
columns not in input" has been fixed to correctly print the columns that
are passthrough columns and not in the input. Previously, it incorrectly
printed input columns that were not passthrough columns.

Release note: None

#### opt: fix SplitDisjunctionOfJoinTerms and SplitDisjunctionOfAntiJoinTerms

The exploration rules SplitDisjunctionOfJoinTerms and
SplitDisjunctionOfAntiJoinTerms previously constructed expressions
during the match phase of the rule. This is an anti-pattern. The match
logic occurs before the `matchedRule` callback is invoked, which is used
to disable exploration rules under the `norm` test directive. As a
result these rules could perform some constructions of new expressions
in `norm` tests where these exploration rules should be disabled. This
confused me quite a bit while debugging a problem with the rules.

The rules have been updated so that the eligibility of the rules are
checked during the match phase, and new expressions are only constructed
during the replace phase.

Epic: None

Release note: None

#### opt: optimize SplitDisjunctionOfJoinTerms and SplitDisjunctionOfAntiJoinTerms

Duplicate computation that occurred in both the match and replace phases
of the SplitDisjunctionOfJoinTerms and SplitDisjunctionOfAntiJoinTerms
rules has been eliminated by performing the computation in only the
match phase, and passing the results to a custom function in the replace
phase.

Release note: None
