### PR TITLE
kvserver,replica_rac2,rac2: partial integration of MsgAppPull mode

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
@@ -1264,7 +1264,11 @@ func TestRangeController(t *testing.T) {
 				var rangeID int
 				d.ScanArgs(t, "range_id", &rangeID)
 				testRC := state.ranges[roachpb.RangeID(rangeID)]
-				testRC.rc.HandleSchedulerEventRaftMuLocked(ctx)
+				mode := MsgAppPull
+				if d.HasArg("push-mode") {
+					mode = MsgAppPush
+				}
+				testRC.rc.HandleSchedulerEventRaftMuLocked(ctx, mode)
 				// Sleep for a bit to allow any timers to fire.
 				time.Sleep(20 * time.Millisecond)
 				return state.sendStreamString(roachpb.RangeID(rangeID))

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/scheduler_event_push
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/scheduler_event_push
@@ -1,0 +1,166 @@
+# Initialize a range with three replicas, none of which have send tokens.
+init regular_init=0 elastic_init=0
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
+t1/s1: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+# Append entries. Replica 2 has a send-queue.
+raft_event pull-mode
+range_id=1
+  entries
+    term=1 index=1 pri=NormalPri size=1MiB
+    term=1 index=2 pri=LowPri size=1MiB
+----
+t1/s1: eval reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+eval deducted: reg=+1.0 MiB ela=+1.0 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=2  tokens=1048576
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,3) precise_q_size=+2.0 MiB watching-for-tokens
+eval deducted: reg=+0 B ela=+2.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+1.0 MiB
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+eval deducted: reg=+1.0 MiB ela=+1.0 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=2  tokens=1048576
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+MsgApps sent in pull mode:
+ to: 3, lowPri: false entries: [1 2]
+++++
+
+# Give s2 some send tokens. The watcher will subtract the available tokens, so
+# elastic tokens will continue to be 0.
+adjust_tokens send
+  store_id=2 pri=HighPri tokens=512KiB
+----
+t1/s1: eval reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=+512 KiB/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+eval deducted: reg=+1.0 MiB ela=+1.0 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=2  tokens=1048576
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,3) precise_q_size=+2.0 MiB deducted=+512 KiB
+eval deducted: reg=+0 B ela=+2.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+1.0 MiB
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+eval deducted: reg=+1.0 MiB ela=+1.0 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=2  tokens=1048576
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+schedule-controller-event-count: 1
+scheduled-replicas: 2
+
+# Scheduler event in push-mode. Replica 2 will switch back to push mode and
+# return the deducted tokens.
+handle_scheduler_event range_id=1 push-mode
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+eval deducted: reg=+1.0 MiB ela=+1.0 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=2  tokens=1048576
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,3) precise_q_size=+2.0 MiB
+eval deducted: reg=+1.0 MiB ela=+1.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+1.0 MiB
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+eval deducted: reg=+1.0 MiB ela=+1.0 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=2  tokens=1048576
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+schedule-controller-event-count: 1
+
+# Noop, to see the current tokens
+adjust_tokens send
+  store_id=2 pri=HighPri tokens=0
+----
+t1/s1: eval reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+t1/s2: eval reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=+512 KiB/+16 MiB ela=+512 KiB/+8.0 MiB
+t1/s3: eval reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+
+
+# Raft event in pull-mode. Replica 2 switches back to pull mode, and deducts
+# tokens.
+raft_event pull-mode
+range_id=1
+----
+t1/s1: eval reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=+512 KiB/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+       send reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+eval deducted: reg=+1.0 MiB ela=+1.0 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=2  tokens=1048576
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,3) precise_q_size=+2.0 MiB deducted=+512 KiB
+eval deducted: reg=+0 B ela=+2.0 MiB
+eval original in send-q: reg=+1.0 MiB ela=+1.0 MiB
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+eval deducted: reg=+1.0 MiB ela=+1.0 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=2  tokens=1048576
+NormalPri:
+  term=1 index=1  tokens=1048576
+++++
+schedule-controller-event-count: 2
+scheduled-replicas: 2

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -396,7 +396,7 @@ type Processor interface {
 	// by the RangeController.
 	//
 	// raftMu is held.
-	ProcessSchedulerEventRaftMuLocked(ctx context.Context)
+	ProcessSchedulerEventRaftMuLocked(ctx context.Context, mode rac2.RaftMsgAppMode)
 
 	// InspectRaftMuLocked returns a handle to inspect the state of the
 	// underlying range controller. It is used to power /inspectz-style debugging
@@ -1177,13 +1177,15 @@ func (p *processorImpl) AdmitForEval(
 }
 
 // ProcessSchedulerEventRaftMuLocked implements Processor.
-func (p *processorImpl) ProcessSchedulerEventRaftMuLocked(ctx context.Context) {
+func (p *processorImpl) ProcessSchedulerEventRaftMuLocked(
+	ctx context.Context, mode rac2.RaftMsgAppMode,
+) {
 	p.opts.Replica.RaftMuAssertHeld()
 	if p.destroyed {
 		return
 	}
 	if rc := p.leader.rc; rc != nil {
-		rc.HandleSchedulerEventRaftMuLocked(ctx)
+		rc.HandleSchedulerEventRaftMuLocked(ctx, mode)
 	}
 }
 

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -246,8 +246,10 @@ func (c *testRangeController) HandleRaftEventRaftMuLocked(
 	return nil
 }
 
-func (c *testRangeController) HandleSchedulerEventRaftMuLocked(ctx context.Context) {
-	panic("HandleSchedulerEventRaftMuLocked should not be called when no send-queues")
+func (c *testRangeController) HandleSchedulerEventRaftMuLocked(
+	ctx context.Context, mode rac2.RaftMsgAppMode,
+) {
+	panic("HandleSchedulerEventRaftMuLocked is unimplemented")
 }
 
 func (c *testRangeController) AdmitRaftMuLocked(

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -884,6 +884,11 @@ type Replica struct {
 		// existing real implementation to be destroyed and replaced with a real
 		// implementation.
 		replicaFlowControlIntegration replicaFlowControlIntegration
+
+		// The currentRACv2Mode is always in-sync with RawNode.
+		// MsgAppPull <=> LazyReplication.
+		// Updated with both raftMu and mu held.
+		currentRACv2Mode rac2.RaftMsgAppMode
 	}
 
 	// The raft log truncations that are pending. Access is protected by its own

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -379,6 +379,7 @@ func newRaftConfig(
 	id raftpb.PeerID,
 	appliedIndex kvpb.RaftIndex,
 	storeCfg StoreConfig,
+	lazyReplication bool,
 	logger raft.Logger,
 	storeLiveness raftstoreliveness.StoreLiveness,
 ) *raft.Config {
@@ -391,6 +392,7 @@ func newRaftConfig(
 		MaxUncommittedEntriesSize:   storeCfg.RaftMaxUncommittedEntriesSize,
 		MaxCommittedSizePerReady:    storeCfg.RaftMaxCommittedSizePerReady,
 		DisableConfChangeValidation: true, // see https://github.com/cockroachdb/cockroach/issues/105797
+		LazyReplication:             lazyReplication,
 		MaxSizePerMsg:               storeCfg.RaftMaxSizePerMsg,
 		MaxInflightMsgs:             storeCfg.RaftMaxInflightMsgs,
 		MaxInflightBytes:            storeCfg.RaftMaxInflightBytes,


### PR DESCRIPTION
The end-to-end code is not exercised, since it depends on changing RaftInterface. The partial integration here introduces a currentRACv2Mode field in Replica, that tracks RawNode's lazy-replication mode.

The mode is switched based on cluster version and settings when executing Replica.HandleRaftReadyRaftMuLocked.

The scheduler event processing in RangeController is passed the current mode, in case it has changed since the last call to RangeController's HandleRaftEventRaftMuLocked. This is mainly a defensive mechanism to avoid having distant invariants -- practically, the change could only be from MsgAppPush => MsgAppPull, which doesn't prevent the replicaSendStream from using pull mode.

There is a small behavior change in quota-pool enablement logic: it stays enabled at earlier cluster versions (which necessarily use push mode). This is consistent with what we have previously done with RACv1.

Informs #130433

Epic: CRDB-37515

Release note: None