### PR TITLE
kvserver: fix dropped raft heartbeats in test helper

### DIFF
--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -4798,11 +4797,7 @@ func (h *flowControlTestHelper) enableVerboseRaftMsgLoggingForRange(rangeID roac
 			&unreliableRaftHandler{
 				rangeID:                    rangeID,
 				IncomingRaftMessageHandler: si,
-				unreliableRaftHandlerFuncs: unreliableRaftHandlerFuncs{
-					dropReq: func(req *kvserverpb.RaftMessageRequest) bool {
-						return false
-					},
-				},
+				unreliableRaftHandlerFuncs: noopRaftHandlerFuncs(),
 			})
 	}
 }


### PR DESCRIPTION
The `unreliableRaftHandlerFuncs` type drops messages by default, if the corresponding "drop" function is nil.

The `enableVerboseRaftMsgLoggingForRange` is meant to add a no-op interceptor of all raft messages, but because of a bug it ended up dropping heartbeat responses. This caused lack of `MsgApp` stream liveness from leader to followers, and a perpetual `StateProbe`.

Fixes #131735