### PR TITLE
roachtest: multitenant-upgrade requires service registration

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -29,7 +29,7 @@ func registerMultiTenantUpgrade(r registry.Registry) {
 		Name:             "multitenant-upgrade",
 		Timeout:          5 * time.Hour,
 		Cluster:          r.MakeClusterSpec(7),
-		CompatibleClouds: registry.AllClouds,
+		CompatibleClouds: registry.CloudsWithServiceRegistration,
 		Suites:           registry.Suites(registry.Nightly),
 		Owner:            registry.OwnerDisasterRecovery,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {


### PR DESCRIPTION
It potentially starts multiple tenants on the same nodes, which only works in clouds with service registration.

Fixes: #132020

Release note: None