### PR TITLE
roachtest: reuse Github issues for runtime-assertions failures

### DIFF
--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -231,7 +231,7 @@ func (g *githubIssues) createPostRequest(
 		labels = append(labels, issues.TestFailureLabel)
 		if !spec.NonReleaseBlocker {
 			// TODO(radu): remove this check once these build types are stabilized.
-			if !coverageBuild && !runtimeAssertionsBuild {
+			if !coverageBuild {
 				labels = append(labels, issues.ReleaseBlockerLabel)
 			}
 		}
@@ -328,7 +328,7 @@ func (g *githubIssues) createPostRequest(
 		TestName:        issueName,
 		Labels:          labels,
 		// Keep issues separate unless the if these labels don't match.
-		AdoptIssueLabelMatchSet: []string{infraFlakeLabel, coverageLabel, runtimeAssertionsLabel},
+		AdoptIssueLabelMatchSet: []string{infraFlakeLabel, coverageLabel},
 		TopLevelNotes:           topLevelNotes,
 		Message:                 issueMessage,
 		Artifacts:               artifacts,

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -258,13 +258,12 @@ func TestCreatePostRequest(t *testing.T) {
 				"coverageBuild":          "false",
 			}),
 		},
-		// 7. Verify that release-blocker label is not applied on runtime assertion builds
-		// (for now).
+		// 7. Verify that release-blocker label is applied on runtime assertion builds
 		{
 			runtimeAssertionsBuild: true,
 			failures:               []failure{createFailure(errors.New("other"))},
 			expectedPost:           true,
-			expectedLabels:         []string{"C-test-failure", "B-runtime-assertions-enabled"},
+			expectedLabels:         []string{"C-test-failure", "B-runtime-assertions-enabled", "release-blocker"},
 			expectedTeam:           "@cockroachdb/unowned",
 			expectedName:           testName,
 			expectedParams: prefixAll(map[string]string{

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -39,7 +39,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
-	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
@@ -1311,20 +1310,7 @@ func (r *testRunner) runTest(
 	case <-time.After(timeout):
 		// NB: We're adding the timeout failure intentionally without cancelling the context
 		// to capture as much state as possible during artifact collection.
-		//
-		// Temporarily route all runtime assertion timeouts to test-eng while
-		// we gauge the frequency they occur and adjust test timeouts accordingly.
-		// TODO(darryl): once we are more confident in the stability of runtime
-		// assertions we can remove this.
-		if tests.UsingRuntimeAssertions(t) {
-			timeoutErr := registry.ErrorWithOwnership{
-				Err:   errors.Newf("test timed out (%s)", timeout),
-				Owner: registry.OwnerTestEng,
-			}
-			t.addFailure(0, "", timeoutErr)
-		} else {
-			t.addFailure(0, "test timed out (%s)", timeout)
-		}
+		t.addFailure(0, "test timed out (%s)", timeout)
 
 		// We suppress other failures from being surfaced to the top as the timeout is always going
 		// to be the main error and subsequent errors (i.e. context cancelled) add noise.


### PR DESCRIPTION
Generally when a test has open failures for both builds with and without runtime assertions, the failures are likely due to the same (non runtime assertion related) issue.

After running tests with runtime-assertions metamorphically on for a few weeks, we have yet to see this not be the case. To reduce toil of tracking and closing extra issues, github issues will now be reused between runtime assertion and regular builds.

Additionally, the release blocker label is no longer omitted for runtime-assertions. This is due to the reuse and also the stability of the builds in our test runs.

Fixes: none
Epic: none
Release note: none