### PR TITLE
sql: update reader tenant keywords

### DIFF
--- a/pkg/ccl/crosscluster/replicationtestutils/testutils.go
+++ b/pkg/ccl/crosscluster/replicationtestutils/testutils.go
@@ -354,9 +354,9 @@ func (c *TenantStreamingClusters) BuildCreateTenantQuery(externalConnection stri
 	}
 	if c.Args.EnableReaderTenant {
 		if c.Args.RetentionTTLSeconds == 0 {
-			streamReplStmt = fmt.Sprintf("%s WITH READ CAPABILITIES", streamReplStmt)
+			streamReplStmt = fmt.Sprintf("%s WITH READ VIRTUAL CLUSTER", streamReplStmt)
 		} else {
-			streamReplStmt = fmt.Sprintf("%s, READ CAPABILITIES", streamReplStmt)
+			streamReplStmt = fmt.Sprintf("%s, READ VIRTUAL CLUSTER", streamReplStmt)
 		}
 	}
 	return streamReplStmt

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4831,7 +4831,7 @@ replication_options:
   {
       $$.val = &tree.TenantReplicationOptions{ExpirationWindow: $4.expr()}
   }
-| READ CAPABILITIES
+| READ VIRTUAL CLUSTER
   {
     $$.val = &tree.TenantReplicationOptions{EnableReaderTenant: tree.MakeDBool(true)}
   }

--- a/pkg/sql/parser/testdata/create_virtual_cluster
+++ b/pkg/sql/parser/testdata/create_virtual_cluster
@@ -71,20 +71,20 @@ CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" 
 CREATE VIRTUAL CLUSTER _ FROM REPLICATION OF _ ON 'pgurl' WITH RETENTION = '36h' -- identifiers removed
 
 parse
-CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH READ CAPABILITIES
+CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH READ VIRTUAL CLUSTER
 ----
-CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH READ CAPABILITIES
-CREATE VIRTUAL CLUSTER ("destination-hyphen") FROM REPLICATION OF ("source-hyphen") ON ('pgurl') WITH READ CAPABILITIES -- fully parenthesized
-CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON '_' WITH READ CAPABILITIES -- literals removed
-CREATE VIRTUAL CLUSTER _ FROM REPLICATION OF _ ON 'pgurl' WITH READ CAPABILITIES -- identifiers removed
+CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH READ VIRTUAL CLUSTER
+CREATE VIRTUAL CLUSTER ("destination-hyphen") FROM REPLICATION OF ("source-hyphen") ON ('pgurl') WITH READ VIRTUAL CLUSTER -- fully parenthesized
+CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON '_' WITH READ VIRTUAL CLUSTER -- literals removed
+CREATE VIRTUAL CLUSTER _ FROM REPLICATION OF _ ON 'pgurl' WITH READ VIRTUAL CLUSTER -- identifiers removed
 
 parse
-CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH OPTIONS (READ CAPABILITIES)
+CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH OPTIONS (READ VIRTUAL CLUSTER)
 ----
-CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH READ CAPABILITIES -- normalized!
-CREATE VIRTUAL CLUSTER ("destination-hyphen") FROM REPLICATION OF ("source-hyphen") ON ('pgurl') WITH READ CAPABILITIES -- fully parenthesized
-CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON '_' WITH READ CAPABILITIES -- literals removed
-CREATE VIRTUAL CLUSTER _ FROM REPLICATION OF _ ON 'pgurl' WITH READ CAPABILITIES -- identifiers removed
+CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH READ VIRTUAL CLUSTER -- normalized!
+CREATE VIRTUAL CLUSTER ("destination-hyphen") FROM REPLICATION OF ("source-hyphen") ON ('pgurl') WITH READ VIRTUAL CLUSTER -- fully parenthesized
+CREATE VIRTUAL CLUSTER "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON '_' WITH READ VIRTUAL CLUSTER -- literals removed
+CREATE VIRTUAL CLUSTER _ FROM REPLICATION OF _ ON 'pgurl' WITH READ VIRTUAL CLUSTER -- identifiers removed
 
 parse
 CREATE VIRTUAL CLUSTER destination FROM REPLICATION OF ('a'||'b') ON ('pg'||'url')

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -2289,7 +2289,7 @@ func (o *TenantReplicationOptions) Format(ctx *FmtCtx) {
 	}
 	if o.EnableReaderTenant != nil {
 		maybeAddSep()
-		ctx.WriteString("READ CAPABILITIES")
+		ctx.WriteString("READ VIRTUAL CLUSTER")
 	}
 }
 
@@ -2314,7 +2314,7 @@ func (o *TenantReplicationOptions) CombineWith(other *TenantReplicationOptions) 
 
 	if o.EnableReaderTenant != nil {
 		if other.EnableReaderTenant != nil {
-			return errors.New("READ CAPABILITIES option specified multiple times")
+			return errors.New("READ VIRTUAL CLUSTER option specified multiple times")
 		} else {
 			o.EnableReaderTenant = other.EnableReaderTenant
 		}


### PR DESCRIPTION
Rename `READ CAPABILITIES` to `READ VIRTUAL CLUSTER` as keywords to enable reader tenant.

Epic: CRDB-23575
Release note: None