### PR TITLE
raft: fix slow_follower_after_compaction test comment

### DIFF
--- a/pkg/raft/testdata/slow_follower_after_compaction.txt
+++ b/pkg/raft/testdata/slow_follower_after_compaction.txt
@@ -96,24 +96,52 @@ compact 1 17
 ----
 1/18 EntryNormal "prop_1_18"
 
-# Trigger a round of empty MsgApp "probe" from leader. It will reach node 3
-# which will reply with a rejection MsgApp because it sees a gap in the log.
-# Node 1 will reset the MsgApp flow and send a snapshot to catch node 3 up.
+# Trigger a round of MsgHeartbeat from the leader. This will cause the leader
+# to first call maybeSendAppend() which will realize that the log got truncated
+# and that follower 3 would reject the MsgApp. Therefore, the leader will send
+# a snapshot to it directly, skipping a round of rejected MsgApp.
 tick-heartbeat 1
 ----
 ok
 
-log-level none
+stabilize 1 3
 ----
-ok
-
-stabilize
-----
-ok
-
-log-level debug
-----
-ok
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->2 MsgHeartbeat Term:1 Log:0/0
+  1->3 MsgHeartbeat Term:1 Log:0/0
+> 3 receiving messages
+  1->3 MsgHeartbeat Term:1 Log:0/0
+> 3 handling Ready
+  Ready MustSync=false:
+  Messages:
+  3->1 MsgHeartbeatResp Term:1 Log:0/0
+> 1 receiving messages
+  3->1 MsgHeartbeatResp Term:1 Log:0/0
+  DEBUG 1 [firstindex: 18, commit: 18] sent snapshot[index: 18, term: 1] to 3 [StateReplicate match=14 next=17 sentCommit=16 matchCommit=14 inflight=2[full]]
+  DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=14 next=19 sentCommit=18 matchCommit=14 paused pendingSnap=18]
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->3 MsgSnap Term:1 Log:0/0
+    Snapshot: Index:18 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+> 3 receiving messages
+  1->3 MsgSnap Term:1 Log:0/0
+    Snapshot: Index:18 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+  INFO log [committed=14, applied=14, applying=14, unstable.offset=15, unstable.offsetInProgress=15, len(unstable.Entries)=0] starts to restore snapshot [index: 18, term: 1]
+  INFO 3 switched to configuration voters=(1 2 3)
+  INFO 3 [commit: 18, lastindex: 18, lastterm: 1] restored snapshot [index: 18, term: 1]
+  INFO 3 [commit: 18] restored snapshot [index: 18, term: 1]
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:18 Lead:1 LeadEpoch:1
+  Snapshot Index:18 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+  Messages:
+  3->1 MsgAppResp Term:1 Log:0/18 Commit:18
+> 1 receiving messages
+  3->1 MsgAppResp Term:1 Log:0/18 Commit:18
+  DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=18 next=19 sentCommit=18 matchCommit=18 paused pendingSnap=18]
 
 # All nodes caught up.
 status 1


### PR DESCRIPTION
This commit changes the slow_follower_after_compaction comment that mentions a round of rejected MsgApp before sending a snapshot. This is because now the leader would detect that the follower will reject the MsgApp, and it sends the snapshot directly.

Epic: None

Release note: None