### PR TITLE
release-24.2: ldapccl: fix LDAP cluster settings callback

### DIFF
--- a/pkg/ccl/ldapccl/authentication_ldap.go
+++ b/pkg/ccl/ldapccl/authentication_ldap.go
@@ -270,6 +270,12 @@ var ConfigureLDAPAuth = func(
 	LDAPDomainCACertificate.SetOnChange(&st.SV, func(ctx context.Context) {
 		authenticator.reloadConfig(ambientCtx.AnnotateCtx(ctx), st)
 	})
+	LDAPClientTLSCertSetting.SetOnChange(&st.SV, func(ctx context.Context) {
+		authenticator.reloadConfig(ambientCtx.AnnotateCtx(ctx), st)
+	})
+	LDAPClientTLSKeySetting.SetOnChange(&st.SV, func(ctx context.Context) {
+		authenticator.reloadConfig(ambientCtx.AnnotateCtx(ctx), st)
+	})
 	return &authenticator
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #131151.

/cc @cockroachdb/release

---

**ldapccl: fix LDAP cluster settings callback**

Epic CRDB-33829

Release note(security, ops): Cluster settings for LDAP cluster settings `server.ldap_authentication.client.tls_certificate` and `server.ldap_authentication.client.tls_key` don't have callbacks installed to reload the settings value for LDAP authManager. This change fixes this by adding the necessary callbacks.

Release justification: this fix is needed as current LDAP cluster settings initialization in broken.
