### PR TITLE
sql/tests: reduce variance in BenchmarkKV

### DIFF
--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -119,6 +119,7 @@ go_test(
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
+        "//pkg/ts",
         "//pkg/util/allstacks",
         "//pkg/util/ctxgroup",
         "//pkg/util/ioctx",

--- a/pkg/sql/tests/kv_test.go
+++ b/pkg/sql/tests/kv_test.go
@@ -25,8 +25,10 @@ import (
 	kv2 "github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
@@ -42,6 +44,13 @@ type kvInterface interface {
 	done()
 }
 
+// disableBackgroundWork disables background work in the cluster settings to
+// make the benchmarks more predictable.
+func disableBackgroundWork(st *cluster.Settings) {
+	ts.TimeseriesStorageEnabled.Override(context.Background(), &st.SV, false)
+	stats.AutomaticStatisticsClusterMode.Override(context.Background(), &st.SV, false)
+}
+
 // kvNative uses the native client package to implement kvInterface.
 type kvNative struct {
 	db     *kv2.DB
@@ -51,7 +60,9 @@ type kvNative struct {
 }
 
 func newKVNative(b *testing.B) kvInterface {
-	s, _, db := serverutils.StartServer(b, base.TestServerArgs{})
+	st := cluster.MakeTestingClusterSettings()
+	disableBackgroundWork(st)
+	s, _, db := serverutils.StartServer(b, base.TestServerArgs{Settings: st})
 
 	// Note that using the local client.DB isn't a strictly fair
 	// comparison with SQL as we want these client requests to be sent
@@ -66,6 +77,7 @@ func newKVNative(b *testing.B) kvInterface {
 
 func newKVNativeAndEngine(tb testing.TB) (*kvNative, storage.Engine) {
 	st := cluster.MakeTestingClusterSettings()
+	disableBackgroundWork(st)
 	s, _, db := serverutils.StartServer(tb, base.TestServerArgs{Settings: st})
 	engines := s.Engines()
 	if len(engines) != 1 {
@@ -185,7 +197,9 @@ type kvSQL struct {
 }
 
 func newKVSQL(b *testing.B) kvInterface {
-	s, db, _ := serverutils.StartServer(b, base.TestServerArgs{UseDatabase: "bench"})
+	st := cluster.MakeTestingClusterSettings()
+	disableBackgroundWork(st)
+	s, db, _ := serverutils.StartServer(b, base.TestServerArgs{Settings: st, UseDatabase: "bench"})
 
 	if _, err := db.Exec(`CREATE DATABASE IF NOT EXISTS bench`); err != nil {
 		b.Fatal(err)


### PR DESCRIPTION
This commit disables timeseries and auto SQL stats collection in the BenchmarkKV test suite. This reduces the variance in the benchmark results, allowing us to run fewer iterations to get stable results.

```
name                  old time/op    new time/op    delta
KV/Update/SQL/rows=1     219µs ± 9%     207µs ± 5%  -5.36%  (p=0.000 n=19+18)

name                  old alloc/op   new alloc/op   delta
KV/Update/SQL/rows=1    57.0kB ± 1%    56.9kB ± 0%  -0.22%  (p=0.002 n=19+20)

name                  old allocs/op  new allocs/op  delta
KV/Update/SQL/rows=1       553 ± 0%       553 ± 0%    ~     (p=0.555 n=19+17)
```

Epic: None
Release note: None