### PR TITLE
workload/schemachanger: address flakes and stabilize this test

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -1218,7 +1218,9 @@ func (og *operationGenerator) violatesFkConstraintsHelper(
 	}
 	checkSharedParentChildRows := ""
 	if len(parentAndChildSameQueryColumns) > 0 {
-		checkSharedParentChildRows = fmt.Sprintf("false = ANY (ARRAY [%s]) AND",
+		// Ensure none of the rows being inserted satisfy the constraint, since
+		//// its referring to itself.
+		checkSharedParentChildRows = fmt.Sprintf("NOT (true = ANY (ARRAY [%s])) AND",
 			strings.Join(parentAndChildSameQueryColumns, ","))
 	}
 	q := fmt.Sprintf(`

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1660,11 +1660,6 @@ func (og *operationGenerator) dropColumn(ctx context.Context, tx pgx.Tx) (*opStm
 		{code: pgcode.DependentObjectsStillExist, condition: columnIsDependedOn || columnRemovalWillDropFKBackingIndexes},
 		{code: pgcode.FeatureNotSupported, condition: hasAlterPKSchemaChange},
 	})
-	// TODO(#126967): We need to add a check for the column being in an expression
-	// to an index. In the case where the expression does not already exist for
-	// us to use, we add an internal crdb_internal_idx_expr prefixed column to
-	// the table.
-	stmt.potentialExecErrors.add(pgcode.InvalidColumnReference)
 	// For legacy schema changer its possible for create index operations to interfere if they
 	// are in progress.
 	if !og.useDeclarativeSchemaChanger {

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -508,6 +509,15 @@ func (w *schemaChangeWorker) runInTxn(
 				// to rollback.
 				if pgcode.MakeCode(pgErr.Code) == pgcode.SerializationFailure {
 					w.recordInHist(timeutil.Since(start), txnRollback)
+					return errors.Mark(
+						err,
+						errRunInTxnRbkSentinel,
+					)
+				}
+				// Command is too large errors are allowed on DML operations since,
+				// some of the tables can be pretty wide in this test.
+				if op.queryType == OpStmtDML && pgcode.MakeCode(pgErr.Code) == pgcode.Uncategorized &&
+					strings.Contains(pgErr.Error(), "command is too large") {
 					return errors.Mark(
 						err,
 						errRunInTxnRbkSentinel,


### PR DESCRIPTION
This patch will address the following flakes:

1. Allow constraint violations on add column / alter pk, since concurrent inserts can cause these errors on commit
2. Fix aborted txn error inside ADD FOREIGN KEY, which was because one of the intropection queries was never run inside a child txn.
3. Address command is too large error in insert, which could cause inserts to fail when a large number of columns existed on a table.
4. Address a bug inside INSERT foreign key validation when multiple rows were inserted in the same batch
5. Handle crdb_internal computed cols in colIsRefByComputed, which removes a potential error from DROP COLUMN

Fixes: #131345
Fixes: #130923
Fixes: #126967