### PR TITLE
crosscluster: destroy reader tenant

### DIFF
--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -184,7 +184,9 @@ message StreamIngestionProgress {
   // if different than ReplicatedTime.
   util.hlc.Timestamp initial_revert_to = 11 [(gogoproto.nullable) = false];
 
-  // Next Id: 10
+  util.hlc.Timestamp replicated_time_at_cutover = 12 [(gogoproto.nullable) = false];
+
+  // Next Id: 13
 }
 
 message HistoryRetentionDetails {


### PR DESCRIPTION
Reader tenant should be stopped and dropped when cutting over to a historical timestamp.

Epic: CRDB-23575
Fixes: #130893
Release note: None