### PR TITLE
raft: rename SupportTracker to FortificationTracker

### DIFF
--- a/pkg/raft/rafttest/interaction_env_handler.go
+++ b/pkg/raft/rafttest/interaction_env_handler.go
@@ -262,17 +262,17 @@ func (env *InteractionEnv) Handle(t *testing.T, d datadriven.TestData) string {
 		// Explanation:
 		// 1 (from_store) grants support for 2 (for_store) at a higher epoch.
 		err = env.handleGrantSupport(t, d)
-	case "print-support-state":
-		// Prints the support state being tracked by a raft leader. Empty on a
+	case "print-fortification-state":
+		// Prints the fortification state being tracked by a raft leader. Empty on a
 		// follower.
 		//
-		// print-support-state id
+		// print-fortification-state id
 		// Arguments are:
-		//    id - id of the raft peer whose support map to print.
+		//    id - id of the raft peer whose fortification map to print.
 		//
 		// Example:
-		// print-support-state 1
-		err = env.handlePrintSupportState(t, d)
+		// print-fortification-state 1
+		err = env.handlePrintFortificationState(t, d)
 
 	default:
 		err = fmt.Errorf("unknown command")

--- a/pkg/raft/rafttest/interaction_env_handler_raftstate.go
+++ b/pkg/raft/rafttest/interaction_env_handler_raftstate.go
@@ -54,10 +54,12 @@ func (env *InteractionEnv) handleRaftState() error {
 	return nil
 }
 
-// handlePrintSupportState pretty-prints the support map being tracked by a raft
+// handlePrintFortificationState pretty-prints the support map being tracked by a raft
 // peer.
-func (env *InteractionEnv) handlePrintSupportState(t *testing.T, d datadriven.TestData) error {
+func (env *InteractionEnv) handlePrintFortificationState(
+	t *testing.T, d datadriven.TestData,
+) error {
 	idx := firstAsNodeIdx(t, d)
-	fmt.Fprint(env.Output, env.Nodes[idx].TestingSupportStateString())
+	fmt.Fprint(env.Output, env.Nodes[idx].TestingFortificationStateString())
 	return nil
 }

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -549,6 +549,6 @@ func (rn *RawNode) TestingStepDown() error {
 	return rn.raft.testingStepDown()
 }
 
-func (rn *RawNode) TestingSupportStateString() string {
-	return rn.raft.supportTracker.String()
+func (rn *RawNode) TestingFortificationStateString() string {
+	return rn.raft.fortificationTracker.String()
 }

--- a/pkg/raft/status.go
+++ b/pkg/raft/status.go
@@ -131,7 +131,7 @@ func getStatus(r *raft) Status {
 	// NOTE: we assign to LeadSupportUntil even if RaftState is not currently
 	// StateLeader. The replica may have been the leader and stepped down to a
 	// follower before its lead support ran out.
-	s.LeadSupportUntil = r.supportTracker.LeadSupportUntil()
+	s.LeadSupportUntil = r.fortificationTracker.LeadSupportUntil()
 	return s
 }
 
@@ -155,7 +155,7 @@ func getSparseStatus(r *raft) SparseStatus {
 func getLeadSupportStatus(r *raft) LeadSupportStatus {
 	var s LeadSupportStatus
 	s.BasicStatus = getBasicStatus(r)
-	s.LeadSupportUntil = r.supportTracker.LeadSupportUntil()
+	s.LeadSupportUntil = r.fortificationTracker.LeadSupportUntil()
 	return s
 }
 

--- a/pkg/raft/testdata/fortification_support_tracking.txt
+++ b/pkg/raft/testdata/fortification_support_tracking.txt
@@ -1,4 +1,4 @@
-# Test to ensure that leaders correctly track fortification support.
+# Test to ensure that leaders correctly track fortification.
 
 log-level debug
 ----
@@ -142,7 +142,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 
-print-support-state 1
+print-fortification-state 1
 ----
 1 : 1
 
@@ -274,7 +274,7 @@ stabilize
   1->2 MsgAppResp Term:2 Log:0/12 Commit:12
   3->2 MsgAppResp Term:2 Log:0/12 Commit:12
 
-print-support-state 2
+print-fortification-state 2
 ----
 1 : 2
 2 : 3

--- a/pkg/raft/tracker/BUILD.bazel
+++ b/pkg/raft/tracker/BUILD.bazel
@@ -4,11 +4,11 @@ go_library(
     name = "tracker",
     srcs = [
         "electiontracker.go",
+        "fortificationtracker.go",
         "inflights.go",
         "progress.go",
         "progresstracker.go",
         "state.go",
-        "supporttracker.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/raft/tracker",
     visibility = ["//visibility:public"],
@@ -23,9 +23,9 @@ go_library(
 go_test(
     name = "tracker_test",
     srcs = [
+        "fortificationtracker_test.go",
         "inflights_test.go",
         "progress_test.go",
-        "supporttracker_test.go",
     ],
     embed = [":tracker"],
     deps = [

--- a/pkg/raft/tracker/fortificationtracker.go
+++ b/pkg/raft/tracker/fortificationtracker.go
@@ -21,53 +21,54 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
-// SupportTracker is used to track fortification support from peers. This can
+// FortificationTracker is used to track fortification from peers. This can
 // then be used to compute until when a leader's support expires.
-type SupportTracker struct {
+type FortificationTracker struct {
 	config        *quorum.Config
 	storeLiveness raftstoreliveness.StoreLiveness
 
-	// support contains a map of nodes which have supported the leader through
-	// fortification handshakes, and the corresponding Store Liveness epochs that
-	// they have supported the leader in.
-	support map[pb.PeerID]pb.Epoch
+	// fortification contains a map of nodes which have fortified the leader
+	// through fortification handshakes, and the corresponding Store Liveness
+	// epochs that they have supported the leader in.
+	fortification map[pb.PeerID]pb.Epoch
 }
 
-// MakeSupportTracker initializes a SupportTracker.
-func MakeSupportTracker(
+// MakeFortificationTracker initializes a FortificationTracker.
+func MakeFortificationTracker(
 	config *quorum.Config, storeLiveness raftstoreliveness.StoreLiveness,
-) SupportTracker {
-	st := SupportTracker{
+) FortificationTracker {
+	st := FortificationTracker{
 		config:        config,
 		storeLiveness: storeLiveness,
-		support:       map[pb.PeerID]pb.Epoch{},
+		fortification: map[pb.PeerID]pb.Epoch{},
 	}
 	return st
 }
 
-// RecordSupport records that the node with the given id supported this Raft
-// instance until the supplied timestamp.
-func (st *SupportTracker) RecordSupport(id pb.PeerID, epoch pb.Epoch) {
+// RecordFortification records that the node with the given id supported this
+// Raft instance until the supplied timestamp.
+func (st *FortificationTracker) RecordFortification(id pb.PeerID, epoch pb.Epoch) {
 	// The supported epoch should never regress. Guard against out of order
 	// delivery of fortify responses by using max.
-	st.support[id] = max(st.support[id], epoch)
+	st.fortification[id] = max(st.fortification[id], epoch)
 }
 
-// Reset clears out any previously tracked support.
-func (st *SupportTracker) Reset() {
-	clear(st.support)
+// Reset clears out any previously tracked fortification.
+func (st *FortificationTracker) Reset() {
+	clear(st.fortification)
 	// TODO(arul): when we introduce st.LeadSupportUntil we need to make sure it
 	// isn't reset here, because we don't want it to regress when a leader steps
 	// down.
 }
 
 // LeadSupportUntil returns the timestamp until which the leader is guaranteed
-// support until based on the support being tracked for it by its peers.
-func (st *SupportTracker) LeadSupportUntil() hlc.Timestamp {
+// fortification until based on the fortification being tracked for it by its
+// peers.
+func (st *FortificationTracker) LeadSupportUntil() hlc.Timestamp {
 	// TODO(arul): avoid this map allocation as we're calling LeadSupportUntil
 	// from hot paths.
 	supportExpMap := make(map[pb.PeerID]hlc.Timestamp)
-	for id, supportEpoch := range st.support {
+	for id, supportEpoch := range st.fortification {
 		curEpoch, curExp, ok := st.storeLiveness.SupportFrom(id)
 		// NB: We can't assert that supportEpoch <= curEpoch because there may be a
 		// race between a successful MsgFortifyLeaderResp and the store liveness
@@ -83,23 +84,23 @@ func (st *SupportTracker) LeadSupportUntil() hlc.Timestamp {
 
 // QuorumActive returns whether the leader is currently supported by a quorum or
 // not.
-func (st *SupportTracker) QuorumActive() bool {
+func (st *FortificationTracker) QuorumActive() bool {
 	return !st.storeLiveness.SupportExpired(st.LeadSupportUntil())
 }
 
-func (st *SupportTracker) String() string {
-	if len(st.support) == 0 {
+func (st *FortificationTracker) String() string {
+	if len(st.fortification) == 0 {
 		return "empty"
 	}
 	// Print the map in sorted order as we assert on its output in tests.
-	ids := make([]pb.PeerID, 0, len(st.support))
-	for id := range st.support {
+	ids := make([]pb.PeerID, 0, len(st.fortification))
+	for id := range st.fortification {
 		ids = append(ids, id)
 	}
 	slices.Sort(ids)
 	var buf strings.Builder
 	for _, id := range ids {
-		fmt.Fprintf(&buf, "%d : %d\n", id, st.support[id])
+		fmt.Fprintf(&buf, "%d : %d\n", id, st.fortification[id])
 	}
 	return buf.String()
 }


### PR DESCRIPTION
This commit renames SupportTracker to FortificationTracker to help disambiguate disambiguate between store liveness support and the leader fortification protocol.

Epic: None

Release note: None