### PR TITLE
crosscluster/logical: don't erroneously log warnings

### DIFF
--- a/pkg/ccl/crosscluster/logical/logical_replication_job.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job.go
@@ -211,7 +211,7 @@ func (r *logicalReplicationResumer) ingest(
 	execPlan := func(ctx context.Context) error {
 
 		metaFn := func(_ context.Context, meta *execinfrapb.ProducerMetadata) error {
-			log.Warningf(ctx, "received unexpected producer meta: %v", meta)
+			log.VInfof(ctx, 2, "received producer meta: %v", meta)
 			return nil
 		}
 		rh := rowHandler{


### PR DESCRIPTION
We expect processors to send producer metas on shutdown.

Release note: None
Epic: none