### PR TITLE
drt-run: Fix warnings to avoid build failure

### DIFF
--- a/pkg/cmd/drt-run/event.go
+++ b/pkg/cmd/drt-run/event.go
@@ -64,25 +64,25 @@ type Event struct {
 // String() implements the Stringer interface.
 func (e *Event) String() string {
 	var builder strings.Builder
-	fmt.Fprintf(&builder, "[%s] ", e.Timestamp.Format(time.RFC3339))
+	_, _ = fmt.Fprintf(&builder, "[%s] ", e.Timestamp.Format(time.RFC3339))
 	switch e.Source {
 	case SourceWorkload:
-		fmt.Fprintf(&builder, "workload %s", e.SourceName)
+		_, _ = fmt.Fprintf(&builder, "workload %s", e.SourceName)
 	case SourceOperation:
-		fmt.Fprintf(&builder, "operation %s", e.SourceName)
+		_, _ = fmt.Fprintf(&builder, "operation %s", e.SourceName)
 	}
 	switch e.Type {
 	case EventOutput:
-		fmt.Fprintf(&builder, ": %s", e.Details)
+		_, _ = fmt.Fprintf(&builder, ": %s", e.Details)
 	case EventFinish:
-		fmt.Fprintf(&builder, " finished with %s", e.Details)
+		_, _ = fmt.Fprintf(&builder, " finished with %s", e.Details)
 	case EventStart:
 		builder.WriteString(" started")
 		if e.Details != "" {
-			fmt.Fprintf(&builder, " with %s", e.Details)
+			_, _ = fmt.Fprintf(&builder, " with %s", e.Details)
 		}
 	case EventError:
-		fmt.Fprintf(&builder, " returned an error %s", e.Details)
+		_, _ = fmt.Fprintf(&builder, " returned an error %s", e.Details)
 	}
 	return builder.String()
 }
@@ -119,16 +119,20 @@ func (l *eventLogger) logWorkloadEvent(ev Event, workloadIdx int) {
 	ev.Source = SourceWorkload
 
 	we := &l.workloadEvents[workloadIdx]
-	we.mu.Lock()
-	idx := we.mu.startIdx
-	we.mu.startIdx = (we.mu.startIdx + 1) % perWorkloadEventRetention
-	if we.mu.numEvents != len(we.events) {
-		we.mu.numEvents++
+	var idx int
+	{
+		we.mu.Lock()
+		defer func() {
+			we.mu.Unlock()
+		}()
+		idx = we.mu.startIdx
+		we.mu.startIdx = (we.mu.startIdx + 1) % perWorkloadEventRetention
+		if we.mu.numEvents != len(we.events) {
+			we.mu.numEvents++
+		}
 	}
-	we.mu.Unlock()
-
 	we.events[idx] = ev
-	io.WriteString(l.outputFile, ev.String()+"\n")
+	_, _ = io.WriteString(l.outputFile, ev.String()+"\n")
 }
 
 // logOperationEvent logs an event in the operation log. Up to operationEventRetention
@@ -137,16 +141,20 @@ func (l *eventLogger) logOperationEvent(ev Event) {
 	ev.Timestamp = timeutil.Now()
 	ev.Source = SourceOperation
 
-	l.mu.Lock()
-	idx := l.mu.operationStartIdx
-	l.mu.operationStartIdx = (l.mu.operationStartIdx + 1) % operationEventRetention
-	if l.mu.operationEvents != len(l.operationEvents) {
-		l.mu.operationEvents++
+	var idx int
+	{
+		l.mu.Lock()
+		defer func() {
+			l.mu.Unlock()
+		}()
+		idx = l.mu.operationStartIdx
+		l.mu.operationStartIdx = (l.mu.operationStartIdx + 1) % operationEventRetention
+		if l.mu.operationEvents != len(l.operationEvents) {
+			l.mu.operationEvents++
+		}
 	}
-	l.mu.Unlock()
-
 	l.operationEvents[idx] = ev
-	io.WriteString(l.outputFile, ev.String()+"\n")
+	_, _ = io.WriteString(l.outputFile, ev.String()+"\n")
 }
 
 // getWorkloadEvents returns workload events for a given workload worker. Up to

--- a/pkg/cmd/drt-run/http.go
+++ b/pkg/cmd/drt-run/http.go
@@ -51,86 +51,86 @@ func (h *httpHandler) writeRunningOperations(rw http.ResponseWriter) {
 	opEvents := h.eventL.getOperationEvents()
 	runningOps := h.o.getRunningOperations()
 
-	fmt.Fprintf(rw, "<p>Operations:</p>\n<ul>")
+	_, _ = fmt.Fprintf(rw, "<p>Operations:</p>\n<ul>")
 
-	fmt.Fprintf(rw, "<table style=\"border: 1px solid black;\">\n<tr><th>Worker</th><th>Operation</th><th>Log entries</th></tr>\n")
+	_, _ = fmt.Fprintf(rw, "<table style=\"border: 1px solid black;\">\n<tr><th>Worker</th><th>Operation</th><th>Log entries</th></tr>\n")
 	for i := range runningOps {
-		fmt.Fprintf(rw, "<tr>\n")
-		fmt.Fprintf(rw, "<td>%d</td>", i)
+		_, _ = fmt.Fprintf(rw, "<tr>\n")
+		_, _ = fmt.Fprintf(rw, "<td>%d</td>", i)
 		if runningOps[i] == "" {
-			fmt.Fprintf(rw, "<td>idle</td><td></td></tr>")
+			_, _ = fmt.Fprintf(rw, "<td>idle</td><td></td></tr>")
 			continue
 		}
-		fmt.Fprintf(rw, "<td>%s</td>", runningOps[i])
-		fmt.Fprintf(rw, "<td><div style=\"font-family: monospace;\">")
+		_, _ = fmt.Fprintf(rw, "<td>%s</td>", runningOps[i])
+		_, _ = fmt.Fprintf(rw, "<td><div style=\"font-family: monospace;\">")
 		for j := range opEvents {
 			if opEvents[j].SourceName == runningOps[i] {
-				fmt.Fprintf(rw, "%s<br>", opEvents[j].String())
+				_, _ = fmt.Fprintf(rw, "%s<br>", opEvents[j].String())
 			}
 		}
-		fmt.Fprintf(rw, "</div></td></tr>")
+		_, _ = fmt.Fprintf(rw, "</div></td></tr>")
 	}
-	fmt.Fprintf(rw, "</table>")
+	_, _ = fmt.Fprintf(rw, "</table>")
 }
 
 func (h *httpHandler) serve(rw http.ResponseWriter, req *http.Request) {
-	fmt.Fprintf(rw, "<!DOCTYPE html>\n")
-	fmt.Fprintf(rw, "<html lang=\"en\">\n")
-	fmt.Fprintf(rw, "<head><title>DRT Run</title><meta charset=\"utf-8\"></head>\n")
-	fmt.Fprintf(rw, "<body>\n")
+	_, _ = fmt.Fprintf(rw, "<!DOCTYPE html>\n")
+	_, _ = fmt.Fprintf(rw, "<html lang=\"en\">\n")
+	_, _ = fmt.Fprintf(rw, "<head><title>DRT Run</title><meta charset=\"utf-8\"></head>\n")
+	_, _ = fmt.Fprintf(rw, "<body>\n")
 
-	fmt.Fprintf(rw, "<h3>Workloads</h3><hr>\n")
+	_, _ = fmt.Fprintf(rw, "<h3>Workloads</h3><hr>\n")
 
-	fmt.Fprintf(rw, "<p>Workloads:</p>\n<ul>")
+	_, _ = fmt.Fprintf(rw, "<p>Workloads:</p>\n<ul>")
 	for i, w := range h.w.config.Workloads {
-		fmt.Fprintf(rw, "<li><a href=\"/workload/?id=%d\">%s (kind %s)</a></li>", i, w.Name, w.Kind)
+		_, _ = fmt.Fprintf(rw, "<li><a href=\"/workload/?id=%d\">%s (kind %s)</a></li>", i, w.Name, w.Kind)
 	}
-	fmt.Fprintf(rw, "</ul>\n")
+	_, _ = fmt.Fprintf(rw, "</ul>\n")
 
-	fmt.Fprintf(rw, "<h3>Operations</h3><hr>\n")
+	_, _ = fmt.Fprintf(rw, "<h3>Operations</h3><hr>\n")
 	h.writeRunningOperations(rw)
 
-	fmt.Fprintf(rw, "<h3>Operations log history</h3><hr>\n")
-	fmt.Fprintf(rw, "<div style=\"font-family: monospace;\">")
+	_, _ = fmt.Fprintf(rw, "<h3>Operations log history</h3><hr>\n")
+	_, _ = fmt.Fprintf(rw, "<div style=\"font-family: monospace;\">")
 	for _, ev := range h.eventL.getOperationEvents() {
-		fmt.Fprintf(rw, "%s<br>", ev.String())
+		_, _ = fmt.Fprintf(rw, "%s<br>", ev.String())
 	}
-	fmt.Fprintf(rw, "</div>")
+	_, _ = fmt.Fprintf(rw, "</div>")
 
-	fmt.Fprintf(rw, "<h3>Configuration</h3><hr>\n")
-	fmt.Fprintf(rw, "<pre>")
+	_, _ = fmt.Fprintf(rw, "<h3>Configuration</h3><hr>\n")
+	_, _ = fmt.Fprintf(rw, "<pre>")
 	encoder := yaml.NewEncoder(rw)
-	encoder.Encode(h.w.config)
-	fmt.Fprintf(rw, "</pre>")
+	_ = encoder.Encode(h.w.config)
+	_, _ = fmt.Fprintf(rw, "</pre>")
 
-	fmt.Fprintf(rw, "</body>\n</html>")
+	_, _ = fmt.Fprintf(rw, "</body>\n</html>")
 
 }
 
 func (h *httpHandler) serveWorkload(rw http.ResponseWriter, req *http.Request) {
 	workloadIdx := req.URL.Query().Get("id")
-	fmt.Fprintf(rw, "<!DOCTYPE html>\n")
-	fmt.Fprintf(rw, "<html lang=\"en\">\n")
-	fmt.Fprintf(rw, "<head><title>DRT Run - Workload %s</title><meta charset=\"utf-8\"></head>\n", workloadIdx)
-	fmt.Fprintf(rw, "<body>\n")
+	_, _ = fmt.Fprintf(rw, "<!DOCTYPE html>\n")
+	_, _ = fmt.Fprintf(rw, "<html lang=\"en\">\n")
+	_, _ = fmt.Fprintf(rw, "<head><title>DRT Run - Workload %s</title><meta charset=\"utf-8\"></head>\n", workloadIdx)
+	_, _ = fmt.Fprintf(rw, "<body>\n")
 
-	fmt.Fprintf(rw, "<h3>Workload %s</h3><hr>\n", workloadIdx)
+	_, _ = fmt.Fprintf(rw, "<h3>Workload %s</h3><hr>\n", workloadIdx)
 
 	idx, err := strconv.Atoi(workloadIdx)
 	if err != nil || idx < 0 || idx >= len(h.w.config.Workloads) {
-		fmt.Fprintf(rw, "error when parsing workload id: %s", err)
-		fmt.Fprintf(rw, "</body></html>")
+		_, _ = fmt.Fprintf(rw, "error when parsing workload id: %s", err)
+		_, _ = fmt.Fprintf(rw, "</body></html>")
 		return
 	}
 
 	events := h.eventL.getWorkloadEvents(idx)
-	fmt.Fprintf(rw, "<p>Workload %s (kind: %s) events:</p>\n<ul>", h.w.config.Workloads[idx].Name, h.w.config.Workloads[idx].Kind)
+	_, _ = fmt.Fprintf(rw, "<p>Workload %s (kind: %s) events:</p>\n<ul>", h.w.config.Workloads[idx].Name, h.w.config.Workloads[idx].Kind)
 
-	fmt.Fprintf(rw, "<div style=\"font-family: monospace;\">")
+	_, _ = fmt.Fprintf(rw, "<div style=\"font-family: monospace;\">")
 	for i := range events {
-		fmt.Fprintf(rw, "%s<br>", events[i].String())
+		_, _ = fmt.Fprintf(rw, "%s<br>", events[i].String())
 	}
-	fmt.Fprintf(rw, "</div>")
+	_, _ = fmt.Fprintf(rw, "</div>")
 
-	fmt.Fprintf(rw, "</body>\n</html>")
+	_, _ = fmt.Fprintf(rw, "</body>\n</html>")
 }

--- a/pkg/cmd/drt-run/main.go
+++ b/pkg/cmd/drt-run/main.go
@@ -91,7 +91,7 @@ func runDRT(configFile string) (retErr error) {
 		o:      or,
 		eventL: eventL,
 	}
-	hh.startHTTPServer(8080, "localhost")
+	_ = hh.startHTTPServer(8080, "localhost")
 	or.Run(ctx)
 
 	return nil

--- a/pkg/cmd/drt-run/workloads.go
+++ b/pkg/cmd/drt-run/workloads.go
@@ -103,7 +103,7 @@ func (w *workloadRunner) runWorkloadStep(
 		}
 	}()
 
-	cmd.Start()
+	_ = cmd.Start()
 	if err := cmd.Wait(); err != nil {
 		w.errChan <- err
 		return


### PR DESCRIPTION
drt-run: Fix warnings to avoid build failure

The build is failing on my mac due to the warnings. This PR fixes the same.

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
compilepkg: nogo: errors found by nogo during build-time code analysis:
pkg/cmd/drt-run/event.go:125:39: if statement between Lock and Unlock may be unsafe, move Unlock to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/event.go:128:8: Unlock is >5 lines away from matching Lock, move it to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/event.go:131:16: unchecked error (errcheck)
pkg/cmd/drt-run/event.go:143:52: if statement between Lock and Unlock may be unsafe, move Unlock to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/event.go:146:7: Unlock is >5 lines away from matching Lock, move it to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/event.go:149:16: unchecked error (errcheck)
pkg/cmd/drt-run/http.go:103:16: unchecked error (errcheck)
pkg/cmd/drt-run/main.go:94:20: unchecked error (errcheck)
pkg/cmd/drt-run/operations.go:112:29: if statement between Lock and Unlock may be unsafe, move Unlock to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/operations.go:119:25: function call between Lock and Unlock may be unsafe, move Unlock to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/operations.go:121:53: if statement between Lock and Unlock may be unsafe, move Unlock to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/operations.go:128:31: function call between Lock and Unlock may be unsafe, move Unlock to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/operations.go:140:4: for loop between Lock and Unlock may be unsafe, move Unlock to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/operations.go:158:8: Unlock is >5 lines away from matching Lock, move it to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/operations.go:218:11: unchecked error (errcheck)
pkg/cmd/drt-run/operations.go:259:74: if statement between Lock and Unlock may be unsafe, move Unlock to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/operations.go:262:2: function call between Lock and Unlock may be unsafe, move Unlock to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/operations.go:263:7: Unlock is >5 lines away from matching Lock, move it to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/workloads.go:106:11: unchecked error (errcheck)
Target //pkg/cmd/drt-run:drt-run failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 85.126s, Critical Path: 61.50s
INFO: 1080 processes: 5 internal, 1075 darwin-sandbox.
ERROR: Build did NOT complete successfully
INFO: Build Event Protocol files produced successfully.
ERROR: exit status 1

Epic: none

Release note: None