### PR TITLE
changefeedccl: enable vmodule for TestAlterChangefeedSwitchFamily

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -278,6 +278,8 @@ func TestAlterChangefeedSwitchFamily(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	require.NoError(t, log.SetVModule("helpers_test=1"))
+
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING, FAMILY onlya (a), FAMILY onlyb (b))`)


### PR DESCRIPTION
This patch enables verbose logging (vmodule `helpers_test=1`) for `TestAlterChangefeedSwitchFamily` so that we can get more information about what, if any, messages that the changefeed sees before the test times out.

Informs #131718

Release note: None