### PR TITLE
server/license: Logging and error message cleanup

### DIFF
--- a/pkg/server/license/enforcer_test.go
+++ b/pkg/server/license/enforcer_test.go
@@ -301,12 +301,12 @@ func TestThrottleErrorMsg(t *testing.T) {
 		{"at-threshold-valid-license-and-telemetry", true, t10d, t10d, ""},
 		{"at-threshold-expired-license-in-grace-valid-telemetry", true, t60d, t55d, ""},
 		{"at-threshold-expired-license-past-grace-valid-telemetry", true, t60d1ms, t55d,
-			"License expired. The maximum number of open transactions has been reached"},
+			"License expired .*. The maximum number of .*"},
 		{"below-threshold-expired-license-past-grace-valid-telemetry", false, t60d1ms, t55d, ""},
 		{"at-threshold-expired-license-in-grace-invalid-telemetry", true, t55d, t10d,
-			"The maximum number of open transactions has been reached because the license requires diagnostic reporting"},
+			"The maximum number of concurrently open transactions has been reached because the license requires diagnostic reporting"},
 		{"at-threshold-valid-license-invalid-telemetry", true, t10d, t0d,
-			"The maximum number of open transactions has been reached because the license requires diagnostic reporting"},
+			"The maximum number of concurrently open transactions has been reached because the license requires diagnostic reporting"},
 		{"below-threshold-invalid-telemetry", false, t10d, t0d, ""},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
This addresses a few late comments from PR #130872:
- The license expiry date is now included when throttling due to an expired license.
- Additional context from the license enforcer is logged whenever a license change occurs.
- The throttle message has been clarified to explicitly state that throttling is due to reaching the maximum number of concurrent open transactions.

Epic: CRDB-39988
Informs: CRDB-39991
Release note: None