### PR TITLE
backupccl: fill incremental cluster id on alter schedule

### DIFF
--- a/pkg/ccl/backupccl/alter_backup_schedule_test.go
+++ b/pkg/ccl/backupccl/alter_backup_schedule_test.go
@@ -158,5 +158,42 @@ INSERT INTO t1 values (1), (10), (100);
 
 	rows = th.sqlDB.QueryStr(t, fmt.Sprintf(`ALTER BACKUP SCHEDULE %d EXECUTE IMMEDIATELY;`, scheduleID))
 	require.Equal(t, trim(th.env.Now().String()), trim(rows[0][3]))
+}
 
+func TestAlterBackupScheduleSetsIncrementalClusterID(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	th, cleanup := newAlterSchedulesTestHelper(t, nil)
+	defer cleanup()
+
+	rows := th.sqlDB.QueryStr(
+		t,
+		`CREATE SCHEDULE FOR BACKUP INTO 'nodelocal://1/backup/alter-schedule' RECURRING '@daily' FULL BACKUP ALWAYS;`,
+	)
+	require.Len(t, rows, 1)
+	scheduleID, err := strconv.Atoi(rows[0][0])
+	require.NoError(t, err)
+
+	// Artificially remove cluster ID from full backup to simulate pre-23.2 schedule.
+	th.sqlDB.QueryStr(
+		t,
+		fmt.Sprintf(`UPDATE system.scheduled_jobs
+			SET
+			schedule_details = crdb_internal.json_to_pb(
+				'cockroach.jobs.jobspb.ScheduleDetails',
+				json_remove_path(
+					crdb_internal.pb_to_json('cockroach.jobs.jobspb.ScheduleDetails', schedule_details),
+					ARRAY['clusterId']
+				)
+			)
+			WHERE schedule_id=%d;`, scheduleID),
+	)
+
+	// Ensure creating incremental from a full backup schedule without a cluster ID passes
+	rows = th.sqlDB.QueryStr(t, fmt.Sprintf(
+		`ALTER BACKUP SCHEDULE %d SET RECURRING '@hourly', SET FULL BACKUP '@daily'`,
+		scheduleID),
+	)
+	require.Len(t, rows, 2)
 }


### PR DESCRIPTION
When altering the recurrence of a singleton full backup schedule created before v23.2, the corresponding new incremental schedule creation will fail due to a missing cluster ID. This patch ensures that the cluster ID is set when creating the incremental.

Fixes: #131127

Release note (bug fix): Fixed a bug introduced in v23.2.0 where creating a new incremental schedule via `ALTER SCHEDULE` on a full backup schedule created on an older version would fail.