### PR TITLE
tablemetadatacache: mock exec fn for TestUpdateTableMetadataCacheJobR…

### DIFF
--- a/pkg/sql/tablemetadatacache/BUILD.bazel
+++ b/pkg/sql/tablemetadatacache/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "//pkg/sql/isql",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
+        "//pkg/testutils/jobutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",


### PR DESCRIPTION
…unsOnRPCTrigger

For TestUpdateTableMetadataCacheJobRunsOnRPCTrigger we previously triggered the full job. Since this test just verifies the job can be triggered via the grpc method, let's mock the job exec fn. We also modify the table metadata job tests to use the jobutils.WaitForJobToRun.

Epic: none

Release note: None