### PR TITLE
opt: add rule to decorrelate union operators

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/with
+++ b/pkg/sql/opt/memo/testdata/stats/with
@@ -116,13 +116,13 @@ with &1 (t0)
            ├── stats: [rows=10000]
            ├── fd: ()-->(30)
            ├── inner-join (cross)
-           │    ├── columns: true_agg:28(bool!null)
+           │    ├── columns: canary_agg:28(bool!null)
            │    ├── stats: [rows=10000]
            │    ├── fd: ()-->(28)
            │    ├── scan a
            │    │    └── stats: [rows=5000]
            │    ├── inner-join (cross)
-           │    │    ├── columns: true_agg:28(bool!null)
+           │    │    ├── columns: canary_agg:28(bool!null)
            │    │    ├── cardinality: [0 - 2]
            │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(one-or-more)
            │    │    ├── stats: [rows=2]
@@ -132,29 +132,29 @@ with &1 (t0)
            │    │    │    ├── cardinality: [1 - 2]
            │    │    │    └── stats: [rows=2]
            │    │    ├── select
-           │    │    │    ├── columns: true_agg:28(bool!null)
+           │    │    │    ├── columns: canary_agg:28(bool!null)
            │    │    │    ├── cardinality: [0 - 1]
            │    │    │    ├── stats: [rows=1, distinct(28)=1, null(28)=0]
            │    │    │    ├── key: ()
            │    │    │    ├── fd: ()-->(28)
            │    │    │    ├── scalar-group-by
-           │    │    │    │    ├── columns: true_agg:28(bool)
+           │    │    │    │    ├── columns: canary_agg:28(bool)
            │    │    │    │    ├── cardinality: [1 - 1]
            │    │    │    │    ├── stats: [rows=1, distinct(28)=1, null(28)=0]
            │    │    │    │    ├── key: ()
            │    │    │    │    ├── fd: ()-->(28)
            │    │    │    │    ├── values
-           │    │    │    │    │    ├── columns: true:27(bool!null)
+           │    │    │    │    │    ├── columns: canary:27(bool!null)
            │    │    │    │    │    ├── cardinality: [1 - 1]
            │    │    │    │    │    ├── stats: [rows=1]
            │    │    │    │    │    ├── key: ()
            │    │    │    │    │    ├── fd: ()-->(27)
            │    │    │    │    │    └── (true,) [type=tuple{bool}]
            │    │    │    │    └── aggregations
-           │    │    │    │         └── const-agg [as=true_agg:28, type=bool, outer=(27)]
-           │    │    │    │              └── true:27 [type=bool]
+           │    │    │    │         └── const-agg [as=canary_agg:28, type=bool, outer=(27)]
+           │    │    │    │              └── canary:27 [type=bool]
            │    │    │    └── filters
-           │    │    │         └── true_agg:28 IS NOT NULL [type=bool, outer=(28), constraints=(/28: (/NULL - ]; tight)]
+           │    │    │         └── canary_agg:28 IS NOT NULL [type=bool, outer=(28), constraints=(/28: (/NULL - ]; tight)]
            │    │    └── filters (true)
            │    └── filters (true)
            └── projections

--- a/pkg/sql/opt/memo/testdata/typing
+++ b/pkg/sql/opt/memo/testdata/typing
@@ -419,28 +419,25 @@ SELECT EXISTS(SELECT * FROM a WHERE expr<0) FROM (SELECT x+1 AS expr FROM a)
 project
  ├── columns: exists:11(bool!null)
  ├── group-by (hash)
- │    ├── columns: x:1(int!null) true_agg:13(bool)
+ │    ├── columns: x:1(int!null) canary_agg:12(int)
  │    ├── grouping columns: x:1(int!null)
  │    ├── left-join (cross)
- │    │    ├── columns: x:1(int!null) expr:5(int!null) true:12(bool)
+ │    │    ├── columns: x:1(int!null) expr:5(int!null) x:6(int)
  │    │    ├── project
  │    │    │    ├── columns: expr:5(int!null) x:1(int!null)
  │    │    │    ├── scan a
  │    │    │    │    └── columns: x:1(int!null)
  │    │    │    └── projections
  │    │    │         └── x:1 + 1 [as=expr:5, type=int]
- │    │    ├── project
- │    │    │    ├── columns: true:12(bool!null)
- │    │    │    ├── scan a
- │    │    │    └── projections
- │    │    │         └── true [as=true:12, type=bool]
+ │    │    ├── scan a
+ │    │    │    └── columns: x:6(int!null)
  │    │    └── filters
  │    │         └── expr:5 < 0 [type=bool]
  │    └── aggregations
- │         └── const-not-null-agg [as=true_agg:13, type=bool]
- │              └── true:12 [type=bool]
+ │         └── const-not-null-agg [as=canary_agg:12, type=int]
+ │              └── x:6 [type=int]
  └── projections
-      └── true_agg:13 IS NOT NULL [as=exists:11, type=bool]
+      └── canary_agg:12 IS NOT NULL [as=exists:11, type=bool]
 
 # Cast
 build

--- a/pkg/sql/opt/memo/testdata/typing
+++ b/pkg/sql/opt/memo/testdata/typing
@@ -419,18 +419,16 @@ SELECT EXISTS(SELECT * FROM a WHERE expr<0) FROM (SELECT x+1 AS expr FROM a)
 project
  ├── columns: exists:11(bool!null)
  ├── group-by (hash)
- │    ├── columns: true_agg:13(bool) rownum:15(int!null)
- │    ├── grouping columns: rownum:15(int!null)
+ │    ├── columns: x:1(int!null) true_agg:13(bool)
+ │    ├── grouping columns: x:1(int!null)
  │    ├── left-join (cross)
- │    │    ├── columns: expr:5(int!null) true:12(bool) rownum:15(int!null)
- │    │    ├── ordinality
- │    │    │    ├── columns: expr:5(int!null) rownum:15(int!null)
- │    │    │    └── project
- │    │    │         ├── columns: expr:5(int!null)
- │    │    │         ├── scan a
- │    │    │         │    └── columns: x:1(int!null)
- │    │    │         └── projections
- │    │    │              └── x:1 + 1 [as=expr:5, type=int]
+ │    │    ├── columns: x:1(int!null) expr:5(int!null) true:12(bool)
+ │    │    ├── project
+ │    │    │    ├── columns: expr:5(int!null) x:1(int!null)
+ │    │    │    ├── scan a
+ │    │    │    │    └── columns: x:1(int!null)
+ │    │    │    └── projections
+ │    │    │         └── x:1 + 1 [as=expr:5, type=int]
  │    │    ├── project
  │    │    │    ├── columns: true:12(bool!null)
  │    │    │    ├── scan a

--- a/pkg/sql/opt/norm/decorrelate_funcs.go
+++ b/pkg/sql/opt/norm/decorrelate_funcs.go
@@ -527,14 +527,9 @@ func (c *CustomFuncs) ConstructApplyJoin(
 // input expression (perhaps augmented with a key column(s) or wrapped by
 // Ordinality).
 func (c *CustomFuncs) EnsureKey(in memo.RelExpr) memo.RelExpr {
-	_, ok := c.CandidateKey(in)
-	if ok {
-		return in
-	}
-
 	// Try to add the preexisting primary key if the input is a Scan or Scan
 	// wrapped in a Select.
-	if res, ok := c.TryAddKeyToScan(in); ok {
+	if res, ok := c.tryFindExistingKey(in); ok {
 		return res
 	}
 
@@ -544,13 +539,22 @@ func (c *CustomFuncs) EnsureKey(in memo.RelExpr) memo.RelExpr {
 	return c.f.ConstructOrdinality(in, &private)
 }
 
-// TryAddKeyToScan checks whether the input expression is a non-virtual table
-// Scan, either alone or wrapped in a Select. If so, it returns a new Scan
-// (possibly wrapped in a Select) augmented with the preexisting primary key
-// for the table.
-func (c *CustomFuncs) TryAddKeyToScan(in memo.RelExpr) (_ memo.RelExpr, ok bool) {
-	augmentScan := func(scan *memo.ScanExpr) (_ memo.RelExpr, ok bool) {
-		private := scan.ScanPrivate
+// tryFindExistingKey attempts to find an existing key for the input expression.
+// It may modify the expression in order to project the key column.
+func (c *CustomFuncs) tryFindExistingKey(in memo.RelExpr) (_ memo.RelExpr, ok bool) {
+	_, hasKey := c.CandidateKey(in)
+	if hasKey {
+		return in, true
+	}
+	switch t := in.(type) {
+	case *memo.ProjectExpr:
+		input, foundKey := c.tryFindExistingKey(t.Input)
+		if foundKey {
+			return c.f.ConstructProject(input, t.Projections, input.Relational().OutputCols), true
+		}
+
+	case *memo.ScanExpr:
+		private := t.ScanPrivate
 		tableID := private.Table
 		table := c.f.Metadata().Table(tableID)
 		if !table.IsVirtualTable() {
@@ -558,20 +562,11 @@ func (c *CustomFuncs) TryAddKeyToScan(in memo.RelExpr) (_ memo.RelExpr, ok bool)
 			private.Cols = private.Cols.Union(keyCols)
 			return c.f.ConstructScan(&private), true
 		}
-		return nil, false
-	}
-
-	switch t := in.(type) {
-	case *memo.ScanExpr:
-		if res, ok := augmentScan(t); ok {
-			return res, true
-		}
 
 	case *memo.SelectExpr:
-		if scan, ok := t.Input.(*memo.ScanExpr); ok {
-			if res, ok := augmentScan(scan); ok {
-				return c.f.ConstructSelect(res, t.Filters), true
-			}
+		input, foundKey := c.tryFindExistingKey(t.Input)
+		if foundKey {
+			return c.f.ConstructSelect(input, t.Filters), true
 		}
 	}
 

--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -406,6 +406,70 @@
     (OutputCols2 $left $right)
 )
 
+# TryDecorrelateUnion replaces a Union/UnionAll beneath a ScalarGroupBy with a
+# cross-join (InnerJoin on True) between two ScalarGroupBy operators. A Project
+# operator coalesces columns from each join input to produce the final result.
+# This transformation applies when the ScalarGroupBy has only "any-not-null"
+# aggregations, which select an arbitrary non-null value from the input column.
+#
+# Here's a simplified example:
+#
+#   scalar-group-by
+#    ├── union-all
+#    │    ├── scan foo
+#    │    └── scan bar (has-outer-cols)
+#    └── aggregations
+#         └── any-not-null
+#   =>
+#   project
+#    ├── inner-join (cross)
+#    │    ├── scalar-group-by
+#    │    │    └── scan foo
+#    │    ├── scalar-group-by
+#    │    │    └── scan bar
+#    │    └── filters (true)
+#    └── projections
+#         └── coalesce
+#
+# This situation occurs after a correlated EXISTS subquery containing a Union is
+# hoisted. Note that TryDecorrelateUnion does not itself decorrelate the Union,
+# but makes it easier for other rules to do so.
+#
+# NOTE: the outer Project operator is necessary just in case the ScalarGroupBy
+# is synthesizing new columns, despite using any-not-null aggregations.
+# NOTE: TryDecorrelateUnion should be ordered before TryDecorrelateScalarGroupBy
+# to ensure that Union operators have a chance to be decorrelated.
+#
+# TODO(drewk): We could extend this rule to apply to other aggregations; for
+# example, for a count() we can sum the counts taken on each side of the join.
+# TODO(drewk): We could extend this rule to handle other set operations. For
+# example, ExceptAll could become an AntiJoin.
+[TryDecorrelateUnion, Normalize]
+(ScalarGroupBy
+    $input:(Union | UnionAll $left:* $right:* $unionPrivate:*) &
+        (HasOuterCols $input)
+    $aggs:* & (AreAllAnyNotNullAggs $aggs)
+    $private:*
+)
+=>
+(Project
+    (Project
+        (InnerJoin
+            (MakeAnyNotNullScalarGroupBy $left)
+            (MakeAnyNotNullScalarGroupBy $right)
+            []
+            (EmptyJoinPrivate)
+        )
+        (MakeCoalesceProjectionsForUnion $unionPrivate)
+        (MakeEmptyColSet)
+    )
+    (ConvertAnyNotNullAggsToProjections $aggs)
+    (IntersectionCols
+        (GroupingOutputCols $private $aggs)
+        (OutputCols $input)
+    )
+)
+
 # TryDecorrelateScalarGroupBy "pushes down" a Join into a ScalarGroupBy
 # operator, in an attempt to keep "digging" down to find and eliminate
 # unnecessary correlation. The eventual hope is to trigger the DecorrelateJoin

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -7552,3 +7552,348 @@ semi-join (hash)
  │         └── a IS DISTINCT FROM CAST(NULL AS INT8)
  └── filters
       └── x = a
+
+# --------------------------------------------------
+# TryDecorrelateUnion
+# --------------------------------------------------
+
+# Case with UnionAll.
+norm expect=TryDecorrelateUnion format=(hide-all,show-columns)
+SELECT *, CASE WHEN EXISTS (SELECT 1 FROM xy WHERE x = k UNION ALL SELECT 1 FROM uv WHERE v = k) THEN 1 ELSE 0 END FROM a;
+----
+project
+ ├── columns: k:1 i:2 f:3 s:4 j:5 case:20
+ ├── group-by (hash)
+ │    ├── columns: k:1 i:2 f:3 s:4 j:5 "?column?":12 "?column?":17
+ │    ├── grouping columns: k:1
+ │    ├── left-join (hash)
+ │    │    ├── columns: k:1 i:2 f:3 s:4 j:5 x:8 "?column?":12 v:14 "?column?":17
+ │    │    ├── left-join (hash)
+ │    │    │    ├── columns: k:1 i:2 f:3 s:4 j:5 x:8 "?column?":12
+ │    │    │    ├── scan a
+ │    │    │    │    └── columns: k:1 i:2 f:3 s:4 j:5
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: "?column?":12 x:8
+ │    │    │    │    ├── scan xy
+ │    │    │    │    │    └── columns: x:8
+ │    │    │    │    └── projections
+ │    │    │    │         └── 1 [as="?column?":12]
+ │    │    │    └── filters
+ │    │    │         └── x:8 = k:1
+ │    │    ├── project
+ │    │    │    ├── columns: "?column?":17 v:14
+ │    │    │    ├── scan uv
+ │    │    │    │    └── columns: v:14
+ │    │    │    └── projections
+ │    │    │         └── 1 [as="?column?":17]
+ │    │    └── filters
+ │    │         └── v:14 = k:1
+ │    └── aggregations
+ │         ├── any-not-null-agg [as="?column?":17]
+ │         │    └── "?column?":17
+ │         ├── const-agg [as="?column?":12]
+ │         │    └── "?column?":12
+ │         ├── const-agg [as=i:2]
+ │         │    └── i:2
+ │         ├── const-agg [as=f:3]
+ │         │    └── f:3
+ │         ├── const-agg [as=s:4]
+ │         │    └── s:4
+ │         └── const-agg [as=j:5]
+ │              └── j:5
+ └── projections
+      └── CASE WHEN COALESCE("?column?":12, "?column?":17) IS NOT NULL THEN 1 ELSE 0 END [as=case:20]
+
+# Case with Union.
+norm expect=TryDecorrelateUnion format=(hide-all,show-columns)
+SELECT *, CASE WHEN EXISTS (SELECT 1 FROM xy WHERE x = k UNION SELECT 1 FROM uv WHERE v = k) THEN 1 ELSE 0 END FROM a;
+----
+project
+ ├── columns: k:1 i:2 f:3 s:4 j:5 case:20
+ ├── group-by (hash)
+ │    ├── columns: k:1 i:2 f:3 s:4 j:5 "?column?":12 "?column?":17
+ │    ├── grouping columns: k:1
+ │    ├── left-join (hash)
+ │    │    ├── columns: k:1 i:2 f:3 s:4 j:5 x:8 "?column?":12 v:14 "?column?":17
+ │    │    ├── left-join (hash)
+ │    │    │    ├── columns: k:1 i:2 f:3 s:4 j:5 x:8 "?column?":12
+ │    │    │    ├── scan a
+ │    │    │    │    └── columns: k:1 i:2 f:3 s:4 j:5
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: "?column?":12 x:8
+ │    │    │    │    ├── scan xy
+ │    │    │    │    │    └── columns: x:8
+ │    │    │    │    └── projections
+ │    │    │    │         └── 1 [as="?column?":12]
+ │    │    │    └── filters
+ │    │    │         └── x:8 = k:1
+ │    │    ├── project
+ │    │    │    ├── columns: "?column?":17 v:14
+ │    │    │    ├── scan uv
+ │    │    │    │    └── columns: v:14
+ │    │    │    └── projections
+ │    │    │         └── 1 [as="?column?":17]
+ │    │    └── filters
+ │    │         └── v:14 = k:1
+ │    └── aggregations
+ │         ├── any-not-null-agg [as="?column?":17]
+ │         │    └── "?column?":17
+ │         ├── const-agg [as="?column?":12]
+ │         │    └── "?column?":12
+ │         ├── const-agg [as=i:2]
+ │         │    └── i:2
+ │         ├── const-agg [as=f:3]
+ │         │    └── f:3
+ │         ├── const-agg [as=s:4]
+ │         │    └── s:4
+ │         └── const-agg [as=j:5]
+ │              └── j:5
+ └── projections
+      └── CASE WHEN COALESCE("?column?":12, "?column?":17) IS NOT NULL THEN 1 ELSE 0 END [as=case:20]
+
+# Case with an uncorrelated Union branch.
+norm expect=TryDecorrelateUnion format=(hide-all,show-columns)
+SELECT *, CASE WHEN EXISTS (SELECT 1 FROM xy WHERE x = k UNION ALL SELECT 1 FROM uv WHERE u = 1) THEN 1 ELSE 0 END FROM a;
+----
+project
+ ├── columns: k:1 i:2 f:3 s:4 j:5 case:20
+ ├── inner-join-apply
+ │    ├── columns: k:1 i:2 f:3 s:4 j:5 "?column?":12 "?column?":17
+ │    ├── scan a
+ │    │    └── columns: k:1 i:2 f:3 s:4 j:5
+ │    ├── inner-join (cross)
+ │    │    ├── columns: "?column?":12 "?column?":17
+ │    │    ├── scalar-group-by
+ │    │    │    ├── columns: "?column?":12
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: "?column?":12
+ │    │    │    │    ├── select
+ │    │    │    │    │    ├── columns: x:8
+ │    │    │    │    │    ├── scan xy
+ │    │    │    │    │    │    └── columns: x:8
+ │    │    │    │    │    └── filters
+ │    │    │    │    │         └── x:8 = k:1
+ │    │    │    │    └── projections
+ │    │    │    │         └── 1 [as="?column?":12]
+ │    │    │    └── aggregations
+ │    │    │         └── any-not-null-agg [as="?column?":12]
+ │    │    │              └── "?column?":12
+ │    │    ├── scalar-group-by
+ │    │    │    ├── columns: "?column?":17
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: "?column?":17
+ │    │    │    │    ├── select
+ │    │    │    │    │    ├── columns: u:13
+ │    │    │    │    │    ├── scan uv
+ │    │    │    │    │    │    └── columns: u:13
+ │    │    │    │    │    └── filters
+ │    │    │    │    │         └── u:13 = 1
+ │    │    │    │    └── projections
+ │    │    │    │         └── 1 [as="?column?":17]
+ │    │    │    └── aggregations
+ │    │    │         └── any-not-null-agg [as="?column?":17]
+ │    │    │              └── "?column?":17
+ │    │    └── filters (true)
+ │    └── filters (true)
+ └── projections
+      └── CASE WHEN COALESCE("?column?":12, "?column?":17) IS NOT NULL THEN 1 ELSE 0 END [as=case:20]
+
+# Case with more than one union operator.
+norm expect=TryDecorrelateUnion format=(hide-all,show-columns)
+SELECT *, CASE WHEN EXISTS (
+  SELECT 1 FROM xy WHERE x = k
+  UNION ALL SELECT 1 FROM uv WHERE v = k
+  UNION ALL SELECT 1 FROM cd WHERE d = k
+) THEN 1 ELSE 0 END FROM a;
+----
+project
+ ├── columns: k:1 i:2 f:3 s:4 j:5 case:26
+ ├── group-by (hash)
+ │    ├── columns: k:1 i:2 f:3 s:4 j:5 "?column?":18 "?column?":23
+ │    ├── grouping columns: k:1
+ │    ├── left-join (hash)
+ │    │    ├── columns: k:1 i:2 f:3 s:4 j:5 "?column?":18 d:20 "?column?":23
+ │    │    ├── project
+ │    │    │    ├── columns: "?column?":18 k:1 i:2 f:3 s:4 j:5
+ │    │    │    ├── group-by (hash)
+ │    │    │    │    ├── columns: k:1 i:2 f:3 s:4 j:5 "?column?":12 "?column?":17
+ │    │    │    │    ├── grouping columns: k:1
+ │    │    │    │    ├── left-join (hash)
+ │    │    │    │    │    ├── columns: k:1 i:2 f:3 s:4 j:5 x:8 "?column?":12 v:14 "?column?":17
+ │    │    │    │    │    ├── left-join (hash)
+ │    │    │    │    │    │    ├── columns: k:1 i:2 f:3 s:4 j:5 x:8 "?column?":12
+ │    │    │    │    │    │    ├── scan a
+ │    │    │    │    │    │    │    └── columns: k:1 i:2 f:3 s:4 j:5
+ │    │    │    │    │    │    ├── project
+ │    │    │    │    │    │    │    ├── columns: "?column?":12 x:8
+ │    │    │    │    │    │    │    ├── scan xy
+ │    │    │    │    │    │    │    │    └── columns: x:8
+ │    │    │    │    │    │    │    └── projections
+ │    │    │    │    │    │    │         └── 1 [as="?column?":12]
+ │    │    │    │    │    │    └── filters
+ │    │    │    │    │    │         └── x:8 = k:1
+ │    │    │    │    │    ├── project
+ │    │    │    │    │    │    ├── columns: "?column?":17 v:14
+ │    │    │    │    │    │    ├── scan uv
+ │    │    │    │    │    │    │    └── columns: v:14
+ │    │    │    │    │    │    └── projections
+ │    │    │    │    │    │         └── 1 [as="?column?":17]
+ │    │    │    │    │    └── filters
+ │    │    │    │    │         └── v:14 = k:1
+ │    │    │    │    └── aggregations
+ │    │    │    │         ├── any-not-null-agg [as="?column?":17]
+ │    │    │    │         │    └── "?column?":17
+ │    │    │    │         ├── const-agg [as="?column?":12]
+ │    │    │    │         │    └── "?column?":12
+ │    │    │    │         ├── const-agg [as=i:2]
+ │    │    │    │         │    └── i:2
+ │    │    │    │         ├── const-agg [as=f:3]
+ │    │    │    │         │    └── f:3
+ │    │    │    │         ├── const-agg [as=s:4]
+ │    │    │    │         │    └── s:4
+ │    │    │    │         └── const-agg [as=j:5]
+ │    │    │    │              └── j:5
+ │    │    │    └── projections
+ │    │    │         └── COALESCE("?column?":12, "?column?":17) [as="?column?":18]
+ │    │    ├── project
+ │    │    │    ├── columns: "?column?":23 d:20
+ │    │    │    ├── scan cd
+ │    │    │    │    └── columns: d:20
+ │    │    │    └── projections
+ │    │    │         └── 1 [as="?column?":23]
+ │    │    └── filters
+ │    │         └── d:20 = k:1
+ │    └── aggregations
+ │         ├── any-not-null-agg [as="?column?":23]
+ │         │    └── "?column?":23
+ │         ├── const-agg [as="?column?":18]
+ │         │    └── "?column?":18
+ │         ├── const-agg [as=i:2]
+ │         │    └── i:2
+ │         ├── const-agg [as=f:3]
+ │         │    └── f:3
+ │         ├── const-agg [as=s:4]
+ │         │    └── s:4
+ │         └── const-agg [as=j:5]
+ │              └── j:5
+ └── projections
+      └── CASE WHEN COALESCE("?column?":18, "?column?":23) IS NOT NULL THEN 1 ELSE 0 END [as=case:26]
+
+# No-op because there is no Union.
+norm expect-not=TryDecorrelateUnion format=(hide-all,show-columns)
+SELECT *, CASE WHEN EXISTS (SELECT 1 FROM xy WHERE x = k) THEN 1 ELSE 0 END FROM a;
+----
+project
+ ├── columns: k:1 i:2 f:3 s:4 j:5 case:14
+ ├── left-join (hash)
+ │    ├── columns: k:1 i:2 f:3 s:4 j:5 x:8
+ │    ├── scan a
+ │    │    └── columns: k:1 i:2 f:3 s:4 j:5
+ │    ├── scan xy
+ │    │    └── columns: x:8
+ │    └── filters
+ │         └── x:8 = k:1
+ └── projections
+      └── CASE WHEN x:8 IS NOT NULL THEN 1 ELSE 0 END [as=case:14]
+
+# No-op because there's an Intersect instead of a Union.
+norm expect-not=TryDecorrelateUnion format=(hide-all,show-columns)
+SELECT *, CASE WHEN EXISTS (SELECT 1 FROM xy WHERE x = k INTERSECT SELECT 1 FROM uv WHERE v = k) THEN 1 ELSE 0 END FROM a;
+----
+project
+ ├── columns: k:1 i:2 f:3 s:4 j:5 case:19
+ ├── left-join-apply
+ │    ├── columns: k:1 i:2 f:3 s:4 j:5 "?column?":12
+ │    ├── scan a
+ │    │    └── columns: k:1 i:2 f:3 s:4 j:5
+ │    ├── intersect-all
+ │    │    ├── columns: "?column?":12
+ │    │    ├── left columns: "?column?":12
+ │    │    ├── right columns: "?column?":17
+ │    │    ├── project
+ │    │    │    ├── columns: "?column?":12
+ │    │    │    ├── select
+ │    │    │    │    ├── columns: x:8
+ │    │    │    │    ├── scan xy
+ │    │    │    │    │    └── columns: x:8
+ │    │    │    │    └── filters
+ │    │    │    │         └── x:8 = k:1
+ │    │    │    └── projections
+ │    │    │         └── 1 [as="?column?":12]
+ │    │    └── project
+ │    │         ├── columns: "?column?":17
+ │    │         ├── select
+ │    │         │    ├── columns: v:14
+ │    │         │    ├── scan uv
+ │    │         │    │    └── columns: v:14
+ │    │         │    └── filters
+ │    │         │         └── v:14 = k:1
+ │    │         └── projections
+ │    │              └── 1 [as="?column?":17]
+ │    └── filters (true)
+ └── projections
+      └── CASE WHEN "?column?":12 IS NOT NULL THEN 1 ELSE 0 END [as=case:19]
+
+# No-op case because one of the aggregations isn't any-not-null.
+norm expect-not=TryDecorrelateUnion format=(hide-all,show-columns)
+SELECT * FROM a INNER JOIN LATERAL (SELECT sum(x) FROM (SELECT x FROM xy WHERE x = k UNION ALL SELECT v FROM uv WHERE v = k)) ON True;
+----
+group-by (hash)
+ ├── columns: k:1 i:2 f:3 s:4 j:5 sum:17
+ ├── grouping columns: k:1
+ ├── left-join-apply
+ │    ├── columns: k:1 i:2 f:3 s:4 j:5 x:16
+ │    ├── scan a
+ │    │    └── columns: k:1 i:2 f:3 s:4 j:5
+ │    ├── union-all
+ │    │    ├── columns: x:16
+ │    │    ├── left columns: xy.x:8
+ │    │    ├── right columns: v:13
+ │    │    ├── select
+ │    │    │    ├── columns: xy.x:8
+ │    │    │    ├── scan xy
+ │    │    │    │    └── columns: xy.x:8
+ │    │    │    └── filters
+ │    │    │         └── xy.x:8 = k:1
+ │    │    └── select
+ │    │         ├── columns: v:13
+ │    │         ├── scan uv
+ │    │         │    └── columns: v:13
+ │    │         └── filters
+ │    │              └── v:13 = k:1
+ │    └── filters (true)
+ └── aggregations
+      ├── sum [as=sum:17]
+      │    └── x:16
+      ├── const-agg [as=i:2]
+      │    └── i:2
+      ├── const-agg [as=f:3]
+      │    └── f:3
+      ├── const-agg [as=s:4]
+      │    └── s:4
+      └── const-agg [as=j:5]
+           └── j:5
+
+# No-op case because the Union isn't correlated.
+norm expect-not=TryDecorrelateUnion format=(hide-all,show-columns)
+SELECT * FROM a INNER JOIN LATERAL (SELECT 1 FROM xy UNION ALL SELECT 1 FROM uv) ON True;
+----
+inner-join (cross)
+ ├── columns: k:1 i:2 f:3 s:4 j:5 "?column?":18
+ ├── scan a
+ │    └── columns: k:1 i:2 f:3 s:4 j:5
+ ├── union-all
+ │    ├── columns: "?column?":18
+ │    ├── left columns: "?column?":12
+ │    ├── right columns: "?column?":17
+ │    ├── project
+ │    │    ├── columns: "?column?":12
+ │    │    ├── scan xy
+ │    │    └── projections
+ │    │         └── 1 [as="?column?":12]
+ │    └── project
+ │         ├── columns: "?column?":17
+ │         ├── scan uv
+ │         └── projections
+ │              └── 1 [as="?column?":17]
+ └── filters (true)

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -5417,26 +5417,25 @@ project
  ├── columns: r:13
  ├── immutable
  ├── group-by (hash)
- │    ├── columns: scalar:14!null bool_or:16 rownum:18!null
- │    ├── grouping columns: rownum:18!null
+ │    ├── columns: k:1!null scalar:14!null bool_or:16
+ │    ├── grouping columns: k:1!null
  │    ├── immutable
- │    ├── key: (18)
- │    ├── fd: ()-->(14), (18)-->(14,16)
+ │    ├── key: (1)
+ │    ├── fd: ()-->(14), (1)-->(14,16)
  │    ├── left-join-apply
- │    │    ├── columns: i:2 column12:12 scalar:14!null notnull:15 rownum:18!null
+ │    │    ├── columns: k:1!null i:2 column12:12 scalar:14!null notnull:15
  │    │    ├── immutable
- │    │    ├── fd: ()-->(14), (18)-->(2)
- │    │    ├── ordinality
- │    │    │    ├── columns: i:2 scalar:14!null rownum:18!null
- │    │    │    ├── key: (18)
- │    │    │    ├── fd: ()-->(14), (18)-->(2,14)
- │    │    │    └── project
- │    │    │         ├── columns: scalar:14!null i:2
- │    │    │         ├── fd: ()-->(14)
- │    │    │         ├── scan a
- │    │    │         │    └── columns: i:2
- │    │    │         └── projections
- │    │    │              └── (5, 50) [as=scalar:14]
+ │    │    ├── fd: ()-->(14), (1)-->(2)
+ │    │    ├── project
+ │    │    │    ├── columns: scalar:14!null k:1!null i:2
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: ()-->(14), (1)-->(2)
+ │    │    │    ├── scan a
+ │    │    │    │    ├── columns: k:1!null i:2
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    └── fd: (1)-->(2)
+ │    │    │    └── projections
+ │    │    │         └── (5, 50) [as=scalar:14]
  │    │    ├── project
  │    │    │    ├── columns: notnull:15!null column12:12!null
  │    │    │    ├── outer: (2)

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -4441,33 +4441,31 @@ project
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  └── select
-      ├── columns: k:1!null i:2 f:3 s:4 j:5 true_agg:14
+      ├── columns: k:1!null i:2 f:3 s:4 j:5 canary_agg:13
       ├── key: (1)
-      ├── fd: (1)-->(2-5,14)
+      ├── fd: (1)-->(2-5,13)
       ├── group-by (hash)
-      │    ├── columns: k:1!null i:2 f:3 s:4 j:5 true_agg:14
+      │    ├── columns: k:1!null i:2 f:3 s:4 j:5 canary_agg:13
       │    ├── grouping columns: k:1!null
       │    ├── key: (1)
-      │    ├── fd: (1)-->(2-5,14)
+      │    ├── fd: (1)-->(2-5,13)
       │    ├── left-join (hash)
-      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 y:9 true:13
-      │    │    ├── fd: (1)-->(2-5)
+      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:8 y:9
+      │    │    ├── key: (1,8)
+      │    │    ├── fd: (1)-->(2-5), (8)-->(9)
       │    │    ├── scan a
       │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
       │    │    │    ├── key: (1)
       │    │    │    └── fd: (1)-->(2-5)
-      │    │    ├── project
-      │    │    │    ├── columns: true:13!null y:9
-      │    │    │    ├── fd: ()-->(13)
-      │    │    │    ├── scan xy
-      │    │    │    │    └── columns: y:9
-      │    │    │    └── projections
-      │    │    │         └── true [as=true:13]
+      │    │    ├── scan xy
+      │    │    │    ├── columns: x:8!null y:9
+      │    │    │    ├── key: (8)
+      │    │    │    └── fd: (8)-->(9)
       │    │    └── filters
       │    │         └── y:9 = i:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
       │    └── aggregations
-      │         ├── const-not-null-agg [as=true_agg:14, outer=(13)]
-      │         │    └── true:13
+      │         ├── const-not-null-agg [as=canary_agg:13, outer=(8)]
+      │         │    └── x:8
       │         ├── const-agg [as=i:2, outer=(2)]
       │         │    └── i:2
       │         ├── const-agg [as=f:3, outer=(3)]
@@ -4477,7 +4475,7 @@ project
       │         └── const-agg [as=j:5, outer=(5)]
       │              └── j:5
       └── filters
-           └── (i:2 = 1) OR (true_agg:14 IS NOT NULL) [outer=(2,14)]
+           └── (i:2 = 1) OR (canary_agg:13 IS NOT NULL) [outer=(2,13)]
 
 # Any with IS NULL.
 norm expect=HoistSelectSubquery
@@ -4710,14 +4708,14 @@ project
  ├── key: (1)
  ├── fd: (1)-->(2-5)
  └── select
-      ├── columns: k:1!null i:2 f:3 s:4 j:5 x:12 column17:17 true:19
+      ├── columns: k:1!null i:2 f:3 s:4 j:5 x:12 column17:17
       ├── key: (1)
-      ├── fd: (1)-->(2-5,12,17,19)
+      ├── fd: (1)-->(2-5,12,17)
       ├── left-join (hash)
-      │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:12 column17:17 true:19
+      │    ├── columns: k:1!null i:2 f:3 s:4 j:5 x:12 column17:17
       │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
       │    ├── key: (1)
-      │    ├── fd: (1)-->(2-5,12,17,19)
+      │    ├── fd: (1)-->(2-5,12,17)
       │    ├── left-join (cross)
       │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 column17:17
       │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
@@ -4741,19 +4739,13 @@ project
       │    │    │    └── projections
       │    │    │         └── true [as=column17:17]
       │    │    └── filters (true)
-      │    ├── project
-      │    │    ├── columns: true:19!null x:12!null
-      │    │    ├── key: (12)
-      │    │    ├── fd: ()-->(19)
-      │    │    ├── scan xy
-      │    │    │    ├── columns: x:12!null
-      │    │    │    └── key: (12)
-      │    │    └── projections
-      │    │         └── true [as=true:19]
+      │    ├── scan xy
+      │    │    ├── columns: x:12!null
+      │    │    └── key: (12)
       │    └── filters
       │         └── x:12 = k:1 [outer=(1,12), constraints=(/1: (/NULL - ]; /12: (/NULL - ]), fd=(1)==(12), (12)==(1)]
       └── filters
-           └── COALESCE(column17:17, false) OR (true:19 IS NOT NULL) [outer=(17,19)]
+           └── COALESCE(column17:17, false) OR (x:12 IS NOT NULL) [outer=(12,17)]
 
 # Hoist an uncorrelated equality subquery.
 norm expect=HoistSelectSubquery
@@ -5345,31 +5337,29 @@ SELECT EXISTS(SELECT * FROM xy WHERE y=i) FROM a
 project
  ├── columns: exists:13!null
  ├── group-by (hash)
- │    ├── columns: k:1!null true_agg:15
+ │    ├── columns: k:1!null canary_agg:14
  │    ├── grouping columns: k:1!null
  │    ├── key: (1)
- │    ├── fd: (1)-->(15)
+ │    ├── fd: (1)-->(14)
  │    ├── left-join (hash)
- │    │    ├── columns: k:1!null i:2 y:9 true:14
- │    │    ├── fd: (1)-->(2)
+ │    │    ├── columns: k:1!null i:2 x:8 y:9
+ │    │    ├── key: (1,8)
+ │    │    ├── fd: (1)-->(2), (8)-->(9)
  │    │    ├── scan a
  │    │    │    ├── columns: k:1!null i:2
  │    │    │    ├── key: (1)
  │    │    │    └── fd: (1)-->(2)
- │    │    ├── project
- │    │    │    ├── columns: true:14!null y:9
- │    │    │    ├── fd: ()-->(14)
- │    │    │    ├── scan xy
- │    │    │    │    └── columns: y:9
- │    │    │    └── projections
- │    │    │         └── true [as=true:14]
+ │    │    ├── scan xy
+ │    │    │    ├── columns: x:8!null y:9
+ │    │    │    ├── key: (8)
+ │    │    │    └── fd: (8)-->(9)
  │    │    └── filters
  │    │         └── y:9 = i:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
  │    └── aggregations
- │         └── const-not-null-agg [as=true_agg:15, outer=(14)]
- │              └── true:14
+ │         └── const-not-null-agg [as=canary_agg:14, outer=(8)]
+ │              └── x:8
  └── projections
-      └── true_agg:15 IS NOT NULL [as=exists:13, outer=(15)]
+      └── canary_agg:14 IS NOT NULL [as=exists:13, outer=(14)]
 
 # Any in projection list.
 norm expect=HoistProjectSubquery
@@ -5473,18 +5463,18 @@ norm expect=HoistProjectSubquery
 SELECT EXISTS(SELECT EXISTS(SELECT * FROM xy WHERE y=i) FROM a)
 ----
 values
- ├── columns: exists:19
+ ├── columns: exists:18
  ├── cardinality: [1 - 1]
  ├── key: ()
- ├── fd: ()-->(19)
+ ├── fd: ()-->(18)
  └── tuple
       └── coalesce
            ├── subquery
            │    └── project
-           │         ├── columns: column18:18!null
+           │         ├── columns: column17:17!null
            │         ├── cardinality: [0 - 1]
            │         ├── key: ()
-           │         ├── fd: ()-->(18)
+           │         ├── fd: ()-->(17)
            │         ├── limit
            │         │    ├── columns: i:2 y:9
            │         │    ├── cardinality: [0 - 1]
@@ -5510,7 +5500,7 @@ values
            │         │    │         └── y:9 = i:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
            │         │    └── 1
            │         └── projections
-           │              └── true [as=column18:18]
+           │              └── true [as=column17:17]
            └── false
 
 # Hoist an uncorrelated equality subquery.
@@ -5659,41 +5649,35 @@ SELECT s, x FROM a INNER JOIN xy ON EXISTS(SELECT * FROM uv WHERE u=y) OR k=x
 project
  ├── columns: s:4 x:8!null
  └── inner-join (cross)
-      ├── columns: k:1!null s:4 x:8!null exists:19!null
+      ├── columns: k:1!null s:4 x:8!null exists:18!null
       ├── key: (1,8)
-      ├── fd: (1)-->(4), (8)-->(19)
+      ├── fd: (1)-->(4), (8)-->(18)
       ├── scan a
       │    ├── columns: k:1!null s:4
       │    ├── key: (1)
       │    └── fd: (1)-->(4)
       ├── project
-      │    ├── columns: exists:19!null x:8!null
+      │    ├── columns: exists:18!null x:8!null
       │    ├── key: (8)
-      │    ├── fd: (8)-->(19)
+      │    ├── fd: (8)-->(18)
       │    ├── left-join (hash)
-      │    │    ├── columns: x:8!null y:9 u:12 true:17
+      │    │    ├── columns: x:8!null y:9 u:12
       │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
       │    │    ├── key: (8)
-      │    │    ├── fd: (8)-->(9,12,17)
+      │    │    ├── fd: (8)-->(9,12)
       │    │    ├── scan xy
       │    │    │    ├── columns: x:8!null y:9
       │    │    │    ├── key: (8)
       │    │    │    └── fd: (8)-->(9)
-      │    │    ├── project
-      │    │    │    ├── columns: true:17!null u:12!null
-      │    │    │    ├── key: (12)
-      │    │    │    ├── fd: ()-->(17)
-      │    │    │    ├── scan uv
-      │    │    │    │    ├── columns: u:12!null
-      │    │    │    │    └── key: (12)
-      │    │    │    └── projections
-      │    │    │         └── true [as=true:17]
+      │    │    ├── scan uv
+      │    │    │    ├── columns: u:12!null
+      │    │    │    └── key: (12)
       │    │    └── filters
       │    │         └── u:12 = y:9 [outer=(9,12), constraints=(/9: (/NULL - ]; /12: (/NULL - ]), fd=(9)==(12), (12)==(9)]
       │    └── projections
-      │         └── true:17 IS NOT NULL [as=exists:19, outer=(17)]
+      │         └── u:12 IS NOT NULL [as=exists:18, outer=(12)]
       └── filters
-           └── exists:19 OR (k:1 = x:8) [outer=(1,8,19)]
+           └── exists:18 OR (k:1 = x:8) [outer=(1,8,18)]
 
 # Any in Join filter disjunction.
 norm expect=HoistJoinSubquery
@@ -5783,19 +5767,19 @@ union
  ├── project
  │    ├── columns: exists:32!null
  │    ├── group-by (hash)
- │    │    ├── columns: a1.k:1!null true_agg:34
+ │    │    ├── columns: a1.k:1!null canary_agg:34
  │    │    ├── grouping columns: a1.k:1!null
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(34)
  │    │    ├── left-join-apply
- │    │    │    ├── columns: a1.k:1!null a1.i:2 true:33
+ │    │    │    ├── columns: a1.k:1!null a1.i:2 canary:33
  │    │    │    ├── fd: (1)-->(2)
  │    │    │    ├── scan a [as=a1]
  │    │    │    │    ├── columns: a1.k:1!null a1.i:2
  │    │    │    │    ├── key: (1)
  │    │    │    │    └── fd: (1)-->(2)
  │    │    │    ├── project
- │    │    │    │    ├── columns: true:33!null
+ │    │    │    │    ├── columns: canary:33!null
  │    │    │    │    ├── outer: (2)
  │    │    │    │    ├── fd: ()-->(33)
  │    │    │    │    ├── semi-join (cross)
@@ -5813,13 +5797,13 @@ union
  │    │    │    │    │                        │    └── columns: a.i:23
  │    │    │    │    │                        └── a1.i:2
  │    │    │    │    └── projections
- │    │    │    │         └── true [as=true:33]
+ │    │    │    │         └── true [as=canary:33]
  │    │    │    └── filters (true)
  │    │    └── aggregations
- │    │         └── const-not-null-agg [as=true_agg:34, outer=(33)]
- │    │              └── true:33
+ │    │         └── const-not-null-agg [as=canary_agg:34, outer=(33)]
+ │    │              └── canary:33
  │    └── projections
- │         └── true_agg:34 IS NOT NULL [as=exists:32, outer=(34)]
+ │         └── canary_agg:34 IS NOT NULL [as=exists:32, outer=(34)]
  └── project
       ├── columns: bool:43!null
       ├── fd: ()-->(43)
@@ -5908,18 +5892,19 @@ anti-join-apply
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
  ├── project
- │    ├── columns: exists:15!null
+ │    ├── columns: exists:14!null
  │    ├── outer: (1)
  │    ├── group-by (hash)
- │    │    ├── columns: u:5!null true_agg:14
+ │    │    ├── columns: u:5!null canary_agg:13
  │    │    ├── grouping columns: u:5!null
  │    │    ├── outer: (1)
  │    │    ├── key: (5)
- │    │    ├── fd: (5)-->(14)
+ │    │    ├── fd: (5)-->(13)
  │    │    ├── left-join (cross)
- │    │    │    ├── columns: u:5!null v:6 true:13
+ │    │    │    ├── columns: u:5!null v:6 c:9 d:10
  │    │    │    ├── outer: (1)
- │    │    │    ├── fd: ()-->(6)
+ │    │    │    ├── key: (5,9)
+ │    │    │    ├── fd: ()-->(6), (9)-->(10)
  │    │    │    ├── select
  │    │    │    │    ├── columns: u:5!null v:6
  │    │    │    │    ├── key: (5)
@@ -5930,28 +5915,19 @@ anti-join-apply
  │    │    │    │    │    └── fd: (5)-->(6)
  │    │    │    │    └── filters
  │    │    │    │         └── v:6 IS NOT DISTINCT FROM CAST(NULL AS INT8) [outer=(6), constraints=(/6: [/NULL - /NULL]; tight), fd=()-->(6)]
- │    │    │    ├── project
- │    │    │    │    ├── columns: true:13!null
- │    │    │    │    ├── outer: (1)
- │    │    │    │    ├── fd: ()-->(13)
- │    │    │    │    ├── select
- │    │    │    │    │    ├── columns: d:10!null
- │    │    │    │    │    ├── outer: (1)
- │    │    │    │    │    ├── fd: ()-->(10)
- │    │    │    │    │    ├── scan cd
- │    │    │    │    │    │    └── columns: d:10!null
- │    │    │    │    │    └── filters
- │    │    │    │    │         └── x:1 = d:10 [outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
- │    │    │    │    └── projections
- │    │    │    │         └── true [as=true:13]
- │    │    │    └── filters (true)
+ │    │    │    ├── scan cd
+ │    │    │    │    ├── columns: c:9!null d:10!null
+ │    │    │    │    ├── key: (9)
+ │    │    │    │    └── fd: (9)-->(10)
+ │    │    │    └── filters
+ │    │    │         └── x:1 = d:10 [outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
  │    │    └── aggregations
- │    │         └── const-not-null-agg [as=true_agg:14, outer=(13)]
- │    │              └── true:13
+ │    │         └── const-not-null-agg [as=canary_agg:13, outer=(9)]
+ │    │              └── c:9
  │    └── projections
- │         └── true_agg:14 IS NOT NULL [as=exists:15, outer=(14)]
+ │         └── canary_agg:13 IS NOT NULL [as=exists:14, outer=(13)]
  └── filters
-      └── exists:15 [outer=(15), constraints=(/15: [/true - /true]; tight), fd=()-->(15)]
+      └── exists:14 [outer=(14), constraints=(/14: [/true - /true]; tight), fd=()-->(14)]
 
 # --------------------------------------------------
 # HoistValuesSubquery
@@ -6011,28 +5987,22 @@ norm expect=HoistValuesSubquery
 SELECT (VALUES (EXISTS(SELECT * FROM xy WHERE x=k))) FROM a
 ----
 project
- ├── columns: column1:17!null
+ ├── columns: column1:16!null
  ├── left-join (hash)
- │    ├── columns: k:1!null x:8 true:14
+ │    ├── columns: k:1!null x:8
  │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
  │    ├── key: (1)
- │    ├── fd: (1)-->(8,14)
+ │    ├── fd: (1)-->(8)
  │    ├── scan a
  │    │    ├── columns: k:1!null
  │    │    └── key: (1)
- │    ├── project
- │    │    ├── columns: true:14!null x:8!null
- │    │    ├── key: (8)
- │    │    ├── fd: ()-->(14)
- │    │    ├── scan xy
- │    │    │    ├── columns: x:8!null
- │    │    │    └── key: (8)
- │    │    └── projections
- │    │         └── true [as=true:14]
+ │    ├── scan xy
+ │    │    ├── columns: x:8!null
+ │    │    └── key: (8)
  │    └── filters
  │         └── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
  └── projections
-      └── true:14 IS NOT NULL [as=column1:17, outer=(14)]
+      └── x:8 IS NOT NULL [as=column1:16, outer=(8)]
 
 # Any in values row.
 norm expect=HoistValuesSubquery
@@ -6364,18 +6334,18 @@ project
  ├── key: (1,12)
  ├── fd: (1)-->(2-9), (1,12)-->(2-9,13)
  └── select
-      ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9 x:12!null y:13 true_agg:22!null
+      ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9 x:12!null y:13 canary_agg:22!null
       ├── immutable
       ├── key: (1,12)
       ├── fd: (1)-->(2-9), (1,12)-->(2-9,13,22)
       ├── group-by (hash)
-      │    ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9 x:12!null y:13 true_agg:22
+      │    ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9 x:12!null y:13 canary_agg:22
       │    ├── grouping columns: id:1!null x:12!null
       │    ├── immutable
       │    ├── key: (1,12)
       │    ├── fd: (1)-->(2-9), (1,12)-->(2-9,13,22)
       │    ├── inner-join-apply
-      │    │    ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9 x:12!null y:13 true:21
+      │    │    ├── columns: id:1!null body:2 description:3 title:4 slug:5 tag_list:6 user_id:7 created_at:8 updated_at:9 x:12!null y:13 canary:21
       │    │    ├── immutable
       │    │    ├── fd: (1)-->(2-9), (1,12)-->(13)
       │    │    ├── scan articles
@@ -6383,7 +6353,7 @@ project
       │    │    │    ├── key: (1)
       │    │    │    └── fd: (1)-->(2-9)
       │    │    ├── left-join-apply
-      │    │    │    ├── columns: x:12!null y:13 true:21
+      │    │    │    ├── columns: x:12!null y:13 canary:21
       │    │    │    ├── outer: (1,4,6)
       │    │    │    ├── immutable
       │    │    │    ├── fd: (12)-->(13)
@@ -6392,7 +6362,7 @@ project
       │    │    │    │    ├── key: (12)
       │    │    │    │    └── fd: (12)-->(13)
       │    │    │    ├── project
-      │    │    │    │    ├── columns: true:21!null
+      │    │    │    │    ├── columns: canary:21!null
       │    │    │    │    ├── outer: (1,4,6,12)
       │    │    │    │    ├── immutable
       │    │    │    │    ├── fd: ()-->(21)
@@ -6410,12 +6380,12 @@ project
       │    │    │    │    │         ├── upper(title:4) [outer=(4), immutable]
       │    │    │    │    │         └── unnest(tag_list:6) [outer=(6), immutable]
       │    │    │    │    └── projections
-      │    │    │    │         └── true [as=true:21]
+      │    │    │    │         └── true [as=canary:21]
       │    │    │    └── filters (true)
       │    │    └── filters (true)
       │    └── aggregations
-      │         ├── const-not-null-agg [as=true_agg:22, outer=(21)]
-      │         │    └── true:21
+      │         ├── const-not-null-agg [as=canary_agg:22, outer=(21)]
+      │         │    └── canary:21
       │         ├── const-agg [as=y:13, outer=(13)]
       │         │    └── y:13
       │         ├── const-agg [as=body:2, outer=(2)]
@@ -6435,7 +6405,7 @@ project
       │         └── const-agg [as=updated_at:9, outer=(9)]
       │              └── updated_at:9
       └── filters
-           └── true_agg:22 IS NOT NULL [outer=(22), constraints=(/22: (/NULL - ]; tight)]
+           └── canary_agg:22 IS NOT NULL [outer=(22), constraints=(/22: (/NULL - ]; tight)]
 
 norm expect=TryDecorrelateProjectSet
 SELECT id FROM articles WHERE title = ANY(

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -1135,10 +1135,10 @@ WHERE y = 2
 project
  ├── columns: case:14!null
  ├── left-join (hash)
- │    ├── columns: x:1!null y:2!null k:5 true:15
+ │    ├── columns: x:1!null y:2!null k:5 i:6
  │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
  │    ├── key: (1)
- │    ├── fd: ()-->(2), (1)-->(5,15)
+ │    ├── fd: ()-->(2), (1)-->(5,6)
  │    ├── select
  │    │    ├── columns: x:1!null y:2!null
  │    │    ├── key: (1)
@@ -1149,26 +1149,20 @@ project
  │    │    │    └── fd: (1)-->(2)
  │    │    └── filters
  │    │         └── y:2 = 2 [outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
- │    ├── project
- │    │    ├── columns: true:15!null k:5!null
+ │    ├── select
+ │    │    ├── columns: k:5!null i:6!null
  │    │    ├── key: (5)
- │    │    ├── fd: ()-->(15)
- │    │    ├── select
+ │    │    ├── fd: ()-->(6)
+ │    │    ├── scan a
  │    │    │    ├── columns: k:5!null i:6!null
  │    │    │    ├── key: (5)
- │    │    │    ├── fd: ()-->(6)
- │    │    │    ├── scan a
- │    │    │    │    ├── columns: k:5!null i:6!null
- │    │    │    │    ├── key: (5)
- │    │    │    │    └── fd: (5)-->(6)
- │    │    │    └── filters
- │    │    │         └── i:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
- │    │    └── projections
- │    │         └── true [as=true:15]
+ │    │    │    └── fd: (5)-->(6)
+ │    │    └── filters
+ │    │         └── i:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
  │    └── filters
  │         └── k:5 = x:1 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
  └── projections
-      └── CASE WHEN true:15 IS NOT NULL THEN 'Y' ELSE 'N' END [as=case:14, outer=(15)]
+      └── CASE WHEN k:5 IS NOT NULL THEN 'Y' ELSE 'N' END [as=case:14, outer=(5)]
 
 # Don't eliminate the GroupBy if there is an aggregate function other than
 # ConstAgg, ConstNotNullAgg, or AnyNotNullAgg.

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -1042,28 +1042,25 @@ project
  ├── columns: exists:14!null
  ├── immutable
  ├── group-by (hash)
- │    ├── columns: true_agg:16 rownum:18!null
- │    ├── grouping columns: rownum:18!null
+ │    ├── columns: k:1!null true_agg:16
+ │    ├── grouping columns: k:1!null
  │    ├── immutable
- │    ├── key: (18)
- │    ├── fd: (18)-->(16)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(16)
  │    ├── left-join (cross)
- │    │    ├── columns: expr:8!null true:15 rownum:18!null
+ │    │    ├── columns: k:1!null expr:8!null true:15
  │    │    ├── immutable
- │    │    ├── fd: (18)-->(8)
- │    │    ├── ordinality
- │    │    │    ├── columns: expr:8!null rownum:18!null
+ │    │    ├── fd: (1)-->(8)
+ │    │    ├── project
+ │    │    │    ├── columns: expr:8!null k:1!null
  │    │    │    ├── immutable
- │    │    │    ├── key: (18)
- │    │    │    ├── fd: (18)-->(8)
- │    │    │    └── project
- │    │    │         ├── columns: expr:8!null
- │    │    │         ├── immutable
- │    │    │         ├── scan a
- │    │    │         │    ├── columns: k:1!null
- │    │    │         │    └── key: (1)
- │    │    │         └── projections
- │    │    │              └── k:1 + 1 [as=expr:8, outer=(1), immutable]
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(8)
+ │    │    │    ├── scan a
+ │    │    │    │    ├── columns: k:1!null
+ │    │    │    │    └── key: (1)
+ │    │    │    └── projections
+ │    │    │         └── k:1 + 1 [as=expr:8, outer=(1), immutable]
  │    │    ├── project
  │    │    │    ├── columns: true:15!null
  │    │    │    ├── fd: ()-->(15)

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -1042,14 +1042,15 @@ project
  ├── columns: exists:14!null
  ├── immutable
  ├── group-by (hash)
- │    ├── columns: k:1!null true_agg:16
+ │    ├── columns: k:1!null canary_agg:15
  │    ├── grouping columns: k:1!null
  │    ├── immutable
  │    ├── key: (1)
- │    ├── fd: (1)-->(16)
+ │    ├── fd: (1)-->(15)
  │    ├── left-join (cross)
- │    │    ├── columns: k:1!null expr:8!null true:15
+ │    │    ├── columns: k:1!null expr:8!null x:9
  │    │    ├── immutable
+ │    │    ├── key: (1,9)
  │    │    ├── fd: (1)-->(8)
  │    │    ├── project
  │    │    │    ├── columns: expr:8!null k:1!null
@@ -1061,19 +1062,16 @@ project
  │    │    │    │    └── key: (1)
  │    │    │    └── projections
  │    │    │         └── k:1 + 1 [as=expr:8, outer=(1), immutable]
- │    │    ├── project
- │    │    │    ├── columns: true:15!null
- │    │    │    ├── fd: ()-->(15)
- │    │    │    ├── scan xy
- │    │    │    └── projections
- │    │    │         └── true [as=true:15]
+ │    │    ├── scan xy
+ │    │    │    ├── columns: x:9!null
+ │    │    │    └── key: (9)
  │    │    └── filters
  │    │         └── expr:8 < 0 [outer=(8), constraints=(/8: (/NULL - /-1]; tight)]
  │    └── aggregations
- │         └── const-not-null-agg [as=true_agg:16, outer=(15)]
- │              └── true:15
+ │         └── const-not-null-agg [as=canary_agg:15, outer=(9)]
+ │              └── x:9
  └── projections
-      └── true_agg:16 IS NOT NULL [as=exists:14, outer=(16)]
+      └── canary_agg:15 IS NOT NULL [as=exists:14, outer=(15)]
 
 # After c is replaced with k+2, (k+2) > 2 should be simplified to k > 0.
 norm

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -1436,51 +1436,46 @@ SELECT (SELECT i_name FROM item LIMIT 1)
     OR (SELECT ol_i_id FROM order_line LIMIT 1) IS NOT NULL;
 ----
 project
- ├── columns: i_name:58
+ ├── columns: i_name:57
  ├── inner-join (hash)
- │    ├── columns: h_data:9!null ol_dist_info:21!null ol_i_id:39 exists:50!null
+ │    ├── columns: h_data:9!null ol_dist_info:21!null ol_i_id:39 exists:49!null
  │    ├── fd: (9)==(21), (21)==(9)
  │    ├── scan history
  │    │    └── columns: h_data:9
  │    ├── select
- │    │    ├── columns: ol_dist_info:21 ol_i_id:39 exists:50!null
+ │    │    ├── columns: ol_dist_info:21 ol_i_id:39 exists:49!null
  │    │    ├── left-join (cross)
- │    │    │    ├── columns: ol_dist_info:21 ol_i_id:39 exists:50!null
+ │    │    │    ├── columns: ol_dist_info:21 ol_i_id:39 exists:49!null
  │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
  │    │    │    ├── project
- │    │    │    │    ├── columns: exists:50!null ol_dist_info:21
+ │    │    │    │    ├── columns: exists:49!null ol_dist_info:21
  │    │    │    │    ├── group-by (hash)
- │    │    │    │    │    ├── columns: ol_o_id:12!null ol_d_id:13!null ol_w_id:14!null ol_number:15!null ol_dist_info:21 true_agg:49
+ │    │    │    │    │    ├── columns: ol_o_id:12!null ol_d_id:13!null ol_w_id:14!null ol_number:15!null ol_dist_info:21 canary_agg:48
  │    │    │    │    │    ├── grouping columns: ol_o_id:12!null ol_d_id:13!null ol_w_id:14!null ol_number:15!null
  │    │    │    │    │    ├── key: (12-15)
- │    │    │    │    │    ├── fd: (12-15)-->(21,49)
+ │    │    │    │    │    ├── fd: (12-15)-->(21,48)
  │    │    │    │    │    ├── left-join (cross)
- │    │    │    │    │    │    ├── columns: ol_o_id:12!null ol_d_id:13!null ol_w_id:14!null ol_number:15!null ol_dist_info:21 true:48
+ │    │    │    │    │    │    ├── columns: ol_o_id:12!null ol_d_id:13!null ol_w_id:14!null ol_number:15!null ol_dist_info:21 rowid:24 h_data:32
  │    │    │    │    │    │    ├── fd: (12-15)-->(21)
  │    │    │    │    │    │    ├── scan order_line
  │    │    │    │    │    │    │    ├── columns: ol_o_id:12!null ol_d_id:13!null ol_w_id:14!null ol_number:15!null ol_dist_info:21
  │    │    │    │    │    │    │    ├── key: (12-15)
  │    │    │    │    │    │    │    └── fd: (12-15)-->(21)
- │    │    │    │    │    │    ├── project
- │    │    │    │    │    │    │    ├── columns: true:48!null
- │    │    │    │    │    │    │    ├── fd: ()-->(48)
- │    │    │    │    │    │    │    ├── select
- │    │    │    │    │    │    │    │    ├── columns: h_data:32!null
- │    │    │    │    │    │    │    │    ├── scan history
- │    │    │    │    │    │    │    │    │    └── columns: h_data:32
- │    │    │    │    │    │    │    │    └── filters
- │    │    │    │    │    │    │    │         └── h_data:32 IS NOT NULL [outer=(32), constraints=(/32: (/NULL - ]; tight)]
- │    │    │    │    │    │    │    └── projections
- │    │    │    │    │    │    │         └── true [as=true:48]
+ │    │    │    │    │    │    ├── select
+ │    │    │    │    │    │    │    ├── columns: rowid:24!null h_data:32!null
+ │    │    │    │    │    │    │    ├── scan history
+ │    │    │    │    │    │    │    │    └── columns: rowid:24!null h_data:32
+ │    │    │    │    │    │    │    └── filters
+ │    │    │    │    │    │    │         └── h_data:32 IS NOT NULL [outer=(32), constraints=(/32: (/NULL - ]; tight)]
  │    │    │    │    │    │    └── filters
  │    │    │    │    │    │         └── ol_dist_info:21 IS NOT NULL [outer=(21), constraints=(/21: (/NULL - ]; tight)]
  │    │    │    │    │    └── aggregations
- │    │    │    │    │         ├── const-not-null-agg [as=true_agg:49, outer=(48)]
- │    │    │    │    │         │    └── true:48
+ │    │    │    │    │         ├── const-not-null-agg [as=canary_agg:48, outer=(24)]
+ │    │    │    │    │         │    └── rowid:24
  │    │    │    │    │         └── const-agg [as=ol_dist_info:21, outer=(21)]
  │    │    │    │    │              └── ol_dist_info:21
  │    │    │    │    └── projections
- │    │    │    │         └── true_agg:49 IS NOT NULL [as=exists:50, outer=(49)]
+ │    │    │    │         └── canary_agg:48 IS NOT NULL [as=exists:49, outer=(48)]
  │    │    │    ├── limit
  │    │    │    │    ├── columns: ol_i_id:39!null
  │    │    │    │    ├── cardinality: [0 - 1]
@@ -1492,18 +1487,18 @@ project
  │    │    │    │    └── 1
  │    │    │    └── filters (true)
  │    │    └── filters
- │    │         └── exists:50 OR (ol_i_id:39 IS NOT NULL) [outer=(39,50)]
+ │    │         └── exists:49 OR (ol_i_id:39 IS NOT NULL) [outer=(39,49)]
  │    └── filters
  │         └── h_data:9 = ol_dist_info:21 [outer=(9,21), constraints=(/9: (/NULL - ]; /21: (/NULL - ]), fd=(9)==(21), (21)==(9)]
  └── projections
-      └── subquery [as=i_name:58, subquery]
+      └── subquery [as=i_name:57, subquery]
            └── limit
-                ├── columns: item.i_name:53
+                ├── columns: item.i_name:52
                 ├── cardinality: [0 - 1]
                 ├── key: ()
-                ├── fd: ()-->(53)
+                ├── fd: ()-->(52)
                 ├── scan item
-                │    ├── columns: item.i_name:53
+                │    ├── columns: item.i_name:52
                 │    └── limit hint: 1.00
                 └── 1
 

--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -547,51 +547,40 @@ norm
 SELECT 1 FROM a AS ref_0 LEFT JOIN a AS ref_1 ON EXISTS(SELECT 1 FROM a WHERE a.s = ref_0.s)
 ----
 project
- ├── columns: "?column?":24!null
- ├── fd: ()-->(24)
+ ├── columns: "?column?":23!null
+ ├── fd: ()-->(23)
  ├── left-join-apply
- │    ├── columns: ref_0.s:4 exists:23
+ │    ├── columns: ref_0.s:4 exists:22
  │    ├── scan a [as=ref_0]
  │    │    └── columns: ref_0.s:4
  │    ├── project
- │    │    ├── columns: exists:23!null
+ │    │    ├── columns: exists:22!null
  │    │    ├── outer: (4)
  │    │    ├── group-by (hash)
- │    │    │    ├── columns: ref_1.k:7!null true_agg:22
+ │    │    │    ├── columns: ref_1.k:7!null canary_agg:21
  │    │    │    ├── grouping columns: ref_1.k:7!null
  │    │    │    ├── outer: (4)
  │    │    │    ├── key: (7)
- │    │    │    ├── fd: (7)-->(22)
+ │    │    │    ├── fd: (7)-->(21)
  │    │    │    ├── left-join (cross)
- │    │    │    │    ├── columns: ref_1.k:7!null true:21
+ │    │    │    │    ├── columns: ref_1.k:7!null a.s:16
  │    │    │    │    ├── outer: (4)
  │    │    │    │    ├── scan a [as=ref_1]
  │    │    │    │    │    ├── columns: ref_1.k:7!null
  │    │    │    │    │    └── key: (7)
- │    │    │    │    ├── project
- │    │    │    │    │    ├── columns: true:21!null
- │    │    │    │    │    ├── outer: (4)
- │    │    │    │    │    ├── fd: ()-->(21)
- │    │    │    │    │    ├── select
- │    │    │    │    │    │    ├── columns: a.s:16!null
- │    │    │    │    │    │    ├── outer: (4)
- │    │    │    │    │    │    ├── fd: ()-->(16)
- │    │    │    │    │    │    ├── scan a
- │    │    │    │    │    │    │    └── columns: a.s:16
- │    │    │    │    │    │    └── filters
- │    │    │    │    │    │         └── a.s:16 = ref_0.s:4 [outer=(4,16), constraints=(/4: (/NULL - ]; /16: (/NULL - ]), fd=(4)==(16), (16)==(4)]
- │    │    │    │    │    └── projections
- │    │    │    │    │         └── true [as=true:21]
- │    │    │    │    └── filters (true)
+ │    │    │    │    ├── scan a
+ │    │    │    │    │    └── columns: a.s:16
+ │    │    │    │    └── filters
+ │    │    │    │         └── a.s:16 = ref_0.s:4 [outer=(4,16), constraints=(/4: (/NULL - ]; /16: (/NULL - ]), fd=(4)==(16), (16)==(4)]
  │    │    │    └── aggregations
- │    │    │         └── const-not-null-agg [as=true_agg:22, outer=(21)]
- │    │    │              └── true:21
+ │    │    │         └── const-not-null-agg [as=canary_agg:21, outer=(16)]
+ │    │    │              └── a.s:16
  │    │    └── projections
- │    │         └── true_agg:22 IS NOT NULL [as=exists:23, outer=(22)]
+ │    │         └── canary_agg:21 IS NOT NULL [as=exists:22, outer=(21)]
  │    └── filters
- │         └── exists:23 [outer=(23), constraints=(/23: [/true - /true]; tight), fd=()-->(23)]
+ │         └── exists:22 [outer=(22), constraints=(/22: [/true - /true]; tight), fd=()-->(22)]
  └── projections
-      └── 1 [as="?column?":24]
+      └── 1 [as="?column?":23]
 
 # Use with multi-argument aggregate function.
 norm expect=RejectNullsGroupBy

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -1890,39 +1890,36 @@ project
  ├── key: (1)
  ├── fd: ()-->(4), (1)-->(2,3,14)
  ├── group-by (hash)
- │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4!null true_agg:16
+ │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4!null canary_agg:15
  │    ├── grouping columns: bids0_.id:1!null
  │    ├── has-placeholder
  │    ├── key: (1)
- │    ├── fd: ()-->(4), (1)-->(2-4,16)
- │    ├── project
- │    │    ├── columns: true:15 bids0_.id:1!null amount:2 createddatetime:3 auctionid:4!null successfulbid:10
+ │    ├── fd: ()-->(4), (1)-->(2-4,15)
+ │    ├── right-join (hash)
+ │    │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4!null a.id:7 successfulbid:10
  │    │    ├── has-placeholder
- │    │    ├── fd: ()-->(4), (1)-->(2,3)
- │    │    ├── right-join (hash)
- │    │    │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4!null successfulbid:10
+ │    │    ├── key: (1,7)
+ │    │    ├── fd: ()-->(4), (1)-->(2,3), (7)-->(10)
+ │    │    ├── scan tauction2 [as=a]
+ │    │    │    ├── columns: a.id:7!null successfulbid:10
+ │    │    │    ├── key: (7)
+ │    │    │    └── fd: (7)-->(10)
+ │    │    ├── select
+ │    │    │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4!null
  │    │    │    ├── has-placeholder
+ │    │    │    ├── key: (1)
  │    │    │    ├── fd: ()-->(4), (1)-->(2,3)
- │    │    │    ├── scan tauction2 [as=a]
- │    │    │    │    └── columns: successfulbid:10
- │    │    │    ├── select
- │    │    │    │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4!null
- │    │    │    │    ├── has-placeholder
+ │    │    │    ├── scan tbid2 [as=bids0_]
+ │    │    │    │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4
  │    │    │    │    ├── key: (1)
- │    │    │    │    ├── fd: ()-->(4), (1)-->(2,3)
- │    │    │    │    ├── scan tbid2 [as=bids0_]
- │    │    │    │    │    ├── columns: bids0_.id:1!null amount:2 createddatetime:3 auctionid:4
- │    │    │    │    │    ├── key: (1)
- │    │    │    │    │    └── fd: (1)-->(2-4)
- │    │    │    │    └── filters
- │    │    │    │         └── auctionid:4 = $1 [outer=(4), constraints=(/4: (/NULL - ]), fd=()-->(4)]
+ │    │    │    │    └── fd: (1)-->(2-4)
  │    │    │    └── filters
- │    │    │         └── successfulbid:10 = bids0_.id:1 [outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
- │    │    └── projections
- │    │         └── CASE successfulbid:10 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:15, outer=(10)]
+ │    │    │         └── auctionid:4 = $1 [outer=(4), constraints=(/4: (/NULL - ]), fd=()-->(4)]
+ │    │    └── filters
+ │    │         └── successfulbid:10 = bids0_.id:1 [outer=(1,10), constraints=(/1: (/NULL - ]; /10: (/NULL - ]), fd=(1)==(10), (10)==(1)]
  │    └── aggregations
- │         ├── const-not-null-agg [as=true_agg:16, outer=(15)]
- │         │    └── true:15
+ │         ├── const-not-null-agg [as=canary_agg:15, outer=(7)]
+ │         │    └── a.id:7
  │         ├── const-agg [as=amount:2, outer=(2)]
  │         │    └── amount:2
  │         ├── const-agg [as=createddatetime:3, outer=(3)]
@@ -1930,7 +1927,7 @@ project
  │         └── const-agg [as=auctionid:4, outer=(4)]
  │              └── auctionid:4
  └── projections
-      └── true_agg:16 IS NOT NULL [as=formula41_1_:14, outer=(16)]
+      └── canary_agg:15 IS NOT NULL [as=formula41_1_:14, outer=(15)]
 
 exec-ddl
 drop table TAuction2, TBid2;

--- a/pkg/sql/opt/xform/testdata/external/liquibase
+++ b/pkg/sql/opt/xform/testdata/external/liquibase
@@ -165,27 +165,27 @@ project
  ├── immutable
  ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37)
  ├── group-by (hash)
- │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 count_rows:154!null column172:172 description:189 rownum:193!null
- │    ├── grouping columns: rownum:193!null
+ │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 count_rows:154!null column172:172 description:189 rownum:192!null
+ │    ├── grouping columns: rownum:192!null
  │    ├── immutable
- │    ├── key: (193)
- │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (193)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,154,172,189)
+ │    ├── key: (192)
+ │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,154,172,189)
  │    ├── right-join (hash)
- │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 pg_inherits.inhparent:150 column172:172 description:189 rownum:193!null
+ │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 pg_inherits.inhparent:150 column172:172 description:189 rownum:192!null
  │    │    ├── immutable
- │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (193)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172,189)
+ │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172,189)
  │    │    ├── scan pg_inherits
  │    │    │    └── columns: pg_inherits.inhparent:150!null
  │    │    ├── distinct-on
- │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 description:189 rownum:193!null
- │    │    │    ├── grouping columns: rownum:193!null
+ │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 description:189 rownum:192!null
+ │    │    │    ├── grouping columns: rownum:192!null
  │    │    │    ├── immutable
- │    │    │    ├── key: (193)
- │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (193)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,172,189)
+ │    │    │    ├── key: (192)
+ │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,172,189)
  │    │    │    ├── right-join (hash)
- │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 objoid:186 description:189 rownum:193!null
+ │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 objoid:186 description:189 rownum:192!null
  │    │    │    │    ├── immutable
- │    │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (193)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172)
+ │    │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172)
  │    │    │    │    ├── union-all
  │    │    │    │    │    ├── columns: objoid:186!null description:189!null
  │    │    │    │    │    ├── left columns: crdb_internal.kv_catalog_comments.objoid:177 crdb_internal.kv_catalog_comments.description:179
@@ -213,165 +213,161 @@ project
  │    │    │    │    │    │              └── objsubid:185 = 0 [outer=(185), constraints=(/185: [/0 - /0]; tight), fd=()-->(185)]
  │    │    │    │    │    └── scan kv_builtin_function_comments
  │    │    │    │    │         └── columns: crdb_internal.kv_builtin_function_comments.oid:181!null crdb_internal.kv_builtin_function_comments.description:182!null
- │    │    │    │    ├── ordinality
- │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 rownum:193!null
+ │    │    │    │    ├── project
+ │    │    │    │    │    ├── columns: column172:172 c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 rownum:192!null
  │    │    │    │    │    ├── immutable
- │    │    │    │    │    ├── key: (193)
- │    │    │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (193)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,172)
- │    │    │    │    │    └── project
- │    │    │    │    │         ├── columns: column172:172 c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140
- │    │    │    │    │         ├── immutable
- │    │    │    │    │         ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37)
- │    │    │    │    │         ├── distinct-on
- │    │    │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relowner:5!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 rolname:158 rownum:192!null
- │    │    │    │    │         │    ├── grouping columns: rownum:192!null
- │    │    │    │    │         │    ├── key: (192)
- │    │    │    │    │         │    ├── fd: ()-->(31), (1)-->(2,5,10,13,15,17,20,22,23,26,27,37), (2)-->(1,5,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,5,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,158)
- │    │    │    │    │         │    ├── right-join (hash)
- │    │    │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 pg_catalog.pg_roles.oid:157 rolname:158 rownum:192!null
- │    │    │    │    │         │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139), (192)-->(1,2,5,8,10,13,15,17,20,22,23,26,27,36,37,44,45,49-51,78,79,84,85,91,105,106,134-136,139,140)
- │    │    │    │    │         │    │    ├── scan pg_roles
- │    │    │    │    │         │    │    │    └── columns: pg_catalog.pg_roles.oid:157 rolname:158
- │    │    │    │    │         │    │    ├── ordinality
- │    │    │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 rownum:192!null
- │    │    │    │    │         │    │    │    ├── key: (192)
- │    │    │    │    │         │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139), (192)-->(1-3,5,8,10,13,15,17,20,22,23,26,27,30,31,36,37,44,45,49-51,78,79,84,85,91,105,106,134-136,139,140)
- │    │    │    │    │         │    │    │    └── left-join (lookup pg_namespace [as=n2])
- │    │    │    │    │         │    │    │         ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
- │    │    │    │    │         │    │    │         ├── key columns: [51] = [78]
- │    │    │    │    │         │    │    │         ├── lookup columns are key
- │    │    │    │    │         │    │    │         ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139)
- │    │    │    │    │         │    │    │         ├── right-join (hash)
- │    │    │    │    │         │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
- │    │    │    │    │         │    │    │         │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(91,105,106), (105)-->(106), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
- │    │    │    │    │         │    │    │         │    ├── inner-join (hash)
- │    │    │    │    │         │    │    │         │    │    ├── columns: i.inhrelid:44!null i.inhparent:45!null c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
- │    │    │    │    │         │    │    │         │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │    │    │    │    │         │    │    │         │    │    ├── fd: (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45)
- │    │    │    │    │         │    │    │         │    │    ├── scan pg_inherits [as=i]
- │    │    │    │    │         │    │    │         │    │    │    └── columns: i.inhrelid:44!null i.inhparent:45!null
- │    │    │    │    │         │    │    │         │    │    ├── scan pg_class@pg_class_relname_nsp_index [as=c2]
- │    │    │    │    │         │    │    │         │    │    │    ├── columns: c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
- │    │    │    │    │         │    │    │         │    │    │    ├── key: (49)
- │    │    │    │    │         │    │    │         │    │    │    └── fd: (49)-->(50,51), (50,51)-->(49)
- │    │    │    │    │         │    │    │         │    │    └── filters
- │    │    │    │    │         │    │    │         │    │         └── i.inhparent:45 = c2.oid:49 [outer=(45,49), constraints=(/45: (/NULL - ]; /49: (/NULL - ]), fd=(45)==(49), (49)==(45)]
- │    │    │    │    │         │    │    │         │    ├── left-join (lookup pg_class [as=ci])
- │    │    │    │    │         │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
- │    │    │    │    │         │    │    │         │    │    ├── key columns: [84] = [105]
- │    │    │    │    │         │    │    │         │    │    ├── lookup columns are key
- │    │    │    │    │         │    │    │         │    │    ├── key: (1,84)
- │    │    │    │    │         │    │    │         │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91,105,106), (105)-->(106), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
- │    │    │    │    │         │    │    │         │    │    ├── left-join (lookup pg_index [as=ind])
- │    │    │    │    │         │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
- │    │    │    │    │         │    │    │         │    │    │    ├── key columns: [967] = [84]
- │    │    │    │    │         │    │    │         │    │    │    ├── lookup columns are key
- │    │    │    │    │         │    │    │         │    │    │    ├── second join in paired joiner
- │    │    │    │    │         │    │    │         │    │    │    ├── key: (1,84)
- │    │    │    │    │         │    │    │         │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
- │    │    │    │    │         │    │    │         │    │    │    ├── left-join (lookup pg_index@pg_index_indrelid_index [as=ind])
- │    │    │    │    │         │    │    │         │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 indexrelid:967 indrelid:968 continuation:988
- │    │    │    │    │         │    │    │         │    │    │    │    ├── key columns: [1] = [968]
- │    │    │    │    │         │    │    │         │    │    │    │    ├── first join in paired joiner; continuation column: continuation:988
- │    │    │    │    │         │    │    │         │    │    │    │    ├── key: (1,967)
- │    │    │    │    │         │    │    │         │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3), (967)-->(968,988)
- │    │    │    │    │         │    │    │         │    │    │    │    ├── left-join (lookup pg_tablespace [as=t])
- │    │    │    │    │         │    │    │         │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
- │    │    │    │    │         │    │    │         │    │    │    │    │    ├── key columns: [8] = [36]
- │    │    │    │    │         │    │    │         │    │    │    │    │    ├── lookup columns are key
- │    │    │    │    │         │    │    │         │    │    │    │    │    ├── key: (1)
- │    │    │    │    │         │    │    │         │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
- │    │    │    │    │         │    │    │         │    │    │    │    │    ├── left-join (lookup pg_foreign_server [as=fs])
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── key columns: [135] = [139]
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── lookup columns are key
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (3)==(30), (30)==(3)
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── left-join (lookup pg_foreign_table [as=ft])
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── key columns: [1] = [134]
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── lookup columns are key
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136), (3)==(30), (30)==(3)
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── inner-join (hash)
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3)
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── select
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── scan pg_class [as=c]
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    └── filters
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │         └── (c.relkind:17 = 'r') OR (c.relkind:17 = 'f') [outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r']; tight)]
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index [as=n]
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: n.oid:30!null n.nspname:31!null
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── constraint: /31: [/'public' - /'public']
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── key: ()
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    └── fd: ()-->(30,31)
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    └── filters
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │         └── n.oid:30 = c.relnamespace:3 [outer=(3,30), constraints=(/3: (/NULL - ]; /30: (/NULL - ]), fd=(3)==(30), (30)==(3)]
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    └── filters (true)
- │    │    │    │    │         │    │    │         │    │    │    │    │    │    └── filters (true)
- │    │    │    │    │         │    │    │         │    │    │    │    │    └── filters (true)
- │    │    │    │    │         │    │    │         │    │    │    │    └── filters (true)
- │    │    │    │    │         │    │    │         │    │    │    └── filters
- │    │    │    │    │         │    │    │         │    │    │         └── indisclustered:91 [outer=(91), constraints=(/91: [/true - /true]; tight), fd=()-->(91)]
- │    │    │    │    │         │    │    │         │    │    └── filters (true)
- │    │    │    │    │         │    │    │         │    └── filters
- │    │    │    │    │         │    │    │         │         └── i.inhrelid:44 = c.oid:1 [outer=(1,44), constraints=(/1: (/NULL - ]; /44: (/NULL - ]), fd=(1)==(44), (44)==(1)]
- │    │    │    │    │         │    │    │         └── filters (true)
- │    │    │    │    │         │    │    └── filters
- │    │    │    │    │         │    │         └── pg_catalog.pg_roles.oid:157 = c.relowner:5 [outer=(5,157), constraints=(/5: (/NULL - ]; /157: (/NULL - ]), fd=(5)==(157), (157)==(5)]
- │    │    │    │    │         │    └── aggregations
- │    │    │    │    │         │         ├── const-agg [as=c.oid:1, outer=(1)]
- │    │    │    │    │         │         │    └── c.oid:1
- │    │    │    │    │         │         ├── const-agg [as=c.relname:2, outer=(2)]
- │    │    │    │    │         │         │    └── c.relname:2
- │    │    │    │    │         │         ├── const-agg [as=c.relowner:5, outer=(5)]
- │    │    │    │    │         │         │    └── c.relowner:5
- │    │    │    │    │         │         ├── const-agg [as=c.reltuples:10, outer=(10)]
- │    │    │    │    │         │         │    └── c.reltuples:10
- │    │    │    │    │         │         ├── const-agg [as=c.relhasindex:13, outer=(13)]
- │    │    │    │    │         │         │    └── c.relhasindex:13
- │    │    │    │    │         │         ├── const-agg [as=c.relpersistence:15, outer=(15)]
- │    │    │    │    │         │         │    └── c.relpersistence:15
- │    │    │    │    │         │         ├── const-agg [as=c.relkind:17, outer=(17)]
- │    │    │    │    │         │         │    └── c.relkind:17
- │    │    │    │    │         │         ├── const-agg [as=c.relhasoids:20, outer=(20)]
- │    │    │    │    │         │         │    └── c.relhasoids:20
- │    │    │    │    │         │         ├── const-agg [as=c.relhasrules:22, outer=(22)]
- │    │    │    │    │         │         │    └── c.relhasrules:22
- │    │    │    │    │         │         ├── const-agg [as=c.relhastriggers:23, outer=(23)]
- │    │    │    │    │         │         │    └── c.relhastriggers:23
- │    │    │    │    │         │         ├── const-agg [as=c.relacl:26, outer=(26)]
- │    │    │    │    │         │         │    └── c.relacl:26
- │    │    │    │    │         │         ├── const-agg [as=c.reloptions:27, outer=(27)]
- │    │    │    │    │         │         │    └── c.reloptions:27
- │    │    │    │    │         │         ├── const-agg [as=n.nspname:31, outer=(31)]
- │    │    │    │    │         │         │    └── n.nspname:31
- │    │    │    │    │         │         ├── const-agg [as=spcname:37, outer=(37)]
- │    │    │    │    │         │         │    └── spcname:37
- │    │    │    │    │         │         ├── const-agg [as=c2.relname:50, outer=(50)]
- │    │    │    │    │         │         │    └── c2.relname:50
- │    │    │    │    │         │         ├── const-agg [as=n2.nspname:79, outer=(79)]
- │    │    │    │    │         │         │    └── n2.nspname:79
- │    │    │    │    │         │         ├── const-agg [as=ci.relname:106, outer=(106)]
- │    │    │    │    │         │         │    └── ci.relname:106
- │    │    │    │    │         │         ├── const-agg [as=ftoptions:136, outer=(136)]
- │    │    │    │    │         │         │    └── ftoptions:136
- │    │    │    │    │         │         ├── const-agg [as=srvname:140, outer=(140)]
- │    │    │    │    │         │         │    └── srvname:140
- │    │    │    │    │         │         └── first-agg [as=rolname:158, outer=(158)]
- │    │    │    │    │         │              └── rolname:158
- │    │    │    │    │         └── projections
- │    │    │    │    │              └── assignment-cast: STRING [as=column172:172, outer=(5,158), immutable]
- │    │    │    │    │                   └── COALESCE(rolname:158, (('unknown (OID=' || c.relowner:5) || ')')::NAME)
+ │    │    │    │    │    ├── key: (192)
+ │    │    │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172)
+ │    │    │    │    │    ├── distinct-on
+ │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relowner:5!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 rolname:158 rownum:192!null
+ │    │    │    │    │    │    ├── grouping columns: rownum:192!null
+ │    │    │    │    │    │    ├── key: (192)
+ │    │    │    │    │    │    ├── fd: ()-->(31), (1)-->(2,5,10,13,15,17,20,22,23,26,27,37), (2)-->(1,5,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,5,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,158)
+ │    │    │    │    │    │    ├── right-join (hash)
+ │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 pg_catalog.pg_roles.oid:157 rolname:158 rownum:192!null
+ │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139), (192)-->(1,2,5,8,10,13,15,17,20,22,23,26,27,36,37,44,45,49-51,78,79,84,85,91,105,106,134-136,139,140)
+ │    │    │    │    │    │    │    ├── scan pg_roles
+ │    │    │    │    │    │    │    │    └── columns: pg_catalog.pg_roles.oid:157 rolname:158
+ │    │    │    │    │    │    │    ├── ordinality
+ │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 rownum:192!null
+ │    │    │    │    │    │    │    │    ├── key: (192)
+ │    │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139), (192)-->(1-3,5,8,10,13,15,17,20,22,23,26,27,30,31,36,37,44,45,49-51,78,79,84,85,91,105,106,134-136,139,140)
+ │    │    │    │    │    │    │    │    └── left-join (lookup pg_namespace [as=n2])
+ │    │    │    │    │    │    │    │         ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+ │    │    │    │    │    │    │    │         ├── key columns: [51] = [78]
+ │    │    │    │    │    │    │    │         ├── lookup columns are key
+ │    │    │    │    │    │    │    │         ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139)
+ │    │    │    │    │    │    │    │         ├── right-join (hash)
+ │    │    │    │    │    │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+ │    │    │    │    │    │    │    │         │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(91,105,106), (105)-->(106), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+ │    │    │    │    │    │    │    │         │    ├── inner-join (hash)
+ │    │    │    │    │    │    │    │         │    │    ├── columns: i.inhrelid:44!null i.inhparent:45!null c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
+ │    │    │    │    │    │    │    │         │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │    │    │    │    │    │    │         │    │    ├── fd: (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45)
+ │    │    │    │    │    │    │    │         │    │    ├── scan pg_inherits [as=i]
+ │    │    │    │    │    │    │    │         │    │    │    └── columns: i.inhrelid:44!null i.inhparent:45!null
+ │    │    │    │    │    │    │    │         │    │    ├── scan pg_class@pg_class_relname_nsp_index [as=c2]
+ │    │    │    │    │    │    │    │         │    │    │    ├── columns: c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
+ │    │    │    │    │    │    │    │         │    │    │    ├── key: (49)
+ │    │    │    │    │    │    │    │         │    │    │    └── fd: (49)-->(50,51), (50,51)-->(49)
+ │    │    │    │    │    │    │    │         │    │    └── filters
+ │    │    │    │    │    │    │    │         │    │         └── i.inhparent:45 = c2.oid:49 [outer=(45,49), constraints=(/45: (/NULL - ]; /49: (/NULL - ]), fd=(45)==(49), (49)==(45)]
+ │    │    │    │    │    │    │    │         │    ├── left-join (lookup pg_class [as=ci])
+ │    │    │    │    │    │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+ │    │    │    │    │    │    │    │         │    │    ├── key columns: [84] = [105]
+ │    │    │    │    │    │    │    │         │    │    ├── lookup columns are key
+ │    │    │    │    │    │    │    │         │    │    ├── key: (1,84)
+ │    │    │    │    │    │    │    │         │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91,105,106), (105)-->(106), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+ │    │    │    │    │    │    │    │         │    │    ├── left-join (lookup pg_index [as=ind])
+ │    │    │    │    │    │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+ │    │    │    │    │    │    │    │         │    │    │    ├── key columns: [966] = [84]
+ │    │    │    │    │    │    │    │         │    │    │    ├── lookup columns are key
+ │    │    │    │    │    │    │    │         │    │    │    ├── second join in paired joiner
+ │    │    │    │    │    │    │    │         │    │    │    ├── key: (1,84)
+ │    │    │    │    │    │    │    │         │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+ │    │    │    │    │    │    │    │         │    │    │    ├── left-join (lookup pg_index@pg_index_indrelid_index [as=ind])
+ │    │    │    │    │    │    │    │         │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 indexrelid:966 indrelid:967 continuation:987
+ │    │    │    │    │    │    │    │         │    │    │    │    ├── key columns: [1] = [967]
+ │    │    │    │    │    │    │    │         │    │    │    │    ├── first join in paired joiner; continuation column: continuation:987
+ │    │    │    │    │    │    │    │         │    │    │    │    ├── key: (1,966)
+ │    │    │    │    │    │    │    │         │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3), (966)-->(967,987)
+ │    │    │    │    │    │    │    │         │    │    │    │    ├── left-join (lookup pg_tablespace [as=t])
+ │    │    │    │    │    │    │    │         │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+ │    │    │    │    │    │    │    │         │    │    │    │    │    ├── key columns: [8] = [36]
+ │    │    │    │    │    │    │    │         │    │    │    │    │    ├── lookup columns are key
+ │    │    │    │    │    │    │    │         │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    │    │    │         │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+ │    │    │    │    │    │    │    │         │    │    │    │    │    ├── left-join (lookup pg_foreign_server [as=fs])
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    ├── key columns: [135] = [139]
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    ├── lookup columns are key
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (3)==(30), (30)==(3)
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    ├── left-join (lookup pg_foreign_table [as=ft])
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    ├── key columns: [1] = [134]
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    ├── lookup columns are key
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136), (3)==(30), (30)==(3)
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    ├── inner-join (hash)
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3)
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    ├── select
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── scan pg_class [as=c]
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    └── filters
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │         └── (c.relkind:17 = 'r') OR (c.relkind:17 = 'f') [outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r']; tight)]
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index [as=n]
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: n.oid:30!null n.nspname:31!null
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── constraint: /31: [/'public' - /'public']
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── key: ()
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    └── fd: ()-->(30,31)
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    └── filters
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │         └── n.oid:30 = c.relnamespace:3 [outer=(3,30), constraints=(/3: (/NULL - ]; /30: (/NULL - ]), fd=(3)==(30), (30)==(3)]
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    └── filters (true)
+ │    │    │    │    │    │    │    │         │    │    │    │    │    │    └── filters (true)
+ │    │    │    │    │    │    │    │         │    │    │    │    │    └── filters (true)
+ │    │    │    │    │    │    │    │         │    │    │    │    └── filters (true)
+ │    │    │    │    │    │    │    │         │    │    │    └── filters
+ │    │    │    │    │    │    │    │         │    │    │         └── indisclustered:91 [outer=(91), constraints=(/91: [/true - /true]; tight), fd=()-->(91)]
+ │    │    │    │    │    │    │    │         │    │    └── filters (true)
+ │    │    │    │    │    │    │    │         │    └── filters
+ │    │    │    │    │    │    │    │         │         └── i.inhrelid:44 = c.oid:1 [outer=(1,44), constraints=(/1: (/NULL - ]; /44: (/NULL - ]), fd=(1)==(44), (44)==(1)]
+ │    │    │    │    │    │    │    │         └── filters (true)
+ │    │    │    │    │    │    │    └── filters
+ │    │    │    │    │    │    │         └── pg_catalog.pg_roles.oid:157 = c.relowner:5 [outer=(5,157), constraints=(/5: (/NULL - ]; /157: (/NULL - ]), fd=(5)==(157), (157)==(5)]
+ │    │    │    │    │    │    └── aggregations
+ │    │    │    │    │    │         ├── const-agg [as=c.oid:1, outer=(1)]
+ │    │    │    │    │    │         │    └── c.oid:1
+ │    │    │    │    │    │         ├── const-agg [as=c.relname:2, outer=(2)]
+ │    │    │    │    │    │         │    └── c.relname:2
+ │    │    │    │    │    │         ├── const-agg [as=c.relowner:5, outer=(5)]
+ │    │    │    │    │    │         │    └── c.relowner:5
+ │    │    │    │    │    │         ├── const-agg [as=c.reltuples:10, outer=(10)]
+ │    │    │    │    │    │         │    └── c.reltuples:10
+ │    │    │    │    │    │         ├── const-agg [as=c.relhasindex:13, outer=(13)]
+ │    │    │    │    │    │         │    └── c.relhasindex:13
+ │    │    │    │    │    │         ├── const-agg [as=c.relpersistence:15, outer=(15)]
+ │    │    │    │    │    │         │    └── c.relpersistence:15
+ │    │    │    │    │    │         ├── const-agg [as=c.relkind:17, outer=(17)]
+ │    │    │    │    │    │         │    └── c.relkind:17
+ │    │    │    │    │    │         ├── const-agg [as=c.relhasoids:20, outer=(20)]
+ │    │    │    │    │    │         │    └── c.relhasoids:20
+ │    │    │    │    │    │         ├── const-agg [as=c.relhasrules:22, outer=(22)]
+ │    │    │    │    │    │         │    └── c.relhasrules:22
+ │    │    │    │    │    │         ├── const-agg [as=c.relhastriggers:23, outer=(23)]
+ │    │    │    │    │    │         │    └── c.relhastriggers:23
+ │    │    │    │    │    │         ├── const-agg [as=c.relacl:26, outer=(26)]
+ │    │    │    │    │    │         │    └── c.relacl:26
+ │    │    │    │    │    │         ├── const-agg [as=c.reloptions:27, outer=(27)]
+ │    │    │    │    │    │         │    └── c.reloptions:27
+ │    │    │    │    │    │         ├── const-agg [as=n.nspname:31, outer=(31)]
+ │    │    │    │    │    │         │    └── n.nspname:31
+ │    │    │    │    │    │         ├── const-agg [as=spcname:37, outer=(37)]
+ │    │    │    │    │    │         │    └── spcname:37
+ │    │    │    │    │    │         ├── const-agg [as=c2.relname:50, outer=(50)]
+ │    │    │    │    │    │         │    └── c2.relname:50
+ │    │    │    │    │    │         ├── const-agg [as=n2.nspname:79, outer=(79)]
+ │    │    │    │    │    │         │    └── n2.nspname:79
+ │    │    │    │    │    │         ├── const-agg [as=ci.relname:106, outer=(106)]
+ │    │    │    │    │    │         │    └── ci.relname:106
+ │    │    │    │    │    │         ├── const-agg [as=ftoptions:136, outer=(136)]
+ │    │    │    │    │    │         │    └── ftoptions:136
+ │    │    │    │    │    │         ├── const-agg [as=srvname:140, outer=(140)]
+ │    │    │    │    │    │         │    └── srvname:140
+ │    │    │    │    │    │         └── first-agg [as=rolname:158, outer=(158)]
+ │    │    │    │    │    │              └── rolname:158
+ │    │    │    │    │    └── projections
+ │    │    │    │    │         └── assignment-cast: STRING [as=column172:172, outer=(5,158), immutable]
+ │    │    │    │    │              └── COALESCE(rolname:158, (('unknown (OID=' || c.relowner:5) || ')')::NAME)
  │    │    │    │    └── filters
  │    │    │    │         └── objoid:186 = c.oid:1 [outer=(1,186), constraints=(/1: (/NULL - ]; /186: (/NULL - ]), fd=(1)==(186), (186)==(1)]
  │    │    │    └── aggregations

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -169,27 +169,27 @@ sort
       ├── immutable
       ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37)
       ├── group-by (hash)
-      │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 count_rows:154!null column172:172 description:189 rownum:193!null
-      │    ├── grouping columns: rownum:193!null
+      │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 count_rows:154!null column172:172 description:189 rownum:192!null
+      │    ├── grouping columns: rownum:192!null
       │    ├── immutable
-      │    ├── key: (193)
-      │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (193)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,154,172,189)
+      │    ├── key: (192)
+      │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,154,172,189)
       │    ├── right-join (hash)
-      │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 pg_inherits.inhparent:150 column172:172 description:189 rownum:193!null
+      │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 pg_inherits.inhparent:150 column172:172 description:189 rownum:192!null
       │    │    ├── immutable
-      │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (193)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172,189)
+      │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172,189)
       │    │    ├── scan pg_inherits
       │    │    │    └── columns: pg_inherits.inhparent:150!null
       │    │    ├── distinct-on
-      │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 description:189 rownum:193!null
-      │    │    │    ├── grouping columns: rownum:193!null
+      │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 description:189 rownum:192!null
+      │    │    │    ├── grouping columns: rownum:192!null
       │    │    │    ├── immutable
-      │    │    │    ├── key: (193)
-      │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (193)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,172,189)
+      │    │    │    ├── key: (192)
+      │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,172,189)
       │    │    │    ├── right-join (hash)
-      │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 objoid:186 description:189 rownum:193!null
+      │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 objoid:186 description:189 rownum:192!null
       │    │    │    │    ├── immutable
-      │    │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (193)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172)
+      │    │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172)
       │    │    │    │    ├── union-all
       │    │    │    │    │    ├── columns: objoid:186!null description:189!null
       │    │    │    │    │    ├── left columns: crdb_internal.kv_catalog_comments.objoid:177 crdb_internal.kv_catalog_comments.description:179
@@ -217,165 +217,161 @@ sort
       │    │    │    │    │    │              └── objsubid:185 = 0 [outer=(185), constraints=(/185: [/0 - /0]; tight), fd=()-->(185)]
       │    │    │    │    │    └── scan kv_builtin_function_comments
       │    │    │    │    │         └── columns: crdb_internal.kv_builtin_function_comments.oid:181!null crdb_internal.kv_builtin_function_comments.description:182!null
-      │    │    │    │    ├── ordinality
-      │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 rownum:193!null
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: column172:172 c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 rownum:192!null
       │    │    │    │    │    ├── immutable
-      │    │    │    │    │    ├── key: (193)
-      │    │    │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (193)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,172)
-      │    │    │    │    │    └── project
-      │    │    │    │    │         ├── columns: column172:172 c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140
-      │    │    │    │    │         ├── immutable
-      │    │    │    │    │         ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37)
-      │    │    │    │    │         ├── distinct-on
-      │    │    │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relowner:5!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 rolname:158 rownum:192!null
-      │    │    │    │    │         │    ├── grouping columns: rownum:192!null
-      │    │    │    │    │         │    ├── key: (192)
-      │    │    │    │    │         │    ├── fd: ()-->(31), (1)-->(2,5,10,13,15,17,20,22,23,26,27,37), (2)-->(1,5,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,5,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,158)
-      │    │    │    │    │         │    ├── right-join (hash)
-      │    │    │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 pg_catalog.pg_roles.oid:157 rolname:158 rownum:192!null
-      │    │    │    │    │         │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139), (192)-->(1,2,5,8,10,13,15,17,20,22,23,26,27,36,37,44,45,49-51,78,79,84,85,91,105,106,134-136,139,140)
-      │    │    │    │    │         │    │    ├── scan pg_roles
-      │    │    │    │    │         │    │    │    └── columns: pg_catalog.pg_roles.oid:157 rolname:158
-      │    │    │    │    │         │    │    ├── ordinality
-      │    │    │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 rownum:192!null
-      │    │    │    │    │         │    │    │    ├── key: (192)
-      │    │    │    │    │         │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139), (192)-->(1-3,5,8,10,13,15,17,20,22,23,26,27,30,31,36,37,44,45,49-51,78,79,84,85,91,105,106,134-136,139,140)
-      │    │    │    │    │         │    │    │    └── left-join (lookup pg_namespace [as=n2])
-      │    │    │    │    │         │    │    │         ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
-      │    │    │    │    │         │    │    │         ├── key columns: [51] = [78]
-      │    │    │    │    │         │    │    │         ├── lookup columns are key
-      │    │    │    │    │         │    │    │         ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139)
-      │    │    │    │    │         │    │    │         ├── right-join (hash)
-      │    │    │    │    │         │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
-      │    │    │    │    │         │    │    │         │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(91,105,106), (105)-->(106), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
-      │    │    │    │    │         │    │    │         │    ├── inner-join (hash)
-      │    │    │    │    │         │    │    │         │    │    ├── columns: i.inhrelid:44!null i.inhparent:45!null c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
-      │    │    │    │    │         │    │    │         │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-      │    │    │    │    │         │    │    │         │    │    ├── fd: (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45)
-      │    │    │    │    │         │    │    │         │    │    ├── scan pg_inherits [as=i]
-      │    │    │    │    │         │    │    │         │    │    │    └── columns: i.inhrelid:44!null i.inhparent:45!null
-      │    │    │    │    │         │    │    │         │    │    ├── scan pg_class@pg_class_relname_nsp_index [as=c2]
-      │    │    │    │    │         │    │    │         │    │    │    ├── columns: c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
-      │    │    │    │    │         │    │    │         │    │    │    ├── key: (49)
-      │    │    │    │    │         │    │    │         │    │    │    └── fd: (49)-->(50,51), (50,51)-->(49)
-      │    │    │    │    │         │    │    │         │    │    └── filters
-      │    │    │    │    │         │    │    │         │    │         └── i.inhparent:45 = c2.oid:49 [outer=(45,49), constraints=(/45: (/NULL - ]; /49: (/NULL - ]), fd=(45)==(49), (49)==(45)]
-      │    │    │    │    │         │    │    │         │    ├── left-join (lookup pg_class [as=ci])
-      │    │    │    │    │         │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
-      │    │    │    │    │         │    │    │         │    │    ├── key columns: [84] = [105]
-      │    │    │    │    │         │    │    │         │    │    ├── lookup columns are key
-      │    │    │    │    │         │    │    │         │    │    ├── key: (1,84)
-      │    │    │    │    │         │    │    │         │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91,105,106), (105)-->(106), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
-      │    │    │    │    │         │    │    │         │    │    ├── left-join (lookup pg_index [as=ind])
-      │    │    │    │    │         │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
-      │    │    │    │    │         │    │    │         │    │    │    ├── key columns: [967] = [84]
-      │    │    │    │    │         │    │    │         │    │    │    ├── lookup columns are key
-      │    │    │    │    │         │    │    │         │    │    │    ├── second join in paired joiner
-      │    │    │    │    │         │    │    │         │    │    │    ├── key: (1,84)
-      │    │    │    │    │         │    │    │         │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
-      │    │    │    │    │         │    │    │         │    │    │    ├── left-join (lookup pg_index@pg_index_indrelid_index [as=ind])
-      │    │    │    │    │         │    │    │         │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 indexrelid:967 indrelid:968 continuation:988
-      │    │    │    │    │         │    │    │         │    │    │    │    ├── key columns: [1] = [968]
-      │    │    │    │    │         │    │    │         │    │    │    │    ├── first join in paired joiner; continuation column: continuation:988
-      │    │    │    │    │         │    │    │         │    │    │    │    ├── key: (1,967)
-      │    │    │    │    │         │    │    │         │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3), (967)-->(968,988)
-      │    │    │    │    │         │    │    │         │    │    │    │    ├── left-join (lookup pg_tablespace [as=t])
-      │    │    │    │    │         │    │    │         │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
-      │    │    │    │    │         │    │    │         │    │    │    │    │    ├── key columns: [8] = [36]
-      │    │    │    │    │         │    │    │         │    │    │    │    │    ├── lookup columns are key
-      │    │    │    │    │         │    │    │         │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │         │    │    │         │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
-      │    │    │    │    │         │    │    │         │    │    │    │    │    ├── left-join (lookup pg_foreign_server [as=fs])
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── key columns: [135] = [139]
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── lookup columns are key
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (3)==(30), (30)==(3)
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── left-join (lookup pg_foreign_table [as=ft])
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── key columns: [1] = [134]
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── lookup columns are key
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136), (3)==(30), (30)==(3)
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── inner-join (hash)
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3)
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── select
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── scan pg_class [as=c]
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │         └── (c.relkind:17 = 'r') OR (c.relkind:17 = 'f') [outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r']; tight)]
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index [as=n]
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: n.oid:30!null n.nspname:31!null
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── constraint: /31: [/'public' - /'public']
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    └── fd: ()-->(30,31)
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │         └── n.oid:30 = c.relnamespace:3 [outer=(3,30), constraints=(/3: (/NULL - ]; /30: (/NULL - ]), fd=(3)==(30), (30)==(3)]
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │         │    │    │         │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │         │    │    │         │    │    │    │    │    └── filters (true)
-      │    │    │    │    │         │    │    │         │    │    │    │    └── filters (true)
-      │    │    │    │    │         │    │    │         │    │    │    └── filters
-      │    │    │    │    │         │    │    │         │    │    │         └── indisclustered:91 [outer=(91), constraints=(/91: [/true - /true]; tight), fd=()-->(91)]
-      │    │    │    │    │         │    │    │         │    │    └── filters (true)
-      │    │    │    │    │         │    │    │         │    └── filters
-      │    │    │    │    │         │    │    │         │         └── i.inhrelid:44 = c.oid:1 [outer=(1,44), constraints=(/1: (/NULL - ]; /44: (/NULL - ]), fd=(1)==(44), (44)==(1)]
-      │    │    │    │    │         │    │    │         └── filters (true)
-      │    │    │    │    │         │    │    └── filters
-      │    │    │    │    │         │    │         └── pg_catalog.pg_roles.oid:157 = c.relowner:5 [outer=(5,157), constraints=(/5: (/NULL - ]; /157: (/NULL - ]), fd=(5)==(157), (157)==(5)]
-      │    │    │    │    │         │    └── aggregations
-      │    │    │    │    │         │         ├── const-agg [as=c.oid:1, outer=(1)]
-      │    │    │    │    │         │         │    └── c.oid:1
-      │    │    │    │    │         │         ├── const-agg [as=c.relname:2, outer=(2)]
-      │    │    │    │    │         │         │    └── c.relname:2
-      │    │    │    │    │         │         ├── const-agg [as=c.relowner:5, outer=(5)]
-      │    │    │    │    │         │         │    └── c.relowner:5
-      │    │    │    │    │         │         ├── const-agg [as=c.reltuples:10, outer=(10)]
-      │    │    │    │    │         │         │    └── c.reltuples:10
-      │    │    │    │    │         │         ├── const-agg [as=c.relhasindex:13, outer=(13)]
-      │    │    │    │    │         │         │    └── c.relhasindex:13
-      │    │    │    │    │         │         ├── const-agg [as=c.relpersistence:15, outer=(15)]
-      │    │    │    │    │         │         │    └── c.relpersistence:15
-      │    │    │    │    │         │         ├── const-agg [as=c.relkind:17, outer=(17)]
-      │    │    │    │    │         │         │    └── c.relkind:17
-      │    │    │    │    │         │         ├── const-agg [as=c.relhasoids:20, outer=(20)]
-      │    │    │    │    │         │         │    └── c.relhasoids:20
-      │    │    │    │    │         │         ├── const-agg [as=c.relhasrules:22, outer=(22)]
-      │    │    │    │    │         │         │    └── c.relhasrules:22
-      │    │    │    │    │         │         ├── const-agg [as=c.relhastriggers:23, outer=(23)]
-      │    │    │    │    │         │         │    └── c.relhastriggers:23
-      │    │    │    │    │         │         ├── const-agg [as=c.relacl:26, outer=(26)]
-      │    │    │    │    │         │         │    └── c.relacl:26
-      │    │    │    │    │         │         ├── const-agg [as=c.reloptions:27, outer=(27)]
-      │    │    │    │    │         │         │    └── c.reloptions:27
-      │    │    │    │    │         │         ├── const-agg [as=n.nspname:31, outer=(31)]
-      │    │    │    │    │         │         │    └── n.nspname:31
-      │    │    │    │    │         │         ├── const-agg [as=spcname:37, outer=(37)]
-      │    │    │    │    │         │         │    └── spcname:37
-      │    │    │    │    │         │         ├── const-agg [as=c2.relname:50, outer=(50)]
-      │    │    │    │    │         │         │    └── c2.relname:50
-      │    │    │    │    │         │         ├── const-agg [as=n2.nspname:79, outer=(79)]
-      │    │    │    │    │         │         │    └── n2.nspname:79
-      │    │    │    │    │         │         ├── const-agg [as=ci.relname:106, outer=(106)]
-      │    │    │    │    │         │         │    └── ci.relname:106
-      │    │    │    │    │         │         ├── const-agg [as=ftoptions:136, outer=(136)]
-      │    │    │    │    │         │         │    └── ftoptions:136
-      │    │    │    │    │         │         ├── const-agg [as=srvname:140, outer=(140)]
-      │    │    │    │    │         │         │    └── srvname:140
-      │    │    │    │    │         │         └── first-agg [as=rolname:158, outer=(158)]
-      │    │    │    │    │         │              └── rolname:158
-      │    │    │    │    │         └── projections
-      │    │    │    │    │              └── assignment-cast: STRING [as=column172:172, outer=(5,158), immutable]
-      │    │    │    │    │                   └── COALESCE(rolname:158, (('unknown (OID=' || c.relowner:5) || ')')::NAME)
+      │    │    │    │    │    ├── key: (192)
+      │    │    │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172)
+      │    │    │    │    │    ├── distinct-on
+      │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relowner:5!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 rolname:158 rownum:192!null
+      │    │    │    │    │    │    ├── grouping columns: rownum:192!null
+      │    │    │    │    │    │    ├── key: (192)
+      │    │    │    │    │    │    ├── fd: ()-->(31), (1)-->(2,5,10,13,15,17,20,22,23,26,27,37), (2)-->(1,5,10,13,15,17,20,22,23,26,27,37), (192)-->(1,2,5,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,158)
+      │    │    │    │    │    │    ├── right-join (hash)
+      │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 pg_catalog.pg_roles.oid:157 rolname:158 rownum:192!null
+      │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139), (192)-->(1,2,5,8,10,13,15,17,20,22,23,26,27,36,37,44,45,49-51,78,79,84,85,91,105,106,134-136,139,140)
+      │    │    │    │    │    │    │    ├── scan pg_roles
+      │    │    │    │    │    │    │    │    └── columns: pg_catalog.pg_roles.oid:157 rolname:158
+      │    │    │    │    │    │    │    ├── ordinality
+      │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 rownum:192!null
+      │    │    │    │    │    │    │    │    ├── key: (192)
+      │    │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139), (192)-->(1-3,5,8,10,13,15,17,20,22,23,26,27,30,31,36,37,44,45,49-51,78,79,84,85,91,105,106,134-136,139,140)
+      │    │    │    │    │    │    │    │    └── left-join (lookup pg_namespace [as=n2])
+      │    │    │    │    │    │    │    │         ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+      │    │    │    │    │    │    │    │         ├── key columns: [51] = [78]
+      │    │    │    │    │    │    │    │         ├── lookup columns are key
+      │    │    │    │    │    │    │    │         ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139)
+      │    │    │    │    │    │    │    │         ├── right-join (hash)
+      │    │    │    │    │    │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+      │    │    │    │    │    │    │    │         │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(91,105,106), (105)-->(106), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+      │    │    │    │    │    │    │    │         │    ├── inner-join (hash)
+      │    │    │    │    │    │    │    │         │    │    ├── columns: i.inhrelid:44!null i.inhparent:45!null c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
+      │    │    │    │    │    │    │    │         │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+      │    │    │    │    │    │    │    │         │    │    ├── fd: (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45)
+      │    │    │    │    │    │    │    │         │    │    ├── scan pg_inherits [as=i]
+      │    │    │    │    │    │    │    │         │    │    │    └── columns: i.inhrelid:44!null i.inhparent:45!null
+      │    │    │    │    │    │    │    │         │    │    ├── scan pg_class@pg_class_relname_nsp_index [as=c2]
+      │    │    │    │    │    │    │    │         │    │    │    ├── columns: c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
+      │    │    │    │    │    │    │    │         │    │    │    ├── key: (49)
+      │    │    │    │    │    │    │    │         │    │    │    └── fd: (49)-->(50,51), (50,51)-->(49)
+      │    │    │    │    │    │    │    │         │    │    └── filters
+      │    │    │    │    │    │    │    │         │    │         └── i.inhparent:45 = c2.oid:49 [outer=(45,49), constraints=(/45: (/NULL - ]; /49: (/NULL - ]), fd=(45)==(49), (49)==(45)]
+      │    │    │    │    │    │    │    │         │    ├── left-join (lookup pg_class [as=ci])
+      │    │    │    │    │    │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+      │    │    │    │    │    │    │    │         │    │    ├── key columns: [84] = [105]
+      │    │    │    │    │    │    │    │         │    │    ├── lookup columns are key
+      │    │    │    │    │    │    │    │         │    │    ├── key: (1,84)
+      │    │    │    │    │    │    │    │         │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91,105,106), (105)-->(106), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+      │    │    │    │    │    │    │    │         │    │    ├── left-join (lookup pg_index [as=ind])
+      │    │    │    │    │    │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+      │    │    │    │    │    │    │    │         │    │    │    ├── key columns: [966] = [84]
+      │    │    │    │    │    │    │    │         │    │    │    ├── lookup columns are key
+      │    │    │    │    │    │    │    │         │    │    │    ├── second join in paired joiner
+      │    │    │    │    │    │    │    │         │    │    │    ├── key: (1,84)
+      │    │    │    │    │    │    │    │         │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+      │    │    │    │    │    │    │    │         │    │    │    ├── left-join (lookup pg_index@pg_index_indrelid_index [as=ind])
+      │    │    │    │    │    │    │    │         │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 indexrelid:966 indrelid:967 continuation:987
+      │    │    │    │    │    │    │    │         │    │    │    │    ├── key columns: [1] = [967]
+      │    │    │    │    │    │    │    │         │    │    │    │    ├── first join in paired joiner; continuation column: continuation:987
+      │    │    │    │    │    │    │    │         │    │    │    │    ├── key: (1,966)
+      │    │    │    │    │    │    │    │         │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3), (966)-->(967,987)
+      │    │    │    │    │    │    │    │         │    │    │    │    ├── left-join (lookup pg_tablespace [as=t])
+      │    │    │    │    │    │    │    │         │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+      │    │    │    │    │    │    │    │         │    │    │    │    │    ├── key columns: [8] = [36]
+      │    │    │    │    │    │    │    │         │    │    │    │    │    ├── lookup columns are key
+      │    │    │    │    │    │    │    │         │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    │         │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+      │    │    │    │    │    │    │    │         │    │    │    │    │    ├── left-join (lookup pg_foreign_server [as=fs])
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    ├── key columns: [135] = [139]
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    ├── lookup columns are key
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (3)==(30), (30)==(3)
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    ├── left-join (lookup pg_foreign_table [as=ft])
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    ├── key columns: [1] = [134]
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    ├── lookup columns are key
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136), (3)==(30), (30)==(3)
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    ├── inner-join (hash)
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3)
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── scan pg_class [as=c]
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │         └── (c.relkind:17 = 'r') OR (c.relkind:17 = 'f') [outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r']; tight)]
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index [as=n]
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: n.oid:30!null n.nspname:31!null
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── constraint: /31: [/'public' - /'public']
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    │    └── fd: ()-->(30,31)
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    │         └── n.oid:30 = c.relnamespace:3 [outer=(3,30), constraints=(/3: (/NULL - ]; /30: (/NULL - ]), fd=(3)==(30), (30)==(3)]
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    │    │    │         │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    │    │    │         │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    │    │    │         │    │    │    │    └── filters (true)
+      │    │    │    │    │    │    │    │         │    │    │    └── filters
+      │    │    │    │    │    │    │    │         │    │    │         └── indisclustered:91 [outer=(91), constraints=(/91: [/true - /true]; tight), fd=()-->(91)]
+      │    │    │    │    │    │    │    │         │    │    └── filters (true)
+      │    │    │    │    │    │    │    │         │    └── filters
+      │    │    │    │    │    │    │    │         │         └── i.inhrelid:44 = c.oid:1 [outer=(1,44), constraints=(/1: (/NULL - ]; /44: (/NULL - ]), fd=(1)==(44), (44)==(1)]
+      │    │    │    │    │    │    │    │         └── filters (true)
+      │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │         └── pg_catalog.pg_roles.oid:157 = c.relowner:5 [outer=(5,157), constraints=(/5: (/NULL - ]; /157: (/NULL - ]), fd=(5)==(157), (157)==(5)]
+      │    │    │    │    │    │    └── aggregations
+      │    │    │    │    │    │         ├── const-agg [as=c.oid:1, outer=(1)]
+      │    │    │    │    │    │         │    └── c.oid:1
+      │    │    │    │    │    │         ├── const-agg [as=c.relname:2, outer=(2)]
+      │    │    │    │    │    │         │    └── c.relname:2
+      │    │    │    │    │    │         ├── const-agg [as=c.relowner:5, outer=(5)]
+      │    │    │    │    │    │         │    └── c.relowner:5
+      │    │    │    │    │    │         ├── const-agg [as=c.reltuples:10, outer=(10)]
+      │    │    │    │    │    │         │    └── c.reltuples:10
+      │    │    │    │    │    │         ├── const-agg [as=c.relhasindex:13, outer=(13)]
+      │    │    │    │    │    │         │    └── c.relhasindex:13
+      │    │    │    │    │    │         ├── const-agg [as=c.relpersistence:15, outer=(15)]
+      │    │    │    │    │    │         │    └── c.relpersistence:15
+      │    │    │    │    │    │         ├── const-agg [as=c.relkind:17, outer=(17)]
+      │    │    │    │    │    │         │    └── c.relkind:17
+      │    │    │    │    │    │         ├── const-agg [as=c.relhasoids:20, outer=(20)]
+      │    │    │    │    │    │         │    └── c.relhasoids:20
+      │    │    │    │    │    │         ├── const-agg [as=c.relhasrules:22, outer=(22)]
+      │    │    │    │    │    │         │    └── c.relhasrules:22
+      │    │    │    │    │    │         ├── const-agg [as=c.relhastriggers:23, outer=(23)]
+      │    │    │    │    │    │         │    └── c.relhastriggers:23
+      │    │    │    │    │    │         ├── const-agg [as=c.relacl:26, outer=(26)]
+      │    │    │    │    │    │         │    └── c.relacl:26
+      │    │    │    │    │    │         ├── const-agg [as=c.reloptions:27, outer=(27)]
+      │    │    │    │    │    │         │    └── c.reloptions:27
+      │    │    │    │    │    │         ├── const-agg [as=n.nspname:31, outer=(31)]
+      │    │    │    │    │    │         │    └── n.nspname:31
+      │    │    │    │    │    │         ├── const-agg [as=spcname:37, outer=(37)]
+      │    │    │    │    │    │         │    └── spcname:37
+      │    │    │    │    │    │         ├── const-agg [as=c2.relname:50, outer=(50)]
+      │    │    │    │    │    │         │    └── c2.relname:50
+      │    │    │    │    │    │         ├── const-agg [as=n2.nspname:79, outer=(79)]
+      │    │    │    │    │    │         │    └── n2.nspname:79
+      │    │    │    │    │    │         ├── const-agg [as=ci.relname:106, outer=(106)]
+      │    │    │    │    │    │         │    └── ci.relname:106
+      │    │    │    │    │    │         ├── const-agg [as=ftoptions:136, outer=(136)]
+      │    │    │    │    │    │         │    └── ftoptions:136
+      │    │    │    │    │    │         ├── const-agg [as=srvname:140, outer=(140)]
+      │    │    │    │    │    │         │    └── srvname:140
+      │    │    │    │    │    │         └── first-agg [as=rolname:158, outer=(158)]
+      │    │    │    │    │    │              └── rolname:158
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── assignment-cast: STRING [as=column172:172, outer=(5,158), immutable]
+      │    │    │    │    │              └── COALESCE(rolname:158, (('unknown (OID=' || c.relowner:5) || ')')::NAME)
       │    │    │    │    └── filters
       │    │    │    │         └── objoid:186 = c.oid:1 [outer=(1,186), constraints=(/1: (/NULL - ]; /186: (/NULL - ]), fd=(1)==(186), (186)==(1)]
       │    │    │    └── aggregations

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -158,92 +158,84 @@ from (select flavors.created_at as flavors_created_at,
 order by anon_1.flavors_id asc
 ----
 project
- ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:34 flavor_extra_specs_1_updated_at:35 flavor_extra_specs_1_id:30 flavor_extra_specs_1_key:31 flavor_extra_specs_1_value:32 flavor_extra_specs_1_flavor_id:33
+ ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:33 flavor_extra_specs_1_updated_at:34 flavor_extra_specs_1_id:29 flavor_extra_specs_1_key:30 flavor_extra_specs_1_value:31 flavor_extra_specs_1_flavor_id:32
  ├── immutable, has-placeholder
- ├── key: (30)
- ├── fd: ()-->(1-12,14,15,33), (30)-->(31,32,34,35), (31)-->(30,32,34,35)
+ ├── key: (29)
+ ├── fd: ()-->(1-12,14,15,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
  └── left-join (lookup flavor_extra_specs [as=flavor_extra_specs_1])
-      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27 flavor_extra_specs_1.id:30 key:31 value:32 flavor_extra_specs_1.flavor_id:33 flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
-      ├── key columns: [30] = [30]
+      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
+      ├── key columns: [29] = [29]
       ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (30)
-      ├── fd: ()-->(1-12,14,15,19,27,33), (30)-->(31,32,34,35), (31)-->(30,32,34,35)
+      ├── key: (29)
+      ├── fd: ()-->(1-12,14,15,19,20,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
       ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx [as=flavor_extra_specs_1])
-      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27 flavor_extra_specs_1.id:30 key:31 flavor_extra_specs_1.flavor_id:33
-      │    ├── key columns: [1] = [33]
+      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20 flavor_extra_specs_1.id:29 key:30 flavor_extra_specs_1.flavor_id:32
+      │    ├── key columns: [1] = [32]
       │    ├── immutable, has-placeholder
-      │    ├── key: (30)
-      │    ├── fd: ()-->(1-12,14,15,19,27,33), (30)-->(31), (31)-->(30)
+      │    ├── key: (29)
+      │    ├── fd: ()-->(1-12,14,15,19,20,32), (29)-->(30), (30)-->(29)
       │    ├── limit
-      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-12,14,15,19,27)
+      │    │    ├── fd: ()-->(1-12,14,15,19,20)
       │    │    ├── offset
-      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
+      │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
-      │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: true:27 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19
+      │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
+      │    │    │    │    ├── left-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
+      │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
+      │    │    │    │    │    ├── key columns: [1] = [19]
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
-      │    │    │    │    │    ├── left-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
-      │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
-      │    │    │    │    │    │    ├── key columns: [1] = [19]
+      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
-      │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
-      │    │    │    │    │    │    │    └── inner-join (lookup flavors)
-      │    │    │    │    │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 "$2":38!null
-      │    │    │    │    │    │    │         ├── key columns: [1] = [1]
-      │    │    │    │    │    │    │         ├── lookup columns are key
-      │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │         ├── has-placeholder
-      │    │    │    │    │    │    │         ├── key: ()
-      │    │    │    │    │    │    │         ├── fd: ()-->(1-12,14,15,38), (38)==(7), (7)==(38)
-      │    │    │    │    │    │    │         ├── inner-join (lookup flavors@flavors_flavorid_key)
-      │    │    │    │    │    │    │         │    ├── columns: flavors.id:1!null flavorid:7!null "$2":38!null
-      │    │    │    │    │    │    │         │    ├── flags: disallow merge join
-      │    │    │    │    │    │    │         │    ├── key columns: [38] = [7]
-      │    │    │    │    │    │    │         │    ├── lookup columns are key
-      │    │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │         │    ├── has-placeholder
-      │    │    │    │    │    │    │         │    ├── key: ()
-      │    │    │    │    │    │    │         │    ├── fd: ()-->(1,7,38), (38)==(7), (7)==(38)
-      │    │    │    │    │    │    │         │    ├── values
-      │    │    │    │    │    │    │         │    │    ├── columns: "$2":38
-      │    │    │    │    │    │    │         │    │    ├── cardinality: [1 - 1]
-      │    │    │    │    │    │    │         │    │    ├── has-placeholder
-      │    │    │    │    │    │    │         │    │    ├── key: ()
-      │    │    │    │    │    │    │         │    │    ├── fd: ()-->(38)
-      │    │    │    │    │    │    │         │    │    └── ($2,)
-      │    │    │    │    │    │    │         │    └── filters (true)
-      │    │    │    │    │    │    │         └── filters (true)
-      │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
-      │    │    │    │    │    └── projections
-      │    │    │    │    │         └── CASE flavor_projects.flavor_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:27, outer=(19)]
+      │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
+      │    │    │    │    │    │    └── inner-join (lookup flavors)
+      │    │    │    │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 "$2":37!null
+      │    │    │    │    │    │         ├── key columns: [1] = [1]
+      │    │    │    │    │    │         ├── lookup columns are key
+      │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │         ├── key: ()
+      │    │    │    │    │    │         ├── fd: ()-->(1-12,14,15,37), (37)==(7), (7)==(37)
+      │    │    │    │    │    │         ├── inner-join (lookup flavors@flavors_flavorid_key)
+      │    │    │    │    │    │         │    ├── columns: flavors.id:1!null flavorid:7!null "$2":37!null
+      │    │    │    │    │    │         │    ├── flags: disallow merge join
+      │    │    │    │    │    │         │    ├── key columns: [37] = [7]
+      │    │    │    │    │    │         │    ├── lookup columns are key
+      │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         │    ├── has-placeholder
+      │    │    │    │    │    │         │    ├── key: ()
+      │    │    │    │    │    │         │    ├── fd: ()-->(1,7,37), (37)==(7), (7)==(37)
+      │    │    │    │    │    │         │    ├── values
+      │    │    │    │    │    │         │    │    ├── columns: "$2":37
+      │    │    │    │    │    │         │    │    ├── cardinality: [1 - 1]
+      │    │    │    │    │    │         │    │    ├── has-placeholder
+      │    │    │    │    │    │         │    │    ├── key: ()
+      │    │    │    │    │    │         │    │    ├── fd: ()-->(37)
+      │    │    │    │    │    │         │    │    └── ($2,)
+      │    │    │    │    │    │         │    └── filters (true)
+      │    │    │    │    │    │         └── filters (true)
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true:27 IS NOT NULL) [outer=(12,27)]
+      │    │    │    │         └── is_public:12 OR (flavor_projects.flavor_id:19 IS NOT NULL) [outer=(12,19)]
       │    │    │    └── $3
       │    │    └── $4
       │    └── filters (true)
@@ -305,69 +297,69 @@ from (select flavors.created_at as flavors_created_at,
 order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
 ----
 sort
- ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11!null anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:46 flavor_extra_specs_1_updated_at:47 flavor_extra_specs_1_id:42 flavor_extra_specs_1_key:43 flavor_extra_specs_1_value:44 flavor_extra_specs_1_flavor_id:45
+ ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11!null anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:44 flavor_extra_specs_1_updated_at:45 flavor_extra_specs_1_id:40 flavor_extra_specs_1_key:41 flavor_extra_specs_1_value:42 flavor_extra_specs_1_flavor_id:43
  ├── immutable, has-placeholder
- ├── key: (1,42)
- ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (42)-->(43-47), (43,45)-->(42,44,46,47)
+ ├── key: (1,40)
+ ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (40)-->(41-45), (41,43)-->(40,42,44,45)
  ├── ordering: +7 opt(11) [actual: +7]
  └── project
-      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:42 key:43 value:44 flavor_extra_specs_1.flavor_id:45 flavor_extra_specs_1.created_at:46 flavor_extra_specs_1.updated_at:47
+      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:40 key:41 value:42 flavor_extra_specs_1.flavor_id:43 flavor_extra_specs_1.created_at:44 flavor_extra_specs_1.updated_at:45
       ├── immutable, has-placeholder
-      ├── key: (1,42)
-      ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (42)-->(43-47), (43,45)-->(42,44,46,47)
+      ├── key: (1,40)
+      ├── fd: ()-->(11), (1)-->(2-10,12,14,15), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (40)-->(41-45), (41,43)-->(40,42,44,45)
       └── right-join (hash)
-           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:36 true:39 flavor_extra_specs_1.id:42 key:43 value:44 flavor_extra_specs_1.flavor_id:45 flavor_extra_specs_1.created_at:46 flavor_extra_specs_1.updated_at:47
+           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20 flavor_projects.flavor_id:27 project_id:28 flavor_extra_specs_1.id:40 key:41 value:42 flavor_extra_specs_1.flavor_id:43 flavor_extra_specs_1.created_at:44 flavor_extra_specs_1.updated_at:45
            ├── immutable, has-placeholder
-           ├── key: (1,42)
-           ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,36,39), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (42)-->(43-47), (43,45)-->(42,44,46,47)
+           ├── key: (1,40)
+           ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,20,27,28), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15), (40)-->(41-45), (41,43)-->(40,42,44,45)
            ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
-           │    ├── columns: flavor_extra_specs_1.id:42!null key:43!null value:44 flavor_extra_specs_1.flavor_id:45!null flavor_extra_specs_1.created_at:46 flavor_extra_specs_1.updated_at:47
-           │    ├── key: (42)
-           │    └── fd: (42)-->(43-47), (43,45)-->(42,44,46,47)
+           │    ├── columns: flavor_extra_specs_1.id:40!null key:41!null value:42 flavor_extra_specs_1.flavor_id:43!null flavor_extra_specs_1.created_at:44 flavor_extra_specs_1.updated_at:45
+           │    ├── key: (40)
+           │    └── fd: (40)-->(41-45), (41,43)-->(40,42,44,45)
            ├── limit
-           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:36 true:39
+           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20 flavor_projects.flavor_id:27 project_id:28
            │    ├── internal-ordering: +7 opt(11)
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,36,39), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,20,27,28), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    ├── offset
-           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:36 true:39
+           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20 flavor_projects.flavor_id:27 project_id:28
            │    │    ├── internal-ordering: +7 opt(11)
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,36,39), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,20,27,28), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    │    ├── ordering: +7 opt(11) [actual: +7]
            │    │    ├── sort
-           │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:36 true:39
+           │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20 flavor_projects.flavor_id:27 project_id:28
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1)
-           │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,36,39), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,20,27,28), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    │    │    ├── ordering: +7 opt(11) [actual: +7]
            │    │    │    └── select
-           │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:36 true:39
+           │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20 flavor_projects.flavor_id:27 project_id:28
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
-           │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,36,39), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │         ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,20,27,28), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    │    │         ├── left-join (merge)
-           │    │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 flavor_projects.flavor_id:27 true:36 true:39
+           │    │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20 flavor_projects.flavor_id:27 project_id:28
            │    │    │         │    ├── left ordering: +1
            │    │    │         │    ├── right ordering: +27
            │    │    │         │    ├── has-placeholder
            │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,27,36,39), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │         │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,20,27,28), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    │    │         │    ├── select
-           │    │    │         │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:36
+           │    │    │         │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
            │    │    │         │    │    ├── has-placeholder
            │    │    │         │    │    ├── key: (1)
-           │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,36), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │         │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,20), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    │    │         │    │    ├── ordering: +1 opt(11) [actual: +1]
            │    │    │         │    │    ├── left-join (merge)
-           │    │    │         │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:36
+           │    │    │         │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
            │    │    │         │    │    │    ├── left ordering: +1
            │    │    │         │    │    │    ├── right ordering: +19
            │    │    │         │    │    │    ├── has-placeholder
            │    │    │         │    │    │    ├── key: (1)
-           │    │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,36), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
+           │    │    │         │    │    │    ├── fd: ()-->(11), (1)-->(2-10,12,14,15,19,20), (7)-->(1-6,8-10,12,14,15), (2)-->(1,3-10,12,14,15)
            │    │    │         │    │    │    ├── ordering: +1 opt(11) [actual: +1]
            │    │    │         │    │    │    ├── select
            │    │    │         │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 flavors.created_at:14 flavors.updated_at:15
@@ -381,56 +373,40 @@ sort
            │    │    │         │    │    │    │    │    └── ordering: +1
            │    │    │         │    │    │    │    └── filters
            │    │    │         │    │    │    │         └── NOT disabled:11 [outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
-           │    │    │         │    │    │    ├── project
-           │    │    │         │    │    │    │    ├── columns: true:36!null flavor_projects.flavor_id:19!null
+           │    │    │         │    │    │    ├── select
+           │    │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
            │    │    │         │    │    │    │    ├── has-placeholder
            │    │    │         │    │    │    │    ├── key: (19)
-           │    │    │         │    │    │    │    ├── fd: ()-->(36)
-           │    │    │         │    │    │    │    ├── ordering: +19 opt(36) [actual: +19]
-           │    │    │         │    │    │    │    ├── select
+           │    │    │         │    │    │    │    ├── fd: ()-->(20)
+           │    │    │         │    │    │    │    ├── ordering: +19 opt(20) [actual: +19]
+           │    │    │         │    │    │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
            │    │    │         │    │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
-           │    │    │         │    │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    │    ├── key: (19)
-           │    │    │         │    │    │    │    │    ├── fd: ()-->(20)
-           │    │    │         │    │    │    │    │    ├── ordering: +19 opt(20) [actual: +19]
-           │    │    │         │    │    │    │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
-           │    │    │         │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
-           │    │    │         │    │    │    │    │    │    ├── key: (19,20)
-           │    │    │         │    │    │    │    │    │    └── ordering: +19
-           │    │    │         │    │    │    │    │    └── filters
-           │    │    │         │    │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
-           │    │    │         │    │    │    │    └── projections
-           │    │    │         │    │    │    │         └── true [as=true:36]
+           │    │    │         │    │    │    │    │    ├── key: (19,20)
+           │    │    │         │    │    │    │    │    └── ordering: +19
+           │    │    │         │    │    │    │    └── filters
+           │    │    │         │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
            │    │    │         │    │    │    └── filters (true)
            │    │    │         │    │    └── filters
-           │    │    │         │    │         └── is_public:12 OR (true:36 IS NOT NULL) [outer=(12,36)]
-           │    │    │         │    ├── project
-           │    │    │         │    │    ├── columns: true:39!null flavor_projects.flavor_id:27!null
+           │    │    │         │    │         └── is_public:12 OR (flavor_projects.flavor_id:19 IS NOT NULL) [outer=(12,19)]
+           │    │    │         │    ├── select
+           │    │    │         │    │    ├── columns: flavor_projects.flavor_id:27!null project_id:28!null
            │    │    │         │    │    ├── has-placeholder
            │    │    │         │    │    ├── key: (27)
-           │    │    │         │    │    ├── fd: ()-->(39)
-           │    │    │         │    │    ├── ordering: +27 opt(39) [actual: +27]
-           │    │    │         │    │    ├── select
+           │    │    │         │    │    ├── fd: ()-->(28)
+           │    │    │         │    │    ├── ordering: +27 opt(28) [actual: +27]
+           │    │    │         │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
            │    │    │         │    │    │    ├── columns: flavor_projects.flavor_id:27!null project_id:28!null
-           │    │    │         │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    ├── key: (27)
-           │    │    │         │    │    │    ├── fd: ()-->(28)
-           │    │    │         │    │    │    ├── ordering: +27 opt(28) [actual: +27]
-           │    │    │         │    │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
-           │    │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:27!null project_id:28!null
-           │    │    │         │    │    │    │    ├── key: (27,28)
-           │    │    │         │    │    │    │    └── ordering: +27
-           │    │    │         │    │    │    └── filters
-           │    │    │         │    │    │         └── project_id:28 = $2 [outer=(28), constraints=(/28: (/NULL - ]), fd=()-->(28)]
-           │    │    │         │    │    └── projections
-           │    │    │         │    │         └── true [as=true:39]
+           │    │    │         │    │    │    ├── key: (27,28)
+           │    │    │         │    │    │    └── ordering: +27
+           │    │    │         │    │    └── filters
+           │    │    │         │    │         └── project_id:28 = $2 [outer=(28), constraints=(/28: (/NULL - ]), fd=()-->(28)]
            │    │    │         │    └── filters (true)
            │    │    │         └── filters
-           │    │    │              └── is_public:12 OR (true:39 IS NOT NULL) [outer=(12,39)]
+           │    │    │              └── is_public:12 OR (flavor_projects.flavor_id:27 IS NOT NULL) [outer=(12,27)]
            │    │    └── $3
            │    └── $4
            └── filters
-                └── flavor_extra_specs_1.flavor_id:45 = flavors.id:1 [outer=(1,45), constraints=(/1: (/NULL - ]; /45: (/NULL - ]), fd=(1)==(45), (45)==(1)]
+                └── flavor_extra_specs_1.flavor_id:43 = flavors.id:1 [outer=(1,43), constraints=(/1: (/NULL - ]; /43: (/NULL - ]), fd=(1)==(43), (43)==(1)]
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -493,63 +469,63 @@ order by anon_1.instance_types_flavorid asc,
          anon_1.instance_types_id asc
 ----
 sort
- ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:39 instance_type_extra_specs_1_updated_at:40 instance_type_extra_specs_1_deleted_at:38 instance_type_extra_specs_1_deleted:37 instance_type_extra_specs_1_id:33 instance_type_extra_specs_1_key:34 instance_type_extra_specs_1_value:35 instance_type_extra_specs_1_instance_type_id:36
+ ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:38 instance_type_extra_specs_1_updated_at:39 instance_type_extra_specs_1_deleted_at:37 instance_type_extra_specs_1_deleted:36 instance_type_extra_specs_1_id:32 instance_type_extra_specs_1_key:33 instance_type_extra_specs_1_value:34 instance_type_extra_specs_1_instance_type_id:35
  ├── immutable, has-placeholder
- ├── key: (1,33)
- ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40), (1,33)-->(37)
+ ├── key: (1,32)
+ ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
  ├── ordering: +7,+1 opt(13) [actual: +7,+1]
  └── project
-      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:33 key:34 value:35 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
+      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
       ├── immutable, has-placeholder
-      ├── key: (1,33)
-      ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40), (1,33)-->(37)
+      ├── key: (1,32)
+      ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
       └── right-join (hash)
-           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30 instance_type_extra_specs_1.id:33 key:34 value:35 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
+           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
            ├── immutable, has-placeholder
-           ├── key: (1,33)
-           ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40), (1,33)-->(37)
+           ├── key: (1,32)
+           ├── fd: ()-->(13), (1)-->(2-12,14-16,20-22), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
            ├── select
-           │    ├── columns: instance_type_extra_specs_1.id:33!null key:34 value:35 instance_type_extra_specs_1.instance_type_id:36!null instance_type_extra_specs_1.deleted:37!null instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
+           │    ├── columns: instance_type_extra_specs_1.id:32!null key:33 value:34 instance_type_extra_specs_1.instance_type_id:35!null instance_type_extra_specs_1.deleted:36!null instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
            │    ├── has-placeholder
-           │    ├── key: (33)
-           │    ├── fd: ()-->(37), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40)
+           │    ├── key: (32)
+           │    ├── fd: ()-->(36), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39)
            │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
-           │    │    ├── columns: instance_type_extra_specs_1.id:33!null key:34 value:35 instance_type_extra_specs_1.instance_type_id:36!null instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
-           │    │    ├── key: (33)
-           │    │    └── fd: (33)-->(34-40), (34,36,37)~~>(33,35,38-40)
+           │    │    ├── columns: instance_type_extra_specs_1.id:32!null key:33 value:34 instance_type_extra_specs_1.instance_type_id:35!null instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
+           │    │    ├── key: (32)
+           │    │    └── fd: (32)-->(33-39), (33,35,36)~~>(32,34,37-39)
            │    └── filters
-           │         └── instance_type_extra_specs_1.deleted:37 = $7 [outer=(37), constraints=(/37: (/NULL - ]), fd=()-->(37)]
+           │         └── instance_type_extra_specs_1.deleted:36 = $7 [outer=(36), constraints=(/36: (/NULL - ]), fd=()-->(36)]
            ├── limit
-           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
            │    ├── internal-ordering: +7,+1 opt(13)
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20-22), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    ├── offset
-           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
            │    │    ├── internal-ordering: +7,+1 opt(13)
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20-22), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    ├── ordering: +7,+1 opt(13) [actual: +7,+1]
            │    │    ├── sort
-           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1)
-           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20-22), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │    ├── ordering: +7,+1 opt(13) [actual: +7,+1]
            │    │    │    └── select
-           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
-           │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,20-22), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │         ├── left-join (merge)
-           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
            │    │    │         │    ├── left ordering: +1
            │    │    │         │    ├── right ordering: +20
            │    │    │         │    ├── has-placeholder
            │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20-22), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │         │    ├── select
            │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │         │    │    ├── has-placeholder
@@ -563,35 +539,27 @@ sort
            │    │    │         │    │    │    └── ordering: +1
            │    │    │         │    │    └── filters
            │    │    │         │    │         └── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
-           │    │    │         │    ├── project
-           │    │    │         │    │    ├── columns: true:30!null instance_type_projects.instance_type_id:20!null
+           │    │    │         │    ├── select
+           │    │    │         │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
            │    │    │         │    │    ├── has-placeholder
            │    │    │         │    │    ├── key: (20)
-           │    │    │         │    │    ├── fd: ()-->(30)
-           │    │    │         │    │    ├── ordering: +20 opt(30) [actual: +20]
-           │    │    │         │    │    ├── select
-           │    │    │         │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
-           │    │    │         │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    ├── key: (20)
-           │    │    │         │    │    │    ├── fd: ()-->(21,22)
-           │    │    │         │    │    │    ├── ordering: +20 opt(21,22) [actual: +20]
-           │    │    │         │    │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
-           │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21 instance_type_projects.deleted:22
-           │    │    │         │    │    │    │    ├── lax-key: (20-22)
-           │    │    │         │    │    │    │    └── ordering: +20
-           │    │    │         │    │    │    └── filters
-           │    │    │         │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
-           │    │    │         │    │    │         ├── instance_type_projects.deleted:22 = $3 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
-           │    │    │         │    │    │         └── project_id:21 = $4 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
-           │    │    │         │    │    └── projections
-           │    │    │         │    │         └── true [as=true:30]
+           │    │    │         │    │    ├── fd: ()-->(21,22)
+           │    │    │         │    │    ├── ordering: +20 opt(21,22) [actual: +20]
+           │    │    │         │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
+           │    │    │         │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21 instance_type_projects.deleted:22
+           │    │    │         │    │    │    ├── lax-key: (20-22)
+           │    │    │         │    │    │    └── ordering: +20
+           │    │    │         │    │    └── filters
+           │    │    │         │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
+           │    │    │         │    │         ├── instance_type_projects.deleted:22 = $3 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
+           │    │    │         │    │         └── project_id:21 = $4 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
            │    │    │         │    └── filters (true)
            │    │    │         └── filters
-           │    │    │              └── is_public:12 OR (true:30 IS NOT NULL) [outer=(12,30)]
+           │    │    │              └── is_public:12 OR (instance_type_projects.instance_type_id:20 IS NOT NULL) [outer=(12,20)]
            │    │    └── $5
            │    └── $6
            └── filters
-                └── instance_type_extra_specs_1.instance_type_id:36 = instance_types.id:1 [outer=(1,36), constraints=(/1: (/NULL - ]; /36: (/NULL - ]), fd=(1)==(36), (36)==(1)]
+                └── instance_type_extra_specs_1.instance_type_id:35 = instance_types.id:1 [outer=(1,35), constraints=(/1: (/NULL - ]; /35: (/NULL - ]), fd=(1)==(35), (35)==(1)]
 
 opt
 select instance_types.created_at as instance_types_created_at,
@@ -643,10 +611,10 @@ sort
       ├── key: (1,19)
       ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (19)-->(20-22,24-26), (20,22,23)~~>(19,21,24-26), (1,19)-->(23)
       └── right-join (hash)
-           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:19 key:20 value:21 instance_type_extra_specs_1.instance_type_id:22 instance_type_extra_specs_1.deleted:23 instance_type_extra_specs_1.deleted_at:24 instance_type_extra_specs_1.created_at:25 instance_type_extra_specs_1.updated_at:26 instance_type_projects.instance_type_id:30 true:40
+           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:19 key:20 value:21 instance_type_extra_specs_1.instance_type_id:22 instance_type_extra_specs_1.deleted:23 instance_type_extra_specs_1.deleted_at:24 instance_type_extra_specs_1.created_at:25 instance_type_extra_specs_1.updated_at:26 instance_type_projects.instance_type_id:30 project_id:31 instance_type_projects.deleted:32
            ├── has-placeholder
            ├── key: (1,19)
-           ├── fd: ()-->(13), (1)-->(2-12,14-16,30,40), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (19)-->(20-22,24-26), (20,22,23)~~>(19,21,24-26), (1,19)-->(23)
+           ├── fd: ()-->(13), (1)-->(2-12,14-16,30-32), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (19)-->(20-22,24-26), (20,22,23)~~>(19,21,24-26), (1,19)-->(23)
            ├── select
            │    ├── columns: instance_type_extra_specs_1.id:19!null key:20 value:21 instance_type_extra_specs_1.instance_type_id:22!null instance_type_extra_specs_1.deleted:23!null instance_type_extra_specs_1.deleted_at:24 instance_type_extra_specs_1.created_at:25 instance_type_extra_specs_1.updated_at:26
            │    ├── has-placeholder
@@ -659,17 +627,17 @@ sort
            │    └── filters
            │         └── instance_type_extra_specs_1.deleted:23 = $1 [outer=(23), constraints=(/23: (/NULL - ]), fd=()-->(23)]
            ├── select
-           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:30 true:40
+           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:30 project_id:31 instance_type_projects.deleted:32
            │    ├── has-placeholder
            │    ├── key: (1)
-           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,30,40), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,30-32), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    ├── left-join (merge)
-           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:30 true:40
+           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:30 project_id:31 instance_type_projects.deleted:32
            │    │    ├── left ordering: +1
            │    │    ├── right ordering: +30
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,30,40), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,30-32), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    ├── select
            │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │    ├── has-placeholder
@@ -683,30 +651,22 @@ sort
            │    │    │    │    └── ordering: +1
            │    │    │    └── filters
            │    │    │         └── instance_types.deleted:13 = $2 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
-           │    │    ├── project
-           │    │    │    ├── columns: true:40!null instance_type_projects.instance_type_id:30!null
+           │    │    ├── select
+           │    │    │    ├── columns: instance_type_projects.instance_type_id:30!null project_id:31!null instance_type_projects.deleted:32!null
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (30)
-           │    │    │    ├── fd: ()-->(40)
-           │    │    │    ├── ordering: +30 opt(40) [actual: +30]
-           │    │    │    ├── select
-           │    │    │    │    ├── columns: instance_type_projects.instance_type_id:30!null project_id:31!null instance_type_projects.deleted:32!null
-           │    │    │    │    ├── has-placeholder
-           │    │    │    │    ├── key: (30)
-           │    │    │    │    ├── fd: ()-->(31,32)
-           │    │    │    │    ├── ordering: +30 opt(31,32) [actual: +30]
-           │    │    │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
-           │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:30!null project_id:31 instance_type_projects.deleted:32
-           │    │    │    │    │    ├── lax-key: (30-32)
-           │    │    │    │    │    └── ordering: +30
-           │    │    │    │    └── filters
-           │    │    │    │         ├── instance_type_projects.deleted:32 = $3 [outer=(32), constraints=(/32: (/NULL - ]), fd=()-->(32)]
-           │    │    │    │         └── project_id:31 = $4 [outer=(31), constraints=(/31: (/NULL - ]), fd=()-->(31)]
-           │    │    │    └── projections
-           │    │    │         └── true [as=true:40]
+           │    │    │    ├── fd: ()-->(31,32)
+           │    │    │    ├── ordering: +30 opt(31,32) [actual: +30]
+           │    │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
+           │    │    │    │    ├── columns: instance_type_projects.instance_type_id:30!null project_id:31 instance_type_projects.deleted:32
+           │    │    │    │    ├── lax-key: (30-32)
+           │    │    │    │    └── ordering: +30
+           │    │    │    └── filters
+           │    │    │         ├── instance_type_projects.deleted:32 = $3 [outer=(32), constraints=(/32: (/NULL - ]), fd=()-->(32)]
+           │    │    │         └── project_id:31 = $4 [outer=(31), constraints=(/31: (/NULL - ]), fd=()-->(31)]
            │    │    └── filters (true)
            │    └── filters
-           │         └── is_public:12 OR (true:40 IS NOT NULL) [outer=(12,40)]
+           │         └── is_public:12 OR (instance_type_projects.instance_type_id:30 IS NOT NULL) [outer=(12,30)]
            └── filters
                 └── instance_type_extra_specs_1.instance_type_id:22 = instance_types.id:1 [outer=(1,22), constraints=(/1: (/NULL - ]; /22: (/NULL - ]), fd=(1)==(22), (22)==(1)]
 
@@ -768,97 +728,89 @@ from (select instance_types.created_at as instance_types_created_at,
         and instance_type_extra_specs_1.deleted = $7
 ----
 project
- ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2!null anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:39 instance_type_extra_specs_1_updated_at:40 instance_type_extra_specs_1_deleted_at:38 instance_type_extra_specs_1_deleted:37 instance_type_extra_specs_1_id:33 instance_type_extra_specs_1_key:34 instance_type_extra_specs_1_value:35 instance_type_extra_specs_1_instance_type_id:36
+ ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2!null anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:38 instance_type_extra_specs_1_updated_at:39 instance_type_extra_specs_1_deleted_at:37 instance_type_extra_specs_1_deleted:36 instance_type_extra_specs_1_id:32 instance_type_extra_specs_1_key:33 instance_type_extra_specs_1_value:34 instance_type_extra_specs_1_instance_type_id:35
  ├── immutable, has-placeholder
- ├── key: (33)
- ├── fd: ()-->(1-16,36), (33)-->(34,35,37-40), (34,36,37)~~>(33,35,38-40)
+ ├── key: (32)
+ ├── fd: ()-->(1-16,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
  └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
-      ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30 instance_type_extra_specs_1.id:33 key:34 value:35 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
-      ├── key columns: [33] = [33]
+      ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
+      ├── key columns: [32] = [32]
       ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (33)
-      ├── fd: ()-->(1-16,20,30,36), (33)-->(34,35,37-40), (34,36,37)~~>(33,35,38-40)
+      ├── key: (32)
+      ├── fd: ()-->(1-16,20-22,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
       ├── left-join (lookup instance_type_extra_specs@instance_type_extra_specs_instance_type_id_key_deleted_key [as=instance_type_extra_specs_1])
-      │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30 instance_type_extra_specs_1.id:33 key:34 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37
-      │    ├── key columns: [1] = [36]
+      │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22 instance_type_extra_specs_1.id:32 key:33 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36
+      │    ├── key columns: [1] = [35]
       │    ├── immutable, has-placeholder
-      │    ├── key: (33)
-      │    ├── fd: ()-->(1-16,20,30,36,37), (33)-->(34), (34,36,37)~~>(33)
+      │    ├── key: (32)
+      │    ├── fd: ()-->(1-16,20-22,35,36), (32)-->(33), (33,35,36)~~>(32)
       │    ├── limit
-      │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+      │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-16,20,30)
+      │    │    ├── fd: ()-->(1-16,20-22)
       │    │    ├── offset
-      │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+      │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-16,20,30)
+      │    │    │    ├── fd: ()-->(1-16,20-22)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+      │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-16,20,30)
-      │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: true:30 instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20
+      │    │    │    │    ├── fd: ()-->(1-16,20-22)
+      │    │    │    │    ├── left-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
+      │    │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
+      │    │    │    │    │    ├── key columns: [1] = [20]
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-16,20,30)
-      │    │    │    │    │    ├── left-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
-      │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
-      │    │    │    │    │    │    ├── key columns: [1] = [20]
+      │    │    │    │    │    ├── fd: ()-->(1-16,20-22)
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    ├── fd: ()-->(1-16,20-22)
-      │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-      │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    ├── fd: ()-->(1-16)
-      │    │    │    │    │    │    │    └── inner-join (lookup instance_types)
-      │    │    │    │    │    │    │         ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 "$1":43!null "$4":44!null
-      │    │    │    │    │    │    │         ├── key columns: [1] = [1]
-      │    │    │    │    │    │    │         ├── lookup columns are key
-      │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │         ├── has-placeholder
-      │    │    │    │    │    │    │         ├── key: ()
-      │    │    │    │    │    │    │         ├── fd: ()-->(1-16,43,44), (43)==(13), (2)==(44), (44)==(2), (13)==(43)
-      │    │    │    │    │    │    │         ├── inner-join (lookup instance_types@instance_types_name_deleted_key)
-      │    │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null name:2!null instance_types.deleted:13!null "$1":43!null "$4":44!null
-      │    │    │    │    │    │    │         │    ├── flags: disallow merge join
-      │    │    │    │    │    │    │         │    ├── key columns: [44 43] = [2 13]
-      │    │    │    │    │    │    │         │    ├── lookup columns are key
-      │    │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │         │    ├── has-placeholder
-      │    │    │    │    │    │    │         │    ├── key: ()
-      │    │    │    │    │    │    │         │    ├── fd: ()-->(1,2,13,43,44), (44)==(2), (13)==(43), (43)==(13), (2)==(44)
-      │    │    │    │    │    │    │         │    ├── values
-      │    │    │    │    │    │    │         │    │    ├── columns: "$1":43 "$4":44
-      │    │    │    │    │    │    │         │    │    ├── cardinality: [1 - 1]
-      │    │    │    │    │    │    │         │    │    ├── has-placeholder
-      │    │    │    │    │    │    │         │    │    ├── key: ()
-      │    │    │    │    │    │    │         │    │    ├── fd: ()-->(43,44)
-      │    │    │    │    │    │    │         │    │    └── ($1, $4)
-      │    │    │    │    │    │    │         │    └── filters (true)
-      │    │    │    │    │    │    │         └── filters (true)
-      │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
-      │    │    │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
-      │    │    │    │    │    └── projections
-      │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:20 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:30, outer=(20)]
+      │    │    │    │    │    │    ├── fd: ()-->(1-16)
+      │    │    │    │    │    │    └── inner-join (lookup instance_types)
+      │    │    │    │    │    │         ├── columns: instance_types.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 "$1":42!null "$4":43!null
+      │    │    │    │    │    │         ├── key columns: [1] = [1]
+      │    │    │    │    │    │         ├── lookup columns are key
+      │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │         ├── key: ()
+      │    │    │    │    │    │         ├── fd: ()-->(1-16,42,43), (42)==(13), (2)==(43), (43)==(2), (13)==(42)
+      │    │    │    │    │    │         ├── inner-join (lookup instance_types@instance_types_name_deleted_key)
+      │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null name:2!null instance_types.deleted:13!null "$1":42!null "$4":43!null
+      │    │    │    │    │    │         │    ├── flags: disallow merge join
+      │    │    │    │    │    │         │    ├── key columns: [43 42] = [2 13]
+      │    │    │    │    │    │         │    ├── lookup columns are key
+      │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         │    ├── has-placeholder
+      │    │    │    │    │    │         │    ├── key: ()
+      │    │    │    │    │    │         │    ├── fd: ()-->(1,2,13,42,43), (43)==(2), (13)==(42), (42)==(13), (2)==(43)
+      │    │    │    │    │    │         │    ├── values
+      │    │    │    │    │    │         │    │    ├── columns: "$1":42 "$4":43
+      │    │    │    │    │    │         │    │    ├── cardinality: [1 - 1]
+      │    │    │    │    │    │         │    │    ├── has-placeholder
+      │    │    │    │    │    │         │    │    ├── key: ()
+      │    │    │    │    │    │         │    │    ├── fd: ()-->(42,43)
+      │    │    │    │    │    │         │    │    └── ($1, $4)
+      │    │    │    │    │    │         │    └── filters (true)
+      │    │    │    │    │    │         └── filters (true)
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
+      │    │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true:30 IS NOT NULL) [outer=(12,30)]
+      │    │    │    │         └── is_public:12 OR (instance_type_projects.instance_type_id:20 IS NOT NULL) [outer=(12,20)]
       │    │    │    └── $5
       │    │    └── $6
       │    └── filters
-      │         └── instance_type_extra_specs_1.deleted:37 = $7 [outer=(37), constraints=(/37: (/NULL - ]), fd=()-->(37)]
+      │         └── instance_type_extra_specs_1.deleted:36 = $7 [outer=(36), constraints=(/36: (/NULL - ]), fd=()-->(36)]
       └── filters (true)
 
 opt generic
@@ -919,49 +871,49 @@ from (select instance_types.created_at as instance_types_created_at,
         and instance_type_extra_specs_1.deleted = $7
 ----
 project
- ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:39 instance_type_extra_specs_1_updated_at:40 instance_type_extra_specs_1_deleted_at:38 instance_type_extra_specs_1_deleted:37 instance_type_extra_specs_1_id:33 instance_type_extra_specs_1_key:34 instance_type_extra_specs_1_value:35 instance_type_extra_specs_1_instance_type_id:36
+ ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:38 instance_type_extra_specs_1_updated_at:39 instance_type_extra_specs_1_deleted_at:37 instance_type_extra_specs_1_deleted:36 instance_type_extra_specs_1_id:32 instance_type_extra_specs_1_key:33 instance_type_extra_specs_1_value:34 instance_type_extra_specs_1_instance_type_id:35
  ├── immutable, has-placeholder
- ├── key: (33)
- ├── fd: ()-->(1-16,36), (33)-->(34,35,37-40), (34,36,37)~~>(33,35,38-40)
+ ├── key: (32)
+ ├── fd: ()-->(1-16,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
  └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
-      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30 instance_type_extra_specs_1.id:33 key:34 value:35 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
-      ├── key columns: [33] = [33]
+      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
+      ├── key columns: [32] = [32]
       ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (33)
-      ├── fd: ()-->(1-16,20,30,36), (33)-->(34,35,37-40), (34,36,37)~~>(33,35,38-40)
+      ├── key: (32)
+      ├── fd: ()-->(1-16,20-22,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
       ├── left-join (lookup instance_type_extra_specs@instance_type_extra_specs_instance_type_id_key_deleted_key [as=instance_type_extra_specs_1])
-      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30 instance_type_extra_specs_1.id:33 key:34 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37
-      │    ├── key columns: [1] = [36]
+      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22 instance_type_extra_specs_1.id:32 key:33 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36
+      │    ├── key columns: [1] = [35]
       │    ├── immutable, has-placeholder
-      │    ├── key: (33)
-      │    ├── fd: ()-->(1-16,20,30,36,37), (33)-->(34), (34,36,37)~~>(33)
+      │    ├── key: (32)
+      │    ├── fd: ()-->(1-16,20-22,35,36), (32)-->(33), (33,35,36)~~>(32)
       │    ├── limit
-      │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+      │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-16,20,30)
+      │    │    ├── fd: ()-->(1-16,20-22)
       │    │    ├── offset
-      │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+      │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-16,20,30)
+      │    │    │    ├── fd: ()-->(1-16,20-22)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+      │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-16,20,30)
+      │    │    │    │    ├── fd: ()-->(1-16,20-22)
       │    │    │    │    ├── left-join (merge)
-      │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+      │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
       │    │    │    │    │    ├── left ordering: +1
       │    │    │    │    │    ├── right ordering: +20
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-16,20,30)
+      │    │    │    │    │    ├── fd: ()-->(1-16,20-22)
       │    │    │    │    │    ├── project
       │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
@@ -969,61 +921,53 @@ project
       │    │    │    │    │    │    ├── key: ()
       │    │    │    │    │    │    ├── fd: ()-->(1-16)
       │    │    │    │    │    │    └── inner-join (lookup instance_types)
-      │    │    │    │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 "$4":43!null "$1":44!null
+      │    │    │    │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 "$4":42!null "$1":43!null
       │    │    │    │    │    │         ├── flags: disallow merge join
-      │    │    │    │    │    │         ├── key columns: [43] = [1]
+      │    │    │    │    │    │         ├── key columns: [42] = [1]
       │    │    │    │    │    │         ├── lookup columns are key
       │    │    │    │    │    │         ├── cardinality: [0 - 1]
       │    │    │    │    │    │         ├── has-placeholder
       │    │    │    │    │    │         ├── key: ()
-      │    │    │    │    │    │         ├── fd: ()-->(1-16,43,44), (43)==(1), (13)==(44), (44)==(13), (1)==(43)
+      │    │    │    │    │    │         ├── fd: ()-->(1-16,42,43), (42)==(1), (13)==(43), (43)==(13), (1)==(42)
       │    │    │    │    │    │         ├── values
-      │    │    │    │    │    │         │    ├── columns: "$4":43 "$1":44
+      │    │    │    │    │    │         │    ├── columns: "$4":42 "$1":43
       │    │    │    │    │    │         │    ├── cardinality: [1 - 1]
       │    │    │    │    │    │         │    ├── has-placeholder
       │    │    │    │    │    │         │    ├── key: ()
-      │    │    │    │    │    │         │    ├── fd: ()-->(43,44)
+      │    │    │    │    │    │         │    ├── fd: ()-->(42,43)
       │    │    │    │    │    │         │    └── ($4, $1)
       │    │    │    │    │    │         └── filters
-      │    │    │    │    │    │              └── instance_types.deleted:13 = "$1":44 [outer=(13,44), constraints=(/13: (/NULL - ]; /44: (/NULL - ]), fd=(13)==(44), (44)==(13)]
+      │    │    │    │    │    │              └── instance_types.deleted:13 = "$1":43 [outer=(13,43), constraints=(/13: (/NULL - ]; /43: (/NULL - ]), fd=(13)==(43), (43)==(13)]
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: true:30!null instance_type_projects.instance_type_id:20!null
+      │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    ├── fd: ()-->(20,30)
-      │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
-      │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    ├── fd: ()-->(20-22)
-      │    │    │    │    │    │    │    └── inner-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
-      │    │    │    │    │    │    │         ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null "$2":45!null "$3":46!null "$4":47!null
-      │    │    │    │    │    │    │         ├── flags: disallow merge join
-      │    │    │    │    │    │    │         ├── key columns: [47 46 45] = [20 21 22]
-      │    │    │    │    │    │    │         ├── lookup columns are key
-      │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │         ├── has-placeholder
-      │    │    │    │    │    │    │         ├── key: ()
-      │    │    │    │    │    │    │         ├── fd: ()-->(20-22,45-47), (45)==(22), (21)==(46), (46)==(21), (20)==(47), (47)==(20), (22)==(45)
-      │    │    │    │    │    │    │         ├── values
-      │    │    │    │    │    │    │         │    ├── columns: "$2":45 "$3":46 "$4":47
-      │    │    │    │    │    │    │         │    ├── cardinality: [1 - 1]
-      │    │    │    │    │    │    │         │    ├── has-placeholder
-      │    │    │    │    │    │    │         │    ├── key: ()
-      │    │    │    │    │    │    │         │    ├── fd: ()-->(45-47)
-      │    │    │    │    │    │    │         │    └── ($2, $3, $4)
-      │    │    │    │    │    │    │         └── filters (true)
-      │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── true [as=true:30]
+      │    │    │    │    │    │    ├── fd: ()-->(20-22)
+      │    │    │    │    │    │    └── inner-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
+      │    │    │    │    │    │         ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null "$2":44!null "$3":45!null "$4":46!null
+      │    │    │    │    │    │         ├── flags: disallow merge join
+      │    │    │    │    │    │         ├── key columns: [46 45 44] = [20 21 22]
+      │    │    │    │    │    │         ├── lookup columns are key
+      │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │         ├── key: ()
+      │    │    │    │    │    │         ├── fd: ()-->(20-22,44-46), (44)==(22), (21)==(45), (45)==(21), (20)==(46), (46)==(20), (22)==(44)
+      │    │    │    │    │    │         ├── values
+      │    │    │    │    │    │         │    ├── columns: "$2":44 "$3":45 "$4":46
+      │    │    │    │    │    │         │    ├── cardinality: [1 - 1]
+      │    │    │    │    │    │         │    ├── has-placeholder
+      │    │    │    │    │    │         │    ├── key: ()
+      │    │    │    │    │    │         │    ├── fd: ()-->(44-46)
+      │    │    │    │    │    │         │    └── ($2, $3, $4)
+      │    │    │    │    │    │         └── filters (true)
       │    │    │    │    │    └── filters (true)
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true:30 IS NOT NULL) [outer=(12,30)]
+      │    │    │    │         └── is_public:12 OR (instance_type_projects.instance_type_id:20 IS NOT NULL) [outer=(12,20)]
       │    │    │    └── $5
       │    │    └── $6
       │    └── filters
-      │         └── instance_type_extra_specs_1.deleted:37 = $7 [outer=(37), constraints=(/37: (/NULL - ]), fd=()-->(37)]
+      │         └── instance_type_extra_specs_1.deleted:36 = $7 [outer=(36), constraints=(/36: (/NULL - ]), fd=()-->(36)]
       └── filters (true)
 
 opt generic
@@ -1075,92 +1019,84 @@ from (select flavors.created_at as flavors_created_at,
      on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
 ----
 project
- ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:34 flavor_extra_specs_1_updated_at:35 flavor_extra_specs_1_id:30 flavor_extra_specs_1_key:31 flavor_extra_specs_1_value:32 flavor_extra_specs_1_flavor_id:33
+ ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:33 flavor_extra_specs_1_updated_at:34 flavor_extra_specs_1_id:29 flavor_extra_specs_1_key:30 flavor_extra_specs_1_value:31 flavor_extra_specs_1_flavor_id:32
  ├── immutable, has-placeholder
- ├── key: (30)
- ├── fd: ()-->(1-12,14,15,33), (30)-->(31,32,34,35), (31)-->(30,32,34,35)
+ ├── key: (29)
+ ├── fd: ()-->(1-12,14,15,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
  └── left-join (lookup flavor_extra_specs [as=flavor_extra_specs_1])
-      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27 flavor_extra_specs_1.id:30 key:31 value:32 flavor_extra_specs_1.flavor_id:33 flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
-      ├── key columns: [30] = [30]
+      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
+      ├── key columns: [29] = [29]
       ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (30)
-      ├── fd: ()-->(1-12,14,15,19,27,33), (30)-->(31,32,34,35), (31)-->(30,32,34,35)
+      ├── key: (29)
+      ├── fd: ()-->(1-12,14,15,19,20,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
       ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx [as=flavor_extra_specs_1])
-      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27 flavor_extra_specs_1.id:30 key:31 flavor_extra_specs_1.flavor_id:33
-      │    ├── key columns: [1] = [33]
+      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20 flavor_extra_specs_1.id:29 key:30 flavor_extra_specs_1.flavor_id:32
+      │    ├── key columns: [1] = [32]
       │    ├── immutable, has-placeholder
-      │    ├── key: (30)
-      │    ├── fd: ()-->(1-12,14,15,19,27,33), (30)-->(31), (31)-->(30)
+      │    ├── key: (29)
+      │    ├── fd: ()-->(1-12,14,15,19,20,32), (29)-->(30), (30)-->(29)
       │    ├── limit
-      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-12,14,15,19,27)
+      │    │    ├── fd: ()-->(1-12,14,15,19,20)
       │    │    ├── offset
-      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
+      │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
-      │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: true:27 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19
+      │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
+      │    │    │    │    ├── left-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
+      │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
+      │    │    │    │    │    ├── key columns: [1] = [19]
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
-      │    │    │    │    │    ├── left-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
-      │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
-      │    │    │    │    │    │    ├── key columns: [1] = [19]
+      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
-      │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
-      │    │    │    │    │    │    │    └── inner-join (lookup flavors)
-      │    │    │    │    │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 "$2":38!null
-      │    │    │    │    │    │    │         ├── key columns: [1] = [1]
-      │    │    │    │    │    │    │         ├── lookup columns are key
-      │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │         ├── has-placeholder
-      │    │    │    │    │    │    │         ├── key: ()
-      │    │    │    │    │    │    │         ├── fd: ()-->(1-12,14,15,38), (38)==(2), (2)==(38)
-      │    │    │    │    │    │    │         ├── inner-join (lookup flavors@flavors_name_key)
-      │    │    │    │    │    │    │         │    ├── columns: flavors.id:1!null name:2!null "$2":38!null
-      │    │    │    │    │    │    │         │    ├── flags: disallow merge join
-      │    │    │    │    │    │    │         │    ├── key columns: [38] = [2]
-      │    │    │    │    │    │    │         │    ├── lookup columns are key
-      │    │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │         │    ├── has-placeholder
-      │    │    │    │    │    │    │         │    ├── key: ()
-      │    │    │    │    │    │    │         │    ├── fd: ()-->(1,2,38), (38)==(2), (2)==(38)
-      │    │    │    │    │    │    │         │    ├── values
-      │    │    │    │    │    │    │         │    │    ├── columns: "$2":38
-      │    │    │    │    │    │    │         │    │    ├── cardinality: [1 - 1]
-      │    │    │    │    │    │    │         │    │    ├── has-placeholder
-      │    │    │    │    │    │    │         │    │    ├── key: ()
-      │    │    │    │    │    │    │         │    │    ├── fd: ()-->(38)
-      │    │    │    │    │    │    │         │    │    └── ($2,)
-      │    │    │    │    │    │    │         │    └── filters (true)
-      │    │    │    │    │    │    │         └── filters (true)
-      │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
-      │    │    │    │    │    └── projections
-      │    │    │    │    │         └── CASE flavor_projects.flavor_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:27, outer=(19)]
+      │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
+      │    │    │    │    │    │    └── inner-join (lookup flavors)
+      │    │    │    │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 "$2":37!null
+      │    │    │    │    │    │         ├── key columns: [1] = [1]
+      │    │    │    │    │    │         ├── lookup columns are key
+      │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │         ├── key: ()
+      │    │    │    │    │    │         ├── fd: ()-->(1-12,14,15,37), (37)==(2), (2)==(37)
+      │    │    │    │    │    │         ├── inner-join (lookup flavors@flavors_name_key)
+      │    │    │    │    │    │         │    ├── columns: flavors.id:1!null name:2!null "$2":37!null
+      │    │    │    │    │    │         │    ├── flags: disallow merge join
+      │    │    │    │    │    │         │    ├── key columns: [37] = [2]
+      │    │    │    │    │    │         │    ├── lookup columns are key
+      │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         │    ├── has-placeholder
+      │    │    │    │    │    │         │    ├── key: ()
+      │    │    │    │    │    │         │    ├── fd: ()-->(1,2,37), (37)==(2), (2)==(37)
+      │    │    │    │    │    │         │    ├── values
+      │    │    │    │    │    │         │    │    ├── columns: "$2":37
+      │    │    │    │    │    │         │    │    ├── cardinality: [1 - 1]
+      │    │    │    │    │    │         │    │    ├── has-placeholder
+      │    │    │    │    │    │         │    │    ├── key: ()
+      │    │    │    │    │    │         │    │    ├── fd: ()-->(37)
+      │    │    │    │    │    │         │    │    └── ($2,)
+      │    │    │    │    │    │         │    └── filters (true)
+      │    │    │    │    │    │         └── filters (true)
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true:27 IS NOT NULL) [outer=(12,27)]
+      │    │    │    │         └── is_public:12 OR (flavor_projects.flavor_id:19 IS NOT NULL) [outer=(12,19)]
       │    │    │    └── $3
       │    │    └── $4
       │    └── filters (true)
@@ -1215,92 +1151,84 @@ from (select flavors.created_at as flavors_created_at,
      on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
 ----
 project
- ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:34 flavor_extra_specs_1_updated_at:35 flavor_extra_specs_1_id:30 flavor_extra_specs_1_key:31 flavor_extra_specs_1_value:32 flavor_extra_specs_1_flavor_id:33
+ ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:33 flavor_extra_specs_1_updated_at:34 flavor_extra_specs_1_id:29 flavor_extra_specs_1_key:30 flavor_extra_specs_1_value:31 flavor_extra_specs_1_flavor_id:32
  ├── immutable, has-placeholder
- ├── key: (30)
- ├── fd: ()-->(1-12,14,15,33), (30)-->(31,32,34,35), (31)-->(30,32,34,35)
+ ├── key: (29)
+ ├── fd: ()-->(1-12,14,15,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
  └── left-join (lookup flavor_extra_specs [as=flavor_extra_specs_1])
-      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27 flavor_extra_specs_1.id:30 key:31 value:32 flavor_extra_specs_1.flavor_id:33 flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
-      ├── key columns: [30] = [30]
+      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
+      ├── key columns: [29] = [29]
       ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (30)
-      ├── fd: ()-->(1-12,14,15,19,27,33), (30)-->(31,32,34,35), (31)-->(30,32,34,35)
+      ├── key: (29)
+      ├── fd: ()-->(1-12,14,15,19,20,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
       ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx [as=flavor_extra_specs_1])
-      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27 flavor_extra_specs_1.id:30 key:31 flavor_extra_specs_1.flavor_id:33
-      │    ├── key columns: [1] = [33]
+      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20 flavor_extra_specs_1.id:29 key:30 flavor_extra_specs_1.flavor_id:32
+      │    ├── key columns: [1] = [32]
       │    ├── immutable, has-placeholder
-      │    ├── key: (30)
-      │    ├── fd: ()-->(1-12,14,15,19,27,33), (30)-->(31), (31)-->(30)
+      │    ├── key: (29)
+      │    ├── fd: ()-->(1-12,14,15,19,20,32), (29)-->(30), (30)-->(29)
       │    ├── limit
-      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-12,14,15,19,27)
+      │    │    ├── fd: ()-->(1-12,14,15,19,20)
       │    │    ├── offset
-      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
+      │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
-      │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: true:27 flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19
+      │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
+      │    │    │    │    ├── left-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
+      │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
+      │    │    │    │    │    ├── key columns: [1] = [19]
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
-      │    │    │    │    │    ├── left-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
-      │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
-      │    │    │    │    │    │    ├── key columns: [1] = [19]
+      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
-      │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
-      │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
-      │    │    │    │    │    │    │    └── inner-join (lookup flavors)
-      │    │    │    │    │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 "$2":38!null
-      │    │    │    │    │    │    │         ├── key columns: [1] = [1]
-      │    │    │    │    │    │    │         ├── lookup columns are key
-      │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │         ├── has-placeholder
-      │    │    │    │    │    │    │         ├── key: ()
-      │    │    │    │    │    │    │         ├── fd: ()-->(1-12,14,15,38), (38)==(7), (7)==(38)
-      │    │    │    │    │    │    │         ├── inner-join (lookup flavors@flavors_flavorid_key)
-      │    │    │    │    │    │    │         │    ├── columns: flavors.id:1!null flavorid:7!null "$2":38!null
-      │    │    │    │    │    │    │         │    ├── flags: disallow merge join
-      │    │    │    │    │    │    │         │    ├── key columns: [38] = [7]
-      │    │    │    │    │    │    │         │    ├── lookup columns are key
-      │    │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │         │    ├── has-placeholder
-      │    │    │    │    │    │    │         │    ├── key: ()
-      │    │    │    │    │    │    │         │    ├── fd: ()-->(1,7,38), (38)==(7), (7)==(38)
-      │    │    │    │    │    │    │         │    ├── values
-      │    │    │    │    │    │    │         │    │    ├── columns: "$2":38
-      │    │    │    │    │    │    │         │    │    ├── cardinality: [1 - 1]
-      │    │    │    │    │    │    │         │    │    ├── has-placeholder
-      │    │    │    │    │    │    │         │    │    ├── key: ()
-      │    │    │    │    │    │    │         │    │    ├── fd: ()-->(38)
-      │    │    │    │    │    │    │         │    │    └── ($2,)
-      │    │    │    │    │    │    │         │    └── filters (true)
-      │    │    │    │    │    │    │         └── filters (true)
-      │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
-      │    │    │    │    │    └── projections
-      │    │    │    │    │         └── CASE flavor_projects.flavor_id:19 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:27, outer=(19)]
+      │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
+      │    │    │    │    │    │    └── inner-join (lookup flavors)
+      │    │    │    │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 "$2":37!null
+      │    │    │    │    │    │         ├── key columns: [1] = [1]
+      │    │    │    │    │    │         ├── lookup columns are key
+      │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │         ├── key: ()
+      │    │    │    │    │    │         ├── fd: ()-->(1-12,14,15,37), (37)==(7), (7)==(37)
+      │    │    │    │    │    │         ├── inner-join (lookup flavors@flavors_flavorid_key)
+      │    │    │    │    │    │         │    ├── columns: flavors.id:1!null flavorid:7!null "$2":37!null
+      │    │    │    │    │    │         │    ├── flags: disallow merge join
+      │    │    │    │    │    │         │    ├── key columns: [37] = [7]
+      │    │    │    │    │    │         │    ├── lookup columns are key
+      │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         │    ├── has-placeholder
+      │    │    │    │    │    │         │    ├── key: ()
+      │    │    │    │    │    │         │    ├── fd: ()-->(1,7,37), (37)==(7), (7)==(37)
+      │    │    │    │    │    │         │    ├── values
+      │    │    │    │    │    │         │    │    ├── columns: "$2":37
+      │    │    │    │    │    │         │    │    ├── cardinality: [1 - 1]
+      │    │    │    │    │    │         │    │    ├── has-placeholder
+      │    │    │    │    │    │         │    │    ├── key: ()
+      │    │    │    │    │    │         │    │    ├── fd: ()-->(37)
+      │    │    │    │    │    │         │    │    └── ($2,)
+      │    │    │    │    │    │         │    └── filters (true)
+      │    │    │    │    │    │         └── filters (true)
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true:27 IS NOT NULL) [outer=(12,27)]
+      │    │    │    │         └── is_public:12 OR (flavor_projects.flavor_id:19 IS NOT NULL) [outer=(12,19)]
       │    │    │    └── $3
       │    │    └── $4
       │    └── filters (true)
@@ -1359,56 +1287,56 @@ from (select flavors.created_at as flavors_created_at,
 order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
 ----
 sort
- ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:34 flavor_extra_specs_1_updated_at:35 flavor_extra_specs_1_id:30 flavor_extra_specs_1_key:31 flavor_extra_specs_1_value:32 flavor_extra_specs_1_flavor_id:33
+ ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:33 flavor_extra_specs_1_updated_at:34 flavor_extra_specs_1_id:29 flavor_extra_specs_1_key:30 flavor_extra_specs_1_value:31 flavor_extra_specs_1_flavor_id:32
  ├── immutable, has-placeholder
- ├── key: (1,30)
- ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (30)-->(31-35), (31,33)-->(30,32,34,35)
+ ├── key: (1,29)
+ ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (29)-->(30-34), (30,32)-->(29,31,33,34)
  ├── ordering: +7
  └── project
-      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:30 key:31 value:32 flavor_extra_specs_1.flavor_id:33 flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
+      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
       ├── immutable, has-placeholder
-      ├── key: (1,30)
-      ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (30)-->(31-35), (31,33)-->(30,32,34,35)
+      ├── key: (1,29)
+      ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (29)-->(30-34), (30,32)-->(29,31,33,34)
       └── right-join (hash)
-           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27 flavor_extra_specs_1.id:30 key:31 value:32 flavor_extra_specs_1.flavor_id:33 flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
+           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
            ├── immutable, has-placeholder
-           ├── key: (1,30)
-           ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (30)-->(31-35), (31,33)-->(30,32,34,35)
+           ├── key: (1,29)
+           ├── fd: (1)-->(2-12,14,15,19,20), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (29)-->(30-34), (30,32)-->(29,31,33,34)
            ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
-           │    ├── columns: flavor_extra_specs_1.id:30!null key:31!null value:32 flavor_extra_specs_1.flavor_id:33!null flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
-           │    ├── key: (30)
-           │    └── fd: (30)-->(31-35), (31,33)-->(30,32,34,35)
+           │    ├── columns: flavor_extra_specs_1.id:29!null key:30!null value:31 flavor_extra_specs_1.flavor_id:32!null flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
+           │    ├── key: (29)
+           │    └── fd: (29)-->(30-34), (30,32)-->(29,31,33,34)
            ├── limit
-           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
            │    ├── internal-ordering: +7
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    ├── fd: (1)-->(2-12,14,15,19,20), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    ├── offset
-           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
            │    │    ├── internal-ordering: +7
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    ├── fd: (1)-->(2-12,14,15,19,20), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    ├── ordering: +7
            │    │    ├── sort
-           │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+           │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1)
-           │    │    │    ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │    ├── fd: (1)-->(2-12,14,15,19,20), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    │    ├── ordering: +7
            │    │    │    └── select
-           │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+           │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
-           │    │    │         ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         ├── fd: (1)-->(2-12,14,15,19,20), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    │         ├── left-join (merge)
-           │    │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+           │    │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
            │    │    │         │    ├── left ordering: +1
            │    │    │         │    ├── right ordering: +19
            │    │    │         │    ├── has-placeholder
            │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         │    ├── fd: (1)-->(2-12,14,15,19,20), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    │         │    ├── select
            │    │    │         │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
            │    │    │         │    │    ├── has-placeholder
@@ -1422,33 +1350,25 @@ sort
            │    │    │         │    │    │    └── ordering: +1
            │    │    │         │    │    └── filters
            │    │    │         │    │         └── (flavorid:7 > $2) OR ((flavorid:7 = $3) AND (flavors.id:1 > $4)) [outer=(1,7), constraints=(/7: (/NULL - ])]
-           │    │    │         │    ├── project
-           │    │    │         │    │    ├── columns: true:27!null flavor_projects.flavor_id:19!null
+           │    │    │         │    ├── select
+           │    │    │         │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
            │    │    │         │    │    ├── has-placeholder
            │    │    │         │    │    ├── key: (19)
-           │    │    │         │    │    ├── fd: ()-->(27)
-           │    │    │         │    │    ├── ordering: +19 opt(27) [actual: +19]
-           │    │    │         │    │    ├── select
+           │    │    │         │    │    ├── fd: ()-->(20)
+           │    │    │         │    │    ├── ordering: +19 opt(20) [actual: +19]
+           │    │    │         │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
            │    │    │         │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
-           │    │    │         │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    ├── key: (19)
-           │    │    │         │    │    │    ├── fd: ()-->(20)
-           │    │    │         │    │    │    ├── ordering: +19 opt(20) [actual: +19]
-           │    │    │         │    │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
-           │    │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
-           │    │    │         │    │    │    │    ├── key: (19,20)
-           │    │    │         │    │    │    │    └── ordering: +19
-           │    │    │         │    │    │    └── filters
-           │    │    │         │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
-           │    │    │         │    │    └── projections
-           │    │    │         │    │         └── true [as=true:27]
+           │    │    │         │    │    │    ├── key: (19,20)
+           │    │    │         │    │    │    └── ordering: +19
+           │    │    │         │    │    └── filters
+           │    │    │         │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
            │    │    │         │    └── filters (true)
            │    │    │         └── filters
-           │    │    │              └── is_public:12 OR (true:27 IS NOT NULL) [outer=(12,27)]
+           │    │    │              └── is_public:12 OR (flavor_projects.flavor_id:19 IS NOT NULL) [outer=(12,19)]
            │    │    └── $5
            │    └── $6
            └── filters
-                └── flavor_extra_specs_1.flavor_id:33 = flavors.id:1 [outer=(1,33), constraints=(/1: (/NULL - ]; /33: (/NULL - ]), fd=(1)==(33), (33)==(1)]
+                └── flavor_extra_specs_1.flavor_id:32 = flavors.id:1 [outer=(1,32), constraints=(/1: (/NULL - ]; /32: (/NULL - ]), fd=(1)==(32), (32)==(1)]
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -1510,63 +1430,63 @@ order by anon_1.instance_types_flavorid asc,
          anon_1.instance_types_id asc
 ----
 sort
- ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:39 instance_type_extra_specs_1_updated_at:40 instance_type_extra_specs_1_deleted_at:38 instance_type_extra_specs_1_deleted:37 instance_type_extra_specs_1_id:33 instance_type_extra_specs_1_key:34 instance_type_extra_specs_1_value:35 instance_type_extra_specs_1_instance_type_id:36
+ ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:38 instance_type_extra_specs_1_updated_at:39 instance_type_extra_specs_1_deleted_at:37 instance_type_extra_specs_1_deleted:36 instance_type_extra_specs_1_id:32 instance_type_extra_specs_1_key:33 instance_type_extra_specs_1_value:34 instance_type_extra_specs_1_instance_type_id:35
  ├── immutable, has-placeholder
- ├── key: (1,33)
- ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40), (1,33)-->(37)
+ ├── key: (1,32)
+ ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
  ├── ordering: +7,+1 opt(13) [actual: +7,+1]
  └── project
-      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:33 key:34 value:35 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
+      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
       ├── immutable, has-placeholder
-      ├── key: (1,33)
-      ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40), (1,33)-->(37)
+      ├── key: (1,32)
+      ├── fd: ()-->(13), (1)-->(2-12,14-16), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
       └── right-join (hash)
-           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30 instance_type_extra_specs_1.id:33 key:34 value:35 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
+           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
            ├── immutable, has-placeholder
-           ├── key: (1,33)
-           ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40), (1,33)-->(37)
+           ├── key: (1,32)
+           ├── fd: ()-->(13), (1)-->(2-12,14-16,20-22), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
            ├── select
-           │    ├── columns: instance_type_extra_specs_1.id:33!null key:34 value:35 instance_type_extra_specs_1.instance_type_id:36!null instance_type_extra_specs_1.deleted:37!null instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
+           │    ├── columns: instance_type_extra_specs_1.id:32!null key:33 value:34 instance_type_extra_specs_1.instance_type_id:35!null instance_type_extra_specs_1.deleted:36!null instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
            │    ├── has-placeholder
-           │    ├── key: (33)
-           │    ├── fd: ()-->(37), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40)
+           │    ├── key: (32)
+           │    ├── fd: ()-->(36), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39)
            │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
-           │    │    ├── columns: instance_type_extra_specs_1.id:33!null key:34 value:35 instance_type_extra_specs_1.instance_type_id:36!null instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
-           │    │    ├── key: (33)
-           │    │    └── fd: (33)-->(34-40), (34,36,37)~~>(33,35,38-40)
+           │    │    ├── columns: instance_type_extra_specs_1.id:32!null key:33 value:34 instance_type_extra_specs_1.instance_type_id:35!null instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
+           │    │    ├── key: (32)
+           │    │    └── fd: (32)-->(33-39), (33,35,36)~~>(32,34,37-39)
            │    └── filters
-           │         └── instance_type_extra_specs_1.deleted:37 = $6 [outer=(37), constraints=(/37: (/NULL - ]), fd=()-->(37)]
+           │         └── instance_type_extra_specs_1.deleted:36 = $6 [outer=(36), constraints=(/36: (/NULL - ]), fd=()-->(36)]
            ├── limit
-           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
            │    ├── internal-ordering: +7,+1 opt(13)
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20-22), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    ├── offset
-           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
            │    │    ├── internal-ordering: +7,+1 opt(13)
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20-22), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    ├── ordering: +7,+1 opt(13) [actual: +7,+1]
            │    │    ├── sort
-           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1)
-           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20-22), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │    ├── ordering: +7,+1 opt(13) [actual: +7,+1]
            │    │    │    └── select
-           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
-           │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,20-22), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │         ├── left-join (merge)
-           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
            │    │    │         │    ├── left ordering: +1
            │    │    │         │    ├── right ordering: +20
            │    │    │         │    ├── has-placeholder
            │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20-22), (7,13)~~>(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │         │    ├── select
            │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │         │    │    ├── has-placeholder
@@ -1580,34 +1500,26 @@ sort
            │    │    │         │    │    │    └── ordering: +1
            │    │    │         │    │    └── filters
            │    │    │         │    │         └── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
-           │    │    │         │    ├── project
-           │    │    │         │    │    ├── columns: true:30!null instance_type_projects.instance_type_id:20!null
+           │    │    │         │    ├── select
+           │    │    │         │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
            │    │    │         │    │    ├── has-placeholder
            │    │    │         │    │    ├── key: (20)
-           │    │    │         │    │    ├── fd: ()-->(30)
-           │    │    │         │    │    ├── ordering: +20 opt(30) [actual: +20]
-           │    │    │         │    │    ├── select
-           │    │    │         │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
-           │    │    │         │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    ├── key: (20)
-           │    │    │         │    │    │    ├── fd: ()-->(21,22)
-           │    │    │         │    │    │    ├── ordering: +20 opt(21,22) [actual: +20]
-           │    │    │         │    │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
-           │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21 instance_type_projects.deleted:22
-           │    │    │         │    │    │    │    ├── lax-key: (20-22)
-           │    │    │         │    │    │    │    └── ordering: +20
-           │    │    │         │    │    │    └── filters
-           │    │    │         │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
-           │    │    │         │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
-           │    │    │         │    │    └── projections
-           │    │    │         │    │         └── true [as=true:30]
+           │    │    │         │    │    ├── fd: ()-->(21,22)
+           │    │    │         │    │    ├── ordering: +20 opt(21,22) [actual: +20]
+           │    │    │         │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
+           │    │    │         │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21 instance_type_projects.deleted:22
+           │    │    │         │    │    │    ├── lax-key: (20-22)
+           │    │    │         │    │    │    └── ordering: +20
+           │    │    │         │    │    └── filters
+           │    │    │         │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
+           │    │    │         │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
            │    │    │         │    └── filters (true)
            │    │    │         └── filters
-           │    │    │              └── is_public:12 OR (true:30 IS NOT NULL) [outer=(12,30)]
+           │    │    │              └── is_public:12 OR (instance_type_projects.instance_type_id:20 IS NOT NULL) [outer=(12,20)]
            │    │    └── $4
            │    └── $5
            └── filters
-                └── instance_type_extra_specs_1.instance_type_id:36 = instance_types.id:1 [outer=(1,36), constraints=(/1: (/NULL - ]; /36: (/NULL - ]), fd=(1)==(36), (36)==(1)]
+                └── instance_type_extra_specs_1.instance_type_id:35 = instance_types.id:1 [outer=(1,35), constraints=(/1: (/NULL - ]; /35: (/NULL - ]), fd=(1)==(35), (35)==(1)]
 
 opt generic
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -1667,97 +1579,89 @@ from (select instance_types.created_at as instance_types_created_at,
         and instance_type_extra_specs_1.deleted = $7
 ----
 project
- ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7!null anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:39 instance_type_extra_specs_1_updated_at:40 instance_type_extra_specs_1_deleted_at:38 instance_type_extra_specs_1_deleted:37 instance_type_extra_specs_1_id:33 instance_type_extra_specs_1_key:34 instance_type_extra_specs_1_value:35 instance_type_extra_specs_1_instance_type_id:36
+ ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7!null anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:38 instance_type_extra_specs_1_updated_at:39 instance_type_extra_specs_1_deleted_at:37 instance_type_extra_specs_1_deleted:36 instance_type_extra_specs_1_id:32 instance_type_extra_specs_1_key:33 instance_type_extra_specs_1_value:34 instance_type_extra_specs_1_instance_type_id:35
  ├── immutable, has-placeholder
- ├── key: (33)
- ├── fd: ()-->(1-16,36), (33)-->(34,35,37-40), (34,36,37)~~>(33,35,38-40)
+ ├── key: (32)
+ ├── fd: ()-->(1-16,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
  └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
-      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30 instance_type_extra_specs_1.id:33 key:34 value:35 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
-      ├── key columns: [33] = [33]
+      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
+      ├── key columns: [32] = [32]
       ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (33)
-      ├── fd: ()-->(1-16,20,30,36), (33)-->(34,35,37-40), (34,36,37)~~>(33,35,38-40)
+      ├── key: (32)
+      ├── fd: ()-->(1-16,20-22,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
       ├── left-join (lookup instance_type_extra_specs@instance_type_extra_specs_instance_type_id_key_deleted_key [as=instance_type_extra_specs_1])
-      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30 instance_type_extra_specs_1.id:33 key:34 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37
-      │    ├── key columns: [1] = [36]
+      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22 instance_type_extra_specs_1.id:32 key:33 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36
+      │    ├── key columns: [1] = [35]
       │    ├── immutable, has-placeholder
-      │    ├── key: (33)
-      │    ├── fd: ()-->(1-16,20,30,36,37), (33)-->(34), (34,36,37)~~>(33)
+      │    ├── key: (32)
+      │    ├── fd: ()-->(1-16,20-22,35,36), (32)-->(33), (33,35,36)~~>(32)
       │    ├── limit
-      │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+      │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-16,20,30)
+      │    │    ├── fd: ()-->(1-16,20-22)
       │    │    ├── offset
-      │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+      │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-16,20,30)
+      │    │    │    ├── fd: ()-->(1-16,20-22)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+      │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-16,20,30)
-      │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: true:30 instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20
+      │    │    │    │    ├── fd: ()-->(1-16,20-22)
+      │    │    │    │    ├── left-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
+      │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
+      │    │    │    │    │    ├── key columns: [1] = [20]
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-16,20,30)
-      │    │    │    │    │    ├── left-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
-      │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
-      │    │    │    │    │    │    ├── key columns: [1] = [20]
+      │    │    │    │    │    ├── fd: ()-->(1-16,20-22)
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    ├── fd: ()-->(1-16,20-22)
-      │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-      │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    ├── fd: ()-->(1-16)
-      │    │    │    │    │    │    │    └── inner-join (lookup instance_types)
-      │    │    │    │    │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 "$1":43!null "$4":44!null
-      │    │    │    │    │    │    │         ├── key columns: [1] = [1]
-      │    │    │    │    │    │    │         ├── lookup columns are key
-      │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │         ├── has-placeholder
-      │    │    │    │    │    │    │         ├── key: ()
-      │    │    │    │    │    │    │         ├── fd: ()-->(1-16,43,44), (43)==(13), (7)==(44), (44)==(7), (13)==(43)
-      │    │    │    │    │    │    │         ├── inner-join (lookup instance_types@instance_types_flavorid_deleted_key)
-      │    │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13!null "$1":43!null "$4":44!null
-      │    │    │    │    │    │    │         │    ├── flags: disallow merge join
-      │    │    │    │    │    │    │         │    ├── key columns: [44 43] = [7 13]
-      │    │    │    │    │    │    │         │    ├── lookup columns are key
-      │    │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │         │    ├── has-placeholder
-      │    │    │    │    │    │    │         │    ├── key: ()
-      │    │    │    │    │    │    │         │    ├── fd: ()-->(1,7,13,43,44), (44)==(7), (13)==(43), (43)==(13), (7)==(44)
-      │    │    │    │    │    │    │         │    ├── values
-      │    │    │    │    │    │    │         │    │    ├── columns: "$1":43 "$4":44
-      │    │    │    │    │    │    │         │    │    ├── cardinality: [1 - 1]
-      │    │    │    │    │    │    │         │    │    ├── has-placeholder
-      │    │    │    │    │    │    │         │    │    ├── key: ()
-      │    │    │    │    │    │    │         │    │    ├── fd: ()-->(43,44)
-      │    │    │    │    │    │    │         │    │    └── ($1, $4)
-      │    │    │    │    │    │    │         │    └── filters (true)
-      │    │    │    │    │    │    │         └── filters (true)
-      │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
-      │    │    │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
-      │    │    │    │    │    └── projections
-      │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:20 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:30, outer=(20)]
+      │    │    │    │    │    │    ├── fd: ()-->(1-16)
+      │    │    │    │    │    │    └── inner-join (lookup instance_types)
+      │    │    │    │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 "$1":42!null "$4":43!null
+      │    │    │    │    │    │         ├── key columns: [1] = [1]
+      │    │    │    │    │    │         ├── lookup columns are key
+      │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │         ├── key: ()
+      │    │    │    │    │    │         ├── fd: ()-->(1-16,42,43), (42)==(13), (7)==(43), (43)==(7), (13)==(42)
+      │    │    │    │    │    │         ├── inner-join (lookup instance_types@instance_types_flavorid_deleted_key)
+      │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13!null "$1":42!null "$4":43!null
+      │    │    │    │    │    │         │    ├── flags: disallow merge join
+      │    │    │    │    │    │         │    ├── key columns: [43 42] = [7 13]
+      │    │    │    │    │    │         │    ├── lookup columns are key
+      │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         │    ├── has-placeholder
+      │    │    │    │    │    │         │    ├── key: ()
+      │    │    │    │    │    │         │    ├── fd: ()-->(1,7,13,42,43), (43)==(7), (13)==(42), (42)==(13), (7)==(43)
+      │    │    │    │    │    │         │    ├── values
+      │    │    │    │    │    │         │    │    ├── columns: "$1":42 "$4":43
+      │    │    │    │    │    │         │    │    ├── cardinality: [1 - 1]
+      │    │    │    │    │    │         │    │    ├── has-placeholder
+      │    │    │    │    │    │         │    │    ├── key: ()
+      │    │    │    │    │    │         │    │    ├── fd: ()-->(42,43)
+      │    │    │    │    │    │         │    │    └── ($1, $4)
+      │    │    │    │    │    │         │    └── filters (true)
+      │    │    │    │    │    │         └── filters (true)
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
+      │    │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true:30 IS NOT NULL) [outer=(12,30)]
+      │    │    │    │         └── is_public:12 OR (instance_type_projects.instance_type_id:20 IS NOT NULL) [outer=(12,20)]
       │    │    │    └── $5
       │    │    └── $6
       │    └── filters
-      │         └── instance_type_extra_specs_1.deleted:37 = $7 [outer=(37), constraints=(/37: (/NULL - ]), fd=()-->(37)]
+      │         └── instance_type_extra_specs_1.deleted:36 = $7 [outer=(36), constraints=(/36: (/NULL - ]), fd=()-->(36)]
       └── filters (true)
 
 opt
@@ -1803,54 +1707,46 @@ sort
       ├── key: (1,18)
       ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (18)-->(19-23), (19,21)-->(18,20,22,23)
       └── right-join (hash)
-           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:18 key:19 value:20 flavor_extra_specs_1.flavor_id:21 flavor_extra_specs_1.created_at:22 flavor_extra_specs_1.updated_at:23 flavor_projects.flavor_id:27 true:35
+           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:18 key:19 value:20 flavor_extra_specs_1.flavor_id:21 flavor_extra_specs_1.created_at:22 flavor_extra_specs_1.updated_at:23 flavor_projects.flavor_id:27 project_id:28
            ├── has-placeholder
            ├── key: (1,18)
-           ├── fd: (1)-->(2-12,14,15,27,35), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (18)-->(19-23), (19,21)-->(18,20,22,23)
+           ├── fd: (1)-->(2-12,14,15,27,28), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (18)-->(19-23), (19,21)-->(18,20,22,23)
            ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
            │    ├── columns: flavor_extra_specs_1.id:18!null key:19!null value:20 flavor_extra_specs_1.flavor_id:21!null flavor_extra_specs_1.created_at:22 flavor_extra_specs_1.updated_at:23
            │    ├── key: (18)
            │    └── fd: (18)-->(19-23), (19,21)-->(18,20,22,23)
            ├── select
-           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:27 true:35
+           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:27 project_id:28
            │    ├── has-placeholder
            │    ├── key: (1)
-           │    ├── fd: (1)-->(2-12,14,15,27,35), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    ├── fd: (1)-->(2-12,14,15,27,28), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    ├── left-join (merge)
-           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:27 true:35
+           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:27 project_id:28
            │    │    ├── left ordering: +1
            │    │    ├── right ordering: +27
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: (1)-->(2-12,14,15,27,35), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    ├── fd: (1)-->(2-12,14,15,27,28), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    ├── scan flavors
            │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
            │    │    │    ├── key: (1)
            │    │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    │    └── ordering: +1
-           │    │    ├── project
-           │    │    │    ├── columns: true:35!null flavor_projects.flavor_id:27!null
+           │    │    ├── select
+           │    │    │    ├── columns: flavor_projects.flavor_id:27!null project_id:28!null
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (27)
-           │    │    │    ├── fd: ()-->(35)
-           │    │    │    ├── ordering: +27 opt(35) [actual: +27]
-           │    │    │    ├── select
+           │    │    │    ├── fd: ()-->(28)
+           │    │    │    ├── ordering: +27 opt(28) [actual: +27]
+           │    │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
            │    │    │    │    ├── columns: flavor_projects.flavor_id:27!null project_id:28!null
-           │    │    │    │    ├── has-placeholder
-           │    │    │    │    ├── key: (27)
-           │    │    │    │    ├── fd: ()-->(28)
-           │    │    │    │    ├── ordering: +27 opt(28) [actual: +27]
-           │    │    │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
-           │    │    │    │    │    ├── columns: flavor_projects.flavor_id:27!null project_id:28!null
-           │    │    │    │    │    ├── key: (27,28)
-           │    │    │    │    │    └── ordering: +27
-           │    │    │    │    └── filters
-           │    │    │    │         └── project_id:28 = $1 [outer=(28), constraints=(/28: (/NULL - ]), fd=()-->(28)]
-           │    │    │    └── projections
-           │    │    │         └── true [as=true:35]
+           │    │    │    │    ├── key: (27,28)
+           │    │    │    │    └── ordering: +27
+           │    │    │    └── filters
+           │    │    │         └── project_id:28 = $1 [outer=(28), constraints=(/28: (/NULL - ]), fd=()-->(28)]
            │    │    └── filters (true)
            │    └── filters
-           │         └── is_public:12 OR (true:35 IS NOT NULL) [outer=(12,35)]
+           │         └── is_public:12 OR (flavor_projects.flavor_id:27 IS NOT NULL) [outer=(12,27)]
            └── filters
                 └── flavor_extra_specs_1.flavor_id:21 = flavors.id:1 [outer=(1,21), constraints=(/1: (/NULL - ]; /21: (/NULL - ]), fd=(1)==(21), (21)==(1)]
 
@@ -1917,63 +1813,63 @@ order by anon_1.instance_types_flavorid asc,
          anon_1.instance_types_id asc
 ----
 sort
- ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7!null anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:39 instance_type_extra_specs_1_updated_at:40 instance_type_extra_specs_1_deleted_at:38 instance_type_extra_specs_1_deleted:37 instance_type_extra_specs_1_id:33 instance_type_extra_specs_1_key:34 instance_type_extra_specs_1_value:35 instance_type_extra_specs_1_instance_type_id:36
+ ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7!null anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:38 instance_type_extra_specs_1_updated_at:39 instance_type_extra_specs_1_deleted_at:37 instance_type_extra_specs_1_deleted:36 instance_type_extra_specs_1_id:32 instance_type_extra_specs_1_key:33 instance_type_extra_specs_1_value:34 instance_type_extra_specs_1_instance_type_id:35
  ├── immutable, has-placeholder
- ├── key: (1,33)
- ├── fd: ()-->(13), (1)-->(2-12,14-16), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40), (1,33)-->(37)
+ ├── key: (1,32)
+ ├── fd: ()-->(13), (1)-->(2-12,14-16), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
  ├── ordering: +7 opt(13) [actual: +7]
  └── project
-      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:33 key:34 value:35 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
+      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
       ├── immutable, has-placeholder
-      ├── key: (1,33)
-      ├── fd: ()-->(13), (1)-->(2-12,14-16), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40), (1,33)-->(37)
+      ├── key: (1,32)
+      ├── fd: ()-->(13), (1)-->(2-12,14-16), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
       └── right-join (hash)
-           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30 instance_type_extra_specs_1.id:33 key:34 value:35 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
+           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
            ├── immutable, has-placeholder
-           ├── key: (1,33)
-           ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40), (1,33)-->(37)
+           ├── key: (1,32)
+           ├── fd: ()-->(13), (1)-->(2-12,14-16,20-22), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39), (1,32)-->(36)
            ├── select
-           │    ├── columns: instance_type_extra_specs_1.id:33!null key:34 value:35 instance_type_extra_specs_1.instance_type_id:36!null instance_type_extra_specs_1.deleted:37!null instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
+           │    ├── columns: instance_type_extra_specs_1.id:32!null key:33 value:34 instance_type_extra_specs_1.instance_type_id:35!null instance_type_extra_specs_1.deleted:36!null instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
            │    ├── has-placeholder
-           │    ├── key: (33)
-           │    ├── fd: ()-->(37), (33)-->(34-36,38-40), (34,36,37)~~>(33,35,38-40)
+           │    ├── key: (32)
+           │    ├── fd: ()-->(36), (32)-->(33-35,37-39), (33,35,36)~~>(32,34,37-39)
            │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
-           │    │    ├── columns: instance_type_extra_specs_1.id:33!null key:34 value:35 instance_type_extra_specs_1.instance_type_id:36!null instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
-           │    │    ├── key: (33)
-           │    │    └── fd: (33)-->(34-40), (34,36,37)~~>(33,35,38-40)
+           │    │    ├── columns: instance_type_extra_specs_1.id:32!null key:33 value:34 instance_type_extra_specs_1.instance_type_id:35!null instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
+           │    │    ├── key: (32)
+           │    │    └── fd: (32)-->(33-39), (33,35,36)~~>(32,34,37-39)
            │    └── filters
-           │         └── instance_type_extra_specs_1.deleted:37 = $9 [outer=(37), constraints=(/37: (/NULL - ]), fd=()-->(37)]
+           │         └── instance_type_extra_specs_1.deleted:36 = $9 [outer=(36), constraints=(/36: (/NULL - ]), fd=()-->(36)]
            ├── limit
-           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
            │    ├── internal-ordering: +7 opt(13)
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20-22), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    ├── offset
-           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
            │    │    ├── internal-ordering: +7 opt(13)
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20-22), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    ├── ordering: +7 opt(13) [actual: +7]
            │    │    ├── sort
-           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1)
-           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20-22), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │    ├── ordering: +7 opt(13) [actual: +7]
            │    │    │    └── select
-           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
-           │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         ├── fd: ()-->(13), (1)-->(2-12,14-16,20-22), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │         ├── left-join (merge)
-           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
            │    │    │         │    ├── left ordering: +1
            │    │    │         │    ├── right ordering: +20
            │    │    │         │    ├── has-placeholder
            │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20,30), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
+           │    │    │         │    ├── fd: ()-->(13), (1)-->(2-12,14-16,20-22), (7)-->(1-6,8-12,14-16), (2,13)~~>(1,3-12,14-16)
            │    │    │         │    ├── select
            │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
            │    │    │         │    │    ├── has-placeholder
@@ -1988,34 +1884,26 @@ sort
            │    │    │         │    │    └── filters
            │    │    │         │    │         ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
            │    │    │         │    │         └── (flavorid:7 > $4) OR ((flavorid:7 = $5) AND (instance_types.id:1 > $6)) [outer=(1,7), constraints=(/7: (/NULL - ])]
-           │    │    │         │    ├── project
-           │    │    │         │    │    ├── columns: true:30!null instance_type_projects.instance_type_id:20!null
+           │    │    │         │    ├── select
+           │    │    │         │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
            │    │    │         │    │    ├── has-placeholder
            │    │    │         │    │    ├── key: (20)
-           │    │    │         │    │    ├── fd: ()-->(30)
-           │    │    │         │    │    ├── ordering: +20 opt(30) [actual: +20]
-           │    │    │         │    │    ├── select
-           │    │    │         │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
-           │    │    │         │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    ├── key: (20)
-           │    │    │         │    │    │    ├── fd: ()-->(21,22)
-           │    │    │         │    │    │    ├── ordering: +20 opt(21,22) [actual: +20]
-           │    │    │         │    │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
-           │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21 instance_type_projects.deleted:22
-           │    │    │         │    │    │    │    ├── lax-key: (20-22)
-           │    │    │         │    │    │    │    └── ordering: +20
-           │    │    │         │    │    │    └── filters
-           │    │    │         │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
-           │    │    │         │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
-           │    │    │         │    │    └── projections
-           │    │    │         │    │         └── true [as=true:30]
+           │    │    │         │    │    ├── fd: ()-->(21,22)
+           │    │    │         │    │    ├── ordering: +20 opt(21,22) [actual: +20]
+           │    │    │         │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
+           │    │    │         │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21 instance_type_projects.deleted:22
+           │    │    │         │    │    │    ├── lax-key: (20-22)
+           │    │    │         │    │    │    └── ordering: +20
+           │    │    │         │    │    └── filters
+           │    │    │         │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
+           │    │    │         │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
            │    │    │         │    └── filters (true)
            │    │    │         └── filters
-           │    │    │              └── is_public:12 OR (true:30 IS NOT NULL) [outer=(12,30)]
+           │    │    │              └── is_public:12 OR (instance_type_projects.instance_type_id:20 IS NOT NULL) [outer=(12,20)]
            │    │    └── $7
            │    └── $8
            └── filters
-                └── instance_type_extra_specs_1.instance_type_id:36 = instance_types.id:1 [outer=(1,36), constraints=(/1: (/NULL - ]; /36: (/NULL - ]), fd=(1)==(36), (36)==(1)]
+                └── instance_type_extra_specs_1.instance_type_id:35 = instance_types.id:1 [outer=(1,35), constraints=(/1: (/NULL - ]; /35: (/NULL - ]), fd=(1)==(35), (35)==(1)]
 
 opt
 select anon_1.flavors_created_at as anon_1_flavors_created_at,
@@ -2067,88 +1955,80 @@ from (select flavors.created_at as flavors_created_at,
 order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
 ----
 sort
- ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:34 flavor_extra_specs_1_updated_at:35 flavor_extra_specs_1_id:30 flavor_extra_specs_1_key:31 flavor_extra_specs_1_value:32 flavor_extra_specs_1_flavor_id:33
+ ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:33 flavor_extra_specs_1_updated_at:34 flavor_extra_specs_1_id:29 flavor_extra_specs_1_key:30 flavor_extra_specs_1_value:31 flavor_extra_specs_1_flavor_id:32
  ├── immutable, has-placeholder
- ├── key: (1,30)
- ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (30)-->(31-35), (31,33)-->(30,32,34,35)
+ ├── key: (1,29)
+ ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (29)-->(30-34), (30,32)-->(29,31,33,34)
  ├── ordering: +7
  └── project
-      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:30 key:31 value:32 flavor_extra_specs_1.flavor_id:33 flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
+      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
       ├── immutable, has-placeholder
-      ├── key: (1,30)
-      ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (30)-->(31-35), (31,33)-->(30,32,34,35)
+      ├── key: (1,29)
+      ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (29)-->(30-34), (30,32)-->(29,31,33,34)
       └── right-join (hash)
-           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27 flavor_extra_specs_1.id:30 key:31 value:32 flavor_extra_specs_1.flavor_id:33 flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
+           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
            ├── immutable, has-placeholder
-           ├── key: (1,30)
-           ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (30)-->(31-35), (31,33)-->(30,32,34,35)
+           ├── key: (1,29)
+           ├── fd: (1)-->(2-12,14,15,19,20), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15), (29)-->(30-34), (30,32)-->(29,31,33,34)
            ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
-           │    ├── columns: flavor_extra_specs_1.id:30!null key:31!null value:32 flavor_extra_specs_1.flavor_id:33!null flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
-           │    ├── key: (30)
-           │    └── fd: (30)-->(31-35), (31,33)-->(30,32,34,35)
+           │    ├── columns: flavor_extra_specs_1.id:29!null key:30!null value:31 flavor_extra_specs_1.flavor_id:32!null flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
+           │    ├── key: (29)
+           │    └── fd: (29)-->(30-34), (30,32)-->(29,31,33,34)
            ├── limit
-           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
            │    ├── internal-ordering: +7
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    ├── fd: (1)-->(2-12,14,15,19,20), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    ├── offset
-           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
            │    │    ├── internal-ordering: +7
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    ├── fd: (1)-->(2-12,14,15,19,20), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    ├── ordering: +7
            │    │    ├── sort
-           │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+           │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1)
-           │    │    │    ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │    ├── fd: (1)-->(2-12,14,15,19,20), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    │    ├── ordering: +7
            │    │    │    └── select
-           │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+           │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
-           │    │    │         ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         ├── fd: (1)-->(2-12,14,15,19,20), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    │         ├── left-join (merge)
-           │    │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+           │    │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
            │    │    │         │    ├── left ordering: +1
            │    │    │         │    ├── right ordering: +19
            │    │    │         │    ├── has-placeholder
            │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: (1)-->(2-12,14,15,19,27), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
+           │    │    │         │    ├── fd: (1)-->(2-12,14,15,19,20), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    │         │    ├── scan flavors
            │    │    │         │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
            │    │    │         │    │    ├── key: (1)
            │    │    │         │    │    ├── fd: (1)-->(2-12,14,15), (7)-->(1-6,8-12,14,15), (2)-->(1,3-12,14,15)
            │    │    │         │    │    └── ordering: +1
-           │    │    │         │    ├── project
-           │    │    │         │    │    ├── columns: true:27!null flavor_projects.flavor_id:19!null
+           │    │    │         │    ├── select
+           │    │    │         │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
            │    │    │         │    │    ├── has-placeholder
            │    │    │         │    │    ├── key: (19)
-           │    │    │         │    │    ├── fd: ()-->(27)
-           │    │    │         │    │    ├── ordering: +19 opt(27) [actual: +19]
-           │    │    │         │    │    ├── select
+           │    │    │         │    │    ├── fd: ()-->(20)
+           │    │    │         │    │    ├── ordering: +19 opt(20) [actual: +19]
+           │    │    │         │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
            │    │    │         │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
-           │    │    │         │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    ├── key: (19)
-           │    │    │         │    │    │    ├── fd: ()-->(20)
-           │    │    │         │    │    │    ├── ordering: +19 opt(20) [actual: +19]
-           │    │    │         │    │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
-           │    │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
-           │    │    │         │    │    │    │    ├── key: (19,20)
-           │    │    │         │    │    │    │    └── ordering: +19
-           │    │    │         │    │    │    └── filters
-           │    │    │         │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
-           │    │    │         │    │    └── projections
-           │    │    │         │    │         └── true [as=true:27]
+           │    │    │         │    │    │    ├── key: (19,20)
+           │    │    │         │    │    │    └── ordering: +19
+           │    │    │         │    │    └── filters
+           │    │    │         │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
            │    │    │         │    └── filters (true)
            │    │    │         └── filters
-           │    │    │              └── is_public:12 OR (true:27 IS NOT NULL) [outer=(12,27)]
+           │    │    │              └── is_public:12 OR (flavor_projects.flavor_id:19 IS NOT NULL) [outer=(12,19)]
            │    │    └── $2
            │    └── $3
            └── filters
-                └── flavor_extra_specs_1.flavor_id:33 = flavors.id:1 [outer=(1,33), constraints=(/1: (/NULL - ]; /33: (/NULL - ]), fd=(1)==(33), (33)==(1)]
+                └── flavor_extra_specs_1.flavor_id:32 = flavors.id:1 [outer=(1,32), constraints=(/1: (/NULL - ]; /32: (/NULL - ]), fd=(1)==(32), (32)==(1)]
 
 opt
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -2218,76 +2098,76 @@ order by anon_1.instance_types_flavorid asc,
          anon_1.instance_types_id asc
 ----
 sort
- ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11!null anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:53 instance_type_extra_specs_1_updated_at:54 instance_type_extra_specs_1_deleted_at:52 instance_type_extra_specs_1_deleted:51 instance_type_extra_specs_1_id:47 instance_type_extra_specs_1_key:48 instance_type_extra_specs_1_value:49 instance_type_extra_specs_1_instance_type_id:50
+ ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7 anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11!null anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:51 instance_type_extra_specs_1_updated_at:52 instance_type_extra_specs_1_deleted_at:50 instance_type_extra_specs_1_deleted:49 instance_type_extra_specs_1_id:45 instance_type_extra_specs_1_key:46 instance_type_extra_specs_1_value:47 instance_type_extra_specs_1_instance_type_id:48
  ├── immutable, has-placeholder
- ├── key: (1,47)
- ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (47)-->(48-50,52-54), (48,50,51)~~>(47,49,52-54), (1,47)-->(51)
+ ├── key: (1,45)
+ ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (45)-->(46-48,50-52), (46,48,49)~~>(45,47,50-52), (1,45)-->(49)
  ├── ordering: +7,+1 opt(11,13) [actual: +7,+1]
  └── project
-      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:47 key:48 value:49 instance_type_extra_specs_1.instance_type_id:50 instance_type_extra_specs_1.deleted:51 instance_type_extra_specs_1.deleted_at:52 instance_type_extra_specs_1.created_at:53 instance_type_extra_specs_1.updated_at:54
+      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_extra_specs_1.id:45 key:46 value:47 instance_type_extra_specs_1.instance_type_id:48 instance_type_extra_specs_1.deleted:49 instance_type_extra_specs_1.deleted_at:50 instance_type_extra_specs_1.created_at:51 instance_type_extra_specs_1.updated_at:52
       ├── immutable, has-placeholder
-      ├── key: (1,47)
-      ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (47)-->(48-50,52-54), (48,50,51)~~>(47,49,52-54), (1,47)-->(51)
+      ├── key: (1,45)
+      ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (45)-->(46-48,50-52), (46,48,49)~~>(45,47,50-52), (1,45)-->(49)
       └── right-join (hash)
-           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:41 true:44 instance_type_extra_specs_1.id:47 key:48 value:49 instance_type_extra_specs_1.instance_type_id:50 instance_type_extra_specs_1.deleted:51 instance_type_extra_specs_1.deleted_at:52 instance_type_extra_specs_1.created_at:53 instance_type_extra_specs_1.updated_at:54
+           ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22 instance_type_projects.instance_type_id:30 project_id:31 instance_type_projects.deleted:32 instance_type_extra_specs_1.id:45 key:46 value:47 instance_type_extra_specs_1.instance_type_id:48 instance_type_extra_specs_1.deleted:49 instance_type_extra_specs_1.deleted_at:50 instance_type_extra_specs_1.created_at:51 instance_type_extra_specs_1.updated_at:52
            ├── immutable, has-placeholder
-           ├── key: (1,47)
-           ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,41,44), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (47)-->(48-50,52-54), (48,50,51)~~>(47,49,52-54), (1,47)-->(51)
+           ├── key: (1,45)
+           ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20-22,30-32), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16), (45)-->(46-48,50-52), (46,48,49)~~>(45,47,50-52), (1,45)-->(49)
            ├── select
-           │    ├── columns: instance_type_extra_specs_1.id:47!null key:48 value:49 instance_type_extra_specs_1.instance_type_id:50!null instance_type_extra_specs_1.deleted:51!null instance_type_extra_specs_1.deleted_at:52 instance_type_extra_specs_1.created_at:53 instance_type_extra_specs_1.updated_at:54
+           │    ├── columns: instance_type_extra_specs_1.id:45!null key:46 value:47 instance_type_extra_specs_1.instance_type_id:48!null instance_type_extra_specs_1.deleted:49!null instance_type_extra_specs_1.deleted_at:50 instance_type_extra_specs_1.created_at:51 instance_type_extra_specs_1.updated_at:52
            │    ├── has-placeholder
-           │    ├── key: (47)
-           │    ├── fd: ()-->(51), (47)-->(48-50,52-54), (48,50,51)~~>(47,49,52-54)
+           │    ├── key: (45)
+           │    ├── fd: ()-->(49), (45)-->(46-48,50-52), (46,48,49)~~>(45,47,50-52)
            │    ├── scan instance_type_extra_specs [as=instance_type_extra_specs_1]
-           │    │    ├── columns: instance_type_extra_specs_1.id:47!null key:48 value:49 instance_type_extra_specs_1.instance_type_id:50!null instance_type_extra_specs_1.deleted:51 instance_type_extra_specs_1.deleted_at:52 instance_type_extra_specs_1.created_at:53 instance_type_extra_specs_1.updated_at:54
-           │    │    ├── key: (47)
-           │    │    └── fd: (47)-->(48-54), (48,50,51)~~>(47,49,52-54)
+           │    │    ├── columns: instance_type_extra_specs_1.id:45!null key:46 value:47 instance_type_extra_specs_1.instance_type_id:48!null instance_type_extra_specs_1.deleted:49 instance_type_extra_specs_1.deleted_at:50 instance_type_extra_specs_1.created_at:51 instance_type_extra_specs_1.updated_at:52
+           │    │    ├── key: (45)
+           │    │    └── fd: (45)-->(46-52), (46,48,49)~~>(45,47,50-52)
            │    └── filters
-           │         └── instance_type_extra_specs_1.deleted:51 = $9 [outer=(51), constraints=(/51: (/NULL - ]), fd=()-->(51)]
+           │         └── instance_type_extra_specs_1.deleted:49 = $9 [outer=(49), constraints=(/49: (/NULL - ]), fd=()-->(49)]
            ├── limit
-           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:41 true:44
+           │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22 instance_type_projects.instance_type_id:30 project_id:31 instance_type_projects.deleted:32
            │    ├── internal-ordering: +7,+1 opt(11,13)
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,41,44), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20-22,30-32), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
            │    ├── offset
-           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:41 true:44
+           │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22 instance_type_projects.instance_type_id:30 project_id:31 instance_type_projects.deleted:32
            │    │    ├── internal-ordering: +7,+1 opt(11,13)
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,41,44), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20-22,30-32), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
            │    │    ├── ordering: +7,+1 opt(11,13) [actual: +7,+1]
            │    │    ├── sort
-           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:41 true:44
+           │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22 instance_type_projects.instance_type_id:30 project_id:31 instance_type_projects.deleted:32
            │    │    │    ├── has-placeholder
            │    │    │    ├── key: (1)
-           │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,41,44), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20-22,30-32), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
            │    │    │    ├── ordering: +7,+1 opt(11,13) [actual: +7,+1]
            │    │    │    └── select
-           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:41 true:44
+           │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22 instance_type_projects.instance_type_id:30 project_id:31 instance_type_projects.deleted:32
            │    │    │         ├── has-placeholder
            │    │    │         ├── key: (1)
-           │    │    │         ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,41,44), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │         ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20-22,30-32), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
            │    │    │         ├── left-join (merge)
-           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 instance_type_projects.instance_type_id:30 true:41 true:44
+           │    │    │         │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22 instance_type_projects.instance_type_id:30 project_id:31 instance_type_projects.deleted:32
            │    │    │         │    ├── left ordering: +1
            │    │    │         │    ├── right ordering: +30
            │    │    │         │    ├── has-placeholder
            │    │    │         │    ├── key: (1)
-           │    │    │         │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,30,41,44), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │         │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20-22,30-32), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
            │    │    │         │    ├── select
-           │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:41
+           │    │    │         │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
            │    │    │         │    │    ├── has-placeholder
            │    │    │         │    │    ├── key: (1)
-           │    │    │         │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,41), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │         │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20-22), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
            │    │    │         │    │    ├── ordering: +1 opt(11,13) [actual: +1]
            │    │    │         │    │    ├── left-join (merge)
-           │    │    │         │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:41
+           │    │    │         │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
            │    │    │         │    │    │    ├── left ordering: +1
            │    │    │         │    │    │    ├── right ordering: +20
            │    │    │         │    │    │    ├── has-placeholder
            │    │    │         │    │    │    ├── key: (1)
-           │    │    │         │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20,41), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
+           │    │    │         │    │    │    ├── fd: ()-->(11,13), (1)-->(2-10,12,14-16,20-22), (7,13)~~>(1-6,8-10,12,14-16), (2,13)~~>(1,3-10,12,14-16)
            │    │    │         │    │    │    ├── ordering: +1 opt(11,13) [actual: +1]
            │    │    │         │    │    │    ├── select
            │    │    │         │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7 swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11!null is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
@@ -2303,59 +2183,43 @@ sort
            │    │    │         │    │    │    │    └── filters
            │    │    │         │    │    │    │         ├── instance_types.deleted:13 = $1 [outer=(13), constraints=(/13: (/NULL - ]), fd=()-->(13)]
            │    │    │         │    │    │    │         └── NOT disabled:11 [outer=(11), constraints=(/11: [/false - /false]; tight), fd=()-->(11)]
-           │    │    │         │    │    │    ├── project
-           │    │    │         │    │    │    │    ├── columns: true:41!null instance_type_projects.instance_type_id:20!null
+           │    │    │         │    │    │    ├── select
+           │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
            │    │    │         │    │    │    │    ├── has-placeholder
            │    │    │         │    │    │    │    ├── key: (20)
-           │    │    │         │    │    │    │    ├── fd: ()-->(41)
-           │    │    │         │    │    │    │    ├── ordering: +20 opt(41) [actual: +20]
-           │    │    │         │    │    │    │    ├── select
-           │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21!null instance_type_projects.deleted:22!null
-           │    │    │         │    │    │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    │    │    ├── key: (20)
-           │    │    │         │    │    │    │    │    ├── fd: ()-->(21,22)
-           │    │    │         │    │    │    │    │    ├── ordering: +20 opt(21,22) [actual: +20]
-           │    │    │         │    │    │    │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
-           │    │    │         │    │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21 instance_type_projects.deleted:22
-           │    │    │         │    │    │    │    │    │    ├── lax-key: (20-22)
-           │    │    │         │    │    │    │    │    │    └── ordering: +20
-           │    │    │         │    │    │    │    │    └── filters
-           │    │    │         │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
-           │    │    │         │    │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
-           │    │    │         │    │    │    │    └── projections
-           │    │    │         │    │    │    │         └── true [as=true:41]
+           │    │    │         │    │    │    │    ├── fd: ()-->(21,22)
+           │    │    │         │    │    │    │    ├── ordering: +20 opt(21,22) [actual: +20]
+           │    │    │         │    │    │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
+           │    │    │         │    │    │    │    │    ├── columns: instance_type_projects.instance_type_id:20!null project_id:21 instance_type_projects.deleted:22
+           │    │    │         │    │    │    │    │    ├── lax-key: (20-22)
+           │    │    │         │    │    │    │    │    └── ordering: +20
+           │    │    │         │    │    │    │    └── filters
+           │    │    │         │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
+           │    │    │         │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
            │    │    │         │    │    │    └── filters (true)
            │    │    │         │    │    └── filters
-           │    │    │         │    │         └── is_public:12 OR (true:41 IS NOT NULL) [outer=(12,41)]
-           │    │    │         │    ├── project
-           │    │    │         │    │    ├── columns: true:44!null instance_type_projects.instance_type_id:30!null
+           │    │    │         │    │         └── is_public:12 OR (instance_type_projects.instance_type_id:20 IS NOT NULL) [outer=(12,20)]
+           │    │    │         │    ├── select
+           │    │    │         │    │    ├── columns: instance_type_projects.instance_type_id:30!null project_id:31!null instance_type_projects.deleted:32!null
            │    │    │         │    │    ├── has-placeholder
            │    │    │         │    │    ├── key: (30)
-           │    │    │         │    │    ├── fd: ()-->(44)
-           │    │    │         │    │    ├── ordering: +30 opt(44) [actual: +30]
-           │    │    │         │    │    ├── select
-           │    │    │         │    │    │    ├── columns: instance_type_projects.instance_type_id:30!null project_id:31!null instance_type_projects.deleted:32!null
-           │    │    │         │    │    │    ├── has-placeholder
-           │    │    │         │    │    │    ├── key: (30)
-           │    │    │         │    │    │    ├── fd: ()-->(31,32)
-           │    │    │         │    │    │    ├── ordering: +30 opt(31,32) [actual: +30]
-           │    │    │         │    │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
-           │    │    │         │    │    │    │    ├── columns: instance_type_projects.instance_type_id:30!null project_id:31 instance_type_projects.deleted:32
-           │    │    │         │    │    │    │    ├── lax-key: (30-32)
-           │    │    │         │    │    │    │    └── ordering: +30
-           │    │    │         │    │    │    └── filters
-           │    │    │         │    │    │         ├── instance_type_projects.deleted:32 = $4 [outer=(32), constraints=(/32: (/NULL - ]), fd=()-->(32)]
-           │    │    │         │    │    │         ├── instance_type_projects.deleted:32 = $5 [outer=(32), constraints=(/32: (/NULL - ]), fd=()-->(32)]
-           │    │    │         │    │    │         └── project_id:31 = $6 [outer=(31), constraints=(/31: (/NULL - ]), fd=()-->(31)]
-           │    │    │         │    │    └── projections
-           │    │    │         │    │         └── true [as=true:44]
+           │    │    │         │    │    ├── fd: ()-->(31,32)
+           │    │    │         │    │    ├── ordering: +30 opt(31,32) [actual: +30]
+           │    │    │         │    │    ├── scan instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key
+           │    │    │         │    │    │    ├── columns: instance_type_projects.instance_type_id:30!null project_id:31 instance_type_projects.deleted:32
+           │    │    │         │    │    │    ├── lax-key: (30-32)
+           │    │    │         │    │    │    └── ordering: +30
+           │    │    │         │    │    └── filters
+           │    │    │         │    │         ├── instance_type_projects.deleted:32 = $4 [outer=(32), constraints=(/32: (/NULL - ]), fd=()-->(32)]
+           │    │    │         │    │         ├── instance_type_projects.deleted:32 = $5 [outer=(32), constraints=(/32: (/NULL - ]), fd=()-->(32)]
+           │    │    │         │    │         └── project_id:31 = $6 [outer=(31), constraints=(/31: (/NULL - ]), fd=()-->(31)]
            │    │    │         │    └── filters (true)
            │    │    │         └── filters
-           │    │    │              └── is_public:12 OR (true:44 IS NOT NULL) [outer=(12,44)]
+           │    │    │              └── is_public:12 OR (instance_type_projects.instance_type_id:30 IS NOT NULL) [outer=(12,30)]
            │    │    └── $7
            │    └── $8
            └── filters
-                └── instance_type_extra_specs_1.instance_type_id:50 = instance_types.id:1 [outer=(1,50), constraints=(/1: (/NULL - ]; /50: (/NULL - ]), fd=(1)==(50), (50)==(1)]
+                └── instance_type_extra_specs_1.instance_type_id:48 = instance_types.id:1 [outer=(1,48), constraints=(/1: (/NULL - ]; /48: (/NULL - ]), fd=(1)==(48), (48)==(1)]
 
 opt generic
 select anon_1.instance_types_created_at as anon_1_instance_types_created_at,
@@ -2418,97 +2282,89 @@ order by anon_1.instance_types_deleted asc,
          anon_1.instance_types_id asc
 ----
 project
- ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7!null anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:39 instance_type_extra_specs_1_updated_at:40 instance_type_extra_specs_1_deleted_at:38 instance_type_extra_specs_1_deleted:37 instance_type_extra_specs_1_id:33 instance_type_extra_specs_1_key:34 instance_type_extra_specs_1_value:35 instance_type_extra_specs_1_instance_type_id:36
+ ├── columns: anon_1_instance_types_created_at:15 anon_1_instance_types_updated_at:16 anon_1_instance_types_deleted_at:14 anon_1_instance_types_deleted:13!null anon_1_instance_types_id:1!null anon_1_instance_types_name:2 anon_1_instance_types_memory_mb:3!null anon_1_instance_types_vcpus:4!null anon_1_instance_types_root_gb:5 anon_1_instance_types_ephemeral_gb:6 anon_1_instance_types_flavorid:7!null anon_1_instance_types_swap:8!null anon_1_instance_types_rxtx_factor:9 anon_1_instance_types_vcpu_weight:10 anon_1_instance_types_disabled:11 anon_1_instance_types_is_public:12 instance_type_extra_specs_1_created_at:38 instance_type_extra_specs_1_updated_at:39 instance_type_extra_specs_1_deleted_at:37 instance_type_extra_specs_1_deleted:36 instance_type_extra_specs_1_id:32 instance_type_extra_specs_1_key:33 instance_type_extra_specs_1_value:34 instance_type_extra_specs_1_instance_type_id:35
  ├── immutable, has-placeholder
- ├── key: (33)
- ├── fd: ()-->(1-16,36), (33)-->(34,35,37-40), (34,36,37)~~>(33,35,38-40)
+ ├── key: (32)
+ ├── fd: ()-->(1-16,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
  └── left-join (lookup instance_type_extra_specs [as=instance_type_extra_specs_1])
-      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30 instance_type_extra_specs_1.id:33 key:34 value:35 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37 instance_type_extra_specs_1.deleted_at:38 instance_type_extra_specs_1.created_at:39 instance_type_extra_specs_1.updated_at:40
-      ├── key columns: [33] = [33]
+      ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22 instance_type_extra_specs_1.id:32 key:33 value:34 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36 instance_type_extra_specs_1.deleted_at:37 instance_type_extra_specs_1.created_at:38 instance_type_extra_specs_1.updated_at:39
+      ├── key columns: [32] = [32]
       ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (33)
-      ├── fd: ()-->(1-16,20,30,36), (33)-->(34,35,37-40), (34,36,37)~~>(33,35,38-40)
+      ├── key: (32)
+      ├── fd: ()-->(1-16,20-22,35), (32)-->(33,34,36-39), (33,35,36)~~>(32,34,37-39)
       ├── left-join (lookup instance_type_extra_specs@instance_type_extra_specs_instance_type_id_key_deleted_key [as=instance_type_extra_specs_1])
-      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30 instance_type_extra_specs_1.id:33 key:34 instance_type_extra_specs_1.instance_type_id:36 instance_type_extra_specs_1.deleted:37
-      │    ├── key columns: [1] = [36]
+      │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22 instance_type_extra_specs_1.id:32 key:33 instance_type_extra_specs_1.instance_type_id:35 instance_type_extra_specs_1.deleted:36
+      │    ├── key columns: [1] = [35]
       │    ├── immutable, has-placeholder
-      │    ├── key: (33)
-      │    ├── fd: ()-->(1-16,20,30,36,37), (33)-->(34), (34,36,37)~~>(33)
+      │    ├── key: (32)
+      │    ├── fd: ()-->(1-16,20-22,35,36), (32)-->(33), (33,35,36)~~>(32)
       │    ├── limit
-      │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+      │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-16,20,30)
+      │    │    ├── fd: ()-->(1-16,20-22)
       │    │    ├── offset
-      │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+      │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-16,20,30)
+      │    │    │    ├── fd: ()-->(1-16,20-22)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 true:30
+      │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-16,20,30)
-      │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: true:30 instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20
+      │    │    │    │    ├── fd: ()-->(1-16,20-22)
+      │    │    │    │    ├── left-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
+      │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
+      │    │    │    │    │    ├── key columns: [1] = [20]
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-16,20,30)
-      │    │    │    │    │    ├── left-join (lookup instance_type_projects@instance_type_projects_instance_type_id_project_id_deleted_key)
-      │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 instance_type_projects.instance_type_id:20 project_id:21 instance_type_projects.deleted:22
-      │    │    │    │    │    │    ├── key columns: [1] = [20]
+      │    │    │    │    │    ├── fd: ()-->(1-16,20-22)
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    ├── fd: ()-->(1-16,20-22)
-      │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16
-      │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    ├── fd: ()-->(1-16)
-      │    │    │    │    │    │    │    └── inner-join (lookup instance_types)
-      │    │    │    │    │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 "$1":43!null "$4":44!null
-      │    │    │    │    │    │    │         ├── key columns: [1] = [1]
-      │    │    │    │    │    │    │         ├── lookup columns are key
-      │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │         ├── has-placeholder
-      │    │    │    │    │    │    │         ├── key: ()
-      │    │    │    │    │    │    │         ├── fd: ()-->(1-16,43,44), (43)==(13), (7)==(44), (44)==(7), (13)==(43)
-      │    │    │    │    │    │    │         ├── inner-join (lookup instance_types@instance_types_flavorid_deleted_key)
-      │    │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13!null "$1":43!null "$4":44!null
-      │    │    │    │    │    │    │         │    ├── flags: disallow merge join
-      │    │    │    │    │    │    │         │    ├── key columns: [44 43] = [7 13]
-      │    │    │    │    │    │    │         │    ├── lookup columns are key
-      │    │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │         │    ├── has-placeholder
-      │    │    │    │    │    │    │         │    ├── key: ()
-      │    │    │    │    │    │    │         │    ├── fd: ()-->(1,7,13,43,44), (44)==(7), (13)==(43), (43)==(13), (7)==(44)
-      │    │    │    │    │    │    │         │    ├── values
-      │    │    │    │    │    │    │         │    │    ├── columns: "$1":43 "$4":44
-      │    │    │    │    │    │    │         │    │    ├── cardinality: [1 - 1]
-      │    │    │    │    │    │    │         │    │    ├── has-placeholder
-      │    │    │    │    │    │    │         │    │    ├── key: ()
-      │    │    │    │    │    │    │         │    │    ├── fd: ()-->(43,44)
-      │    │    │    │    │    │    │         │    │    └── ($1, $4)
-      │    │    │    │    │    │    │         │    └── filters (true)
-      │    │    │    │    │    │    │         └── filters (true)
-      │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
-      │    │    │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
-      │    │    │    │    │    └── projections
-      │    │    │    │    │         └── CASE instance_type_projects.instance_type_id:20 IS NULL WHEN true THEN CAST(NULL AS BOOL) ELSE true END [as=true:30, outer=(20)]
+      │    │    │    │    │    │    ├── fd: ()-->(1-16)
+      │    │    │    │    │    │    └── inner-join (lookup instance_types)
+      │    │    │    │    │    │         ├── columns: instance_types.id:1!null name:2 memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 instance_types.deleted:13!null instance_types.deleted_at:14 instance_types.created_at:15 instance_types.updated_at:16 "$1":42!null "$4":43!null
+      │    │    │    │    │    │         ├── key columns: [1] = [1]
+      │    │    │    │    │    │         ├── lookup columns are key
+      │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │         ├── key: ()
+      │    │    │    │    │    │         ├── fd: ()-->(1-16,42,43), (42)==(13), (7)==(43), (43)==(7), (13)==(42)
+      │    │    │    │    │    │         ├── inner-join (lookup instance_types@instance_types_flavorid_deleted_key)
+      │    │    │    │    │    │         │    ├── columns: instance_types.id:1!null flavorid:7!null instance_types.deleted:13!null "$1":42!null "$4":43!null
+      │    │    │    │    │    │         │    ├── flags: disallow merge join
+      │    │    │    │    │    │         │    ├── key columns: [43 42] = [7 13]
+      │    │    │    │    │    │         │    ├── lookup columns are key
+      │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         │    ├── has-placeholder
+      │    │    │    │    │    │         │    ├── key: ()
+      │    │    │    │    │    │         │    ├── fd: ()-->(1,7,13,42,43), (43)==(7), (13)==(42), (42)==(13), (7)==(43)
+      │    │    │    │    │    │         │    ├── values
+      │    │    │    │    │    │         │    │    ├── columns: "$1":42 "$4":43
+      │    │    │    │    │    │         │    │    ├── cardinality: [1 - 1]
+      │    │    │    │    │    │         │    │    ├── has-placeholder
+      │    │    │    │    │    │         │    │    ├── key: ()
+      │    │    │    │    │    │         │    │    ├── fd: ()-->(42,43)
+      │    │    │    │    │    │         │    │    └── ($1, $4)
+      │    │    │    │    │    │         │    └── filters (true)
+      │    │    │    │    │    │         └── filters (true)
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         ├── instance_type_projects.deleted:22 = $2 [outer=(22), constraints=(/22: (/NULL - ]), fd=()-->(22)]
+      │    │    │    │    │         └── project_id:21 = $3 [outer=(21), constraints=(/21: (/NULL - ]), fd=()-->(21)]
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true:30 IS NOT NULL) [outer=(12,30)]
+      │    │    │    │         └── is_public:12 OR (instance_type_projects.instance_type_id:20 IS NOT NULL) [outer=(12,20)]
       │    │    │    └── $5
       │    │    └── $6
       │    └── filters
-      │         └── instance_type_extra_specs_1.deleted:37 = $7 [outer=(37), constraints=(/37: (/NULL - ]), fd=()-->(37)]
+      │         └── instance_type_extra_specs_1.deleted:36 = $7 [outer=(36), constraints=(/36: (/NULL - ]), fd=()-->(36)]
       └── filters (true)
 
 opt generic
@@ -2560,49 +2416,49 @@ from (select flavors.created_at as flavors_created_at,
      on flavor_extra_specs_1.flavor_id = anon_1.flavors_id
 ----
 project
- ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:34 flavor_extra_specs_1_updated_at:35 flavor_extra_specs_1_id:30 flavor_extra_specs_1_key:31 flavor_extra_specs_1_value:32 flavor_extra_specs_1_flavor_id:33
+ ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 flavor_extra_specs_1_created_at:33 flavor_extra_specs_1_updated_at:34 flavor_extra_specs_1_id:29 flavor_extra_specs_1_key:30 flavor_extra_specs_1_value:31 flavor_extra_specs_1_flavor_id:32
  ├── immutable, has-placeholder
- ├── key: (30)
- ├── fd: ()-->(1-12,14,15,33), (30)-->(31,32,34,35), (31)-->(30,32,34,35)
+ ├── key: (29)
+ ├── fd: ()-->(1-12,14,15,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
  └── left-join (lookup flavor_extra_specs [as=flavor_extra_specs_1])
-      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27 flavor_extra_specs_1.id:30 key:31 value:32 flavor_extra_specs_1.flavor_id:33 flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
-      ├── key columns: [30] = [30]
+      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
+      ├── key columns: [29] = [29]
       ├── lookup columns are key
       ├── immutable, has-placeholder
-      ├── key: (30)
-      ├── fd: ()-->(1-12,14,15,19,27,33), (30)-->(31,32,34,35), (31)-->(30,32,34,35)
+      ├── key: (29)
+      ├── fd: ()-->(1-12,14,15,19,20,32), (29)-->(30,31,33,34), (30)-->(29,31,33,34)
       ├── left-join (lookup flavor_extra_specs@flavor_extra_specs_flavor_id_key_idx [as=flavor_extra_specs_1])
-      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27 flavor_extra_specs_1.id:30 key:31 flavor_extra_specs_1.flavor_id:33
-      │    ├── key columns: [1] = [33]
+      │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20 flavor_extra_specs_1.id:29 key:30 flavor_extra_specs_1.flavor_id:32
+      │    ├── key columns: [1] = [32]
       │    ├── immutable, has-placeholder
-      │    ├── key: (30)
-      │    ├── fd: ()-->(1-12,14,15,19,27,33), (30)-->(31), (31)-->(30)
+      │    ├── key: (29)
+      │    ├── fd: ()-->(1-12,14,15,19,20,32), (29)-->(30), (30)-->(29)
       │    ├── limit
-      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+      │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── immutable, has-placeholder
       │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1-12,14,15,19,27)
+      │    │    ├── fd: ()-->(1-12,14,15,19,20)
       │    │    ├── offset
-      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+      │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
       │    │    │    ├── cardinality: [0 - 1]
       │    │    │    ├── has-placeholder
       │    │    │    ├── key: ()
-      │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
+      │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
       │    │    │    ├── select
-      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+      │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
       │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    ├── has-placeholder
       │    │    │    │    ├── key: ()
-      │    │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
+      │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
       │    │    │    │    ├── left-join (merge)
-      │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+      │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
       │    │    │    │    │    ├── left ordering: +1
       │    │    │    │    │    ├── right ordering: +19
       │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,27)
+      │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
       │    │    │    │    │    ├── project
       │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
@@ -2610,56 +2466,48 @@ project
       │    │    │    │    │    │    ├── key: ()
       │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
       │    │    │    │    │    │    └── inner-join (lookup flavors)
-      │    │    │    │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 "$2":38!null
+      │    │    │    │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 "$2":37!null
       │    │    │    │    │    │         ├── flags: disallow merge join
-      │    │    │    │    │    │         ├── key columns: [38] = [1]
+      │    │    │    │    │    │         ├── key columns: [37] = [1]
       │    │    │    │    │    │         ├── lookup columns are key
       │    │    │    │    │    │         ├── cardinality: [0 - 1]
       │    │    │    │    │    │         ├── has-placeholder
       │    │    │    │    │    │         ├── key: ()
-      │    │    │    │    │    │         ├── fd: ()-->(1-12,14,15,38), (38)==(1), (1)==(38)
+      │    │    │    │    │    │         ├── fd: ()-->(1-12,14,15,37), (37)==(1), (1)==(37)
       │    │    │    │    │    │         ├── values
-      │    │    │    │    │    │         │    ├── columns: "$2":38
+      │    │    │    │    │    │         │    ├── columns: "$2":37
       │    │    │    │    │    │         │    ├── cardinality: [1 - 1]
       │    │    │    │    │    │         │    ├── has-placeholder
       │    │    │    │    │    │         │    ├── key: ()
-      │    │    │    │    │    │         │    ├── fd: ()-->(38)
+      │    │    │    │    │    │         │    ├── fd: ()-->(37)
       │    │    │    │    │    │         │    └── ($2,)
       │    │    │    │    │    │         └── filters (true)
       │    │    │    │    │    ├── project
-      │    │    │    │    │    │    ├── columns: true:27!null flavor_projects.flavor_id:19!null
+      │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    ├── fd: ()-->(19,27)
-      │    │    │    │    │    │    ├── project
-      │    │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
-      │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │    ├── has-placeholder
-      │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │    │    │    ├── fd: ()-->(19,20)
-      │    │    │    │    │    │    │    └── inner-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
-      │    │    │    │    │    │    │         ├── columns: flavor_projects.flavor_id:19!null project_id:20!null "$1":39!null "$2":40!null
-      │    │    │    │    │    │    │         ├── flags: disallow merge join
-      │    │    │    │    │    │    │         ├── key columns: [40 39] = [19 20]
-      │    │    │    │    │    │    │         ├── lookup columns are key
-      │    │    │    │    │    │    │         ├── cardinality: [0 - 1]
-      │    │    │    │    │    │    │         ├── has-placeholder
-      │    │    │    │    │    │    │         ├── key: ()
-      │    │    │    │    │    │    │         ├── fd: ()-->(19,20,39,40), (39)==(20), (19)==(40), (40)==(19), (20)==(39)
-      │    │    │    │    │    │    │         ├── values
-      │    │    │    │    │    │    │         │    ├── columns: "$1":39 "$2":40
-      │    │    │    │    │    │    │         │    ├── cardinality: [1 - 1]
-      │    │    │    │    │    │    │         │    ├── has-placeholder
-      │    │    │    │    │    │    │         │    ├── key: ()
-      │    │    │    │    │    │    │         │    ├── fd: ()-->(39,40)
-      │    │    │    │    │    │    │         │    └── ($1, $2)
-      │    │    │    │    │    │    │         └── filters (true)
-      │    │    │    │    │    │    └── projections
-      │    │    │    │    │    │         └── true [as=true:27]
+      │    │    │    │    │    │    ├── fd: ()-->(19,20)
+      │    │    │    │    │    │    └── inner-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
+      │    │    │    │    │    │         ├── columns: flavor_projects.flavor_id:19!null project_id:20!null "$1":38!null "$2":39!null
+      │    │    │    │    │    │         ├── flags: disallow merge join
+      │    │    │    │    │    │         ├── key columns: [39 38] = [19 20]
+      │    │    │    │    │    │         ├── lookup columns are key
+      │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         ├── has-placeholder
+      │    │    │    │    │    │         ├── key: ()
+      │    │    │    │    │    │         ├── fd: ()-->(19,20,38,39), (38)==(20), (19)==(39), (39)==(19), (20)==(38)
+      │    │    │    │    │    │         ├── values
+      │    │    │    │    │    │         │    ├── columns: "$1":38 "$2":39
+      │    │    │    │    │    │         │    ├── cardinality: [1 - 1]
+      │    │    │    │    │    │         │    ├── has-placeholder
+      │    │    │    │    │    │         │    ├── key: ()
+      │    │    │    │    │    │         │    ├── fd: ()-->(38,39)
+      │    │    │    │    │    │         │    └── ($1, $2)
+      │    │    │    │    │    │         └── filters (true)
       │    │    │    │    │    └── filters (true)
       │    │    │    │    └── filters
-      │    │    │    │         └── is_public:12 OR (true:27 IS NOT NULL) [outer=(12,27)]
+      │    │    │    │         └── is_public:12 OR (flavor_projects.flavor_id:19 IS NOT NULL) [outer=(12,19)]
       │    │    │    └── $3
       │    │    └── $4
       │    └── filters (true)
@@ -2716,77 +2564,69 @@ from (select flavors.created_at as flavors_created_at,
 order by anon_1.flavors_flavorid asc, anon_1.flavors_id asc
 ----
 sort
- ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 anon_1_flavors_description:13 flavor_extra_specs_1_created_at:34 flavor_extra_specs_1_updated_at:35 flavor_extra_specs_1_id:30 flavor_extra_specs_1_key:31 flavor_extra_specs_1_value:32 flavor_extra_specs_1_flavor_id:33
+ ├── columns: anon_1_flavors_created_at:14 anon_1_flavors_updated_at:15 anon_1_flavors_id:1!null anon_1_flavors_name:2!null anon_1_flavors_memory_mb:3!null anon_1_flavors_vcpus:4!null anon_1_flavors_root_gb:5 anon_1_flavors_ephemeral_gb:6 anon_1_flavors_flavorid:7!null anon_1_flavors_swap:8!null anon_1_flavors_rxtx_factor:9 anon_1_flavors_vcpu_weight:10 anon_1_flavors_disabled:11 anon_1_flavors_is_public:12 anon_1_flavors_description:13 flavor_extra_specs_1_created_at:33 flavor_extra_specs_1_updated_at:34 flavor_extra_specs_1_id:29 flavor_extra_specs_1_key:30 flavor_extra_specs_1_value:31 flavor_extra_specs_1_flavor_id:32
  ├── immutable, has-placeholder
- ├── key: (1,30)
- ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), (30)-->(31-35), (31,33)-->(30,32,34,35)
+ ├── key: (1,29)
+ ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), (29)-->(30-34), (30,32)-->(29,31,33,34)
  ├── ordering: +7
  └── project
-      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:30 key:31 value:32 flavor_extra_specs_1.flavor_id:33 flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
+      ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
       ├── immutable, has-placeholder
-      ├── key: (1,30)
-      ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), (30)-->(31-35), (31,33)-->(30,32,34,35)
+      ├── key: (1,29)
+      ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15), (29)-->(30-34), (30,32)-->(29,31,33,34)
       └── right-join (hash)
-           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27 flavor_extra_specs_1.id:30 key:31 value:32 flavor_extra_specs_1.flavor_id:33 flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
+           ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20 flavor_extra_specs_1.id:29 key:30 value:31 flavor_extra_specs_1.flavor_id:32 flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
            ├── immutable, has-placeholder
-           ├── key: (1,30)
-           ├── fd: (1)-->(2-15,19,27), (7)-->(1-6,8-15), (2)-->(1,3-15), (30)-->(31-35), (31,33)-->(30,32,34,35)
+           ├── key: (1,29)
+           ├── fd: (1)-->(2-15,19,20), (7)-->(1-6,8-15), (2)-->(1,3-15), (29)-->(30-34), (30,32)-->(29,31,33,34)
            ├── scan flavor_extra_specs [as=flavor_extra_specs_1]
-           │    ├── columns: flavor_extra_specs_1.id:30!null key:31!null value:32 flavor_extra_specs_1.flavor_id:33!null flavor_extra_specs_1.created_at:34 flavor_extra_specs_1.updated_at:35
-           │    ├── key: (30)
-           │    └── fd: (30)-->(31-35), (31,33)-->(30,32,34,35)
+           │    ├── columns: flavor_extra_specs_1.id:29!null key:30!null value:31 flavor_extra_specs_1.flavor_id:32!null flavor_extra_specs_1.created_at:33 flavor_extra_specs_1.updated_at:34
+           │    ├── key: (29)
+           │    └── fd: (29)-->(30-34), (30,32)-->(29,31,33,34)
            ├── limit
-           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+           │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
            │    ├── internal-ordering: +7
            │    ├── immutable, has-placeholder
            │    ├── key: (1)
-           │    ├── fd: (1)-->(2-15,19,27), (7)-->(1-6,8-15), (2)-->(1,3-15)
+           │    ├── fd: (1)-->(2-15,19,20), (7)-->(1-6,8-15), (2)-->(1,3-15)
            │    ├── sort
-           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+           │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
            │    │    ├── has-placeholder
            │    │    ├── key: (1)
-           │    │    ├── fd: (1)-->(2-15,19,27), (7)-->(1-6,8-15), (2)-->(1,3-15)
+           │    │    ├── fd: (1)-->(2-15,19,20), (7)-->(1-6,8-15), (2)-->(1,3-15)
            │    │    ├── ordering: +7
            │    │    └── select
-           │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+           │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
            │    │         ├── has-placeholder
            │    │         ├── key: (1)
-           │    │         ├── fd: (1)-->(2-15,19,27), (7)-->(1-6,8-15), (2)-->(1,3-15)
+           │    │         ├── fd: (1)-->(2-15,19,20), (7)-->(1-6,8-15), (2)-->(1,3-15)
            │    │         ├── left-join (merge)
-           │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 true:27
+           │    │         │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15 flavor_projects.flavor_id:19 project_id:20
            │    │         │    ├── left ordering: +1
            │    │         │    ├── right ordering: +19
            │    │         │    ├── has-placeholder
            │    │         │    ├── key: (1)
-           │    │         │    ├── fd: (1)-->(2-15,19,27), (7)-->(1-6,8-15), (2)-->(1,3-15)
+           │    │         │    ├── fd: (1)-->(2-15,19,20), (7)-->(1-6,8-15), (2)-->(1,3-15)
            │    │         │    ├── scan flavors
            │    │         │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 description:13 flavors.created_at:14 flavors.updated_at:15
            │    │         │    │    ├── key: (1)
            │    │         │    │    ├── fd: (1)-->(2-15), (7)-->(1-6,8-15), (2)-->(1,3-15)
            │    │         │    │    └── ordering: +1
-           │    │         │    ├── project
-           │    │         │    │    ├── columns: true:27!null flavor_projects.flavor_id:19!null
+           │    │         │    ├── select
+           │    │         │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
            │    │         │    │    ├── has-placeholder
            │    │         │    │    ├── key: (19)
-           │    │         │    │    ├── fd: ()-->(27)
-           │    │         │    │    ├── ordering: +19 opt(27) [actual: +19]
-           │    │         │    │    ├── select
+           │    │         │    │    ├── fd: ()-->(20)
+           │    │         │    │    ├── ordering: +19 opt(20) [actual: +19]
+           │    │         │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
            │    │         │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
-           │    │         │    │    │    ├── has-placeholder
-           │    │         │    │    │    ├── key: (19)
-           │    │         │    │    │    ├── fd: ()-->(20)
-           │    │         │    │    │    ├── ordering: +19 opt(20) [actual: +19]
-           │    │         │    │    │    ├── scan flavor_projects@flavor_projects_flavor_id_project_id_key
-           │    │         │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
-           │    │         │    │    │    │    ├── key: (19,20)
-           │    │         │    │    │    │    └── ordering: +19
-           │    │         │    │    │    └── filters
-           │    │         │    │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
-           │    │         │    │    └── projections
-           │    │         │    │         └── true [as=true:27]
+           │    │         │    │    │    ├── key: (19,20)
+           │    │         │    │    │    └── ordering: +19
+           │    │         │    │    └── filters
+           │    │         │    │         └── project_id:20 = $1 [outer=(20), constraints=(/20: (/NULL - ]), fd=()-->(20)]
            │    │         │    └── filters (true)
            │    │         └── filters
-           │    │              └── is_public:12 OR (true:27 IS NOT NULL) [outer=(12,27)]
+           │    │              └── is_public:12 OR (flavor_projects.flavor_id:19 IS NOT NULL) [outer=(12,19)]
            │    └── $2
            └── filters
-                └── flavor_extra_specs_1.flavor_id:33 = flavors.id:1 [outer=(1,33), constraints=(/1: (/NULL - ]; /33: (/NULL - ]), fd=(1)==(33), (33)==(1)]
+                └── flavor_extra_specs_1.flavor_id:32 = flavors.id:1 [outer=(1,32), constraints=(/1: (/NULL - ]; /32: (/NULL - ]), fd=(1)==(32), (32)==(1)]


### PR DESCRIPTION
#### opt: improve EnsureKey custom function

This commit makes a small improvement to the `EnsureKey` custom function
(used in decorrelation rules), so that it can add passthrough columns to
a `Project` operator in an effort to find a key. This can prevent rules
from adding unnecessary `Ordinality` operators to the query plan.

Epic: None

Release note: None

#### opt: improve exists subquery hoisting

This commit makes a small improvement to the subquery-hoisting rules so
that hoisting an `EXISTS` subquery can often avoid projecting a new
column to check for NULL values. This can allow other optimization rules
to match later on.

Epic: None

Release note: None

#### opt: add rule to decorrelate unions in EXISTS subqueries

This commit adds a new rule `TryDecorrelateUnion`, which matches on a
`Union` or `UnionAll` operator in the input of a `ScalarGroupBy`. The
`ScalarGroupBy` must have "any-not-null" semantics, meaning it produces
an arbitrary non-null value from each input column.

If these conditions are satisfied, the `Union` operator is replaced by an
`InnerJoin` between two `ScalarGroupBy` operators. A `Project` coalesces
columns from each side of the join to produce the final aggregated values.

This transformation does not itself decorrelate the `Union` operators, but
it does make it easier for other rules to do so.

Release note: None

Epic: None