### PR TITLE
server: add tablemetadata job cluster settings to job status api

### DIFF
--- a/pkg/server/api_v2_databases_metadata.go
+++ b/pkg/server/api_v2_databases_metadata.go
@@ -850,6 +850,9 @@ func (a *apiV2Server) TableMetadataJob(w http.ResponseWriter, r *http.Request) {
 func (a *apiV2Server) getTableMetadataUpdateJobStatus(
 	ctx context.Context,
 ) (jobStatus tmUpdateJobStatusResponse, retErr error) {
+	jobStatus.DataValidDuration = tablemetadatacache.DataValidDurationSetting.Get(&a.sqlServer.execCfg.Settings.SV)
+	jobStatus.AutomaticUpdatesEnabled = tablemetadatacache.AutomaticCacheUpdatesEnabledSetting.Get(&a.sqlServer.execCfg.Settings.SV)
+
 	query := safesql.NewQuery()
 	query.Append(`
 	SELECT 
@@ -1000,6 +1003,10 @@ type tmUpdateJobStatusResponse struct {
 	LastStartTime     *time.Time `json:"last_start_time"`
 	LastCompletedTime *time.Time `json:"last_completed_time"`
 	LastUpdatedTime   *time.Time `json:"last_updated_time"`
+	// The value of tablemetadatacache.DataValidDurationSetting
+	DataValidDuration time.Duration `json:"data_valid_duration"`
+	// The value of tablemetadatacache.AutomaticCacheUpdatesEnabledSetting
+	AutomaticUpdatesEnabled bool `json:"automatic_updates_enabled"`
 }
 
 type tmJobTriggeredResponse struct {

--- a/pkg/sql/tablemetadatacache/cluster_settings.go
+++ b/pkg/sql/tablemetadatacache/cluster_settings.go
@@ -19,7 +19,7 @@ import (
 
 const defaultDataValidDuration = time.Minute * 20
 
-var tableMetadataCacheAutoUpdatesEnabled = settings.RegisterBoolSetting(
+var AutomaticCacheUpdatesEnabledSetting = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"obs.tablemetadata.automatic_updates.enabled",
 	"enables automatic updates of the table metadata cache system.table_metadata",

--- a/pkg/sql/tablemetadatacache/update_table_metadata_cache_job.go
+++ b/pkg/sql/tablemetadatacache/update_table_metadata_cache_job.go
@@ -66,7 +66,7 @@ func (j *tableMetadataUpdateJobResumer) Resume(ctx context.Context, execCtxI int
 	settings := execCtx.ExecCfg().Settings
 	// Register callbacks to signal the job to reset the timer when timer related settings change.
 	scheduleSettingsCh := make(chan struct{})
-	tableMetadataCacheAutoUpdatesEnabled.SetOnChange(&settings.SV, func(_ context.Context) {
+	AutomaticCacheUpdatesEnabledSetting.SetOnChange(&settings.SV, func(_ context.Context) {
 		select {
 		case scheduleSettingsCh <- struct{}{}:
 		default:
@@ -84,7 +84,7 @@ func (j *tableMetadataUpdateJobResumer) Resume(ctx context.Context, execCtxI int
 		onJobReady()
 	}
 	for {
-		if tableMetadataCacheAutoUpdatesEnabled.Get(&settings.SV) {
+		if AutomaticCacheUpdatesEnabledSetting.Get(&settings.SV) {
 			timer.Reset(DataValidDurationSetting.Get(&settings.SV))
 		}
 		select {


### PR DESCRIPTION
Add the cluster setting values for the update table metadata job to the job status api.

Epic: CRDB-37558
Release note: None