### PR TITLE
cli: improve tsdump datadog discoverability

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -167,7 +167,7 @@
 /pkg/cli/syncbench/          @cockroachdb/storage @cockroachdb/kv-prs
 /pkg/cli/swappable_fs*       @cockroachdb/storage
 /pkg/cli/testutils.go        @cockroachdb/test-eng
-/pkg/cli/tsdump.go           @cockroachdb/obs-prs @cockroachdb/obs-india-prs
+/pkg/cli/tsdump*.go          @cockroachdb/obs-prs @cockroachdb/obs-india-prs
 /pkg/cli/userfile.go         @cockroachdb/disaster-recovery
 /pkg/cli/workload*           @cockroachdb/sql-foundations
 /pkg/cli/zip*.go             @cockroachdb/obs-prs    @cockroachdb/cli-prs @cockroachdb/obs-india-prs


### PR DESCRIPTION
Previously, upload id is shared at start of tsdump upload command. This id was getting truncated during command execution due to command line outputs. To address this, we are sharing upload id at the end of command execution. Along with this, we are generating custom datadog dashboard link to visualize uploaded data.

Epic: none
Release note: none