### PR TITLE
release-24.2: storage: remove WAL failover enterprise license check

### DIFF
--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/disk"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/pebble/vfs"
@@ -448,7 +447,6 @@ func WALFailover(
 func makePebbleWALFailoverOptsForDir(
 	settings *cluster.Settings, dir wal.Dir,
 ) *pebble.WALFailoverOptions {
-	cclWALFailoverLogEvery := log.Every(10 * time.Minute)
 	return &pebble.WALFailoverOptions{
 		Secondary: dir,
 		FailoverOptions: wal.FailoverOptions{
@@ -464,12 +462,7 @@ func makePebbleWALFailoverOptsForDir(
 				// NB: We do not use settings.Version.IsActive because we do not have a
 				// guarantee that the cluster version has been initialized.
 				versionOK := settings.Version.ActiveVersionOrEmpty(context.TODO()).IsActive(clusterversion.V24_1Start)
-				// WAL failover is a licensed feature.
-				licenseOK := base.CCLDistributionAndEnterpriseEnabled(settings)
-				if !licenseOK && cclWALFailoverLogEvery.ShouldLog() {
-					log.Warningf(context.Background(), "Ignoring WAL failover configuration because it requires an enterprise license.")
-				}
-				return walFailoverUnhealthyOpThreshold.Get(&settings.SV), versionOK && licenseOK
+				return walFailoverUnhealthyOpThreshold.Get(&settings.SV), versionOK
 			},
 		},
 	}

--- a/pkg/storage/open_test.go
+++ b/pkg/storage/open_test.go
@@ -128,11 +128,6 @@ func TestWALFailover(t *testing.T) {
 				}
 				settings := cluster.MakeTestingClusterSettingsWithVersions(version, version, true /* initializeVersion */)
 
-				// Mock an enterpise license, or not if disable-enterprise is specified.
-				enterpriseEnabledFunc := base.CCLDistributionAndEnterpriseEnabled
-				base.CCLDistributionAndEnterpriseEnabled = func(st *cluster.Settings) bool { return !td.HasArg("disable-enterprise") }
-				defer func() { base.CCLDistributionAndEnterpriseEnabled = enterpriseEnabledFunc }()
-
 				engine, err := Open(context.Background(), openEnv, settings, WALFailover(cfg, envs, defaultFS, nil))
 				if err != nil {
 					openEnv.Close()

--- a/pkg/storage/testdata/wal_failover_config
+++ b/pkg/storage/testdata/wal_failover_config
@@ -102,14 +102,6 @@ open flag=disabled envs=(foo,bar) open=bar
 OK
 WALRecoveryDir: foo/auxiliary/wals-among-stores
 
-# Ensure that WAL failover refuses to failover if there's no enterprise
-# license configured.
-open flag=among-stores envs=(foo,bar) open=foo disable-enterprise
-----
-OK
-secondary = bar/auxiliary/wals-among-stores
-UnhealthyOperationLatencyThreshold() = (100ms,false)
-
 open flag=disabled envs=(foo,bar) open=foo
 ----
 OK


### PR DESCRIPTION
24.2 backport of #131357.

----

The license check may be performed before the node has fully initialized and knows whether a valid enterprise license is available. A warning may be logged erroneously, which may confuse. Remove the license check altogether given the direction CockroachDB enterprise licensing is moving in general.

Epic: none
Informs #129240.
Release note: none
Release justification: Fixes deceiving error message.