### PR TITLE
crosscluster/logical: add SKIP SCHEMA CHECK option

### DIFF
--- a/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
@@ -258,7 +258,7 @@ func createLogicalReplicationStreamPlanHook(
 			}
 		}
 		for i := range srcTableDescs {
-			err := tabledesc.CheckLogicalReplicationCompatibility(srcTableDescs[i], dstTableDescs[i].TableDesc())
+			err := tabledesc.CheckLogicalReplicationCompatibility(srcTableDescs[i], dstTableDescs[i].TableDesc(), options.SkipSchemaCheck())
 			if err != nil {
 				return err
 			}
@@ -321,6 +321,7 @@ func createLogicalReplicationStreamTypeCheck(
 		},
 		exprutil.Bools{
 			stmt.Options.IgnoreCDCIgnoredTTLDeletes,
+			stmt.Options.SkipSchemaCheck,
 		},
 	}
 	if err := exprutil.TypeCheck(ctx, "LOGICAL REPLICATION STREAM", p.SemaCtx(),
@@ -339,6 +340,7 @@ type resolvedLogicalReplicationOptions struct {
 	// Mapping of table name to function descriptor
 	userFunctions              map[string]int32
 	ignoreCDCIgnoredTTLDeletes bool
+	skipSchemaCheck            bool
 }
 
 func evalLogicalReplicationOptions(
@@ -416,6 +418,9 @@ func evalLogicalReplicationOptions(
 	if options.IgnoreCDCIgnoredTTLDeletes == tree.DBoolTrue {
 		r.ignoreCDCIgnoredTTLDeletes = true
 	}
+	if options.SkipSchemaCheck == tree.DBoolTrue {
+		r.skipSchemaCheck = true
+	}
 	return r, nil
 }
 
@@ -473,4 +478,11 @@ func (r *resolvedLogicalReplicationOptions) IgnoreCDCIgnoredTTLDeletes() bool {
 		return false
 	}
 	return r.ignoreCDCIgnoredTTLDeletes
+}
+
+func (r *resolvedLogicalReplicationOptions) SkipSchemaCheck() bool {
+	if r == nil {
+		return false
+	}
+	return r.skipSchemaCheck
 }

--- a/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
@@ -1992,6 +1992,14 @@ func TestLogicalReplicationCreationChecks(t *testing.T) {
 		`cannot create logical replication stream: destination table tab CHECK constraints do not match source table tab`,
 		"CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab", dbBURL.String(),
 	)
+	// Allos user to create LDR stream with mismatched CHECK via SKIP SCHEMA CHECK.
+	var jobIDSkipSchemaCheck jobspb.JobID
+	dbA.QueryRow(t,
+		"CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab WITH SKIP SCHEMA CHECK",
+		dbBURL.String(),
+	).Scan(&jobIDSkipSchemaCheck)
+	dbA.Exec(t, "CANCEL JOB $1", jobIDSkipSchemaCheck)
+	jobutils.WaitForJobToCancel(t, dbA, jobIDSkipSchemaCheck)
 
 	// Add missing CHECK constraints, and verify that the stream can be created.
 	dbA.Exec(t, "ALTER TABLE tab ADD CONSTRAINT check_constraint_2 CHECK (length(payload) > 1)")
@@ -2015,6 +2023,13 @@ func TestLogicalReplicationCreationChecks(t *testing.T) {
 		`cannot create logical replication stream: destination table tab column enum_col has user-defined type USER DEFINED ENUM: public.mytype`,
 		"CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab", dbBURL.String(),
 	)
+	// Allows user to create LDR stream with UDT via SKIP SCHEMA CHECK.
+	dbA.QueryRow(t,
+		"CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab WITH SKIP SCHEMA CHECK",
+		dbBURL.String(),
+	).Scan(&jobIDSkipSchemaCheck)
+	dbA.Exec(t, "CANCEL JOB $1", jobIDSkipSchemaCheck)
+	jobutils.WaitForJobToCancel(t, dbA, jobIDSkipSchemaCheck)
 
 	// Check that UNIQUE indexes match.
 	dbA.Exec(t, "ALTER TABLE tab DROP COLUMN enum_col")

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4737,6 +4737,10 @@ logical_replication_options:
   {
     $$.val = &tree.LogicalReplicationOptions{IgnoreCDCIgnoredTTLDeletes: tree.MakeDBool(true)}
   }
+| SKIP SCHEMA CHECK
+  {
+    $$.val = &tree.LogicalReplicationOptions{SkipSchemaCheck: tree.MakeDBool(true)} 
+  }
 
 // %Help: CREATE VIRTUAL CLUSTER - create a new virtual cluster
 // %Category: Experimental

--- a/pkg/sql/sem/tree/create_logical_replication.go
+++ b/pkg/sql/sem/tree/create_logical_replication.go
@@ -35,6 +35,7 @@ type LogicalReplicationOptions struct {
 	Mode                       Expr
 	DefaultFunction            Expr
 	IgnoreCDCIgnoredTTLDeletes *DBool
+	SkipSchemaCheck            *DBool
 }
 
 var _ Statement = &CreateLogicalReplicationStream{}
@@ -129,6 +130,10 @@ func (lro *LogicalReplicationOptions) Format(ctx *FmtCtx) {
 		maybeAddSep()
 		ctx.WriteString("IGNORE_CDC_IGNORED_TTL_DELETES")
 	}
+	if lro.SkipSchemaCheck != nil && *lro.SkipSchemaCheck {
+		maybeAddSep()
+		ctx.WriteString("SKIP SCHEMA CHECK")
+	}
 }
 
 func (o *LogicalReplicationOptions) CombineWith(other *LogicalReplicationOptions) error {
@@ -175,6 +180,13 @@ func (o *LogicalReplicationOptions) CombineWith(other *LogicalReplicationOptions
 	} else {
 		o.IgnoreCDCIgnoredTTLDeletes = other.IgnoreCDCIgnoredTTLDeletes
 	}
+	if o.SkipSchemaCheck != nil {
+		if other.SkipSchemaCheck != nil {
+			return errors.New("SKIP SCHEMA CHECK option specified multiple times")
+		}
+	} else {
+		o.SkipSchemaCheck = other.SkipSchemaCheck
+	}
 
 	return nil
 }
@@ -186,5 +198,6 @@ func (o LogicalReplicationOptions) IsDefault() bool {
 		o.Mode == options.Mode &&
 		o.DefaultFunction == options.DefaultFunction &&
 		o.UserFunctions == nil &&
-		o.IgnoreCDCIgnoredTTLDeletes == options.IgnoreCDCIgnoredTTLDeletes
+		o.IgnoreCDCIgnoredTTLDeletes == options.IgnoreCDCIgnoredTTLDeletes &&
+		o.SkipSchemaCheck == options.SkipSchemaCheck
 }


### PR DESCRIPTION
PR #130905 added several checks to LDR stream planning to ensure a bidrectional stream will suceed. A user may want to skip the table equivalency checks (e.g. all constraints are matching) if they are running a unidirectional stream or if they simply want to live life on the edge.

Epic: none

Release note: none