### PR TITLE
raft: fortify new peers on config change

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -2344,6 +2344,10 @@ func (r *raft) switchToConfig(cfg quorum.Config, progressMap tracker.ProgressMap
 	}
 
 	r.maybeCommit()
+	// If the configuration change means that there are new followers, fortify
+	// them immediately, without waiting for the next heartbeatTimeout to fire.
+	// bcastFortify is a no-op for peers that are already fortified.
+	r.bcastFortify()
 	// If the configuration change means that more entries are committed now,
 	// broadcast/append to everyone in the updated config.
 	//

--- a/pkg/raft/testdata/confchange_disable_validation.txt
+++ b/pkg/raft/testdata/confchange_disable_validation.txt
@@ -7,11 +7,20 @@
 # has applied, a second (compatible, but the node doesn't know this yet)
 # configuration change is proposed. That configuration change is accepted into
 # the log since due to DisableConfChangeValidation=true.
-add-nodes 1 voters=(1) index=2 max-committed-size-per-ready=1 disable-conf-change-validation=true
+add-nodes 4 voters=(1) index=2 max-committed-size-per-ready=1 disable-conf-change-validation=true
 ----
 INFO 1 switched to configuration voters=(1)
 INFO 1 became follower at term 0
 INFO newRaft 1 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
+INFO 2 switched to configuration voters=(1)
+INFO 2 became follower at term 0
+INFO newRaft 2 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
+INFO 3 switched to configuration voters=(1)
+INFO 3 became follower at term 0
+INFO newRaft 3 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
+INFO 4 switched to configuration voters=(1)
+INFO 4 became follower at term 0
+INFO newRaft 4 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
 
 campaign 1
 ----

--- a/pkg/raft/testdata/confchange_disable_validation.txt
+++ b/pkg/raft/testdata/confchange_disable_validation.txt
@@ -62,6 +62,8 @@ stabilize 1
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
+  1->2 MsgFortifyLeader Term:1 Log:0/0
+  1->3 MsgFortifyLeader Term:1 Log:0/0
   1->2 MsgApp Term:1 Log:1/4 Commit:5 Entries:[1/5 EntryConfChangeV2 l2 l3]
   1->3 MsgApp Term:1 Log:1/4 Commit:5 Entries:[1/5 EntryConfChangeV2 l2 l3]
 

--- a/pkg/raft/testdata/confchange_drop_if_unapplied.txt
+++ b/pkg/raft/testdata/confchange_drop_if_unapplied.txt
@@ -3,11 +3,20 @@
 # https://github.com/etcd-io/etcd/issues/7625#issuecomment-489232411
 
 # The check should be performed even if conf change validation is disabled.
-add-nodes 1 voters=(1) index=2 disable-conf-change-validation=true
+add-nodes 4 voters=(1) index=2 disable-conf-change-validation=true
 ----
 INFO 1 switched to configuration voters=(1)
 INFO 1 became follower at term 0
 INFO newRaft 1 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
+INFO 2 switched to configuration voters=(1)
+INFO 2 became follower at term 0
+INFO newRaft 2 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
+INFO 3 switched to configuration voters=(1)
+INFO 3 became follower at term 0
+INFO newRaft 3 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
+INFO 4 switched to configuration voters=(1)
+INFO 4 became follower at term 0
+INFO newRaft 4 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
 
 campaign 1
 ----

--- a/pkg/raft/testdata/confchange_drop_if_unapplied.txt
+++ b/pkg/raft/testdata/confchange_drop_if_unapplied.txt
@@ -64,5 +64,7 @@ stabilize 1
   CommittedEntries:
   1/5 EntryNormal ""
   Messages:
+  1->2 MsgFortifyLeader Term:1 Log:0/0
+  1->3 MsgFortifyLeader Term:1 Log:0/0
   1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]

--- a/pkg/raft/testdata/confchange_v1_add_single.txt
+++ b/pkg/raft/testdata/confchange_v1_add_single.txt
@@ -56,18 +56,22 @@ stabilize
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
+  1->2 MsgFortifyLeader Term:1 Log:0/0
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChange v2]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChange v2]
-  INFO 2 [term: 0] received a MsgApp message with higher term from 1 [term: 1]
+  1->2 MsgFortifyLeader Term:1 Log:0/0
+  INFO 2 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1]
   INFO 2 became follower at term 1
+  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChange v2]
   DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:0 Lead:1 LeadEpoch:0
+  HardState Term:1 Commit:0 Lead:1 LeadEpoch:1
   Messages:
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
@@ -87,7 +91,7 @@ stabilize
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:4 Lead:1 LeadEpoch:0
+  HardState Term:1 Commit:4 Lead:1 LeadEpoch:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4

--- a/pkg/raft/testdata/confchange_v2_add_double_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_auto.txt
@@ -70,6 +70,8 @@ stabilize 1
   Entries:
   1/5 EntryConfChangeV2
   Messages:
+  1->2 MsgFortifyLeader Term:1 Log:0/0
+  1->3 MsgFortifyLeader Term:1 Log:0/0
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2 v3]
   1->3 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2 v3]
 
@@ -81,16 +83,19 @@ stabilize 1
 stabilize 1 2
 ----
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2 v3]
-  INFO 2 [term: 0] received a MsgApp message with higher term from 1 [term: 1]
+  1->2 MsgFortifyLeader Term:1 Log:0/0
+  INFO 2 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1]
   INFO 2 became follower at term 1
+  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2 v3]
   DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:0 Lead:1 LeadEpoch:0
+  HardState Term:1 Commit:0 Lead:1 LeadEpoch:1
   Messages:
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
@@ -110,7 +115,7 @@ stabilize 1 2
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:4 Lead:1 LeadEpoch:0
+  HardState Term:1 Commit:4 Lead:1 LeadEpoch:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
   Messages:
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
@@ -141,9 +146,13 @@ stabilize 1 2
   INFO 1 switched to configuration voters=(1 2 3)
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/5 Commit:5
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->3 MsgFortifyLeader Term:1 Log:0/0
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:5 Lead:1 LeadEpoch:0
+  HardState Term:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryConfChangeV2
   Messages:
@@ -156,21 +165,27 @@ stabilize 1 2
 stabilize 1 3
 ----
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2 v3]
-  INFO 3 [term: 0] received a MsgApp message with higher term from 1 [term: 1]
+  1->3 MsgFortifyLeader Term:1 Log:0/0
+  INFO 3 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1]
   INFO 3 became follower at term 1
+  1->3 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2 v3]
   DEBUG 3 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
+  1->3 MsgFortifyLeader Term:1 Log:0/0
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:0 Lead:1 LeadEpoch:0
+  HardState Term:1 Commit:0 Lead:1 LeadEpoch:1
   Messages:
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
 > 1 receiving messages
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 3 for index 3
   DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
   DEBUG 1 [firstindex: 3, commit: 5] sent snapshot[index: 5, term: 1] to 3 [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
   DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=6 sentCommit=5 matchCommit=0 paused pendingSnap=5]
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
@@ -185,7 +200,7 @@ stabilize 1 3
   INFO 3 [commit: 5] restored snapshot [index: 5, term: 1]
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:5 Lead:1 LeadEpoch:0
+  HardState Term:1 Commit:5 Lead:1 LeadEpoch:1
   Snapshot Index:5 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
   3->1 MsgAppResp Term:1 Log:0/5 Commit:5
@@ -298,7 +313,7 @@ stabilize 2 3
   1->3 MsgApp Term:1 Log:1/8 Commit:6 Entries:[1/9 EntryConfChangeV2]
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:6 Lead:1 LeadEpoch:0
+  HardState Term:1 Commit:6 Lead:1 LeadEpoch:1
   Entries:
   1/7 EntryNormal "foo"
   1/8 EntryNormal "bar"
@@ -313,7 +328,7 @@ stabilize 2 3
   INFO 2 switched to configuration voters=(1)&&(1 2 3) autoleave
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:6 Lead:1 LeadEpoch:0
+  HardState Term:1 Commit:6 Lead:1 LeadEpoch:1
   Entries:
   1/7 EntryNormal "foo"
   1/8 EntryNormal "bar"
@@ -366,7 +381,7 @@ stabilize
   1->3 MsgApp Term:1 Log:1/9 Commit:9
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:9 Lead:1 LeadEpoch:0
+  HardState Term:1 Commit:9 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/7 EntryNormal "foo"
   1/8 EntryNormal "bar"
@@ -378,7 +393,7 @@ stabilize
   INFO 2 switched to configuration voters=(1)
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:9 Lead:1 LeadEpoch:0
+  HardState Term:1 Commit:9 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/7 EntryNormal "foo"
   1/8 EntryNormal "bar"

--- a/pkg/raft/testdata/confchange_v2_add_double_implicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_implicit.txt
@@ -62,18 +62,22 @@ stabilize 1 2
   Entries:
   1/5 EntryConfChangeV2
   Messages:
+  1->2 MsgFortifyLeader Term:1 Log:0/0
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
-  INFO 2 [term: 0] received a MsgApp message with higher term from 1 [term: 1]
+  1->2 MsgFortifyLeader Term:1 Log:0/0
+  INFO 2 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1]
   INFO 2 became follower at term 1
+  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
   DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:0 Lead:1 LeadEpoch:0
+  HardState Term:1 Commit:0 Lead:1 LeadEpoch:1
   Messages:
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
@@ -93,7 +97,7 @@ stabilize 1 2
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:4 Lead:1 LeadEpoch:0
+  HardState Term:1 Commit:4 Lead:1 LeadEpoch:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
   Messages:
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
@@ -126,7 +130,7 @@ stabilize 1 2
   1->2 MsgApp Term:1 Log:1/5 Commit:5
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:5 Lead:1 LeadEpoch:0
+  HardState Term:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryConfChangeV2
   Messages:

--- a/pkg/raft/testdata/confchange_v2_add_single_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_auto.txt
@@ -57,18 +57,22 @@ stabilize
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
+  1->2 MsgFortifyLeader Term:1 Log:0/0
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
-  INFO 2 [term: 0] received a MsgApp message with higher term from 1 [term: 1]
+  1->2 MsgFortifyLeader Term:1 Log:0/0
+  INFO 2 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1]
   INFO 2 became follower at term 1
+  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
   DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:0 Lead:1 LeadEpoch:0
+  HardState Term:1 Commit:0 Lead:1 LeadEpoch:1
   Messages:
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
@@ -88,7 +92,7 @@ stabilize
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:4 Lead:1 LeadEpoch:0
+  HardState Term:1 Commit:4 Lead:1 LeadEpoch:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4

--- a/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
@@ -57,18 +57,22 @@ stabilize 1 2
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
+  1->2 MsgFortifyLeader Term:1 Log:0/0
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
-  INFO 2 [term: 0] received a MsgApp message with higher term from 1 [term: 1]
+  1->2 MsgFortifyLeader Term:1 Log:0/0
+  INFO 2 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1]
   INFO 2 became follower at term 1
+  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
   DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:0 Lead:1 LeadEpoch:0
+  HardState Term:1 Commit:0 Lead:1 LeadEpoch:1
   Messages:
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
 > 1 receiving messages
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
@@ -88,7 +92,7 @@ stabilize 1 2
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:4 Lead:1 LeadEpoch:0
+  HardState Term:1 Commit:4 Lead:1 LeadEpoch:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
@@ -149,7 +153,7 @@ stabilize
   1->2 MsgApp Term:1 Log:1/6 Commit:6
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:6 Lead:1 LeadEpoch:0
+  HardState Term:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryNormal ""
   1/6 EntryConfChangeV2
@@ -196,7 +200,7 @@ stabilize
   1->2 MsgApp Term:1 Log:1/7 Commit:7
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:7 Lead:1 LeadEpoch:0
+  HardState Term:1 Commit:7 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/7 EntryNormal ""
   Messages:

--- a/pkg/raft/testdata/confchange_v2_replace_leader.txt
+++ b/pkg/raft/testdata/confchange_v2_replace_leader.txt
@@ -57,7 +57,7 @@ raft-state
 1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
 2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
 3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
-4: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:0
+4: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
 
 # n4 will propose a transition out of the joint config.
 propose-conf-change 4
@@ -148,7 +148,7 @@ stabilize
   INFO 3 switched to configuration voters=(2 3 4)
 > 4 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:5 Lead:1 LeadEpoch:0
+  HardState Term:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryConfChangeV2
   Messages:
@@ -165,7 +165,7 @@ raft-state
 1: StateFollower (Non-Voter) Term:1 Lead:0 LeadEpoch:1
 2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
 3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
-4: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:0
+4: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
 
 # Make sure n1 cannot campaign to become leader.
 campaign 1

--- a/pkg/raft/testdata/fortification_basic.txt
+++ b/pkg/raft/testdata/fortification_basic.txt
@@ -74,7 +74,7 @@ stabilize 1
   1->4 MsgVote Term:1 Log:1/2
   INFO 1 received MsgVoteResp from 1 at term 1
   INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
-  
+
 stabilize 2 3 4
 ----
 > 2 receiving messages

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
@@ -85,7 +85,7 @@ stabilize 3
   Messages:
   3->1 MsgHeartbeatResp Term:1 Log:0/0
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
-  
+
 # The leader in turn will realize that n3 needs a snapshot, which it initiates.
 stabilize 1
 ----


### PR DESCRIPTION
Informs #125355.

This commit adds a call to `bcastFortify` in `raft.switchToConfig`, so that raft leaders fortify new followers immediately after they are added to the configuration. This avoids needing to wait for the next `heartbeatTimeout` to fire.

Release note: None