### PR TITLE
log/eventpb: add job ID to all changefeed structured log events

### DIFF
--- a/build/GNUmakefile.obsolete
+++ b/build/GNUmakefile.obsolete
@@ -1644,7 +1644,8 @@ EVENTPB_PROTOS = \
   pkg/util/log/eventpb/job_events.proto \
   pkg/util/log/eventpb/health_events.proto \
   pkg/util/log/eventpb/storage_events.proto \
-  pkg/util/log/eventpb/telemetry.proto
+  pkg/util/log/eventpb/telemetry.proto \
+  pkg/util/log/eventpb/changefeed_events.proto
 
 EVENTLOG_PROTOS = pkg/util/log/logpb/event.proto $(EVENTPB_PROTOS)
 

--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -35,7 +35,6 @@ An event of type `changefeed_emitted_bytes` is an event representing the bytes e
 
 | Field | Description | Sensitive |
 |--|--|--|
-| `JobId` | The job id for enterprise changefeeds. | no |
 | `EmittedBytes` | The number of bytes emitted. | no |
 | `EmittedMessages` | The number of messages emitted. | no |
 | `LoggingInterval` | The time period in nanoseconds between emitting telemetry events of this type (per-aggregator). | no |
@@ -52,6 +51,7 @@ An event of type `changefeed_emitted_bytes` is an event representing the bytes e
 | `Resolved` | The behavior of emitted resolved spans (ex: yes, no, 10s) | no |
 | `InitialScan` | The desired behavior of initial scans (ex: yes, no, only) | no |
 | `Format` | The data format being emitted (ex: JSON, Avro). | no |
+| `JobId` | The job id for enterprise changefeeds. | no |
 
 ### `changefeed_failed`
 
@@ -74,6 +74,7 @@ was triggered.
 | `Resolved` | The behavior of emitted resolved spans (ex: yes, no, 10s) | no |
 | `InitialScan` | The desired behavior of initial scans (ex: yes, no, only) | no |
 | `Format` | The data format being emitted (ex: JSON, Avro). | no |
+| `JobId` | The job id for enterprise changefeeds. | no |
 
 ### `create_changefeed`
 
@@ -97,6 +98,7 @@ ChangefeedFailed events.
 | `Resolved` | The behavior of emitted resolved spans (ex: yes, no, 10s) | no |
 | `InitialScan` | The desired behavior of initial scans (ex: yes, no, only) | no |
 | `Format` | The data format being emitted (ex: JSON, Avro). | no |
+| `JobId` | The job id for enterprise changefeeds. | no |
 
 ## Cluster-level events
 

--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -21,6 +21,83 @@ provided the `redactable` functionality is enabled on the logging sink.
 
 Events not documented on this page will have an unstructured format in log messages.
 
+## Changefeed telemetry events
+
+Events in this category pertain to changefeed usage and metrics.
+
+Events in this category are logged to the `TELEMETRY` channel.
+
+
+### `changefeed_emitted_bytes`
+
+An event of type `changefeed_emitted_bytes` is an event representing the bytes emitted by a changefeed over an interval.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `JobId` | The job id for enterprise changefeeds. | no |
+| `EmittedBytes` | The number of bytes emitted. | no |
+| `EmittedMessages` | The number of messages emitted. | no |
+| `LoggingInterval` | The time period in nanoseconds between emitting telemetry events of this type (per-aggregator). | no |
+| `Closing` | Flag to indicate that the changefeed is closing. | no |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Description` | The description of that would show up in the job's description field, redacted | yes |
+| `SinkType` | The type of sink being emitted to (ex: kafka, nodelocal, webhook-https). | no |
+| `NumTables` | The number of tables listed in the query that the changefeed is to run on. | no |
+| `Resolved` | The behavior of emitted resolved spans (ex: yes, no, 10s) | no |
+| `InitialScan` | The desired behavior of initial scans (ex: yes, no, only) | no |
+| `Format` | The data format being emitted (ex: JSON, Avro). | no |
+
+### `changefeed_failed`
+
+An event of type `changefeed_failed` is an event for any changefeed failure since the plan hook
+was triggered.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `FailureType` | The reason / environment with which the changefeed failed (ex: connection_closed, changefeed_behind). | no |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Description` | The description of that would show up in the job's description field, redacted | yes |
+| `SinkType` | The type of sink being emitted to (ex: kafka, nodelocal, webhook-https). | no |
+| `NumTables` | The number of tables listed in the query that the changefeed is to run on. | no |
+| `Resolved` | The behavior of emitted resolved spans (ex: yes, no, 10s) | no |
+| `InitialScan` | The desired behavior of initial scans (ex: yes, no, only) | no |
+| `Format` | The data format being emitted (ex: JSON, Avro). | no |
+
+### `create_changefeed`
+
+An event of type `create_changefeed` is an event for any CREATE CHANGEFEED query that
+successfully starts running. Failed CREATE statements will show up as
+ChangefeedFailed events.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Transformation` | Flag representing whether the changefeed is using CDC queries. | no |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Description` | The description of that would show up in the job's description field, redacted | yes |
+| `SinkType` | The type of sink being emitted to (ex: kafka, nodelocal, webhook-https). | no |
+| `NumTables` | The number of tables listed in the query that the changefeed is to run on. | no |
+| `Resolved` | The behavior of emitted resolved spans (ex: yes, no, 10s) | no |
+| `InitialScan` | The desired behavior of initial scans (ex: yes, no, only) | no |
+| `Format` | The data format being emitted (ex: JSON, Avro). | no |
+
 ## Cluster-level events
 
 Events in this category pertain to an entire cluster and are
@@ -2890,76 +2967,6 @@ An event of type `captured_index_usage_stats`
 |--|--|--|
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
-
-### `changefeed_emitted_bytes`
-
-An event of type `changefeed_emitted_bytes` is an event representing the bytes emitted by a changefeed over an interval.
-
-
-| Field | Description | Sensitive |
-|--|--|--|
-| `JobId` | The job id for enterprise changefeeds. | no |
-| `EmittedBytes` | The number of bytes emitted. | no |
-| `EmittedMessages` | The number of messages emitted. | no |
-| `LoggingInterval` | The time period in nanoseconds between emitting telemetry events of this type (per-aggregator). | no |
-| `Closing` | Flag to indicate that the changefeed is closing. | no |
-
-
-#### Common fields
-
-| Field | Description | Sensitive |
-|--|--|--|
-| `Description` | The description of that would show up in the job's description field, redacted | yes |
-| `SinkType` | The type of sink being emitted to (ex: kafka, nodelocal, webhook-https). | no |
-| `NumTables` | The number of tables listed in the query that the changefeed is to run on. | no |
-| `Resolved` | The behavior of emitted resolved spans (ex: yes, no, 10s) | no |
-| `InitialScan` | The desired behavior of initial scans (ex: yes, no, only) | no |
-| `Format` | The data format being emitted (ex: JSON, Avro). | no |
-
-### `changefeed_failed`
-
-An event of type `changefeed_failed` is an event for any Changefeed failure since the plan hook
-was triggered.
-
-
-| Field | Description | Sensitive |
-|--|--|--|
-| `FailureType` | The reason / environment with which the changefeed failed (ex: connection_closed, changefeed_behind) | no |
-
-
-#### Common fields
-
-| Field | Description | Sensitive |
-|--|--|--|
-| `Description` | The description of that would show up in the job's description field, redacted | yes |
-| `SinkType` | The type of sink being emitted to (ex: kafka, nodelocal, webhook-https). | no |
-| `NumTables` | The number of tables listed in the query that the changefeed is to run on. | no |
-| `Resolved` | The behavior of emitted resolved spans (ex: yes, no, 10s) | no |
-| `InitialScan` | The desired behavior of initial scans (ex: yes, no, only) | no |
-| `Format` | The data format being emitted (ex: JSON, Avro). | no |
-
-### `create_changefeed`
-
-An event of type `create_changefeed` is an event for any CREATE CHANGEFEED query that
-successfully starts running.  Failed CREATE statements will show up as
-ChangefeedFailed events.
-
-
-| Field | Description | Sensitive |
-|--|--|--|
-| `Transformation` |  | no |
-
-
-#### Common fields
-
-| Field | Description | Sensitive |
-|--|--|--|
-| `Description` | The description of that would show up in the job's description field, redacted | yes |
-| `SinkType` | The type of sink being emitted to (ex: kafka, nodelocal, webhook-https). | no |
-| `NumTables` | The number of tables listed in the query that the changefeed is to run on. | no |
-| `Resolved` | The behavior of emitted resolved spans (ex: yes, no, 10s) | no |
-| `InitialScan` | The desired behavior of initial scans (ex: yes, no, only) | no |
-| `Format` | The data format being emitted (ex: JSON, Avro). | no |
 
 ### `hot_ranges_stats`
 

--- a/pkg/ccl/changefeedccl/telemetry.go
+++ b/pkg/ccl/changefeedccl/telemetry.go
@@ -66,7 +66,7 @@ func makePeriodicTelemetryLogger(
 	return &periodicTelemetryLogger{
 		ctx:               ctx,
 		job:               job,
-		changefeedDetails: getCommonChangefeedEventDetails(ctx, job.Details().(jobspb.ChangefeedDetails), job.Payload().Description),
+		changefeedDetails: makeCommonChangefeedEventDetails(ctx, job.Details().(jobspb.ChangefeedDetails), job.Payload().Description, job.ID()),
 		sinkTelemetryData: sinkTelemetryData{},
 		settings:          s,
 	}, nil
@@ -112,7 +112,6 @@ func (ptl *periodicTelemetryLogger) maybeFlushLogs() {
 
 	continuousTelemetryEvent := &eventpb.ChangefeedEmittedBytes{
 		CommonChangefeedEventDetails: ptl.changefeedDetails,
-		JobId:                        int64(ptl.job.ID()),
 		EmittedBytes:                 ptl.resetEmittedBytes(),
 		EmittedMessages:              ptl.resetEmittedMessages(),
 		LoggingInterval:              loggingInterval,
@@ -128,7 +127,6 @@ func (ptl *periodicTelemetryLogger) close() {
 
 	continuousTelemetryEvent := &eventpb.ChangefeedEmittedBytes{
 		CommonChangefeedEventDetails: ptl.changefeedDetails,
-		JobId:                        int64(ptl.job.ID()),
 		EmittedBytes:                 ptl.resetEmittedBytes(),
 		EmittedMessages:              ptl.resetEmittedMessages(),
 		LoggingInterval:              loggingInterval,

--- a/pkg/util/log/eventpb/BUILD.bazel
+++ b/pkg/util/log/eventpb/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
 proto_library(
     name = "eventpb_proto",
     srcs = [
+        "changefeed_events.proto",
         "cluster_events.proto",
         "ddl_events.proto",
         "debug_events.proto",

--- a/pkg/util/log/eventpb/PROTOS.bzl
+++ b/pkg/util/log/eventpb/PROTOS.bzl
@@ -19,6 +19,7 @@ EVENTPB_PROTOS = [
     "health_events.proto",
     "storage_events.proto",
     "telemetry.proto",
+    "changefeed_events.proto",
 ]
 
 EVENTPB_PROTO_DEPS = [ "//pkg/util/log/logpb:event.proto", ] + EVENTPB_PROTOS

--- a/pkg/util/log/eventpb/changefeed_events.proto
+++ b/pkg/util/log/eventpb/changefeed_events.proto
@@ -45,8 +45,7 @@ message ChangefeedFailed {
 message ChangefeedEmittedBytes {
   CommonChangefeedEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
 
-  // The job id for enterprise changefeeds.
-  int64 job_id = 2 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) =  "redact:\"nonsensitive\""];
+  reserved 2;
 
   // The number of bytes emitted.
   int64 emitted_bytes = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];

--- a/pkg/util/log/eventpb/changefeed_events.proto
+++ b/pkg/util/log/eventpb/changefeed_events.proto
@@ -1,0 +1,62 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+syntax = "proto3";
+package cockroach.util.log.eventpb;
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/log/eventpb";
+
+import "gogoproto/gogo.proto";
+import "util/log/eventpb/events.proto";
+import "util/log/logpb/event.proto";
+
+// Category: Changefeed telemetry events
+// Channel: TELEMETRY
+//
+// Events in this category pertain to changefeed usage and metrics.
+
+// CreateChangefeed is an event for any CREATE CHANGEFEED query that
+// successfully starts running. Failed CREATE statements will show up as
+// ChangefeedFailed events.
+message CreateChangefeed {
+  CommonChangefeedEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+
+  // Flag representing whether the changefeed is using CDC queries.
+  bool transformation = 2 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+}
+
+// ChangefeedFailed is an event for any changefeed failure since the plan hook
+// was triggered.
+message ChangefeedFailed {
+  CommonChangefeedEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+
+  // The reason / environment with which the changefeed failed
+  // (ex: connection_closed, changefeed_behind).
+  string failure_type = 2 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+}
+
+// ChangefeedEmittedBytes is an event representing the bytes emitted by a changefeed over an interval.
+message ChangefeedEmittedBytes {
+  CommonChangefeedEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+
+  // The job id for enterprise changefeeds.
+  int64 job_id = 2 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) =  "redact:\"nonsensitive\""];
+
+  // The number of bytes emitted.
+  int64 emitted_bytes = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // The number of messages emitted.
+  int64 emitted_messages = 6 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // The time period in nanoseconds between emitting telemetry events of this type (per-aggregator).
+  int64 logging_interval = 4 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // Flag to indicate that the changefeed is closing.
+  bool closing = 5 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+}

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -5,6 +5,15 @@ package eventpb
 import "github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 
 // LoggingChannel implements the EventPayload interface.
+func (m *ChangefeedEmittedBytes) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
+
+// LoggingChannel implements the EventPayload interface.
+func (m *ChangefeedFailed) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
+
+// LoggingChannel implements the EventPayload interface.
+func (m *CreateChangefeed) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *CertsReload) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
 
 // LoggingChannel implements the EventPayload interface.
@@ -333,15 +342,6 @@ func (m *StoreStats) LoggingChannel() logpb.Channel { return logpb.Channel_TELEM
 
 // LoggingChannel implements the EventPayload interface.
 func (m *CapturedIndexUsageStats) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
-
-// LoggingChannel implements the EventPayload interface.
-func (m *ChangefeedEmittedBytes) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
-
-// LoggingChannel implements the EventPayload interface.
-func (m *ChangefeedFailed) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
-
-// LoggingChannel implements the EventPayload interface.
-func (m *CreateChangefeed) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
 
 // LoggingChannel implements the EventPayload interface.
 func (m *HotRangesStats) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }

--- a/pkg/util/log/eventpb/events.proto
+++ b/pkg/util/log/eventpb/events.proto
@@ -98,4 +98,7 @@ message CommonChangefeedEventDetails {
 
   // The data format being emitted (ex: JSON, Avro).
   string format = 7 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) =  "redact:\"nonsensitive\""];
+
+  // The job id for enterprise changefeeds.
+  int64 job_id = 8 [(gogoproto.jsontag) = ",omitempty"];
 }

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -980,15 +980,6 @@ func (m *ChangefeedEmittedBytes) AppendJSONFields(printComma bool, b redact.Reda
 
 	printComma, b = m.CommonChangefeedEventDetails.AppendJSONFields(printComma, b)
 
-	if m.JobId != 0 {
-		if printComma {
-			b = append(b, ',')
-		}
-		printComma = true
-		b = append(b, "\"JobId\":"...)
-		b = strconv.AppendInt(b, int64(m.JobId), 10)
-	}
-
 	if m.EmittedBytes != 0 {
 		if printComma {
 			b = append(b, ',')
@@ -1594,6 +1585,15 @@ func (m *CommonChangefeedEventDetails) AppendJSONFields(printComma bool, b redac
 		b = append(b, "\"Format\":\""...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Format)))
 		b = append(b, '"')
+	}
+
+	if m.JobId != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"JobId\":"...)
+		b = strconv.AppendInt(b, int64(m.JobId), 10)
 	}
 
 	return printComma, b

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -556,45 +556,6 @@ message CapturedIndexUsageStats {
   string schema_name = 13 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }
 
-// CreateChangefeed is an event for any CREATE CHANGEFEED query that
-// successfully starts running.  Failed CREATE statements will show up as
-// ChangefeedFailed events.
-message CreateChangefeed {
-  CommonChangefeedEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
-
-  bool transformation = 2 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
-}
-
-// ChangefeedFailed is an event for any Changefeed failure since the plan hook
-// was triggered.
-message ChangefeedFailed {
-  CommonChangefeedEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
-
-  // The reason / environment with which the changefeed failed (ex:
-  // connection_closed, changefeed_behind)
-  string failure_type = 2 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
-}
-
-// ChangefeedEmittedBytes is an event representing the bytes emitted by a changefeed over an interval.
-message ChangefeedEmittedBytes {
-  CommonChangefeedEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
-
-  // The job id for enterprise changefeeds.
-  int64 job_id = 2 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) =  "redact:\"nonsensitive\""];
-
-  // The number of bytes emitted.
-  int64 emitted_bytes = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
-
-  // The number of messages emitted.
-  int64 emitted_messages = 6 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
-
-  // The time period in nanoseconds between emitting telemetry events of this type (per-aggregator).
-  int64 logging_interval = 4 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
-
-  // Flag to indicate that the changefeed is closing.
-  bool closing = 5 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
-}
-
 // RecoveryEvent is an event that is logged on every invocation of BACKUP,
 // RESTORE, and on every BACKUP schedule creation, with the appropriate subset
 // of fields populated depending on the type of event. This event is is also


### PR DESCRIPTION
**log/eventpb: move changefeed structured log events to separate category** 

Release note: None

----

**log/eventpb: add job ID to all changefeed structured log events** 

Release note (ops change): `changefeed_failed` and `create_changefeed`
log events now include a `JobId` field for enterprise changefeeds.

----

Informs #121697
