### PR TITLE
release-24.1: roachprod: validate cloud providers

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1494,6 +1494,18 @@ func validateAndConfigure(cmd *cobra.Command, args []string) {
 			_ = cmd.Flags().Set("arch", string(arch))
 		}
 	}
+
+	// Validate cloud providers, if set.
+	providersSet := make(map[string]struct{})
+	for _, p := range createVMOpts.VMProviders {
+		if _, ok := vm.Providers[p]; !ok {
+			printErrAndExit(fmt.Errorf("unknown cloud provider %q", p))
+		}
+		if _, ok := providersSet[p]; ok {
+			printErrAndExit(fmt.Errorf("duplicate cloud provider specified %q", p))
+		}
+		providersSet[p] = struct{}{}
+	}
 }
 
 var updateCmd = &cobra.Command{


### PR DESCRIPTION
Backport 1/1 commits from #131218.

/cc @cockroachdb/release

---

Previously, when calling the `create` command, it was possible to pass the same cloud twice by specifying `-c` or `--clouds` for the same provider more than once. There was no early validation that caught this and the resulting error after attempting to create the cluster would be confusing.

This change adds validation that warns the user early on a duplicate provider has been passed.

Epic: None
Release note: None
Release justification: Test-only change.
