### PR TITLE
server: use no-store header for HTTP

### DIFF
--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -358,7 +358,7 @@ func startHTTPService(
 // gzip middleware, then delegates to the mux for handling the request.
 func (s *httpServer) baseHandler(w http.ResponseWriter, r *http.Request) {
 	// Disable caching of responses.
-	w.Header().Set("Cache-control", "no-cache")
+	w.Header().Set("Cache-control", "no-store")
 
 	if HSTSEnabled.Get(&s.cfg.Settings.SV) {
 		w.Header().Set("Strict-Transport-Security", hstsHeaderValue)


### PR DESCRIPTION
The `no-store` header is preferred in situations where we don't want
the browser to cache the information. Customers prefer this as it
improves security by reducing the scope of information cached by the
browser.

Previously, we set the `Cache-Control` header to `no-cache` which
doesn't prevent caching in the browser, but requires the browser the
re-validate prior to using the cached value.

Most information in the DB Console shouldn't be cached by the browser,
and is instead cached in the Redux store already with specific
timeouts.

Source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control

Release note: None