### PR TITLE
raft: switch LazyReplication dynamically

### DIFF
--- a/pkg/raft/rafttest/interaction_env_handler.go
+++ b/pkg/raft/rafttest/interaction_env_handler.go
@@ -199,6 +199,11 @@ func (env *InteractionEnv) Handle(t *testing.T, d datadriven.TestData) string {
 		// v5
 		err = env.handleProposeConfChange(t, d)
 
+	case "set-lazy-replication":
+		// Set the lazy replication mode for a node dynamically.
+		// Example: set-lazy-replication 1 true
+		err = env.handleSetLazyReplication(t, d)
+
 	case "send-msg-app":
 		// Send a MsgApp from the leader to a peer.
 		// Example: send-msg-app 1 to=2 lo=10 hi=20

--- a/pkg/raft/rafttest/interaction_env_handler_send_msgapp.go
+++ b/pkg/raft/rafttest/interaction_env_handler_send_msgapp.go
@@ -13,6 +13,7 @@ package rafttest
 import (
 	"fmt"
 	"math"
+	"strconv"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/raft"
@@ -20,6 +21,15 @@ import (
 	"github.com/cockroachdb/datadriven"
 	"github.com/stretchr/testify/require"
 )
+
+func (env *InteractionEnv) handleSetLazyReplication(t *testing.T, d datadriven.TestData) error {
+	require.Len(t, d.CmdArgs, 2)
+	idx := firstAsNodeIdx(t, d)
+	lazy, err := strconv.ParseBool(d.CmdArgs[1].Key)
+	require.NoError(t, err)
+	env.Nodes[idx].SetLazyReplication(lazy)
+	return nil
+}
 
 func (env *InteractionEnv) handleSendMsgApp(t *testing.T, d datadriven.TestData) error {
 	require.Len(t, d.CmdArgs, 4)

--- a/pkg/raft/testdata/lazy_replication.txt
+++ b/pkg/raft/testdata/lazy_replication.txt
@@ -153,3 +153,161 @@ status 1
 1: StateReplicate match=13 next=14 sentCommit=11 matchCommit=11
 2: StateReplicate match=13 next=14 sentCommit=13 matchCommit=13
 3: StateReplicate match=13 next=14 sentCommit=13 matchCommit=13
+
+################################################################################
+# Test switching back to the eager replication mode.
+
+propose 1 data-3
+----
+ok
+
+# MsgApps are still not sent eagerly.
+stabilize
+----
+> 1 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/14 EntryNormal "data-3"
+
+set-lazy-replication 1 false
+----
+ok
+
+# Immediately after the switch, the appends are broadcast to the followers.
+stabilize
+----
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->2 MsgApp Term:1 Log:1/13 Commit:13 Entries:[1/14 EntryNormal "data-3"]
+  1->3 MsgApp Term:1 Log:1/13 Commit:13 Entries:[1/14 EntryNormal "data-3"]
+> 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/13 Commit:13 Entries:[1/14 EntryNormal "data-3"]
+> 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/13 Commit:13 Entries:[1/14 EntryNormal "data-3"]
+> 2 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/14 EntryNormal "data-3"
+  Messages:
+  2->1 MsgAppResp Term:1 Log:0/14 Commit:13
+> 3 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/14 EntryNormal "data-3"
+  Messages:
+  3->1 MsgAppResp Term:1 Log:0/14 Commit:13
+> 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/14 Commit:13
+  3->1 MsgAppResp Term:1 Log:0/14 Commit:13
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:14 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/14 EntryNormal "data-3"
+  Messages:
+  1->2 MsgApp Term:1 Log:1/14 Commit:14
+  1->3 MsgApp Term:1 Log:1/14 Commit:14
+> 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/14 Commit:14
+> 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/14 Commit:14
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:14 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/14 EntryNormal "data-3"
+  Messages:
+  2->1 MsgAppResp Term:1 Log:0/14 Commit:14
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:14 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/14 EntryNormal "data-3"
+  Messages:
+  3->1 MsgAppResp Term:1 Log:0/14 Commit:14
+> 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/14 Commit:14
+  3->1 MsgAppResp Term:1 Log:0/14 Commit:14
+
+# A new proposal triggers replication immediately.
+propose 1 data-4
+----
+ok
+
+# If we switch back to lazy replication while there are pending MsgApp messages
+# in the queue (generated after the proposal above), the messages will pop up in
+# the next Ready.
+set-lazy-replication 1 true
+----
+ok
+
+stabilize
+----
+> 1 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/15 EntryNormal "data-4"
+  Messages:
+  1->2 MsgApp Term:1 Log:1/14 Commit:14 Entries:[1/15 EntryNormal "data-4"]
+  1->3 MsgApp Term:1 Log:1/14 Commit:14 Entries:[1/15 EntryNormal "data-4"]
+> 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/14 Commit:14 Entries:[1/15 EntryNormal "data-4"]
+> 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/14 Commit:14 Entries:[1/15 EntryNormal "data-4"]
+> 2 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/15 EntryNormal "data-4"
+  Messages:
+  2->1 MsgAppResp Term:1 Log:0/15 Commit:14
+> 3 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/15 EntryNormal "data-4"
+  Messages:
+  3->1 MsgAppResp Term:1 Log:0/15 Commit:14
+> 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/15 Commit:14
+  3->1 MsgAppResp Term:1 Log:0/15 Commit:14
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:15 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/15 EntryNormal "data-4"
+  Messages:
+  1->2 MsgApp Term:1 Log:1/15 Commit:15
+  1->3 MsgApp Term:1 Log:1/15 Commit:15
+> 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/15 Commit:15
+> 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/15 Commit:15
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:15 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/15 EntryNormal "data-4"
+  Messages:
+  2->1 MsgAppResp Term:1 Log:0/15 Commit:15
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:15 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/15 EntryNormal "data-4"
+  Messages:
+  3->1 MsgAppResp Term:1 Log:0/15 Commit:15
+> 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/15 Commit:15
+  3->1 MsgAppResp Term:1 Log:0/15 Commit:15
+
+# After the Ready handling, messages are no longer sent eagerly.
+propose 1 data-5
+----
+ok
+
+stabilize
+----
+> 1 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/16 EntryNormal "data-5"


### PR DESCRIPTION
This PR makes it possible to dynamically switch the lazy `MsgApp` replication mode for flows in `StateReplicate`.

Part of #128779