### PR TITLE
cluster-ui: populate db name in v2 db details page and add breadcrumbs

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/databaseIdsToNamesApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databaseIdsToNamesApi.ts
@@ -1,0 +1,56 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { useMemo } from "react";
+import useSWR from "swr";
+import useSWRImmutable from "swr/immutable";
+
+import { executeInternalSql } from "./sqlApi";
+
+// This call is issued if we don't have the current db id in the cache.
+const getDatabases = `SELECT id, name FROM crdb_internal.databases`;
+
+type DatabaseNameRow = {
+  id: number;
+  name: string;
+};
+
+const fetchDbIdsToNames = async () =>
+  executeInternalSql<DatabaseNameRow>({
+    statements: [{ sql: getDatabases }],
+    execute: true,
+  });
+
+export const useDbIdToName = (id: number) => {
+  const { data, isLoading, error } = useSWRImmutable(
+    `dbIdsToNames`,
+    fetchDbIdsToNames,
+  );
+
+  const idsToName = useMemo(() => {
+    const idsToName = new Map<number, string>();
+    if (!data?.execution?.txn_results?.length) {
+      return idsToName;
+    }
+
+    data.execution.txn_results[0].rows.forEach(row => {
+      idsToName.set(row.id, row.name);
+    });
+    return idsToName;
+  }, [data]);
+
+  const name = idsToName.get(id);
+
+  return {
+    name,
+    isLoading: isLoading && !name,
+    error: !name ? error : null,
+  };
+};

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/index.tsx
@@ -11,7 +11,9 @@
 import { Tabs } from "antd";
 import React, { useState } from "react";
 
+import { useDbIdToName } from "src/api/databaseIdsToNamesApi";
 import { commonStyles } from "src/common";
+import { useRouteParams } from "src/hooks/useRouteParams";
 import { PageLayout } from "src/layouts";
 import { PageHeader } from "src/sharedFromCloud/pageHeader";
 
@@ -23,13 +25,15 @@ enum TabKeys {
   TABLES = "tables",
   GRANTS = "grants",
 }
+
 export const DatabaseDetailsPageV2 = () => {
   const [currentTab, setCurrentTab] = useState(TabKeys.TABLES);
+  const { dbID } = useRouteParams();
+  const { name } = useDbIdToName(parseInt(dbID, 10));
 
-  // TODO (xinhaoz) #131119 - Populate db name here.
   return (
     <PageLayout>
-      <PageHeader title="myDB" />
+      <PageHeader title={name} />
       <Tabs
         defaultActiveKey={TabKeys.TABLES}
         className={commonStyles("cockroach--tabs")}

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/index.tsx
@@ -31,9 +31,20 @@ export const DatabaseDetailsPageV2 = () => {
   const { dbID } = useRouteParams();
   const { name } = useDbIdToName(parseInt(dbID, 10));
 
+  const breadcrumbs = [
+    {
+      name: "Databases",
+      link: "/v2/databases",
+    },
+    {
+      name: name,
+      link: null,
+    },
+  ];
+
   return (
     <PageLayout>
-      <PageHeader title={name} />
+      <PageHeader title={name} breadcrumbItems={breadcrumbs} />
       <Tabs
         defaultActiveKey={TabKeys.TABLES}
         className={commonStyles("cockroach--tabs")}

--- a/pkg/ui/workspaces/cluster-ui/src/sharedFromCloud/table.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sharedFromCloud/table.tsx
@@ -134,7 +134,7 @@ function mapTableColumnsToAntDesignColumns<T>(
   return antDTableColumns;
 }
 
-const DEFAULT_EMPTY_ICON = emptyListResultsImg;
+const DEFAULT_EMPTY_ICON = <img src={emptyListResultsImg} />;
 
 // export component for quick custom empty states
 export const EmptyState = ({


### PR DESCRIPTION
This commit populates the db name in the db details page. A new hook is created that fetches and caches db names by id from the backend by querying crdb_internal.databases. We use `useSWRImmutable` for data fetching  since we don't expect the payload to change in the session.

This commit also fixes the placeholder image for an empty table.

Fixes: #131119
Epic: CRDB-37558

Release note: None