### PR TITLE
rac2,replica_rac2: order replicaSendStream.mu before Replica.mu

### DIFF
--- a/pkg/kv/kvserver/flow_control_replica_integration.go
+++ b/pkg/kv/kvserver/flow_control_replica_integration.go
@@ -491,3 +491,13 @@ func (r *replicaForRACv2) LeaseholderMuRLocked() roachpb.ReplicaID {
 func (r *replicaForRACv2) IsScratchRange() bool {
 	return (*Replica)(r).IsScratchRange()
 }
+
+// MuLock implements replica_rac2.ReplicaForRaftNode.
+func (r *replicaForRACv2) MuLock() {
+	r.mu.Lock()
+}
+
+// MuUnlock implements replica_rac2.ReplicaForRaftNode.
+func (r *replicaForRACv2) MuUnlock() {
+	r.mu.Unlock()
+}

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
@@ -319,7 +319,7 @@ func (r *testingRCRange) replicasStateInfo() map[roachpb.ReplicaID]ReplicaStateI
 	return replicasStateInfo
 }
 
-func (r *testingRCRange) SendPingReplicaMuLocked(roachpb.ReplicaID) bool {
+func (r *testingRCRange) SendPingRaftMuLocked(roachpb.ReplicaID) bool {
 	return false
 }
 

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -261,9 +261,9 @@ type SideChannelInfoUsingRaftMessageRequest struct {
 // We *strongly* prefer methods to be called without holding Replica.mu, since
 // then the callee (implementation of Processor) does not need to worry about
 // (a) deadlocks, since it sometimes needs to lock Replica.mu itself, (b) the
-// amount of work it is doing under this critical section. There are three
+// amount of work it is doing under this critical section. There are two
 // exceptions to this, due to difficulty in changing the calling code:
-// InitRaftLocked, OnDescChangedLocked and MaybeSendPingsLocked.
+// InitRaftLocked, OnDescChangedLocked.
 type Processor interface {
 	// InitRaftLocked is called when RaftNode is initialized for the Replica.
 	// NB: can be called twice before the Replica is fully initialized.
@@ -376,15 +376,15 @@ type Processor interface {
 	// raftMu is held.
 	AdmitRaftMuLocked(context.Context, roachpb.ReplicaID, rac2.AdmittedVector)
 
-	// MaybeSendPingsLocked sends a MsgApp ping to each raft peer whose admitted
-	// vector is lagging, and there wasn't a recent MsgApp to this peer. The
-	// messages are added to raft's message queue, and will be extracted from
-	// raft and sent during the next Ready processing.
+	// MaybeSendPingsRaftMuLocked sends a MsgApp ping to each raft peer whose
+	// admitted vector is lagging, and there wasn't a recent MsgApp to this
+	// peer. The messages are added to raft's message queue, and will be
+	// extracted from raft and sent during the next Ready processing.
 	//
 	// If the replica is not the leader, this call does nothing.
 	//
-	// Both Replica.raftMu and Replica.mu are held.
-	MaybeSendPingsLocked()
+	// raftMu is held.
+	MaybeSendPingsRaftMuLocked()
 
 	// AdmitForEval is called to admit work that wants to evaluate at the
 	// leaseholder.
@@ -1131,12 +1131,11 @@ func (p *processorImpl) AdmitRaftMuLocked(
 	}
 }
 
-// MaybeSendPingsLocked implements Processor.
-func (p *processorImpl) MaybeSendPingsLocked() {
+// MaybeSendPingsRaftMuLocked implements Processor.
+func (p *processorImpl) MaybeSendPingsRaftMuLocked() {
 	p.opts.Replica.RaftMuAssertHeld()
-	p.opts.Replica.MuAssertHeld()
 	if rc := p.leader.rc; rc != nil {
-		rc.MaybeSendPingsLocked()
+		rc.MaybeSendPingsRaftMuLocked()
 	}
 }
 

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -138,8 +138,8 @@ func (rn *testRaftNode) ReplicasStateLocked(_ map[roachpb.ReplicaID]rac2.Replica
 	fmt.Fprint(rn.b, " RaftNode.ReplicasStateLocked\n")
 }
 
-func (rn *testRaftNode) SendPingReplicaMuLocked(to roachpb.ReplicaID) bool {
-	fmt.Fprintf(rn.b, " RaftNode.SendPingReplicaMuLocked(%d)\n", to)
+func (rn *testRaftNode) SendPingRaftMuLocked(to roachpb.ReplicaID) bool {
+	fmt.Fprintf(rn.b, " RaftNode.SendPingRaftMuLocked(%d)\n", to)
 	return true
 }
 
@@ -252,8 +252,8 @@ func (c *testRangeController) AdmitRaftMuLocked(
 	fmt.Fprintf(c.b, " RangeController.AdmitRaftMuLocked(%s, %+v)\n", replicaID, av)
 }
 
-func (c *testRangeController) MaybeSendPingsLocked() {
-	fmt.Fprintf(c.b, " RangeController.MaybeSendPingsLocked()\n")
+func (c *testRangeController) MaybeSendPingsRaftMuLocked() {
+	fmt.Fprintf(c.b, " RangeController.MaybeSendPingsRaftMuLocked()\n")
 }
 
 func (c *testRangeController) SetReplicasRaftMuLocked(

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -325,7 +325,7 @@ func (r *Replica) initRaftGroupRaftMuLockedReplicaMuLocked() error {
 		return err
 	}
 	r.mu.internalRaftGroup = rg
-	r.flowControlV2.InitRaftLocked(ctx, replica_rac2.NewRaftNode(rg))
+	r.flowControlV2.InitRaftLocked(ctx, replica_rac2.NewRaftNode(rg, (*replicaForRACv2)(r)))
 	return nil
 }
 


### PR DESCRIPTION
The other way around is too hard to work with when we add pull mode. We will call MakeMsgAppAndAssumeSent from inside a replicaSendStream and will be adjusting replicaSendStream state before and after that call. During that call Replica.mu needs to be held, since Raft state for this follower (like Next) is being modified. It is not convenient to release and reacquire replicaSendStream.mu just for this purpose.

Informs #130433

Epic: CRDB-37515

Release note: None