### PR TITLE
dev: support --rewrite for CCL execbuilder tests

### DIFF
--- a/pkg/cmd/dev/testlogic.go
+++ b/pkg/cmd/dev/testlogic.go
@@ -188,13 +188,17 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 		}
 
 		if rewrite {
+			writeablePathArg := func(dir string) string {
+				return fmt.Sprintf("--sandbox_writable_path=%s", filepath.Join(workspace, dir))
+			}
+
 			dir := filepath.Join(filepath.Dir(baseTestsDir), "testdata")
-			args = append(args, fmt.Sprintf("--sandbox_writable_path=%s", filepath.Join(workspace, dir)))
+			args = append(args, writeablePathArg(dir))
 			if choice == "ccl" {
 				// The ccl logictest target shares the testdata directory with the base
 				// logictest target -- make an allowance explicitly for that.
-				args = append(args, fmt.Sprintf("--sandbox_writable_path=%s",
-					filepath.Join(workspace, "pkg/sql/logictest")))
+				args = append(args, writeablePathArg("pkg/sql/logictest"))
+				args = append(args, writeablePathArg("pkg/sql/opt/exec/execbuilder/testdata/"))
 			}
 		}
 	}


### PR DESCRIPTION
The CCL config includes tests from execbuilder. Such tests can't be rewritten currently because we don't include the execbuilder tests in the set of writable paths.

Epic: none
Release note: None