### PR TITLE
license lint: only lint on the CockroachDB Software License (CSL)

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -38,24 +38,6 @@ import (
 
 // Various copyright file headers we lint on.
 var (
-	bslHeader = regexp.MustCompile(`// Copyright 20\d\d The Cockroach Authors.
-//
-// Use of this software is governed by the Business Source License
-// included in the file licenses/BSL.txt.
-//
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0, included in the file
-// licenses/APL.txt.
-`)
-	cclHeader = regexp.MustCompile(`// Copyright 20\d\d The Cockroach Authors.
-//
-// Licensed as a CockroachDB Enterprise file under the Cockroach Community
-// License \(the "License"\); you may not use this file except in compliance with
-// the License. You may obtain a copy of the License at
-//
-//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
-`)
 	cslHeader = regexp.MustCompile(`// Copyright 20\d\d The Cockroach Authors.
 //
 // Use of this software is governed by the CockroachDB Software License
@@ -330,20 +312,15 @@ func TestLint(t *testing.T) {
 			}
 			data = data[0:n]
 
-			isCCL := strings.Contains(filename, "ccl/")
 			isApache := strings.HasPrefix(filename, "obsservice")
 			switch {
-			case isCCL:
-				if cclHeader.Find(data) == nil && cslHeader.Find(data) == nil {
-					t.Errorf("did not find expected CCL or CSL license header in %s", filename)
-				}
 			case isApache:
 				if apacheHeader.Find(data) == nil {
 					t.Errorf("did not find expected Apache license header in %s", filename)
 				}
 			default:
-				if bslHeader.Find(data) == nil && cslHeader.Find(data) == nil {
-					t.Errorf("did not find expected BSL or CSL license header in %s", filename)
+				if cslHeader.Find(data) == nil {
+					t.Errorf("did not find expected CSL license header in %s", filename)
 				}
 			}
 		}); err != nil {
@@ -422,11 +399,11 @@ func TestLint(t *testing.T) {
 				// new code, and is moved from an existing etcd forked file, the
 				// author may consider it as modified; the linter is liberal enough
 				// to allow either of these.
-				assert.True(t, (bslHeader.Find(data) != nil || cslHeader.Find(data) != nil) ||
+				assert.True(t, (cslHeader.Find(data) != nil) ||
 					(etcdApacheHeader.Find(data) != nil && cockroachModifiedCopyright.Find(data) != nil),
-					"did not find expected a) Cockroach BSL license header, b) CockroachDB "+
-						"Software License header or c) Apache license header and Cockroach "+
-						"copyright header in %s", filename)
+					"did not find expected a) CockroachDB Software License header or b) "+
+						"Apache license header and Cockroach copyright header in %s",
+					filename)
 			} else {
 				assert.NotNilf(t, etcdApacheHeader.Find(data),
 					"did not find expected Apache license header in %s", filename)

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.spec.tsx
@@ -1,12 +1,7 @@
 // Copyright 2024 The Cockroach Authors.
 //
-// Use of this software is governed by the Business Source License
-// included in the file licenses/BSL.txt.
-//
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0, included in the file
-// licenses/APL.txt.
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
 
 import { mount, ReactWrapper } from "enzyme";
 import moment from "moment";

--- a/pkg/upgrade/upgrades/v24_3_add_table_metadata_cols.go
+++ b/pkg/upgrade/upgrades/v24_3_add_table_metadata_cols.go
@@ -1,12 +1,7 @@
 // Copyright 2024 The Cockroach Authors.
 //
-// Use of this software is governed by the Business Source License
-// included in the file licenses/BSL.txt.
-//
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0, included in the file
-// licenses/APL.txt.
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
 
 package upgrades
 

--- a/pkg/upgrade/upgrades/v24_3_add_table_metadata_cols_test.go
+++ b/pkg/upgrade/upgrades/v24_3_add_table_metadata_cols_test.go
@@ -1,12 +1,7 @@
 // Copyright 2024 The Cockroach Authors.
 //
-// Use of this software is governed by the Business Source License
-// included in the file licenses/BSL.txt.
-//
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0, included in the file
-// licenses/APL.txt.
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
 
 package upgrades_test
 


### PR DESCRIPTION
Given all the headers have been updated to use the CockroachDB Software License (CSL), switch to only linting for CSL headers.

Part of RE-658

Release note: none