### PR TITLE
cluster-ui: add table stats collection to v2 db pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/databases/getTableMetadataApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databases/getTableMetadataApi.ts
@@ -40,6 +40,9 @@ export type TableMetadata = {
   store_ids: number[];
   last_updated: string;
   last_update_error: string | null;
+  auto_stats_enabled: boolean;
+  // Optimizer stats.
+  stats_last_updated: string | null;
 };
 
 type TableMetadataResponse = APIV2ResponseWithPaginationState<TableMetadata[]>;

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/constants.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/constants.ts
@@ -11,4 +11,5 @@ export enum TableColName {
   NODE_REGIONS = "Regions / Nodes",
   LIVE_DATA_PERCENTAGE = "% of Live data",
   STATS_LAST_UPDATED = "Stats last updated",
+  AUTO_STATS_ENABLED = "Table auto stats enabled",
 }

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
@@ -18,7 +18,6 @@ import { RegionNodesLabel } from "src/components/regionNodesLabel";
 import { TableMetadataJobControl } from "src/components/tableMetadataLastUpdated/tableMetadataJobControl";
 import { useRouteParams } from "src/hooks/useRouteParams";
 import { PageSection } from "src/layouts";
-import { Loading } from "src/loading";
 import { PageConfig, PageConfigItem } from "src/pageConfig";
 import PageCount from "src/sharedFromCloud/pageCount";
 import { Search } from "src/sharedFromCloud/search";
@@ -278,30 +277,30 @@ export const TablesPageV2 = () => {
         </PageConfig>
       </PageSection>
       <PageSection>
-        <Loading page="TablesV2" loading={isLoading} error={error}>
-          <PageCount
-            page={params.pagination.page}
-            pageSize={params.pagination.pageSize}
-            total={data?.pagination_info?.total_results ?? 0}
-            entity="tables"
-          />
-          <Table
-            actionButton={
-              <TableMetadataJobControl onDataUpdated={refreshTables} />
-            }
-            columns={colsWithSort}
-            dataSource={tableData}
-            pagination={{
-              size: "small",
-              current: params.pagination.page,
-              pageSize: params.pagination.pageSize,
-              showSizeChanger: false,
-              position: ["bottomCenter"],
-              total: paginationState?.total_results,
-            }}
-            onChange={onTableChange}
-          />
-        </Loading>
+        <PageCount
+          page={params.pagination.page}
+          pageSize={params.pagination.pageSize}
+          total={data?.pagination_info?.total_results ?? 0}
+          entity="tables"
+        />
+        <Table
+          loading={isLoading}
+          error={error}
+          actionButton={
+            <TableMetadataJobControl onDataUpdated={refreshTables} />
+          }
+          columns={colsWithSort}
+          dataSource={tableData}
+          pagination={{
+            size: "small",
+            current: params.pagination.page,
+            pageSize: params.pagination.pageSize,
+            showSizeChanger: false,
+            position: ["bottomCenter"],
+            total: paginationState?.total_results,
+          }}
+          onChange={onTableChange}
+        />
       </PageSection>
     </>
   );

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/types.ts
@@ -21,5 +21,6 @@ export type TableRow = {
   liveDataBytes: number;
   totalDataBytes: number;
   statsLastUpdated: Moment;
+  autoStatsEnabled: boolean;
   key: string;
 };

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/utils.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/utils.tsx
@@ -6,8 +6,7 @@
 import moment from "moment-timezone";
 
 import { TableMetadata } from "src/api/databases/getTableMetadataApi";
-
-import { NodeID, StoreID } from "../types/clusterTypes";
+import { NodeID, StoreID } from "src/types/clusterTypes";
 
 import { TableRow } from "./types";
 
@@ -43,7 +42,8 @@ export const rawTableMetadataToRows = (
       liveDataPercentage: table.percent_live_data,
       liveDataBytes: table.total_live_data_bytes,
       totalDataBytes: table.total_data_bytes,
-      statsLastUpdated: moment.utc(table.last_updated), // TODO (xinhaoz): populate this
+      statsLastUpdated: moment.utc(table.stats_last_updated),
+      autoStatsEnabled: table.auto_stats_enabled,
       key: table.table_id.toString(),
       qualifiedNameWithSchema: `${table.schema_name}.${table.table_name}`,
     };

--- a/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
@@ -18,7 +18,6 @@ import { NodeRegionsSelector } from "src/components/nodeRegionsSelector/nodeRegi
 import { RegionNodesLabel } from "src/components/regionNodesLabel";
 import { TableMetadataJobControl } from "src/components/tableMetadataLastUpdated/tableMetadataJobControl";
 import { PageLayout, PageSection } from "src/layouts";
-import { Loading } from "src/loading";
 import { PageConfig, PageConfigItem } from "src/pageConfig";
 import PageCount from "src/sharedFromCloud/pageCount";
 import { PageHeader } from "src/sharedFromCloud/pageHeader";
@@ -220,30 +219,30 @@ export const DatabasesPageV2 = () => {
         </PageConfig>
       </PageSection>
       <PageSection>
-        <Loading page="Databases overview" loading={isLoading} error={error}>
-          <PageCount
-            page={params.pagination.page}
-            pageSize={params.pagination.pageSize}
-            total={paginationState?.total_results}
-            entity="databases"
-          />
-          <Table
-            actionButton={
-              <TableMetadataJobControl onDataUpdated={refreshDatabases} />
-            }
-            columns={colsWithSort}
-            dataSource={tableData}
-            pagination={{
-              size: "small",
-              current: params.pagination.page,
-              pageSize: params.pagination.pageSize,
-              showSizeChanger: false,
-              position: ["bottomCenter"],
-              total: paginationState?.total_results,
-            }}
-            onChange={onTableChange}
-          />
-        </Loading>
+        <PageCount
+          page={params.pagination.page ?? 0}
+          pageSize={params.pagination.pageSize ?? 0}
+          total={paginationState?.total_results ?? 0}
+          entity="databases"
+        />
+        <Table
+          loading={isLoading}
+          error={error}
+          actionButton={
+            <TableMetadataJobControl onDataUpdated={refreshDatabases} />
+          }
+          columns={colsWithSort}
+          dataSource={tableData}
+          pagination={{
+            size: "small",
+            current: params.pagination.page,
+            pageSize: params.pagination.pageSize,
+            showSizeChanger: false,
+            position: ["bottomCenter"],
+            total: paginationState?.total_results,
+          }}
+          onChange={onTableChange}
+        />
       </PageSection>
     </PageLayout>
   );

--- a/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/tableOverview.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/tableOverview.tsx
@@ -6,21 +6,16 @@
 import { Icon } from "@cockroachlabs/ui-components";
 import { Col, Row, Skeleton, Tooltip } from "antd";
 import moment from "moment-timezone";
-import React, { useContext } from "react";
+import React from "react";
 
+import { useNodeStatuses } from "src/api";
 import { TableDetailsResponse } from "src/api/databases/getTableMetadataApi";
 import { PageSection } from "src/layouts";
 import { SqlBox, SqlBoxSize } from "src/sql";
-
-import { useNodeStatuses } from "../api";
-import { TimezoneContext } from "../contexts";
-import { SummaryCard, SummaryCardItem } from "../summaryCard";
-import { StoreID } from "../types/clusterTypes";
-import {
-  Bytes,
-  DATE_WITH_SECONDS_FORMAT_24_TZ,
-  FormatWithTimezone,
-} from "../util";
+import { SummaryCard, SummaryCardItem } from "src/summaryCard";
+import { Timestamp } from "src/timestamp";
+import { StoreID } from "src/types/clusterTypes";
+import { Bytes, DATE_WITH_SECONDS_FORMAT_24_TZ } from "src/util";
 
 type TableOverviewProps = {
   tableDetails: TableDetailsResponse;
@@ -63,12 +58,6 @@ export const TableOverview: React.FC<TableOverviewProps> = ({
     metadata.percent_live_data * 100
   ).toFixed(2);
 
-  const timezone = useContext(TimezoneContext);
-  const lastUpdatedText = FormatWithTimezone(
-    moment.utc(metadata.last_updated),
-    DATE_WITH_SECONDS_FORMAT_24_TZ,
-    timezone,
-  );
   const formattedErrorText = metadata.last_update_error
     ? "Update error: " + metadata.last_update_error
     : "";
@@ -89,7 +78,13 @@ export const TableOverview: React.FC<TableOverviewProps> = ({
                 {metadata.last_update_error && (
                   <Icon fill="warning" iconName={"Caution"} />
                 )}
-                <Col>Last updated: {lastUpdatedText}</Col>
+                <Col>
+                  Last updated:{" "}
+                  <Timestamp
+                    time={moment.utc(metadata.last_updated)}
+                    format={DATE_WITH_SECONDS_FORMAT_24_TZ}
+                  />
+                </Col>
               </Row>
             </Tooltip>
           </Col>
@@ -124,6 +119,20 @@ export const TableOverview: React.FC<TableOverviewProps> = ({
                       {Bytes(metadata.total_live_data_bytes)}
                     </div>
                   </div>
+                }
+              />
+              <SummaryCardItem
+                label="Auto stats collections"
+                value={metadata.auto_stats_enabled ? "Enabled" : "Disabled"}
+              />
+              <SummaryCardItem
+                label="Stats last updated"
+                value={
+                  <Timestamp
+                    time={moment.utc(metadata.stats_last_updated)}
+                    format={DATE_WITH_SECONDS_FORMAT_24_TZ}
+                    fallback={"Never"}
+                  />
                 }
               />
             </SummaryCard>


### PR DESCRIPTION
Instead of wrapping these components in <Loading /> we can
use the equivalent loading and error props.

Epic: none

Release note: None


cluster-ui: add table stats collection to v2 db pages

This commit adds information about table stats collection
to the v2 db pages. We now show if automatic stats
collection is enabled for each table and the timestamp
of the last collection time.

Epic: [CRDB-37558](https://cockroachlabs.atlassian.net/browse/CRDB-37558)

Release note: None