### PR TITLE
keys,server: use TableSpan from SQLCodec

### DIFF
--- a/pkg/keys/sql.go
+++ b/pkg/keys/sql.go
@@ -185,6 +185,12 @@ func (e sqlEncoder) TenantSpan() roachpb.Span {
 	return roachpb.Span{Key: key, EndKey: endKey}
 }
 
+// TableSpan returns a span representing the table's keyspace.
+func (e sqlEncoder) TableSpan(tableID uint32) roachpb.Span {
+	key := e.TablePrefix(tableID)
+	return roachpb.Span{Key: key, EndKey: key.PrefixEnd()}
+}
+
 // TablePrefix returns the key prefix used for the table's data.
 func (e sqlEncoder) TablePrefix(tableID uint32) roachpb.Key {
 	k := e.TenantPrefix()

--- a/pkg/server/systemconfigwatcher/cache.go
+++ b/pkg/server/systemconfigwatcher/cache.go
@@ -85,14 +85,8 @@ func NewWithAdditionalProvider(
 	c.additionalKVsSource = additional
 
 	spans := []roachpb.Span{
-		{
-			Key:    append(codec.TenantPrefix(), keys.SystemDescriptorTableSpan.Key...),
-			EndKey: append(codec.TenantPrefix(), keys.SystemDescriptorTableSpan.EndKey...),
-		},
-		{
-			Key:    append(codec.TenantPrefix(), keys.SystemZonesTableSpan.Key...),
-			EndKey: append(codec.TenantPrefix(), keys.SystemZonesTableSpan.EndKey...),
-		},
+		codec.TableSpan(keys.DescriptorTableID),
+		codec.TableSpan(keys.ZonesTableID),
 	}
 	c.w = rangefeedcache.NewWatcher(
 		"system-config-cache", clock, f,


### PR DESCRIPTION
Add TableSpan implementation to SQLCodec and use that to build table spans. This refactoring helps with migration experiment of default system tenant from tenantID {1} to {2}.

Informs: https://github.com/cockroachdb/cockroach/issues/131902
Epic: CRDB-42740
Release note: None