### PR TITLE
server: fix dbMetadata type json

### DIFF
--- a/pkg/server/api_v2_databases_metadata.go
+++ b/pkg/server/api_v2_databases_metadata.go
@@ -994,10 +994,10 @@ type tableMetadata struct {
 }
 
 type dbMetadata struct {
-	DbId        int64      `json:"db_id,omitempty"`
-	DbName      string     `json:"db_name,omitempty"`
-	SizeBytes   int64      `json:"size_bytes,omitempty"`
-	TableCount  int64      `json:"table_count,omitempty"`
+	DbId        int64      `json:"db_id"`
+	DbName      string     `json:"db_name"`
+	SizeBytes   int64      `json:"size_bytes"`
+	TableCount  int64      `json:"table_count"`
 	StoreIds    []int64    `json:"store_ids"`
 	LastUpdated *time.Time `json:"last_updated"`
 }


### PR DESCRIPTION
Updates the dbMetadata type to not have `omitempty` in the json struct tags for any fields.

Epic: None
Release note: None