### PR TITLE
roachtest: remove another `panic` from a `go` function

### DIFF
--- a/pkg/cmd/roachtest/tests/limit_capacity.go
+++ b/pkg/cmd/roachtest/tests/limit_capacity.go
@@ -101,7 +101,7 @@ func runLimitCapacity(ctx context.Context, t test.Test, c cluster.Cluster, cfg l
 
 	t.Status(fmt.Sprintf("waiting %s for baseline workload throughput", initialDuration))
 	wait(c.NewMonitor(ctx, c.CRDBNodes()), initialDuration)
-	qpsInitial := measureQPS(ctx, t, 10*time.Second, conn)
+	qpsInitial := measureQPS(ctx, t, c, 10*time.Second, c.Node(1))
 	t.Status(fmt.Sprintf("initial (single node) qps: %.0f", qpsInitial))
 
 	if cfg.writeCapBytes >= 0 {
@@ -127,7 +127,7 @@ func runLimitCapacity(ctx context.Context, t test.Test, c cluster.Cluster, cfg l
 	}
 
 	wait(c.NewMonitor(ctx, c.CRDBNodes()), limitDuration)
-	qpsFinal := measureQPS(ctx, t, 10*time.Second, conn)
+	qpsFinal := measureQPS(ctx, t, c, 10*time.Second, c.Node(1))
 	qpsRelative := qpsFinal / qpsInitial
 	t.Status(fmt.Sprintf("initial qps=%f final qps=%f (%f%%)", qpsInitial, qpsFinal, 100*qpsRelative))
 	for _, cancel := range cancels {


### PR DESCRIPTION
In #130803, a fix was made to avoid the possibility of a panic in the `measureQPS` function, which runs some logic using the `go` keyword.

However, `kv.go` has an identical function with the same problem that wasn't fixed in that PR.

In this commit, we remove that duplication, using the correct implementation.

Epic: none

Release note: None