### PR TITLE
kv: add ReturnRawMVCCValue to Get, Scan and ReverseScan requests

### DIFF
--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -263,6 +263,18 @@ message GetRequest {
   // transactions that need guaranteed locks for correctness (read:
   // read-committed or snapshot isolation transactions).
   kv.kvserver.concurrency.lock.Durability key_locking_durability = 3;
+
+  // ReturnRawMVCCValues indicates that the returned roachpb.Values
+  // should contain the full bytes of the underlying MVCCValue,
+  // including the MVCCValueHeader. If the MVCCValueHeader is
+  // non-empty, the returned value will be encoded using the extended
+  // encoding with MVCC_EXTENDED_ENCODING_SENTINEL value type as its
+  // tag. If the MVCCValueHeader is empty, the default, simple
+  // encoding will be used.
+  //
+  // This option is not compatible for reads over inline values (see
+  // https://github.com/cockroachdb/cockroach/issues/131667)
+  bool return_raw_mvcc_values = 4 [(gogoproto.customname) = "ReturnRawMVCCValues"];
 }
 
 // A GetResponse is the return value from the Get() method.
@@ -702,6 +714,18 @@ message ScanRequest {
   // transactions that need guaranteed locks for correctness (read:
   // read-committed or snapshot isolation transactions).
   kv.kvserver.concurrency.lock.Durability key_locking_durability = 6;
+
+  // ReturnRawMVCCValues indicates that the returned roachpb.Values
+  // should contain the full bytes of the underlying MVCCValue,
+  // including the MVCCValueHeader. If the MVCCValueHeader is
+  // non-empty, the returned value will be encoded using the extended
+  // encoding with MVCC_EXTENDED_ENCODING_SENTINEL value type as its
+  // tag. If the MVCCValueHeader is empty, the default, simple
+  // encoding will be used.
+  //
+  // This option is not compatible for reads over inline values (see
+  // https://github.com/cockroachdb/cockroach/issues/131667)
+  bool return_raw_mvcc_values = 7 [(gogoproto.customname) = "ReturnRawMVCCValues"];
 }
 
 // A ScanResponse is the return value from the Scan() method.
@@ -790,6 +814,18 @@ message ReverseScanRequest {
   // transactions that need guaranteed locks for correctness (read:
   // read-committed or snapshot isolation transactions).
   kv.kvserver.concurrency.lock.Durability key_locking_durability = 6;
+
+  // ReturnRawMVCCValues indicates that the returned roachpb.Values
+  // should contain the full bytes of the underlying MVCCValue,
+  // including the MVCCValueHeader. If the MVCCValueHeader is
+  // non-empty, the returned value will be encoded using the extended
+  // encoding with MVCC_EXTENDED_ENCODING_SENTINEL value type as its
+  // tag. If the MVCCValueHeader is empty, the default, simple
+  // encoding will be used.
+  //
+  // This option is not compatible for reads over inline values (see
+  // https://github.com/cockroachdb/cockroach/issues/131667)
+  bool return_raw_mvcc_values = 7 [(gogoproto.customname) = "ReturnRawMVCCValues"];
 }
 
 // A ReverseScanResponse is the return value from the ReverseScan() method.

--- a/pkg/kv/kvserver/batcheval/cmd_get.go
+++ b/pkg/kv/kvserver/batcheval/cmd_get.go
@@ -56,6 +56,7 @@ func Get(
 		TargetBytes:           cArgs.Header.TargetBytes,
 		AllowEmpty:            cArgs.Header.AllowEmpty,
 		ReadCategory:          fs.BatchEvalReadCategory,
+		ReturnRawMVCCValues:   args.ReturnRawMVCCValues,
 	})
 	if err != nil {
 		return result.Result{}, err

--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -66,6 +66,7 @@ func ReverseScan(
 		LockTable:               lockTableForSkipLocked,
 		DontInterleaveIntents:   cArgs.DontInterleaveIntents,
 		ReadCategory:            readCategory,
+		ReturnRawMVCCValues:     args.ReturnRawMVCCValues,
 	}
 
 	switch args.ScanFormat {

--- a/pkg/kv/kvserver/batcheval/cmd_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan.go
@@ -68,6 +68,7 @@ func Scan(
 		LockTable:               lockTableForSkipLocked,
 		DontInterleaveIntents:   cArgs.DontInterleaveIntents,
 		ReadCategory:            readCategory,
+		ReturnRawMVCCValues:     args.ReturnRawMVCCValues,
 	}
 
 	switch args.ScanFormat {

--- a/pkg/kv/kvserver/batcheval/cmd_scan_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -228,6 +229,173 @@ func TestScanReverseScanWholeRows(t *testing.T) {
 		}
 
 		require.EqualValues(t, resp.Header().NumKeys, 3)
+	})
+}
+
+// TestScanReturnRawMVCC tests that a ScanRequest with the
+// ReturnRawMVCC option set should return the full bytes of the
+// MVCCValue in the RawBytes field of returned roachpb.Values.
+func TestScanReturnRawMVCC(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	// Write a value with WriteOptions that will produce an
+	// MVCCValueHeader.
+	clock := hlc.NewClockForTesting(nil)
+	settings := cluster.MakeTestingClusterSettings()
+	evalCtx := (&MockEvalCtx{Clock: clock, ClusterSettings: settings}).EvalContext()
+	ts := clock.Now()
+
+	var (
+		expectedOriginID = uint32(42)
+		key1             = roachpb.Key([]byte{'a'}) // Will have MVCCValueHeader
+		key2             = roachpb.Key([]byte{'b'}) // Will have MVCCValueHeader
+		key3             = roachpb.Key([]byte{'c'}) // No MVCCValueHeader
+		key4             = roachpb.Key([]byte{'d'})
+		value            = roachpb.MakeValueFromString("woohoo")
+	)
+
+	putWithWriteOptions := func(key roachpb.Key, value roachpb.Value, writeOpts *kvpb.WriteOptions, db storage.Engine, txn *roachpb.Transaction) {
+		putResp := kvpb.PutResponse{}
+		_, err := Put(ctx, db, CommandArgs{
+			EvalCtx: evalCtx,
+			Header: kvpb.Header{
+				Txn:          txn,
+				Timestamp:    ts,
+				WriteOptions: writeOpts,
+			},
+			Args: &kvpb.PutRequest{
+				RequestHeader: kvpb.RequestHeader{Key: key},
+				Value:         value,
+			},
+		}, &putResp)
+		require.NoError(t, err)
+	}
+	putWithOriginIDSet := func(key roachpb.Key, value roachpb.Value, db storage.Engine, txn *roachpb.Transaction) {
+		putWithWriteOptions(key, value, &kvpb.WriteOptions{OriginID: expectedOriginID}, db, txn)
+	}
+
+	setup := func(db storage.Engine, txn *roachpb.Transaction) {
+		putWithOriginIDSet(key1, value, db, txn)
+		putWithOriginIDSet(key2, value, db, txn)
+		putWithWriteOptions(key3, value, nil, db, txn)
+	}
+	checkRow := func(expOriginID uint32, v roachpb.Value) {
+		mvccValue, err := storage.DecodeMVCCValue(v.RawBytes)
+		require.NoError(t, err)
+		require.Equal(t, expOriginID, mvccValue.OriginID)
+	}
+	scan := func(returnRaw bool, db storage.Engine, txn *roachpb.Transaction) kvpb.ScanResponse {
+		resp := kvpb.ScanResponse{}
+		_, err := Scan(ctx, db, CommandArgs{
+			EvalCtx: evalCtx,
+			Header:  kvpb.Header{Txn: txn, Timestamp: clock.Now()},
+			Args: &kvpb.ScanRequest{
+				ReturnRawMVCCValues: returnRaw,
+				RequestHeader: kvpb.RequestHeader{
+					Key:    key1,
+					EndKey: key4,
+				},
+			},
+		}, &resp)
+		require.NoError(t, err)
+		return resp
+	}
+	rscan := func(returnRaw bool, db storage.Engine, txn *roachpb.Transaction) kvpb.ReverseScanResponse {
+		resp := kvpb.ReverseScanResponse{}
+		_, err := ReverseScan(ctx, db, CommandArgs{
+			EvalCtx: evalCtx,
+			Header:  kvpb.Header{Txn: txn, Timestamp: ts},
+			Args: &kvpb.ReverseScanRequest{
+				ReturnRawMVCCValues: returnRaw,
+				RequestHeader: kvpb.RequestHeader{
+					Key:    key1,
+					EndKey: key4,
+				},
+			},
+		}, &resp)
+		require.NoError(t, err)
+		return resp
+	}
+	get := func(key roachpb.Key, returnRaw bool, db storage.Engine, txn *roachpb.Transaction) kvpb.GetResponse {
+		getResp := kvpb.GetResponse{}
+		_, err := Get(ctx, db, CommandArgs{
+			EvalCtx: evalCtx,
+			Header:  kvpb.Header{Txn: txn, Timestamp: ts},
+			Args: &kvpb.GetRequest{
+				ReturnRawMVCCValues: returnRaw,
+				RequestHeader:       kvpb.RequestHeader{Key: key},
+			},
+		}, &getResp)
+		require.NoError(t, err)
+		return getResp
+	}
+
+	testutils.RunTrueAndFalse(t, "txn", func(t *testing.T, useTxn bool) {
+		testutils.RunTrueAndFalse(t, "ReturnRawMVCCValues", func(t *testing.T, returnRaw bool) {
+			db := storage.NewDefaultInMemForTesting()
+			defer db.Close()
+
+			var txn *roachpb.Transaction
+			if useTxn {
+				txn1 := roachpb.MakeTransaction("test", nil, /* baseKey */
+					isolation.Serializable,
+					roachpb.NormalUserPriority, ts, 0, 0, 0, false /* omitInRangefeeds */)
+				txn = &txn1
+			}
+			expOriginID := expectedOriginID
+			// If we are running without ReturnRaweMVCCValues, we
+			// should never see the originID.
+			if !returnRaw {
+				expOriginID = 0
+			}
+			setup(db, txn)
+			t.Run("scan", func(t *testing.T) {
+				resp := scan(returnRaw, db, txn)
+				require.Equal(t, 3, len(resp.Rows))
+				checkRow(expOriginID, resp.Rows[0].Value)
+				checkRow(expOriginID, resp.Rows[1].Value)
+				checkRow(0, resp.Rows[2].Value)
+			})
+			t.Run("reverse_scan", func(t *testing.T) {
+				resp := rscan(returnRaw, db, txn)
+				require.Equal(t, 3, len(resp.Rows))
+				checkRow(expOriginID, resp.Rows[2].Value)
+				checkRow(expOriginID, resp.Rows[1].Value)
+				checkRow(0, resp.Rows[0].Value)
+			})
+			t.Run("get", func(t *testing.T) {
+				resp := get(key1, returnRaw, db, txn)
+				checkRow(expOriginID, *resp.Value)
+				resp = get(key3, returnRaw, db, txn)
+				checkRow(0, *resp.Value)
+			})
+		})
+	})
+
+	t.Run("scan_at_lower_sequence_number", func(t *testing.T) {
+		db := storage.NewDefaultInMemForTesting()
+		defer db.Close()
+
+		txn := roachpb.MakeTransaction("test", nil, /* baseKey */
+			isolation.Serializable,
+			roachpb.NormalUserPriority, ts, 0, 0, 0, false /* omitInRangefeeds */)
+		setup(db, &txn)
+		// Write 3 values at a higher sequence number with no
+		// origin ID. We should still get the originID written
+		// at a lower sequence number. Txn is captured in the
+		// funcs above.
+		txn.Sequence += 1
+		putWithWriteOptions(key1, value, nil, db, &txn)
+		putWithWriteOptions(key2, value, nil, db, &txn)
+		putWithWriteOptions(key3, value, nil, db, &txn)
+		txn.Sequence = 0
+
+		resp := scan(true, db, &txn)
+		require.Equal(t, 3, len(resp.Rows))
+		checkRow(expectedOriginID, resp.Rows[0].Value)
+		checkRow(expectedOriginID, resp.Rows[1].Value)
+		checkRow(0, resp.Rows[2].Value)
 	})
 }
 

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -1261,6 +1261,10 @@ type MVCCGetOptions struct {
 	// ReadCategory is used to map to a user-understandable category string, for
 	// stats aggregation and metrics, and a Pebble-understandable QoS.
 	ReadCategory fs.ReadCategory
+	// ReturnRawMVCCValues indicates the get should return a
+	// roachpb.Value whose RawBytes may contain MVCCValueHeader
+	// data.
+	ReturnRawMVCCValues bool
 }
 
 // MVCCGetResult bundles return values for the MVCCGet family of functions.
@@ -1557,6 +1561,7 @@ func mvccGet(
 		inconsistent:     opts.Inconsistent,
 		skipLocked:       opts.SkipLocked,
 		tombstones:       opts.Tombstones,
+		rawMVCCValues:    opts.ReturnRawMVCCValues,
 		failOnMoreRecent: opts.FailOnMoreRecent,
 		keyBuf:           mvccScanner.keyBuf,
 	}
@@ -4557,6 +4562,7 @@ func mvccScanInit(
 		maxKeys:          opts.MaxKeys,
 		targetBytes:      opts.TargetBytes,
 		allowEmpty:       opts.AllowEmpty,
+		rawMVCCValues:    opts.ReturnRawMVCCValues,
 		wholeRows:        opts.WholeRowsOfSize > 1, // single-KV rows don't need processing
 		maxLockConflicts: opts.MaxLockConflicts,
 		inconsistent:     opts.Inconsistent,
@@ -4820,6 +4826,10 @@ type MVCCScanOptions struct {
 	// ReadCategory is used to map to a user-understandable category string, for
 	// stats aggregation and metrics, and a Pebble-understandable QoS.
 	ReadCategory fs.ReadCategory
+	// ReturnRawMVCCValues indicates that the scan should return
+	// roachpb.Value whose RawBytes may contain MVCCValueHeader
+	// data.
+	ReturnRawMVCCValues bool
 }
 
 func (opts *MVCCScanOptions) validate() error {

--- a/pkg/storage/pebble_mvcc_scanner_test.go
+++ b/pkg/storage/pebble_mvcc_scanner_test.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/uncertainty"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -293,4 +294,162 @@ func TestMVCCScanWithMemoryAccounting(t *testing.T) {
 		require.Contains(t, err.Error(), "memory budget exceeded")
 		cleanup()
 	}
+}
+
+// TestMVCCScanWithMVCCValueHeaders tests that when the rawMVCCValues
+// option is given to pebbleMVCCScanner, the returned values can be
+// parsed using the extended encoding and the value header is
+// preserved.
+func TestMVCCScanWithMVCCValueHeaders(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	eng, err := Open(context.Background(), InMemory(),
+		cluster.MakeClusterSettings(),
+		CacheSize(1<<20))
+	require.NoError(t, err)
+	defer eng.Close()
+
+	// We write
+	//
+	// a@1                       with ValueHeader
+	// d@1                       without ValueHeader
+	//
+	// d-e@2 (DelRange)          with ValueHeader
+	//
+	// c1@3                      with ValueHeader
+	// c2@3                      with ValueHeader
+	// c2@4                      without ValueHeader
+	//
+	// b@3 Seq = 0 (provisional) with ValueHeader
+	// b@3 Seq = 1 (provisional) without ValueHeader
+	//
+	// We then read with tombstones at ts3,seq=0 and expect to see
+	// 5 values all with value headers:
+	//
+	// a@1
+	// b@3 Seq = 0
+	// c1@3
+	// c2@3
+	// d@2 (synthesized from range key)
+	keyA := roachpb.Key("a")
+	keyB := roachpb.Key("b")
+	keyC1 := roachpb.Key("c1")
+	keyC2 := roachpb.Key("c2")
+	keyD := roachpb.Key("d")
+	keyE := roachpb.Key("e")
+	ts1 := hlc.Timestamp{WallTime: 1}
+	ts2 := hlc.Timestamp{WallTime: 2}
+	ts3 := hlc.Timestamp{WallTime: 3}
+	ts4 := hlc.Timestamp{WallTime: 4}
+	expectedOriginID := uint32(42)
+
+	writeValue := func(key roachpb.Key, ts hlc.Timestamp, txn *roachpb.Transaction, originID uint32) {
+		_, err := MVCCPut(ctx, eng, key, ts,
+			roachpb.MakeValueFromString(fmt.Sprintf("%s-val", key)),
+			MVCCWriteOptions{
+				Txn:      txn,
+				OriginID: originID,
+			},
+		)
+		require.NoError(t, err)
+	}
+
+	writeValue(keyA, ts1, nil, expectedOriginID)
+	writeValue(keyD, ts1, nil, 0)
+
+	require.NoError(t, eng.PutMVCCRangeKey(MVCCRangeKey{StartKey: keyD, EndKey: keyE, Timestamp: ts2}, MVCCValue{
+		MVCCValueHeader: enginepb.MVCCValueHeader{OriginID: expectedOriginID},
+	}))
+
+	txn1 := roachpb.MakeTransaction("test", nil, isolation.Serializable, roachpb.NormalUserPriority,
+		ts3, 1, 1, 0, false /* omitInRangefeeds */)
+	writeValue(keyB, ts3, &txn1, expectedOriginID)
+	txn1.Sequence++
+	writeValue(keyB, ts3, &txn1, 0)
+	txn1.Sequence--
+
+	writeValue(keyC1, ts3, nil, expectedOriginID)
+	writeValue(keyC2, ts3, nil, expectedOriginID)
+	writeValue(keyC2, ts4, nil, 0)
+
+	reader := eng.NewReader(StandardDurability)
+	defer reader.Close()
+
+	createScanner := func(startKey roachpb.Key) (*pebbleMVCCScanner, func()) {
+		iter, err := reader.NewMVCCIterator(ctx, MVCCKeyAndIntentsIterKind, IterOptions{
+			KeyTypes:   IterKeyTypePointsAndRanges,
+			LowerBound: startKey,
+			UpperBound: keyE})
+		require.NoError(t, err)
+		return &pebbleMVCCScanner{
+			parent:        iter,
+			memAccount:    mon.NewStandaloneUnlimitedAccount(),
+			start:         keyA,
+			end:           keyE,
+			ts:            ts3,
+			tombstones:    true,
+			rawMVCCValues: true,
+		}, iter.Close
+	}
+	checkKVData := func(kvData [][]byte) {
+		require.NoError(t, MVCCScanDecodeKeyValues(kvData, func(k MVCCKey, v []byte) error {
+			mvccValue, err := DecodeMVCCValue(v)
+			require.NoError(t, err)
+			require.Equal(t, expectedOriginID, mvccValue.OriginID)
+			return nil
+		}))
+	}
+
+	t.Run("scan", func(t *testing.T) {
+		t.Run("maxIterBeforeSeek=0", func(t *testing.T) {
+			oldMaxItersBeforeSeek := maxItersBeforeSeek
+			defer func() { maxItersBeforeSeek = oldMaxItersBeforeSeek }()
+			maxItersBeforeSeek = 0
+
+			mvccScanner, cleanup := createScanner(keyA)
+			defer cleanup()
+
+			var results pebbleResults
+			mvccScanner.init(&txn1, uncertainty.Interval{}, &results)
+			_, _, _, err = mvccScanner.scan(ctx)
+			require.NoError(t, err)
+			kvData := results.finish()
+			require.Equal(t, int64(5), results.count)
+			checkKVData(kvData)
+		})
+		t.Run("maxIterBeforeSeek=default", func(t *testing.T) {
+			mvccScanner, cleanup := createScanner(keyA)
+			defer cleanup()
+
+			var results pebbleResults
+			mvccScanner.init(&txn1, uncertainty.Interval{}, &results)
+			_, _, _, err = mvccScanner.scan(ctx)
+			require.NoError(t, err)
+			kvData := results.finish()
+			require.Equal(t, int64(5), results.count)
+			checkKVData(kvData)
+		})
+	})
+	t.Run("get", func(t *testing.T) {
+		getKeyWithScanner := func(key roachpb.Key) {
+			mvccScanner, cleanup := createScanner(key)
+			defer cleanup()
+
+			var results pebbleResults
+			mvccScanner.init(&txn1, uncertainty.Interval{}, &results)
+			mvccScanner.get(ctx)
+			kvData := results.finish()
+			require.Equal(t, int64(1), results.count)
+			checkKVData(kvData)
+		}
+		getKeyWithScanner(keyA)
+		getKeyWithScanner(keyB)
+		getKeyWithScanner(keyC1)
+		getKeyWithScanner(keyC2)
+		getKeyWithScanner(keyD)
+		// This is a key covered by a range tombstone but not
+		// otherwise written to. In this case, get() will
+		// still synthesize a tombstone.
+		getKeyWithScanner(roachpb.Key("dd"))
+	})
 }


### PR DESCRIPTION
Logical Data Replication (LDR) and Import now both write values into the MVCCValueHeader of keys. We would eventually like to be able to read these values from SQL. In the case of LDR this will allow the SQL-write-path to continue to function even after the OriginTimetamp column is moved out of the user's table schema and into the MVCCValueHeader.

Here, we take the first step in that direction by adding a ReturnRawMVCCValue option to GetRequest, ScanRequest, and ReverseScanRequest.

Future work will modify the row and column fetchers to pass this option and correctly handle the results.

Epic: none
Release note: None