### PR TITLE
release-24.2: util/log/logconfig: allow `format` for stderr log sink

### DIFF
--- a/pkg/util/log/logconfig/config.go
+++ b/pkg/util/log/logconfig/config.go
@@ -30,9 +30,6 @@ import (
 const DefaultFileFormat = `crdb-v2`
 
 // DefaultStderrFormat is the entry format for stderr sinks.
-// NB: The format for stderr is always set to `crdb-v2-tty`,
-// and cannot be changed. We enforce this in the validation step.
-// See: https://www.cockroachlabs.com/docs/stable/configure-logs#output-to-stderr
 const DefaultStderrFormat = `crdb-v2-tty`
 
 // DefaultFluentFormat is the entry format for fluent sinks

--- a/pkg/util/log/logconfig/testdata/validate
+++ b/pkg/util/log/logconfig/testdata/validate
@@ -254,7 +254,7 @@ capture-stray-errors:
   dir: /default-dir
   max-group-size: 100MiB
 
-# Check that file-defaults format options are transferred to stderr if using a crdb-v2 format.
+# Check that file-defaults format options are transferred to stderr if using the same format (crdb-v2).
 yaml
 file-defaults:
   format: crdb-v2
@@ -276,7 +276,38 @@ capture-stray-errors:
   dir: /default-dir
   max-group-size: 100MiB
 
-# Check that file-defaults format options are NOT transferred to stderr if NOT using a crdb-v2 format.
+# Check that file-defaults format options are transferred to stderr if stderr is using the same format (json).
+yaml
+file-defaults:
+  format: json
+  format-options: {datetime-format: rfc3339, datetime-timezone: America/New_York}
+sinks:
+  stderr:
+    format: json
+----
+sinks:
+  file-groups:
+    default:
+      channels: {INFO: all}
+      filter: INFO
+      format: json
+      format-options:
+        datetime-format: rfc3339
+        datetime-timezone: America/New_York
+  stderr:
+    filter: NONE
+    format: json
+    format-options:
+      datetime-format: rfc3339
+      datetime-timezone: America/New_York
+capture-stray-errors:
+  enable: true
+  dir: /default-dir
+  max-group-size: 100MiB
+
+# Check that file-defaults format options are NOT transferred to stderr if stderr is NOT using the same format
+# as file-defaults.
+# Note that here, we are using the default stderr format crdb-v2-tty.
 yaml
 file-defaults:
   format: json
@@ -323,7 +354,7 @@ capture-stray-errors:
   dir: /default-dir
   max-group-size: 100MiB
 
-# Check that stderr always uses crdb-v2-tty format, even if we try to set it to an invalid format
+# Check that stderr can accept formats other than crdb-v2-tty.
 yaml
 sinks:
   stderr:
@@ -336,6 +367,7 @@ sinks:
       filter: INFO
   stderr:
     filter: NONE
+    format: crdb-v1-tty
 capture-stray-errors:
   enable: true
   dir: /default-dir


### PR DESCRIPTION
Backport 1/1 commits from #131529.

/cc @cockroachdb/release

Release justification: fix regression

---

Previously in #113532 we fixed the stderr sink log format to `crdb-v2-tty`. This was deemed to be a regression, as the stderr sink could previously be set to any available format. This commit reverts the restriction.

The following are still true after this commit:
- `format` in `file-defaults` is not propagated to `format` of the stderr sink. To set `stderr` format, one must explicitly define it in the `stderr` sink section of the log config.
- `format-options` in `file-defaults` are only applied to stderr if the format of the stderr sink and that in file-defaults are compatible.

Epic: none
Fixes: #128665

Release note (ops change): Users may set the log format for the stderr sink by setting the `format` field in the logging config under the `stderr` sink section.
