### PR TITLE
nodedialer: bump test conn health timeout

### DIFF
--- a/pkg/rpc/nodedialer/nodedialer_test.go
+++ b/pkg/rpc/nodedialer/nodedialer_test.go
@@ -163,9 +163,12 @@ func TestConnHealth(t *testing.T) {
 	// Closing the remote connection should fail ConnHealth.
 	require.NoError(t, ln.popConn().Close())
 	hbDecommission.Store(true)
-	require.Eventually(t, func() bool {
-		return nd.ConnHealth(staticNodeID, rpc.DefaultClass) != nil
-	}, time.Second, 10*time.Millisecond)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NotNil(c, nd.ConnHealth(staticNodeID, rpc.DefaultClass),
+			"expected nd.ConnHealth(%v,rpc.DefaultClass) == nil", staticNodeID)
+	}, 5*time.Second, 20*time.Millisecond,
+		"expected closing the remote connection to n%v to fail ConnHealth, "+
+			"but remained healthy for last 5 seconds", staticNodeID)
 }
 
 func TestConnHealthTryDial(t *testing.T) {


### PR DESCRIPTION
`TestConnHealth` failed in https://github.com/cockroachdb/cockroach/issues/131738, expecting the connection health to
change to some, non-healthy (non-nil) state after closing the remote
connection, but didn't before timing out.

Bump the `require.Eventually(...)` timeout from 1s to 5s and format a
useful failure message.

Informs: https://github.com/cockroachdb/cockroach/issues/131738
Release note: None