### PR TITLE
kvserver: group fields mutated under raftMu+mu

### DIFF
--- a/pkg/kv/kvserver/allocator_impl_test.go
+++ b/pkg/kv/kvserver/allocator_impl_test.go
@@ -294,7 +294,7 @@ func TestAllocatorRebalanceTarget(t *testing.T) {
 		{NodeID: 5, StoreID: 5, ReplicaID: 5},
 	}
 	repl := &Replica{RangeID: firstRangeID}
-	repl.mu.orRaftMu.state.Stats = &enginepb.MVCCStats{}
+	repl.shMu.state.Stats = &enginepb.MVCCStats{}
 	repl.loadStats = load.NewReplicaLoad(clock, nil)
 
 	var rangeUsageInfo allocator.RangeUsageInfo

--- a/pkg/kv/kvserver/allocator_impl_test.go
+++ b/pkg/kv/kvserver/allocator_impl_test.go
@@ -294,11 +294,7 @@ func TestAllocatorRebalanceTarget(t *testing.T) {
 		{NodeID: 5, StoreID: 5, ReplicaID: 5},
 	}
 	repl := &Replica{RangeID: firstRangeID}
-
-	repl.mu.Lock()
-	repl.mu.state.Stats = &enginepb.MVCCStats{}
-	repl.mu.Unlock()
-
+	repl.mu.orRaftMu.state.Stats = &enginepb.MVCCStats{}
 	repl.loadStats = load.NewReplicaLoad(clock, nil)
 
 	var rangeUsageInfo allocator.RangeUsageInfo

--- a/pkg/kv/kvserver/flow_control_replica_integration.go
+++ b/pkg/kv/kvserver/flow_control_replica_integration.go
@@ -479,7 +479,7 @@ func (r *replicaForRACv2) MuRUnlock() {
 
 // LeaseholderMuRLocked implements replica_rac2.Replica.
 func (r *replicaForRACv2) LeaseholderMuRLocked() roachpb.ReplicaID {
-	return r.mu.state.Lease.Replica.ReplicaID
+	return r.mu.orRaftMu.state.Lease.Replica.ReplicaID
 }
 
 // IsScratchRange implements replica_rac2.Replica.

--- a/pkg/kv/kvserver/flow_control_replica_integration.go
+++ b/pkg/kv/kvserver/flow_control_replica_integration.go
@@ -479,7 +479,7 @@ func (r *replicaForRACv2) MuRUnlock() {
 
 // LeaseholderMuRLocked implements replica_rac2.Replica.
 func (r *replicaForRACv2) LeaseholderMuRLocked() roachpb.ReplicaID {
-	return r.mu.orRaftMu.state.Lease.Replica.ReplicaID
+	return r.shMu.state.Lease.Replica.ReplicaID
 }
 
 // IsScratchRange implements replica_rac2.Replica.

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -440,7 +440,7 @@ func (r *Replica) ShouldBackpressureWrites(_ context.Context) bool {
 func (r *Replica) GetRaftLogSize() (int64, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.mu.orRaftMu.raftLogSize, r.mu.orRaftMu.raftLogSizeTrusted
+	return r.shMu.raftLogSize, r.shMu.raftLogSizeTrusted
 }
 
 // GetCachedLastTerm returns the cached last term value. May return
@@ -448,7 +448,7 @@ func (r *Replica) GetRaftLogSize() (int64, bool) {
 func (r *Replica) GetCachedLastTerm() kvpb.RaftTerm {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.mu.orRaftMu.lastTermNotDurable
+	return r.shMu.lastTermNotDurable
 }
 
 // SideloadedRaftMuLocked returns r.raftMu.sideloaded. Requires a previous call

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -440,7 +440,7 @@ func (r *Replica) ShouldBackpressureWrites(_ context.Context) bool {
 func (r *Replica) GetRaftLogSize() (int64, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.mu.raftLogSize, r.mu.raftLogSizeTrusted
+	return r.mu.orRaftMu.raftLogSize, r.mu.orRaftMu.raftLogSizeTrusted
 }
 
 // GetCachedLastTerm returns the cached last term value. May return
@@ -448,7 +448,7 @@ func (r *Replica) GetRaftLogSize() (int64, bool) {
 func (r *Replica) GetCachedLastTerm() kvpb.RaftTerm {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.mu.lastTermNotDurable
+	return r.mu.orRaftMu.lastTermNotDurable
 }
 
 // SideloadedRaftMuLocked returns r.raftMu.sideloaded. Requires a previous call

--- a/pkg/kv/kvserver/merge_queue_test.go
+++ b/pkg/kv/kvserver/merge_queue_test.go
@@ -147,8 +147,8 @@ func TestMergeQueueShouldQueue(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
 			repl := &Replica{store: testCtx.store}
-			repl.mu.orRaftMu.state.Desc = &roachpb.RangeDescriptor{StartKey: tc.startKey, EndKey: tc.endKey}
-			repl.mu.orRaftMu.state.Stats = &enginepb.MVCCStats{KeyBytes: tc.bytes}
+			repl.shMu.state.Desc = &roachpb.RangeDescriptor{StartKey: tc.startKey, EndKey: tc.endKey}
+			repl.shMu.state.Stats = &enginepb.MVCCStats{KeyBytes: tc.bytes}
 			zoneConfig := zonepb.DefaultZoneConfigRef()
 			zoneConfig.RangeMinBytes = proto.Int64(tc.minBytes)
 			repl.SetSpanConfig(zoneConfig.AsSpanConfig(), roachpb.Span{Key: tc.startKey, EndKey: tc.endKey})

--- a/pkg/kv/kvserver/merge_queue_test.go
+++ b/pkg/kv/kvserver/merge_queue_test.go
@@ -147,8 +147,8 @@ func TestMergeQueueShouldQueue(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
 			repl := &Replica{store: testCtx.store}
-			repl.mu.state.Desc = &roachpb.RangeDescriptor{StartKey: tc.startKey, EndKey: tc.endKey}
-			repl.mu.state.Stats = &enginepb.MVCCStats{KeyBytes: tc.bytes}
+			repl.mu.orRaftMu.state.Desc = &roachpb.RangeDescriptor{StartKey: tc.startKey, EndKey: tc.endKey}
+			repl.mu.orRaftMu.state.Stats = &enginepb.MVCCStats{KeyBytes: tc.bytes}
 			zoneConfig := zonepb.DefaultZoneConfigRef()
 			zoneConfig.RangeMinBytes = proto.Int64(tc.minBytes)
 			repl.SetSpanConfig(zoneConfig.AsSpanConfig(), roachpb.Span{Key: tc.startKey, EndKey: tc.endKey})

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -295,8 +295,8 @@ func makeMVCCGCQueueScore(
 	canAdvanceGCThreshold bool,
 ) mvccGCQueueScore {
 	repl.mu.RLock()
-	ms := *repl.mu.state.Stats
-	hint := *repl.mu.state.GCHint
+	ms := *repl.mu.orRaftMu.state.Stats
+	hint := *repl.mu.orRaftMu.state.GCHint
 	repl.mu.RUnlock()
 
 	if repl.store.cfg.TestingKnobs.DisableLastProcessedCheck {

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -295,8 +295,8 @@ func makeMVCCGCQueueScore(
 	canAdvanceGCThreshold bool,
 ) mvccGCQueueScore {
 	repl.mu.RLock()
-	ms := *repl.mu.orRaftMu.state.Stats
-	hint := *repl.mu.orRaftMu.state.GCHint
+	ms := *repl.shMu.state.Stats
+	hint := *repl.shMu.state.GCHint
 	repl.mu.RUnlock()
 
 	if repl.store.cfg.TestingKnobs.DisableLastProcessedCheck {

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -244,7 +244,7 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 	now := timeutil.Now()
 
 	r.mu.RLock()
-	raftLogSize := r.pendingLogTruncations.computePostTruncLogSize(r.mu.orRaftMu.raftLogSize)
+	raftLogSize := r.pendingLogTruncations.computePostTruncLogSize(r.shMu.raftLogSize)
 	// A "cooperative" truncation (i.e. one that does not cut off followers from
 	// the log) takes place whenever there are more than
 	// RaftLogQueueStaleThreshold entries or the log's estimated size is above
@@ -265,7 +265,7 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 
 	const anyRecipientStore roachpb.StoreID = 0
 	_, pendingSnapshotIndex := r.getSnapshotLogTruncationConstraintsRLocked(anyRecipientStore, false /* initialOnly */)
-	lastIndex := r.mu.orRaftMu.lastIndexNotDurable
+	lastIndex := r.shMu.lastIndexNotDurable
 	// NB: raftLogSize above adjusts for pending truncations that have already
 	// been successfully replicated via raft, but logSizeTrusted does not see if
 	// those pending truncations would cause a transition from trusted =>
@@ -274,7 +274,7 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 	// soon as those pending truncations are enacted r.mu.raftLogSizeTrusted
 	// will become false and we will recompute the size -- so this cannot cause
 	// an indefinite delay in recomputation.
-	logSizeTrusted := r.mu.orRaftMu.raftLogSizeTrusted
+	logSizeTrusted := r.shMu.raftLogSizeTrusted
 	firstIndex := r.raftFirstIndexRLocked()
 	r.mu.RUnlock()
 	firstIndex = r.pendingLogTruncations.computePostTruncFirstIndex(firstIndex)
@@ -690,9 +690,9 @@ func (rlq *raftLogQueue) process(
 		n, err := ComputeRaftLogSize(ctx, r.RangeID, r.store.TODOEngine(), r.raftMu.sideloaded)
 		if err == nil {
 			r.mu.Lock()
-			r.mu.orRaftMu.raftLogSize = n
-			r.mu.orRaftMu.raftLogLastCheckSize = n
-			r.mu.orRaftMu.raftLogSizeTrusted = true
+			r.shMu.raftLogSize = n
+			r.shMu.raftLogLastCheckSize = n
+			r.shMu.raftLogSizeTrusted = true
 			r.mu.Unlock()
 		}
 		r.raftMu.Unlock()

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -244,7 +244,7 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 	now := timeutil.Now()
 
 	r.mu.RLock()
-	raftLogSize := r.pendingLogTruncations.computePostTruncLogSize(r.mu.raftLogSize)
+	raftLogSize := r.pendingLogTruncations.computePostTruncLogSize(r.mu.orRaftMu.raftLogSize)
 	// A "cooperative" truncation (i.e. one that does not cut off followers from
 	// the log) takes place whenever there are more than
 	// RaftLogQueueStaleThreshold entries or the log's estimated size is above
@@ -265,7 +265,7 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 
 	const anyRecipientStore roachpb.StoreID = 0
 	_, pendingSnapshotIndex := r.getSnapshotLogTruncationConstraintsRLocked(anyRecipientStore, false /* initialOnly */)
-	lastIndex := r.mu.lastIndexNotDurable
+	lastIndex := r.mu.orRaftMu.lastIndexNotDurable
 	// NB: raftLogSize above adjusts for pending truncations that have already
 	// been successfully replicated via raft, but logSizeTrusted does not see if
 	// those pending truncations would cause a transition from trusted =>
@@ -274,7 +274,7 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 	// soon as those pending truncations are enacted r.mu.raftLogSizeTrusted
 	// will become false and we will recompute the size -- so this cannot cause
 	// an indefinite delay in recomputation.
-	logSizeTrusted := r.mu.raftLogSizeTrusted
+	logSizeTrusted := r.mu.orRaftMu.raftLogSizeTrusted
 	firstIndex := r.raftFirstIndexRLocked()
 	r.mu.RUnlock()
 	firstIndex = r.pendingLogTruncations.computePostTruncFirstIndex(firstIndex)
@@ -690,9 +690,9 @@ func (rlq *raftLogQueue) process(
 		n, err := ComputeRaftLogSize(ctx, r.RangeID, r.store.TODOEngine(), r.raftMu.sideloaded)
 		if err == nil {
 			r.mu.Lock()
-			r.mu.raftLogSize = n
-			r.mu.raftLogLastCheckSize = n
-			r.mu.raftLogSizeTrusted = true
+			r.mu.orRaftMu.raftLogSize = n
+			r.mu.orRaftMu.raftLogLastCheckSize = n
+			r.mu.orRaftMu.raftLogSizeTrusted = true
 			r.mu.Unlock()
 		}
 		r.raftMu.Unlock()

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -329,9 +329,7 @@ func verifyLogSizeInSync(t *testing.T, r *Replica) {
 	t.Helper()
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()
-	r.mu.Lock()
 	raftLogSize := r.mu.orRaftMu.raftLogSize
-	r.mu.Unlock()
 	actualRaftLogSize, err := ComputeRaftLogSize(context.Background(), r.RangeID, r.store.TODOEngine(), r.SideloadedRaftMuLocked())
 	if err != nil {
 		t.Fatal(err)
@@ -859,8 +857,8 @@ func TestTruncateLogRecompute(t *testing.T) {
 	repl := tc.store.LookupReplica(keys.MustAddr(key))
 
 	trusted := func() bool {
-		repl.mu.Lock()
-		defer repl.mu.Unlock()
+		repl.mu.RLock()
+		defer repl.mu.RUnlock()
 		return repl.mu.orRaftMu.raftLogSizeTrusted
 	}
 

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -639,7 +639,7 @@ func TestSnapshotLogTruncationConstraints(t *testing.T) {
 		index2 = 60
 	)
 
-	r.mu.state.RaftAppliedIndex = index1
+	r.mu.orRaftMu.state.RaftAppliedIndex = index1
 	// Add first constraint.
 	_, cleanup1 := r.addSnapshotLogTruncationConstraint(ctx, id1, false /* initial */, storeID)
 	exp1 := map[uuid.UUID]snapTruncationInfo{id1: {index: index1}}
@@ -647,7 +647,7 @@ func TestSnapshotLogTruncationConstraints(t *testing.T) {
 	// Make sure it registered.
 	assert.Equal(t, r.mu.snapshotLogTruncationConstraints, exp1)
 
-	r.mu.state.RaftAppliedIndex = index2
+	r.mu.orRaftMu.state.RaftAppliedIndex = index2
 	// Add another constraint with the same id. Extremely unlikely in practice
 	// but we want to make sure it doesn't blow anything up. Collisions are
 	// handled by ignoring the colliding update.
@@ -668,7 +668,7 @@ func TestSnapshotLogTruncationConstraints(t *testing.T) {
 	// colliding update at index2 is not represented.
 	assertMin(index1, time.Time{})
 
-	r.mu.state.RaftAppliedIndex = index2
+	r.mu.orRaftMu.state.RaftAppliedIndex = index2
 	// Add another, higher, index. We're not going to notice it's around
 	// until the lower one disappears.
 	_, cleanup3 := r.addSnapshotLogTruncationConstraint(ctx, id2, false /* initial */, storeID)

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -330,7 +330,7 @@ func verifyLogSizeInSync(t *testing.T, r *Replica) {
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()
 	r.mu.Lock()
-	raftLogSize := r.mu.raftLogSize
+	raftLogSize := r.mu.orRaftMu.raftLogSize
 	r.mu.Unlock()
 	actualRaftLogSize, err := ComputeRaftLogSize(context.Background(), r.RangeID, r.store.TODOEngine(), r.SideloadedRaftMuLocked())
 	if err != nil {
@@ -861,7 +861,7 @@ func TestTruncateLogRecompute(t *testing.T) {
 	trusted := func() bool {
 		repl.mu.Lock()
 		defer repl.mu.Unlock()
-		return repl.mu.raftLogSizeTrusted
+		return repl.mu.orRaftMu.raftLogSizeTrusted
 	}
 
 	put := func() {
@@ -885,11 +885,13 @@ func TestTruncateLogRecompute(t *testing.T) {
 	// Should never trust initially, until recomputed at least once.
 	assert.False(t, trusted())
 
+	repl.raftMu.Lock()
 	repl.mu.Lock()
-	repl.mu.raftLogSizeTrusted = false
-	repl.mu.raftLogSize += 12          // garbage
-	repl.mu.raftLogLastCheckSize += 12 // garbage
+	repl.mu.orRaftMu.raftLogSizeTrusted = false
+	repl.mu.orRaftMu.raftLogSize += 12          // garbage
+	repl.mu.orRaftMu.raftLogLastCheckSize += 12 // garbage
 	repl.mu.Unlock()
+	repl.raftMu.Unlock()
 
 	// Force a raft log queue run. The result should be a nonzero Raft log of
 	// size below the threshold (though we won't check that since it could have

--- a/pkg/kv/kvserver/raft_truncator_replica.go
+++ b/pkg/kv/kvserver/raft_truncator_replica.go
@@ -41,20 +41,21 @@ func (r *raftTruncatorReplica) setTruncatedStateAndSideEffects(
 }
 
 func (r *raftTruncatorReplica) setTruncationDeltaAndTrusted(deltaBytes int64, isDeltaTrusted bool) {
+	r.raftMu.AssertHeld()
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.mu.raftLogSize += deltaBytes
-	r.mu.raftLogLastCheckSize += deltaBytes
+	r.mu.orRaftMu.raftLogSize += deltaBytes
+	r.mu.orRaftMu.raftLogLastCheckSize += deltaBytes
 	// Ensure raftLog{,LastCheck}Size is not negative since it isn't persisted
 	// between server restarts.
-	if r.mu.raftLogSize < 0 {
-		r.mu.raftLogSize = 0
+	if r.mu.orRaftMu.raftLogSize < 0 {
+		r.mu.orRaftMu.raftLogSize = 0
 	}
-	if r.mu.raftLogLastCheckSize < 0 {
-		r.mu.raftLogLastCheckSize = 0
+	if r.mu.orRaftMu.raftLogLastCheckSize < 0 {
+		r.mu.orRaftMu.raftLogLastCheckSize = 0
 	}
 	if !isDeltaTrusted {
-		r.mu.raftLogSizeTrusted = false
+		r.mu.orRaftMu.raftLogSizeTrusted = false
 	}
 }
 

--- a/pkg/kv/kvserver/raft_truncator_replica.go
+++ b/pkg/kv/kvserver/raft_truncator_replica.go
@@ -27,7 +27,7 @@ func (r *raftTruncatorReplica) getTruncatedState() kvserverpb.RaftTruncatedState
 	r.mu.Lock() // TODO(pav-kv): not needed if raftMu is held.
 	defer r.mu.Unlock()
 	// TruncatedState is guaranteed to be non-nil.
-	return *r.mu.orRaftMu.state.TruncatedState
+	return *r.shMu.state.TruncatedState
 }
 
 func (r *raftTruncatorReplica) setTruncatedStateAndSideEffects(
@@ -44,18 +44,18 @@ func (r *raftTruncatorReplica) setTruncationDeltaAndTrusted(deltaBytes int64, is
 	r.raftMu.AssertHeld()
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.mu.orRaftMu.raftLogSize += deltaBytes
-	r.mu.orRaftMu.raftLogLastCheckSize += deltaBytes
+	r.shMu.raftLogSize += deltaBytes
+	r.shMu.raftLogLastCheckSize += deltaBytes
 	// Ensure raftLog{,LastCheck}Size is not negative since it isn't persisted
 	// between server restarts.
-	if r.mu.orRaftMu.raftLogSize < 0 {
-		r.mu.orRaftMu.raftLogSize = 0
+	if r.shMu.raftLogSize < 0 {
+		r.shMu.raftLogSize = 0
 	}
-	if r.mu.orRaftMu.raftLogLastCheckSize < 0 {
-		r.mu.orRaftMu.raftLogLastCheckSize = 0
+	if r.shMu.raftLogLastCheckSize < 0 {
+		r.shMu.raftLogLastCheckSize = 0
 	}
 	if !isDeltaTrusted {
-		r.mu.orRaftMu.raftLogSizeTrusted = false
+		r.shMu.raftLogSizeTrusted = false
 	}
 }
 

--- a/pkg/kv/kvserver/raft_truncator_replica.go
+++ b/pkg/kv/kvserver/raft_truncator_replica.go
@@ -24,10 +24,10 @@ func (r *raftTruncatorReplica) getRangeID() roachpb.RangeID {
 }
 
 func (r *raftTruncatorReplica) getTruncatedState() kvserverpb.RaftTruncatedState {
-	r.mu.Lock()
+	r.mu.Lock() // TODO(pav-kv): not needed if raftMu is held.
 	defer r.mu.Unlock()
 	// TruncatedState is guaranteed to be non-nil.
-	return *r.mu.state.TruncatedState
+	return *r.mu.orRaftMu.state.TruncatedState
 }
 
 func (r *raftTruncatorReplica) setTruncatedStateAndSideEffects(

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -432,6 +432,46 @@ type Replica struct {
 	// timestamp, independent of the source.
 	sideTransportClosedTimestamp sidetransportAccess
 
+	// shMu contains "shared" fields which are mutated while both raftMu and mu are
+	// held. They can be accessed when either of the two mutexes is held.
+	//
+	// TODO(pav-kv): audit all other fields and include here.
+	shMu struct {
+		// The state of the Raft state machine.
+		state kvserverpb.ReplicaState
+		// Last index/term written to the raft log (not necessarily durable locally
+		// or committed by the group). Note that lastTermNotDurable may be 0 (and
+		// thus invalid) even when lastIndexNotDurable is known, in which case the
+		// term will have to be retrieved from the Raft log entry. Use the
+		// invalidLastTerm constant for this case.
+		lastIndexNotDurable kvpb.RaftIndex
+		lastTermNotDurable  kvpb.RaftTerm
+		// raftLogSize is the approximate size in bytes of the persisted raft
+		// log, including sideloaded entries' payloads. The value itself is not
+		// persisted and is computed lazily, paced by the raft log truncation
+		// queue which will recompute the log size when it finds it
+		// uninitialized. This recomputation mechanism isn't relevant for ranges
+		// which see regular write activity (for those the log size will deviate
+		// from zero quickly, and so it won't be recomputed but will undercount
+		// until the first truncation is carried out), but it prevents a large
+		// dormant Raft log from sitting around forever, which has caused problems
+		// in the past.
+		//
+		// Note that both raftLogSize and raftLogSizeTrusted do not include the
+		// effect of pending log truncations (see Replica.pendingLogTruncations).
+		// Hence, they are fine for metrics etc., but not for deciding whether we
+		// should create another pending truncation. For the latter, we compute
+		// the post-pending-truncation size using pendingLogTruncations.
+		raftLogSize int64
+		// If raftLogSizeTrusted is false, don't trust the above raftLogSize until
+		// it has been recomputed.
+		raftLogSizeTrusted bool
+		// raftLogLastCheckSize is the value of raftLogSize the last time the Raft
+		// log was checked for truncation or at the time of the last Raft log
+		// truncation.
+		raftLogLastCheckSize int64
+	}
+
 	mu struct {
 		// Protects all fields in the mu struct.
 		ReplicaMutex
@@ -466,44 +506,6 @@ type Replica struct {
 		// mergeTxnID contains the ID of the in-progress merge transaction, if a
 		// merge is currently in progress. Otherwise, the ID is empty.
 		mergeTxnID uuid.UUID
-
-		// orRaftMu contains fields which are mutated while both raftMu and mu are
-		// held. They can be accessed when either of the two mutexes is held.
-		orRaftMu struct {
-			// The state of the Raft state machine.
-			state kvserverpb.ReplicaState
-			// Last index/term written to the raft log (not necessarily durable locally
-			// or committed by the group). Note that lastTermNotDurable may be 0 (and
-			// thus invalid) even when lastIndexNotDurable is known, in which case the
-			// term will have to be retrieved from the Raft log entry. Use the
-			// invalidLastTerm constant for this case.
-			lastIndexNotDurable kvpb.RaftIndex
-			lastTermNotDurable  kvpb.RaftTerm
-			// raftLogSize is the approximate size in bytes of the persisted raft
-			// log, including sideloaded entries' payloads. The value itself is not
-			// persisted and is computed lazily, paced by the raft log truncation
-			// queue which will recompute the log size when it finds it
-			// uninitialized. This recomputation mechanism isn't relevant for ranges
-			// which see regular write activity (for those the log size will deviate
-			// from zero quickly, and so it won't be recomputed but will undercount
-			// until the first truncation is carried out), but it prevents a large
-			// dormant Raft log from sitting around forever, which has caused problems
-			// in the past.
-			//
-			// Note that both raftLogSize and raftLogSizeTrusted do not include the
-			// effect of pending log truncations (see Replica.pendingLogTruncations).
-			// Hence, they are fine for metrics etc., but not for deciding whether we
-			// should create another pending truncation. For the latter, we compute
-			// the post-pending-truncation size using pendingLogTruncations.
-			raftLogSize int64
-			// If raftLogSizeTrusted is false, don't trust the above raftLogSize until
-			// it has been recomputed.
-			raftLogSizeTrusted bool
-			// raftLogLastCheckSize is the value of raftLogSize the last time the Raft
-			// log was checked for truncation or at the time of the last Raft log
-			// truncation.
-			raftLogLastCheckSize int64
-		}
 		// A map of raft log index of pending snapshots to deadlines.
 		// Used to prohibit raft log truncations that would leave a gap between
 		// the snapshot and the new first index. The map entry has a zero
@@ -1019,7 +1021,7 @@ func (r *Replica) SetSpanConfig(conf roachpb.SpanConfig, sp roachpb.Span) bool {
 	oldConf := r.mu.conf
 
 	if r.IsInitialized() && !r.mu.conf.IsEmpty() && !conf.IsEmpty() {
-		total := r.mu.orRaftMu.state.Stats.Total()
+		total := r.shMu.state.Stats.Total()
 
 		// Set largestPreviousMaxRangeSizeBytes if the current range size is
 		// greater than the new limit, if the limit has decreased from what we
@@ -1135,7 +1137,7 @@ func (r *Replica) DescAndSpanConfig() (*roachpb.RangeDescriptor, *roachpb.SpanCo
 	// This method is being removed shortly. We can't pass out a pointer to the
 	// underlying replica's SpanConfig.
 	conf := r.mu.conf
-	return r.mu.orRaftMu.state.Desc, &conf
+	return r.shMu.state.Desc, &conf
 }
 
 // LoadSpanConfig loads the authoritative span config for the replica.
@@ -1153,12 +1155,12 @@ func (r *Replica) LoadSpanConfig(_ context.Context) (*roachpb.SpanConfig, error)
 func (r *Replica) Desc() *roachpb.RangeDescriptor {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.mu.orRaftMu.state.Desc
+	return r.shMu.state.Desc
 }
 
 func (r *Replica) descRLocked() *roachpb.RangeDescriptor {
 	r.mu.AssertRHeld()
-	return r.mu.orRaftMu.state.Desc
+	return r.shMu.state.Desc
 }
 
 // closedTimestampPolicyRLocked returns the closed timestamp policy of the
@@ -1169,7 +1171,7 @@ func (r *Replica) descRLocked() *roachpb.RangeDescriptor {
 // lock exists in helpers_test.go. Move here if needed.
 func (r *Replica) closedTimestampPolicyRLocked() roachpb.RangeClosedTimestampPolicy {
 	if r.mu.conf.GlobalReads {
-		if !r.mu.orRaftMu.state.Desc.ContainsKey(roachpb.RKey(keys.NodeLivenessPrefix)) {
+		if !r.shMu.state.Desc.ContainsKey(roachpb.RKey(keys.NodeLivenessPrefix)) {
 			return roachpb.LEAD_FOR_GLOBAL_READS
 		}
 		// The node liveness range ignores zone configs and always uses a
@@ -1233,14 +1235,14 @@ func (r *Replica) GetRangeID() roachpb.RangeID {
 func (r *Replica) GetGCThreshold() hlc.Timestamp {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return *r.mu.orRaftMu.state.GCThreshold
+	return *r.shMu.state.GCThreshold
 }
 
 // GetGCHint returns the GC hint.
 func (r *Replica) GetGCHint() roachpb.GCHint {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return *r.mu.orRaftMu.state.GCHint
+	return *r.shMu.state.GCHint
 }
 
 // ExcludeDataFromBackup returns whether the replica is to be excluded from a
@@ -1286,7 +1288,7 @@ func (r *Replica) entireSpanExcludedFromBackupRLocked(
 func (r *Replica) Version() roachpb.Version {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	if r.mu.orRaftMu.state.Version == nil {
+	if r.shMu.state.Version == nil {
 		// We introduced replica versions in v21.1 to service long-running
 		// migrations. For replicas that were instantiated pre-21.1, it's
 		// possible that the replica version is unset (but not for too long!).
@@ -1305,7 +1307,7 @@ func (r *Replica) Version() roachpb.Version {
 		// always have replica versions.
 		return roachpb.Version{}
 	}
-	return *r.mu.orRaftMu.state.Version
+	return *r.shMu.state.Version
 }
 
 // GetRangeInfo atomically reads the range's current range info.
@@ -1349,7 +1351,7 @@ func (r *Replica) getImpliedGCThresholdRLocked(
 	// The GC threshold is the oldest value we can return here.
 	if isAdmin || !StrictGCEnforcement.Get(&r.store.ClusterSettings().SV) ||
 		r.shouldIgnoreStrictGCEnforcementRLocked() {
-		return *r.mu.orRaftMu.state.GCThreshold
+		return *r.shMu.state.GCThreshold
 	}
 
 	// In order to make this check inexpensive, we keep a copy of the reading of
@@ -1362,7 +1364,7 @@ func (r *Replica) getImpliedGCThresholdRLocked(
 	// as they are after the GC threshold.
 	c := r.mu.cachedProtectedTS
 	if st.State != kvserverpb.LeaseState_VALID || c.readAt.Less(st.Lease.Start.ToTimestamp()) {
-		return *r.mu.orRaftMu.state.GCThreshold
+		return *r.shMu.state.GCThreshold
 	}
 
 	gcTTL := r.mu.conf.TTL()
@@ -1377,7 +1379,7 @@ func (r *Replica) getImpliedGCThresholdRLocked(
 			gcThreshold = impliedGCThreshold
 		}
 	}
-	gcThreshold.Forward(*r.mu.orRaftMu.state.GCThreshold)
+	gcThreshold.Forward(*r.shMu.state.GCThreshold)
 
 	return gcThreshold
 }
@@ -1443,7 +1445,7 @@ func (r *Replica) GetReplicaDescriptor() (roachpb.ReplicaDescriptor, error) {
 // getReplicaDescriptorRLocked is like getReplicaDescriptor, but assumes that
 // r.mu is held for either reading or writing.
 func (r *Replica) getReplicaDescriptorRLocked() (roachpb.ReplicaDescriptor, error) {
-	repDesc, ok := r.mu.orRaftMu.state.Desc.GetReplicaDescriptor(r.store.StoreID())
+	repDesc, ok := r.shMu.state.Desc.GetReplicaDescriptor(r.store.StoreID())
 	if ok {
 		return repDesc, nil
 	}
@@ -1490,7 +1492,7 @@ func (r *Replica) getLastReplicaDescriptors() (to, from roachpb.ReplicaDescripto
 func (r *Replica) GetMVCCStats() enginepb.MVCCStats {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return *r.mu.orRaftMu.state.Stats
+	return *r.shMu.state.Stats
 }
 
 // SetMVCCStatsForTesting updates the MVCC stats on the repl object only, it does
@@ -1498,7 +1500,7 @@ func (r *Replica) GetMVCCStats() enginepb.MVCCStats {
 func (r *Replica) SetMVCCStatsForTesting(stats *enginepb.MVCCStats) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	r.mu.orRaftMu.state.Stats = stats
+	r.shMu.state.Stats = stats
 }
 
 // GetMaxSplitQPS returns the Replica's maximum queries/s request rate over a
@@ -1666,11 +1668,11 @@ func (r *Replica) State(ctx context.Context) kvserverpb.RangeInfo {
 
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	ri.ReplicaState = *(protoutil.Clone(&r.mu.orRaftMu.state)).(*kvserverpb.ReplicaState)
-	ri.LastIndex = r.mu.orRaftMu.lastIndexNotDurable
+	ri.ReplicaState = *(protoutil.Clone(&r.shMu.state)).(*kvserverpb.ReplicaState)
+	ri.LastIndex = r.shMu.lastIndexNotDurable
 	ri.NumPending = uint64(r.numPendingProposalsRLocked())
-	ri.RaftLogSize = r.mu.orRaftMu.raftLogSize
-	ri.RaftLogSizeTrusted = r.mu.orRaftMu.raftLogSizeTrusted
+	ri.RaftLogSize = r.shMu.raftLogSize
+	ri.RaftLogSizeTrusted = r.shMu.raftLogSizeTrusted
 	ri.NumDropped = uint64(r.mu.droppedMessages)
 	if r.mu.proposalQuota != nil {
 		ri.ApproximateProposalQuota = int64(r.mu.proposalQuota.ApproximateQuota())
@@ -1692,7 +1694,7 @@ func (r *Replica) State(ctx context.Context) kvserverpb.RangeInfo {
 	ri.ClosedTimestampSideTransportInfo.ReplicaLAI = r.sideTransportClosedTimestamp.mu.cur.lai
 	r.sideTransportClosedTimestamp.mu.Unlock()
 	centralClosed, centralLAI := r.store.cfg.ClosedTimestampReceiver.GetClosedTimestamp(
-		ctx, r.RangeID, r.mu.orRaftMu.state.Lease.Replica.NodeID)
+		ctx, r.RangeID, r.shMu.state.Lease.Replica.NodeID)
 	ri.ClosedTimestampSideTransportInfo.CentralClosed = centralClosed
 	ri.ClosedTimestampSideTransportInfo.CentralLAI = centralLAI
 	if err := r.breaker.Signal().Err(); err != nil {
@@ -1715,7 +1717,7 @@ func (r *Replica) State(ctx context.Context) kvserverpb.RangeInfo {
 func (r *Replica) assertStateRaftMuLockedReplicaMuRLocked(
 	ctx context.Context, reader storage.Reader,
 ) {
-	diskState, err := r.mu.stateLoader.Load(ctx, reader, r.mu.orRaftMu.state.Desc)
+	diskState, err := r.mu.stateLoader.Load(ctx, reader, r.shMu.state.Desc)
 	if err != nil {
 		log.Fatalf(ctx, "%v", err)
 	}
@@ -1723,21 +1725,21 @@ func (r *Replica) assertStateRaftMuLockedReplicaMuRLocked(
 	// We don't care about this field; see comment on
 	// DeprecatedUsingAppliedStateKey for more details. This can be removed once
 	// we stop loading the replica state from snapshot protos.
-	diskState.DeprecatedUsingAppliedStateKey = r.mu.orRaftMu.state.DeprecatedUsingAppliedStateKey
-	if !diskState.Equal(r.mu.orRaftMu.state) {
+	diskState.DeprecatedUsingAppliedStateKey = r.shMu.state.DeprecatedUsingAppliedStateKey
+	if !diskState.Equal(r.shMu.state) {
 		// The roundabout way of printing here is to expose this information in sentry.io.
 		//
 		// TODO(dt): expose properly once #15892 is addressed.
 		log.Errorf(ctx, "on-disk and in-memory state diverged:\n%s",
-			pretty.Diff(diskState, r.mu.orRaftMu.state))
-		r.mu.orRaftMu.state.Desc, diskState.Desc = nil, nil
+			pretty.Diff(diskState, r.shMu.state))
+		r.shMu.state.Desc, diskState.Desc = nil, nil
 		log.Fatalf(ctx, "on-disk and in-memory state diverged: %s",
-			redact.Safe(pretty.Diff(diskState, r.mu.orRaftMu.state)))
+			redact.Safe(pretty.Diff(diskState, r.shMu.state)))
 	}
 	if r.IsInitialized() {
-		if !r.startKey.Equal(r.mu.orRaftMu.state.Desc.StartKey) {
+		if !r.startKey.Equal(r.shMu.state.Desc.StartKey) {
 			log.Fatalf(ctx, "denormalized start key %s diverged from %s",
-				r.startKey, r.mu.orRaftMu.state.Desc.StartKey)
+				r.startKey, r.shMu.state.Desc.StartKey)
 		}
 	}
 	// A replica is always contained in its descriptor. This is an invariant. When
@@ -1763,13 +1765,13 @@ func (r *Replica) assertStateRaftMuLockedReplicaMuRLocked(
 	//
 	// See:
 	// https://github.com/cockroachdb/cockroach/pull/40892
-	if !r.store.TestingKnobs().DisableEagerReplicaRemoval && r.mu.orRaftMu.state.Desc.IsInitialized() {
-		replDesc, ok := r.mu.orRaftMu.state.Desc.GetReplicaDescriptor(r.store.StoreID())
+	if !r.store.TestingKnobs().DisableEagerReplicaRemoval && r.shMu.state.Desc.IsInitialized() {
+		replDesc, ok := r.shMu.state.Desc.GetReplicaDescriptor(r.store.StoreID())
 		if !ok {
-			log.Fatalf(ctx, "%+v does not contain local store s%d", r.mu.orRaftMu.state.Desc, r.store.StoreID())
+			log.Fatalf(ctx, "%+v does not contain local store s%d", r.shMu.state.Desc, r.store.StoreID())
 		}
 		if replDesc.ReplicaID != r.replicaID {
-			log.Fatalf(ctx, "replica's replicaID %d diverges from descriptor %+v", r.replicaID, r.mu.orRaftMu.state.Desc)
+			log.Fatalf(ctx, "replica's replicaID %d diverges from descriptor %+v", r.replicaID, r.shMu.state.Desc)
 		}
 	}
 	diskReplID, err := r.mu.stateLoader.LoadRaftReplicaID(ctx, reader)
@@ -1990,13 +1992,13 @@ func (r *Replica) checkExecutionCanProceedForRangeFeed(
 // checkSpanInRangeRLocked returns an error if a request (identified by its
 // key span) can not be run on the replica.
 func (r *Replica) checkSpanInRangeRLocked(ctx context.Context, rspan roachpb.RSpan) error {
-	desc := r.mu.orRaftMu.state.Desc
+	desc := r.shMu.state.Desc
 	if desc.ContainsKeyRange(rspan.Key, rspan.EndKey) {
 		return nil
 	}
 	return kvpb.NewRangeKeyMismatchErrorWithCTPolicy(
 		ctx, rspan.Key.AsRawKey(), rspan.EndKey.AsRawKey(), desc,
-		r.mu.orRaftMu.state.Lease, r.closedTimestampPolicyRLocked())
+		r.shMu.state.Lease, r.closedTimestampPolicyRLocked())
 }
 
 // checkTSAboveGCThresholdRLocked returns an error if a request (identified by
@@ -2372,7 +2374,7 @@ func (r *Replica) maybeWatchForMergeLocked(ctx context.Context) (bool, error) {
 func (r *Replica) getReplicaDescriptorByIDRLocked(
 	replicaID roachpb.ReplicaID, fallback roachpb.ReplicaDescriptor,
 ) (roachpb.ReplicaDescriptor, error) {
-	if repDesc, ok := r.mu.orRaftMu.state.Desc.GetReplicaDescriptorByID(replicaID); ok {
+	if repDesc, ok := r.shMu.state.Desc.GetReplicaDescriptorByID(replicaID); ok {
 		return repDesc, nil
 	}
 	if fallback.ReplicaID == replicaID {
@@ -2380,7 +2382,7 @@ func (r *Replica) getReplicaDescriptorByIDRLocked(
 	}
 	return roachpb.ReplicaDescriptor{},
 		errors.Errorf("replica %d not present in %v, %v",
-			replicaID, fallback, r.mu.orRaftMu.state.Desc.Replicas())
+			replicaID, fallback, r.shMu.state.Desc.Replicas())
 }
 
 // checkIfTxnAborted checks the txn AbortSpan for the given

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1498,8 +1498,10 @@ func (r *Replica) GetMVCCStats() enginepb.MVCCStats {
 // SetMVCCStatsForTesting updates the MVCC stats on the repl object only, it does
 // not affect the on disk state and is only safe to use for testing purposes.
 func (r *Replica) SetMVCCStatsForTesting(stats *enginepb.MVCCStats) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.raftMu.Lock()
+	defer r.raftMu.Unlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.shMu.state.Stats = stats
 }
 

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -469,13 +469,42 @@ type Replica struct {
 		// The state of the Raft state machine. Updated only when raftMu and mu are
 		// both held.
 		state kvserverpb.ReplicaState
-		// Last index/term written to the raft log (not necessarily durable locally
-		// or committed by the group). Note that lastTermNotDurable may be 0 (and
-		// thus invalid) even when lastIndexNotDurable is known, in which case the
-		// term will have to be retrieved from the Raft log entry. Use the
-		// invalidLastTerm constant for this case.
-		lastIndexNotDurable kvpb.RaftIndex
-		lastTermNotDurable  kvpb.RaftTerm
+
+		// orRaftMu contains fields which are mutated while both raftMu and mu are
+		// held. They can be accessed when either of the two mutexes is held.
+		orRaftMu struct {
+			// Last index/term written to the raft log (not necessarily durable locally
+			// or committed by the group). Note that lastTermNotDurable may be 0 (and
+			// thus invalid) even when lastIndexNotDurable is known, in which case the
+			// term will have to be retrieved from the Raft log entry. Use the
+			// invalidLastTerm constant for this case.
+			lastIndexNotDurable kvpb.RaftIndex
+			lastTermNotDurable  kvpb.RaftTerm
+			// raftLogSize is the approximate size in bytes of the persisted raft
+			// log, including sideloaded entries' payloads. The value itself is not
+			// persisted and is computed lazily, paced by the raft log truncation
+			// queue which will recompute the log size when it finds it
+			// uninitialized. This recomputation mechanism isn't relevant for ranges
+			// which see regular write activity (for those the log size will deviate
+			// from zero quickly, and so it won't be recomputed but will undercount
+			// until the first truncation is carried out), but it prevents a large
+			// dormant Raft log from sitting around forever, which has caused problems
+			// in the past.
+			//
+			// Note that both raftLogSize and raftLogSizeTrusted do not include the
+			// effect of pending log truncations (see Replica.pendingLogTruncations).
+			// Hence, they are fine for metrics etc., but not for deciding whether we
+			// should create another pending truncation. For the latter, we compute
+			// the post-pending-truncation size using pendingLogTruncations.
+			raftLogSize int64
+			// If raftLogSizeTrusted is false, don't trust the above raftLogSize until
+			// it has been recomputed.
+			raftLogSizeTrusted bool
+			// raftLogLastCheckSize is the value of raftLogSize the last time the Raft
+			// log was checked for truncation or at the time of the last Raft log
+			// truncation.
+			raftLogLastCheckSize int64
+		}
 		// A map of raft log index of pending snapshots to deadlines.
 		// Used to prohibit raft log truncations that would leave a gap between
 		// the snapshot and the new first index. The map entry has a zero
@@ -489,30 +518,6 @@ type Replica struct {
 		// already finished snapshot "pending" for extended periods of time
 		// (preventing log truncation).
 		snapshotLogTruncationConstraints map[uuid.UUID]snapTruncationInfo
-		// raftLogSize is the approximate size in bytes of the persisted raft
-		// log, including sideloaded entries' payloads. The value itself is not
-		// persisted and is computed lazily, paced by the raft log truncation
-		// queue which will recompute the log size when it finds it
-		// uninitialized. This recomputation mechanism isn't relevant for ranges
-		// which see regular write activity (for those the log size will deviate
-		// from zero quickly, and so it won't be recomputed but will undercount
-		// until the first truncation is carried out), but it prevents a large
-		// dormant Raft log from sitting around forever, which has caused problems
-		// in the past.
-		//
-		// Note that both raftLogSize and raftLogSizeTrusted do not include the
-		// effect of pending log truncations (see Replica.pendingLogTruncations).
-		// Hence, they are fine for metrics etc., but not for deciding whether we
-		// should create another pending truncation. For the latter, we compute
-		// the post-pending-truncation size using pendingLogTruncations.
-		raftLogSize int64
-		// If raftLogSizeTrusted is false, don't trust the above raftLogSize until
-		// it has been recomputed.
-		raftLogSizeTrusted bool
-		// raftLogLastCheckSize is the value of raftLogSize the last time the Raft
-		// log was checked for truncation or at the time of the last Raft log
-		// truncation.
-		raftLogLastCheckSize int64
 		// pendingLeaseRequest is used to coalesce RequestLease requests.
 		pendingLeaseRequest pendingLeaseRequest
 		// minLeaseProposedTS is the minimum acceptable lease.ProposedTS; only
@@ -1664,10 +1669,10 @@ func (r *Replica) State(ctx context.Context) kvserverpb.RangeInfo {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	ri.ReplicaState = *(protoutil.Clone(&r.mu.state)).(*kvserverpb.ReplicaState)
-	ri.LastIndex = r.mu.lastIndexNotDurable
+	ri.LastIndex = r.mu.orRaftMu.lastIndexNotDurable
 	ri.NumPending = uint64(r.numPendingProposalsRLocked())
-	ri.RaftLogSize = r.mu.raftLogSize
-	ri.RaftLogSizeTrusted = r.mu.raftLogSizeTrusted
+	ri.RaftLogSize = r.mu.orRaftMu.raftLogSize
+	ri.RaftLogSizeTrusted = r.mu.orRaftMu.raftLogSizeTrusted
 	ri.NumDropped = uint64(r.mu.droppedMessages)
 	if r.mu.proposalQuota != nil {
 		ri.ApproximateProposalQuota = int64(r.mu.proposalQuota.ApproximateQuota())

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -468,7 +468,7 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 				// TODO(sumeer): this code will be deleted when there is no
 				// !looselyCoupledTruncation code path.
 				b.r.mu.Lock()
-				b.r.mu.raftLogSizeTrusted = false
+				b.r.mu.orRaftMu.raftLogSizeTrusted = false
 				b.r.mu.Unlock()
 			}
 		}

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -468,7 +468,7 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 				// TODO(sumeer): this code will be deleted when there is no
 				// !looselyCoupledTruncation code path.
 				b.r.mu.Lock()
-				b.r.mu.orRaftMu.raftLogSizeTrusted = false
+				b.r.shMu.raftLogSizeTrusted = false
 				b.r.mu.Unlock()
 			}
 		}
@@ -616,12 +616,12 @@ func (b *replicaAppBatch) ApplyToStateMachine(ctx context.Context) error {
 	// Update the replica's applied indexes, mvcc stats and closed timestamp.
 	r := b.r
 	r.mu.Lock()
-	r.mu.orRaftMu.state.RaftAppliedIndex = b.state.RaftAppliedIndex
-	r.mu.orRaftMu.state.RaftAppliedIndexTerm = b.state.RaftAppliedIndexTerm
-	r.mu.orRaftMu.state.LeaseAppliedIndex = b.state.LeaseAppliedIndex
+	r.shMu.state.RaftAppliedIndex = b.state.RaftAppliedIndex
+	r.shMu.state.RaftAppliedIndexTerm = b.state.RaftAppliedIndexTerm
+	r.shMu.state.LeaseAppliedIndex = b.state.LeaseAppliedIndex
 
 	// Sanity check that the RaftClosedTimestamp doesn't go backwards.
-	existingClosed := r.mu.orRaftMu.state.RaftClosedTimestamp
+	existingClosed := r.shMu.state.RaftClosedTimestamp
 	newClosed := b.state.RaftClosedTimestamp
 	if !newClosed.IsEmpty() && newClosed.Less(existingClosed) {
 		err := errors.AssertionFailedf(
@@ -631,9 +631,9 @@ func (b *replicaAppBatch) ApplyToStateMachine(ctx context.Context) error {
 	}
 	r.mu.closedTimestampSetter = b.closedTimestampSetter
 
-	closedTimestampUpdated := r.mu.orRaftMu.state.RaftClosedTimestamp.Forward(b.state.RaftClosedTimestamp)
-	prevStats := *r.mu.orRaftMu.state.Stats
-	*r.mu.orRaftMu.state.Stats = *b.state.Stats
+	closedTimestampUpdated := r.shMu.state.RaftClosedTimestamp.Forward(b.state.RaftClosedTimestamp)
+	prevStats := *r.shMu.state.Stats
+	*r.shMu.state.Stats = *b.state.Stats
 
 	// If the range is now less than its RangeMaxBytes, clear the history of its
 	// largest previous max bytes.

--- a/pkg/kv/kvserver/replica_application_decoder.go
+++ b/pkg/kv/kvserver/replica_application_decoder.go
@@ -75,7 +75,7 @@ func (d *replicaDecoder) decode(ctx context.Context, ents []raftpb.Entry) error 
 // with a proposal in that way are considered "local", meaning a client is
 // waiting on their result, and may be reproposed (as a new proposal) with a new
 // lease index in case they apply with an illegal lease index (see
-// tryReproposeWithNewLeaseIndex).
+// tryReproposeWithNewLeaseIndexRaftMuLocked).
 func (d *replicaDecoder) retrieveLocalProposals() (anyLocal bool) {
 	d.r.mu.Lock()
 	defer d.r.mu.Unlock()

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -106,7 +106,7 @@ func (r *Replica) prepareLocalResult(ctx context.Context, cmd *replicatedCmd) {
 		case kvserverbase.ProposalRejectionPermanent:
 		case kvserverbase.ProposalRejectionIllegalLeaseIndex:
 			// Reset the error as it's now going to be determined by the outcome of
-			// reproposing (or not); note that tryReproposeWithNewLeaseIndex will
+			// reproposing (or not); note that tryReproposeWithNewLeaseIndexRaftMuLocked will
 			// return `nil` if the entry is not eligible for reproposals.
 			//
 			// If pErr gets "reset" here as a result, we will mark the proposal as
@@ -132,7 +132,7 @@ func (r *Replica) prepareLocalResult(ctx context.Context, cmd *replicatedCmd) {
 			// Similarly, if the proposal associated with this rejected raft entry is
 			// superseded by a different (larger) MaxLeaseIndex than the one we decoded
 			// from the entry itself, the command must have already passed through
-			// tryReproposeWithNewLeaseIndex previously (this can happen if there are
+			// tryReproposeWithNewLeaseIndexRaftMuLocked previously (this can happen if there are
 			// multiple copies of the command in the logs; see
 			// TestReplicaRefreshMultiple). We must not create multiple copies with
 			// multiple lease indexes, so don't repropose it again. This ensures that at
@@ -140,7 +140,7 @@ func (r *Replica) prepareLocalResult(ctx context.Context, cmd *replicatedCmd) {
 			// succeeding in the Raft log for a given command.
 			//
 			// Taking a looking glass to the last paragraph, we see that the situation
-			// is much more subtle. As tryReproposeWithNewLeaseIndex gets to the stage
+			// is much more subtle. As tryReproposeWithNewLeaseIndexRaftMuLocked gets to the stage
 			// where it calls `(*Replica).propose` (i.e. it passed the closed
 			// timestamp checks), it *resets* `cmd.proposal.MaxLeaseIndex` to zero.
 			// This means that the proposal immediately supersedes any other copy
@@ -158,7 +158,7 @@ func (r *Replica) prepareLocalResult(ctx context.Context, cmd *replicatedCmd) {
 			// LAI will be assigned to `cmd.proposal.MaxLeaseIndex` AND the command
 			// will have re-entered the proposals map. So even if we remove the
 			// "zeroing" of the MaxLeaseIndex prior to proposing, we still have to
-			// contend with the fact that once `tryReproposeWithNewLeaseIndex` may
+			// contend with the fact that once `tryReproposeWithNewLeaseIndexRaftMuLocked` may
 			// or may not be in the map. (At least it is assigned a new LAI if and
 			// only if it is back in the map!).
 			//
@@ -171,7 +171,7 @@ func (r *Replica) prepareLocalResult(ctx context.Context, cmd *replicatedCmd) {
 				}
 			}
 			if pErr == nil { // since we might have injected an error
-				pErr = kvpb.NewError(r.tryReproposeWithNewLeaseIndex(ctx, cmd))
+				pErr = kvpb.NewError(r.tryReproposeWithNewLeaseIndexRaftMuLocked(ctx, cmd))
 				if pErr == nil {
 					// Avoid falling through below. We managed to repropose, but this
 					// proposal is still erroring out. We don't want to assign to
@@ -182,7 +182,7 @@ func (r *Replica) prepareLocalResult(ctx context.Context, cmd *replicatedCmd) {
 			}
 
 			if pErr != nil {
-				// An error from tryReproposeWithNewLeaseIndex implies that the current
+				// An error from tryReproposeWithNewLeaseIndexRaftMuLocked implies that the current
 				// entry is not superseded (i.e. we don't have a reproposal at a higher
 				// MaxLeaseIndex in the log).
 				//
@@ -399,7 +399,11 @@ func (r *Replica) makeReproposal(origP *ProposalData) (reproposal *ProposalData,
 	}
 }
 
-func (r *Replica) tryReproposeWithNewLeaseIndex(ctx context.Context, origCmd *replicatedCmd) error {
+func (r *Replica) tryReproposeWithNewLeaseIndexRaftMuLocked(
+	ctx context.Context, origCmd *replicatedCmd,
+) error {
+	r.raftMu.AssertHeld() // we're in the applications stack
+
 	newProposal, onSuccess := r.makeReproposal(origCmd.proposal)
 
 	// We need to track the request again in order to protect its timestamp until
@@ -414,8 +418,6 @@ func (r *Replica) tryReproposeWithNewLeaseIndex(ctx context.Context, origCmd *re
 		// The tracker wants us to forward the request timestamp, but we can't
 		// do that without re-evaluating, so give up. The error returned here
 		// will go to back to DistSender, so send something it can digest.
-		r.mu.RLock()
-		defer r.mu.RUnlock()
 		return kvpb.NewNotLeaseHolderError(
 			*r.mu.orRaftMu.state.Lease,
 			r.store.StoreID(),

--- a/pkg/kv/kvserver/replica_application_result_test.go
+++ b/pkg/kv/kvserver/replica_application_result_test.go
@@ -66,7 +66,7 @@ func TestProposalDataAndRaftCommandAreConsideredWhenAddingFields(t *testing.T) {
 
 	prop := makeProposalData()
 	// If you are adding a field to ProposalData or RaftCommand, please consider the
-	// desired semantics of that field in `tryReproposeWithNewLeaseIndex{,v2}`. Once
+	// desired semantics of that field in `tryReproposeWithNewLeaseIndexRaftMuLocked{,v2}`. Once
 	// this has been done, adjust the expected number of fields below, and populate
 	// the field above, to let this test pass.
 	//

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -130,7 +130,7 @@ func (sm *replicaStateMachine) NewEphemeralBatch() apply.EphemeralBatch {
 	mb := &sm.ephemeralBatch
 	mb.r = r
 	r.raftMu.AssertHeld()
-	mb.state = r.mu.orRaftMu.state
+	mb.state = r.shMu.state
 	return mb
 }
 
@@ -142,9 +142,9 @@ func (sm *replicaStateMachine) NewBatch() apply.Batch {
 	b.applyStats = &sm.applyStats
 	b.batch = r.store.TODOEngine().NewBatch()
 	r.mu.RLock()
-	b.state = r.mu.orRaftMu.state
+	b.state = r.shMu.state
 	b.state.Stats = &sm.stats
-	*b.state.Stats = *r.mu.orRaftMu.state.Stats
+	*b.state.Stats = *r.shMu.state.Stats
 	b.closedTimestampSetter = r.mu.closedTimestampSetter
 	r.mu.RUnlock()
 	b.start = timeutil.Now()

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -129,9 +129,8 @@ func (sm *replicaStateMachine) NewEphemeralBatch() apply.EphemeralBatch {
 	r := sm.r
 	mb := &sm.ephemeralBatch
 	mb.r = r
-	r.mu.RLock()
+	r.raftMu.AssertHeld()
 	mb.state = r.mu.orRaftMu.state
-	r.mu.RUnlock()
 	return mb
 }
 

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -130,7 +130,7 @@ func (sm *replicaStateMachine) NewEphemeralBatch() apply.EphemeralBatch {
 	mb := &sm.ephemeralBatch
 	mb.r = r
 	r.mu.RLock()
-	mb.state = r.mu.state
+	mb.state = r.mu.orRaftMu.state
 	r.mu.RUnlock()
 	return mb
 }
@@ -143,9 +143,9 @@ func (sm *replicaStateMachine) NewBatch() apply.Batch {
 	b.applyStats = &sm.applyStats
 	b.batch = r.store.TODOEngine().NewBatch()
 	r.mu.RLock()
-	b.state = r.mu.state
+	b.state = r.mu.orRaftMu.state
 	b.state.Stats = &sm.stats
-	*b.state.Stats = *r.mu.state.Stats
+	*b.state.Stats = *r.mu.orRaftMu.state.Stats
 	b.closedTimestampSetter = r.mu.closedTimestampSetter
 	r.mu.RUnlock()
 	b.start = timeutil.Now()

--- a/pkg/kv/kvserver/replica_application_state_machine_test.go
+++ b/pkg/kv/kvserver/replica_application_state_machine_test.go
@@ -179,10 +179,10 @@ func TestReplicaStateMachineRaftLogTruncationStronglyCoupled(t *testing.T) {
 		r.mu.Lock()
 		raftAppliedIndex := r.mu.state.RaftAppliedIndex
 		truncatedIndex := r.mu.state.TruncatedState.Index
-		raftLogSize := r.mu.raftLogSize
+		raftLogSize := r.mu.orRaftMu.raftLogSize
 		// Overwrite to be trusted, since we want to check if transitions to false
 		// or not.
-		r.mu.raftLogSizeTrusted = true
+		r.mu.orRaftMu.raftLogSizeTrusted = true
 		r.mu.Unlock()
 
 		expectedFirstIndex := truncatedIndex + 1
@@ -245,8 +245,8 @@ func TestReplicaStateMachineRaftLogTruncationStronglyCoupled(t *testing.T) {
 			if expectedSize < 0 {
 				expectedSize = 0
 			}
-			require.Equal(t, expectedSize, r.mu.raftLogSize)
-			require.Equal(t, accurate, r.mu.raftLogSizeTrusted)
+			require.Equal(t, expectedSize, r.mu.orRaftMu.raftLogSize)
+			require.Equal(t, accurate, r.mu.orRaftMu.raftLogSizeTrusted)
 			truncState, err := r.mu.stateLoader.LoadRaftTruncatedState(context.Background(), tc.engine)
 			require.NoError(t, err)
 			require.Equal(t, r.mu.state.TruncatedState.Index, truncState.Index)
@@ -292,10 +292,10 @@ func TestReplicaStateMachineRaftLogTruncationLooselyCoupled(t *testing.T) {
 			r.mu.Lock()
 			raftAppliedIndex := r.mu.state.RaftAppliedIndex
 			truncatedIndex := r.mu.state.TruncatedState.Index
-			raftLogSize := r.mu.raftLogSize
+			raftLogSize := r.mu.orRaftMu.raftLogSize
 			// Overwrite to be trusted, since we want to check if transitions to false
 			// or not.
-			r.mu.raftLogSizeTrusted = true
+			r.mu.orRaftMu.raftLogSizeTrusted = true
 			r.mu.Unlock()
 			expectedFirstIndex := truncatedIndex + 1
 			if !accurate {
@@ -347,12 +347,12 @@ func TestReplicaStateMachineRaftLogTruncationLooselyCoupled(t *testing.T) {
 			_, err = sm.ApplySideEffects(checkedCmd.Ctx(), checkedCmd)
 			require.NoError(t, err)
 			func() {
-				r.mu.Lock()
+				r.mu.Lock() // TODO(pav-kv): don't need these
 				defer r.mu.Unlock()
 				require.Equal(t, raftAppliedIndex+1, r.mu.state.RaftAppliedIndex)
 				// No truncation.
 				require.Equal(t, truncatedIndex, r.mu.state.TruncatedState.Index)
-				require.True(t, r.mu.raftLogSizeTrusted)
+				require.True(t, r.mu.orRaftMu.raftLogSizeTrusted)
 			}()
 			require.False(t, r.pendingLogTruncations.isEmptyLocked())
 			trunc := r.pendingLogTruncations.frontLocked()
@@ -378,10 +378,10 @@ func TestReplicaStateMachineRaftLogTruncationLooselyCoupled(t *testing.T) {
 			if r.mu.state.TruncatedState.Index != truncatedIndex+1 {
 				return errors.Errorf("not truncated")
 			}
-			if r.mu.raftLogSize != expectedSize {
+			if r.mu.orRaftMu.raftLogSize != expectedSize {
 				return errors.Errorf("not truncated")
 			}
-			if accurate != r.mu.raftLogSizeTrusted {
+			if accurate != r.mu.orRaftMu.raftLogSizeTrusted {
 				return errors.Errorf("not truncated")
 			}
 			r.pendingLogTruncations.mu.Lock()

--- a/pkg/kv/kvserver/replica_application_state_machine_test.go
+++ b/pkg/kv/kvserver/replica_application_state_machine_test.go
@@ -89,17 +89,17 @@ func TestReplicaStateMachineChangeReplicas(t *testing.T) {
 		// Stage a command with the ChangeReplicas trigger.
 		ent := &raftlog.Entry{
 			Entry: raftpb.Entry{
-				Index: uint64(r.mu.orRaftMu.state.RaftAppliedIndex + 1),
+				Index: uint64(r.shMu.state.RaftAppliedIndex + 1),
 				Type:  raftpb.EntryConfChange,
 			},
 			ID: raftlog.MakeCmdIDKey(),
 			Cmd: kvserverpb.RaftCommand{
-				ProposerLeaseSequence: r.mu.orRaftMu.state.Lease.Sequence,
-				MaxLeaseIndex:         r.mu.orRaftMu.state.LeaseAppliedIndex + 1,
+				ProposerLeaseSequence: r.shMu.state.Lease.Sequence,
+				MaxLeaseIndex:         r.shMu.state.LeaseAppliedIndex + 1,
 				ReplicatedEvalResult: kvserverpb.ReplicatedEvalResult{
 					State:          &kvserverpb.ReplicaState{Desc: &newDesc},
 					ChangeReplicas: &kvserverpb.ChangeReplicas{ChangeReplicasTrigger: trigger},
-					WriteTimestamp: r.mu.orRaftMu.state.GCThreshold.Add(1, 0),
+					WriteTimestamp: r.shMu.state.GCThreshold.Add(1, 0),
 				},
 			},
 			ConfChangeV1: &confChange,
@@ -177,12 +177,12 @@ func TestReplicaStateMachineRaftLogTruncationStronglyCoupled(t *testing.T) {
 		defer b.Close()
 
 		r.mu.Lock()
-		raftAppliedIndex := r.mu.orRaftMu.state.RaftAppliedIndex
-		truncatedIndex := r.mu.orRaftMu.state.TruncatedState.Index
-		raftLogSize := r.mu.orRaftMu.raftLogSize
+		raftAppliedIndex := r.shMu.state.RaftAppliedIndex
+		truncatedIndex := r.shMu.state.TruncatedState.Index
+		raftLogSize := r.shMu.raftLogSize
 		// Overwrite to be trusted, since we want to check if transitions to false
 		// or not.
-		r.mu.orRaftMu.raftLogSizeTrusted = true
+		r.shMu.raftLogSizeTrusted = true
 		r.mu.Unlock()
 
 		expectedFirstIndex := truncatedIndex + 1
@@ -198,8 +198,8 @@ func TestReplicaStateMachineRaftLogTruncationStronglyCoupled(t *testing.T) {
 			},
 			ID: raftlog.MakeCmdIDKey(),
 			Cmd: kvserverpb.RaftCommand{
-				ProposerLeaseSequence: r.mu.orRaftMu.state.Lease.Sequence,
-				MaxLeaseIndex:         r.mu.orRaftMu.state.LeaseAppliedIndex + 1,
+				ProposerLeaseSequence: r.shMu.state.Lease.Sequence,
+				MaxLeaseIndex:         r.shMu.state.LeaseAppliedIndex + 1,
 				ReplicatedEvalResult: kvserverpb.ReplicatedEvalResult{
 					State: &kvserverpb.ReplicaState{
 						TruncatedState: &kvserverpb.RaftTruncatedState{
@@ -208,7 +208,7 @@ func TestReplicaStateMachineRaftLogTruncationStronglyCoupled(t *testing.T) {
 					},
 					RaftLogDelta:           -1,
 					RaftExpectedFirstIndex: expectedFirstIndex,
-					WriteTimestamp:         r.mu.orRaftMu.state.GCThreshold.Add(1, 0),
+					WriteTimestamp:         r.shMu.state.GCThreshold.Add(1, 0),
 				},
 			},
 		}
@@ -237,19 +237,19 @@ func TestReplicaStateMachineRaftLogTruncationStronglyCoupled(t *testing.T) {
 			// log index that we pulled out of thin air above.
 			r.mu.destroyStatus.Set(errors.New("test done"), destroyReasonRemoved)
 
-			require.Equal(t, raftAppliedIndex+1, r.mu.orRaftMu.state.RaftAppliedIndex)
-			require.Equal(t, truncatedIndex+1, r.mu.orRaftMu.state.TruncatedState.Index)
+			require.Equal(t, raftAppliedIndex+1, r.shMu.state.RaftAppliedIndex)
+			require.Equal(t, truncatedIndex+1, r.shMu.state.TruncatedState.Index)
 			expectedSize := raftLogSize - 1
 			// We typically have a raftLogSize > 0 (based on inspecting some test
 			// runs), but we can't be sure.
 			if expectedSize < 0 {
 				expectedSize = 0
 			}
-			require.Equal(t, expectedSize, r.mu.orRaftMu.raftLogSize)
-			require.Equal(t, accurate, r.mu.orRaftMu.raftLogSizeTrusted)
+			require.Equal(t, expectedSize, r.shMu.raftLogSize)
+			require.Equal(t, accurate, r.shMu.raftLogSizeTrusted)
 			truncState, err := r.mu.stateLoader.LoadRaftTruncatedState(context.Background(), tc.engine)
 			require.NoError(t, err)
-			require.Equal(t, r.mu.orRaftMu.state.TruncatedState.Index, truncState.Index)
+			require.Equal(t, r.shMu.state.TruncatedState.Index, truncState.Index)
 		}()
 	})
 }
@@ -290,12 +290,12 @@ func TestReplicaStateMachineRaftLogTruncationLooselyCoupled(t *testing.T) {
 			r.raftMu.Lock()
 			defer r.raftMu.Unlock()
 			r.mu.Lock()
-			raftAppliedIndex := r.mu.orRaftMu.state.RaftAppliedIndex
-			truncatedIndex := r.mu.orRaftMu.state.TruncatedState.Index
-			raftLogSize := r.mu.orRaftMu.raftLogSize
+			raftAppliedIndex := r.shMu.state.RaftAppliedIndex
+			truncatedIndex := r.shMu.state.TruncatedState.Index
+			raftLogSize := r.shMu.raftLogSize
 			// Overwrite to be trusted, since we want to check if transitions to false
 			// or not.
-			r.mu.orRaftMu.raftLogSizeTrusted = true
+			r.shMu.raftLogSizeTrusted = true
 			r.mu.Unlock()
 			expectedFirstIndex := truncatedIndex + 1
 			if !accurate {
@@ -317,8 +317,8 @@ func TestReplicaStateMachineRaftLogTruncationLooselyCoupled(t *testing.T) {
 				},
 				ID: raftlog.MakeCmdIDKey(),
 				Cmd: kvserverpb.RaftCommand{
-					ProposerLeaseSequence: r.mu.orRaftMu.state.Lease.Sequence,
-					MaxLeaseIndex:         r.mu.orRaftMu.state.LeaseAppliedIndex + 1,
+					ProposerLeaseSequence: r.shMu.state.Lease.Sequence,
+					MaxLeaseIndex:         r.shMu.state.LeaseAppliedIndex + 1,
 					ReplicatedEvalResult: kvserverpb.ReplicatedEvalResult{
 						State: &kvserverpb.ReplicaState{
 							TruncatedState: &kvserverpb.RaftTruncatedState{
@@ -327,7 +327,7 @@ func TestReplicaStateMachineRaftLogTruncationLooselyCoupled(t *testing.T) {
 						},
 						RaftLogDelta:           -1,
 						RaftExpectedFirstIndex: expectedFirstIndex,
-						WriteTimestamp:         r.mu.orRaftMu.state.GCThreshold.Add(1, 0),
+						WriteTimestamp:         r.shMu.state.GCThreshold.Add(1, 0),
 					},
 				},
 			}
@@ -349,10 +349,10 @@ func TestReplicaStateMachineRaftLogTruncationLooselyCoupled(t *testing.T) {
 			func() {
 				r.mu.Lock() // TODO(pav-kv): don't need these
 				defer r.mu.Unlock()
-				require.Equal(t, raftAppliedIndex+1, r.mu.orRaftMu.state.RaftAppliedIndex)
+				require.Equal(t, raftAppliedIndex+1, r.shMu.state.RaftAppliedIndex)
 				// No truncation.
-				require.Equal(t, truncatedIndex, r.mu.orRaftMu.state.TruncatedState.Index)
-				require.True(t, r.mu.orRaftMu.raftLogSizeTrusted)
+				require.Equal(t, truncatedIndex, r.shMu.state.TruncatedState.Index)
+				require.True(t, r.shMu.raftLogSizeTrusted)
 			}()
 			require.False(t, r.pendingLogTruncations.isEmptyLocked())
 			trunc := r.pendingLogTruncations.frontLocked()
@@ -375,13 +375,13 @@ func TestReplicaStateMachineRaftLogTruncationLooselyCoupled(t *testing.T) {
 		testutils.SucceedsSoon(t, func() error {
 			r.mu.Lock()
 			defer r.mu.Unlock()
-			if r.mu.orRaftMu.state.TruncatedState.Index != truncatedIndex+1 {
+			if r.shMu.state.TruncatedState.Index != truncatedIndex+1 {
 				return errors.Errorf("not truncated")
 			}
-			if r.mu.orRaftMu.raftLogSize != expectedSize {
+			if r.shMu.raftLogSize != expectedSize {
 				return errors.Errorf("not truncated")
 			}
-			if accurate != r.mu.orRaftMu.raftLogSizeTrusted {
+			if accurate != r.shMu.raftLogSizeTrusted {
 				return errors.Errorf("not truncated")
 			}
 			r.pendingLogTruncations.mu.Lock()
@@ -418,7 +418,7 @@ func TestReplicaStateMachineEphemeralAppBatchRejection(t *testing.T) {
 	sm := r.getStateMachine()
 
 	r.mu.RLock()
-	raftAppliedIndex := r.mu.orRaftMu.state.RaftAppliedIndex
+	raftAppliedIndex := r.shMu.state.RaftAppliedIndex
 	r.mu.RUnlock()
 
 	descWriteRepr := func(v string) (kvpb.Request, []byte) {
@@ -448,8 +448,8 @@ func TestReplicaStateMachineEphemeralAppBatchRejection(t *testing.T) {
 			},
 			ID: raftlog.MakeCmdIDKey(),
 			Cmd: kvserverpb.RaftCommand{
-				ProposerLeaseSequence: r.mu.orRaftMu.state.Lease.Sequence,
-				MaxLeaseIndex:         r.mu.orRaftMu.state.LeaseAppliedIndex + 1,
+				ProposerLeaseSequence: r.shMu.state.Lease.Sequence,
+				MaxLeaseIndex:         r.shMu.state.LeaseAppliedIndex + 1,
 				WriteBatch:            &kvserverpb.WriteBatch{Data: repr},
 			},
 		}

--- a/pkg/kv/kvserver/replica_application_state_machine_test.go
+++ b/pkg/kv/kvserver/replica_application_state_machine_test.go
@@ -417,9 +417,9 @@ func TestReplicaStateMachineEphemeralAppBatchRejection(t *testing.T) {
 
 	sm := r.getStateMachine()
 
-	r.mu.Lock()
+	r.mu.RLock()
 	raftAppliedIndex := r.mu.orRaftMu.state.RaftAppliedIndex
-	r.mu.Unlock()
+	r.mu.RUnlock()
 
 	descWriteRepr := func(v string) (kvpb.Request, []byte) {
 		b := tc.store.TODOEngine().NewBatch()

--- a/pkg/kv/kvserver/replica_backpressure.go
+++ b/pkg/kv/kvserver/replica_backpressure.go
@@ -148,7 +148,7 @@ func (r *Replica) shouldBackpressureWrites() bool {
 	// we'll allow. Don't bother with any multipliers/byte tolerance calculations
 	// if it is.
 	rangeSizeHardCap := backpressureRangeHardCap.Get(&r.store.cfg.Settings.SV)
-	size := r.mu.orRaftMu.state.Stats.Total()
+	size := r.shMu.state.Stats.Total()
 	if size >= rangeSizeHardCap {
 		return true
 	}

--- a/pkg/kv/kvserver/replica_backpressure.go
+++ b/pkg/kv/kvserver/replica_backpressure.go
@@ -148,7 +148,7 @@ func (r *Replica) shouldBackpressureWrites() bool {
 	// we'll allow. Don't bother with any multipliers/byte tolerance calculations
 	// if it is.
 	rangeSizeHardCap := backpressureRangeHardCap.Get(&r.store.cfg.Settings.SV)
-	size := r.mu.state.Stats.Total()
+	size := r.mu.orRaftMu.state.Stats.Total()
 	if size >= rangeSizeHardCap {
 		return true
 	}

--- a/pkg/kv/kvserver/replica_closedts.go
+++ b/pkg/kv/kvserver/replica_closedts.go
@@ -49,7 +49,7 @@ func (r *Replica) BumpSideTransportClosed(
 		return res
 	}
 
-	lai := r.mu.state.LeaseAppliedIndex
+	lai := r.mu.orRaftMu.state.LeaseAppliedIndex
 	policy := r.closedTimestampPolicyRLocked()
 	target := targetByPolicy[policy]
 	st := r.leaseStatusForRequestRLocked(ctx, now, hlc.Timestamp{} /* reqTS */)

--- a/pkg/kv/kvserver/replica_closedts.go
+++ b/pkg/kv/kvserver/replica_closedts.go
@@ -49,7 +49,7 @@ func (r *Replica) BumpSideTransportClosed(
 		return res
 	}
 
-	lai := r.mu.orRaftMu.state.LeaseAppliedIndex
+	lai := r.shMu.state.LeaseAppliedIndex
 	policy := r.closedTimestampPolicyRLocked()
 	target := targetByPolicy[policy]
 	st := r.leaseStatusForRequestRLocked(ctx, now, hlc.Timestamp{} /* reqTS */)

--- a/pkg/kv/kvserver/replica_closedts_internal_test.go
+++ b/pkg/kv/kvserver/replica_closedts_internal_test.go
@@ -560,10 +560,12 @@ func TestReplicaClosedTimestamp(t *testing.T) {
 			cfg.TestingKnobs.DontCloseTimestamps = true
 			cfg.ClosedTimestampReceiver = &r
 			tc.StartWithStoreConfig(ctx, t, stopper, cfg)
+			tc.repl.raftMu.Lock()
 			tc.repl.mu.Lock()
 			defer tc.repl.mu.Unlock()
-			tc.repl.mu.state.RaftClosedTimestamp = test.raftClosed
-			tc.repl.mu.state.LeaseAppliedIndex = test.applied
+			tc.repl.mu.orRaftMu.state.RaftClosedTimestamp = test.raftClosed
+			tc.repl.mu.orRaftMu.state.LeaseAppliedIndex = test.applied
+			tc.repl.raftMu.Unlock()
 			// NB: don't release the mutex to make this test a bit more resilient to
 			// problems that could arise should something propose a command to this
 			// replica whose LeaseAppliedIndex we've mutated.
@@ -675,8 +677,10 @@ func TestQueryResolvedTimestamp(t *testing.T) {
 			// to the testing knobs in this test.
 
 			// Inject a closed timestamp.
+			tc.repl.raftMu.Lock()
 			tc.repl.mu.Lock()
-			tc.repl.mu.state.RaftClosedTimestamp = test.closedTS
+			tc.repl.mu.orRaftMu.state.RaftClosedTimestamp = test.closedTS
+			tc.repl.raftMu.Unlock()
 			tc.repl.mu.Unlock()
 
 			// Issue a QueryResolvedTimestamp request.
@@ -739,8 +743,10 @@ func TestQueryResolvedTimestampResolvesAbandonedIntents(t *testing.T) {
 
 	// Bump the clock and inject a closed timestamp.
 	tc.manualClock.AdvanceTo(ts20.GoTime())
+	tc.repl.raftMu.Lock()
 	tc.repl.mu.Lock()
-	tc.repl.mu.state.RaftClosedTimestamp = ts20
+	tc.repl.mu.orRaftMu.state.RaftClosedTimestamp = ts20
+	tc.repl.raftMu.Unlock()
 	tc.repl.mu.Unlock()
 
 	// Issue a QueryResolvedTimestamp request. Should return resolved timestamp
@@ -978,8 +984,10 @@ func TestServerSideBoundedStalenessNegotiation(t *testing.T) {
 				require.Nil(t, pErr)
 
 				// Inject a closed timestamp.
+				tc.repl.raftMu.Lock()
 				tc.repl.mu.Lock()
-				tc.repl.mu.state.RaftClosedTimestamp = closedTS
+				tc.repl.mu.orRaftMu.state.RaftClosedTimestamp = closedTS
+				tc.repl.raftMu.Unlock()
 				tc.repl.mu.Unlock()
 
 				// Construct and issue the request.
@@ -1072,8 +1080,10 @@ func TestServerSideBoundedStalenessNegotiationWithResumeSpan(t *testing.T) {
 		writeValue("h", 7)
 
 		// Inject a closed timestamp.
+		tc.repl.raftMu.Lock()
 		tc.repl.mu.Lock()
-		tc.repl.mu.state.RaftClosedTimestamp = makeTS(30)
+		tc.repl.mu.orRaftMu.state.RaftClosedTimestamp = makeTS(30)
+		tc.repl.raftMu.Unlock()
 		tc.repl.mu.Unlock()
 
 		// Return the timestamp of the earliest intent.

--- a/pkg/kv/kvserver/replica_closedts_internal_test.go
+++ b/pkg/kv/kvserver/replica_closedts_internal_test.go
@@ -563,8 +563,8 @@ func TestReplicaClosedTimestamp(t *testing.T) {
 			tc.repl.raftMu.Lock()
 			tc.repl.mu.Lock()
 			defer tc.repl.mu.Unlock()
-			tc.repl.mu.orRaftMu.state.RaftClosedTimestamp = test.raftClosed
-			tc.repl.mu.orRaftMu.state.LeaseAppliedIndex = test.applied
+			tc.repl.shMu.state.RaftClosedTimestamp = test.raftClosed
+			tc.repl.shMu.state.LeaseAppliedIndex = test.applied
 			tc.repl.raftMu.Unlock()
 			// NB: don't release the mutex to make this test a bit more resilient to
 			// problems that could arise should something propose a command to this
@@ -679,7 +679,7 @@ func TestQueryResolvedTimestamp(t *testing.T) {
 			// Inject a closed timestamp.
 			tc.repl.raftMu.Lock()
 			tc.repl.mu.Lock()
-			tc.repl.mu.orRaftMu.state.RaftClosedTimestamp = test.closedTS
+			tc.repl.shMu.state.RaftClosedTimestamp = test.closedTS
 			tc.repl.raftMu.Unlock()
 			tc.repl.mu.Unlock()
 
@@ -745,7 +745,7 @@ func TestQueryResolvedTimestampResolvesAbandonedIntents(t *testing.T) {
 	tc.manualClock.AdvanceTo(ts20.GoTime())
 	tc.repl.raftMu.Lock()
 	tc.repl.mu.Lock()
-	tc.repl.mu.orRaftMu.state.RaftClosedTimestamp = ts20
+	tc.repl.shMu.state.RaftClosedTimestamp = ts20
 	tc.repl.raftMu.Unlock()
 	tc.repl.mu.Unlock()
 
@@ -986,7 +986,7 @@ func TestServerSideBoundedStalenessNegotiation(t *testing.T) {
 				// Inject a closed timestamp.
 				tc.repl.raftMu.Lock()
 				tc.repl.mu.Lock()
-				tc.repl.mu.orRaftMu.state.RaftClosedTimestamp = closedTS
+				tc.repl.shMu.state.RaftClosedTimestamp = closedTS
 				tc.repl.raftMu.Unlock()
 				tc.repl.mu.Unlock()
 
@@ -1082,7 +1082,7 @@ func TestServerSideBoundedStalenessNegotiationWithResumeSpan(t *testing.T) {
 		// Inject a closed timestamp.
 		tc.repl.raftMu.Lock()
 		tc.repl.mu.Lock()
-		tc.repl.mu.orRaftMu.state.RaftClosedTimestamp = makeTS(30)
+		tc.repl.shMu.state.RaftClosedTimestamp = makeTS(30)
 		tc.repl.raftMu.Unlock()
 		tc.repl.mu.Unlock()
 

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -3097,7 +3097,7 @@ func (r *Replica) validateSnapshotDelegationRequest(
 	// is not too far behind the leaseholder. If the delegate is too far behind
 	// that is also needs a snapshot, then any snapshot it sends will be useless.
 	r.mu.RLock()
-	replIdx := r.mu.state.RaftAppliedIndex + 1
+	replIdx := r.mu.orRaftMu.state.RaftAppliedIndex + 1
 	status := r.raftBasicStatusRLocked()
 	r.mu.RUnlock()
 

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -3097,7 +3097,7 @@ func (r *Replica) validateSnapshotDelegationRequest(
 	// is not too far behind the leaseholder. If the delegate is too far behind
 	// that is also needs a snapshot, then any snapshot it sends will be useless.
 	r.mu.RLock()
-	replIdx := r.mu.orRaftMu.state.RaftAppliedIndex + 1
+	replIdx := r.shMu.state.RaftAppliedIndex + 1
 	status := r.raftBasicStatusRLocked()
 	r.mu.RUnlock()
 

--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -98,7 +98,7 @@ func TestStoreCheckpointSpans(t *testing.T) {
 	addReplica := func(rangeID roachpb.RangeID, start, end string) {
 		desc := makeDesc(rangeID, start, end)
 		r := &Replica{RangeID: rangeID, startKey: desc.StartKey}
-		r.mu.state.Desc = &desc
+		r.mu.orRaftMu.state.Desc = &desc
 		r.isInitialized.Store(desc.IsInitialized())
 		require.NoError(t, s.addToReplicasByRangeIDLocked(r))
 		if r.IsInitialized() {

--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -98,7 +98,7 @@ func TestStoreCheckpointSpans(t *testing.T) {
 	addReplica := func(rangeID roachpb.RangeID, start, end string) {
 		desc := makeDesc(rangeID, start, end)
 		r := &Replica{RangeID: rangeID, startKey: desc.StartKey}
-		r.mu.orRaftMu.state.Desc = &desc
+		r.shMu.state.Desc = &desc
 		r.isInitialized.Store(desc.IsInitialized())
 		require.NoError(t, s.addToReplicasByRangeIDLocked(r))
 		if r.IsInitialized() {

--- a/pkg/kv/kvserver/replica_follower_read.go
+++ b/pkg/kv/kvserver/replica_follower_read.go
@@ -148,9 +148,9 @@ func (r *Replica) canServeFollowerReadRLocked(ctx context.Context, ba *kvpb.Batc
 func (r *Replica) getCurrentClosedTimestampLocked(
 	ctx context.Context, sufficient hlc.Timestamp,
 ) hlc.Timestamp {
-	appliedLAI := r.mu.orRaftMu.state.LeaseAppliedIndex
-	leaseholder := r.mu.orRaftMu.state.Lease.Replica.NodeID
-	raftClosed := r.mu.orRaftMu.state.RaftClosedTimestamp
+	appliedLAI := r.shMu.state.LeaseAppliedIndex
+	leaseholder := r.shMu.state.Lease.Replica.NodeID
+	raftClosed := r.shMu.state.RaftClosedTimestamp
 	sideTransportClosed := r.sideTransportClosedTimestamp.get(ctx, leaseholder, appliedLAI, sufficient)
 
 	var maxClosed hlc.Timestamp

--- a/pkg/kv/kvserver/replica_follower_read.go
+++ b/pkg/kv/kvserver/replica_follower_read.go
@@ -148,9 +148,9 @@ func (r *Replica) canServeFollowerReadRLocked(ctx context.Context, ba *kvpb.Batc
 func (r *Replica) getCurrentClosedTimestampLocked(
 	ctx context.Context, sufficient hlc.Timestamp,
 ) hlc.Timestamp {
-	appliedLAI := r.mu.state.LeaseAppliedIndex
-	leaseholder := r.mu.state.Lease.Replica.NodeID
-	raftClosed := r.mu.state.RaftClosedTimestamp
+	appliedLAI := r.mu.orRaftMu.state.LeaseAppliedIndex
+	leaseholder := r.mu.orRaftMu.state.Lease.Replica.NodeID
+	raftClosed := r.mu.orRaftMu.state.RaftClosedTimestamp
 	sideTransportClosed := r.sideTransportClosedTimestamp.get(ctx, leaseholder, appliedLAI, sufficient)
 
 	var maxClosed hlc.Timestamp

--- a/pkg/kv/kvserver/replica_gossip.go
+++ b/pkg/kv/kvserver/replica_gossip.go
@@ -44,10 +44,10 @@ func (r *Replica) gossipFirstRangeLocked(ctx context.Context) {
 	}
 	if log.V(1) {
 		log.Infof(ctx, "gossiping first range from store %d, r%d: %s",
-			r.store.StoreID(), r.RangeID, r.mu.state.Desc.Replicas())
+			r.store.StoreID(), r.RangeID, r.mu.orRaftMu.state.Desc.Replicas())
 	}
 	if err := r.store.Gossip().AddInfoProto(
-		gossip.KeyFirstRangeDescriptor, r.mu.state.Desc, configGossipTTL); err != nil {
+		gossip.KeyFirstRangeDescriptor, r.mu.orRaftMu.state.Desc, configGossipTTL); err != nil {
 		log.Errorf(ctx, "failed to gossip first range metadata: %+v", err)
 	}
 }

--- a/pkg/kv/kvserver/replica_gossip.go
+++ b/pkg/kv/kvserver/replica_gossip.go
@@ -44,10 +44,10 @@ func (r *Replica) gossipFirstRangeLocked(ctx context.Context) {
 	}
 	if log.V(1) {
 		log.Infof(ctx, "gossiping first range from store %d, r%d: %s",
-			r.store.StoreID(), r.RangeID, r.mu.orRaftMu.state.Desc.Replicas())
+			r.store.StoreID(), r.RangeID, r.shMu.state.Desc.Replicas())
 	}
 	if err := r.store.Gossip().AddInfoProto(
-		gossip.KeyFirstRangeDescriptor, r.mu.orRaftMu.state.Desc, configGossipTTL); err != nil {
+		gossip.KeyFirstRangeDescriptor, r.shMu.state.Desc, configGossipTTL); err != nil {
 		log.Errorf(ctx, "failed to gossip first range metadata: %+v", err)
 	}
 }

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -183,7 +183,7 @@ func newUninitializedReplicaWithoutRaftGroup(
 	r.lastProblemRangeReplicateEnqueueTime.Store(store.Clock().PhysicalTime())
 
 	// NB: the state will be loaded when the replica gets initialized.
-	r.mu.state = uninitState
+	r.mu.orRaftMu.state = uninitState
 	r.rangeStr.store(replicaID, uninitState.Desc)
 	// Add replica log tag - the value is rangeStr.String().
 	r.AmbientContext.AddLogTag("r", &r.rangeStr)
@@ -273,7 +273,7 @@ func (r *Replica) initRaftMuLockedReplicaMuLocked(s kvstorage.LoadedReplicaState
 
 	r.setStartKeyLocked(desc.StartKey)
 
-	r.mu.state = s.ReplState
+	r.mu.orRaftMu.state = s.ReplState
 	r.mu.orRaftMu.lastIndexNotDurable = s.LastIndex
 	r.mu.orRaftMu.lastTermNotDurable = invalidLastTerm
 
@@ -296,7 +296,7 @@ func (r *Replica) initRaftMuLockedReplicaMuLocked(s kvstorage.LoadedReplicaState
 	// this problem would multiply to a number of replicas at cluster bootstrap.
 	// Instead, we make the first lease special (which is OK) and the problem
 	// disappears.
-	if r.mu.state.Lease.Sequence > 0 {
+	if r.mu.orRaftMu.state.Lease.Sequence > 0 {
 		r.mu.minLeaseProposedTS = r.Clock().NowAsClockTimestamp()
 	}
 
@@ -311,7 +311,7 @@ func (r *Replica) initRaftGroupRaftMuLockedReplicaMuLocked() error {
 		ctx,
 		(*replicaRaftStorage)(r),
 		raftpb.PeerID(r.replicaID),
-		r.mu.state.RaftAppliedIndex,
+		r.mu.orRaftMu.state.RaftAppliedIndex,
 		r.store.cfg,
 		&raftLogger{ctx: ctx},
 		(*replicaRLockedStoreLiveness)(r),
@@ -371,15 +371,15 @@ func (r *Replica) setDescLockedRaftMuLocked(ctx context.Context, desc *roachpb.R
 		log.Fatalf(ctx, "range descriptor ID (%d) does not match replica's range ID (%d)",
 			desc.RangeID, r.RangeID)
 	}
-	if r.mu.state.Desc.IsInitialized() &&
+	if r.mu.orRaftMu.state.Desc.IsInitialized() &&
 		(desc == nil || !desc.IsInitialized()) {
 		log.Fatalf(ctx, "cannot replace initialized descriptor with uninitialized one: %+v -> %+v",
-			r.mu.state.Desc, desc)
+			r.mu.orRaftMu.state.Desc, desc)
 	}
-	if r.mu.state.Desc.IsInitialized() &&
-		!r.mu.state.Desc.StartKey.Equal(desc.StartKey) {
+	if r.mu.orRaftMu.state.Desc.IsInitialized() &&
+		!r.mu.orRaftMu.state.Desc.StartKey.Equal(desc.StartKey) {
 		log.Fatalf(ctx, "attempted to change replica's start key from %s to %s",
-			r.mu.state.Desc.StartKey, desc.StartKey)
+			r.mu.orRaftMu.state.Desc.StartKey, desc.StartKey)
 	}
 
 	// NB: It might be nice to assert that the current replica exists in desc
@@ -417,7 +417,7 @@ func (r *Replica) setDescLockedRaftMuLocked(ctx context.Context, desc *roachpb.R
 
 	// Determine if a new replica was added. This is true if the new max replica
 	// ID is greater than the old max replica ID.
-	oldMaxID := maxReplicaIDOfAny(r.mu.state.Desc)
+	oldMaxID := maxReplicaIDOfAny(r.mu.orRaftMu.state.Desc)
 	newMaxID := maxReplicaIDOfAny(desc)
 	if newMaxID > oldMaxID {
 		r.mu.lastReplicaAdded = newMaxID
@@ -432,7 +432,7 @@ func (r *Replica) setDescLockedRaftMuLocked(ctx context.Context, desc *roachpb.R
 	r.isInitialized.Store(desc.IsInitialized())
 	r.connectionClass.set(rpc.ConnectionClassForKey(desc.StartKey, defRaftConnClass))
 	r.concMgr.OnRangeDescUpdated(desc)
-	r.mu.state.Desc = desc
+	r.mu.orRaftMu.state.Desc = desc
 	r.mu.replicaFlowControlIntegration.onDescChanged(ctx)
 	r.flowControlV2.OnDescChangedLocked(ctx, desc, r.mu.tenantID)
 

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -183,7 +183,7 @@ func newUninitializedReplicaWithoutRaftGroup(
 	r.lastProblemRangeReplicateEnqueueTime.Store(store.Clock().PhysicalTime())
 
 	// NB: the state will be loaded when the replica gets initialized.
-	r.mu.orRaftMu.state = uninitState
+	r.shMu.state = uninitState
 	r.rangeStr.store(replicaID, uninitState.Desc)
 	// Add replica log tag - the value is rangeStr.String().
 	r.AmbientContext.AddLogTag("r", &r.rangeStr)
@@ -273,9 +273,9 @@ func (r *Replica) initRaftMuLockedReplicaMuLocked(s kvstorage.LoadedReplicaState
 
 	r.setStartKeyLocked(desc.StartKey)
 
-	r.mu.orRaftMu.state = s.ReplState
-	r.mu.orRaftMu.lastIndexNotDurable = s.LastIndex
-	r.mu.orRaftMu.lastTermNotDurable = invalidLastTerm
+	r.shMu.state = s.ReplState
+	r.shMu.lastIndexNotDurable = s.LastIndex
+	r.shMu.lastTermNotDurable = invalidLastTerm
 
 	// Initialize the Raft group. This may replace a Raft group that was installed
 	// for the uninitialized replica to process Raft requests or snapshots.
@@ -296,7 +296,7 @@ func (r *Replica) initRaftMuLockedReplicaMuLocked(s kvstorage.LoadedReplicaState
 	// this problem would multiply to a number of replicas at cluster bootstrap.
 	// Instead, we make the first lease special (which is OK) and the problem
 	// disappears.
-	if r.mu.orRaftMu.state.Lease.Sequence > 0 {
+	if r.shMu.state.Lease.Sequence > 0 {
 		r.mu.minLeaseProposedTS = r.Clock().NowAsClockTimestamp()
 	}
 
@@ -311,7 +311,7 @@ func (r *Replica) initRaftGroupRaftMuLockedReplicaMuLocked() error {
 		ctx,
 		(*replicaRaftStorage)(r),
 		raftpb.PeerID(r.replicaID),
-		r.mu.orRaftMu.state.RaftAppliedIndex,
+		r.shMu.state.RaftAppliedIndex,
 		r.store.cfg,
 		&raftLogger{ctx: ctx},
 		(*replicaRLockedStoreLiveness)(r),
@@ -371,15 +371,15 @@ func (r *Replica) setDescLockedRaftMuLocked(ctx context.Context, desc *roachpb.R
 		log.Fatalf(ctx, "range descriptor ID (%d) does not match replica's range ID (%d)",
 			desc.RangeID, r.RangeID)
 	}
-	if r.mu.orRaftMu.state.Desc.IsInitialized() &&
+	if r.shMu.state.Desc.IsInitialized() &&
 		(desc == nil || !desc.IsInitialized()) {
 		log.Fatalf(ctx, "cannot replace initialized descriptor with uninitialized one: %+v -> %+v",
-			r.mu.orRaftMu.state.Desc, desc)
+			r.shMu.state.Desc, desc)
 	}
-	if r.mu.orRaftMu.state.Desc.IsInitialized() &&
-		!r.mu.orRaftMu.state.Desc.StartKey.Equal(desc.StartKey) {
+	if r.shMu.state.Desc.IsInitialized() &&
+		!r.shMu.state.Desc.StartKey.Equal(desc.StartKey) {
 		log.Fatalf(ctx, "attempted to change replica's start key from %s to %s",
-			r.mu.orRaftMu.state.Desc.StartKey, desc.StartKey)
+			r.shMu.state.Desc.StartKey, desc.StartKey)
 	}
 
 	// NB: It might be nice to assert that the current replica exists in desc
@@ -417,7 +417,7 @@ func (r *Replica) setDescLockedRaftMuLocked(ctx context.Context, desc *roachpb.R
 
 	// Determine if a new replica was added. This is true if the new max replica
 	// ID is greater than the old max replica ID.
-	oldMaxID := maxReplicaIDOfAny(r.mu.orRaftMu.state.Desc)
+	oldMaxID := maxReplicaIDOfAny(r.shMu.state.Desc)
 	newMaxID := maxReplicaIDOfAny(desc)
 	if newMaxID > oldMaxID {
 		r.mu.lastReplicaAdded = newMaxID
@@ -432,7 +432,7 @@ func (r *Replica) setDescLockedRaftMuLocked(ctx context.Context, desc *roachpb.R
 	r.isInitialized.Store(desc.IsInitialized())
 	r.connectionClass.set(rpc.ConnectionClassForKey(desc.StartKey, defRaftConnClass))
 	r.concMgr.OnRangeDescUpdated(desc)
-	r.mu.orRaftMu.state.Desc = desc
+	r.shMu.state.Desc = desc
 	r.mu.replicaFlowControlIntegration.onDescChanged(ctx)
 	r.flowControlV2.OnDescChangedLocked(ctx, desc, r.mu.tenantID)
 

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -274,8 +274,8 @@ func (r *Replica) initRaftMuLockedReplicaMuLocked(s kvstorage.LoadedReplicaState
 	r.setStartKeyLocked(desc.StartKey)
 
 	r.mu.state = s.ReplState
-	r.mu.lastIndexNotDurable = s.LastIndex
-	r.mu.lastTermNotDurable = invalidLastTerm
+	r.mu.orRaftMu.lastIndexNotDurable = s.LastIndex
+	r.mu.orRaftMu.lastTermNotDurable = invalidLastTerm
 
 	// Initialize the Raft group. This may replace a Raft group that was installed
 	// for the uninitialized replica to process Raft requests or snapshots.

--- a/pkg/kv/kvserver/replica_init_test.go
+++ b/pkg/kv/kvserver/replica_init_test.go
@@ -58,7 +58,7 @@ func TestReplicaUpdateLastReplicaAdded(t *testing.T) {
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
 			var r Replica
-			r.mu.state.Desc = &c.oldDesc
+			r.mu.orRaftMu.state.Desc = &c.oldDesc
 			r.mu.lastReplicaAdded = c.lastReplicaAdded
 			r.mu.replicaFlowControlIntegration = newReplicaFlowControlIntegration((*replicaFlowControl)(&r), nil, nil)
 			r.flowControlV2 = noopProcessor{}

--- a/pkg/kv/kvserver/replica_init_test.go
+++ b/pkg/kv/kvserver/replica_init_test.go
@@ -58,7 +58,7 @@ func TestReplicaUpdateLastReplicaAdded(t *testing.T) {
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
 			var r Replica
-			r.mu.orRaftMu.state.Desc = &c.oldDesc
+			r.shMu.state.Desc = &c.oldDesc
 			r.mu.lastReplicaAdded = c.lastReplicaAdded
 			r.mu.replicaFlowControlIntegration = newReplicaFlowControlIntegration((*replicaFlowControl)(&r), nil, nil)
 			r.flowControlV2 = noopProcessor{}

--- a/pkg/kv/kvserver/replica_metrics.go
+++ b/pkg/kv/kvserver/replica_metrics.go
@@ -93,7 +93,7 @@ func (r *Replica) Metrics(
 		conf:                     r.mu.conf,
 		vitalityMap:              vitalityMap,
 		clusterNodes:             clusterNodes,
-		desc:                     r.mu.state.Desc,
+		desc:                     r.mu.orRaftMu.state.Desc,
 		raftStatus:               r.raftSparseStatusRLocked(),
 		leaseStatus:              r.leaseStatusAtRLocked(ctx, now),
 		storeID:                  r.store.StoreID(),
@@ -106,7 +106,7 @@ func (r *Replica) Metrics(
 		lockTableMetrics:         lockTableMetrics,
 		raftLogSize:              r.mu.orRaftMu.raftLogSize,
 		raftLogSizeTrusted:       r.mu.orRaftMu.raftLogSizeTrusted,
-		rangeSize:                r.mu.state.Stats.Total(),
+		rangeSize:                r.mu.orRaftMu.state.Stats.Total(),
 		qpUsed:                   qpUsed,
 		qpCapacity:               qpCap,
 		paused:                   r.mu.pausedFollowers,
@@ -354,7 +354,7 @@ func (r *Replica) needsSplitBySizeRLocked() bool {
 }
 
 func (r *Replica) needsMergeBySizeRLocked() bool {
-	return r.mu.state.Stats.Total() < r.mu.conf.RangeMinBytes
+	return r.mu.orRaftMu.state.Stats.Total() < r.mu.conf.RangeMinBytes
 }
 
 func (r *Replica) needsRaftLogTruncationLocked() bool {
@@ -385,7 +385,7 @@ func (r *Replica) exceedsMultipleOfSplitSizeRLocked(mult float64) (exceeded bool
 	if r.mu.largestPreviousMaxRangeSizeBytes > maxBytes {
 		maxBytes = r.mu.largestPreviousMaxRangeSizeBytes
 	}
-	size := r.mu.state.Stats.Total()
+	size := r.mu.orRaftMu.state.Stats.Total()
 	maxSize := int64(float64(maxBytes)*mult) + 1
 	if maxBytes <= 0 || size <= maxSize {
 		return false, 0

--- a/pkg/kv/kvserver/replica_metrics.go
+++ b/pkg/kv/kvserver/replica_metrics.go
@@ -93,7 +93,7 @@ func (r *Replica) Metrics(
 		conf:                     r.mu.conf,
 		vitalityMap:              vitalityMap,
 		clusterNodes:             clusterNodes,
-		desc:                     r.mu.orRaftMu.state.Desc,
+		desc:                     r.shMu.state.Desc,
 		raftStatus:               r.raftSparseStatusRLocked(),
 		leaseStatus:              r.leaseStatusAtRLocked(ctx, now),
 		storeID:                  r.store.StoreID(),
@@ -104,9 +104,9 @@ func (r *Replica) Metrics(
 		ticking:                  ticking,
 		latchMetrics:             latchMetrics,
 		lockTableMetrics:         lockTableMetrics,
-		raftLogSize:              r.mu.orRaftMu.raftLogSize,
-		raftLogSizeTrusted:       r.mu.orRaftMu.raftLogSizeTrusted,
-		rangeSize:                r.mu.orRaftMu.state.Stats.Total(),
+		raftLogSize:              r.shMu.raftLogSize,
+		raftLogSizeTrusted:       r.shMu.raftLogSizeTrusted,
+		rangeSize:                r.shMu.state.Stats.Total(),
 		qpUsed:                   qpUsed,
 		qpCapacity:               qpCap,
 		paused:                   r.mu.pausedFollowers,
@@ -354,7 +354,7 @@ func (r *Replica) needsSplitBySizeRLocked() bool {
 }
 
 func (r *Replica) needsMergeBySizeRLocked() bool {
-	return r.mu.orRaftMu.state.Stats.Total() < r.mu.conf.RangeMinBytes
+	return r.shMu.state.Stats.Total() < r.mu.conf.RangeMinBytes
 }
 
 func (r *Replica) needsRaftLogTruncationLocked() bool {
@@ -366,10 +366,10 @@ func (r *Replica) needsRaftLogTruncationLocked() bool {
 	// of the bytes in raftLogLastCheckSize are already part of pending
 	// truncations since this comparison is looking at whether the raft log has
 	// grown sufficiently.
-	checkRaftLog := r.mu.orRaftMu.raftLogSize-r.mu.orRaftMu.raftLogLastCheckSize >= RaftLogQueueStaleSize
+	checkRaftLog := r.shMu.raftLogSize-r.shMu.raftLogLastCheckSize >= RaftLogQueueStaleSize
 	if checkRaftLog {
 		r.raftMu.AssertHeld()
-		r.mu.orRaftMu.raftLogLastCheckSize = r.mu.orRaftMu.raftLogSize
+		r.shMu.raftLogLastCheckSize = r.shMu.raftLogSize
 	}
 	return checkRaftLog
 }
@@ -385,7 +385,7 @@ func (r *Replica) exceedsMultipleOfSplitSizeRLocked(mult float64) (exceeded bool
 	if r.mu.largestPreviousMaxRangeSizeBytes > maxBytes {
 		maxBytes = r.mu.largestPreviousMaxRangeSizeBytes
 	}
-	size := r.mu.orRaftMu.state.Stats.Total()
+	size := r.shMu.state.Stats.Total()
 	maxSize := int64(float64(maxBytes)*mult) + 1
 	if maxBytes <= 0 || size <= maxSize {
 		return false, 0

--- a/pkg/kv/kvserver/replica_metrics.go
+++ b/pkg/kv/kvserver/replica_metrics.go
@@ -104,8 +104,8 @@ func (r *Replica) Metrics(
 		ticking:                  ticking,
 		latchMetrics:             latchMetrics,
 		lockTableMetrics:         lockTableMetrics,
-		raftLogSize:              r.mu.raftLogSize,
-		raftLogSizeTrusted:       r.mu.raftLogSizeTrusted,
+		raftLogSize:              r.mu.orRaftMu.raftLogSize,
+		raftLogSizeTrusted:       r.mu.orRaftMu.raftLogSizeTrusted,
 		rangeSize:                r.mu.state.Stats.Total(),
 		qpUsed:                   qpUsed,
 		qpCapacity:               qpCap,
@@ -366,9 +366,10 @@ func (r *Replica) needsRaftLogTruncationLocked() bool {
 	// of the bytes in raftLogLastCheckSize are already part of pending
 	// truncations since this comparison is looking at whether the raft log has
 	// grown sufficiently.
-	checkRaftLog := r.mu.raftLogSize-r.mu.raftLogLastCheckSize >= RaftLogQueueStaleSize
+	checkRaftLog := r.mu.orRaftMu.raftLogSize-r.mu.orRaftMu.raftLogLastCheckSize >= RaftLogQueueStaleSize
 	if checkRaftLog {
-		r.mu.raftLogLastCheckSize = r.mu.raftLogSize
+		r.raftMu.AssertHeld()
+		r.mu.orRaftMu.raftLogLastCheckSize = r.mu.orRaftMu.raftLogSize
 	}
 	return checkRaftLog
 }

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -86,7 +86,7 @@ import (
 // in an (identical) copy of the proposal being added to the log. (All but the
 // first copy that will be applied will not be associated with a proposal).
 // [5]: if the entry applies under an already-consumed LeaseAppliedIndex,
-// tryReproposeWithNewLeaseIndex creates a *new* proposal (which inherits the
+// tryReproposeWithNewLeaseIndexRaftMuLocked creates a *new* proposal (which inherits the
 // waiting caller, latches, etc) and the cycle begins again whereas the current
 // proposal results in an error (which nobody is listening to).
 //
@@ -146,7 +146,7 @@ type ProposalData struct {
 
 	// quotaAlloc is the allocation retrieved from the proposalQuota. The quota is
 	// released when the command comes up for application (even if it will be
-	// reproposed). See retrieveLocalProposals and tryReproposeWithNewLeaseIndex.
+	// reproposed). See retrieveLocalProposals and tryReproposeWithNewLeaseIndexRaftMuLocked.
 	quotaAlloc *quotapool.IntAlloc
 
 	// ec.done is called after command application to update the timestamp
@@ -159,7 +159,7 @@ type ProposalData struct {
 	ec endCmds
 
 	// applied is set when the a command finishes application. It is a remnant of
-	// an earlier version of tryReproposeWithNewLeaseIndex that has yet to be
+	// an earlier version of tryReproposeWithNewLeaseIndexRaftMuLocked that has yet to be
 	// phased out.
 	//
 	// TODO(repl): phase this field out.

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -448,14 +448,15 @@ func (r *Replica) leasePostApplyLocked(
 
 	// Inform the propBuf about the new lease so that it can initialize its closed
 	// timestamp tracking.
-	r.mu.proposalBuf.OnLeaseChangeLocked(iAmTheLeaseHolder, r.mu.state.RaftClosedTimestamp, r.mu.state.LeaseAppliedIndex)
+	r.mu.proposalBuf.OnLeaseChangeLocked(iAmTheLeaseHolder,
+		r.mu.orRaftMu.state.RaftClosedTimestamp, r.mu.orRaftMu.state.LeaseAppliedIndex)
 
 	// Ordering is critical here. We only install the new lease after we've
 	// checked for an in-progress merge and updated the timestamp cache. If the
 	// ordering were reversed, it would be possible for requests to see the new
 	// lease but not the updated merge or timestamp cache state, which can result
 	// in serializability violations.
-	r.mu.state.Lease = newLease
+	r.mu.orRaftMu.state.Lease = newLease
 
 	now := r.store.Clock().NowAsClockTimestamp()
 

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -449,14 +449,14 @@ func (r *Replica) leasePostApplyLocked(
 	// Inform the propBuf about the new lease so that it can initialize its closed
 	// timestamp tracking.
 	r.mu.proposalBuf.OnLeaseChangeLocked(iAmTheLeaseHolder,
-		r.mu.orRaftMu.state.RaftClosedTimestamp, r.mu.orRaftMu.state.LeaseAppliedIndex)
+		r.shMu.state.RaftClosedTimestamp, r.shMu.state.LeaseAppliedIndex)
 
 	// Ordering is critical here. We only install the new lease after we've
 	// checked for an in-progress merge and updated the timestamp cache. If the
 	// ordering were reversed, it would be possible for requests to see the new
 	// lease but not the updated merge or timestamp cache state, which can result
 	// in serializability violations.
-	r.mu.orRaftMu.state.Lease = newLease
+	r.shMu.state.Lease = newLease
 
 	now := r.store.Clock().NowAsClockTimestamp()
 

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -1164,7 +1164,7 @@ func (rp *replicaProposer) destroyed() destroyStatus {
 }
 
 func (rp *replicaProposer) leaseAppliedIndex() kvpb.LeaseAppliedIndex {
-	return rp.mu.state.LeaseAppliedIndex
+	return rp.mu.orRaftMu.state.LeaseAppliedIndex
 }
 
 func (rp *replicaProposer) enqueueUpdateCheck() {
@@ -1195,7 +1195,7 @@ func (rp *replicaProposer) onErrProposalDropped(
 }
 
 func (rp *replicaProposer) leaseDebugRLocked() string {
-	return rp.mu.state.Lease.String()
+	return rp.mu.orRaftMu.state.Lease.String()
 }
 
 func (rp *replicaProposer) registerProposalLocked(p *ProposalData) {

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -1164,7 +1164,7 @@ func (rp *replicaProposer) destroyed() destroyStatus {
 }
 
 func (rp *replicaProposer) leaseAppliedIndex() kvpb.LeaseAppliedIndex {
-	return rp.mu.orRaftMu.state.LeaseAppliedIndex
+	return rp.shMu.state.LeaseAppliedIndex
 }
 
 func (rp *replicaProposer) enqueueUpdateCheck() {
@@ -1195,7 +1195,7 @@ func (rp *replicaProposer) onErrProposalDropped(
 }
 
 func (rp *replicaProposer) leaseDebugRLocked() string {
-	return rp.mu.orRaftMu.state.Lease.String()
+	return rp.shMu.state.Lease.String()
 }
 
 func (rp *replicaProposer) registerProposalLocked(p *ProposalData) {

--- a/pkg/kv/kvserver/replica_proposal_quota.go
+++ b/pkg/kv/kvserver/replica_proposal_quota.go
@@ -103,7 +103,7 @@ func (r *Replica) getQuotaPoolEnabledRLocked(ctx context.Context) bool {
 	return enableRaftProposalQuota.Get(&r.store.cfg.Settings.SV) &&
 		(kvflowcontrol.Mode.Get(&r.store.cfg.Settings.SV) == kvflowcontrol.ApplyToElastic ||
 			!kvflowcontrol.Enabled.Get(&r.store.cfg.Settings.SV)) &&
-		quotaPoolEnabledForRange(r.mu.orRaftMu.state.Desc)
+		quotaPoolEnabledForRange(r.shMu.state.Desc)
 }
 
 func (r *Replica) updateProposalQuotaRaftMuLocked(
@@ -123,7 +123,7 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 	if r.mu.leaderID != lastLeaderID {
 		if r.replicaID == r.mu.leaderID {
 			r.mu.lastUpdateTimes = make(map[roachpb.ReplicaID]time.Time)
-			r.mu.lastUpdateTimes.updateOnBecomeLeader(r.mu.orRaftMu.state.Desc.Replicas().Descriptors(), now)
+			r.mu.lastUpdateTimes.updateOnBecomeLeader(r.shMu.state.Desc.Replicas().Descriptors(), now)
 			r.mu.replicaFlowControlIntegration.onBecameLeader(ctx)
 			r.mu.lastProposalAtTicks = r.mu.ticks // delay imminent quiescence
 			// We're the new leader but we only create the quota pool if it's enabled
@@ -194,7 +194,7 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 	minIndex := kvpb.RaftIndex(status.Applied)
 
 	r.mu.internalRaftGroup.WithProgress(func(id raftpb.PeerID, _ raft.ProgressType, progress tracker.Progress) {
-		rep, ok := r.mu.orRaftMu.state.Desc.GetReplicaDescriptorByID(roachpb.ReplicaID(id))
+		rep, ok := r.shMu.state.Desc.GetReplicaDescriptorByID(roachpb.ReplicaID(id))
 		if !ok {
 			return
 		}

--- a/pkg/kv/kvserver/replica_proposal_quota.go
+++ b/pkg/kv/kvserver/replica_proposal_quota.go
@@ -103,7 +103,7 @@ func (r *Replica) getQuotaPoolEnabledRLocked(ctx context.Context) bool {
 	return enableRaftProposalQuota.Get(&r.store.cfg.Settings.SV) &&
 		(kvflowcontrol.Mode.Get(&r.store.cfg.Settings.SV) == kvflowcontrol.ApplyToElastic ||
 			!kvflowcontrol.Enabled.Get(&r.store.cfg.Settings.SV)) &&
-		quotaPoolEnabledForRange(r.mu.state.Desc)
+		quotaPoolEnabledForRange(r.mu.orRaftMu.state.Desc)
 }
 
 func (r *Replica) updateProposalQuotaRaftMuLocked(
@@ -123,7 +123,7 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 	if r.mu.leaderID != lastLeaderID {
 		if r.replicaID == r.mu.leaderID {
 			r.mu.lastUpdateTimes = make(map[roachpb.ReplicaID]time.Time)
-			r.mu.lastUpdateTimes.updateOnBecomeLeader(r.mu.state.Desc.Replicas().Descriptors(), now)
+			r.mu.lastUpdateTimes.updateOnBecomeLeader(r.mu.orRaftMu.state.Desc.Replicas().Descriptors(), now)
 			r.mu.replicaFlowControlIntegration.onBecameLeader(ctx)
 			r.mu.lastProposalAtTicks = r.mu.ticks // delay imminent quiescence
 			// We're the new leader but we only create the quota pool if it's enabled
@@ -194,7 +194,7 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 	minIndex := kvpb.RaftIndex(status.Applied)
 
 	r.mu.internalRaftGroup.WithProgress(func(id raftpb.PeerID, _ raft.ProgressType, progress tracker.Progress) {
-		rep, ok := r.mu.state.Desc.GetReplicaDescriptorByID(roachpb.ReplicaID(id))
+		rep, ok := r.mu.orRaftMu.state.Desc.GetReplicaDescriptorByID(roachpb.ReplicaID(id))
 		if !ok {
 			return
 		}

--- a/pkg/kv/kvserver/replica_protected_timestamp.go
+++ b/pkg/kv/kvserver/replica_protected_timestamp.go
@@ -63,7 +63,7 @@ func (r *Replica) readProtectedTimestampsRLocked(
 	ctx context.Context,
 ) (ts cachedProtectedTimestampState, _ error) {
 	desc := r.descRLocked()
-	gcThreshold := *r.mu.orRaftMu.state.GCThreshold
+	gcThreshold := *r.shMu.state.GCThreshold
 
 	sp := roachpb.Span{
 		Key:    roachpb.Key(desc.StartKey),
@@ -121,8 +121,8 @@ func (r *Replica) checkProtectedTimestampsForGC(
 	defer r.mu.RUnlock()
 	defer read.clearIfNotNewer(r.mu.cachedProtectedTS)
 
-	oldThreshold = *r.mu.orRaftMu.state.GCThreshold
-	lease := *r.mu.orRaftMu.state.Lease
+	oldThreshold = *r.shMu.state.GCThreshold
+	lease := *r.shMu.state.Lease
 
 	// read.earliestRecord is the record with the earliest timestamp which is
 	// greater than the existing gcThreshold.

--- a/pkg/kv/kvserver/replica_protected_timestamp.go
+++ b/pkg/kv/kvserver/replica_protected_timestamp.go
@@ -63,7 +63,7 @@ func (r *Replica) readProtectedTimestampsRLocked(
 	ctx context.Context,
 ) (ts cachedProtectedTimestampState, _ error) {
 	desc := r.descRLocked()
-	gcThreshold := *r.mu.state.GCThreshold
+	gcThreshold := *r.mu.orRaftMu.state.GCThreshold
 
 	sp := roachpb.Span{
 		Key:    roachpb.Key(desc.StartKey),
@@ -121,8 +121,8 @@ func (r *Replica) checkProtectedTimestampsForGC(
 	defer r.mu.RUnlock()
 	defer read.clearIfNotNewer(r.mu.cachedProtectedTS)
 
-	oldThreshold = *r.mu.state.GCThreshold
-	lease := *r.mu.state.Lease
+	oldThreshold = *r.mu.orRaftMu.state.GCThreshold
+	lease := *r.mu.orRaftMu.state.Lease
 
 	// read.earliestRecord is the record with the earliest timestamp which is
 	// greater than the existing gcThreshold.

--- a/pkg/kv/kvserver/replica_protected_timestamp_test.go
+++ b/pkg/kv/kvserver/replica_protected_timestamp_test.go
@@ -41,7 +41,7 @@ func TestCheckProtectedTimestampsForGC(t *testing.T) {
 		{
 			name: "lease is too new",
 			test: func(t *testing.T, r *Replica, _ *manualPTSReader) {
-				r.mu.orRaftMu.state.Lease.Start = r.store.Clock().NowAsClockTimestamp()
+				r.shMu.state.Lease.Start = r.store.Clock().NowAsClockTimestamp()
 				canGC, _, gcTimestamp, _, _, err := r.checkProtectedTimestampsForGC(ctx, makeTTLDuration(10))
 				require.NoError(t, err)
 				require.False(t, canGC)
@@ -102,7 +102,7 @@ func TestCheckProtectedTimestampsForGC(t *testing.T) {
 			name: "have overlapping but have already GC'd right up to the threshold",
 			test: func(t *testing.T, r *Replica, mp *manualPTSReader) {
 				r.mu.Lock()
-				th := *r.mu.orRaftMu.state.GCThreshold
+				th := *r.shMu.state.GCThreshold
 				r.mu.Unlock()
 				mp.asOf = r.store.Clock().Now().Next()
 				mp.protections = append(mp.protections, manualPTSReaderProtection{
@@ -126,7 +126,7 @@ func TestCheckProtectedTimestampsForGC(t *testing.T) {
 			test: func(t *testing.T, r *Replica, mp *manualPTSReader) {
 				ts := r.store.Clock().Now()
 				thresh := ts.Next()
-				r.mu.orRaftMu.state.GCThreshold = &thresh
+				r.shMu.state.GCThreshold = &thresh
 				mp.asOf = thresh.Next()
 				mp.protections = append(mp.protections, manualPTSReaderProtection{
 					sp:                   roachpb.Span{Key: keys.MinKey, EndKey: keys.MaxKey},
@@ -167,8 +167,8 @@ func TestCheckProtectedTimestampsForGC(t *testing.T) {
 				})
 				r.raftMu.Lock()
 				r.mu.Lock()
-				r.mu.orRaftMu.state.GCThreshold = &tsMinus60s
-				r.mu.orRaftMu.state.Lease.Start = ts.UnsafeToClockTimestamp()
+				r.shMu.state.GCThreshold = &tsMinus60s
+				r.shMu.state.Lease.Start = ts.UnsafeToClockTimestamp()
 				r.raftMu.Unlock()
 				r.mu.Unlock()
 
@@ -226,7 +226,7 @@ func TestCheckProtectedTimestampsForGC(t *testing.T) {
 			name: "multiple timestamps present including failed",
 			test: func(t *testing.T, r *Replica, mp *manualPTSReader) {
 				mp.asOf = r.store.Clock().Now().Next()
-				thresh := r.mu.orRaftMu.state.GCThreshold
+				thresh := r.shMu.state.GCThreshold
 				ts1 := thresh.Add(-7*time.Second.Nanoseconds(), 0)
 				ts2 := thresh.Add(-4*time.Second.Nanoseconds(), 0)
 				ts3 := thresh.Add(14*time.Second.Nanoseconds(), 0)

--- a/pkg/kv/kvserver/replica_protected_timestamp_test.go
+++ b/pkg/kv/kvserver/replica_protected_timestamp_test.go
@@ -41,7 +41,7 @@ func TestCheckProtectedTimestampsForGC(t *testing.T) {
 		{
 			name: "lease is too new",
 			test: func(t *testing.T, r *Replica, _ *manualPTSReader) {
-				r.mu.state.Lease.Start = r.store.Clock().NowAsClockTimestamp()
+				r.mu.orRaftMu.state.Lease.Start = r.store.Clock().NowAsClockTimestamp()
 				canGC, _, gcTimestamp, _, _, err := r.checkProtectedTimestampsForGC(ctx, makeTTLDuration(10))
 				require.NoError(t, err)
 				require.False(t, canGC)
@@ -102,7 +102,7 @@ func TestCheckProtectedTimestampsForGC(t *testing.T) {
 			name: "have overlapping but have already GC'd right up to the threshold",
 			test: func(t *testing.T, r *Replica, mp *manualPTSReader) {
 				r.mu.Lock()
-				th := *r.mu.state.GCThreshold
+				th := *r.mu.orRaftMu.state.GCThreshold
 				r.mu.Unlock()
 				mp.asOf = r.store.Clock().Now().Next()
 				mp.protections = append(mp.protections, manualPTSReaderProtection{
@@ -126,7 +126,7 @@ func TestCheckProtectedTimestampsForGC(t *testing.T) {
 			test: func(t *testing.T, r *Replica, mp *manualPTSReader) {
 				ts := r.store.Clock().Now()
 				thresh := ts.Next()
-				r.mu.state.GCThreshold = &thresh
+				r.mu.orRaftMu.state.GCThreshold = &thresh
 				mp.asOf = thresh.Next()
 				mp.protections = append(mp.protections, manualPTSReaderProtection{
 					sp:                   roachpb.Span{Key: keys.MinKey, EndKey: keys.MaxKey},
@@ -165,9 +165,11 @@ func TestCheckProtectedTimestampsForGC(t *testing.T) {
 					sp:                   roachpb.Span{Key: keys.MinKey, EndKey: keys.MaxKey},
 					protectionTimestamps: []hlc.Timestamp{tsMinus30s},
 				})
+				r.raftMu.Lock()
 				r.mu.Lock()
-				r.mu.state.GCThreshold = &tsMinus60s
-				r.mu.state.Lease.Start = ts.UnsafeToClockTimestamp()
+				r.mu.orRaftMu.state.GCThreshold = &tsMinus60s
+				r.mu.orRaftMu.state.Lease.Start = ts.UnsafeToClockTimestamp()
+				r.raftMu.Unlock()
 				r.mu.Unlock()
 
 				canGC, readAt, gcTimestamp, oldThreshold, newThreshold, err := r.checkProtectedTimestampsForGC(ctx, makeTTLDuration(gcTTLSec))
@@ -224,7 +226,7 @@ func TestCheckProtectedTimestampsForGC(t *testing.T) {
 			name: "multiple timestamps present including failed",
 			test: func(t *testing.T, r *Replica, mp *manualPTSReader) {
 				mp.asOf = r.store.Clock().Now().Next()
-				thresh := r.mu.state.GCThreshold
+				thresh := r.mu.orRaftMu.state.GCThreshold
 				ts1 := thresh.Add(-7*time.Second.Nanoseconds(), 0)
 				ts2 := thresh.Add(-4*time.Second.Nanoseconds(), 0)
 				ts3 := thresh.Add(14*time.Second.Nanoseconds(), 0)

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1071,16 +1071,14 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 			stats.tSnapEnd = timeutil.Now()
 			stats.snap.applied = true
 
-			// r.mu.lastIndexNotDurable, r.mu.lastTermNotDurable and r.mu.raftLogSize
-			// were updated in applySnapshot, but we also want to make sure we reflect
-			// these changes in the local variables we're tracking here.
-			r.mu.RLock()
+			// lastIndexNotDurable, lastTermNotDurable and raftLogSize were updated in
+			// applySnapshot, but we also want to make sure we reflect these changes
+			// in the local variables we're tracking here.
 			state = logstore.RaftState{
 				LastIndex: r.mu.orRaftMu.lastIndexNotDurable,
 				LastTerm:  r.mu.orRaftMu.lastTermNotDurable,
 				ByteSize:  r.mu.orRaftMu.raftLogSize,
 			}
-			r.mu.RUnlock()
 
 			// We refresh pending commands after applying a snapshot because this
 			// replica may have been temporarily partitioned from the Raft group and

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -870,9 +870,9 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	var msgStorageAppend, msgStorageApply raftpb.Message
 	r.mu.Lock()
 	state := logstore.RaftState{ // used for append below
-		LastIndex: r.mu.lastIndexNotDurable,
-		LastTerm:  r.mu.lastTermNotDurable,
-		ByteSize:  r.mu.raftLogSize,
+		LastIndex: r.mu.orRaftMu.lastIndexNotDurable,
+		LastTerm:  r.mu.orRaftMu.lastTermNotDurable,
+		ByteSize:  r.mu.orRaftMu.raftLogSize,
 	}
 	leaderID := r.mu.leaderID
 	lastLeaderID := leaderID
@@ -1076,9 +1076,9 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 			// these changes in the local variables we're tracking here.
 			r.mu.RLock()
 			state = logstore.RaftState{
-				LastIndex: r.mu.lastIndexNotDurable,
-				LastTerm:  r.mu.lastTermNotDurable,
-				ByteSize:  r.mu.raftLogSize,
+				LastIndex: r.mu.orRaftMu.lastIndexNotDurable,
+				LastTerm:  r.mu.orRaftMu.lastTermNotDurable,
+				ByteSize:  r.mu.orRaftMu.raftLogSize,
 			}
 			r.mu.RUnlock()
 
@@ -1148,9 +1148,9 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	// leader ID.
 	r.mu.Lock()
 	// TODO(pavelkalinnikov): put logstore.RaftState to r.mu directly.
-	r.mu.lastIndexNotDurable = state.LastIndex
-	r.mu.lastTermNotDurable = state.LastTerm
-	r.mu.raftLogSize = state.ByteSize
+	r.mu.orRaftMu.lastIndexNotDurable = state.LastIndex
+	r.mu.orRaftMu.lastTermNotDurable = state.LastTerm
+	r.mu.orRaftMu.raftLogSize = state.ByteSize
 	var becameLeader bool
 	if r.mu.leaderID != leaderID {
 		r.mu.leaderID = leaderID

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1546,7 +1546,7 @@ func (r *Replica) refreshProposalsLocked(
 			//
 			// NB: lease proposals have MaxLeaseIndex 0, so they are cleaned
 			// up here too.
-			if p.command.MaxLeaseIndex <= r.mu.state.LeaseAppliedIndex {
+			if p.command.MaxLeaseIndex <= r.mu.orRaftMu.state.LeaseAppliedIndex {
 				r.cleanupFailedProposalLocked(p)
 				log.Eventf(p.ctx, "retry proposal %x: %s", p.idKey, reason)
 				p.finishApplication(ctx, makeProposalResultErr(
@@ -1606,8 +1606,8 @@ func (r *Replica) refreshProposalsLocked(
 
 	log.VInfof(ctx, 2,
 		"pending commands: reproposing %d (at applied index %d, lease applied index %d) %s",
-		len(reproposals), r.mu.state.RaftAppliedIndex,
-		r.mu.state.LeaseAppliedIndex, reason)
+		len(reproposals), r.mu.orRaftMu.state.RaftAppliedIndex,
+		r.mu.orRaftMu.state.LeaseAppliedIndex, reason)
 
 	// Reproposals are those commands which we weren't able to send back to the
 	// client (since we're not sure that another copy of them could apply at
@@ -2051,7 +2051,7 @@ func (r *Replica) addSnapshotLogTruncationConstraint(
 ) (kvpb.RaftIndex, func()) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	appliedIndex := r.mu.state.RaftAppliedIndex
+	appliedIndex := r.mu.orRaftMu.state.RaftAppliedIndex
 	// Cleared when OutgoingSnapshot closes.
 	if r.mu.snapshotLogTruncationConstraints == nil {
 		r.mu.snapshotLogTruncationConstraints = make(map[uuid.UUID]snapTruncationInfo)
@@ -2287,7 +2287,7 @@ func (r *Replica) maybeCampaignOnWakeLocked(ctx context.Context) {
 	// method were to be called on an uninitialized replica (which
 	// has no state and thus an empty raft config), this might cause
 	// problems.
-	if _, currentMember := r.mu.state.Desc.GetReplicaDescriptorByID(r.replicaID); !currentMember {
+	if _, currentMember := r.mu.orRaftMu.state.Desc.GetReplicaDescriptorByID(r.replicaID); !currentMember {
 		return
 	}
 

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -369,7 +369,7 @@ func (r *Replica) encodePriorityForRACv2() bool {
 // of the proposal buffer.
 //
 // Note that this method is called for "new" proposals but also by
-// `tryReproposeWithNewLeaseIndex`. This second call leaves questions on what
+// `tryReproposeWithNewLeaseIndexRaftMuLocked`. This second call leaves questions on what
 // exactly the desired semantics are - some fields (MaxLeaseIndex,
 // ClosedTimestamp) will be set and this re-entrance into `propose`
 // is hard to fully understand. (The reset of `MaxLeaseIndex`	inside this

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -88,7 +88,7 @@ func (r *Replica) maybeUnquiesceLocked(wakeLeader, mayCampaign bool) bool {
 	st := r.raftSparseStatusRLocked()
 	if st.RaftState == raft.StateLeader {
 		r.mu.lastUpdateTimes.updateOnUnquiesce(
-			r.mu.state.Desc.Replicas().Descriptors(), st.Progress, r.Clock().PhysicalTime())
+			r.mu.orRaftMu.state.Desc.Replicas().Descriptors(), st.Progress, r.Clock().PhysicalTime())
 
 	} else if st.RaftState == raft.StateFollower && st.Lead != raft.None && wakeLeader {
 		// Propose an empty command which will wake the leader.

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -88,7 +88,7 @@ func (r *Replica) maybeUnquiesceLocked(wakeLeader, mayCampaign bool) bool {
 	st := r.raftSparseStatusRLocked()
 	if st.RaftState == raft.StateLeader {
 		r.mu.lastUpdateTimes.updateOnUnquiesce(
-			r.mu.orRaftMu.state.Desc.Replicas().Descriptors(), st.Progress, r.Clock().PhysicalTime())
+			r.shMu.state.Desc.Replicas().Descriptors(), st.Progress, r.Clock().PhysicalTime())
 
 	} else if st.RaftState == raft.StateFollower && st.Lead != raft.None && wakeLeader {
 		// Propose an empty command which will wake the leader.

--- a/pkg/kv/kvserver/replica_raftlog.go
+++ b/pkg/kv/kvserver/replica_raftlog.go
@@ -108,8 +108,8 @@ func (r *replicaLogStorage) termLocked(i kvpb.RaftIndex) (kvpb.RaftTerm, error) 
 	//   r.mu.lastIndexNotDurable == i && r.mu.lastTermNotDurable == invalidLastTerm?
 	// TODO(pav-kv): we should rather always remember the last entry term, and
 	// remove invalidLastTerm special case.
-	if r.mu.lastIndexNotDurable == i && r.mu.lastTermNotDurable != invalidLastTerm {
-		return r.mu.lastTermNotDurable, nil
+	if r.mu.orRaftMu.lastIndexNotDurable == i && r.mu.orRaftMu.lastTermNotDurable != invalidLastTerm {
+		return r.mu.orRaftMu.lastTermNotDurable, nil
 	}
 	return logstore.LoadTerm(r.AnnotateCtx(context.TODO()),
 		r.mu.stateLoader.StateLoader, r.store.TODOEngine(), r.RangeID,
@@ -138,7 +138,7 @@ func (r *replicaLogStorage) LastIndex() uint64 {
 
 // raftLastIndexRLocked implements the LastIndex() call.
 func (r *Replica) raftLastIndexRLocked() kvpb.RaftIndex {
-	return r.mu.lastIndexNotDurable
+	return r.mu.orRaftMu.lastIndexNotDurable
 }
 
 // GetLastIndex returns the index of the last entry in the raft log.
@@ -244,8 +244,8 @@ func (r *replicaRaftMuLogSnap) termRaftMuLocked(i kvpb.RaftIndex) (kvpb.RaftTerm
 	r.raftMu.AssertHeld()
 	// NB: the r.mu fields accessed here are always written under both r.raftMu
 	// and r.mu, and the reads are safe under r.raftMu.
-	if r.mu.lastIndexNotDurable == i && r.mu.lastTermNotDurable != invalidLastTerm {
-		return r.mu.lastTermNotDurable, nil
+	if r.mu.orRaftMu.lastIndexNotDurable == i && r.mu.orRaftMu.lastTermNotDurable != invalidLastTerm {
+		return r.mu.orRaftMu.lastTermNotDurable, nil
 	}
 	return logstore.LoadTerm(r.AnnotateCtx(context.TODO()),
 		r.raftMu.stateLoader.StateLoader, r.store.TODOEngine(), r.RangeID,
@@ -260,7 +260,7 @@ func (r *replicaRaftMuLogSnap) LastIndex() uint64 {
 	// safe to access while holding any of these mutexes. We enforce raftMu
 	// because this is a raftMu-based snapshot.
 	r.raftMu.AssertHeld()
-	return uint64(r.mu.lastIndexNotDurable)
+	return uint64(r.mu.orRaftMu.lastIndexNotDurable)
 }
 
 // FirstIndex implements the raft.LogStorageSnapshot interface.

--- a/pkg/kv/kvserver/replica_raftlog.go
+++ b/pkg/kv/kvserver/replica_raftlog.go
@@ -158,7 +158,7 @@ func (r *replicaLogStorage) FirstIndex() uint64 {
 // raftFirstIndexRLocked implements the FirstIndex() call.
 func (r *Replica) raftFirstIndexRLocked() kvpb.RaftIndex {
 	// TruncatedState is guaranteed to be non-nil.
-	return r.mu.state.TruncatedState.Index + 1
+	return r.mu.orRaftMu.state.TruncatedState.Index + 1
 }
 
 // GetFirstIndex returns the index of the first entry in the raft log.
@@ -268,7 +268,7 @@ func (r *replicaRaftMuLogSnap) LastIndex() uint64 {
 func (r *replicaRaftMuLogSnap) FirstIndex() uint64 {
 	r.raftMu.AssertHeld()
 	// r.mu.state is mutated both under r.raftMu and r.mu, so the access is safe.
-	return uint64(r.mu.state.TruncatedState.Index + 1)
+	return uint64(r.mu.orRaftMu.state.TruncatedState.Index + 1)
 }
 
 // LogSnapshot implements the raft.LogStorageSnapshot interface.

--- a/pkg/kv/kvserver/replica_raftlog.go
+++ b/pkg/kv/kvserver/replica_raftlog.go
@@ -108,8 +108,8 @@ func (r *replicaLogStorage) termLocked(i kvpb.RaftIndex) (kvpb.RaftTerm, error) 
 	//   r.mu.lastIndexNotDurable == i && r.mu.lastTermNotDurable == invalidLastTerm?
 	// TODO(pav-kv): we should rather always remember the last entry term, and
 	// remove invalidLastTerm special case.
-	if r.mu.orRaftMu.lastIndexNotDurable == i && r.mu.orRaftMu.lastTermNotDurable != invalidLastTerm {
-		return r.mu.orRaftMu.lastTermNotDurable, nil
+	if r.shMu.lastIndexNotDurable == i && r.shMu.lastTermNotDurable != invalidLastTerm {
+		return r.shMu.lastTermNotDurable, nil
 	}
 	return logstore.LoadTerm(r.AnnotateCtx(context.TODO()),
 		r.mu.stateLoader.StateLoader, r.store.TODOEngine(), r.RangeID,
@@ -138,7 +138,7 @@ func (r *replicaLogStorage) LastIndex() uint64 {
 
 // raftLastIndexRLocked implements the LastIndex() call.
 func (r *Replica) raftLastIndexRLocked() kvpb.RaftIndex {
-	return r.mu.orRaftMu.lastIndexNotDurable
+	return r.shMu.lastIndexNotDurable
 }
 
 // GetLastIndex returns the index of the last entry in the raft log.
@@ -158,7 +158,7 @@ func (r *replicaLogStorage) FirstIndex() uint64 {
 // raftFirstIndexRLocked implements the FirstIndex() call.
 func (r *Replica) raftFirstIndexRLocked() kvpb.RaftIndex {
 	// TruncatedState is guaranteed to be non-nil.
-	return r.mu.orRaftMu.state.TruncatedState.Index + 1
+	return r.shMu.state.TruncatedState.Index + 1
 }
 
 // GetFirstIndex returns the index of the first entry in the raft log.
@@ -244,8 +244,8 @@ func (r *replicaRaftMuLogSnap) termRaftMuLocked(i kvpb.RaftIndex) (kvpb.RaftTerm
 	r.raftMu.AssertHeld()
 	// NB: the r.mu fields accessed here are always written under both r.raftMu
 	// and r.mu, and the reads are safe under r.raftMu.
-	if r.mu.orRaftMu.lastIndexNotDurable == i && r.mu.orRaftMu.lastTermNotDurable != invalidLastTerm {
-		return r.mu.orRaftMu.lastTermNotDurable, nil
+	if r.shMu.lastIndexNotDurable == i && r.shMu.lastTermNotDurable != invalidLastTerm {
+		return r.shMu.lastTermNotDurable, nil
 	}
 	return logstore.LoadTerm(r.AnnotateCtx(context.TODO()),
 		r.raftMu.stateLoader.StateLoader, r.store.TODOEngine(), r.RangeID,
@@ -260,7 +260,7 @@ func (r *replicaRaftMuLogSnap) LastIndex() uint64 {
 	// safe to access while holding any of these mutexes. We enforce raftMu
 	// because this is a raftMu-based snapshot.
 	r.raftMu.AssertHeld()
-	return uint64(r.mu.orRaftMu.lastIndexNotDurable)
+	return uint64(r.shMu.lastIndexNotDurable)
 }
 
 // FirstIndex implements the raft.LogStorageSnapshot interface.
@@ -268,7 +268,7 @@ func (r *replicaRaftMuLogSnap) LastIndex() uint64 {
 func (r *replicaRaftMuLogSnap) FirstIndex() uint64 {
 	r.raftMu.AssertHeld()
 	// r.mu.state is mutated both under r.raftMu and r.mu, so the access is safe.
-	return uint64(r.mu.orRaftMu.state.TruncatedState.Index + 1)
+	return uint64(r.shMu.state.TruncatedState.Index + 1)
 }
 
 // LogSnapshot implements the raft.LogStorageSnapshot interface.

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -714,14 +714,14 @@ func (r *Replica) applySnapshot(
 	// performance implications are not likely to be drastic. If our
 	// feelings about this ever change, we can add a LastIndex field to
 	// raftpb.SnapshotMetadata.
-	r.mu.lastIndexNotDurable = state.RaftAppliedIndex
+	r.mu.orRaftMu.lastIndexNotDurable = state.RaftAppliedIndex
 
 	// TODO(sumeer): We should be able to set this to
 	// nonemptySnap.Metadata.Term. See
 	// https://github.com/cockroachdb/cockroach/pull/75675#pullrequestreview-867926687
 	// for a discussion regarding this.
-	r.mu.lastTermNotDurable = invalidLastTerm
-	r.mu.raftLogSize = 0
+	r.mu.orRaftMu.lastTermNotDurable = invalidLastTerm
+	r.mu.orRaftMu.raftLogSize = 0
 	// Update the store stats for the data in the snapshot.
 	r.store.metrics.subtractMVCCStats(ctx, r.tenantMetricsRef, *r.mu.state.Stats)
 	r.store.metrics.addMVCCStats(ctx, r.tenantMetricsRef, *state.Stats)
@@ -733,7 +733,7 @@ func (r *Replica) applySnapshot(
 	r.mu.state = state
 	// Snapshots typically have fewer log entries than the leaseholder. The next
 	// time we hold the lease, recompute the log size before making decisions.
-	r.mu.raftLogSizeTrusted = false
+	r.mu.orRaftMu.raftLogSizeTrusted = false
 
 	// Invoke the leasePostApply method to ensure we properly initialize the
 	// replica according to whether it holds the lease. We allow jumps in the

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -139,7 +139,7 @@ func (r *replicaRaftStorage) InitialState() (raftpb.HardState, raftpb.ConfState,
 		return raftpb.HardState{}, raftpb.ConfState{}, nil
 	}
 	// NB: r.mu.state is guarded by both r.raftMu and r.mu.
-	cs := r.mu.orRaftMu.state.Desc.Replicas().ConfState()
+	cs := r.shMu.state.Desc.Replicas().ConfState()
 	return hs, cs, nil
 }
 
@@ -147,7 +147,7 @@ func (r *replicaRaftStorage) InitialState() (raftpb.HardState, raftpb.ConfState,
 func (r *Replica) GetLeaseAppliedIndex() kvpb.LeaseAppliedIndex {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.mu.orRaftMu.state.LeaseAppliedIndex
+	return r.shMu.state.LeaseAppliedIndex
 }
 
 // Snapshot implements the raft.Storage interface.
@@ -170,8 +170,8 @@ func (r *replicaRaftStorage) Snapshot() (raftpb.Snapshot, error) {
 	r.mu.AssertHeld()
 	return raftpb.Snapshot{
 		Metadata: raftpb.SnapshotMetadata{
-			Index: uint64(r.mu.orRaftMu.state.RaftAppliedIndex),
-			Term:  uint64(r.mu.orRaftMu.state.RaftAppliedIndexTerm),
+			Index: uint64(r.shMu.state.RaftAppliedIndex),
+			Term:  uint64(r.shMu.state.RaftAppliedIndexTerm),
 		},
 	}, nil
 }
@@ -201,12 +201,12 @@ func (r *Replica) GetSnapshot(
 	// the corresponding Raft command not applied yet).
 	var snap storage.Reader
 	r.raftMu.Lock()
-	startKey := r.mu.orRaftMu.state.Desc.StartKey
+	startKey := r.shMu.state.Desc.StartKey
 	if r.store.cfg.SharedStorageEnabled || storage.ShouldUseEFOS(&r.ClusterSettings().SV) {
 		var ss *spanset.SpanSet
-		spans := rditer.MakeAllKeySpans(r.mu.orRaftMu.state.Desc) // needs unreplicated to access Raft state
+		spans := rditer.MakeAllKeySpans(r.shMu.state.Desc) // needs unreplicated to access Raft state
 		if util.RaceEnabled {
-			ss = rditer.MakeAllKeySpanSet(r.mu.orRaftMu.state.Desc)
+			ss = rditer.MakeAllKeySpanSet(r.shMu.state.Desc)
 			defer ss.Release()
 		}
 		efos := r.store.TODOEngine().NewEventuallyFileOnlySnapshot(spans)
@@ -705,26 +705,26 @@ func (r *Replica) applySnapshot(
 	// performance implications are not likely to be drastic. If our
 	// feelings about this ever change, we can add a LastIndex field to
 	// raftpb.SnapshotMetadata.
-	r.mu.orRaftMu.lastIndexNotDurable = state.RaftAppliedIndex
+	r.shMu.lastIndexNotDurable = state.RaftAppliedIndex
 
 	// TODO(sumeer): We should be able to set this to
 	// nonemptySnap.Metadata.Term. See
 	// https://github.com/cockroachdb/cockroach/pull/75675#pullrequestreview-867926687
 	// for a discussion regarding this.
-	r.mu.orRaftMu.lastTermNotDurable = invalidLastTerm
-	r.mu.orRaftMu.raftLogSize = 0
+	r.shMu.lastTermNotDurable = invalidLastTerm
+	r.shMu.raftLogSize = 0
 	// Update the store stats for the data in the snapshot.
-	r.store.metrics.subtractMVCCStats(ctx, r.tenantMetricsRef, *r.mu.orRaftMu.state.Stats)
+	r.store.metrics.subtractMVCCStats(ctx, r.tenantMetricsRef, *r.shMu.state.Stats)
 	r.store.metrics.addMVCCStats(ctx, r.tenantMetricsRef, *state.Stats)
-	lastKnownLease := r.mu.orRaftMu.state.Lease
+	lastKnownLease := r.shMu.state.Lease
 	// Update the rest of the Raft state. Changes to r.mu.state.Desc must be
 	// managed by r.setDescRaftMuLocked and changes to r.mu.state.Lease must be handled
 	// by r.leasePostApply, but we called those above, so now it's safe to
 	// wholesale replace r.mu.state.
-	r.mu.orRaftMu.state = state
+	r.shMu.state = state
 	// Snapshots typically have fewer log entries than the leaseholder. The next
 	// time we hold the lease, recompute the log size before making decisions.
-	r.mu.orRaftMu.raftLogSizeTrusted = false
+	r.shMu.raftLogSizeTrusted = false
 
 	// Invoke the leasePostApply method to ensure we properly initialize the
 	// replica according to whether it holds the lease. We allow jumps in the
@@ -745,7 +745,7 @@ func (r *Replica) applySnapshot(
 
 	if fn := r.store.cfg.TestingKnobs.AfterSnapshotApplication; fn != nil {
 		desc, _ := r.getReplicaDescriptorRLocked()
-		fn(desc, r.mu.orRaftMu.state, inSnap)
+		fn(desc, r.shMu.state, inSnap)
 	}
 
 	r.mu.Unlock()

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -252,7 +252,7 @@ func (p *pendingLeaseRequest) RequestPending() (roachpb.Lease, bool) {
 func (p *pendingLeaseRequest) AcquisitionInProgress() bool {
 	if nextLease, ok := p.RequestPending(); ok {
 		// Is the lease being acquired? (as opposed to extended or transferred)
-		prevLocal := p.repl.ReplicaID() == p.repl.mu.state.Lease.Replica.ReplicaID
+		prevLocal := p.repl.ReplicaID() == p.repl.mu.orRaftMu.state.Lease.Replica.ReplicaID
 		nextLocal := p.repl.ReplicaID() == nextLease.Replica.ReplicaID
 		return !prevLocal && nextLocal
 	}
@@ -416,7 +416,7 @@ func (p *pendingLeaseRequest) InitOrJoinRequest(
 			// back to indicate that we have no idea who the range lease holder might
 			// be; we've withdrawn from active duty.
 			llHandle.resolve(kvpb.NewError(
-				kvpb.NewNotLeaseHolderError(roachpb.Lease{}, p.repl.store.StoreID(), p.repl.mu.state.Desc,
+				kvpb.NewNotLeaseHolderError(roachpb.Lease{}, p.repl.store.StoreID(), p.repl.mu.orRaftMu.state.Desc,
 					"lease acquisition task couldn't be started; node is shutting down")))
 		}
 		return llHandle
@@ -733,7 +733,7 @@ func (r *Replica) leaseStatusForRequestRLocked(
 		MinProposedTs:      r.mu.minLeaseProposedTS,
 		MinValidObservedTs: r.mu.minValidObservedTimestamp,
 		RequestTs:          reqTS,
-		Lease:              *r.mu.state.Lease,
+		Lease:              *r.mu.orRaftMu.state.Lease,
 	}
 	// TODO(nvanbenschoten): evaluate whether this is too expensive to compute for
 	// every lease status request. We may need to cache this result. If, at that
@@ -797,7 +797,7 @@ func (r *Replica) GetRangeLeaseDuration() time.Duration {
 // callers: when expiration leases don't quiesce and are always eagerly renewed.
 func (r *Replica) requiresExpirationLeaseRLocked() bool {
 	return r.store.cfg.NodeLiveness == nil ||
-		r.mu.state.Desc.StartKey.Less(roachpb.RKey(keys.NodeLivenessKeyMax))
+		r.mu.orRaftMu.state.Desc.StartKey.Less(roachpb.RKey(keys.NodeLivenessKeyMax))
 }
 
 // shouldUseExpirationLeaseRLocked returns true if this range should be using an
@@ -866,7 +866,7 @@ func (r *Replica) requestLeaseLocked(
 		return r.mu.pendingLeaseRequest.newResolvedHandle(kvpb.NewError(err))
 	}
 	return r.mu.pendingLeaseRequest.InitOrJoinRequest(
-		ctx, repDesc, status, r.mu.state.Desc.StartKey.AsRawKey(),
+		ctx, repDesc, status, r.mu.orRaftMu.state.Desc.StartKey.AsRawKey(),
 		false /* bypassSafetyChecks */, limiter)
 }
 
@@ -914,7 +914,7 @@ func (r *Replica) AdminTransferLease(
 			// The target is already the lease holder. Nothing to do.
 			return nil, nil, nil
 		}
-		desc := r.mu.state.Desc
+		desc := r.mu.orRaftMu.state.Desc
 		if !status.Lease.OwnedBy(r.store.StoreID()) {
 			return nil, nil, kvpb.NewNotLeaseHolderError(status.Lease, r.store.StoreID(), desc,
 				"can't transfer the lease because this store doesn't own it")
@@ -1019,9 +1019,9 @@ func (r *Replica) GetLease() (roachpb.Lease, roachpb.Lease) {
 
 func (r *Replica) getLeaseRLocked() (roachpb.Lease, roachpb.Lease) {
 	if nextLease, ok := r.mu.pendingLeaseRequest.RequestPending(); ok {
-		return *r.mu.state.Lease, nextLease
+		return *r.mu.orRaftMu.state.Lease, nextLease
 	}
-	return *r.mu.state.Lease, roachpb.Lease{}
+	return *r.mu.orRaftMu.state.Lease, roachpb.Lease{}
 }
 
 // RevokeLease stops the replica from using its current lease, if that lease
@@ -1030,7 +1030,7 @@ func (r *Replica) getLeaseRLocked() (roachpb.Lease, roachpb.Lease) {
 func (r *Replica) RevokeLease(ctx context.Context, seq roachpb.LeaseSequence) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if r.mu.state.Lease.Sequence == seq {
+	if r.mu.orRaftMu.state.Lease.Sequence == seq {
 		r.mu.minLeaseProposedTS = r.Clock().NowAsClockTimestamp()
 	}
 }
@@ -1123,7 +1123,7 @@ func (r *Replica) leaseGoodToGoForStatusRLocked(
 	}
 	if !st.Lease.OwnedBy(r.store.StoreID()) {
 		// Case (3): not leaseholder.
-		_, stillMember := r.mu.state.Desc.GetReplicaDescriptor(st.Lease.Replica.StoreID)
+		_, stillMember := r.mu.orRaftMu.state.Desc.GetReplicaDescriptor(st.Lease.Replica.StoreID)
 		if !stillMember {
 			// This would be the situation in which the lease holder gets removed when
 			// holding the lease, or in which a lease request erroneously gets accepted
@@ -1273,11 +1273,11 @@ func (r *Replica) redirectOnOrAcquireLeaseForRequest(
 				// hit this path more. Do we need to add the lease to this
 				// NotLeaseHolder error to ensure fast redirection?
 				return nil, kvserverpb.LeaseStatus{}, false, kvpb.NewError(
-					kvpb.NewNotLeaseHolderError(roachpb.Lease{}, r.store.StoreID(), r.mu.state.Desc, msg))
+					kvpb.NewNotLeaseHolderError(roachpb.Lease{}, r.store.StoreID(), r.mu.orRaftMu.state.Desc, msg))
 
 			case kvserverpb.LeaseState_VALID, kvserverpb.LeaseState_UNUSABLE:
 				if !status.Lease.OwnedBy(r.store.StoreID()) {
-					_, stillMember := r.mu.state.Desc.GetReplicaDescriptor(status.Lease.Replica.StoreID)
+					_, stillMember := r.mu.orRaftMu.state.Desc.GetReplicaDescriptor(status.Lease.Replica.StoreID)
 					if !stillMember {
 						// See corresponding comment in leaseGoodToGoRLocked.
 						log.Errorf(ctx, "lease %s owned by replica %+v that no longer exists",
@@ -1286,7 +1286,7 @@ func (r *Replica) redirectOnOrAcquireLeaseForRequest(
 					// Otherwise, if the lease is currently held by another replica, redirect
 					// to the holder.
 					return nil, kvserverpb.LeaseStatus{}, false, kvpb.NewError(
-						kvpb.NewNotLeaseHolderError(status.Lease, r.store.StoreID(), r.mu.state.Desc,
+						kvpb.NewNotLeaseHolderError(status.Lease, r.store.StoreID(), r.mu.orRaftMu.state.Desc,
 							"lease held by different store"))
 				}
 
@@ -1314,7 +1314,7 @@ func (r *Replica) redirectOnOrAcquireLeaseForRequest(
 				}
 				// If lease is currently held by another, redirect to holder.
 				return nil, kvserverpb.LeaseStatus{}, false, kvpb.NewError(
-					kvpb.NewNotLeaseHolderError(status.Lease, r.store.StoreID(), r.mu.state.Desc, "lease proscribed"))
+					kvpb.NewNotLeaseHolderError(status.Lease, r.store.StoreID(), r.mu.orRaftMu.state.Desc, "lease proscribed"))
 
 			default:
 				return nil, kvserverpb.LeaseStatus{}, false, kvpb.NewErrorf("unknown lease status state %v", status)

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -252,7 +252,7 @@ func (p *pendingLeaseRequest) RequestPending() (roachpb.Lease, bool) {
 func (p *pendingLeaseRequest) AcquisitionInProgress() bool {
 	if nextLease, ok := p.RequestPending(); ok {
 		// Is the lease being acquired? (as opposed to extended or transferred)
-		prevLocal := p.repl.ReplicaID() == p.repl.mu.orRaftMu.state.Lease.Replica.ReplicaID
+		prevLocal := p.repl.ReplicaID() == p.repl.shMu.state.Lease.Replica.ReplicaID
 		nextLocal := p.repl.ReplicaID() == nextLease.Replica.ReplicaID
 		return !prevLocal && nextLocal
 	}
@@ -416,7 +416,7 @@ func (p *pendingLeaseRequest) InitOrJoinRequest(
 			// back to indicate that we have no idea who the range lease holder might
 			// be; we've withdrawn from active duty.
 			llHandle.resolve(kvpb.NewError(
-				kvpb.NewNotLeaseHolderError(roachpb.Lease{}, p.repl.store.StoreID(), p.repl.mu.orRaftMu.state.Desc,
+				kvpb.NewNotLeaseHolderError(roachpb.Lease{}, p.repl.store.StoreID(), p.repl.shMu.state.Desc,
 					"lease acquisition task couldn't be started; node is shutting down")))
 		}
 		return llHandle
@@ -733,7 +733,7 @@ func (r *Replica) leaseStatusForRequestRLocked(
 		MinProposedTs:      r.mu.minLeaseProposedTS,
 		MinValidObservedTs: r.mu.minValidObservedTimestamp,
 		RequestTs:          reqTS,
-		Lease:              *r.mu.orRaftMu.state.Lease,
+		Lease:              *r.shMu.state.Lease,
 	}
 	// TODO(nvanbenschoten): evaluate whether this is too expensive to compute for
 	// every lease status request. We may need to cache this result. If, at that
@@ -797,7 +797,7 @@ func (r *Replica) GetRangeLeaseDuration() time.Duration {
 // callers: when expiration leases don't quiesce and are always eagerly renewed.
 func (r *Replica) requiresExpirationLeaseRLocked() bool {
 	return r.store.cfg.NodeLiveness == nil ||
-		r.mu.orRaftMu.state.Desc.StartKey.Less(roachpb.RKey(keys.NodeLivenessKeyMax))
+		r.shMu.state.Desc.StartKey.Less(roachpb.RKey(keys.NodeLivenessKeyMax))
 }
 
 // shouldUseExpirationLeaseRLocked returns true if this range should be using an
@@ -866,7 +866,7 @@ func (r *Replica) requestLeaseLocked(
 		return r.mu.pendingLeaseRequest.newResolvedHandle(kvpb.NewError(err))
 	}
 	return r.mu.pendingLeaseRequest.InitOrJoinRequest(
-		ctx, repDesc, status, r.mu.orRaftMu.state.Desc.StartKey.AsRawKey(),
+		ctx, repDesc, status, r.shMu.state.Desc.StartKey.AsRawKey(),
 		false /* bypassSafetyChecks */, limiter)
 }
 
@@ -914,7 +914,7 @@ func (r *Replica) AdminTransferLease(
 			// The target is already the lease holder. Nothing to do.
 			return nil, nil, nil
 		}
-		desc := r.mu.orRaftMu.state.Desc
+		desc := r.shMu.state.Desc
 		if !status.Lease.OwnedBy(r.store.StoreID()) {
 			return nil, nil, kvpb.NewNotLeaseHolderError(status.Lease, r.store.StoreID(), desc,
 				"can't transfer the lease because this store doesn't own it")
@@ -1019,9 +1019,9 @@ func (r *Replica) GetLease() (roachpb.Lease, roachpb.Lease) {
 
 func (r *Replica) getLeaseRLocked() (roachpb.Lease, roachpb.Lease) {
 	if nextLease, ok := r.mu.pendingLeaseRequest.RequestPending(); ok {
-		return *r.mu.orRaftMu.state.Lease, nextLease
+		return *r.shMu.state.Lease, nextLease
 	}
-	return *r.mu.orRaftMu.state.Lease, roachpb.Lease{}
+	return *r.shMu.state.Lease, roachpb.Lease{}
 }
 
 // RevokeLease stops the replica from using its current lease, if that lease
@@ -1030,7 +1030,7 @@ func (r *Replica) getLeaseRLocked() (roachpb.Lease, roachpb.Lease) {
 func (r *Replica) RevokeLease(ctx context.Context, seq roachpb.LeaseSequence) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if r.mu.orRaftMu.state.Lease.Sequence == seq {
+	if r.shMu.state.Lease.Sequence == seq {
 		r.mu.minLeaseProposedTS = r.Clock().NowAsClockTimestamp()
 	}
 }
@@ -1123,7 +1123,7 @@ func (r *Replica) leaseGoodToGoForStatusRLocked(
 	}
 	if !st.Lease.OwnedBy(r.store.StoreID()) {
 		// Case (3): not leaseholder.
-		_, stillMember := r.mu.orRaftMu.state.Desc.GetReplicaDescriptor(st.Lease.Replica.StoreID)
+		_, stillMember := r.shMu.state.Desc.GetReplicaDescriptor(st.Lease.Replica.StoreID)
 		if !stillMember {
 			// This would be the situation in which the lease holder gets removed when
 			// holding the lease, or in which a lease request erroneously gets accepted
@@ -1273,11 +1273,11 @@ func (r *Replica) redirectOnOrAcquireLeaseForRequest(
 				// hit this path more. Do we need to add the lease to this
 				// NotLeaseHolder error to ensure fast redirection?
 				return nil, kvserverpb.LeaseStatus{}, false, kvpb.NewError(
-					kvpb.NewNotLeaseHolderError(roachpb.Lease{}, r.store.StoreID(), r.mu.orRaftMu.state.Desc, msg))
+					kvpb.NewNotLeaseHolderError(roachpb.Lease{}, r.store.StoreID(), r.shMu.state.Desc, msg))
 
 			case kvserverpb.LeaseState_VALID, kvserverpb.LeaseState_UNUSABLE:
 				if !status.Lease.OwnedBy(r.store.StoreID()) {
-					_, stillMember := r.mu.orRaftMu.state.Desc.GetReplicaDescriptor(status.Lease.Replica.StoreID)
+					_, stillMember := r.shMu.state.Desc.GetReplicaDescriptor(status.Lease.Replica.StoreID)
 					if !stillMember {
 						// See corresponding comment in leaseGoodToGoRLocked.
 						log.Errorf(ctx, "lease %s owned by replica %+v that no longer exists",
@@ -1286,7 +1286,7 @@ func (r *Replica) redirectOnOrAcquireLeaseForRequest(
 					// Otherwise, if the lease is currently held by another replica, redirect
 					// to the holder.
 					return nil, kvserverpb.LeaseStatus{}, false, kvpb.NewError(
-						kvpb.NewNotLeaseHolderError(status.Lease, r.store.StoreID(), r.mu.orRaftMu.state.Desc,
+						kvpb.NewNotLeaseHolderError(status.Lease, r.store.StoreID(), r.shMu.state.Desc,
 							"lease held by different store"))
 				}
 
@@ -1314,7 +1314,7 @@ func (r *Replica) redirectOnOrAcquireLeaseForRequest(
 				}
 				// If lease is currently held by another, redirect to holder.
 				return nil, kvserverpb.LeaseStatus{}, false, kvpb.NewError(
-					kvpb.NewNotLeaseHolderError(status.Lease, r.store.StoreID(), r.mu.orRaftMu.state.Desc, "lease proscribed"))
+					kvpb.NewNotLeaseHolderError(status.Lease, r.store.StoreID(), r.shMu.state.Desc, "lease proscribed"))
 
 			default:
 				return nil, kvserverpb.LeaseStatus{}, false, kvpb.NewErrorf("unknown lease status state %v", status)

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -1106,7 +1106,7 @@ func (r *Replica) collectSpans(
 	latchSpans, lockSpans = spanset.New(), lockspanset.New()
 	r.mu.RLock()
 	desc := r.descRLocked()
-	liveCount := r.mu.orRaftMu.state.Stats.LiveCount
+	liveCount := r.shMu.state.Stats.LiveCount
 	r.mu.RUnlock()
 	// TODO(bdarnell): need to make this less global when local
 	// latches are used more heavily. For example, a split will

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -1106,7 +1106,7 @@ func (r *Replica) collectSpans(
 	latchSpans, lockSpans = spanset.New(), lockspanset.New()
 	r.mu.RLock()
 	desc := r.descRLocked()
-	liveCount := r.mu.state.Stats.LiveCount
+	liveCount := r.mu.orRaftMu.state.Stats.LiveCount
 	r.mu.RUnlock()
 	// TODO(bdarnell): need to make this less global when local
 	// latches are used more heavily. For example, a split will

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -175,7 +175,7 @@ func TestRaftSSTableSideloading(t *testing.T) {
 
 	rsl := logstore.NewStateLoader(tc.repl.RangeID)
 	lo := tc.repl.mu.state.TruncatedState.Index + 1
-	hi := tc.repl.mu.lastIndexNotDurable + 1
+	hi := tc.repl.mu.orRaftMu.lastIndexNotDurable + 1
 
 	tc.store.raftEntryCache.Clear(tc.repl.RangeID, hi)
 	ents, cachedBytes, _, err := logstore.LoadEntries(

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -174,7 +174,7 @@ func TestRaftSSTableSideloading(t *testing.T) {
 	defer tc.repl.mu.Unlock()
 
 	rsl := logstore.NewStateLoader(tc.repl.RangeID)
-	lo := tc.repl.mu.state.TruncatedState.Index + 1
+	lo := tc.repl.mu.orRaftMu.state.TruncatedState.Index + 1
 	hi := tc.repl.mu.orRaftMu.lastIndexNotDurable + 1
 
 	tc.store.raftEntryCache.Clear(tc.repl.RangeID, hi)

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -174,8 +174,8 @@ func TestRaftSSTableSideloading(t *testing.T) {
 	defer tc.repl.mu.Unlock()
 
 	rsl := logstore.NewStateLoader(tc.repl.RangeID)
-	lo := tc.repl.mu.orRaftMu.state.TruncatedState.Index + 1
-	hi := tc.repl.mu.orRaftMu.lastIndexNotDurable + 1
+	lo := tc.repl.shMu.state.TruncatedState.Index + 1
+	hi := tc.repl.shMu.lastIndexNotDurable + 1
 
 	tc.store.raftEntryCache.Clear(tc.repl.RangeID, hi)
 	ents, cachedBytes, _, err := logstore.LoadEntries(

--- a/pkg/kv/kvserver/replica_store_liveness.go
+++ b/pkg/kv/kvserver/replica_store_liveness.go
@@ -48,7 +48,7 @@ func (r *replicaRLockedStoreLiveness) getStoreIdent(
 	replicaID raftpb.PeerID,
 ) (slpb.StoreIdent, bool) {
 	r.mu.AssertRHeld()
-	desc, ok := r.mu.orRaftMu.state.Desc.GetReplicaDescriptorByID(roachpb.ReplicaID(replicaID))
+	desc, ok := r.shMu.state.Desc.GetReplicaDescriptorByID(roachpb.ReplicaID(replicaID))
 	if !ok {
 		return slpb.StoreIdent{}, false
 	}

--- a/pkg/kv/kvserver/replica_store_liveness.go
+++ b/pkg/kv/kvserver/replica_store_liveness.go
@@ -48,7 +48,7 @@ func (r *replicaRLockedStoreLiveness) getStoreIdent(
 	replicaID raftpb.PeerID,
 ) (slpb.StoreIdent, bool) {
 	r.mu.AssertRHeld()
-	desc, ok := r.mu.state.Desc.GetReplicaDescriptorByID(roachpb.ReplicaID(replicaID))
+	desc, ok := r.mu.orRaftMu.state.Desc.GetReplicaDescriptorByID(roachpb.ReplicaID(replicaID))
 	if !ok {
 		return slpb.StoreIdent{}, false
 	}

--- a/pkg/kv/kvserver/scanner_test.go
+++ b/pkg/kv/kvserver/scanner_test.go
@@ -48,13 +48,13 @@ func newTestRangeSet(count int, t *testing.T) *testRangeSet {
 		repl := &Replica{
 			RangeID: desc.RangeID,
 		}
-		repl.mu.orRaftMu.state.Stats = &enginepb.MVCCStats{
+		repl.shMu.state.Stats = &enginepb.MVCCStats{
 			KeyBytes:  1,
 			ValBytes:  2,
 			KeyCount:  1,
 			LiveCount: 1,
 		}
-		repl.mu.orRaftMu.state.Desc = desc
+		repl.shMu.state.Desc = desc
 		repl.startKey = desc.StartKey // actually used by replicasByKey
 		if exRngItem := rs.replicasByKey.ReplaceOrInsert((*btreeReplica)(repl)); exRngItem != nil {
 			t.Fatalf("failed to insert range %s", repl)

--- a/pkg/kv/kvserver/scanner_test.go
+++ b/pkg/kv/kvserver/scanner_test.go
@@ -48,13 +48,13 @@ func newTestRangeSet(count int, t *testing.T) *testRangeSet {
 		repl := &Replica{
 			RangeID: desc.RangeID,
 		}
-		repl.mu.state.Stats = &enginepb.MVCCStats{
+		repl.mu.orRaftMu.state.Stats = &enginepb.MVCCStats{
 			KeyBytes:  1,
 			ValBytes:  2,
 			KeyCount:  1,
 			LiveCount: 1,
 		}
-		repl.mu.state.Desc = desc
+		repl.mu.orRaftMu.state.Desc = desc
 		repl.startKey = desc.StartKey // actually used by replicasByKey
 		if exRngItem := rs.replicasByKey.ReplaceOrInsert((*btreeReplica)(repl)); exRngItem != nil {
 			t.Fatalf("failed to insert range %s", repl)

--- a/pkg/kv/kvserver/split_queue_test.go
+++ b/pkg/kv/kvserver/split_queue_test.go
@@ -101,7 +101,7 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		}
 
 		repl.mu.Lock()
-		repl.mu.state.Stats = &enginepb.MVCCStats{KeyBytes: test.bytes}
+		repl.mu.orRaftMu.state.Stats = &enginepb.MVCCStats{KeyBytes: test.bytes}
 		repl.mu.Unlock()
 		conf := roachpb.TestingDefaultSpanConfig()
 		conf.RangeMaxBytes = test.maxBytes

--- a/pkg/kv/kvserver/split_queue_test.go
+++ b/pkg/kv/kvserver/split_queue_test.go
@@ -101,7 +101,7 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		}
 
 		repl.mu.Lock()
-		repl.mu.orRaftMu.state.Stats = &enginepb.MVCCStats{KeyBytes: test.bytes}
+		repl.shMu.state.Stats = &enginepb.MVCCStats{KeyBytes: test.bytes}
 		repl.mu.Unlock()
 		conf := roachpb.TestingDefaultSpanConfig()
 		conf.RangeMaxBytes = test.maxBytes

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -245,7 +245,7 @@ func fromReplicaIsTooOldRLocked(toReplica *Replica, fromReplica *roachpb.Replica
 	if fromReplica == nil {
 		return false
 	}
-	desc := toReplica.mu.orRaftMu.state.Desc
+	desc := toReplica.shMu.state.Desc
 	_, found := desc.GetReplicaDescriptorByID(fromReplica.ReplicaID)
 	return !found && fromReplica.ReplicaID < desc.NextReplicaID
 }

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -245,7 +245,7 @@ func fromReplicaIsTooOldRLocked(toReplica *Replica, fromReplica *roachpb.Replica
 	if fromReplica == nil {
 		return false
 	}
-	desc := toReplica.mu.state.Desc
+	desc := toReplica.mu.orRaftMu.state.Desc
 	_, found := desc.GetReplicaDescriptorByID(fromReplica.ReplicaID)
 	return !found && fromReplica.ReplicaID < desc.NextReplicaID
 }

--- a/pkg/kv/kvserver/store_pool_test.go
+++ b/pkg/kv/kvserver/store_pool_test.go
@@ -115,7 +115,7 @@ func TestStorePoolUpdateLocalStore(t *testing.T) {
 
 	replica := Replica{RangeID: 1}
 	replica.mu.Lock()
-	replica.mu.orRaftMu.state.Stats = &enginepb.MVCCStats{
+	replica.shMu.state.Stats = &enginepb.MVCCStats{
 		KeyBytes: 2,
 		ValBytes: 4,
 	}

--- a/pkg/kv/kvserver/store_pool_test.go
+++ b/pkg/kv/kvserver/store_pool_test.go
@@ -115,7 +115,7 @@ func TestStorePoolUpdateLocalStore(t *testing.T) {
 
 	replica := Replica{RangeID: 1}
 	replica.mu.Lock()
-	replica.mu.state.Stats = &enginepb.MVCCStats{
+	replica.mu.orRaftMu.state.Stats = &enginepb.MVCCStats{
 		KeyBytes: 2,
 		ValBytes: 4,
 	}

--- a/pkg/kv/kvserver/store_rebalancer_test.go
+++ b/pkg/kv/kvserver/store_rebalancer_test.go
@@ -496,32 +496,32 @@ func loadRanges(rr *ReplicaRankings, s *Store, ranges []testRange) {
 	for i, r := range ranges {
 		rangeID := roachpb.RangeID(i + 1)
 		repl := &Replica{store: s, RangeID: rangeID}
-		repl.mu.state.Desc = &roachpb.RangeDescriptor{RangeID: rangeID}
+		repl.mu.orRaftMu.state.Desc = &roachpb.RangeDescriptor{RangeID: rangeID}
 		repl.mu.conf = s.cfg.DefaultSpanConfig
 		for _, storeID := range r.voters {
-			repl.mu.state.Desc.InternalReplicas = append(repl.mu.state.Desc.InternalReplicas, roachpb.ReplicaDescriptor{
+			repl.mu.orRaftMu.state.Desc.InternalReplicas = append(repl.mu.orRaftMu.state.Desc.InternalReplicas, roachpb.ReplicaDescriptor{
 				NodeID:    roachpb.NodeID(storeID),
 				StoreID:   storeID,
 				ReplicaID: roachpb.ReplicaID(storeID),
 				Type:      roachpb.VOTER_FULL,
 			})
 		}
-		repl.mu.state.Lease = &roachpb.Lease{
+		repl.mu.orRaftMu.state.Lease = &roachpb.Lease{
 			Expiration: &hlc.MaxTimestamp,
-			Replica:    repl.mu.state.Desc.InternalReplicas[0],
+			Replica:    repl.mu.orRaftMu.state.Desc.InternalReplicas[0],
 		}
 		// NB: We set the index to 2 corresponding to the match in
 		// TestingRaftStatusFn. Matches that are 0 are considered behind.
-		repl.mu.state.TruncatedState = &kvserverpb.RaftTruncatedState{Index: 2}
+		repl.mu.orRaftMu.state.TruncatedState = &kvserverpb.RaftTruncatedState{Index: 2}
 		for _, storeID := range r.nonVoters {
-			repl.mu.state.Desc.InternalReplicas = append(repl.mu.state.Desc.InternalReplicas, roachpb.ReplicaDescriptor{
+			repl.mu.orRaftMu.state.Desc.InternalReplicas = append(repl.mu.orRaftMu.state.Desc.InternalReplicas, roachpb.ReplicaDescriptor{
 				NodeID:    roachpb.NodeID(storeID),
 				StoreID:   storeID,
 				ReplicaID: roachpb.ReplicaID(storeID),
 				Type:      roachpb.NON_VOTER,
 			})
 		}
-		repl.mu.state.Stats = &enginepb.MVCCStats{}
+		repl.mu.orRaftMu.state.Stats = &enginepb.MVCCStats{}
 		repl.loadStats = rload.NewReplicaLoad(s.Clock(), nil)
 		repl.loadStats.TestingSetStat(rload.Queries, r.qps)
 		repl.loadStats.TestingSetStat(rload.ReqCPUNanos, r.reqCPU)

--- a/pkg/kv/kvserver/store_rebalancer_test.go
+++ b/pkg/kv/kvserver/store_rebalancer_test.go
@@ -496,32 +496,32 @@ func loadRanges(rr *ReplicaRankings, s *Store, ranges []testRange) {
 	for i, r := range ranges {
 		rangeID := roachpb.RangeID(i + 1)
 		repl := &Replica{store: s, RangeID: rangeID}
-		repl.mu.orRaftMu.state.Desc = &roachpb.RangeDescriptor{RangeID: rangeID}
+		repl.shMu.state.Desc = &roachpb.RangeDescriptor{RangeID: rangeID}
 		repl.mu.conf = s.cfg.DefaultSpanConfig
 		for _, storeID := range r.voters {
-			repl.mu.orRaftMu.state.Desc.InternalReplicas = append(repl.mu.orRaftMu.state.Desc.InternalReplicas, roachpb.ReplicaDescriptor{
+			repl.shMu.state.Desc.InternalReplicas = append(repl.shMu.state.Desc.InternalReplicas, roachpb.ReplicaDescriptor{
 				NodeID:    roachpb.NodeID(storeID),
 				StoreID:   storeID,
 				ReplicaID: roachpb.ReplicaID(storeID),
 				Type:      roachpb.VOTER_FULL,
 			})
 		}
-		repl.mu.orRaftMu.state.Lease = &roachpb.Lease{
+		repl.shMu.state.Lease = &roachpb.Lease{
 			Expiration: &hlc.MaxTimestamp,
-			Replica:    repl.mu.orRaftMu.state.Desc.InternalReplicas[0],
+			Replica:    repl.shMu.state.Desc.InternalReplicas[0],
 		}
 		// NB: We set the index to 2 corresponding to the match in
 		// TestingRaftStatusFn. Matches that are 0 are considered behind.
-		repl.mu.orRaftMu.state.TruncatedState = &kvserverpb.RaftTruncatedState{Index: 2}
+		repl.shMu.state.TruncatedState = &kvserverpb.RaftTruncatedState{Index: 2}
 		for _, storeID := range r.nonVoters {
-			repl.mu.orRaftMu.state.Desc.InternalReplicas = append(repl.mu.orRaftMu.state.Desc.InternalReplicas, roachpb.ReplicaDescriptor{
+			repl.shMu.state.Desc.InternalReplicas = append(repl.shMu.state.Desc.InternalReplicas, roachpb.ReplicaDescriptor{
 				NodeID:    roachpb.NodeID(storeID),
 				StoreID:   storeID,
 				ReplicaID: roachpb.ReplicaID(storeID),
 				Type:      roachpb.NON_VOTER,
 			})
 		}
-		repl.mu.orRaftMu.state.Stats = &enginepb.MVCCStats{}
+		repl.shMu.state.Stats = &enginepb.MVCCStats{}
 		repl.loadStats = rload.NewReplicaLoad(s.Clock(), nil)
 		repl.loadStats.TestingSetStat(rload.Queries, r.qps)
 		repl.loadStats.TestingSetStat(rload.ReqCPUNanos, r.reqCPU)

--- a/pkg/kv/kvserver/store_remove_replica.go
+++ b/pkg/kv/kvserver/store_remove_replica.go
@@ -125,7 +125,7 @@ func (s *Store) removeInitializedReplicaRaftMuLocked(
 
 		// Now we know that the Store's Replica is identical to the passed-in
 		// Replica.
-		desc := rep.mu.orRaftMu.state.Desc
+		desc := rep.shMu.state.Desc
 		if repDesc, ok := desc.GetReplicaDescriptor(s.StoreID()); ok && repDesc.ReplicaID >= nextReplicaID {
 			// The ReplicaID of a Replica is immutable.
 			return nil, errors.AssertionFailedf("replica descriptor's ID has changed (%s >= %s)",

--- a/pkg/kv/kvserver/store_remove_replica.go
+++ b/pkg/kv/kvserver/store_remove_replica.go
@@ -125,7 +125,7 @@ func (s *Store) removeInitializedReplicaRaftMuLocked(
 
 		// Now we know that the Store's Replica is identical to the passed-in
 		// Replica.
-		desc := rep.mu.state.Desc
+		desc := rep.mu.orRaftMu.state.Desc
 		if repDesc, ok := desc.GetReplicaDescriptor(s.StoreID()); ok && repDesc.ReplicaID >= nextReplicaID {
 			// The ReplicaID of a Replica is immutable.
 			return nil, errors.AssertionFailedf("replica descriptor's ID has changed (%s >= %s)",

--- a/pkg/kv/kvserver/store_replica_btree_test.go
+++ b/pkg/kv/kvserver/store_replica_btree_test.go
@@ -91,7 +91,7 @@ func TestStoreReplicaBTree_LookupPrecedingAndNextReplica(t *testing.T) {
 		desc.StartKey = roachpb.RKey(start)
 		desc.EndKey = roachpb.RKey(end)
 		r := &Replica{}
-		r.mu.orRaftMu.state.Desc = desc
+		r.shMu.state.Desc = desc
 		r.startKey = desc.StartKey // this is what's actually used in the btree
 		return r
 	}
@@ -145,7 +145,7 @@ func TestStoreReplicaBTree_ReplicaCanBeLockedDuringInsert(t *testing.T) {
 	ctx := context.Background()
 	repl := &Replica{}
 	k := roachpb.RKey("a")
-	repl.mu.orRaftMu.state.Desc = &roachpb.RangeDescriptor{
+	repl.shMu.state.Desc = &roachpb.RangeDescriptor{
 		RangeID: 12,
 	}
 	repl.startKey = k

--- a/pkg/kv/kvserver/store_replica_btree_test.go
+++ b/pkg/kv/kvserver/store_replica_btree_test.go
@@ -91,7 +91,7 @@ func TestStoreReplicaBTree_LookupPrecedingAndNextReplica(t *testing.T) {
 		desc.StartKey = roachpb.RKey(start)
 		desc.EndKey = roachpb.RKey(end)
 		r := &Replica{}
-		r.mu.state.Desc = desc
+		r.mu.orRaftMu.state.Desc = desc
 		r.startKey = desc.StartKey // this is what's actually used in the btree
 		return r
 	}
@@ -145,7 +145,7 @@ func TestStoreReplicaBTree_ReplicaCanBeLockedDuringInsert(t *testing.T) {
 	ctx := context.Background()
 	repl := &Replica{}
 	k := roachpb.RKey("a")
-	repl.mu.state.Desc = &roachpb.RangeDescriptor{
+	repl.mu.orRaftMu.state.Desc = &roachpb.RangeDescriptor{
 		RangeID: 12,
 	}
 	repl.startKey = k

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -1402,7 +1402,7 @@ func (s *Store) canAcceptSnapshotLocked(
 	existingRepl.raftMu.AssertHeld()
 
 	existingRepl.mu.RLock()
-	existingDesc := existingRepl.mu.state.Desc
+	existingDesc := existingRepl.mu.orRaftMu.state.Desc
 	existingIsInitialized := existingDesc.IsInitialized()
 	existingDestroyStatus := existingRepl.mu.destroyStatus
 	existingRepl.mu.RUnlock()

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -1402,7 +1402,7 @@ func (s *Store) canAcceptSnapshotLocked(
 	existingRepl.raftMu.AssertHeld()
 
 	existingRepl.mu.RLock()
-	existingDesc := existingRepl.mu.orRaftMu.state.Desc
+	existingDesc := existingRepl.shMu.state.Desc
 	existingIsInitialized := existingDesc.IsInitialized()
 	existingDestroyStatus := existingRepl.mu.destroyStatus
 	existingRepl.mu.RUnlock()

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -263,9 +263,9 @@ func prepareRightReplicaForSplit(
 	// the replica according to whether it holds the lease. This enables the
 	// txnWaitQueue.
 	rightRepl.leasePostApplyLocked(ctx,
-		rightRepl.mu.state.Lease, /* prevLease */
-		rightRepl.mu.state.Lease, /* newLease - same as prevLease */
-		nil,                      /* priorReadSum */
+		rightRepl.mu.orRaftMu.state.Lease, /* prevLease */
+		rightRepl.mu.orRaftMu.state.Lease, /* newLease - same as prevLease */
+		nil,                               /* priorReadSum */
 		assertNoLeaseJump)
 
 	// We need to explicitly unquiesce the Raft group on the right-hand range or

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -263,9 +263,9 @@ func prepareRightReplicaForSplit(
 	// the replica according to whether it holds the lease. This enables the
 	// txnWaitQueue.
 	rightRepl.leasePostApplyLocked(ctx,
-		rightRepl.mu.orRaftMu.state.Lease, /* prevLease */
-		rightRepl.mu.orRaftMu.state.Lease, /* newLease - same as prevLease */
-		nil,                               /* priorReadSum */
+		rightRepl.shMu.state.Lease, /* prevLease */
+		rightRepl.shMu.state.Lease, /* newLease - same as prevLease */
+		nil,                        /* priorReadSum */
 		assertNoLeaseJump)
 
 	// We need to explicitly unquiesce the Raft group on the right-hand range or

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -699,10 +699,12 @@ func TestReplicasByKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	rep.raftMu.Lock()
 	rep.mu.Lock()
-	desc := *rep.mu.state.Desc // shallow copy to replace desc wholesale
+	desc := *rep.mu.orRaftMu.state.Desc // shallow copy to replace desc wholesale
 	desc.EndKey = roachpb.RKey("e")
-	rep.mu.state.Desc = &desc
+	rep.mu.orRaftMu.state.Desc = &desc
+	rep.raftMu.Unlock()
 	rep.mu.Unlock()
 
 	// Ensure that this shrinkage is recognized by future additions to replicasByKey.
@@ -2787,7 +2789,7 @@ func TestStoreGCThreshold(t *testing.T) {
 			t.Fatal(err)
 		}
 		repl.mu.Lock()
-		gcThreshold := *repl.mu.state.GCThreshold
+		gcThreshold := *repl.mu.orRaftMu.state.GCThreshold
 		pgcThreshold, err := repl.mu.stateLoader.LoadGCThreshold(context.Background(), store.TODOEngine())
 		repl.mu.Unlock()
 		if err != nil {

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -701,9 +701,9 @@ func TestReplicasByKey(t *testing.T) {
 
 	rep.raftMu.Lock()
 	rep.mu.Lock()
-	desc := *rep.mu.orRaftMu.state.Desc // shallow copy to replace desc wholesale
+	desc := *rep.shMu.state.Desc // shallow copy to replace desc wholesale
 	desc.EndKey = roachpb.RKey("e")
-	rep.mu.orRaftMu.state.Desc = &desc
+	rep.shMu.state.Desc = &desc
 	rep.raftMu.Unlock()
 	rep.mu.Unlock()
 
@@ -2789,7 +2789,7 @@ func TestStoreGCThreshold(t *testing.T) {
 			t.Fatal(err)
 		}
 		repl.mu.Lock()
-		gcThreshold := *repl.mu.orRaftMu.state.GCThreshold
+		gcThreshold := *repl.shMu.state.GCThreshold
 		pgcThreshold, err := repl.mu.stateLoader.LoadGCThreshold(context.Background(), store.TODOEngine())
 		repl.mu.Unlock()
 		if err != nil {

--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -87,7 +87,7 @@ func (is Server) WaitForApplication(
 				return err
 			}
 			repl.mu.RLock()
-			leaseAppliedIndex := repl.mu.orRaftMu.state.LeaseAppliedIndex
+			leaseAppliedIndex := repl.shMu.state.LeaseAppliedIndex
 			repl.mu.RUnlock()
 			if leaseAppliedIndex >= req.LeaseIndex {
 				// For performance reasons, we don't sync to disk when

--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -87,7 +87,7 @@ func (is Server) WaitForApplication(
 				return err
 			}
 			repl.mu.RLock()
-			leaseAppliedIndex := repl.mu.state.LeaseAppliedIndex
+			leaseAppliedIndex := repl.mu.orRaftMu.state.LeaseAppliedIndex
 			repl.mu.RUnlock()
 			if leaseAppliedIndex >= req.LeaseIndex {
 				// For performance reasons, we don't sync to disk when

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -524,7 +524,7 @@ type StoreTestingKnobs struct {
 	// rangeID should ignore the queue being disabled, and be processed anyway.
 	BaseQueueDisabledBypassFilter func(rangeID roachpb.RangeID) bool
 
-	// InjectReproposalError injects an error in tryReproposeWithNewLeaseIndex.
+	// InjectReproposalError injects an error in tryReproposeWithNewLeaseIndexRaftMuLocked.
 	// If nil is returned, reproposal will be attempted.
 	InjectReproposalError func(p *ProposalData) error
 


### PR DESCRIPTION
This PR groups fields mutated under both `raftMu+mu` into a section of `Replica` fields explicitly marked/commented as such. All the fields in this section can be read with only one of the two mutexes held.

This PR also eliminates a few cases when `Replica.mu` is locked unnecessarily.

Epic: none
Release note: none