### PR TITLE
raft: remove unused store-liveness-nodes option

### DIFF
--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
@@ -12,8 +12,7 @@ log-level none
 ok
 
 # Start with two nodes, but the config already has a third.
-# We set store-liveness-nodes=3 because we add 3 voters despite having 2 nodes.
-add-nodes 2 voters=(1,2,3) index=10 store-liveness-nodes=3
+add-nodes 2 voters=(1,2,3) index=10
 ----
 ok
 
@@ -48,9 +47,7 @@ status 1
 
 # Add the node that will receive a snapshot (it has no state at all, does not
 # even have a config).
-# We set store-liveness-nodes=0 because we already added a third
-# store-liveness-node earlier.
-add-nodes 1 store-liveness-nodes=0
+add-nodes 1
 ----
 INFO 3 switched to configuration voters=()
 INFO 3 became follower at term 0


### PR DESCRIPTION
This was left over from one of the intermediate revisions of e20bf34f.

Epic: None
Release note: None