### PR TITLE
storage: disable checkUncertainty on failOnMoreRecent in scanner

### DIFF
--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -551,7 +551,13 @@ func (p *pebbleMVCCScanner) init(
 	// because the local uncertainty limit cannot be applied to values with
 	// future-time timestamps with earlier local timestamps. We are only able
 	// to skip uncertainty checks if p.ts >= global_uncertainty_limit.
-	p.checkUncertainty = p.ts.Less(p.uncertainty.GlobalLimit)
+	//
+	// We disable checkUncertainty when the scanner is configured with failOnMoreRecent.
+	// This avoids cases in which a scan would have failed with a WriteTooOldError
+	// but instead gets an unexpected ReadWithinUncertaintyIntervalError
+	// See:
+	// https://github.com/cockroachdb/cockroach/issues/119681
+	p.checkUncertainty = p.ts.Less(p.uncertainty.GlobalLimit) && !p.failOnMoreRecent
 }
 
 // get seeks to the start key exactly once and adds one KV to the result set.

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_scans
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_scans
@@ -477,6 +477,18 @@ scan k=b end=d ts=3 globalUncertaintyLimit=4
 scan: "b"-"d" -> <no data>
 error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 3.000000000,0 encountered previous write with future timestamp 4.000000000,0 within uncertainty interval `t <= (local=0,0, global=0,0)`; observed timestamps: []
 
+run error
+scan k=b end=d ts=3 globalUncertaintyLimit=4 failOnMoreRecent
+----
+scan: "b"-"d" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 3.000000000,0 encountered previous write with future timestamp 4.000000000,0 within uncertainty interval `t <= (local=0,0, global=0,0)`; observed timestamps: []
+
+run error
+get k=c ts=3 globalUncertaintyLimit=4 failOnMoreRecent
+----
+get: "c" -> <no data>
+error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 3.000000000,0 encountered previous write with future timestamp 4.000000000,0 within uncertainty interval `t <= (local=0,0, global=0,0)`; observed timestamps: []
+
 run ok
 scan k=b end=d ts=4 globalUncertaintyLimit=5
 ----

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_scans
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_scans
@@ -481,13 +481,13 @@ run error
 scan k=b end=d ts=3 globalUncertaintyLimit=4 failOnMoreRecent
 ----
 scan: "b"-"d" -> <no data>
-error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 3.000000000,0 encountered previous write with future timestamp 4.000000000,0 within uncertainty interval `t <= (local=0,0, global=0,0)`; observed timestamps: []
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 3.000000000,0 too old; must write at or above 4.000000000,1
 
 run error
 get k=c ts=3 globalUncertaintyLimit=4 failOnMoreRecent
 ----
 get: "c" -> <no data>
-error: (*kvpb.ReadWithinUncertaintyIntervalError:) ReadWithinUncertaintyIntervalError: read at time 3.000000000,0 encountered previous write with future timestamp 4.000000000,0 within uncertainty interval `t <= (local=0,0, global=0,0)`; observed timestamps: []
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "c" at timestamp 3.000000000,0 too old; must write at or above 4.000000000,1
 
 run ok
 scan k=b end=d ts=4 globalUncertaintyLimit=5


### PR DESCRIPTION
It was possible for reads with failOnMoreRecent to hit a
ReadWithinUncertaintyIntervalError instead of the desired
WriteTooOldError. This commit disables uncertainty checks when
failOnMoreRecent is active, as the latter is a stronger check anyway.

Fixes https://github.com/cockroachdb/cockroach/issues/119681.
Fixes https://github.com/cockroachdb/cockroach/issues/131005.

Epic: none
Release note: None