### PR TITLE
changefeedccl: protect system.role_members using protected timestamps

### DIFF
--- a/pkg/ccl/changefeedccl/protected_timestamps.go
+++ b/pkg/ccl/changefeedccl/protected_timestamps.go
@@ -49,12 +49,12 @@ var systemTablesToProtect = []descpb.ID{
 	keys.DescriptorTableID,
 	keys.CommentsTableID,
 	keys.ZonesTableID,
+	// Required for CDC Queries.
+	keys.RoleMembersTableID,
+	// TODO(#128806): identify and add any more required tables (such as, possibly, `keys.UsersTableID`)
 }
 
 func makeTargetToProtect(targets changefeedbase.Targets) *ptpb.Target {
-	// NB: We add 1 because we're also going to protect system.descriptors.
-	// We protect system.descriptors because a changefeed needs all of the history
-	// of table descriptors to version data.
 	tablesToProtect := make(descpb.IDs, 0, targets.NumUniqueTables()+len(systemTablesToProtect))
 	_ = targets.EachTableID(func(id descpb.ID) error {
 		tablesToProtect = append(tablesToProtect, id)


### PR DESCRIPTION
Adds `system.role_members` to the list of system
tables that are protected by changefeeds.

Informs: #128806
See also: #130622

Release note (bug fix): Fix a bug which could
result in changefeeds using cdc queries failing
due to a system table being GC'd.
