### PR TITLE
db-console: reroute db page on nav to v2 dbs

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/tableCells.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/tableCells.tsx
@@ -183,7 +183,7 @@ export const DbDetailsBreadcrumbs = ({ dbName }: { dbName: string }) => {
   return (
     <Breadcrumbs
       items={[
-        { link: "/databases", name: "Databases" },
+        { link: "/legacy/databases", name: "Databases" },
         {
           link: isCockroachCloud
             ? `/databases/${EncodeUriName(dbName)}`

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/helperComponents.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/helperComponents.tsx
@@ -81,7 +81,7 @@ export const DbTablesBreadcrumbs = ({
   return (
     <Breadcrumbs
       items={[
-        { link: "/databases", name: "Databases" },
+        { link: "/legacy/databases", name: "Databases" },
         {
           link: isCockroachCloud
             ? `/databases/${EncodeUriName(databaseName)}`

--- a/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
@@ -49,7 +49,7 @@ const COLUMNS: (TableColumnProps<DatabaseRow> & {
     sorter: (a, b) => a.name.localeCompare(b.name),
     sortKey: DatabaseSortOptions.NAME,
     render: (db: DatabaseRow) => {
-      return <Link to={`/v2/databases/${db.id}`}>{db.name}</Link>;
+      return <Link to={`/databases/${db.id}`}>{db.name}</Link>;
     },
   },
   {

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsConnected.ts
@@ -60,7 +60,7 @@ function createManagedServiceBreadcrumbs(
   index: string,
 ): BreadcrumbItem[] {
   return [
-    { link: "/databases", name: "Databases" },
+    { link: "legacy/databases", name: "Databases" },
     {
       link: `/databases/${database}`,
       name: "Tables",

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.stories.tsx
@@ -44,7 +44,7 @@ const withData: IndexDetailsPageProps = {
     ],
   },
   breadcrumbItems: [
-    { link: "/databases", name: "Databases" },
+    { link: "/legacy/databases", name: "Databases" },
     {
       link: `/databases/story_db`,
       name: "Tables",

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
@@ -389,7 +389,7 @@ export class IndexDetailsPage extends React.Component<
     return (
       <Breadcrumbs
         items={[
-          { link: "/databases", name: "Databases" },
+          { link: "/legacy/databases", name: "Databases" },
           {
             link: EncodeDatabaseUri(this.props.databaseName),
             name: "Tables",

--- a/pkg/ui/workspaces/db-console/src/app.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.spec.tsx
@@ -14,12 +14,20 @@
 // eslint-disable-next-line import/order
 import { stubComponentInModule } from "./test-utils/mockComponent";
 
+stubComponentInModule(
+  "@cockroachlabs/cluster-ui",
+  "DatabasesPageV2",
+  "DatabaseDetailsPageV2",
+);
 stubComponentInModule("src/views/cluster/containers/nodeGraphs", "default");
 stubComponentInModule("src/views/cluster/containers/events", "EventPage");
-stubComponentInModule("src/views/databases/databasesPage", "DatabasesPage");
+stubComponentInModule(
+  "src/views/databases/databasesPage",
+  "DatabasesPageLegacy",
+);
 stubComponentInModule(
   "src/views/databases/databaseDetailsPage",
-  "DatabaseDetailsPage",
+  "DatabaseDetailsPageLegacy",
 );
 stubComponentInModule(
   "src/views/databases/databaseTablePage",
@@ -277,27 +285,20 @@ describe("Routing to", () => {
     /* databases */
   }
   describe("'/databases' path", () => {
-    test("routes to <DatabasesPage> component", () => {
+    test("routes to <DatabasesPageV2> component", () => {
       navigateToPath("/databases");
-      screen.getByTestId("DatabasesPage");
+      screen.getByTestId("DatabasesPageV2");
     });
   });
 
-  describe("'/databases/tables' path", () => {
-    test("redirected to '/databases'", () => {
-      navigateToPath("/databases/tables");
-      expect(history.location.pathname).toBe("/databases");
+  describe("'/databases/:${databaseId} path", () => {
+    test("routes to <DatabaseDetailsPageV2> component", () => {
+      navigateToPath("/databases/1");
+      screen.getByTestId("DatabaseDetailsPageV2");
     });
   });
 
-  describe("'/databases/grants' path", () => {
-    test("redirected to '/databases'", () => {
-      navigateToPath("/databases/grants");
-      expect(history.location.pathname).toBe("/databases");
-    });
-  });
-
-  describe("'/databases/database/:${databaseNameAttr}/table/:${tableNameAttr}' path", () => {
+  describe("legacy '/databases/database/:${databaseNameAttr}/table/:${tableNameAttr}' path", () => {
     test("redirected to '/database/:${databaseNameAttr}/table/:${tableNameAttr}'", () => {
       navigateToPath("/databases/database/some-db-name/table/some-table-name");
       expect(history.location.pathname).toBe(
@@ -313,10 +314,17 @@ describe("Routing to", () => {
     });
   });
 
-  describe("'/database/:${databaseNameAttr}' path", () => {
-    test("routes to <DatabaseDetailsPage> component", () => {
+  describe("legacy '/legacy/databases' path", () => {
+    test("routes to <DatabasesPageLegacy> component", () => {
+      navigateToPath("/legacy/databases");
+      screen.getByTestId("DatabasesPageLegacy");
+    });
+  });
+
+  describe("legacy '/database/:${databaseNameAttr}' path", () => {
+    test("routes to <DatabaseDetailsPageLegacy> component", () => {
       navigateToPath("/database/some-db-name");
-      screen.getByTestId("DatabaseDetailsPage");
+      screen.getByTestId("DatabaseDetailsPageLegacy");
     });
   });
 

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -58,8 +58,8 @@ import { EventPage } from "src/views/cluster/containers/events";
 import NodeGraphs from "src/views/cluster/containers/nodeGraphs";
 import NodeLogs from "src/views/cluster/containers/nodeLogs";
 import NodeOverview from "src/views/cluster/containers/nodeOverview";
-import { DatabaseDetailsPage } from "src/views/databases/databaseDetailsPage";
-import { DatabasesPage } from "src/views/databases/databasesPage";
+import { DatabaseDetailsPageLegacy } from "src/views/databases/databaseDetailsPage";
+import { DatabasesPageLegacy } from "src/views/databases/databasesPage";
 import { DatabaseTablePage } from "src/views/databases/databaseTablePage";
 import { IndexDetailsPage } from "src/views/databases/indexDetailsPage";
 import Raft from "src/views/devtools/containers/raft";
@@ -210,28 +210,18 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                         {/* databases */}
                         <Route
                           exact
-                          path={"/v2/databases"}
+                          path={"/databases"}
                           component={DatabasesPageV2}
                         />
                         <Route
                           exact
-                          path={`/v2/databases/:${databaseIDAttr}`}
+                          path={`/databases/:${databaseIDAttr}`}
                           component={DatabaseDetailsPageV2}
                         />
                         <Route
                           exact
-                          path="/databases"
-                          component={DatabasesPage}
-                        />
-                        <Redirect
-                          exact
-                          from="/databases/tables"
-                          to="/databases"
-                        />
-                        <Redirect
-                          exact
-                          from="/databases/grants"
-                          to="/databases"
+                          path="/legacy/databases"
+                          component={DatabasesPageLegacy}
                         />
                         <Redirect
                           from={`/databases/database/:${databaseNameAttr}/table/:${tableNameAttr}`}
@@ -242,7 +232,7 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                         <Route
                           exact
                           path={`/database/:${databaseNameAttr}`}
-                          component={DatabaseDetailsPage}
+                          component={DatabaseDetailsPageLegacy}
                         />
                         <Redirect
                           exact

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/index.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/index.ts
@@ -20,4 +20,4 @@ const connected = withRouter(
   })(DatabaseDetailsPage),
 );
 
-export { connected as DatabaseDetailsPage };
+export { connected as DatabaseDetailsPageLegacy };

--- a/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/index.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/index.ts
@@ -32,4 +32,4 @@ const connected = withRouter(
   )(DatabasesPage),
 );
 
-export { connected as DatabasesPage };
+export { connected as DatabasesPageLegacy };

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
@@ -601,6 +601,12 @@ export default function Debug() {
             note="_status/hotranges?node_id=[node_id]"
           />
         </DebugTableRow>
+        <DebugTableRow title="Databases">
+          <DebugTableLink
+            name="Databases Page (Legacy)"
+            url="#/legacy/databases"
+          />
+        </DebugTableRow>
         <DebugTableRow
           title="Single Node Specific"
           disabled={disable_kv_level_advanced_debug}


### PR DESCRIPTION
This commit reroutes the `Databases` link on the
side navigation panel to the new databases page.

New db pages are routed at:
- /databases - list of databases in cluster
- /databases/:dbId - database details view (tables, grants)

The old dbs page has been moved to the following route, and is available via the Debug page under the link `Databases Page (Legacy)`.
- /legacy/databases

Epic: CRDB-37558

Release note (ui change): New db pages are available from the side navigation `Databases` link.