### PR TITLE
opt/exec/explain: gracefully handle unknown indexes in plan gists

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
@@ -196,3 +196,10 @@ query T nosort
 SELECT crdb_internal.decode_external_plan_gist('Ag8f')
 ----
 • union all
+
+# Regression test for #130758. Gracefully handle unknown indexes.
+query T nosort
+SELECT crdb_internal.decode_external_plan_gist('AixE')
+----
+• split
+  index: ?@?

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -639,7 +639,7 @@ func (u *unknownIndex) Name() tree.Name {
 }
 
 func (u *unknownIndex) Table() cat.Table {
-	panic(errors.AssertionFailedf("not implemented"))
+	return &unknownTable{}
 }
 
 func (u *unknownIndex) Ordinal() cat.IndexOrdinal {


### PR DESCRIPTION
Fixes #130758

Release note: None