### PR TITLE
sql/inverted: remove unused Expression interface

### DIFF
--- a/pkg/sql/inverted/expression_test.go
+++ b/pkg/sql/inverted/expression_test.go
@@ -34,15 +34,10 @@ new-span-leaf name=<name> tight=<true|false> unique=<true|false> span=<start>[,<
 
   Creates a new leaf SpanExpression with the given name
 
-new-unknown-leaf name=<name> tight=<true|false>
-----
-
-  Creates a new leaf unknownExpression with the given name
-
 new-non-inverted-leaf name=<name>
 ----
 
-  Creates a new NonInvertedColExpression with the given name
+  Creates a new nil expression with the given name
 
 and result=<name> left=<name> right=<name>
 ----
@@ -77,59 +72,43 @@ func getSpan(t *testing.T, d *datadriven.TestData) Span {
 	}
 }
 
-type UnknownExpression struct {
-	tight bool
-}
-
-func (u *UnknownExpression) IsTight() bool { return u.tight }
-func (u *UnknownExpression) SetNotTight()  { u.tight = false }
-func (u *UnknownExpression) String() string {
-	return fmt.Sprintf("unknown expression: tight=%t", u.tight)
-}
-func (u *UnknownExpression) Copy() Expression {
-	return &UnknownExpression{tight: u.tight}
-}
-
 // Makes a (shallow) copy of the root node of the expression identified
 // by name, since calls to And() and Or() can modify that root node, and
 // the test wants to preserve the unmodified expression for later use.
 func getExprCopy(
-	t *testing.T, d *datadriven.TestData, name string, exprsByName map[string]Expression,
-) Expression {
-	expr := exprsByName[name]
-	if expr == nil {
+	t *testing.T, d *datadriven.TestData, name string, exprsByName map[string]*SpanExpression,
+) *SpanExpression {
+	expr, ok := exprsByName[name]
+	if !ok {
 		d.Fatalf(t, "unknown expr: %s", name)
 	}
-	switch e := expr.(type) {
-	case *SpanExpression:
-		return &SpanExpression{
-			Tight:              e.Tight,
-			Unique:             e.Unique,
-			SpansToRead:        append([]Span(nil), e.SpansToRead...),
-			FactoredUnionSpans: append([]Span(nil), e.FactoredUnionSpans...),
-			Operator:           e.Operator,
-			Left:               e.Left,
-			Right:              e.Right,
-		}
-	case NonInvertedColExpression:
-		return NonInvertedColExpression{}
-	case *UnknownExpression:
-		return &UnknownExpression{tight: e.tight}
-	default:
-		d.Fatalf(t, "unknown expr type")
+	if expr == nil {
 		return nil
+	}
+	return &SpanExpression{
+		Tight:              expr.Tight,
+		Unique:             expr.Unique,
+		SpansToRead:        append([]Span(nil), expr.SpansToRead...),
+		FactoredUnionSpans: append([]Span(nil), expr.FactoredUnionSpans...),
+		Operator:           expr.Operator,
+		Left:               expr.Left,
+		Right:              expr.Right,
 	}
 }
 
-func toString(expr Expression) string {
+func toString(expr *SpanExpression) string {
 	tp := treeprinter.New()
+	if expr == nil {
+		tp.Child("nil")
+		return tp.String()
+	}
 	formatExpression(tp, expr, true /* includeSpansToRead */, false /* redactable */)
 	return tp.String()
 }
 
 func getLeftAndRightExpr(
-	t *testing.T, d *datadriven.TestData, exprsByName map[string]Expression,
-) (Expression, Expression) {
+	t *testing.T, d *datadriven.TestData, exprsByName map[string]*SpanExpression,
+) (*SpanExpression, *SpanExpression) {
 	var leftName, rightName string
 	d.ScanArgs(t, "left", &leftName)
 	d.ScanArgs(t, "right", &rightName)
@@ -138,7 +117,7 @@ func getLeftAndRightExpr(
 
 func TestExpression(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	exprsByName := make(map[string]Expression)
+	exprsByName := make(map[string]*SpanExpression)
 
 	datadriven.RunTest(t, datapathutils.TestDataPath(t, "expression"), func(t *testing.T, d *datadriven.TestData) string {
 		switch d.Cmd {
@@ -153,18 +132,10 @@ func TestExpression(t *testing.T) {
 			expr.Unique = unique
 			exprsByName[name] = expr
 			return expr.String()
-		case "new-unknown-leaf":
-			var name string
-			d.ScanArgs(t, "name", &name)
-			var tight bool
-			d.ScanArgs(t, "tight", &tight)
-			expr := &UnknownExpression{tight: tight}
-			exprsByName[name] = expr
-			return fmt.Sprintf("%v", expr)
 		case "new-non-inverted-leaf":
 			var name string
 			d.ScanArgs(t, "name", &name)
-			exprsByName[name] = NonInvertedColExpression{}
+			exprsByName[name] = nil
 			return ""
 		case "and":
 			var name string
@@ -187,7 +158,7 @@ func TestExpression(t *testing.T) {
 			if expr == nil {
 				expr = (*SpanExpression)(nil)
 			}
-			return proto.MarshalTextString(expr.(*SpanExpression).ToProto())
+			return proto.MarshalTextString(expr.ToProto())
 		default:
 			return fmt.Sprintf("unknown command: %s", d.Cmd)
 		}
@@ -337,7 +308,7 @@ type spanExprForTest struct {
 
 // makeSpanExpression converts a spanExprForTest to a SpanExpression.
 func (expr spanExprForTest) makeSpanExpression() *SpanExpression {
-	var invertedExpr Expression
+	var invertedExpr *SpanExpression
 
 	for i := range expr.unionSpans {
 		spanExpr := ExprForSpan(Span{
@@ -367,10 +338,7 @@ func (expr spanExprForTest) makeSpanExpression() *SpanExpression {
 		}
 	}
 
-	if invertedExpr == nil {
-		return nil
-	}
-	return invertedExpr.(*SpanExpression)
+	return invertedExpr
 }
 
 // permute randomly changes the order of the nodes in the span expression tree.

--- a/pkg/sql/inverted/testdata/expression
+++ b/pkg/sql/inverted/testdata/expression
@@ -5,154 +5,8 @@ span expression
  ├── to read: ["b", "b"]
  └── union spans: ["b", "b"]
 
-new-unknown-leaf name=u-tight tight=true
-----
-unknown expression: tight=true
-
-new-unknown-leaf name=u-not-tight tight=false
-----
-unknown expression: tight=false
-
 # -----------------------------------------------------
-# Tests involving UnknownExpression.
-# -----------------------------------------------------
-
-# Or of tight [b, b] with tight UnknownExpression. They
-# become the left and right child and the result is tight.
-or result=bt left=b right=u-tight
-----
-span expression
- ├── tight: true, unique: false
- ├── to read: ["b", "b"]
- ├── union spans: ["b", "b"]
- └── UNION
-      ├── span expression
-      │    ├── tight: true, unique: true
-      │    ├── to read: ["b", "b"]
-      │    └── union spans: empty
-      └── unknown expression: tight=true
-
-# Same as previous with left and right reversed in the
-# call to Or.
-or result=bt left=u-tight right=b
-----
-span expression
- ├── tight: true, unique: false
- ├── to read: ["b", "b"]
- ├── union spans: ["b", "b"]
- └── UNION
-      ├── span expression
-      │    ├── tight: true, unique: true
-      │    ├── to read: ["b", "b"]
-      │    └── union spans: empty
-      └── unknown expression: tight=true
-
-# Or of tight [b, b] with non-tight UnknownExpression.
-# Unlike bt, the result here is not tight.
-or result=bnt left=b right=u-not-tight
-----
-span expression
- ├── tight: false, unique: false
- ├── to read: ["b", "b"]
- ├── union spans: ["b", "b"]
- └── UNION
-      ├── span expression
-      │    ├── tight: true, unique: true
-      │    ├── to read: ["b", "b"]
-      │    └── union spans: empty
-      └── unknown expression: tight=false
-
-# And of tight [b, b] with tight UnknownExpression.
-# No factoring is possible.
-and result=b-and-unknown left=b right=u-tight
-----
-span expression
- ├── tight: true, unique: false
- ├── to read: ["b", "b"]
- ├── union spans: empty
- └── INTERSECTION
-      ├── span expression
-      │    ├── tight: true, unique: true
-      │    ├── to read: ["b", "b"]
-      │    └── union spans: ["b", "b"]
-      └── unknown expression: tight=true
-
-# Similar and as previous but with non-tight UnknownExpression.
-# Only output difference is that the result is not tight.
-and result=b-and-unknown left=b right=u-not-tight
-----
-span expression
- ├── tight: false, unique: false
- ├── to read: ["b", "b"]
- ├── union spans: empty
- └── INTERSECTION
-      ├── span expression
-      │    ├── tight: true, unique: true
-      │    ├── to read: ["b", "b"]
-      │    └── union spans: ["b", "b"]
-      └── unknown expression: tight=false
-
-# And of bt and bnt. Factoring is possible. The result is
-# not tight.
-and result=bt-and-bnt left=bt right=bnt
-----
-span expression
- ├── tight: false, unique: false
- ├── to read: ["b", "b"]
- ├── union spans: ["b", "b"]
- └── INTERSECTION
-      ├── span expression
-      │    ├── tight: true, unique: false
-      │    ├── to read: ["b", "b"]
-      │    ├── union spans: empty
-      │    └── UNION
-      │         ├── span expression
-      │         │    ├── tight: true, unique: true
-      │         │    ├── to read: ["b", "b"]
-      │         │    └── union spans: empty
-      │         └── unknown expression: tight=true
-      └── span expression
-           ├── tight: false, unique: false
-           ├── to read: ["b", "b"]
-           ├── union spans: empty
-           └── UNION
-                ├── span expression
-                │    ├── tight: true, unique: true
-                │    ├── to read: ["b", "b"]
-                │    └── union spans: empty
-                └── unknown expression: tight=false
-
-# Or of bt and bnt. Similar to And in toRead and unionSpans.
-or result=bt-or-bnt left=bnt right=bt
-----
-span expression
- ├── tight: false, unique: false
- ├── to read: ["b", "b"]
- ├── union spans: ["b", "b"]
- └── UNION
-      ├── span expression
-      │    ├── tight: false, unique: false
-      │    ├── to read: ["b", "b"]
-      │    ├── union spans: empty
-      │    └── UNION
-      │         ├── span expression
-      │         │    ├── tight: true, unique: true
-      │         │    ├── to read: ["b", "b"]
-      │         │    └── union spans: empty
-      │         └── unknown expression: tight=false
-      └── span expression
-           ├── tight: true, unique: false
-           ├── to read: ["b", "b"]
-           ├── union spans: empty
-           └── UNION
-                ├── span expression
-                │    ├── tight: true, unique: true
-                │    ├── to read: ["b", "b"]
-                │    └── union spans: empty
-                └── unknown expression: tight=true
-
-# -----------------------------------------------------
-# Tests involving NonInvertedColExpression.
+# Tests involving non-inverted expressions.
 # -----------------------------------------------------
 
 new-non-inverted-leaf name=niexpr
@@ -160,24 +14,18 @@ new-non-inverted-leaf name=niexpr
 
 # And with a NonInvertedColExpression makes the result
 # not tight.
-and result=bt-and-niexpr left=bt right=niexpr
+and result=b-and-niexpr left=b right=niexpr
 ----
 span expression
- ├── tight: false, unique: false
+ ├── tight: false, unique: true
  ├── to read: ["b", "b"]
- ├── union spans: ["b", "b"]
- └── UNION
-      ├── span expression
-      │    ├── tight: true, unique: true
-      │    ├── to read: ["b", "b"]
-      │    └── union spans: empty
-      └── unknown expression: tight=true
+ └── union spans: ["b", "b"]
 
 # Or with a NonInvertedColExpression results in a
 # NonInvertedColExpression.
-or result=bt-or-niexpr left=niexpr right=bt
+or result=bt-or-niexpr left=niexpr right=b
 ----
-{}
+nil
 
 # -----------------------------------------------------
 # Tests involving only SpanExpressions.

--- a/pkg/sql/opt/invertedexpr/geo_expression.go
+++ b/pkg/sql/opt/invertedexpr/geo_expression.go
@@ -61,9 +61,9 @@ func geoToSpan(span geoindex.KeySpan, b []byte) (inverted.Span, []byte) {
 
 // GeoUnionKeySpansToSpanExpr converts geoindex.UnionKeySpans to a
 // SpanExpression.
-func GeoUnionKeySpansToSpanExpr(ukSpans geoindex.UnionKeySpans) inverted.Expression {
+func GeoUnionKeySpansToSpanExpr(ukSpans geoindex.UnionKeySpans) *inverted.SpanExpression {
 	if len(ukSpans) == 0 {
-		return inverted.NonInvertedColExpression{}
+		return nil
 	}
 	// Avoid per-span heap allocations. Each of the 2 keys in a span is the
 	// geoInvertedIndexMarker (1 byte) followed by a varint.
@@ -79,9 +79,9 @@ func GeoUnionKeySpansToSpanExpr(ukSpans geoindex.UnionKeySpans) inverted.Express
 }
 
 // GeoRPKeyExprToSpanExpr converts geoindex.RPKeyExpr to SpanExpression.
-func GeoRPKeyExprToSpanExpr(rpExpr geoindex.RPKeyExpr) (inverted.Expression, error) {
+func GeoRPKeyExprToSpanExpr(rpExpr geoindex.RPKeyExpr) (*inverted.SpanExpression, error) {
 	if len(rpExpr) == 0 {
-		return inverted.NonInvertedColExpression{}, nil
+		return nil, nil
 	}
 	spansToRead := make([]inverted.Span, 0, len(rpExpr))
 	var b []byte // avoid per-expr heap allocations
@@ -128,7 +128,7 @@ func GeoRPKeyExprToSpanExpr(rpExpr geoindex.RPKeyExpr) (inverted.Expression, err
 		}
 	}
 	if len(stack) != 1 {
-		return inverted.NonInvertedColExpression{}, errors.Errorf("malformed expression: %s", rpExpr)
+		return nil, errors.Errorf("malformed expression: %s", rpExpr)
 	}
 	spanExpr := *stack[0]
 	spanExpr.SpansToRead = spansToRead

--- a/pkg/sql/opt/invertedidx/geo.go
+++ b/pkg/sql/opt/invertedidx/geo.go
@@ -66,7 +66,7 @@ func GetGeoIndexRelationship(expr opt.ScalarExpr) (_ geoindex.RelationshipType, 
 // and getSpanExprForGeometryIndex and used in extractGeoFilterCondition.
 type getSpanExprForGeoIndexFn func(
 	context.Context, tree.Datum, []tree.Datum, geoindex.RelationshipType, geopb.Config,
-) inverted.Expression
+) *inverted.SpanExpression
 
 // getSpanExprForGeographyIndex gets a SpanExpression that constrains the given
 // geography index according to the given constant and geospatial relationship.
@@ -76,7 +76,7 @@ func getSpanExprForGeographyIndex(
 	additionalParams []tree.Datum,
 	relationship geoindex.RelationshipType,
 	indexConfig geopb.Config,
-) inverted.Expression {
+) *inverted.SpanExpression {
 	geogIdx := geoindex.NewS2GeographyIndex(*indexConfig.S2Geography)
 	geog := d.(*tree.DGeography).Geography
 
@@ -163,7 +163,7 @@ func getSpanExprForGeometryIndex(
 	additionalParams []tree.Datum,
 	relationship geoindex.RelationshipType,
 	indexConfig geopb.Config,
-) inverted.Expression {
+) *inverted.SpanExpression {
 	geomIdx := geoindex.NewS2GeometryIndex(*indexConfig.S2Geometry)
 	geom := d.(*tree.DGeometry).Geometry
 
@@ -551,7 +551,7 @@ func (g *geoFilterPlanner) maybeDeriveUsefulInvertedFilterCondition(
 func (g *geoFilterPlanner) extractInvertedFilterConditionFromLeaf(
 	ctx context.Context, evalCtx *eval.Context, expr opt.ScalarExpr,
 ) (
-	invertedExpr inverted.Expression,
+	invertedExpr *inverted.SpanExpression,
 	remainingFilters opt.ScalarExpr,
 	_ *invertedexpr.PreFiltererStateForInvertedFilterer,
 ) {
@@ -575,7 +575,7 @@ func (g *geoFilterPlanner) extractInvertedFilterConditionFromLeaf(
 		}
 
 	default:
-		return inverted.NonInvertedColExpression{}, expr, nil
+		return nil, expr, nil
 	}
 
 	// Try to extract an inverted filter condition from the given expression.
@@ -592,10 +592,13 @@ func (g *geoFilterPlanner) extractInvertedFilterConditionFromLeaf(
 	invertedExpr, pfState := extractGeoFilterCondition(
 		ctx, g.factory, expr, args, false /* commuteArgs */, g.tabID, g.index, g.getSpanExpr,
 	)
-	if _, ok := invertedExpr.(inverted.NonInvertedColExpression); ok {
+	if invertedExpr == nil {
 		invertedExpr, pfState = extractGeoFilterCondition(
 			ctx, g.factory, expr, args, true /* commuteArgs */, g.tabID, g.index, g.getSpanExpr,
 		)
+	}
+	if invertedExpr == nil {
+		return nil, nil, nil
 	}
 	// A derived filter may not be semantically equivalent to the original, so we
 	// need to apply the original filter in that case, the same as when the
@@ -620,15 +623,15 @@ func extractGeoFilterCondition(
 	tabID opt.TableID,
 	index cat.Index,
 	getSpanExpr getSpanExprForGeoIndexFn,
-) (inverted.Expression, *invertedexpr.PreFiltererStateForInvertedFilterer) {
+) (*inverted.SpanExpression, *invertedexpr.PreFiltererStateForInvertedFilterer) {
 	relationship, arg1, arg2, additionalParams, ok :=
 		extractInfoFromExpr(expr, args, commuteArgs, tabID, index)
 	if !ok {
-		return inverted.NonInvertedColExpression{}, nil
+		return nil, nil
 	}
 	// The first argument should be a constant.
 	if !memo.CanExtractConstDatum(arg1) {
-		return inverted.NonInvertedColExpression{}, nil
+		return nil, nil
 	}
 	d := memo.ExtractConstDatum(arg1)
 
@@ -753,7 +756,7 @@ type geoInvertedExpr struct {
 
 	// invertedExpr is the result of evaluating the geospatial relationship
 	// represented by this geoInvertedExpr. It is nil prior to evaluation.
-	invertedExpr inverted.Expression
+	invertedExpr *inverted.SpanExpression
 }
 
 var _ tree.TypedExpr = &geoInvertedExpr{}
@@ -1025,7 +1028,7 @@ func NewGeoDatumsToInvertedExpr(
 
 			// If possible, get the span expression now so we don't need to recompute
 			// it for every row.
-			var invertedExpr inverted.Expression
+			var invertedExpr *inverted.SpanExpression
 			if d, ok := nonIndexParam.(tree.Datum); ok {
 				invertedExpr = g.getSpanExpr(ctx, d, additionalParams, relationship, g.indexConfig)
 			} else if funcExprCount == 1 {
@@ -1067,7 +1070,7 @@ func (g *geoDatumsToInvertedExpr) Convert(
 	defer g.evalCtx.PopIVarContainer()
 
 	var preFilterState interface{}
-	evalInvertedExprLeaf := func(expr tree.TypedExpr) (inverted.Expression, error) {
+	evalInvertedExprLeaf := func(expr tree.TypedExpr) (*inverted.SpanExpression, error) {
 		switch t := expr.(type) {
 		case *geoInvertedExpr:
 			if t.invertedExpr != nil {
@@ -1100,12 +1103,7 @@ func (g *geoDatumsToInvertedExpr) Convert(
 		return nil, nil, nil
 	}
 
-	spanExpr, ok := invertedExpr.(*inverted.SpanExpression)
-	if !ok {
-		return nil, nil, fmt.Errorf("unable to construct span expression")
-	}
-
-	return spanExpr.ToProto(), preFilterState, nil
+	return invertedExpr.ToProto(), preFilterState, nil
 }
 
 func (g *geoDatumsToInvertedExpr) CanPreFilter() bool {

--- a/pkg/sql/opt/invertedidx/inverted_index_expr.go
+++ b/pkg/sql/opt/invertedidx/inverted_index_expr.go
@@ -151,7 +151,7 @@ func TryFilterInvertedIndex(
 		}
 	}
 
-	var invertedExpr inverted.Expression
+	var invertedExpr *inverted.SpanExpression
 	var pfState *invertedexpr.PreFiltererStateForInvertedFilterer
 	for i := range filters {
 		invertedExprLocal, remFiltersLocal, pfStateLocal := extractInvertedFilterCondition(
@@ -177,15 +177,11 @@ func TryFilterInvertedIndex(
 		return nil, nil, nil, nil, false
 	}
 
-	spanExpr, ok = invertedExpr.(*inverted.SpanExpression)
-	if !ok {
-		return nil, nil, nil, nil, false
-	}
 	if pfState != nil {
 		pfState.Typ = typ
 	}
 
-	return spanExpr, constraint, remainingFilters, pfState, true
+	return invertedExpr, constraint, remainingFilters, pfState, true
 }
 
 // TryFilterInvertedIndexBySimilarity attempts to constrain an inverted trigram
@@ -599,8 +595,9 @@ func getInvertedExpr(
 // expressions, and returns the resulting inverted.Expression. Delegates
 // evaluation of leaf expressions to the given evalInvertedExprLeaf function.
 func evalInvertedExpr(
-	expr tree.TypedExpr, evalInvertedExprLeaf func(expr tree.TypedExpr) (inverted.Expression, error),
-) (inverted.Expression, error) {
+	expr tree.TypedExpr,
+	evalInvertedExprLeaf func(expr tree.TypedExpr) (*inverted.SpanExpression, error),
+) (*inverted.SpanExpression, error) {
 	switch t := expr.(type) {
 	case *tree.AndExpr:
 		leftExpr, err := evalInvertedExpr(t.TypedLeft(), evalInvertedExprLeaf)
@@ -735,7 +732,7 @@ type invertedFilterPlanner interface {
 	//   tight, and
 	// - pre-filterer state that can be used to reduce false positives.
 	extractInvertedFilterConditionFromLeaf(ctx context.Context, evalCtx *eval.Context, expr opt.ScalarExpr) (
-		invertedExpr inverted.Expression,
+		invertedExpr *inverted.SpanExpression,
 		remainingFilters opt.ScalarExpr,
 		_ *invertedexpr.PreFiltererStateForInvertedFilterer,
 	)
@@ -762,7 +759,7 @@ func extractInvertedFilterCondition(
 	filterCond opt.ScalarExpr,
 	filterPlanner invertedFilterPlanner,
 ) (
-	invertedExpr inverted.Expression,
+	invertedExpr *inverted.SpanExpression,
 	remainingFilters opt.ScalarExpr,
 	_ *invertedexpr.PreFiltererStateForInvertedFilterer,
 ) {

--- a/pkg/sql/opt/invertedidx/json_array.go
+++ b/pkg/sql/opt/invertedidx/json_array.go
@@ -127,7 +127,7 @@ func (j *jsonOrArrayJoinPlanner) extractJSONOrArrayJoinCondition(
 // column contains (@>) a constant.
 func getInvertedExprForJSONOrArrayIndexForContaining(
 	ctx context.Context, evalCtx *eval.Context, d tree.Datum,
-) inverted.Expression {
+) *inverted.SpanExpression {
 	invertedExpr, err := rowenc.EncodeContainingInvertedIndexSpans(ctx, evalCtx, d)
 	if err != nil {
 		panic(err)
@@ -142,7 +142,7 @@ func getInvertedExprForJSONOrArrayIndexForContaining(
 // indexed column is contained by (<@) a constant.
 func getInvertedExprForJSONOrArrayIndexForContainedBy(
 	ctx context.Context, evalCtx *eval.Context, d tree.Datum,
-) inverted.Expression {
+) *inverted.SpanExpression {
 	invertedExpr, err := rowenc.EncodeContainedInvertedIndexSpans(ctx, evalCtx, d)
 	if err != nil {
 		panic(err)
@@ -158,7 +158,7 @@ func getInvertedExprForJSONOrArrayIndexForContainedBy(
 // true, and a disjunction otherwise.
 func getInvertedExprForJSONIndexForExists(
 	ctx context.Context, evalCtx *eval.Context, d tree.Datum, all bool,
-) inverted.Expression {
+) *inverted.SpanExpression {
 	invertedExpr, err := rowenc.EncodeExistsInvertedIndexSpans(ctx, evalCtx, d, all)
 	if err != nil {
 		panic(err)
@@ -173,7 +173,7 @@ func getInvertedExprForJSONIndexForExists(
 // indexed Array column overlaps (&&) with a constant.
 func getInvertedExprForArrayIndexForOverlaps(
 	ctx context.Context, evalCtx *eval.Context, d tree.Datum,
-) inverted.Expression {
+) *inverted.SpanExpression {
 	invertedExpr, err := rowenc.EncodeOverlapsInvertedIndexSpans(ctx, evalCtx, d)
 	if err != nil {
 		panic(err)
@@ -248,24 +248,22 @@ func NewJSONOrArrayDatumsToInvertedExpr(
 			// it for every row.
 			var spanExpr *inverted.SpanExpression
 			if d, ok := nonIndexParam.(tree.Datum); ok {
-				var invertedExpr inverted.Expression
 				switch t.Operator.Symbol {
 				case treecmp.ContainedBy:
-					invertedExpr = getInvertedExprForJSONOrArrayIndexForContainedBy(ctx, evalCtx, d)
+					spanExpr = getInvertedExprForJSONOrArrayIndexForContainedBy(ctx, evalCtx, d)
 				case treecmp.Contains:
-					invertedExpr = getInvertedExprForJSONOrArrayIndexForContaining(ctx, evalCtx, d)
+					spanExpr = getInvertedExprForJSONOrArrayIndexForContaining(ctx, evalCtx, d)
 				case treecmp.Overlaps:
-					invertedExpr = getInvertedExprForArrayIndexForOverlaps(ctx, evalCtx, d)
+					spanExpr = getInvertedExprForArrayIndexForOverlaps(ctx, evalCtx, d)
 				case treecmp.JSONExists:
-					invertedExpr = getInvertedExprForJSONIndexForExists(ctx, evalCtx, d, true /* all */)
+					spanExpr = getInvertedExprForJSONIndexForExists(ctx, evalCtx, d, true /* all */)
 				case treecmp.JSONSomeExists:
-					invertedExpr = getInvertedExprForJSONIndexForExists(ctx, evalCtx, d, false /* all */)
+					spanExpr = getInvertedExprForJSONIndexForExists(ctx, evalCtx, d, false /* all */)
 				case treecmp.JSONAllExists:
-					invertedExpr = getInvertedExprForJSONIndexForExists(ctx, evalCtx, d, true /* all */)
+					spanExpr = getInvertedExprForJSONIndexForExists(ctx, evalCtx, d, true /* all */)
 				default:
 					return nil, fmt.Errorf("%s cannot be index-accelerated", t)
 				}
-				spanExpr, _ = invertedExpr.(*inverted.SpanExpression)
 			}
 
 			return &jsonOrArrayInvertedExpr{
@@ -295,7 +293,7 @@ func (g *jsonOrArrayDatumsToInvertedExpr) Convert(
 	g.evalCtx.PushIVarContainer(g)
 	defer g.evalCtx.PopIVarContainer()
 
-	evalInvertedExprLeaf := func(expr tree.TypedExpr) (inverted.Expression, error) {
+	evalInvertedExprLeaf := func(expr tree.TypedExpr) (*inverted.SpanExpression, error) {
 		switch t := expr.(type) {
 		case *jsonOrArrayInvertedExpr:
 			if t.spanExpr != nil {
@@ -334,12 +332,7 @@ func (g *jsonOrArrayDatumsToInvertedExpr) Convert(
 		return nil, nil, nil
 	}
 
-	spanExpr, ok := invertedExpr.(*inverted.SpanExpression)
-	if !ok {
-		return nil, nil, fmt.Errorf("unable to construct span expression")
-	}
-
-	return spanExpr.ToProto(), nil, nil
+	return invertedExpr.ToProto(), nil, nil
 }
 
 func (g *jsonOrArrayDatumsToInvertedExpr) CanPreFilter() bool {
@@ -365,7 +358,7 @@ var _ invertedFilterPlanner = &jsonOrArrayFilterPlanner{}
 func (j *jsonOrArrayFilterPlanner) extractInvertedFilterConditionFromLeaf(
 	ctx context.Context, evalCtx *eval.Context, expr opt.ScalarExpr,
 ) (
-	invertedExpr inverted.Expression,
+	invertedExpr *inverted.SpanExpression,
 	remainingFilters opt.ScalarExpr,
 	_ *invertedexpr.PreFiltererStateForInvertedFilterer,
 ) {
@@ -396,7 +389,7 @@ func (j *jsonOrArrayFilterPlanner) extractInvertedFilterConditionFromLeaf(
 
 	if invertedExpr == nil {
 		// An inverted expression could not be extracted.
-		return inverted.NonInvertedColExpression{}, expr, nil
+		return nil, expr, nil
 	}
 
 	// If the extracted inverted expression is not tight then remaining filters
@@ -417,7 +410,7 @@ func (j *jsonOrArrayFilterPlanner) extractInvertedFilterConditionFromLeaf(
 // inverted.NonInvertedColExpression is returned.
 func (j *jsonOrArrayFilterPlanner) extractJSONInCondition(
 	ctx context.Context, evalCtx *eval.Context, left opt.ScalarExpr, right *memo.TupleExpr,
-) inverted.Expression {
+) *inverted.SpanExpression {
 
 	fetch := false
 	switch left.(type) {
@@ -426,17 +419,17 @@ func (j *jsonOrArrayFilterPlanner) extractJSONInCondition(
 	case *memo.VariableExpr:
 		fetch = false
 	default:
-		return inverted.NonInvertedColExpression{}
+		return nil
 	}
 
 	// The right side of the expression should be a constant JSON value.
 	if !memo.CanExtractConstDatum(right) {
-		return inverted.NonInvertedColExpression{}
+		return nil
 	}
-	var invertedExpr inverted.Expression
-	var expr inverted.Expression
+	var invertedExpr *inverted.SpanExpression
 	for i := range right.Elems {
 		scalarExprElem := right.Elems[i]
+		var expr *inverted.SpanExpression
 		if fetch {
 			expr = j.extractJSONFetchValEqCondition(ctx, evalCtx, left.(*memo.FetchValExpr), scalarExprElem)
 		} else {
@@ -451,7 +444,7 @@ func (j *jsonOrArrayFilterPlanner) extractJSONInCondition(
 
 	if invertedExpr == nil {
 		// An inverted expression could not be extracted.
-		return inverted.NonInvertedColExpression{}
+		return nil
 	}
 
 	return invertedExpr
@@ -464,7 +457,7 @@ func (j *jsonOrArrayFilterPlanner) extractJSONInCondition(
 // InvertedExpression if no inverted filter could be extracted.
 func (j *jsonOrArrayFilterPlanner) extractArrayOverlapsCondition(
 	ctx context.Context, evalCtx *eval.Context, left, right opt.ScalarExpr,
-) inverted.Expression {
+) *inverted.SpanExpression {
 	var constantVal opt.ScalarExpr
 	if isIndexColumn(j.tabID, j.index, left, j.computedColumns) && memo.CanExtractConstDatum(right) {
 		// When the first argument is a variable or expression corresponding to the
@@ -478,7 +471,7 @@ func (j *jsonOrArrayFilterPlanner) extractArrayOverlapsCondition(
 		constantVal = left
 	} else {
 		// If none of the conditions are met, we cannot create an InvertedExpression.
-		return inverted.NonInvertedColExpression{}
+		return nil
 	}
 	return getInvertedExprForArrayIndexForOverlaps(ctx, evalCtx, memo.ExtractConstDatum(constantVal))
 }
@@ -489,7 +482,7 @@ func (j *jsonOrArrayFilterPlanner) extractArrayOverlapsCondition(
 // InvertedExpression if no inverted filter could be extracted.
 func (j *jsonOrArrayFilterPlanner) extractJSONOrArrayContainsCondition(
 	ctx context.Context, evalCtx *eval.Context, left, right opt.ScalarExpr, containedBy bool,
-) inverted.Expression {
+) *inverted.SpanExpression {
 	var indexColumn, constantVal opt.ScalarExpr
 	if isIndexColumn(j.tabID, j.index, left, j.computedColumns) && memo.CanExtractConstDatum(right) {
 		// When the first argument is a variable or expression corresponding to the
@@ -514,7 +507,7 @@ func (j *jsonOrArrayFilterPlanner) extractJSONOrArrayContainsCondition(
 			return j.extractJSONFetchValContainsCondition(ctx, evalCtx, fetch, left, !containedBy)
 		}
 		// If none of the conditions are met, we cannot create an InvertedExpression.
-		return inverted.NonInvertedColExpression{}
+		return nil
 	}
 	d := memo.ExtractConstDatum(constantVal)
 	if indexColumn.DataType().Family() == types.ArrayFamily &&
@@ -522,7 +515,7 @@ func (j *jsonOrArrayFilterPlanner) extractJSONOrArrayContainsCondition(
 		if arr, ok := d.(*tree.DArray); ok && (containedBy || arr.Len() == 0) {
 			// We cannot constrain array indexes that do not include
 			// keys for empty arrays.
-			return inverted.NonInvertedColExpression{}
+			return nil
 		}
 	}
 	if containedBy {
@@ -538,7 +531,7 @@ func (j *jsonOrArrayFilterPlanner) extractJSONOrArrayContainsCondition(
 // extracted.
 func (j *jsonOrArrayFilterPlanner) extractJSONExistsCondition(
 	ctx context.Context, evalCtx *eval.Context, left, right opt.ScalarExpr, all bool,
-) inverted.Expression {
+) *inverted.SpanExpression {
 	if isIndexColumn(j.tabID, j.index, left, j.computedColumns) && memo.CanExtractConstDatum(right) {
 		// When the first argument is a variable or expression corresponding to the
 		// index column and the second argument is a constant, we get the
@@ -548,7 +541,7 @@ func (j *jsonOrArrayFilterPlanner) extractJSONExistsCondition(
 		return getInvertedExprForJSONIndexForExists(ctx, evalCtx, d, all)
 	}
 	// If none of the conditions are met, we cannot create an InvertedExpression.
-	return inverted.NonInvertedColExpression{}
+	return nil
 }
 
 // extractJSONEqCondition extracts an InvertedExpression representing an
@@ -559,20 +552,20 @@ func (j *jsonOrArrayFilterPlanner) extractJSONExistsCondition(
 // checking for equality.
 func (j *jsonOrArrayFilterPlanner) extractJSONEqCondition(
 	ctx context.Context, evalCtx *eval.Context, left *memo.VariableExpr, right opt.ScalarExpr,
-) inverted.Expression {
+) *inverted.SpanExpression {
 	// The left side of the expression must be a variable expression of the
 	// indexed column.
 	if !isIndexColumn(j.tabID, j.index, left, j.computedColumns) {
-		return inverted.NonInvertedColExpression{}
+		return nil
 	}
 
 	// The right side of the expression must be a constant JSON value.
 	if !memo.CanExtractConstDatum(right) {
-		return inverted.NonInvertedColExpression{}
+		return nil
 	}
 	val, ok := memo.ExtractConstDatum(right).(*tree.DJSON)
 	if !ok {
-		return inverted.NonInvertedColExpression{}
+		return nil
 	}
 
 	// For Equals expressions, we will generate the inverted expression for val.
@@ -605,21 +598,21 @@ func (j *jsonOrArrayFilterPlanner) extractJSONEqCondition(
 // constant JSON value.
 func (j *jsonOrArrayFilterPlanner) extractJSONFetchValEqCondition(
 	ctx context.Context, evalCtx *eval.Context, left *memo.FetchValExpr, right opt.ScalarExpr,
-) inverted.Expression {
+) *inverted.SpanExpression {
 	// The right side of the expression should be a constant JSON value.
 	if !memo.CanExtractConstDatum(right) {
-		return inverted.NonInvertedColExpression{}
+		return nil
 	}
 	val, ok := memo.ExtractConstDatum(right).(*tree.DJSON)
 	if !ok {
-		return inverted.NonInvertedColExpression{}
+		return nil
 	}
 
 	// Collect a slice of keys from the fetch val expression.
 	var keys tree.Datums
 	keys = j.collectKeys(keys, left)
 	if len(keys) == 0 {
-		return inverted.NonInvertedColExpression{}
+		return nil
 	}
 
 	// Build a new JSON object with the collected keys and val.
@@ -682,39 +675,37 @@ func (j *jsonOrArrayFilterPlanner) extractJSONFetchValContainsCondition(
 	left *memo.FetchValExpr,
 	right opt.ScalarExpr,
 	containedBy bool,
-) inverted.Expression {
+) (invertedExpr *inverted.SpanExpression) {
 	// The right side of the expression should be a constant JSON value.
 	if !memo.CanExtractConstDatum(right) {
-		return inverted.NonInvertedColExpression{}
+		return nil
 	}
 	val, ok := memo.ExtractConstDatum(right).(*tree.DJSON)
 	if !ok {
-		return inverted.NonInvertedColExpression{}
+		return nil
 	}
 
 	// Collect a slice of keys from the fetch val expression.
 	var keys tree.Datums
 	keys = j.collectKeys(keys, left)
 	if len(keys) == 0 {
-		return inverted.NonInvertedColExpression{}
+		return nil
 	}
 
 	// Build a new JSON object with the collected keys and val.
 	obj := buildObject(keys, val.JSON)
 
-	var invertedExpr inverted.Expression
-
 	// For Contains and ContainedBy expressions, we may need to build additional
 	// objects to cover all possibilities.
 	objs, err := buildFetchContainmentObjects(keys, val.JSON, containedBy)
 	if err != nil {
-		return inverted.NonInvertedColExpression{}
+		return nil
 	}
 	objs = append(objs, obj)
 	// We get an inverted expression for each object constructed, and union
 	// these expressions.
 	for i := range objs {
-		var expr inverted.Expression
+		var expr *inverted.SpanExpression
 		if containedBy {
 			expr = getInvertedExprForJSONOrArrayIndexForContainedBy(ctx, evalCtx, tree.NewDJSON(objs[i]))
 		} else {

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -1571,8 +1571,8 @@ func (c *CustomFuncs) GenerateInvertedIndexZigzagJoins(
 		// spanExpr or will return some false positives (in which case tight=false,
 		// and we will need to re-apply the filters).
 		vals := make([]inverted.EncVal, 0, 2)
-		var getVals func(invertedExpr inverted.Expression) (tight bool)
-		getVals = func(invertedExpr inverted.Expression) (tight bool) {
+		var getVals func(invertedExpr *inverted.SpanExpression) (tight bool)
+		getVals = func(invertedExpr *inverted.SpanExpression) (tight bool) {
 			if len(vals) >= 2 {
 				// We only need two constraints to plan a zigzag join, so don't bother
 				// exploring further.
@@ -1580,21 +1580,20 @@ func (c *CustomFuncs) GenerateInvertedIndexZigzagJoins(
 				// constraints instead of the first two.
 				return false
 			}
-			spanExprLocal, ok := invertedExpr.(*inverted.SpanExpression)
-			if !ok {
+			if invertedExpr == nil {
 				// The invertedExpr was a NonInvertedColExpression and cannot be used
 				// to constrain the index. (This shouldn't ever happen, since
 				// TryFilterInvertedIndex should have returned ok=false in this case,
 				// but we don't want to panic if it does happen.)
 				return false
 			}
-			switch spanExprLocal.Operator {
+			switch invertedExpr.Operator {
 			case inverted.None:
 				// Check that this span expression represents a single-key span that is
 				// guaranteed not to produce duplicate primary keys.
-				if spanExprLocal.Unique && len(spanExprLocal.SpansToRead) == 1 &&
-					spanExprLocal.SpansToRead[0].IsSingleVal() {
-					vals = append(vals, spanExprLocal.SpansToRead[0].Start)
+				if invertedExpr.Unique && len(invertedExpr.SpansToRead) == 1 &&
+					invertedExpr.SpansToRead[0].IsSingleVal() {
+					vals = append(vals, invertedExpr.SpansToRead[0].Start)
 					return true
 				}
 
@@ -1603,9 +1602,9 @@ func (c *CustomFuncs) GenerateInvertedIndexZigzagJoins(
 				// non-empty FactoredUnionSpans is equivalent to a UNION between the
 				// FactoredUnionSpans and the intersected children, so we can't build a
 				// zigzag join with the subtree.
-				if len(spanExprLocal.FactoredUnionSpans) == 0 {
-					leftTight := getVals(spanExprLocal.Left)
-					rightTight := getVals(spanExprLocal.Right)
+				if len(invertedExpr.FactoredUnionSpans) == 0 {
+					leftTight := getVals(invertedExpr.Left)
+					rightTight := getVals(invertedExpr.Right)
 					return leftTight && rightTight
 				}
 

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -6303,19 +6303,24 @@ project
       │    ├── fd: (1)-->(3,4)
       │    └── inverted-filter
       │         ├── columns: k:1!null
-      │         ├── inverted expression: /7
+      │         ├── inverted expression: /8
       │         │    ├── tight: false, unique: false
-      │         │    └── union spans: ["B\x89", "B\xfd \x00\x00\x00\x00\x00\x00\x00")
+      │         │    └── union spans
+      │         │         ├── ["B\xfdL\x00\x00\x00\x00\x00\x00\x00", "B\xfdL\x00\x00\x00\x00\x00\x00\x00"]
+      │         │         ├── ["B\xfdN\x00\x00\x00\x00\x00\x00\x01", "B\xfdP\x00\x00\x00\x00\x00\x00\x00")
+      │         │         └── ["B\xfdP\x00\x00\x00\x00\x00\x00\x00", "B\xfdP\x00\x00\x00\x00\x00\x00\x00"]
       │         ├── pre-filterer expression
-      │         │    └── st_overlaps('0102000000020000000000000000000000000000000000000000000000000000000000000000000040', geom:3)
+      │         │    └── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4)
       │         ├── key: (1)
-      │         └── scan g@geom_idx,inverted
-      │              ├── columns: k:1!null geom_inverted_key:7!null
-      │              └── inverted constraint: /7/1
-      │                   └── spans: ["B\x89", "B\xfd \x00\x00\x00\x00\x00\x00\x00")
+      │         └── scan g@geog_idx,inverted
+      │              ├── columns: k:1!null geog_inverted_key:8!null
+      │              └── inverted constraint: /8/1
+      │                   └── spans
+      │                        ├── ["B\xfdL\x00\x00\x00\x00\x00\x00\x00", "B\xfdL\x00\x00\x00\x00\x00\x00\x00"]
+      │                        ├── ["B\xfdN\x00\x00\x00\x00\x00\x00\x01", "B\xfdP\x00\x00\x00\x00\x00\x00\x00")
+      │                        └── ["B\xfdP\x00\x00\x00\x00\x00\x00\x00", "B\xfdP\x00\x00\x00\x00\x00\x00\x00"]
       └── filters
-           ├── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
-           └── st_overlaps('0102000000020000000000000000000000000000000000000000000000000000000000000000000040', geom:3) [outer=(3), immutable, constraints=(/3: (/NULL - ])]
+           └── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4) [outer=(4), immutable, constraints=(/4: (/NULL - ])]
 
 # We can use both indexes because of the SplitDisjunction rule.
 opt
@@ -6406,31 +6411,80 @@ project
  ├── columns: k:1!null
  ├── immutable
  ├── key: (1)
- └── select
+ └── distinct-on
       ├── columns: k:1!null geom:3 geog:4!null
+      ├── grouping columns: k:1!null
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(3,4)
-      ├── index-join g
-      │    ├── columns: k:1!null geom:3 geog:4
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(3,4)
-      │    └── inverted-filter
-      │         ├── columns: k:1!null
-      │         ├── inverted expression: /8
-      │         │    ├── tight: false, unique: false
-      │         │    └── union spans
-      │         │         ├── ["B\xfdL\x00\x00\x00\x00\x00\x00\x00", "B\xfdL\x00\x00\x00\x00\x00\x00\x00"]
-      │         │         └── ["B\xfdN\x00\x00\x00\x00\x00\x00\x01", "B\xfdP\x00\x00\x00\x00\x00\x00\x01")
-      │         ├── key: (1)
-      │         └── scan g@geog_idx,inverted
-      │              ├── columns: k:1!null geog_inverted_key:8!null
-      │              └── inverted constraint: /8/1
-      │                   └── spans
-      │                        ├── ["B\xfdL\x00\x00\x00\x00\x00\x00\x00", "B\xfdL\x00\x00\x00\x00\x00\x00\x00"]
-      │                        └── ["B\xfdN\x00\x00\x00\x00\x00\x00\x01", "B\xfdP\x00\x00\x00\x00\x00\x00\x01")
-      └── filters
-           └── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:4) OR (st_intersects('0101000020E61000009279E40F061E44C0BEE36FD63B9D5140', geog:4) AND st_crosses('0102000000020000000000000000000000000000000000000000000000000000000000000000000040', geom:3)) [outer=(3,4), immutable, constraints=(/4: (/NULL - ])]
+      ├── union-all
+      │    ├── columns: k:1!null geom:3 geog:4!null
+      │    ├── left columns: k:9 geom:11 geog:12
+      │    ├── right columns: k:17 geom:19 geog:20
+      │    ├── immutable
+      │    ├── select
+      │    │    ├── columns: k:9!null geom:11 geog:12!null
+      │    │    ├── immutable
+      │    │    ├── key: (9)
+      │    │    ├── fd: (9)-->(11,12)
+      │    │    ├── index-join g
+      │    │    │    ├── columns: k:9!null geom:11 geog:12
+      │    │    │    ├── key: (9)
+      │    │    │    ├── fd: (9)-->(11,12)
+      │    │    │    └── inverted-filter
+      │    │    │         ├── columns: k:9!null
+      │    │    │         ├── inverted expression: /16
+      │    │    │         │    ├── tight: false, unique: false
+      │    │    │         │    └── union spans
+      │    │    │         │         ├── ["B\xfdL\x00\x00\x00\x00\x00\x00\x00", "B\xfdL\x00\x00\x00\x00\x00\x00\x00"]
+      │    │    │         │         ├── ["B\xfdN\x00\x00\x00\x00\x00\x00\x01", "B\xfdP\x00\x00\x00\x00\x00\x00\x00")
+      │    │    │         │         └── ["B\xfdP\x00\x00\x00\x00\x00\x00\x00", "B\xfdP\x00\x00\x00\x00\x00\x00\x00"]
+      │    │    │         ├── pre-filterer expression
+      │    │    │         │    └── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:12)
+      │    │    │         ├── key: (9)
+      │    │    │         └── scan g@geog_idx,inverted
+      │    │    │              ├── columns: k:9!null geog_inverted_key:16!null
+      │    │    │              └── inverted constraint: /16/9
+      │    │    │                   └── spans
+      │    │    │                        ├── ["B\xfdL\x00\x00\x00\x00\x00\x00\x00", "B\xfdL\x00\x00\x00\x00\x00\x00\x00"]
+      │    │    │                        ├── ["B\xfdN\x00\x00\x00\x00\x00\x00\x01", "B\xfdP\x00\x00\x00\x00\x00\x00\x00")
+      │    │    │                        └── ["B\xfdP\x00\x00\x00\x00\x00\x00\x00", "B\xfdP\x00\x00\x00\x00\x00\x00\x00"]
+      │    │    └── filters
+      │    │         └── st_covers('0101000020E61000009279E40F069E45C0BEE36FD63B1D5240', geog:12) [outer=(12), immutable, constraints=(/12: (/NULL - ])]
+      │    └── select
+      │         ├── columns: k:17!null geom:19!null geog:20!null
+      │         ├── immutable
+      │         ├── key: (17)
+      │         ├── fd: (17)-->(19,20)
+      │         ├── index-join g
+      │         │    ├── columns: k:17!null geom:19 geog:20
+      │         │    ├── key: (17)
+      │         │    ├── fd: (17)-->(19,20)
+      │         │    └── inverted-filter
+      │         │         ├── columns: k:17!null
+      │         │         ├── inverted expression: /24
+      │         │         │    ├── tight: false, unique: false
+      │         │         │    └── union spans
+      │         │         │         ├── ["B\xfdL\x00\x00\x00\x00\x00\x00\x00", "B\xfdL\x00\x00\x00\x00\x00\x00\x00"]
+      │         │         │         ├── ["B\xfdN\x00\x00\x00\x00\x00\x00\x01", "B\xfdP\x00\x00\x00\x00\x00\x00\x00")
+      │         │         │         └── ["B\xfdP\x00\x00\x00\x00\x00\x00\x00", "B\xfdP\x00\x00\x00\x00\x00\x00\x00"]
+      │         │         ├── pre-filterer expression
+      │         │         │    └── st_intersects('0101000020E61000009279E40F061E44C0BEE36FD63B9D5140', geog:20)
+      │         │         ├── key: (17)
+      │         │         └── scan g@geog_idx,inverted
+      │         │              ├── columns: k:17!null geog_inverted_key:24!null
+      │         │              └── inverted constraint: /24/17
+      │         │                   └── spans
+      │         │                        ├── ["B\xfdL\x00\x00\x00\x00\x00\x00\x00", "B\xfdL\x00\x00\x00\x00\x00\x00\x00"]
+      │         │                        ├── ["B\xfdN\x00\x00\x00\x00\x00\x00\x01", "B\xfdP\x00\x00\x00\x00\x00\x00\x00")
+      │         │                        └── ["B\xfdP\x00\x00\x00\x00\x00\x00\x00", "B\xfdP\x00\x00\x00\x00\x00\x00\x00"]
+      │         └── filters
+      │              └── st_intersects('0101000020E61000009279E40F061E44C0BEE36FD63B9D5140', geog:20) [outer=(20), immutable, constraints=(/20: (/NULL - ])]
+      └── aggregations
+           ├── const-agg [as=geom:3, outer=(3)]
+           │    └── geom:3
+           └── const-agg [as=geog:4, outer=(4)]
+                └── geog:4
 
 # Filters on other columns.
 opt expect=GenerateInvertedIndexScans

--- a/pkg/util/json/encoded.go
+++ b/pkg/util/json/encoded.go
@@ -772,7 +772,7 @@ func (j *jsonEncoded) encodeInvertedIndexKeys(b []byte) ([][]byte, error) {
 
 func (j *jsonEncoded) encodeContainingInvertedIndexSpans(
 	b []byte, isRoot, isObjectValue bool,
-) (inverted.Expression, error) {
+) (*inverted.SpanExpression, error) {
 	decoded, err := j.decode()
 	if err != nil {
 		return nil, err
@@ -782,7 +782,7 @@ func (j *jsonEncoded) encodeContainingInvertedIndexSpans(
 
 func (j *jsonEncoded) encodeContainedInvertedIndexSpans(
 	b []byte, isRoot, isObjectValue bool,
-) (inverted.Expression, error) {
+) (*inverted.SpanExpression, error) {
 	decoded, err := j.decode()
 	if err != nil {
 		return nil, err

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -118,7 +118,7 @@ type JSON interface {
 	// the same time.
 	encodeContainingInvertedIndexSpans(
 		b []byte, isRoot, isObjectValue bool,
-	) (invertedExpr inverted.Expression, err error)
+	) (invertedExpr *inverted.SpanExpression, err error)
 
 	// encodeContainedInvertedIndexSpans takes in a key prefix and returns the
 	// spans that must be scanned in the inverted index to evaluate a contained
@@ -135,7 +135,7 @@ type JSON interface {
 	// the same time.
 	encodeContainedInvertedIndexSpans(
 		b []byte, isRoot, isObjectValue bool,
-	) (invertedExpr inverted.Expression, err error)
+	) (invertedExpr *inverted.SpanExpression, err error)
 
 	// numInvertedIndexEntries returns the number of entries that will be
 	// produced if this JSON gets included in an inverted index.
@@ -990,7 +990,7 @@ func EncodeInvertedIndexKeys(b []byte, json JSON) ([][]byte, error) {
 // The input inKey is prefixed to the keys in all returned spans.
 func EncodeContainingInvertedIndexSpans(
 	b []byte, json JSON,
-) (invertedExpr inverted.Expression, err error) {
+) (invertedExpr *inverted.SpanExpression, err error) {
 	return json.encodeContainingInvertedIndexSpans(
 		encoding.EncodeJSONAscending(b), true /* isRoot */, false, /* isObjectValue */
 	)
@@ -1008,7 +1008,7 @@ func EncodeContainingInvertedIndexSpans(
 // The input inKey is prefixed to the keys in all returned spans.
 func EncodeContainedInvertedIndexSpans(
 	b []byte, json JSON,
-) (invertedExpr inverted.Expression, err error) {
+) (invertedExpr *inverted.SpanExpression, err error) {
 	invertedExpr, err = json.encodeContainedInvertedIndexSpans(
 		encoding.EncodeJSONAscending(b), true /* isRoot */, false, /* isObjectValue */
 	)
@@ -1039,7 +1039,7 @@ func EncodeContainedInvertedIndexSpans(
 // The input inKey is prefixed to the keys in all returned spans.
 func EncodeExistsInvertedIndexSpans(
 	b []byte, s string,
-) (invertedExpr inverted.Expression, err error) {
+) (invertedExpr *inverted.SpanExpression, err error) {
 	b = encoding.EncodeJSONAscending(b)
 	js := jsonString(s)
 	// Make an inverted expression that contains both arrays containing the input
@@ -1087,13 +1087,13 @@ func (j jsonNull) encodeInvertedIndexKeys(b []byte) ([][]byte, error) {
 
 func (j jsonNull) encodeContainingInvertedIndexSpans(
 	b []byte, isRoot, isObjectValue bool,
-) (inverted.Expression, error) {
+) (*inverted.SpanExpression, error) {
 	return encodeContainingInvertedIndexSpansFromLeaf(j, b, isRoot, isObjectValue)
 }
 
 func (j jsonNull) encodeContainedInvertedIndexSpans(
 	b []byte, isRoot, isObjectValue bool,
-) (inverted.Expression, error) {
+) (*inverted.SpanExpression, error) {
 	invertedExpr, err := encodeContainedInvertedIndexSpansFromLeaf(j, b, isRoot)
 	return invertedExpr, err
 }
@@ -1105,13 +1105,13 @@ func (jsonTrue) encodeInvertedIndexKeys(b []byte) ([][]byte, error) {
 
 func (j jsonTrue) encodeContainingInvertedIndexSpans(
 	b []byte, isRoot, isObjectValue bool,
-) (inverted.Expression, error) {
+) (*inverted.SpanExpression, error) {
 	return encodeContainingInvertedIndexSpansFromLeaf(j, b, isRoot, isObjectValue)
 }
 
 func (j jsonTrue) encodeContainedInvertedIndexSpans(
 	b []byte, isRoot, isObjectValue bool,
-) (inverted.Expression, error) {
+) (*inverted.SpanExpression, error) {
 	invertedExpr, err := encodeContainedInvertedIndexSpansFromLeaf(j, b, isRoot)
 	return invertedExpr, err
 }
@@ -1123,13 +1123,13 @@ func (jsonFalse) encodeInvertedIndexKeys(b []byte) ([][]byte, error) {
 
 func (j jsonFalse) encodeContainingInvertedIndexSpans(
 	b []byte, isRoot, isObjectValue bool,
-) (inverted.Expression, error) {
+) (*inverted.SpanExpression, error) {
 	return encodeContainingInvertedIndexSpansFromLeaf(j, b, isRoot, isObjectValue)
 }
 
 func (j jsonFalse) encodeContainedInvertedIndexSpans(
 	b []byte, isRoot, isObjectValue bool,
-) (inverted.Expression, error) {
+) (*inverted.SpanExpression, error) {
 	invertedExpr, err := encodeContainedInvertedIndexSpansFromLeaf(j, b, isRoot)
 	return invertedExpr, err
 }
@@ -1141,13 +1141,13 @@ func (j jsonString) encodeInvertedIndexKeys(b []byte) ([][]byte, error) {
 
 func (j jsonString) encodeContainingInvertedIndexSpans(
 	b []byte, isRoot, isObjectValue bool,
-) (inverted.Expression, error) {
+) (*inverted.SpanExpression, error) {
 	return encodeContainingInvertedIndexSpansFromLeaf(j, b, isRoot, isObjectValue)
 }
 
 func (j jsonString) encodeContainedInvertedIndexSpans(
 	b []byte, isRoot, isObjectValue bool,
-) (inverted.Expression, error) {
+) (*inverted.SpanExpression, error) {
 	invertedExpr, err := encodeContainedInvertedIndexSpansFromLeaf(j, b, isRoot)
 	return invertedExpr, err
 }
@@ -1160,13 +1160,13 @@ func (j jsonNumber) encodeInvertedIndexKeys(b []byte) ([][]byte, error) {
 
 func (j jsonNumber) encodeContainingInvertedIndexSpans(
 	b []byte, isRoot, isObjectValue bool,
-) (inverted.Expression, error) {
+) (*inverted.SpanExpression, error) {
 	return encodeContainingInvertedIndexSpansFromLeaf(j, b, isRoot, isObjectValue)
 }
 
 func (j jsonNumber) encodeContainedInvertedIndexSpans(
 	b []byte, isRoot, isObjectValue bool,
-) (inverted.Expression, error) {
+) (*inverted.SpanExpression, error) {
 	invertedExpr, err := encodeContainedInvertedIndexSpansFromLeaf(j, b, isRoot)
 	return invertedExpr, err
 }
@@ -1197,7 +1197,7 @@ func (j jsonArray) encodeInvertedIndexKeys(b []byte) ([][]byte, error) {
 
 func (j jsonArray) encodeContainingInvertedIndexSpans(
 	b []byte, isRoot, isObjectValue bool,
-) (invertedExpr inverted.Expression, err error) {
+) (invertedExpr *inverted.SpanExpression, err error) {
 	// Checking for an empty array.
 	if len(j) == 0 {
 		return encodeContainingInvertedIndexSpansFromLeaf(j, b, isRoot, isObjectValue)
@@ -1232,8 +1232,7 @@ func (j jsonArray) encodeContainingInvertedIndexSpans(
 	// function performs some deduplication, so it's possible that the original
 	// array had duplicates that were removed, causing the intersection to be
 	// removed.
-	if spanExpr, ok := invertedExpr.(*inverted.SpanExpression); ok &&
-		!isRoot && j.Len() > 1 && spanExpr.Operator == inverted.SetIntersection {
+	if !isRoot && j.Len() > 1 && invertedExpr.Operator == inverted.SetIntersection {
 		invertedExpr.SetNotTight()
 	}
 
@@ -1242,7 +1241,7 @@ func (j jsonArray) encodeContainingInvertedIndexSpans(
 
 func (j jsonArray) encodeContainedInvertedIndexSpans(
 	b []byte, isRoot, isObjectValue bool,
-) (invertedExpr inverted.Expression, err error) {
+) (invertedExpr *inverted.SpanExpression, err error) {
 	if !isObjectValue || len(j) == 0 {
 		// The empty array should always be added to the spans, since it is contained
 		// by everything. Empty array values are already accounted for when getting
@@ -1327,7 +1326,7 @@ func (j jsonObject) encodeInvertedIndexKeys(b []byte) ([][]byte, error) {
 
 func (j jsonObject) encodeContainingInvertedIndexSpans(
 	b []byte, isRoot, isObjectValue bool,
-) (invertedExpr inverted.Expression, err error) {
+) (invertedExpr *inverted.SpanExpression, err error) {
 	if len(j) == 0 {
 		return encodeContainingInvertedIndexSpansFromLeaf(j, b, isRoot, isObjectValue)
 	}
@@ -1370,7 +1369,7 @@ func (j jsonObject) encodeContainingInvertedIndexSpans(
 
 func (j jsonObject) encodeContainedInvertedIndexSpans(
 	b []byte, isRoot, isObjectValue bool,
-) (invertedExpr inverted.Expression, err error) {
+) (invertedExpr *inverted.SpanExpression, err error) {
 	// The empty object should always be added to the spans, since it is contained
 	// by everything. Empty object values are already accounted for when getting
 	// the spans for a non-empty object value, so they should be excluded.
@@ -1483,7 +1482,7 @@ func emptyJSONForType(json JSON) JSON {
 // the same time.
 func encodeContainingInvertedIndexSpansFromLeaf(
 	j JSON, b []byte, isRoot, isObjectValue bool,
-) (invertedExpr inverted.Expression, err error) {
+) (invertedExpr *inverted.SpanExpression, err error) {
 	keys, err := j.encodeInvertedIndexKeys(b)
 	if err != nil {
 		return nil, err
@@ -1598,9 +1597,7 @@ func encodeContainingInvertedIndexSpansFromLeaf(
 			inverted.MakeSingleValSpan(inverted.EncVal(key)), true, /* tight */
 		))
 	}
-	if spanExpr, ok := invertedExpr.(*inverted.SpanExpression); ok {
-		spanExpr.Unique = unique
-	}
+	invertedExpr.Unique = unique
 
 	return invertedExpr, nil
 }
@@ -1616,7 +1613,7 @@ func encodeContainingInvertedIndexSpansFromLeaf(
 // JSON hierarchy.
 func encodeContainedInvertedIndexSpansFromLeaf(
 	j JSON, b []byte, isRoot bool,
-) (invertedExpr inverted.Expression, err error) {
+) (invertedExpr *inverted.SpanExpression, err error) {
 	keys, err := j.encodeInvertedIndexKeys(b)
 	if err != nil {
 		return nil, err
@@ -1648,9 +1645,7 @@ func encodeContainedInvertedIndexSpansFromLeaf(
 				inverted.MakeSingleValSpan(key), false, /* tight */
 			))
 		}
-		if spanExpr, ok := invertedExpr.(*inverted.SpanExpression); ok {
-			spanExpr.Unique = unique
-		}
+		invertedExpr.Unique = unique
 
 		return invertedExpr, nil
 	}

--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -21,7 +21,6 @@ import (
 	"unicode/utf8"
 
 	"github.com/cockroachdb/apd/v3"
-	"github.com/cockroachdb/cockroach/pkg/sql/inverted"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -1667,20 +1666,19 @@ func TestEncodeContainingJSONInvertedIndexSpans(t *testing.T) {
 		invertedExpr, err := EncodeContainingInvertedIndexSpans(nil, right)
 		require.NoError(t, err)
 
-		spanExpr, ok := invertedExpr.(*inverted.SpanExpression)
-		if !ok {
-			t.Fatalf("invertedExpr %v is not a SpanExpression", invertedExpr)
+		if invertedExpr == nil {
+			t.Fatal("invertedExpr is nil")
 		}
 
-		if spanExpr.Unique != expectUnique {
-			t.Errorf("For %s, expected unique=%v, but got %v", right, expectUnique, spanExpr.Unique)
+		if invertedExpr.Unique != expectUnique {
+			t.Errorf("For %s, expected unique=%v, but got %v", right, expectUnique, invertedExpr.Unique)
 		}
 
-		actual, err := spanExpr.ContainsKeys(keys)
+		actual, err := invertedExpr.ContainsKeys(keys)
 		require.NoError(t, err)
 
 		// There may be some false positives, so filter those out.
-		if actual && !spanExpr.Tight {
+		if actual && !invertedExpr.Tight {
 			actual, err = Contains(left, right)
 			require.NoError(t, err)
 		}
@@ -1693,7 +1691,7 @@ func TestEncodeContainingJSONInvertedIndexSpans(t *testing.T) {
 			}
 		}
 
-		return spanExpr.Tight
+		return invertedExpr.Tight
 	}
 
 	// Run pre-defined test cases from above.
@@ -1848,21 +1846,20 @@ func TestEncodeContainedJSONInvertedIndexSpans(t *testing.T) {
 		invertedExpr, err := EncodeContainedInvertedIndexSpans(nil, value)
 		require.NoError(t, err)
 
-		spanExpr, ok := invertedExpr.(*inverted.SpanExpression)
-		if !ok {
-			t.Fatalf("invertedExpr %v is not a SpanExpression", invertedExpr)
+		if invertedExpr == nil {
+			t.Fatal("invertedExpr is nil")
 		}
 
 		// Spans should never be tight for contained by.
-		if spanExpr.Tight {
+		if invertedExpr.Tight {
 			t.Errorf("For %s, expected tight=false, but got true", value)
 		}
 
-		if spanExpr.Unique != expectUnique {
-			t.Errorf("For %s, expected unique=%v, but got %v", value, expectUnique, spanExpr.Unique)
+		if invertedExpr.Unique != expectUnique {
+			t.Errorf("For %s, expected unique=%v, but got %v", value, expectUnique, invertedExpr.Unique)
 		}
 
-		containsKeys, err := spanExpr.ContainsKeys(keys)
+		containsKeys, err := invertedExpr.ContainsKeys(keys)
 		require.NoError(t, err)
 
 		if containsKeys != expectContainsKeys {
@@ -1976,22 +1973,21 @@ func TestEncodeExistsJSONInvertedIndexSpans(t *testing.T) {
 		invertedExpr, err := EncodeExistsInvertedIndexSpans(nil, value)
 		require.NoError(t, err)
 
-		spanExpr, ok := invertedExpr.(*inverted.SpanExpression)
-		if !ok {
-			t.Fatalf("invertedExpr %v is not a SpanExpression", invertedExpr)
+		if invertedExpr == nil {
+			t.Fatalf("invertedExpr is nil")
 		}
 
 		// Spans should always be tight for exists.
-		if !spanExpr.Tight {
+		if !invertedExpr.Tight {
 			t.Errorf("For %s, expected tight=true, but got false", value)
 		}
 
 		// Spans should never be unique for exists.
-		if spanExpr.Unique {
+		if invertedExpr.Unique {
 			t.Errorf("For %s, expected unique=false, but got true", value)
 		}
 
-		containsKeys, err := spanExpr.ContainsKeys(keys)
+		containsKeys, err := invertedExpr.ContainsKeys(keys)
 		require.NoError(t, err)
 
 		if containsKeys != expected {

--- a/pkg/util/tsearch/encoding_test.go
+++ b/pkg/util/tsearch/encoding_test.go
@@ -13,7 +13,6 @@ package tsearch
 import (
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/inverted"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/stretchr/testify/assert"
 )
@@ -127,19 +126,17 @@ func TestEncodeTSQueryInvertedIndexSpans(t *testing.T) {
 
 		invertedExpr, err := right.GetInvertedExpr()
 		assert.NoError(t, err)
+		assert.NotNil(t, invertedExpr)
 
-		spanExpr, ok := invertedExpr.(*inverted.SpanExpression)
-		assert.True(t, ok)
-
-		if spanExpr.Unique != expectUnique {
-			t.Errorf("For %s, expected unique=%v, but got %v", right, expectUnique, spanExpr.Unique)
+		if invertedExpr.Unique != expectUnique {
+			t.Errorf("For %s, expected unique=%v, but got %v", right, expectUnique, invertedExpr.Unique)
 		}
 
-		actual, err := spanExpr.ContainsKeys(keys)
+		actual, err := invertedExpr.ContainsKeys(keys)
 		assert.NoError(t, err)
 
 		// There may be some false positives, so filter those out.
-		if actual && !spanExpr.Tight {
+		if actual && !invertedExpr.Tight {
 			actual, err = EvalTSQuery(right, left)
 			assert.NoError(t, err)
 		}
@@ -152,7 +149,7 @@ func TestEncodeTSQueryInvertedIndexSpans(t *testing.T) {
 			}
 		}
 
-		return spanExpr.Tight
+		return invertedExpr.Tight
 	}
 
 	// Run pre-defined test cases from above.
@@ -202,7 +199,8 @@ func TestEncodeTSQueryInvertedIndexSpans(t *testing.T) {
 			// nothing to test here.
 			continue
 		}
-		expectedUnique := invertedExpr.(*inverted.SpanExpression).Unique
+		assert.NotNil(t, invertedExpr)
+		expectedUnique := invertedExpr.Unique
 
 		// Now check that we get the same result with the inverted index spans.
 		runTest(vector, query, res, expectedUnique)

--- a/pkg/util/tsearch/tsquery.go
+++ b/pkg/util/tsearch/tsquery.go
@@ -195,11 +195,11 @@ func (q TSQuery) String() string {
 
 // GetInvertedExpr returns the inverted expression that can be used to search
 // an index.
-func (q TSQuery) GetInvertedExpr() (expr inverted.Expression, err error) {
+func (q TSQuery) GetInvertedExpr() (expr *inverted.SpanExpression, err error) {
 	return q.root.getInvertedExpr()
 }
 
-func (n *tsNode) getInvertedExpr() (inverted.Expression, error) {
+func (n *tsNode) getInvertedExpr() (*inverted.SpanExpression, error) {
 	switch n.op {
 	case invalid:
 		// We're looking at a lexeme match.


### PR DESCRIPTION
The `inverted.Expression` interface has been removed and replaced with
the `inverted.SpanExpression` struct, which previously implemented the
interface. The interface was unused and unnecessary.

Release note: None
