### PR TITLE
roachtest: bump passing criteria for perturbation/* tests

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -203,17 +203,17 @@ func registerLatencyTests(r registry.Registry) {
 	// them to fail as a comment in the test.
 	addMetamorphic(r, restart{}, math.Inf(1))
 	addMetamorphic(r, partition{}, math.Inf(1))
-	addMetamorphic(r, addNode{}, 2.0)
-	addMetamorphic(r, decommission{}, 2.0)
-	addMetamorphic(r, backfill{}, 20.0)
+	addMetamorphic(r, addNode{}, 3.0)
+	addMetamorphic(r, decommission{}, 3.0)
+	addMetamorphic(r, backfill{}, 40.0)
 
 	// NB: If these tests fail, it likely signals a regression. Investigate the
 	// history of the test on roachperf to see what changed.
 	addFull(r, restart{}, math.Inf(1))
 	addFull(r, partition{}, math.Inf(1))
-	addFull(r, addNode{}, 2.0)
-	addFull(r, decommission{}, 2.0)
-	addFull(r, backfill{}, 20.0)
+	addFull(r, addNode{}, 3.0)
+	addFull(r, decommission{}, 3.0)
+	addFull(r, backfill{}, 40.0)
 
 	// NB: These tests will never fail and are not enabled, but they are useful
 	// for development.


### PR DESCRIPTION
Now that the perturbation tests are running consistently each night, some of the tests are failing with the default values. This change reduces the chance of failure by allowing larger impacts for most of the tests.

Note that the metamorphic tests might still fail, but we want to continue to look at failures and determine if they are acceptable while reducing noise. Additionally we may decide to change the full mode tests to match the "worst" metamorphic variant.

Fixes: #131189
Fixes: #131577
Fixes: #131557
Fixes: #131287
Fixes: #131189

Release note: None