### PR TITLE
server/license: Permit secondary tenant to read cluster initialization timestamp

### DIFF
--- a/pkg/kv/kvserver/tenantrate/limiter_test.go
+++ b/pkg/kv/kvserver/tenantrate/limiter_test.go
@@ -668,7 +668,9 @@ func (ts *testState) BindReader(tenantcapabilities.Reader) {}
 
 var _ tenantcapabilities.Authorizer = &testState{}
 
-func (ts *testState) HasCrossTenantRead(ctx context.Context, tenID roachpb.TenantID) bool {
+func (ts *testState) HasCrossTenantRead(
+	ctx context.Context, tenID roachpb.TenantID, key roachpb.RKey,
+) bool {
 	return false
 }
 
@@ -790,7 +792,9 @@ type fakeAuthorizer struct{}
 
 var _ tenantcapabilities.Authorizer = &fakeAuthorizer{}
 
-func (fakeAuthorizer) HasCrossTenantRead(ctx context.Context, tenID roachpb.TenantID) bool {
+func (fakeAuthorizer) HasCrossTenantRead(
+	ctx context.Context, tenID roachpb.TenantID, key roachpb.RKey,
+) bool {
 	return false
 }
 

--- a/pkg/multitenant/tenantcapabilities/interfaces.go
+++ b/pkg/multitenant/tenantcapabilities/interfaces.go
@@ -42,7 +42,7 @@ type Reader interface {
 // usage pattern over a timespan.
 type Authorizer interface {
 	// HasCrossTenantRead returns true if a tenant can read other tenant spans.
-	HasCrossTenantRead(ctx context.Context, tenID roachpb.TenantID) bool
+	HasCrossTenantRead(ctx context.Context, tenID roachpb.TenantID, key roachpb.RKey) bool
 
 	// HasCapabilityForBatch returns an error if a tenant, referenced by its ID,
 	// is not allowed to execute the supplied batch request given the capabilities

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/BUILD.bazel
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/keys",
         "//pkg/kv/kvpb",
         "//pkg/multitenant/mtinfopb",
         "//pkg/multitenant/tenantcapabilities",

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/allow_everything.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/allow_everything.go
@@ -31,7 +31,7 @@ func NewAllowEverythingAuthorizer() *AllowEverythingAuthorizer {
 
 // HasCrossTenantRead returns true if a tenant can read from other tenants.
 func (n *AllowEverythingAuthorizer) HasCrossTenantRead(
-	ctx context.Context, tenID roachpb.TenantID,
+	ctx context.Context, tenID roachpb.TenantID, key roachpb.RKey,
 ) bool {
 	return true
 }

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/allow_nothing.go
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/allow_nothing.go
@@ -32,7 +32,7 @@ func NewAllowNothingAuthorizer() *AllowNothingAuthorizer {
 
 // HasCrossTenantRead returns true if a tenant can read from other tenants.
 func (n *AllowNothingAuthorizer) HasCrossTenantRead(
-	ctx context.Context, tenID roachpb.TenantID,
+	ctx context.Context, tenID roachpb.TenantID, key roachpb.RKey,
 ) bool {
 	return false
 }

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -205,7 +205,7 @@ func (a tenantAuthorizer) authBatch(
 	tenSpan := tenantPrefix(tenID)
 
 	if outsideTenant(rSpan, tenSpan) {
-		if args.IsReadOnly() && a.capabilitiesAuthorizer.HasCrossTenantRead(ctx, tenID) {
+		if args.IsReadOnly() && a.capabilitiesAuthorizer.HasCrossTenantRead(ctx, tenID, rSpan.Key) {
 			return nil
 		}
 		return spanErr(rSpan, tenSpan)
@@ -239,7 +239,7 @@ func (a tenantAuthorizer) authRangeLookup(
 	tenSpan := tenantPrefix(tenID)
 	if !tenSpan.ContainsKey(args.Key) {
 		// Allow it anyway if the tenant can read other tenants.
-		if a.capabilitiesAuthorizer.HasCrossTenantRead(ctx, tenID) {
+		if a.capabilitiesAuthorizer.HasCrossTenantRead(ctx, tenID, args.Key) {
 			return nil
 		}
 		return authErrorf("requested key %s not fully contained in tenant keyspace %s", args.Key, tenSpan)
@@ -491,7 +491,7 @@ func validateSpan(
 	}
 	if outsideTenant(rSpan, tenSpan) {
 		// Allow it anyway if the tenant can read other tenants.
-		if isRead && a.capabilitiesAuthorizer.HasCrossTenantRead(ctx, tenID) {
+		if isRead && a.capabilitiesAuthorizer.HasCrossTenantRead(ctx, tenID, rSpan.Key) {
 			return nil
 		}
 		return spanErr(rSpan, tenSpan)

--- a/pkg/rpc/auth_test.go
+++ b/pkg/rpc/auth_test.go
@@ -1120,7 +1120,9 @@ func (m mockAuthorizer) HasProcessDebugCapability(
 	return errors.New("tenant does not have capability")
 }
 
-func (m mockAuthorizer) HasCrossTenantRead(ctx context.Context, tenID roachpb.TenantID) bool {
+func (m mockAuthorizer) HasCrossTenantRead(
+	ctx context.Context, tenID roachpb.TenantID, key roachpb.RKey,
+) bool {
 	return m.hasCrossTenantRead
 }
 

--- a/pkg/server/license/enforcer_test.go
+++ b/pkg/server/license/enforcer_test.go
@@ -48,7 +48,6 @@ func TestClusterInitGracePeriod_NoOverwrite(t *testing.T) {
 	// This will be set when bringing up the server.
 	ts1 := timeutil.Unix(1724329716, 0)
 	ts1_30d := ts1.Add(30 * 24 * time.Hour)
-	ts1_7d := ts1.Add(7 * 24 * time.Hour)
 
 	ctx := context.Background()
 	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
@@ -87,13 +86,7 @@ func TestClusterInitGracePeriod_NoOverwrite(t *testing.T) {
 	// Access the enforcer that is cached in the executor config to make sure they
 	// work for the system tenant and secondary tenant.
 	require.Equal(t, ts1_30d, srv.SystemLayer().ExecutorConfig().(sql.ExecutorConfig).LicenseEnforcer.GetClusterInitGracePeriodEndTS())
-	// TODO(spilchen): Until the secondary tenant can read from the KV, it will
-	// guess the ending grace period to be 7-days after start. This will be fixed
-	// in CRDB-42309. Depending on how the test was initialized, it will be either
-	// the shared process secondary tenant (ts1_30d) or the separate process
-	// secondary tenant (ts1_7d).
-	require.Contains(t, []time.Time{ts1_30d, ts1_7d},
-		srv.ApplicationLayer().ExecutorConfig().(sql.ExecutorConfig).LicenseEnforcer.GetClusterInitGracePeriodEndTS())
+	require.Equal(t, ts1_30d, srv.ApplicationLayer().ExecutorConfig().(sql.ExecutorConfig).LicenseEnforcer.GetClusterInitGracePeriodEndTS())
 }
 
 func TestClusterInitGracePeriod_NewClusterEstimation(t *testing.T) {


### PR DESCRIPTION
Previously, the secondary tenant could not access the cluster initialization timestamp, as it is stored in the system keyspace, and tenants are restricted to their own keyspace. This change introduces an exception that allows cross-tenant read access to this specific key within the system keyspace. Write access remains restricted, and any attempts to modify this key will still result in an error.

This change will be back ported to 24.2, 24.1, 23.2 and 23.1.

Epic: CRDB-39988
Closes CRDB-42309
Release note: none