### PR TITLE
cli: add --user flag to client cmds

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -815,6 +815,12 @@ func init() {
 		}
 
 		f := cmd.PersistentFlags()
+
+		// The strict TLS validation below fails if the client cert names don't match
+		// the username. But if the user flag isn't hooked up, it will always expect
+		// 'root'.
+		cliflagcfg.StringFlag(f, &cliCtx.clientOpts.User, cliflags.User)
+
 		cliflagcfg.VarFlag(f, clienturl.NewURLParser(cmd, &cliCtx.clientOpts, true /* strictTLS */, func(format string, args ...interface{}) {
 			fmt.Fprintf(stderr, format, args...)
 		}), cliflags.URL)

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -798,7 +798,6 @@ func init() {
 	sqlCmds = append(sqlCmds, nodeLocalCmds...)
 	sqlCmds = append(sqlCmds, importCmds...)
 	sqlCmds = append(sqlCmds, userFileCmds...)
-	sqlCmds = append(sqlCmds, genHAProxyCmd)
 	for _, cmd := range sqlCmds {
 		clientflags.AddSQLFlags(cmd, &cliCtx.clientOpts, sqlCtx,
 			cmd == sqlShellCmd, /* isShell */

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -294,6 +294,7 @@ func TestClientURLFlagEquivalence(t *testing.T) {
 	defer func() { _ = cleanup2() }()
 
 	anyCmd := []string{"sql", "node drain"}
+	anyClientNonSQLCmd := []string{"gen haproxy"}
 	anyNonSQL := []string{"node drain", "init"}
 	anySQL := []string{"sql"}
 	sqlShell := []string{"sql"}
@@ -320,7 +321,7 @@ func TestClientURLFlagEquivalence(t *testing.T) {
 		{anyNonSQLShell, []string{"--url=postgresql://foo/bar"}, []string{"--host=foo" /*db ignored*/}, "", ""},
 
 		{anySQL, []string{"--url=postgresql://foo@"}, []string{"--user=foo"}, "", ""},
-		{anyNonSQL, []string{"--url=postgresql://foo@bar"}, []string{"--host=bar" /*user ignored*/}, "", ""},
+		{anyNonSQL, []string{"--url=postgresql://foo@bar"}, []string{"--user=foo", "--host=bar"}, "", ""},
 
 		{sqlShell, []string{"--url=postgresql://a@b:12345/d"}, []string{"--user=a", "--host=b", "--port=12345", "--database=d"}, "", ""},
 		{sqlShell, []string{"--url=postgresql://a@b:c/d"}, nil, `invalid port ":c" after host`, ""},
@@ -385,6 +386,10 @@ func TestClientURLFlagEquivalence(t *testing.T) {
 		{anyNonSQL, []string{"--url=postgresql://foo?sslmode=verify-full&sslrootcert=blih/loh.crt"}, nil, `invalid file name for "sslrootcert": expected .* got .*`, ""},
 		{anyNonSQL, []string{"--url=postgresql://foo?sslmode=verify-full&sslcert=blih/loh.crt"}, nil, `invalid file name for "sslcert": expected .* got .*`, ""},
 		{anyNonSQL, []string{"--url=postgresql://foo?sslmode=verify-full&sslkey=blih/loh.crt"}, nil, `invalid file name for "sslkey": expected .* got .*`, ""},
+		// Check that client commands take username into account when enforcing
+		// client cert names. Concretely, it's looking for 'timapples' in the client
+		// cert key file name, not 'root'.
+		{anyClientNonSQLCmd, []string{"--url=postgresql://timapples@foo?sslmode=verify-full&sslkey=/certs/client.roachprod.key"}, nil, `invalid file name for "sslkey": expected "client.timapples.key", got .*`, ""},
 
 		// Check that not specifying a certs dir will cause Go to use root trust store.
 		{anyCmd, []string{"--url=postgresql://foo?sslmode=verify-full"}, []string{"--host=foo"}, "", ""},


### PR DESCRIPTION
I originally sent #130827 in reaction to finding that `./cockroach gen
haproxy` didn't work with SQL urls that used client certs for a non-root
user (it would erroneously expect to be pointed at the root client certs).

That PR caused problems too; now one needed to specify `--certs` even
though the certs were in the URL. There's a fix for that too (#131894)
but it all seems pretty tangled up.

This PR takes a more straightforward route: we revert #130827 and add
the `--user` flag to all client commands (who all already get the
`--sql` flag.

This should have fewer unintended consequences, and solves the problem.

Fixes https://github.com/cockroachdb/cockroach/issues/131802.
Fixes https://github.com/cockroachdb/cockroach/issues/131812.
Fixes https://github.com/cockroachdb/cockroach/issues/131814.
Fixes https://github.com/cockroachdb/cockroach/issues/131815.
Fixes https://github.com/cockroachdb/cockroach/issues/131816.
Fixes https://github.com/cockroachdb/cockroach/issues/131817.

Epic: none
Release note: None

