### PR TITLE
kvserver,rac2,replica_rac2: add Scheduler.ScheduleControllerEvent

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -65,7 +65,7 @@ type RangeController interface {
 	// controller.
 	//
 	// Requires replica.raftMu to be held.
-	HandleSchedulerEventRaftMuLocked(ctx context.Context) error
+	HandleSchedulerEventRaftMuLocked(ctx context.Context)
 	// AdmitRaftMuLocked handles the notification about the given replica's
 	// admitted vector change. No-op if the replica is not known, or the admitted
 	// vector is stale (either in Term, or the indices).
@@ -240,6 +240,13 @@ type RaftEvent struct {
 	ReplicasStateInfo map[roachpb.ReplicaID]ReplicaStateInfo
 }
 
+// Scheduler abstracts the raftScheduler to allow the RangeController to
+// schedule its own internal processing. This internal processing is to pop
+// some entries from the send queue and send them in a MsgApp.
+type Scheduler interface {
+	ScheduleControllerEvent(rangeID roachpb.RangeID)
+}
+
 // RaftEventFromMsgStorageAppendAndMsgApps constructs a RaftEvent from the
 // given raft MsgStorageAppend message, and outboundMsgs. The replicaID is the
 // local replica. The outboundMsgs will only contain MsgApps on the leader.
@@ -354,6 +361,7 @@ type RangeControllerOptions struct {
 	RaftInterface       RaftInterface
 	Clock               *hlc.Clock
 	CloseTimerScheduler ProbeToCloseTimerScheduler
+	Scheduler           Scheduler
 	EvalWaitMetrics     *EvalWaitMetrics
 	Knobs               *kvflowcontrol.TestingKnobs
 }
@@ -394,6 +402,13 @@ type rangeController struct {
 	}
 
 	replicaMap map[roachpb.ReplicaID]*replicaState
+
+	scheduledMu struct {
+		syncutil.Mutex
+		// When HandleControllerSchedulerEventRaftMuLocked is called, this is used
+		// to call into the replicaSendStreams that have asked to be scheduled.
+		replicas map[roachpb.ReplicaID]struct{}
+	}
 }
 
 // voterStateForWaiters informs whether WaitForEval is required to wait for
@@ -439,6 +454,7 @@ func NewRangeController(
 		nextRaftIndex: init.NextRaftIndex,
 		replicaMap:    make(map[roachpb.ReplicaID]*replicaState),
 	}
+	rc.scheduledMu.replicas = make(map[roachpb.ReplicaID]struct{})
 	rc.mu.waiterSetRefreshCh = make(chan struct{})
 	rc.updateReplicaSet(ctx, init.ReplicaSet)
 	rc.updateWaiterSetsRaftMuLocked()
@@ -1042,8 +1058,46 @@ func (rc *rangeController) computeVoterDirectives(
 // controller.
 //
 // Requires replica.raftMu to be held.
-func (rc *rangeController) HandleSchedulerEventRaftMuLocked(ctx context.Context) error {
-	panic("unimplemented")
+func (rc *rangeController) HandleSchedulerEventRaftMuLocked(ctx context.Context) {
+	var scheduledScratch [5]*replicaState
+	// scheduled will contain all the replicas in scheduledMu.replicas, filtered
+	// by whether they have a replicaSendStream.
+	scheduled := scheduledScratch[:0:cap(scheduledScratch)]
+	func() {
+		rc.scheduledMu.Lock()
+		defer rc.scheduledMu.Unlock()
+		for r := range rc.scheduledMu.replicas {
+			if rs, ok := rc.replicaMap[r]; ok && rs.sendStream != nil {
+				scheduled = append(scheduled, rs)
+			}
+		}
+		clear(rc.scheduledMu.replicas)
+	}()
+
+	// nextScheduled contains all the replicas that need to be scheduled again.
+	// We reuse the scheduled slice since we only overwrite scheduled[i] after
+	// it has already been read.
+	nextScheduled := scheduled[:0]
+	for _, rs := range scheduled {
+		scheduleAgain := rs.sendStream.scheduled(ctx)
+		if scheduleAgain {
+			nextScheduled = append(nextScheduled, rs)
+		}
+	}
+	if len(nextScheduled) > 0 {
+		// Need to update the scheduledMu.replicas map.
+		func() {
+			rc.scheduledMu.Lock()
+			defer rc.scheduledMu.Unlock()
+			// Call ScheduleControllerEvent on transition from empty => non-empty.
+			if len(rc.scheduledMu.replicas) == 0 {
+				rc.opts.Scheduler.ScheduleControllerEvent(rc.opts.RangeID)
+			}
+			for _, rs := range nextScheduled {
+				rc.scheduledMu.replicas[rs.desc.ReplicaID] = struct{}{}
+			}
+		}()
+	}
 }
 
 // AdmitRaftMuLocked handles the notification about the given replica's
@@ -1264,6 +1318,18 @@ func (rc *rangeController) updateWaiterSetsRaftMuLocked() {
 	rc.mu.nonVoterSet = nonVoterSet
 	close(rc.mu.waiterSetRefreshCh)
 	rc.mu.waiterSetRefreshCh = make(chan struct{})
+}
+
+// scheduleReplica may be called with or without raftMu held.
+func (rc *rangeController) scheduleReplica(r roachpb.ReplicaID) {
+	rc.scheduledMu.Lock()
+	defer rc.scheduledMu.Unlock()
+
+	rc.scheduledMu.replicas[r] = struct{}{}
+	if len(rc.scheduledMu.replicas) == 1 {
+		// Call ScheduleControllerEvent on transition from empty => non-empty.
+		rc.opts.Scheduler.ScheduleControllerEvent(rc.opts.RangeID)
+	}
 }
 
 type replicaState struct {
@@ -1979,6 +2045,11 @@ func (rss *replicaSendStream) startForceFlushLocked(ctx context.Context) {
 func (rss *replicaSendStream) stopForceFlushLocked(ctx context.Context) {
 	// TODO(kvoli):
 	rss.mu.sendQueue.forceFlushScheduled = false
+}
+
+func (rss *replicaSendStream) scheduled(ctx context.Context) bool {
+	// TODO(sumeer):
+	return false
 }
 
 func (rss *replicaSendStream) isEmptySendQueueLocked() bool {

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/handle_raft_event
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/handle_raft_event
@@ -228,3 +228,98 @@ check_state
 ----
 range_id=1 tenant_id={1} local_replica_id=1
   name=a pri=low-pri  done=true  waited=true  err=<nil>
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[5,8) send_queue=[8,8) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=5  tokens=1048576
+  term=1 index=6  tokens=1048576
+  term=1 index=7  tokens=1048576
+++++
+(n2,s2):2: closed
+++++
+(n3,s3):3: state=replicate closed=false inflight=[5,8) send_queue=[8,8) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=5  tokens=1048576
+  term=1 index=6  tokens=1048576
+  term=1 index=7  tokens=1048576
+++++
+
+# Schedule replica 2 for scheduler event. The schedule-controller-event-count becomes 1.
+internal_schedule_replica range_id=1 replica_id=2
+----
+(n1,s1):1: state=replicate closed=false inflight=[5,8) send_queue=[8,8) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=5  tokens=1048576
+  term=1 index=6  tokens=1048576
+  term=1 index=7  tokens=1048576
+++++
+(n2,s2):2: closed
+++++
+(n3,s3):3: state=replicate closed=false inflight=[5,8) send_queue=[8,8) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=5  tokens=1048576
+  term=1 index=6  tokens=1048576
+  term=1 index=7  tokens=1048576
+++++
+schedule-controller-event-count: 1
+scheduled-replicas: 2
+
+# Schedule replica 3 for scheduler event. The schedule-controller-event-count
+# stays 1 since we have already told the scheduler. Both replicas are being
+# tracked in scheduled-replicas.
+internal_schedule_replica range_id=1 replica_id=3
+----
+(n1,s1):1: state=replicate closed=false inflight=[5,8) send_queue=[8,8) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=5  tokens=1048576
+  term=1 index=6  tokens=1048576
+  term=1 index=7  tokens=1048576
+++++
+(n2,s2):2: closed
+++++
+(n3,s3):3: state=replicate closed=false inflight=[5,8) send_queue=[8,8) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=5  tokens=1048576
+  term=1 index=6  tokens=1048576
+  term=1 index=7  tokens=1048576
+++++
+schedule-controller-event-count: 1
+scheduled-replicas: 2 3
+
+# Handle the scheduler event. There are no replicas remaining in
+# scheduled-replicas.
+handle_scheduler_event range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[5,8) send_queue=[8,8) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=5  tokens=1048576
+  term=1 index=6  tokens=1048576
+  term=1 index=7  tokens=1048576
+++++
+(n2,s2):2: closed
+++++
+(n3,s3):3: state=replicate closed=false inflight=[5,8) send_queue=[8,8) precise_q_size=+0 B force-flush=false
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=5  tokens=1048576
+  term=1 index=6  tokens=1048576
+  term=1 index=7  tokens=1048576
+++++
+schedule-controller-event-count: 1

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -390,6 +390,12 @@ type Processor interface {
 	AdmitForEval(
 		ctx context.Context, pri admissionpb.WorkPriority, ct time.Time) (admitted bool, err error)
 
+	// ProcessSchedulerEventRaftMuLocked is called to process events scheduled
+	// by the RangeController.
+	//
+	// raftMu is held.
+	ProcessSchedulerEventRaftMuLocked(ctx context.Context)
+
 	// InspectRaftMuLocked returns a handle to inspect the state of the
 	// underlying range controller. It is used to power /inspectz-style debugging
 	// pages.
@@ -1063,8 +1069,10 @@ func (p *processorImpl) ProcessPiggybackedAdmittedAtLeaderRaftMuLocked(ctx conte
 	}(); updatesEmpty {
 		return
 	}
-	for replicaID, state := range updates {
-		p.leader.rc.AdmitRaftMuLocked(ctx, replicaID, state)
+	if p.leader.rc != nil {
+		for replicaID, state := range updates {
+			p.leader.rc.AdmitRaftMuLocked(ctx, replicaID, state)
+		}
 	}
 	// Clear the scratch from the updates that we have just handled.
 	clear(p.leader.scratch)
@@ -1165,6 +1173,17 @@ func (p *processorImpl) AdmitForEval(
 	return rc.WaitForEval(ctx, pri)
 }
 
+// ProcessSchedulerEventRaftMuLocked implements Processor.
+func (p *processorImpl) ProcessSchedulerEventRaftMuLocked(ctx context.Context) {
+	p.opts.Replica.RaftMuAssertHeld()
+	if p.destroyed {
+		return
+	}
+	if rc := p.leader.rc; rc != nil {
+		rc.HandleSchedulerEventRaftMuLocked(ctx)
+	}
+}
+
 // InspectRaftMuLocked implements Processor.
 func (p *processorImpl) InspectRaftMuLocked(ctx context.Context) (kvflowinspectpb.Handle, bool) {
 	p.opts.Replica.RaftMuAssertHeld()
@@ -1197,6 +1216,7 @@ type RangeControllerFactoryImpl struct {
 	evalWaitMetrics            *rac2.EvalWaitMetrics
 	streamTokenCounterProvider *rac2.StreamTokenCounterProvider
 	closeTimerScheduler        rac2.ProbeToCloseTimerScheduler
+	scheduler                  rac2.Scheduler
 	knobs                      *kvflowcontrol.TestingKnobs
 }
 
@@ -1205,6 +1225,7 @@ func NewRangeControllerFactoryImpl(
 	evalWaitMetrics *rac2.EvalWaitMetrics,
 	streamTokenCounterProvider *rac2.StreamTokenCounterProvider,
 	closeTimerScheduler rac2.ProbeToCloseTimerScheduler,
+	scheduler rac2.Scheduler,
 	knobs *kvflowcontrol.TestingKnobs,
 ) RangeControllerFactoryImpl {
 	return RangeControllerFactoryImpl{
@@ -1212,6 +1233,7 @@ func NewRangeControllerFactoryImpl(
 		evalWaitMetrics:            evalWaitMetrics,
 		streamTokenCounterProvider: streamTokenCounterProvider,
 		closeTimerScheduler:        closeTimerScheduler,
+		scheduler:                  scheduler,
 		knobs:                      knobs,
 	}
 }
@@ -1230,6 +1252,7 @@ func (f RangeControllerFactoryImpl) New(
 			RaftInterface:       state.raftInterface,
 			Clock:               f.clock,
 			CloseTimerScheduler: f.closeTimerScheduler,
+			Scheduler:           f.scheduler,
 			EvalWaitMetrics:     f.evalWaitMetrics,
 			Knobs:               f.knobs,
 		},

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -237,7 +237,7 @@ func (c *testRangeController) HandleRaftEventRaftMuLocked(
 	return nil
 }
 
-func (c *testRangeController) HandleSchedulerEventRaftMuLocked(ctx context.Context) error {
+func (c *testRangeController) HandleSchedulerEventRaftMuLocked(ctx context.Context) {
 	panic("HandleSchedulerEventRaftMuLocked should not be called when no send-queues")
 }
 

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1460,6 +1460,12 @@ func (r *Replica) processRACv2PiggybackedAdmitted(ctx context.Context) {
 	r.flowControlV2.ProcessPiggybackedAdmittedAtLeaderRaftMuLocked(ctx)
 }
 
+func (r *Replica) processRACv2RangeController(ctx context.Context) {
+	r.raftMu.Lock()
+	defer r.raftMu.Unlock()
+	r.flowControlV2.ProcessSchedulerEventRaftMuLocked(ctx)
+}
+
 func (r *Replica) hasRaftReadyRLocked() bool {
 	return r.mu.internalRaftGroup.HasReady()
 }

--- a/pkg/kv/kvserver/scheduler_test.go
+++ b/pkg/kv/kvserver/scheduler_test.go
@@ -128,10 +128,12 @@ func TestRangeIDQueue(t *testing.T) {
 type testProcessor struct {
 	mu struct {
 		syncutil.Mutex
-		raftReady   map[roachpb.RangeID]int
-		raftRequest map[roachpb.RangeID]int
-		raftTick    map[roachpb.RangeID]int
-		ready       func(roachpb.RangeID)
+		raftReady               map[roachpb.RangeID]int
+		raftRequest             map[roachpb.RangeID]int
+		raftTick                map[roachpb.RangeID]int
+		rac2PiggybackedAdmitted map[roachpb.RangeID]int
+		rac2RangeController     map[roachpb.RangeID]int
+		ready                   func(roachpb.RangeID)
 	}
 }
 
@@ -140,6 +142,8 @@ func newTestProcessor() *testProcessor {
 	p.mu.raftReady = make(map[roachpb.RangeID]int)
 	p.mu.raftRequest = make(map[roachpb.RangeID]int)
 	p.mu.raftTick = make(map[roachpb.RangeID]int)
+	p.mu.rac2PiggybackedAdmitted = make(map[roachpb.RangeID]int)
+	p.mu.rac2RangeController = make(map[roachpb.RangeID]int)
 	return p
 }
 
@@ -174,7 +178,18 @@ func (p *testProcessor) processTick(_ context.Context, rangeID roachpb.RangeID) 
 	return false
 }
 
-func (p *testProcessor) processRACv2PiggybackedAdmitted(_ context.Context, _ roachpb.RangeID) {
+func (p *testProcessor) processRACv2PiggybackedAdmitted(
+	_ context.Context, rangeID roachpb.RangeID,
+) {
+	p.mu.Lock()
+	p.mu.rac2PiggybackedAdmitted[rangeID]++
+	p.mu.Unlock()
+}
+
+func (p *testProcessor) processRACv2RangeController(_ context.Context, rangeID roachpb.RangeID) {
+	p.mu.Lock()
+	p.mu.rac2RangeController[rangeID]++
+	p.mu.Unlock()
 }
 
 func (p *testProcessor) readyCount(rangeID roachpb.RangeID) int {
@@ -204,10 +219,12 @@ func (p *testProcessor) countsLocked(m map[roachpb.RangeID]int) string {
 func (p *testProcessor) String() string {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return fmt.Sprintf("ready=%s request=%s tick=%s",
+	return fmt.Sprintf("ready=%s request=%s tick=%s piggybacked-admitted=%s range-controller=%s",
 		p.countsLocked(p.mu.raftReady),
 		p.countsLocked(p.mu.raftRequest),
-		p.countsLocked(p.mu.raftTick))
+		p.countsLocked(p.mu.raftTick),
+		p.countsLocked(p.mu.rac2PiggybackedAdmitted),
+		p.countsLocked(p.mu.rac2RangeController))
 }
 
 // Verify that enqueuing more ranges than the number of workers correctly
@@ -234,7 +251,7 @@ func TestSchedulerLoop(t *testing.T) {
 	s.EnqueueRaftTicks(batch)
 
 	testutils.SucceedsSoon(t, func() error {
-		const expected = "ready=[] request=[] tick=[1:1,2:1,3:1]"
+		const expected = "ready=[] request=[] tick=[1:1,2:1,3:1] piggybacked-admitted=[] range-controller=[]"
 		if s := p.String(); expected != s {
 			return errors.Errorf("expected %s, but got %s", expected, s)
 		}
@@ -268,18 +285,29 @@ func TestSchedulerBuffering(t *testing.T) {
 		ticks int
 		want  string
 	}{
-		{flag: stateRaftReady, want: "ready=[1:1] request=[] tick=[]"},
-		{flag: stateRaftRequest, want: "ready=[1:1] request=[1:1] tick=[]"},
-		{flag: stateRaftTick, want: "ready=[1:1] request=[1:1] tick=[1:5]"},
+		{flag: stateRaftReady,
+			want: "ready=[1:1] request=[] tick=[] piggybacked-admitted=[] range-controller=[]"},
+		{flag: stateRaftRequest,
+			want: "ready=[1:1] request=[1:1] tick=[] piggybacked-admitted=[] range-controller=[]"},
+		{flag: stateRaftTick,
+			want: "ready=[1:1] request=[1:1] tick=[1:5] piggybacked-admitted=[] range-controller=[]"},
 		{flag: stateRaftReady | stateRaftRequest | stateRaftTick,
-			want: "ready=[1:2] request=[1:2] tick=[1:10]"},
-		{flag: stateRaftTick, want: "ready=[1:2] request=[1:2] tick=[1:15]"},
+			want: "ready=[1:2] request=[1:2] tick=[1:10] piggybacked-admitted=[] range-controller=[]"},
+		{flag: stateRaftTick,
+			want: "ready=[1:2] request=[1:2] tick=[1:15] piggybacked-admitted=[] range-controller=[]"},
 		// All 4 ticks are processed.
-		{flag: 0, ticks: 4, want: "ready=[1:2] request=[1:2] tick=[1:19]"},
+		{flag: 0, ticks: 4,
+			want: "ready=[1:2] request=[1:2] tick=[1:19] piggybacked-admitted=[] range-controller=[]"},
 		// Only 5/10 ticks are buffered while Raft processing is slow.
-		{flag: stateRaftReady, slow: true, ticks: 10, want: "ready=[1:3] request=[1:2] tick=[1:24]"},
+		{flag: stateRaftReady, slow: true, ticks: 10,
+			want: "ready=[1:3] request=[1:2] tick=[1:24] piggybacked-admitted=[] range-controller=[]"},
 		// All 3 ticks are processed even if processing is slow.
-		{flag: stateRaftReady, slow: true, ticks: 3, want: "ready=[1:4] request=[1:2] tick=[1:27]"},
+		{flag: stateRaftReady, slow: true, ticks: 3,
+			want: "ready=[1:4] request=[1:2] tick=[1:27] piggybacked-admitted=[] range-controller=[]"},
+		{flag: stateRACv2PiggybackedAdmitted,
+			want: "ready=[1:4] request=[1:2] tick=[1:27] piggybacked-admitted=[1:1] range-controller=[]"},
+		{flag: stateRACv2RangeController,
+			want: "ready=[1:4] request=[1:2] tick=[1:27] piggybacked-admitted=[1:1] range-controller=[1:1]"},
 	}
 
 	for _, c := range testCases {

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1541,6 +1541,7 @@ func NewStore(
 		s.cfg.KVFlowStreamTokenProvider,
 		replica_rac2.NewStreamCloseScheduler(
 			s.stopper, timeutil.DefaultTimeSource{}, s.scheduler),
+		(*racV2Scheduler)(s.scheduler),
 		s.TestingKnobs().FlowControlTestingKnobs,
 	)
 

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -722,6 +722,12 @@ func (s *Store) processRACv2PiggybackedAdmitted(ctx context.Context, rangeID roa
 	}
 }
 
+func (s *Store) processRACv2RangeController(ctx context.Context, rangeID roachpb.RangeID) {
+	if r, ok := s.mu.replicasByRangeID.Load(rangeID); ok {
+		r.processRACv2RangeController(ctx)
+	}
+}
+
 // nodeIsLiveCallback is invoked when a node transitions from non-live to live.
 // Iterate through all replicas and find any which belong to ranges containing
 // the implicated node. Unquiesce if currently quiesced and the node's replica


### PR DESCRIPTION
It is implemented using raftScheduler. It will be used for both force-flush and when a send-queue has tokens.

Informs #130433

Epic: CRDB-37515

Release note: None