### PR TITLE
sql/schemachanger: Ensure new PK is visible and old secondary is invisible in the same stage

### DIFF
--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_add_index.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_add_index.go
@@ -209,7 +209,7 @@ func init() {
 
 	registerDepRule(
 		"primary index with new columns should exist before secondary indexes",
-		scgraph.Precedence,
+		scgraph.SameStagePrecedence,
 		"primary-index", "secondary-index",
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_swap_index.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_swap_index.go
@@ -135,7 +135,7 @@ func init() {
 	// new enough version.
 	registerDepRule(
 		"replacement secondary index should be validated before the old one becomes invisible",
-		scgraph.Precedence,
+		scgraph.SameStagePrecedence,
 		"new-index", "old-index",
 		func(from, to NodeVars) rel.Clauses {
 			// Detect a potential secondary index recreation because of a ALTER

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -3820,7 +3820,7 @@ deprules
     - joinTargetNode($old-index, $old-index-Target, $old-index-Node)
 - name: primary index with new columns should exist before secondary indexes
   from: primary-index-Node
-  kind: Precedence
+  kind: SameStagePrecedence
   to: secondary-index-Node
   query:
     - $primary-index[Type] = '*scpb.PrimaryIndex'
@@ -3943,7 +3943,7 @@ deprules
     - joinTargetNode($index, $index-Target, $index-Node)
 - name: replacement secondary index should be validated before the old one becomes invisible
   from: new-index-Node
-  kind: Precedence
+  kind: SameStagePrecedence
   to: old-index-Node
   query:
     - $old-index[Type] = '*scpb.SecondaryIndex'
@@ -8196,7 +8196,7 @@ deprules
     - joinTargetNode($old-index, $old-index-Target, $old-index-Node)
 - name: primary index with new columns should exist before secondary indexes
   from: primary-index-Node
-  kind: Precedence
+  kind: SameStagePrecedence
   to: secondary-index-Node
   query:
     - $primary-index[Type] = '*scpb.PrimaryIndex'
@@ -8319,7 +8319,7 @@ deprules
     - joinTargetNode($index, $index-Target, $index-Node)
 - name: replacement secondary index should be validated before the old one becomes invisible
   from: new-index-Node
-  kind: Precedence
+  kind: SameStagePrecedence
   to: old-index-Node
   query:
     - $old-index[Type] = '*scpb.SecondaryIndex'

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column
@@ -3191,7 +3191,7 @@ ALTER TABLE defaultdb.baz ADD g INT UNIQUE DEFAULT 1
   rule: swapped primary index public before column
 - from: [PrimaryIndex:{DescID: 109, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC]
   to:   [SecondaryIndex:{DescID: 109, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0}, BACKFILL_ONLY]
-  kind: Precedence
+  kind: SameStagePrecedence
   rule: primary index with new columns should exist before secondary indexes
 - from: [PrimaryIndex:{DescID: 109, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC]
   to:   [TemporaryIndex:{DescID: 109, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, DELETE_ONLY]


### PR DESCRIPTION
We encountered a situation where, during a primary key modification, the old secondary index was used to retrieve a column from the new primary key. This triggered an assertion failure because the query assumed that all secondary indexes include the primary key columns as a prefix, which was not the case for the old secondary index.

This change ensures that when the new primary key becomes visible, the old secondary index is made invisible within the same stage. There are two dependency rules involved here: one ensures the primary key is in place before the secondary index, and another handles the swap between old and new secondary indexes. Both rules have been adjusted to execute within the same stage.

Note: I was unable to reproduce the issue, so no new test case has been added.

Epic: None
Closes #130282
Release note: None