### PR TITLE
util-interval: fix license attribution

### DIFF
--- a/pkg/util/interval/interval.go
+++ b/pkg/util/interval/interval.go
@@ -1,6 +1,6 @@
 // Copyright ©2012 The bíogo Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// license that can be found in licenses/BSD-biogo.txt.
 
 // Portions of this file are additionally subject to the following
 // license and copyright.


### PR DESCRIPTION
Seven years ago, the pkg/util/interval/interval.go file had it's license header incorrectly changed to say the license could be found in the /LICENSE file. This commit corrects the header to point at the correct file: licenses/BSD-biogo.txt.

Here is the commit that incorrectly changed the license file location:

https://github.com/cockroachdb/cockroach/commit/dfd20a10cafb9f6122024050c9adb319f335bbd1#diff-7aa3308cec134c09350fe7c80dc62b35f8b40d0538f6a020a8e8c718bd3c7409

In that commit, all the other files that contained the same original header still pointed to the licenses/BSD-biogo.txt file, which indicates this file was incorrectly changed.

Epic: none

Release note: none