### PR TITLE
release-24.1: license lint: make license header linter accept CockroachDB Software License

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -252,6 +252,12 @@ func TestLint(t *testing.T) {
 //     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
 `)
 
+		cslHeader := regexp.MustCompile(`// Copyright 20\d\d The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+`)
+
 		apacheHeader := regexp.MustCompile(`// Copyright 20\d\d The Cockroach Authors.
 //
 // Licensed under the Apache License, Version 2.0 \(the "License"\);
@@ -312,16 +318,16 @@ func TestLint(t *testing.T) {
 			isApache := strings.HasPrefix(filename, "obsservice")
 			switch {
 			case isCCL:
-				if cclHeader.Find(data) == nil {
-					t.Errorf("did not find expected CCL license header in %s", filename)
+				if cclHeader.Find(data) == nil && cslHeader.Find(data) == nil {
+					t.Errorf("did not find expected CCL or CSL license header in %s", filename)
 				}
 			case isApache:
 				if apacheHeader.Find(data) == nil {
 					t.Errorf("did not find expected Apache license header in %s", filename)
 				}
 			default:
-				if bslHeader.Find(data) == nil {
-					t.Errorf("did not find expected BSL license header in %s", filename)
+				if bslHeader.Find(data) == nil && cslHeader.Find(data) == nil {
+					t.Errorf("did not find expected BSL or CSL license header in %s", filename)
 				}
 			}
 		}); err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #131665.

/cc @cockroachdb/release

---

Change the license header linter so it accepts the existing options or the CockroachDB Software License (CSL) for these cases:

- CCL files
- BSL files

This change allows the piecemeal changing of license headers to the CockroachDB Software License over multiple PRs.

Part of RE-658

Release note: none

---

Release justification: Need to change the cockroach license to the CockroachDB Software License (CSL).