### PR TITLE
roachtest: mark perturbation/full/* tests as Benchmark

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -247,7 +247,6 @@ func addMetamorphic(r registry.Registry, p perturbation, acceptableChange float6
 		Cluster:          v.makeClusterSpec(),
 		Leases:           v.leaseType,
 		Randomized:       true,
-		Benchmark:        true,
 		Run:              v.runTest,
 	})
 }
@@ -262,6 +261,7 @@ func addFull(r registry.Registry, p perturbation, acceptableChange float64) {
 		Owner:            registry.OwnerKV,
 		Cluster:          v.makeClusterSpec(),
 		Leases:           v.leaseType,
+		Benchmark:        true,
 		Run:              v.runTest,
 	})
 }


### PR DESCRIPTION
Previously the perturbation/metamorphic/* tests were marked as Benchmark tests (which record the perf data). This should have been done on the Full tests instead.

Epic: none

Release note: None