### PR TITLE
roachtest: reword github runtime assertion failure note

### DIFF
--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -312,8 +312,8 @@ func (g *githubIssues) createPostRequest(
 	if runtimeAssertionsBuild {
 		topLevelNotes = append(topLevelNotes,
 			"This build has runtime assertions enabled. If the same failure was hit in a run without assertions "+
-				"enabled, there should be a similar issue without the "+runtimeAssertionsLabel+" label. If there "+
-				"isn't one, then this failure is likely due to an assertion violation or (assertion) timeout.")
+				"enabled, there should be a similar failure without this message. If there isn't one, "+
+				"then this failure is likely due to an assertion violation or (assertion) timeout.")
 	}
 
 	sideEyeMsg := ""


### PR DESCRIPTION
The old message mentioned that there may be a seperate issue without the runtime-assertions label. This is no longer true now that we reuse the issue and may be confusing. This change rewords the message.

Fixes: none
Epic: none
Release note: none