### PR TITLE
hlc: remove log dependency

### DIFF
--- a/pkg/util/hlc/BUILD.bazel
+++ b/pkg/util/hlc/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
     deps = [
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
-        "//pkg/util/log",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",


### PR DESCRIPTION
Currently, any package that disallows imports from the log package (e.g. the `pkg/sql/sem/tree`) cannot import the hlc package as the hlc package depends on the log package. This patch removes converts the log.Fatal calls to panics and removes the one use of log.Warning.

This patch will unblock #131456

Release note: none