### PR TITLE
server: enable `_status/connectivity` for secondary tenants (shared-process)

### DIFF
--- a/pkg/ccl/changefeedccl/mocks/tenant_status_server_generated.go
+++ b/pkg/ccl/changefeedccl/mocks/tenant_status_server_generated.go
@@ -66,6 +66,21 @@ func (mr *MockTenantStatusServerMockRecorder) HotRangesV2(arg0, arg1 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HotRangesV2", reflect.TypeOf((*MockTenantStatusServer)(nil).HotRangesV2), arg0, arg1)
 }
 
+// NetworkConnectivity mocks base method.
+func (m *MockTenantStatusServer) NetworkConnectivity(arg0 context.Context, arg1 *serverpb.NetworkConnectivityRequest) (*serverpb.NetworkConnectivityResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NetworkConnectivity", arg0, arg1)
+	ret0, _ := ret[0].(*serverpb.NetworkConnectivityResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NetworkConnectivity indicates an expected call of NetworkConnectivity.
+func (mr *MockTenantStatusServerMockRecorder) NetworkConnectivity(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkConnectivity", reflect.TypeOf((*MockTenantStatusServer)(nil).NetworkConnectivity), arg0, arg1)
+}
+
 // Nodes mocks base method.
 func (m *MockTenantStatusServer) Nodes(arg0 context.Context, arg1 *serverpb.NodesRequest) (*serverpb.NodesResponse, error) {
 	m.ctrl.T.Helper()

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -684,6 +684,17 @@ func (c *connector) TenantRanges(
 	return
 }
 
+// NetworkConnectivity implements the serverpb.TenantStatusServer interface
+func (c *connector) NetworkConnectivity(
+	ctx context.Context, req *serverpb.NetworkConnectivityRequest,
+) (resp *serverpb.NetworkConnectivityResponse, retErr error) {
+	retErr = c.withClient(ctx, func(ctx context.Context, client *client) (err error) {
+		resp, err = client.NetworkConnectivity(ctx, req)
+		return
+	})
+	return
+}
+
 // NewIterator implements the rangedesc.IteratorFactory interface.
 func (c *connector) NewIterator(
 	ctx context.Context, span roachpb.Span,

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/testdata/authorizer_enabled
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/testdata/authorizer_enabled
@@ -50,7 +50,7 @@ client tenant does not have capability to query timeseries data
 
 has-tsdb-all-capability ten=10
 ----
-client tenant does not have capability to query timeseries data
+client tenant does not have capability to query non-tenant metrics
 
 # Disable the capability checks by allowing all requests.
 set-authorizer-mode value=allow-all

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -118,6 +118,9 @@ func (a tenantAuthorizer) authorize(
 	case "/cockroach.server.serverpb.Status/Ranges":
 		return a.authRanges(tenID)
 
+	case "/cockroach.server.serverpb.Status/NetworkConnectivity":
+		return a.capabilitiesAuthorizer.HasProcessDebugCapability(ctx, tenID)
+
 	case "/cockroach.server.serverpb.Status/TransactionContentionEvents":
 		return a.authTenant(tenID)
 

--- a/pkg/server/serverpb/status.go
+++ b/pkg/server/serverpb/status.go
@@ -90,6 +90,7 @@ type TenantStatusServer interface {
 	// download remote files. A method that mutates state should not be on the
 	// status server and so in the long run we should move it.
 	DownloadSpan(ctx context.Context, request *DownloadSpanRequest) (*DownloadSpanResponse, error)
+	NetworkConnectivity(context.Context, *NetworkConnectivityRequest) (*NetworkConnectivityResponse, error)
 }
 
 // OptionalNodesStatusServer returns the wrapped NodesStatusServer, if it is


### PR DESCRIPTION
This works well for shared-process mode where inter-node network
connectivity for a secondary tenant is the same as for the system tenant.
However, in external-process mode, this endpoint won't provide a complete
picture of network connectivity since the SQL server may run entirely
outside the KV node. We may need to extend this endpoint or create a new
one for SQL-SQL servers and SQL server to KV nodes. This work is left for
the future, and currently, this endpoint only shows KV-KV nodes network
connectivity. As a result, this endpoint isn't ready for external-process
mode and should only be enabled for shared-mode tenants. On the backend,
there is nothing enforcing this, which shouldn't be a problem.

Fixes: #110024

Epic: #CRDB-38968

Release note: None
