### PR TITLE
tablemetadatacache: specify BulkLowPri for tmj queries

### DIFF
--- a/pkg/sql/sessiondata/internal.go
+++ b/pkg/sql/sessiondata/internal.go
@@ -101,3 +101,11 @@ var NodeUserWithLowUserPrioritySessionDataOverride = InternalExecutorOverride{
 	User:             username.MakeSQLUsernameFromPreNormalizedString(username.NodeUser),
 	QualityOfService: &sessiondatapb.UserLowQoS,
 }
+
+// NodeUserWithBulkLowPriSessionDataOverride is an InternalExecutorOverride
+// which overrides the user to the NodeUser and sets the quality of service to
+// sessiondatapb.BulkLow.
+var NodeUserWithBulkLowPriSessionDataOverride = InternalExecutorOverride{
+	User:             username.MakeSQLUsernameFromPreNormalizedString(username.NodeUser),
+	QualityOfService: &sessiondatapb.BulkLowQoS,
+}

--- a/pkg/sql/tablemetadatacache/table_metadata_batch_iterator.go
+++ b/pkg/sql/tablemetadatacache/table_metadata_batch_iterator.go
@@ -109,7 +109,7 @@ func (batchIter *tableMetadataBatchIterator) fetchNextBatch(
 			ctx,
 			"fetch-table-metadata-batch",
 			nil, /* txn */
-			sessiondata.NodeUserWithLowUserPrioritySessionDataOverride, `
+			sessiondata.NodeUserWithBulkLowPriSessionDataOverride, `
 WITH tables AS (SELECT n.id,
                        n.name,
                        n."parentID",

--- a/pkg/sql/tablemetadatacache/table_metadata_updater.go
+++ b/pkg/sql/tablemetadatacache/table_metadata_updater.go
@@ -78,7 +78,7 @@ func (u *tableMetadataUpdater) pruneCache(ctx context.Context) (removed int, err
 			ctx,
 			"prune-table-metadata",
 			nil, // txn
-			sessiondata.NodeUserWithLowUserPrioritySessionDataOverride, `
+			sessiondata.NodeUserWithBulkLowPriSessionDataOverride, `
 DELETE FROM system.table_metadata
 WHERE table_id IN (
   SELECT table_id
@@ -129,7 +129,7 @@ func (u *tableMetadataUpdater) upsertBatch(
 		ctx,
 		"batch-upsert-table-metadata",
 		nil, // txn
-		sessiondata.NodeUserWithLowUserPrioritySessionDataOverride,
+		sessiondata.NodeUserWithBulkLowPriSessionDataOverride,
 		u.upsertQuery.getQuery(),
 		u.upsertQuery.args...,
 	)


### PR DESCRIPTION
Previously we were using `UserLow` priority, which still slots for CPU and does not subject reads to elastic CPU. This commit changes the priority for all queries in the update table metadata job to `BulkLow`.

Epic: CRDB-37558
Release note: None