### PR TITLE
raft: use LogMark in checkMatch

### DIFF
--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -18,6 +18,7 @@
 package raft
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/raft/raftlogger"
@@ -979,4 +980,12 @@ func intRange[T constraints.Integer](from, to T) []T {
 		slice[i] = from + T(i)
 	}
 	return slice
+}
+
+func (s logSlice) withTerm(term uint64) logSlice {
+	if term < s.term {
+		panic(fmt.Sprintf("can't bump logSlice term from %d to %d", s.term, term))
+	}
+	s.term = term
+	return s
 }

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -2116,7 +2116,7 @@ func logSliceFromMsgApp(m *pb.Message) logSlice {
 }
 
 func (r *raft) handleAppendEntries(m pb.Message) {
-	r.checkMatch(m.Match)
+	r.checkMatch(LogMark{Term: m.Term, Index: m.Match})
 
 	// TODO(pav-kv): construct logSlice up the stack next to receiving the
 	// message, and validate it before taking any action (e.g. bumping term).
@@ -2178,22 +2178,34 @@ func (r *raft) handleAppendEntries(m pb.Message) {
 	})
 }
 
-// checkMatch ensures that the follower's log size does not contradict to the
-// leader's idea where it matches.
-func (r *raft) checkMatch(match uint64) {
-	// TODO(pav-kv): lastIndex() might be not yet durable. Make this check
-	// stronger by comparing `match` with the last durable index.
-	//
-	// TODO(pav-kv): make this check stronger when the raftLog stores the last
-	// accepted term. If `match` is non-zero, this follower's log last accepted
-	// term must equal the leader term, and have entries up to `match` durable.
-	if last := r.raftLog.lastIndex(); last < match {
-		r.logger.Panicf("match(%d) is out of range [lastIndex(%d)]. Was the raft log corrupted, truncated, or lost?", match, last)
+// checkMatch ensures that this peer's log mark does not contradict to the
+// leader's idea about its lower bound.
+func (r *raft) checkMatch(match LogMark) {
+	if match.Index == 0 {
+		return
+	}
+	// TODO(pav-kv): make this check against the real raftLog.mark() when the last
+	// accepted term is persisted and can't regress (#122446). For now, we check
+	// against a pseudo-LogMark, with the Term conservatively bumped to raft.Term
+	// (which is >= accTerm). This is safe because match.After(pseudo) implies
+	// match.After(raftLog.mark()), so there are no false panics. We may miss some
+	// kinds of regressions though.
+	pseudo := LogMark{Term: r.Term, Index: r.raftLog.lastIndex()}
+	// NB: technically, we should be comparing against a persisted LogMark, rather
+	// than the unstable one. However, the leader can learn our persisted state
+	// earlier than this RawNode, due to the fact that MsgAppResp is sent from
+	// outside the RawNode immediately after the log sync event. We can't do
+	// better here unless we ensure that the storage syncs are delivered to this
+	// RawNode earlier than a match LogMark from the leader. A stronger check
+	// could be done at the log storage level.
+	if match.After(pseudo) {
+		r.logger.Panicf("match(t%d,i%d) is out of range [lastIndex(%d)]. Was the raft log corrupted, truncated, or lost?",
+			match.Term, match.Index, pseudo.Index)
 	}
 }
 
 func (r *raft) handleHeartbeat(m pb.Message) {
-	r.checkMatch(m.Match)
+	r.checkMatch(LogMark{Term: m.Term, Index: m.Match})
 
 	// The m.Term leader is indicating to us through this heartbeat message
 	// that indices <= m.Commit in its log are committed. If our log matches

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -1096,48 +1096,63 @@ func TestStepIgnoreOldTermMsg(t *testing.T) {
 	assert.False(t, called)
 }
 
-// TestHandleMsgApp ensures:
-//  1. Reply false if log doesn’t contain an entry at prevLogIndex whose term matches prevLogTerm.
-//  2. If an existing entry conflicts with a new one (same index but different terms),
-//     delete the existing entry and all that follow it; append any new entries not already in the log.
-//  3. If leaderCommit > commitIndex, set commitIndex = min(leaderCommit, index of last new entry).
 func TestHandleMsgApp(t *testing.T) {
-	tests := []struct {
-		m       pb.Message
+	for _, tt := range []struct {
+		ls     logSlice
+		commit uint64
+
 		wIndex  uint64
 		wCommit uint64
 		wReject bool
 	}{
-		// Ensure 1
-		{pb.Message{Type: pb.MsgApp, Term: 3, LogTerm: 3, Index: 2, Commit: 3}, 2, 0, true}, // previous log mismatch
-		{pb.Message{Type: pb.MsgApp, Term: 3, LogTerm: 3, Index: 3, Commit: 3}, 2, 0, true}, // previous log non-exist
-
-		// Ensure 2
-		{pb.Message{Type: pb.MsgApp, Term: 2, LogTerm: 1, Index: 1, Commit: 1}, 2, 1, false},
-		{pb.Message{Type: pb.MsgApp, Term: 3, LogTerm: 0, Index: 0, Commit: 1, Entries: []pb.Entry{{Index: 1, Term: 3}}}, 1, 1, false},
-		{pb.Message{Type: pb.MsgApp, Term: 2, LogTerm: 2, Index: 2, Commit: 3, Entries: []pb.Entry{{Index: 3, Term: 2}, {Index: 4, Term: 2}}}, 4, 3, false},
-		{pb.Message{Type: pb.MsgApp, Term: 2, LogTerm: 2, Index: 2, Commit: 4, Entries: []pb.Entry{{Index: 3, Term: 2}}}, 3, 3, false},
-		{pb.Message{Type: pb.MsgApp, Term: 2, LogTerm: 1, Index: 1, Commit: 4, Entries: []pb.Entry{{Index: 2, Term: 2}}}, 2, 2, false},
-
-		// Ensure 3
-		{pb.Message{Type: pb.MsgApp, Term: 1, LogTerm: 1, Index: 1, Commit: 3}, 2, 1, false},                                           // match entry 1, commit up to last new entry 1
-		{pb.Message{Type: pb.MsgApp, Term: 2, LogTerm: 1, Index: 1, Commit: 3, Entries: []pb.Entry{{Index: 2, Term: 2}}}, 2, 2, false}, // match entry 1, commit up to last new entry 2
-		{pb.Message{Type: pb.MsgApp, Term: 2, LogTerm: 2, Index: 2, Commit: 3}, 2, 2, false},                                           // match entry 2, commit up to last new entry 2
-		{pb.Message{Type: pb.MsgApp, Term: 2, LogTerm: 2, Index: 2, Commit: 4}, 2, 2, false},                                           // commit up to log.last()
-	}
-
-	for i, tt := range tests {
-		storage := newTestMemoryStorage(withPeers(1))
-		require.NoError(t, storage.Append(index(1).terms(1, 2)))
-		sm := newTestRaft(1, 10, 1, storage)
-		sm.becomeFollower(2, None)
-
-		sm.handleAppendEntries(tt.m)
-		assert.Equal(t, tt.wIndex, sm.raftLog.lastIndex(), "#%d", i)
-		assert.Equal(t, tt.wCommit, sm.raftLog.committed, "#%d", i)
-		m := sm.readMessages()
-		require.Len(t, m, 1, "#%d", i)
-		assert.Equal(t, tt.wReject, m[0].Reject, "#%d", i)
+		// Append rejections cases.
+		{ls: entryID{index: 1, term: 1}.append(1), wReject: true}, // stale append
+		{ls: entryID{index: 2, term: 1}.append(), wReject: true},  // prev mismatch
+		{ls: entryID{index: 3, term: 2}.append(), wReject: true},  // prev missing
+		// No-op append that only bumps the commit index.
+		{
+			ls: entryID{term: 1, index: 1}.append().withTerm(2), commit: 1,
+			wIndex: 2, wCommit: 1,
+		},
+		// Appends that overwrite a suffix of the log.
+		{ls: entryID{}.append(3), commit: 1, wIndex: 1, wCommit: 1},
+		{ls: entryID{index: 1, term: 1}.append(3, 3), commit: 2, wIndex: 3, wCommit: 2},
+		{ls: entryID{index: 2, term: 2}.append(2, 2), commit: 3, wIndex: 4, wCommit: 3},
+		{ls: entryID{index: 2, term: 2}.append(2), commit: 4, wIndex: 3, wCommit: 3},
+		// Commit index bumps, capped at the follower's log last index.
+		{ls: entryID{index: 1, term: 1}.append(), commit: 3, wIndex: 2, wCommit: 1},
+		{ls: entryID{index: 1, term: 1}.append(2), commit: 3, wIndex: 2, wCommit: 2},
+		{ls: entryID{index: 1, term: 1}.append(2), commit: 4, wIndex: 2, wCommit: 2},
+		{ls: entryID{index: 2, term: 2}.append(), commit: 3, wIndex: 2, wCommit: 2},
+		{ls: entryID{index: 2, term: 2}.append(), commit: 4, wIndex: 2, wCommit: 2},
+	} {
+		t.Run("", func(t *testing.T) {
+			storage := newTestMemoryStorage(withPeers(1))
+			require.NoError(t, storage.Append(index(1).terms(1, 2)))
+			sm := newTestRaft(1, 10, 1, storage)
+			sm.becomeFollower(2, None)
+			sm.handleAppendEntries(pb.Message{
+				To:      sm.id,
+				Type:    pb.MsgApp,
+				Term:    tt.ls.term,
+				Index:   tt.ls.prev.index,
+				LogTerm: tt.ls.prev.term,
+				Entries: tt.ls.entries,
+				Commit:  tt.commit,
+				Match:   0, // TODO(pav-kv): test this behaviour too
+			})
+			m := sm.readMessages()
+			require.Len(t, m, 1)
+			assert.Equal(t, tt.wReject, m[0].Reject)
+			if tt.wReject {
+				// The log and the commit index should stay the same.
+				assert.Equal(t, uint64(2), sm.raftLog.lastIndex())
+				assert.Equal(t, uint64(0), sm.raftLog.committed)
+			} else {
+				assert.Equal(t, tt.wIndex, sm.raftLog.lastIndex())
+				assert.Equal(t, tt.wCommit, sm.raftLog.committed)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This commit puts `checkMatch` into the `LogMark` coordinate system. The ultimate check that should be done is that the leader's idea about the follower's `LogMark` is not below its real persisted `LogMark` (which could have regressed after a restart if fsyncs malfunction).

There are a couple of limitations preventing the implementation of the strongest version of this check, explained in the comments. We implement a conservative check which can miss some kinds of regressions, yet is still correct and doesn't have false negatives.

Epic: none
Release note: none