### PR TITLE
cockroach-oss: remove test forbidding use of `ccl` packages

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -138,7 +138,6 @@ ALL_TESTS = [
     "//pkg/cmd/bazci/testfilter:testfilter_test",
     "//pkg/cmd/bazci:bazci_lib_disallowed_imports_test",
     "//pkg/cmd/cmpconn:cmpconn_test",
-    "//pkg/cmd/cockroach-oss:cockroach-oss_disallowed_imports_test",
     "//pkg/cmd/cockroach:cockroach_lib_disallowed_imports_test",
     "//pkg/cmd/dev:dev_lib_disallowed_imports_test",
     "//pkg/cmd/dev:dev_test",

--- a/pkg/cmd/cockroach-oss/BUILD.bazel
+++ b/pkg/cmd/cockroach-oss/BUILD.bazel
@@ -18,12 +18,3 @@ go_binary(
     exec_properties = {"Pool": "large"},
     visibility = ["//visibility:public"],
 )
-
-disallowed_imports_test(
-    "cockroach-oss",
-    disallowed_list = [],
-    disallowed_prefixes = [
-        "pkg/ccl",
-        "pkg/ui/distccl",
-    ],
-)


### PR DESCRIPTION
This requirement can be relaxed in preparation for the core deprecation.

Part of: DEVINF-1246

Epic: none
Release note: None