### PR TITLE
raft: add FortificationEnabled() to the FortificationTracker

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -735,7 +735,7 @@ func (r *raft) sendHeartbeat(to pb.PeerID) {
 // maybeSendFortify sends a fortification RPC to the given peer if it isn't
 // fortified but the peer's store supports the leader's store in StoreLiveness.
 func (r *raft) maybeSendFortify(id pb.PeerID) {
-	if !r.storeLiveness.SupportFromEnabled() {
+	if !r.fortificationTracker.FortificationEnabled() {
 		// The underlying store liveness fabric hasn't been enabled to allow the
 		// leader to request support from peers. No-op.
 		return

--- a/pkg/raft/tracker/fortificationtracker.go
+++ b/pkg/raft/tracker/fortificationtracker.go
@@ -45,6 +45,12 @@ func MakeFortificationTracker(
 	return st
 }
 
+// FortificationEnabled returns whether the raft fortification protocol is
+// enabled or not.
+func (st *FortificationTracker) FortificationEnabled() bool {
+	return st.storeLiveness.SupportFromEnabled()
+}
+
 // RecordFortification records that the node with the given id supported this
 // Raft instance until the supplied timestamp.
 func (st *FortificationTracker) RecordFortification(id pb.PeerID, epoch pb.Epoch) {

--- a/pkg/raft/tracker/fortificationtracker_test.go
+++ b/pkg/raft/tracker/fortificationtracker_test.go
@@ -22,6 +22,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestFortificationEnabled(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testCases := []struct {
+		storeLiveness raftstoreliveness.StoreLiveness
+		expectEnabled bool
+	}{
+		{
+			storeLiveness: raftstoreliveness.Disabled{},
+			expectEnabled: false,
+		},
+		{
+			storeLiveness: raftstoreliveness.AlwaysLive{},
+			expectEnabled: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		cfg := quorum.MakeEmptyConfig()
+		fortificationTracker := MakeFortificationTracker(&cfg, tc.storeLiveness)
+		require.Equal(t, tc.expectEnabled, fortificationTracker.FortificationEnabled())
+	}
+}
+
 func TestLeadSupportUntil(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -143,7 +168,7 @@ func TestLeadSupportUntil(t *testing.T) {
 	}
 }
 
-func TestIsSupportedBy(t *testing.T) {
+func TestIsFortifiedBy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 


### PR DESCRIPTION
This commit adds the function FortificationEnabled() to be called from Raft to know if the raft fortification protocol is enabled or not.

Epic: None

Release note: None