### PR TITLE
cloud/amazon: test kms against mock server

### DIFF
--- a/pkg/cloud/amazon/BUILD.bazel
+++ b/pkg/cloud/amazon/BUILD.bazel
@@ -61,6 +61,7 @@ go_test(
         "//pkg/cloud/cloudpb",
         "//pkg/cloud/cloudtestutils",
         "//pkg/security/username",
+        "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/testutils",
         "//pkg/testutils/skip",


### PR DESCRIPTION
Release note: none.
Epic: none.