### PR TITLE
release-23.1: insights: fix flaky insights test

### DIFF
--- a/pkg/sql/sqlstats/insights/integration/insights_test.go
+++ b/pkg/sql/sqlstats/insights/integration/insights_test.go
@@ -668,11 +668,6 @@ func TestInsightsIntegrationForContention(t *testing.T) {
 				continue
 			}
 
-			if waitingTxnFingerprintID == "0000000000000000" || waitingTxnFingerprintID == "" {
-				lastErr = fmt.Errorf("waitingTxnFingerprintID is default value\n%s", prettyPrintRow)
-				continue
-			}
-
 			foundRow = true
 			break
 		}


### PR DESCRIPTION
This test is flaky because the async tagging of the TransactionId to the insight sometimes takes a long time to complete. This issue has been seen in other branches and the code has been removed.

To fix, the code which is testing the value of waitingTxnFingerprintID has been removed.

For reference, the PR in merged into master is https://github.com/cockroachdb/cockroach/pull/126524

Resolves: #130348
Release note: None