### PR TITLE
raft: forbid direct voter removal without demotion

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -528,6 +528,8 @@ func checkReplicationChangeAllowed(
 		return err
 	}
 
+	// TODO(nvanbenschoten): check against direct voter removal.
+
 	return nil
 }
 

--- a/pkg/raft/confchange/BUILD.bazel
+++ b/pkg/raft/confchange/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "confchange.go",
         "restore.go",
+        "validate.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/raft/confchange",
     visibility = ["//visibility:public"],
@@ -22,6 +23,7 @@ go_test(
         "datadriven_test.go",
         "quick_test.go",
         "restore_test.go",
+        "validate_test.go",
     ],
     data = glob(["testdata/**"]),
     embed = [":confchange"],
@@ -31,5 +33,6 @@ go_test(
         "//pkg/raft/tracker",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/raft/confchange/validate.go
+++ b/pkg/raft/confchange/validate.go
@@ -1,0 +1,57 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package confchange
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/raft/quorum"
+	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/errors"
+)
+
+// ValidationContext is a context struct that that is passed to ValidateProp to
+// allow it to validate a proposed ConfChange against the current state of the
+// Raft group.
+type ValidationContext struct {
+	CurConfig                         *quorum.Config
+	Applied                           uint64
+	PendingConfIndex                  uint64
+	DisableValidationAgainstCurConfig bool
+}
+
+// ValidateProp validates a proposed ConfChange against the current state of the
+// Raft group. It returns an error if the proposed change is invalid and must
+// not be proposed.
+func ValidateProp(ctx ValidationContext, cc pb.ConfChangeV2) error {
+	// Per the "Apply" invariant in the config change safety argument[^1],
+	// the leader must not append a config change if it hasn't applied all
+	// config changes in its log.
+	//
+	// [^1]: https://github.com/etcd-io/etcd/issues/7625#issuecomment-489232411
+	if ctx.PendingConfIndex > ctx.Applied {
+		return errors.Errorf("possible unapplied conf change at index %d (applied to %d)",
+			ctx.PendingConfIndex, ctx.Applied)
+	}
+
+	// The DisableValidationAgainstCurConfig flag allows disabling config change
+	// constraints that are guaranteed by the upper state machine layer (incorrect
+	// ones will apply as no-ops). See raft.Config.DisableConfChangeValidation for
+	// an explanation of why this may be used.
+	if !ctx.DisableValidationAgainstCurConfig {
+		curConfig := ctx.CurConfig
+
+		alreadyJoint := len(curConfig.Voters[1]) > 0
+		wantsLeaveJoint := cc.LeaveJoint()
+		if alreadyJoint && !wantsLeaveJoint {
+			return errors.New("must transition out of joint config first")
+		} else if !alreadyJoint && wantsLeaveJoint {
+			return errors.New("not in joint state; refusing empty conf change")
+		}
+
+		// TODO(nvanbenschoten): check against direct voter removal.
+	}
+
+	return nil
+}

--- a/pkg/raft/confchange/validate_test.go
+++ b/pkg/raft/confchange/validate_test.go
@@ -1,0 +1,117 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package confchange
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/raft/quorum"
+	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateProp(t *testing.T) {
+	configNormal := &quorum.Config{Voters: quorum.JointConfig{
+		quorum.MajorityConfig{1: struct{}{}, 2: struct{}{}, 3: struct{}{}},
+		quorum.MajorityConfig{},
+	}}
+	configJoint := &quorum.Config{Voters: quorum.JointConfig{
+		quorum.MajorityConfig{1: struct{}{}, 2: struct{}{}, 3: struct{}{}},
+		quorum.MajorityConfig{1: struct{}{}, 2: struct{}{}, 4: struct{}{}},
+	}}
+
+	changeNormal := pb.ConfChangeV2{Changes: []pb.ConfChangeSingle{
+		{Type: pb.ConfChangeAddNode, NodeID: 5},
+	}}
+	changeLeaveJoint := pb.ConfChangeV2{Changes: []pb.ConfChangeSingle{}}
+
+	tests := []struct {
+		name   string
+		ctx    ValidationContext
+		cc     pb.ConfChangeV2
+		expErr string
+	}{
+		{
+			name: "valid",
+			ctx: ValidationContext{
+				CurConfig:        configNormal,
+				Applied:          10,
+				PendingConfIndex: 5,
+			},
+			cc: changeNormal,
+		},
+		{
+			name: "valid, just applied conf change",
+			ctx: ValidationContext{
+				CurConfig:        configNormal,
+				Applied:          10,
+				PendingConfIndex: 10,
+			},
+			cc: changeNormal,
+		},
+		{
+			name: "invalid, unapplied conf change",
+			ctx: ValidationContext{
+				CurConfig:        configNormal,
+				Applied:          10,
+				PendingConfIndex: 15,
+			},
+			cc:     changeNormal,
+			expErr: "possible unapplied conf change at index 15 \\(applied to 10\\)",
+		},
+		{
+			name: "invalid, already in joint state",
+			ctx: ValidationContext{
+				CurConfig:        configJoint,
+				Applied:          10,
+				PendingConfIndex: 5,
+			},
+			cc:     changeNormal,
+			expErr: "must transition out of joint config first",
+		},
+		{
+			name: "invalid, not in joint state",
+			ctx: ValidationContext{
+				CurConfig:        configNormal,
+				Applied:          10,
+				PendingConfIndex: 5,
+			},
+			cc:     changeLeaveJoint,
+			expErr: "not in joint state; refusing empty conf change",
+		},
+		{
+			name: "invalid, already in joint state, validation disabled",
+			ctx: ValidationContext{
+				CurConfig:                         configJoint,
+				Applied:                           10,
+				PendingConfIndex:                  5,
+				DisableValidationAgainstCurConfig: true,
+			},
+			cc: changeNormal,
+		},
+		{
+			name: "invalid, not in joint state, validation disabled",
+			ctx: ValidationContext{
+				CurConfig:                         configNormal,
+				Applied:                           10,
+				PendingConfIndex:                  5,
+				DisableValidationAgainstCurConfig: true,
+			},
+			cc: changeLeaveJoint,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateProp(tt.ctx, tt.cc)
+			if tt.expErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Regexp(t, tt.expErr, err)
+			}
+		})
+	}
+}

--- a/pkg/raft/confchange/validate_test.go
+++ b/pkg/raft/confchange/validate_test.go
@@ -102,6 +102,83 @@ func TestValidateProp(t *testing.T) {
 			},
 			cc: changeLeaveJoint,
 		},
+		{
+			name: "valid, voter demoted",
+			ctx: ValidationContext{
+				CurConfig:        configNormal,
+				Applied:          10,
+				PendingConfIndex: 5,
+			},
+			cc: pb.ConfChangeV2{Changes: []pb.ConfChangeSingle{
+				{Type: pb.ConfChangeRemoveNode, NodeID: 3},
+				{Type: pb.ConfChangeAddLearnerNode, NodeID: 3},
+			}},
+		},
+		{
+			// NOTE: this case shouldn't happen in practice, but we handle it.
+			name: "valid, voter replaced",
+			ctx: ValidationContext{
+				CurConfig:        configNormal,
+				Applied:          10,
+				PendingConfIndex: 5,
+			},
+			cc: pb.ConfChangeV2{Changes: []pb.ConfChangeSingle{
+				{Type: pb.ConfChangeRemoveNode, NodeID: 3},
+				{Type: pb.ConfChangeAddNode, NodeID: 3},
+			}},
+		},
+		{
+			name: "invalid, voter removed",
+			ctx: ValidationContext{
+				CurConfig:        configNormal,
+				Applied:          10,
+				PendingConfIndex: 5,
+			},
+			cc: pb.ConfChangeV2{Changes: []pb.ConfChangeSingle{
+				{Type: pb.ConfChangeRemoveNode, NodeID: 3},
+			}},
+			expErr: "voters must be demoted to learners before being removed",
+		},
+		{
+			// NOTE: this case shouldn't happen in practice, but we handle it.
+			name: "invalid, voter demoted in wrong order",
+			ctx: ValidationContext{
+				CurConfig:        configNormal,
+				Applied:          10,
+				PendingConfIndex: 5,
+			},
+			cc: pb.ConfChangeV2{Changes: []pb.ConfChangeSingle{
+				{Type: pb.ConfChangeAddLearnerNode, NodeID: 3},
+				{Type: pb.ConfChangeRemoveNode, NodeID: 3},
+			}},
+			expErr: "voters must be demoted to learners before being removed",
+		},
+		{
+			name: "invalid, voter removed, validation disabled",
+			ctx: ValidationContext{
+				CurConfig:                         configNormal,
+				Applied:                           10,
+				PendingConfIndex:                  5,
+				DisableValidationAgainstCurConfig: true,
+			},
+			cc: pb.ConfChangeV2{Changes: []pb.ConfChangeSingle{
+				{Type: pb.ConfChangeRemoveNode, NodeID: 3},
+			}},
+		},
+		{
+			// NOTE: this case shouldn't happen in practice, but we handle it.
+			name: "invalid, voter demoted in wrong order, validation disabled",
+			ctx: ValidationContext{
+				CurConfig:                         configNormal,
+				Applied:                           10,
+				PendingConfIndex:                  5,
+				DisableValidationAgainstCurConfig: true,
+			},
+			cc: pb.ConfChangeV2{Changes: []pb.ConfChangeSingle{
+				{Type: pb.ConfChangeAddLearnerNode, NodeID: 3},
+				{Type: pb.ConfChangeRemoveNode, NodeID: 3},
+			}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1630,31 +1630,14 @@ func stepLeader(r *raft, m pb.Message) error {
 				cc = ccc
 			}
 			if cc != nil {
-				// Per the "Apply" invariant in the config change safety argument[^1],
-				// the leader must not append a config change if it hasn't applied all
-				// config changes in its log.
-				//
-				// [^1]: https://github.com/etcd-io/etcd/issues/7625#issuecomment-489232411
-				alreadyPending := r.pendingConfIndex > r.raftLog.applied
-
-				alreadyJoint := len(r.config.Voters[1]) > 0
-				wantsLeaveJoint := len(cc.AsV2().Changes) == 0
-
-				var failedCheck string
-				if alreadyPending {
-					failedCheck = fmt.Sprintf("possible unapplied conf change at index %d (applied to %d)", r.pendingConfIndex, r.raftLog.applied)
-				} else if alreadyJoint && !wantsLeaveJoint {
-					failedCheck = "must transition out of joint config first"
-				} else if !alreadyJoint && wantsLeaveJoint {
-					failedCheck = "not in joint state; refusing empty conf change"
+				ccCtx := confchange.ValidationContext{
+					CurConfig:                         &r.config,
+					Applied:                           r.raftLog.applied,
+					PendingConfIndex:                  r.pendingConfIndex,
+					DisableValidationAgainstCurConfig: r.disableConfChangeValidation,
 				}
-
-				// Allow disabling config change constraints that are guaranteed by the
-				// upper state machine layer (incorrect ones will apply as no-ops).
-				//
-				// NB: !alreadyPending requirement is always respected, for safety.
-				if alreadyPending || (failedCheck != "" && !r.disableConfChangeValidation) {
-					r.logger.Infof("%x ignoring conf change %v at config %s: %s", r.id, cc, r.config, failedCheck)
+				if err := confchange.ValidateProp(ccCtx, cc.AsV2()); err != nil {
+					r.logger.Infof("%x ignoring conf change %v at config %s: %s", r.id, cc, r.config, err)
 					m.Entries[i] = pb.Entry{Type: pb.EntryNormal}
 				} else {
 					r.pendingConfIndex = r.raftLog.lastIndex() + uint64(i) + 1

--- a/pkg/raft/testdata/confchange_v1_remove_leader.txt
+++ b/pkg/raft/testdata/confchange_v1_remove_leader.txt
@@ -1,3 +1,9 @@
+# Run a V2 membership change that demotes the leader, using joint consensus and
+# explicitly determining when to transition out of the joint config. Leadership
+# is transferred by campaigning a designated voter in the new config once the
+# old leader steps down. After the reconfiguration completes, we verify that the
+# demoted leader cannot campaign to become leader.
+
 # We'll turn this back on after the boilerplate.
 log-level none
 ----
@@ -27,9 +33,24 @@ raft-state
 2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
 3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
 
-# Start removing n1.
+# A removal without a demotion should be rejected.
 propose-conf-change 1 v1=true
 r1
+----
+INFO 1 ignoring conf change {ConfChangeRemoveNode 1 [] 0} at config voters=(1 2 3): voters must be demoted to learners before being removed
+
+# Instead, demote n1 to a learner in a joint config.
+propose-conf-change 1 v1=false transition=explicit
+r1 l1
+----
+ok
+
+stabilize log-level=none
+----
+ok
+
+# Exit the joint config.
+propose-conf-change 1
 ----
 ok
 
@@ -49,29 +70,40 @@ process-ready 1
 ----
 Ready MustSync=true:
 Entries:
-1/4 EntryConfChange r1
-1/5 EntryNormal "foo"
+1/6 EntryConfChangeV2
+1/7 EntryNormal "foo"
 Messages:
-1->2 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChange r1]
-1->3 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChange r1]
-1->2 MsgApp Term:1 Log:1/4 Commit:3 Entries:[1/5 EntryNormal "foo"]
-1->3 MsgApp Term:1 Log:1/4 Commit:3 Entries:[1/5 EntryNormal "foo"]
+1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
+1->3 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
+1->2 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
+1->3 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
 
-# Send response from n2 (which is enough to commit the entries so far next time
-# n1 runs).
-stabilize 2
+# Send response from n2 and n3 (which is enough to commit the entries so far
+# next time n1 runs).
+stabilize 2 3
 ----
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChange r1]
-  1->2 MsgApp Term:1 Log:1/4 Commit:3 Entries:[1/5 EntryNormal "foo"]
+  1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
+  1->2 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
+> 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
+  1->3 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  1/4 EntryConfChange r1
-  1/5 EntryNormal "foo"
+  1/6 EntryConfChangeV2
+  1/7 EntryNormal "foo"
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/4 Commit:3
-  2->1 MsgAppResp Term:1 Log:0/5 Commit:3
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:5
+> 3 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/6 EntryConfChangeV2
+  1/7 EntryNormal "foo"
+  Messages:
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/7 Commit:5
 
 # Put another entry in n1's log.
 propose 1 bar
@@ -85,25 +117,27 @@ stabilize 1
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/6 EntryNormal "bar"
+  1/8 EntryNormal "bar"
   Messages:
-  1->2 MsgApp Term:1 Log:1/5 Commit:3 Entries:[1/6 EntryNormal "bar"]
-  1->3 MsgApp Term:1 Log:1/5 Commit:3 Entries:[1/6 EntryNormal "bar"]
+  1->2 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
+  1->3 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/4 Commit:3
-  2->1 MsgAppResp Term:1 Log:0/5 Commit:3
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/7 Commit:5
 > 1 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
+  HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
   CommittedEntries:
-  1/4 EntryConfChange r1
-  1/5 EntryNormal "foo"
+  1/6 EntryConfChangeV2
+  1/7 EntryNormal "foo"
   Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:4
-  1->3 MsgApp Term:1 Log:1/6 Commit:4
-  1->2 MsgApp Term:1 Log:1/6 Commit:5
-  1->3 MsgApp Term:1 Log:1/6 Commit:5
-  INFO 1 switched to configuration voters=(2 3)
+  1->2 MsgApp Term:1 Log:1/8 Commit:6
+  1->3 MsgApp Term:1 Log:1/8 Commit:6
+  1->2 MsgApp Term:1 Log:1/8 Commit:7
+  1->3 MsgApp Term:1 Log:1/8 Commit:7
+  INFO 1 switched to configuration voters=(2 3) learners=(1)
   INFO 1 became follower at term 1
 > 1 handling Ready
   Ready MustSync=false:
@@ -119,63 +153,55 @@ raft-state
 stabilize 2
 ----
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/5 Commit:3 Entries:[1/6 EntryNormal "bar"]
-  1->2 MsgApp Term:1 Log:1/6 Commit:4
-  1->2 MsgApp Term:1 Log:1/6 Commit:5
+  1->2 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
+  1->2 MsgApp Term:1 Log:1/8 Commit:6
+  1->2 MsgApp Term:1 Log:1/8 Commit:7
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
+  HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
   Entries:
-  1/6 EntryNormal "bar"
+  1/8 EntryNormal "bar"
   CommittedEntries:
-  1/4 EntryConfChange r1
-  1/5 EntryNormal "foo"
+  1/6 EntryConfChangeV2
+  1/7 EntryNormal "foo"
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:3
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:4
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  INFO 2 switched to configuration voters=(2 3)
+  2->1 MsgAppResp Term:1 Log:0/8 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/8 Commit:6
+  2->1 MsgAppResp Term:1 Log:0/8 Commit:7
+  INFO 2 switched to configuration voters=(2 3) learners=(1)
 
 # ...because the old leader n1 ignores the append responses.
 stabilize 1
 ----
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:3
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:4
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/8 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/8 Commit:6
+  2->1 MsgAppResp Term:1 Log:0/8 Commit:7
 
 # When n3 responds, quorum is reached and everything falls into place.
 stabilize
 ----
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChange r1]
-  1->3 MsgApp Term:1 Log:1/4 Commit:3 Entries:[1/5 EntryNormal "foo"]
-  1->3 MsgApp Term:1 Log:1/5 Commit:3 Entries:[1/6 EntryNormal "bar"]
-  1->3 MsgApp Term:1 Log:1/6 Commit:4
-  1->3 MsgApp Term:1 Log:1/6 Commit:5
+  1->3 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
+  1->3 MsgApp Term:1 Log:1/8 Commit:6
+  1->3 MsgApp Term:1 Log:1/8 Commit:7
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
+  HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
   Entries:
-  1/4 EntryConfChange r1
-  1/5 EntryNormal "foo"
-  1/6 EntryNormal "bar"
+  1/8 EntryNormal "bar"
   CommittedEntries:
-  1/4 EntryConfChange r1
-  1/5 EntryNormal "foo"
+  1/6 EntryConfChangeV2
+  1/7 EntryNormal "foo"
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/4 Commit:3
-  3->1 MsgAppResp Term:1 Log:0/5 Commit:3
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:3
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:4
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  INFO 3 switched to configuration voters=(2 3)
+  3->1 MsgAppResp Term:1 Log:0/8 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/8 Commit:6
+  3->1 MsgAppResp Term:1 Log:0/8 Commit:7
+  INFO 3 switched to configuration voters=(2 3) learners=(1)
 > 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:0/4 Commit:3
-  3->1 MsgAppResp Term:1 Log:0/5 Commit:3
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:3
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:4
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/8 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/8 Commit:6
+  3->1 MsgAppResp Term:1 Log:0/8 Commit:7
 
 # n1 can no longer propose.
 propose 1 baz

--- a/pkg/raft/testdata/confchange_v2_add_double_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_auto.txt
@@ -213,11 +213,11 @@ stabilize
 ----
 ok
 
-# Now remove two nodes. What's new here is that the leader will actually have
+# Now demote two nodes. What's new here is that the leader will actually have
 # to go to a quorum to commit the transition into the joint config.
 
 propose-conf-change 1
-r2 r3
+r2 r3 l2 l3
 ----
 ok
 
@@ -227,28 +227,28 @@ stabilize 1
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/6 EntryConfChangeV2 r2 r3
+  1/6 EntryConfChangeV2 r2 r3 l2 l3
   Messages:
-  1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2 r2 r3]
-  1->3 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2 r2 r3]
+  1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2 r2 r3 l2 l3]
+  1->3 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2 r2 r3 l2 l3]
 
 # n2, n3 ack them.
 stabilize 2 3
 ----
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2 r2 r3]
+  1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2 r2 r3 l2 l3]
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2 r2 r3]
+  1->3 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2 r2 r3 l2 l3]
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  1/6 EntryConfChangeV2 r2 r3
+  1/6 EntryConfChangeV2 r2 r3 l2 l3
   Messages:
   2->1 MsgAppResp Term:1 Log:0/6 Commit:5
 > 3 handling Ready
   Ready MustSync=true:
   Entries:
-  1/6 EntryConfChangeV2 r2 r3
+  1/6 EntryConfChangeV2 r2 r3 l2 l3
   Messages:
   3->1 MsgAppResp Term:1 Log:0/6 Commit:5
 
@@ -284,12 +284,12 @@ stabilize 1
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
-  1/6 EntryConfChangeV2 r2 r3
+  1/6 EntryConfChangeV2 r2 r3 l2 l3
   Messages:
   1->2 MsgApp Term:1 Log:1/8 Commit:6
   1->3 MsgApp Term:1 Log:1/8 Commit:6
-  INFO 1 switched to configuration voters=(1)&&(1 2 3) autoleave
-  INFO initiating automatic transition out of joint configuration voters=(1)&&(1 2 3) autoleave
+  INFO 1 switched to configuration voters=(1)&&(1 2 3) learners_next=(2 3) autoleave
+  INFO initiating automatic transition out of joint configuration voters=(1)&&(1 2 3) learners_next=(2 3) autoleave
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
@@ -319,13 +319,13 @@ stabilize 2 3
   1/8 EntryNormal "bar"
   1/9 EntryConfChangeV2
   CommittedEntries:
-  1/6 EntryConfChangeV2 r2 r3
+  1/6 EntryConfChangeV2 r2 r3 l2 l3
   Messages:
   2->1 MsgAppResp Term:1 Log:0/7 Commit:5
   2->1 MsgAppResp Term:1 Log:0/8 Commit:5
   2->1 MsgAppResp Term:1 Log:0/8 Commit:6
   2->1 MsgAppResp Term:1 Log:0/9 Commit:6
-  INFO 2 switched to configuration voters=(1)&&(1 2 3) autoleave
+  INFO 2 switched to configuration voters=(1)&&(1 2 3) learners_next=(2 3) autoleave
 > 3 handling Ready
   Ready MustSync=true:
   HardState Term:1 Commit:6 Lead:1 LeadEpoch:1
@@ -334,13 +334,13 @@ stabilize 2 3
   1/8 EntryNormal "bar"
   1/9 EntryConfChangeV2
   CommittedEntries:
-  1/6 EntryConfChangeV2 r2 r3
+  1/6 EntryConfChangeV2 r2 r3 l2 l3
   Messages:
   3->1 MsgAppResp Term:1 Log:0/7 Commit:5
   3->1 MsgAppResp Term:1 Log:0/8 Commit:5
   3->1 MsgAppResp Term:1 Log:0/8 Commit:6
   3->1 MsgAppResp Term:1 Log:0/9 Commit:6
-  INFO 3 switched to configuration voters=(1)&&(1 2 3) autoleave
+  INFO 3 switched to configuration voters=(1)&&(1 2 3) learners_next=(2 3) autoleave
 
 # n2 and n3 also leave the joint config and the dust settles. We see at the very
 # end that n1 receives some messages from them that it refuses because it does
@@ -370,7 +370,7 @@ stabilize
   1->3 MsgApp Term:1 Log:1/9 Commit:8
   1->2 MsgApp Term:1 Log:1/9 Commit:9
   1->3 MsgApp Term:1 Log:1/9 Commit:9
-  INFO 1 switched to configuration voters=(1)
+  INFO 1 switched to configuration voters=(1) learners=(2 3)
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/9 Commit:7
   1->2 MsgApp Term:1 Log:1/9 Commit:8
@@ -390,7 +390,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/9 Commit:7
   2->1 MsgAppResp Term:1 Log:0/9 Commit:8
   2->1 MsgAppResp Term:1 Log:0/9 Commit:9
-  INFO 2 switched to configuration voters=(1)
+  INFO 2 switched to configuration voters=(1) learners=(2 3)
 > 3 handling Ready
   Ready MustSync=true:
   HardState Term:1 Commit:9 Lead:1 LeadEpoch:1
@@ -402,17 +402,11 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/9 Commit:7
   3->1 MsgAppResp Term:1 Log:0/9 Commit:8
   3->1 MsgAppResp Term:1 Log:0/9 Commit:9
-  INFO 3 switched to configuration voters=(1)
+  INFO 3 switched to configuration voters=(1) learners=(2 3)
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/9 Commit:7
-  raft: cannot step as peer not found
   2->1 MsgAppResp Term:1 Log:0/9 Commit:8
-  raft: cannot step as peer not found
   2->1 MsgAppResp Term:1 Log:0/9 Commit:9
-  raft: cannot step as peer not found
   3->1 MsgAppResp Term:1 Log:0/9 Commit:7
-  raft: cannot step as peer not found
   3->1 MsgAppResp Term:1 Log:0/9 Commit:8
-  raft: cannot step as peer not found
   3->1 MsgAppResp Term:1 Log:0/9 Commit:9
-  raft: cannot step as peer not found

--- a/pkg/raft/testdata/confchange_v2_replace_leader.txt
+++ b/pkg/raft/testdata/confchange_v2_replace_leader.txt
@@ -1,8 +1,8 @@
-# Run a V2 membership change that removes the leader and adds another voter as a
+# Run a V2 membership change that demotes the leader and adds another voter as a
 # single operation, using joint consensus and explicitly determining when to
 # transition out of the joint config. Leadership is transferred by campaigning a
 # designated voter in the new config once the old leader steps down. After the
-# reconfiguration completes, we verify that the removed leader cannot campaign
+# reconfiguration completes, we verify that the demoted leader cannot campaign
 # to become leader.
 
 # We'll turn this back on after the boilerplate.
@@ -43,7 +43,7 @@ INFO newRaft 4 [peers: [], term: 0, commit: 0, applied: 0, lastindex: 0, lastter
 
 # Start reconfiguration to remove n1 and add n4.
 propose-conf-change 1 v1=false transition=explicit
-r1 v4
+r1 l1 v4
 ----
 ok
 
@@ -119,7 +119,7 @@ stabilize
   1->2 MsgApp Term:1 Log:1/5 Commit:5
   1->3 MsgApp Term:1 Log:1/5 Commit:5
   1->4 MsgApp Term:1 Log:1/5 Commit:5
-  INFO 1 switched to configuration voters=(2 3 4)
+  INFO 1 switched to configuration voters=(2 3 4) learners=(1)
   INFO 1 became follower at term 1
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/5 Commit:5
@@ -137,7 +137,7 @@ stabilize
   1/5 EntryConfChangeV2
   Messages:
   2->1 MsgAppResp Term:1 Log:0/5 Commit:5
-  INFO 2 switched to configuration voters=(2 3 4)
+  INFO 2 switched to configuration voters=(2 3 4) learners=(1)
 > 3 handling Ready
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
@@ -145,7 +145,7 @@ stabilize
   1/5 EntryConfChangeV2
   Messages:
   3->1 MsgAppResp Term:1 Log:0/5 Commit:5
-  INFO 3 switched to configuration voters=(2 3 4)
+  INFO 3 switched to configuration voters=(2 3 4) learners=(1)
 > 4 handling Ready
   Ready MustSync=true:
   HardState Term:1 Commit:5 Lead:1 LeadEpoch:1
@@ -153,7 +153,7 @@ stabilize
   1/5 EntryConfChangeV2
   Messages:
   4->1 MsgAppResp Term:1 Log:0/5 Commit:5
-  INFO 4 switched to configuration voters=(2 3 4)
+  INFO 4 switched to configuration voters=(2 3 4) learners=(1)
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/5 Commit:5
   3->1 MsgAppResp Term:1 Log:0/5 Commit:5
@@ -196,7 +196,7 @@ ok
 
 raft-state
 ----
-1: StateFollower (Non-Voter) Term:1 Lead:0 LeadEpoch:1
+1: StateFollower (Non-Voter) Term:2 Lead:2 LeadEpoch:1
 2: StateLeader (Voter) Term:2 Lead:2 LeadEpoch:1
 3: StateFollower (Voter) Term:2 Lead:2 LeadEpoch:1
 4: StateFollower (Voter) Term:2 Lead:2 LeadEpoch:1


### PR DESCRIPTION
Informs #129796.
Informs #125355.

This commit is a natural continuation of 7f37eaa (from 5 years ago). The commit made it so that the replicateQueue would never issue a ChangeReplicas request that removed a voter replica. Instead, the replicate queue would always demote the voter replica to a learner replica first.

This commit makes it so that raft will no longer allow direct voter removal in a proposed configuration change. Instead, it requires the voter (who may be the leader) to first be demoted to a learner. This prevents abuse and strengthens the guarantee that we will never perform such unsafe configuration changes.

Release note: None