### PR TITLE
kvserver: disable quota pool when kvflowcontrol mode is apply-to-all

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowdispatch"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/node_rac2"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
@@ -2519,10 +2520,16 @@ func TestQuotaPool(t *testing.T) {
 
 	ctx := context.Background()
 
+	settings := cluster.MakeTestingClusterSettings()
+	// Override the kvflowcontrol.Mode setting to apply_to_elastic, as when
+	// apply_to_all is set (metamorphically), the quota pool will be disabled.
+	// See getQuotaPoolEnabledRLocked.
+	kvflowcontrol.Mode.Override(ctx, &settings.SV, kvflowcontrol.ApplyToElastic)
 	tc := testcluster.StartTestCluster(t, numReplicas,
 		base.TestClusterArgs{
 			ReplicationMode: base.ReplicationManual,
 			ServerArgs: base.TestServerArgs{
+				Settings: settings,
 				RaftConfig: base.RaftConfig{
 					// Suppress timeout-based elections to avoid leadership changes in ways
 					// this test doesn't expect.

--- a/pkg/kv/kvserver/replica_proposal_quota.go
+++ b/pkg/kv/kvserver/replica_proposal_quota.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
 	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
@@ -45,20 +46,14 @@ func (r *Replica) maybeAcquireProposalQuota(
 		return nil, nil
 	}
 
-	// If the quota pool is disabled via the setting, we don't need to acquire
-	// quota.
-	if !enableRaftProposalQuota.Get(&r.store.cfg.Settings.SV) {
-		// TODO(kvoli): Once we have a setting for RACv2 pull vs push mode, we
-		// should abstract this check into a function that also disables quota
-		// acquisition for pull mode.
-		return nil, nil
-	}
-
 	r.mu.RLock()
+	enabled := r.getQuotaPoolEnabledRLocked(ctx)
 	quotaPool := r.mu.proposalQuota
-	desc := r.mu.state.Desc
 	r.mu.RUnlock()
 
+	if !enabled {
+		return nil, nil
+	}
 	// Quota acquisition only takes place on the leader replica,
 	// r.mu.proposalQuota is set to nil if a node is a follower (see
 	// updateProposalQuotaRaftMuLocked). For the cases where the range lease
@@ -69,12 +64,7 @@ func (r *Replica) maybeAcquireProposalQuota(
 	//
 	// NB: It is necessary to allow proposals with a nil quota pool to go
 	// through, for otherwise a follower could never request the lease.
-
 	if quotaPool == nil {
-		return nil, nil
-	}
-
-	if !quotaPoolEnabledForRange(desc) {
 		return nil, nil
 	}
 
@@ -104,6 +94,23 @@ var logSlowRaftProposalQuotaAcquisition = quotapool.OnSlowAcquisition(
 	base.SlowRequestThreshold, quotapool.LogSlowAcquisition,
 )
 
+// getQuotaPoolEnabledRLocked returns whether the quota pool is enabled for the
+// replica. The quota pool is enabled iff all of the following conditions are
+// met:
+//
+//  1. "kv.raft.proposal_quota.enabled" is true
+//  2. "kvadmission.flow_control.mode" is set to "apply_to_elastic" OR
+//     "kvadmission.flow_control.enabled" is set to false
+//  3. the range is not the NodeLiveness range
+//
+// Replica.mu must be RLocked.
+func (r *Replica) getQuotaPoolEnabledRLocked(ctx context.Context) bool {
+	return enableRaftProposalQuota.Get(&r.store.cfg.Settings.SV) &&
+		(kvflowcontrol.Mode.Get(&r.store.cfg.Settings.SV) == kvflowcontrol.ApplyToElastic ||
+			!kvflowcontrol.Enabled.Get(&r.store.cfg.Settings.SV)) &&
+		quotaPoolEnabledForRange(r.mu.state.Desc)
+}
+
 func (r *Replica) updateProposalQuotaRaftMuLocked(
 	ctx context.Context, lastLeaderID roachpb.ReplicaID,
 ) {
@@ -112,53 +119,71 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 	defer r.mu.Unlock()
 
 	status := r.mu.internalRaftGroup.BasicStatus()
+	enabled := r.getQuotaPoolEnabledRLocked(ctx)
+	// NB: We initialize and destroy the quota pool here, on leadership changes
+	// and when it's enabled/disabled via settings (see below). This obviates the
+	// need for a setting change callback, as handleRaftReady (the caller), will
+	// be called at least at the tick interval for a non-quiescent range.
+	shouldInitQuotaPool := false
 	if r.mu.leaderID != lastLeaderID {
 		if r.replicaID == r.mu.leaderID {
-			// We're becoming the leader.
-			// Initialize the proposalQuotaBaseIndex at the applied index.
-			// After the proposal quota is enabled all entries applied by this replica
-			// will be appended to the quotaReleaseQueue. The proposalQuotaBaseIndex
-			// and the quotaReleaseQueue together track status.Applied exactly.
-			r.mu.proposalQuotaBaseIndex = kvpb.RaftIndex(status.Applied)
-			if r.mu.proposalQuota != nil {
-				log.Fatal(ctx, "proposalQuota was not nil before becoming the leader")
-			}
-			if releaseQueueLen := len(r.mu.quotaReleaseQueue); releaseQueueLen != 0 {
-				log.Fatalf(ctx, "len(r.mu.quotaReleaseQueue) = %d, expected 0", releaseQueueLen)
-			}
-
-			// Raft may propose commands itself (specifically the empty
-			// commands when leadership changes), and these commands don't go
-			// through the code paths where we acquire quota from the pool. To
-			// offset this we reset the quota pool whenever leadership changes
-			// hands.
-			r.mu.proposalQuota = quotapool.NewIntPool(
-				"raft proposal",
-				uint64(r.store.cfg.RaftProposalQuota),
-				logSlowRaftProposalQuotaAcquisition,
-			)
 			r.mu.lastUpdateTimes = make(map[roachpb.ReplicaID]time.Time)
 			r.mu.lastUpdateTimes.updateOnBecomeLeader(r.mu.state.Desc.Replicas().Descriptors(), now)
 			r.mu.replicaFlowControlIntegration.onBecameLeader(ctx)
 			r.mu.lastProposalAtTicks = r.mu.ticks // delay imminent quiescence
-		} else if r.mu.proposalQuota != nil {
+			// We're the new leader but we only create the quota pool if it's enabled
+			// for the range and generally enabled for the cluster, see
+			// getQuotaPoolEnabledRLocked.
+			if enabled {
+				// Raft may propose commands itself (specifically the empty
+				// commands when leadership changes), and these commands don't go
+				// through the code paths where we acquire quota from the pool. To
+				// offset this we reset the quota pool whenever leadership changes
+				// hands.
+				shouldInitQuotaPool = true
+			}
+		} else {
 			// We're becoming a follower.
-			// We unblock all ongoing and subsequent quota acquisition goroutines
-			// (if any) and release the quotaReleaseQueue so its allocs are pooled.
-			r.mu.proposalQuota.Close("leader change")
-			r.mu.proposalQuota.Release(r.mu.quotaReleaseQueue...)
-			r.mu.quotaReleaseQueue = nil
-			r.mu.proposalQuota = nil
 			r.mu.lastUpdateTimes = nil
 			r.mu.replicaFlowControlIntegration.onBecameFollower(ctx)
+			if r.mu.proposalQuota != nil {
+				// We unblock all ongoing and subsequent quota acquisition goroutines
+				// (if any) and release the quotaReleaseQueue so its allocs are pooled.
+				r.mu.proposalQuota.Close("leader change")
+				r.mu.proposalQuota.Release(r.mu.quotaReleaseQueue...)
+				r.mu.quotaReleaseQueue = nil
+				r.mu.proposalQuota = nil
+			}
+			return
 		}
+	} else if r.replicaID == r.mu.leaderID && r.mu.proposalQuota == nil && enabled {
+		r.mu.lastProposalAtTicks = r.mu.ticks // delay imminent quiescence
+		shouldInitQuotaPool = true
+	} else if r.replicaID != r.mu.leaderID {
+		// We're a follower and have been since the last update. Nothing to do.
 		return
-	} else if r.mu.proposalQuota == nil {
-		if r.replicaID == r.mu.leaderID {
-			log.Fatal(ctx, "leader has uninitialized proposalQuota pool")
+	}
+
+	if shouldInitQuotaPool {
+		// We're becoming the leader and the quota pool is enabled for the range,
+		// or we were the leader and the quota pool has dynamically been enabled.
+		//
+		// Initialize the proposalQuotaBaseIndex at the applied index.
+		// After the proposal quota is enabled all entries applied by this replica
+		// will be appended to the quotaReleaseQueue. The proposalQuotaBaseIndex
+		// and the quotaReleaseQueue together track status.Applied exactly.
+		r.mu.proposalQuotaBaseIndex = kvpb.RaftIndex(status.Applied)
+		if r.mu.proposalQuota != nil {
+			log.Fatal(ctx, "proposalQuota was not nil before becoming the leader")
 		}
-		// We're a follower.
-		return
+		if releaseQueueLen := len(r.mu.quotaReleaseQueue); releaseQueueLen != 0 {
+			log.Fatalf(ctx, "len(r.mu.quotaReleaseQueue) = %d, expected 0", releaseQueueLen)
+		}
+		r.mu.proposalQuota = quotapool.NewIntPool(
+			"raft proposal",
+			uint64(r.store.cfg.RaftProposalQuota),
+			logSlowRaftProposalQuotaAcquisition,
+		)
 	}
 
 	// We're still the leader.
@@ -252,31 +277,40 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 		}
 	})
 
-	if r.mu.proposalQuotaBaseIndex < minIndex {
-		// We've persisted at least minIndex-r.mu.proposalQuotaBaseIndex entries
-		// to the raft log on all 'active' replicas and applied at least minIndex
-		// entries locally since last we checked, so we are able to release the
-		// difference back to the quota pool.
-		numReleases := minIndex - r.mu.proposalQuotaBaseIndex
+	if enabled {
+		if r.mu.proposalQuotaBaseIndex < minIndex {
+			// We've persisted at least minIndex-r.mu.proposalQuotaBaseIndex entries
+			// to the raft log on all 'active' replicas and applied at least minIndex
+			// entries locally since last we checked, so we are able to release the
+			// difference back to the quota pool.
+			numReleases := minIndex - r.mu.proposalQuotaBaseIndex
 
-		// NB: Release deals with cases where allocs being released do not originate
-		// from this incarnation of quotaReleaseQueue, which can happen if a
-		// proposal acquires quota while this replica is the raft leader in some
-		// term and then commits while at a different term.
-		r.mu.proposalQuota.Release(r.mu.quotaReleaseQueue[:numReleases]...)
-		r.mu.quotaReleaseQueue = r.mu.quotaReleaseQueue[numReleases:]
-		r.mu.proposalQuotaBaseIndex += numReleases
-	}
-	// Assert the sanity of the base index and the queue. Queue entries should
-	// correspond to applied entries. It should not be possible for the base
-	// index and the not yet released applied entries to not equal the applied
-	// index.
-	releasableIndex := r.mu.proposalQuotaBaseIndex + kvpb.RaftIndex(len(r.mu.quotaReleaseQueue))
-	if releasableIndex != kvpb.RaftIndex(status.Applied) {
-		log.Fatalf(ctx, "proposalQuotaBaseIndex (%d) + quotaReleaseQueueLen (%d) = %d"+
-			" must equal the applied index (%d)",
-			r.mu.proposalQuotaBaseIndex, len(r.mu.quotaReleaseQueue), releasableIndex,
-			status.Applied)
+			// NB: Release deals with cases where allocs being released do not originate
+			// from this incarnation of quotaReleaseQueue, which can happen if a
+			// proposal acquires quota while this replica is the raft leader in some
+			// term and then commits while at a different term.
+			r.mu.proposalQuota.Release(r.mu.quotaReleaseQueue[:numReleases]...)
+			r.mu.quotaReleaseQueue = r.mu.quotaReleaseQueue[numReleases:]
+			r.mu.proposalQuotaBaseIndex += numReleases
+		}
+		// Assert the sanity of the base index and the queue. Queue entries should
+		// correspond to applied entries. It should not be possible for the base
+		// index and the not yet released applied entries to not equal the applied
+		// index.
+		releasableIndex := r.mu.proposalQuotaBaseIndex + kvpb.RaftIndex(len(r.mu.quotaReleaseQueue))
+		if releasableIndex != kvpb.RaftIndex(status.Applied) {
+			log.Fatalf(ctx, "proposalQuotaBaseIndex (%d) + quotaReleaseQueueLen (%d) = %d"+
+				" must equal the applied index (%d)",
+				r.mu.proposalQuotaBaseIndex, len(r.mu.quotaReleaseQueue), releasableIndex,
+				status.Applied)
+		}
+	} else if !enabled && r.mu.proposalQuota != nil {
+		// The quota pool was previously enabled on this leader, but it is no longer
+		// enabled. We release all quota back to the pool and close the pool.
+		r.mu.proposalQuota.Close("quota pool disabled")
+		r.mu.proposalQuota.Release(r.mu.quotaReleaseQueue...)
+		r.mu.quotaReleaseQueue = nil
+		r.mu.proposalQuota = nil
 	}
 
 	// Tick the replicaFlowControlIntegration interface. This is as convenient a

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/intentresolver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
@@ -7206,38 +7207,82 @@ func TestReplicaDestroy(t *testing.T) {
 }
 
 // TestQuotaPoolDisabled tests that the no quota is acquired by proposals when
-// the quota pool enablement setting is disabled.
+// the quota pool enablement setting is disabled or the flow control mode is
+// set to kvflowcontrol.ApplyToAll and kvflowcontrol is enabled.
 func TestQuotaPoolDisabled(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	ctx := context.Background()
 
-	tc := testContext{}
-	stopper := stop.NewStopper()
-	defer stopper.Stop(ctx)
+	testutils.RunTrueAndFalse(t, "enableRaftProposalQuota", func(t *testing.T, quotaPoolSettingEnabled bool) {
+		testutils.RunValues(t, "flowControlMode",
+			[]kvflowcontrol.ModeT{
+				kvflowcontrol.ApplyToElastic,
+				kvflowcontrol.ApplyToAll,
+			}, func(t *testing.T, flowControlMode kvflowcontrol.ModeT) {
+				testutils.RunTrueAndFalse(t, "flowControlEnabled", func(t *testing.T, flowControlEnabled bool) {
+					ctx := context.Background()
+					propErr := errors.New("proposal error")
+					type magicKey struct{}
 
-	tsc := TestStoreConfig(nil /* clock */)
-	enableRaftProposalQuota.Override(ctx, &tsc.Settings.SV, false)
-	tsc.TestingKnobs.TestingProposalFilter = func(args kvserverbase.ProposalFilterArgs) *kvpb.Error {
-		// Expect no quota allocation when the quota pool is disabled.
-		require.Nil(t, args.QuotaAlloc)
-		return nil
-	}
-	tc.StartWithStoreConfig(ctx, t, stopper, tsc)
+					// We expect the quota pool to be enabled when both the quota pool
+					// setting is enabled and the flow control mode is set to
+					// ApplyToElastic or flow control is disabled.
+					expectEnabled := quotaPoolSettingEnabled &&
+						(flowControlMode == kvflowcontrol.ApplyToElastic || !flowControlEnabled)
 
-	// Flush a write all the way through the Raft proposal pipeline to ensure
-	// that the replica becomes the Raft leader and sets up its quota pool.
-	iArgs := incrementArgs([]byte("a"), 1)
-	_, pErr := tc.SendWrapped(iArgs)
-	require.Nil(t, pErr)
+					tc := testContext{}
+					stopper := stop.NewStopper()
+					defer stopper.Stop(ctx)
 
-	initialQuota := tc.repl.QuotaAvailable()
-	for i := 0; i < 10; i++ {
-		pArg := putArgs(roachpb.Key("a"), make([]byte, 1<<10))
-		_, pErr = tc.SendWrapped(&pArg)
-		require.Nil(t, pErr)
-	}
-	require.Equal(t, initialQuota, tc.repl.QuotaAvailable())
+					tsc := TestStoreConfig(nil /* clock */)
+					enableRaftProposalQuota.Override(ctx, &tsc.Settings.SV, quotaPoolSettingEnabled)
+					kvflowcontrol.Mode.Override(ctx, &tsc.Settings.SV, flowControlMode)
+					kvflowcontrol.Enabled.Override(ctx, &tsc.Settings.SV, flowControlEnabled)
+					tsc.TestingKnobs.TestingProposalFilter = func(args kvserverbase.ProposalFilterArgs) *kvpb.Error {
+						// Expect no quota allocation when the quota pool is disabled,
+						// otherwise expect some quota for our requests only (some ranges are
+						// also disabled selectively).
+						if v := args.Ctx.Value(magicKey{}); v != nil && expectEnabled {
+							require.NotNil(t, args.QuotaAlloc)
+							return kvpb.NewError(propErr)
+						} else if !expectEnabled {
+							require.Nil(t, args.QuotaAlloc)
+						}
+						return nil
+					}
+					tc.StartWithStoreConfig(ctx, t, stopper, tsc)
+
+					// Flush a write all the way through the Raft proposal pipeline to ensure
+					// that the replica becomes the Raft leader and sets up its quota pool.
+					iArgs := incrementArgs([]byte("a"), 1)
+					_, pErr := tc.SendWrapped(iArgs)
+					require.Nil(t, pErr)
+
+					// The quota pool shouldn't be initialized if the pool is disabled via
+					// either setting.
+					if expectEnabled {
+						require.NotNil(t, tc.repl.mu.proposalQuota)
+					} else {
+						require.Nil(t, tc.repl.mu.proposalQuota)
+					}
+
+					for i := 0; i < 10; i++ {
+						ctx = context.WithValue(ctx, magicKey{}, "foo")
+						ba := &kvpb.BatchRequest{}
+						pArg := putArgs(roachpb.Key("a"), make([]byte, 1<<10))
+						ba.Add(&pArg)
+						_, pErr := tc.Sender().Send(ctx, ba)
+						if expectEnabled {
+							if !testutils.IsPError(pErr, propErr.Error()) {
+								t.Fatalf("expected error %v, found %v", propErr, pErr)
+							}
+						} else {
+							require.Nil(t, pErr)
+						}
+					}
+				})
+			})
+	})
 }
 
 // TestQuotaPoolReleasedOnFailedProposal tests that the quota acquired by
@@ -7256,6 +7301,10 @@ func TestQuotaPoolReleasedOnFailedProposal(t *testing.T) {
 	propErr := errors.New("proposal error")
 
 	tsc := TestStoreConfig(nil /* clock */)
+	// Override the kvflowcontrol.Mode setting to apply_to_elastic, as when
+	// apply_to_all is set (metamorphically), the quota pool will be disabled.
+	// See getQuotaPoolEnabledRLocked.
+	kvflowcontrol.Mode.Override(ctx, &tsc.Settings.SV, kvflowcontrol.ApplyToElastic)
 	tsc.TestingKnobs.TestingProposalFilter = func(args kvserverbase.ProposalFilterArgs) *kvpb.Error {
 		if v := args.Ctx.Value(magicKey{}); v != nil {
 			minQuotaSize = tc.repl.mu.proposalQuota.ApproximateQuota() + args.QuotaAlloc.Acquired()
@@ -7295,7 +7344,13 @@ func TestQuotaPoolAccessOnDestroyedReplica(t *testing.T) {
 	tc := testContext{}
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
-	tc.Start(ctx, t, stopper)
+
+	// Override the kvflowcontrol.Mode setting to apply_to_elastic, as when
+	// apply_to_all is set (metamorphically), the quota pool will be disabled.
+	// See getQuotaPoolEnabledRLocked.
+	tsc := TestStoreConfig(nil /* clock */)
+	kvflowcontrol.Mode.Override(ctx, &tsc.Settings.SV, kvflowcontrol.ApplyToElastic)
+	tc.StartWithStoreConfig(ctx, t, stopper, tsc)
 
 	repl, err := tc.store.GetReplica(1)
 	if err != nil {


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/pull/131423, we added a cluster setting to selectively disable the quota
pool. Now also selectively disable the quota pool if
"kvadmission.flow_control.mode" is set to "apply_to_all", meaning that
all replication traffic is subject to replication admission control.

The quota pool now has the following enablement conditions, all of which
need to be true for it to be enabled for a range:

```
(1) "kv.raft.proposal_quota.enabled" is true
(2) "kvadmission.flow_control.mode" is set to "apply_to_elastic" OR
    "kvadmission.flow_control.enabled" is set to false
(3) the range is not the NodeLiveness range
```

Also ensure that the quota pool is closed or created upon a setting
change.

Resolves: https://github.com/cockroachdb/cockroach/issues/131438
Release note: None