### PR TITLE
storeliveness: react faster to new store additions

### DIFF
--- a/pkg/kv/kvserver/storeliveness/support_manager.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager.go
@@ -211,22 +211,23 @@ func (sm *SupportManager) startLoop(ctx context.Context) {
 
 	for {
 		// NOTE: only listen to the receive queue's signal if we don't already have
-		// heartbeats to send or support to check. This prevents a constant flow of
-		// inbound messages from delaying the other work due to the random selection
-		// between multiple enabled channels.
+		// stores to add, heartbeats to send, or support to check. This prevents a
+		// constant flow of inbound messages from delaying the other work due to the
+		// random selection between multiple enabled channels.
 		var receiveQueueSig <-chan struct{}
-		if len(heartbeatTicker.C) == 0 && len(supportExpiryTicker.C) == 0 {
+		if len(heartbeatTicker.C) == 0 &&
+			len(supportExpiryTicker.C) == 0 &&
+			len(sm.storesToAdd.sig) == 0 {
 			receiveQueueSig = sm.receiveQueue.Sig()
 		}
 
 		select {
-		case <-heartbeatTicker.C:
-			// First check if any stores need to be added to ensure they are included
-			// in the round of heartbeats below.
+		case <-sm.storesToAdd.sig:
 			sm.maybeAddStores()
-			if sm.SupportFromEnabled(ctx) {
-				sm.sendHeartbeats(ctx)
-			}
+			sm.sendHeartbeats(ctx)
+
+		case <-heartbeatTicker.C:
+			sm.sendHeartbeats(ctx)
 
 		case <-supportExpiryTicker.C:
 			sm.withdrawSupport(ctx)
@@ -263,6 +264,10 @@ func (sm *SupportManager) maybeAddStores() {
 // sendHeartbeats delegates heartbeat generation to the requesterStateHandler
 // and sends the resulting messages via Transport.
 func (sm *SupportManager) sendHeartbeats(ctx context.Context) {
+	// If Store Liveness is not enabled, don't send heartbeats.
+	if !sm.SupportFromEnabled(ctx) {
+		return
+	}
 	rsfu := sm.requesterStateHandler.checkOutUpdate()
 	defer sm.requesterStateHandler.finishUpdate(rsfu)
 	livenessInterval := sm.options.LivenessInterval
@@ -422,11 +427,13 @@ func (q *receiveQueue) Drain() []*slpb.Message {
 // requesterState.supportFrom.
 type storesToAdd struct {
 	mu     syncutil.Mutex
+	sig    chan struct{}
 	stores map[slpb.StoreIdent]struct{}
 }
 
 func newStoresToAdd() storesToAdd {
 	return storesToAdd{
+		sig:    make(chan struct{}, 1),
 		stores: make(map[slpb.StoreIdent]struct{}),
 	}
 }
@@ -435,6 +442,10 @@ func (sta *storesToAdd) addStore(id slpb.StoreIdent) {
 	sta.mu.Lock()
 	defer sta.mu.Unlock()
 	sta.stores[id] = struct{}{}
+	select {
+	case sta.sig <- struct{}{}:
+	default:
+	}
 }
 
 func (sta *storesToAdd) drainStoresToAdd() []slpb.StoreIdent {

--- a/pkg/kv/kvserver/storeliveness/support_manager_test.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager_test.go
@@ -404,6 +404,41 @@ func TestSupportManagerReceiveQueueLimit(t *testing.T) {
 	require.Regexp(t, sm.HandleMessage(heartbeat), "store liveness receive queue is full")
 }
 
+// TestSupportManagerHeartbeatNewStore tests that when a store is added (in the
+// first call of SupportFrom), heartbeats are sent to it immediately, before a
+// heartbeat interval has expired.
+func TestSupportManagerHeartbeatNewStore(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	engine := storage.NewDefaultInMemForTesting()
+	defer engine.Close()
+	settings := clustersettings.MakeTestingClusterSettings()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	manual := hlc.NewHybridManualClock()
+	clock := hlc.NewClockForTesting(manual)
+	sender := &testMessageSender{}
+	// Set a very large heartbeat interval to ensure heartbeats for new stores are
+	// sent out before the heartbeat ticker is signalled.
+	options.HeartbeatInterval = time.Hour
+	sm := NewSupportManager(store, engine, options, settings, stopper, clock, sender)
+	require.NoError(t, sm.Start(ctx))
+
+	// Start sending heartbeats to the remote store by calling SupportFrom.
+	sm.SupportFrom(remoteStore)
+
+	testutils.SucceedsSoon(
+		t, func() error {
+			if sm.metrics.HeartbeatSuccesses.Count() == int64(0) {
+				return errors.New("heartbeat not sent yet")
+			}
+			return nil
+		},
+	)
+}
+
 func ensureHeartbeats(t *testing.T, sender *testMessageSender, expectedNum int) []slpb.Message {
 	var msgs []slpb.Message
 	testutils.SucceedsSoon(


### PR DESCRIPTION
Previously, Store Liveness could wait for up to a heartbeat interval before going through the queue of new stores to add, and starting to heartbeat them. This would result in wait times of over 1s until higher layers can use Store Liveness support.

This commit adds a mechanism to react faster to new store additions.

Part of: #129090

Release note: None