### PR TITLE
release-23.2: logcrash, ccl: fail if setting incompatible license and reporting cfg

### DIFF
--- a/pkg/ccl/utilccl/license_check.go
+++ b/pkg/ccl/utilccl/license_check.go
@@ -10,6 +10,7 @@ package utilccl
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -36,8 +37,36 @@ var enterpriseLicense = settings.RegisterStringSetting(
 	"",
 	settings.WithValidateString(
 		func(sv *settings.Values, s string) error {
-			_, err := decode(s)
-			return err
+			l, err := decode(s)
+			if err != nil {
+				return err
+			}
+			if l == nil {
+				return nil
+			}
+
+			reportingSetting, ok, _ := settings.LookupForLocalAccess("diagnostics.reporting.enabled", true /* forSystemTenant */)
+			if !ok {
+				log.Warning(context.Background(), "unable to find setting for diagnostic reporting")
+				return nil
+			}
+			reportingStr, err := reportingSetting.DecodeToString(reportingSetting.Encoded(sv))
+			if err != nil {
+				return err
+			}
+
+			reporting, err := strconv.ParseBool(reportingStr)
+			if err != nil {
+				return err
+			}
+
+			// if the cluster license is limited and the reporting value passed in is
+			// disabled, then do not allow diagnostics to be set.
+			isLimited := l != nil && l.Type == licenseccl.License_Free || l.Type == licenseccl.License_Trial
+			if !reporting && isLimited {
+				return errors.New("diagnostics.reporting.enabled must be true to use this license")
+			}
+			return nil
 		},
 	),
 	// Even though string settings are non-reportable by default, we

--- a/pkg/ccl/utilccl/license_check_test.go
+++ b/pkg/ccl/utilccl/license_check_test.go
@@ -11,6 +11,7 @@ package utilccl
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -66,6 +67,108 @@ func TestSettingAndCheckingLicense(t *testing.T) {
 		if !testutils.IsError(err, tc.err) {
 			l, _ := decode(tc.lic)
 			t.Fatalf("%d: lic %v, update by %T, checked at %s, got %q", i, l, updater, tc.checkTime, err)
+		}
+	}
+}
+
+// test setting a license with a specific diagnostics setting.
+func TestSetLicenseWithDiagnosticsReporting(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	t0 := timeutil.Unix(0, 0)
+	updater := st.MakeUpdater()
+	var enterpriseLicense, err = (&licenseccl.License{
+		Type:              licenseccl.License_Enterprise,
+		ValidUntilUnixSec: t0.AddDate(0, 1, 0).Unix(),
+	}).Encode()
+	require.NoError(t, err)
+
+	resetLicense := func() {
+		err = setLicense(ctx, updater, enterpriseLicense)
+		require.NoError(t, err)
+	}
+
+	for _, tc := range []struct {
+		lit         licenseccl.License_Type
+		diagnostics bool
+		err         string
+	}{
+		{licenseccl.License_Free, false, "diagnostics.reporting.enabled must be true to use this license"},
+		{licenseccl.License_Free, true, ""},
+		{licenseccl.License_Trial, false, "diagnostics.reporting.enabled must be true to use this license"},
+		{licenseccl.License_Trial, true, ""},
+		{licenseccl.License_NonCommercial, false, ""},
+		{licenseccl.License_NonCommercial, true, ""},
+		{licenseccl.License_Enterprise, false, ""},
+		{licenseccl.License_Enterprise, true, ""},
+		{licenseccl.License_Evaluation, false, ""},
+		{licenseccl.License_Evaluation, true, ""},
+	} {
+		// First set the license to enterprise so that we can change the diagnostics setting.
+		resetLicense()
+		// Then, set the diagnostics value for the test.
+		if err := setDiagnosticsReporting(ctx, updater, tc.diagnostics); err != nil {
+			t.Fatal(err)
+		}
+		// Finally, verify that trying to set the license gives the appropriate validation response.
+		lic, _ := (&licenseccl.License{
+			Type:              tc.lit,
+			ValidUntilUnixSec: t0.AddDate(0, 1, 0).Unix(),
+		}).Encode()
+		if err := setLicense(ctx, updater, lic); !testutils.IsError(
+			err, tc.err,
+		) {
+			t.Fatalf("%s %t: expected err %q, got %v", tc.lit, tc.diagnostics, tc.err, err)
+		}
+
+	}
+}
+
+// test setting the diagnostics setting with a specific license.
+func TestSetDiagnosticsReportingWithLicense(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	t0 := timeutil.Unix(0, 0)
+	updater := st.MakeUpdater()
+
+	resetDiagnostics := func() {
+		err := setDiagnosticsReporting(ctx, updater, true)
+		require.NoError(t, err)
+	}
+
+	for _, tc := range []struct {
+		lit         licenseccl.License_Type
+		diagnostics bool
+		err         string
+	}{
+		{licenseccl.License_Free, false, "unable to disable diagnostics with license type Free"},
+		{licenseccl.License_Free, true, ""},
+		{licenseccl.License_Trial, false, "unable to disable diagnostics with license type Trial"},
+		{licenseccl.License_Trial, true, ""},
+		{licenseccl.License_NonCommercial, false, ""},
+		{licenseccl.License_NonCommercial, true, ""},
+		{licenseccl.License_Enterprise, false, ""},
+		{licenseccl.License_Enterprise, true, ""},
+		{licenseccl.License_Evaluation, false, ""},
+		{licenseccl.License_Evaluation, true, ""},
+	} {
+		// First set the diagnostics to true so that we can change the license
+		resetDiagnostics()
+		// Then change the license value for the test.
+		lic, _ := (&licenseccl.License{
+			Type:              tc.lit,
+			ValidUntilUnixSec: t0.AddDate(0, 1, 0).Unix(),
+		}).Encode()
+		if err := setLicense(ctx, updater, lic); err != nil {
+			t.Fatal(err)
+		}
+		// Finally, verify that trying to set the diagnostics value gives the appropriate validation response.
+		if err := setDiagnosticsReporting(ctx, updater, tc.diagnostics); !testutils.IsError(
+			err, tc.err,
+		) {
+			t.Fatalf("%s %t: expected err %q, got %v", tc.lit, tc.diagnostics, tc.err, err)
 		}
 	}
 }
@@ -221,9 +324,10 @@ func TestTimeToEnterpriseLicenseExpiry(t *testing.T) {
 func TestApplyTenantLicenseWithLicense(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	license, _ := (&licenseccl.License{
+	license, err := (&licenseccl.License{
 		Type: licenseccl.License_Enterprise,
 	}).Encode()
+	require.NoError(t, err)
 
 	defer TestingDisableEnterprise()()
 	defer envutil.TestSetEnv(t, "COCKROACH_TENANT_LICENSE", license)()
@@ -264,6 +368,13 @@ func setLicense(ctx context.Context, updater settings.Updater, val string) error
 	return updater.Set(ctx, "enterprise.license", settings.EncodedValue{
 		Value: val,
 		Type:  "s",
+	})
+}
+
+func setDiagnosticsReporting(ctx context.Context, updater settings.Updater, val bool) error {
+	return updater.Set(ctx, "diagnostics.reporting.enabled", settings.EncodedValue{
+		Value: strconv.FormatBool(val),
+		Type:  "b",
 	})
 }
 

--- a/pkg/settings/bool.go
+++ b/pkg/settings/bool.go
@@ -13,6 +13,8 @@ package settings
 import (
 	"context"
 	"strconv"
+
+	"github.com/cockroachdb/errors"
 )
 
 // BoolSetting is the interface of a setting variable that will be
@@ -21,6 +23,7 @@ import (
 type BoolSetting struct {
 	common
 	defaultValue bool
+	validateFn   func(*Values, bool) error
 }
 
 var _ internalSetting = &BoolSetting{}
@@ -82,32 +85,65 @@ var _ = (*BoolSetting).Default
 // For testing usage only.
 func (b *BoolSetting) Override(ctx context.Context, sv *Values, v bool) {
 	sv.setValueOrigin(ctx, b.slot, OriginOverride)
-	b.set(ctx, sv, v)
+	_ = b.set(ctx, sv, v)
 	sv.setDefaultOverride(b.slot, v)
 }
 
-func (b *BoolSetting) set(ctx context.Context, sv *Values, v bool) {
+// Validate that a value conforms with the validation function.
+func (b *BoolSetting) Validate(sv *Values, v bool) error {
+	if b.validateFn != nil {
+		if err := b.validateFn(sv, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (b *BoolSetting) set(ctx context.Context, sv *Values, v bool) error {
+	if err := b.Validate(sv, v); err != nil {
+		return err
+	}
 	vInt := int64(0)
 	if v {
 		vInt = 1
 	}
 	sv.setInt64(ctx, b.slot, vInt)
+	return nil
 }
 
 func (b *BoolSetting) setToDefault(ctx context.Context, sv *Values) {
 	// See if the default value was overridden.
 	if val := sv.getDefaultOverride(b.slot); val != nil {
-		b.set(ctx, sv, val.(bool))
+		// As per the semantics of override, these values don't go through
+		// validation.
+		_ = b.set(ctx, sv, val.(bool))
 		return
 	}
-	b.set(ctx, sv, b.defaultValue)
+	if err := b.set(ctx, sv, b.defaultValue); err != nil {
+		panic(err)
+	}
 }
 
 // RegisterBoolSetting defines a new setting with type bool.
 func RegisterBoolSetting(
 	class Class, key InternalKey, desc string, defaultValue bool, opts ...SettingOption,
 ) *BoolSetting {
-	setting := &BoolSetting{defaultValue: defaultValue}
+	validateFn := func(sv *Values, val bool) error {
+		for _, opt := range opts {
+			switch {
+			case opt.commonOpt != nil:
+				continue
+			case opt.validateBoolFn != nil:
+			default:
+				panic(errors.AssertionFailedf("wrong validator type"))
+			}
+			if err := opt.validateBoolFn(sv, val); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	setting := &BoolSetting{defaultValue: defaultValue, validateFn: validateFn}
 	register(class, key, desc, setting)
 	setting.apply(opts)
 	return setting

--- a/pkg/settings/options.go
+++ b/pkg/settings/options.go
@@ -19,6 +19,7 @@ import (
 // SettingOption is the type of an option that can be passed to Register.
 type SettingOption struct {
 	commonOpt          func(*common)
+	validateBoolFn     func(*Values, bool) error
 	validateDurationFn func(time.Duration) error
 	validateInt64Fn    func(int64) error
 	validateFloat64Fn  func(float64) error
@@ -106,6 +107,11 @@ func WithValidateInt(fn func(int64) error) SettingOption {
 // WithValidateFloat adds a validation function for a float64 setting.
 func WithValidateFloat(fn func(float64) error) SettingOption {
 	return SettingOption{validateFloat64Fn: fn}
+}
+
+// WithValidateBool adds a validation function for a boolean setting.
+func WithValidateBool(fn func(*Values, bool) error) SettingOption {
+	return SettingOption{validateBoolFn: fn}
 }
 
 // WithValidateString adds a validation function for a string setting.

--- a/pkg/settings/updater.go
+++ b/pkg/settings/updater.go
@@ -177,8 +177,7 @@ func (u updater) setInternal(
 		if err != nil {
 			return err
 		}
-		setting.set(ctx, u.sv, b)
-		return nil
+		return setting.set(ctx, u.sv, b)
 
 	case numericSetting:
 		i, err := setting.DecodeValue(value.Value)

--- a/pkg/settings/validation_test.go
+++ b/pkg/settings/validation_test.go
@@ -20,6 +20,20 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 )
 
+var cantBeTrue = settings.WithValidateBool(func(sv *settings.Values, b bool) error {
+	if b {
+		return fmt.Errorf("it cant be true")
+	}
+	return nil
+})
+
+var cantBeFalse = settings.WithValidateBool(func(sv *settings.Values, b bool) error {
+	if !b {
+		return fmt.Errorf("it cant be false")
+	}
+	return nil
+})
+
 func TestValidationOptions(t *testing.T) {
 	type subTest struct {
 		val         interface{}
@@ -180,6 +194,26 @@ func TestValidationOptions(t *testing.T) {
 				{val: 1, opt: settings.ByteSizeWithMinimum(10), expectedErr: "cannot be set to a value lower than 10 B"},
 				{val: 10, opt: settings.ByteSizeWithMinimum(10), expectedErr: ""},
 				{val: 11, opt: settings.ByteSizeWithMinimum(10), expectedErr: ""},
+			},
+		},
+		{
+			testLabel: "bool",
+			settingFn: func(n int, bval interface{}, opt settings.SettingOption) settings.Setting {
+				val := bval.(bool)
+				b := settings.RegisterBoolSetting(settings.SystemOnly, settings.InternalKey(fmt.Sprintf("test-%d", n)), "desc",
+					val, opt)
+				// We explicitly check here to test validation which does not happen on initialization.
+				err := b.Validate(&settings.Values{}, val)
+				if err != nil {
+					panic(err)
+				}
+				return b
+			},
+			subTests: []subTest{
+				{val: true, opt: cantBeTrue, expectedErr: "it cant be true"},
+				{val: false, opt: cantBeTrue, expectedErr: ""},
+				{val: true, opt: cantBeFalse, expectedErr: ""},
+				{val: false, opt: cantBeFalse, expectedErr: "it cant be false"},
 			},
 		},
 	}

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -818,6 +818,9 @@ func toSettingString(
 		return "", errors.Errorf("cannot use %s %T value for string setting", d.ResolvedType(), d)
 	case *settings.BoolSetting:
 		if b, ok := d.(*tree.DBool); ok {
+			if err := setting.Validate(&st.SV, bool(*b)); err != nil {
+				return "", err
+			}
 			return settings.EncodeBool(bool(*b)), nil
 		}
 		return "", errors.Errorf("cannot use %s %T value for bool setting", d.ResolvedType(), d)

--- a/pkg/util/log/logcrash/BUILD.bazel
+++ b/pkg/util/log/logcrash/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     },
     deps = [
         "//pkg/build",
+        "//pkg/ccl/utilccl/licenseccl",
         "//pkg/settings",
         "//pkg/util/envutil",
         "//pkg/util/log",

--- a/pkg/util/log/logcrash/crash_reporting.go
+++ b/pkg/util/log/logcrash/crash_reporting.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl/licenseccl"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -56,8 +57,47 @@ var (
 		settings.ApplicationLevel,
 		"diagnostics.reporting.enabled",
 		"enable reporting diagnostic metrics to cockroach labs",
-		false,
-		settings.WithPublic)
+		true,
+		settings.WithPublic,
+		settings.WithValidateBool(func(sv *settings.Values, b bool) error {
+			// If the user wants to turn on diagnostics, no validation is needed.
+			if b {
+				return nil
+			}
+
+			// The validator looks for a valid license, but fails gracefully if one is
+			// not found. It's possible at this point one is not set, and because
+			// failure will panic on startup, we allow the setting of any value.
+			licenseSetting, ok, _ := settings.LookupForLocalAccess("enterprise.license", true /* forSystemTenant */)
+			if !ok {
+				log.Warning(context.Background(), "unable to find license configuring diagnostic reporting")
+				return nil
+			}
+			lic, err := licenseSetting.DecodeToString(licenseSetting.Encoded(sv))
+			if err != nil {
+				log.Errorf(context.Background(), "error configuring diagnostics: %s", err)
+				return nil
+			}
+
+			license, err := licenseccl.Decode(lic)
+			if err != nil {
+				log.Errorf(context.Background(), "error configuring diagnostics: %s", err)
+				return nil
+			}
+			if license == nil {
+				log.Warning(context.Background(), "unable to read license while setting diagnostics.reporting.enabled")
+				return nil
+			}
+
+			// If the license is limited and diagnostics are off, we prevent the user
+			// from disabling diagnostics reporting.
+			isLimited := license.Type == licenseccl.License_Free || license.Type == licenseccl.License_Trial
+			if isLimited {
+				return fmt.Errorf("unable to disable diagnostics with license type %s", license.Type)
+			}
+			return nil
+		}),
+	)
 
 	// CrashReports wraps "diagnostics.reporting.send_crash_reports.enabled".
 	CrashReports = settings.RegisterBoolSetting(

--- a/pkg/util/log/logcrash/crash_reporting_test.go
+++ b/pkg/util/log/logcrash/crash_reporting_test.go
@@ -83,7 +83,7 @@ Error types: (1) *runtime.TypeAssertionError`,
 			expErr: `some visible detail: interface conversion: interface {} is nil, not int
 (1) attached stack trace
   -- stack trace:
-  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func3
   | 	...crash_reporting_test.go:NN
   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init
   | 	...crash_reporting_test.go:NN
@@ -105,7 +105,7 @@ Error types: (1) *withstack.withStack (2) *errutil.withPrefix (3) *runtime.TypeA
 			expErr: `interface conversion: interface {} is nil, not int
 (1) attached stack trace
   -- stack trace:
-  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func3
   | 	...crash_reporting_test.go:NN
   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init
   | 	...crash_reporting_test.go:NN
@@ -137,7 +137,7 @@ Error types: (1) *safedetails.withSafeDetails (2) *runtime.TypeAssertionError`,
 			expErr: `I like A and my pin code is ` + rm + ` or 9999
 (1) attached stack trace
   -- stack trace:
-  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func3
   | 	...crash_reporting_test.go:NN
   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init
   | 	...crash_reporting_test.go:NN
@@ -157,7 +157,7 @@ Error types: (1) *withstack.withStack (2) *errutil.leafError`,
 			expErr: `this is preserved: 6: context canceled
 (1) attached stack trace
   -- stack trace:
-  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func3
   | 	...crash_reporting_test.go:NN
   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init
   | 	...crash_reporting_test.go:NN
@@ -193,7 +193,7 @@ Error types: (1) *os.LinkError (2) *safedetails.withSafeDetails (3) logcrash.lea
 			expErr: `this is reportable as well: this is reportable too: this is reportable: ` + rm + `
 (1) attached stack trace
   -- stack trace:
-  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func3
   | 	...crash_reporting_test.go:NN
   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init
   | 	...crash_reporting_test.go:NN
@@ -206,7 +206,7 @@ Error types: (1) *os.LinkError (2) *safedetails.withSafeDetails (3) logcrash.lea
 Wraps: (2) this is reportable as well
 Wraps: (3) attached stack trace
   -- stack trace:
-  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func3
   | 	...crash_reporting_test.go:NN
   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init
   | 	...crash_reporting_test.go:NN
@@ -219,13 +219,13 @@ Wraps: (3) attached stack trace
 Wraps: (4) this is reportable too
 Wraps: (5) attached stack trace
   -- stack trace:
-  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func3
   | 	...crash_reporting_test.go:NN
   | [...repeated from below...]
 Wraps: (6) this is reportable
 Wraps: (7) attached stack trace
   -- stack trace:
-  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func3
   | 	...crash_reporting_test.go:NN
   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init
   | 	...crash_reporting_test.go:NN
@@ -258,7 +258,7 @@ Error types: (1) *net.OpError (2) logcrash.leafErr`,
 			expErr: `this embed an error: this is reportable too: this is reportable: ` + rm + `
 (1) attached stack trace
   -- stack trace:
-  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func3
   | 	...crash_reporting_test.go:NN
   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init
   | 	...crash_reporting_test.go:NN
@@ -274,7 +274,7 @@ Wraps: (2) secondary error attachment
   | this is reportable too: this is reportable: ` + rm + `
   | (1) attached stack trace
   |   -- stack trace:
-  |   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  |   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func3
   |   | 	...crash_reporting_test.go:NN
   |   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init
   |   | 	...crash_reporting_test.go:NN
@@ -287,13 +287,13 @@ Wraps: (2) secondary error attachment
   | Wraps: (2) this is reportable too
   | Wraps: (3) attached stack trace
   |   -- stack trace:
-  |   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  |   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func3
   |   | 	...crash_reporting_test.go:NN
   |   | [...repeated from below...]
   | Wraps: (4) this is reportable
   | Wraps: (5) attached stack trace
   |   -- stack trace:
-  |   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func2
+  |   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.glob..func3
   |   | 	...crash_reporting_test.go:NN
   |   | github.com/cockroachdb/cockroach/pkg/util/log/logcrash.init
   |   | 	...crash_reporting_test.go:NN


### PR DESCRIPTION
Backport 1/1 commits from #131097.

/cc @cockroachdb/release

---

With the rollout of the license requirements with CRDB, we are going to begin disallowing the disabling of diagnostics under specific license types. If the caller is to disable diagnostics, they must have a license which is not Free or Trial. Conversely, if the caller is to set a Free or Trial license, they must already be submitting diagnostics information for it to succeed.

Epic: CRDB-40209
Fixes: CRDB-41232

Release note (sql change): cluster settings enterprise.license and diagnostics.reporting.enabled have additional validation

Release justification: required settings changes for core deprecation
