### PR TITLE
ui: update noted package licenses to CockroachDB Software License

### DIFF
--- a/pkg/ui/workspaces/e2e-tests/package.json
+++ b/pkg/ui/workspaces/e2e-tests/package.json
@@ -2,7 +2,7 @@
   "name": "@cockroachlabs/e2e-tests",
   "version": "1.0.0",
   "description": "End-to-end tests for the CockroachDB UI",
-  "license": "BSL",
+  "license": "CockroachDB Software License",
   "private": true,
   "scripts": {
     "test": "./build/start-crdb-then.sh pnpm cy:run",

--- a/pkg/ui/workspaces/eslint-plugin-crdb/package.json
+++ b/pkg/ui/workspaces/eslint-plugin-crdb/package.json
@@ -6,7 +6,7 @@
   "files": [
     "dist/"
   ],
-  "license": "BSL",
+  "license": "CockroachDB Software License",
   "private": true,
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Changing two UI packages from BSL to the CockroachDB Software License.

Part of RE-658

Release note (general change): Change the license cockroach is distributed under to the new CockroachDB Software License (CSL).