### PR TITLE
roachtest: deflake splits/load/ycsb/d/obj=cpu

### DIFF
--- a/pkg/cmd/roachtest/tests/split.go
+++ b/pkg/cmd/roachtest/tests/split.go
@@ -383,7 +383,7 @@ func registerLoadSplits(r registry.Registry) {
 				// hashed - this will lead to many hotspots over the keyspace that
 				// move. Expect a few less splits than A and B.
 				minimumRanges:     15,
-				maximumRanges:     25,
+				maximumRanges:     30,
 				initialRangeCount: 2,
 				load: ycsbSplitLoad{
 					workload:     "d",


### PR DESCRIPTION
The number of splits to assert on is historically flaky, when giving absolute bounds, as unrelated changes such as consuming more/less cpu on replica requests, will cause a different number of splits overall. Nevertheless, bump the number of expected splits from 24 to 29.

Fixes: #128254
Release note: None