### PR TITLE
server/license: Flow cluster init timestamp through tenant connector

### DIFF
--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -133,6 +133,11 @@ type Connector interface {
 	// mixed version 21.2->22.1 state where the tenant has not yet configured
 	// its own zones.
 	config.SystemConfigProvider
+
+	// GetClusterInitGracePeriodTS will return the timestamp used to signal the
+	// end of the grace period for clusters with a license. The timestamp is
+	// represented as the number of seconds since the Unix epoch.
+	GetClusterInitGracePeriodTS() int64
 }
 
 // TokenBucketProvider supplies an endpoint (to tenants) for the TokenBucket API
@@ -212,10 +217,11 @@ type connector struct {
 		// metadata bits has been received.
 		receivedFirstMetadata bool
 
-		tenantName   roachpb.TenantName
-		dataState    mtinfopb.TenantDataState
-		serviceMode  mtinfopb.TenantServiceMode
-		capabilities *tenantcapabilitiespb.TenantCapabilities
+		tenantName               roachpb.TenantName
+		dataState                mtinfopb.TenantDataState
+		serviceMode              mtinfopb.TenantServiceMode
+		capabilities             *tenantcapabilitiespb.TenantCapabilities
+		clusterInitGracePeriodTS int64
 
 		// notifyCh is closed when there are changes to the metadata.
 		notifyCh chan struct{}

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -3567,7 +3567,15 @@ message TenantSettingsEvent {
   // can't do that yet due to a dependency cycle. We should break the cycle.
   uint32 service_mode = 9;
 
-  // NEXT ID: 10
+  // ClusterInitGracePeriodEndTS is the timestamp (in seconds since the Unix epoch)
+  // marking the end of the grace period for clusters without a license. After this
+  // timestamp, if no license is installed, the cluster will be subject to throttling.
+  // Since secondary tenants cannot access the KV store where this is saved, the value
+  // is propagated through the tenant settings. This is only set when the event type is
+  // METADATA_EVENT.
+  int64 ClusterInitGracePeriodEndTS = 10;
+
+  // NEXT ID: 11
 }
 
 // TenantSetting contains the setting key and value of a tenant setting.

--- a/pkg/server/license/enforcer.go
+++ b/pkg/server/license/enforcer.go
@@ -90,6 +90,17 @@ type Enforcer struct {
 	// db is a pointer to the database for use for KV read/writes. This is only
 	// set for the system tenant.
 	db isql.DB
+
+	// metadataAccessor is a pointer to a tenant connector that has the latest
+	// cluster init grace period timestamp. This is only set when this is
+	// initialized by the secondary tenant.
+	metadataAccessor atomic.Pointer[MetadataAccessor]
+
+	// continueToPollMetadataAccessor indicates whether requests for the cluster
+	// init grace period timestamp should continue polling for the latest value
+	// in the metadata accessor. This is set to true during initialization if the
+	// latest timestamp was not received.
+	continueToPollMetadataAccessor atomic.Bool
 }
 
 type TestingKnobs struct {
@@ -133,6 +144,14 @@ type TelemetryStatusReporter interface {
 	// GetLastSuccessfulTelemetryPing returns the time of the last time the
 	// telemetry data got back an acknowledgement from Cockroach Labs.
 	GetLastSuccessfulTelemetryPing() time.Time
+}
+
+// MetadataAccessor is the interface to access license metadata stored in the KV.
+type MetadataAccessor interface {
+	// GetClusterInitGracePeriodTS returns the grace period end time for clusters
+	// without a license installed. The timestamp is represented as the number of
+	// seconds since the Unix epoch.
+	GetClusterInitGracePeriodTS() int64
 }
 
 // NewEnforcer creates a new Enforcer object.
@@ -187,7 +206,7 @@ func (e *Enforcer) Start(ctx context.Context, st *cluster.Settings, opts ...Opti
 	e.maybeLogActiveOverrides(ctx)
 
 	if !startDisabled {
-		if err := e.readClusterMetadata(ctx, options); err != nil {
+		if err := e.initClusterMetadata(ctx, options); err != nil {
 			return err
 		}
 	}
@@ -210,22 +229,31 @@ func (e *Enforcer) Start(ctx context.Context, st *cluster.Settings, opts ...Opti
 	return nil
 }
 
-// readClusterMetadata will read, and maybe write, cluster metadata for license
+// initClusterMetadata will read, and maybe write, cluster metadata for license
 // enforcement. The metadata is stored in the KV system keyspace.
-func (e *Enforcer) readClusterMetadata(ctx context.Context, options options) error {
+func (e *Enforcer) initClusterMetadata(ctx context.Context, options options) error {
 	// Secondary tenants do not have access to the system keyspace where
-	// the cluster init grace period is stored. As a fallback, we apply a 7-day
-	// grace period from the tenant's start time, which is used only when no
-	// license is installed. This logic applies specifically when secondary
-	// tenants are started in a separate process from the system tenant. If they
-	// are not, a shared enforcer will have access to the system keyspace and
-	// handle the grace period.
-	// TODO(spilchen): Change to give the secondary tenant read access to the
-	// system keyspace KV.
+	// the cluster init grace period is stored. In those instances, we rely on
+	// fetching that information from the system tenant using the tenant connector.
 	if !options.isSystemTenant {
-		gracePeriodLength := e.getGracePeriodDuration(7 * 24 * time.Hour)
-		end := e.getStartTime().Add(gracePeriodLength)
-		e.clusterInitGracePeriodEndTS.Store(end.Unix())
+		if options.metadataAccessor == nil {
+			return errors.AssertionFailedf("no metadata accessor for secondary tenant")
+		}
+		e.metadataAccessor.Store(&options.metadataAccessor)
+		end := (*e.metadataAccessor.Load()).GetClusterInitGracePeriodTS()
+		if end != 0 {
+			e.clusterInitGracePeriodEndTS.Store(end)
+			log.Infof(ctx, "fetched cluster init grace period end time from system tenant: %s", e.GetClusterInitGracePeriodEndTS().String())
+		} else {
+			// No timestamp was received, likely due to a mixed-version workload.
+			// We'll use an estimate of 7 days from this node's startup time instead
+			// and set a flag to continue polling for an updated timestamp.
+			// An update should be sent once the KV starts up on the new version.
+			gracePeriodLength := e.getGracePeriodDuration(7 * 24 * time.Hour)
+			e.clusterInitGracePeriodEndTS.Store(e.getStartTime().Add(gracePeriodLength).Unix())
+			log.Infof(ctx, "estimated cluster init grace period end time as: %s", e.GetClusterInitGracePeriodEndTS().String())
+			e.continueToPollMetadataAccessor.Store(true)
+		}
 		return nil
 	}
 
@@ -364,6 +392,13 @@ func (e *Enforcer) MaybeFailIfThrottled(
 	// we can exit without any further checks.
 	if !e.licenseRequiresTelemetry.Load() && hasExpiry && expiryTS.After(now) {
 		return
+	}
+
+	// When no license is installed, the cluster initialization grace period determines
+	// the throttling window. If the value wasn’t available in the KV during initialization,
+	// check if it can be retrieved from the tenant connector now.
+	if !e.GetHasLicense() && e.continueToPollMetadataAccessor.Load() {
+		e.pollMetadataAccessor(ctx)
 	}
 
 	// Throttle if the license has expired, is missing, and the grace period has ended.
@@ -688,4 +723,21 @@ func (e *Enforcer) getLicenseExpiryTS() (ts time.Time, ok bool) {
 // a notice that we haven't received telemetry and we will throttle soon.
 func (e *Enforcer) addThrottleWarningDelayForNoTelemetry(t time.Time) time.Time {
 	return t.Add(3 * 24 * time.Hour)
+}
+
+// pollMetadataAccessor retrieves the cached cluster initialization grace period timestamp
+// from the tenant connector. It is used to update the grace period if the correct timestamp
+// wasn’t available during initialization. Once the timestamp is obtained, the polling is disabled.
+func (e *Enforcer) pollMetadataAccessor(ctx context.Context) {
+	if e.metadataAccessor.Load() != nil && e.continueToPollMetadataAccessor.Load() {
+		ts := (*e.metadataAccessor.Load()).GetClusterInitGracePeriodTS()
+		if ts != 0 {
+			// Received the timestamp from the KV store. Cache it and stop polling.
+			e.clusterInitGracePeriodEndTS.Store(ts)
+			e.storeNewGracePeriodEndDate(e.GetClusterInitGracePeriodEndTS(), 0)
+			e.continueToPollMetadataAccessor.Store(false)
+			log.Infof(ctx, "late retrieval of cluster initialization grace period end time from system tenant: %s",
+				e.GetClusterInitGracePeriodEndTS().String())
+		}
+	}
 }

--- a/pkg/server/license/enforcer_test.go
+++ b/pkg/server/license/enforcer_test.go
@@ -42,7 +42,6 @@ func TestClusterInitGracePeriod_NoOverwrite(t *testing.T) {
 	// This will be set when bringing up the server.
 	ts1 := timeutil.Unix(1724329716, 0)
 	ts1_30d := ts1.Add(30 * 24 * time.Hour)
-	ts1_7d := ts1.Add(7 * 24 * time.Hour)
 
 	ctx := context.Background()
 	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
@@ -79,13 +78,7 @@ func TestClusterInitGracePeriod_NoOverwrite(t *testing.T) {
 	// Access the enforcer that is cached in the executor config to make sure they
 	// work for the system tenant and secondary tenant.
 	require.Equal(t, ts1_30d, srv.SystemLayer().ExecutorConfig().(sql.ExecutorConfig).LicenseEnforcer.GetClusterInitGracePeriodEndTS())
-	// TODO(spilchen): Until the secondary tenant can read from the KV, it will
-	// guess the ending grace period to be 7-days after start. This will be fixed
-	// in CRDB-42309. Depending on how the test was initialized, it will be either
-	// the shared process secondary tenant (ts1_30d) or the separate process
-	// secondary tenant (ts1_7d).
-	require.Contains(t, []time.Time{ts1_30d, ts1_7d},
-		srv.ApplicationLayer().ExecutorConfig().(sql.ExecutorConfig).LicenseEnforcer.GetClusterInitGracePeriodEndTS())
+	require.Equal(t, ts1_30d, srv.ApplicationLayer().ExecutorConfig().(sql.ExecutorConfig).LicenseEnforcer.GetClusterInitGracePeriodEndTS())
 }
 
 func TestClusterInitGracePeriod_NewClusterEstimation(t *testing.T) {
@@ -149,6 +142,72 @@ func TestClusterInitGracePeriod_NewClusterEstimation(t *testing.T) {
 			require.Equal(t, tc.expGracePeriodEndTS, enforcer.GetClusterInitGracePeriodEndTS())
 		})
 	}
+}
+
+type mockMetadataAccessor struct {
+	ts *int64
+}
+
+func (m *mockMetadataAccessor) GetClusterInitGracePeriodTS() int64 {
+	return *m.ts
+}
+
+func TestClusterInitGracePeriod_DelayedTenantConnector(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ts0 := timeutil.Unix(1667764800, 0) // 2022-11-6 8pm
+	ts1d := ts0.Add(24 * time.Hour)
+	ts8d := ts0.Add(8 * 24 * time.Hour)
+	ts9d := ts0.Add(9 * 24 * time.Hour)
+	ts30d := ts0.Add(30 * 24 * time.Hour)
+
+	// Start the system tenant
+	ctx := context.Background()
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			LicenseTestingKnobs: &license.TestingKnobs{
+				Enable:            true,
+				OverrideStartTime: &ts0,
+			},
+		},
+	})
+	defer srv.Stopper().Stop(ctx)
+
+	// This is a timestamp that we'll change to mock receiving the cluster
+	// init timestamp from tenant connector.
+	var connectTS int64
+
+	// Start up the enforcer for the secondary tenant using a metadata accessor
+	// that has not yet received the cluster init grace period timestamp.
+	enforcer := license.NewEnforcer(&license.TestingKnobs{
+		Enable:                    true,
+		OverrideStartTime:         &ts1d,
+		OverrideThrottleCheckTime: &ts9d,
+	})
+	err := enforcer.Start(ctx, srv.ClusterSettings(),
+		license.WithSystemTenant(false),
+		license.WithMetadataAccessor(&mockMetadataAccessor{ts: &connectTS}),
+	)
+	require.NoError(t, err)
+
+	// The cluster init grace period timestamp hasn't been received yet.
+	// Default to 7 days from the enforcer's start time.
+	require.Equal(t, ts8d, enforcer.GetClusterInitGracePeriodEndTS())
+
+	// We will be throttled because the check time is 9-days after start,
+	// which is beyond the grace period.
+	const beyondThreshold = 10
+	_, err = enforcer.MaybeFailIfThrottled(ctx, beyondThreshold)
+	require.Error(t, err)
+
+	// Now mock receiving the timestamp from the system tenant. It should now
+	// be 30-days after the start time of the system tenant.
+	connectTS = ts30d.Unix()
+	// The check for throttling will refresh the value.
+	_, err = enforcer.MaybeFailIfThrottled(ctx, beyondThreshold)
+	require.NoError(t, err)
+	require.Equal(t, ts30d, enforcer.GetClusterInitGracePeriodEndTS())
 }
 
 func TestThrottle(t *testing.T) {

--- a/pkg/server/license/opts.go
+++ b/pkg/server/license/opts.go
@@ -12,6 +12,7 @@ type options struct {
 	isSystemTenant          bool
 	testingKnobs            *TestingKnobs
 	telemetryStatusReporter TelemetryStatusReporter
+	metadataAccessor        MetadataAccessor
 }
 
 type Option interface {
@@ -47,5 +48,11 @@ func WithTestingKnobs(tk *TestingKnobs) Option {
 func WithTelemetryStatusReporter(r TelemetryStatusReporter) Option {
 	return optionFunc(func(o *options) {
 		o.telemetryStatusReporter = r
+	})
+}
+
+func WithMetadataAccessor(m MetadataAccessor) Option {
+	return optionFunc(func(o *options) {
+		o.metadataAccessor = m
 	})
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -952,6 +952,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		spanConfig.kvAccessor,
 		spanConfig.reporter,
 		distSender,
+		cfg.LicenseEnforcer,
 	)
 	kvpb.RegisterInternalServer(grpcServer.Server, node)
 	kvserver.RegisterPerReplicaServer(grpcServer.Server, node.perReplicaServer)

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1923,6 +1923,9 @@ func (s *SQLServer) startLicenseEnforcer(ctx context.Context, knobs base.Testing
 		license.WithSystemTenant(s.execCfg.Codec.ForSystemTenant()),
 		license.WithTelemetryStatusReporter(s.diagnosticsReporter),
 	}
+	if s.tenantConnect != nil {
+		opts = append(opts, license.WithMetadataAccessor(s.tenantConnect))
+	}
 	if knobs.LicenseTestingKnobs != nil {
 		opts = append(opts, license.WithTestingKnobs(knobs.LicenseTestingKnobs.(*license.TestingKnobs)))
 	}


### PR DESCRIPTION
Currently, secondary tenants cannot access the cluster initialization grace period timestamp in the KV store because they lack permission to access the system keyspace. Instead of reading it directly from the KV, we now pass the timestamp through the tenant connector, making it accessible to secondary tenants. The timestamp is only written once during the system tenant’s initial startup, so it remains a constant value from the perspective of secondary tenants. The value is sent from the system tenant to secondary tenants using the existing TenantSettingsRequest for METADATA_EVENT.

This change will be backported to versions 24.2, 24.1, 23.2, and 23.1.

Epic: CRDB-39988
Closes CRDB-42309
Release note: none