### PR TITLE
eval: fix nil pointer when evaluating aggregate builtins

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/set_local
+++ b/pkg/sql/logictest/testdata/logic_test/set_local
@@ -547,3 +547,12 @@ def
 # Regression test for the special "tracing" variable.
 query error parameter \"tracing\" cannot be changed
 SET LOCAL tracing = 'off'
+
+# Regression test for using builtin functions as the value for SET.
+# Normal functions work, but aggregate functions are not allowed.
+# See https://github.com/cockroachdb/cockroach/issues/131158.
+statement ok
+SET LOCAL search_path = concat('1', 'a')
+
+statement error cannot evaluate function in this context
+SET LOCAL search_path = string_agg('1', ',')

--- a/pkg/sql/sem/eval/expr.go
+++ b/pkg/sql/sem/eval/expr.go
@@ -472,6 +472,12 @@ func (e *evaluator) EvalFuncExpr(ctx context.Context, expr *tree.FuncExpr) (tree
 	}
 
 	if fn.Body != "" {
+		// This expression evaluator cannot run functions defined with a SQL body.
+		return nil, pgerror.Newf(pgcode.FeatureNotSupported, "cannot evaluate function in this context")
+	}
+	if fn.Fn == nil {
+		// This expression evaluator cannot run functions that are not "normal"
+		// builtins; that is, not aggregate or window functions.
 		return nil, pgerror.Newf(pgcode.FeatureNotSupported, "cannot evaluate function in this context")
 	}
 


### PR DESCRIPTION
The `(*eval.evaluator).EvalFuncExpr` function can only handle normal, non-aggregate builtin functions. It was possible to invoke it for aggregate functions, so this patch adds a nil-guard.

fixes https://github.com/cockroachdb/cockroach/issues/131158
Release note (bug fix): Fixed an error that could happen if an aggregate function was used as the value in a SET command.