### PR TITLE
kvserver: wait for gossip status change in decom non-voter test

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -796,9 +796,31 @@ func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 		require.NoError(t,
 			tc.Server(0).Decommission(ctx, livenesspb.MembershipStatus_DECOMMISSIONING, nonVoterNodeIDs))
 
+		testutils.SucceedsSoon(t, func() error {
+			// Ensure that the leaseholder store notices the decommissioning nodes
+			// before we re-enable the replicate queue. This is necessary because the
+			// replicate queue might otherwise race with the gossip update, removing
+			// the non-voters without noticing they are decommissioning, failing the
+			// RemoveDecommissioningNonVoterReplicaCount assertion below. See
+			// #115750.
+			repl, err := store.GetReplica(scratchRange.RangeID)
+			if err != nil {
+				return err
+			}
+			if decomRepls := store.GetStoreConfig().StorePool.DecommissioningReplicas(
+				repl.Desc().Replicas().Descriptors()); len(decomRepls) < 2 {
+				return errors.Errorf(
+					"expected 2 decommissioning replicas, found %d [%v]",
+					len(decomRepls), decomRepls)
+			}
+			return nil
+		})
+
 		// At this point, we know that we have an over-replicated range with
-		// non-voters on nodes that are marked as decommissioning. So turn the
-		// replicateQueue on and ensure that these redundant non-voters are removed.
+		// non-voters on nodes that are marked as decommissioning, and that the
+		// leaseholder store has received the gossip update which changes the
+		// non-voter node status to decommissioning. So turn the replicateQueue on
+		// and ensure that these redundant non-voters are removed.
 		tc.ToggleReplicateQueues(true)
 		require.Eventually(t, func() bool {
 			ok, err := checkReplicaCount(ctx, tc, &scratchRange, 1 /* voterCount */, 0 /* nonVoterCount */)


### PR DESCRIPTION
`TestReplicateQueueDecommissioningNonVoters/remove` decommissions nodes which have non-voter replicas, drops the replication factor to 1 and asserts the metrics reflect the non-voting replicas being removed as decommissioning.

The test could occasionally flake, due to a race between the leaseholder store's replicate queue and receiving the gossip update changing the decommissioning membership status.

Deflake the test by waiting on the leaseholder node to notice the membership status change prior to re-enabling the replicate queue.

Fixes: #118817
Release note: None