### PR TITLE
tablemetadatacache: grant test an additional core under `race`

### DIFF
--- a/pkg/sql/tablemetadatacache/BUILD.bazel
+++ b/pkg/sql/tablemetadatacache/BUILD.bazel
@@ -37,6 +37,10 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":tablemetadatacache"],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         "//pkg/base",
         "//pkg/jobs",


### PR DESCRIPTION
Epic: none
Release note: None