### PR TITLE
sql: index backfiller can end up writing non-stored columns in families

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -4001,3 +4001,86 @@ statement error pq: \*tree.ColumnTableDef not implemented in the new schema chan
 alter table roach add column serial_id2 SERIAL
 
 subtest end
+
+statement ok
+set use_declarative_schema_changer = on
+
+# Tests for #131948 where we incorrectly backfilled empty column
+# families for composite datums.
+subtest composite_type_131948
+
+statement ok
+CREATE TABLE t1_with_composite(i int, j STRING COLLATE de_DE NOT NULL, family(i), family(j));
+INSERT INTO t1_with_composite VALUES(1, 'a');
+INSERT INTO t1_with_composite VALUES(2, 'b');
+
+statement ok
+ALTER TABLE t1_with_composite DROP COLUMN j;
+
+query I
+SELECT * FROM t1_with_composite ORDER BY i ASC;
+----
+1
+2
+
+subtest end
+
+subtest sanity_test_pk_with_composite_columns
+
+# Sanity testing for single table column families with composite types.
+statement ok
+CREATE TABLE tbl_with_dft_column_family(f float NOT NULL, d decimal NOT NULL, j json NOT NULL, s STRING COLLATE de_DE NOT NULL, family(f), family(d), family(j), family(s))
+
+statement ok
+INSERT INTO tbl_with_dft_column_family VALUES(1.0, 1.0, '{"cat": "mouse"}', 'abc');
+INSERT INTO tbl_with_dft_column_family VALUES(2.0, 2.0, '{"lion": "gazelle"}', 'def');
+INSERT INTO tbl_with_dft_column_family VALUES(3.0, 3.0, '{"wolf": "sheep"}', 'ghi');
+
+query FFTT
+SELECT f, d, j, s FROM tbl_with_dft_column_family ORDER BY 1
+----
+1  1.0  {"cat": "mouse"}     abc
+2  2.0  {"lion": "gazelle"}  def
+3  3.0  {"wolf": "sheep"}    ghi
+
+statement ok
+ALTER TABLE tbl_with_dft_column_family ALTER PRIMARY KEY USING COLUMNS (f);
+
+query FFTT
+SELECT * FROM tbl_with_dft_column_family ORDER BY 1
+----
+1  1.0  {"cat": "mouse"}     abc
+2  2.0  {"lion": "gazelle"}  def
+3  3.0  {"wolf": "sheep"}    ghi
+
+statement ok
+ALTER TABLE tbl_with_dft_column_family ALTER PRIMARY KEY USING COLUMNS (d);
+
+query FFTT
+SELECT * FROM tbl_with_dft_column_family ORDER BY 1
+----
+1  1.0  {"cat": "mouse"}     abc
+2  2.0  {"lion": "gazelle"}  def
+3  3.0  {"wolf": "sheep"}    ghi
+
+statement ok
+ALTER TABLE tbl_with_dft_column_family ALTER PRIMARY KEY USING COLUMNS (j);
+
+query FFTT
+SELECT * FROM tbl_with_dft_column_family ORDER BY 1
+----
+1  1.0  {"cat": "mouse"}     abc
+2  2.0  {"lion": "gazelle"}  def
+3  3.0  {"wolf": "sheep"}    ghi
+
+statement ok
+ALTER TABLE tbl_with_dft_column_family ALTER PRIMARY KEY USING COLUMNS (s);
+
+query FFTT
+SELECT * FROM tbl_with_dft_column_family ORDER BY 1
+----
+1  1.0  {"cat": "mouse"}     abc
+2  2.0  {"lion": "gazelle"}  def
+3  3.0  {"wolf": "sheep"}    ghi
+
+subtest end

--- a/pkg/sql/row/helper.go
+++ b/pkg/sql/row/helper.go
@@ -257,17 +257,7 @@ func (rh *RowHelper) SkipColumnNotInPrimaryIndexValue(
 		rh.primaryIndexKeyCols = rh.TableDesc.GetPrimaryIndex().CollectKeyColumnIDs()
 		rh.primaryIndexValueCols = rh.TableDesc.GetPrimaryIndex().CollectPrimaryStoredColumnIDs()
 	}
-	if !rh.primaryIndexKeyCols.Contains(colID) {
-		return !rh.primaryIndexValueCols.Contains(colID), false
-	}
-	if cdatum, ok := value.(tree.CompositeDatum); ok {
-		// Composite columns are encoded in both the key and the value.
-		return !cdatum.IsComposite(), true
-	}
-	// Skip primary key columns as their values are encoded in the key of
-	// each family. Family 0 is guaranteed to exist and acts as a
-	// sentinel.
-	return true, false
+	return rowenc.SkipColumnNotInPrimaryIndexValue(colID, value, rh.primaryIndexKeyCols, rh.primaryIndexValueCols)
 }
 
 func (rh *RowHelper) SortedColumnFamily(famID descpb.FamilyID) ([]descpb.ColumnID, bool) {


### PR DESCRIPTION
During a drop column schmea change it's possible for column families to
exist temporarily until they get cleaned up at a later stage. These
column families would be empty because they don't have any stored
columns from the new primary index. When we added a check to skip this
logic, we added extra logic ignore composite datums, which was partially
correct but insufficient (i.e. it didn't properly check if a composite
datum needed to be stored, and always assumed this was the case). As a
result, we can end up writing composite columns into the primary index,
even if their families will be cleaned up. This can later make tables
unreadable with invalid data. To address this, this patch will skip over
any column families without stored columns, even if they have composite
datums.

The exact scenario that leads to this bug is the following
1) A table has multiple column families
2) One of these column families contains only a single column, which
 is not the first column family.
3) A column is FLOAT4/8, DECIMAL, JSON, collated string type, or array.
4) This column ends up being dropped.

Fixes: #131948

Release note (bug fix): Addressed a rare bug where dropping a column of
FLOAT4/8, DECIMAL, JSON, collated string type, or array types that were
stored in a single column family could make a table unreadable (if the
column family is not the first one).