### PR TITLE
roachpb,kv: remove write_too_old flag

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
@@ -230,62 +230,13 @@ func (sr *txnSpanRefresher) maybeCondenseRefreshSpans(
 func (sr *txnSpanRefresher) sendLockedWithRefreshAttempts(
 	ctx context.Context, ba *kvpb.BatchRequest, maxRefreshAttempts int,
 ) (*kvpb.BatchResponse, *kvpb.Error) {
-	if ba.Txn.WriteTooOld {
-		// The WriteTooOld flag is not supposed to be set on requests. It's only set
-		// by the server and it's terminated by this interceptor on the client.
-		log.Fatalf(ctx, "unexpected WriteTooOld request. ba: %s (txn: %s)",
-			ba.String(), ba.Txn.String())
-	}
 	br, pErr := sr.wrapped.SendLocked(ctx, ba)
-
-	// We might receive errors with the WriteTooOld flag set. This interceptor
-	// wants to always terminate that flag. In the case of an error, we can just
-	// ignore it.
-	if pErr != nil && pErr.GetTxn() != nil {
-		pErr.GetTxn().WriteTooOld = false
-	}
 
 	// Check for server-side refresh.
 	if err := sr.forwardRefreshTimestampOnResponse(ba, br, pErr); err != nil {
 		return nil, kvpb.NewError(err)
 	}
 
-	if pErr == nil && br.Txn.WriteTooOld {
-		// If the transaction is no longer pending, terminate the WriteTooOld flag
-		// without hitting the logic below. It's not clear that this can happen in
-		// practice, but it's better to be safe.
-		if br.Txn.Status != roachpb.PENDING {
-			br.Txn = br.Txn.Clone()
-			br.Txn.WriteTooOld = false
-			return br, nil
-		}
-		// If we got a response with the WriteTooOld flag set, then we pretend that
-		// we got a WriteTooOldError, which will cause us to attempt to refresh and
-		// propagate the error if we failed. When it can, the server prefers to
-		// return the WriteTooOld flag, rather than a WriteTooOldError because, in
-		// the former case, it can leave intents behind. We like refreshing eagerly
-		// when the WriteTooOld flag is set because it's likely that the refresh
-		// will fail (if we previously read the key that's now causing a WTO, then
-		// the refresh will surely fail).
-		// TODO(andrei): Implement a more discerning policy based on whether we've
-		// read that key before.
-		//
-		// If the refresh fails, we could continue running the transaction even
-		// though it will not be able to commit, in order for it to lay down more
-		// intents. Not doing so, though, gives the SQL a chance to auto-retry.
-		// TODO(andrei): Implement a more discerning policy based on whether
-		// auto-retries are still possible.
-		//
-		// For the refresh, we have two options: either refresh everything read
-		// *before* this batch, and then retry this batch, or refresh the current
-		// batch's reads too and then, if successful, there'd be nothing to retry.
-		// We take the former option by setting br = nil below to minimized the
-		// chances that the refresh fails.
-		bumpedTxn := br.Txn.Clone()
-		bumpedTxn.WriteTooOld = false
-		pErr = kvpb.NewErrorWithTxn(kvpb.NewTransactionRetryError(kvpb.RETRY_WRITE_TOO_OLD, "WriteTooOld flag converted to WriteTooOldError"), bumpedTxn)
-		br = nil
-	}
 	if pErr != nil {
 		if maxRefreshAttempts > 0 {
 			br, pErr = sr.maybeRefreshAndRetrySend(ctx, ba, pErr, maxRefreshAttempts)
@@ -504,7 +455,7 @@ func (sr *txnSpanRefresher) maybeRefreshPreemptively(
 	refreshInevitable := hasET && args.(*kvpb.EndTxnRequest).Commit &&
 		// If the transaction can tolerate write skew, no preemptive refresh is
 		// necessary, even if its write timestamp has been bumped. Transactions run
-		// at weak isolation levels may refresh in response to WriteTooOld errors or
+		// at weak isolation levels may refresh in response to
 		// ReadWithinUncertaintyInterval errors returned by requests, but they do
 		// not need to refresh preemptively ahead of an EndTxn request.
 		!ba.Txn.IsoLevel.ToleratesWriteSkew()
@@ -542,9 +493,6 @@ func newRetryErrorOnFailedPreemptiveRefresh(
 	txn *roachpb.Transaction, pErr *kvpb.Error,
 ) *kvpb.Error {
 	reason := kvpb.RETRY_SERIALIZABLE
-	if txn.WriteTooOld {
-		reason = kvpb.RETRY_WRITE_TOO_OLD
-	}
 	var conflictingTxn *enginepb.TxnMeta
 	msg := redact.StringBuilder{}
 	msg.SafeString("failed preemptive refresh")

--- a/pkg/kv/kvpb/batch.go
+++ b/pkg/kv/kvpb/batch.go
@@ -937,11 +937,6 @@ func (ba *BatchRequest) ValidateForEvaluation() error {
 	if _, ok := ba.GetArg(EndTxn); ok && ba.Txn == nil {
 		return errors.AssertionFailedf("EndTxn request without transaction")
 	}
-	if ba.Txn != nil {
-		if ba.Txn.WriteTooOld && ba.Txn.ReadTimestamp == ba.Txn.WriteTimestamp {
-			return errors.AssertionFailedf("WriteTooOld set but no offset in timestamps. txn: %s", ba.Txn)
-		}
-	}
 	return nil
 }
 

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -537,11 +537,6 @@ func IsEndTxnExceedingDeadline(commitTS hlc.Timestamp, deadline hlc.Timestamp) b
 func IsEndTxnTriggeringRetryError(
 	txn *roachpb.Transaction, deadline hlc.Timestamp,
 ) (retry bool, reason kvpb.TransactionRetryReason, extraMsg redact.RedactableString) {
-	if txn.WriteTooOld {
-		// If we saw any WriteTooOldErrors, we must restart to avoid lost
-		// update anomalies.
-		return true, kvpb.RETRY_WRITE_TOO_OLD, ""
-	}
 	if !txn.IsoLevel.ToleratesWriteSkew() && txn.WriteTimestamp != txn.ReadTimestamp {
 		// Return a transaction retry error if the commit timestamp isn't equal to
 		// the txn timestamp.

--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -170,15 +170,6 @@ func evaluateBatch(
 	evalPath batchEvalPath,
 	omitInRangefeeds bool, // only relevant for transactional writes
 ) (_ *kvpb.BatchResponse, _ result.Result, retErr *kvpb.Error) {
-	defer func() {
-		// Ensure that errors don't carry the WriteTooOld flag set. The client
-		// handles non-error responses with the WriteTooOld flag set, and errors
-		// with this flag set confuse it.
-		if retErr != nil && retErr.GetTxn() != nil {
-			retErr.GetTxn().WriteTooOld = false
-		}
-	}()
-
 	// NB: Don't mutate BatchRequest directly.
 	baReqs := ba.Requests
 
@@ -230,12 +221,6 @@ func evaluateBatch(
 
 	var mergedResult result.Result
 
-	// WriteTooOldErrors have particular handling. Evaluation of the current batch
-	// continues after a WriteTooOldError in order to find out if there's more
-	// conflicts and chose the highest timestamp to return for more efficient
-	// retries.
-	var deferredWriteTooOldErr *kvpb.WriteTooOldError
-
 	// Only collect the scan stats if the tracing is enabled.
 	var ss *kvpb.ScanStats
 	if sp := tracing.SpanFromContext(ctx); sp.RecordingType() != tracingpb.RecordingOff {
@@ -257,17 +242,6 @@ func evaluateBatch(
 	for index, union := range baReqs {
 		// Execute the command.
 		args := union.GetInner()
-
-		if deferredWriteTooOldErr != nil && args.Method() == kvpb.EndTxn {
-			// ... unless we have been deferring a WriteTooOld error and have now
-			// reached an EndTxn request. In such cases, break and return the error.
-			// The transaction needs to handle the WriteTooOld error before it tries
-			// to commit. This short-circuiting is not necessary for correctness as
-			// the write batch will be discarded in favor of the deferred error, but
-			// we don't want to bother with potentially expensive EndTxn evaluation if
-			// we know the result will be thrown away.
-			break
-		}
 
 		if baHeader.Txn != nil {
 			// Set the Request's sequence number on the TxnMeta for this
@@ -353,36 +327,10 @@ func evaluateBatch(
 
 		// Handle errors thrown by evaluation, either eagerly or through deferral.
 		if err != nil {
-			var wtoErr *kvpb.WriteTooOldError
-			switch {
-			case errors.As(err, &wtoErr):
-				// We got a WriteTooOldError. We continue on to run all commands in the
-				// batch in order to determine the highest timestamp for more efficient
-				// retries.
-				if deferredWriteTooOldErr != nil {
-					deferredWriteTooOldErr.ActualTimestamp.Forward(wtoErr.ActualTimestamp)
-				} else {
-					deferredWriteTooOldErr = wtoErr
-				}
-
-				if baHeader.Txn != nil {
-					log.VEventf(ctx, 2, "advancing write timestamp due to "+
-						"WriteTooOld error on key: %s. wts: %s -> %s",
-						args.Header().Key, baHeader.Txn.WriteTimestamp, wtoErr.ActualTimestamp)
-					baHeader.Txn.WriteTimestamp.Forward(wtoErr.ActualTimestamp)
-				}
-
-				// Clear error and fall through to the success path; we're done
-				// processing the error for now. We'll return it below after we've
-				// evaluated all requests.
-				err = nil
-
-			default:
-				// For all other error types, immediately propagate the error.
-				pErr := kvpb.NewErrorWithTxn(err, baHeader.Txn)
-				pErr.SetErrorIndex(int32(index))
-				return nil, mergedResult, pErr
-			}
+			// Immediately propagate the error.
+			pErr := kvpb.NewErrorWithTxn(err, baHeader.Txn)
+			pErr.SetErrorIndex(int32(index))
+			return nil, mergedResult, pErr
 		}
 
 		// If the last request was carried out with a limit, subtract the number
@@ -414,18 +362,6 @@ func evaluateBatch(
 				baHeader.TargetBytes = -1
 			}
 		}
-	}
-
-	// If we made it here, there was no error during evaluation, with the exception of
-	// a deferred WriteTooOld error. Return that now.
-	//
-	// TODO(tbg): we could attach the index of the first WriteTooOldError seen, but does
-	// that buy us anything?
-	if deferredWriteTooOldErr != nil {
-		// NB: we can't do any error wrapping here yet due to compatibility with 20.2 nodes;
-		// there needs to be an ErrorDetail here.
-		// TODO(nvanbenschoten): this comment is now stale. Address it.
-		return nil, mergedResult, kvpb.NewErrorWithTxn(deferredWriteTooOldErr, baHeader.Txn)
 	}
 
 	// Update the batch response timestamp field to the timestamp at which the

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1206,7 +1206,6 @@ func (t *Transaction) Restart(
 	t.UpgradePriority(upgradePriority)
 	// Reset all epoch-scoped state.
 	t.Sequence = 0
-	t.WriteTooOld = false
 	t.ReadTimestampFixed = false
 	t.LockSpans = nil
 	t.InFlightWrites = nil
@@ -1247,8 +1246,6 @@ func (t *Transaction) BumpEpoch() {
 func (t *Transaction) BumpReadTimestamp(timestamp hlc.Timestamp) {
 	t.ReadTimestamp.Forward(timestamp)
 	t.WriteTimestamp.Forward(t.ReadTimestamp)
-	// TODO(nvanbenschoten): remove this when the WriteTooOld flag is removed.
-	t.WriteTooOld = false
 }
 
 // Update ratchets priority, timestamp and original timestamp values (among
@@ -1283,7 +1280,6 @@ func (t *Transaction) Update(o *Transaction) {
 		}
 		// Replace all epoch-scoped state.
 		t.Epoch = o.Epoch
-		t.WriteTooOld = o.WriteTooOld
 		t.ReadTimestampFixed = o.ReadTimestampFixed
 		t.Sequence = o.Sequence
 		t.LockSpans = o.LockSpans
@@ -1307,17 +1303,8 @@ func (t *Transaction) Update(o *Transaction) {
 		}
 
 		if t.ReadTimestamp == o.ReadTimestamp {
-			// If neither of the transactions has a bumped ReadTimestamp, then the
-			// WriteTooOld flag is cumulative.
-			t.WriteTooOld = t.WriteTooOld || o.WriteTooOld
 			t.ReadTimestampFixed = t.ReadTimestampFixed || o.ReadTimestampFixed
 		} else if t.ReadTimestamp.Less(o.ReadTimestamp) {
-			// If `o` has a higher ReadTimestamp (i.e. it's the result of a refresh,
-			// which refresh generally clears the WriteTooOld field), then it dictates
-			// the WriteTooOld field. This relies on refreshes not being performed
-			// concurrently with any requests whose response's WriteTooOld field
-			// matters.
-			t.WriteTooOld = o.WriteTooOld
 			t.ReadTimestampFixed = o.ReadTimestampFixed
 		}
 		// If t has a higher ReadTimestamp, than it gets to dictate the
@@ -1426,8 +1413,8 @@ func (t Transaction) SafeFormat(w redact.SafePrinter, _ rune) {
 	if len(t.Name) > 0 {
 		w.Printf("%q ", redact.SafeString(t.Name))
 	}
-	w.Printf("meta={%s} lock=%t stat=%s rts=%s wto=%t gul=%s",
-		t.TxnMeta, t.IsLocking(), t.Status, t.ReadTimestamp, t.WriteTooOld, t.GlobalUncertaintyLimit)
+	w.Printf("meta={%s} lock=%t stat=%s rts=%s gul=%s",
+		t.TxnMeta, t.IsLocking(), t.Status, t.ReadTimestamp, t.GlobalUncertaintyLimit)
 	if ni := len(t.LockSpans); t.Status != PENDING && ni > 0 {
 		w.Printf(" int=%d", ni)
 	}

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -450,35 +450,6 @@ message Transaction {
   // slice should be treated as immutable and all updates should be performed
   // on a copy of the slice.
   repeated ObservedTimestamp observed_timestamps = 8 [(gogoproto.nullable) = false];
-  // If set, a write performed by the transaction could not be performed at the
-  // transaction's read timestamp because a newer value was present. Had our
-  // write been performed, it would have overwritten the other value even though
-  // that value might not have been read by a previous read in the transaction
-  // (i.e. lost update anomaly). The write is still performed, but this flag is
-  // set and the txn's write timestamp is bumped, so the client will not be able
-  // to commit without performing a refresh.
-  //
-  // Since 20.1, errors do not carry this flag; only successful BatchResponses
-  // do. When possible, such a BatchResponse is preferred to a WriteTooOldError
-  // because the former leaves intents behind to act as locks.
-  //
-  // On the client, the txnSpanRefresher terminates this flag by refreshing
-  // eagerly when the flag is set. If the key that generated the write too old
-  // condition had been previously read by the transaction, a refresh of the
-  // transaction's read span will surely fail. The client is not currently smart
-  // enough to avoid hopeless refreshes, though.
-  //
-  // Historically, this field was also important for SNAPSHOT transactions which
-  // could commit in other situations when the write timestamp is bumped, but
-  // not when this flag is set (since lost updates cannot be tolerated even in
-  // SNAPSHOT). In SERIALIZABLE isolation, transactions generally don't commit
-  // with a bumped write timestamp, so this flag is only telling us that a
-  // refresh is less likely to succeed than in other cases where
-  // ReadTimestamp != WriteTimestamp.
-  //
-  // TODO(nvanbenschoten): this flag is no longer assigned by v23.2 nodes.
-  // Remove it when compatibility with v23.1 nodes is no longer a concern.
-  bool write_too_old = 12;
   // Set of spans that the transaction has acquired locks within. These are
   // spans which must be resolved on txn completion. Note that these spans
   // may be condensed to cover aggregate spans if the keys locked by the
@@ -535,7 +506,7 @@ message Transaction {
   // choose which writes are exported on a per-transaction basis.
   bool omit_in_rangefeeds = 20;
 
-  reserved 3, 6, 9, 13, 14;
+  reserved 3, 6, 9, 12, 13, 14;
 }
 
 // A TransactionRecord message contains the subset of the fields in a


### PR DESCRIPTION
The `Transaction.WriteTooOld` flag has been unused since #102808. Remove it now that there is no need to maintain backwards compatibility with 23.1.

Touches #119414.

Release note: None.

Epic: CRDB-37617.