### PR TITLE
release-23.2: sql: disable lease and merge queue in relocate tests

### DIFF
--- a/pkg/sql/multitenant_admin_function_test.go
+++ b/pkg/sql/multitenant_admin_function_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -61,6 +62,7 @@ func createTestClusterArgs(ctx context.Context, numReplicas, numVoters int32) ba
 
 	clusterSettings := cluster.MakeTestingClusterSettings()
 	kvserver.LoadBasedRebalancingMode.Override(ctx, &clusterSettings.SV, int64(kvserver.LBRebalancingOff))
+	kvserverbase.MergeQueueEnabled.Override(ctx, &clusterSettings.SV, false)
 	return base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
 			Settings: clusterSettings,
@@ -734,6 +736,7 @@ func TestRelocateVoters(t *testing.T) {
 					require.NoErrorf(t, err, message)
 					err = testCluster.WaitForFullReplication()
 					require.NoErrorf(t, err, message)
+					testCluster.ToggleLeaseQueues(false)
 					testCluster.ToggleReplicateQueues(false)
 					replicaState := getReplicaState(
 						t,
@@ -811,6 +814,7 @@ func TestExperimentalRelocateVoters(t *testing.T) {
 					require.NoErrorf(t, err, message)
 					err = testCluster.WaitForFullReplication()
 					require.NoErrorf(t, err, message)
+					testCluster.ToggleLeaseQueues(false)
 					testCluster.ToggleReplicateQueues(false)
 					replicaState := getReplicaState(
 						t,
@@ -903,6 +907,7 @@ func TestRelocateNonVoters(t *testing.T) {
 					require.NoErrorf(t, err, message)
 					err = testCluster.WaitForFullReplication()
 					require.NoErrorf(t, err, message)
+					testCluster.ToggleLeaseQueues(false)
 					testCluster.ToggleReplicateQueues(false)
 					replicaState := getReplicaState(
 						t,
@@ -976,6 +981,7 @@ func TestExperimentalRelocateNonVoters(t *testing.T) {
 					require.NoErrorf(t, err, message)
 					err = testCluster.WaitForFullReplication()
 					require.NoErrorf(t, err, message)
+					testCluster.ToggleLeaseQueues(false)
 					testCluster.ToggleReplicateQueues(false)
 					replicaState := getReplicaState(
 						t,

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -253,6 +253,10 @@ type TestClusterInterface interface {
 	// ToggleReplicateQueues activates or deactivates the replication queues on all
 	// the stores on all the nodes.
 	ToggleReplicateQueues(active bool)
+
+	// ToggleLeaseQueues activates or deactivates the lease queues on all
+	// the stores on all the nodes.
+	ToggleLeaseQueues(active bool)
 }
 
 // SplitPoint describes a split point that is passed to SplitTable.

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -1594,6 +1594,16 @@ func (tc *TestCluster) ToggleReplicateQueues(active bool) {
 	}
 }
 
+// ToggleLeaseQueues implements TestClusterInterface.
+func (tc *TestCluster) ToggleLeaseQueues(active bool) {
+	for _, s := range tc.Servers {
+		_ = s.StorageLayer().GetStores().(*kvserver.Stores).VisitStores(func(store *kvserver.Store) error {
+			store.TestingSetLeaseQueueActive(active)
+			return nil
+		})
+	}
+}
+
 // ReadIntFromStores reads the current integer value at the given key
 // from all configured engines on un-stopped servers, filling in zeros
 // when the value is not found.


### PR DESCRIPTION
Backport 1/1 commits from #131789.

/cc @cockroachdb/release

Release justification: test only change

---

These would occasionally fail due to a race with either the merge queue, or the lease queue. Note that the replicate queue, split queue and store rebalancer are already disabled, which would be the other racing contributors

Resolves: #126541
Release note: None
