### PR TITLE
roachtest: add session variable operations

### DIFF
--- a/pkg/cmd/roachtest/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/operations/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "pause_job.go",
         "register.go",
         "resize.go",
+        "session_vars.go",
         "utils.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operations",

--- a/pkg/cmd/roachtest/operations/cluster_settings.go
+++ b/pkg/cmd/roachtest/operations/cluster_settings.go
@@ -2,7 +2,6 @@
 //
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
-//
 
 package operations
 
@@ -83,7 +82,7 @@ func registerClusterSettings(r registry.Registry) {
 		// Weekly cycle.
 		{
 			Name:      "kv.expiration_leases_only.enabled",
-			Generator: timeBasedValues(timeSupplier, []string{"true", "false"}, 24*7*time.Minute),
+			Generator: timeBasedValues(timeSupplier, []string{"true", "false"}, 24*7*time.Hour),
 			Owner:     registry.OwnerKV,
 		},
 		// When running multi-store with `--wal-failover=among-stores`, this configures

--- a/pkg/cmd/roachtest/operations/cluster_settings.go
+++ b/pkg/cmd/roachtest/operations/cluster_settings.go
@@ -74,15 +74,12 @@ func setClusterSetting(
 }
 
 func registerClusterSettings(r registry.Registry) {
-	timeSupplier := func() time.Time {
-		return timeutil.Now()
-	}
 	ops := []clusterSettingOp{
 		// Converts all leases to expiration. Tradeoff between lower throughput and higher availability.
 		// Weekly cycle.
 		{
 			Name:      "kv.expiration_leases_only.enabled",
-			Generator: timeBasedValues(timeSupplier, []string{"true", "false"}, 24*7*time.Hour),
+			Generator: timeBasedValues(timeutil.Now, []string{"true", "false"}, 24*7*time.Hour),
 			Owner:     registry.OwnerKV,
 		},
 		// When running multi-store with `--wal-failover=among-stores`, this configures
@@ -90,7 +87,7 @@ func registerClusterSettings(r registry.Registry) {
 		// 20-minute cycle.
 		{
 			Name: "storage.wal_failover.unhealthy_op_threshold",
-			Generator: timeBasedRandomValue(timeSupplier, 20*time.Minute, func(rng *rand.Rand) string {
+			Generator: timeBasedRandomValue(timeutil.Now, 20*time.Minute, func(rng *rand.Rand) string {
 				return fmt.Sprintf("%d", rng.Intn(246)+5)
 			}),
 			Owner: registry.OwnerStorage,

--- a/pkg/cmd/roachtest/operations/register.go
+++ b/pkg/cmd/roachtest/operations/register.go
@@ -20,4 +20,5 @@ func RegisterOperations(r registry.Registry) {
 	registerResize(r)
 	registerPauseLDRJob(r)
 	registerLicenseThrottle(r)
+	registerSessionVariables(r)
 }

--- a/pkg/cmd/roachtest/operations/session_vars.go
+++ b/pkg/cmd/roachtest/operations/session_vars.go
@@ -63,9 +63,6 @@ func setSessionVariables(
 }
 
 func registerSessionVariables(r registry.Registry) {
-	timeSupplier := func() time.Time {
-		return timeutil.Now()
-	}
 	ops := []sessionVariableOp{
 		// Sets the default transaction isolation level for a tpcc-like database.
 		// 1-hour cycle.
@@ -73,7 +70,7 @@ func registerSessionVariables(r registry.Registry) {
 			Name:      "default_transaction_isolation",
 			DBPattern: "tpcc",
 			Generator: timeBasedValues(
-				timeSupplier,
+				timeutil.Now,
 				[]string{"read committed", "repeatable read", "serializable"},
 				1*time.Hour,
 			),

--- a/pkg/cmd/roachtest/operations/session_vars.go
+++ b/pkg/cmd/roachtest/operations/session_vars.go
@@ -1,0 +1,96 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package operations
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+)
+
+type sessionVariableOp struct {
+	Name      string
+	DBPattern string
+	// See cluster_settings.go for a collection of utilities that can be used for
+	// the Generator function.
+	Generator func() string
+	Owner     registry.Owner
+}
+
+func setSessionVariables(
+	ctx context.Context, o operation.Operation, c cluster.Cluster, op sessionVariableOp,
+) registry.OperationCleanup {
+	value := op.Generator()
+	conn := c.Conn(ctx, o.L(), 1, option.VirtualClusterName(roachtestflags.VirtualCluster))
+	defer conn.Close()
+
+	// Select a random database that matches the pattern.
+	row := conn.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT database_name
+		FROM [SHOW DATABASES]
+		WHERE database_name ~ '%s'
+		ORDER BY random()
+		LIMIT 1`,
+		op.DBPattern,
+	))
+	var dbName string
+	if err := row.Scan(&dbName); err != nil {
+		if errors.Is(err, gosql.ErrNoRows) {
+			o.Status(fmt.Sprintf("did not find a db matching pattern %q", op.DBPattern))
+			return nil
+		}
+		o.Fatal(err)
+	}
+
+	o.Status(fmt.Sprintf("setting session variable %s on database %s to %s", op.Name, dbName, value))
+	_, err := conn.ExecContext(ctx, fmt.Sprintf("ALTER DATABASE %s SET %s = '%s'", dbName, op.Name, value))
+	if err != nil {
+		o.Fatal(err)
+	}
+	return nil
+}
+
+func registerSessionVariables(r registry.Registry) {
+	timeSupplier := func() time.Time {
+		return timeutil.Now()
+	}
+	ops := []sessionVariableOp{
+		// Sets the default transaction isolation level for a tpcc-like database.
+		// 1-hour cycle.
+		{
+			Name:      "default_transaction_isolation",
+			DBPattern: "tpcc",
+			Generator: timeBasedValues(
+				timeSupplier,
+				[]string{"read committed", "repeatable read", "serializable"},
+				1*time.Hour,
+			),
+			Owner: registry.OwnerSQLFoundations,
+		},
+	}
+	for _, op := range ops {
+		r.AddOperation(registry.OperationSpec{
+			Name:               "session-variables/scheduled/" + op.Name,
+			Owner:              op.Owner,
+			Timeout:            5 * time.Minute,
+			CompatibleClouds:   registry.AllClouds,
+			CanRunConcurrently: registry.OperationCannotRunConcurrentlyWithItself,
+			Dependencies:       []registry.OperationDependency{registry.OperationRequiresNodes},
+			Run: func(ctx context.Context, o operation.Operation, c cluster.Cluster) registry.OperationCleanup {
+				return setSessionVariables(ctx, o, c, op)
+			},
+		})
+	}
+}

--- a/scripts/drtprod
+++ b/scripts/drtprod
@@ -422,6 +422,12 @@ EOF"
         $0 sql drt-ua1:1 --cluster=system -- -e "SET CLUSTER SETTING kv.rangefeed.enabled = true"
         $0 sql drt-ua2:1 --cluster=system -- -e "SET CLUSTER SETTING kv.rangefeed.enabled = true"
 
+        # enable weak transaction isolation levels.
+        $0 sql drt-ua1:1 --cluster=system -- -e "SET CLUSTER SETTING sql.txn.read_committed_isolation.enabled = true"
+        $0 sql drt-ua2:1 --cluster=system -- -e "SET CLUSTER SETTING sql.txn.read_committed_isolation.enabled = true"
+        $0 sql drt-ua1:1 --cluster=system -- -e "SET CLUSTER SETTING sql.txn.snapshot_isolation.enabled = true"
+        $0 sql drt-ua2:1 --cluster=system -- -e "SET CLUSTER SETTING sql.txn.snapshot_isolation.enabled = true"
+
         # Setup the main tenant, on ua1 initilly.
         $0 sql drt-ua1:1 --cluster=system -- -e "CREATE VIRTUAL CLUSTER main"
         $0 sql drt-ua1:1 --cluster=system -- -e "ALTER VIRTUAL CLUSTER main START SERVICE SHARED"
@@ -543,11 +549,15 @@ EOF"
         $0 sql drt-ldr1:1 -- -e "SET CLUSTER SETTING sql.ttl.default_delete_batch_size = 1000"
         $0 sql drt-ldr1:1 -- -e "SET CLUSTER SETTING sql.ttl.default_delete_rate_limit = 2000"
         $0 sql drt-ldr1:1 -- -e "SET CLUSTER SETTING sql.ttl.default_select_batch_size = 5000"
+        $0 sql drt-ldr1:1 -- -e "SET CLUSTER SETTING sql.txn.read_committed_isolation.enabled = true"
+        $0 sql drt-ldr1:1 -- -e "SET CLUSTER SETTING sql.txn.snapshot_isolation.enabled = true"
 
         $0 sql drt-ldr2:1 -- -e "SET CLUSTER SETTING kv.rangefeed.enabled = true"
         $0 sql drt-ldr2:1 -- -e "SET CLUSTER SETTING sql.ttl.default_delete_batch_size = 1000"
         $0 sql drt-ldr2:1 -- -e "SET CLUSTER SETTING sql.ttl.default_delete_rate_limit = 2000"
         $0 sql drt-ldr2:1 -- -e "SET CLUSTER SETTING sql.ttl.default_select_batch_size = 5000"
+        $0 sql drt-ldr2:1 -- -e "SET CLUSTER SETTING sql.txn.read_committed_isolation.enabled = true"
+        $0 sql drt-ldr2:1 -- -e "SET CLUSTER SETTING sql.txn.snapshot_isolation.enabled = true"
 
         # import the workload
         $0 sql drt-ldr1:1 -- -e "CREATE DATABASE ycsb"


### PR DESCRIPTION
This change adds operations to mutate the session variables assigned to a database. Like the cluster setting operations, the values are mutated based on a preset frequency and RNG.

The first use of this is to test the behavior of different default transaction isolation levels on "tpcc"-like databases.

While here, we also enable all transaction isolation levels at startup.

Epic: None
Release note: None