### PR TITLE
kvserver: update TruncatedState before writing

### DIFF
--- a/pkg/kv/kvserver/raft_log_truncator_test.go
+++ b/pkg/kv/kvserver/raft_log_truncator_test.go
@@ -156,18 +156,15 @@ func (r *replicaTruncatorTest) getStateLoader() stateloader.StateLoader {
 }
 
 func (r *replicaTruncatorTest) stagePendingTruncation(_ context.Context, pt pendingTruncation) {
-	expectedFirstIndexWasAccurate := r.truncState.Index+1 == pt.expectedFirstIndex
-	r.truncState = pt.RaftTruncatedState
-	// TODO(pav-kv): this is printing the legacy func names. Fix.
+	trusted := pt.isDeltaTrusted && r.truncState.Index+1 == pt.expectedFirstIndex
 	fmt.Fprintf(r.buf,
-		"r%d.setTruncatedStateAndSideEffects(..., expectedFirstIndex:%d) => trusted:%t\n",
-		r.rangeID, pt.expectedFirstIndex, expectedFirstIndexWasAccurate)
-	deltaTrusted := pt.isDeltaTrusted && expectedFirstIndexWasAccurate
-	fmt.Fprintf(r.buf, "r%d.setTruncationDeltaAndTrusted(delta:%d, trusted:%t)\n",
-		r.rangeID, pt.logDeltaBytes, deltaTrusted)
+		"r%d.stagePendingTruncation(..., expFirstIndex:%d, delta:%v, trusted:%t) => trusted:%t\n",
+		r.rangeID, pt.expectedFirstIndex, pt.logDeltaBytes, pt.isDeltaTrusted, trusted)
+	r.truncState = pt.RaftTruncatedState
 }
 
 func (r *replicaTruncatorTest) finalizeTruncation(_ context.Context) {
+	fmt.Fprintf(r.buf, "r%d.finalizeTruncation\n", r.rangeID)
 }
 
 func (r *replicaTruncatorTest) writeRaftStateToEngine(

--- a/pkg/kv/kvserver/raft_log_truncator_test.go
+++ b/pkg/kv/kvserver/raft_log_truncator_test.go
@@ -155,7 +155,7 @@ func (r *replicaTruncatorTest) getStateLoader() stateloader.StateLoader {
 	return r.stateLoader
 }
 
-func (r *replicaTruncatorTest) handleTruncationResult(_ context.Context, pt pendingTruncation) {
+func (r *replicaTruncatorTest) stagePendingTruncation(_ context.Context, pt pendingTruncation) {
 	expectedFirstIndexWasAccurate := r.truncState.Index+1 == pt.expectedFirstIndex
 	r.truncState = pt.RaftTruncatedState
 	// TODO(pav-kv): this is printing the legacy func names. Fix.
@@ -165,6 +165,9 @@ func (r *replicaTruncatorTest) handleTruncationResult(_ context.Context, pt pend
 	deltaTrusted := pt.isDeltaTrusted && expectedFirstIndexWasAccurate
 	fmt.Fprintf(r.buf, "r%d.setTruncationDeltaAndTrusted(delta:%d, trusted:%t)\n",
 		r.rangeID, pt.logDeltaBytes, deltaTrusted)
+}
+
+func (r *replicaTruncatorTest) finalizeTruncation(_ context.Context) {
 }
 
 func (r *replicaTruncatorTest) writeRaftStateToEngine(

--- a/pkg/kv/kvserver/raft_truncator_replica.go
+++ b/pkg/kv/kvserver/raft_truncator_replica.go
@@ -29,8 +29,12 @@ func (r *raftTruncatorReplica) getTruncatedState() kvserverpb.RaftTruncatedState
 	return r.shMu.raftTruncState
 }
 
-func (r *raftTruncatorReplica) handleTruncationResult(ctx context.Context, pt pendingTruncation) {
-	(*Replica)(r).handleTruncatedStateResultRaftMuLocked(ctx, pt)
+func (r *raftTruncatorReplica) stagePendingTruncation(_ context.Context, pt pendingTruncation) {
+	(*Replica)(r).stagePendingTruncationRaftMuLocked(pt)
+}
+
+func (r *raftTruncatorReplica) finalizeTruncation(ctx context.Context) {
+	(*Replica)(r).finalizeTruncationRaftMuLocked(ctx)
 }
 
 func (r *raftTruncatorReplica) getPendingTruncs() *pendingLogTruncations {

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -64,11 +64,6 @@ type replicaAppBatch struct {
 	// sideloaded storage file. Such commands may apply side effects only after
 	// their application to state machine is synced.
 	changeTruncatesSideloadedFiles bool
-	// truncatedSideloadedSize is set when changeTruncatesSideloadedFiles is true,
-	// and contains the total size of the removed sideloaded entry files.
-	// TODO(pav-kv): make a type for the truncation-related parameters.
-	// Potentially, can use the pendingTruncation type here.
-	truncatedSideloadedSize int64
 
 	start                   time.Time // time at NewBatch()
 	followerStoreWriteBytes kvadmission.FollowerStoreWriteBytes
@@ -511,6 +506,13 @@ func (b *replicaAppBatch) stageTruncation(
 	); err != nil {
 		return errors.Wrap(err, "unable to handle truncated state")
 	}
+
+	pt := pendingTruncation{
+		RaftTruncatedState: *truncatedState,
+		expectedFirstIndex: res.RaftExpectedFirstIndex,
+		logDeltaBytes:      res.RaftLogDelta,
+		isDeltaTrusted:     true,
+	}
 	// Determine if there are any sideloaded entries that will be removed as a
 	// side effect, and the total size of these entries.
 	//
@@ -526,8 +528,11 @@ func (b *replicaAppBatch) stageTruncation(
 		return errors.Wrap(err, "failed searching for sideloaded entries")
 	} else if entries != 0 {
 		b.changeTruncatesSideloadedFiles = true
-		b.truncatedSideloadedSize = size
+		pt.logDeltaBytes -= size
+		pt.hasSideloaded = true // unused, but set for "completeness"
 	}
+
+	b.r.stagePendingTruncationRaftMuLocked(pt)
 	return nil
 }
 

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -506,7 +506,7 @@ func (r *Replica) stagePendingTruncationRaftMuLocked(pt pendingTruncation) {
 	// v22.1 that added it, when all truncations were strongly coupled. It is not
 	// safe to consider the log size delta trusted in this case. Conveniently,
 	// this doesn't need any special casing.
-	isDeltaTrusted := pt.isDeltaTrusted && r.shMu.raftTruncState.Index+1 == pt.expectedFirstIndex
+	pt.isDeltaTrusted = pt.isDeltaTrusted && r.shMu.raftTruncState.Index+1 == pt.expectedFirstIndex
 
 	r.mu.Lock()
 	r.shMu.raftTruncState = pt.RaftTruncatedState
@@ -515,7 +515,7 @@ func (r *Replica) stagePendingTruncationRaftMuLocked(pt pendingTruncation) {
 	// TODO(pav-kv): should we distrust the log size if it goes negative?
 	r.shMu.raftLogSize = max(r.shMu.raftLogSize+pt.logDeltaBytes, 0)
 	r.shMu.raftLogLastCheckSize = max(r.shMu.raftLogLastCheckSize+pt.logDeltaBytes, 0)
-	if !isDeltaTrusted {
+	if !pt.isDeltaTrusted {
 		r.shMu.raftLogSizeTrusted = false
 	}
 	r.mu.Unlock()

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -498,44 +498,41 @@ func (r *Replica) handleLeaseResult(
 		assertNoLeaseJump)
 }
 
-// handleTruncatedStateResultRaftMuLocked is a post-apply handler for the raft
-// log truncation command. It updates the in-memory state of the Replica with
-// the new RaftTruncatedState and log size delta, and removes obsolete entries
-// from the raft log cache and sideloaded storage.
-func (r *Replica) handleTruncatedStateResultRaftMuLocked(
-	ctx context.Context, pt pendingTruncation,
-) {
+// stagePendingTruncationRaftMuLocked installs the new RaftTruncatedState,
+// updates the log size, and truncates the raft log cache.
+func (r *Replica) stagePendingTruncationRaftMuLocked(pt pendingTruncation) {
 	r.raftMu.AssertHeld()
 	// NB: The expected first index can be zero if this proposal is from before
 	// v22.1 that added it, when all truncations were strongly coupled. It is not
 	// safe to consider the log size delta trusted in this case. Conveniently,
 	// this doesn't need any special casing.
 	isDeltaTrusted := pt.isDeltaTrusted && r.shMu.raftTruncState.Index+1 == pt.expectedFirstIndex
-
-	// TODO(#132114, #131063): updating the truncated state after the storage
-	// writes leads to a necessity of the ErrCompacted handling in raft, when
-	// reads are made under Replica.mu. This error API can be removed entirely if
-	// the truncated state is updated first. The semantics would be that the log
-	// is truncated "logically" first, and then physically under raftMu.
 	r.mu.Lock()
 	r.shMu.raftTruncState = pt.RaftTruncatedState
 	r.handleRaftLogDeltaResultRaftMuLockedReplicaMuLocked(pt.logDeltaBytes, isDeltaTrusted)
 	r.mu.Unlock()
-
-	// Clear any entries in the Raft log entry cache for this range up
-	// to and including the most recently truncated index.
-	//
-	// It is safe to do this here, after the storage write. Before this line, raft
-	// log reads under Replica.mu (from within RawNode) may temporarily return
-	// cached entries that are already removed from storage. It appears as if the
-	// read is performed right before the truncation batch was written.
+	// Clear entries in the raft log entry cache for this range up to and
+	// including the truncated index. Ordering this after updating the truncated
+	// state matters here. At this point, there can not be a concurrent reader of
+	// the raft log holding only Replica.mu that tries to read the entries below
+	// the new truncated index.
 	r.store.raftEntryCache.Clear(r.RangeID, pt.Index)
+}
 
+// finalizeTruncationRaftMuLocked is a post-apply handler for the raft log
+// truncation. It removes the obsolete sideloaded entries if any.
+func (r *Replica) finalizeTruncationRaftMuLocked(ctx context.Context) {
+	r.raftMu.AssertHeld()
+	index := r.shMu.raftTruncState.Index
 	// Truncate the sideloaded storage. This is safe because the new truncated
 	// state is already synced. If it wasn't, a crash right after removing the
 	// sideloaded entries could result in missing entries in the log.
-	log.Eventf(ctx, "truncating sideloaded storage up to (and including) index %d", pt.Index)
-	if err := r.raftMu.sideloaded.TruncateTo(ctx, pt.Index); err != nil {
+	//
+	// TODO(pav-kv): skip this step if !pendingTruncation.hasSideloaded. The
+	// caller has this information available. Or better delegate deletions to an
+	// asynchronous job, that also makes sure to clean up dangling files.
+	log.Eventf(ctx, "truncating sideloaded storage up to (and including) index %d", index)
+	if err := r.raftMu.sideloaded.TruncateTo(ctx, index); err != nil {
 		// We don't *have* to remove these entries for correctness. Log a loud
 		// error, but keep humming along.
 		log.Errorf(ctx, "while removing sideloaded files during log truncation: %+v", err)

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -153,7 +153,6 @@ func (sm *replicaStateMachine) NewBatch() apply.Batch {
 	r.mu.RUnlock()
 	b.changeRemovesReplica = false
 	b.changeTruncatesSideloadedFiles = false
-	b.truncatedSideloadedSize = 0
 	// TODO(pav-kv): what about b.ab and b.followerStoreWriteBytes?
 	b.start = timeutil.Now()
 	return b
@@ -313,16 +312,8 @@ func (sm *replicaStateMachine) handleNonTrivialReplicatedEvalResult(
 
 	// TODO(#93248): the strongly coupled truncation code will be removed once the
 	// loosely coupled truncations are the default.
-	if truncState := rResult.GetRaftTruncatedState(); truncState != nil {
-		// The size delta in the proposal is accurate, but does not account for the
-		// sideloaded entries, so we fix it up.
-		sm.r.handleTruncatedStateResultRaftMuLocked(ctx, pendingTruncation{
-			RaftTruncatedState: *truncState,
-			expectedFirstIndex: rResult.RaftExpectedFirstIndex,
-			logDeltaBytes:      rResult.RaftLogDelta - sm.batch.truncatedSideloadedSize,
-			isDeltaTrusted:     true,
-			hasSideloaded:      false, // unused, but listed here for completeness
-		})
+	if rResult.GetRaftTruncatedState() != nil {
+		sm.r.finalizeTruncationRaftMuLocked(ctx)
 		rResult.DiscardRaftTruncation()
 	}
 

--- a/pkg/kv/kvserver/replica_raftlog_writes.go
+++ b/pkg/kv/kvserver/replica_raftlog_writes.go
@@ -17,11 +17,6 @@ import (
 // never attempts to read log indices that have pending writes. See also the
 // replicaRaftStorage comment for more details.
 //
-// TODO(#131063): there is one subtle exception - the log can be compacted
-// concurrently with reading from its "readable" prefix. Incorrect ordering of
-// raftMu/mu updates during log compactions can cause read attempts for deleted
-// indices. We should fix it.
-//
 // For performance reasons, the raft log storage state (such as the last index)
 // needs to be accessible under Replica.mu. When appending is done, the state
 // needs to be transferred into the Replica.mu section.

--- a/pkg/kv/kvserver/testdata/raft_log_truncator
+++ b/pkg/kv/kvserver/testdata/raft_log_truncator
@@ -91,8 +91,8 @@ acquireReplica(1)
 r1.getTruncatedState
 r1.getPendingTruncs
 r1.getStateLoader
-r1.setTruncatedStateAndSideEffects(..., expectedFirstIndex:16) => trusted:false
-r1.setTruncationDeltaAndTrusted(delta:-30, trusted:false)
+r1.stagePendingTruncation(..., expFirstIndex:16, delta:-30, trusted:true) => trusted:false
+r1.finalizeTruncation
 releaseReplica(1)
 acquireReplica(2)
 r2.getTruncatedState
@@ -167,8 +167,8 @@ acquireReplica(2)
 r2.getTruncatedState
 r2.getPendingTruncs
 r2.getStateLoader
-r2.setTruncatedStateAndSideEffects(..., expectedFirstIndex:21) => trusted:true
-r2.setTruncationDeltaAndTrusted(delta:-30, trusted:true)
+r2.stagePendingTruncation(..., expFirstIndex:21, delta:-30, trusted:true) => trusted:true
+r2.finalizeTruncation
 releaseReplica(2)
 truncator ranges:
 
@@ -205,8 +205,8 @@ acquireReplica(2)
 r2.getTruncatedState
 r2.getPendingTruncs
 r2.getStateLoader
-r2.setTruncatedStateAndSideEffects(..., expectedFirstIndex:21) => trusted:false
-r2.setTruncationDeltaAndTrusted(delta:-30, trusted:false)
+r2.stagePendingTruncation(..., expFirstIndex:21, delta:-30, trusted:true) => trusted:false
+r2.finalizeTruncation
 releaseReplica(2)
 truncator ranges:
 
@@ -269,8 +269,8 @@ acquireReplica(2)
 r2.getTruncatedState
 r2.getPendingTruncs
 r2.getStateLoader
-r2.setTruncatedStateAndSideEffects(..., expectedFirstIndex:25) => trusted:true
-r2.setTruncationDeltaAndTrusted(delta:-30, trusted:true)
+r2.stagePendingTruncation(..., expFirstIndex:25, delta:-30, trusted:true) => trusted:true
+r2.finalizeTruncation
 releaseReplica(2)
 truncator ranges: 2
 
@@ -316,10 +316,9 @@ acquireReplica(2)
 r2.getTruncatedState
 r2.getPendingTruncs
 r2.getStateLoader
-r2.setTruncatedStateAndSideEffects(..., expectedFirstIndex:27) => trusted:true
-r2.setTruncationDeltaAndTrusted(delta:-60, trusted:false)
-r2.setTruncatedStateAndSideEffects(..., expectedFirstIndex:30) => trusted:true
-r2.setTruncationDeltaAndTrusted(delta:-30, trusted:true)
+r2.stagePendingTruncation(..., expFirstIndex:27, delta:-60, trusted:false) => trusted:false
+r2.stagePendingTruncation(..., expFirstIndex:30, delta:-30, trusted:true) => trusted:true
+r2.finalizeTruncation
 releaseReplica(2)
 truncator ranges:
 
@@ -382,10 +381,9 @@ acquireReplica(2)
 r2.getTruncatedState
 r2.getPendingTruncs
 r2.getStateLoader
-r2.setTruncatedStateAndSideEffects(..., expectedFirstIndex:32) => trusted:true
-r2.setTruncationDeltaAndTrusted(delta:-30, trusted:true)
-r2.setTruncatedStateAndSideEffects(..., expectedFirstIndex:33) => trusted:true
-r2.setTruncationDeltaAndTrusted(delta:-50, trusted:false)
+r2.stagePendingTruncation(..., expFirstIndex:32, delta:-30, trusted:true) => trusted:true
+r2.stagePendingTruncation(..., expFirstIndex:33, delta:-50, trusted:false) => trusted:false
+r2.finalizeTruncation
 releaseReplica(2)
 truncator ranges:
 
@@ -472,8 +470,8 @@ acquireReplica(3)
 r3.getTruncatedState
 r3.getPendingTruncs
 r3.getStateLoader
-r3.setTruncatedStateAndSideEffects(..., expectedFirstIndex:21) => trusted:true
-r3.setTruncationDeltaAndTrusted(delta:-30, trusted:true)
+r3.stagePendingTruncation(..., expFirstIndex:21, delta:-30, trusted:true) => trusted:true
+r3.finalizeTruncation
 releaseReplica(3)
 truncator ranges: 3
 


### PR DESCRIPTION
This PR fixes a truncation "race" that causes raft log entries being not found with `ErrCompacted` during normal operation.

---

Previously, truncations were carried out as follows:

1. Under `Replica.raftMu`, write a batch to Pebble that removes a prefix of the log and updates the `RaftTruncatedState` in the log storage.
2. Under `Replica.{raftMu,mu}`, move the in-memory `RaftTruncatedState` forward.

Between steps 1 and 2, there can be a goroutine holding `Replica.mu` that reads the log based on the previous `RaftTruncatedState`. It can unwillingly observe that the entries in `(previous.Index, next.Index]` interval are missing (the raft log returns `ErrCompacted` for them).

There are at least 2 `Replica.mu`-only `RawNode.Step` [paths](https://github.com/cockroachdb/cockroach/pull/131041#pullrequestreview-2316995320) affected by this.

This PR swaps the order of the updates: the truncated state is moved forward first (along with updating the log size stats), signifying a logical deletion; and only then the entries are deleted from storage, physically. This removes the possibility of the race, and eliminates the need to handle `ErrCompacted`, as long as the reader respects the `RaftTruncatedState` when accessing the log. It makes the raft log always consistent under `Replica.mu` and/or `Replica.raftMu`.

---

Part of #132114, #143355
Related to #130955, #131041 