### PR TITLE
upgrades: give test an additional core under remote exec

### DIFF
--- a/pkg/upgrade/upgrades/BUILD.bazel
+++ b/pkg/upgrade/upgrades/BUILD.bazel
@@ -99,6 +99,7 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":upgrades"],
+    exec_properties = {"test.Pool": "large"},
     shard_count = 16,
     deps = [
         "//pkg/base",


### PR DESCRIPTION
This has been timing out.

Epic: none
Release note: None