### PR TITLE
roachtest: ignore version changes in pg_regress issue URIs

### DIFF
--- a/pkg/cmd/roachtest/tests/pg_regress.go
+++ b/pkg/cmd/roachtest/tests/pg_regress.go
@@ -432,6 +432,12 @@ func runPGRegress(ctx context.Context, t test.Test, c cluster.Cluster) {
 	if err != nil {
 		t.L().Printf("Failed to read %s: %s", testdata, err)
 	}
+
+	// Replace specific versions in URIs with a generic "_version_".
+	issueURI := regexp.MustCompile(`https:\/\/go\.crdb\.dev\/issue-v\/(\d+)\/[^\/|^\s]+`)
+	actualB = issueURI.ReplaceAll(actualB, []byte("https://go.crdb.dev/issue-v/$1/_version_"))
+	docsURI := regexp.MustCompile(`https:\/\/www\.cockroachlabs.com\/docs\/[^\/|^\s]+`)
+	actualB = docsURI.ReplaceAll(actualB, []byte("https://www.cockroachlabs.com/docs/_version_"))
 	actual := string(actualB)
 
 	if expected != actual {


### PR DESCRIPTION
This commit replaces specific versions in the expected and actual output
of pg_regress tests with a generic `_version_`, preventing version bumps
from changing the diff. This should eliminate the most common source of
changes to the diff.

Epic: None

Release note: None
