### PR TITLE
sql,crosscluster: correctly handle NULLABLE columns in KV writer

### DIFF
--- a/pkg/ccl/crosscluster/logical/BUILD.bazel
+++ b/pkg/ccl/crosscluster/logical/BUILD.bazel
@@ -97,6 +97,7 @@ go_test(
     srcs = [
         "dead_letter_queue_test.go",
         "logical_replication_job_test.go",
+        "lww_kv_processor_test.go",
         "lww_row_processor_test.go",
         "main_test.go",
         "purgatory_test.go",

--- a/pkg/ccl/crosscluster/logical/lww_kv_processor.go
+++ b/pkg/ccl/crosscluster/logical/lww_kv_processor.go
@@ -425,11 +425,13 @@ func (p *kvTableWriter) deleteRow(
 	var ph row.PartialIndexUpdateHelper
 	// TODO(dt): support partial indexes.
 	oth := &row.OriginTimestampCPutHelper{
-		OriginTimestamp: after.MvccTimestamp,
+		PreviousWasDeleted: before.IsDeleted(),
+		OriginTimestamp:    after.MvccTimestamp,
 		// TODO(ssd): We should choose this based by comparing the cluster IDs of the source
 		// and destination clusters.
 		ShouldWinTie: true,
 	}
+
 	return p.rd.DeleteRow(ctx, b, p.oldVals, ph, oth, false)
 }
 

--- a/pkg/ccl/crosscluster/logical/lww_kv_processor_test.go
+++ b/pkg/ccl/crosscluster/logical/lww_kv_processor_test.go
@@ -1,0 +1,184 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package logical
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/crosscluster/replicationtestutils"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKVWriterUpdateEncoding(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
+
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+
+	tableWithNullableColumns := `CREATE TABLE %s (pk INT PRIMARY KEY, payload1 STRING NULL, payload2 STRING NULL)`
+
+	tableNumber := 0
+	createTable := func(t *testing.T, schema string) string {
+		tableName := fmt.Sprintf("tab%d", tableNumber)
+		runner.Exec(t, fmt.Sprintf(schema, tableName))
+		runner.Exec(t, fmt.Sprintf(
+			"ALTER TABLE %s "+lwwColumnAdd,
+			tableName))
+		tableNumber++
+		return tableName
+	}
+
+	type encoderFn func(datums ...interface{}) roachpb.KeyValue
+
+	setup := func(t *testing.T, schema string) (string, RowProcessor, encoderFn) {
+		tableName := createTable(t, schema)
+		desc := desctestutils.TestingGetPublicTableDescriptor(s.DB(), s.Codec(), "defaultdb", tableName)
+
+		rp, err := newKVRowProcessor(ctx,
+			&execinfra.ServerConfig{
+				DB:           s.InternalDB().(descs.DB),
+				LeaseManager: s.LeaseManager(),
+			}, &eval.Context{
+				Codec:    s.Codec(),
+				Settings: s.ClusterSettings(),
+			}, map[descpb.ID]sqlProcessorTableConfig{
+				desc.GetID(): {
+					srcDesc: desc,
+				},
+			})
+		require.NoError(t, err)
+		return tableName, rp, func(datums ...interface{}) roachpb.KeyValue {
+			kv := replicationtestutils.EncodeKV(t, s.Codec(), desc, datums...)
+			kv.Value.Timestamp = hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
+			return kv
+		}
+	}
+
+	insertRow := func(rp RowProcessor, keyValue roachpb.KeyValue, prevValue roachpb.Value) error {
+		_, err := rp.ProcessRow(ctx, nil, keyValue, prevValue)
+		return err
+	}
+
+	rng, _ := randutil.NewTestRand()
+	useRandomPrevValue := rng.Float32() < 0.5
+	t.Logf("using random previous values = %v", useRandomPrevValue)
+
+	maybeRandomPrevValue := func(expectedPrev roachpb.KeyValue, encoder encoderFn) roachpb.KeyValue {
+		if useRandomPrevValue {
+			return encoder(1, fmt.Sprintf("rand-%d", rng.Int63()), fmt.Sprintf("rand-%d", rng.Int63()))
+		}
+		return expectedPrev
+	}
+
+	t.Run("one-NULL-to-not-NULL", func(t *testing.T) {
+		tableNameDst, rp, encoder := setup(t, tableWithNullableColumns)
+
+		runner.Exec(t, fmt.Sprintf("INSERT INTO %s VALUES ($1, $2, NULL)", tableNameDst), 1, "not null")
+
+		keyValue1 := encoder(1, "not null", "not null")
+		keyValue2 := maybeRandomPrevValue(encoder(1, "not null", tree.DNull), encoder)
+		require.NoError(t, insertRow(rp, keyValue1, keyValue2.Value))
+		expectedRows := [][]string{
+			{"1", "not null", "not null"},
+		}
+		runner.CheckQueryResults(t, fmt.Sprintf("SELECT * from %s", tableNameDst), expectedRows)
+	})
+	t.Run("one-not-NULL-to-NULL", func(t *testing.T) {
+		tableNameDst, rp, encoder := setup(t, tableWithNullableColumns)
+
+		runner.Exec(t, fmt.Sprintf("INSERT INTO %s VALUES ($1, $2, $3)", tableNameDst), 1, "not null", "not null")
+
+		keyValue1 := encoder(1, "not null", tree.DNull)
+		keyValue2 := maybeRandomPrevValue(encoder(1, "not null", "not null"), encoder)
+		require.NoError(t, insertRow(rp, keyValue1, keyValue2.Value))
+		expectedRows := [][]string{
+			{"1", "not null", "NULL"},
+		}
+		runner.CheckQueryResults(t, fmt.Sprintf("SELECT * from %s", tableNameDst), expectedRows)
+	})
+	t.Run("all-NULL-to-not-NULL", func(t *testing.T) {
+		tableNameDst, rp, encoder := setup(t, tableWithNullableColumns)
+
+		runner.Exec(t, fmt.Sprintf("INSERT INTO %s VALUES ($1, NULL, NULL)", tableNameDst), 1)
+
+		keyValue1 := encoder(1, "not null", "not null")
+		keyValue2 := maybeRandomPrevValue(encoder(1, tree.DNull, tree.DNull), encoder)
+		require.NoError(t, insertRow(rp, keyValue1, keyValue2.Value))
+		expectedRows := [][]string{
+			{"1", "not null", "not null"},
+		}
+		runner.CheckQueryResults(t, fmt.Sprintf("SELECT * from %s", tableNameDst), expectedRows)
+	})
+	t.Run("all-not-NULL-to-NULL", func(t *testing.T) {
+		tableNameDst, rp, encoder := setup(t, tableWithNullableColumns)
+
+		runner.Exec(t, fmt.Sprintf("INSERT INTO %s VALUES ($1, $2, $3)", tableNameDst), 1, "not null", "not null")
+
+		keyValue1 := encoder(1, tree.DNull, tree.DNull)
+		keyValue2 := maybeRandomPrevValue(encoder(1, "not null", "not null"), encoder)
+		require.NoError(t, insertRow(rp, keyValue1, keyValue2.Value))
+		expectedRows := [][]string{
+			{"1", "NULL", "NULL"},
+		}
+		runner.CheckQueryResults(t, fmt.Sprintf("SELECT * from %s", tableNameDst), expectedRows)
+	})
+	t.Run("deleted-one-NULL", func(t *testing.T) {
+		tableNameDst, rp, encoder := setup(t, tableWithNullableColumns)
+		runner.Exec(t, fmt.Sprintf("INSERT INTO %s VALUES ($1, $2, NULL)", tableNameDst), 1, "not null")
+
+		keyValue1 := encoder(1, "not null", tree.DNull)
+		keyValue1.Value.RawBytes = nil
+		keyValue2 := maybeRandomPrevValue(encoder(1, "not null", tree.DNull), encoder)
+		require.NoError(t, insertRow(rp, keyValue1, keyValue2.Value))
+
+		expectedRows := [][]string{}
+		runner.CheckQueryResults(t, fmt.Sprintf("SELECT * from %s", tableNameDst), expectedRows)
+	})
+	t.Run("deleted-all-NULL", func(t *testing.T) {
+		tableNameDst, rp, encoder := setup(t, tableWithNullableColumns)
+		runner.Exec(t, fmt.Sprintf("INSERT INTO %s VALUES ($1, NULL, NULL)", tableNameDst), 1)
+
+		keyValue1 := maybeRandomPrevValue(encoder(1, tree.DNull, tree.DNull), encoder)
+		keyValue1.Value.RawBytes = nil
+		keyValue2 := encoder(1, tree.DNull, tree.DNull)
+		require.NoError(t, insertRow(rp, keyValue1, keyValue2.Value))
+
+		expectedRows := [][]string{}
+		runner.CheckQueryResults(t, fmt.Sprintf("SELECT * from %s", tableNameDst), expectedRows)
+	})
+	t.Run("phantom-delete", func(t *testing.T) {
+		tableNameDst, rp, encoder := setup(t, tableWithNullableColumns)
+
+		keyValue1 := encoder(1, tree.DNull, tree.DNull)
+		keyValue1.Value.RawBytes = nil
+		require.NoError(t, insertRow(rp, keyValue1, keyValue1.Value))
+
+		expectedRows := [][]string{}
+		runner.CheckQueryResults(t, fmt.Sprintf("SELECT * from %s", tableNameDst), expectedRows)
+	})
+}

--- a/pkg/sql/row/writer.go
+++ b/pkg/sql/row/writer.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/valueside"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -157,9 +156,6 @@ func prepareInsertOrUpdateBatch(
 				}
 			}
 
-			// TODO(ssd): Here and below investigate reducing the
-			// number of allocations required to marshal the old
-			// value.
 			var oldVal []byte
 			if oth.IsSet() && len(oldValues) > 0 {
 				// If the column could be composite, we only encode the old value if it
@@ -203,51 +199,34 @@ func prepareInsertOrUpdateBatch(
 			continue
 		}
 
-		rawValueBuf = rawValueBuf[:0]
-
-		var lastColID descpb.ColumnID
-		var oldBytes []byte
-
 		familySortedColumnIDs, ok := helper.SortedColumnFamily(family.ID)
 		if !ok {
 			return nil, errors.AssertionFailedf("invalid family sorted column id map")
 		}
-		for _, colID := range familySortedColumnIDs {
-			idx, ok := valColIDMapping.Get(colID)
-			if !ok || values[idx] == tree.DNull {
-				// Column not being updated or inserted.
-				continue
-			}
 
-			if skip, _ := helper.SkipColumnNotInPrimaryIndexValue(colID, values[idx]); skip {
-				continue
-			}
+		rawValueBuf = rawValueBuf[:0]
+		var err error
+		rawValueBuf, err = helper.encodePrimaryIndexValuesToBuf(values, valColIDMapping, familySortedColumnIDs, fetchedCols, rawValueBuf)
+		if err != nil {
+			return nil, err
+		}
 
-			col := fetchedCols[idx]
-			if lastColID > col.GetID() {
-				return nil, errors.AssertionFailedf("cannot write column id %d after %d", col.GetID(), lastColID)
-			}
-			colIDDelta := valueside.MakeColumnIDDelta(lastColID, col.GetID())
-			lastColID = col.GetID()
-			var err error
-			rawValueBuf, err = valueside.Encode(rawValueBuf, colIDDelta, values[idx], nil)
+		// TODO(ssd): Here and below investigate reducing the number of
+		// allocations required to marshal the old value.
+		var expBytes []byte
+		if oth.IsSet() && len(oldValues) > 0 {
+			var oldBytes []byte
+			oldBytes, err = helper.encodePrimaryIndexValuesToBuf(oldValues, valColIDMapping, familySortedColumnIDs, fetchedCols, oldBytes)
 			if err != nil {
 				return nil, err
 			}
-			if oth.IsSet() && len(oldValues) > 0 {
-				var err error
-				oldBytes, err = valueside.Encode(oldBytes, colIDDelta, oldValues[idx], nil)
-				if err != nil {
-					return nil, err
-				}
+			// For family 0, we expect a value even when
+			// no columns have been encoded to oldBytes.
+			if family.ID == 0 || len(oldBytes) > 0 {
+				old := &roachpb.Value{}
+				old.SetTuple(oldBytes)
+				expBytes = old.TagAndDataBytes()
 			}
-		}
-
-		var expBytes []byte
-		if oth.IsSet() && len(oldBytes) > 0 {
-			old := &roachpb.Value{}
-			old.SetTuple(oldBytes)
-			expBytes = old.TagAndDataBytes()
 		}
 
 		if family.ID != 0 && len(rawValueBuf) == 0 {


### PR DESCRIPTION
Previously, we were skipping encoding values based on whether the _new_ value was NULL, producing an incorrect _previous_ value.

Further, if _all_ columns were NULL we were not correctly writing a sentinel value.

Epic: none
Release note: None