### PR TITLE
release-23.2: roachtest, teamcity: publish runner logs to same directory

### DIFF
--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -321,6 +321,14 @@ var (
 		Name:  "global-seed",
 		Usage: `The global random seed used for all tests.`,
 	})
+
+	AlwaysCollectArtifacts bool = false
+	_                           = registerRunFlag(&AlwaysCollectArtifacts, FlagInfo{
+		Name: "always-collect-artifacts",
+		Usage: `
+						Always collect artifacts during test teardown, even if the test did not
+						time out or fail.`,
+	})
 )
 
 // The flags below override the final cluster configuration. They have no

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -167,7 +167,7 @@ func runTests(register func(registry.Registry), filter *registry.TestFilter) err
 
 	if roachtestflags.TeamCity {
 		// Collect the runner logs.
-		fmt.Printf("##teamcity[publishArtifacts '%s']\n", filepath.Join(literalArtifactsDir, runnerLogsDir))
+		fmt.Printf("##teamcity[publishArtifacts '%s' => '%s']\n", filepath.Join(literalArtifactsDir, runnerLogsDir), runnerLogsDir)
 	}
 	return err
 }

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1297,7 +1297,7 @@ func (r *testRunner) postTestAssertions(
 func (r *testRunner) teardownTest(
 	ctx context.Context, t *testImpl, c *clusterImpl, timedOut bool,
 ) error {
-	if timedOut || t.Failed() {
+	if timedOut || t.Failed() || roachtestflags.AlwaysCollectArtifacts {
 		err := r.collectArtifacts(ctx, t, c, timedOut, time.Hour)
 		if err != nil {
 			t.L().Printf("error collecting artifacts: %v", err)


### PR DESCRIPTION
Backport 2/2 commits from #130963.

/cc @cockroachdb/release

---

Previously we would publish the runner logs to the top level directory, causing it to be hard to find. This change publishes them to their own directory.

Fixes: #125298
Epic: none
Release note: none
