### PR TITLE
kvserver: fail helpfully in and deflake TestOptimisticEvalNoContention

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -4886,31 +4886,35 @@ func TestRangeMigration(t *testing.T) {
 	assertVersion(endV)
 }
 
-func setupDBAndWriteAAndB(t *testing.T) (serverutils.TestServerInterface, *kv.DB) {
+// setupDBWithDisableCanAckBeforeApplicationAndWriteAAndB sets up a DB that
+// contains writes at keys a and b.
+//
+// The tests that use this helper are highly sensitive to latches that are
+// still active on the keys written here. We disable CanAckBeforeReplication
+// and write them via 1PC to ensure that latches are fully released and there
+// no errant intent resolutions or anything of the kind is inflight by the time
+// this method returns.
+//
+// See: https://github.com/cockroachdb/cockroach/pull/131071#issuecomment-2449439120.
+func setupDBWithDisableCanAckBeforeApplicationAndWriteAAndB(
+	t *testing.T,
+) (serverutils.TestServerInterface, *kv.DB) {
 	ctx := context.Background()
 	args := base.TestServerArgs{}
+	args.Knobs.Store = &kvserver.StoreTestingKnobs{DisableCanAckBeforeApplication: true}
 	s, _, db := serverutils.StartServer(t, args)
-
 	require.NoError(t, db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
 		defer func() {
 			if err != nil {
 				t.Log(err)
 			}
 		}()
-		if err := txn.Put(ctx, "a", "a"); err != nil {
-			return err
-		}
-		if err := txn.Put(ctx, "b", "b"); err != nil {
-			return err
-		}
-		return txn.Commit(ctx)
+		b := txn.NewBatch()
+		b.Put("a", "a")
+		b.Put("b", "b")
+		return txn.CommitInBatch(ctx, b)
 	}))
-	tup, err := db.Get(ctx, "a")
-	require.NoError(t, err)
-	require.NotNil(t, tup.Value)
-	tup, err = db.Get(ctx, "b")
-	require.NoError(t, err)
-	require.NotNil(t, tup.Value)
+
 	return s, db
 }
 
@@ -4924,7 +4928,7 @@ func TestNonTransactionalLockingRequestsConflictWithReplicatedLocks(t *testing.T
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, db := setupDBAndWriteAAndB(t)
+	s, db := setupDBWithDisableCanAckBeforeApplicationAndWriteAAndB(t)
 	defer s.Stopper().Stop(ctx)
 
 	keyA, keyB, keyC := roachpb.Key("a"), roachpb.Key("b"), roachpb.Key("c")
@@ -5142,7 +5146,7 @@ func TestSharedLocksBasic(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, db := setupDBAndWriteAAndB(t)
+	s, db := setupDBWithDisableCanAckBeforeApplicationAndWriteAAndB(t)
 	defer s.Stopper().Stop(ctx)
 
 	testutils.RunTrueAndFalse(t, "guaranteed-durability", func(t *testing.T, guaranteedDurability bool) {
@@ -5204,7 +5208,7 @@ func TestOptimisticEvalRetry(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, db := setupDBAndWriteAAndB(t)
+	s, db := setupDBWithDisableCanAckBeforeApplicationAndWriteAAndB(t)
 	defer s.Stopper().Stop(ctx)
 
 	txn1 := db.NewTxn(ctx, "locking txn")
@@ -5260,7 +5264,7 @@ func TestOptimisticEvalNoContention(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-	s, db := setupDBAndWriteAAndB(t)
+	s, db := setupDBWithDisableCanAckBeforeApplicationAndWriteAAndB(t)
 	defer s.Stopper().Stop(ctx)
 
 	txn1 := db.NewTxn(ctx, "locking txn")
@@ -5301,7 +5305,7 @@ func TestOptimisticEvalWithConcurrentWriters(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, db := setupDBAndWriteAAndB(t)
+	s, db := setupDBWithDisableCanAckBeforeApplicationAndWriteAAndB(t)
 	defer s.Stopper().Stop(ctx)
 
 	finish := make(chan struct{})


### PR DESCRIPTION
We've seen[^1] that in rare cases, the limited scan in that test does
not successfully evaluate optimistically, and ends up blocking on an
intent indefinitely.

This commit adds a timeout to the scan as well as wraps it in a verbose
trace so that we can understand this problem better the next time we
see it.

I looked at the optimistic read path and see no obvious way this can
be turned off (short of randomizing the cluster setting[^2], which we
don't seem to be doing). So perhaps the read hits a retry or the like,
but either way it will be less poking around in the dark once we get
a repro after this commit.

[^1]: https://github.com/cockroachdb/cockroach/issues/123986#issuecomment-2107606634
[^2]: https://github.com/cockroachdb/cockroach/issues/123986#issuecomment-2107606634

Closes #130973.

Epic: none
Release note: None
