### PR TITLE
roachprod, aws: simplify zone distribution logic

### DIFF
--- a/pkg/roachprod/vm/aws/config.go
+++ b/pkg/roachprod/vm/aws/config.go
@@ -108,16 +108,6 @@ func (c *awsConfig) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (c *awsConfig) getRegion(name string) *AWSRegion {
-	i := sort.Search(len(c.Regions), func(i int) bool {
-		return c.Regions[i].Name >= name
-	})
-	if i < len(c.Regions) && c.Regions[i].Name == name {
-		return &c.Regions[i]
-	}
-	return nil
-}
-
 func (c *awsConfig) regionNames() (names []string) {
 	for _, r := range c.Regions {
 		names = append(names, r.Name)


### PR DESCRIPTION
Previously when creating a non geo aws cluster, roachprod would attempt to default to the first region passed in, and randomize the availabilty zone if multiple were specified.

One minor side effect of this is that users would pass in multiple zones to `--aws-zones`, expecting it to create a geo-distributed cluster. This would fail and only one zone would be used unless the `--geo` flag was also used. This contradicts the help message of aws-zones which states 'the cluster will be spread out evenly by zone regardless of geo'.

This change removes the logic to randomize availabilty zones for non geo clusters, and brings it in line with other clouds.

Fixes: none
Epic: none
Release note: none