### PR TITLE
server: support "nodes" API endpoint for secondary tenants (draft)

### DIFF
--- a/pkg/ccl/changefeedccl/mocks/tenant_status_server_generated.go
+++ b/pkg/ccl/changefeedccl/mocks/tenant_status_server_generated.go
@@ -10,6 +10,7 @@ import (
 
 	roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
 	serverpb "github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	statuspb "github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -64,6 +65,21 @@ func (m *MockTenantStatusServer) HotRangesV2(arg0 context.Context, arg1 *serverp
 func (mr *MockTenantStatusServerMockRecorder) HotRangesV2(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HotRangesV2", reflect.TypeOf((*MockTenantStatusServer)(nil).HotRangesV2), arg0, arg1)
+}
+
+// Node mocks base method.
+func (m *MockTenantStatusServer) Node(arg0 context.Context, arg1 *serverpb.NodeRequest) (*statuspb.NodeStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Node", arg0, arg1)
+	ret0, _ := ret[0].(*statuspb.NodeStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Node indicates an expected call of Node.
+func (mr *MockTenantStatusServerMockRecorder) Node(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Node", reflect.TypeOf((*MockTenantStatusServer)(nil).Node), arg0, arg1)
 }
 
 // Nodes mocks base method.

--- a/pkg/kv/kvclient/kvtenant/BUILD.bazel
+++ b/pkg/kv/kvclient/kvtenant/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/rpc/nodedialer",
         "//pkg/server/serverpb",
         "//pkg/server/settingswatcher",
+        "//pkg/server/status/statuspb",
         "//pkg/settings",
         "//pkg/spanconfig",
         "//pkg/sql/isql",

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/settingswatcher"
+	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
@@ -645,6 +646,16 @@ func (c *connector) Nodes(
 ) (resp *serverpb.NodesResponse, retErr error) {
 	retErr = c.withClient(ctx, func(ctx context.Context, client *client) (err error) {
 		resp, err = client.Nodes(ctx, req)
+		return
+	})
+	return
+}
+
+func (c *connector) Node(
+	ctx context.Context, req *serverpb.NodeRequest,
+) (resp *statuspb.NodeStatus, retErr error) {
+	retErr = c.withClient(ctx, func(ctx context.Context, client *client) (err error) {
+		resp, err = client.Node(ctx, req)
 		return
 	})
 	return

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -146,6 +146,9 @@ func (a tenantAuthorizer) authorize(
 	case "/cockroach.server.serverpb.Status/Nodes":
 		return a.capabilitiesAuthorizer.HasNodeStatusCapability(ctx, tenID)
 
+	case "/cockroach.server.serverpb.Status/Node":
+		return a.capabilitiesAuthorizer.HasNodeStatusCapability(ctx, tenID)
+
 	case "/cockroach.server.serverpb.Admin/Liveness":
 		return a.capabilitiesAuthorizer.HasNodeStatusCapability(ctx, tenID)
 

--- a/pkg/server/serverpb/BUILD.bazel
+++ b/pkg/server/serverpb/BUILD.bazel
@@ -108,6 +108,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/roachpb",
+        "//pkg/server/status/statuspb",
         "//pkg/util/errorutil",
         "//pkg/util/metric",
         "@com_github_prometheus_client_model//go",

--- a/pkg/server/serverpb/status.go
+++ b/pkg/server/serverpb/status.go
@@ -14,6 +14,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	statuspb "github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 )
 
@@ -90,6 +91,7 @@ type TenantStatusServer interface {
 	// SpanStats is used to access MVCC stats from KV
 	SpanStats(context.Context, *roachpb.SpanStatsRequest) (*roachpb.SpanStatsResponse, error)
 	Nodes(context.Context, *NodesRequest) (*NodesResponse, error)
+	Node(context.Context, *NodeRequest) (*statuspb.NodeStatus, error)
 	// TODO(adityamaru): DownloadSpan has the side effect of telling the engine to
 	// download remote files. A method that mutates state should not be on the
 	// status server and so in the long run we should move it.

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1861,6 +1861,20 @@ func (s *systemStatusServer) Nodes(
 	return resp, nil
 }
 
+func (s *statusServer) Nodes(
+	ctx context.Context, req *serverpb.NodesRequest,
+) (*serverpb.NodesResponse, error) {
+	ctx = authserver.ForwardSQLIdentityThroughRPCCalls(ctx)
+	ctx = s.AnnotateCtx(ctx)
+
+	err := s.privilegeChecker.RequireViewClusterMetadataPermission(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.sqlServer.tenantConnect.Nodes(ctx, req)
+}
+
 // TODO: Enhance with redaction middleware, refer: https://github.com/cockroachdb/cockroach/issues/109594
 func (s *statusServer) redactNodesResponse(resp *serverpb.NodesResponse) *serverpb.NodesResponse {
 	for i := range resp.Nodes {

--- a/pkg/server/storage_api/nodes_test.go
+++ b/pkg/server/storage_api/nodes_test.go
@@ -89,7 +89,7 @@ func TestNodeStatusResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(110023),
+		DefaultTestTenant: base.TestTenantAlwaysEnabled,
 	})
 	defer srv.Stopper().Stop(context.Background())
 

--- a/pkg/server/storage_api/nodes_test.go
+++ b/pkg/server/storage_api/nodes_test.go
@@ -89,7 +89,7 @@ func TestNodeStatusResponse(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestTenantAlwaysEnabled,
+		DefaultTestTenant: base.TestTenantProbabilistic,
 	})
 	defer srv.Stopper().Stop(context.Background())
 


### PR DESCRIPTION
The "nodes" status API endpoint should work with secondary tenants with capability `can_view_node_info`. Since nodes are common to all the tenants, this API endpoint behaves similar to that of system tenant.

Tenant connector implements `TenantStatusServer` interface. Status server in secondary tenants make use of tenant connector to fetch the nodes information.

<needs_input> Status server is trimmed down version of full system status server. System status extends standard status server with additional API implementations. The odd thing about this implementation is that, it injects tenantStatusServer client into status server for secondary tenants but uses a unimplemented version for system tenants. I believe this can be simplified.

Alternate considerations is to fetch nodes information and cache them for later use. This API is likely to have a low QPS and therefore async caching only complicates the implementation.

Fixes: https://github.com/cockroachdb/cockroach/issues/110023
Epic: https://cockroachlabs.atlassian.net/browse/CRDB-38968