### PR TITLE
release-24.1: multiregionccl: deflake TestMrSystemDatabase

### DIFF
--- a/pkg/ccl/multiregionccl/multiregion_system_table_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_system_table_test.go
@@ -85,12 +85,28 @@ func TestMrSystemDatabase(t *testing.T) {
 	tDB.CheckQueryResults(t, `SELECT * FROM crdb_internal.invalid_objects`, [][]string{})
 
 	t.Run("Sqlliveness", func(t *testing.T) {
-		row := tDB.QueryRow(t, `SELECT crdb_region, session_id, expiration FROM system.sqlliveness LIMIT 1`)
-		var sessionID string
-		var crdbRegion string
-		var rawExpiration apd.Decimal
-		row.Scan(&crdbRegion, &sessionID, &rawExpiration)
-		require.Equal(t, "us-east1", crdbRegion)
+		// When optimizing the system database the ALTER DATABASE command will
+		// delete stats, but these are refreshed in memory using a range feed.
+		// Since there can be a delay in the new stats being picked up its possible
+		// for this query to fail with:
+		// "unsupported comparison: bytes to crdb_internal_region"
+		// querying table statistics. This is a transient condition that will
+		// clear up once the range feed catches up.
+		testutils.SucceedsSoon(t, func() error {
+			row := tDB.DB.QueryRowContext(ctx, `SELECT crdb_region, session_id, expiration FROM system.sqlliveness LIMIT 1`)
+			var sessionID string
+			var crdbRegion string
+			var rawExpiration apd.Decimal
+			err := row.Scan(&crdbRegion, &sessionID, &rawExpiration)
+			if err != nil {
+				return err
+			}
+			if crdbRegion != "us-east1" {
+				return errors.AssertionFailedf("unexpected region, got: %q expected: %q",
+					crdbRegion, "us-east1")
+			}
+			return nil
+		})
 	})
 
 	t.Run("Sqlinstances", func(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #131018.

/cc @cockroachdb/release

---

Previously, the test TestMrSystemDatabase could encounter "unsupported comparison" errors from the optimizer on the sqlliveness table, which would happen because the statistics in memory would not have the crdb_internal_region type. When altering the system database to be multiregion we delete the statistics for the sqlliveness table, which are only reflected in memory with range feed. If the range feed is *slow* then transient errors could occur. To address this, this patch tolerates transient errors on the system.sqlliveness table test.

Fixes: #128781
Release note: None
Release justification: test only change to deflake