### PR TITLE
sql: ALTER COLUMN TYPE does not check partial index definitions

### DIFF
--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -67,10 +67,16 @@ func AlterColumnType(
 			)
 		}
 	}
-	if err := schemaexpr.ValidateTTLExpressionDoesNotDependOnColumn(tableDesc, tableDesc.GetRowLevelTTL(), col, tn, op); err != nil {
+
+	if err := schemaexpr.ValidateTTLExpression(tableDesc, tableDesc.GetRowLevelTTL(), col, tn, op); err != nil {
 		return err
 	}
+
 	if err := schemaexpr.ValidateComputedColumnExpressionDoesNotDependOnColumn(tableDesc, col, objType, op); err != nil {
+		return err
+	}
+
+	if err := schemaexpr.ValidatePartialIndex(tableDesc, col, objType, op); err != nil {
 		return err
 	}
 

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1933,7 +1933,7 @@ func dropColumnImpl(
 	if err := schemaexpr.ValidateColumnHasNoDependents(tableDesc, colToDrop); err != nil {
 		return nil, err
 	}
-	if err := schemaexpr.ValidateTTLExpressionDoesNotDependOnColumn(tableDesc, rowLevelTTL, colToDrop, tn, "drop"); err != nil {
+	if err := schemaexpr.ValidateTTLExpression(tableDesc, rowLevelTTL, colToDrop, tn, "drop"); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/catalog/schemaexpr/expr.go
+++ b/pkg/sql/catalog/schemaexpr/expr.go
@@ -468,9 +468,9 @@ func SanitizeVarFreeExpr(
 	return typedExpr, nil
 }
 
-// ValidateTTLExpressionDoesNotDependOnColumn verifies that the
+// ValidateTTLExpression verifies that the
 // ttl_expiration_expression, if any, does not reference the given column.
-func ValidateTTLExpressionDoesNotDependOnColumn(
+func ValidateTTLExpression(
 	tableDesc catalog.TableDescriptor,
 	rowLevelTTL *catpb.RowLevelTTL,
 	col catalog.Column,
@@ -504,6 +504,33 @@ func ValidateComputedColumnExpressionDoesNotDependOnColumn(
 			} else if hasRef {
 				return sqlerrors.NewDependentBlocksOpError(op, objType,
 					string(dependentCol.ColName()), "computed column", string(col.ColName()))
+			}
+		}
+	}
+	return nil
+}
+
+// ValidatePartialIndex verifies that we have no partial indexes
+// that reference the column through the partial index's predicate.
+func ValidatePartialIndex(
+	tableDesc catalog.TableDescriptor, dependentCol catalog.Column, objType, op string,
+) error {
+	for _, idx := range tableDesc.AllIndexes() {
+		if idx.IsPartial() {
+			expr, err := parser.ParseExpr(idx.GetPredicate())
+			if err != nil {
+				return err
+			}
+
+			colIDs, err := ExtractColumnIDs(tableDesc, expr)
+			if err != nil {
+				return err
+			}
+
+			isReferencedByPredicate := colIDs.Contains(dependentCol.GetID())
+
+			if isReferencedByPredicate {
+				return sqlerrors.ColumnReferencedByPartialIndex(op, objType, string(dependentCol.ColName()), idx.GetName())
 			}
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -1215,4 +1215,21 @@ t_int  CREATE TABLE public.t_int (
 statement ok
 DROP TABLE t_int;
 
+subtest partial_index_fails_with_error
+
+statement ok
+create table roach_village ( roach_id int primary key, name text, age smallint, legs smallint );
+
+statement ok
+create index idx on roach_village(age) where name = 'papa roach';
+
+statement error pq: cannot alter type of column "name" because it is referenced by partial index "idx"
+alter table roach_village alter column name set data type char(20);
+
+statement ok
+alter table roach_village alter column age set data type bigint;
+
+statement ok
+alter table roach_village alter column legs set data type bigint;
+
 subtest end


### PR DESCRIPTION
Previously we would allow ALTER COLUMN TYPE to succeed on a column even when we have a partial index on it.  This would cause issues down the line for example at insert and is inconsistent with postgres.  This fix now checks for partial index and errors out like postgres when your run the ALTER COLUMN TYPE command on a column with a partial index.

Fixes: #72456
Epic: CRDB-25314

Release note (bug fix): ALTER COLUMN TYPE now errors out when we have a partial index dependent on the column being altered.