### PR TITLE
roachtest: Add LDAP conn. latency test via roachtest

### DIFF
--- a/pkg/cmd/roachtest/testdata/ldap_authentication_hba_conf
+++ b/pkg/cmd/roachtest/testdata/ldap_authentication_hba_conf
@@ -1,0 +1,3 @@
+host    all           roachprod           0.0.0.0/0          password
+host    all           all            all                 ldap ldapserver=%s ldapport=636 "ldapbasedn=OU=Users,DC=example,DC=com" "ldapbinddn=CN=John Doe,OU=Users,DC=example,DC=com" ldapbindpasswd=%s ldapsearchattribute=uid "ldapsearchfilter=(mail=*)"
+host    all           root           0.0.0.0/0          password

--- a/pkg/cmd/roachtest/testdata/ldap_base_structure.ldif
+++ b/pkg/cmd/roachtest/testdata/ldap_base_structure.ldif
@@ -1,0 +1,11 @@
+# Organizational Unit: Users
+dn: ou=Users,dc=example,dc=com
+objectClass: top
+objectClass: organizationalUnit
+ou: Users
+
+# Organizational Unit: Groups
+dn: ou=Groups,dc=example,dc=com
+objectClass: top
+objectClass: organizationalUnit
+ou: Groups

--- a/pkg/cmd/roachtest/testdata/ldap_user_group.ldif
+++ b/pkg/cmd/roachtest/testdata/ldap_user_group.ldif
@@ -1,0 +1,63 @@
+# User 1: John Doe
+dn: cn=John Doe,ou=Users,dc=example,dc=com
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: shadowAccount
+uid: jdoe
+cn: John Doe
+sn: Doe
+givenName: John
+displayName: John Doe
+mail: jdoe@example.com
+uidNumber: 1001
+gidNumber: 5000
+homeDirectory: /home/jdoe
+loginShell: /bin/bash
+userPassword: {SSHA}UweAl2O1Zh95nijbT+SaQB5FuaHi7xnE
+
+# User 2: Alice Smith
+dn: cn=Alice Smith,ou=Users,dc=example,dc=com
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: shadowAccount
+uid: asmith
+cn: Alice Smith
+sn: Smith
+givenName: Alice
+displayName: Alice Smith
+mail: asmith@example.com
+uidNumber: 1002
+gidNumber: 5000
+homeDirectory: /home/asmith
+loginShell: /bin/bash
+userPassword: {SSHA}PK9Mq7jpwPR4hslWym9zFpGDyz92iiSs
+
+# User 3: Robert Brown
+dn: cn=Robert Brown,ou=Users,dc=example,dc=com
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: shadowAccount
+uid: rbrown
+cn: Robert Brown
+sn: Brown
+givenName: Robert
+displayName: Robert Brown
+mail: rbrown@example.com
+uidNumber: 1003
+gidNumber: 5000
+homeDirectory: /home/rbrown
+loginShell: /bin/bash
+userPassword: {SSHA}WA/veP8/qFKW74DrCjTw+6DEGxm6Pqb9
+
+# Group: Developers
+dn: cn=Developers,ou=Groups,dc=example,dc=com
+objectClass: top
+objectClass: groupOfUniqueNames
+cn: Developers
+description: Group for software development team members
+uniqueMember: cn=John Doe,ou=Users,dc=example,dc=com
+uniqueMember: cn=Alice Smith,ou=Users,dc=example,dc=com
+uniqueMember: cn=Robert Brown,ou=Users,dc=example,dc=com

--- a/pkg/cmd/roachtest/tests/connection_latency.go
+++ b/pkg/cmd/roachtest/tests/connection_latency.go
@@ -16,7 +16,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/jackc/pgx/v4"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,6 +27,10 @@ const (
 	regionUsCentral = "us-central1-b"
 	regionUsWest    = "us-west1-b"
 	regionEuWest    = "europe-west2-b"
+
+	ldapTestUserName     = "jdoe"
+	ldapTestUserPassword = "password"
+	ldapAdminPassword    = "password"
 )
 
 func runConnectionLatencyTest(
@@ -144,4 +150,402 @@ func registerConnectionLatencyTest(r registry.Registry) {
 			runConnectionLatencyTest(ctx, t, c, numMultiRegionNodes, numZones, true /*password*/)
 		},
 	})
+}
+
+func registerLDAPConnectionLatencyTest(r registry.Registry) {
+
+	// Single region, 1 node test for LDAP connection latency
+	numNodes := 1
+	r.Add(registry.TestSpec{
+		Name:                       "ldap_connection_latency",
+		Owner:                      registry.OwnerProductSecurity,
+		Benchmark:                  true,
+		Cluster:                    r.MakeClusterSpec(numNodes, spec.GCEZones(regionUsCentral)),
+		RequiresDeprecatedWorkload: true,
+		// Cannot be run locally as it is dependent on Linux.
+		CompatibleClouds: registry.OnlyGCE,
+		Suites:           registry.Suites(registry.Nightly),
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runLDAPConnectionLatencyTest(ctx, t, c, numNodes)
+		},
+	})
+}
+
+// runLDAPConnectionLatencyTest creates a local openLDAP server
+// and measures the connection latency.
+// NOTE: The tests accesses the testdata. Since this is an implicit dependency
+// of the test, the test will fail if the roachtest binary is executed
+// outside the project directory.
+func runLDAPConnectionLatencyTest(
+	ctx context.Context, t test.Test, c cluster.Cluster, numNodes int,
+) {
+
+	// put the workload binary onto each node
+	err := c.PutE(ctx, t.L(), t.DeprecatedWorkload(), "./workload")
+	require.NoError(t, err)
+
+	// Initialize default cluster settings for the cluster
+	settings := install.MakeClusterSettings()
+
+	// Don't start a backup schedule as this roachtest reports roachperf results.
+	err = c.StartE(ctx, t.L(),
+		option.NewStartOpts(option.NoBackupSchedule), settings)
+	require.NoError(t, err)
+
+	// Prepare the user which will later be used for ldap bind.
+	prepareSQLUserForLDAP(ctx, t, c, ldapTestUserName)
+
+	nodeArr := make([]int, numNodes)
+	for i := 1; i <= numNodes; i++ {
+		nodeArr[i-1] = i
+	}
+	nodeListOptions := c.Nodes(nodeArr...)
+
+	// Get the hostname, to be used for openLDAP configuration setup.
+	hostName := getLDAPHostName(ctx, t, c)
+
+	// These functions are responsible for setting up openLDAP on the cluster.
+	installOpenLDAPOnHost(ctx, t, c, nodeListOptions)
+	createCertificates(ctx, t, c, nodeListOptions, hostName)
+	updateOpenLDAPConfig(ctx, t, c, nodeListOptions)
+
+	// Import the user and groups to make LDAP directory structure,
+	// this creates 3 users and adds them as members of the group.
+	importUserAndGroupsToLDAPServer(ctx, t, c, nodeListOptions)
+
+	// Setup CRDB specific configs for LDAP authentication.
+	// Update the relevant cluster settings for configuring and debugging.
+	setupCRDBForLDAPAuth(ctx, t, c, hostName)
+
+	urlTemplate := func(host string) string {
+		return fmt.Sprintf("postgresql://%s:%s@localhost:{pgport:1}",
+			ldapTestUserName, ldapTestUserPassword)
+	}
+
+	// Create the SQL authenticating URL and test the connection.
+	testAuthCmd := fmt.Sprintf(
+		"./cockroach sql --url \"%s\" --certs-dir=certs", urlTemplate("localhost"))
+	err = c.RunE(ctx, option.WithNodes(nodeListOptions), testAuthCmd)
+	require.NoError(t, err)
+
+	runWorkload := func(roachNodes, loadNode option.NodeListOption, locality string) {
+		var urlString string
+		var urls []string
+		externalIps, err := c.ExternalIP(ctx, t.L(), roachNodes)
+		require.NoError(t, err)
+
+		for _, u := range externalIps {
+			url := urlTemplate(u)
+			urls = append(urls, fmt.Sprintf("'%s'", url))
+		}
+		urlString = strings.Join(urls, " ")
+
+		t.L().Printf("running workload in %q against urls:\n%s", locality, strings.Join(urls, "\n"))
+
+		workloadCmd := fmt.Sprintf(
+			`./workload run connectionlatency %s --secure --duration 30s --histograms=%s/stats.json --locality %s`,
+			urlString,
+			t.PerfArtifactsDir(),
+			locality,
+		)
+		err = c.RunE(ctx, option.WithNodes(loadNode), workloadCmd)
+		require.NoError(t, err)
+	}
+
+	//Run only on the load node.
+	runWorkload(c.Range(1, numNodes), c.Node(1), regionUsCentral)
+}
+
+// getLDAPHostName retrieves the hostname of the cluster node
+// the result is returned by trimming the trailing '\n'.
+func getLDAPHostName(ctx context.Context, t test.Test, c cluster.Cluster) string {
+	cmd := "hostname -f"
+	out, err := c.RunWithDetailsSingleNode(ctx, t.L(),
+		option.WithNodes(c.Node(1)), cmd)
+	require.NoError(t, err)
+
+	return strings.ReplaceAll(out.Stdout, "\n", "")
+}
+
+// Install the packages to set up openLDAP on ubuntu.
+func installOpenLDAPOnHost(
+	ctx context.Context, t test.Test, c cluster.Cluster, nodeListOptions option.NodeListOption,
+) {
+	// debconf-set-selections must be updated to preset the
+	// prompts for installing `slapd` silently.
+	configCmd := `cat <<EOF | sudo debconf-set-selections
+slapd slapd/no_configuration boolean false
+slapd slapd/domain string example.com
+slapd shared/organization string Example Organization
+slapd slapd/backend select HDB
+slapd slapd/purge_database boolean true
+slapd slapd/move_old_database boolean true
+slapd slapd/allow_ldap_v2 boolean false
+slapd slapd/password1 password password
+slapd slapd/password2 password password
+slapd slapd/internal/generated_adminpw string
+slapd slapd/internal/adminpw string
+EOF`
+	err := c.RunE(ctx, option.WithNodes(nodeListOptions), configCmd)
+	require.NoError(t, err)
+
+	// run the command to install the relevant packages in non-interactibve mode.
+	installCmd := "sudo DEBIAN_FRONTEND=noninteractive apt install -yyq slapd ldap-utils"
+	err = c.RunE(ctx, option.WithNodes(nodeListOptions), installCmd)
+	require.NoError(t, err)
+
+	// The slapd installation has to be reconfigured as the previous command
+	// even after specifically unsetting `slapd/internal/generated_adminpw`
+	// and `slapd/internal/adminpw` was generating a randomized passsword
+	// for the admin user. Hence, this is a hack to not let that happen
+	// and set the admin password as `password`.
+	// Same `debconf-set-selections` is used without the last line
+	// `slapd slapd/internal/adminpw string` which makes the reconfiguration work
+	configCmd = `cat <<EOF | sudo debconf-set-selections
+slapd slapd/no_configuration boolean false
+slapd slapd/domain string example.com
+slapd shared/organization string Example Organization
+slapd slapd/backend select HDB
+slapd slapd/purge_database boolean true
+slapd slapd/move_old_database boolean true
+slapd slapd/allow_ldap_v2 boolean false
+slapd slapd/password1 password password
+slapd slapd/password2 password password
+slapd slapd/internal/generated_adminpw string
+EOF`
+	err = c.RunE(ctx, option.WithNodes(nodeListOptions), configCmd)
+	require.NoError(t, err)
+
+	// Reconfigure the slapd, by taking the above inputs.
+	reconfigureCmd := "sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure slapd"
+	err = c.RunE(ctx, option.WithNodes(nodeListOptions), reconfigureCmd)
+	require.NoError(t, err)
+
+	// Verify that the installation was successful by
+	// authenticating the admin user.
+	testSlapdCmd := fmt.Sprintf("ldapwhoami -H ldap://localhost -D \"cn=admin,dc=example,dc=com\" -w %s", ldapAdminPassword)
+	err = c.RunE(ctx, option.WithNodes(nodeListOptions), testSlapdCmd)
+	require.NoError(t, err)
+}
+
+// Create the certificates to run the openLDAP with TLS
+func createCertificates(
+	ctx context.Context,
+	t test.Test,
+	c cluster.Cluster,
+	nodeListOptions option.NodeListOption,
+	hostName string,
+) {
+
+	// Create directories to keep the openLDAP specific certificates on the node.
+	createFolderCmd := "mkdir certificates my-safe-directory"
+	err := c.RunE(ctx, option.WithNodes(nodeListOptions), createFolderCmd)
+	require.NoError(t, err)
+
+	// Create a custom CA by using the cockroach commands.
+	createCACertCmd := "./cockroach cert create-ca --certs-dir=certificates --ca-key=my-safe-directory/ca.key"
+	err = c.RunE(ctx, option.WithNodes(nodeListOptions), createCACertCmd)
+	require.NoError(t, err)
+
+	// Create a server certificate using the above created CA cert.
+	createServerCertCmd := fmt.Sprintf("./cockroach cert create-node %s --certs-dir=certificates --ca-key=/home/ubuntu/my-safe-directory/ca.key", hostName)
+	err = c.RunE(ctx, option.WithNodes(nodeListOptions), createServerCertCmd)
+	require.NoError(t, err)
+
+	// Copy the certificates to the default directory for LDAP configuration.
+	copyCertCmd := fmt.Sprintf("sudo cp %[1]s/ca.crt %[1]s/node.crt %[1]s/node.key /etc/ssl/certs/", "/home/ubuntu/certificates")
+	err = c.RunE(ctx, option.WithNodes(nodeListOptions), copyCertCmd)
+	require.NoError(t, err)
+
+	// Give openldap permission to access the certificates in the
+	// `/etc/ssl/certs` directory.
+	accessPermissionCmd := "sudo chown openldap:openldap /etc/ssl/certs/ca.crt /etc/ssl/certs/node.key /etc/ssl/certs/node.crt"
+	err = c.RunE(ctx, option.WithNodes(nodeListOptions), accessPermissionCmd)
+	require.NoError(t, err)
+}
+
+// Update all the openLDAP configurations and test correctness.
+func updateOpenLDAPConfig(
+	ctx context.Context, t test.Test, c cluster.Cluster, nodeListOptions option.NodeListOption,
+) {
+
+	// Create a ldif file to be used to modify the LDAP config
+	// containing all the certificate information for TLS.
+	// each of the certificates have action as `replace`
+	// which would update if already present else add if the
+	// certificates were already present.
+	updateCertCmd := `cat <<EOF | sudo tee /etc/ldap/tls.ldif
+dn: cn=config
+changetype: modify
+replace: olcTLSCACertificateFile
+olcTLSCACertificateFile: /etc/ssl/certs/ca.crt
+-
+replace: olcTLSCertificateKeyFile
+olcTLSCertificateKeyFile: /etc/ssl/certs/node.key
+-
+replace: olcTLSCertificateFile
+olcTLSCertificateFile: /etc/ssl/certs/node.crt
+EOF`
+	err := c.RunE(ctx, option.WithNodes(nodeListOptions), updateCertCmd)
+	require.NoError(t, err)
+
+	// Use the above created file to modify the ldap config.
+	ldapModifyCmd := "sudo ldapmodify -Y EXTERNAL -H ldapi:/// -f /etc/ldap/tls.ldif"
+	err = c.RunE(ctx, option.WithNodes(nodeListOptions), ldapModifyCmd)
+	require.NoError(t, err)
+
+	// Configure the Uncomplicated Firewall (UFW) to allow incoming
+	// connections on port 636
+	enableFirewallCmd := "sudo ufw allow 636"
+	err = c.RunE(ctx, option.WithNodes(nodeListOptions), enableFirewallCmd)
+	require.NoError(t, err)
+
+	// Update the file /etc/default/slapd, to contain
+	// SLAPD_SERVICES="ldap:/// ldaps:/// ldapi:///"
+	// this enables connection over LDAP with TLS.
+	updateSlapdConfigCmd := "sudo sed -i 's/^SLAPD_SERVICES=.*/" +
+		"SLAPD_SERVICES=\"ldap:\\/\\/\\/ ldapi:\\/\\/\\/ " +
+		"ldaps:\\/\\/\\/\"/' /etc/default/slapd"
+	err = c.RunE(ctx, option.WithNodes(nodeListOptions), updateSlapdConfigCmd)
+	require.NoError(t, err)
+
+	// Copy the CA certificate to `/usr/local/share/ca-certificates/`
+	// to add it as a trusted CA for the host node.
+	trustedCACertCmd := "sudo cp /etc/ssl/certs/ca.crt /usr/local/share/ca-certificates/"
+	err = c.RunE(ctx, option.WithNodes(nodeListOptions), trustedCACertCmd)
+	require.NoError(t, err)
+
+	// Add the custom CA created before as a trusted CA cert for the host node.
+	updateCACertCmd := "sudo update-ca-certificates"
+	err = c.RunE(ctx, option.WithNodes(nodeListOptions), updateCACertCmd)
+	require.NoError(t, err)
+
+	// Restart the slapd service running in the background
+	// to apply all the configurations changed above.
+	restartSlapdCmd := "sudo systemctl restart slapd"
+	err = c.RunE(ctx, option.WithNodes(nodeListOptions), restartSlapdCmd)
+	require.NoError(t, err)
+
+	// Test the ldap connection over TLS
+	cmd := "sudo ldapsearch -H ldaps://localhost -x -b \"\" -s base -LLL -d 1"
+	_, err = c.RunWithDetailsSingleNode(ctx, t.L(),
+		option.WithNodes(c.Node(1)), cmd)
+	require.NoError(t, err)
+}
+
+// Create the directory structure for openLDAP and test LDAP bind
+// using the `ldapwhoami` command.
+func importUserAndGroupsToLDAPServer(
+	ctx context.Context, t test.Test, c cluster.Cluster, nodeListOptions option.NodeListOption,
+) {
+	// Copy the base structure file onto the node
+	content := getTestDataFileContent(
+		t, "./pkg/cmd/roachtest/testdata/ldap_base_structure.ldif")
+	err := c.PutString(ctx, content, "base_structure.ldif", 0755)
+	require.NoError(t, err)
+
+	// Apply the base structure onto the running LDAP service.
+	baseStructureAddCmd := fmt.Sprintf("ldapadd -x -D \"cn=admin,dc=example,dc=com\" -w %s -f base_structure.ldif", ldapAdminPassword)
+	err = c.RunE(ctx, option.WithNodes(nodeListOptions), baseStructureAddCmd)
+	require.NoError(t, err)
+
+	// Copy the user and groups file onto the node.
+	content = getTestDataFileContent(
+		t, "./pkg/cmd/roachtest/testdata/ldap_user_group.ldif")
+	err = c.PutString(ctx, content, "ldap_user_group.ldif", 0755)
+	require.NoError(t, err)
+
+	// Apply the user and group creation onto the running LDAP service.
+	structureAddCmd := fmt.Sprintf("ldapadd -x -D \"cn=admin,dc=example,dc=com\" -w %s -f ldap_user_group.ldif", ldapAdminPassword)
+	err = c.RunE(ctx, option.WithNodes(nodeListOptions), structureAddCmd)
+	require.NoError(t, err)
+
+	testImportCmd := "ldapsearch -x -LLL -b \"dc=example,dc=com\" \"(objectClass=*)\""
+	err = c.RunE(ctx, option.WithNodes(nodeListOptions), testImportCmd)
+	require.NoError(t, err)
+
+	testBindCmd := fmt.Sprintf("ldapwhoami -x -H ldaps://localhost -D \"cn=John Doe,ou=Users,dc=example,dc=com\" -w %s", ldapAdminPassword)
+	err = c.RunE(ctx, option.WithNodes(nodeListOptions), testBindCmd)
+	require.NoError(t, err)
+}
+
+// Setup CRDB specific configs for LDAP authentication.
+// Update the relevant cluster settings for configuring and debugging.
+func setupCRDBForLDAPAuth(ctx context.Context, t test.Test, c cluster.Cluster, hostName string) {
+	// Connect to the node using the root user to update the
+	// cluster settings for LDAP.
+	conn := createPgxConnWithExternalURL(ctx, t, c)
+
+	// read and set the HBA conf for LDAP bind of the user `jdoe`.
+	// this also retains the login of roachprod user using
+	// password authentication as that is required for roachtest.
+	hba := fmt.Sprintf(getTestDataFileContent(
+		t, "./pkg/cmd/roachtest/testdata/ldap_authentication_hba_conf"),
+		hostName, ldapTestUserPassword)
+	hbaQuery := createClusterSettingQuery(
+		"server.host_based_authentication.configuration", fmt.Sprintf("'%s'", hba))
+	runSQLQueryForConnection(ctx, t, conn, hbaQuery)
+
+	// Get the ca.crt used to setup TLS on the openLDAP server.
+	getCACertCmd := "cd certificates && cat ca.crt"
+	out, err := c.RunWithDetailsSingleNode(ctx, t.L(),
+		option.WithNodes(c.Node(1)), getCACertCmd)
+	require.NoError(t, err)
+	trimmed := strings.TrimSuffix(out.Stdout, "\n")
+
+	caCertQuery := createClusterSettingQuery(
+		"server.ldap_authentication.domain.custom_ca", fmt.Sprintf("'%s'", trimmed))
+	runSQLQueryForConnection(ctx, t, conn, caCertQuery)
+
+	// This is required for better debugging in-case of failures in authentication.
+	debuggingQuery := createClusterSettingQuery(
+		"server.auth_log.sql_sessions.enabled", "true")
+	runSQLQueryForConnection(ctx, t, conn, debuggingQuery)
+}
+
+// runSQLQueryForConnection uses the provided psql connection
+// to execute the given query.
+func runSQLQueryForConnection(ctx context.Context, t test.Test, conn *pgx.Conn, query string) {
+	row, err := conn.Query(ctx, query)
+	require.NoError(t, err)
+	// The row must be closed for the connection to be used again
+	row.Close()
+}
+
+// createClusterSettingQuery returns the template for updating
+// cluster settings.
+func createClusterSettingQuery(key, value string) string {
+	return fmt.Sprintf("SET cluster setting %s=%s", key, value)
+}
+
+// prepareUserForLDAP creates a SQL user and grants admin privilege
+// to the user. The `ldapUserName` must be same as the username
+// on the LDAP server.
+func prepareSQLUserForLDAP(
+	ctx context.Context, t test.Test, c cluster.Cluster, ldapUserName string,
+) {
+	// Connect to the node to create the required SQL users
+	// which will be authenticated using LDAP.
+	conn := createPgxConnWithExternalURL(ctx, t, c)
+
+	runSQLQueryForConnection(ctx, t, conn,
+		fmt.Sprintf("CREATE ROLE %s LOGIN", ldapUserName))
+
+	// connectionlatency workload checks the presence of the database named
+	// `connectionlatency`, if not present it creates it using the logged-in user
+	// Hence for ease of use, giving admin privilege to the user.
+	runSQLQueryForConnection(ctx, t, conn,
+		fmt.Sprintf("GRANT admin to %s", ldapUserName))
+}
+
+// createPgxConnWithExternalURL returns a psql connection
+// using the cluster's external url.
+func createPgxConnWithExternalURL(ctx context.Context, t test.Test, c cluster.Cluster) *pgx.Conn {
+	pgURL, err := c.ExternalPGUrl(ctx, t.L(),
+		c.Node(1), roachprod.PGURLOptions{})
+	require.NoError(t, err)
+	require.NotEmpty(t, pgURL)
+	conn, err := pgx.Connect(ctx, pgURL[0])
+	require.NoError(t, err)
+	return conn
 }

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -87,6 +87,7 @@ func RegisterTests(r registry.Registry) {
 	registerKnex(r)
 	registerLOQRecovery(r)
 	registerLargeRange(r)
+	registerLDAPConnectionLatencyTest(r)
 	registerLeasePreferences(r)
 	registerLedger(r)
 	registerLibPQ(r)


### PR DESCRIPTION
No test previously existed to compute and monitor LDAP
connection latency

Created a roachtest which leverages the workload
to get the stats for LDAP connection latency
The test provisions an openLDAP service and it's user `jdoe`
which is authenticated on the CRDB via LDAP.
The test
* provisions openLDAP with TLS connection
* Creates a user named jdoe into CRDB
* Sets the HBA conf and custom CA into the cluster settings
* runs the workload binary to compute the connection latency

Epic: [CRDB-40412](https://cockroachlabs.atlassian.net/browse/CRDB-40412)
Fixes: https://github.com/cockroachdb/cockroach/issues/127358

Release note: None