### PR TITLE
cluster-ui: add tmj cache refresh components

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/databases/getDatabaseMetadataApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databases/getDatabaseMetadataApi.ts
@@ -88,7 +88,7 @@ const createKey = (req: DatabaseMetadataRequest) => {
 };
 
 export const useDatabaseMetadata = (req: DatabaseMetadataRequest) => {
-  const { data, error, isLoading } = useSWR<DatabaseMetadataResponse>(
+  const { data, error, isLoading, mutate } = useSWR<DatabaseMetadataResponse>(
     createKey(req),
     () => getDatabaseMetadata(req),
     {
@@ -101,5 +101,6 @@ export const useDatabaseMetadata = (req: DatabaseMetadataRequest) => {
     data,
     error,
     isLoading,
+    refreshDatabases: mutate,
   };
 };

--- a/pkg/ui/workspaces/cluster-ui/src/api/databases/getTableMetadataApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databases/getTableMetadataApi.ts
@@ -103,9 +103,10 @@ const createKey = (req: TableMetadataRequest) => {
 
 export const useTableMetadata = (req: TableMetadataRequest) => {
   const key = createKey(req);
-  const { data, error, isLoading } = useSWR<TableMetadataResponse>(key, () =>
-    getTableMetadata(req),
+  const { data, error, isLoading, mutate } = useSWR<TableMetadataResponse>(
+    key,
+    () => getTableMetadata(req),
   );
 
-  return { data, error, isLoading };
+  return { data, error, isLoading, refreshTables: mutate };
 };

--- a/pkg/ui/workspaces/cluster-ui/src/api/databases/tableMetaUpdateJobApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databases/tableMetaUpdateJobApi.ts
@@ -1,0 +1,144 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import moment from "moment-timezone";
+import { useEffect, useMemo } from "react";
+import useSWR from "swr";
+
+import { fetchDataJSON } from "../fetchData";
+
+const TABLE_META_JOB_API = "api/v2/table_metadata/updatejob/";
+
+export enum TableMetadataJobStatus {
+  NOT_RUNNING = "NOT_RUNNING",
+  RUNNING = "RUNNING",
+}
+
+type TableMetaUpdateJobResponse = {
+  current_status: TableMetadataJobStatus;
+  progress: number;
+  last_start_time: string | null;
+  last_completed_time: string | null;
+  last_updated_time: string | null;
+  data_valid_duration: number;
+  automatic_updates_enabled: boolean;
+};
+
+type TableMetaUpdateJobInfo = {
+  currentStatus: TableMetaUpdateJobResponse["current_status"];
+  progress: number;
+  lastStartTime: moment.Moment | null;
+  lastCompletedTime: moment.Moment | null;
+  lastUpdatedTime: moment.Moment | null;
+  dataValidDuration: moment.Duration;
+  automaticUpdatesEnabled: boolean;
+};
+
+const getTableMetaUpdateJobInfo = async () => {
+  return fetchDataJSON<TableMetaUpdateJobResponse, null>(TABLE_META_JOB_API);
+};
+
+// useTableMetaUpdateJob is a hook that fetches the current status of the table
+// metadata update job and returns the status and other relevant information.
+// The hook polls the API every 3 seconds if the job status is parsed as running.
+export const useTableMetaUpdateJob = () => {
+  const { data, isLoading, mutate } = useSWR(
+    "tableMetaUpdateJob",
+    getTableMetaUpdateJobInfo,
+    {
+      focusThrottleInterval: 10000,
+      refreshInterval: (latest: TableMetaUpdateJobResponse) => {
+        return latest?.current_status === TableMetadataJobStatus.RUNNING
+          ? 3000
+          : 0;
+      },
+      dedupingInterval: 3000,
+    },
+  );
+
+  const formattedResp: TableMetaUpdateJobInfo = useMemo(() => {
+    if (!data) {
+      return null;
+    }
+
+    return {
+      currentStatus: data.current_status,
+      progress: data.progress,
+      lastStartTime: data.last_start_time
+        ? moment.utc(data.last_start_time)
+        : null,
+      lastCompletedTime: data.last_completed_time
+        ? moment.utc(data.last_completed_time)
+        : null,
+      lastUpdatedTime: data.last_updated_time
+        ? moment.utc(data.last_updated_time)
+        : null,
+      dataValidDuration: moment.duration(
+        data.data_valid_duration * 1e-6,
+        "millisecond",
+      ),
+      automaticUpdatesEnabled: data.automatic_updates_enabled,
+    };
+  }, [data]);
+
+  const dataValidDurationMs = formattedResp?.dataValidDuration.asMilliseconds();
+  // Last completed is only non-null if the job has completed at least once.
+  const lastCompletedTimeUnixMs =
+    (formattedResp?.lastCompletedTime?.unix() ?? 0) * 1000;
+
+  useEffect(() => {
+    // This effect is triggered whenever the job's last completed time has changed.
+    // It will schedule a job trigger request a little after when the data is scheduled
+    // to expire: lastCompletedTime + dataValidDuration.
+    // We add a 3 second slack to the delay.
+    if (isLoading) {
+      return;
+    }
+
+    const msSinceLastCompletedWithSlack =
+      Date.now() - lastCompletedTimeUnixMs + 3000;
+    const delay = Math.max(
+      0,
+      dataValidDurationMs - msSinceLastCompletedWithSlack,
+    );
+    const nextUpdated = setTimeout(() => {
+      return mutate();
+    }, delay);
+
+    return () => clearTimeout(nextUpdated);
+  }, [dataValidDurationMs, isLoading, lastCompletedTimeUnixMs, mutate]);
+
+  return {
+    jobStatus: formattedResp,
+    refreshJobStatus: mutate,
+    isLoading,
+  };
+};
+
+type TriggerTableMetaUpdateJobRequest = {
+  onlyIfStale?: boolean;
+};
+type TriggerTableMetaUpdateJobResponse = {
+  job_triggered: boolean;
+  message: string;
+};
+
+export const triggerUpdateTableMetaJobApi = async (
+  req: TriggerTableMetaUpdateJobRequest,
+) => {
+  const urlParams = new URLSearchParams();
+  if (req.onlyIfStale) {
+    urlParams.append("onlyIfStale", req.onlyIfStale.toString());
+  }
+  return fetchDataJSON<
+    TriggerTableMetaUpdateJobResponse,
+    TriggerTableMetaUpdateJobRequest
+  >(TABLE_META_JOB_API + "?" + urlParams.toString(), req);
+};

--- a/pkg/ui/workspaces/cluster-ui/src/components/tableMetadataLastUpdated/tableMetadataJobControl.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/components/tableMetadataLastUpdated/tableMetadataJobControl.module.scss
@@ -1,0 +1,7 @@
+@import "src/core/index.module.scss";
+
+.controls-container {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/components/tableMetadataLastUpdated/tableMetadataJobControl.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/components/tableMetadataLastUpdated/tableMetadataJobControl.tsx
@@ -1,0 +1,123 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { RedoOutlined } from "@ant-design/icons";
+import { Skeleton, Tooltip } from "antd";
+import React, { useCallback, useContext, useEffect } from "react";
+
+import {
+  TableMetadataJobStatus,
+  triggerUpdateTableMetaJobApi,
+  useTableMetaUpdateJob,
+} from "src/api/databases/tableMetaUpdateJobApi";
+import { TimezoneContext } from "src/contexts";
+import Button from "src/sharedFromCloud/button";
+import { DATE_WITH_SECONDS_FORMAT_24_TZ, FormatWithTimezone } from "src/util";
+import { usePrevious } from "src/util/hooks";
+
+import styles from "./tableMetadataJobControl.module.scss";
+
+type TableMetadataJobControlProps = {
+  // Callback for when the job has updated the metadata, i.e. the
+  // lastUpdatedTime has changed.
+  onDataUpdated?: () => void;
+};
+
+export const TableMetadataJobControl: React.FC<
+  TableMetadataJobControlProps
+> = ({ onDataUpdated }) => {
+  const { jobStatus, refreshJobStatus, isLoading } = useTableMetaUpdateJob();
+  const previousUpdateCompletedUnixSecs = usePrevious(
+    jobStatus?.lastCompletedTime?.unix(),
+  );
+  const lastUpdateCompletedUnixSecs = jobStatus?.lastCompletedTime?.unix();
+  const timezone = useContext(TimezoneContext);
+  const lastUpdatedText = jobStatus?.lastUpdatedTime
+    ? FormatWithTimezone(
+        jobStatus?.lastCompletedTime,
+        DATE_WITH_SECONDS_FORMAT_24_TZ,
+        timezone,
+      )
+    : "Never";
+
+  const triggerUpdateTableMetaJob = useCallback(
+    async (onlyIfStale = true) => {
+      const resp = await triggerUpdateTableMetaJobApi({ onlyIfStale });
+      if (resp.job_triggered) {
+        return refreshJobStatus();
+      }
+    },
+    [refreshJobStatus],
+  );
+
+  const dataValidMs = jobStatus?.dataValidDuration.asMilliseconds();
+  useEffect(() => {
+    if (isLoading) {
+      return;
+    }
+    // Schedule the next update request after the dataValidMs has passed since
+    // the last update completed.
+    const msSinceLastCompleted =
+      Date.now() - lastUpdateCompletedUnixSecs * 1000;
+    const delayMs = Math.max(0, dataValidMs - msSinceLastCompleted);
+    const nextUpdated = setTimeout(() => {
+      triggerUpdateTableMetaJob();
+    }, delayMs);
+
+    return () => clearTimeout(nextUpdated);
+  }, [
+    dataValidMs,
+    lastUpdateCompletedUnixSecs,
+    triggerUpdateTableMetaJob,
+    isLoading,
+  ]);
+
+  useEffect(() => {
+    // If the last completed time has changed, call the callback.
+    if (previousUpdateCompletedUnixSecs === lastUpdateCompletedUnixSecs) {
+      return;
+    }
+    onDataUpdated && onDataUpdated();
+  }, [
+    previousUpdateCompletedUnixSecs,
+    lastUpdateCompletedUnixSecs,
+    onDataUpdated,
+  ]);
+
+  const onRefreshClick = () => {
+    // Force refresh.
+    triggerUpdateTableMetaJob(false);
+  };
+
+  const isRunning = jobStatus?.currentStatus === TableMetadataJobStatus.RUNNING;
+  return (
+    <div className={styles["controls-container"]}>
+      <Skeleton loading={isLoading}>
+        <Tooltip
+          title={
+            "Data is last refreshed automatically (per cluster setting) or manually."
+          }
+        >
+          Last refreshed: {lastUpdatedText}{" "}
+        </Tooltip>
+      </Skeleton>
+      <Tooltip placement="top" title={"Refresh data"}>
+        <div>
+          <Button
+            disabled={isRunning}
+            category={"icon-container"}
+            icon={<RedoOutlined />}
+            onClick={onRefreshClick}
+          />
+        </div>
+      </Tooltip>
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
@@ -19,6 +19,7 @@ import {
 } from "src/api/databases/getTableMetadataApi";
 import { NodeRegionsSelector } from "src/components/nodeRegionsSelector/nodeRegionsSelector";
 import { RegionNodesLabel } from "src/components/regionNodesLabel";
+import { TableMetadataJobControl } from "src/components/tableMetadataLastUpdated/tableMetadataJobControl";
 import { useRouteParams } from "src/hooks/useRouteParams";
 import { PageSection } from "src/layouts";
 import { Loading } from "src/loading";
@@ -208,7 +209,7 @@ export const TablesPageV2 = () => {
 
   // Get db id from the URL.
   const { dbID } = useRouteParams();
-  const { data, error, isLoading } = useTableMetadata(
+  const { data, error, isLoading, refreshTables } = useTableMetadata(
     createTableMetadataRequestFromParams(dbID, params),
   );
   const nodesResp = useNodeStatuses();
@@ -292,6 +293,9 @@ export const TablesPageV2 = () => {
             entity="tables"
           />
           <Table
+            actionButton={
+              <TableMetadataJobControl onDataUpdated={refreshTables} />
+            }
             columns={colsWithSort}
             dataSource={tableData}
             pagination={{

--- a/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
@@ -12,13 +12,16 @@ import { Skeleton } from "antd";
 import React, { useMemo } from "react";
 import { Link } from "react-router-dom";
 
+import { useNodeStatuses } from "src/api";
 import {
   DatabaseMetadataRequest,
   DatabaseSortOptions,
   useDatabaseMetadata,
 } from "src/api/databases/getDatabaseMetadataApi";
 import { ColumnTitle } from "src/components/columnTitle";
+import { NodeRegionsSelector } from "src/components/nodeRegionsSelector/nodeRegionsSelector";
 import { RegionNodesLabel } from "src/components/regionNodesLabel";
+import { TableMetadataJobControl } from "src/components/tableMetadataLastUpdated/tableMetadataJobControl";
 import { PageLayout, PageSection } from "src/layouts";
 import { Loading } from "src/loading";
 import { PageConfig, PageConfigItem } from "src/pageConfig";
@@ -32,11 +35,8 @@ import {
   TableColumnProps,
 } from "src/sharedFromCloud/table";
 import useTable, { TableParams } from "src/sharedFromCloud/useTable";
+import { StoreID } from "src/types/clusterTypes";
 import { Bytes } from "src/util";
-
-import { useNodeStatuses } from "../api";
-import { NodeRegionsSelector } from "../components/nodeRegionsSelector/nodeRegionsSelector";
-import { StoreID } from "../types/clusterTypes";
 
 import { DatabaseColName } from "./constants";
 import { DatabaseRow } from "./databaseTypes";
@@ -151,11 +151,11 @@ export const DatabasesPageV2 = () => {
   const { params, setFilters, setSort, setSearch, setPagination } = useTable({
     initial: initialParams,
   });
-
-  const { data, error, isLoading } = useDatabaseMetadata(
+  const { data, error, isLoading, refreshDatabases } = useDatabaseMetadata(
     createDatabaseMetadataRequestFromParams(params),
   );
   const nodesResp = useNodeStatuses();
+
   const paginationState = data?.pagination_info;
 
   const onNodeRegionsChange = (storeIDs: StoreID[]) => {
@@ -233,6 +233,9 @@ export const DatabasesPageV2 = () => {
             entity="databases"
           />
           <Table
+            actionButton={
+              <TableMetadataJobControl onDataUpdated={refreshDatabases} />
+            }
             columns={colsWithSort}
             dataSource={tableData}
             pagination={{


### PR DESCRIPTION
This commit enables the UI to trigger the update table metadata job. The job is triggered via the UI in 2 ways:
- Implicitly from the `Databases` or `Database Details - Tables`. These pages will schedule job trigger requests based on the job's last completed time and the data validity duration as retrieved from the server. These requests specify the `onlyIfStale` flag, - at the server side, the requests will only be sent to the coordinator node if the job's last completed time is past the data validity interval.
- Explicitly, via the refresh button in the top right hand corner of the databases table and db tables table.

Components introduced:
- `TableMetaJobControl` - displays the last completed time of the update job, and renders a refresh button to forcibly trigger the refresh job.

Epic: CRDB-37558
Fixes: #130959

Release note: None