### PR TITLE
storeliveness: return the actual epoch in Support{For,From}

### DIFF
--- a/pkg/kv/kvserver/storeliveness/fabric.go
+++ b/pkg/kv/kvserver/storeliveness/fabric.go
@@ -23,7 +23,8 @@ type Fabric interface {
 	// SupportFor returns the epoch of the current uninterrupted period of Store
 	// Liveness support from the local store (S_local) for the store (S_remote)
 	// corresponding to the specified id, and a boolean indicating whether S_local
-	// supports S_remote. The epoch is 0 if and only if the boolean is false.
+	// supports S_remote. Epochs returned by successive SupportFor calls are
+	// guaranteed to be monotonically increasing.
 	//
 	// S_remote may not be aware of the full extent of support from S_local, as
 	// Store Liveness heartbeat response messages may be lost or delayed. However,
@@ -35,11 +36,16 @@ type Fabric interface {
 	// SupportFrom returns the epoch of the current uninterrupted period of Store
 	// Liveness support for the local store (S_local) from the store (S_remote)
 	// corresponding to the specified id, and the timestamp until which the
-	// support is provided (an expiration). The epoch is 0 if and only if the
-	// timestamp is the zero timestamp.
+	// support is provided (an expiration).
 	//
-	// It is the caller's responsibility to infer whether support has expired, by
-	// comparing the returned timestamp to its local clock.
+	// Epochs returned by SupportFrom are guaranteed to be monotonically
+	// increasing except after a restart, when a zero epoch and zero timestamp are
+	// returned until support is established again. This is because support-from
+	// state is not persisted to disk.
+	//
+	// A zero timestamp indicates that S_local does not have support from
+	// S_remote. It is the caller's responsibility to infer whether support has
+	// expired, by comparing the returned timestamp to its local clock.
 	//
 	// S_local may not be aware of the full extent of support from S_remote, as
 	// Store Liveness heartbeat response messages may be lost or delayed. However,

--- a/pkg/kv/kvserver/storeliveness/support_manager.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager.go
@@ -97,10 +97,7 @@ var _ MessageHandler = (*SupportManager)(nil)
 func (sm *SupportManager) SupportFor(id slpb.StoreIdent) (slpb.Epoch, bool) {
 	ss := sm.supporterStateHandler.getSupportFor(id)
 	// An empty expiration implies support has expired.
-	if ss.Expiration.IsEmpty() {
-		return 0, false
-	}
-	return ss.Epoch, true
+	return ss.Epoch, !ss.Expiration.IsEmpty()
 }
 
 // SupportFrom implements the Fabric interface. It delegates the response to the
@@ -119,10 +116,6 @@ func (sm *SupportManager) SupportFrom(id slpb.StoreIdent) (slpb.Epoch, hlc.Times
 			context.Background(), 2,
 			"store %+v enqueued to add remote store %+v", sm.storeID, id,
 		)
-		return 0, hlc.Timestamp{}
-	}
-	// An empty expiration implies support has expired.
-	if ss.Expiration.IsEmpty() {
 		return 0, hlc.Timestamp{}
 	}
 	return ss.Epoch, ss.Expiration

--- a/pkg/kv/kvserver/storeliveness/support_manager_test.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager_test.go
@@ -156,7 +156,7 @@ func TestSupportManagerProvidesSupport(t *testing.T) {
 			if supported {
 				return errors.New("support not withdrawn yet")
 			}
-			require.Equal(t, slpb.Epoch(0), epoch)
+			require.Equal(t, slpb.Epoch(2), epoch)
 			require.False(t, supported)
 			return nil
 		},

--- a/pkg/kv/kvserver/storeliveness/testdata/basic
+++ b/pkg/kv/kvserver/storeliveness/testdata/basic
@@ -35,7 +35,7 @@ withdraw-support now=201
 
 support-for node-id=2 store-id=2
 ----
-epoch: 0, support provided: false
+epoch: 3, support provided: false
 
 debug-requester-state
 ----

--- a/pkg/kv/kvserver/storeliveness/testdata/requester_state
+++ b/pkg/kv/kvserver/storeliveness/testdata/requester_state
@@ -65,7 +65,7 @@ handle-messages
 
 support-from node-id=2 store-id=2
 ----
-epoch: 0, expiration: 0,0
+epoch: 2, expiration: 0,0
 
 debug-requester-state
 ----

--- a/pkg/kv/kvserver/storeliveness/testdata/supporter_state
+++ b/pkg/kv/kvserver/storeliveness/testdata/supporter_state
@@ -17,6 +17,13 @@ support-for node-id=2 store-id=2
 ----
 epoch: 1, support provided: true
 
+# -------------------------------------------------------------
+# Store (n1, s1) does not provide support for an unknown store.
+# -------------------------------------------------------------
+
+support-for node-id=3 store-id=3
+----
+epoch: 0, support provided: false
 
 # -------------------------------------------------------------
 # Store (n1, s1) extends support.
@@ -54,7 +61,7 @@ withdraw-support now=201
 
 support-for node-id=2 store-id=2
 ----
-epoch: 0, support provided: false
+epoch: 2, support provided: false
 
 debug-supporter-state
 ----

--- a/pkg/raft/raftstoreliveness/store_liveness.go
+++ b/pkg/raft/raftstoreliveness/store_liveness.go
@@ -21,7 +21,7 @@ type StoreLiveness interface {
 	// SupportFor returns the epoch of the current uninterrupted period of Store
 	// Liveness support from the local store (S_local) for the store (S_remote)
 	// corresponding to the specified id, and a boolean indicating whether S_local
-	// supports S_remote. The epoch is 0 if and only if the boolean is false.
+	// supports S_remote.
 	//
 	// S_remote may not be aware of the full extent of support from S_local, as
 	// Store Liveness heartbeat response messages may be lost or delayed. However,
@@ -35,11 +35,16 @@ type StoreLiveness interface {
 	// SupportFrom returns the epoch of the current uninterrupted period of Store
 	// Liveness support for the local store (S_local) from the store (S_remote)
 	// corresponding to the specified id, and the timestamp until which the
-	// support is provided (an expiration). The epoch is 0 if and only if the
-	// timestamp is the zero timestamp.
+	// support is provided (an expiration).
 	//
-	// It is the caller's responsibility to infer whether support has expired, by
-	// calling SupportExpired.
+	// Epochs returned by SupportFrom are guaranteed to be monotonically
+	// increasing except after a restart, when a zero epoch and zero timestamp are
+	// returned until support is established again. This is because support-from
+	// state is not persisted to disk.
+	//
+	// A zero timestamp indicates that S_local does not have support from
+	// S_remote.It is the caller's responsibility to infer whether support has
+	// expired, by calling SupportExpired.
 	//
 	// S_local may not be aware of the full extent of support from S_remote, as
 	// Store Liveness heartbeat response messages may be lost or delayed. However,


### PR DESCRIPTION
Previously, Store Liveness would return a zero epoch in `SupportFrom` and `SupportFor` if the expiration timestamp was zero (i.e. support is not provided). As a result, Raft couldn't easily assert that epochs don't regress, and had to handle the zero-epoch case in various places.

This commit returns the actual epoch even if the expiration is zero.

Part of: #125063

Release note: None