### PR TITLE
roachtest: fix rebalance/by-load/*/mixed-version shared process tests

### DIFF
--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -367,6 +367,14 @@ func makeStoreCPUFn(
 			}
 			// Take the latest CPU data point only.
 			cpu := result.Datapoints[len(result.Datapoints)-1].Value
+			// The datapoint is a float representing a percentage in [0,1.0]. Assert
+			// as much to avoid any surprises.
+			if cpu < 0 || cpu > 1 {
+				return nil, errors.Newf(
+					"node %d has core count normalized CPU utilization ts datapoint "+
+						"not in [0%,100%] (impossible!): %f [resp=%+v]", node, cpu, resp)
+			}
+
 			nodeIdx := node * storesPerNode
 			for storeOffset := 0; storeOffset < storesPerNode; storeOffset++ {
 				// The values will be a normalized float in [0,1.0], scale to a

--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/mixedversion"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
@@ -343,6 +344,7 @@ func makeStoreCPUFn(
 			name:      "cr.node.sys.cpu.combined.percent-normalized",
 			queryType: total,
 			sources:   []string{fmt.Sprintf("%d", i+1)},
+			tenantID:  roachpb.SystemTenantID,
 		}
 	}
 

--- a/pkg/cmd/roachtest/tests/ts_util.go
+++ b/pkg/cmd/roachtest/tests/ts_util.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 )
@@ -40,6 +41,11 @@ type tsQuery struct {
 	name      string
 	queryType tsQueryType
 	sources   []string
+	// tenantID specifies which tenant to query metrics for. If uninitialized,
+	// the query will be for all tenants (default). Use roachpb.SystemTenantID as
+	// the value here to query just the system tenant metrics, in a multi-tenant
+	// cluster.
+	tenantID roachpb.TenantID
 }
 
 func mustGetMetrics(
@@ -110,6 +116,7 @@ func getMetricsWithSamplePeriod(
 				Downsampler:      tspb.TimeSeriesQueryAggregator_AVG.Enum(),
 				SourceAggregator: tspb.TimeSeriesQueryAggregator_SUM.Enum(),
 				Sources:          tsQueries[i].sources,
+				TenantID:         tsQueries[i].tenantID,
 			}
 		case rate:
 			queries[i] = tspb.Query{
@@ -118,6 +125,7 @@ func getMetricsWithSamplePeriod(
 				SourceAggregator: tspb.TimeSeriesQueryAggregator_SUM.Enum(),
 				Derivative:       tspb.TimeSeriesQueryDerivative_NON_NEGATIVE_DERIVATIVE.Enum(),
 				Sources:          tsQueries[i].sources,
+				TenantID:         tsQueries[i].tenantID,
 			}
 		default:
 			panic("unexpected")


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/pull/129117, `rebalance/by-load/*/mixed-version` roachtest had
shared-process multi-tenancy introduced, which would occasionally cause
these tests to fail erroneously.

The cause of all the failures was identical, CPU utilization of some
nodes which couldn't have been possible, > 100%, e.g.,

```
CPU not evenly balanced after timeout: outside bounds mean=102.5 tolerance=20.0% (±20.5) bounds=[82.0, 123.0]
below  = [s3: 81 (-20.7%), s5: 65 (-36.5%)]
within = [s2: 116 (+14.0%), s4: 92 (-9.7%), s6: 88 (-13.2%)]
above  = [s1: 170 (+66.1%)]
```

As the query would aggregate every tenant's timeseries data on a given
node, instead of only the system tenant.

Update the timeseries utility used to query the CPU to also take in a
`TenantID` parameter, which is then used to query only the system
tenant.

Fixes: https://github.com/cockroachdb/cockroach/issues/129962
Fixes: https://github.com/cockroachdb/cockroach/issues/131274
Fixes: https://github.com/cockroachdb/cockroach/issues/129464
Release note: None