### PR TITLE
roachprod, azure: combine location and zone flags

### DIFF
--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -534,22 +534,15 @@ func (s *ClusterSpec) SetRoachprodOptsZones(
 		providerOpts.(*gce.ProviderOpts).Zones = zones
 		workloadProviderOpts.(*gce.ProviderOpts).Zones = zones
 	case Azure:
-		// Azure splits up the availability zone from the region and roachprod
-		// assumes that only one zone is ever used. So we're not actually changing
-		// the zone here, just the region.
-		// TODO(darrylwong): we should support multiple zones. To keep things
-		// consistent amongst clouds, we could keep the zone=region+az convention
-		// and parse it at the provider level.
 		if len(zones) == 0 {
 			if !s.Geo {
-				zones = azure.DefaultLocations[:1]
+				zones = azure.DefaultZones[:1]
 			} else {
-				zones = azure.DefaultLocations
+				zones = azure.DefaultZones
 			}
 		}
-		// Azure accepts
-		providerOpts.(*azure.ProviderOpts).Locations = zones
-		workloadProviderOpts.(*azure.ProviderOpts).Locations = zones
+		providerOpts.(*azure.ProviderOpts).Zones = zones
+		workloadProviderOpts.(*azure.ProviderOpts).Zones = zones
 	}
 	return providerOpts, workloadProviderOpts
 }

--- a/pkg/roachprod/vm/azure/BUILD.bazel
+++ b/pkg/roachprod/vm/azure/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "@com_github_azure_go_autorest_autorest_to//:to",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_spf13_pflag//:pflag",
+        "@org_golang_x_exp//maps",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -285,6 +286,45 @@ func (p *Provider) editLabels(
 	return nil
 }
 
+type Zone struct {
+	Location         string
+	AvailabilityZone string
+}
+
+func (z Zone) String() string {
+	return fmt.Sprintf("%s-%s", z.Location, z.AvailabilityZone)
+}
+
+func parseZones(opts vm.CreateOpts, providerOpts *ProviderOpts) ([]Zone, error) {
+	zonesFlag, err := vm.ExpandZonesFlag(providerOpts.Zones)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(zonesFlag) == 0 {
+		if opts.GeoDistributed {
+			zonesFlag = DefaultZones
+		} else {
+			zonesFlag = []string{DefaultZones[0]}
+		}
+	}
+
+	var zones []Zone
+	for _, z := range zonesFlag {
+		parts := strings.Split(z, "-")
+		// TODO(darrylwong): Many Azure regions don't actually support Availability Zones.
+		// However the assumption that they all do is made throughout our creation logic.
+		// This means that we can't create VMs in regions that don't support Availability Zones.
+		// We should support this, but a cleaner solution would be to rework the creation logic
+		// to use Terraform instead which will also support geo-distributed clusters.
+		if len(parts) != 2 {
+			return nil, errors.Errorf("parseZones: invalid zone %s. Zones should be of format Location-AvailabilityZone", z)
+		}
+		zones = append(zones, Zone{Location: parts[0], AvailabilityZone: parts[1]})
+	}
+	return zones, nil
+}
+
 // Create implements vm.Provider.
 func (p *Provider) Create(
 	l *logger.Logger, names []string, opts vm.CreateOpts, vmProviderOpts vm.ProviderOpts,
@@ -317,37 +357,39 @@ func (p *Provider) Create(
 	ctx, cancel := context.WithTimeout(context.Background(), p.OperationTimeout)
 	defer cancel()
 
-	if len(providerOpts.Locations) == 0 {
-		if opts.GeoDistributed {
-			providerOpts.Locations = DefaultLocations
-		} else {
-			providerOpts.Locations = []string{DefaultLocations[0]}
-		}
-	}
-
-	if len(providerOpts.Zone) == 0 {
-		providerOpts.Zone = defaultZone
-	}
-
-	if _, err := p.createVNets(l, ctx, providerOpts.Locations, *providerOpts); err != nil {
+	zones, err := parseZones(opts, providerOpts)
+	if err != nil {
 		return err
 	}
 
-	// Effectively a map of node number to location.
-	nodeLocations := vm.ZonePlacement(len(providerOpts.Locations), len(names))
+	// Effectively a map of node number to zone.
+	nodeZones := vm.ZonePlacement(len(zones), len(names))
 	// Invert it.
-	nodesByLocIdx := make(map[int][]int, len(providerOpts.Locations))
-	for nodeIdx, locIdx := range nodeLocations {
-		nodesByLocIdx[locIdx] = append(nodesByLocIdx[locIdx], nodeIdx)
+	zoneToHostNames := make(map[Zone][]string, min(len(zones), len(names)))
+	for i, name := range names {
+		zone := zones[nodeZones[i]]
+		zoneToHostNames[zone] = append(zoneToHostNames[zone], name)
+	}
+
+	var usedZones []string
+	for zone := range zoneToHostNames {
+		usedZones = append(usedZones, zone.String())
+	}
+	l.Printf("Creating %d instances, distributed across [%s]", len(names), strings.Join(usedZones, ", "))
+
+	uniqueLocations := make(map[string]struct{})
+	for zone := range zoneToHostNames {
+		uniqueLocations[zone.Location] = struct{}{}
+	}
+
+	if _, err := p.createVNets(l, ctx, maps.Keys(uniqueLocations), *providerOpts); err != nil {
+		return err
 	}
 
 	errs, _ := errgroup.WithContext(ctx)
-	for locIdx, nodes := range nodesByLocIdx {
-		// Shadow variables for closure.
-		locIdx := locIdx
-		nodes := nodes
+	for zone, nodes := range zoneToHostNames {
 		errs.Go(func() error {
-			location := providerOpts.Locations[locIdx]
+			location := zone.Location
 
 			// Create a resource group within the location.
 			group, err := p.getOrCreateResourceGroup(ctx, getClusterResourceGroupName(location), location, clusterTags)
@@ -365,10 +407,9 @@ func (p *Provider) Create(
 				return errors.Errorf("missing subnet for location %q", location)
 			}
 
-			for _, nodeIdx := range nodes {
-				name := names[nodeIdx]
+			for _, name := range nodes {
 				errs.Go(func() error {
-					_, err := p.createVM(l, ctx, group, subnet, name, sshKey, opts, *providerOpts)
+					_, err := p.createVM(l, ctx, group, subnet, name, sshKey, zone, opts, *providerOpts)
 					err = errors.Wrapf(err, "creating VM %s", name)
 					if err == nil {
 						l.Printf("created VM %s", name)
@@ -737,6 +778,7 @@ func (p *Provider) createVM(
 	group resources.Group,
 	subnet network.Subnet,
 	name, sshKey string,
+	zone Zone,
 	opts vm.CreateOpts,
 	providerOpts ProviderOpts,
 ) (machine compute.VirtualMachine, err error) {
@@ -767,7 +809,7 @@ func (p *Provider) createVM(
 	}
 
 	// We first need to allocate a NIC to give the VM network access
-	ip, err := p.createIP(l, ctx, group, name, providerOpts)
+	ip, err := p.createIP(l, ctx, group, name, zone)
 	if err != nil {
 		return compute.VirtualMachine{}, err
 	}
@@ -808,7 +850,7 @@ func (p *Provider) createVM(
 	// https://github.com/Azure-Samples/azure-sdk-for-go-samples/blob/79e3f3af791c3873d810efe094f9d61e93a6ccaa/compute/vm.go#L41
 	machine = compute.VirtualMachine{
 		Location: group.Location,
-		Zones:    to.StringSlicePtr([]string{providerOpts.Zone}),
+		Zones:    to.StringSlicePtr([]string{zone.AvailabilityZone}),
 		Tags:     tags,
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
 			HardwareProfile: &compute.HardwareProfile{
@@ -889,7 +931,7 @@ func (p *Provider) createVM(
 		switch providerOpts.NetworkDiskType {
 		case "ultra-disk":
 			var ultraDisk compute.Disk
-			ultraDisk, err = p.createUltraDisk(l, ctx, group, name+"-ultra-disk", providerOpts)
+			ultraDisk, err = p.createUltraDisk(l, ctx, group, name+"-ultra-disk", zone, providerOpts)
 			if err != nil {
 				return compute.VirtualMachine{}, err
 			}
@@ -1173,7 +1215,7 @@ func (p *Provider) createVNets(
 	}
 	newSubnetsCreated := false
 
-	for _, location := range providerOpts.Locations {
+	for _, location := range locations {
 		group, _ := p.getResourcesAndSecurityGroupByName(vnetResourceGroupName(location), "")
 		// Prefix already exists for the resource group.
 		if prefixString := group.Tags[tagSubnet]; prefixString != nil {
@@ -1352,11 +1394,7 @@ func (p *Provider) createVNetPeerings(
 
 // createIP allocates an IP address that will later be bound to a NIC.
 func (p *Provider) createIP(
-	l *logger.Logger,
-	ctx context.Context,
-	group resources.Group,
-	name string,
-	providerOpts ProviderOpts,
+	l *logger.Logger, ctx context.Context, group resources.Group, name string, zone Zone,
 ) (ip network.PublicIPAddress, err error) {
 	sub, err := p.getSubscription(ctx)
 	if err != nil {
@@ -1373,7 +1411,7 @@ func (p *Provider) createIP(
 				Name: network.PublicIPAddressSkuNameStandard,
 			},
 			Location: group.Location,
-			Zones:    to.StringSlicePtr([]string{providerOpts.Zone}),
+			Zones:    to.StringSlicePtr([]string{zone.AvailabilityZone}),
 			PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 				PublicIPAddressVersion:   network.IPv4,
 				PublicIPAllocationMethod: network.Static,
@@ -1511,6 +1549,7 @@ func (p *Provider) createUltraDisk(
 	ctx context.Context,
 	group resources.Group,
 	name string,
+	zone Zone,
 	providerOpts ProviderOpts,
 ) (compute.Disk, error) {
 	sub, err := p.getSubscription(ctx)
@@ -1525,7 +1564,7 @@ func (p *Provider) createUltraDisk(
 
 	future, err := client.CreateOrUpdate(ctx, *group.Name, name,
 		compute.Disk{
-			Zones:    to.StringSlicePtr([]string{providerOpts.Zone}),
+			Zones:    to.StringSlicePtr([]string{zone.AvailabilityZone}),
 			Location: group.Location,
 			Sku: &compute.DiskSku{
 				Name: compute.UltraSSDLRS,

--- a/pkg/roachprod/vm/azure/flags.go
+++ b/pkg/roachprod/vm/azure/flags.go
@@ -21,10 +21,12 @@ import (
 
 // ProviderOpts provides user-configurable, azure-specific create options.
 type ProviderOpts struct {
-	Locations       []string
+	// N.B. Azure splits up the region (location) and availability zone, but
+	// to keep things consistent with other providers, we treat zone to mean
+	// both and split it up later.
+	Zones           []string
 	MachineType     string
 	VnetName        string
-	Zone            string
 	NetworkDiskType string
 	NetworkDiskSize int32
 	UltraDiskIOPS   int64
@@ -34,21 +36,18 @@ type ProviderOpts struct {
 // These default locations support availability zones. At the time of
 // this comment, `westus` did not and `westus2` is consistently out of
 // capacity.
-var DefaultLocations = []string{
-	"eastus",
-	"canadacentral",
-	"westus3",
+var DefaultZones = []string{
+	"eastus-1",
+	"canadacentral-1",
+	"westus3-1",
 }
-
-var defaultZone = "1"
 
 // DefaultProviderOpts returns a new azure.ProviderOpts with default values set.
 func DefaultProviderOpts() *ProviderOpts {
 	return &ProviderOpts{
-		Locations:       nil,
+		Zones:           nil,
 		MachineType:     string(armcompute.VirtualMachineSizeTypesStandardD4V3),
 		VnetName:        "common",
-		Zone:            "",
 		NetworkDiskType: "premium-disk",
 		NetworkDiskSize: 500,
 		UltraDiskIOPS:   5000,
@@ -70,12 +69,14 @@ func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&o.MachineType, ProviderName+"-machine-type",
 		string(armcompute.VirtualMachineSizeTypesStandardD4V3),
 		"Machine type (see https://azure.microsoft.com/en-us/pricing/details/virtual-machines/linux/)")
-	flags.StringSliceVar(&o.Locations, ProviderName+"-locations", nil,
-		fmt.Sprintf("Locations for cluster (see `az account list-locations`) (default\n[%s])",
-			strings.Join(DefaultLocations, ",")))
+	flags.StringSliceVar(&o.Zones, ProviderName+"-zones", nil,
+		fmt.Sprintf("Zones for cluster, where a zone is a location (see `az account list-locations`)\n"+
+			"and availability zone seperated by a dash. If zones are formatted as Location-AZ:N where N is an integer,\n"+
+			"the zone will be repeated N times. If > 1 zone specified, nodes will be geo-distributed\n"+
+			"regardless of geo (default [%s])",
+			strings.Join(DefaultZones, ",")))
 	flags.StringVar(&o.VnetName, ProviderName+"-vnet-name", "common",
 		"The name of the VNet to use")
-	flags.StringVar(&o.Zone, ProviderName+"-availability-zone", "", "Availability Zone to create VMs in")
 	flags.StringVar(&o.NetworkDiskType, ProviderName+"-network-disk-type", "premium-disk",
 		"type of network disk [premium-disk, ultra-disk]. only used if local-ssd is false")
 	flags.Int32Var(&o.NetworkDiskSize, ProviderName+"-volume-size", 500,


### PR DESCRIPTION
When creating a VM in azure, a location and availabilty zone must be specified. This is different from other clouds where a single zone is specified that contains information about both.

Previously, roachprod had flags for locations and an availabilty zone. This had the limitation of only allowing one availabilty zone to be used for a cluster. It also meant specifiying a location+zone for azure took two flags compared to one for other clouds.

This change combines the two, exposing only a single zone flag to the user. It handles splitting the location and availabilty zone in the azure VM creation logic instead.

Release note: none
Epic: none
Fixes: none