### PR TITLE
server: organize new api v2 constants

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "admin.go",
         "admission.go",
         "api_v2.go",
+        "api_v2_constants.go",
         "api_v2_databases_metadata.go",
         "api_v2_ranges.go",
         "api_v2_sql.go",

--- a/pkg/server/api_v2_constants.go
+++ b/pkg/server/api_v2_constants.go
@@ -1,0 +1,36 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import "strings"
+
+// Shared url query string keys.
+const (
+	sortByKey    = "sortBy"
+	sortOrderKey = "sortOrder"
+	pageNumKey   = "pageNum"
+	pageSizeKey  = "pageSize"
+)
+
+// validateSortOrderValue validates the sort order value and returns
+// the sql sort order value and a boolean indicating if the value is
+// valid. If the value is empty, it defaults to "ASC".
+func validateSortOrderValue(sortOrder string) (string, bool) {
+	toUpper := strings.ToUpper(sortOrder)
+	switch toUpper {
+	case "":
+		return "ASC", true
+	case "ASC", "DESC":
+		return toUpper, true
+	default:
+		return "", false
+	}
+}

--- a/pkg/server/api_v2_databases_metadata_test.go
+++ b/pkg/server/api_v2_databases_metadata_test.go
@@ -293,7 +293,7 @@ func TestGetTableMetadata(t *testing.T) {
 			})
 		}
 	})
-	t.Run("422 unprocessable", func(t *testing.T) {
+	t.Run("400 bad request", func(t *testing.T) {
 		var unprocessableTest = []struct {
 			name        string
 			queryString string
@@ -303,6 +303,7 @@ func TestGetTableMetadata(t *testing.T) {
 			{"pageSize", "?pageSize=a"},
 			{"storeId", "?storeId=a"},
 			{"multiple storeIds", "?storeId=1&storeId=a"},
+			{"invalid sort order", "?sortBy=name&sortOrder=ascending"},
 		}
 		for _, tt := range unprocessableTest {
 			t.Run(tt.name, func(t *testing.T) {
@@ -312,7 +313,7 @@ func TestGetTableMetadata(t *testing.T) {
 				resp, err := client.Do(req)
 				require.NoError(t, err)
 				defer resp.Body.Close()
-				require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+				require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 			})
 		}
 	})
@@ -575,7 +576,7 @@ func TestGetDBMetadata(t *testing.T) {
 			})
 		}
 	})
-	t.Run("422 unprocessable", func(t *testing.T) {
+	t.Run("400 bad request", func(t *testing.T) {
 		var unprocessableTest = []struct {
 			name        string
 			queryString string
@@ -584,6 +585,7 @@ func TestGetDBMetadata(t *testing.T) {
 			{"pageSize", "?pageSize=a"},
 			{"storeId", "?storeId=a"},
 			{"multiple storeIds", "?storeId=1&storeId=a"},
+			{"invalid sort order", "?sortBy=name&sortOrder=ascending"},
 		}
 		for _, tt := range unprocessableTest {
 			t.Run(tt.name, func(t *testing.T) {
@@ -593,7 +595,7 @@ func TestGetDBMetadata(t *testing.T) {
 				resp, err := client.Do(req)
 				require.NoError(t, err)
 				defer resp.Body.Close()
-				require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+				require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 			})
 		}
 	})


### PR DESCRIPTION
Some refactoring:
- Adds api_v2_constants.go which defines constants that may be shared across v2 apis.
- Convert previous 422 error codes in db and table metadata apis to use 400 bad request.
- Provide validation for sort key query param.

Epic: CRDB-37558

Release note: None