### PR TITLE
raft: handle MsgFortifyLeader from an older term

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1405,7 +1405,8 @@ func (r *raft) Step(m pb.Message) error {
 		}
 
 	case m.Term < r.Term:
-		if (r.checkQuorum || r.preVote) && (m.Type == pb.MsgHeartbeat || m.Type == pb.MsgApp) {
+		if (r.checkQuorum || r.preVote) &&
+			(m.Type == pb.MsgHeartbeat || m.Type == pb.MsgApp || m.Type == pb.MsgFortifyLeader) {
 			// We have received messages from a leader at a lower term. It is possible
 			// that these messages were simply delayed in the network, but this could
 			// also mean that this node has advanced its term number during a network

--- a/pkg/raft/testdata/checkquorum.txt
+++ b/pkg/raft/testdata/checkquorum.txt
@@ -100,19 +100,14 @@ stabilize
 > 2 receiving messages
   1->2 MsgHeartbeat Term:1 Log:0/0
   1->2 MsgFortifyLeader Term:1 Log:0/0
-  INFO 2 [term: 2] ignored a MsgFortifyLeader message with lower term from 1 [term: 1]
   1->2 MsgHeartbeat Term:1 Log:0/0
   1->2 MsgFortifyLeader Term:1 Log:0/0
-  INFO 2 [term: 2] ignored a MsgFortifyLeader message with lower term from 1 [term: 1]
   1->2 MsgHeartbeat Term:1 Log:0/0
   1->2 MsgFortifyLeader Term:1 Log:0/0
-  INFO 2 [term: 2] ignored a MsgFortifyLeader message with lower term from 1 [term: 1]
   1->2 MsgHeartbeat Term:1 Log:0/0
   1->2 MsgFortifyLeader Term:1 Log:0/0
-  INFO 2 [term: 2] ignored a MsgFortifyLeader message with lower term from 1 [term: 1]
   1->2 MsgHeartbeat Term:1 Log:0/0
   1->2 MsgFortifyLeader Term:1 Log:0/0
-  INFO 2 [term: 2] ignored a MsgFortifyLeader message with lower term from 1 [term: 1]
 > 3 receiving messages
   1->3 MsgHeartbeat Term:1 Log:0/0
   1->3 MsgFortifyLeader Term:1 Log:0/0
@@ -127,6 +122,11 @@ stabilize
 > 2 handling Ready
   Ready MustSync=false:
   Messages:
+  2->1 MsgAppResp Term:2 Log:0/0
+  2->1 MsgAppResp Term:2 Log:0/0
+  2->1 MsgAppResp Term:2 Log:0/0
+  2->1 MsgAppResp Term:2 Log:0/0
+  2->1 MsgAppResp Term:2 Log:0/0
   2->1 MsgAppResp Term:2 Log:0/0
   2->1 MsgAppResp Term:2 Log:0/0
   2->1 MsgAppResp Term:2 Log:0/0
@@ -150,6 +150,11 @@ stabilize
   2->1 MsgAppResp Term:2 Log:0/0
   INFO 1 [term: 1] received a MsgAppResp message with higher term from 2 [term: 2]
   INFO 1 became follower at term 2
+  2->1 MsgAppResp Term:2 Log:0/0
+  2->1 MsgAppResp Term:2 Log:0/0
+  2->1 MsgAppResp Term:2 Log:0/0
+  2->1 MsgAppResp Term:2 Log:0/0
+  2->1 MsgAppResp Term:2 Log:0/0
   2->1 MsgAppResp Term:2 Log:0/0
   2->1 MsgAppResp Term:2 Log:0/0
   2->1 MsgAppResp Term:2 Log:0/0


### PR DESCRIPTION
Right now in Raft, a node could get stranded at a higher term and not be able to neither join a quorum nor become the leader. The way we handle this situation is by detecting messages that indicate leadership at a lower term, and we send them an empty MsgAppResp (from our higher term) that will cause them to step down.

This commit adds MsgFortifyLeader to the list of messages that does that.

Epic: None

Release note: None