### PR TITLE
sql: fix TestAuthenticationAndHBARules for special_cases data-driven test

### DIFF
--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -135,6 +135,7 @@ func TestAuthenticationAndHBARules(t *testing.T) {
 	skip.UnderRace(t, "takes >1min under race")
 
 	testutils.RunTrueAndFalse(t, "insecure", func(t *testing.T, insecure bool) {
+		defer leaktest.AfterTest(t)()
 		hbaRunTest(t, insecure)
 	})
 }
@@ -271,6 +272,9 @@ func hbaRunTest(t *testing.T, insecure bool) {
 
 				case "accept_sql_without_tls":
 					testServer.SetAcceptSQLWithoutTLS(true)
+
+				case "reject_sql_without_tls":
+					testServer.SetAcceptSQLWithoutTLS(false)
 
 				case "set_hba":
 					_, err := conn.ExecContext(context.Background(),

--- a/pkg/sql/pgwire/testdata/auth/secure_non_tls
+++ b/pkg/sql/pgwire/testdata/auth/secure_non_tls
@@ -71,3 +71,7 @@ local     all      all          password
 connect password=abc user=testuser sslmode=disable
 ----
 ERROR: authentication rejected by configuration (SQLSTATE 28000)
+
+# Revert enable non-TLS secure connections.
+reject_sql_without_tls
+----


### PR DESCRIPTION
informs #131532
informs #131110
informs #130253
informs #127745
Epic: CRDB-41958

`TestAuthenticationAndHBARules` fails for special_cases data driven test. We suspect it might be due to client for `special_cases` test accessing the test server from a previous test `secure_non_tls` which sets `accept_sql_without_tls` to true. This results in the following error `ERROR: pq: SSL is not enabled on the server` while the client was expecting an SSL connection with the server. We fix this in the PR.

Release note: None