### PR TITLE
[roachtest/operations] Expand DR tests

### DIFF
--- a/pkg/cmd/roachtest/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/operations/BUILD.bazel
@@ -2,6 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "operations",
+    testonly = 1,
     srcs = [
         "add_column.go",
         "add_index.go",
@@ -25,7 +26,11 @@ go_library(
         "//pkg/cmd/roachtest/registry",
         "//pkg/cmd/roachtest/roachtestflags",
         "//pkg/cmd/roachtest/roachtestutil",
+        "//pkg/cmd/roachtest/tests",
+        "//pkg/sql/catalog/catpb",
         "//pkg/testutils",
+        "//pkg/testutils/fingerprintutils",
+        "//pkg/util/hlc",
         "//pkg/util/randutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/cmd/roachtest/operations/backup_restore.go
+++ b/pkg/cmd/roachtest/operations/backup_restore.go
@@ -8,6 +8,7 @@ package operations
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -15,7 +16,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/fingerprintutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -38,7 +43,7 @@ func (cl *backupRestoreCleanup) Cleanup(
 }
 
 func runBackupRestore(
-	ctx context.Context, o operation.Operation, c cluster.Cluster,
+	ctx context.Context, o operation.Operation, c cluster.Cluster, online bool, validate bool,
 ) registry.OperationCleanup {
 	// This operation looks for the district table in a database named cct_tpcc or tpcc.
 	rng, _ := randutil.NewPseudoRand()
@@ -69,64 +74,127 @@ outer:
 		return nil
 	}
 
-	backupTS := timeutil.Now().Add(-1 * time.Minute).UTC().Format(time.DateTime)
-
-	o.Status(fmt.Sprintf("backing up table district in db %s", dbName))
+	o.Status(fmt.Sprintf("backing db %s (full)", dbName))
 	bucket := fmt.Sprintf("gs://%s/operation-backup-restore/%d/?AUTH=implicit", testutils.BackupTestingBucket(), timeutil.Now().UnixNano())
 
-	_, err = conn.ExecContext(ctx, fmt.Sprintf("BACKUP TABLE %s.district TO '%s' AS OF SYSTEM TIME '%s'", dbName, bucket, backupTS))
+	backupTS := hlc.Timestamp{WallTime: timeutil.Now().Add(-10 * time.Second).UTC().UnixNano()}
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("BACKUP DATABASE %s INTO '%s' AS OF SYSTEM TIME '%s'", dbName, bucket, backupTS.AsOfSystemTime()))
 	if err != nil {
 		o.Fatal(err)
+	}
+
+	if !online {
+		for i := range 24 {
+			o.Status(fmt.Sprintf("backing up db %s (incremental layer %d)", dbName, i))
+			// Update backupTS to match the latest layer.
+			backupTS = hlc.Timestamp{WallTime: timeutil.Now().Add(-10 * time.Second).UTC().UnixNano()}
+			_, err = conn.ExecContext(ctx, fmt.Sprintf("BACKUP DATABASE %s INTO LATEST IN '%s' AS OF SYSTEM TIME '%s'", dbName, bucket, backupTS.AsOfSystemTime()))
+			if err != nil {
+				o.Fatal(err)
+			}
+		}
 	}
 
 	restoreDBName := fmt.Sprintf("backup_restore_op_%d", rng.Int63())
-	_, err = conn.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE %s", restoreDBName))
-	if err != nil {
-		o.Fatal(err)
-	}
 
-	o.Status(fmt.Sprintf("restoring table district into db %s", restoreDBName))
-	_, err = conn.ExecContext(ctx, fmt.Sprintf("RESTORE TABLE %s.district FROM '%s' AS OF SYSTEM TIME '%s' WITH OPTIONS (into_db = '%s', skip_missing_foreign_keys)", dbName, bucket, backupTS, restoreDBName))
+	onlineStr := "online"
+	if !online {
+		onlineStr = "offline"
+	}
+	o.Status(fmt.Sprintf("restoring %s into db %s", onlineStr, restoreDBName))
 
-	if err != nil {
-		o.Fatal(err)
-	}
+	startTime := timeutil.Now()
+	if !online {
+		o.Status("beginning offline restore")
+		_, err = conn.ExecContext(ctx, fmt.Sprintf("RESTORE DATABASE %s FROM LATEST IN '%s' WITH OPTIONS (new_db_name = '%s')", dbName, bucket, restoreDBName))
+		if err != nil {
+			o.Fatal(err)
+		}
+	} else {
+		var id, tables, approxRows, approxBytes int64
+		var downloadJobId catpb.JobID
+		o.Status("beginning online restore")
+		res := conn.QueryRowContext(ctx, fmt.Sprintf("RESTORE DATABASE %s FROM LATEST IN '%s' WITH OPTIONS (new_db_name = '%s', EXPERIMENTAL DEFERRED COPY)", dbName, bucket, restoreDBName))
 
-	o.Status(fmt.Sprintf("verifying table district in db %s", restoreDBName))
-	backupRow, err := conn.QueryContext(ctx, fmt.Sprintf("SELECT fingerprint FROM [SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE %s.district] AS OF SYSTEM TIME '%s'", dbName, backupTS))
-	if err != nil {
-		o.Fatal(err)
-	}
-	backupRow.Next()
-	var backupFingerprint, restoreFingerprint int64
-	if err := backupRow.Scan(&backupFingerprint); err != nil {
-		o.Fatal(err)
-	}
+		err := res.Scan(&id, &tables, &approxRows, &approxBytes, &downloadJobId)
+		if err != nil {
+			o.Fatal(err)
+		}
 
-	restoredRow, err := conn.QueryContext(ctx, fmt.Sprintf("SELECT fingerprint FROM [SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE %s.district]", restoreDBName))
-	if err != nil {
-		o.Fatal(err)
+		err = tests.WaitForSucceeded(ctx, conn, downloadJobId, 8760*time.Hour /* 1 year - test specs define their own timeouts */)
+		if err != nil {
+			o.Fatal(err)
+		}
 	}
-	restoredRow.Next()
-	if err := restoredRow.Scan(&restoreFingerprint); err != nil {
-		o.Fatal(err)
-	}
+	o.Status(fmt.Sprintf("completed restore in %v", timeutil.Since(startTime)))
 
-	if backupFingerprint != restoreFingerprint {
-		o.Fatalf("backup and restore fingerprints do not match: %d != %d", backupFingerprint, restoreFingerprint)
+	if validate {
+		o.Status(fmt.Sprintf("verifying db %s matches %s", dbName, restoreDBName))
+		sourceFingerprints, err := fingerprintutils.FingerprintDatabase(ctx, conn, dbName, fingerprintutils.AOST(backupTS), fingerprintutils.Stripped())
+		if err != nil {
+			o.Fatal(err)
+		}
+
+		// No AOST here; the timestamps are rewritten on restore. But nobody else is touching this database, so that's fine.
+		destFingerprints, err := fingerprintutils.FingerprintDatabase(ctx, conn, restoreDBName, fingerprintutils.Stripped())
+		if err != nil {
+			o.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(sourceFingerprints, destFingerprints) {
+			o.Fatalf("backup and restore fingerprints do not match: %v != %v", sourceFingerprints, destFingerprints)
+		}
 	}
 
 	return &backupRestoreCleanup{db: restoreDBName}
 }
 
+func runBackupRestoreFn(
+	online bool, validate bool,
+) func(context.Context, operation.Operation, cluster.Cluster) registry.OperationCleanup {
+	return func(ctx context.Context, o operation.Operation, c cluster.Cluster) registry.OperationCleanup {
+		return runBackupRestore(ctx, o, c, online, validate)
+	}
+}
+
 func registerBackupRestore(r registry.Registry) {
 	r.AddOperation(registry.OperationSpec{
-		Name:               "backup-restore/tpcc/district",
+		Name:               "backup-restore/tpcc/online=false/fingerprint=true",
+		Owner:              registry.OwnerDisasterRecovery,
+		Timeout:            96 * time.Hour,
+		CompatibleClouds:   registry.AllClouds,
+		CanRunConcurrently: registry.OperationCanRunConcurrently,
+		Dependencies:       []registry.OperationDependency{registry.OperationRequiresPopulatedDatabase},
+		Run:                runBackupRestoreFn(false, true),
+	})
+
+	r.AddOperation(registry.OperationSpec{
+		Name:               "backup-restore/tpcc/online=false/fingerprint=false",
 		Owner:              registry.OwnerDisasterRecovery,
 		Timeout:            24 * time.Hour,
 		CompatibleClouds:   registry.AllClouds,
 		CanRunConcurrently: registry.OperationCanRunConcurrently,
 		Dependencies:       []registry.OperationDependency{registry.OperationRequiresPopulatedDatabase},
-		Run:                runBackupRestore,
+		Run:                runBackupRestoreFn(false, false),
+	})
+
+	r.AddOperation(registry.OperationSpec{
+		Name:               "backup-restore/tpcc/online=true/fingerprint=true",
+		Owner:              registry.OwnerDisasterRecovery,
+		Timeout:            96 * time.Hour,
+		CompatibleClouds:   registry.AllClouds,
+		CanRunConcurrently: registry.OperationCanRunConcurrently,
+		Dependencies:       []registry.OperationDependency{registry.OperationRequiresPopulatedDatabase},
+		Run:                runBackupRestoreFn(true, true),
+	})
+
+	r.AddOperation(registry.OperationSpec{
+		Name:               "backup-restore/tpcc/online=true/fingerprint=false",
+		Owner:              registry.OwnerDisasterRecovery,
+		Timeout:            24 * time.Hour,
+		CompatibleClouds:   registry.AllClouds,
+		CanRunConcurrently: registry.OperationCanRunConcurrently,
+		Dependencies:       []registry.OperationDependency{registry.OperationRequiresPopulatedDatabase},
+		Run:                runBackupRestoreFn(true, false),
 	})
 }


### PR DESCRIPTION
Adds an Online Restore test, and incremental layers to the existing backup/restore test.

Release note: None