### PR TITLE
ldapccl: fix LDAP cluster settings callback

### DIFF
--- a/pkg/ccl/ldapccl/ldap_manager.go
+++ b/pkg/ccl/ldapccl/ldap_manager.go
@@ -170,6 +170,12 @@ var ConfigureLDAPAuth = func(
 	LDAPDomainCACertificate.SetOnChange(&st.SV, func(ctx context.Context) {
 		authManager.reloadConfig(ambientCtx.AnnotateCtx(ctx), st)
 	})
+	LDAPClientTLSCertSetting.SetOnChange(&st.SV, func(ctx context.Context) {
+		authManager.reloadConfig(ambientCtx.AnnotateCtx(ctx), st)
+	})
+	LDAPClientTLSKeySetting.SetOnChange(&st.SV, func(ctx context.Context) {
+		authManager.reloadConfig(ambientCtx.AnnotateCtx(ctx), st)
+	})
 	return &authManager
 }
 


### PR DESCRIPTION
**ldapccl: fix LDAP cluster settings callback**

Epic CRDB-33829

Release note(security, ops): Cluster settings for LDAP cluster settings `server.ldap_authentication.client.tls_certificate` and `server.ldap_authentication.client.tls_key` don't have callbacks installed to reload the settings value for LDAP authManager. This change fixes this by adding the necessary callbacks.