### PR TITLE
roachtest: use system 3-node cluster in separate-process

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -1287,9 +1287,26 @@ func assertValidTest(test *Test, fatalFunc func(...interface{})) {
 	// valid (i.e., part of the `allDeploymentModes` list). This stops
 	// us from having to implement a `default` branch with an error when
 	// switching on deployment mode.
+	var supportsSeparateProcess bool
 	for _, dm := range test.options.enabledDeploymentModes {
 		if !validDeploymentMode(dm) {
 			fail(fmt.Errorf("invalid test options: unknown deployment mode %q", dm))
 		}
+
+		if dm == SeparateProcessDeployment {
+			supportsSeparateProcess = true
+		}
+	}
+
+	// In separate process deployments, we need to make sure the storage
+	// cluster is still functional while a node is restarting.
+	// Otherwise, the tenant could fail to keep its sqllivenes record
+	// active, causing it to voluntarily shutdown.
+	const minSeparateProcessNodes = 3
+	if supportsSeparateProcess && len(test.crdbNodes) < minSeparateProcessNodes {
+		fail(fmt.Errorf(
+			"invalid test options: %s deployments require cluster with at least %d nodes",
+			SeparateProcessDeployment, minSeparateProcessNodes,
+		))
 	}
 }

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion_test.go
@@ -192,6 +192,16 @@ func Test_assertValidTest(t *testing.T) {
 		fatalErr.Error(),
 	)
 
+	// separate-process deployments requires cluster validation
+	mvt = newTest(NeverUseFixtures, EnabledDeploymentModes(allDeploymentModes...))
+	mvt.crdbNodes = option.NodeListOption{1}
+	assertValidTest(mvt, fatalFunc())
+	require.Error(t, fatalErr)
+	require.Equal(t,
+		`mixedversion.NewTest: invalid test options: separate-process deployments require cluster with at least 3 nodes`,
+		fatalErr.Error(),
+	)
+
 	mvt = newTest(MinimumSupportedVersion("v22.2.0"))
 	assertValidTest(mvt, fatalFunc())
 	require.NoError(t, fatalErr)

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -157,6 +157,7 @@ func RegisterTests(r registry.Registry) {
 	registerTPCHVec(r)
 	registerTypeORM(r)
 	registerUnoptimizedQueryOracle(r)
+	registerValidateSystemSchemaAfterVersionUpgradeSeparateProcess(r)
 	registerYCSB(r)
 	registerDeclarativeSchemaChangerJobCompatibilityInMixedVersion(r)
 	registerMultiRegionMixedVersion(r)

--- a/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
+++ b/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/mixedversion"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
@@ -80,13 +81,8 @@ func (c tenantSystemSchemaComparison) Diff() error {
 	return nil
 }
 
-// This test tests that, after bootstrapping a cluster from a previous
-// release's binary and upgrading it to the latest version, the `system`
-// database "contains the expected tables".
-// Specifically, we do the check with `USE system; SHOW CREATE ALL TABLES;`
-// and assert that the output matches the expected output content.
-func runValidateSystemSchemaAfterVersionUpgrade(
-	ctx context.Context, t test.Test, c cluster.Cluster,
+func validateSystemSchemaAfterUpgradeTest(
+	ctx context.Context, t test.Test, c cluster.Cluster, opts ...mixedversion.CustomOption,
 ) {
 	// Obtain system table definitions with `SHOW CREATE ALL TABLES` in the SYSTEM db.
 	obtainSystemSchema := func(
@@ -119,28 +115,6 @@ func runValidateSystemSchemaAfterVersionUpgrade(
 	systemComparison := newTenantSystemSchemaComparison(install.SystemInterfaceName)
 	var tenantComparison *tenantSystemSchemaComparison
 	var deploymentMode mixedversion.DeploymentMode
-
-	opts := []mixedversion.CustomOption{
-		// We limit the number of upgrades since the test is not expected to work
-		// on versions older than 22.2.
-		mixedversion.MaxUpgrades(3),
-		// Fixtures are generated on a version that's too old for this test.
-		mixedversion.NeverUseFixtures,
-	}
-
-	if c.IsLocal() {
-		opts = append(opts,
-			// Separate-process deployments are still in its early
-			// days. Disable it in local clusters (such as in CI) to avoid
-			// disruptions.
-			//
-			// TODO(testeng): enable separate-process deployments once it is
-			// considered stable enough.
-			mixedversion.EnabledDeploymentModes(
-				mixedversion.SystemOnlyDeployment,
-				mixedversion.SharedProcessDeployment,
-			))
-	}
 
 	mvt := mixedversion.NewTest(ctx, t, t.L(), c, c.All(), opts...)
 	mvt.AfterUpgradeFinalized(
@@ -210,4 +184,58 @@ func runValidateSystemSchemaAfterVersionUpgrade(
 
 		t.L().Printf("validation succeeded for non-system tenant")
 	}
+}
+
+// This test tests that, after bootstrapping a cluster from a previous
+// release's binary and upgrading it to the latest version, the `system`
+// database "contains the expected tables".
+// Specifically, we do the check with `USE system; SHOW CREATE ALL TABLES;`
+// and assert that the output matches the expected output content.
+func runValidateSystemSchemaAfterVersionUpgrade(
+	ctx context.Context, t test.Test, c cluster.Cluster,
+) {
+	validateSystemSchemaAfterUpgradeTest(ctx, t, c,
+		// We limit the number of upgrades since the test is not expected to work
+		// on versions older than 22.2.
+		mixedversion.MaxUpgrades(3),
+		// Fixtures are generated on a version that's too old for this test.
+		mixedversion.NeverUseFixtures,
+		// Separate-process deployments can't run in 1-node clusters since
+		// the tenant process can die when the storage cluster is
+		// restarting. See `runValidateSystemSchemaAfterVersionUpgradeSeparateProcess`
+		// for a variant of this test for separate-process deployments.
+		mixedversion.EnabledDeploymentModes(
+			mixedversion.SystemOnlyDeployment,
+			mixedversion.SharedProcessDeployment,
+		),
+	)
+}
+
+// Like `runValidateSystemSchemaAfterVersionUpgrade`, but for
+// separate-process deployments.
+func runValidateSystemSchemaAfterVersionUpgradeSeparateProcess(
+	ctx context.Context, t test.Test, c cluster.Cluster,
+) {
+	validateSystemSchemaAfterUpgradeTest(ctx, t, c,
+		// We limit the number of upgrades since the test is not expected to work
+		// on versions older than 22.2.
+		mixedversion.MaxUpgrades(3),
+		// Fixtures are generated on a version that's too old for this test.
+		mixedversion.NeverUseFixtures,
+		mixedversion.EnabledDeploymentModes(mixedversion.SeparateProcessDeployment),
+	)
+}
+
+func registerValidateSystemSchemaAfterVersionUpgradeSeparateProcess(r registry.Registry) {
+	r.Add(registry.TestSpec{
+		Name:             "validate-system-schema-after-version-upgrade/separate-process",
+		Owner:            registry.OwnerSQLFoundations,
+		CompatibleClouds: registry.AllClouds,
+		Suites:           registry.Suites(registry.Nightly),
+		Cluster:          r.MakeClusterSpec(3),
+		RequiresLicense:  false,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runValidateSystemSchemaAfterVersionUpgradeSeparateProcess(ctx, t, c)
+		},
+	})
 }


### PR DESCRIPTION
**roachtest: use system 3-node cluster in separate-process**
This updates the `validate-system-schema-after-version-upgrade`
roachtest to only run in system-only and shared-process deployment
modes. That is because this test is an acceptance test that runs on
1-node clusters. In that scenario, tenant processes could die while
the storage cluster is restarting.

In order to perform this test in separate-process deployments, a new
variant of this test is added in this commit that only runs in
separate-process mode. This variant runs nightly and on a 3-node cluster.

Fixes: #131481

Release note: None

**roachtest: mixedversion: validate cluster in separate-process deployments**
We can't run these tests on 1-node clusters.

Epic: none

Release note: None