### PR TITLE
rac2: add support for pull mode in RangeController

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/simulation_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/simulation_test.go
@@ -175,7 +175,7 @@ func TestUsingSimulation(t *testing.T) {
 					rangeID := rangeIDSeq
 					handleToRangeID[handle] = rangeID
 					sim.state.getOrInitRange(t, makeSingleVoterTestingRange(
-						rangeID, testingLocalTenantID, testingLocalNodeID, testingLocalStoreID))
+						rangeID, testingLocalTenantID, testingLocalNodeID, testingLocalStoreID), MsgAppPush)
 				}
 
 			case "timeline":

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/close
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/close
@@ -18,11 +18,17 @@ t1/s3: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
 # There should be no tracked entries for the range.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,1) send_queue=[1,1)
+(n1,s1):1: state=replicate closed=false inflight=[1,1) send_queue=[1,1) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,1)
+(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,1) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,1) send_queue=[1,1)
+(n3,s3):3: state=replicate closed=false inflight=[1,1) send_queue=[1,1) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 ++++
 
 
@@ -43,19 +49,25 @@ t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
+(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
+(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
@@ -74,6 +86,30 @@ t1/s2: eval reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
 t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
        send reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
 
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=3  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[2,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
+++++
+
 # Change s3 to StateSnapshot. This should close the send stream and return the
 # tracked deductions for entries in [1,3].
 set_replicas
@@ -86,16 +122,21 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
+(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
 (n3,s3):3: closed
+++++
 
 # The tokens should be returned as well, s3 should have no outstanding tokens.
 adjust_tokens

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_choice
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_choice
@@ -1,0 +1,530 @@
+# Initialize a range with five replicas, none of which have send tokens.
+init regular_init=0 elastic_init=0
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
+  store_id=4 replica_id=4 type=VOTER_FULL state=StateReplicate next=1
+  store_id=5 replica_id=5 type=VOTER_FULL state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
+t1/s1: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s4: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s5: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+# Make replica 2 and 3 have positive send tokens, so they don't form a
+# send-queue. Replica 1 can't form a send-queue because it is the leader.
+adjust_tokens send
+  store_id=2 pri=HighPri tokens=512KiB
+  store_id=3 pri=HighPri tokens=512KiB
+----
+t1/s1: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+512 KiB/+16 MiB ela=+512 KiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+512 KiB/+16 MiB ela=+512 KiB/+8.0 MiB
+t1/s4: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s5: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+# Append one entry. Replicas 4, 5 have a send-queue.
+raft_event pull-mode
+range_id=1
+  entries
+    term=1 index=1 pri=NormalPri size=1MiB
+----
+t1/s1: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s2: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-512 KiB/+16 MiB ela=-512 KiB/+8.0 MiB
+t1/s3: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-512 KiB/+16 MiB ela=-512 KiB/+8.0 MiB
+t1/s4: eval reg=+0 B/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s5: eval reg=+0 B/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n4,s4):4: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n5,s5):5: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+
+# Replica 3 transitions to StateSnapshot. Replica 5 is picked to force-flush
+# because of the replicaID tiebreaker (both 4 and 5 have the same send and
+# eval tokens).
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=2
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=2
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=2
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateSnapshot next=2
+  store_id=4 replica_id=4 type=VOTER_FULL state=StateReplicate next=1
+  store_id=5 replica_id=5 type=VOTER_FULL state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n3,s3):3: closed
+++++
+(n4,s4):4: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n5,s5):5: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=true
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+
+# Replica 3 transitions back to StateReplicate. Replica 5 is no longer
+# force-flushing.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=2
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=2
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=2
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=2
+  store_id=4 replica_id=4 type=VOTER_FULL state=StateReplicate next=1
+  store_id=5 replica_id=5 type=VOTER_FULL state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+(n4,s4):4: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n5,s5):5: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+
+# Make replica 5 look more overloaded wrt the bucketed elastic send tokens
+# (bucket size is 0.8MiB).
+adjust_tokens send
+  store_id=5 pri=LowPri tokens=-1MiB
+----
+t1/s1: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s2: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-512 KiB/+16 MiB ela=-512 KiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+512 KiB/+16 MiB ela=+512 KiB/+8.0 MiB
+t1/s4: eval reg=+0 B/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s5: eval reg=+0 B/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-1.0 MiB/+8.0 MiB
+
+# Replica 3 transitions to StateSnapshot again. Replica 4 is picked to
+# force-flush since it is less overloaded wrt bucketed elastic send tokens.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=2
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=2
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=2
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateSnapshot next=2
+  store_id=4 replica_id=4 type=VOTER_FULL state=StateReplicate next=1
+  store_id=5 replica_id=5 type=VOTER_FULL state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n3,s3):3: closed
+++++
+(n4,s4):4: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=true
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n5,s5):5: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+
+# Replica 3 transitions back to StateReplicate. Replica 4 is no longer
+# force-flushing.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=2
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=2
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=2
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=2
+  store_id=4 replica_id=4 type=VOTER_FULL state=StateReplicate next=1
+  store_id=5 replica_id=5 type=VOTER_FULL state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+(n4,s4):4: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n5,s5):5: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+
+# Make replica 4 look more overloaded wrt the elastic send tokens, but after
+# bucketing, replica 4 and 5 look the same (bucket size is 0.8MiB).
+adjust_tokens send
+  store_id=4 pri=LowPri tokens=-512KiB
+  store_id=5 pri=LowPri tokens=768KiB
+----
+t1/s1: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s2: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-512 KiB/+16 MiB ela=-512 KiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+512 KiB/+16 MiB ela=+512 KiB/+8.0 MiB
+t1/s4: eval reg=+0 B/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-512 KiB/+8.0 MiB
+t1/s5: eval reg=+0 B/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-256 KiB/+8.0 MiB
+
+# Make replica 5 look more overloaded wrt elastic eval tokens. Since this is
+# the second field in the tuple comparison and the first field is equal, this
+# field will be used to pick.
+adjust_tokens eval
+  store_id=5 pri=LowPri tokens=-512KiB
+----
+t1/s1: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s2: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-512 KiB/+16 MiB ela=-512 KiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+512 KiB/+16 MiB ela=+512 KiB/+8.0 MiB
+t1/s4: eval reg=+0 B/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-512 KiB/+8.0 MiB
+t1/s5: eval reg=+0 B/+16 MiB ela=-1.5 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-256 KiB/+8.0 MiB
+
+# Replica 3 transitions to StateSnapshot again. Replica 4 is picked to
+# force-flush since it is less overloaded wrt elastic eval tokens.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=2
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=2
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=2
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateSnapshot next=2
+  store_id=4 replica_id=4 type=VOTER_FULL state=StateReplicate next=1
+  store_id=5 replica_id=5 type=VOTER_FULL state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n3,s3):3: closed
+++++
+(n4,s4):4: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=true
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n5,s5):5: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+
+# Replica 2 also transitions to StateSnapshot. Replicas 4, 5 are
+# force-flushing.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=2
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=2
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateSnapshot next=2
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateSnapshot next=2
+  store_id=4 replica_id=4 type=VOTER_FULL state=StateReplicate next=1
+  store_id=5 replica_id=5 type=VOTER_FULL state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: closed
+++++
+(n3,s3):3: closed
+++++
+(n4,s4):4: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=true
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n5,s5):5: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=true
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+
+# Replica 2 transitions back to StateReplicate. Replica 5 is no longer
+# force-flushing. Replica 4 continues to force-flush.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=2
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=2
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=2
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateSnapshot next=2
+  store_id=4 replica_id=4 type=VOTER_FULL state=StateReplicate next=1
+  store_id=5 replica_id=5 type=VOTER_FULL state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+(n3,s3):3: closed
+++++
+(n4,s4):4: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=true
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n5,s5):5: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+
+# Replica 2 transitions to StateSnapshot. Replica 5 also starts
+# force-flushing.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=2
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=2
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateSnapshot next=2
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateSnapshot next=2
+  store_id=4 replica_id=4 type=VOTER_FULL state=StateReplicate next=1
+  store_id=5 replica_id=5 type=VOTER_FULL state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: closed
+++++
+(n3,s3):3: closed
+++++
+(n4,s4):4: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=true
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n5,s5):5: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=true
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+
+# Replicas 2, 3 transition back to StateReplicate. Replicas 4, 5 stop
+# force-flushing.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=2
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=2
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=2
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=2
+  store_id=4 replica_id=4 type=VOTER_FULL state=StateReplicate next=1
+  store_id=5 replica_id=5 type=VOTER_FULL state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+(n4,s4):4: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n5,s5):5: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+
+# Replicas 2, 3 transition back to StateSnapshot. Replicas 4, 5 start
+# force-flushing.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=2
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=2
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateSnapshot next=2
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateSnapshot next=2
+  store_id=4 replica_id=4 type=VOTER_FULL state=StateReplicate next=1
+  store_id=5 replica_id=5 type=VOTER_FULL state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: closed
+++++
+(n3,s3):3: closed
+++++
+(n4,s4):4: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=true
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n5,s5):5: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=true
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+
+# Push mode. Replicas 4, 5 stop force-flushing in push mode.
+raft_event
+range_id=1
+----
+t1/s1: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+512 KiB/+16 MiB ela=+512 KiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+512 KiB/+16 MiB ela=+512 KiB/+8.0 MiB
+t1/s4: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-512 KiB/+8.0 MiB
+t1/s5: eval reg=-1.0 MiB/+16 MiB ela=-1.5 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-256 KiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: closed
+++++
+(n3,s3):3: closed
+++++
+(n4,s4):4: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n5,s5):5: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_no_send_q_joint_config
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_no_send_q_joint_config
@@ -1,0 +1,393 @@
+# This test exercises non formation of send-queue, and force-flush, when there
+# is a joint configuration. Replica 1 and 2 are in both configurations, with
+# replica 1 the leader and leaseholder. Replica 3 is an outgoing voter and
+# replica 4 is an incoming voter. None of these replicas have send tokens.
+init regular_init=0 elastic_init=0
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL              state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL              state=StateReplicate next=1
+  store_id=3 replica_id=3 type=VOTER_DEMOTING_LEARNER  state=StateReplicate next=1
+  store_id=4 replica_id=4 type=VOTER_INCOMING          state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3VOTER_DEMOTING_LEARNER,(n4,s4):4VOTER_INCOMING]
+t1/s1: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s4: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+# Make replica 3 and 4 look more overloaded than replica 2.
+adjust_tokens eval
+  store_id=3 pri=LowPri tokens=-512KiB
+  store_id=4 pri=LowPri tokens=-1MiB
+----
+t1/s1: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=-512 KiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s4: eval reg=+0 B/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+# Append an entry. Since replica 2 is less overloaded than replica 3, 4, it is
+# not permitted to form a send-queue. And since it is in both configurations,
+# this is sufficient for quorum.
+raft_event pull-mode
+range_id=1
+  entries
+    term=1 index=1 pri=NormalPri size=1MiB
+----
+t1/s1: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s2: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=-1.5 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s4: eval reg=+0 B/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n3,s3):3VOTER_DEMOTING_LEARNER: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+
+# Transition replica 2 to StateSnapshot. Both replica 3 and 4 need to
+# force-flush for both sets in the joint configuration to have quorum.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=2
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=2
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateSnapshot next=2
+  store_id=3 replica_id=3 type=VOTER_DEMOTING_LEARNER state=StateReplicate next=1
+  store_id=4 replica_id=4 type=VOTER_INCOMING state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3VOTER_DEMOTING_LEARNER,(n4,s4):4VOTER_INCOMING]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: closed
+++++
+(n3,s3):3VOTER_DEMOTING_LEARNER: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=true
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=true
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+
+# Make replica 3 and 4 have no send-queue.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=2
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=2
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateSnapshot next=2
+  store_id=3 replica_id=3 type=VOTER_DEMOTING_LEARNER state=StateReplicate next=2
+  store_id=4 replica_id=4 type=VOTER_INCOMING state=StateReplicate next=2
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3VOTER_DEMOTING_LEARNER,(n4,s4):4VOTER_INCOMING]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: closed
+++++
+(n3,s3):3VOTER_DEMOTING_LEARNER: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+
+# Append an entry. Both replica 3, 4 are not allowed to have a send-queue, to
+# ensure quorum in both sets of voters.
+raft_event pull-mode
+range_id=1
+  entries
+    term=1 index=2 pri=NormalPri size=1MiB
+----
+t1/s1: eval reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=-1.0 MiB/+16 MiB ela=-1.5 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s4: eval reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+++++
+(n2,s2):2: closed
+++++
+(n3,s3):3VOTER_DEMOTING_LEARNER: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=2  tokens=1048576
+++++
+(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=2  tokens=1048576
+++++
+
+# Transition replica 2 to StateReplicate with no send-queue.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=3
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=3
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=3
+  store_id=3 replica_id=3 type=VOTER_DEMOTING_LEARNER state=StateReplicate next=3
+  store_id=4 replica_id=4 type=VOTER_INCOMING state=StateReplicate next=3
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3VOTER_DEMOTING_LEARNER,(n4,s4):4VOTER_INCOMING]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+(n3,s3):3VOTER_DEMOTING_LEARNER: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=2  tokens=1048576
+++++
+(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=2  tokens=1048576
+++++
+
+# Make replica 2 look more overloaded than replica 3, 4.
+adjust_tokens send
+  store_id=2 pri=LowPri tokens=-3MiB
+----
+t1/s1: eval reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-3.0 MiB/+8.0 MiB
+t1/s3: eval reg=-1.0 MiB/+16 MiB ela=-1.5 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s4: eval reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+
+# Append an entry. Both replica 3 and 4 are not allowed to form a send-queue,
+# since they are less overloaded than replica 2.
+raft_event pull-mode
+range_id=1
+  entries
+    term=1 index=3 pri=NormalPri size=1MiB
+----
+t1/s1: eval reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
+       send reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-3.0 MiB/+8.0 MiB
+t1/s3: eval reg=-2.0 MiB/+16 MiB ela=-2.5 MiB/+8.0 MiB
+       send reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+t1/s4: eval reg=-2.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
+       send reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n3,s3):3VOTER_DEMOTING_LEARNER: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
+++++
+(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
+++++
+
+# Transition replica 3 to StateSnapshot. Replica 2 needs to force-flush.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=3
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=4
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=3
+  store_id=3 replica_id=3 type=VOTER_DEMOTING_LEARNER state=StateSnapshot next=4
+  store_id=4 replica_id=4 type=VOTER_INCOMING state=StateReplicate next=4
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3VOTER_DEMOTING_LEARNER,(n4,s4):4VOTER_INCOMING]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+1.0 MiB force-flush=true
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n3,s3):3VOTER_DEMOTING_LEARNER: closed
+++++
+(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
+++++
+
+# Transition replica 4 to StateSnapshot too. Replica 2 continues to
+# force-flush.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=3
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=4
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=3
+  store_id=3 replica_id=3 type=VOTER_DEMOTING_LEARNER state=StateSnapshot next=4
+  store_id=4 replica_id=4 type=VOTER_INCOMING state=StateSnapshot next=4
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3VOTER_DEMOTING_LEARNER,(n4,s4):4VOTER_INCOMING]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+1.0 MiB force-flush=true
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n3,s3):3VOTER_DEMOTING_LEARNER: closed
+++++
+(n4,s4):4VOTER_INCOMING: closed
+++++
+
+# Transition replica 3, 4 back to StateReplicate. Replica 2 continues to
+# force-flush since we don't stop force-flushing in a joint config.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=3
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=4
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=3
+  store_id=3 replica_id=3 type=VOTER_DEMOTING_LEARNER state=StateReplicate next=4
+  store_id=4 replica_id=4 type=VOTER_INCOMING state=StateReplicate next=4
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3VOTER_DEMOTING_LEARNER,(n4,s4):4VOTER_INCOMING]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+1.0 MiB force-flush=true
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n3,s3):3VOTER_DEMOTING_LEARNER: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+
+# Transition out of joint-config. Replica 2 stops force-flushing.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=3
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=4
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=3
+  store_id=4 replica_id=4 type=VOTER_FULL state=StateReplicate next=4
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n4,s4):4]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n4,s4):4: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/handle_raft_event
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/handle_raft_event
@@ -17,11 +17,17 @@ t1/s3: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
 # There should be no tracked entries for the range.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,1) send_queue=[1,1)
+(n1,s1):1: state=replicate closed=false inflight=[1,1) send_queue=[1,1) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,1)
+(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,1) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,1) send_queue=[1,1)
+(n3,s3):3: state=replicate closed=false inflight=[1,1) send_queue=[1,1) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 ++++
 
 # Simulate a call to `HandleRaftEventRaftMuLocked` on s1 (leader/local
@@ -45,19 +51,25 @@ t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
 # replica stream (1,2,3).
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
+(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
+(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
@@ -81,11 +93,17 @@ t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[4,4) send_queue=[4,4)
+(n1,s1):1: state=replicate closed=false inflight=[4,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[4,4) send_queue=[4,4)
+(n2,s2):2: state=replicate closed=false inflight=[4,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
+(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
@@ -104,34 +122,45 @@ range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=4
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 
 # Tick the clock by less than the probe to close delay, the stream should still
-# be open in state probeRecentlyReplicate but all deducted tokens should be
+# be open in state probeRecentlyNoSendQ but all deducted tokens should be
 # returned.
-tick duration=500ms
+tick duration=200ms
 ----
-now=500ms
+now=200ms
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
+(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n3,s3):3: state=probeRecentlyReplicate closed=false inflight=[1,4) send_queue=[4,4)
+(n3,s3):3: state=probeRecentlyNoSendQ closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 ++++
 
 # Tick the clock by the remaining probe to close delay, the stream should now
 # be closed and all tokens returned.
-tick duration=500ms
+tick duration=200ms
 ----
-now=1s
+now=400ms
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
+(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 ++++
 (n3,s3):3: closed
+++++
 
 # Next, start a WaitForEval operation. We will update the state of s3 to be
 # Replicate, which should trigger the WaitForEval to refresh. First, deduct all

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/handle_raft_event_partial_msg_app
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/handle_raft_event_partial_msg_app
@@ -38,18 +38,24 @@ t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
 # while r2 and r3 have partial entry tracking.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4)
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4)
+(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+1.0 MiB ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,4)
+(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+2.0 MiB force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+2.0 MiB ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
@@ -80,7 +86,9 @@ t1/s3: eval reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[4,6) send_queue=[6,6)
+(n1,s1):1: state=replicate closed=false inflight=[4,6) send_queue=[6,6) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+5.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
@@ -88,11 +96,15 @@ NormalPri:
   term=1 index=4  tokens=1048576
   term=1 index=5  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[2,5) send_queue=[5,6)
+(n2,s2):2: state=replicate closed=false inflight=[2,5) send_queue=[5,6) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+1.0 MiB ela=+0 B
 NormalPri:
   term=1 index=4  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,6)
+(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,6) precise_q_size=+2.0 MiB force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+2.0 MiB ela=+0 B
 ++++
 
 # Partially admit the entries, with r3 lagging by one entry. Expect to see the
@@ -113,13 +125,19 @@ t1/s3: eval reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[5,6) send_queue=[6,6)
+(n1,s1):1: state=replicate closed=false inflight=[5,6) send_queue=[6,6) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=5  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[5,5) send_queue=[5,6)
+(n2,s2):2: state=replicate closed=false inflight=[5,5) send_queue=[5,6) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+1.0 MiB ela=+0 B
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[4,4) send_queue=[4,6)
+(n3,s3):3: state=replicate closed=false inflight=[4,4) send_queue=[4,6) precise_q_size=+2.0 MiB force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+2.0 MiB ela=+0 B
 ++++
 
 # Send a raft_event that contains the unsent entries for each replica, in
@@ -142,17 +160,23 @@ t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[6,7) send_queue=[7,7)
+(n1,s1):1: state=replicate closed=false inflight=[6,7) send_queue=[7,7) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=5  tokens=1048576
   term=1 index=6  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[5,7) send_queue=[7,7)
+(n2,s2):2: state=replicate closed=false inflight=[5,7) send_queue=[7,7) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=5  tokens=1048576
   term=1 index=6  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[4,7) send_queue=[7,7)
+(n3,s3):3: state=replicate closed=false inflight=[4,7) send_queue=[7,7) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=4  tokens=1048576
   term=1 index=5  tokens=1048576
@@ -172,6 +196,21 @@ t1/s2: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
        send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
 t1/s3: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
        send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[7,7) send_queue=[7,7) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+(n2,s2):2: state=replicate closed=false inflight=[7,7) send_queue=[7,7) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+(n3,s3):3: state=replicate closed=false inflight=[7,7) send_queue=[7,7) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
 
 close_rcs
 ----

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/leaseholder_force_flush_no_send_q
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/leaseholder_force_flush_no_send_q
@@ -1,0 +1,198 @@
+# Initialize a range with three replicas, none of which have send tokens.
+init regular_init=0 elastic_init=0
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
+t1/s1: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+# Give send tokens to replica 3.
+adjust_tokens send
+  store_id=3 pri=HighPri tokens=4MiB
+----
+t1/s1: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+4.0 MiB/+16 MiB ela=+4.0 MiB/+8.0 MiB
+
+# Make replica 2 the leaseholder.
+set_leaseholder range_id=1 replica_id=2
+----
+r1: [(n1,s1):1,(n2,s2):2*,(n3,s3):3]
+
+# Append raft event. Only replica 3 has send tokens so it will not form a
+# send-queue. Replica 1 is the leader and replica 2 is the leaseholder, and so
+# they are not permitted to form a send-queue even though they have no send
+# tokens.
+raft_event pull-mode
+range_id=1
+  entries
+    term=1 index=1 pri=NormalPri size=1MiB
+----
+t1/s1: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s2: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s3: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=+3.0 MiB/+16 MiB ela=+3.0 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+
+# Set the leaseholder back to replica 1, which is the leader and append
+# another entry. Now replica 2 has a send-queue.
+set_leaseholder range_id=1 replica_id=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
+
+raft_event pull-mode
+range_id=1
+  entries
+    term=1 index=2 pri=NormalPri size=1MiB
+----
+t1/s1: eval reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+t1/s2: eval reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s3: eval reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=+2.0 MiB/+16 MiB ela=+2.0 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,3) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+1.0 MiB ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n3,s3):3: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+++++
+
+# Make replica 2 the leaseholder again. It is told to force-flush because it
+# is the leaseholder, even though replica 1 and 3 already constitute a quorum
+# without a send-queue.
+set_leaseholder range_id=1 replica_id=2
+----
+r1: [(n1,s1):1,(n2,s2):2*,(n3,s3):3]
+
+raft_event pull-mode
+range_id=1
+----
+t1/s1: eval reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+t1/s2: eval reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s3: eval reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=+2.0 MiB/+16 MiB ela=+2.0 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,3) precise_q_size=+1.0 MiB force-flush=true
+eval deducted: reg=+1.0 MiB ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n3,s3):3: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+++++
+
+# Another raft event. Replica 2 continues force-flushing.
+raft_event pull-mode
+range_id=1
+----
+t1/s1: eval reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+t1/s2: eval reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s3: eval reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=+2.0 MiB/+16 MiB ela=+2.0 MiB/+8.0 MiB
+
+# Set replica 1 to be the leaseholder. Since replica 2 is no longer the
+# leaseholder, it can stop force-flushing.
+set_leaseholder range_id=1 replica_id=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
+
+raft_event pull-mode
+range_id=1
+----
+t1/s1: eval reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+t1/s2: eval reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s3: eval reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=+2.0 MiB/+16 MiB ela=+2.0 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,3) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+1.0 MiB ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n3,s3):3: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+++++

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/no_send_q_choice
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/no_send_q_choice
@@ -1,0 +1,233 @@
+# Initialize a range with five replicas, none of which have send tokens.
+init regular_init=0 elastic_init=0
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
+  store_id=4 replica_id=4 type=VOTER_FULL state=StateReplicate next=1
+  store_id=5 replica_id=5 type=VOTER_FULL state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
+t1/s1: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s4: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s5: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+# Append one entry. Replica 1 (leader), 4, 5 are not allowed to form a
+# send-queue even though they have no send tokens.
+raft_event pull-mode
+range_id=1
+  entries
+    term=1 index=1 pri=NormalPri size=1MiB
+----
+t1/s1: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s4: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s5: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n4,s4):4: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n5,s5):5: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+
+# Make replica 5 look more overloaded than replica 4. Note that once we have
+# picked a replica to not have a send-queue it will be picked again if needed
+# for quorum, even though another replica with a send-queue may be less
+# overloaded. That is, we don't keep revisiting this choice (just like we
+# don't revisit who to force-flush). In practice, new eval will stop since
+# there isn't a quorum with eval tokens.
+adjust_tokens eval
+  store_id=5 pri=LowPri tokens=-512KiB
+----
+t1/s1: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s4: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s5: eval reg=-1.0 MiB/+16 MiB ela=-1.5 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+
+# Append another entry. Again replicas 1, 4, 5 are not allowed to have a
+# send-queue despite no send tokens.
+raft_event pull-mode
+range_id=1
+  entries
+    term=1 index=2 pri=NormalPri size=1MiB
+----
+t1/s1: eval reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s4: eval reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+t1/s5: eval reg=-2.0 MiB/+16 MiB ela=-2.5 MiB/+8.0 MiB
+       send reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,3) precise_q_size=+2.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+2.0 MiB
+eval original in send-q: reg=+2.0 MiB ela=+0 B
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,1) send_queue=[1,3) precise_q_size=+2.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+2.0 MiB
+eval original in send-q: reg=+2.0 MiB ela=+0 B
+++++
+(n4,s4):4: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+++++
+(n5,s5):5: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+++++
+
+# Make replica 2 catchup (say there was a transition to StateSnapshot and back
+# to StateReplicate that we missed. Replica 3 transitions to StateSnapshot.
+# Now replica 1, 2, 4, 5 have no send-queue. Since replica 5 is more
+# overloaded than replicas 4 and 2, the latter two will not be permitted to
+# form a send-queue on the next append.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=3
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=3
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=3
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateSnapshot next=1
+  store_id=4 replica_id=4 type=VOTER_FULL state=StateReplicate next=3
+  store_id=5 replica_id=5 type=VOTER_FULL state=StateReplicate next=3
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+(n3,s3):3: closed
+++++
+(n4,s4):4: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+++++
+(n5,s5):5: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+++++
+
+raft_event pull-mode
+range_id=1
+  entries
+    term=1 index=3 pri=NormalPri size=1MiB
+----
+t1/s1: eval reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
+       send reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
+t1/s2: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s4: eval reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
+       send reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
+t1/s5: eval reg=-2.0 MiB/+16 MiB ela=-3.5 MiB/+8.0 MiB
+       send reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+
+# Replica 5 now has a send-queue.
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=3  tokens=1048576
+++++
+(n3,s3):3: closed
+++++
+(n4,s4):4: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
+++++
+(n5,s5):5: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+2.0 MiB ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+++++

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/non_voter_send_q
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/non_voter_send_q
@@ -1,0 +1,102 @@
+# Initialize a range with three voter replicas, and one non-voter, none of which have send tokens.
+init regular_init=0 elastic_init=0
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
+  store_id=4 replica_id=4 type=NON_VOTER  state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4NON_VOTER]
+t1/s1: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s4: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+# Make replica 3 more overloaded than replica 2 and replica 2 more overloaded
+# than replica 4.
+adjust_tokens send
+  store_id=2 pri=HighPri tokens=-2MiB
+  store_id=3 pri=HighPri tokens=-3MiB
+----
+t1/s1: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
+t1/s4: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+# Append an entry. Replica 1, 2 are not permitted to form a send-queue, even
+# though they have no send tokens. Replica 4 is not picked since it is a
+# non-voter.
+raft_event pull-mode
+range_id=1
+  entries
+    term=1 index=1 pri=NormalPri size=1MiB
+----
+t1/s1: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s2: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
+t1/s4: eval reg=+0 B/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n4,s4):4NON_VOTER: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+
+# Make replica 2 transition to StateSnapshot. Now replica 2 is picked for
+# force-flush instead of replica 4, since the latter is a non-voter.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=2
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=2
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateSnapshot next=2
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
+  store_id=4 replica_id=4 type=NON_VOTER state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4NON_VOTER]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: closed
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=true
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n4,s4):4NON_VOTER: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/probe_state
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/probe_state
@@ -1,0 +1,195 @@
+# Initialize a range with three replicas, none of which have send tokens.
+init regular_init=0 elastic_init=0
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
+t1/s1: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+# Append one entry. Replica 2 has a send-queue.
+raft_event pull-mode
+range_id=1
+  entries
+    term=1 index=1 pri=NormalPri size=1MiB
+----
+t1/s1: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+
+# Transition replica 2 to StateProbe. Since it has a send-queue, it is
+# immediately closed and does not transition to probeRecentlyNoSendQ.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=2
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=2
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateProbe next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=2
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: closed
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+
+# Transition replica 2 to StateProbe.Since it has no send-queue, it
+# transitions to probeRecentlyNoSendQ, but returns all its tokens.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=2
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=2
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateProbe next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateProbe next=2
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: closed
+++++
+(n3,s3):3: state=probeRecentlyNoSendQ closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+
+# Append another event. It does not change replica 3's state, which is in probeRecentlyNoSendQ.
+raft_event pull-mode
+range_id=1
+  entries
+    term=1 index=2 pri=NormalPri size=1MiB
+----
+t1/s1: eval reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+++++
+(n2,s2):2: closed
+++++
+(n3,s3):3: state=probeRecentlyNoSendQ closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+
+# Transition replica 2 back to StateReplicate, and it starts with a
+# send-queue. Since replica 3 is in probeRecentlyNoSendQ, and pretending not
+# to have a send-queue, replica 2 is not asked to force-flush.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=3
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=3
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=2
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateProbe next=2
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+(n3,s3):3: state=probeRecentlyNoSendQ closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+
+# Make replica 3 look more overloaded than replica 3.
+adjust_tokens eval
+  store_id=3 pri=HighPri tokens=-512KiB
+----
+t1/s1: eval reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=-512 KiB/+16 MiB ela=-512 KiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+# Transition replica 3 back to StateReplicate, with a send-queue. Now replica
+# 2 is asked to force-flush.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=3
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=3
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=2
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=2
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,3) precise_q_size=+0 B force-flush=true
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/quorum_without_send_q
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/quorum_without_send_q
@@ -1,0 +1,195 @@
+# Initialize a range with three replicas, none of which have send tokens.
+init regular_init=0 elastic_init=0
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
+t1/s1: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+# Make replica 2 and 3 have positive send tokens.
+adjust_tokens send
+  store_id=2 pri=HighPri tokens=512KiB
+  store_id=3 pri=HighPri tokens=512KiB
+----
+t1/s1: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+512 KiB/+16 MiB ela=+512 KiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+512 KiB/+16 MiB ela=+512 KiB/+8.0 MiB
+
+# Append one entry. Replica 1 has no send tokens, but is not allowed to form a
+# send-queue since it is the leader.
+raft_event pull-mode
+range_id=1
+  entries
+    term=1 index=1 pri=NormalPri size=1MiB
+----
+t1/s1: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+t1/s2: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-512 KiB/+16 MiB ela=-512 KiB/+8.0 MiB
+t1/s3: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
+       send reg=-512 KiB/+16 MiB ela=-512 KiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+
+# Append another entry. One of the follower replicas, replica 3, is not
+# permitted to form a send-queue.
+raft_event pull-mode
+range_id=1
+  entries
+    term=1 index=2 pri=NormalPri size=1MiB
+----
+t1/s1: eval reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+t1/s2: eval reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-512 KiB/+16 MiB ela=-512 KiB/+8.0 MiB
+t1/s3: eval reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-1.5 MiB/+16 MiB ela=-1.5 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,3) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+1.0 MiB ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n3,s3):3: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+++++
+
+# Replica 3 transitions to StateSnapshot.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=3
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=3
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=2
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateSnapshot next=3
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
+
+# Ignore the regression in the Match value (the starting index in "inflight")
+# for replica 1, which is just a test artifact when using set_replicas.
+# RangeController does not store or use the Match value.
+#
+# Replica 2 is told to force-flush.
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,3) precise_q_size=+1.0 MiB force-flush=true
+eval deducted: reg=+1.0 MiB ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n3,s3):3: closed
+++++
+
+# Append another entry. Since there is no quorum without a send-queue, replica
+# 3 continues to force-flush.
+raft_event pull-mode
+range_id=1
+  entries
+    term=1 index=3 pri=NormalPri size=1MiB
+----
+t1/s1: eval reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
+       send reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
+t1/s2: eval reg=-1.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
+       send reg=-512 KiB/+16 MiB ela=-512 KiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+512 KiB/+16 MiB ela=+512 KiB/+8.0 MiB
+
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+2.0 MiB force-flush=true
+eval deducted: reg=+1.0 MiB ela=+2.0 MiB
+eval original in send-q: reg=+2.0 MiB ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n3,s3):3: closed
+++++
+
+# Replica 3 returns without a send-queue.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=4
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=4
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=2
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=4
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
+
+# Replica 2 is told to stop force-flushing.
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+2.0 MiB force-flush=false
+eval deducted: reg=+1.0 MiB ela=+2.0 MiB
+eval original in send-q: reg=+2.0 MiB ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/sendq_push_pull
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/sendq_push_pull
@@ -1,0 +1,150 @@
+# This test creates send-queues in push and pull mode.
+init
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
+t1/s1: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s2: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s3: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+
+# Replica 1 is the leader so sending [1,1) is ignored and everything is
+# considered sent (the leader does not see MsgApps for itself).
+raft_event
+range_id=1
+  entries
+    term=1 index=1 pri=NormalPri size=1MiB
+    term=1 index=2 pri=LowPri size=2MiB
+  sending
+    replica_id=1 [1,1)
+    replica_id=2 [1,3)
+    replica_id=3 [1,1)
+----
+t1/s1: eval reg=+15 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+       send reg=+15 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+t1/s2: eval reg=+15 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+       send reg=+15 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+t1/s3: eval reg=+15 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+
+# Replica 3 has a send-queue where one item deduct elastic eval tokens and
+# another regular eval tokens.
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+2.0 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=2  tokens=2097152
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+1.0 MiB ela=+2.0 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=2  tokens=2097152
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,1) send_queue=[1,3) precise_q_size=+3.0 MiB force-flush=false
+eval deducted: reg=+1.0 MiB ela=+2.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+2.0 MiB
+++++
+
+# Switch to pull mode and add more to the send-queue of replica 3.
+raft_event pull-mode
+range_id=1
+  entries
+    term=1 index=3 pri=NormalPri size=1MiB
+    term=1 index=4 pri=LowPri size=3MiB
+----
+t1/s1: eval reg=+14 MiB/+16 MiB ela=+1.0 MiB/+8.0 MiB
+       send reg=+14 MiB/+16 MiB ela=+1.0 MiB/+8.0 MiB
+t1/s2: eval reg=+14 MiB/+16 MiB ela=+1.0 MiB/+8.0 MiB
+       send reg=+14 MiB/+16 MiB ela=+1.0 MiB/+8.0 MiB
+t1/s3: eval reg=+16 MiB/+16 MiB ela=+1.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+
+# In pull mode, all entries in the send-queue deduct elastic eval tokens.
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[3,5) send_queue=[5,5) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+5.0 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=2  tokens=2097152
+  term=1 index=4  tokens=3145728
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=3  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[3,5) send_queue=[5,5) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+2.0 MiB ela=+5.0 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=2  tokens=2097152
+  term=1 index=4  tokens=3145728
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=3  tokens=1048576
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,1) send_queue=[1,5) precise_q_size=+7.0 MiB force-flush=false
+eval deducted: reg=+0 B ela=+7.0 MiB
+eval original in send-q: reg=+2.0 MiB ela=+5.0 MiB
+++++
+
+# Switch back to push mode and pop index 1 from the send-queue of replica 3.
+raft_event
+range_id=1
+  entries
+    term=1 index=5 pri=NormalPri size=1MiB
+  sending
+    replica_id=1 [5,5)
+    replica_id=2 [5,6)
+    replica_id=3 [1,2)
+----
+t1/s1: eval reg=+13 MiB/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+13 MiB/+16 MiB ela=+0 B/+8.0 MiB
+t1/s2: eval reg=+13 MiB/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+13 MiB/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=+13 MiB/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+15 MiB/+16 MiB ela=+7.0 MiB/+8.0 MiB
+
+# The popped item is regular, and is counted as regular since we are in push
+# mode.
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[5,6) send_queue=[6,6) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+5.0 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=2  tokens=2097152
+  term=1 index=4  tokens=3145728
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=3  tokens=1048576
+  term=1 index=5  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[5,6) send_queue=[6,6) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+5.0 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=2  tokens=2097152
+  term=1 index=4  tokens=3145728
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=3  tokens=1048576
+  term=1 index=5  tokens=1048576
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,6) precise_q_size=+7.0 MiB force-flush=false
+eval deducted: reg=+3.0 MiB ela=+5.0 MiB
+eval original in send-q: reg=+2.0 MiB ela=+5.0 MiB
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval_send_q
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval_send_q
@@ -18,11 +18,17 @@ t1/s3: eval reg=+8.0 MiB/+8.0 MiB ela=+1 B/+1 B
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2)
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,2)
+(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,1) send_queue=[1,2)
+(n3,s3):3: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 ++++
 
 # Start a high priority evaluation. It should not complete due to lack of
@@ -43,11 +49,16 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2)
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2)
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 ++++
 (n3,s3):3: closed
+++++
 
 # Evaluation completes.
 check_state
@@ -63,6 +74,21 @@ range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=2
   store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=2
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
 
 wait_for_eval name=b range_id=1 pri=HighPri
 ----
@@ -92,17 +118,23 @@ t1/s3: eval reg=+5.0 MiB/+8.0 MiB ela=-3.0 MiB/+1 B
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[2,5) send_queue=[5,5)
+(n1,s1):1: state=replicate closed=false inflight=[2,5) send_queue=[5,5) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
   term=1 index=4  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[2,3) send_queue=[3,5)
+(n2,s2):2: state=replicate closed=false inflight=[2,3) send_queue=[3,5) precise_q_size=+2.0 MiB force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+2.0 MiB ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[2,4) send_queue=[4,5)
+(n3,s3):3: state=replicate closed=false inflight=[2,4) send_queue=[4,5) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+1.0 MiB ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
@@ -135,21 +167,27 @@ t1/s3: eval reg=+4.0 MiB/+8.0 MiB ela=-4.0 MiB/+1 B
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[5,6) send_queue=[6,6)
+(n1,s1):1: state=replicate closed=false inflight=[5,6) send_queue=[6,6) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+4.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
   term=1 index=4  tokens=1048576
   term=1 index=5  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[3,6) send_queue=[6,6)
+(n2,s2):2: state=replicate closed=false inflight=[3,6) send_queue=[6,6) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+4.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
   term=1 index=4  tokens=1048576
   term=1 index=5  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[4,5) send_queue=[5,6)
+(n3,s3):3: state=replicate closed=false inflight=[4,5) send_queue=[5,6) precise_q_size=+1.0 MiB force-flush=false
+eval deducted: reg=+4.0 MiB ela=+0 B
+eval original in send-q: reg=+1.0 MiB ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter.go
@@ -228,19 +228,19 @@ func newTokenCounter(
 }
 
 // String returns a string representation of the token counter.
-func (b *tokenCounter) String() string {
-	return redact.StringWithoutMarkers(b)
+func (t *tokenCounter) String() string {
+	return redact.StringWithoutMarkers(t)
 }
 
 // SafeFormat implements the redact.SafeFormatter interface.
-func (b *tokenCounter) SafeFormat(w redact.SafePrinter, _ rune) {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
+func (t *tokenCounter) SafeFormat(w redact.SafePrinter, _ rune) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
 	w.Printf("reg=%v/%v ela=%v/%v",
-		b.mu.counters[admissionpb.RegularWorkClass].tokens,
-		b.mu.counters[admissionpb.RegularWorkClass].limit,
-		b.mu.counters[admissionpb.ElasticWorkClass].tokens,
-		b.mu.counters[admissionpb.ElasticWorkClass].limit)
+		t.mu.counters[admissionpb.RegularWorkClass].tokens,
+		t.mu.counters[admissionpb.RegularWorkClass].limit,
+		t.mu.counters[admissionpb.ElasticWorkClass].tokens,
+		t.mu.counters[admissionpb.ElasticWorkClass].limit)
 }
 
 // Stream returns the flow control stream for which tokens are being adjusted.
@@ -263,8 +263,14 @@ func (t *tokenCounter) tokens(wc admissionpb.WorkClass) kvflowcontrol.Tokens {
 	return t.tokensLocked(wc)
 }
 
-func (b *tokenCounter) tokensLocked(wc admissionpb.WorkClass) kvflowcontrol.Tokens {
-	return b.mu.counters[wc].tokens
+func (t *tokenCounter) tokensLocked(wc admissionpb.WorkClass) kvflowcontrol.Tokens {
+	return t.mu.counters[wc].tokens
+}
+
+func (t *tokenCounter) limit(wc admissionpb.WorkClass) kvflowcontrol.Tokens {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.mu.counters[wc].limit
 }
 
 // TokensAvailable returns true if tokens are available. If false, it returns


### PR DESCRIPTION
The RangeController dynamically switches between push and pull mode based on RaftEvent.

The support is incomplete, in that pacing the popping from the send-queue, and force flushing is unimplemented. Given those will be calling MakeMsgApp, which is only permitted in pull mode, we will need a way for the RangeController to also query the current mode, outside what it is told by RaftEvent.

This PR implements:
- Deciding when to start force-flushing and to stop force-flushing (latter is useful if quorum with no send-queue is restored before force-flush completes).
- Deciding which replica should not be allowed to form a send-queue.
- Introduces probeRecentlyNoSendQueue which pretends to be in StateReplicate and have no send-queue for a limited amount of time, to avoid short-lived back and forth state transitions causing force-flush on a severely backlogged store.

One simplification made here for the quorum related decision making is that if send-tokens are > 0 and there is no send-queue, we decide up front that we will send all the new entries in a MsgApp. This admits a burst, when transitioning from no send-queue to send-queue, akin to the eval burst, but is deemed acceptable.

Informs #130433

Epic: CRDB-37515

Release note: None