### PR TITLE
sql/logictest: address flake inside synthetic_privileges

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/synthetic_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/synthetic_privileges
@@ -291,7 +291,7 @@ CREATE USER testuser4
 statement ok
 REVOKE SELECT ON crdb_internal.tables FROM public
 
-query B
+query B retry
 SELECT has_table_privilege('testuser4', 'crdb_internal.tables', 'SELECT')
 ----
 false


### PR DESCRIPTION
Previously, the logic test synthetic_privileges would flake with transaction retry errors querying from has_table_privilege. To address this, this patch makes the problematic invocation as retryable.

Fixes: #128370

Release note: None