### PR TITLE
cluster-ui: add tooltips to v2 db pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/components/columnTitle/columnTitle.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/components/columnTitle/columnTitle.module.scss
@@ -1,0 +1,5 @@
+@import "src/core/index.module";
+
+.title-with-tooltip {
+  border-bottom: 1px dashed $colors--neutral-5;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/components/columnTitle/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/components/columnTitle/index.tsx
@@ -1,0 +1,39 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { Tooltip } from "antd";
+import React from "react";
+
+import styles from "./columnTitle.module.scss";
+
+type ColumnTitleProps = {
+  withToolTip?: {
+    tooltipText: React.ReactNode;
+    placement?: "top" | "bottom" | "left" | "right";
+  };
+  title: React.ReactNode;
+};
+
+export const ColumnTitle: React.FC<ColumnTitleProps> = ({
+  withToolTip,
+  title,
+}) => {
+  return withToolTip ? (
+    <Tooltip
+      className={styles["title-with-tooltip"]}
+      placement={withToolTip.placement ?? "top"}
+      title={withToolTip.tooltipText}
+    >
+      {title}
+    </Tooltip>
+  ) : (
+    <>{title}</>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
@@ -35,6 +35,8 @@ import useTable, { TableParams } from "src/sharedFromCloud/useTable";
 import { StoreID } from "src/types/clusterTypes";
 import { Bytes, EncodeDatabaseTableUri } from "src/util";
 
+import { ColumnTitle } from "../components/columnTitle";
+
 import { TableColName } from "./constants";
 import { TableRow } from "./types";
 import { rawTableMetadataToRows } from "./utils";
@@ -42,7 +44,14 @@ import { rawTableMetadataToRows } from "./utils";
 const COLUMNS: (TableColumnProps<TableRow> & { sortKey?: TableSortOption })[] =
   [
     {
-      title: TableColName.NAME,
+      title: (
+        <ColumnTitle
+          title={TableColName.NAME}
+          withToolTip={{
+            tooltipText: "The name of the table.",
+          }}
+        />
+      ),
       width: "15%",
       sorter: (a, b) => a.name.localeCompare(b.name),
       render: (t: TableRow) => {
@@ -54,7 +63,15 @@ const COLUMNS: (TableColumnProps<TableRow> & { sortKey?: TableSortOption })[] =
       sortKey: TableSortOption.NAME,
     },
     {
-      title: TableColName.REPLICATION_SIZE,
+      title: (
+        <ColumnTitle
+          title={TableColName.REPLICATION_SIZE}
+          withToolTip={{
+            tooltipText:
+              "The approximate compressed total disk size across all replicas of the table.",
+          }}
+        />
+      ),
       width: "fit-content",
       sorter: (a, b) => a.replicationSizeBytes - b.replicationSizeBytes,
       render: (t: TableRow) => {
@@ -63,7 +80,14 @@ const COLUMNS: (TableColumnProps<TableRow> & { sortKey?: TableSortOption })[] =
       sortKey: TableSortOption.REPLICATION_SIZE,
     },
     {
-      title: TableColName.RANGE_COUNT,
+      title: (
+        <ColumnTitle
+          title={TableColName.RANGE_COUNT}
+          withToolTip={{
+            tooltipText: "The number of ranges the table.",
+          }}
+        />
+      ),
       width: "fit-content",
       sorter: true,
       render: (t: TableRow) => {
@@ -81,7 +105,14 @@ const COLUMNS: (TableColumnProps<TableRow> & { sortKey?: TableSortOption })[] =
       sortKey: TableSortOption.COLUMNS,
     },
     {
-      title: TableColName.NODE_REGIONS,
+      title: (
+        <ColumnTitle
+          title={TableColName.NODE_REGIONS}
+          withToolTip={{
+            tooltipText: "Regions/Nodes on which the table's data is stored.",
+          }}
+        />
+      ),
       width: "20%",
       render: (t: TableRow) => (
         <div>
@@ -96,7 +127,16 @@ const COLUMNS: (TableColumnProps<TableRow> & { sortKey?: TableSortOption })[] =
       ),
     },
     {
-      title: TableColName.LIVE_DATA_PERCENTAGE,
+      title: (
+        <ColumnTitle
+          title={TableColName.LIVE_DATA_PERCENTAGE}
+          withToolTip={{
+            tooltipText: `
+            % of total uncompressed logical data that has not been modified (updated or deleted).
+            A low percentage can cause statements to scan more data`,
+          }}
+        />
+      ),
       sorter: true,
       width: "fit-content",
       sortKey: TableSortOption.LIVE_DATA,
@@ -112,7 +152,15 @@ const COLUMNS: (TableColumnProps<TableRow> & { sortKey?: TableSortOption })[] =
       },
     },
     {
-      title: TableColName.STATS_LAST_UPDATED,
+      title: (
+        <ColumnTitle
+          title={TableColName.STATS_LAST_UPDATED}
+          withToolTip={{
+            tooltipText:
+              "The last time table statistics used by the SQL optimizer were updated.",
+          }}
+        />
+      ),
       sorter: true,
       render: (t: TableRow) => {
         return t.statsLastUpdated.format("YYYY-MM-DD HH:mm:ss");

--- a/pkg/ui/workspaces/cluster-ui/src/databasesV2/constants.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesV2/constants.ts
@@ -11,7 +11,6 @@
 export enum DatabaseColName {
   NAME = "Name",
   SIZE = "Size",
-  RANGE_COUNT = "Range Count",
   TABLE_COUNT = "Table Count",
   NODE_REGIONS = "Regions / Nodes",
 }

--- a/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
@@ -17,6 +17,7 @@ import {
   DatabaseSortOptions,
   useDatabaseMetadata,
 } from "src/api/databases/getDatabaseMetadataApi";
+import { ColumnTitle } from "src/components/columnTitle";
 import { RegionNodesLabel } from "src/components/regionNodesLabel";
 import { PageLayout, PageSection } from "src/layouts";
 import { Loading } from "src/loading";
@@ -45,7 +46,14 @@ const COLUMNS: (TableColumnProps<DatabaseRow> & {
   sortKey?: DatabaseSortOptions;
 })[] = [
   {
-    title: DatabaseColName.NAME,
+    title: (
+      <ColumnTitle
+        title={DatabaseColName.NAME}
+        withToolTip={{
+          tooltipText: "The name of the database.",
+        }}
+      />
+    ),
     sorter: (a, b) => a.name.localeCompare(b.name),
     sortKey: DatabaseSortOptions.NAME,
     render: (db: DatabaseRow) => {
@@ -53,7 +61,15 @@ const COLUMNS: (TableColumnProps<DatabaseRow> & {
     },
   },
   {
-    title: DatabaseColName.SIZE,
+    title: (
+      <ColumnTitle
+        title={DatabaseColName.SIZE}
+        withToolTip={{
+          tooltipText:
+            "The approximate total disk size across all table replicas in the database.",
+        }}
+      />
+    ),
     sortKey: DatabaseSortOptions.REPLICATION_SIZE,
     sorter: (a, b) => a.approximateDiskSizeBytes - b.approximateDiskSizeBytes,
     render: (db: DatabaseRow) => {
@@ -61,7 +77,14 @@ const COLUMNS: (TableColumnProps<DatabaseRow> & {
     },
   },
   {
-    title: DatabaseColName.TABLE_COUNT,
+    title: (
+      <ColumnTitle
+        title={DatabaseColName.TABLE_COUNT}
+        withToolTip={{
+          tooltipText: "The total number of tables in the database.",
+        }}
+      />
+    ),
     sortKey: DatabaseSortOptions.TABLE_COUNT,
     sorter: true,
     render: (db: DatabaseRow) => {
@@ -69,15 +92,15 @@ const COLUMNS: (TableColumnProps<DatabaseRow> & {
     },
   },
   {
-    title: DatabaseColName.RANGE_COUNT,
-    sortKey: DatabaseSortOptions.RANGES,
-    sorter: true,
-    render: (db: DatabaseRow) => {
-      return db.rangeCount;
-    },
-  },
-  {
-    title: DatabaseColName.NODE_REGIONS,
+    title: (
+      <ColumnTitle
+        title={DatabaseColName.NODE_REGIONS}
+        withToolTip={{
+          tooltipText:
+            "Regions/Nodes on which the database tables are located.",
+        }}
+      />
+    ),
     render: (db: DatabaseRow) => (
       <Skeleton loading={db.nodesByRegion.isLoading}>
         <div>
@@ -91,12 +114,6 @@ const COLUMNS: (TableColumnProps<DatabaseRow> & {
         </div>
       </Skeleton>
     ),
-  },
-  {
-    title: "Schema insights",
-    render: (db: DatabaseRow) => {
-      return db.schemaInsightsCount;
-    },
   },
 ];
 


### PR DESCRIPTION
This commit adds tooltips to the column titles in the new db pages. A new component is created, `ColumnTitle` that is used for all column titles in the new pages.

The Schema Insights column is also temporarily removed while
we deliberate how to fetch and show this data (https://github.com/cockroachdb/cockroach/issues/130887).

Epic: CRDB-37558

Release note: None