### PR TITLE
sql/catalog/bootstrap: don't call PrefixEnd on tenant start key

### DIFF
--- a/pkg/sql/catalog/bootstrap/bootstrap_test.go
+++ b/pkg/sql/catalog/bootstrap/bootstrap_test.go
@@ -103,11 +103,11 @@ func TestRoundTripInitialValuesStringRepresentation(t *testing.T) {
 		roundTripInitialValuesStringRepresentation(t, 0 /* tenantID */)
 	})
 	t.Run("tenant", func(t *testing.T) {
-		const dummyTenantID = 54321
+		const dummyTenantID = 109
 		roundTripInitialValuesStringRepresentation(t, dummyTenantID)
 	})
 	t.Run("tenants", func(t *testing.T) {
-		const dummyTenantID1, dummyTenantID2 = 54321, 12345
+		const dummyTenantID1, dummyTenantID2 = 109, 255
 		require.Equal(t,
 			InitialValuesToString(makeMetadataSchema(dummyTenantID1)),
 			InitialValuesToString(makeMetadataSchema(dummyTenantID2)),

--- a/pkg/sql/catalog/bootstrap/metadata.go
+++ b/pkg/sql/catalog/bootstrap/metadata.go
@@ -326,7 +326,7 @@ func InitialValuesFromString(
 	}
 	// Add back the filtered out tenant end key.
 	if !codec.ForSystemTenant() {
-		splits = append(splits, roachpb.RKey(p.PrefixEnd()))
+		splits = append(splits, roachpb.RKey(codec.TenantEndKey()))
 	}
 	return kvs, splits, nil
 }


### PR DESCRIPTION
KVServer expects that split keys have a valid tenant prefix. Calling PrefixEnd() on the start key to a tenant does not produce a valid key as the tenant ID is encoded as a varint.

Epic: none
Release note: None