### PR TITLE
roachtest: add more logging to `tpcc-nowait/isolation-level=mixed/nodes=3/w=1`

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -675,7 +675,7 @@ func registerTPCC(r registry.Registry) {
 				// Increase the vmodule level around transaction pushes so that if we do
 				// see a transaction retry error, we can debug it. This may affect perf,
 				// so we should not use this as a performance test.
-				ExtraStartArgs: []string{"--vmodule=cmd_push_txn=2,queue=2,transaction=2"},
+				ExtraStartArgs: []string{"--vmodule=cmd_push_txn=2,queue=2,transaction=2,lock_table_waiter=3,manager=2"},
 				WorkloadInstances: func() (ret []workloadInstance) {
 					isoLevels := []string{"read_uncommitted", "read_committed", "repeatable_read", "snapshot", "serializable"}
 					for i, isoLevel := range isoLevels {


### PR DESCRIPTION
This commit adds `lock_table_waiter=3,manager=2` to the vmodule flag of `tpcc-nowait/isolation-level=mixed/nodes=3/w=1` to help debug the failure in #130309.

Informs: #130309

Release note: None