### PR TITLE
roachtest: do not schedule mutator steps concurrent with restarts

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mutators.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mutators.go
@@ -253,8 +253,10 @@ func (m clusterSettingMutator) Generate(rng *rand.Rand, plan *TestPlan) []mutati
 
 			// We skip restart steps as we might insert the cluster setting
 			// change step concurrently with the selected step.
-			_, isRestartNode := s.impl.(restartWithNewBinaryStep)
-			return s.context.System.Stage >= OnStartupStage && !isRestartNode
+			_, isRestartSystem := s.impl.(restartWithNewBinaryStep)
+			_, isRestartTenant := s.impl.(restartVirtualClusterStep)
+			isRestart := isRestartSystem || isRestartTenant
+			return s.context.System.Stage >= OnStartupStage && !isRestart
 		})
 
 	for _, changeStep := range m.changeSteps(rng, len(possiblePointsInTime)) {


### PR DESCRIPTION
The `cluster_setting` mutator can insert steps to change the value of a cluster setting at any valid point in a test plan.

The mutator already makes sure to not insert steps concurrently with the restart of storage cluster nodes. However, with the introduction of separate-process deployments, we now also need to ensure these steps are not concurrent with the restart of SQL server processes. If they are, there is a chance that the fetching of debug information that happens before every step runs (binary and cluster versions) may fail, as it tries to connect to a restarting SQL server.

Epic: none

Release note: None