### PR TITLE
ui: show throttle metadata from cluster in db console 

### DIFF
--- a/pkg/ui/workspaces/db-console/src/app.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.spec.tsx
@@ -61,6 +61,10 @@ stubComponentInModule(
   "src/views/app/components/tenantDropdown/tenantDropdown",
   "default",
 );
+stubComponentInModule(
+  "src/views/shared/components/alertBar/alertBar",
+  "ThrottleNotificationBar",
+);
 
 // NOTE: All imports should go after `stubComponentInModule` functions calls.
 import { screen, render } from "@testing-library/react";

--- a/pkg/ui/workspaces/db-console/src/redux/alerts.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/alerts.ts
@@ -673,15 +673,22 @@ export const dataFromServerAlertSelector = createSelector(
   },
 );
 
-const licenseTypeNames = new Map<
-  string,
-  "Trial" | "Enterprise" | "Non-Commercial" | "None"
->([
-  ["Evaluation", "Trial"],
+export type LicenseType =
+  | "Evaluation"
+  | "Trial"
+  | "Enterprise"
+  | "Non-Commercial"
+  | "None"
+  | "Free";
+
+const licenseTypeNames = new Map<string, LicenseType>([
+  ["Evaluation", "Evaluation"],
   ["Enterprise", "Enterprise"],
   ["NonCommercial", "Non-Commercial"],
   ["OSS", "None"],
   ["BSD", "None"],
+  ["Free", "Free"],
+  ["Trial", "Trial"],
 ]);
 
 // licenseTypeSelector returns user-friendly names of license types.

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -206,6 +206,11 @@ export type NetworkConnectivityRequest =
 export type NetworkConnectivityResponse =
   protos.cockroach.server.serverpb.NetworkConnectivityResponse;
 
+export type GetThrottlingMetadataRequest =
+  protos.cockroach.server.serverpb.GetThrottlingMetadataRequest;
+export type GetThrottlingMetadataResponse =
+  protos.cockroach.server.serverpb.GetThrottlingMetadataResponse;
+
 // API constants
 
 export const API_PREFIX = "_admin/v1";
@@ -852,6 +857,17 @@ export function getNetworkConnectivity(
     serverpb.NetworkConnectivityResponse,
     `${STATUS_PREFIX}/connectivity`,
     req as any,
+    timeout,
+  );
+}
+
+export function getThrottlingMetadata(
+  timeout?: moment.Duration,
+): Promise<GetThrottlingMetadataResponse> {
+  return timeoutFetch(
+    serverpb.GetThrottlingMetadataResponse,
+    `${STATUS_PREFIX}/throttling`,
+    null,
     timeout,
   );
 }

--- a/pkg/ui/workspaces/db-console/src/util/docs.ts
+++ b/pkg/ui/workspaces/db-console/src/util/docs.ts
@@ -56,6 +56,7 @@ export let showSessions: string;
 export let sessionsTable: string;
 export let upgradeTroubleshooting: string;
 export let licensingFaqs: string;
+export let throttlingFaqs: string;
 // Note that these explicitly don't use the current version, since we want to
 // link to the most up-to-date documentation available.
 export const enterpriseLicenseUpdate =
@@ -136,6 +137,7 @@ export const recomputeDocsURLs = () => {
     "upgrade-cockroach-version.html#troubleshooting",
   );
   licensingFaqs = docsURL("licensing-faqs#renew-an-expired-license");
+  throttlingFaqs = docsURL("licensing-faqs#monitor-for-license-expiry");
 };
 
 recomputeDocsURLs();

--- a/pkg/ui/workspaces/db-console/src/views/app/containers/layout/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/containers/layout/index.tsx
@@ -31,6 +31,7 @@ import LoginIndicator from "src/views/app/components/loginIndicator";
 import AlertBanner from "src/views/app/containers/alertBanner";
 import TimeWindowManager from "src/views/app/containers/metricsTimeManager";
 import RequireLogin from "src/views/login/requireLogin";
+import { ThrottleNotificationBar } from "src/views/shared/components/alertBar/alertBar";
 
 import "./layout.styl";
 import "./layoutPanel.styl";
@@ -99,6 +100,7 @@ class Layout extends React.Component<LayoutProps & RouteComponentProps> {
               <TenantDropdown />
             </PageHeader>
           </div>
+          <ThrottleNotificationBar />
           <div className="layout-panel__body">
             <div className="layout-panel__sidebar">
               <NavigationBar />

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.module.styl
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.module.styl
@@ -20,3 +20,6 @@
   color $colors--neutral-9
   a
     color $colors--neutral-9
+
+.alert-tooltip
+  border-bottom 1px dashed

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.spec.tsx
@@ -1,0 +1,160 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { mount, ReactWrapper } from "enzyme";
+import moment from "moment";
+import React from "react";
+
+import { AlertBar } from "src/views/shared/components/alertBar/alertBar";
+
+describe("AlertBar", () => {
+  let wrapper: ReactWrapper;
+
+  it("displays nothing if no grace period and no telemetry deadline and 3 nodes", () => {
+    wrapper = mount(
+      <AlertBar
+        hasGracePeriod={false}
+        hasTelemetryDeadline={false}
+        numNodes={3}
+        license={"None"}
+        throttled={false}
+      />,
+    );
+
+    expect(wrapper.isEmptyRender());
+  });
+
+  it("displays nothing if 1 node even if grace period is present", () => {
+    wrapper = mount(
+      <AlertBar
+        hasGracePeriod={true}
+        hasTelemetryDeadline={true}
+        numNodes={1}
+        license={"Free"}
+        throttled={false}
+      />,
+    );
+
+    expect(wrapper.isEmptyRender());
+  });
+
+  it("displays throttle message: grace period = elapsed, license = expired, cluster = throttled", () => {
+    wrapper = mount(
+      <AlertBar
+        hasGracePeriod={true}
+        hasTelemetryDeadline={true}
+        numNodes={3}
+        license={"Free"}
+        throttled={true}
+        licenseExpiryDate={moment("2024-09-15")}
+        gracePeriodEnd={moment("2024-09-07")}
+      />,
+    );
+
+    expect(wrapper.text()).toContain(
+      "Your license key expired on September 15th, 2024 and the cluster was throttled. " +
+        "Please add a license key to continue using this cluster. Learn more",
+    );
+  });
+
+  it("displays warning message: grace period = active, license = expired, cluster = not throttled", () => {
+    const gracePeriodEnd = moment().add(1, "days");
+    wrapper = mount(
+      <AlertBar
+        hasGracePeriod={true}
+        hasTelemetryDeadline={true}
+        numNodes={3}
+        license={"Free"}
+        throttled={false}
+        licenseExpiryDate={moment("2024-09-15")}
+        gracePeriodEnd={gracePeriodEnd}
+      />,
+    );
+
+    expect(wrapper.text()).toContain(
+      "Your license key expired on September 15th, 2024. " +
+        `The cluster will be throttled on ${gracePeriodEnd.format("MMMM Do, YYYY")} unless the license is renewed. Learn more`,
+    );
+  });
+
+  it("displays throttle message: telemetry = missing, license = active, cluster = throttled", () => {
+    wrapper = mount(
+      <AlertBar
+        hasGracePeriod={false}
+        hasTelemetryDeadline={true}
+        numNodes={3}
+        nodesMissingTelemetry={["1", "2", "3"]}
+        license={"Free"}
+        throttled={true}
+        lastSuccessfulTelemetryDate={moment("2024-09-01")}
+        telemetryDeadline={moment("2024-09-15")}
+      />,
+    );
+
+    expect(wrapper.text()).toContain(
+      "Telemetry has not been received from some nodes in this cluster since " +
+        "September 1st, 2024. These nodes were throttled on September 15th, 2024. Learn more",
+    );
+  });
+
+  it("displays warning message: telemetry = missing recently, license = active, cluster = not throttled", () => {
+    const telemetryDeadline = moment().add(1, "days");
+    wrapper = mount(
+      <AlertBar
+        hasGracePeriod={false}
+        hasTelemetryDeadline={true}
+        numNodes={3}
+        nodesMissingTelemetry={["1", "2", "3"]}
+        license={"Free"}
+        throttled={false}
+        lastSuccessfulTelemetryDate={moment("2024-09-01")}
+        telemetryDeadline={telemetryDeadline}
+      />,
+    );
+
+    expect(wrapper.text()).toContain(
+      "Telemetry has not been received from some nodes in this cluster since " +
+        `September 1st, 2024. These nodes will be throttled on ${telemetryDeadline.format("MMMM Do, YYYY")} unless telemetry is received. Learn more`,
+    );
+  });
+
+  it("displays throttle message: license = None, cluster = throttled", () => {
+    wrapper = mount(
+      <AlertBar
+        hasGracePeriod={true}
+        hasTelemetryDeadline={false}
+        numNodes={3}
+        license={"None"}
+        throttled={true}
+      />,
+    );
+
+    expect(wrapper.text()).toContain(
+      "This cluster was throttled because it requires a license key. Please add a license key to continue using this cluster. Learn more",
+    );
+  });
+  it("displays warning message: license = None, cluster = not throttled", () => {
+    const gracePeriodEnd = moment().add(1, "days");
+    wrapper = mount(
+      <AlertBar
+        hasGracePeriod={true}
+        hasTelemetryDeadline={false}
+        numNodes={3}
+        license={"None"}
+        throttled={false}
+        gracePeriodEnd={gracePeriodEnd}
+      />,
+    );
+
+    expect(wrapper.text()).toContain(
+      `This cluster will require a license key by ${gracePeriodEnd.format("MMMM Do, YYYY")} or the cluster will be throttled. Learn more`,
+    );
+  });
+});

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.stories.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.stories.tsx
@@ -20,8 +20,9 @@ storiesOf("AlertBar", module)
       license={"None"}
       numNodes={3}
       throttled={false}
-      telemetrySuccessful={true}
-      throttleDate={moment("2025-01-04")}
+      hasTelemetryDeadline={true}
+      gracePeriodEnd={moment("2025-01-04")}
+      hasGracePeriod={true}
     />
   ))
   .add(`3.4.2 [pre-license] license key required, cluster throttled`, () => (
@@ -29,8 +30,9 @@ storiesOf("AlertBar", module)
       license={"None"}
       numNodes={3}
       throttled={true}
-      telemetrySuccessful={true}
-      throttleDate={moment("2023-01-04")}
+      hasTelemetryDeadline={true}
+      gracePeriodEnd={moment("2024-01-04")}
+      hasGracePeriod={true}
     />
   ))
   .add(
@@ -40,9 +42,10 @@ storiesOf("AlertBar", module)
         license={"Free"}
         numNodes={3}
         throttled={false}
-        telemetrySuccessful={true}
+        hasGracePeriod={true}
+        hasTelemetryDeadline={true}
         licenseExpiryDate={moment().subtract(1, "month")}
-        throttleDate={moment().add(3, "day")}
+        gracePeriodEnd={moment().add(3, "day")}
       />
     ),
   )
@@ -53,9 +56,10 @@ storiesOf("AlertBar", module)
         license={"Free"}
         numNodes={3}
         throttled={true}
-        telemetrySuccessful={true}
+        hasGracePeriod={true}
+        hasTelemetryDeadline={true}
         licenseExpiryDate={moment().subtract(1, "month")}
-        throttleDate={moment().subtract(1, "day")}
+        gracePeriodEnd={moment().subtract(3, "day")}
       />
     ),
   )
@@ -66,10 +70,13 @@ storiesOf("AlertBar", module)
         license={"Free"}
         numNodes={3}
         throttled={false}
-        telemetrySuccessful={false}
-        licenseExpiryDate={moment().add(6, "month")}
-        lastSuccessfulTelemetryDate={moment().subtract(3, "day")}
-        throttleDate={moment().add(3, "day")}
+        hasGracePeriod={true}
+        hasTelemetryDeadline={true}
+        licenseExpiryDate={moment().add(1, "month")}
+        gracePeriodEnd={moment().add(2, "month")}
+        lastSuccessfulTelemetryDate={moment().subtract(2, "day")}
+        telemetryDeadline={moment().add(2, "day")}
+        nodesMissingTelemetry={["1", "2", "3"]}
       />
     ),
   )
@@ -80,10 +87,13 @@ storiesOf("AlertBar", module)
         license={"Free"}
         numNodes={3}
         throttled={true}
-        telemetrySuccessful={false}
-        licenseExpiryDate={moment().add(6, "month")}
-        lastSuccessfulTelemetryDate={moment().subtract(1, "month")}
-        throttleDate={moment().subtract(3, "day")}
+        hasGracePeriod={true}
+        hasTelemetryDeadline={true}
+        licenseExpiryDate={moment().add(1, "month")}
+        gracePeriodEnd={moment().add(2, "month")}
+        lastSuccessfulTelemetryDate={moment().subtract(9, "day")}
+        telemetryDeadline={moment().subtract(2, "day")}
+        nodesMissingTelemetry={["1", "2", "3"]}
       />
     ),
   );

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.tsx
@@ -5,104 +5,200 @@
 
 import classNames from "classnames/bind";
 import moment from "moment";
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
 
-import { enterpriseLicenseUpdate } from "src/util/docs";
+import { Tooltip } from "src/components";
+import {
+  daysUntilLicenseExpiresSelector,
+  LicenseType,
+  licenseTypeSelector,
+} from "src/redux/alerts";
+import { nodeIDsSelector } from "src/redux/nodes";
+import {
+  getThrottlingMetadata,
+  GetThrottlingMetadataResponse,
+} from "src/util/api";
+import { throttlingFaqs } from "src/util/docs";
 
 import styles from "./alertBar.module.styl";
 
-type License = "Enterprise" | "Free" | "None";
-
 interface AlertBarProps {
-  license: License;
+  license: LicenseType;
   numNodes: number;
   throttled: boolean;
-  telemetrySuccessful: boolean;
+
+  hasGracePeriod: boolean;
   licenseExpiryDate?: moment.Moment;
+  gracePeriodEnd?: moment.Moment;
+
+  hasTelemetryDeadline: boolean;
   lastSuccessfulTelemetryDate?: moment.Moment;
-  throttleDate?: moment.Moment;
-  nodesMissingTelemetry?: [number];
+  telemetryDeadline?: moment.Moment;
+  nodesMissingTelemetry?: string[];
 }
 
 const cx = classNames.bind(styles);
+
+export const ThrottleNotificationBar = () => {
+  const [loaded, updateLoaded] = useState(false);
+  const daysUntilLicenseExpires = useSelector(daysUntilLicenseExpiresSelector);
+  const licenseType = useSelector(licenseTypeSelector);
+  const nodeIDs = useSelector(nodeIDsSelector);
+  const init: GetThrottlingMetadataResponse = {
+    throttled: false,
+    throttleExplanation: "",
+    hasGracePeriod: false,
+    gracePeriodEndSeconds: undefined,
+    hasTelemetryDeadline: false,
+    telemetryDeadlineSeconds: undefined,
+    lastTelemetryReceivedSeconds: undefined,
+    nodeIdsWithTelemetryProblems: [],
+  };
+  const [throttleMetadata, updateThrottleMetadata] = useState(init);
+
+  useEffect(() => {
+    if (!loaded) {
+      getThrottlingMetadata().then(resp => {
+        updateThrottleMetadata(resp);
+        updateLoaded(true);
+      });
+    }
+  }, [loaded]);
+
+  if (loaded) {
+    return (
+      <AlertBar
+        license={licenseType}
+        numNodes={nodeIDs.length}
+        throttled={throttleMetadata.throttled}
+        hasGracePeriod={throttleMetadata.hasGracePeriod}
+        licenseExpiryDate={moment().add(daysUntilLicenseExpires, "days")}
+        gracePeriodEnd={moment.unix(
+          throttleMetadata.gracePeriodEndSeconds.toNumber(),
+        )}
+        hasTelemetryDeadline={throttleMetadata.hasTelemetryDeadline}
+        lastSuccessfulTelemetryDate={moment.unix(
+          throttleMetadata.lastTelemetryReceivedSeconds.toNumber(),
+        )}
+        telemetryDeadline={moment.unix(
+          throttleMetadata.telemetryDeadlineSeconds.toNumber(),
+        )}
+        nodesMissingTelemetry={throttleMetadata.nodeIdsWithTelemetryProblems}
+      />
+    );
+  } else {
+    return null;
+  }
+};
 
 export const AlertBar = ({
   license,
   numNodes,
   throttled,
-  telemetrySuccessful,
+  hasGracePeriod,
   licenseExpiryDate,
+  gracePeriodEnd,
+  hasTelemetryDeadline,
   lastSuccessfulTelemetryDate,
-  throttleDate,
+  telemetryDeadline,
+  nodesMissingTelemetry,
 }: AlertBarProps) => {
-  if (license === "Enterprise" || numNodes < 2) {
-    return null; // No matter what, an enterprise license is never throttled.
+  // If there's no grace period, or telemetry deadline, or the cluster
+  // is single-node, never show anything.
+  if (
+    (!throttled && !hasGracePeriod && !hasTelemetryDeadline) ||
+    numNodes < 2
+  ) {
+    return null;
   }
 
-  if (license === "Free") {
-    // If license is expired, we throttle.
-    if (licenseExpiryDate.isBefore(moment())) {
-      if (throttled) {
-        return (
-          <div className={cx("alert-bar", "alert--alert")}>
-            Your license key expired on{" "}
-            {licenseExpiryDate.format("MMMM Do, YYYY")} and the cluster was
-            throttled. Please add a license key to continue using this cluster.{" "}
-            <a href={enterpriseLicenseUpdate}>Learn more</a>
-          </div>
-        );
-      } else {
-        return (
-          <div className={cx("alert-bar", "alert--warning")}>
-            Your license key expired on{" "}
-            {licenseExpiryDate.format("MMMM Do, YYYY")}. The cluster will be
-            throttled on {throttleDate.format("MMMM Do, YYYY")} unless the
-            license is renewed. <a href={enterpriseLicenseUpdate}>Learn more</a>
-          </div>
-        );
-      }
-    }
-    if (!telemetrySuccessful) {
-      if (throttled) {
-        return (
-          <div className={cx("alert-bar", "alert--alert")}>
-            Telemetry has not been received from some nodes in this cluster
-            since {lastSuccessfulTelemetryDate.format("MMMM Do, YYYY")}. These
-            nodes were throttled on {throttleDate.format("MMMM Do, YYYY")}.{" "}
-            <a href={enterpriseLicenseUpdate}>Learn more</a>
-          </div>
-        );
-      } else {
-        return (
-          <div className={cx("alert-bar", "alert--warning")}>
-            Telemetry has not been received from some nodes in this cluster
-            since {lastSuccessfulTelemetryDate.format("MMMM Do, YYYY")}. These
-            nodes will be throttled on {throttleDate.format("MMMM Do, YYYY")}{" "}
-            unless telemetry is received.{" "}
-            <a href={enterpriseLicenseUpdate}>Learn more</a>
-          </div>
-        );
-      }
+  // If the license has a grace period (i.e. it's a trial/free
+  // license), and it's expired, we will show a warning or alert based
+  // on throttle status.
+  if (hasGracePeriod && licenseExpiryDate?.isBefore(moment())) {
+    if (throttled || gracePeriodEnd?.isSameOrBefore(moment())) {
+      return (
+        <div className={cx("alert-bar", "alert--alert")}>
+          Your license key expired on{" "}
+          {licenseExpiryDate.format("MMMM Do, YYYY")} and the cluster was
+          throttled. Please add a license key to continue using this cluster.{" "}
+          <a href={throttlingFaqs}>Learn more</a>
+        </div>
+      );
+    } else {
+      return (
+        <div className={cx("alert-bar", "alert--warning")}>
+          Your license key expired on{" "}
+          {licenseExpiryDate.format("MMMM Do, YYYY")}. The cluster will be
+          throttled on {gracePeriodEnd.format("MMMM Do, YYYY")} unless the
+          license is renewed. <a href={throttlingFaqs}>Learn more</a>
+        </div>
+      );
     }
   }
 
+  // If the license has a telemetry deadline (i.e. it's a trial/free
+  // license), and it's been >1d since we received telemetry, we will
+  // show a warning or alert based on throttle status.
+  if (
+    hasTelemetryDeadline &&
+    lastSuccessfulTelemetryDate?.isBefore(moment().subtract(1, "day"))
+  ) {
+    const someNodes = (
+      <Tooltip
+        placement="bottom"
+        title={
+          <p>
+            Nodes failing to send telemetry:
+            <br />
+            {nodesMissingTelemetry.sort().join(", ")}
+          </p>
+        }
+      >
+        <span className={cx("alert-tooltip")}>some nodes in this cluster</span>
+      </Tooltip>
+    );
+
+    if (throttled || telemetryDeadline?.isSameOrBefore(moment())) {
+      return (
+        <div className={cx("alert-bar", "alert--alert")}>
+          Telemetry has not been received from {someNodes} since{" "}
+          {lastSuccessfulTelemetryDate.format("MMMM Do, YYYY")}. These nodes
+          were throttled on {telemetryDeadline.format("MMMM Do, YYYY")}.{" "}
+          <a href={throttlingFaqs}>Learn more</a>
+        </div>
+      );
+    } else {
+      return (
+        <div className={cx("alert-bar", "alert--warning")}>
+          Telemetry has not been received from {someNodes} since{" "}
+          {lastSuccessfulTelemetryDate.format("MMMM Do, YYYY")}. These nodes
+          will be throttled on {telemetryDeadline.format("MMMM Do, YYYY")}{" "}
+          unless telemetry is received. <a href={throttlingFaqs}>Learn more</a>
+        </div>
+      );
+    }
+  }
   if (license === "None") {
     if (throttled) {
       return (
         <div className={cx("alert-bar", "alert--alert")}>
           This cluster was throttled because it requires a license key. Please
           add a license key to continue using this cluster.{" "}
-          <a href={enterpriseLicenseUpdate}>Learn more</a>
+          <a href={throttlingFaqs}>Learn more</a>
         </div>
       );
     } else {
       return (
         <div className={cx("alert-bar", "alert--warning")}>
           This cluster will require a license key by{" "}
-          {throttleDate.format("MMMM Do, YYYY")} or the cluster will be
-          throttled. <a href={enterpriseLicenseUpdate}>Learn more</a>
+          {gracePeriodEnd.format("MMMM Do, YYYY")} or the cluster will be
+          throttled. <a href={throttlingFaqs}>Learn more</a>
         </div>
       );
     }
   }
+
+  return null;
 };


### PR DESCRIPTION
This commit connects the `AlertBar` component in the DB Console to
the newly created `/_status/throttling` gRPC endpoint that delivers
cluster-wide throttling metadata.

Depending on various parameters in the response, we compose an alert
to show to the user. If the cluster is throttled the banner is red, if
it's going to be throttled in the future the banner is yellow.

Resolves: [CRDB-40937](https://cockroachlabs.atlassian.net/browse/CRDB-40937)
Epic: [CRDB-40853](https://cockroachlabs.atlassian.net/browse/CRDB-40853)

Release note (ui change): DB Console will reflect any throttling
behavior from the cluster due to an expired license or missing
telemetry data. Enterprise licenses are not affected.

---
Some example renders:

<img width="1611" alt="Screenshot 2024-09-24 at 19 26 57" src="https://github.com/user-attachments/assets/62dd43e0-007c-4ced-9f4c-1cde9471964d">
<img width="1616" alt="Screenshot 2024-09-24 at 18 38 38" src="https://github.com/user-attachments/assets/dbd665a5-3ee8-4f83-a473-5e238f17c224">
<img width="1506" alt="Screenshot 2024-09-24 at 19 41 18" src="https://github.com/user-attachments/assets/415ce6a1-0c87-4c2c-90ac-c0bedb612d92">
