### PR TITLE
roachprod: disable Ubuntu's unattended upgrades

### DIFF
--- a/pkg/roachprod/vm/aws/support.go
+++ b/pkg/roachprod/vm/aws/support.go
@@ -167,6 +167,11 @@ zpool list
 
 sudo apt-get install -qy chrony
 
+# Uninstall unattended-upgrades
+sudo service unattended-upgrades stop
+sudo rm -rf /var/log/unattended-upgrades
+sudo apt-get purge -y unattended-upgrades
+
 # Override the chrony config. In particular,
 # log aggressively when clock is adjusted (0.01s)
 # and exclusively use a single time server.

--- a/pkg/roachprod/vm/azure/utils.go
+++ b/pkg/roachprod/vm/azure/utils.go
@@ -103,6 +103,11 @@ EOF
 # See https://ubuntu.pkgs.org/22.04/ubuntu-main-amd64/tcpdump_4.99.1-3build2_amd64.deb.html
 sudo ln -s /usr/bin/tcpdump /usr/sbin/tcpdump
 
+# Uninstall unattended-upgrades
+systemctl stop unattended-upgrades
+sudo rm -rf /var/log/unattended-upgrades
+apt-get purge -y unattended-upgrades
+
 # Enable core dumps
 cat <<EOF > /etc/security/limits.d/core_unlimited.conf
 * soft core unlimited

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -222,6 +222,7 @@ sudo apt-get install -qy chrony
 
 # Uninstall some packages to prevent them running cronjobs and similar jobs in parallel
 systemctl stop unattended-upgrades
+sudo rm -rf /var/log/unattended-upgrades
 apt-get purge -y unattended-upgrades
 
 {{ if not .EnableCron }}


### PR DESCRIPTION
Previously, we had disabled `unattended-upgrades` only on GCE. This was inadequate because we were seeing failures on AWS and Azure tests since there were packages upgrading in the background. This PR disables `unattended-upgrades` on AWS and Azure.

Epic: none
Fixes: #127518
Release note: None