### PR TITLE
drt-run: Fix warnings to avoid build failure

### DIFF
--- a/pkg/cmd/drt-run/config/drt-chaos.yaml
+++ b/pkg/cmd/drt-run/config/drt-chaos.yaml
@@ -4,36 +4,36 @@ workloads:
     steps:
       - command: run
         args:
-          - --warehouses 12000
-          - --active-warehouses 1700
-          - --db cct_tpcc
+          - --warehouses=12000
+          - --active-warehouses=1700
+          - --db=cct_tpcc
           - --secure
-          - --ramp 10m
-          - --display-every 5s
-          - --duration 12h
-          - --prometheus-port 2112
-          - --user cct_tpcc_user
+          - --ramp=10m
+          - --display-every=5s
+          - --duration=12h
+          - --prometheus-port=2112
+          - --user=cct_tpcc_user
           - --tolerate-errors
-          - --password tpcc
+          - --password=tpcc
   - name: kv-main
     kind: kv
     steps:
       - command: run
         args:
-          - --concurrency 8
-          - --histograms kv/stats.json
-          - --db kv
-          - --splits 500
-          - --read-percent 50
-          - --cycle-length 100000
-          - --min-block-bytes 100
-          - --max-block-bytes 1000
-          - --max-rate 120
+          - --concurrency=8
+          - --histograms=kv/stats.json
+          - --db=kv
+          - --splits=500
+          - --read-percent=50
+          - --cycle-length=100000
+          - --min-block-bytes=100
+          - --max-block-bytes=1000
+          - --max-rate=120
           - --secure
-          - --prometheus-port 2114
-          - --ramp 10m
-          - --display-every 5s
-          - --duration 12h
+          - --prometheus-port=2114
+          - --ramp=10m
+          - --display-every=5s
+          - --duration=12h
           - --tolerate-errors
           - --enum
 operations:

--- a/pkg/cmd/drt-run/http.go
+++ b/pkg/cmd/drt-run/http.go
@@ -100,7 +100,7 @@ func (h *httpHandler) serve(rw http.ResponseWriter, req *http.Request) {
 	fmt.Fprintf(rw, "<h3>Configuration</h3><hr>\n")
 	fmt.Fprintf(rw, "<pre>")
 	encoder := yaml.NewEncoder(rw)
-	encoder.Encode(h.w.config)
+	_ = encoder.Encode(h.w.config)
 	fmt.Fprintf(rw, "</pre>")
 
 	fmt.Fprintf(rw, "</body>\n</html>")

--- a/pkg/cmd/drt-run/main.go
+++ b/pkg/cmd/drt-run/main.go
@@ -91,7 +91,7 @@ func runDRT(configFile string) (retErr error) {
 		o:      or,
 		eventL: eventL,
 	}
-	hh.startHTTPServer(8080, "localhost")
+	_ = hh.startHTTPServer(8080, "localhost")
 	or.Run(ctx)
 
 	return nil

--- a/pkg/cmd/drt-run/workloads.go
+++ b/pkg/cmd/drt-run/workloads.go
@@ -103,7 +103,7 @@ func (w *workloadRunner) runWorkloadStep(
 		}
 	}()
 
-	cmd.Start()
+	_ = cmd.Start()
 	if err := cmd.Wait(); err != nil {
 		w.errChan <- err
 		return

--- a/pkg/cmd/roachtest/operations/node_kill.go
+++ b/pkg/cmd/roachtest/operations/node_kill.go
@@ -103,7 +103,7 @@ func registerNodeKill(r registry.Registry) {
 		Owner:              registry.OwnerServer,
 		Timeout:            15 * time.Minute,
 		CompatibleClouds:   registry.AllClouds,
-		CanRunConcurrently: registry.OperationCannotRunConcurrentlyWithItself,
+		CanRunConcurrently: registry.OperationCannotRunConcurrently,
 		Dependencies:       []registry.OperationDependency{registry.OperationRequiresZeroUnderreplicatedRanges},
 		Run:                nodeKillRunner(9 /* signal */, true /* drain */),
 	})
@@ -112,7 +112,7 @@ func registerNodeKill(r registry.Registry) {
 		Owner:              registry.OwnerServer,
 		Timeout:            10 * time.Minute,
 		CompatibleClouds:   registry.AllClouds,
-		CanRunConcurrently: registry.OperationCannotRunConcurrentlyWithItself,
+		CanRunConcurrently: registry.OperationCannotRunConcurrently,
 		Dependencies:       []registry.OperationDependency{registry.OperationRequiresZeroUnderreplicatedRanges},
 		Run:                nodeKillRunner(9 /* signal */, false /* drain */),
 	})
@@ -121,7 +121,7 @@ func registerNodeKill(r registry.Registry) {
 		Owner:              registry.OwnerServer,
 		Timeout:            15 * time.Minute,
 		CompatibleClouds:   registry.AllClouds,
-		CanRunConcurrently: registry.OperationCannotRunConcurrentlyWithItself,
+		CanRunConcurrently: registry.OperationCannotRunConcurrently,
 		Dependencies:       []registry.OperationDependency{registry.OperationRequiresZeroUnderreplicatedRanges},
 		Run:                nodeKillRunner(15 /* signal */, true /* drain */),
 	})


### PR DESCRIPTION
The build is failing on my mac due to the warnings. This PR fixes the same.
```
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
compilepkg: nogo: errors found by nogo during build-time code analysis:
pkg/cmd/drt-run/event.go:125:39: if statement between Lock and Unlock may be unsafe, move Unlock to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/event.go:128:8: Unlock is >5 lines away from matching Lock, move it to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/event.go:131:16: unchecked error (errcheck)
pkg/cmd/drt-run/event.go:143:52: if statement between Lock and Unlock may be unsafe, move Unlock to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/event.go:146:7: Unlock is >5 lines away from matching Lock, move it to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/event.go:149:16: unchecked error (errcheck)
pkg/cmd/drt-run/http.go:103:16: unchecked error (errcheck)
pkg/cmd/drt-run/main.go:94:20: unchecked error (errcheck)
pkg/cmd/drt-run/operations.go:112:29: if statement between Lock and Unlock may be unsafe, move Unlock to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/operations.go:119:25: function call between Lock and Unlock may be unsafe, move Unlock to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/operations.go:121:53: if statement between Lock and Unlock may be unsafe, move Unlock to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/operations.go:128:31: function call between Lock and Unlock may be unsafe, move Unlock to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/operations.go:140:4: for loop between Lock and Unlock may be unsafe, move Unlock to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/operations.go:158:8: Unlock is >5 lines away from matching Lock, move it to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/operations.go:218:11: unchecked error (errcheck)
pkg/cmd/drt-run/operations.go:259:74: if statement between Lock and Unlock may be unsafe, move Unlock to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/operations.go:262:2: function call between Lock and Unlock may be unsafe, move Unlock to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/operations.go:263:7: Unlock is >5 lines away from matching Lock, move it to a defer statement after Lock (deferunlockcheck)
pkg/cmd/drt-run/workloads.go:106:11: unchecked error (errcheck)
Target //pkg/cmd/drt-run:drt-run failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 85.126s, Critical Path: 61.50s
INFO: 1080 processes: 5 internal, 1075 darwin-sandbox.
ERROR: Build did NOT complete successfully
INFO: Build Event Protocol files produced successfully.
ERROR: exit status 1
```

Epic: none

Release note: None