### PR TITLE
kvserver: misc rac2 race conditions fixes

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
@@ -241,7 +241,6 @@ func (s *testingRCState) getOrInitRange(t *testing.T, r testingRange) *testingRC
 			TenantID:            r.tenantID,
 			LocalReplicaID:      r.localReplicaID,
 			SSTokenCounter:      s.ssTokenCounter,
-			RaftInterface:       testRC,
 			Clock:               s.clock,
 			CloseTimerScheduler: s.probeToCloseScheduler,
 			EvalWaitMetrics:     s.evalMetrics,
@@ -258,7 +257,7 @@ func (s *testingRCState) getOrInitRange(t *testing.T, r testingRange) *testingRC
 	s.maybeSetInitialTokens(r)
 	// Send through an empty raft event to trigger creating necessary replica
 	// send streams for the range.
-	require.NoError(t, testRC.rc.HandleRaftEventRaftMuLocked(s.testCtx, RaftEvent{}))
+	require.NoError(t, testRC.rc.HandleRaftEventRaftMuLocked(s.testCtx, testRC.makeRaftEventWithReplicasState()))
 	return testRC
 }
 
@@ -294,15 +293,21 @@ type testingRCRange struct {
 	}
 }
 
-func (r *testingRCRange) FollowerStateRaftMuLocked(replicaID roachpb.ReplicaID) FollowerStateInfo {
+func (r *testingRCRange) makeRaftEventWithReplicasState() RaftEvent {
+	return RaftEvent{
+		ReplicasStateInfo: r.replicasStateInfo(),
+	}
+}
+
+func (r *testingRCRange) replicasStateInfo() map[roachpb.ReplicaID]ReplicaStateInfo {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	replica, ok := r.mu.r.replicaSet[replicaID]
-	if !ok {
-		return FollowerStateInfo{}
+	replicasStateInfo := map[roachpb.ReplicaID]ReplicaStateInfo{}
+	for _, replica := range r.mu.r.replicaSet {
+		replicasStateInfo[replica.desc.ReplicaID] = replica.info
 	}
-	return replica.info
+	return replicasStateInfo
 }
 
 func (r *testingRCRange) SendPingRaftMuLocked(roachpb.ReplicaID) bool {
@@ -386,7 +391,7 @@ const invalidTrackerState = tracker.StateSnapshot + 1
 
 type testingReplica struct {
 	desc roachpb.ReplicaDescriptor
-	info FollowerStateInfo
+	info ReplicaStateInfo
 }
 
 func scanRanges(t *testing.T, input string) []testingRange {
@@ -503,7 +508,7 @@ func scanReplica(t *testing.T, line string) testingReplica {
 			ReplicaID: roachpb.ReplicaID(replicaID),
 			Type:      replicaType,
 		},
-		info: FollowerStateInfo{State: state},
+		info: ReplicaStateInfo{State: state},
 	}
 }
 
@@ -597,7 +602,7 @@ func (t *testingProbeToCloseTimerScheduler) ScheduleSendStreamCloseRaftMuLocked(
 		}
 		timer.MarkRead()
 		require.NoError(t.state.t,
-			t.state.ranges[rangeID].rc.HandleRaftEventRaftMuLocked(ctx, RaftEvent{}))
+			t.state.ranges[rangeID].rc.HandleRaftEventRaftMuLocked(ctx, t.state.ranges[rangeID].makeRaftEventWithReplicasState()))
 	}()
 }
 
@@ -791,7 +796,7 @@ func TestRangeController(t *testing.T) {
 					require.NoError(t, testRC.rc.SetReplicasRaftMuLocked(ctx, r.replicas()))
 					// Send an empty raft event in order to trigger any potential
 					// connectedState changes.
-					require.NoError(t, testRC.rc.HandleRaftEventRaftMuLocked(ctx, RaftEvent{}))
+					require.NoError(t, testRC.rc.HandleRaftEventRaftMuLocked(ctx, testRC.makeRaftEventWithReplicasState()))
 				}
 				// Sleep for a bit to allow any timers to fire.
 				time.Sleep(20 * time.Millisecond)
@@ -877,7 +882,8 @@ func TestRangeController(t *testing.T) {
 
 				propRangeEntries := func() {
 					event := RaftEvent{
-						Entries: make([]raftpb.Entry, len(buf)),
+						Entries:           make([]raftpb.Entry, len(buf)),
+						ReplicasStateInfo: state.ranges[lastRangeID].replicasStateInfo(),
 					}
 					for i, state := range buf {
 						event.Entries[i] = testingCreateEntry(t, state)

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/simulation_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/simulation_test.go
@@ -1110,7 +1110,8 @@ func (r *testingRCRange) testingDeductTokens(
 	r.mu.quorumPosition.Index++
 
 	require.NoError(t, r.rc.HandleRaftEventRaftMuLocked(ctx, RaftEvent{
-		Term: r.mu.quorumPosition.Term,
+		ReplicasStateInfo: r.replicasStateInfo(),
+		Term:              r.mu.quorumPosition.Term,
 		Entries: []raftpb.Entry{testingCreateEntry(t, entryInfo{
 			term:   r.mu.quorumPosition.Term,
 			index:  r.mu.quorumPosition.Index,
@@ -1161,7 +1162,7 @@ func (r *testingRCRange) testingReturnTokens(
 		repl.info.Next = r.mu.quorumPosition.Index + 1
 		r.mu.r.replicaSet[rid] = repl
 		r.rc.AdmitRaftMuLocked(ctx, rs.desc.ReplicaID, av)
-		require.NoError(t, r.rc.HandleRaftEventRaftMuLocked(ctx, RaftEvent{}))
+		require.NoError(t, r.rc.HandleRaftEventRaftMuLocked(ctx, r.makeRaftEventWithReplicasState()))
 	}
 }
 
@@ -1198,7 +1199,7 @@ func (r *testingRCRange) testingConnectStream(
 			ReplicaID: roachpb.ReplicaID(stream.StoreID),
 			Type:      roachpb.VOTER_FULL,
 		},
-		info: FollowerStateInfo{
+		info: ReplicaStateInfo{
 			State: tracker.StateReplicate,
 			Match: position.Index,
 			Next:  position.Index + 1,
@@ -1206,7 +1207,7 @@ func (r *testingRCRange) testingConnectStream(
 	}
 	// Send an empty raft event in order to trigger any state changes.
 	require.NoError(t, r.rc.SetReplicasRaftMuLocked(ctx, r.mu.r.replicas()))
-	require.NoError(t, r.rc.HandleRaftEventRaftMuLocked(ctx, RaftEvent{}))
+	require.NoError(t, r.rc.HandleRaftEventRaftMuLocked(ctx, r.makeRaftEventWithReplicasState()))
 }
 
 // testingDisconnectStream changes the tracker state of a given stream's
@@ -1223,7 +1224,7 @@ func (r *testingRCRange) testingDisconnectStream(
 	rs.info.State = tracker.StateSnapshot
 	r.mu.r.replicaSet[rid] = rs
 	// Send an empty raft event in order to trigger any state changes.
-	require.NoError(t, r.rc.HandleRaftEventRaftMuLocked(ctx, RaftEvent{}))
+	require.NoError(t, r.rc.HandleRaftEventRaftMuLocked(ctx, r.makeRaftEventWithReplicasState()))
 }
 
 // testingString returns a string representation of the tracker state for use

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -94,8 +94,6 @@ type RaftScheduler interface {
 // reads Raft state at various points while holding raftMu, and expects those
 // various reads to be mutually consistent.
 type RaftNode interface {
-	// RaftInterface is an interface that abstracts the raft.RawNode for use in
-	// the RangeController.
 	rac2.RaftInterface
 	// TermLocked returns the current term of this replica.
 	TermLocked() uint64
@@ -114,6 +112,19 @@ type RaftNode interface {
 	// NB: NextUnstableIndex can regress when the node accepts appends or
 	// snapshots from a newer leader.
 	NextUnstableIndexLocked() uint64
+	// ReplicasStateLocked returns the current status state of all replicas.
+	// RACv2 uses the Match and Next indices only for replicas in StateReplicate.
+	// All entries >= Next have not had MsgApps constructed during the lifetime
+	// of this StateReplicate (they may have been constructed previously).
+	//
+	// When a follower transitions from {StateProbe,StateSnapshot} =>
+	// StateReplicate, we start trying to send MsgApps. We should notice such
+	// transitions both in rac2.HandleRaftEventRaftMuLocked and
+	// rac2.SetReplicasRaftMuLocked.
+	//
+	// infoMap is an in-out parameter. It is expected to be empty, and is
+	// populated with the ReplicaStateInfos for all replicas.
+	ReplicasStateLocked(infoMap map[roachpb.ReplicaID]rac2.ReplicaStateInfo)
 }
 
 // AdmittedPiggybacker is used to enqueue admitted vector messages addressed to
@@ -423,6 +434,10 @@ type processorImpl struct {
 	// leaseholderID is the currently known leaseholder replica.
 	leaseholderID roachpb.ReplicaID
 
+	// scratchInfoMap is used as a pre-allocated in-out parameter for calling
+	// ReplicasStateLocked when constructing a rac2.RaftEvent.
+	scratchInfoMap map[roachpb.ReplicaID]rac2.ReplicaStateInfo
+
 	// State at a follower.
 	follower struct {
 		// isLeaderUsingV2Protocol is true when the leaderID indicated that it's
@@ -511,6 +526,7 @@ func NewProcessor(opts ProcessorOptions) Processor {
 		opts:                       opts,
 		enabledWhenLeader:          opts.EnabledWhenLeaderLevel,
 		v1EncodingPriorityMismatch: log.Every(time.Minute),
+		scratchInfoMap:             make(map[roachpb.ReplicaID]rac2.ReplicaStateInfo),
 	}
 }
 
@@ -775,6 +791,10 @@ func (p *processorImpl) HandleRaftReadyRaftMuLocked(ctx context.Context, e rac2.
 		log.Fatal(ctx, "RaftNode is not initialized")
 		return
 	}
+
+	// We will use the scratchInfoMap to get the latest state of the replicas and
+	// construct the RaftEvent. Ensure that it is empty before we start.
+	clear(p.scratchInfoMap)
 	// NB: we need to call makeStateConsistentRaftMuLocked even if
 	// NotEnabledWhenLeader, since this replica could be a follower and the leader
 	// may switch to v2.
@@ -790,6 +810,7 @@ func (p *processorImpl) HandleRaftReadyRaftMuLocked(ctx context.Context, e rac2.
 		leaderID = p.replMu.raftNode.LeaderLocked()
 		leaseholderID = p.opts.Replica.LeaseholderMuRLocked()
 		term = p.replMu.raftNode.TermLocked()
+		p.replMu.raftNode.ReplicasStateLocked(p.scratchInfoMap)
 	}()
 	if len(e.Entries) > 0 {
 		nextUnstableIndex = e.Entries[0].Index
@@ -803,6 +824,7 @@ func (p *processorImpl) HandleRaftReadyRaftMuLocked(ctx context.Context, e rac2.
 	// NB: since we've registered the latest log/snapshot write (if any) above,
 	// our admitted vector is likely consistent with the latest leader term.
 	p.maybeSendAdmittedRaftMuLocked(ctx)
+	e.ReplicasStateInfo = p.scratchInfoMap
 	if rc := p.leader.rc; rc != nil {
 		if knobs := p.opts.Knobs; knobs == nil || !knobs.UseOnlyForScratchRanges ||
 			p.opts.Replica.IsScratchRange() {
@@ -1022,8 +1044,9 @@ func (p *processorImpl) ProcessPiggybackedAdmittedAtLeaderRaftMuLocked(ctx conte
 	// p.leader.scratch, so can be read and written without holding
 	// pendingAdmittedMu.
 	var updates map[roachpb.ReplicaID]rac2.AdmittedVector
-	// Swap the pendingAdmittedMu.updates map with the empty scratch if non-empty. This is an optimization to
-	// minimize the time we hold the pendingAdmittedMu lock.
+	// Swap the pendingAdmittedMu.updates map with the empty scratch if
+	// non-empty. This is an optimization to minimize the time we hold the
+	// pendingAdmittedMu lock.
 	if updatesEmpty := func() bool {
 		p.leader.pendingAdmittedMu.Lock()
 		defer p.leader.pendingAdmittedMu.Unlock()

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -1018,18 +1018,23 @@ func (p *processorImpl) ProcessPiggybackedAdmittedAtLeaderRaftMuLocked(ctx conte
 	if p.destroyed {
 		return
 	}
+	// updates is left unset (so empty unallocated map) or refers to the map in
+	// p.leader.scratch, so can be read and written without holding
+	// pendingAdmittedMu.
 	var updates map[roachpb.ReplicaID]rac2.AdmittedVector
-	// Swap the updates map with the empty scratch. This is an optimization to
+	// Swap the pendingAdmittedMu.updates map with the empty scratch if non-empty. This is an optimization to
 	// minimize the time we hold the pendingAdmittedMu lock.
-	func() {
+	if updatesEmpty := func() bool {
 		p.leader.pendingAdmittedMu.Lock()
 		defer p.leader.pendingAdmittedMu.Unlock()
-		if updates = p.leader.pendingAdmittedMu.updates; len(updates) != 0 {
+		if len(p.leader.pendingAdmittedMu.updates) > 0 {
+			updates = p.leader.pendingAdmittedMu.updates
 			p.leader.pendingAdmittedMu.updates = p.leader.scratch
 			p.leader.scratch = updates
+			return false
 		}
-	}()
-	if len(updates) == 0 {
+		return true
+	}(); updatesEmpty {
 		return
 	}
 	for replicaID, state := range updates {

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -133,13 +133,9 @@ func (rn *testRaftNode) NextUnstableIndexLocked() uint64 {
 	return rn.nextUnstableIndex
 }
 
-func (rn *testRaftNode) FollowerStateRaftMuLocked(
-	replicaID roachpb.ReplicaID,
-) rac2.FollowerStateInfo {
-	rn.r.mu.AssertHeld()
-	fmt.Fprintf(rn.b, " RaftNode.FollowerStateRaftMuLocked(%v)\n", replicaID)
-	// TODO(kvoli,sumeerbhola): implement.
-	return rac2.FollowerStateInfo{}
+func (rn *testRaftNode) ReplicasStateLocked(_ map[roachpb.ReplicaID]rac2.ReplicaStateInfo) {
+	rn.r.mu.AssertRHeld()
+	fmt.Fprint(rn.b, " RaftNode.ReplicasStateLocked\n")
 }
 
 func (rn *testRaftNode) SendPingRaftMuLocked(to roachpb.ReplicaID) bool {

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/raft_node.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/raft_node.go
@@ -43,20 +43,16 @@ func (rn raftNodeForRACv2) NextUnstableIndexLocked() uint64 {
 	return rn.NextUnstableIndex()
 }
 
-func (rn raftNodeForRACv2) FollowerStateRaftMuLocked(
-	replicaID roachpb.ReplicaID,
-) rac2.FollowerStateInfo {
-	// TODO(pav-kv): this is a temporary implementation.
-	status := rn.Status()
-	if progress, ok := status.Progress[raftpb.PeerID(replicaID)]; ok {
-		return rac2.FollowerStateInfo{
-			State: progress.State,
+func (rn raftNodeForRACv2) ReplicasStateLocked(
+	infoMap map[roachpb.ReplicaID]rac2.ReplicaStateInfo,
+) {
+	rn.WithProgress(func(peerID raftpb.PeerID, _ raft.ProgressType, progress tracker.Progress) {
+		infoMap[roachpb.ReplicaID(peerID)] = rac2.ReplicaStateInfo{
 			Match: progress.Match,
 			Next:  progress.Next,
+			State: progress.State,
 		}
-	}
-
-	return rac2.FollowerStateInfo{State: tracker.StateProbe}
+	})
 }
 
 func (rn raftNodeForRACv2) SendPingRaftMuLocked(to roachpb.ReplicaID) bool {

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
@@ -90,6 +90,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 10
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 50
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
 .....
 AdmitRaftEntries:
@@ -117,6 +118,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 10
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 50
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
 .....
 AdmitRaftEntries:
@@ -150,6 +152,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 11
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 50
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
  Piggybacker.Add(n11, [r3,s11,5->11] admitted=t50/[24 25 25 25])
 .....
@@ -174,6 +177,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 11
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 50
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
 .....
 AdmitRaftEntries:
@@ -193,6 +197,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 11
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 50
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
 .....
 
@@ -216,6 +221,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 11
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 50
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
  Piggybacker.Add(n11, [r3,s11,5->11] admitted=t50/[24 26 25 26])
 .....
@@ -238,6 +244,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 11
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 50
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
  Piggybacker.Add(n11, [r3,s11,5->11] admitted=t50/[26 26 25 26])
 .....
@@ -262,6 +269,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 11
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 50
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
 .....
 AdmitRaftEntries:
@@ -292,6 +300,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 11
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 50
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
  Piggybacker.Add(n11, [r3,s11,5->11] admitted=t50/[26 26 26 26])
 .....
@@ -325,6 +334,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 11
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 51
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
 .....
 
@@ -339,6 +349,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 11
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 51
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
 .....
 AdmitRaftEntries:
@@ -365,6 +376,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 11
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 51
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
  Piggybacker.Add(n11, [r3,s11,5->11] admitted=t51/[26 26 26 26])
 .....
@@ -403,6 +415,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 52
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
  RangeControllerFactory.New(replicaSet=[(n1,s2):5,(n11,s11):11], leaseholder=10, nextRaftIndex=28)
  RangeController.AdmitRaftMuLocked(5, term:52, admitted:[LowPri:26,NormalPri:26,AboveNormalPri:26,HighPri:26])
@@ -473,6 +486,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 52
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
@@ -493,6 +507,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 52
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
  RangeController.AdmitRaftMuLocked(5, term:52, admitted:[LowPri:28,NormalPri:28,AboveNormalPri:28,HighPri:28])
  RangeController.HandleRaftEventRaftMuLocked([])
@@ -532,6 +547,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 53
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
  RangeController.CloseRaftMuLocked
  RangeControllerFactory.New(replicaSet=[(n1,s2):5,(n11,s11):11], leaseholder=10, nextRaftIndex=29)
@@ -553,6 +569,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 53
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
  RangeController.SetReplicasRaftMuLocked([(n1,s2):5,(n11,s11):11,(n13,s13):13])
  RangeController.SetLeaseholderRaftMuLocked(10)
@@ -651,6 +668,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 50
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
 .....
 
@@ -668,6 +686,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 50
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
 .....
 AdmitRaftEntries:
@@ -699,6 +718,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 50
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
  RangeController.HandleRaftEventRaftMuLocked([26])
 .....
@@ -723,6 +743,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 50
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
@@ -741,6 +762,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 50
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
  RangeController.AdmitRaftMuLocked(5, term:50, admitted:[LowPri:26,NormalPri:26,AboveNormalPri:26,HighPri:26])
  RangeController.HandleRaftEventRaftMuLocked([])
@@ -760,6 +782,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 50
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
  RangeController.HandleRaftEventRaftMuLocked([27])
 .....
@@ -781,6 +804,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 5
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 50
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
  RangeController.AdmitRaftMuLocked(5, term:50, admitted:[LowPri:27,NormalPri:27,AboveNormalPri:27,HighPri:27])
  RangeController.HandleRaftEventRaftMuLocked([])
@@ -805,6 +829,7 @@ HandleRaftReady:
  RaftNode.LeaderLocked() = 0
  Replica.LeaseholderMuRLocked
  RaftNode.TermLocked() = 51
+ RaftNode.ReplicasStateLocked
  Replica.MuRUnlock
  RangeController.CloseRaftMuLocked
 .....


### PR DESCRIPTION
In `ProcessPiggybackedAdmittedAtLeaderRaftMuLocked`, we swap the
pending updates map with another one before releasing the mutex, in
order to minimize the time holding a mutex. Subsequently, the method
would then check if the updates map was empty by calling `len()`,
performing a read.

When the updates map was not empty, the read was against a map which was
now only referenced in this function, because a new map was swapped in
under the lock.

When the updates map was empty, the map isn't swapped out and is
referenced by the receiver struct instance, reading a ref without
locking.

Return whether the updates map was empty, to avoid racing when reading
the length of the shared ref empty map.

---

Goroutines can mutate the Raft node state without acquiring raftMu,
however must acquire replica mu.

Acquire a read lock on replica mu when reading the tracker progress
state from the raw node in `FollowerStateRaftMuLocked` to prevent races.

Part of: #130187
Release note: None