### PR TITLE
replica_rac2: pass leaderTerm to lowPriOverrideState.getEffectivePrio…

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/testutils/datapathutils",
         "//pkg/util/admission/admissionpb",
+        "//pkg/util/buildutil",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/protoutil",

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -221,7 +221,8 @@ type ProcessorOptions struct {
 type SideChannelInfoUsingRaftMessageRequest struct {
 	UsingV2Protocol bool
 	LeaderTerm      uint64
-	// Following are only used if UsingV2Protocol is true.
+	// Following are only used if UsingV2Protocol is true. Represents [First,
+	// Last], i.e., both are inclusive.
 	First, Last    uint64
 	LowPriOverride bool
 }
@@ -984,7 +985,10 @@ func (p *processorImpl) AdmitRaftEntriesRaftMuLocked(ctx context.Context, e rac2
 			if raftPri != priBits {
 				panic(errors.AssertionFailedf("inconsistent priorities %s, %s", raftPri, priBits))
 			}
-			raftPri = p.follower.lowPriOverrideState.getEffectivePriority(entry.Index, raftPri)
+			if p.leaderID != p.opts.ReplicaID {
+				// Follower.
+				raftPri = p.follower.lowPriOverrideState.getEffectivePriority(e.Term, entry.Index, raftPri)
+			}
 		} else {
 			raftPri = raftpb.LowPri
 			if admissionpb.WorkClassFromPri(admissionpb.WorkPriority(meta.AdmissionPriority)) ==
@@ -1102,7 +1106,8 @@ func (p *processorImpl) SideChannelForPriorityOverrideAtFollowerRaftMuLocked(
 	} else {
 		if p.follower.lowPriOverrideState.sideChannelForV1Leader(info.LeaderTerm) &&
 			p.follower.isLeaderUsingV2Protocol {
-			// Leader term advanced, so this is switching back to v1.
+			// Leader term advanced, so this is a different leader switching back to
+			// v1.
 			p.follower.isLeaderUsingV2Protocol = false
 		}
 	}

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/low_pri_override_state
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/low_pri_override_state
@@ -1,4 +1,5 @@
-get-effective-priority index=10 pri=NormalPri
+# Ask for effective priority using a future term. Will panic.
+get-effective-priority leader-term=2 index=10 pri=NormalPri should-panic
 ----
 pri: NormalPri
 leader-term: 0
@@ -29,7 +30,7 @@ intervals:
  [ 11,  14] => false
  [ 15,  20] => true
 
-get-effective-priority index=4 pri=HighPri
+get-effective-priority leader-term=4 index=4 pri=HighPri
 ----
 pri: HighPri
 leader-term: 4
@@ -38,7 +39,7 @@ intervals:
  [ 11,  14] => false
  [ 15,  20] => true
 
-get-effective-priority index=6 pri=AboveNormalPri
+get-effective-priority leader-term=4 index=6 pri=AboveNormalPri
 ----
 pri: LowPri
 leader-term: 4
@@ -47,7 +48,18 @@ intervals:
  [ 11,  14] => false
  [ 15,  20] => true
 
-get-effective-priority index=10 pri=NormalPri
+# Ask for effective priority using an old term. Will panic, and state does not
+# change.
+get-effective-priority leader-term=3 index=10 pri=NormalPri should-panic
+----
+pri: NormalPri
+leader-term: 4
+intervals:
+ [  7,  10] => true
+ [ 11,  14] => false
+ [ 15,  20] => true
+
+get-effective-priority leader-term=4 index=10 pri=NormalPri
 ----
 pri: LowPri
 leader-term: 4
@@ -55,7 +67,7 @@ intervals:
  [ 11,  14] => false
  [ 15,  20] => true
 
-get-effective-priority index=11 pri=HighPri
+get-effective-priority leader-term=4 index=11 pri=HighPri
 ----
 pri: HighPri
 leader-term: 4
@@ -63,7 +75,7 @@ intervals:
  [ 12,  14] => false
  [ 15,  20] => true
 
-get-effective-priority index=13 pri=AboveNormalPri
+get-effective-priority leader-term=4 index=13 pri=AboveNormalPri
 ----
 pri: AboveNormalPri
 leader-term: 4
@@ -71,7 +83,7 @@ intervals:
  [ 14,  14] => false
  [ 15,  20] => true
 
-get-effective-priority index=15 pri=HighPri
+get-effective-priority leader-term=4 index=15 pri=HighPri
 ----
 pri: LowPri
 leader-term: 4
@@ -113,14 +125,14 @@ intervals:
  [ 26,  30] => true
  [ 35,  40] => true
 
-get-effective-priority index=32 pri=NormalPri
+get-effective-priority leader-term=6 index=32 pri=NormalPri
 ----
 pri: NormalPri
 leader-term: 6
 intervals:
  [ 35,  40] => true
 
-get-effective-priority index=40 pri=HighPri
+get-effective-priority leader-term=6 index=40 pri=HighPri
 ----
 pri: LowPri
 leader-term: 6


### PR DESCRIPTION
…rity

We use this to strengthen the invariant for retrieval of the priority override state, since we don't want to accidentally have an entry accounted for as normal priority on the leader be considered low priority at a follower.

Epic: CRDB-37515

Release note: None