### PR TITLE
kvflowcontrol: fix mode metamorphic constant name

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/kvflowcontrol.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowcontrol.go
@@ -38,7 +38,7 @@ var Mode = settings.RegisterEnumSetting(
 	"kvadmission.flow_control.mode",
 	"determines the 'mode' of flow control we use for replication traffic in KV, if enabled",
 	metamorphic.ConstantWithTestChoice(
-		"kv.snapshot.ingest_as_write_threshold",
+		"kvadmission.flow_control.mode",
 		modeDict[ApplyToElastic], /* default value */
 		modeDict[ApplyToAll],     /* other value */
 	),


### PR DESCRIPTION
`kvadmission.flow_control.mode` has a metamorphic test constant which
can initialize the value to either `apply_to_all` or `apply_to_elastic`.

Metamorphic constants are given a name, which is printed in the test
log. The name was incorrect, marked as
`kv.snapshot.ingest_as_write_threshold`, instead of
`kvadmission.flow_control.mode` e.g.

```
initialized metamorphic constant "kv.snapshot.ingest_as_write_threshold" with value apply_to_all
```

Change the name to be the same as the setting name.

Fixes: https://github.com/cockroachdb/cockroach/issues/131756
Release note: None