### PR TITLE
storeliveness: fix the liveness and heartbeat interval assignment

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2187,9 +2187,9 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	)
 	s.metrics.registry.AddMetricStruct(s.recoveryMgr.Metrics())
 
-	heartbeatInterval, livenessInterval := s.cfg.StoreLivenessDurations()
+	livenessInterval, heartbeatInterval := s.cfg.StoreLivenessDurations()
 	supportGracePeriod := s.cfg.RPCContext.StoreLivenessWithdrawalGracePeriod()
-	options := storeliveness.NewOptions(heartbeatInterval, livenessInterval, supportGracePeriod)
+	options := storeliveness.NewOptions(livenessInterval, heartbeatInterval, supportGracePeriod)
 	sm := storeliveness.NewSupportManager(
 		slpb.StoreIdent{NodeID: s.nodeDesc.NodeID, StoreID: s.StoreID()}, s.StateEngine(), options,
 		s.cfg.Settings, s.stopper, s.cfg.Clock, s.cfg.StoreLivenessTransport,

--- a/pkg/kv/kvserver/storeliveness/config.go
+++ b/pkg/kv/kvserver/storeliveness/config.go
@@ -13,11 +13,12 @@ package storeliveness
 import "time"
 
 // Options includes all Store Liveness durations needed by the SupportManager.
+// TODO(mira): make sure these are initialized correctly as part of #125066.
 type Options struct {
-	// HeartbeatInterval determines how often Store Liveness sends heartbeats.
-	HeartbeatInterval time.Duration
 	// LivenessInterval determines the Store Liveness support expiration time.
 	LivenessInterval time.Duration
+	// HeartbeatInterval determines how often Store Liveness sends heartbeats.
+	HeartbeatInterval time.Duration
 	// SupportExpiryInterval determines how often Store Liveness checks if support
 	// should be withdrawn.
 	SupportExpiryInterval time.Duration
@@ -32,13 +33,13 @@ type Options struct {
 
 // NewOptions instantiates the Store Liveness Options.
 func NewOptions(
-	heartbeatInterval time.Duration,
 	livenessInterval time.Duration,
+	heartbeatInterval time.Duration,
 	supportWithdrawalGracePeriod time.Duration,
 ) Options {
 	return Options{
-		HeartbeatInterval:            heartbeatInterval,
 		LivenessInterval:             livenessInterval,
+		HeartbeatInterval:            heartbeatInterval,
 		SupportExpiryInterval:        1 * time.Second,
 		IdleSupportFromInterval:      1 * time.Minute,
 		SupportWithdrawalGracePeriod: supportWithdrawalGracePeriod,

--- a/pkg/kv/kvserver/storeliveness/support_manager_test.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager_test.go
@@ -33,8 +33,8 @@ var (
 	store       = slpb.StoreIdent{NodeID: roachpb.NodeID(1), StoreID: roachpb.StoreID(1)}
 	remoteStore = slpb.StoreIdent{NodeID: roachpb.NodeID(2), StoreID: roachpb.StoreID(2)}
 	options     = Options{
-		HeartbeatInterval:       3 * time.Millisecond,
 		LivenessInterval:        6 * time.Millisecond,
+		HeartbeatInterval:       3 * time.Millisecond,
 		SupportExpiryInterval:   1 * time.Millisecond,
 		IdleSupportFromInterval: 1 * time.Minute,
 	}


### PR DESCRIPTION
A bug was introduced as part of #130026 where the liveness- and heartbeat-interval durations were switched up, resulting in a liveness duration half of the heartbeat duration. This caused support churn in Store Liveness because support expired every time due to the infrequent hearbeats and short liveness duration.

This commit reorders the two intervals. Testing will be added as part of #125066.

Part of: #125064

Release note: None