### PR TITLE
release-23.1: logcrash, ccl: fail if setting incompatible license and reporting cfg

### DIFF
--- a/pkg/ccl/utilccl/license_check_test.go
+++ b/pkg/ccl/utilccl/license_check_test.go
@@ -11,6 +11,7 @@ package utilccl
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -79,6 +80,108 @@ func TestSettingAndCheckingLicense(t *testing.T) {
 		if !testutils.IsError(err, tc.err) {
 			l, _ := decode(tc.lic)
 			t.Fatalf("%d: lic %v, update by %T, checked by %s at %s, got %q", i, l, updater, tc.checkCluster, tc.checkTime, err)
+		}
+	}
+}
+
+// test setting a license with a specific diagnostics setting.
+func TestSetLicenseWithDiagnosticsReporting(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	t0 := timeutil.Unix(0, 0)
+	updater := st.MakeUpdater()
+	var enterpriseLicense, err = (&licenseccl.License{
+		Type:              licenseccl.License_Enterprise,
+		ValidUntilUnixSec: t0.AddDate(0, 1, 0).Unix(),
+	}).Encode()
+	require.NoError(t, err)
+
+	resetLicense := func() {
+		err = setLicense(ctx, updater, enterpriseLicense)
+		require.NoError(t, err)
+	}
+
+	for _, tc := range []struct {
+		lit         licenseccl.License_Type
+		diagnostics bool
+		err         string
+	}{
+		{licenseccl.License_Free, false, "diagnostics.reporting.enabled must be true to use this license"},
+		{licenseccl.License_Free, true, ""},
+		{licenseccl.License_Trial, false, "diagnostics.reporting.enabled must be true to use this license"},
+		{licenseccl.License_Trial, true, ""},
+		{licenseccl.License_NonCommercial, false, ""},
+		{licenseccl.License_NonCommercial, true, ""},
+		{licenseccl.License_Enterprise, false, ""},
+		{licenseccl.License_Enterprise, true, ""},
+		{licenseccl.License_Evaluation, false, ""},
+		{licenseccl.License_Evaluation, true, ""},
+	} {
+		// First set the license to enterprise so that we can change the diagnostics setting.
+		resetLicense()
+		// Then, set the diagnostics value for the test.
+		if err := setDiagnosticsReporting(ctx, updater, tc.diagnostics); err != nil {
+			t.Fatal(err)
+		}
+		// Finally, verify that trying to set the license gives the appropriate validation response.
+		lic, _ := (&licenseccl.License{
+			Type:              tc.lit,
+			ValidUntilUnixSec: t0.AddDate(0, 1, 0).Unix(),
+		}).Encode()
+		if err := setLicense(ctx, updater, lic); !testutils.IsError(
+			err, tc.err,
+		) {
+			t.Fatalf("%s %t: expected err %q, got %v", tc.lit, tc.diagnostics, tc.err, err)
+		}
+
+	}
+}
+
+// test setting the diagnostics setting with a specific license.
+func TestSetDiagnosticsReportingWithLicense(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	t0 := timeutil.Unix(0, 0)
+	updater := st.MakeUpdater()
+
+	resetDiagnostics := func() {
+		err := setDiagnosticsReporting(ctx, updater, true)
+		require.NoError(t, err)
+	}
+
+	for _, tc := range []struct {
+		lit         licenseccl.License_Type
+		diagnostics bool
+		err         string
+	}{
+		{licenseccl.License_Free, false, "unable to disable diagnostics with license type Free"},
+		{licenseccl.License_Free, true, ""},
+		{licenseccl.License_Trial, false, "unable to disable diagnostics with license type Trial"},
+		{licenseccl.License_Trial, true, ""},
+		{licenseccl.License_NonCommercial, false, ""},
+		{licenseccl.License_NonCommercial, true, ""},
+		{licenseccl.License_Enterprise, false, ""},
+		{licenseccl.License_Enterprise, true, ""},
+		{licenseccl.License_Evaluation, false, ""},
+		{licenseccl.License_Evaluation, true, ""},
+	} {
+		// First set the diagnostics to true so that we can change the license
+		resetDiagnostics()
+		// Then change the license value for the test.
+		lic, _ := (&licenseccl.License{
+			Type:              tc.lit,
+			ValidUntilUnixSec: t0.AddDate(0, 1, 0).Unix(),
+		}).Encode()
+		if err := setLicense(ctx, updater, lic); err != nil {
+			t.Fatal(err)
+		}
+		// Finally, verify that trying to set the diagnostics value gives the appropriate validation response.
+		if err := setDiagnosticsReporting(ctx, updater, tc.diagnostics); !testutils.IsError(
+			err, tc.err,
+		) {
+			t.Fatalf("%s %t: expected err %q, got %v", tc.lit, tc.diagnostics, tc.err, err)
 		}
 	}
 }
@@ -211,9 +314,10 @@ func TestTimeToEnterpriseLicenseExpiry(t *testing.T) {
 func TestApplyTenantLicenseWithLicense(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	license, _ := (&licenseccl.License{
+	license, err := (&licenseccl.License{
 		Type: licenseccl.License_Enterprise,
 	}).Encode()
+	require.NoError(t, err)
 
 	defer TestingDisableEnterprise()()
 	defer envutil.TestSetEnv(t, "COCKROACH_TENANT_LICENSE", license)()
@@ -254,6 +358,13 @@ func setLicense(ctx context.Context, updater settings.Updater, val string) error
 	return updater.Set(ctx, "enterprise.license", settings.EncodedValue{
 		Value: val,
 		Type:  "s",
+	})
+}
+
+func setDiagnosticsReporting(ctx context.Context, updater settings.Updater, val bool) error {
+	return updater.Set(ctx, "diagnostics.reporting.enabled", settings.EncodedValue{
+		Value: strconv.FormatBool(val),
+		Type:  "b",
 	})
 }
 

--- a/pkg/settings/updater.go
+++ b/pkg/settings/updater.go
@@ -128,8 +128,7 @@ func (u updater) Set(ctx context.Context, key string, value EncodedValue) error 
 		if err != nil {
 			return err
 		}
-		setting.set(ctx, u.sv, b)
-		return nil
+		return setting.set(ctx, u.sv, b)
 	case numericSetting:
 		i, err := setting.DecodeValue(value.Value)
 		if err != nil {

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -757,6 +757,9 @@ func toSettingString(
 		return "", errors.Errorf("cannot use %s %T value for string setting", d.ResolvedType(), d)
 	case *settings.BoolSetting:
 		if b, ok := d.(*tree.DBool); ok {
+			if err := setting.Validate(&st.SV, bool(*b)); err != nil {
+				return "", err
+			}
 			return settings.EncodeBool(bool(*b)), nil
 		}
 		return "", errors.Errorf("cannot use %s %T value for bool setting", d.ResolvedType(), d)

--- a/pkg/util/log/logcrash/BUILD.bazel
+++ b/pkg/util/log/logcrash/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     },
     deps = [
         "//pkg/build",
+        "//pkg/ccl/utilccl/licenseccl",
         "//pkg/settings",
         "//pkg/util/envutil",
         "//pkg/util/log",

--- a/pkg/util/log/logcrash/crash_reporting.go
+++ b/pkg/util/log/logcrash/crash_reporting.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl/licenseccl"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -56,6 +57,44 @@ var (
 		"diagnostics.reporting.enabled",
 		"enable reporting diagnostic metrics to cockroach labs",
 		false,
+		func(sv *settings.Values, b bool) error {
+			// If the user wants to turn on diagnostics, no validation is needed.
+			if b {
+				return nil
+			}
+
+			// The validator looks for a valid license, but fails gracefully if one is
+			// not found. It's possible at this point one is not set, and because
+			// failure will panic on startup, we allow the setting of any value.
+			licenseSetting, ok := settings.LookupForLocalAccess("enterprise.license", true /* forSystemTenant */)
+			if !ok {
+				log.Warning(context.Background(), "unable to find license configuring diagnostic reporting")
+				return nil
+			}
+			lic, err := licenseSetting.DecodeToString(licenseSetting.Encoded(sv))
+			if err != nil {
+				log.Errorf(context.Background(), "error configuring diagnostics: %s", err)
+				return nil
+			}
+
+			license, err := licenseccl.Decode(lic)
+			if err != nil {
+				log.Errorf(context.Background(), "error configuring diagnostics: %s", err)
+				return nil
+			}
+			if license == nil {
+				log.Warning(context.Background(), "unable to read license while setting diagnostics.reporting.enabled")
+				return nil
+			}
+
+			// If the license is limited and diagnostics are off, we prevent the user
+			// from disabling diagnostics reporting.
+			isLimited := license.Type == licenseccl.License_Free || license.Type == licenseccl.License_Trial
+			if isLimited {
+				return fmt.Errorf("unable to disable diagnostics with license type %s", license.Type)
+			}
+			return nil
+		},
 	).WithPublic()
 
 	// CrashReports wraps "diagnostics.reporting.send_crash_reports".

--- a/pkg/util/log/logcrash/crash_reporting_test.go
+++ b/pkg/util/log/logcrash/crash_reporting_test.go
@@ -81,7 +81,7 @@ Error types: (1) *runtime.TypeAssertionError`,
 			expErr: `some visible detail: interface conversion: interface {} is nil, not int
 (1) attached stack trace
   -- stack trace:
-  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init.func3
   | 	...crash_reporting_test.go:NN
   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init
   | 	...crash_reporting_test.go:NN
@@ -103,7 +103,7 @@ Error types: (1) *withstack.withStack (2) *errutil.withPrefix (3) *runtime.TypeA
 			expErr: `interface conversion: interface {} is nil, not int
 (1) attached stack trace
   -- stack trace:
-  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init.func3
   | 	...crash_reporting_test.go:NN
   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init
   | 	...crash_reporting_test.go:NN
@@ -135,7 +135,7 @@ Error types: (1) *safedetails.withSafeDetails (2) *runtime.TypeAssertionError`,
 			expErr: `I like A and my pin code is ` + rm + ` or 9999
 (1) attached stack trace
   -- stack trace:
-  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init.func3
   | 	...crash_reporting_test.go:NN
   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init
   | 	...crash_reporting_test.go:NN
@@ -155,7 +155,7 @@ Error types: (1) *withstack.withStack (2) *errutil.leafError`,
 			expErr: `this is preserved: 6: context canceled
 (1) attached stack trace
   -- stack trace:
-  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init.func3
   | 	...crash_reporting_test.go:NN
   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init
   | 	...crash_reporting_test.go:NN
@@ -191,7 +191,7 @@ Error types: (1) *os.LinkError (2) *safedetails.withSafeDetails (3) logcrash.lea
 			expErr: `this is reportable as well: this is reportable too: this is reportable: ` + rm + `
 (1) attached stack trace
   -- stack trace:
-  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init.func3
   | 	...crash_reporting_test.go:NN
   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init
   | 	...crash_reporting_test.go:NN
@@ -204,7 +204,7 @@ Error types: (1) *os.LinkError (2) *safedetails.withSafeDetails (3) logcrash.lea
 Wraps: (2) this is reportable as well
 Wraps: (3) attached stack trace
   -- stack trace:
-  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init.func3
   | 	...crash_reporting_test.go:NN
   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init
   | 	...crash_reporting_test.go:NN
@@ -217,13 +217,13 @@ Wraps: (3) attached stack trace
 Wraps: (4) this is reportable too
 Wraps: (5) attached stack trace
   -- stack trace:
-  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init.func3
   | 	...crash_reporting_test.go:NN
   | [...repeated from below...]
 Wraps: (6) this is reportable
 Wraps: (7) attached stack trace
   -- stack trace:
-  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init.func3
   | 	...crash_reporting_test.go:NN
   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init
   | 	...crash_reporting_test.go:NN
@@ -256,7 +256,7 @@ Error types: (1) *net.OpError (2) logcrash.leafErr`,
 			expErr: `this embed an error: this is reportable too: this is reportable: ` + rm + `
 (1) attached stack trace
   -- stack trace:
-  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init.func3
   | 	...crash_reporting_test.go:NN
   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init
   | 	...crash_reporting_test.go:NN
@@ -272,7 +272,7 @@ Wraps: (2) secondary error attachment
   | this is reportable too: this is reportable: ` + rm + `
   | (1) attached stack trace
   |   -- stack trace:
-  |   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  |   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init.func3
   |   | 	...crash_reporting_test.go:NN
   |   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init
   |   | 	...crash_reporting_test.go:NN
@@ -285,13 +285,13 @@ Wraps: (2) secondary error attachment
   | Wraps: (2) this is reportable too
   | Wraps: (3) attached stack trace
   |   -- stack trace:
-  |   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  |   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init.func3
   |   | 	...crash_reporting_test.go:NN
   |   | [...repeated from below...]
   | Wraps: (4) this is reportable
   | Wraps: (5) attached stack trace
   |   -- stack trace:
-  |   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  |   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init.func3
   |   | 	...crash_reporting_test.go:NN
   |   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init
   |   | 	...crash_reporting_test.go:NN


### PR DESCRIPTION
Backport 1/1 commits from #131097.

/cc @cockroachdb/release

---

With the rollout of the license requirements with CRDB, we are going to begin disallowing the disabling of diagnostics under specific license types. If the caller is to disable diagnostics, they must have a license which is not Free or Trial. Conversely, if the caller is to set a Free or Trial license, they must already be submitting diagnostics information for it to succeed.

Epic: CRDB-40209
Fixes: CRDB-41232

Release note (sql change): cluster settings enterprise.license and diagnostics.reporting.enabled have additional validation

Release justification: required settings changes for core deprecation