### PR TITLE
release-23.2: server/license: Initial support for serverless

### DIFF
--- a/pkg/ccl/utilccl/BUILD.bazel
+++ b/pkg/ccl/utilccl/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "//pkg/server/license",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/sql",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/util/envutil",

--- a/pkg/ccl/utilccl/license_check_test.go
+++ b/pkg/ccl/utilccl/license_check_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/license"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -294,7 +295,7 @@ func TestRefreshLicenseEnforcerOnLicenseChange(t *testing.T) {
 
 	// Test to ensure that the state is correctly registered on startup before
 	// changing the license.
-	enforcer := license.GetEnforcerInstance()
+	enforcer := srv.SystemLayer().ExecutorConfig().(sql.ExecutorConfig).LicenseEnforcer
 	require.Equal(t, false, enforcer.GetHasLicense())
 	gracePeriodTS, hasGracePeriod := enforcer.GetGracePeriodEndTS()
 	require.True(t, hasGracePeriod)

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server/autoconfig/acprovider"
+	"github.com/cockroachdb/cockroach/pkg/server/license"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
@@ -548,6 +549,9 @@ type SQLConfig struct {
 	// NodeMetricsRecorder is the node's MetricRecorder; the tenant's metrics will
 	// be recorded with it. Nil if this is not a shared-process tenant.
 	NodeMetricsRecorder *status.MetricsRecorder
+
+	// LicenseEnforcer is used to enforce license policies.
+	LicenseEnforcer *license.Enforcer
 }
 
 // LocalKVServerInfo is used to group information about the local KV server
@@ -581,6 +585,7 @@ func (sqlCfg *SQLConfig) SetDefaults(tempStorageCfg base.TempStorageConfig) {
 	sqlCfg.TableStatCacheSize = defaultSQLTableStatCacheSize
 	sqlCfg.QueryCacheSize = defaultSQLQueryCacheSize
 	sqlCfg.TempStorageConfig = tempStorageCfg
+	sqlCfg.LicenseEnforcer = license.NewEnforcer(nil)
 }
 
 // setOpenFileLimit sets the soft limit for open file descriptors to the hard

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -134,6 +134,9 @@ func TestReadEnvironmentVariables(t *testing.T) {
 	// Temp storage disk monitors will have slightly different names, so we
 	// override them to point to the same one.
 	cfgExpected.TempStorageConfig.Mon = cfg.TempStorageConfig.Mon
+	// The LicenseEnforcer initializes a start time, which can vary between runs,
+	// so we ensure they are the same for comparison.
+	cfgExpected.LicenseEnforcer = cfg.LicenseEnforcer
 	require.Equal(t, cfgExpected, cfg)
 
 	// Set all the environment variables to valid values and ensure they are set

--- a/pkg/server/license/BUILD.bazel
+++ b/pkg/server/license/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "cclbridge.go",
         "enforcer.go",
+        "opts.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/server/license",
     visibility = ["//visibility:public"],

--- a/pkg/server/license/enforcer_test.go
+++ b/pkg/server/license/enforcer_test.go
@@ -47,7 +47,8 @@ func TestClusterInitGracePeriod_NoOverwrite(t *testing.T) {
 	// This is the timestamp that we'll override the grace period init timestamp with.
 	// This will be set when bringing up the server.
 	ts1 := timeutil.Unix(1724329716, 0)
-	ts1End := ts1.Add(30 * 24 * time.Hour) // Calculate the end of the grace period based on ts1
+	ts1_30d := ts1.Add(30 * 24 * time.Hour)
+	ts1_7d := ts1.Add(7 * 24 * time.Hour)
 
 	ctx := context.Background()
 	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
@@ -64,26 +65,35 @@ func TestClusterInitGracePeriod_NoOverwrite(t *testing.T) {
 
 	// Create a new enforcer, to test that it won't overwrite the grace period init
 	// timestamp that was already setup.
-	enforcer := &license.Enforcer{}
 	ts2 := ts1.Add(1)
 	ts2End := ts2.Add(7 * 24 * time.Hour) // Calculate the end of the grace period
-	enforcer.SetTestingKnobs(&license.TestingKnobs{
-		Enable:            true,
-		OverrideStartTime: &ts2,
-	})
+	enforcer := license.NewEnforcer(
+		&license.TestingKnobs{
+			Enable:            true,
+			OverrideStartTime: &ts2,
+		})
 	// Ensure request for the grace period init ts1 before start just returns the start
 	// time used when the enforcer was created.
 	require.Equal(t, ts2End, enforcer.GetClusterInitGracePeriodEndTS())
 	// Start the enforcer to read the timestamp from the KV.
-	enforcer.SetTelemetryStatusReporter(&mockTelemetryStatusReporter{lastPingTime: ts1})
-	err := enforcer.Start(ctx, srv.ClusterSettings(), srv.SystemLayer().InternalDB().(descs.DB))
+	err := enforcer.Start(ctx, srv.ClusterSettings(),
+		license.WithDB(srv.SystemLayer().InternalDB().(descs.DB)),
+		license.WithSystemTenant(true),
+		license.WithTelemetryStatusReporter(&mockTelemetryStatusReporter{lastPingTime: ts1}),
+	)
 	require.NoError(t, err)
-	require.Equal(t, ts1End, enforcer.GetClusterInitGracePeriodEndTS())
+	require.Equal(t, ts1_30d, enforcer.GetClusterInitGracePeriodEndTS())
 
 	// Access the enforcer that is cached in the executor config to make sure they
 	// work for the system tenant and secondary tenant.
-	require.Equal(t, ts1End, srv.SystemLayer().ExecutorConfig().(sql.ExecutorConfig).LicenseEnforcer.GetClusterInitGracePeriodEndTS())
-	require.Equal(t, ts1End, srv.ApplicationLayer().ExecutorConfig().(sql.ExecutorConfig).LicenseEnforcer.GetClusterInitGracePeriodEndTS())
+	require.Equal(t, ts1_30d, srv.SystemLayer().ExecutorConfig().(sql.ExecutorConfig).LicenseEnforcer.GetClusterInitGracePeriodEndTS())
+	// TODO(spilchen): Until the secondary tenant can read from the KV, it will
+	// guess the ending grace period to be 7-days after start. This will be fixed
+	// in CRDB-42309. Depending on how the test was initialized, it will be either
+	// the shared process secondary tenant (ts1_30d) or the separate process
+	// secondary tenant (ts1_7d).
+	require.Contains(t, []time.Time{ts1_30d, ts1_7d},
+		srv.ApplicationLayer().ExecutorConfig().(sql.ExecutorConfig).LicenseEnforcer.GetClusterInitGracePeriodEndTS())
 }
 
 func TestClusterInitGracePeriod_NewClusterEstimation(t *testing.T) {
@@ -117,12 +127,12 @@ func TestClusterInitGracePeriod_NewClusterEstimation(t *testing.T) {
 		{"init-1h1min-ago", ts1.Add(-61 * time.Minute), ts1.Add(30 * 24 * time.Hour)},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			enforcer := &license.Enforcer{}
-			enforcer.SetTestingKnobs(&license.TestingKnobs{
-				Enable:                            true,
-				OverrideStartTime:                 &ts1,
-				OverwriteClusterInitGracePeriodTS: true,
-			})
+			enforcer := license.NewEnforcer(
+				&license.TestingKnobs{
+					Enable:                            true,
+					OverrideStartTime:                 &ts1,
+					OverwriteClusterInitGracePeriodTS: true,
+				})
 
 			// Set up the min time in system.migrations. This is used by the enforcer
 			// to figure out if the cluster is new or old. The grace period length is
@@ -136,7 +146,15 @@ func TestClusterInitGracePeriod_NewClusterEstimation(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			err = enforcer.Start(ctx, srv.ClusterSettings(), srv.SystemLayer().InternalDB().(descs.DB))
+			err = enforcer.Start(ctx, srv.ClusterSettings(),
+				license.WithDB(db),
+				license.WithSystemTenant(true),
+				license.WithTestingKnobs(&license.TestingKnobs{
+					Enable:                            true,
+					OverrideStartTime:                 &ts1,
+					OverwriteClusterInitGracePeriodTS: true,
+				}),
+			)
 			require.NoError(t, err)
 			require.Equal(t, tc.expGracePeriodEndTS, enforcer.GetClusterInitGracePeriodEndTS())
 		})
@@ -210,11 +228,12 @@ func TestThrottle(t *testing.T) {
 		{OverTxnThreshold, license.LicTypeEvaluation, t0, t0, t15d, t46d, "License expired", ""},
 	} {
 		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
-			e := license.Enforcer{}
-			e.SetTestingKnobs(&license.TestingKnobs{
-				OverrideStartTime:         &tc.gracePeriodInit,
-				OverrideThrottleCheckTime: &tc.checkTs,
-			})
+			e := license.NewEnforcer(
+				&license.TestingKnobs{
+					Enable:                    true,
+					OverrideStartTime:         &tc.gracePeriodInit,
+					OverrideThrottleCheckTime: &tc.checkTs,
+				})
 			e.SetTelemetryStatusReporter(&mockTelemetryStatusReporter{
 				lastPingTime: tc.lastTelemetryPingTime,
 			})
@@ -296,7 +315,7 @@ func TestThrottleErrorMsg(t *testing.T) {
 	defer srv.Stopper().Stop(ctx)
 
 	// Set up a free license that will expire in 30 days
-	licenseEnforcer := srv.SystemLayer().ExecutorConfig().(sql.ExecutorConfig).LicenseEnforcer
+	licenseEnforcer := srv.ApplicationLayer().ExecutorConfig().(sql.ExecutorConfig).LicenseEnforcer
 	licenseEnforcer.RefreshForLicenseChange(ctx, license.LicTypeFree, t30d)
 
 	for _, tc := range []struct {

--- a/pkg/server/license/opts.go
+++ b/pkg/server/license/opts.go
@@ -1,0 +1,56 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package license
+
+import "github.com/cockroachdb/cockroach/pkg/sql/isql"
+
+type options struct {
+	db                      isql.DB
+	isSystemTenant          bool
+	testingKnobs            *TestingKnobs
+	telemetryStatusReporter TelemetryStatusReporter
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type optionFunc func(*options)
+
+func (f optionFunc) apply(o *options) {
+	f(o)
+}
+
+func WithDB(db isql.DB) Option {
+	return optionFunc(func(o *options) {
+		o.db = db
+	})
+}
+
+func WithSystemTenant(v bool) Option {
+	return optionFunc(func(o *options) {
+		o.isSystemTenant = v
+	})
+}
+
+func WithTestingKnobs(tk *TestingKnobs) Option {
+	return optionFunc(func(o *options) {
+		if tk != nil {
+			o.testingKnobs = tk
+		}
+	})
+}
+
+func WithTelemetryStatusReporter(r TelemetryStatusReporter) Option {
+	return optionFunc(func(o *options) {
+		o.telemetryStatusReporter = r
+	})
+}

--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -357,6 +357,7 @@ func makeSharedProcessTenantServerConfig(
 	sqlCfg.LocalKVServerInfo = &kvServerInfo
 
 	sqlCfg.NodeMetricsRecorder = nodeMetricsRecorder
+	sqlCfg.LicenseEnforcer = kvServerCfg.SQLConfig.LicenseEnforcer
 
 	return baseCfg, sqlCfg, nil
 }

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1037,7 +1037,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		NodeDescs:                  cfg.nodeDescs,
 		TenantCapabilitiesReader:   cfg.tenantCapabilitiesReader,
 		AutoConfigProvider:         cfg.AutoConfigProvider,
-		LicenseEnforcer:            license.GetEnforcerInstance(),
+		LicenseEnforcer:            cfg.SQLConfig.LicenseEnforcer,
 		CidrLookup:                 cfg.BaseConfig.CidrLookup,
 	}
 
@@ -1911,23 +1911,23 @@ func (s *SQLServer) startLicenseEnforcer(ctx context.Context, knobs base.Testing
 	// Start the license enforcer. This is only started for the system tenant since
 	// it requires access to the system keyspace. For secondary tenants, this struct
 	// is shared to provide access to the values cached from the KV read.
-	if s.execCfg.Codec.ForSystemTenant() {
-		licenseEnforcer := s.execCfg.LicenseEnforcer
-		if knobs.Server != nil {
-			s.execCfg.LicenseEnforcer.SetTestingKnobs(&knobs.Server.(*TestingKnobs).LicenseTestingKnobs)
-		}
-		licenseEnforcer.SetTelemetryStatusReporter(s.diagnosticsReporter)
-		// TODO(spilchen): we need to tell the license enforcer about the
-		// diagnostics reporter. This will be handled in CRDB-39991
-		err := startup.RunIdempotentWithRetry(ctx, s.stopper.ShouldQuiesce(), "license enforcer start",
-			func(ctx context.Context) error {
-				return licenseEnforcer.Start(ctx, s.cfg.Settings, s.internalDB)
-			})
-		// This is not a critical component. If it fails to start, we log a warning
-		// rather than prevent the entire server from starting.
-		if err != nil {
-			log.Warningf(ctx, "failed to start the license enforcer: %v", err)
-		}
+	licenseEnforcer := s.execCfg.LicenseEnforcer
+	opts := []license.Option{
+		license.WithDB(s.internalDB),
+		license.WithSystemTenant(s.execCfg.Codec.ForSystemTenant()),
+		license.WithTelemetryStatusReporter(s.diagnosticsReporter),
+	}
+	if knobs.Server != nil {
+		opts = append(opts, license.WithTestingKnobs(&knobs.Server.(*TestingKnobs).LicenseTestingKnobs))
+	}
+	err := startup.RunIdempotentWithRetry(ctx, s.stopper.ShouldQuiesce(), "license enforcer start",
+		func(ctx context.Context) error {
+			return licenseEnforcer.Start(ctx, s.cfg.Settings, opts...)
+		})
+	// This is not a critical component. If it fails to start, we log a warning
+	// rather than prevent the entire server from starting.
+	if err != nil {
+		log.Warningf(ctx, "failed to start the license enforcer: %v", err)
 	}
 }
 

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -642,6 +642,7 @@ func (ts *testServer) startDefaultTestTenant(
 
 	if ts.params.Knobs.Server != nil {
 		params.TestingKnobs.Server.(*TestingKnobs).DiagnosticsTestingKnobs = ts.params.Knobs.Server.(*TestingKnobs).DiagnosticsTestingKnobs
+		params.TestingKnobs.Server.(*TestingKnobs).LicenseTestingKnobs = ts.params.Knobs.Server.(*TestingKnobs).LicenseTestingKnobs
 	}
 	return ts.StartTenant(ctx, params)
 }
@@ -657,6 +658,7 @@ func (ts *testServer) getSharedProcessDefaultTenantArgs() base.TestSharedProcess
 	args.Knobs.Server = &TestingKnobs{}
 	if ts.params.Knobs.Server != nil {
 		args.Knobs.Server.(*TestingKnobs).DiagnosticsTestingKnobs = ts.params.Knobs.Server.(*TestingKnobs).DiagnosticsTestingKnobs
+		args.Knobs.Server.(*TestingKnobs).LicenseTestingKnobs = ts.params.Knobs.Server.(*TestingKnobs).LicenseTestingKnobs
 	}
 	return args
 }

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -347,7 +347,7 @@ func startConnExecutor(
 		StmtDiagnosticsRecorder: stmtdiagnostics.NewRegistry(nil, st),
 		HistogramWindowInterval: base.DefaultHistogramWindowInterval(),
 		CollectionFactory:       collectionFactory,
-		LicenseEnforcer:         license.GetEnforcerInstance(),
+		LicenseEnforcer:         license.NewEnforcer(nil),
 	}
 
 	s := NewServer(cfg, pool)


### PR DESCRIPTION
Backport 1/1 commits from #131347.

/cc @cockroachdb/release

---

Previously, the license enforcer was not initialized for secondary tenants. There are two modes for secondary tenants: when the tenant runs as a separate process from the system tenant (serverless), and when it shares the same process. In the shared process mode, the enforcer relied on a shared singleton—initialized for the system tenant and reused for secondary tenants. However, when the secondary tenant runs in a separate process (serverless), the enforcer had throttling fully disabled.

This change is the first step in supporting serverless. The main challenge in allowing secondary tenants to initialize the enforcer is that they don’t have access to the KV key stored in the system keyspace, which records the grace period's end when no license is installed. This change doesn’t resolve that yet, but it sets the foundation for future work. For now, it estimates the grace period by setting it to 7 days from the time the enforcer is created.

Several changes were made to support serverless in this form:
- Call the enforcer’s `Start()` function for secondary tenants as well.
- Allow `Start()` to be called multiple times.
- Move all parameters for `Start` into an options struct.
- Remove the enforcer singleton, as it caused more issues (especially in tests) than benefits.
- Secondary tenants that share the same process will still share the same enforcer, but now the enforcer is passed around by storing a copy in `SQLConfig`.

This change will be backported to 24.2, 24.1, 23.2 and 23.1.

Epic: CRDB-39988
Informs: CRDB-42309
Release note: None
Release justification: This work is part of the CockroachDB core deprecation.