### PR TITLE
release-24.1: ccl/oidcccl: TestOIDCEnabled failed under stress

### DIFF
--- a/pkg/ccl/oidcccl/authentication_oidc_test.go
+++ b/pkg/ccl/oidcccl/authentication_oidc_test.go
@@ -123,17 +123,18 @@ func TestOIDCEnabled(t *testing.T) {
 		NewOIDCManager = realNewManager
 	}()
 
-	// Set minimum settings to successfully enable the OIDC client
 	sqlDB := sqlutils.MakeSQLRunner(db)
 	sqlDB.Exec(t, fmt.Sprintf(`CREATE USER %s with password 'unused'`, usernameUnderTest))
-	sqlDB.Exec(t, `SET CLUSTER SETTING server.oidc_authentication.provider_url = "providerURL"`)
-	sqlDB.Exec(t, `SET CLUSTER SETTING server.oidc_authentication.client_id = "fake_client_id"`)
-	sqlDB.Exec(t, `SET CLUSTER SETTING server.oidc_authentication.client_secret = "fake_client_secret"`)
-	sqlDB.Exec(t, `SET CLUSTER SETTING server.oidc_authentication.redirect_url = "https://cockroachlabs.com/oidc/v1/callback"`)
-	sqlDB.Exec(t, `set cluster setting server.oidc_authentication.claim_json_key = "email"`)
-	sqlDB.Exec(t, `set cluster setting server.oidc_authentication.principal_regex = '^([^@]+)@[^@]+$'`)
-	sqlDB.Exec(t, fmt.Sprintf(`SET CLUSTER SETTING server.http.base_path = "%s"`, basePath))
-	sqlDB.Exec(t, `SET CLUSTER SETTING server.oidc_authentication.enabled = "true"`)
+
+	// Set minimum settings to successfully enable the OIDC client
+	OIDCProviderURL.Override(ctx, &s.ClusterSettings().SV, "providerURL")
+	OIDCClientID.Override(ctx, &s.ClusterSettings().SV, "fake_client_id")
+	OIDCClientSecret.Override(ctx, &s.ClusterSettings().SV, "fake_client_secret")
+	OIDCRedirectURL.Override(ctx, &s.ClusterSettings().SV, "https://cockroachlabs.com/oidc/v1/callback")
+	OIDCClaimJSONKey.Override(ctx, &s.ClusterSettings().SV, "email")
+	OIDCPrincipalRegex.Override(ctx, &s.ClusterSettings().SV, "^([^@]+)@[^@]+$")
+	server.ServerHTTPBasePath.Override(ctx, &s.ClusterSettings().SV, basePath)
+	OIDCEnabled.Override(ctx, &s.ClusterSettings().SV, true)
 
 	testCertsContext := s.NewClientRPCContext(ctx, username.TestUserName())
 	client, err := testCertsContext.GetHTTPClient()


### PR DESCRIPTION
Backport 1/1 commits from #131180.

/cc @cockroachdb/release

---

TestOIDCEnabled used to update the OIDC related cluster settings via SQL. This takes time to get reflected within the application handler and flakes the test under stress.

Updated the unit test to directly override cluster setting values within the application.

Fixes: #130637

Release note: None

---

Release justification: The test failure occurred on 23.2, hence backporting to subsequent releases.