### PR TITLE
storage: remove WAL failover enterprise license check

### DIFF
--- a/pkg/storage/open_test.go
+++ b/pkg/storage/open_test.go
@@ -128,11 +128,6 @@ func TestWALFailover(t *testing.T) {
 				}
 				settings := cluster.MakeTestingClusterSettingsWithVersions(version, version, true /* initializeVersion */)
 
-				// Mock an enterpise license, or not if disable-enterprise is specified.
-				enterpriseEnabledFunc := base.CCLDistributionAndEnterpriseEnabled
-				base.CCLDistributionAndEnterpriseEnabled = func(st *cluster.Settings) bool { return !td.HasArg("disable-enterprise") }
-				defer func() { base.CCLDistributionAndEnterpriseEnabled = enterpriseEnabledFunc }()
-
 				engine, err := Open(context.Background(), openEnv, settings, WALFailover(cfg, envs, defaultFS, nil))
 				if err != nil {
 					openEnv.Close()

--- a/pkg/storage/testdata/wal_failover_config
+++ b/pkg/storage/testdata/wal_failover_config
@@ -90,14 +90,6 @@ open flag=disabled envs=(foo,bar) open=bar
 OK
 WALRecoveryDir: foo/auxiliary/wals-among-stores
 
-# Ensure that WAL failover refuses to failover if there's no enterprise
-# license configured.
-open flag=among-stores envs=(foo,bar) open=foo disable-enterprise
-----
-OK
-secondary = bar/auxiliary/wals-among-stores
-UnhealthyOperationLatencyThreshold() = (100ms,false)
-
 open flag=disabled envs=(foo,bar) open=foo
 ----
 OK


### PR DESCRIPTION
The license check may be performed before the node has fully initialized and knows whether a valid enterprise license is available. A warning may be logged erroneously, which may confuse. Remove the license check altogether given the direction CockroachDB enterprise licensing is moving in general.

Epic: none
Informs #129240.
Release note: none