### PR TITLE
release-23.2: sql: deflake distsql_stats logic test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -2740,7 +2740,7 @@ NULL  {o}  1000  32    true
 statement ok
 SET optimizer_use_virtual_computed_column_stats = true
 
-query T
+query T retry
 EXPLAIN SELECT * FROM mno WHERE n = 1 AND o = 9
 ----
 distribution: full


### PR DESCRIPTION
Backport 1/1 commits from #125150.

/cc @cockroachdb/release

---

I stressed this for a while and was not able to reproduce it. However, I have a theory: the failing statement is racing the rangefeed that invalidates the stats cache, and occasionally starts planning before the rangefeed causes the stale entry to be evicted from the cache.

(SHOW STATISTICS does not go through the stats cache, which is why we can hit this even after that statement succeeds.)

A retry on the first non-SHOW-STATISTICS statement after ANALYZE should work. (This is also what we did in #81560.)

Fixes: #121424
Fixes: #131377

Release note: None

---

Release justification: test-only change.