### PR TITLE
cluster-ui: add grants view to table details 

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/databases/grantsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databases/grantsApi.ts
@@ -70,3 +70,53 @@ export const useDatabaseGrantsImmutable = (req: DatabaseGrantsRequest) => {
     error: error,
   };
 };
+
+type TableGrantsRequest = {
+  tableId: number;
+  sortBy?: GrantsSortOptions;
+  sortOrder?: "asc" | "desc";
+  pagination?: SimplePaginationState;
+};
+
+export type TableGrantsResponse = APIV2ResponseWithPaginationState<
+  DatabaseGrant[]
+>;
+
+const createTableGrantsPath = (req: TableGrantsRequest): string => {
+  const { tableId, pagination, sortBy, sortOrder } = req;
+  const urlParams = new URLSearchParams();
+  if (pagination?.pageNum) {
+    urlParams.append("pageNum", pagination.pageNum.toString());
+  }
+  if (pagination?.pageSize) {
+    urlParams.append("pageSize", pagination.pageSize.toString());
+  }
+  if (sortBy) {
+    urlParams.append("sortBy", sortBy);
+  }
+  if (sortOrder) {
+    urlParams.append("sortOrder", sortOrder);
+  }
+  return `api/v2/grants/tables/${tableId}/?` + urlParams.toString();
+};
+
+const fetchTableGrants = (
+  req: TableGrantsRequest,
+): Promise<TableGrantsResponse> => {
+  const path = createTableGrantsPath(req);
+  return fetchDataJSON(path);
+};
+
+export const useTableGrantsImmutable = (req: TableGrantsRequest) => {
+  const { data, isLoading, error } = useSWRImmutable(
+    createTableGrantsPath(req),
+    () => fetchTableGrants(req),
+  );
+
+  return {
+    tableGrants: data?.results,
+    pagination: data?.pagination_info,
+    isLoading,
+    error: error,
+  };
+};

--- a/pkg/ui/workspaces/cluster-ui/src/components/grantsTable/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/components/grantsTable/index.tsx
@@ -1,0 +1,85 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import React, { useState } from "react";
+
+import { GrantsSortOptions } from "src/api/databases/grantsApi";
+import PageCount from "src/sharedFromCloud/pageCount";
+import {
+  TableColumnProps,
+  Table,
+  TableChangeFn,
+} from "src/sharedFromCloud/table";
+
+// This type is used by data source for the table.
+export type GrantsByUser = {
+  key: string;
+  grantee: string;
+  privileges: string[];
+};
+
+const COLUMNS: (TableColumnProps<GrantsByUser> & {
+  sortKey: GrantsSortOptions;
+})[] = [
+  {
+    title: "Grantee",
+    sorter: (a, b) => a.grantee.localeCompare(b.grantee),
+    sortKey: GrantsSortOptions.GRANTEE,
+    render: grant => grant.grantee,
+  },
+  {
+    title: "Privileges",
+    sortKey: GrantsSortOptions.PRIVILEGE,
+    render: grant => grant.privileges.join(", "),
+  },
+];
+
+const PAGE_SIZE = 20;
+
+type GrantsTableProps = {
+  data: GrantsByUser[];
+  error?: Error;
+  loading?: boolean;
+};
+
+export const GrantsTable: React.FC<GrantsTableProps> = ({
+  data,
+  error,
+  loading,
+}) => {
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const onTableChange: TableChangeFn<GrantsByUser> = pagination => {
+    if (pagination.current) {
+      setCurrentPage(pagination.current);
+    }
+  };
+
+  return (
+    <>
+      <PageCount
+        page={currentPage}
+        pageSize={PAGE_SIZE}
+        total={data.length}
+        entity="grants"
+      />
+      <Table
+        error={error}
+        loading={loading}
+        dataSource={data}
+        columns={COLUMNS}
+        pagination={{
+          size: "small",
+          current: currentPage,
+          pageSize: PAGE_SIZE,
+          showSizeChanger: false,
+          position: ["bottomCenter"],
+          total: data.length,
+        }}
+        onChange={onTableChange}
+      />
+    </>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/components/grantsTable/util.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/components/grantsTable/util.ts
@@ -1,0 +1,28 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+type FlatGrant = {
+  grantee: string;
+  privilege: string;
+};
+export const groupGrantsByGrantee = (grants: FlatGrant[]) => {
+  if (!grants?.length) {
+    return [];
+  }
+
+  const grantsByUser = {} as Record<string, string[]>;
+  grants.forEach(grant => {
+    if (!grantsByUser[grant.grantee]) {
+      grantsByUser[grant.grantee] = [];
+    }
+    grantsByUser[grant.grantee].push(grant.privilege);
+  });
+
+  return Object.entries(grantsByUser).map(([grantee, privileges]) => ({
+    key: grantee,
+    grantee,
+    privileges,
+  }));
+};

--- a/pkg/ui/workspaces/cluster-ui/src/components/grantsTable/utils.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/components/grantsTable/utils.spec.ts
@@ -1,0 +1,39 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { groupGrantsByGrantee } from "./util";
+
+describe("groupGrantsByGrantee", () => {
+  it("should group grants by grantee", () => {
+    const grants = [
+      { grantee: "user1", privilege: "a" },
+      { grantee: "user1", privilege: "b" },
+      { grantee: "user1", privilege: "c" },
+      { grantee: "user2", privilege: "privilege1" },
+      { grantee: "user2", privilege: "privilege2" },
+      { grantee: "user3", privilege: "singlePriv" },
+    ];
+
+    const result = groupGrantsByGrantee(grants);
+
+    expect(result).toEqual([
+      { key: "user1", grantee: "user1", privileges: ["a", "b", "c"] },
+      {
+        key: "user2",
+        grantee: "user2",
+        privileges: ["privilege1", "privilege2"],
+      },
+      { key: "user3", grantee: "user3", privileges: ["singlePriv"] },
+    ]);
+  });
+
+  it("should return empty array if the argument is empty or null", () => {
+    const result = groupGrantsByGrantee([]);
+    expect(result).toEqual([]);
+
+    const resultUsingNull = groupGrantsByGrantee(null);
+    expect(resultUsingNull).toEqual([]);
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/index.tsx
@@ -13,6 +13,7 @@ import { PageLayout } from "src/layouts";
 import { Loading } from "src/loading";
 import { PageHeader } from "src/sharedFromCloud/pageHeader";
 
+import { TableGrantsView } from "./tableGrantsView";
 import { TableOverview } from "./tableOverview";
 
 enum TabKeys {
@@ -58,7 +59,7 @@ export const TableDetailsPageV2 = () => {
         </Loading>
       ),
     },
-    { key: TabKeys.GRANTS, label: "Grants" },
+    { key: TabKeys.GRANTS, label: "Grants", children: <TableGrantsView /> },
     { key: TabKeys.INDEXES, label: "Indexes" },
   ];
 

--- a/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/tableGrantsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/tableGrantsView.tsx
@@ -5,17 +5,17 @@
 
 import React, { useMemo } from "react";
 
-import { useDatabaseGrantsImmutable } from "src/api/databases/grantsApi";
+import { useTableGrantsImmutable } from "src/api/databases/grantsApi";
 import { GrantsByUser, GrantsTable } from "src/components/grantsTable";
 import { groupGrantsByGrantee } from "src/components/grantsTable/util";
 import { useRouteParams } from "src/hooks/useRouteParams";
 import { PageSection } from "src/layouts";
 
-export const DbGrantsView: React.FC = () => {
-  const { dbID } = useRouteParams();
+export const TableGrantsView: React.FC = () => {
+  const { tableID } = useRouteParams();
 
-  const { databaseGrants, isLoading, error } = useDatabaseGrantsImmutable({
-    dbId: parseInt(dbID, 10),
+  const { tableGrants, isLoading, error } = useTableGrantsImmutable({
+    tableId: parseInt(tableID, 10),
     pagination: {
       pageSize: 0, // Get all.
       pageNum: 0,
@@ -23,12 +23,12 @@ export const DbGrantsView: React.FC = () => {
   });
 
   const dataWithKey: GrantsByUser[] = useMemo(() => {
-    return groupGrantsByGrantee(databaseGrants);
-  }, [databaseGrants]);
+    return groupGrantsByGrantee(tableGrants);
+  }, [tableGrants]);
 
   return (
     <PageSection heading={"Grants"}>
-      <GrantsTable data={dataWithKey ?? []} loading={isLoading} error={error} />
+      <GrantsTable error={error} loading={isLoading} data={dataWithKey ?? []} />
     </PageSection>
   );
 };


### PR DESCRIPTION
Please note only the last commit should be reviewed.
Previous: https://github.com/cockroachdb/cockroach/pull/131769

--------------------------------------------------------------

This commit populates the grant tab in the v2 table
details page. The grants table previously used by
the db details grants tab is extracted so that both
db details and table details grants tab views may
use it.

Epic: [CRDB-37558](https://cockroachlabs.atlassian.net/browse/CRDB-37558)
Closes: https://github.com/cockroachdb/cockroach/issues/131211

Release note: None