### PR TITLE
raft: introduce CommitMark

### DIFF
--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -361,7 +361,7 @@ func (l *raftLog) lastIndex() uint64 {
 
 // commitTo bumps the commit index to the given value if it is higher than the
 // current commit index.
-func (l *raftLog) commitTo(mark LogMark) {
+func (l *raftLog) commitTo(mark CommitMark) {
 	// TODO(pav-kv): it is only safe to update the commit index if our log is
 	// consistent with the mark.term leader. If the mark.term leader sees the
 	// mark.index entry as committed, all future leaders have it in the log. It is

--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -379,22 +379,44 @@ func (l *raftLog) lastIndex() uint64 {
 	return l.unstable.lastIndex()
 }
 
-// commitTo bumps the commit index to the given value if it is higher than the
-// current commit index.
-func (l *raftLog) commitTo(mark CommitMark) {
-	// TODO(pav-kv): it is only safe to update the commit index if our log is
-	// consistent with the mark.term leader. If the mark.term leader sees the
-	// mark.index entry as committed, all future leaders have it in the log. It is
-	// thus safe to bump the commit index to min(mark.index, lastIndex) if our
-	// accTerm >= mark.term. Do this once raftLog/unstable tracks the accTerm.
-
-	// never decrease commit
-	if l.committed < mark.Index {
-		if l.lastIndex() < mark.Index {
-			l.logger.Panicf("tocommit(%d) is out of range [lastIndex(%d)]. Was the raft log corrupted, truncated, or lost?", mark.Index, l.lastIndex())
-		}
-		l.committed = mark.Index
+// maybeCommit bumps the commit index if the given entry ID matches the log.
+func (l *raftLog) maybeCommit(id entryID) bool {
+	if id.index <= l.committed || !l.matchTerm(id) {
+		return false
 	}
+	l.committed = id.index
+	return true
+}
+
+// commitTo bumps the commit index in response to the knowledge that entries are
+// committed at the given mark. It can be a no-op if updating the commit index
+// is not safe, or the index is stale, or the entire log is already committed.
+//
+// Returns true iff the commit index has been bumped.
+func (l *raftLog) commitTo(mark CommitMark) bool {
+	// In the absence of evidence that entry in accTerm leader log (and so in our
+	// log too, even if it isn't there yet) matches the one in the mark.Term log
+	// (and so does the entire log prefix), it is only safe to bump the commit
+	// index if mark.Term <= accTerm (which implies this matching guarantee).
+	if mark.Term > l.accTerm() {
+		// NB: in this case, our log is lagging the leader's. If the leader is
+		// stable, we will eventually accept a MsgApp or snapshot which bumps
+		// accTerm and enables advancing the commit index again. By this, we have
+		// the guarantee that our commit index converges to the leader's.
+		return false
+	}
+	// Cap the committed index so that it does not cross the log's last index.
+	//
+	// NB: we could proactively remember the highest committed mark even if it
+	// extends beyond the local log. The advantage would be the ability to apply
+	// the corresponding entries immediately when they get accepted in the future.
+	// However, the next MsgApp typically carries a newer commit mark, so this
+	// optimization would be hardly necessary.
+	if index := min(mark.Index, l.lastIndex()); index > l.committed {
+		l.committed = index
+		return true
+	}
+	return false
 }
 
 func (l *raftLog) appliedTo(i uint64, size entryEncodingSize) {

--- a/pkg/raft/log_unstable.go
+++ b/pkg/raft/log_unstable.go
@@ -227,8 +227,9 @@ func (u *unstable) stableSnapTo(i uint64) {
 // restore resets the state to the given snapshot. It effectively truncates the
 // log after s.lastEntryID(), so the caller must ensure this is safe.
 func (u *unstable) restore(s snapshot) bool {
-	// All logs >= s.term are consistent with the log covered by the snapshot. If
-	// our log is such, disallow restoring a snapshot at indices below our last
+	mark := s.commitMark()
+	// All logs >= mark.Term are consistent with the log covered by the snapshot.
+	// If our log is such, disallow restoring a snapshot at indices below our last
 	// index, to avoid truncating a meaningful suffix of the log and losing its
 	// durability which could have been used to commit entries in this suffix.
 	//
@@ -236,14 +237,16 @@ func (u *unstable) restore(s snapshot) bool {
 	// Alternatively, we could retain a suffix of the log instead of truncating
 	// it, but at the time of writing the whole stack (including storage) is
 	// written such that a snapshot always clears the log.
-	if s.term <= u.term && s.lastIndex() < u.lastIndex() {
+	if mark.Term <= u.term && mark.Index < u.lastIndex() {
 		return false
 	}
-	// If s.term <= u.term, our log is consistent with the snapshot. Set the new
-	// accepted term to the max of the two so that u.term does not regress. At the
-	// time of writing, s.term is always >= u.term, because s.term == raft.Term
-	// and u.term <= raft.Term. It could be relaxed in the future.
-	term := max(u.term, s.term)
+	// If mark.Term <= u.term, our log is consistent with the snapshot. Set the
+	// new accepted term to the max of the two so that u.term does not regress. At
+	// the time of writing, mark.Term is always >= u.term, because mark.Term ==
+	// raft.Term and u.term <= raft.Term. It could be relaxed in the future.
+	//
+	// TODO(pav-kv): try placing this logic in the CommitMark type.
+	term := max(u.term, mark.Term)
 
 	u.snapshot = &s.snap
 	u.logSlice = logSlice{term: term, prev: s.lastEntryID()}

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -1166,7 +1166,7 @@ func TestHandleHeartbeat(t *testing.T) {
 		require.NoError(t, storage.Append(init.entries))
 		sm := newTestRaft(1, 5, 1, storage)
 		sm.becomeFollower(init.term, 2)
-		sm.raftLog.commitTo(LogMark{Term: init.term, Index: commit})
+		sm.raftLog.commitTo(CommitMark{Term: init.term, Index: commit})
 		sm.handleHeartbeat(tt.m)
 		m := sm.readMessages()
 		require.Len(t, m, 1, "#%d", i)
@@ -1183,7 +1183,7 @@ func TestHandleHeartbeatRespStoreLivenessDisabled(t *testing.T) {
 	sm := newTestRaft(1, 5, 1, storage, withFortificationDisabled())
 	sm.becomeCandidate()
 	sm.becomeLeader()
-	sm.raftLog.commitTo(sm.raftLog.unstable.mark())
+	sm.raftLog.commitTo(CommitMark(sm.raftLog.unstable.mark()))
 
 	// A heartbeat response from a node that is behind; re-send MsgApp
 	sm.Step(pb.Message{From: 2, Type: pb.MsgHeartbeatResp})
@@ -1223,7 +1223,7 @@ func TestHandleHeatbeatTimeoutStoreLivenessEnabled(t *testing.T) {
 	sm.becomeLeader()
 	sm.fortificationTracker.RecordFortification(pb.PeerID(2), 1)
 	sm.fortificationTracker.RecordFortification(pb.PeerID(3), 1)
-	sm.raftLog.commitTo(sm.raftLog.unstable.mark())
+	sm.raftLog.commitTo(CommitMark(sm.raftLog.unstable.mark()))
 
 	// On heartbeat timeout, the leader sends a MsgApp.
 	for ticks := sm.heartbeatTimeout; ticks > 0; ticks-- {
@@ -2511,7 +2511,7 @@ func TestRestoreIgnoreSnapshot(t *testing.T) {
 	storage := newTestMemoryStorage(withPeers(1, 2))
 	sm := newTestRaft(1, 10, 1, storage)
 	require.True(t, sm.raftLog.append(init))
-	sm.raftLog.commitTo(LogMark{Term: init.term, Index: commit})
+	sm.raftLog.commitTo(CommitMark{Term: init.term, Index: commit})
 
 	s := snapshot{
 		term: 1,

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -1120,7 +1120,7 @@ func TestHandleMsgApp(t *testing.T) {
 		{pb.Message{Type: pb.MsgApp, Term: 2, LogTerm: 1, Index: 1, Commit: 4, Entries: []pb.Entry{{Index: 2, Term: 2}}}, 2, 2, false},
 
 		// Ensure 3
-		{pb.Message{Type: pb.MsgApp, Term: 1, LogTerm: 1, Index: 1, Commit: 3}, 2, 1, false},                                           // match entry 1, commit up to last new entry 1
+		{pb.Message{Type: pb.MsgApp, Term: 1, LogTerm: 1, Index: 1, Commit: 3}, 2, 2, false},                                           // match entry 1, commit up to last entry 2
 		{pb.Message{Type: pb.MsgApp, Term: 2, LogTerm: 1, Index: 1, Commit: 3, Entries: []pb.Entry{{Index: 2, Term: 2}}}, 2, 2, false}, // match entry 1, commit up to last new entry 2
 		{pb.Message{Type: pb.MsgApp, Term: 2, LogTerm: 2, Index: 2, Commit: 3}, 2, 2, false},                                           // match entry 2, commit up to last new entry 2
 		{pb.Message{Type: pb.MsgApp, Term: 2, LogTerm: 2, Index: 2, Commit: 4}, 2, 2, false},                                           // commit up to log.last()

--- a/pkg/raft/types_test.go
+++ b/pkg/raft/types_test.go
@@ -164,7 +164,7 @@ func TestSnapshot(t *testing.T) {
 			last := s.lastEntryID()
 			require.Equal(t, tt.last, last)
 			require.Equal(t, last.index, s.lastIndex())
-			require.Equal(t, LogMark{Term: tt.term, Index: last.index}, s.mark())
+			require.Equal(t, CommitMark{Term: tt.term, Index: last.index}, s.commitMark())
 		})
 	}
 }


### PR DESCRIPTION
This PR introduces the logically missing `CommitMark` coordinate system that carries the semantics of raft commits. A commit mark `(Term, Index)` guarantees that all the entries at indices <= `Index` in the log are committed as of the given `Term`, and will be present and committed in all future term logs.

These newly explained semantics are then used to formalize the meaning of the `raftLog.committed` field. Namely, the fact that `raftLog.committed` index is a `CommitMark` with `Term == raft.Term`.

The last commit moves the commit index capping logic inside `raftLog.commitTo`, and equips the latter with a safety check that ensures the commit index only moves forward if the reported `CommitMark` proves that out log matches the committed one. It also makes the commit index advancement more liberal, which today is not fully utilized and in the future can reduce tail latency of applies in leader change situations.

There is one case when this safe logic needs to be circumvented. When we receive a snapshot at the index that is already in the log, and the corresponding entry ID matches the snapshot, we [bump the commit index](https://github.com/cockroachdb/cockroach/blob/a590b2f8da8e086d421bf068d80b9ab621649420/pkg/raft/raft.go#L1889) unconditionally instead of applying the snapshot. This (pre-existing) case is what puts the commit index in the `CommitMark` coordinate system of the `raft.Term` leader, rather than our log's accepted term.

This quirk causes a "time travel" effect when the `accTerm` log can learn about an entry commit that actually happens at a higher term. The newly added comment for the `raftLog.committed` field explains in detail why this is safe: the phase-1 promise (`raft.Term`) prevents overwriting this entry by an uncommitted one. There is a second check that double-saves us: we [never try](https://github.com/cockroachdb/cockroach/blob/a590b2f8da8e086d421bf068d80b9ab621649420/pkg/raft/raft.go#L1715-L1718) to overwrite committed entries.

---

Part of #122100
Related to #127348, #127349
Related to #132030