### PR TITLE
kvserver,rac2: add BenchmarkFlowControlV2Basic

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -415,7 +415,9 @@ var _ RangeController = &rangeController{}
 func NewRangeController(
 	ctx context.Context, o RangeControllerOptions, init RangeControllerInitState,
 ) *rangeController {
-	log.VInfof(ctx, 1, "r%v creating range controller", o.RangeID)
+	if log.V(1) {
+		log.VInfof(ctx, 1, "r%v creating range controller", o.RangeID)
+	}
 	rc := &rangeController{
 		opts:          o,
 		leaseholder:   init.Leaseholder,
@@ -537,8 +539,10 @@ retry:
 		}
 	}
 	waitDuration := rc.opts.Clock.PhysicalTime().Sub(start)
-	log.VEventf(ctx, 2, "r%v/%v admitted request (pri=%v wait-duration=%s wait-for-all=%v)",
-		rc.opts.RangeID, rc.opts.LocalReplicaID, pri, waitDuration, waitForAllReplicateHandles)
+	if log.ExpensiveLogEnabled(ctx, 2) {
+		log.VEventf(ctx, 2, "r%v/%v admitted request (pri=%v wait-duration=%s wait-for-all=%v)",
+			rc.opts.RangeID, rc.opts.LocalReplicaID, pri, waitDuration, waitForAllReplicateHandles)
+	}
 	rc.opts.EvalWaitMetrics.OnAdmitted(wc, waitDuration)
 	return true, nil
 }
@@ -819,7 +823,9 @@ func (rc *rangeController) SetLeaseholderRaftMuLocked(
 	if replica == rc.leaseholder {
 		return
 	}
-	log.VInfof(ctx, 1, "r%v setting range leaseholder replica_id=%v", rc.opts.RangeID, replica)
+	if log.V(1) {
+		log.VInfof(ctx, 1, "r%v setting range leaseholder replica_id=%v", rc.opts.RangeID, replica)
+	}
 	rc.leaseholder = replica
 	rc.updateWaiterSetsRaftMuLocked()
 }
@@ -828,7 +834,9 @@ func (rc *rangeController) SetLeaseholderRaftMuLocked(
 //
 // Requires replica.raftMu to be held.
 func (rc *rangeController) CloseRaftMuLocked(ctx context.Context) {
-	log.VInfof(ctx, 1, "r%v closing range controller", rc.opts.RangeID)
+	if log.V(1) {
+		log.VInfof(ctx, 1, "r%v closing range controller", rc.opts.RangeID)
+	}
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
 
@@ -1108,8 +1116,10 @@ func (rss *replicaSendStream) shouldPing() bool {
 }
 
 func (rss *replicaSendStream) admit(ctx context.Context, av AdmittedVector) {
-	log.VInfof(ctx, 2, "r%v:%v stream %v admit %v",
-		rss.parent.parent.opts.RangeID, rss.parent.desc, rss.parent.stream, av)
+	if log.V(2) {
+		log.VInfof(ctx, 2, "r%v:%v stream %v admit %v",
+			rss.parent.parent.opts.RangeID, rss.parent.desc, rss.parent.stream, av)
+	}
 	rss.mu.Lock()
 	defer rss.mu.Unlock()
 
@@ -1142,7 +1152,9 @@ func (rs *replicaState) createReplicaSendStream(
 	ctx context.Context, indexToSend uint64, nextRaftIndex uint64,
 ) {
 	// Must be in StateReplicate on creation.
-	log.VEventf(ctx, 1, "creating send stream %v for replica %v", rs.stream, rs.desc)
+	if log.ExpensiveLogEnabled(ctx, 1) {
+		log.VEventf(ctx, 1, "creating send stream %v for replica %v", rs.stream, rs.desc)
+	}
 	rs.sendStream = &replicaSendStream{
 		parent: rs,
 	}
@@ -1285,7 +1297,9 @@ func (rs *replicaState) handleReadyState(
 }
 
 func (rss *replicaState) closeSendStream(ctx context.Context) {
-	log.VEventf(ctx, 1, "closing send stream %v for replica %v", rss.stream, rss.desc)
+	if log.ExpensiveLogEnabled(ctx, 1) {
+		log.VEventf(ctx, 1, "closing send stream %v for replica %v", rss.stream, rss.desc)
+	}
 	rss.sendStream.mu.Lock()
 	defer rss.sendStream.mu.Unlock()
 
@@ -1401,8 +1415,10 @@ func (rss *replicaSendStream) isEmptySendQueueLocked() bool {
 }
 
 func (rss *replicaSendStream) changeToProbeLocked(ctx context.Context, now time.Time) {
-	log.VEventf(ctx, 1, "r%v:%v stream %v changing to probe",
-		rss.parent.parent.opts.RangeID, rss.parent.desc, rss.parent.stream)
+	if log.ExpensiveLogEnabled(ctx, 1) {
+		log.VEventf(ctx, 1, "r%v:%v stream %v changing to probe",
+			rss.parent.parent.opts.RangeID, rss.parent.desc, rss.parent.stream)
+	}
 	// This is the first time we've seen the replica change to StateProbe,
 	// update the connected state and start time. If the state doesn't
 	// change within probeRecentlyReplicateDuration, we will close the


### PR DESCRIPTION
Make small logging tweaks in rac2 to avoid allocations caused by passing a value through an interface{}.

On my m1 macbook:
```
BenchmarkFlowControlV2Basic/v2_enabled_when_leader_level=1         	    4840	    262413 ns/op	   96600 B/op	     267 allocs/op
BenchmarkFlowControlV2Basic/v2_enabled_when_leader_level=2         	    5752	    266266 ns/op	   96621 B/op	     267 allocs/op
```

RAC2 code isn't visible in the cpu profile and is < 1% of the memory profile.

Informs #128034

Epic: CRDB-37515

Release note: None