### PR TITLE
catalog/lease: prevent panic inside upsertLeaseLocked

### DIFF
--- a/pkg/sql/catalog/lease/descriptor_state.go
+++ b/pkg/sql/catalog/lease/descriptor_state.go
@@ -185,7 +185,9 @@ func (t *descriptorState) upsertLeaseLocked(
 	// is subsumed we have nothing to delete. In dual-write mode clearing
 	// this guarantees only the old expiry based lease is cleaned up. In
 	// Session only clearing this means the release is a no-op.
-	toRelease.sessionID = nil
+	if toRelease != nil {
+		toRelease.sessionID = nil
+	}
 	return nil, toRelease, nil
 }
 


### PR DESCRIPTION
Previously, it was possible to panic inside upsertLeaseLocked, if the stored lease was nil. This could happen in tests which are designed to instantly release dereferenced leases. For example this was seen inside: TestAsOfSystemTimeUsesCache. To address this, this patch will add defensive code to check for a valid stored lease, before clearing the session ID stored inside the lease.

Fixes: #131300

Release note: None