### PR TITLE
pkg/cli: Make 'crdb-v1' the default log format in zip upload

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1589,8 +1589,12 @@ func init() {
 		"Name of the cluster to associate with the debug zip artifacts. This can be used to identify data in the upstream observability tool.")
 	f.Var(&debugZipUploadOpts.from, "from", "oldest timestamp to include (inclusive)")
 	f.Var(&debugZipUploadOpts.to, "to", "newest timestamp to include (inclusive)")
-	f.StringVar(&debugZipUploadOpts.logFormat, "log-format", "",
+	f.StringVar(&debugZipUploadOpts.logFormat, "log-format", "crdb-v1",
 		"log format of the input files")
+	// the log-format flag is depricated. It will
+	// eventually be removed completely. keeping it hidden for now incase we ever
+	// need to specify the log format
+	f.Lookup("log-format").Hidden = true
 	f.StringVar(&debugZipUploadOpts.gcpProjectID, "gcp-project-id",
 		defaultGCPProjectID, "GCP project ID to use to send debug.zip logs to GCS")
 

--- a/pkg/cli/testdata/upload/logs
+++ b/pkg/cli/testdata/upload/logs
@@ -18,7 +18,7 @@ upload-logs
 ----
 ABC/123/dt=20240716/hour=17:
 Upload ID: 123
-debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=logs --log-format=crdb-v1
+debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=logs
 {"data":{"type":"archives","attributes":{"name":"123","query":"-*","destination":{"type":"gcs","path":"ABC/123","bucket":"debugzip-archives","integration":{"project_id":"arjun-sandbox-424904","client_email":"datadog-archive@arjun-sandbox-424904.iam.gserviceaccount.com"}}}}}
 {"timestamp":1721152304,"date":"2024-07-16T17:51:44Z","message":"failed to start query profiler worker: failed to detect cgroup memory limit: failed to read memory cgroup from cgroups file: /proc/self/cgroup: open /proc/self/cgroup: no such file or directory","tags":["cluster:ABC","env:debug","node_id:1","service:CRDB-SH","source:cockroachdb","upload_id:123"],"_id":"a1b2c3","attributes":{"goroutine":100,"file":"server/env_sampler.go","line":125,"counter":33,"tenant_id":"1","date":"2024-07-16T17:51:44Z","timestamp":1721152304,"channel":"DEV","severity":"WARNING"}}
 {"timestamp":1721152304,"date":"2024-07-16T17:51:44Z","message":"initialized store s1","tags":["cluster:ABC","env:debug","node_id:1","service:CRDB-SH","source:cockroachdb","upload_id:123"],"_id":"a1b2c3","attributes":{"goroutine":100,"file":"server/node.go","line":533,"counter":24,"tenant_id":"1","date":"2024-07-16T17:51:44Z","timestamp":1721152304,"channel":"DEV","severity":"INFO"}}
@@ -48,7 +48,7 @@ debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --clus
 
 
 # multi-node
-upload-logs
+upload-logs log-format=crdb-v1
 {
   "nodes": {
     "1": {

--- a/pkg/cli/zip_upload_test.go
+++ b/pkg/cli/zip_upload_test.go
@@ -172,16 +172,12 @@ func TestUploadZipEndToEnd(t *testing.T) {
 			case "upload-profiles":
 				includeFlag = "--include=profiles"
 			case "upload-logs":
-				var logFormat string
+				includeFlag = "--include=logs"
 				if d.HasArg("log-format") {
+					var logFormat string
 					d.ScanArgs(t, "log-format", &logFormat)
+					includeFlag = fmt.Sprintf("%s --log-format=%s", includeFlag, logFormat)
 				}
-
-				if logFormat == "" {
-					logFormat = "crdb-v1"
-				}
-
-				includeFlag = fmt.Sprintf("--include=logs --log-format=%s", logFormat)
 			}
 
 			debugDir, cleanup := setupZipDir(t, testInput)


### PR DESCRIPTION
The `--log-format` nuances are confusing. The format of logs found in the debug zip will always be `crdb-v1`. So, it’s better to just assume that the log format is `crdb-v1` instead of asking the user for it.

For now, this commit make `crdb-v1` the default format and hides the `--log-format` from the help text. That way, incase we do need to provide a specific log format for whatever reason, we still can.

Part of: CRDB-42529
Release note: None