### PR TITLE
crosscluster/physical: use correct lag replan cluster setting

### DIFF
--- a/pkg/ccl/crosscluster/physical/stream_ingestion_frontier_processor.go
+++ b/pkg/ccl/crosscluster/physical/stream_ingestion_frontier_processor.go
@@ -435,11 +435,7 @@ func (sf *streamIngestionFrontier) maybePersistFrontierEntries() error {
 
 func (sf *streamIngestionFrontier) maybeCheckForLaggingNodes() error {
 	ctx := sf.Ctx()
-
-	// We halve the frequency relative to the ReplanFrequency setting (i.e.
-	// check twice as often), because the node lag checker will only restart the
-	// distSQL plan if a node is lagging for 2 checks in a row.
-	checkFreq := crosscluster.ReplanFrequency.Get(&sf.FlowCtx.Cfg.Settings.SV) / 2
+	checkFreq := crosscluster.LagCheckFrequency.Get(&sf.FlowCtx.Cfg.Settings.SV)
 	maxLag := crosscluster.InterNodeLag.Get(&sf.FlowCtx.Cfg.Settings.SV)
 	if sf.persistedReplicatedTime.IsEmpty() {
 		log.VEvent(ctx, 2, "skipping lag replanning check: no persisted replicated time")


### PR DESCRIPTION
Previously the `stream_replication.replan_flow_frequency` setting determined the frequency that the frontier processor checked for lagging nodes, not the `stream_replication.lag_check_frequency` setting, as intended. The latter didn't control anything. This patch fixes this.

Epic: none
Release note: none