### PR TITLE
testutils: data race when TestCluster fails to start

### DIFF
--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -685,7 +685,11 @@ func (tc *TestCluster) WaitForNStores(t serverutils.TestFataler, n int, g *gossi
 			}
 			t.Fatal(err)
 		case <-time.After(testutils.DefaultSucceedsSoonDuration):
-			t.Fatalf("timed out waiting for %d store descriptors: %v", n-seen, stores)
+			func() {
+				storesMu.Lock()
+				defer storesMu.Unlock()
+				t.Fatalf("timed out waiting for %d store descriptors: %v", n-seen, stores)
+			}()
 		}
 	}
 }


### PR DESCRIPTION
Previously, we were running into a race condition due to the access of the `stores` map in the error reporting inside the timeout logic. This patch fixes this by reporting the error after grabbing a lock on `stores`.

Epic: none
Fixes: #87592
Release note: None