### PR TITLE
cli: add retries in zip upload

### DIFF
--- a/pkg/cli/tsdump_upload.go
+++ b/pkg/cli/tsdump_upload.go
@@ -260,8 +260,9 @@ func (d *datadogWriter) flush(data []DatadogSeries) error {
 
 	retryOpts := base.DefaultRetryOptions()
 	retryOpts.MaxRetries = 5
+	var req *http.Request
 	for retry := retry.Start(retryOpts); retry.Next(); {
-		req, err := http.NewRequest("POST", d.targetURL, &zipBuf)
+		req, err = http.NewRequest("POST", d.targetURL, &zipBuf)
 		if err != nil {
 			return err
 		}
@@ -313,7 +314,7 @@ func (d *datadogWriter) upload(fileName string) error {
 			for data := range ch {
 				err := d.emitDataDogMetrics(data)
 				if err != nil {
-					fmt.Printf("retries exhausted for datadog upload containing series %s with error %v", data[0].Metric, err)
+					fmt.Printf("retries exhausted for datadog upload containing series %s with error %v\n", data[0].Metric, err)
 					wg.Done()
 					return
 				}


### PR DESCRIPTION
Previously, we do not had retries in zip upload for profiles and logs. This would result in execution failure as soon as we receive an error in upload. This change add retries for datadog & GCS upload requests in case of profile & log upload respectively.

Epic: none
Release note: none