### PR TITLE
raft: support sending MsgApp on demand

### DIFF
--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -552,9 +552,7 @@ func (l *raftLog) slice(lo, hi uint64, maxSize entryEncodingSize) ([]pb.Entry, e
 //
 // Returns at least one entry if the interval contains any. The maxSize can only
 // be exceeded if the first entry (lo+1) is larger.
-//
-// TODO(pav-kv): export the logSlice type so that the caller can use it.
-func (l LogSnapshot) LogSlice(lo, hi uint64, maxSize uint64) (logSlice, error) {
+func (l LogSnapshot) LogSlice(lo, hi uint64, maxSize uint64) (LogSlice, error) {
 	prevTerm, err := l.term(lo)
 	if err != nil {
 		// The log is probably compacted at index > lo (err == ErrCompacted), or it

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -510,13 +510,24 @@ func (r *raft) hardState() pb.HardState {
 	}
 }
 
-// send schedules persisting state to a stable storage and AFTER that
-// sending the message (as part of next Ready message processing).
+// send prepares the given message for being sent, and puts it into the outgoing
+// message queue. The message will be handed over to the application via the
+// next Ready handling cycle, except in one condition below.
+//
+// Certain message types are scheduled for being sent *after* the unstable state
+// is durably persisted in storage. If AsyncStorageWrites config flag is true,
+// the responsibility of upholding this condition is on the application, so the
+// message will be handed over via the next Ready as usually; if false, the
+// message will skip one Ready handling cycle, and will be sent after the
+// application has persisted the state.
+//
+// TODO(pav-kv): remove this special case after !AsyncStorageWrites is removed.
 func (r *raft) send(m pb.Message) {
 	if m.From == None {
 		m.From = r.id
 	}
-	if m.Type == pb.MsgVote || m.Type == pb.MsgVoteResp || m.Type == pb.MsgPreVote || m.Type == pb.MsgPreVoteResp {
+	switch m.Type {
+	case pb.MsgVote, pb.MsgVoteResp, pb.MsgPreVote, pb.MsgPreVoteResp:
 		if m.Term == 0 {
 			// All {pre-,}campaign messages need to have the term set when
 			// sending.
@@ -532,7 +543,7 @@ func (r *raft) send(m pb.Message) {
 			//   same reasons MsgPreVote is
 			r.logger.Panicf("term should be set when sending %s", m.Type)
 		}
-	} else {
+	default:
 		if m.Term != 0 {
 			r.logger.Panicf("term should not be set when sending %s (was %d)", m.Type, m.Term)
 		}
@@ -542,8 +553,9 @@ func (r *raft) send(m pb.Message) {
 			m.Term = r.Term
 		}
 	}
-	if m.Type == pb.MsgAppResp || m.Type == pb.MsgVoteResp ||
-		m.Type == pb.MsgPreVoteResp || m.Type == pb.MsgFortifyLeaderResp {
+
+	switch m.Type {
+	case pb.MsgAppResp, pb.MsgVoteResp, pb.MsgPreVoteResp, pb.MsgFortifyLeaderResp:
 		// If async storage writes are enabled, messages added to the msgs slice
 		// are allowed to be sent out before unstable state (e.g. log entry
 		// writes and election votes) have been durably synced to the local
@@ -592,7 +604,7 @@ func (r *raft) send(m pb.Message) {
 		// we err on the side of safety and omit a `&& !m.Reject` condition
 		// above.
 		r.msgsAfterAppend = append(r.msgsAfterAppend, m)
-	} else {
+	default:
 		if m.To == r.id {
 			r.logger.Panicf("message should not be self-addressed when sending %s", m.Type)
 		}

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -543,6 +543,10 @@ func (r *raft) send(m pb.Message) {
 			//   same reasons MsgPreVote is
 			r.logger.Panicf("term should be set when sending %s", m.Type)
 		}
+	case pb.MsgApp:
+		if m.Term != r.Term {
+			r.logger.Panicf("invalid term %d in MsgApp, must be %d", m.Term, r.Term)
+		}
 	default:
 		if m.Term != 0 {
 			r.logger.Panicf("term should not be set when sending %s (was %d)", m.Type, m.Term)
@@ -612,6 +616,28 @@ func (r *raft) send(m pb.Message) {
 	}
 }
 
+// prepareMsgApp constructs a MsgApp message for being sent to the given peer,
+// and hands it over to the caller. Updates the replication flow control state
+// to account for the fact that the message is about to be sent.
+func (r *raft) prepareMsgApp(to pb.PeerID, pr *tracker.Progress, ls logSlice) pb.Message {
+	commit := r.raftLog.committed
+	// Update the progress accordingly to the message being sent.
+	pr.SentEntries(len(ls.entries), uint64(payloadsSize(ls.entries)))
+	pr.MaybeUpdateSentCommit(commit)
+	// Hand over the message to the caller.
+	return pb.Message{
+		From:    r.id,
+		To:      to,
+		Type:    pb.MsgApp,
+		Term:    ls.term,
+		Index:   ls.prev.index,
+		LogTerm: ls.prev.term,
+		Entries: ls.entries,
+		Commit:  commit,
+		Match:   pr.Match,
+	}
+}
+
 // maybeSendAppend sends an append RPC with log entries (if any) that are not
 // yet known to be replicated in the given peer's log, as well as the current
 // commit index. Usually it sends a MsgApp message, but in some cases (e.g. the
@@ -640,7 +666,6 @@ func (r *raft) maybeSendAppend(to pb.PeerID) bool {
 		// follower log anymore. Send a snapshot instead.
 		return r.maybeSendSnapshot(to, pr)
 	}
-
 	var entries []pb.Entry
 	if pr.CanSendEntries(last) {
 		if entries, err = r.raftLog.entries(prevIndex, r.maxMsgSize); err != nil {
@@ -649,18 +674,11 @@ func (r *raft) maybeSendAppend(to pb.PeerID) bool {
 		}
 	}
 
-	// Send the MsgApp, and update the progress accordingly.
-	r.send(pb.Message{
-		To:      to,
-		Type:    pb.MsgApp,
-		Index:   prevIndex,
-		LogTerm: prevTerm,
-		Entries: entries,
-		Commit:  commit,
-		Match:   pr.Match,
-	})
-	pr.SentEntries(len(entries), uint64(payloadsSize(entries)))
-	pr.MaybeUpdateSentCommit(commit)
+	r.send(r.prepareMsgApp(to, pr, logSlice{
+		term:    r.Term,
+		prev:    entryID{index: prevIndex, term: prevTerm},
+		entries: entries,
+	}))
 	return true
 }
 
@@ -672,7 +690,6 @@ func (r *raft) sendPing(to pb.PeerID) bool {
 	if pr == nil || pr.State != tracker.StateReplicate || pr.MsgAppProbesPaused {
 		return false
 	}
-	commit := r.raftLog.committed
 	prevIndex := pr.Next - 1
 	prevTerm, err := r.raftLog.term(prevIndex)
 	// An error happens then the log is truncated beyond Next. We can't send a
@@ -680,16 +697,11 @@ func (r *raft) sendPing(to pb.PeerID) bool {
 	if err != nil {
 		return false
 	}
-	r.send(pb.Message{
-		To:      to,
-		Type:    pb.MsgApp,
-		Index:   prevIndex,
-		LogTerm: prevTerm,
-		Commit:  commit,
-		Match:   pr.Match,
-	})
-	pr.SentEntries(0, 0) // NB: this sets MsgAppProbesPaused to true again.
-	pr.MaybeUpdateSentCommit(commit)
+	// NB: this sets MsgAppProbesPaused to true again.
+	r.send(r.prepareMsgApp(to, pr, logSlice{
+		term: r.Term,
+		prev: entryID{index: prevIndex, term: prevTerm},
+	}))
 	return true
 }
 

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -133,6 +133,22 @@ func (rn *RawNode) LogSnapshot() LogSnapshot {
 	return rn.raft.raftLog.snap(rn.raft.raftLog.storage.LogSnapshot())
 }
 
+// SendMsgApp conditionally sends a MsgApp message containing the given log
+// slice to the given peer. The message is returned to the caller, who is
+// responsible for actually sending it. The RawNode only updates the internal
+// state to reflect the fact that it was sent.
+//
+// The message can be sent only if all the conditions are true:
+//   - this node is the leader of term to which the slice corresponds
+//   - the given peer exists
+//   - the replication flow to the given peer is in StateReplicate
+//   - the first slice index matches the Next index to send to this peer
+//
+// Returns false if the message can not be sent.
+func (rn *RawNode) SendMsgApp(to pb.PeerID, slice logSlice) (pb.Message, bool) {
+	return rn.raft.maybePrepareMsgApp(to, slice)
+}
+
 // Ready returns the outstanding work that the application needs to handle. This
 // includes appending and applying entries or a snapshot, updating the HardState,
 // and sending messages. The returned Ready() *must* be handled and subsequently

--- a/pkg/raft/types.go
+++ b/pkg/raft/types.go
@@ -61,6 +61,8 @@ func (l LogMark) After(other LogMark) bool {
 	return l.Term > other.Term || l.Term == other.Term && l.Index > other.Index
 }
 
+type LogSlice = logSlice // TODO(pav-kv): export logSlice properly
+
 // logSlice describes a correct slice of a raft log.
 //
 // Every log slice is considered in a context of a specific leader term. This


### PR DESCRIPTION
This PR introduces a `RawNode` method that allows `MsgApp` messages construction and sending from outside the `RawNode`. To be used by RACv2.

Part of #128779