### PR TITLE
roachtest: move more tpcc bytes to lower level in disagg-rebalance

### DIFF
--- a/pkg/cmd/roachtest/tests/disagg_rebalance.go
+++ b/pkg/cmd/roachtest/tests/disagg_rebalance.go
@@ -42,7 +42,6 @@ func registerDisaggRebalance(r registry.Registry) {
 			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, fmt.Sprintf("--experimental-shared-storage=%s", s3dir))
 			c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.Range(1, 3))
 
-			initialWaitDuration := 2 * time.Minute
 			warehouses := 1000
 			activeWarehouses := 20
 
@@ -65,17 +64,15 @@ func registerDisaggRebalance(r registry.Registry) {
 				t.Status("run tpcc")
 
 				cmd := fmt.Sprintf(
-					"./cockroach workload run tpcc --warehouses=%d --active-warehouses=%d --duration=10m {pgurl:1-3}",
+					"./cockroach workload run tpcc --warehouses=%d --active-warehouses=%d --duration=2m {pgurl:1-3}",
 					warehouses, activeWarehouses,
 				)
 
 				return c.RunE(ctx, option.WithNodes(c.Node(1)), cmd)
 			})
 
-			select {
-			case <-time.After(initialWaitDuration):
-			case <-ctx.Done():
-				return
+			if err := m2.WaitE(); err != nil {
+				t.Fatal(err)
 			}
 
 			// Compact the ranges containing tpcc on the first three nodes. This increases
@@ -85,8 +82,8 @@ func registerDisaggRebalance(r registry.Registry) {
 				db := c.Conn(ctx, t.L(), i+1)
 				_, err := db.ExecContext(ctx, `SELECT crdb_internal.compact_engine_span(
 					$1, $2,
-					(SELECT raw_start_key FROM [SHOW RANGES FROM DATABASE tpcc WITH KEYS] LIMIT 1),
-					(SELECT raw_end_key FROM [SHOW RANGES FROM DATABASE tpcc WITH KEYS] LIMIT 1))`, i+1, i+1)
+					(SELECT raw_start_key FROM [SHOW RANGES FROM DATABASE tpcc WITH KEYS] ORDER BY start_key LIMIT 1),
+					(SELECT raw_end_key FROM [SHOW RANGES FROM DATABASE tpcc WITH KEYS] ORDER BY end_key DESC LIMIT 1))`, i+1, i+1)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -159,11 +156,6 @@ func registerDisaggRebalance(r registry.Registry) {
 				return nil
 			}, 5*time.Minute)
 
-			t.Status("continue tpcc")
-
-			if err := m2.WaitE(); err != nil {
-				t.Fatal(err)
-			}
 		},
 	})
 }


### PR DESCRIPTION
The disagg-rebalance roachtest can flake if a lot of bytes happen to be in higher levels of the LSM (eg. L4) for a particular range. This change reduces the likelihood of that happening by widening the manual compaction run before the rebalance, and by pausing tpc-c while the manual compaction is running.

Fixes #130994.

Epic: none

Release note: None