### PR TITLE
roachtest: UT for test selection with randomisation

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -121,6 +121,7 @@ go_test(
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/echotest",
+        "//pkg/util/randutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/version",

--- a/pkg/cmd/roachtest/main_test.go
+++ b/pkg/cmd/roachtest/main_test.go
@@ -9,9 +9,13 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
+	"math"
+	"math/rand"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -22,6 +26,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/testselector"
 	"github.com/cockroachdb/cockroach/pkg/internal/team"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -162,6 +169,206 @@ func Test_updateSpecForSelectiveTests(t *testing.T) {
 			}
 		}
 	})
+	// We run the randomized tests 1000 times for 100 randomly generated tests
+	t.Run("run with randomised data", func(t *testing.T) {
+		iteration := 0
+		totalIterations := 1000
+		totalTestCount := 100
+		oldSuite := roachtestflags.Suite
+		roachtestflags.Suite = registry.Nightly
+		defer func() {
+			roachtestflags.Suite = oldSuite
+		}()
+		oldSuccessfulTestsSelectPct := roachtestflags.SuccessfulTestsSelectPct
+		roachtestflags.SuccessfulTestsSelectPct = 0.30
+		defer func() {
+			roachtestflags.SuccessfulTestsSelectPct = oldSuccessfulTestsSelectPct
+		}()
+		dbs := make([]*gosql.DB, totalIterations)
+		mocks := make([]sqlmock.Sqlmock, totalIterations)
+		// each iteration is run in a go routine
+		wg := sync.WaitGroup{}
+		// we need to ensure that "SqlConnectorFunc" returns the right DB for each iteration. So, this locks
+		// each iteration till the db is returned
+		mu := syncutil.Mutex{}
+		for iteration < totalIterations {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				dbs[i], mocks[i], err = sqlmock.New()
+				require.Nil(t, err)
+				specs, data, rows, toBeSelectedTestsMap := getRandomisedTests(t, totalTestCount)
+				mocks[i].ExpectPrepare(regexp.QuoteMeta(testselector.PreparedQuery))
+				mocks[i].ExpectQuery(regexp.QuoteMeta(testselector.PreparedQuery)).WillReturnRows(rows)
+				specsLengthBefore := len(specs)
+				// we need to keep a count of all already skipped tests. This is to assert that the skip is not overwritten.
+				countOfSpecSkippedTests := 0
+				for _, s := range specs {
+					if s.Skip != "" {
+						countOfSpecSkippedTests++
+					}
+				}
+				// the iteration locks till the SqlConnectorFunc returns the current DB.
+				mu.Lock()
+				testselector.SqlConnectorFunc = func(_, _ string) (*gosql.DB, error) {
+					defer mu.Unlock()
+					return dbs[i], err
+				}
+				updateSpecForSelectiveTests(ctx, specs)
+				require.Equal(t, specsLengthBefore, len(specs))
+				// dataMap is used of assertions
+				dataMap := make(map[string][]string)
+				for _, d := range data {
+					dataMap[d[testselector.DataTestNameIndex]] = d
+				}
+				// allTestsToBeSelected keeps a count of all tests that are there in spec and toBeSelectedTestsMap
+				// the count should be equal to the length of toBeSelectedTestsMap which ensures that all the tests
+				// we selected
+				allTestsToBeSelected := 0
+				// get the count of skipped tests that are not skipped by test selector.
+				// this should remain the same as countOfSpecSkippedTests.
+				skippedTestsInSpec := 0
+				for _, s := range specs {
+					if s.Skip == getSkippedMessage(s.Name) {
+						skippedTestsInSpec++
+					}
+					// if the test is present in dataMap and snowflake response has "last_failure_is_preempt=true", the same
+					// must be marked in the spec
+					if d, ok := dataMap[s.Name]; ok && d[testselector.DataLastPreempted] == "yes" {
+						require.True(t, s.IsLastFailurePreempt())
+					} else {
+						require.False(t, s.IsLastFailurePreempt())
+					}
+					// if the test is present in dataMap and snowflake response and the test is skipped by test selector
+					// the entry dataMap must be "selected=no"
+					if d, ok := dataMap[s.Name]; ok && s.Skip == "test selector" {
+						require.Equal(t, "no", d[testselector.DataSelectedIndex])
+					}
+					// if a test is in toBeSelectedTestsMap, this test has to be selected by test selector unless it is skipped already
+					// So, the Skip is either blank or has a value as "<test name> skipped"
+					if _, ok := toBeSelectedTestsMap[s.Name]; ok {
+						allTestsToBeSelected++
+						assert.True(t, s.Skip == "" || s.Skip == getSkippedMessage(s.Name), s.Skip)
+					}
+				}
+				require.Equal(t, countOfSpecSkippedTests, skippedTestsInSpec)
+				require.Equal(t, allTestsToBeSelected, len(toBeSelectedTestsMap))
+			}(iteration)
+			iteration++
+		}
+		wg.Wait()
+	})
+}
+
+func getSkippedMessage(testName string) string {
+	return fmt.Sprintf("%s skipped", testName)
+}
+
+// getRandomisedTests returns "totalTests" number of randomised tests.
+// Out of the totalTests,
+// > 0-90% of the tests are added as tests in specs
+// > 10-100% of the tests are added as snowflake returned tests
+// So, the overlap is 80%
+// The above tests are shuffled and randomly added different conditions.
+// The function returns:
+// > List of test specs
+// > The rows to be returned by the snowflake as [][]string
+// > The rows as *sqlmock.Rows
+// > The map of tests that will be selected based on the percent criteria
+func getRandomisedTests(
+	t *testing.T, totalTests int,
+) ([]registry.TestSpec, [][]string, *sqlmock.Rows, map[string]struct{}) {
+	r, _ := randutil.NewTestRand()
+	testNames, err := generateUniqueStrings(r, totalTests, 10, 100)
+	require.Nil(t, err)
+	// As mentioned,
+	// 0% to 90% of tests are added to test spec
+	// 10% to 100% of tests are added to snowflake tests
+	// So, the overlap is 80%
+	sfStart := int(float32(len(testNames)) * 0.1)
+	specEnd := int(float32(len(testNames)) * 0.9)
+	// testForSF are the name of tests which are returned by SF query
+	testForSF := shuffleStrings(r, testNames[sfStart:])
+	// testForSpecs are the name of tests which are in the test spec
+	testForSpecs := shuffleStrings(r, testNames[:specEnd])
+	// commonSuccessTestMap contains all test that are present in both specs and snowflake minus the tests that are
+	// marked as "selected=true"
+	commonSuccessTestMap := make(map[string]struct{})
+	for _, tn := range testNames[sfStart:specEnd] {
+		// all the common tests are added first. The tests marked as "selected=true" will be removed later.
+		commonSuccessTestMap[tn] = struct{}{}
+	}
+	rows := sqlmock.NewRows(testselector.AllRows)
+	// data is created and returned for easier assertions
+	data := make([][]string, len(testForSF))
+	// testSelected is a randomised value which is the number of tests that are marked as "selected=true"
+	testSelected := randutil.RandIntInRange(r, 0, int(0.6*float32(len(testForSF))))
+	for i, sfn := range testForSF {
+		selected := "no"
+		lastFailureIsPreempt := "no"
+		if i < testSelected {
+			// mark the tests as selected sequentially
+			selected = "yes"
+			// delete the entry from the success map as this is selected.
+			delete(commonSuccessTestMap, sfn)
+			// from the selected tests mark a few tests as "last_failure_is_preempt=yes"
+			numTestsPreempted := randutil.RandIntInRange(r, 0, testSelected)
+			if numTestsPreempted <= int(0.05*float64(testSelected)) {
+				lastFailureIsPreempt = "yes"
+			}
+		}
+		// generate a random duration value
+		duration := randutil.RandIntInRange(r, 0, 10000000)
+		// populate the data
+		data[i] = []string{sfn, selected, strconv.Itoa(duration + 1), lastFailureIsPreempt}
+		// add the same to the rows
+		rows.FromCSVString(strings.Join(data[i], ","))
+	}
+	// numberOfTestsToSelect is based on the same criteria of successful percent selection
+	// Here, commonSuccessTestMap contains all the successful tests, so, we have calculated the percent from that
+	numberOfTestsToSelect := int(math.Ceil(float64(len(commonSuccessTestMap)) * roachtestflags.SuccessfulTestsSelectPct))
+	selectedTestCount := 0
+	// toBeSelectedTestsMap contains all the tests that will be selected based on the success percent criteria
+	toBeSelectedTestsMap := make(map[string]struct{})
+	// iterating over all the data in sequence to identify the exact tests that will be selected as a part of
+	// the percentage  criteria
+	for _, d := range data {
+		// if the test name is not in commonSuccessTestMap, this should be skipped as this test is not in spec
+		if _, ok := commonSuccessTestMap[d[testselector.DataTestNameIndex]]; !ok {
+			continue
+		}
+		// add the test to the toBeSelectedTestsMap
+		toBeSelectedTestsMap[d[testselector.DataTestNameIndex]] = struct{}{}
+		// if the selectedTestCount exceeds numberOfTestsToSelect, we stop.
+		selectedTestCount++
+		if selectedTestCount >= numberOfTestsToSelect {
+			break
+		}
+	}
+	// populate the test specs
+	specs := make([]registry.TestSpec, len(testForSpecs))
+	for i, sn := range testForSpecs {
+		s := registry.TestSpec{Name: sn}
+		// randomly mark "Randomized=true" for 1% of tests
+		randomizedTests := randutil.RandIntInRange(r, 0, len(testForSpecs))
+		if randomizedTests <= int(0.01*float64(len(testForSpecs))) {
+			s.Randomized = true
+		}
+		// randomly mark test as opted out for 3% of tests
+		optOutTests := randutil.RandIntInRange(r, 0, len(testForSpecs))
+		if optOutTests <= int(0.03*float64(len(testForSpecs))) {
+			s.TestSelectionOptOutSuites = registry.Suites(registry.Nightly)
+		}
+		// randomly mark test as skipped out for 5% of tests
+		skippedTests := randutil.RandIntInRange(r, 0, len(testForSpecs))
+		if skippedTests <= int(0.05*float64(len(testForSpecs))) {
+			s.Skip = getSkippedMessage(sn)
+			s.SkipDetails = fmt.Sprintf("%s skipped by spec", sn)
+		}
+		s.Suites = registry.Suites(registry.Nightly, registry.Weekly)
+		specs[i] = s
+	}
+	return specs, data, rows, toBeSelectedTestsMap
 }
 
 // getTestSelectionMockData returns the mock data as:
@@ -228,12 +435,40 @@ func getTestSelectionMockData() ([]registry.TestSpec, *sqlmock.Rows) {
 		{"t_randomized", "no", "5", "no"},
 	}
 	// rows are the rows that are returned by snowflake. The list of string represents the columns of each row
-	rows := sqlmock.NewRows([]string{
-		"name", "selected", "avg_duration", "last_failure_is_preempt",
-	})
+	rows := sqlmock.NewRows(testselector.AllRows)
 	// rows are populated with the data
 	for _, ds := range data {
 		rows.FromCSVString(strings.Join(ds, ","))
 	}
 	return specs, rows
+}
+
+// generateUniqueStrings generates the requested number of unique random strings
+// with random lengths between minLength and maxLength
+func generateUniqueStrings(r *rand.Rand, totalSpecs, minLength, maxLength int) ([]string, error) {
+	uniqueStrings := make(map[string]struct{})
+	var result []string
+
+	for len(uniqueStrings) < totalSpecs {
+		// this generates a random string length within the specified range
+		strLength := randutil.RandIntInRange(r, minLength, maxLength)
+
+		// Generate a random string of the chosen length
+		randomStr := randutil.RandString(r, strLength, randutil.PrintableKeyAlphabet)
+
+		// we need to ensure that the string is unique
+		if _, exists := uniqueStrings[randomStr]; !exists {
+			uniqueStrings[randomStr] = struct{}{}
+			result = append(result, randomStr)
+		}
+	}
+
+	return result, nil
+}
+
+func shuffleStrings(r *rand.Rand, strings []string) []string {
+	r.Shuffle(len(strings), func(i, j int) {
+		strings[i], strings[j] = strings[j], strings[i]
+	})
+	return strings
 }

--- a/pkg/cmd/roachtest/testselector/selector.go
+++ b/pkg/cmd/roachtest/testselector/selector.go
@@ -30,7 +30,16 @@ const (
 	// sfUsernameEnv and sfPasswordEnv are the environment variables that are used for Snowflake access
 	sfUsernameEnv = "SFUSER"
 	sfPasswordEnv = "SFPASSWORD"
+
+	// DataTestNameIndex and the following corresponds to the index of the row where the data is returned
+	DataTestNameIndex = 0
+	DataSelectedIndex = 1
+	DataDurationIndex = 2
+	DataLastPreempted = 3
 )
+
+// AllRows are all the rows returned by snowflake. This is used for testing
+var AllRows = []string{"name", "selected", "avg_duration", "last_failure_is_preempt"}
 
 //go:embed snowflake_query.sql
 var PreparedQuery string
@@ -129,10 +138,10 @@ func CategoriseTests(ctx context.Context, req *SelectTestsReq) ([]*TestDetails, 
 		// 2. average duration of the test
 		// 3. last failure is due to an infra flake
 		testDetails := &TestDetails{
-			Name:                 testInfos[0],
-			Selected:             testInfos[1] != "no",
-			AvgDurationInMillis:  getDuration(testInfos[2]),
-			LastFailureIsPreempt: testInfos[3] == "yes",
+			Name:                 testInfos[DataTestNameIndex],
+			Selected:             testInfos[DataSelectedIndex] != "no",
+			AvgDurationInMillis:  getDuration(testInfos[DataDurationIndex]),
+			LastFailureIsPreempt: testInfos[DataLastPreempted] == "yes",
 		}
 		allTestDetails = append(allTestDetails, testDetails)
 	}

--- a/pkg/cmd/roachtest/testselector/selector_test.go
+++ b/pkg/cmd/roachtest/testselector/selector_test.go
@@ -77,9 +77,7 @@ func TestCategoriseTests(t *testing.T) {
 	t.Run("expect the sequence of response list is maintained for success", func(t *testing.T) {
 		db, mock, err = sqlmock.New()
 		mock.ExpectPrepare(regexp.QuoteMeta(PreparedQuery))
-		rows := sqlmock.NewRows([]string{
-			"name", "selected", "avg_duration", "last_failure_is_preempt",
-		})
+		rows := sqlmock.NewRows(AllRows)
 		data := [][]string{
 			{"t1", "no", "12345", "no"},
 			{"t2", "no", "12345", "no"},
@@ -108,10 +106,10 @@ func TestCategoriseTests(t *testing.T) {
 		// the sequence of response list must be maintained.
 		for i, d := range data {
 			td := tds[i]
-			require.Equal(t, d[0], td.Name)
-			require.Equal(t, d[1] != "no", td.Selected)
-			require.Equal(t, getDuration(d[2]), td.AvgDurationInMillis)
-			require.Equal(t, d[3] == "yes", td.LastFailureIsPreempt)
+			require.Equal(t, d[DataTestNameIndex], td.Name)
+			require.Equal(t, d[DataSelectedIndex] != "no", td.Selected)
+			require.Equal(t, getDuration(d[DataDurationIndex]), td.AvgDurationInMillis)
+			require.Equal(t, d[DataLastPreempted] == "yes", td.LastFailureIsPreempt)
 		}
 	})
 }


### PR DESCRIPTION
This PR has the unit tests for the test selection changes. This UT randomly generates 100000 test names and shuffles the same into snowflake query response and test specs. It also randomly adds different conditions:
- "selected=yes", "last_failure_is_preempt=yes" in snowflake returned data
- "randomised=true", "skip=true", opt out in the specs data.

This change will ensure better coverage of the test selection as the data keeps changing in every run.

Fixes: #129786
Epic: None