### PR TITLE
release-23.2: jobs: create jobs ignoring user session timezone

### DIFF
--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -1167,8 +1167,15 @@ func TestRegistryLifecycle(t *testing.T) {
 			CreatedBy: &jobs.CreatedByInfo{Name: createdByType, ID: 123},
 			Username:  username.TestUserName(),
 		}
-		job, err := rts.registry.CreateAdoptableJobWithTxn(rts.ctx, record, jobID, nil /* txn */)
-		require.NoError(t, err)
+		var job *jobs.Job
+		require.NoError(t, rts.s.InternalDB().(isql.DB).Txn(rts.ctx, func(ctx context.Context, txn isql.Txn) error {
+			txn.SessionData().Location = time.FixedZone("UTC+5", 5*60*60)
+			j, err := rts.registry.CreateAdoptableJobWithTxn(rts.ctx, record, jobID, txn)
+			job = j
+			return err
+		}))
+
+		rts.sqlDB.CheckQueryResults(t, "SELECT created <= now() FROM system.jobs WHERE id = "+jobID.String(), [][]string{{"true"}})
 
 		loadedJob, err := rts.registry.LoadJob(rts.ctx, jobID)
 		require.NoError(t, err)

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -776,20 +776,19 @@ func (r *Registry) CreateAdoptableJobWithTxn(
 		}
 		typ := j.mu.payload.Type().String()
 
-		nCols := 7
-		cols := []string{"id", "status", "payload", "progress", "created_by_type", "created_by_id", "job_type"}
-		placeholders := []string{"$1", "$2", "$3", "$4", "$5", "$6", "$7"}
+		nCols := 8
+		cols := []string{"id", "created", "status", "payload", "progress", "created_by_type", "created_by_id", "job_type"}
+		placeholders := []string{"$1", "now() at time zone 'utc'", "$2", "$3", "$4", "$5", "$6", "$7"}
 		values := []interface{}{jobID, StatusRunning, payloadBytes, progressBytes, createdByType, createdByID, typ}
 		if !r.settings.Version.IsActive(ctx, clusterversion.V23_1AddTypeColumnToJobsTable) {
 			nCols -= 1
 		}
 		if r.settings.Version.IsActive(ctx, clusterversion.V23_1StopWritingPayloadAndProgressToSystemJobs) {
-			cols = []string{"id", "status", "created_by_type", "created_by_id", "job_type"}
-			placeholders = []string{"$1", "$2", "$3", "$4", "$5"}
+			cols = []string{"id", "created", "status", "created_by_type", "created_by_id", "job_type"}
+			placeholders = []string{"$1", "now() at time zone 'utc'", "$2", "$3", "$4", "$5"}
 			values = []interface{}{jobID, StatusRunning, createdByType, createdByID, typ}
-			nCols = 5
+			nCols = 6
 		}
-		// Insert the job row, but do not set a `claim_session_id`. By not
 		// setting the claim, the job can be adopted by any node and will
 		// be adopted by the node which next runs the adoption loop.
 		stmt := fmt.Sprintf(
@@ -799,7 +798,7 @@ func (r *Registry) CreateAdoptableJobWithTxn(
 		_, err = txn.ExecEx(ctx, "job-insert", txn.KV(), sessiondata.InternalExecutorOverride{
 			User:     username.NodeUserName(),
 			Database: catconstants.SystemDatabaseName,
-		}, stmt, values[:nCols]...)
+		}, stmt, values[:nCols-1]...)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Backport 1/1 commits from #123632.

/cc @cockroachdb/release

---

Release note (bug fix): fixes a bug where jobs created in session with non-zero session timezone offsets could hang before starting or report incorrect creation times when viewed in SHOW JOBS and the console.

Epic: none.
