### PR TITLE
add ability to freeze stats

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3877,6 +3877,10 @@ func (m *sessionDataMutator) SetOptimizerPushLimitIntoProjectFilteredScan(val bo
 	m.data.OptimizerPushLimitIntoProjectFilteredScan = val
 }
 
+func (m *sessionDataMutator) SetOptimizerFreezeStats(val string) {
+	m.data.OptimizerFreezeStats = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -257,6 +257,9 @@ type TableStatistic interface {
 
 	// IsAuto returns true if this statistic was collected automatically.
 	IsAuto() bool
+
+	// Name returns the name of the statistics.
+	Name() string
 }
 
 // HistogramBucket contains the data for a single histogram bucket. Note

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -589,10 +589,15 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 						}
 					}
 
+					var freezeStr string
+					if s.Freeze != "" {
+						freezeStr = fmt.Sprintf("; using frozen stats %s", s.Freeze)
+					}
+
 					e.ob.AddField("estimated row count", fmt.Sprintf(
-						"%s (%s%% of the table; stats collected %s ago%s)",
+						"%s (%s%% of the table; stats collected %s ago%s%s)",
 						estimatedRowCountString, percentageStr,
-						duration, forecastStr,
+						duration, forecastStr, freezeStr,
 					))
 				} else {
 					e.ob.AddField("estimated row count", estimatedRowCountString)

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -402,6 +402,8 @@ type EstimatedStats struct {
 	// ForecastAt is set only for scans with forecasted stats; it is the time the
 	// forecast was for (which could be in the past, present, or future).
 	ForecastAt time.Time
+	// Freeze is set when using frozen stats.
+	Freeze string
 }
 
 // ExecutionStats contain statistics about a given operator gathered from the

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -202,6 +202,7 @@ type Memo struct {
 	usePolymorphicParameterFix                 bool
 	useConditionalHoistFix                     bool
 	pushLimitIntoProjectFilteredScan           bool
+	freezeStats                                string
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -290,6 +291,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		usePolymorphicParameterFix:                 evalCtx.SessionData().OptimizerUsePolymorphicParameterFix,
 		useConditionalHoistFix:                     evalCtx.SessionData().OptimizerUseConditionalHoistFix,
 		pushLimitIntoProjectFilteredScan:           evalCtx.SessionData().OptimizerPushLimitIntoProjectFilteredScan,
+		freezeStats:                                evalCtx.SessionData().OptimizerFreezeStats,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -456,6 +458,7 @@ func (m *Memo) IsStale(
 		m.usePolymorphicParameterFix != evalCtx.SessionData().OptimizerUsePolymorphicParameterFix ||
 		m.useConditionalHoistFix != evalCtx.SessionData().OptimizerUseConditionalHoistFix ||
 		m.pushLimitIntoProjectFilteredScan != evalCtx.SessionData().OptimizerPushLimitIntoProjectFilteredScan ||
+		m.freezeStats != evalCtx.SessionData().OptimizerFreezeStats ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1904,6 +1904,10 @@ func (os *optTableStat) IsAuto() bool {
 	return os.stat.IsAuto()
 }
 
+func (os *optTableStat) Name() string {
+	return os.stat.Name
+}
+
 // optFamily is a wrapper around descpb.ColumnFamilyDescriptor that keeps a
 // reference to the table wrapper.
 type optFamily struct {

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -539,16 +539,18 @@ func (s *sampleAggregator) writeResults(ctx context.Context) error {
 
 			// Delete old stats that have been superseded,
 			// if the new statistic is not partial
-			if si.spec.PartialPredicate == "" {
-				if err := stats.DeleteOldStatsForColumns(
-					ctx,
-					txn,
-					s.tableID,
-					columnIDs,
-				); err != nil {
-					return err
+			/*
+				if si.spec.PartialPredicate == "" {
+					if err := stats.DeleteOldStatsForColumns(
+						ctx,
+						txn,
+						s.tableID,
+						columnIDs,
+					); err != nil {
+						return err
+					}
 				}
-			}
+			*/
 
 			// Insert the new stat.
 			if err := stats.InsertNewStat(

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -548,6 +548,9 @@ message LocalOnlySessionData {
   // OptimizerPushLimitIntoProjectFilteredScan, when true, indicates that the
   // optimizer should push limit expressions into projects of filtered scans.
   bool optimizer_push_limit_into_project_filtered_scan = 139;
+  // OptimizerFreezeStats, when set to something other than the empty string,
+  // forces the optimizer to use only stats matching the provided name.
+  string optimizer_freeze_stats = 140;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3487,6 +3487,25 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	// CockroachDB extension.
+	`optimizer_freeze_stats`: {
+		GetStringVal: func(
+			ctx context.Context, evalCtx *extendedEvalContext, values []tree.TypedExpr, _ *kv.Txn,
+		) (string, error) {
+			return getStringVal(ctx, &evalCtx.Context, `optimizer_freeze_stats`, values)
+		},
+		Set: func(_ context.Context, m sessionDataMutator, statsName string) error {
+			m.SetOptimizerFreezeStats(statsName)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return evalCtx.SessionData().OptimizerFreezeStats, nil
+		},
+		GlobalDefault: func(_ *settings.Values) string {
+			return ""
+		},
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
Here's a short demo:

```
demo@127.0.0.1:26257/demoapp/defaultdb> CREATE TABLE ab (a INT PRIMARY KEY, b INT, INDEX (b));
CREATE TABLE

Time: 8ms total (execution 7ms / network 1ms)

demo@127.0.0.1:26257/demoapp/defaultdb> CREATE TABLE c (c INT PRIMARY KEY);
CREATE TABLE

Time: 7ms total (execution 6ms / network 1ms)

demo@127.0.0.1:26257/demoapp/defaultdb> CREATE STATISTICS x FROM ab;
CREATE STATISTICS

Time: 43ms total (execution 43ms / network 0ms)

demo@127.0.0.1:26257/demoapp/defaultdb> CREATE STATISTICS x FROM c;
CREATE STATISTICS

Time: 34ms total (execution 34ms / network 0ms)

demo@127.0.0.1:26257/demoapp/defaultdb> INSERT INTO c SELECT generate_series(0, 99);
INSERT 0 100

Time: 2ms total (execution 2ms / network 0ms)

demo@127.0.0.1:26257/demoapp/defaultdb> INSERT INTO ab SELECT generate_series(0, 99), 1;
INSERT 0 100

Time: 5ms total (execution 5ms / network 1ms)

demo@127.0.0.1:26257/demoapp/defaultdb> CREATE STATISTICS y FROM c;
CREATE STATISTICS

Time: 34ms total (execution 34ms / network 0ms)

demo@127.0.0.1:26257/demoapp/defaultdb> CREATE STATISTICS y FROM ab;
CREATE STATISTICS

Time: 42ms total (execution 41ms / network 0ms)

demo@127.0.0.1:26257/demoapp/defaultdb> SHOW STATISTICS FOR TABLE c;
  statistics_name | column_names |            created            | row_count | distinct_count | null_count | avg_size | partial_predicate |    histogram_id     | full_histogram_id
------------------+--------------+-------------------------------+-----------+----------------+------------+----------+-------------------+---------------------+--------------------
  x               | {c}          | 2024-10-01 05:40:23.019311+00 |         0 |              0 |          0 |        0 | NULL              | 1008241288872001537 |                 0
  y               | {c}          | 2024-10-01 05:40:36.433433+00 |       100 |            100 |          0 |        1 | NULL              | 1008241332827521025 |                 0
(2 rows)

Time: 7ms total (execution 6ms / network 1ms)

demo@127.0.0.1:26257/demoapp/defaultdb> SHOW STATISTICS FOR TABLE ab;
  statistics_name | column_names |            created            | row_count | distinct_count | null_count | avg_size | partial_predicate |    histogram_id     | full_histogram_id
------------------+--------------+-------------------------------+-----------+----------------+------------+----------+-------------------+---------------------+--------------------
  x               | {a}          | 2024-10-01 05:40:20.482712+00 |         0 |              0 |          0 |        0 | NULL              | 1008241280560037889 |                 0
  x               | {b}          | 2024-10-01 05:40:20.482712+00 |         0 |              0 |          0 |        0 | NULL              | 1008241280562200577 |                 0
  y               | {a}          | 2024-10-01 05:40:42.743618+00 |       100 |            100 |          0 |        1 | NULL              | 1008241353504751617 |                 0
  y               | {b}          | 2024-10-01 05:40:42.743618+00 |       100 |              1 |          0 |        2 | NULL              | 1008241353507504129 |                 0
(4 rows)

Time: 7ms total (execution 6ms / network 1ms)

demo@127.0.0.1:26257/demoapp/defaultdb> EXPLAIN SELECT * FROM ab INNER MERGE JOIN c ON c = a;
                                         info
--------------------------------------------------------------------------------------
  distribution: local
  vectorized: true

  • merge join
  │ estimated row count: 100
  │ equality: (a) = (c)
  │ left cols are key
  │ right cols are key
  │
  ├── • scan
  │     estimated row count: 100 (100% of the table; stats collected 13 seconds ago)
  │     table: ab@ab_pkey
  │     spans: FULL SCAN
  │
  └── • scan
        estimated row count: 100 (100% of the table; stats collected 19 seconds ago)
        table: c@c_pkey
        spans: FULL SCAN
(18 rows)

Time: 3ms total (execution 3ms / network 1ms)

demo@127.0.0.1:26257/demoapp/defaultdb> SET optimizer_freeze_stats = 'x';
SET

Time: 1ms total (execution 1ms / network 0ms)

demo@127.0.0.1:26257/demoapp/defaultdb> EXPLAIN SELECT * FROM ab INNER MERGE JOIN c ON c = a;
                                                   info
----------------------------------------------------------------------------------------------------------
  distribution: local
  vectorized: true

  • merge join
  │ estimated row count: 1
  │ equality: (a) = (c)
  │ left cols are key
  │ right cols are key
  │
  ├── • scan
  │     estimated row count: 1 (100% of the table; stats collected 43 seconds ago; using frozen stats x)
  │     table: ab@ab_pkey
  │     spans: FULL SCAN
  │
  └── • scan
        estimated row count: 1 (100% of the table; stats collected 40 seconds ago; using frozen stats x)
        table: c@c_pkey
        spans: FULL SCAN
(18 rows)

Time: 3ms total (execution 2ms / network 1ms)

demo@127.0.0.1:26257/demoapp/defaultdb> EXPLAIN SELECT * FROM ab INNER MERGE JOIN c ON c = a;
                                                   info
----------------------------------------------------------------------------------------------------------
  distribution: local
  vectorized: true

  • merge join
  │ estimated row count: 1
  │ equality: (a) = (c)
  │ left cols are key
  │ right cols are key
  │
  ├── • scan
  │     estimated row count: 1 (100% of the table; stats collected 52 seconds ago; using frozen stats x)
  │     table: ab@ab_pkey
  │     spans: FULL SCAN
  │
  └── • scan
        estimated row count: 1 (100% of the table; stats collected 50 seconds ago; using frozen stats x)
        table: c@c_pkey
        spans: FULL SCAN
(18 rows)

Time: 3ms total (execution 3ms / network 1ms)

demo@127.0.0.1:26257/demoapp/defaultdb> SET optimizer_freeze_stats = 'y';
SET

Time: 1ms total (execution 1ms / network 1ms)

demo@127.0.0.1:26257/demoapp/defaultdb> EXPLAIN SELECT * FROM ab INNER MERGE JOIN c ON c = a;
                                                    info
------------------------------------------------------------------------------------------------------------
  distribution: local
  vectorized: true

  • merge join
  │ estimated row count: 100
  │ equality: (a) = (c)
  │ left cols are key
  │ right cols are key
  │
  ├── • scan
  │     estimated row count: 100 (100% of the table; stats collected 42 seconds ago; using frozen stats y)
  │     table: ab@ab_pkey
  │     spans: FULL SCAN
  │
  └── • scan
        estimated row count: 100 (100% of the table; stats collected 49 seconds ago; using frozen stats y)
        table: c@c_pkey
        spans: FULL SCAN
(18 rows)

Time: 3ms total (execution 2ms / network 1ms)

demo@127.0.0.1:26257/demoapp/defaultdb> SET optimizer_freeze_stats = '';
SET

Time: 1ms total (execution 1ms / network 0ms)

demo@127.0.0.1:26257/demoapp/defaultdb> EXPLAIN SELECT * FROM ab INNER MERGE JOIN c ON c = a;
                                         info
--------------------------------------------------------------------------------------
  distribution: local
  vectorized: true

  • merge join
  │ estimated row count: 100
  │ equality: (a) = (c)
  │ left cols are key
  │ right cols are key
  │
  ├── • scan
  │     estimated row count: 100 (100% of the table; stats collected 34 seconds ago)
  │     table: ab@ab_pkey
  │     spans: FULL SCAN
  │
  └── • scan
        estimated row count: 100 (100% of the table; stats collected 33 seconds ago)
        table: c@c_pkey
        spans: FULL SCAN
(18 rows)

Time: 3ms total (execution 2ms / network 1ms)
```