### PR TITLE
raft: send de-fortification requests with the correct term

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -851,13 +851,10 @@ func (r *raft) sendDeFortify(to pb.PeerID) {
 	if to == r.id {
 		// We handle the case where the leader is trying to de-fortify itself
 		// specially. Doing so avoids a self-addressed message.
-		// TODO(arul): Same comment as below. This r.Term is incorrect.
-		r.deFortify(r.id, r.Term)
+		r.deFortify(r.id, r.fortificationTracker.Term())
 		return
 	}
-	// TODO(arul): instead of the current term, we need to freeze it when the
-	// leader steps down and copy that over here instead.
-	r.send(pb.Message{To: to, Type: pb.MsgDeFortifyLeader, Term: r.Term})
+	r.send(pb.Message{To: to, Type: pb.MsgDeFortifyLeader, Term: r.fortificationTracker.Term()})
 }
 
 // bcastAppend sends RPC, with entries to all peers that are not up-to-date
@@ -1004,12 +1001,6 @@ func (r *raft) reset(term uint64) {
 		r.Vote = None
 		r.lead = None
 		r.leadEpoch = 0
-		// TODO(arul): We'll only want to reset the fortification tracker when we're
-		// stepping up to become the leader again. This allows us to de-fortify any
-		// followers that may still be providing us support once we've stepped down,
-		// as the state of who to de-fortify, when to de-fortify, and which term to
-		// de-fortify for will be stored in the fortificationTracker.
-		r.fortificationTracker.Reset()
 	}
 
 	r.electionElapsed = 0
@@ -1223,6 +1214,11 @@ func (r *raft) becomeLeader() {
 	}
 	r.step = stepLeader
 	r.reset(r.Term)
+	// NB: The fortificationTracker holds state from a peer's leadership stint
+	// that's acted upon after it has stepped down. We reset it right before
+	// stepping up to become leader again, but not when stepping down as leader
+	// and not even when learning of a leader in a later term.
+	r.fortificationTracker.Reset(r.Term)
 	r.tick = r.tickHeartbeat
 	r.lead = r.id
 	r.state = StateLeader
@@ -1607,11 +1603,12 @@ func stepLeader(r *raft, m pb.Message) error {
 		if !quorumActiveByHeartbeats && !quorumActiveByFortification {
 			r.logger.Warningf("%x stepped down to follower since quorum is not active", r.id)
 			// NB: Stepping down because of CheckQuorum is a special, in that we know
-			// the LeadSupportUntil is in the past. This means that the leader can safely call a
-			// new election or vote for a different peer without regressing LeadSupportUntil.
-			// We don't need to/want to give this any special treatment -- instead, we
-			// handle this like the general step down case by simply remembering the
-			// term/lead information from our stint as the leader.
+			// the LeadSupportUntil is in the past. This means that the leader can
+			// safely call a new election or vote for a different peer without
+			// regressing LeadSupportUntil. We don't need to/want to give this any
+			// special treatment -- instead, we handle this like the general step down
+			// case by simply remembering the term/lead information from our stint as
+			// the leader.
 			r.becomeFollower(r.Term, r.id)
 		}
 		// Mark everyone (but ourselves) as inactive in preparation for the next

--- a/pkg/raft/testdata/de_fortification_basic.txt
+++ b/pkg/raft/testdata/de_fortification_basic.txt
@@ -932,3 +932,552 @@ raft-state
 1: StateFollower (Voter) Term:4 Lead:3 LeadEpoch:1
 2: StateFollower (Voter) Term:4 Lead:3 LeadEpoch:1
 3: StateLeader (Voter) Term:4 Lead:3 LeadEpoch:1
+
+# Ensure that the leader sends out MsgDeFortifyLeader messages for the correct
+# term. In particular, the term from its leadership stint (2), not the term
+# currently known to it.
+
+# 2 was the leader above.
+print-fortification-state 2
+----
+1 : 1
+2 : 1
+3 : 1
+
+send-de-fortify 2 1
+----
+ok
+
+send-de-fortify 2 3
+----
+ok
+
+stabilize
+----
+> 2 handling Ready
+  Ready MustSync=false:
+  Messages:
+  2->1 MsgDeFortifyLeader Term:2 Log:0/0
+  2->3 MsgDeFortifyLeader Term:2 Log:0/0
+> 1 receiving messages
+  2->1 MsgDeFortifyLeader Term:2 Log:0/0
+  INFO 1 [term: 4] ignored a MsgDeFortifyLeader message with lower term from 2 [term: 2]
+> 3 receiving messages
+  2->3 MsgDeFortifyLeader Term:2 Log:0/0
+  INFO 3 [term: 4] ignored a MsgDeFortifyLeader message with lower term from 2 [term: 2]
+
+# Ensure that when 2 steps up, steps down, and then de-fortifies again, it does
+# so at the correct term.
+bump-epoch 3
+----
+  1 2 3
+1 3 1 2
+2 3 1 2
+3 x 1 2
+
+campaign 2
+----
+INFO 2 is starting a new election at term 4
+INFO 2 became candidate at term 5
+INFO 2 [logterm: 4, index: 5] sent MsgVote request to 1 at term 5
+INFO 2 [logterm: 4, index: 5] sent MsgVote request to 3 at term 5
+
+stabilize
+----
+> 2 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:5 Vote:2 Commit:5 Lead:0 LeadEpoch:0
+  Messages:
+  2->1 MsgVote Term:5 Log:4/5
+  2->3 MsgVote Term:5 Log:4/5
+  2->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:5 Vote:2 Responses:[
+    2->2 MsgVoteResp Term:5 Log:0/0
+  ]
+> 1 receiving messages
+  2->1 MsgVote Term:5 Log:4/5
+  INFO 1 [term: 4] received a MsgVote message with higher term from 2 [term: 5]
+  INFO 1 became follower at term 5
+  INFO 1 [logterm: 4, index: 5, vote: 0] cast MsgVote for 2 [logterm: 4, index: 5] at term 5
+> 3 receiving messages
+  2->3 MsgVote Term:5 Log:4/5
+  INFO 3 [term: 4] received a MsgVote message with higher term from 2 [term: 5]
+  INFO 3 became follower at term 5
+  INFO 3 [logterm: 4, index: 5, vote: 0] cast MsgVote for 2 [logterm: 4, index: 5] at term 5
+> 2 processing append thread
+  Processing:
+  2->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:5 Vote:2
+  Responses:
+  2->2 MsgVoteResp Term:5 Log:0/0
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:5 Vote:2 Commit:5 Lead:0 LeadEpoch:0
+  Messages:
+  1->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:5 Vote:2 Responses:[
+    1->2 MsgVoteResp Term:5 Log:0/0
+  ]
+> 3 handling Ready
+  Ready MustSync=true:
+  State:StateFollower
+  HardState Term:5 Vote:2 Commit:5 Lead:0 LeadEpoch:0
+  Messages:
+  3->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:5 Vote:2 Responses:[
+    3->2 MsgVoteResp Term:5 Log:0/0
+  ]
+> 2 receiving messages
+  2->2 MsgVoteResp Term:5 Log:0/0
+  INFO 2 received MsgVoteResp from 2 at term 5
+  INFO 2 has received 1 MsgVoteResp votes and 0 vote rejections
+> 1 processing append thread
+  Processing:
+  1->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:5 Vote:2
+  Responses:
+  1->2 MsgVoteResp Term:5 Log:0/0
+> 3 processing append thread
+  Processing:
+  3->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:5 Vote:2
+  Responses:
+  3->2 MsgVoteResp Term:5 Log:0/0
+> 2 receiving messages
+  1->2 MsgVoteResp Term:5 Log:0/0
+  INFO 2 received MsgVoteResp from 1 at term 5
+  INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
+  INFO 2 became leader at term 5
+  3->2 MsgVoteResp Term:5 Log:0/0
+> 2 handling Ready
+  Ready MustSync=true:
+  State:StateLeader
+  HardState Term:5 Vote:2 Commit:5 Lead:2 LeadEpoch:1
+  Entries:
+  5/6 EntryNormal ""
+  Messages:
+  2->1 MsgFortifyLeader Term:5 Log:0/0
+  2->3 MsgFortifyLeader Term:5 Log:0/0
+  2->1 MsgApp Term:5 Log:4/5 Commit:5 Entries:[5/6 EntryNormal ""]
+  2->3 MsgApp Term:5 Log:4/5 Commit:5 Entries:[5/6 EntryNormal ""]
+  2->AppendThread MsgStorageAppend Term:5 Log:5/6 Commit:5 Vote:2 Lead:2 LeadEpoch:1 Entries:[5/6 EntryNormal ""] Responses:[
+    2->2 MsgAppResp Term:5 Log:0/6 Commit:5
+    2->2 MsgFortifyLeaderResp Term:5 Log:0/0 LeadEpoch:1
+    AppendThread->2 MsgStorageAppendResp Term:0 Log:5/6
+  ]
+> 1 receiving messages
+  2->1 MsgFortifyLeader Term:5 Log:0/0
+  2->1 MsgApp Term:5 Log:4/5 Commit:5 Entries:[5/6 EntryNormal ""]
+> 3 receiving messages
+  2->3 MsgFortifyLeader Term:5 Log:0/0
+  2->3 MsgApp Term:5 Log:4/5 Commit:5 Entries:[5/6 EntryNormal ""]
+> 2 processing append thread
+  Processing:
+  2->AppendThread MsgStorageAppend Term:5 Log:5/6 Commit:5 Vote:2 Lead:2 LeadEpoch:1 Entries:[5/6 EntryNormal ""]
+  Responses:
+  2->2 MsgAppResp Term:5 Log:0/6 Commit:5
+  2->2 MsgFortifyLeaderResp Term:5 Log:0/0 LeadEpoch:1
+  AppendThread->2 MsgStorageAppendResp Term:0 Log:5/6
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:5 Vote:2 Commit:5 Lead:2 LeadEpoch:1
+  Entries:
+  5/6 EntryNormal ""
+  Messages:
+  1->AppendThread MsgStorageAppend Term:5 Log:5/6 Commit:5 Vote:2 Lead:2 LeadEpoch:1 Entries:[5/6 EntryNormal ""] Responses:[
+    1->2 MsgFortifyLeaderResp Term:5 Log:0/0 LeadEpoch:1
+    1->2 MsgAppResp Term:5 Log:0/6 Commit:5
+    AppendThread->1 MsgStorageAppendResp Term:0 Log:5/6
+  ]
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:5 Vote:2 Commit:5 Lead:2 LeadEpoch:1
+  Entries:
+  5/6 EntryNormal ""
+  Messages:
+  3->AppendThread MsgStorageAppend Term:5 Log:5/6 Commit:5 Vote:2 Lead:2 LeadEpoch:1 Entries:[5/6 EntryNormal ""] Responses:[
+    3->2 MsgFortifyLeaderResp Term:5 Log:0/0 LeadEpoch:1
+    3->2 MsgAppResp Term:5 Log:0/6 Commit:5
+    AppendThread->3 MsgStorageAppendResp Term:0 Log:5/6
+  ]
+> 2 receiving messages
+  2->2 MsgAppResp Term:5 Log:0/6 Commit:5
+  2->2 MsgFortifyLeaderResp Term:5 Log:0/0 LeadEpoch:1
+  AppendThread->2 MsgStorageAppendResp Term:0 Log:5/6
+> 1 processing append thread
+  Processing:
+  1->AppendThread MsgStorageAppend Term:5 Log:5/6 Commit:5 Vote:2 Lead:2 LeadEpoch:1 Entries:[5/6 EntryNormal ""]
+  Responses:
+  1->2 MsgFortifyLeaderResp Term:5 Log:0/0 LeadEpoch:1
+  1->2 MsgAppResp Term:5 Log:0/6 Commit:5
+  AppendThread->1 MsgStorageAppendResp Term:0 Log:5/6
+> 3 processing append thread
+  Processing:
+  3->AppendThread MsgStorageAppend Term:5 Log:5/6 Commit:5 Vote:2 Lead:2 LeadEpoch:1 Entries:[5/6 EntryNormal ""]
+  Responses:
+  3->2 MsgFortifyLeaderResp Term:5 Log:0/0 LeadEpoch:1
+  3->2 MsgAppResp Term:5 Log:0/6 Commit:5
+  AppendThread->3 MsgStorageAppendResp Term:0 Log:5/6
+> 1 receiving messages
+  AppendThread->1 MsgStorageAppendResp Term:0 Log:5/6
+> 2 receiving messages
+  1->2 MsgFortifyLeaderResp Term:5 Log:0/0 LeadEpoch:1
+  1->2 MsgAppResp Term:5 Log:0/6 Commit:5
+  3->2 MsgFortifyLeaderResp Term:5 Log:0/0 LeadEpoch:1
+  3->2 MsgAppResp Term:5 Log:0/6 Commit:5
+> 3 receiving messages
+  AppendThread->3 MsgStorageAppendResp Term:0 Log:5/6
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:5 Vote:2 Commit:6 Lead:2 LeadEpoch:1
+  CommittedEntries:
+  5/6 EntryNormal ""
+  Messages:
+  2->1 MsgApp Term:5 Log:5/6 Commit:6
+  2->3 MsgApp Term:5 Log:5/6 Commit:6
+  2->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:6 Vote:2 Lead:2 LeadEpoch:1
+  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[5/6 EntryNormal ""] Responses:[
+    ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[5/6 EntryNormal ""]
+  ]
+> 1 receiving messages
+  2->1 MsgApp Term:5 Log:5/6 Commit:6
+> 3 receiving messages
+  2->3 MsgApp Term:5 Log:5/6 Commit:6
+> 2 processing append thread
+  Processing:
+  2->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:6 Vote:2 Lead:2 LeadEpoch:1
+  Responses:
+> 2 processing apply thread
+  Processing:
+  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[5/6 EntryNormal ""]
+  Responses:
+  ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[5/6 EntryNormal ""]
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:5 Vote:2 Commit:6 Lead:2 LeadEpoch:1
+  CommittedEntries:
+  5/6 EntryNormal ""
+  Messages:
+  1->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:6 Vote:2 Lead:2 LeadEpoch:1 Responses:[
+    1->2 MsgAppResp Term:5 Log:0/6 Commit:6
+  ]
+  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[5/6 EntryNormal ""] Responses:[
+    ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[5/6 EntryNormal ""]
+  ]
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:5 Vote:2 Commit:6 Lead:2 LeadEpoch:1
+  CommittedEntries:
+  5/6 EntryNormal ""
+  Messages:
+  3->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:6 Vote:2 Lead:2 LeadEpoch:1 Responses:[
+    3->2 MsgAppResp Term:5 Log:0/6 Commit:6
+  ]
+  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[5/6 EntryNormal ""] Responses:[
+    ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[5/6 EntryNormal ""]
+  ]
+> 2 receiving messages
+  ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[5/6 EntryNormal ""]
+> 1 processing append thread
+  Processing:
+  1->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:6 Vote:2 Lead:2 LeadEpoch:1
+  Responses:
+  1->2 MsgAppResp Term:5 Log:0/6 Commit:6
+> 3 processing append thread
+  Processing:
+  3->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:6 Vote:2 Lead:2 LeadEpoch:1
+  Responses:
+  3->2 MsgAppResp Term:5 Log:0/6 Commit:6
+> 1 processing apply thread
+  Processing:
+  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[5/6 EntryNormal ""]
+  Responses:
+  ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[5/6 EntryNormal ""]
+> 3 processing apply thread
+  Processing:
+  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[5/6 EntryNormal ""]
+  Responses:
+  ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[5/6 EntryNormal ""]
+> 1 receiving messages
+  ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[5/6 EntryNormal ""]
+> 2 receiving messages
+  1->2 MsgAppResp Term:5 Log:0/6 Commit:6
+  3->2 MsgAppResp Term:5 Log:0/6 Commit:6
+> 3 receiving messages
+  ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[5/6 EntryNormal ""]
+
+raft-state
+----
+1: StateFollower (Voter) Term:5 Lead:2 LeadEpoch:1
+2: StateLeader (Voter) Term:5 Lead:2 LeadEpoch:1
+3: StateFollower (Voter) Term:5 Lead:2 LeadEpoch:1
+
+step-down 2
+----
+INFO 2 became follower at term 5
+
+send-de-fortify 2 1
+----
+ok
+
+# NB: 2 won't vote for someone else, because even though it has stepped down, it
+# still remembers the lead/leadEpoch from its leadership stint. This is fine, as
+# typically, we'll freeze the LeadSupportUntil on leader step down, and use this
+# to determine whether we can vote or not. For now, manually withdraw support
+# for 2 from 2.
+# TODO(arul): ^ needs to be done.
+
+withdraw-support 2 2
+----
+  1 2 3
+1 3 1 2
+2 3 x 2
+3 x 1 2
+
+stabilize
+----
+> 2 handling Ready
+  Ready MustSync=false:
+  State:StateFollower
+  Messages:
+  2->1 MsgDeFortifyLeader Term:5 Log:0/0
+> 1 receiving messages
+  2->1 MsgDeFortifyLeader Term:5 Log:0/0
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:5 Vote:2 Commit:6 Lead:2 LeadEpoch:0
+  Messages:
+  1->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:6 Vote:2 Lead:2
+> 1 processing append thread
+  Processing:
+  1->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:6 Vote:2 Lead:2
+  Responses:
+
+raft-state
+----
+1: StateFollower (Voter) Term:5 Lead:2 LeadEpoch:0
+2: StateFollower (Voter) Term:5 Lead:0 LeadEpoch:1
+3: StateFollower (Voter) Term:5 Lead:2 LeadEpoch:1
+
+campaign 1
+----
+INFO 1 is starting a new election at term 5
+INFO 1 became candidate at term 6
+INFO 1 [logterm: 5, index: 6] sent MsgVote request to 2 at term 6
+INFO 1 [logterm: 5, index: 6] sent MsgVote request to 3 at term 6
+
+stabilize
+----
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:6 Vote:1 Commit:6 Lead:0 LeadEpoch:0
+  Messages:
+  1->2 MsgVote Term:6 Log:5/6
+  1->3 MsgVote Term:6 Log:5/6
+  1->AppendThread MsgStorageAppend Term:6 Log:0/0 Commit:6 Vote:1 Responses:[
+    1->1 MsgVoteResp Term:6 Log:0/0
+  ]
+> 2 receiving messages
+  1->2 MsgVote Term:6 Log:5/6
+  INFO 2 [term: 5] received a MsgVote message with higher term from 1 [term: 6]
+  INFO 2 became follower at term 6
+  INFO 2 [logterm: 5, index: 6, vote: 0] cast MsgVote for 1 [logterm: 5, index: 6] at term 6
+> 3 receiving messages
+  1->3 MsgVote Term:6 Log:5/6
+  INFO 3 [logterm: 5, index: 6, vote: 2] ignored MsgVote from 1 [logterm: 5, index: 6] at term 5: supporting fortified leader 2 at epoch 1
+> 1 processing append thread
+  Processing:
+  1->AppendThread MsgStorageAppend Term:6 Log:0/0 Commit:6 Vote:1
+  Responses:
+  1->1 MsgVoteResp Term:6 Log:0/0
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:6 Vote:1 Commit:6 Lead:0 LeadEpoch:0
+  Messages:
+  2->AppendThread MsgStorageAppend Term:6 Log:0/0 Commit:6 Vote:1 Responses:[
+    2->1 MsgVoteResp Term:6 Log:0/0
+  ]
+> 1 receiving messages
+  1->1 MsgVoteResp Term:6 Log:0/0
+  INFO 1 received MsgVoteResp from 1 at term 6
+  INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
+> 2 processing append thread
+  Processing:
+  2->AppendThread MsgStorageAppend Term:6 Log:0/0 Commit:6 Vote:1
+  Responses:
+  2->1 MsgVoteResp Term:6 Log:0/0
+> 1 receiving messages
+  2->1 MsgVoteResp Term:6 Log:0/0
+  INFO 1 received MsgVoteResp from 2 at term 6
+  INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
+  INFO 1 became leader at term 6
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateLeader
+  HardState Term:6 Vote:1 Commit:6 Lead:1 LeadEpoch:3
+  Entries:
+  6/7 EntryNormal ""
+  Messages:
+  1->2 MsgFortifyLeader Term:6 Log:0/0
+  1->2 MsgApp Term:6 Log:5/6 Commit:6 Entries:[6/7 EntryNormal ""]
+  1->3 MsgApp Term:6 Log:5/6 Commit:6 Entries:[6/7 EntryNormal ""]
+  1->AppendThread MsgStorageAppend Term:6 Log:6/7 Commit:6 Vote:1 Lead:1 LeadEpoch:3 Entries:[6/7 EntryNormal ""] Responses:[
+    1->1 MsgAppResp Term:6 Log:0/7 Commit:6
+    1->1 MsgFortifyLeaderResp Term:6 Log:0/0 LeadEpoch:3
+    AppendThread->1 MsgStorageAppendResp Term:0 Log:6/7
+  ]
+> 2 receiving messages
+  1->2 MsgFortifyLeader Term:6 Log:0/0
+  1->2 MsgApp Term:6 Log:5/6 Commit:6 Entries:[6/7 EntryNormal ""]
+> 3 receiving messages
+  1->3 MsgApp Term:6 Log:5/6 Commit:6 Entries:[6/7 EntryNormal ""]
+  INFO 3 [term: 5] received a MsgApp message with higher term from 1 [term: 6]
+  INFO 3 became follower at term 6
+> 1 processing append thread
+  Processing:
+  1->AppendThread MsgStorageAppend Term:6 Log:6/7 Commit:6 Vote:1 Lead:1 LeadEpoch:3 Entries:[6/7 EntryNormal ""]
+  Responses:
+  1->1 MsgAppResp Term:6 Log:0/7 Commit:6
+  1->1 MsgFortifyLeaderResp Term:6 Log:0/0 LeadEpoch:3
+  AppendThread->1 MsgStorageAppendResp Term:0 Log:6/7
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:6 Vote:1 Commit:6 Lead:1 LeadEpoch:3
+  Entries:
+  6/7 EntryNormal ""
+  Messages:
+  2->AppendThread MsgStorageAppend Term:6 Log:6/7 Commit:6 Vote:1 Lead:1 LeadEpoch:3 Entries:[6/7 EntryNormal ""] Responses:[
+    2->1 MsgFortifyLeaderResp Term:6 Log:0/0 LeadEpoch:3
+    2->1 MsgAppResp Term:6 Log:0/7 Commit:6
+    AppendThread->2 MsgStorageAppendResp Term:0 Log:6/7
+  ]
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:6 Commit:6 Lead:1 LeadEpoch:0
+  Entries:
+  6/7 EntryNormal ""
+  Messages:
+  3->AppendThread MsgStorageAppend Term:6 Log:6/7 Commit:6 Lead:1 Entries:[6/7 EntryNormal ""] Responses:[
+    3->1 MsgAppResp Term:6 Log:0/7 Commit:6
+    AppendThread->3 MsgStorageAppendResp Term:0 Log:6/7
+  ]
+> 1 receiving messages
+  1->1 MsgAppResp Term:6 Log:0/7 Commit:6
+  1->1 MsgFortifyLeaderResp Term:6 Log:0/0 LeadEpoch:3
+  AppendThread->1 MsgStorageAppendResp Term:0 Log:6/7
+> 2 processing append thread
+  Processing:
+  2->AppendThread MsgStorageAppend Term:6 Log:6/7 Commit:6 Vote:1 Lead:1 LeadEpoch:3 Entries:[6/7 EntryNormal ""]
+  Responses:
+  2->1 MsgFortifyLeaderResp Term:6 Log:0/0 LeadEpoch:3
+  2->1 MsgAppResp Term:6 Log:0/7 Commit:6
+  AppendThread->2 MsgStorageAppendResp Term:0 Log:6/7
+> 3 processing append thread
+  Processing:
+  3->AppendThread MsgStorageAppend Term:6 Log:6/7 Commit:6 Lead:1 Entries:[6/7 EntryNormal ""]
+  Responses:
+  3->1 MsgAppResp Term:6 Log:0/7 Commit:6
+  AppendThread->3 MsgStorageAppendResp Term:0 Log:6/7
+> 1 receiving messages
+  2->1 MsgFortifyLeaderResp Term:6 Log:0/0 LeadEpoch:3
+  2->1 MsgAppResp Term:6 Log:0/7 Commit:6
+  3->1 MsgAppResp Term:6 Log:0/7 Commit:6
+> 2 receiving messages
+  AppendThread->2 MsgStorageAppendResp Term:0 Log:6/7
+> 3 receiving messages
+  AppendThread->3 MsgStorageAppendResp Term:0 Log:6/7
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:6 Vote:1 Commit:7 Lead:1 LeadEpoch:3
+  CommittedEntries:
+  6/7 EntryNormal ""
+  Messages:
+  1->2 MsgApp Term:6 Log:6/7 Commit:7
+  1->3 MsgApp Term:6 Log:6/7 Commit:7
+  1->AppendThread MsgStorageAppend Term:6 Log:0/0 Commit:7 Vote:1 Lead:1 LeadEpoch:3
+  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[6/7 EntryNormal ""] Responses:[
+    ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[6/7 EntryNormal ""]
+  ]
+> 2 receiving messages
+  1->2 MsgApp Term:6 Log:6/7 Commit:7
+> 3 receiving messages
+  1->3 MsgApp Term:6 Log:6/7 Commit:7
+> 1 processing append thread
+  Processing:
+  1->AppendThread MsgStorageAppend Term:6 Log:0/0 Commit:7 Vote:1 Lead:1 LeadEpoch:3
+  Responses:
+> 1 processing apply thread
+  Processing:
+  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[6/7 EntryNormal ""]
+  Responses:
+  ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[6/7 EntryNormal ""]
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:6 Vote:1 Commit:7 Lead:1 LeadEpoch:3
+  CommittedEntries:
+  6/7 EntryNormal ""
+  Messages:
+  2->AppendThread MsgStorageAppend Term:6 Log:0/0 Commit:7 Vote:1 Lead:1 LeadEpoch:3 Responses:[
+    2->1 MsgAppResp Term:6 Log:0/7 Commit:7
+  ]
+  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[6/7 EntryNormal ""] Responses:[
+    ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[6/7 EntryNormal ""]
+  ]
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:6 Commit:7 Lead:1 LeadEpoch:0
+  CommittedEntries:
+  6/7 EntryNormal ""
+  Messages:
+  3->AppendThread MsgStorageAppend Term:6 Log:0/0 Commit:7 Lead:1 Responses:[
+    3->1 MsgAppResp Term:6 Log:0/7 Commit:7
+  ]
+  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[6/7 EntryNormal ""] Responses:[
+    ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[6/7 EntryNormal ""]
+  ]
+> 1 receiving messages
+  ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[6/7 EntryNormal ""]
+> 2 processing append thread
+  Processing:
+  2->AppendThread MsgStorageAppend Term:6 Log:0/0 Commit:7 Vote:1 Lead:1 LeadEpoch:3
+  Responses:
+  2->1 MsgAppResp Term:6 Log:0/7 Commit:7
+> 3 processing append thread
+  Processing:
+  3->AppendThread MsgStorageAppend Term:6 Log:0/0 Commit:7 Lead:1
+  Responses:
+  3->1 MsgAppResp Term:6 Log:0/7 Commit:7
+> 2 processing apply thread
+  Processing:
+  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[6/7 EntryNormal ""]
+  Responses:
+  ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[6/7 EntryNormal ""]
+> 3 processing apply thread
+  Processing:
+  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[6/7 EntryNormal ""]
+  Responses:
+  ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[6/7 EntryNormal ""]
+> 1 receiving messages
+  2->1 MsgAppResp Term:6 Log:0/7 Commit:7
+  3->1 MsgAppResp Term:6 Log:0/7 Commit:7
+> 2 receiving messages
+  ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[6/7 EntryNormal ""]
+> 3 receiving messages
+  ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[6/7 EntryNormal ""]
+
+raft-state
+----
+1: StateLeader (Voter) Term:6 Lead:1 LeadEpoch:3
+2: StateFollower (Voter) Term:6 Lead:1 LeadEpoch:3
+3: StateFollower (Voter) Term:6 Lead:1 LeadEpoch:0
+
+# Ensure 2 sends a MsgDeFortifyLeader at term 5 (not term 2).
+send-de-fortify 2 1
+----
+ok
+
+stabilize
+----
+> 2 handling Ready
+  Ready MustSync=false:
+  Messages:
+  2->1 MsgDeFortifyLeader Term:5 Log:0/0
+> 1 receiving messages
+  2->1 MsgDeFortifyLeader Term:5 Log:0/0
+  INFO 1 [term: 6] ignored a MsgDeFortifyLeader message with lower term from 2 [term: 5]


### PR DESCRIPTION
First 2 commits from https://github.com/cockroachdb/cockroach/pull/131668

----

Addresses a TODO, where we were plopping an incorrect term on
MsgDeFortifyLeader. A MsgDeFortifyLeader should include the leadership
term that's being de-fortified, not the currently known term to old
leader that's trying to de-fortify. To enable this, we track the term on
the FortificationTracker and ensure it's only reset when a peer steps up
to become leader again.

Informs https://github.com/cockroachdb/cockroach/issues/129098

Release note: None