### PR TITLE
roachtest: validate-system-schema/separate process is OnlyGCE

### DIFF
--- a/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
+++ b/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
@@ -225,7 +225,7 @@ func registerValidateSystemSchemaAfterVersionUpgradeSeparateProcess(r registry.R
 	r.Add(registry.TestSpec{
 		Name:             "validate-system-schema-after-version-upgrade/separate-process",
 		Owner:            registry.OwnerSQLFoundations,
-		CompatibleClouds: registry.AllClouds,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Cluster:          r.MakeClusterSpec(3),
 		RequiresLicense:  false,


### PR DESCRIPTION
This test is meant to run on the `SeparateProcess` deployment mode, which is only supported on GCE.

Fixes: #131801

Release note: None