### PR TITLE
hlc: update docs to include Store Liveness

### DIFF
--- a/pkg/kv/kvserver/storeliveness/storelivenesspb/service.proto
+++ b/pkg/kv/kvserver/storeliveness/storelivenesspb/service.proto
@@ -52,9 +52,24 @@ message Message {
 // streaming Store Liveness RPC service.
 message MessageBatch {
   repeated Message messages = 1 [(gogoproto.nullable) = false];
-  // Now is used to update the HLC clock of the message recipient; this is not
-  // necessary for the correctness of the Store Liveness algorithm but it helps
-  // keep the stores' clocks more tightly synchronized, which allows them to
+  // Now is used to update the HLC clock of the message recipient. This is
+  // necessary to ensure the Support Disjointness Invariant of Store Liveness.
+  // Without propagating this timestamp, the following scenario is possible:
+  // - At time 5, according to its own clock, store A has support from store B
+  //   with epoch 1 and expiration 10.
+  // - Store B withdraws support when its clock reaches time 10 and bumps store
+  //   A's epoch to 2.
+  // - Store A's clock is still at time 6, and it requests to extend support
+  //   for epoch 1 until time 12.
+  // - Store B responds with the bumped epoch 2 (essentially a nack).
+  // - Store A, whose clock is at time 7, receives that message (does not update
+  //   its clock to match store B's) and requests support for epoch 2 and
+  //   expiration 13.
+  // - Store B agrees and store A receives that response at time 8.
+  // Now Store A has two overlapping periods of support for epochs 1 and 2:
+  // [5, 10) and [8, 12).
+  //
+  // Keeping the stores' clocks more tightly synchronized also allows them to
   // provide/withdraw support promptly.
   util.hlc.Timestamp now    = 2 [(gogoproto.nullable) = false,
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/util/hlc.ClockTimestamp"];

--- a/pkg/util/hlc/doc.go
+++ b/pkg/util/hlc/doc.go
@@ -30,6 +30,12 @@ message that they receive to update their local clock.
 There are currently three channels through which HLC timestamps are passed
 between nodes in a cluster:
 
+  - Store Liveness (bidirectional): stores attach clock readings to all messages.
+    Whenever a store receives a messages, it forwards its clock to the clock
+    reading included in the message.
+
+    Ref: (storeliveness.MessageBatch).Timestamp.
+
   - Raft (unidirectional): proposers of Raft commands (i.e. leaseholders) attach
     clock readings to some of these command (e.g. lease transfers, range merges),
     which are later consumed by followers when commands are applied to their Raft
@@ -141,6 +147,29 @@ turn out to exist in the future of the local HLC when the intent gets resolved.
     restarting at a timestamp above the local clock back then because we had yet
     to separate the "clock timestamp" domain from the "transaction timestamp"
     domain.
+
+  - Store Liveness Support Disjointness (Store Liveness channel). One of the key
+    Store Liveness properties, the Support Disjointness Invariant, states that
+    no two support intervals with different epochs should overlap. This helps
+    establish the Lease Disjointness Invariant at the leasing layer. To be able
+    to guarantee the Support Disjointness Invariant, Store Liveness ensures that
+    a store does not request support for a new epoch before it considers the
+    previous epoch's support as expired according to its own clock. This needs
+    to happen in at least two cases:
+
+    (1) When a store restarts and increments its own epoch, it waits out any
+    previously requested support, as described in (storeliveness.RequesterMeta).
+    MaxRequested. This case does not need clock propagation.
+
+    (2) When a store learns that a supporter has withdrawn support for an
+    epoch, it needs to forward its clock to the supporter's clock to ensure
+    that any future support at a higher epoch does not overlap with the
+    previous one. For an example, see (storeliveness.MessageBatch).Timestamp.
+
+    Even though Store Liveness needs clock readings only on HeartbeatResponse
+    messages, they are included on all messages, which has the added benefit of
+    helping stores' clocks stay more closely synchronized, so they can provide
+    and withdraw support in a timely manner.
 
 # Strict monotonicity
 


### PR DESCRIPTION
Store Liveness propagates logical clock readings in all messages in order to guarantee the Support Disjointness Invariant.

This commit updates the HLC documentation to include this use case.

Fixes: #125069

Release note: None