### PR TITLE
cli: set strict TLS for generate haproxy command

### DIFF
--- a/pkg/cli/clientflags/client_flags.go
+++ b/pkg/cli/clientflags/client_flags.go
@@ -55,6 +55,7 @@ func AddSQLFlags(
 	sqlCfg *clisqlcfg.Context,
 	isShell bool,
 	isDemo bool,
+	strictTLS bool,
 ) {
 	f := cmd.PersistentFlags()
 
@@ -72,7 +73,7 @@ func AddSQLFlags(
 	warnFn := func(format string, args ...interface{}) {
 		fmt.Fprintf(os.Stderr, format, args...)
 	}
-	cliflagcfg.VarFlagDepth(1, f, clienturl.NewURLParser(cmd, clientOpts, false /* strictTLS */, warnFn), cliflags.URL)
+	cliflagcfg.VarFlagDepth(1, f, clienturl.NewURLParser(cmd, clientOpts, strictTLS, warnFn), cliflags.URL)
 
 	// --user/-u
 	cliflagcfg.StringFlagDepth(1, f, &clientOpts.User, cliflags.User)

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -801,6 +801,7 @@ func init() {
 		clientflags.AddSQLFlags(cmd, &cliCtx.clientOpts, sqlCtx,
 			cmd == sqlShellCmd, /* isShell */
 			cmd == demoCmd || cmd == statementBundleRecreateCmd, /* isDemo */
+			cmd == genHAProxyCmd, /* strictTLS */
 		)
 	}
 

--- a/pkg/cmd/cockroach-sql/main.go
+++ b/pkg/cmd/cockroach-sql/main.go
@@ -81,7 +81,7 @@ func runMain() error {
 
 	// Configure the command-line flags.
 	clientflags.AddBaseFlags(sqlCmd, &copts, &copts.Insecure, &copts.CertsDir)
-	clientflags.AddSQLFlags(sqlCmd, &copts, cfg, true /* isShell */, false /* isDemo */)
+	clientflags.AddSQLFlags(sqlCmd, &copts, cfg, true /* isShell */, false /* isDemo */, false /* strictTLS */)
 	// Configure the format flag
 	cliflagcfg.VarFlagDepth(1, sqlCmd.PersistentFlags(), &cfg.ExecCtx.TableDisplayFormat, cliflags.TableDisplayFormat)
 


### PR DESCRIPTION
Previously, "gen haproxy" was not a SQL command (See: #130827), but was recently updated to be one. The command uses a status client. In order for the certificate dirs to properly propagate we require strict TLS when parsing the URL flag. This is because our certificate manager and not the lib/pq one is required for this command to work properly.

Fixes: #131802

Epic: None
Release note: None