### PR TITLE
server: add API to fetch table metadata for table id

### DIFF
--- a/pkg/server/api_v2.go
+++ b/pkg/server/api_v2.go
@@ -189,6 +189,7 @@ func registerRoutes(
 		{"sql/", a.execSQL, true, authserver.RegularRole, true},
 		{"database_metadata/", a.GetDBMetadata, true, authserver.RegularRole, true},
 		{"table_metadata/", a.GetTableMetadata, true, authserver.RegularRole, true},
+		{"table_metadata/{table_id:[0-9]+}/", a.GetTableMetadataWithDetails, true, authserver.RegularRole, true},
 		{"table_metadata/updatejob/", a.TableMetadataJob, true, authserver.RegularRole, true},
 	}
 


### PR DESCRIPTION
Adds a new API v2 endpoint, `GET /api/v2/table_metadata/<id>`, where id is a specific table id.

This API will return table metadata as well as its create statement

Resolves: #131222
Epic: CRDB-37558
Release note: None