### PR TITLE
cluster-ui: add v2 table details page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/databases/getTableMetadataApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databases/getTableMetadataApi.ts
@@ -39,6 +39,7 @@ export type TableMetadata = {
   total_data_bytes: number;
   store_ids: number[];
   last_updated: string;
+  last_update_error: string | null;
 };
 
 type TableMetadataResponse = APIV2ResponseWithPaginationState<TableMetadata[]>;

--- a/pkg/ui/workspaces/cluster-ui/src/api/databases/getTableMetadataApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databases/getTableMetadataApi.ts
@@ -43,7 +43,7 @@ export type TableMetadata = {
 
 type TableMetadataResponse = APIV2ResponseWithPaginationState<TableMetadata[]>;
 
-export type TableMetadataRequest = {
+export type ListTableMetadataRequest = {
   dbId?: number;
   sortBy?: string;
   sortOrder?: "asc" | "desc";
@@ -52,8 +52,8 @@ export type TableMetadataRequest = {
   name?: string;
 };
 
-export async function getTableMetadata(
-  req: TableMetadataRequest,
+async function getTableMetadata(
+  req: ListTableMetadataRequest,
 ): Promise<TableMetadataResponse> {
   const urlParams = new URLSearchParams();
   if (req.dbId) {
@@ -82,7 +82,7 @@ export async function getTableMetadata(
   return fetchDataJSON(TABLE_METADATA_API_PATH + "?" + urlParams.toString());
 }
 
-const createKey = (req: TableMetadataRequest) => {
+const createKey = (req: ListTableMetadataRequest) => {
   const { dbId, sortBy, sortOrder, pagination, storeIds, name } = req;
   return [
     "tableMetadata",
@@ -96,7 +96,7 @@ const createKey = (req: TableMetadataRequest) => {
   ].join("|");
 };
 
-export const useTableMetadata = (req: TableMetadataRequest) => {
+export const useTableMetadata = (req: ListTableMetadataRequest) => {
   const key = createKey(req);
   const { data, error, isLoading, mutate } = useSWR<TableMetadataResponse>(
     key,
@@ -104,4 +104,30 @@ export const useTableMetadata = (req: TableMetadataRequest) => {
   );
 
   return { data, error, isLoading, refreshTables: mutate };
+};
+
+type TableDetailsRequest = {
+  tableId: number;
+};
+
+export type TableDetailsResponse = {
+  metadata: TableMetadata;
+  create_statement: string;
+};
+async function getTableDetails(
+  req: TableDetailsRequest,
+): Promise<TableDetailsResponse> {
+  if (!req.tableId || Number.isNaN(req.tableId)) {
+    throw new Error("Table ID is required");
+  }
+  return fetchDataJSON(`${TABLE_METADATA_API_PATH}${req.tableId}/`);
+}
+
+export const useTableDetails = (req: TableDetailsRequest) => {
+  const { data, error, isLoading } = useSWR<TableDetailsResponse>(
+    req.tableId.toString(),
+    () => getTableDetails(req),
+  );
+
+  return { data, error: error, isLoading };
 };

--- a/pkg/ui/workspaces/cluster-ui/src/api/nodesApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/nodesApi.ts
@@ -22,6 +22,7 @@ export const getNodes =
 export const useNodeStatuses = () => {
   const { data, isLoading, error } = useSWR(NODES_PATH, getNodes, {
     revalidateOnFocus: false,
+    dedupingInterval: 10000, // 10 seconds.
   });
 
   const { storeIDToNodeID, nodeIDToRegion } = useMemo(() => {

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
@@ -8,7 +8,7 @@ import { Link } from "react-router-dom";
 
 import { useNodeStatuses } from "src/api";
 import {
-  TableMetadataRequest,
+  ListTableMetadataRequest,
   TableSortOption,
   useTableMetadata,
 } from "src/api/databases/getTableMetadataApi";
@@ -167,7 +167,7 @@ const COLUMNS: (TableColumnProps<TableRow> & { sortKey?: TableSortOption })[] =
 const createTableMetadataRequestFromParams = (
   dbID: string,
   params: TableParams,
-): TableMetadataRequest => {
+): ListTableMetadataRequest => {
   return {
     pagination: {
       pageSize: params.pagination.pageSize,

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
@@ -12,6 +12,7 @@ import {
   TableSortOption,
   useTableMetadata,
 } from "src/api/databases/getTableMetadataApi";
+import { ColumnTitle } from "src/components/columnTitle";
 import { NodeRegionsSelector } from "src/components/nodeRegionsSelector/nodeRegionsSelector";
 import { RegionNodesLabel } from "src/components/regionNodesLabel";
 import { TableMetadataJobControl } from "src/components/tableMetadataLastUpdated/tableMetadataJobControl";
@@ -29,9 +30,7 @@ import {
 } from "src/sharedFromCloud/table";
 import useTable, { TableParams } from "src/sharedFromCloud/useTable";
 import { StoreID } from "src/types/clusterTypes";
-import { Bytes, EncodeDatabaseTableUri, tabAttr } from "src/util";
-
-import { ColumnTitle } from "../components/columnTitle";
+import { Bytes, tabAttr } from "src/util";
 
 import { TableColName } from "./constants";
 import { TableRow } from "./types";
@@ -51,10 +50,9 @@ const COLUMNS: (TableColumnProps<TableRow> & { sortKey?: TableSortOption })[] =
       width: "15%",
       sorter: (a, b) => a.name.localeCompare(b.name),
       render: (t: TableRow) => {
-        // This linking is just temporary. We'll need to update it to the correct path
-        // using db ID and table ID once we have the table details page.
-        const encodedDBPath = EncodeDatabaseTableUri(t.dbName, t.name);
-        return <Link to={encodedDBPath}>{t.qualifiedNameWithSchema}</Link>;
+        return (
+          <Link to={`/table/${t.tableID}`}>{t.qualifiedNameWithSchema}</Link>
+        );
       },
       sortKey: TableSortOption.NAME,
     },

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/types.ts
@@ -11,6 +11,7 @@ export type TableRow = {
   qualifiedNameWithSchema: string;
   name: string;
   dbName: string;
+  tableID: number;
   dbID: number;
   replicationSizeBytes: number;
   rangeCount: number;

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/utils.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/utils.tsx
@@ -34,6 +34,7 @@ export const rawTableMetadataToRows = (
     return {
       name: table.table_name,
       dbName: table.db_name,
+      tableID: table.table_id,
       dbID: table.db_id,
       replicationSizeBytes: table.replication_size_bytes,
       rangeCount: table.range_count,

--- a/pkg/ui/workspaces/cluster-ui/src/hooks/useRouteParams.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/hooks/useRouteParams.ts
@@ -5,10 +5,10 @@
 
 import { useParams } from "react-router";
 
-import { databaseIDAttr } from "src/util";
+import { databaseIDAttr, tableIdAttr } from "src/util";
 
 type Params = {
   [databaseIDAttr]: string;
-  // Add more as needed.
+  [tableIdAttr]: string;
 };
 export const useRouteParams = useParams<Params>;

--- a/pkg/ui/workspaces/cluster-ui/src/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/index.ts
@@ -54,6 +54,7 @@ export * from "./databases";
 export * from "./antdTheme";
 export * from "./databasesV2";
 export * from "./databaseDetailsV2";
+export * from "./tableDetailsV2";
 // Reexport ConfigProvider instance from cluster-ui as exact instance
 // required in Db Console to apply Antd theme in Db Console.
 // TODO (koorosh): is it possible to define antd pacakge as peerDependency

--- a/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/index.tsx
@@ -1,0 +1,81 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { Tabs } from "antd";
+import React, { useState } from "react";
+
+import { useTableDetails } from "src/api/databases/getTableMetadataApi";
+import { commonStyles } from "src/common";
+import { useRouteParams } from "src/hooks/useRouteParams";
+import { PageLayout } from "src/layouts";
+import { Loading } from "src/loading";
+import { PageHeader } from "src/sharedFromCloud/pageHeader";
+
+import { TableOverview } from "./tableOverview";
+
+enum TabKeys {
+  OVERVIEW = "overview",
+  GRANTS = "grants",
+  INDEXES = "indexes",
+}
+
+export const TableDetailsPageV2 = () => {
+  const [currentTab, setCurrentTab] = useState(TabKeys.OVERVIEW);
+  const { tableID } = useRouteParams();
+  const { data, error, isLoading } = useTableDetails({
+    tableId: parseInt(tableID, 10),
+  });
+  // The table name is undefined if the table does not exist.
+  const tableNotFound = error?.status === 404;
+
+  const partiallyQualifiedTableName = !tableNotFound
+    ? data
+      ? data.metadata.schema_name + "." + data.metadata.table_name
+      : ""
+    : "Table not found";
+
+  const breadCrumbItems = [
+    { link: `/databases`, name: "Databases" },
+    {
+      link: `/databases/${data?.metadata.db_id}`,
+      name: data?.metadata.db_name,
+    },
+    {
+      link: null,
+      name: partiallyQualifiedTableName,
+    },
+  ].filter(item => item.name);
+
+  const tabItems = [
+    {
+      key: TabKeys.OVERVIEW,
+      label: "Overview",
+      children: (
+        <Loading page="TableDetailsOverview" loading={isLoading}>
+          <TableOverview tableDetails={data} />
+        </Loading>
+      ),
+    },
+    { key: TabKeys.GRANTS, label: "Grants" },
+    { key: TabKeys.INDEXES, label: "Indexes" },
+  ];
+
+  return (
+    <PageLayout>
+      <PageHeader
+        breadcrumbItems={breadCrumbItems}
+        title={partiallyQualifiedTableName}
+      />
+      <Tabs
+        defaultActiveKey={TabKeys.OVERVIEW}
+        className={commonStyles("cockroach--tabs")}
+        onChange={setCurrentTab}
+        activeKey={currentTab}
+        items={tabItems}
+        destroyInactiveTabPane
+      />
+    </PageLayout>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/tableOverview.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/tableOverview.tsx
@@ -1,0 +1,135 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { Icon } from "@cockroachlabs/ui-components";
+import { Col, Row, Skeleton, Tooltip } from "antd";
+import moment from "moment-timezone";
+import React, { useContext } from "react";
+
+import { TableDetailsResponse } from "src/api/databases/getTableMetadataApi";
+import { PageSection } from "src/layouts";
+import { SqlBox, SqlBoxSize } from "src/sql";
+
+import { useNodeStatuses } from "../api";
+import { TimezoneContext } from "../contexts";
+import { SummaryCard, SummaryCardItem } from "../summaryCard";
+import { StoreID } from "../types/clusterTypes";
+import {
+  Bytes,
+  DATE_WITH_SECONDS_FORMAT_24_TZ,
+  FormatWithTimezone,
+} from "../util";
+
+type TableOverviewProps = {
+  tableDetails: TableDetailsResponse;
+};
+
+export const TableOverview: React.FC<TableOverviewProps> = ({
+  tableDetails,
+}) => {
+  const { metadata } = tableDetails;
+  const {
+    nodeIDToRegion,
+    storeIDToNodeID,
+    isLoading: nodesLoading,
+  } = useNodeStatuses();
+
+  // getNodesByRegionDisplayStr returns a string that displays
+  // the regions and nodes that the table is replicated across.
+  const getNodesByRegionDisplayStr = (): string => {
+    if (nodesLoading || !tableDetails?.metadata) {
+      return "";
+    }
+    const nodesByRegion: Record<string, number[]> = {};
+    metadata.store_ids.forEach(storeID => {
+      const nodeID = storeIDToNodeID[storeID as StoreID];
+      const region = nodeIDToRegion[nodeID];
+      if (!nodesByRegion[region]) {
+        nodesByRegion[region] = [];
+      }
+      nodesByRegion[region].push(nodeID);
+    });
+    return Object.entries(nodesByRegion)
+      .map(
+        ([region, nodes]) =>
+          `${region} (${nodes.map(nid => "n" + nid).join(",")})`,
+      )
+      .join(", ");
+  };
+
+  const percentLiveDataWithPrecision = (
+    metadata.percent_live_data * 100
+  ).toFixed(2);
+
+  const timezone = useContext(TimezoneContext);
+  const lastUpdatedText = FormatWithTimezone(
+    moment.utc(metadata.last_updated),
+    DATE_WITH_SECONDS_FORMAT_24_TZ,
+    timezone,
+  );
+  const formattedErrorText = metadata.last_update_error
+    ? "Update error: " + metadata.last_update_error
+    : "";
+
+  return (
+    <>
+      <PageSection>
+        <SqlBox
+          value={tableDetails.create_statement}
+          size={SqlBoxSize.CUSTOM}
+        />
+      </PageSection>
+      <PageSection>
+        <Row justify={"end"}>
+          <Col>
+            <Tooltip title={formattedErrorText}>
+              <Row gutter={8} align={"middle"} justify={"center"}>
+                {metadata.last_update_error && (
+                  <Icon fill="warning" iconName={"Caution"} />
+                )}
+                <Col>Last updated: {lastUpdatedText}</Col>
+              </Row>
+            </Tooltip>
+          </Col>
+        </Row>
+        <Row gutter={8}>
+          <Col span={12}>
+            <SummaryCard>
+              <SummaryCardItem
+                label="Size"
+                value={Bytes(metadata.replication_size_bytes)}
+              />
+              <SummaryCardItem label="Ranges" value={metadata.range_count} />
+              <SummaryCardItem
+                label="Regions / Nodes"
+                value={
+                  <Skeleton loading={nodesLoading}>
+                    {getNodesByRegionDisplayStr()}
+                  </Skeleton>
+                }
+              />
+            </SummaryCard>
+          </Col>
+          <Col span={12}>
+            <SummaryCard>
+              <SummaryCardItem
+                label="% of Live data"
+                value={
+                  <div>
+                    <div>{percentLiveDataWithPrecision}% </div>
+                    <div>
+                      {Bytes(metadata.total_live_data_bytes)} /{" "}
+                      {Bytes(metadata.total_live_data_bytes)}
+                    </div>
+                  </div>
+                }
+              />
+            </SummaryCard>
+          </Col>
+        </Row>
+      </PageSection>
+    </>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
@@ -26,6 +26,7 @@ export const tabAttr = "tab";
 export const schemaNameAttr = "schemaName";
 export const tableNameAttr = "table_name";
 export const tableNameCCAttr = "tableName";
+export const tableIdAttr = "tableID";
 export const indexNameAttr = "index_name";
 export const txnFingerprintIdAttr = "txn_fingerprint_id";
 export const unset = "(unset)";

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -9,6 +9,7 @@ import {
   ConfigProvider as ClusterUIConfigProvider,
   DatabasesPageV2,
   DatabaseDetailsPageV2,
+  TableDetailsPageV2,
 } from "@cockroachlabs/cluster-ui";
 import { ConfigProvider } from "antd";
 import { ConnectedRouter } from "connected-react-router";
@@ -45,6 +46,7 @@ import {
   txnFingerprintIdAttr,
   viewAttr,
   idAttr,
+  tableIdAttr,
 } from "src/util/constants";
 import NotFound from "src/views/app/components/errorMessage/notFound";
 import Layout from "src/views/app/containers/layout";
@@ -212,6 +214,11 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                           exact
                           path={`/databases/:${databaseIDAttr}`}
                           component={DatabaseDetailsPageV2}
+                        />
+                        <Route
+                          exact
+                          path={`/table/:${tableIdAttr}`}
+                          component={TableDetailsPageV2}
                         />
                         <Route
                           exact

--- a/pkg/ui/workspaces/db-console/src/util/constants.ts
+++ b/pkg/ui/workspaces/db-console/src/util/constants.ts
@@ -27,6 +27,7 @@ export const {
   sessionAttr,
   tabAttr,
   tableNameAttr,
+  tableIdAttr,
   txnFingerprintIdAttr,
   unset,
   viewAttr,


### PR DESCRIPTION
cluster-ui: add get tablemetadata by table id api

This commit adds a hook that fetches table details by
using the `/api/v2/table_metadata/:tableId` route.

Epic: CRDB-37558
Part of: #130687

Release note: None

------------------------

cluster-ui: add v2 table details page base components

This commit adds the redesigned table details page with
the overview tab.
The overview tab currently contains the following:
- sql create stmt
- replication size
- ranges count
- node / region information
- percent live data

To be added in future PRs after the information is available
in the API:
- auto stats collection enabled
- stats last updated time

The page also displays the last updated time of the cache information.

Epic: [CRDB-37558](https://cockroachlabs.atlassian.net/browse/CRDB-37558)
Part of: https://github.com/cockroachdb/cockroach/issues/130687

Release note (ui change): The table details page has been
updated to show cached data in the overview page, which is
the same data source as what is shown in the databases and
databases > tables list overview pages.