### PR TITLE
sql: lazy backfill

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -123,6 +123,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, serverArgs, configIdx, glob)
 }
 
+func TestTenantLogic_add_column_with_default_value(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "add_column_with_default_value")
+}
+
 func TestTenantLogic_aggregate(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -121,6 +121,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, serverArgs, configIdx, glob)
 }
 
+func TestReadCommittedLogic_add_column_with_default_value(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "add_column_with_default_value")
+}
+
 func TestReadCommittedLogic_aggregate(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
@@ -121,6 +121,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, serverArgs, configIdx, glob)
 }
 
+func TestRepeatableReadLogic_add_column_with_default_value(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "add_column_with_default_value")
+}
+
 func TestRepeatableReadLogic_aggregate(
 	t *testing.T,
 ) {

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -2384,18 +2384,19 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 ) error {
 	log.Infof(ctx, "clearing and backfilling columns")
 
-	if err := sc.distColumnBackfill(
-		ctx,
-		version,
-		columnBackfillBatchSize.Get(&sc.settings.SV),
-		uint64(columnBackfillUpdateChunkSizeThresholdBytes.Get(&sc.settings.SV)),
-		backfill.ColumnMutationFilter,
-	); err != nil {
-		if errors.HasType(err, &kvpb.InsufficientSpaceError{}) {
-			return jobs.MarkPauseRequestError(errors.UnwrapAll(err))
-		}
-		return err
-	}
+	// if err := sc.distColumnBackfill(
+	// 	ctx,
+	// 	version,
+	// 	columnBackfillBatchSize.Get(&sc.settings.SV),
+	// 	uint64(columnBackfillUpdateChunkSizeThresholdBytes.Get(&sc.settings.SV)),
+	// 	backfill.ColumnMutationFilter,
+	// ); err != nil {
+	// 	if errors.HasType(err, &kvpb.InsufficientSpaceError{}) {
+	// 		return jobs.MarkPauseRequestError(errors.UnwrapAll(err))
+	// 	}
+	// 	return err
+	// }
+
 	log.Info(ctx, "finished clearing and backfilling columns")
 	return nil
 }

--- a/pkg/sql/catalog/fetchpb/index_fetch.proto
+++ b/pkg/sql/catalog/fetchpb/index_fetch.proto
@@ -40,6 +40,8 @@ message IndexFetchSpec {
     // encounter a NULL value for this column (i.e. the column is non-nullable
     // and not a mutation column).
     optional bool is_non_nullable = 4 [(gogoproto.nullable) = false];
+
+    optional string default_expr = 5 [(gogoproto.nullable) = false];
   }
 
   // KeyColumn describes a column that is encoded using the key encoding.

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -915,6 +915,10 @@ func (cf *cFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 				cf.machine.timestampCol[cf.machine.rowIdx] = eval.TimestampToDecimal(cf.table.rowLastModified)
 			}
 
+			if err := cf.fillDefaults(); err != nil {
+				return nil, err
+			}
+
 			// We're finished with a row. Fill the row in with nulls if
 			// necessary, perform the memory accounting for the row, bump the
 			// row index, emit the batch if necessary, and move to the next
@@ -1278,6 +1282,35 @@ func (cf *cFetcher) processValueBytes(
 		prettyValue = cf.machine.prettyValueBuf.String()
 	}
 	return prettyKey, prettyValue, nil
+}
+
+func (cf *cFetcher) fillDefaults() error {
+	if cf.machine.remainingValueColsByIdx.Empty() {
+		return nil
+	}
+	for i, ok := cf.machine.remainingValueColsByIdx.Next(0); ok; i, ok = cf.machine.remainingValueColsByIdx.Next(i + 1) {
+		defaultExpr := cf.table.spec.FetchedColumns[i].DefaultExpr
+		if defaultExpr != "" {
+			e := tree.NewDString(defaultExpr)
+			val, err := eval.Expr(nil, nil, e)
+			if err != nil {
+				return err
+			}
+
+			vec := cf.machine.colvecs.Vecs[i]
+
+			bytes := vec.Bytes()
+			// xclog.Print("---")
+			// xclog.Print("bytes: %v", bytes.String())
+
+			rowIdx := cf.machine.rowIdx
+			bytes.Set(rowIdx, []byte(val.String()))
+
+			// xclog.Print("bytes: %v", bytes.String())
+			// xclog.Print("---")
+		}
+	}
+	return nil
 }
 
 func (cf *cFetcher) fillNulls() error {

--- a/pkg/sql/logictest/testdata/logic_test/add_column_with_default_value
+++ b/pkg/sql/logictest/testdata/logic_test/add_column_with_default_value
@@ -1,0 +1,20 @@
+statement ok
+SET use_declarative_schema_changer='off';
+
+statement ok
+CREATE TABLE foo (a INT PRIMARY KEY, b STRING);
+
+statement ok
+INSERT INTO foo VALUES (1, 'abc');
+
+statement ok
+ALTER TABLE foo ADD COLUMN c STRING DEFAULT 'xiaochen_default';
+
+statement ok
+INSERT INTO foo VALUES (2, 'xyz', NULL);
+
+query ITT rowsort
+SELECT * FROM foo;
+----
+1  abc  xiaochen_default
+2  xyz  NULL

--- a/pkg/sql/logictest/testdata/logic_test/timestamp
+++ b/pkg/sql/logictest/testdata/logic_test/timestamp
@@ -1,3 +1,46 @@
+# statement ok
+# CREATE TABLE foo (a INT PRIMARY KEY, b STRING, c STRING DEFAULT 'xiaochen_default', FAMILY f1 (a, b, c));
+# 
+# statement ok
+# INSERT INTO foo VALUES (1, 'abc', NULL);
+# 
+# query ITT
+# SELECT * FROM foo;
+# ----
+# 1  abc  xiaochen_default
+# 
+# # use a incorrect result to stop the test
+# query T
+# SELECT '2000-05-05 10:00:00+03':::TIMESTAMP
+# ----
+# infinity
+
+statement ok
+SET use_declarative_schema_changer='off';
+
+statement ok
+CREATE TABLE foo (a INT PRIMARY KEY, b STRING);
+
+statement ok
+INSERT INTO foo VALUES (1, 'abc');
+
+statement ok
+ALTER TABLE foo ADD COLUMN c STRING DEFAULT 'xiaochen_default';
+
+statement ok
+INSERT INTO foo VALUES (2, 'xyz', NULL);
+
+query ITT
+SELECT * FROM foo;
+----
+1  abc  xiaochen_default
+2  xyz  NULL
+
+query T
+SELECT '2000-05-05 10:00:00+03':::TIMESTAMP
+----
+infinity
+
 query T
 SELECT '2000-05-05 10:00:00+03':::TIMESTAMP
 ----

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -78,6 +78,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestLogic_add_column_with_default_value(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "add_column_with_default_value")
+}
+
 func TestLogic_aggregate(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -78,6 +78,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestLogic_add_column_with_default_value(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "add_column_with_default_value")
+}
+
 func TestLogic_aggregate(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -78,6 +78,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestLogic_add_column_with_default_value(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "add_column_with_default_value")
+}
+
 func TestLogic_aggregate(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -78,6 +78,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestLogic_add_column_with_default_value(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "add_column_with_default_value")
+}
+
 func TestLogic_aggregate(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-24.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-24.1/generated_test.go
@@ -78,6 +78,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestLogic_add_column_with_default_value(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "add_column_with_default_value")
+}
+
 func TestLogic_aggregate(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-24.2/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-24.2/generated_test.go
@@ -78,6 +78,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestLogic_add_column_with_default_value(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "add_column_with_default_value")
+}
+
 func TestLogic_aggregate(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -78,6 +78,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestLogic_add_column_with_default_value(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "add_column_with_default_value")
+}
+
 func TestLogic_aggregate(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -78,6 +78,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestLogic_add_column_with_default_value(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "add_column_with_default_value")
+}
+
 func TestLogic_aggregate(
 	t *testing.T,
 ) {

--- a/pkg/sql/schemachanger/comparator_generated_test.go
+++ b/pkg/sql/schemachanger/comparator_generated_test.go
@@ -18,6 +18,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
+func TestSchemaChangeComparator_add_column_with_default_value(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/add_column_with_default_value"
+	runSchemaChangeComparatorTest(t, logicTestFile)
+}
 func TestSchemaChangeComparator_aggregate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var logicTestFile = "pkg/sql/logictest/testdata/logic_test/aggregate"


### PR DESCRIPTION
**this is a simple POC and still under progress, it was committed just to make sure the development is on the right track**

### current progress

- [x] fill the default value in the procedure of query
- [x] doesn't run backfill job in the scope of DDL statement
- [ ] issue backfill job when system load is low (or user ask for it explicitly)
- [ ] conduct benchmark to evaluate the performance improvement
- [ ] fix the code style (and file layout) to align with the CRDB standard

### how to review

I disabled the actual backfill job at here:
[pkg/sql/backfill.go](https://github.com/cockroachdb/cockroach/pull/131129/files#diff-72a5b2bf318bc33efee1a0e05fa3e7dbc718767c43bcdc38621dd9e5ae5b16f4)

The filling of default value in the query procedure is done at here:
[pkg/sql/colfetcher/cfetcher.go](https://github.com/cockroachdb/cockroach/pull/131129/files#diff-486b9f416da6e4540a47464b8711211d02ca5d97755184957a30268122ecb864)

I wrote this logic test to ensure the query result is right:
[pkg/sql/logictest/testdata/logic_test/add_column_with_default_value](https://github.com/cockroachdb/cockroach/pull/131129/files#diff-9ab664b85f42d192ff561b607f763c0f21659a476dfb47232cedb6ef03ba6cab)

### commit message

Previously, the backfill action was triggered when issuing a DDL to add a column with a default value. Specifically, CRDB would populate the default value for all existing rows, and this action could potentially overload the database beyond safe limits.

This commit addresses this issue by:

- Instead of running the actual backfill job when adding a column, delay it to the moment when user ask for it explicity or the system load is relatively low.

Fixes: #126850

Release note (performance improvement): Increase the speed of schema change through lazy-backfill.