### PR TITLE
roachtest: prevent leaked goroutine in mvccgc roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/mvcc_gc.go
+++ b/pkg/cmd/roachtest/tests/mvcc_gc.go
@@ -138,7 +138,7 @@ func runMVCCGC(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 		wlCtx, wlCancel := context.WithCancel(ctx)
 		defer wlCancel()
-		wlFailure := make(chan error)
+		wlFailure := make(chan error, 1)
 		go func() {
 			defer close(wlFailure)
 			cmd = roachtestutil.NewCommand("./cockroach workload run kv").


### PR DESCRIPTION
Noticed while looking at the artifacts for an unrelated
test failure:

```
goroutine 686898 [chan send, 446 minutes]:
github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests.runMVCCGC.func3.1()
        github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests/mvcc_gc.go:153 +0x85e
created by github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests.runMVCCGC.func3 in goroutine 686834
        github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests/mvcc_gc.go:142 +0x689
```

This is because the test doesn't consume from this unbuffered channel on success,
thereby leaking the worker goroutine forever.

Making the result channel 1-buffered avoids this problem.

Epic: none
Release note: None
