### PR TITLE
server/license: Enable the License Enforcer

### DIFF
--- a/pkg/ccl/utilccl/license_check_test.go
+++ b/pkg/ccl/utilccl/license_check_test.go
@@ -386,7 +386,6 @@ func TestRefreshLicenseEnforcerOnLicenseChange(t *testing.T) {
 		DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
 		Knobs: base.TestingKnobs{
 			LicenseTestingKnobs: &license.TestingKnobs{
-				Enable:            true,
 				SkipDisable:       true,
 				OverrideStartTime: &ts1,
 			},

--- a/pkg/server/application_api/telemetry_test.go
+++ b/pkg/server/application_api/telemetry_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/srvtestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -131,13 +132,14 @@ func TestThrottlingMetadata(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.UnderRace(t, "times out under race")
+
 	testtime := timeutil.Now()
 
 	s := serverutils.StartCluster(t, 3, base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				LicenseTestingKnobs: &license.TestingKnobs{
-					Enable:            true,
 					OverrideStartTime: &testtime,
 				},
 			},

--- a/pkg/server/license/enforcer_test.go
+++ b/pkg/server/license/enforcer_test.go
@@ -47,7 +47,6 @@ func TestClusterInitGracePeriod_NoOverwrite(t *testing.T) {
 	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			LicenseTestingKnobs: &license.TestingKnobs{
-				Enable:            true,
 				OverrideStartTime: &ts1,
 			},
 		},
@@ -60,7 +59,6 @@ func TestClusterInitGracePeriod_NoOverwrite(t *testing.T) {
 	ts2End := ts2.Add(7 * 24 * time.Hour) // Calculate the end of the grace period
 	enforcer := license.NewEnforcer(
 		&license.TestingKnobs{
-			Enable:            true,
 			OverrideStartTime: &ts2,
 		})
 	// Ensure request for the grace period init ts1 before start just returns the start
@@ -92,7 +90,6 @@ func TestClusterInitGracePeriod_NewClusterEstimation(t *testing.T) {
 	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			LicenseTestingKnobs: &license.TestingKnobs{
-				Enable:            true,
 				OverrideStartTime: &ts1,
 			},
 		},
@@ -112,7 +109,6 @@ func TestClusterInitGracePeriod_NewClusterEstimation(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			enforcer := license.NewEnforcer(
 				&license.TestingKnobs{
-					Enable:                            true,
 					OverrideStartTime:                 &ts1,
 					OverwriteClusterInitGracePeriodTS: true,
 				})
@@ -133,7 +129,6 @@ func TestClusterInitGracePeriod_NewClusterEstimation(t *testing.T) {
 				license.WithDB(db),
 				license.WithSystemTenant(true),
 				license.WithTestingKnobs(&license.TestingKnobs{
-					Enable:                            true,
 					OverrideStartTime:                 &ts1,
 					OverwriteClusterInitGracePeriodTS: true,
 				}),
@@ -167,7 +162,6 @@ func TestClusterInitGracePeriod_DelayedTenantConnector(t *testing.T) {
 	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			LicenseTestingKnobs: &license.TestingKnobs{
-				Enable:            true,
 				OverrideStartTime: &ts0,
 			},
 		},
@@ -181,7 +175,6 @@ func TestClusterInitGracePeriod_DelayedTenantConnector(t *testing.T) {
 	// Start up the enforcer for the secondary tenant using a metadata accessor
 	// that has not yet received the cluster init grace period timestamp.
 	enforcer := license.NewEnforcer(&license.TestingKnobs{
-		Enable:                    true,
 		OverrideStartTime:         &ts1d,
 		OverrideThrottleCheckTime: &ts9d,
 	})
@@ -279,7 +272,6 @@ func TestThrottle(t *testing.T) {
 		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
 			e := license.NewEnforcer(
 				&license.TestingKnobs{
-					Enable:                    true,
 					OverrideStartTime:         &tc.gracePeriodInit,
 					OverrideThrottleCheckTime: &tc.checkTs,
 				})
@@ -345,7 +337,6 @@ func TestThrottleErrorMsg(t *testing.T) {
 	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			LicenseTestingKnobs: &license.TestingKnobs{
-				Enable: true,
 				// The mock server we bring up is single-node, which disables all
 				// throttling checks. We need to avoid that for this test to verify
 				// the throttle message.

--- a/pkg/upgrade/upgradebase/testing_knobs.go
+++ b/pkg/upgrade/upgradebase/testing_knobs.go
@@ -70,6 +70,10 @@ type TestingKnobs struct {
 	SkipMVCCStatisticsJobBootstrap bool
 
 	SkipUpdateTableMetadataCacheBootstrap bool
+
+	// ForceCheckLicenseViolation is true if we want the v24_3_check_license_violation.go
+	// task to continue even though we are in a test environment.
+	ForceCheckLicenseViolation bool
 }
 
 // ModuleTestingKnobs makes TestingKnobs a base.ModuleTestingKnobs.

--- a/pkg/upgrade/upgrademanager/manager.go
+++ b/pkg/upgrade/upgrademanager/manager.go
@@ -852,6 +852,7 @@ func (m *Manager) checkPreconditions(ctx context.Context, versions []roachpb.Ver
 			LeaseManager:       m.lm,
 			InternalExecutor:   m.ie,
 			JobRegistry:        m.jr,
+			TestingKnobs:       &m.knobs,
 			ClusterID:          m.clusterID.Get(),
 			LicenseEnforcer:    m.le,
 			TenantInfoAccessor: m.deps.TenantInfoAccessor,

--- a/pkg/upgrade/upgrades/BUILD.bazel
+++ b/pkg/upgrade/upgrades/BUILD.bazel
@@ -61,6 +61,7 @@ go_library(
         "//pkg/sql/tablemetadatacache",
         "//pkg/upgrade",
         "//pkg/upgrade/upgradebase",
+        "//pkg/util/buildutil",
         "//pkg/util/envutil",
         "//pkg/util/log",
         "//pkg/util/log/logcrash",

--- a/pkg/upgrade/upgrades/v24_3_check_license_violation_test.go
+++ b/pkg/upgrade/upgrades/v24_3_check_license_violation_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/upgrade/upgradebase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -50,8 +51,10 @@ func TestCheckLicenseViolations(t *testing.T) {
 				ClusterVersionOverride:         v1,
 			},
 			LicenseTestingKnobs: &license.TestingKnobs{
-				Enable:      true,
 				SkipDisable: true,
+			},
+			UpgradeManager: &upgradebase.TestingKnobs{
+				ForceCheckLicenseViolation: true,
 			},
 			// Make the upgrade faster by accelerating jobs.
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),


### PR DESCRIPTION
Previously, the license enforcer was disabled by default and only enabled in specific test cases designed for it. This change fully activates the license enforcer and removes the option to disable it.

Some upgrade tests were failing because upgrades cannot be finalized without a valid license. To address this, I relaxed the restriction in test environments rather than modifying all mixed-mode tests to ensure a license is present.

We still do the enterprise check in this PR. Another PR (#131943) will be opened to remove them as it has quite a bit more test changes needed.

This change will be backported to versions 24.2, 24.1, 23.2, and 23.1.

Epic: CRDB-39988
Closes: CRDB-41758
Release note: none