### PR TITLE
sql/schemachanger: identify which clause in a dependency rule didn’t match

### DIFF
--- a/pkg/sql/schemachanger/rel/BUILD.bazel
+++ b/pkg/sql/schemachanger/rel/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "rel",
     srcs = [
         "attribute.go",
+        "clause_id.go",
         "compare.go",
         "database.go",
         "database_entity_set.go",
@@ -37,6 +38,7 @@ go_library(
         "//pkg/util/intsets",
         "//pkg/util/iterutil",
         "//pkg/util/syncutil",
+        "//pkg/util/timeutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_google_btree//:btree",
@@ -50,6 +52,7 @@ go_test(
     size = "small",
     srcs = [
         "bench_test.go",
+        "clause_id_test.go",
         "ordinal_set_test.go",
         "rel_internal_test.go",
         "rel_test.go",

--- a/pkg/sql/schemachanger/rel/bench_test.go
+++ b/pkg/sql/schemachanger/rel/bench_test.go
@@ -129,7 +129,7 @@ func BenchmarkLinkedList(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			q = rand.Intn(numQueries)
-			require.NoError(b, queries[q].Iterate(db, run))
+			require.NoError(b, queries[q].Iterate(db, nil, run))
 		}
 	}
 

--- a/pkg/sql/schemachanger/rel/clause_id.go
+++ b/pkg/sql/schemachanger/rel/clause_id.go
@@ -1,0 +1,40 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rel
+
+// clauseIDBuilder is a helper struct to keep track of IDs for clauses. The IDs
+// are meant to be used to identify the clause that created a slot for the query.
+// They refer back to an entry in the Query.Clause(). For this reason, the IDs
+// frozen when generating clause IDs for a subquery.
+type clauseIDBuilder struct {
+	nextClauseID int
+	isSubquery   bool
+}
+
+// nextID will return the ID of the next clause. If we are in a subquery, the
+// ID remains fixed so that it can refer back to the parent clause.
+func (c *clauseIDBuilder) nextID() int {
+	n := c.nextClauseID
+	if !c.isSubquery {
+		c.nextClauseID++
+	}
+	return n
+}
+
+// newBuilderForSubquery will return a new clauseIDBuilder that can be used to
+// assign IDs to clauses found in a subquery.
+func (c *clauseIDBuilder) newBuilderForSubquery() *clauseIDBuilder {
+	cib := &clauseIDBuilder{
+		nextClauseID: c.nextClauseID, isSubquery: true,
+	}
+	c.nextID() // Advance the clauseID for the parent query.
+	return cib
+}

--- a/pkg/sql/schemachanger/rel/clause_id_test.go
+++ b/pkg/sql/schemachanger/rel/clause_id_test.go
@@ -1,0 +1,29 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClauseIDBuilder(t *testing.T) {
+	cb := clauseIDBuilder{}
+	require.Equal(t, 0, cb.nextID())
+	require.Equal(t, 1, cb.nextID())
+	subCB := cb.newBuilderForSubquery()
+	require.Equal(t, 2, subCB.nextID())
+	require.Equal(t, 2, subCB.nextID())
+	subSubCB := subCB.newBuilderForSubquery()
+	require.Equal(t, 2, subSubCB.nextID())
+	require.Equal(t, 3, cb.nextID())
+}

--- a/pkg/sql/schemachanger/rel/query_build.go
+++ b/pkg/sql/schemachanger/rel/query_build.go
@@ -32,12 +32,22 @@ type queryBuilder struct {
 	// slotIdx is a join target.
 	slotIsEntity []bool
 
+	// This slice mirrors the slots slice. It identifies the clause that caused
+	// each slot to be created. It is separate from the slots directory since its
+	// constant from query to query, so it doesn't need to be cloned like the slots
+	// directory is.
+	clauseIDs []int
+
+	// curClauseID is the ID of the clause to use for any new slots that are
+	// created.
+	curClauseID int
+
 	notJoins []subQuery
 }
 
 // newQuery constructs a query. Errors are panicked and caught
 // in the calling NewQuery function.
-func newQuery(sc *Schema, clauses Clauses) *Query {
+func newQuery(sc *Schema, clauses Clauses, cib *clauseIDBuilder) *Query {
 	p := &queryBuilder{
 		sc:            sc,
 		variableSlots: map[Var]slotIdx{},
@@ -46,8 +56,15 @@ func newQuery(sc *Schema, clauses Clauses) *Query {
 	// if we add something like or-join or not-join. At time of writing,
 	// the and case in processClause is an assertion failure.
 	forDisplay := flattened(clauses)
-	for _, t := range expanded(clauses) {
-		p.processClause(t)
+	for _, displayClause := range forDisplay {
+		// Advance the clause ID only for clauses in forDisplay. The clauseID is used
+		// for debugging to report clauses that didn't match, so it must correspond
+		// to the clauses shown for display purposes.
+		p.curClauseID = cib.nextID()
+
+		for _, t := range expanded([]Clause{displayClause}) {
+			p.processClause(t, cib)
+		}
 	}
 	for _, s := range p.variableSlots {
 		p.facts = append(p.facts, fact{
@@ -103,10 +120,11 @@ func newQuery(sc *Schema, clauses Clauses) *Query {
 		slots:         p.slots,
 		filters:       p.filters,
 		notJoins:      p.notJoins,
+		clauseIDs:     p.clauseIDs,
 	}
 }
 
-func (p *queryBuilder) processClause(t Clause) {
+func (p *queryBuilder) processClause(t Clause, cib *clauseIDBuilder) {
 	defer func() {
 		if r := recover(); r != nil {
 			rErr, ok := r.(error)
@@ -136,7 +154,7 @@ func (p *queryBuilder) processClause(t Clause) {
 			panic(errors.AssertionFailedf("rule invocations which aren't not-joins" +
 				" should have been flattened away"))
 		}
-		p.processNotJoin(t)
+		p.processNotJoin(t, cib)
 	case and:
 		panic(errors.AssertionFailedf("and clauses should be flattened away"))
 	default:
@@ -273,6 +291,7 @@ func (p *queryBuilder) processFilterDecl(t filterDecl) {
 	p.filters = append(p.filters, filter{
 		input:     slots,
 		predicate: fv,
+		clauseID:  p.curClauseID,
 	})
 }
 
@@ -335,6 +354,7 @@ func (p *queryBuilder) fillSlot(sd slot, isEntity bool) slotIdx {
 	s := slotIdx(len(p.slots))
 	p.slots = append(p.slots, sd)
 	p.slotIsEntity = append(p.slotIsEntity, isEntity)
+	p.clauseIDs = append(p.clauseIDs, p.curClauseID)
 	return s
 }
 
@@ -365,7 +385,7 @@ func (p *queryBuilder) typeCheck(f fact) {
 	}
 }
 
-func (p *queryBuilder) processNotJoin(t ruleInvocation) {
+func (p *queryBuilder) processNotJoin(t ruleInvocation, cib *clauseIDBuilder) {
 	// If we have a not-join, then we need to find the slots for the inputs,
 	// and we have to build the sub-query, which is a whole new query, and
 	// we have to then figure out its depth. At this point, we build the
@@ -392,7 +412,7 @@ func (p *queryBuilder) processNotJoin(t ruleInvocation) {
 		}
 	}
 	clauses = append(clauses, t.rule.clauses...)
-	sub.query = newQuery(p.sc, clauses)
+	sub.query = newQuery(p.sc, clauses, cib.newBuilderForSubquery())
 	for i, v := range t.args {
 		src := p.variableSlots[v]
 		dst, ok := sub.query.variableSlots[t.rule.paramVars[i]]

--- a/pkg/sql/schemachanger/rel/query_data.go
+++ b/pkg/sql/schemachanger/rel/query_data.go
@@ -177,4 +177,5 @@ func maybeSet(
 type filter struct {
 	input     []slotIdx
 	predicate reflect.Value
+	clauseID  int
 }

--- a/pkg/sql/schemachanger/rel/query_eval.go
+++ b/pkg/sql/schemachanger/rel/query_eval.go
@@ -12,6 +12,7 @@ package rel
 
 import (
 	"reflect"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
@@ -30,17 +31,39 @@ type evalContext struct {
 	// depth and cur relate to the join depth in the entities list.
 	depth, cur queryDepth
 
+	// Keeps track of stats for the query. Is reset each time a new query is run.
+	stats QueryStats
+
 	slots             []slot
+	slotResetCount    []int8 // Keeps track of the number of times a slot has been reset
 	filterSliceCaches map[int][]reflect.Value
 	curSubQuery       int
 }
 
+type QueryStats struct {
+	// StartTime is the timestamp when the query started.
+	StartTime time.Time
+	// ResultsFound tracks the number of results returned by the query.
+	ResultsFound int
+	// FirstUnsatisfiedClause is the index of the first clause in the query that
+	// wasn't satisfied. This is set when a query runs and no results are found
+	// (ResultsFound is zero). The index refers to an entry in []Query.clauses.
+	FirstUnsatisfiedClause int
+	// FiltersCheckStarted indicates whether the query completed all slots and
+	// began applying filters.
+	FiltersCheckStarted bool
+	// LastFilterChecked is the index of the last filter applied. This is valid
+	// only if FiltersCheckStarted is true.
+	LastFilterChecked int
+}
+
 func newEvalContext(q *Query) *evalContext {
 	return &evalContext{
-		q:     q,
-		depth: queryDepth(len(q.entities)),
-		slots: cloneSlots(q.slots),
-		facts: q.facts,
+		q:              q,
+		depth:          queryDepth(len(q.entities)),
+		slots:          cloneSlots(q.slots),
+		slotResetCount: make([]int8, len(q.slots)),
+		facts:          q.facts,
 	}
 }
 
@@ -112,6 +135,7 @@ func (ec *evalContext) iterateNext() error {
 		if ec.haveUnboundSlots() || ec.checkFilters() {
 			return nil
 		}
+		ec.stats.ResultsFound++
 		return ec.ri((*evalResult)(ec))
 	}
 
@@ -157,7 +181,10 @@ func (ec *evalContext) visit(e entity) error {
 	// evaluation and then unset them when we pop out of this stack frame.
 	var slotsFilled intsets.Fast
 	defer func() {
-		slotsFilled.ForEach(func(i int) { ec.slots[i].reset() })
+		slotsFilled.ForEach(func(i int) {
+			ec.slotResetCount[i]++
+			ec.slots[i].reset()
+		})
 	}()
 
 	// Fill in the slot corresponding to this entity. It should not be filled
@@ -227,10 +254,13 @@ func (ec *evalContext) haveUnboundSlots() bool {
 }
 
 func (ec *evalContext) checkFilters() (done bool) {
+	ec.stats.FiltersCheckStarted = true
+	ec.stats.LastFilterChecked = 0
 	for i := range ec.q.filters {
 		if done = ec.checkFilter(i); done {
 			return true
 		}
+		ec.stats.LastFilterChecked++
 	}
 	return false
 }
@@ -428,6 +458,7 @@ func (ec *evalContext) visitSubquery(query int) (done bool, _ error) {
 	defer sub.query.putEvalContext(sec)
 	defer func() { // reset the slots populated to run the subquery
 		sub.inputSlotMappings.ForEach(func(_, subSlot int) {
+			sec.slotResetCount[subSlot]++
 			sec.slots[subSlot].reset()
 		})
 	}()
@@ -475,3 +506,32 @@ func (ec *evalContext) findSlotVariable(src int) Var {
 }
 
 var errResultSetNotEmpty = errors.New("result set not empty")
+
+// findFirstClauseNotSatisfied returns a clause that wasn't satisfied in the
+// last query. There could be multiple clauses unsatisfied, this function
+// returns the earliest one, which should be investigated first when debugging
+// the rule. The index of the clause is returned, which can be used to lookup in
+// Query.Clauses().
+func (ec *evalContext) findFirstClauseNotSatisfied() (int, error) {
+	minUnsatisfiedClauseInx := len(ec.q.clauses)
+	for i := range ec.slots {
+		if ec.slots[i].empty() && ec.slotResetCount[i] == 0 {
+			minUnsatisfiedClauseInx = min(minUnsatisfiedClauseInx, ec.q.clauseIDs[i])
+		}
+	}
+
+	if minUnsatisfiedClauseInx < len(ec.q.clauses) {
+		return minUnsatisfiedClauseInx, nil
+	}
+
+	// If we found satisfied entries in all slots, it indicates that the filters,
+	// which are evaluated at the end, did not satisfy the query. Locate the last
+	// filter that was applied.
+	if !ec.stats.FiltersCheckStarted || ec.stats.LastFilterChecked >= len(ec.q.filters) {
+		return -1,
+			errors.AssertionFailedf("cound not find a clause that was not satisfied: "+
+				"FiltesCheckStarted=%t, LastFilterChecked=%d, len(filters)=%d",
+				ec.stats.FiltersCheckStarted, ec.stats.LastFilterChecked, len(ec.q.filters))
+	}
+	return ec.q.filters[ec.stats.LastFilterChecked].clauseID, nil
+}

--- a/pkg/sql/schemachanger/rel/rel_test.go
+++ b/pkg/sql/schemachanger/rel/rel_test.go
@@ -322,7 +322,7 @@ func TestTooManyAttributesInValues(t *testing.T) {
 		{
 			q, err := rel.NewQuery(sc, append(base, c.Type((*tooManyAttrs)(nil)))...)
 			require.NoError(t, err)
-			require.Regexp(t, "failed to create predicate with more than 8 attributes", q.Iterate(db, func(r rel.Result) error {
+			require.Regexp(t, "failed to create predicate with more than 8 attributes", q.Iterate(db, &rel.QueryStats{}, func(r rel.Result) error {
 				return nil
 			}))
 		}
@@ -332,7 +332,7 @@ func TestTooManyAttributesInValues(t *testing.T) {
 					base, c.Type((*tooManyAttrs)(nil), (*rel.Schema)(nil)),
 				)...)
 				require.NoError(t, err)
-				require.Regexp(t, "failed to create predicate with more than 8 attributes", q.Iterate(db, func(r rel.Result) error {
+				require.Regexp(t, "failed to create predicate with more than 8 attributes", q.Iterate(db, nil, func(r rel.Result) error {
 					return nil
 				}))
 			}
@@ -527,7 +527,7 @@ func TestConcurrentQueryInDifferentDatabases(t *testing.T) {
 	run := func(i int) func() error {
 		return func() error {
 			var got []*entity
-			assert.NoError(t, q.Iterate(dbs[i%len(dbs)], func(r rel.Result) error {
+			assert.NoError(t, q.Iterate(dbs[i%len(dbs)], nil, func(r rel.Result) error {
 				got = append(got, r.Var("e").(*entity))
 				return nil
 			}))

--- a/pkg/sql/schemachanger/rel/reltest/database.go
+++ b/pkg/sql/schemachanger/rel/reltest/database.go
@@ -90,7 +90,8 @@ func (qc QueryTest) run(t *testing.T, indexes int, db *rel.Database) {
 
 	require.NoError(t, err)
 	require.Equal(t, qc.Entities, q.Entities())
-	if err := q.Iterate(db, func(r rel.Result) error {
+	stats := &rel.QueryStats{}
+	if err := q.Iterate(db, stats, func(r rel.Result) error {
 		var cur []interface{}
 		for _, v := range qc.ResVars {
 			cur = append(cur, r.Var(v))
@@ -106,6 +107,12 @@ func (qc QueryTest) run(t *testing.T, indexes int, db *rel.Database) {
 		t.Fatal(err)
 	} else if intsets.MakeFast(qc.UnsatisfiableIndexes...).Contains(indexes) {
 		t.Fatalf("expected to fail with indexes %d", indexes)
+	}
+	if len(results) == 0 {
+		require.Equal(t, 0, stats.ResultsFound)
+		require.Less(t, stats.FirstUnsatisfiedClause, len(q.Clauses()),
+			"There are %d clauses in the query, but the first unsatisfied clause is %d",
+			len(q.Clauses()), stats.FirstUnsatisfiedClause)
 	}
 	expResults := append(qc.Results[:0:0], qc.Results...)
 	findResultInExp := func(res []interface{}) (found bool) {

--- a/pkg/sql/schemachanger/scplan/internal/opgen/target.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/target.go
@@ -74,7 +74,7 @@ func makeTarget(e scpb.Element, spec targetSpec) (t target, err error) {
 		return t, errors.Wrap(err, "failed to construct query")
 	}
 	t.iterateFunc = func(database *rel.Database, f func(*screl.Node) error) error {
-		return q.Iterate(database, func(r rel.Result) error {
+		return q.Iterate(database, nil, func(r rel.Result) error {
 			return f(r.Var(node).(*screl.Node))
 		})
 	}

--- a/pkg/sql/schemachanger/scplan/internal/rules/registry.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/registry.go
@@ -32,10 +32,15 @@ import (
 // ApplyDepRules adds dependency edges to the graph according to the
 // registered dependency rules.
 func (r *Registry) ApplyDepRules(ctx context.Context, g *scgraph.Graph) error {
+	// If expensive logging is enabled, we'll collect stats on the query and
+	// report on how each dep rule performed.
+	var stats *rel.QueryStats
+	if log.ExpensiveLogEnabled(ctx, 2) {
+		stats = &rel.QueryStats{}
+	}
+
 	for _, dr := range r.depRules {
-		start := timeutil.Now()
-		var added int
-		if err := dr.q.Iterate(g.Database(), func(r rel.Result) error {
+		if err := dr.q.Iterate(g.Database(), stats, func(r rel.Result) error {
 			// Applying the dep rules can be slow in some cases. Check for
 			// cancellation when applying the rules to ensure we don't spin for
 			// too long while the user is waiting for the task to exit cleanly.
@@ -44,18 +49,30 @@ func (r *Registry) ApplyDepRules(ctx context.Context, g *scgraph.Graph) error {
 			}
 			from := r.Var(dr.from).(*screl.Node)
 			to := r.Var(dr.to).(*screl.Node)
-			added++
 			return g.AddDepEdge(
 				dr.name, dr.kind, from.Target, from.CurrentStatus, to.Target, to.CurrentStatus,
 			)
 		}); err != nil {
 			return errors.Wrapf(err, "applying dep rule %s", dr.name)
 		}
-		if log.ExpensiveLogEnabled(ctx, 2) {
+		if stats != nil {
 			log.Infof(
-				ctx, "applying dep rule %s %d took %v",
-				dr.name, added, timeutil.Since(start),
+				ctx, "applying dep rule %q, %d results found that took %v",
+				dr.name, stats.ResultsFound, timeutil.Since(stats.StartTime),
 			)
+			if stats.ResultsFound == 0 {
+				cl := dr.q.Clauses()
+				if stats.FirstUnsatisfiedClause >= len(cl) {
+					return errors.AssertionFailedf("no unsatisfied clause found: %d >= %d",
+						stats.FirstUnsatisfiedClause, len(cl))
+				}
+				clauseStr, err := yaml.Marshal(cl[stats.FirstUnsatisfiedClause])
+				if err != nil {
+					return errors.Wrapf(err, "failed to marshal clause %d", stats.FirstUnsatisfiedClause)
+				}
+				log.Infof(ctx, "dep rule %q did not apply. The first unsatisfied clause is: %s",
+					dr.name, clauseStr)
+			}
 		}
 	}
 	return nil

--- a/pkg/sql/schemachanger/screl/query_test.go
+++ b/pkg/sql/schemachanger/screl/query_test.go
@@ -155,7 +155,8 @@ func TestQueryBasic(t *testing.T) {
 			for _, q := range c.queries {
 				t.Run("", func(t *testing.T) {
 					var results []string
-					require.NoError(t, q.query.Iterate(tr, func(r rel.Result) error {
+					stats := &rel.QueryStats{}
+					require.NoError(t, q.query.Iterate(tr, stats, func(r rel.Result) error {
 						results = append(results, formatResults(r, q.nodes))
 						return nil
 					}))


### PR DESCRIPTION
Before this change, debugging why a dependency rule for the Declarative Schema Changer didn’t apply was challenging. This update simplifies debugging by identifying the specific clause in each rule that didn’t qualify.

Here’s how the debug process works. Suppose we mistakenly swapped the `to` and `from` variables while checking the `TargetStatus` in this dependency rule:

```
       registerDepRule(
                "column type is changed to public after doing validation of a transient check constraint",
                scgraph.SameStagePrecedence,
                "transient-check-constraint", "column-type",
                func(from, to NodeVars) rel.Clauses {
                        colID := rel.Var("columnID")
                        return rel.Clauses{
                                from.Type((*scpb.CheckConstraint)(nil)),
                                to.Type((*scpb.ColumnType)(nil)),
                                JoinOnDescID(from, to, "table-id"),
                                to.El.AttrEqVar(screl.ColumnID, colID),
                                from.ReferencedColumnIDsContains(colID),
-                               from.TargetStatus(scpb.Transient),
-                               to.TargetStatus(scpb.ToPublic),
+                               to.TargetStatus(scpb.Transient),
+                               from.TargetStatus(scpb.ToPublic),
                                from.CurrentStatus(scpb.Status_TRANSIENT_VALIDATED),
                                to.CurrentStatus(scpb.Status_PUBLIC),
                        }
                },
        )
 }
```

During a schema change job, we might find that this rule no longer applies. To identify which clause in the rule failed, enable tracing:

```
SET tracing = on;
```

Run your schema change as usual. I ran it with `EXPLAIN` to avoid executing the job and instead focus on building the dependency graph using the rules:

```
EXPLAIN (ddl) ALTER TABLE t1 ALTER COLUMN c1 TYPE smallint;
```

After completion, check the `cockroach.log` for trace information. Search for the rule by name, and you’ll see entries like these:

```
I240925 15:52:36.394784 5910 sql/schemachanger/scplan/internal/rules/registry.go:59 ⋮ [T2,Vdemoapp,n1,client=127.0.0.1:53428,hostssl,user=‹demo›] 1131 applying dep rule "column type is changed to public after doing validation of a transient check constraint", 0 results found, took 25.938µs
I240925 15:52:36.394863 5910 sql/schemachanger/scplan/internal/rules/registry.go:73 ⋮ [T2,Vdemoapp,n1,client=127.0.0.1:53428,hostssl,user=‹demo›] 1132 dep rule "column type is changed to public after doing validation of a transient check constraint" did not apply. The first unsatisfied clause is: ‹$column-type-Target[TargetStatus] = TRANSIENT_ABSENT›
```

The first log shows no results were found by the rule, while the second log identifies the specific clause that didn’t work. In this case, the clause we changed is what broke the rule.

Since the logic to identify failed clauses can impact performance, this behavior only occurs when tracing is enabled.

Epic: None
Informs #127014
Release note: None