### PR TITLE
logictest: don't use regexp matching for noticetrace

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_block
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_block
@@ -490,7 +490,7 @@ query T noticetrace
 CALL p();
 ----
 NOTICE: outer handler
-NOTICE: inner block 100
+NOTICE: inner block x=100
 
 # A block nested in an exception handler can have its own exception handler.
 statement ok
@@ -519,7 +519,7 @@ CALL p();
 ----
 NOTICE: outer handler
 NOTICE: inner block
-NOTICE: inner handler 100
+NOTICE: inner handler x=100
 
 # A block can be nested inside another block that has an exception handler.
 statement ok

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -948,6 +948,10 @@ type logicQuery struct {
 	// noticetrace indicates we're comparing the output of a notice trace.
 	noticetrace bool
 
+	// regexp indicates the output should be compared as a regexp expression,
+	// rather than via direct string comparison.
+	regexp bool
+
 	// rawOpts are the query options, before parsing. Used to display in error
 	// messages.
 	rawOpts string
@@ -2838,6 +2842,9 @@ func (t *logicTest) processSubtest(
 						case "noticetrace":
 							query.noticetrace = true
 
+						case "regexp":
+							query.regexp = true
+
 						case "async":
 							query.expectAsync = true
 
@@ -3871,7 +3878,7 @@ func (t *logicTest) finishExecQuery(query logicQuery, rows *gosql.Rows, err erro
 		for i := range query.expectedResults {
 			expected, actual := query.expectedResults[i], actualResults[i]
 			var resultMatches bool
-			if query.noticetrace {
+			if query.regexp {
 				resultMatches, err = regexp.MatchString(expected, actual)
 				if err != nil {
 					return errors.CombineErrors(makeError(), err)

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -4223,14 +4223,14 @@ skipif config weak-iso-level-configs
 query T noticetrace
 CREATE TABLE t2_fk ( pk INT PRIMARY KEY, t1_fk_col1 CHAR(8), t1_fk_col2 INT4, col3 INT, FOREIGN KEY (t1_fk_col1,t1_fk_col2) REFERENCES t1_fk(col1, col2), FAMILY f1 (pk,t1_fk_col1,t1_fk_col2) );
 ----
-NOTICE: type of foreign key column "t1_fk_col1" \(CHAR\(8\)\) is not identical to referenced column "t1_fk"."col1" \(CHAR\(7\)\)
+NOTICE: type of foreign key column "t1_fk_col1" (CHAR(8)) is not identical to referenced column "t1_fk"."col1" (CHAR(7))
 
 onlyif config weak-iso-level-configs
 query T noticetrace
 CREATE TABLE t2_fk ( pk INT PRIMARY KEY, t1_fk_col1 CHAR(8), t1_fk_col2 INT4, col3 INT, FOREIGN KEY (t1_fk_col1,t1_fk_col2) REFERENCES t1_fk(col1, col2), FAMILY f1 (pk,t1_fk_col1,t1_fk_col2) );
 ----
 NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
-NOTICE: type of foreign key column "t1_fk_col1" \(CHAR\(8\)\) is not identical to referenced column "t1_fk"."col1" \(CHAR\(7\)\)
+NOTICE: type of foreign key column "t1_fk_col1" (CHAR(8)) is not identical to referenced column "t1_fk"."col1" (CHAR(7))
 
 # Test trivial data type change
 skipif config local-legacy-schema-changer
@@ -4239,14 +4239,14 @@ skipif config weak-iso-level-configs
 query T noticetrace
 ALTER TABLE t2_fk ALTER COLUMN t1_fk_col2 SET DATA TYPE INT8
 ----
-NOTICE: type of foreign key column "t1_fk_col2" \(INT8\) is not identical to referenced column "t1_fk"."col2" \(INT4\)
+NOTICE: type of foreign key column "t1_fk_col2" (INT8) is not identical to referenced column "t1_fk"."col2" (INT4)
 
 onlyif config weak-iso-level-configs
 query T noticetrace
 ALTER TABLE t2_fk ALTER COLUMN t1_fk_col2 SET DATA TYPE INT8
 ----
 NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
-NOTICE: type of foreign key column "t1_fk_col2" \(INT8\) is not identical to referenced column "t1_fk"."col2" \(INT4\)
+NOTICE: type of foreign key column "t1_fk_col2" (INT8) is not identical to referenced column "t1_fk"."col2" (INT4)
 
 # Test validation data type change
 skipif config local-legacy-schema-changer
@@ -4255,14 +4255,14 @@ skipif config weak-iso-level-configs
 query T noticetrace
 ALTER TABLE t2_fk ALTER COLUMN t1_fk_col1 SET DATA TYPE CHAR(5)
 ----
-NOTICE: type of foreign key column "t1_fk_col1" \(CHAR\(5\)\) is not identical to referenced column "t1_fk"."col1" \(CHAR\(7\)\)
+NOTICE: type of foreign key column "t1_fk_col1" (CHAR(5)) is not identical to referenced column "t1_fk"."col1" (CHAR(7))
 
 onlyif config weak-iso-level-configs
 query T noticetrace
 ALTER TABLE t2_fk ALTER COLUMN t1_fk_col1 SET DATA TYPE CHAR(5)
 ----
 NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
-NOTICE: type of foreign key column "t1_fk_col1" \(CHAR\(5\)\) is not identical to referenced column "t1_fk"."col1" \(CHAR\(7\)\)
+NOTICE: type of foreign key column "t1_fk_col1" (CHAR(5)) is not identical to referenced column "t1_fk"."col1" (CHAR(7))
 
 
 skipif config local-legacy-schema-changer


### PR DESCRIPTION
Previously, the `noticetrace` output for logic tests used regexp matching for comparing against an expected output. This meant that `noticetrace` tests were required to work around special characters, which is cumbersome. This commit adds a new `regexp` option to recover regexp matching behavior, and reverts the `noticetrace` format to using string matching by default.

Epic: None

Release note: None