### PR TITLE
sql: support SHOW TYPES WITH COMMENT

### DIFF
--- a/docs/generated/sql/bnf/show_types_stmt.bnf
+++ b/docs/generated/sql/bnf/show_types_stmt.bnf
@@ -1,2 +1,2 @@
 show_types_stmt ::=
-	'SHOW' 'TYPES'
+	'SHOW' 'TYPES' with_comment

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -842,7 +842,7 @@ show_external_connections_stmt ::=
 	| 'SHOW' 'EXTERNAL' 'CONNECTION' string_or_placeholder
 
 show_types_stmt ::=
-	'SHOW' 'TYPES'
+	'SHOW' 'TYPES' with_comment
 
 show_functions_stmt ::=
 	'SHOW' 'FUNCTIONS' 'FROM' name '.' name

--- a/pkg/sql/delegate/delegate.go
+++ b/pkg/sql/delegate/delegate.go
@@ -58,7 +58,7 @@ func TryDelegate(
 		return d.delegateShowEnums(t)
 
 	case *tree.ShowTypes:
-		return d.delegateShowTypes()
+		return d.delegateShowTypes(t)
 
 	case *tree.ShowCreate:
 		return d.delegateShowCreate(t)

--- a/pkg/sql/delegate/show_types.go
+++ b/pkg/sql/delegate/show_types.go
@@ -14,11 +14,31 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 )
 
-func (d *delegator) delegateShowTypes() (tree.Statement, error) {
+func (d *delegator) delegateShowTypes(n *tree.ShowTypes) (tree.Statement, error) {
+
+	dbName := lexbase.EscapeSQLIdent(d.evalCtx.SessionData().Database)
+	commentColumn, commentJoin := ``, ``
+	if n.WithComment {
+		commentColumn = `, comment`
+		commentJoin = fmt.Sprintf(`
+			LEFT JOIN
+				(
+					SELECT 
+						objoid, description as comment
+					FROM
+						%s.pg_catalog.pg_description
+					WHERE
+						classoid = %d
+				) c
+			ON
+				 	(types.oid::int - 100000) = c.objoid`, dbName, catconstants.PgCatalogTypeTableID)
+	}
+
 	// Query all enum and composite types. Two explanations about the WHERE
 	// clause we use:
 	// - we filter out types defined in internally generated namespaces so that
@@ -30,16 +50,17 @@ func (d *delegator) delegateShowTypes() (tree.Statement, error) {
 SELECT
 	nsp.nspname AS schema,
 	types.typname AS name,
-	rl.rolname AS owner
+	rl.rolname AS owner %[2]s
 FROM
 	%[1]s.pg_catalog.pg_type AS types
 	LEFT JOIN %[1]s.pg_catalog.pg_roles AS rl on (types.typowner = rl.oid)
 	JOIN %[1]s.pg_catalog.pg_namespace AS nsp ON (types.typnamespace = nsp.oid)
+	%[3]s
 WHERE types.typtype IN ('e','c') AND
       types.typrelid IN (0, types.oid) AND
       nsp.nspname NOT IN ('information_schema', 'pg_catalog', 'crdb_internal', 'pg_extension')
 ORDER BY (nsp.nspname, types.typname)
-`, lexbase.EscapeSQLIdent(d.evalCtx.SessionData().Database))
+`, dbName, commentColumn, commentJoin)
 	return d.parse(query)
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/comment_on
+++ b/pkg/sql/logictest/testdata/logic_test/comment_on
@@ -345,6 +345,15 @@ type  object_id  sub_id  comment
 
 skipif config local-legacy-schema-changer
 skipif config local-mixed-24.1
+query TTTT colnames,rowsort
+SHOW TYPES WITH COMMENT
+----
+schema  name             owner  comment
+public  roach_dwellings  root   First-CRDB-comment-on-types-again
+public  roach_legs       root   Second-CRDB-comment-on-types-again
+
+skipif config local-legacy-schema-changer
+skipif config local-mixed-24.1
 statement ok
 COMMENT ON TYPE roach_dwellings IS NULL;
 
@@ -352,6 +361,15 @@ skipif config local-legacy-schema-changer
 skipif config local-mixed-24.1
 statement ok
 COMMENT ON TYPE roach_legs IS NULL;
+
+skipif config local-legacy-schema-changer
+skipif config local-mixed-24.1
+query TTTT colnames,rowsort
+SHOW TYPES WITH COMMENT
+----
+schema  name             owner  comment
+public  roach_dwellings  root   NULL
+public  roach_legs       root   NULL
 
 skipif config local-legacy-schema-changer
 skipif config local-mixed-24.1

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -8624,11 +8624,11 @@ show_external_connections_stmt:
 
 // %Help: SHOW TYPES - list user defined types
 // %Category: Misc
-// %Text: SHOW TYPES
+// %Text: SHOW TYPES [WITH_COMMENT]
 show_types_stmt:
-  SHOW TYPES
+  SHOW TYPES with_comment
   {
-    $$.val = &tree.ShowTypes{}
+    $$.val = &tree.ShowTypes{WithComment: $3.bool()}
   }
 | SHOW TYPES error // SHOW HELP: SHOW TYPES
 

--- a/pkg/sql/parser/testdata/show
+++ b/pkg/sql/parser/testdata/show
@@ -327,12 +327,28 @@ SHOW TYPES -- literals removed
 SHOW TYPES -- identifiers removed
 
 parse
+SHOW TYPES WITH COMMENT
+----
+SHOW TYPES WITH COMMENT
+SHOW TYPES WITH COMMENT -- fully parenthesized
+SHOW TYPES WITH COMMENT -- literals removed
+SHOW TYPES WITH COMMENT -- identifiers removed
+
+parse
 EXPLAIN SHOW TYPES
 ----
 EXPLAIN SHOW TYPES
 EXPLAIN SHOW TYPES -- fully parenthesized
 EXPLAIN SHOW TYPES -- literals removed
 EXPLAIN SHOW TYPES -- identifiers removed
+
+parse
+EXPLAIN SHOW TYPES WITH COMMENT
+----
+EXPLAIN SHOW TYPES WITH COMMENT
+EXPLAIN SHOW TYPES WITH COMMENT -- fully parenthesized
+EXPLAIN SHOW TYPES WITH COMMENT -- literals removed
+EXPLAIN SHOW TYPES WITH COMMENT -- identifiers removed
 
 parse
 SHOW SCHEMAS

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -408,11 +408,17 @@ func (node *ShowEnums) Format(ctx *FmtCtx) {
 }
 
 // ShowTypes represents a SHOW TYPES statement.
-type ShowTypes struct{}
+type ShowTypes struct {
+	WithComment bool
+}
 
 // Format implements the NodeFormatter interface.
 func (node *ShowTypes) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW TYPES")
+
+	if node.WithComment {
+		ctx.WriteString(" WITH COMMENT")
+	}
 }
 
 // ShowTraceType is an enum of SHOW TRACE variants.


### PR DESCRIPTION
Previously SHOW TYPES WITH COMMENT were missing
for show types, this is inconsistent with show databases and show tables. The code changes in this PR make show types work similar to show tables and show databases.

```
roachprod@localhost:29000/defaultdb> show types with comment;                                                                     
  schema |      name       |   owner   |              comment
---------+-----------------+-----------+-------------------------------------
  public | roach_dwellings | roachprod | First-CRDB-comment-on-types-again
  public | roach_legs      | roachprod | Second-CRDB-comment-on-types-again
  public | test_sajain     | roachprod | test
(3 rows)

```

**Approach:**
`pg_dewcription` table shows the comments and we can use `catconstants.PgCatalogTypeTableID` (enum 4294966974) to filter out comments on type.
```
roachprod@localhost:29000/defaultdb> select * from pg_catalog.pg_description where classoid = 4294966974;                                                
  objoid  |    classoid  |              description
---------+---------------+---------------------------------------------
 116    |      4294966974 | First-CRDB-comment-on-types-again
 118    |      4294966974 | Second-CRDB-comment-on-types-again
 120    |      4294966974 | test
(3 rows)

Time: 4ms total (execution 3ms / network 1ms)
```

And `pg_type` table stores type data as
```
roachprod@localhost:29000/defaultdb> select oid, typname, typowner, typnamespace from pg_type where typname in ('roach_legs',     
                                  -> 'roach_dwellings', 'test_sajain');                                                           
   oid   |     typname     |  typowner  | typnamespace
---------+-----------------+------------+---------------
  100116 | roach_dwellings | 2200414634 |          101
  100118 | roach_legs      | 2200414634 |          101
  100120 | test_sajain     | 2200414634 |          101
(3 rows)

Time: 11ms total (execution 10ms / network 1ms)
```

The correlation b/w the above tables in that the `object_id` of the comments table is 100000 more than the respective `oid` in the `pg_type` table. Hence this change uses this criteria to join the comments table.

Release note (sql change): Added SHOW TYPES WITH COMMENT functionality similar to show schemas, show databases and show tables;
Fixes: https://github.com/cockroachdb/cockroach/issues/126009