### PR TITLE
storage: skip MVCCValueHeader parsing in some cases

### DIFF
--- a/pkg/storage/bench_data_test.go
+++ b/pkg/storage/bench_data_test.go
@@ -204,6 +204,10 @@ type mvccBenchData struct {
 	// mode simulates data that has been RESTOREd or is old enough to have been
 	// fully compacted.
 	transactional bool
+
+	// When includeHeader is set, values will be written with
+	// non-empty MVCCValueHeaders.
+	includeHeader bool
 }
 
 var _ initialState = mvccBenchData{}
@@ -223,6 +227,9 @@ func (d mvccBenchData) Key() []string {
 	}
 	if d.transactional {
 		key = append(key, fmt.Sprintf("transactional_%t", d.transactional))
+	}
+	if d.includeHeader {
+		key = append(key, fmt.Sprintf("headers_%t", d.includeHeader))
 	}
 	return key
 }
@@ -321,7 +328,11 @@ func (d mvccBenchData) Build(ctx context.Context, b *testing.B, eng Engine) erro
 			txn.ReadTimestamp = ts
 			txn.WriteTimestamp = ts
 		}
-		_, err := MVCCPut(ctx, batch, key, ts, value, MVCCWriteOptions{Txn: txn})
+		originID := uint32(0)
+		if d.includeHeader {
+			originID = 1
+		}
+		_, err := MVCCPut(ctx, batch, key, ts, value, MVCCWriteOptions{Txn: txn, OriginID: originID})
 		require.NoError(b, err)
 	}
 

--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -80,10 +80,11 @@ func BenchmarkMVCCScan_Pebble(b *testing.B) {
 	defer log.Scope(b).Close(b)
 
 	type testCase struct {
-		numRows      int
-		numVersions  int
-		valueSize    int
-		numRangeKeys int
+		numRows       int
+		numVersions   int
+		valueSize     int
+		numRangeKeys  int
+		includeHeader bool
 	}
 	var testCases []testCase
 	for _, numRows := range []int{1, 10, 100, 1000, 10000, 50000} {
@@ -110,18 +111,27 @@ func BenchmarkMVCCScan_Pebble(b *testing.B) {
 		}
 	}
 
+	testCases = append(testCases, testCase{
+		numRows:       1000,
+		numVersions:   2,
+		valueSize:     64,
+		numRangeKeys:  0,
+		includeHeader: true,
+	})
+
 	for _, tc := range testCases {
 		name := fmt.Sprintf(
-			"rows=%d/versions=%d/valueSize=%d/numRangeKeys=%d",
-			tc.numRows, tc.numVersions, tc.valueSize, tc.numRangeKeys,
+			"rows=%d/versions=%d/valueSize=%d/numRangeKeys=%d/headers=%v",
+			tc.numRows, tc.numVersions, tc.valueSize, tc.numRangeKeys, tc.includeHeader,
 		)
 		b.Run(name, func(b *testing.B) {
 			ctx := context.Background()
 			runMVCCScan(ctx, b, benchScanOptions{
 				mvccBenchData: mvccBenchData{
-					numVersions:  tc.numVersions,
-					valueBytes:   tc.valueSize,
-					numRangeKeys: tc.numRangeKeys,
+					numVersions:   tc.numVersions,
+					valueBytes:    tc.valueSize,
+					numRangeKeys:  tc.numRangeKeys,
+					includeHeader: tc.includeHeader,
 				},
 				numRows: tc.numRows,
 				reverse: false,

--- a/pkg/storage/engine_key.go
+++ b/pkg/storage/engine_key.go
@@ -396,10 +396,7 @@ func (key *EngineKey) Verify(value []byte) error {
 // decodeMVCCValueAndVerify will try to decode the value as
 // MVCCValue and then verify the checksum.
 func decodeMVCCValueAndVerify(key roachpb.Key, value []byte) error {
-	mvccValue, ok, err := tryDecodeSimpleMVCCValue(value)
-	if !ok && err == nil {
-		mvccValue, err = decodeExtendedMVCCValue(value)
-	}
+	mvccValue, err := decodeMVCCValueIgnoringHeader(value)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/fingerprint_writer.go
+++ b/pkg/storage/fingerprint_writer.go
@@ -293,10 +293,7 @@ func FingerprintRangekeys(
 			if err := fw.hashTimestamp(v.Timestamp); err != nil {
 				return 0, err
 			}
-			mvccValue, ok, err := tryDecodeSimpleMVCCValue(v.Value)
-			if !ok && err == nil {
-				mvccValue, err = decodeExtendedMVCCValue(v.Value)
-			}
+			mvccValue, err := decodeMVCCValueIgnoringHeader(v.Value)
 			if err != nil {
 				return 0, errors.Wrapf(err, "decoding mvcc value %s", v.Value)
 			}

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -1552,18 +1552,19 @@ func mvccGet(
 	// specify an empty key for the end key which will ensure we don't retrieve a
 	// key different than the start key. This is a bit of a hack.
 	*mvccScanner = pebbleMVCCScanner{
-		parent:           iter,
-		memAccount:       memAccount,
-		lockTable:        opts.LockTable,
-		start:            key,
-		ts:               timestamp,
-		maxKeys:          1,
-		inconsistent:     opts.Inconsistent,
-		skipLocked:       opts.SkipLocked,
-		tombstones:       opts.Tombstones,
-		rawMVCCValues:    opts.ReturnRawMVCCValues,
-		failOnMoreRecent: opts.FailOnMoreRecent,
-		keyBuf:           mvccScanner.keyBuf,
+		parent:            iter,
+		memAccount:        memAccount,
+		lockTable:         opts.LockTable,
+		start:             key,
+		ts:                timestamp,
+		maxKeys:           1,
+		inconsistent:      opts.Inconsistent,
+		skipLocked:        opts.SkipLocked,
+		tombstones:        opts.Tombstones,
+		rawMVCCValues:     opts.ReturnRawMVCCValues,
+		failOnMoreRecent:  opts.FailOnMoreRecent,
+		keyBuf:            mvccScanner.keyBuf,
+		decodeMVCCHeaders: true,
 	}
 
 	results := &mvccScanner.alloc.pebbleResults
@@ -8057,7 +8058,7 @@ func mvccExportToWriter(
 			for _, v := range rangeKeys.Versions {
 				mvccValue, ok, err := tryDecodeSimpleMVCCValue(v.Value)
 				if !ok && err == nil {
-					mvccValue, err = decodeExtendedMVCCValue(v.Value)
+					mvccValue, err = decodeExtendedMVCCValue(v.Value, false)
 				}
 				if err != nil {
 					return kvpb.BulkOpSummary{}, ExportRequestResumeInfo{}, errors.Wrapf(err,
@@ -8133,7 +8134,7 @@ func mvccExportToWriter(
 		if unsafeKey.IsValue() {
 			mvccValue, ok, err := tryDecodeSimpleMVCCValue(unsafeValue)
 			if !ok && err == nil {
-				mvccValue, err = decodeExtendedMVCCValue(unsafeValue)
+				mvccValue, err = decodeExtendedMVCCValue(unsafeValue, opts.IncludeMVCCValueHeader)
 			}
 			if err != nil {
 				return kvpb.BulkOpSummary{}, ExportRequestResumeInfo{}, errors.Wrapf(err, "decoding mvcc value %s", unsafeKey)
@@ -8244,7 +8245,7 @@ func mvccExportToWriter(
 		for _, v := range rangeKeys.Versions {
 			mvccValue, ok, err := tryDecodeSimpleMVCCValue(v.Value)
 			if !ok && err == nil {
-				mvccValue, err = decodeExtendedMVCCValue(v.Value)
+				mvccValue, err = decodeExtendedMVCCValue(v.Value, false)
 			}
 			if err != nil {
 				return kvpb.BulkOpSummary{}, ExportRequestResumeInfo{}, errors.Wrapf(err,

--- a/pkg/storage/mvcc_value.go
+++ b/pkg/storage/mvcc_value.go
@@ -257,7 +257,7 @@ func DecodeMVCCValue(buf []byte) (MVCCValue, error) {
 	if ok || err != nil {
 		return v, err
 	}
-	return decodeExtendedMVCCValue(buf)
+	return decodeExtendedMVCCValue(buf, true)
 }
 
 // DecodeValueFromMVCCValue decodes and MVCCValue and returns the
@@ -265,6 +265,8 @@ func DecodeMVCCValue(buf []byte) (MVCCValue, error) {
 //
 // NB: Caller assumes that this function does not copy or re-allocate
 // the underlying byte slice.
+//
+//gcassert:inline
 func DecodeValueFromMVCCValue(buf []byte) (roachpb.Value, error) {
 	if len(buf) == 0 {
 		// Tombstone with no header.
@@ -322,17 +324,40 @@ func tryDecodeSimpleMVCCValue(buf []byte) (MVCCValue, bool, error) {
 	return MVCCValue{}, false, nil
 }
 
-func decodeExtendedMVCCValue(buf []byte) (MVCCValue, error) {
+//gcassert:inline
+func decodeMVCCValueIgnoringHeader(buf []byte) (MVCCValue, error) {
+	if len(buf) == 0 {
+		return MVCCValue{}, nil
+	}
+	if len(buf) <= tagPos {
+		return MVCCValue{}, errMVCCValueMissingTag
+	}
+	if buf[tagPos] != extendedEncodingSentinel {
+		return MVCCValue{Value: roachpb.Value{RawBytes: buf}}, nil
+	}
+
+	// Extended encoding
+	headerLen := binary.BigEndian.Uint32(buf)
+	headerSize := extendedPreludeSize + headerLen
+	if len(buf) < int(headerSize) {
+		return MVCCValue{}, errMVCCValueMissingHeader
+	}
+	return MVCCValue{Value: roachpb.Value{RawBytes: buf[headerSize:]}}, nil
+}
+
+func decodeExtendedMVCCValue(buf []byte, unmarshalHeader bool) (MVCCValue, error) {
 	headerLen := binary.BigEndian.Uint32(buf)
 	headerSize := extendedPreludeSize + headerLen
 	if len(buf) < int(headerSize) {
 		return MVCCValue{}, errMVCCValueMissingHeader
 	}
 	var v MVCCValue
-	// NOTE: we don't use protoutil to avoid passing header through an interface,
-	// which would cause a heap allocation and incur the cost of dynamic dispatch.
-	if err := v.MVCCValueHeader.Unmarshal(buf[extendedPreludeSize:headerSize]); err != nil {
-		return MVCCValue{}, errors.Wrapf(err, "unmarshaling MVCCValueHeader")
+	if unmarshalHeader {
+		// NOTE: we don't use protoutil to avoid passing header through an interface,
+		// which would cause a heap allocation and incur the cost of dynamic dispatch.
+		if err := v.MVCCValueHeader.Unmarshal(buf[extendedPreludeSize:headerSize]); err != nil {
+			return MVCCValue{}, errors.Wrapf(err, "unmarshaling MVCCValueHeader")
+		}
 	}
 	v.Value.RawBytes = buf[headerSize:]
 	return v, nil

--- a/pkg/storage/mvcc_value_test.go
+++ b/pkg/storage/mvcc_value_test.go
@@ -400,7 +400,7 @@ func BenchmarkDecodeMVCCValue(b *testing.B) {
 							var ok bool
 							res, ok, err = tryDecodeSimpleMVCCValue(buf)
 							if !ok && err == nil {
-								res, err = decodeExtendedMVCCValue(buf)
+								res, err = decodeExtendedMVCCValue(buf, true)
 							}
 						} else {
 							res, err = DecodeMVCCValue(buf)

--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -408,6 +408,10 @@ type pebbleMVCCScanner struct {
 	// allowEmpty is false, and the partial row is the first row in the result,
 	// the row will instead be completed by fetching additional KV pairs.
 	wholeRows bool
+	// decodeMVCCHeaders is set by callers who expect to be able
+	// to read the full MVCCValueHeader off of
+	// curUnsafeValue. Used by mvccGet.
+	decodeMVCCHeaders bool
 	// Stop adding intents and abort scan once maxLockConflicts threshold is
 	// reached. This limit is only applicable to consistent scans since they
 	// return intents as an error.
@@ -823,7 +827,13 @@ func (p *pebbleMVCCScanner) getOne(ctx context.Context) (ok, added bool) {
 		if !valid {
 			return false, false
 		}
-		if extended, valid := p.tryDecodeCurrentValueSimple(v); !valid {
+
+		uncertaintyCheckRequired := p.checkUncertainty && !p.curUnsafeKey.Timestamp.LessEq(p.ts)
+		if !p.mvccHeaderRequired(uncertaintyCheckRequired) {
+			if !p.decodeCurrentValueIgnoringHeader(v) {
+				return false, false
+			}
+		} else if extended, valid := p.tryDecodeCurrentValueSimple(v); !valid {
 			return false, false
 		} else if extended {
 			if !p.decodeCurrentValueExtended(v) {
@@ -1349,7 +1359,7 @@ func (p *pebbleMVCCScanner) addSynthetic(
 	var simple bool
 	value, simple, p.err = tryDecodeSimpleMVCCValue(version.Value)
 	if !simple && p.err == nil {
-		value, p.err = decodeExtendedMVCCValue(version.Value)
+		value, p.err = decodeExtendedMVCCValue(version.Value, p.decodeMVCCHeaders)
 	}
 	if p.err != nil {
 		return false, false
@@ -1398,14 +1408,19 @@ func (p *pebbleMVCCScanner) seekVersion(
 			if !valid {
 				return false, false
 			}
-			if extended, valid := p.tryDecodeCurrentValueSimple(v); !valid {
+			uncertaintyCheckRequired := uncertaintyCheck && !p.curUnsafeKey.Timestamp.LessEq(p.ts)
+			if !p.mvccHeaderRequired(uncertaintyCheckRequired) {
+				if !p.decodeCurrentValueIgnoringHeader(v) {
+					return false, false
+				}
+			} else if extended, valid := p.tryDecodeCurrentValueSimple(v); !valid {
 				return false, false
 			} else if extended {
 				if !p.decodeCurrentValueExtended(v) {
 					return false, false
 				}
 			}
-			if !uncertaintyCheck || p.curUnsafeKey.Timestamp.LessEq(p.ts) {
+			if !uncertaintyCheckRequired {
 				if rkv, ok := p.coveredByRangeKey(p.curUnsafeKey.Timestamp); ok {
 					return p.addSynthetic(ctx, p.curUnsafeKey.Key, rkv)
 				}
@@ -1440,14 +1455,20 @@ func (p *pebbleMVCCScanner) seekVersion(
 		if !valid {
 			return false, false
 		}
-		if extended, valid := p.tryDecodeCurrentValueSimple(v); !valid {
+
+		uncertaintyCheckRequired := uncertaintyCheck && !p.curUnsafeKey.Timestamp.LessEq(p.ts)
+		if !p.mvccHeaderRequired(uncertaintyCheckRequired) {
+			if !p.decodeCurrentValueIgnoringHeader(v) {
+				return false, false
+			}
+		} else if extended, valid := p.tryDecodeCurrentValueSimple(v); !valid {
 			return false, false
 		} else if extended {
 			if !p.decodeCurrentValueExtended(v) {
 				return false, false
 			}
 		}
-		if !uncertaintyCheck || p.curUnsafeKey.Timestamp.LessEq(p.ts) {
+		if !uncertaintyCheckRequired {
 			if rkv, ok := p.coveredByRangeKey(p.curUnsafeKey.Timestamp); ok {
 				return p.addSynthetic(ctx, p.curUnsafeKey.Key, rkv)
 			}
@@ -1560,7 +1581,7 @@ func (p *pebbleMVCCScanner) processRangeKeys(seeked bool, reverse bool) bool {
 					var simple bool
 					value, simple, p.err = tryDecodeSimpleMVCCValue(version.Value)
 					if !simple && p.err == nil {
-						value, p.err = decodeExtendedMVCCValue(version.Value)
+						value, p.err = decodeExtendedMVCCValue(version.Value, true)
 					}
 					if p.err != nil {
 						return false
@@ -1641,8 +1662,26 @@ func (p *pebbleMVCCScanner) decodeCurrentMetadata() bool {
 	return true
 }
 
+// mvccHeaderRequired returns true if the caller should fully
+// unmarshal the MVCCValueHeader when parsing an MVCCValue.
+//
+// The passed bool indicates whether the caller needs the
+// MVCCValueHeader because they are going to do an uncertainty check,
+// which may require the LocalTimestamp stored in the MVCCValueHeader
+//
 //gcassert:inline
-func (p *pebbleMVCCScanner) tryDecodeCurrentValueSimple(v []byte) (extended, valid bool) {
+func (p *pebbleMVCCScanner) mvccHeaderRequired(uncertaintyCheckRequired bool) bool {
+	return uncertaintyCheckRequired || p.decodeMVCCHeaders
+}
+
+//gcassert:inline
+func (p *pebbleMVCCScanner) decodeCurrentValueIgnoringHeader(v []byte) bool {
+	p.curUnsafeValue, p.err = decodeMVCCValueIgnoringHeader(v)
+	return p.err == nil
+}
+
+//gcassert:inline
+func (p *pebbleMVCCScanner) tryDecodeCurrentValueSimple(v []byte) (extended bool, valid bool) {
 	var simple bool
 	p.curUnsafeValue, simple, p.err = tryDecodeSimpleMVCCValue(v)
 	return !simple, p.err == nil
@@ -1650,7 +1689,7 @@ func (p *pebbleMVCCScanner) tryDecodeCurrentValueSimple(v []byte) (extended, val
 
 //gcassert:inline
 func (p *pebbleMVCCScanner) decodeCurrentValueExtended(v []byte) bool {
-	p.curUnsafeValue, p.err = decodeExtendedMVCCValue(v)
+	p.curUnsafeValue, p.err = decodeExtendedMVCCValue(v, true)
 	return p.err == nil
 }
 

--- a/pkg/storage/verifying_iterator.go
+++ b/pkg/storage/verifying_iterator.go
@@ -41,10 +41,7 @@ func (i *verifyingMVCCIterator) saveAndVerify() {
 	if i.hasPoint {
 		i.value, _ = i.pebbleIterator.UnsafeValue()
 		if i.key.IsValue() {
-			mvccValue, ok, err := tryDecodeSimpleMVCCValue(i.value)
-			if !ok && err == nil {
-				mvccValue, err = decodeExtendedMVCCValue(i.value)
-			}
+			mvccValue, err := decodeMVCCValueIgnoringHeader(i.value)
 			if err == nil {
 				err = mvccValue.Value.Verify(i.key.Key)
 			}


### PR DESCRIPTION
Many callers to the functions in pkg/storage do not care about the contents of the MVCCValueHeader. Previously, we would always parse this header anyway. Previously, the impact of this was likely small since most values were unlikely to include an MVCCValueHeader.

However, now IMPORT and LDR both write headers into a large number of rows.

Here, I've added the ability for the caller of decodeExtendedMVCCValue to indicate whether or not they require the value header to be parsed.

In pebbleMVCCScanner we've gone a little further and added a new method decodeValueMVCCValueIgnoringHeader that allows the scanner to avoid the non-inlinable decodeExtnededMVCCValue.

In the added benchmark case, this has been observed to produce a 7-10% improvement:

```
                                                                              │ before.txt  │              after.txt              │
                                                                              │   sec/op    │   sec/op     vs base                │
MVCCScan_Pebble/rows=1000/versions=2/valueSize=64/numRangeKeys=0/headers=true   403.5µ ± 1%   362.7µ ± 1%  -10.13% (p=0.000 n=20)

                                                                              │  before.txt  │              after.txt               │
                                                                              │     B/s      │     B/s       vs base                │
MVCCScan_Pebble/rows=1000/versions=2/valueSize=64/numRangeKeys=0/headers=true   151.2Mi ± 1%   168.3Mi ± 1%  +11.27% (p=0.000 n=20)
```

No larger scale testing of this has been done.

If the code looks a bit tortured to your eye, I agree. I've attempted to make sure that the same amount of inlining was happening. This is a bit finicky since many of the functions involved are very close to the default complexity limit for inlining functions.

Informs #131359

Epic: none
Release note: None