### PR TITLE
cluster-ui: add table sort to v2 db page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/databases/getDatabaseMetadataApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databases/getDatabaseMetadataApi.ts
@@ -23,9 +23,7 @@ export enum DatabaseSortOptions {
   NAME = "name",
   REPLICATION_SIZE = "replicationSize",
   RANGES = "ranges",
-  LIVE_DATA = "liveData",
-  COLUMNS = "columns",
-  INDEXES = "indexes",
+  TABLE_COUNT = "tableCount",
   LAST_UPDATED = "lastUpdated",
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
@@ -66,7 +66,7 @@ const COLUMNS: TableColumnProps<DatabaseRow>[] = [
   },
   {
     title: DatabaseColName.TABLE_COUNT,
-    sorter: false,
+    sorter: true,
     render: (db: DatabaseRow) => {
       return db.tableCount;
     },

--- a/pkg/ui/workspaces/cluster-ui/src/databasesV2/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesV2/utils.ts
@@ -27,7 +27,7 @@ export const getSortKeyFromColTitle = (
     case DatabaseColName.RANGE_COUNT:
       return DatabaseSortOptions.RANGES;
     case DatabaseColName.TABLE_COUNT:
-      return DatabaseSortOptions.LIVE_DATA;
+      return DatabaseSortOptions.TABLE_COUNT;
     default:
       throw new Error(`Unsupported sort column ${col}`);
   }
@@ -43,7 +43,7 @@ export const getColTitleFromSortKey = (
       return DatabaseColName.SIZE;
     case DatabaseSortOptions.RANGES:
       return DatabaseColName.RANGE_COUNT;
-    case DatabaseSortOptions.LIVE_DATA:
+    case DatabaseSortOptions.TABLE_COUNT:
       return DatabaseColName.TABLE_COUNT;
     default:
       return DatabaseColName.NAME;


### PR DESCRIPTION
Add sort by table count now that the sort option
is available on the api. We've also deleted sort
options that don't apply for the db page.

Epic: CRDB-37558

Release note: None