### PR TITLE
sql: internal error with BUCKET_COUNT = NULL

### DIFF
--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -285,6 +285,10 @@ func EvalShardBucketCount(
 		if paramVal != nil {
 			shardBuckets = paramVal
 		}
+		// Check if shardBuckets is NULL
+		if shardBuckets == tree.DNull {
+			return 0, pgerror.Newf(pgcode.InvalidParameterValue, invalidBucketCountMsg, "NULL")
+		}
 		typedExpr, err := schemaexpr.SanitizeVarFreeExpr(
 			ctx, shardBuckets, types.Int, "BUCKET_COUNT", semaCtx, volatility.Volatile, false, /*allowAssignmentCast*/
 		)

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -739,6 +739,10 @@ CREATE TABLE t_bad_param (
   a INT PRIMARY KEY USING HASH WITH BUCKET_COUNT = 5 WITH (bucket_count=5)
 );
 
+statement error pq: hash sharded index bucket count must be in range \[2, 2048\], got NULL
+CREATE TABLE t_bad_param (
+  a INT PRIMARY KEY USING HASH WITH BUCKET_COUNT = NULL
+);
 
 statement error pq: invalid storage param "s2_max_level" on primary key
 CREATE TABLE t_bad_param (


### PR DESCRIPTION
Previously, the `EvalShardBucketCount` function did not properly handle the case where `BUCKET_COUNT` was set to `NULL`, causing evaluation errors. This change adds explicit handling for `NULL` values, ensuring that `BUCKET_COUNT` cannot be set to `NULL` and returns an appropriate error message.

Epic: none
Fixes: #130353
Release note: None