### PR TITLE
cluster-ui: populate db name in db details page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/databases/getDatabaseMetadataApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databases/getDatabaseMetadataApi.ts
@@ -99,3 +99,30 @@ export const useDatabaseMetadata = (req: DatabaseMetadataRequest) => {
     refreshDatabases: mutate,
   };
 };
+
+type DatabaseMetadataByIDResponse = {
+  metadata: DatabaseMetadata;
+};
+
+const getDatabaseMetadataByID = async (
+  dbID: number,
+): Promise<DatabaseMetadataByIDResponse> => {
+  return fetchDataJSON(DATABASES_API_V2 + dbID + "/");
+};
+
+export const useDatabaseMetadataByID = (dbID: number) => {
+  const { data, error, isLoading } = useSWR<DatabaseMetadataByIDResponse>(
+    ["databaseMetadataByID", dbID],
+    () => getDatabaseMetadataByID(dbID),
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    },
+  );
+
+  return {
+    data,
+    error,
+    isLoading,
+  };
+};

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/index.tsx
@@ -3,15 +3,18 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import { Tabs } from "antd";
+import { Skeleton, Tabs } from "antd";
 import React from "react";
 import { useHistory, useLocation } from "react-router";
 
+import { useDatabaseMetadataByID } from "src/api/databases/getDatabaseMetadataApi";
 import { commonStyles } from "src/common";
+import { useRouteParams } from "src/hooks/useRouteParams";
 import { PageLayout } from "src/layouts";
 import { PageHeader } from "src/sharedFromCloud/pageHeader";
+import { queryByName, tabAttr } from "src/util";
 
-import { queryByName, tabAttr } from "../util";
+import { DB_PAGE_PATH } from "../util/routes";
 
 import { DbGrantsView } from "./dbGrantsView";
 import { TablesPageV2 } from "./tablesView";
@@ -21,6 +24,9 @@ enum TabKeys {
   GRANTS = "grants",
 }
 export const DatabaseDetailsPageV2 = () => {
+  const { dbID: dbIdRouteParam } = useRouteParams();
+  const dbId = parseInt(dbIdRouteParam, 10);
+  const { data, isLoading, error } = useDatabaseMetadataByID(dbId);
   const history = useHistory();
   const location = useLocation();
   const tab = queryByName(location, tabAttr) ?? TabKeys.TABLES;
@@ -38,7 +44,6 @@ export const DatabaseDetailsPageV2 = () => {
     });
   };
 
-  // TODO (xinhaoz) #131119 - Populate db name here.
   const tabItems = [
     {
       key: TabKeys.TABLES,
@@ -52,9 +57,25 @@ export const DatabaseDetailsPageV2 = () => {
     },
   ];
 
+  const dbName =
+    error?.status === 404 || !data
+      ? "Database Not Found"
+      : data.metadata.db_name;
+
+  const breadCrumbItems = [
+    { name: "Databases", link: DB_PAGE_PATH },
+    {
+      name: dbName,
+      link: null,
+    },
+  ];
+
   return (
     <PageLayout>
-      <PageHeader title="myDB" />
+      <PageHeader
+        breadcrumbItems={breadCrumbItems}
+        title={<Skeleton loading={isLoading}>{dbName}</Skeleton>}
+      />
       <Tabs
         defaultActiveKey={TabKeys.TABLES}
         className={commonStyles("cockroach--tabs")}

--- a/pkg/ui/workspaces/cluster-ui/src/util/routes.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/routes.ts
@@ -1,0 +1,7 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+export const DB_PAGE_PATH = "/databases";
+export const databaseDetailsPagePath = (dbId: number) => `/databases/${dbId}`;


### PR DESCRIPTION
This commit populates the db name as the page title
in the v2 db details page as well as breadcrumb navigation
back to the db list page. To do so we all the get db metadata
by id api on the details page.


Epic: CRDB-37558
Fixes: #131119

Release note: None