### PR TITLE
nogo: fix unconvert exclude rules

### DIFF
--- a/build/bazelutil/nogo_config.json
+++ b/build/bazelutil/nogo_config.json
@@ -1624,7 +1624,7 @@
             "github.com/elastic/gosigar": "third-party",
             "github.com/shirou/gopsutil": "third-party code",
             "pkg/.*\\.eg\\.go$": "generated code",
-            ".*\\.pb\\.go$": "generated code",
+            ".*\\.pb(_[0-9]+)?\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
             "pkg/.*_generated\\.go$": "generated code"
         }


### PR DESCRIPTION
In [1], a regression was added in `exclude_files`
for the `unconvert` linter. This regression only
affects builds instrumented with coverage; see [2] for further details.

As a workaround for [2], we extend `exclude_files` to exclude Go sources generated from protobuf,
having the optional suffix of the form `_[0-9]+`.

[1] https://github.com/cockroachdb/cockroach/pull/124155
[2] https://github.com/bazelbuild/rules_go/issues/4110

Epic: none

Release note: None