### PR TITLE
crosscluster/logical: hydrate table descriptors with types for event decoding

### DIFF
--- a/pkg/ccl/crosscluster/logical/BUILD.bazel
+++ b/pkg/ccl/crosscluster/logical/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/exprutil",
+        "//pkg/sql/importer",
         "//pkg/sql/isql",
         "//pkg/sql/lexbase",
         "//pkg/sql/parser",

--- a/pkg/ccl/crosscluster/producer/BUILD.bazel
+++ b/pkg/ccl/crosscluster/producer/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/resolver",
         "//pkg/sql/catalog/systemschema",
+        "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/clusterunique",
         "//pkg/sql/isql",
         "//pkg/sql/parser",

--- a/pkg/ccl/crosscluster/producer/BUILD.bazel
+++ b/pkg/ccl/crosscluster/producer/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/spanconfig/spanconfigkvsubscriber",
         "//pkg/sql",
+        "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/resolver",

--- a/pkg/ccl/crosscluster/producer/replication_manager.go
+++ b/pkg/ccl/crosscluster/producer/replication_manager.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
@@ -90,6 +91,9 @@ func (r *replicationStreamManagerImpl) StartReplicationStreamForTables(
 		}
 		spans = append(spans, td.PrimaryIndexSpan(r.evalCtx.Codec))
 		tableDescs[name] = td.TableDescriptor
+
+		// TODO (msbutler): get all udts across target tables to conduct
+		// verification during planning.
 	}
 
 	registry := execConfig.JobRegistry
@@ -137,13 +141,42 @@ func (r *replicationStreamManagerImpl) PlanLogicalReplication(
 
 	spans := make([]roachpb.Span, 0, len(req.TableIDs))
 	tableDescs := make([]descpb.TableDescriptor, 0, len(req.TableIDs))
+	typeDescriptors := make([]descpb.TypeDescriptor, 0)
+	foundTypeDescriptors := make(map[descpb.ID]struct{})
+	descriptors := r.txn.Descriptors()
 	for _, requestedTableID := range req.TableIDs {
-		td, err := r.txn.Descriptors().MutableByID(r.txn.KV()).Table(ctx, descpb.ID(requestedTableID))
+
+		td, err := descriptors.MutableByID(r.txn.KV()).Table(ctx, descpb.ID(requestedTableID))
 		if err != nil {
 			return nil, err
 		}
 		spans = append(spans, td.PrimaryIndexSpan(r.evalCtx.Codec))
 		tableDescs = append(tableDescs, td.TableDescriptor)
+
+		// fetch Type Descriptors, if any.
+		dbDesc, err := descriptors.MutableByID(r.txn.KV()).Database(ctx, td.GetParentID())
+		if err != nil {
+			return nil, err
+		}
+		typeIDs, _, err := td.GetAllReferencedTypeIDs(dbDesc,
+			func(id descpb.ID) (catalog.TypeDescriptor, error) {
+				if _, ok := foundTypeDescriptors[id]; ok {
+					return nil, nil
+				}
+				foundTypeDescriptors[id] = struct{}{}
+				return descriptors.ByIDWithLeased(r.txn.KV()).WithoutNonPublic().Get().Type(ctx, id)
+			})
+		if err != nil {
+			return nil, errors.Wrap(err, "resolving type descriptors")
+		}
+		for _, typeID := range typeIDs {
+			typeDesc, err := descriptors.MutableByID(r.txn.KV()).Type(ctx, typeID)
+			if err != nil {
+				return nil, err
+			}
+
+			typeDescriptors = append(typeDescriptors, typeDesc.TypeDescriptor)
+		}
 	}
 	spec, err := buildReplicationStreamSpec(ctx, r.evalCtx, tenID, false, spans)
 	if err != nil {
@@ -151,6 +184,7 @@ func (r *replicationStreamManagerImpl) PlanLogicalReplication(
 	}
 	spec.TableDescriptors = tableDescs
 	spec.TableSpans = spans
+	spec.TypeDescriptors = typeDescriptors
 	return spec, nil
 }
 

--- a/pkg/ccl/crosscluster/streamclient/partitioned_stream_client.go
+++ b/pkg/ccl/crosscluster/streamclient/partitioned_stream_client.go
@@ -297,6 +297,7 @@ type LogicalReplicationPlan struct {
 	Topology      Topology
 	SourceSpans   []roachpb.Span
 	DescriptorMap map[int32]descpb.TableDescriptor
+	SourceTypes   []*descpb.TypeDescriptor
 }
 
 func (p *partitionedStreamClient) PlanLogicalReplication(
@@ -341,10 +342,16 @@ func (p *partitionedStreamClient) PlanLogicalReplication(
 		descMap[int32(desc.ID)] = desc
 	}
 
+	sourceTypes := make([]*descpb.TypeDescriptor, len(streamSpec.TypeDescriptors))
+	for _, desc := range streamSpec.TypeDescriptors {
+		sourceTypes = append(sourceTypes, &desc)
+	}
+
 	return LogicalReplicationPlan{
 		Topology:      topology,
 		SourceSpans:   streamSpec.TableSpans,
 		DescriptorMap: descMap,
+		SourceTypes:   sourceTypes,
 	}, nil
 }
 

--- a/pkg/repstream/streampb/stream.proto
+++ b/pkg/repstream/streampb/stream.proto
@@ -51,6 +51,8 @@ message ReplicationProducerSpec {
   // TODO(ssd): We likely want to remove this one-time table
   // descriptor fetch with a schemafeed that the consumer starts.
   map<string, cockroach.sql.sqlbase.TableDescriptor> table_descriptors = 7 [(gogoproto.nullable) = false];
+
+  repeated cockroach.sql.sqlbase.TypeDescriptor type_descriptors = 8 [(gogoproto.nullable) = false];
 }
 
 // ReplicationProducerRequest is sent by the consuming cluster when

--- a/pkg/repstream/streampb/stream.proto
+++ b/pkg/repstream/streampb/stream.proto
@@ -204,6 +204,7 @@ message ReplicationStreamSpec {
   // this is in response to a LogicalReplicationPlanRequest.
   repeated roachpb.Span table_spans = 4 [(gogoproto.nullable) = false];
   repeated cockroach.sql.sqlbase.TableDescriptor table_descriptors = 5 [(gogoproto.nullable) = false];
+  repeated cockroach.sql.sqlbase.TypeDescriptor type_descriptors = 6 [(gogoproto.nullable) = false];
 }
 
 // StreamedSpanConfigEntry holds a span config update and its source side commit timestamp

--- a/pkg/sql/importer/import_type_resolver.go
+++ b/pkg/sql/importer/import_type_resolver.go
@@ -20,16 +20,16 @@ import (
 	"github.com/lib/pq/oid"
 )
 
-type importTypeResolver struct {
+type ImportTypeResolver struct {
 	typeIDToDesc   map[descpb.ID]*descpb.TypeDescriptor
 	typeNameToDesc map[string][]*descpb.TypeDescriptor
 }
 
-var _ tree.TypeReferenceResolver = importTypeResolver{}
-var _ catalog.TypeDescriptorResolver = importTypeResolver{}
+var _ tree.TypeReferenceResolver = ImportTypeResolver{}
+var _ catalog.TypeDescriptorResolver = ImportTypeResolver{}
 
-func makeImportTypeResolver(typeDescs []*descpb.TypeDescriptor) importTypeResolver {
-	itr := importTypeResolver{
+func MakeImportTypeResolver(typeDescs []*descpb.TypeDescriptor) ImportTypeResolver {
+	itr := ImportTypeResolver{
 		typeIDToDesc:   make(map[descpb.ID]*descpb.TypeDescriptor),
 		typeNameToDesc: make(map[string][]*descpb.TypeDescriptor),
 	}
@@ -52,7 +52,7 @@ func makeImportTypeResolver(typeDescs []*descpb.TypeDescriptor) importTypeResolv
 // Note that if a table happens to have multiple types with the same name (but
 // different schemas), this implementation will return a "feature unsupported"
 // error.
-func (i importTypeResolver) ResolveType(
+func (i ImportTypeResolver) ResolveType(
 	ctx context.Context, name *tree.UnresolvedObjectName,
 ) (*types.T, error) {
 	var descs []*descpb.TypeDescriptor
@@ -75,12 +75,12 @@ func (i importTypeResolver) ResolveType(
 }
 
 // ResolveTypeByOID implements the tree.TypeReferenceResolver interface.
-func (i importTypeResolver) ResolveTypeByOID(ctx context.Context, oid oid.Oid) (*types.T, error) {
+func (i ImportTypeResolver) ResolveTypeByOID(ctx context.Context, oid oid.Oid) (*types.T, error) {
 	return typedesc.ResolveHydratedTByOID(ctx, oid, i)
 }
 
 // GetTypeDescriptor implements the catalog.TypeDescriptorResolver interface.
-func (i importTypeResolver) GetTypeDescriptor(
+func (i ImportTypeResolver) GetTypeDescriptor(
 	_ context.Context, id descpb.ID,
 ) (tree.TypeName, catalog.TypeDescriptor, error) {
 	var desc *descpb.TypeDescriptor

--- a/pkg/sql/importer/read_import_base.go
+++ b/pkg/sql/importer/read_import_base.go
@@ -55,7 +55,7 @@ func runImport(
 
 	// Install type metadata in all of the import tables.
 	spec = protoutil.Clone(spec).(*execinfrapb.ReadImportDataSpec)
-	importResolver := makeImportTypeResolver(spec.Types)
+	importResolver := MakeImportTypeResolver(spec.Types)
 	for _, table := range spec.Tables {
 		cpy := tabledesc.NewBuilder(table.Desc).BuildCreatedMutableTable()
 		if err := typedesc.HydrateTypesInDescriptor(ctx, cpy, importResolver); err != nil {


### PR DESCRIPTION
This hydrates the source side table descriptors with their referencing type
descriptors if they have any. This allows ldr ingestion to properly decode
tables with user defined types.

Note that LDR will still fast fail on replicating a table with user defined
types (unless the SKIP SCHEMA CHECK OPTION is used) because we still need to
teach LDR to:
- validate that the source and destination enum's are _physically_ identical
  (contain the same map from int to enum values)
- support UDT replication on sql path, which currently fails because the passed
  in datum points to the source side udt instead of the destination udt.

As another step down the line, we should relax the requirement that UDTs must
physically equivalent. Instead, they only need to be _logically_ equivalent
(i.e. have the same user facing enum values). Supporting this requires
remapping the ints from two logically equivalent enums.

Epic: none

Release note: none