### PR TITLE
roachtest: fix kv/gracefuldraining cpu profiling interval

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -530,7 +530,7 @@ func registerKVGracefulDraining(r registry.Registry) {
 			// #131569, disable this once the issue is resolved.
 			settings := install.MakeClusterSettings()
 			settings.ClusterSettings["server.cpu_profile.duration"] = "5s"
-			settings.ClusterSettings["server.cpu_profile.interval"] = "0s"
+			settings.ClusterSettings["server.cpu_profile.interval"] = "1s"
 			settings.ClusterSettings["server.cpu_profile.cpu_usage_combined_threshold"] = "15"
 			settings.ClusterSettings["server.cpu_profile.total_dump_size_limit"] = fmt.Sprintf("%d", 256<<20 /* 256MB */)
 			c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())


### PR DESCRIPTION
The interval must be positive, but was set to 0 to enable continuous CPU profiling. Set the interval to 1s, which should be close enough to continuous.

Informs: #131569
Release note: None