### PR TITLE
pgwire: reduce allocations when writing string columns

### DIFF
--- a/pkg/sql/sem/tree/pgwire_encode.go
+++ b/pkg/sql/sem/tree/pgwire_encode.go
@@ -32,6 +32,17 @@ func ResolveBlankPaddedChar(s string, t *types.T) string {
 	return s
 }
 
+// ResolveBlankPaddedCharBytes is similar to ResolveBlankPaddedChar but operates
+// on a slice of bytes instead of a string.
+func ResolveBlankPaddedCharBytes(v []byte, t *types.T) []byte {
+	if t.Oid() == oid.T_bpchar && len(v) < int(t.Width()) {
+		// Pad spaces on the right of the byte slice to make it of length
+		// specified in the type t.
+		return append(v, bytes.Repeat([]byte(" "), int(t.Width())-len(v))...)
+	}
+	return v
+}
+
 func (d *DTuple) pgwireFormat(ctx *FmtCtx) {
 	// When converting a tuple to text in "postgres mode" there is
 	// special behavior: values are printed in "postgres mode" then the


### PR DESCRIPTION
An unnecessary `[]byte` to `string` cast that requires a heap allocation
in `(*writeBuffer).writeBinaryColumnarElement` has been removed. In
order to achieve this, `writeBinaryBytes` has been updated to handle
cases where the type of the column is a string-like type. It now
includes the same special cases for `CHAR(N)` and `"char"` types  that
`writeBinaryString` already has.

Epic: CRDB-41124

Release note (performance improvement): The system now more efficiently
writes string-like values in the pgwire protocol.
