### PR TITLE
server: enable `_status/ranges` API for secondary tenants

### DIFF
--- a/pkg/ccl/changefeedccl/mocks/tenant_status_server_generated.go
+++ b/pkg/ccl/changefeedccl/mocks/tenant_status_server_generated.go
@@ -81,6 +81,21 @@ func (mr *MockTenantStatusServerMockRecorder) Nodes(arg0, arg1 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nodes", reflect.TypeOf((*MockTenantStatusServer)(nil).Nodes), arg0, arg1)
 }
 
+// Ranges mocks base method.
+func (m *MockTenantStatusServer) Ranges(arg0 context.Context, arg1 *serverpb.RangesRequest) (*serverpb.RangesResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Ranges", arg0, arg1)
+	ret0, _ := ret[0].(*serverpb.RangesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Ranges indicates an expected call of Ranges.
+func (mr *MockTenantStatusServerMockRecorder) Ranges(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ranges", reflect.TypeOf((*MockTenantStatusServer)(nil).Ranges), arg0, arg1)
+}
+
 // Regions mocks base method.
 func (m *MockTenantStatusServer) Regions(arg0 context.Context, arg1 *serverpb.RegionsRequest) (*serverpb.RegionsResponse, error) {
 	m.ctrl.T.Helper()

--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -119,6 +119,10 @@ func TestTenantStatusAPI(t *testing.T) {
 		testTenantRangesRPC(ctx, t, testHelper)
 	})
 
+	t.Run("ranges", func(t *testing.T) {
+		testRangesRPC(ctx, t, testHelper)
+	})
+
 	t.Run("tenant_auth_statement", func(t *testing.T) {
 		testTenantAuthOnStatements(ctx, t, testHelper)
 	})
@@ -218,6 +222,7 @@ func testTenantSpanStats(ctx context.Context, t *testing.T, helper serverccl.Ten
 
 		makeKey := func(keys ...[]byte) roachpb.Key {
 			return bytes.Join(keys, nil)
+
 		}
 
 		// Create a new range in this tenant.
@@ -1366,8 +1371,7 @@ func testTxnIDResolutionRPC(ctx context.Context, t *testing.T, helper serverccl.
 	t.Run("tenant_cluster", func(t *testing.T) {
 		// Select a different tenant status server here so a pod-to-pod RPC will
 		// happen.
-		status :=
-			helper.TestCluster().TenantStatusSrv(2 /* idx */)
+		status := helper.TestCluster().TenantStatusSrv(2 /* idx */)
 		sqlConn := helper.TestCluster().TenantConn(0 /* idx */)
 		run(sqlConn, status, 1 /* coordinatorNodeID */)
 	})
@@ -1378,20 +1382,10 @@ func testTenantRangesRPC(_ context.Context, t *testing.T, helper serverccl.Tenan
 	tenantB := helper.ControlCluster().TenantStatusSrv(0).(serverpb.TenantStatusServer)
 
 	// Wait for range splits to occur so we get more than just a single range during our tests.
-	testutils.SucceedsSoon(t, func() error {
-		resp, err := tenantA.TenantRanges(context.Background(), &serverpb.TenantRangesRequest{})
-		if err != nil {
-			return err
-		}
-		for _, ranges := range resp.RangesByLocality {
-			if len(ranges.Ranges) > 1 {
-				return nil
-			}
-		}
-		return errors.New("waiting for tenant range split")
-	})
+	waitForRangeSplit(t, tenantA)
+	waitForRangeSplit(t, tenantB)
 
-	t.Run("test tenant ranges respects tenant isolation", func(t *testing.T) {
+	t.Run("test TenantRanges respects tenant isolation", func(t *testing.T) {
 		tenIDA := helper.TestCluster().Tenant(0).GetRPCContext().TenantID
 		tenIDB := helper.ControlCluster().Tenant(0).GetRPCContext().TenantID
 		keySpanForA := keys.MakeTenantSpan(tenIDA)
@@ -1420,7 +1414,7 @@ func testTenantRangesRPC(_ context.Context, t *testing.T, helper serverccl.Tenan
 		}
 	})
 
-	t.Run("test tenant ranges pagination", func(t *testing.T) {
+	t.Run("test TenantRanges pagination", func(t *testing.T) {
 		ctx := context.Background()
 		resp1, err := tenantA.TenantRanges(ctx, &serverpb.TenantRangesRequest{
 			Limit: 1,
@@ -1459,6 +1453,54 @@ func testTenantRangesRPC(_ context.Context, t *testing.T, helper serverccl.Tenan
 			return nil
 		})
 
+	})
+}
+
+func testRangesRPC(_ context.Context, t *testing.T, helper serverccl.TenantTestHelper) {
+	tenantA := helper.TestCluster().TenantStatusSrv(0).(serverpb.TenantStatusServer)
+	tenantB := helper.ControlCluster().TenantStatusSrv(0).(serverpb.TenantStatusServer)
+
+	req := &serverpb.RangesRequest{NodeId: "1"}
+
+	// Wait for range splits to occur so we get more than just a single range during our tests.
+	waitForRangeSplit(t, tenantA)
+	waitForRangeSplit(t, tenantB)
+
+	t.Run("test Ranges respects tenant isolation", func(t *testing.T) {
+		tenIDA := helper.TestCluster().Tenant(0).GetRPCContext().TenantID
+		tenIDB := helper.ControlCluster().Tenant(0).GetRPCContext().TenantID
+		keySpanForA := keys.MakeTenantSpan(tenIDA)
+		keySpanForB := keys.MakeTenantSpan(tenIDB)
+
+		resp, err := tenantA.Ranges(context.Background(), req)
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.Ranges)
+		for _, r := range resp.Ranges {
+			assertStartKeyInRange(t, r.Span.StartKey, keySpanForA.Key)
+			assertEndKeyInRange(t, r.Span.EndKey, keySpanForA.Key, keySpanForA.EndKey)
+		}
+
+		resp, err = tenantB.Ranges(context.Background(), req)
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.Ranges)
+		for _, r := range resp.Ranges {
+			assertStartKeyInRange(t, r.Span.StartKey, keySpanForB.Key)
+			assertEndKeyInRange(t, r.Span.EndKey, keySpanForB.Key, keySpanForB.EndKey)
+		}
+	})
+}
+
+func waitForRangeSplit(t *testing.T, tenant serverpb.TenantStatusServer) {
+	req := &serverpb.RangesRequest{NodeId: "1"}
+	testutils.SucceedsSoon(t, func() error {
+		resp, err := tenant.Ranges(context.Background(), req)
+		if err != nil {
+			return err
+		}
+		if len(resp.Ranges) <= 1 {
+			return errors.New("waiting for tenant range split")
+		}
+		return nil
 	})
 }
 

--- a/pkg/cli/testdata/zip/testzip_external_process_virtualization
+++ b/pkg/cli/testdata/zip/testzip_external_process_virtualization
@@ -151,9 +151,8 @@ debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
 [node ?] ? cpu profiles found
 [node 1] requesting log files list... received response... done
 [node ?] ? log files found
-[node 1] requesting ranges... received response...
-[node 1] requesting ranges: last request failed: rpc error: ...
-[node 1] requesting ranges: creating error output: debug/nodes/1/ranges.err.txt... done
+[node 1] requesting ranges... received response... done
+[node 1] writing ranges... writing JSON output: debug/nodes/1/ranges.json... done
 [cluster] pprof summary script... writing binary output: debug/pprof-summary.sh... done
 [cluster] hot range summary script... writing binary output: debug/hot-ranges.sh... done
 [cluster] tenant hot range summary script... writing binary output: debug/hot-ranges-tenant.sh... done

--- a/pkg/cli/testdata/zip/testzip_shared_process_virtualization
+++ b/pkg/cli/testdata/zip/testzip_shared_process_virtualization
@@ -286,9 +286,8 @@ debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
 [node 1] requesting cpu profile list: creating error output: debug/cluster/test-tenant/nodes/1/cpuprof.err.txt... done
 [node 1] requesting log files list... received response... done
 [node ?] ? log files found
-[node 1] requesting ranges... received response...
-[node 1] requesting ranges: last request failed: rpc error: ...
-[node 1] requesting ranges: creating error output: debug/cluster/test-tenant/nodes/1/ranges.err.txt... done
+[node 1] requesting ranges... received response... done
+[node 1] writing ranges... writing JSON output: debug/cluster/test-tenant/nodes/1/ranges.json... done
 [cluster] pprof summary script... writing binary output: debug/cluster/test-tenant/pprof-summary.sh... done
 [cluster] hot range summary script... writing binary output: debug/cluster/test-tenant/hot-ranges.sh... done
 [cluster] tenant hot range summary script... writing binary output: debug/cluster/test-tenant/hot-ranges-tenant.sh... done

--- a/pkg/cli/testdata/zip/testzip_shared_process_virtualization_with_default_tenant
+++ b/pkg/cli/testdata/zip/testzip_shared_process_virtualization_with_default_tenant
@@ -286,9 +286,8 @@ debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
 [node 1] requesting cpu profile list: creating error output: debug/cluster/test-tenant/nodes/1/cpuprof.err.txt... done
 [node 1] requesting log files list... received response... done
 [node ?] ? log files found
-[node 1] requesting ranges... received response...
-[node 1] requesting ranges: last request failed: rpc error: ...
-[node 1] requesting ranges: creating error output: debug/cluster/test-tenant/nodes/1/ranges.err.txt... done
+[node 1] requesting ranges... received response... done
+[node 1] writing ranges... writing JSON output: debug/cluster/test-tenant/nodes/1/ranges.json... done
 [cluster] pprof summary script... writing binary output: debug/cluster/test-tenant/pprof-summary.sh... done
 [cluster] hot range summary script... writing binary output: debug/cluster/test-tenant/hot-ranges.sh... done
 [cluster] tenant hot range summary script... writing binary output: debug/cluster/test-tenant/hot-ranges-tenant.sh... done

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -662,6 +662,17 @@ func (c *connector) Regions(
 	return
 }
 
+// Ranges implements the serverpb.TenantStatusServer interface
+func (c *connector) Ranges(
+	ctx context.Context, req *serverpb.RangesRequest,
+) (resp *serverpb.RangesResponse, retErr error) {
+	retErr = c.withClient(ctx, func(ctx context.Context, client *client) (err error) {
+		resp, err = client.Ranges(ctx, req)
+		return
+	})
+	return
+}
+
 // TenantRanges implements the serverpb.TenantStatusServer interface
 func (c *connector) TenantRanges(
 	ctx context.Context, req *serverpb.TenantRangesRequest,

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -114,6 +114,9 @@ func (a tenantAuthorizer) authorize(
 	case "/cockroach.server.serverpb.Status/TenantRanges":
 		return a.authTenantRanges(tenID)
 
+	case "/cockroach.server.serverpb.Status/Ranges":
+		return a.authRanges(tenID)
+
 	case "/cockroach.server.serverpb.Status/TransactionContentionEvents":
 		return a.authTenant(tenID)
 
@@ -299,6 +302,15 @@ var gossipSubscriptionPatternAllowlist = []string{
 func (a tenantAuthorizer) authTenantRanges(tenID roachpb.TenantID) error {
 	if !tenID.IsSet() {
 		return authErrorf("tenant ranges request with unspecified tenant not permitted.")
+	}
+	return nil
+}
+
+// authRanges authorizes the provided tenant to invoke the Ranges RPC with the
+// provided args. It requires that an authorized tenantID has been set.
+func (a tenantAuthorizer) authRanges(tenID roachpb.TenantID) error {
+	if !tenID.IsSet() {
+		return authErrorf("ranges request with unspecified tenant not permitted.")
 	}
 	return nil
 }

--- a/pkg/server/serverpb/status.go
+++ b/pkg/server/serverpb/status.go
@@ -78,6 +78,7 @@ type NodesStatusServer interface {
 //
 // It is available for all tenants.
 type TenantStatusServer interface {
+	Ranges(context.Context, *RangesRequest) (*RangesResponse, error)
 	TenantRanges(context.Context, *TenantRangesRequest) (*TenantRangesResponse, error)
 	Regions(context.Context, *RegionsRequest) (*RegionsResponse, error)
 	HotRangesV2(context.Context, *HotRangesRequest) (*HotRangesResponseV2, error)

--- a/pkg/server/storage_api/BUILD.bazel
+++ b/pkg/server/storage_api/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
+        "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/ts",
         "//pkg/util/leaktest",

--- a/pkg/server/storage_api/ranges_test.go
+++ b/pkg/server/storage_api/ranges_test.go
@@ -7,6 +7,7 @@ package storage_api_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -17,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/srvtestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -27,14 +29,16 @@ func TestRangesResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	defer kvserver.EnableLeaseHistoryForTesting(100)()
-	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(110019),
-	})
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer srv.Stopper().Stop(context.Background())
 	ts := srv.ApplicationLayer()
 
-	// TODO(#110019): grant a special capability to the secondary tenant
-	// before the endpoint can be accessed.
+	// Create few ranges
+	r := sqlutils.MakeSQLRunner(ts.SQLConn(t))
+	r.Exec(t, "CREATE TABLE t (x INT PRIMARY KEY, xsquared INT)")
+	for i := 0; i < 5; i++ {
+		r.Exec(t, fmt.Sprintf("ALTER TABLE t SPLIT AT VALUES (%d)", 100*i/5))
+	}
 
 	t.Run("test ranges response", func(t *testing.T) {
 		// Perform a scan to ensure that all the raft groups are initialized.


### PR DESCRIPTION
Previously, the above endpoint was only available for the system tenant. With this change, it now works for secondary tenants and returns the ranges belonging to the currently logged-in tenant.

Note that although we have `TenantRanges`, which is quite similar to `Ranges`, it was developed to meet the needs of the `debug` command and has a different response body. Another difference is that `TenantRanges` returns ranges for all nodes, while `Ranges` returns data for a particular node.

Fixes: #110019

Epic: CRDB-38968

Release note (multi-tenancy): The `ranges` endpoint on the `Advanced Debug` section of the DB Console is now enabled for secondary tenants and will return the ranges only for the currently logged-in tenant. For the system tenant, it will continue to work as before, returning ranges for all tenants on the specified node.