### PR TITLE
[DNM] kv: demonstrate lost write on stalled disk before #129808

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_resolve_intent.go
+++ b/pkg/kv/kvserver/batcheval/cmd_resolve_intent.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
@@ -101,6 +102,9 @@ func ResolveIntent(
 		ctx, readWriter, ms, update, storage.MVCCResolveWriteIntentOptions{TargetBytes: h.TargetBytes})
 	if err != nil {
 		return result.Result{}, err
+	}
+	if !ok {
+		log.Infof(ctx, "unable to resolve intent %s; not found", args.IntentTxn)
 	}
 	reply := resp.(*kvpb.ResolveIntentResponse)
 	reply.NumBytes = numBytes

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -505,7 +505,7 @@ func (p *pendingLeaseRequest) requestLease(
 	// work because the liveness record interval and the expiration-based lease
 	// interval are the same.
 	expToEpochPromo := extension && status.Lease.Type() == roachpb.LeaseExpiration && reqLease.Type() == roachpb.LeaseEpoch
-	if expToEpochPromo && reqLeaseLiveness.Expiration.ToTimestamp().Less(status.Lease.GetExpiration()) {
+	if expToEpochPromo && reqLeaseLiveness.Expiration.ToTimestamp().Less(status.Lease.GetExpiration()) && false {
 		curLiveness := reqLeaseLiveness
 		for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
 			err := p.repl.store.cfg.NodeLiveness.Heartbeat(ctx, curLiveness)


### PR DESCRIPTION
This commit demonstrates that without the protection provided by #129808, a lease expiration regression and subsequent leaseholder mutual exclusion violation can lead to a lost write.

This is caused by a stale read during async intent resolution which allows one or more intents to be missed and later rolled back instead of committed. One such history looks like the following:
```
- t90: range R1 has a lease on n128 with a lease that extends until time 100
- t91: range R1's lease is promoted to epoch-based with epoch 72
- t92: n128 epoch is incremented to 73
- t93: R1's lease is considered expired and stolen by n129. WARNING: we now have two replicas that think they are the leaseholder in real time!
- t94: intents for txn1 get written to range R1/n129. The intent write commits in the raft log and is acked, but does not make it to n128
- t95: txn1 commits record on range R2
- t96: async intent resolution runs. ResolveIntent(commit) is sent to R1/n128 (old leaseholder). It still thinks it holds the lease (even without a skewed clock). It does not find any of the intents, so it returns "successfully" as a no-op.
- t97: async intent resolution completes. txn1's committed record is GCed.
- t150 (later): intents that were not resolved are seen on R1/n129. PushTxn returns ABORTED. Intents are removed.
```

The commit rolls back #129808 (in v23.2.11+) and then adds a test that creates this scenario. The test fails with the following error:
```
--- FAIL: TestLeaseRequestFromExpirationToEpochRegressionLosesWrites (9.93s)
    test_log_scope.go:170: test logs captured to: /tmp/_tmp/577bfc8ed46850d1aaafa923fa37ce78/logTestLeaseRequestFromExpirationToEpochRegressionLosesWrites789216875
    test_log_scope.go:81: use -show-logs to present logs inline
    client_lease_test.go:1755: split and upreplicated ranges
    client_lease_test.go:1764: teach n2 about n3's lease
    client_lease_test.go:1775: waiting for liveness liveness(nid:3 epo:1 exp:1727217033.884469000,1) to expire
    client_lease_test.go:1777: liveness expired
    client_lease_test.go:1799: stall n3's incoming raft traffic
    client_lease_test.go:1816: enabling epoch-based lease promotion
    client_lease_test.go:1821: waiting for lease to fail over
    client_lease_test.go:1834: lease on n3 is {Lease:repl=(n3,s3):3 seq=2 start=1727217028.002131000,1 exp=1727217037.334807000,0 pro=1727217031.334807000,0 Now:1727217034.968272000,0 RequestTime:1727217034.968272000,0 State:VALID ErrInfo: Liveness:liveness(nid:0 epo:0 exp:0,0) MinValidObservedTimestamp:1727217028.002131000,1}
    client_lease_test.go:1837: reading from n1 after lease failover
    client_lease_test.go:1843: writing across ranges
    client_lease_test.go:1854: scanning across ranges
    client_lease_test.go:1857:
        	Error Trace:	github.com/cockroachdb/cockroach/pkg/kv/kvserver_test/pkg/kv/kvserver/client_lease_test.go:1857
        	Error:      	Not equal:
        	            	expected: 2
        	            	actual  : 1
        	Test:       	TestLeaseRequestFromExpirationToEpochRegressionLosesWrites
        	Messages:   	expected 2 keys, got [{Key:"a" Value:raw_bytes:"o!\267?\003valA (not lost" timestamp:<wall_time:1727217034969484000 > }]
```

With #129808 added back in, the test passes.