### PR TITLE
sql/stats: fix the incorrect data range in "randBounds"

### DIFF
--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -916,9 +916,13 @@ type PGNumeric struct {
 // for a timestamp. To create a timestamp from this value, it takes the microseconds
 // delta and adds it to PGEpochJDate.
 func pgBinaryToTime(i int64) time.Time {
+	// Postgres uses math.MaxInt64 microseconds as the "infinity" timestamp, see:
+	// https://github.com/postgres/postgres/blob/9380e5f129d2a160ecc2444f61bb7cb97fd51fbb/src/include/datatype/timestamp.h#L151
 	if i == math.MaxInt64 {
 		return pgdate.TimeInfinity
 	}
+	// Postgres uses math.MinInt64 microseconds as the "-infinity" timestamp, see:
+	// https://github.com/postgres/postgres/blob/9380e5f129d2a160ecc2444f61bb7cb97fd51fbb/src/include/datatype/timestamp.h#L150
 	if i == math.MinInt64 {
 		return pgdate.TimeNegativeInfinity
 	}

--- a/pkg/sql/sem/tree/parse_string.go
+++ b/pkg/sql/sem/tree/parse_string.go
@@ -265,7 +265,7 @@ func ParseAndRequireStringHandler(
 		var ts time.Time
 		if ts, _, err = pgdate.ParseTimestampWithoutTimezone(now, dateStyle(ctx), s, dateParseHelper(ctx)); err == nil {
 			// Always normalize time to the current location.
-			if ts, err = checkTimeBounds(ts, TimeFamilyPrecisionToRoundDuration(t.Precision())); err == nil {
+			if ts, err = roundAndCheck(ts, TimeFamilyPrecisionToRoundDuration(t.Precision())); err == nil {
 				vh.TimestampTZ(ts)
 			}
 		}

--- a/pkg/sql/stats/quantile_test.go
+++ b/pkg/sql/stats/quantile_test.go
@@ -193,17 +193,18 @@ func randBounds(colType *types.T, rng *rand.Rand, num int) tree.Datums {
 	case types.TimestampFamily, types.TimestampTZFamily:
 		roundTo := tree.TimeFamilyPrecisionToRoundDuration(colType.Precision())
 		var lo, hi int
-		if pgdate.TimeInfinitySec < math.MaxInt/2 {
-			lo = int(pgdate.TimeNegativeInfinitySec)
-			hi = int(pgdate.TimeInfinitySec)
+		if tree.MaxSupportedTimeSec < math.MaxInt/2 {
+			lo = int(tree.MinSupportedTimeSec)
+			hi = int(tree.MaxSupportedTimeSec)
 		} else {
-			// Make sure we won't overflow in randInts (i.e. make sure that
-			// hi - lo + 1 <= math.MaxInt which requires -2 for hi).
-			w := int(bits.UintSize) - 2
+			// Make sure we don't overflow in randInts on 32-bit systems.
+			// Specifically, make sure that hi - lo + 1 <= math.MaxInt, which requires subtracting 2 from hi.
+			w := bits.UintSize - 2
 			lo = -1 << w
 			hi = (1 << w) - 2
 		}
 		secs := randInts(num, lo, hi)
+
 		for i := range datums {
 			t := timeutil.Unix(int64(secs[i]), 0)
 			var err error
@@ -794,12 +795,12 @@ func TestQuantileValueRoundTrip(t *testing.T) {
 		{
 			typ: types.Timestamp,
 			dat: &tree.DTimestamp{Time: pgdate.TimeInfinity},
-			val: pgdate.TimeInfinitySec,
+			err: true,
 		},
 		{
 			typ: types.Timestamp,
 			dat: &tree.DTimestamp{Time: pgdate.TimeNegativeInfinity},
-			val: pgdate.TimeNegativeInfinitySec,
+			err: true,
 		},
 		{
 			typ: types.TimestampTZ,
@@ -809,12 +810,12 @@ func TestQuantileValueRoundTrip(t *testing.T) {
 		{
 			typ: types.TimestampTZ,
 			dat: &tree.DTimestampTZ{Time: pgdate.TimeInfinity},
-			val: pgdate.TimeInfinitySec,
+			err: true,
 		},
 		{
 			typ: types.TimestampTZ,
 			dat: &tree.DTimestampTZ{Time: pgdate.TimeNegativeInfinity},
-			val: pgdate.TimeNegativeInfinitySec,
+			err: true,
 		},
 	}
 	ctx := context.Background()
@@ -1049,50 +1050,43 @@ func TestQuantileValueRoundTripOverflow(t *testing.T) {
 		{
 			typ: types.Timestamp,
 			val: float64(pgdate.TimeNegativeInfinity.Unix()),
-			dat: &tree.DTimestamp{Time: pgdate.TimeNegativeInfinity},
-			res: pgdate.TimeNegativeInfinitySec,
+			err: true,
 		},
 		{
 			typ: types.Timestamp,
 			val: float64(pgdate.TimeInfinity.Unix()),
-			dat: &tree.DTimestamp{Time: pgdate.TimeInfinity},
-			res: pgdate.TimeInfinitySec,
+			err: true,
 		},
 		{
 			typ: types.Timestamp,
 			val: -math.MaxFloat64,
-			dat: &tree.DTimestamp{Time: pgdate.TimeNegativeInfinity},
-			res: pgdate.TimeNegativeInfinitySec,
+			err: true,
 		},
 		{
 			typ: types.Timestamp,
 			val: math.MaxFloat64,
-			dat: &tree.DTimestamp{Time: pgdate.TimeInfinity},
-			res: pgdate.TimeInfinitySec,
+			err: true,
 		},
+		// TimestampTZ cases.
 		{
 			typ: types.TimestampTZ,
 			val: float64(pgdate.TimeNegativeInfinity.Unix()),
-			dat: &tree.DTimestampTZ{Time: pgdate.TimeNegativeInfinity},
-			res: pgdate.TimeNegativeInfinitySec,
+			err: true,
 		},
 		{
 			typ: types.TimestampTZ,
 			val: float64(pgdate.TimeInfinity.Unix()),
-			dat: &tree.DTimestampTZ{Time: pgdate.TimeInfinity},
-			res: pgdate.TimeInfinitySec,
+			err: true,
 		},
 		{
 			typ: types.TimestampTZ,
 			val: -math.MaxFloat64,
-			dat: &tree.DTimestampTZ{Time: pgdate.TimeNegativeInfinity},
-			res: pgdate.TimeNegativeInfinitySec,
+			err: true,
 		},
 		{
 			typ: types.TimestampTZ,
 			val: math.MaxFloat64,
-			dat: &tree.DTimestampTZ{Time: pgdate.TimeInfinity},
-			res: pgdate.TimeInfinitySec,
+			err: true,
 		},
 	}
 	ctx := context.Background()

--- a/pkg/util/timeutil/pgdate/parsing.go
+++ b/pkg/util/timeutil/pgdate/parsing.go
@@ -73,13 +73,9 @@ var (
 	// resulted in '23:59:59.999999'.) This behavior may change in the future, see issue #129148
 	// for more details.
 	//
-	// Postgres uses math.MaxInt64 microseconds as the infinity value.
-	// See: https://github.com/postgres/postgres/blob/9380e5f129d2a160ecc2444f61bb7cb97fd51fbb/src/include/datatype/timestamp.h#L157
-	//
 	// Refer to the doc comments of the function "timeutil.Unix" for the process of
 	// deriving the arguments to construct a specific time.Time.
-	TimeInfinity    = timeutil.Unix(9224318102399 /* sec */, 999999000 /* nsec */)
-	TimeInfinitySec = float64(TimeInfinity.Unix())
+	TimeInfinity = timeutil.Unix(9224318102399 /* sec */, 999999000 /* nsec */)
 	// TimeNegativeInfinity represents the "lowest" possible time. Its value is
 	// "-4714-11-23 00:00:00 +0000 UTC", which is 24 hours before "MinSupportedTime"
 	// ("-4714-11-24 00:00:00 +0000 UTC").
@@ -92,13 +88,9 @@ var (
 	// resulted in '00:00:00'.) This behavior may change in the future, see issue #129148
 	// for more details.
 	//
-	// Postgres uses math.MinInt64 microseconds as the -infinity value.
-	// See: https://github.com/postgres/postgres/blob/9380e5f129d2a160ecc2444f61bb7cb97fd51fbb/src/include/datatype/timestamp.h#L156
-	//
 	// Refer to the doc comments of the function "timeutil.Unix" for the process of
 	// deriving the arguments to construct a specific time.Time.
-	TimeNegativeInfinity    = timeutil.Unix(-210898425600 /* sec */, 0 /* nsec */)
-	TimeNegativeInfinitySec = float64(TimeNegativeInfinity.Unix())
+	TimeNegativeInfinity = timeutil.Unix(-210898425600 /* sec */, 0 /* nsec */)
 )
 
 type ParseHelper struct {


### PR DESCRIPTION
### summary

Previously, "randBounds" function generate timestamp in the range of [TimeNegativeInfinity, TimeInfinity], which is incorrect since it exceeds the time range that supported by CRDB, causing issue #130371

This commit addresses this issue by:

- Change the range of data to [MinSupportedTime, MaxSupportedTime].
- Add edge cases to the test to expose potential bugs.

This commit also:

- Move the comments about postgres encoding of "infinity" timestamp to appropriate place.
- Add doc comments for "checkTimeBounds" and change its name to improve semantic clarity.

Fixes: #130371

Release note (bug fix): Fixed a bug where "randBounds" may generate invalid timestamp.

### how to review

- I fixed the incorrect data range, and added edge cases in [pkg/sql/stats/quantile_test.go](https://github.com/cockroachdb/cockroach/pull/131437/files#diff-84cbf7f41dc9d7df996b797c5715daad07f72f053614d66614e9f74a09000580)
- Others are aesthetic changes.