### PR TITLE
server: add API to fetch database metadata for database id

### DIFF
--- a/pkg/server/api_v2.go
+++ b/pkg/server/api_v2.go
@@ -187,7 +187,8 @@ func registerRoutes(
 		{"rules/", a.listRules, false, authserver.RegularRole, true},
 
 		{"sql/", a.execSQL, true, authserver.RegularRole, true},
-		{"database_metadata/", a.GetDBMetadata, true, authserver.RegularRole, true},
+		{"database_metadata/", a.GetDbMetadata, true, authserver.RegularRole, true},
+		{"database_metadata/{database_id:[0-9]+}/", a.GetDbMetadataForId, true, authserver.RegularRole, true},
 		{"table_metadata/", a.GetTableMetadata, true, authserver.RegularRole, true},
 		{"table_metadata/{table_id:[0-9]+}/", a.GetTableMetadataWithDetails, true, authserver.RegularRole, true},
 		{"table_metadata/updatejob/", a.TableMetadataJob, true, authserver.RegularRole, true},


### PR DESCRIPTION
Only the last 2 commits in the PR need to be reviewed

---
### server: refactor databases_metadata api
In preparation for an upcoming API, this commit refactors the query and mapping of rows to dbMetadata structs to separate methods to be reused.

Release note: None
Epic: [CRDB-37558](https://cockroachlabs.atlassian.net/browse/CRDB-37558)

### server: add API to fetch database metadata for database id
Adds a new API v2 endpoint, `GET /api/v2/database_metadata/<id>`, where id is a specific database id.

This API will return database metadata

Resolves: https://github.com/cockroachdb/cockroach/issues/131304
Epic: [CRDB-37558](https://cockroachlabs.atlassian.net/browse/CRDB-37558)
Release note: None