### PR TITLE
roachtest/large-schema-benchmark: use SSL for web console API

### DIFF
--- a/pkg/cmd/roachtest/tests/large_schema_benchmark.go
+++ b/pkg/cmd/roachtest/tests/large_schema_benchmark.go
@@ -192,7 +192,7 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 			webConsoleURLs, err := c.ExternalAdminUIAddr(ctx, t.L(), c.Range(1, c.Spec().NodeCount-1))
 			require.NoError(t, err)
 			for urlIdx := range webConsoleURLs {
-				webConsoleURLs[urlIdx] = "http://" + webConsoleURLs[urlIdx]
+				webConsoleURLs[urlIdx] = "https://" + webConsoleURLs[urlIdx]
 			}
 			// Next startup the workload for our list of databases from earlier.
 			for dbListType, dbList := range [][]string{activeDBList, inactiveDBList} {


### PR DESCRIPTION
Previously, we have been noticing flakes lately on certain scales of this test due to the end point giving connection refused, and TLS errors in the log files. To address this we are going to switch to the HTTPS end point, which should hopefully help with the flake we have been seeing.

Fixes: #131566
Fixes: #131556
Fixes: #131554

Release note: None