### PR TITLE
kvserver,rac2,replica_rac2: consistently read from RawNode

### DIFF
--- a/pkg/kv/kvserver/flow_control_replica_integration.go
+++ b/pkg/kv/kvserver/flow_control_replica_integration.go
@@ -467,21 +467,6 @@ func (r *replicaForRACv2) MuAssertHeld() {
 	r.mu.AssertHeld()
 }
 
-// MuRLock implements replica_rac2.Replica.
-func (r *replicaForRACv2) MuRLock() {
-	r.mu.RLock()
-}
-
-// MuRUnlock implements replica_rac2.Replica.
-func (r *replicaForRACv2) MuRUnlock() {
-	r.mu.RUnlock()
-}
-
-// LeaseholderMuRLocked implements replica_rac2.Replica.
-func (r *replicaForRACv2) LeaseholderMuRLocked() roachpb.ReplicaID {
-	return r.shMu.state.Lease.Replica.ReplicaID
-}
-
 // IsScratchRange implements replica_rac2.Replica.
 func (r *replicaForRACv2) IsScratchRange() bool {
 	return (*Replica)(r).IsScratchRange()

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -273,15 +273,14 @@ func RaftEventFromMsgStorageAppendAndMsgApps(
 	outboundMsgs []raftpb.Message,
 	logSnapshot RaftLogSnapshot,
 	msgAppScratch map[roachpb.ReplicaID][]raftpb.Message,
+	replicaStateInfoMap map[roachpb.ReplicaID]ReplicaStateInfo,
 ) RaftEvent {
-	event := RaftEvent{MsgAppMode: mode, LogSnapshot: logSnapshot}
+	event := RaftEvent{
+		MsgAppMode: mode, LogSnapshot: logSnapshot, ReplicasStateInfo: replicaStateInfoMap}
 	if appendMsg.Type == raftpb.MsgStorageAppend {
-		event = RaftEvent{
-			MsgAppMode: event.MsgAppMode,
-			Term:       appendMsg.LogTerm,
-			Snap:       appendMsg.Snapshot,
-			Entries:    appendMsg.Entries,
-		}
+		event.Term = appendMsg.LogTerm
+		event.Snap = appendMsg.Snapshot
+		event.Entries = appendMsg.Entries
 	}
 	if len(outboundMsgs) == 0 {
 		return event

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
@@ -54,7 +54,6 @@ init-raft log-term=40 log-index=23
 ----
  Replica.RaftMuAssertHeld
  Replica.MuAssertHeld
- RaftNode.LogMarkLocked() = {Term:40 Index:23}
 
 set-raft-state term=50 leader=10 leaseholder=10
 ----
@@ -85,13 +84,6 @@ handle-raft-ready-and-admit entries=v1/i24/t45/pri0/time2/len100 leader-term=50
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 25
- RaftNode.LeaderLocked() = 10
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 50
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
 .....
 AdmitRaftEntries:
 destroyed-or-leader-using-v2: false
@@ -113,13 +105,6 @@ handle-raft-ready-and-admit entries=v1/i25/t45/pri0/time2/len100 leader-term=50
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 26
- RaftNode.LeaderLocked() = 10
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 50
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
 .....
 AdmitRaftEntries:
  ACWorkQueue.Admit({StoreID:2 TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false RangeID:3 ReplicaID:5 CallbackState:{Mark:{Term:50 Index:25} Priority:LowPri}}) = true
@@ -147,13 +132,6 @@ handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 26
- RaftNode.LeaderLocked() = 11
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 50
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
  Piggybacker.Add(n11, [r3,s11,5->11] admitted=t50/[24 25 25 25])
 .....
 
@@ -172,13 +150,6 @@ handle-raft-ready-and-admit entries=v2/i26/t45/pri2/time2/len100 leader-term=50
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 27
- RaftNode.LeaderLocked() = 11
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 50
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
 .....
 AdmitRaftEntries:
  ACWorkQueue.Admit({StoreID:2 TenantID:4 Priority:user-high-pri CreateTime:2 RequestedCount:100 Ingested:false RangeID:3 ReplicaID:5 CallbackState:{Mark:{Term:50 Index:26} Priority:AboveNormalPri}}) = true
@@ -192,13 +163,6 @@ handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 27
- RaftNode.LeaderLocked() = 11
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 50
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
 .....
 
 # Stable index is advanced, which should allow some priorities to advance
@@ -216,13 +180,6 @@ handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 27
- RaftNode.LeaderLocked() = 11
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 50
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
  Piggybacker.Add(n11, [r3,s11,5->11] admitted=t50/[24 26 25 26])
 .....
 
@@ -239,13 +196,6 @@ handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 27
- RaftNode.LeaderLocked() = 11
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 50
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
  Piggybacker.Add(n11, [r3,s11,5->11] admitted=t50/[26 26 25 26])
 .....
 
@@ -264,13 +214,6 @@ handle-raft-ready-and-admit entries=v2/i27/t45/pri2/time2/len100 leader-term=50
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 28
- RaftNode.LeaderLocked() = 11
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 50
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
 .....
 AdmitRaftEntries:
  ACWorkQueue.Admit({StoreID:2 TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false RangeID:3 ReplicaID:5 CallbackState:{Mark:{Term:50 Index:27} Priority:LowPri}}) = true
@@ -295,13 +238,6 @@ handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 28
- RaftNode.LeaderLocked() = 11
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 50
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
  Piggybacker.Add(n11, [r3,s11,5->11] admitted=t50/[26 26 26 26])
 .....
 
@@ -329,13 +265,6 @@ handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 28
- RaftNode.LeaderLocked() = 11
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 51
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
 .....
 
 # A new entry at index 27 overwrites the previous one, and regresses the stable
@@ -344,13 +273,6 @@ handle-raft-ready-and-admit entries=v1/i27/t46/pri0/time2/len100 leader-term=51
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 28
- RaftNode.LeaderLocked() = 11
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 51
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
 .....
 AdmitRaftEntries:
 destroyed-or-leader-using-v2: false
@@ -371,13 +293,6 @@ handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 28
- RaftNode.LeaderLocked() = 11
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 51
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
  Piggybacker.Add(n11, [r3,s11,5->11] admitted=t51/[26 26 26 26])
 .....
 
@@ -410,13 +325,6 @@ handle-raft-ready-and-admit entries=v1/i28/t46/pri0/time2/len100 leader-term=52
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 29
- RaftNode.LeaderLocked() = 5
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 52
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
  RangeControllerFactory.New(replicaSet=[(n1,s2):5,(n11,s11):11], leaseholder=10, nextRaftIndex=28)
  RangeController.AdmitRaftMuLocked(5, term:52, admitted:[LowPri:26,NormalPri:26,AboveNormalPri:26,HighPri:26])
  RangeController.HandleRaftEventRaftMuLocked([28])
@@ -481,13 +389,6 @@ handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 29
- RaftNode.LeaderLocked() = 5
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 52
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
 
@@ -502,13 +403,6 @@ handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 29
- RaftNode.LeaderLocked() = 5
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 52
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
  RangeController.AdmitRaftMuLocked(5, term:52, admitted:[LowPri:28,NormalPri:28,AboveNormalPri:28,HighPri:28])
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
@@ -542,13 +436,6 @@ handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 29
- RaftNode.LeaderLocked() = 5
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 53
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
  RangeController.CloseRaftMuLocked
  RangeControllerFactory.New(replicaSet=[(n1,s2):5,(n11,s11):11], leaseholder=10, nextRaftIndex=29)
  RangeController.HandleRaftEventRaftMuLocked([])
@@ -564,13 +451,6 @@ handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 29
- RaftNode.LeaderLocked() = 5
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 53
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
  RangeController.SetReplicasRaftMuLocked([(n1,s2):5,(n11,s11):11,(n13,s13):13])
  RangeController.SetLeaseholderRaftMuLocked(10)
  RangeController.HandleRaftEventRaftMuLocked([])
@@ -640,7 +520,6 @@ init-raft log-term=50 log-index=24
 ----
  Replica.RaftMuAssertHeld
  Replica.MuAssertHeld
- RaftNode.LogMarkLocked() = {Term:50 Index:24}
 
 set-raft-state term=50 leader=5 leaseholder=5
 ----
@@ -663,13 +542,6 @@ handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 25
- RaftNode.LeaderLocked() = 5
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 50
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
 .....
 
 set-raft-state log-term=50 log-index=25 next-unstable-index=26
@@ -681,13 +553,6 @@ handle-raft-ready-and-admit entries=v1/i25/t45/pri0/time2/len100 leader-term=50
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 26
- RaftNode.LeaderLocked() = 5
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 50
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
 .....
 AdmitRaftEntries:
 destroyed-or-leader-using-v2: false
@@ -697,11 +562,6 @@ LogTracker: mark:{Term:50 Index:25}, stable:24, admitted:[24 24 24 24]
 set-enabled-level enabled-level=v1-encoding
 ----
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.LeaderLocked() = 5
- RaftNode.TermLocked() = 50
- RaftNode.NextUnstableIndexLocked() = 26
- Replica.MuRUnlock
  RangeControllerFactory.New(replicaSet=[(n11,s11):11,(n13,s13):13], leaseholder=5, nextRaftIndex=26)
 
 set-raft-state log-term=50 log-index=26 next-unstable-index=27
@@ -713,13 +573,6 @@ handle-raft-ready-and-admit entries=v1/i26/t45/pri0/time2/len100 leader-term=50
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 27
- RaftNode.LeaderLocked() = 5
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 50
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
  RangeController.HandleRaftEventRaftMuLocked([26])
 .....
 AdmitRaftEntries:
@@ -738,13 +591,6 @@ handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 27
- RaftNode.LeaderLocked() = 5
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 50
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
 
@@ -757,13 +603,6 @@ handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 27
- RaftNode.LeaderLocked() = 5
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 50
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
  RangeController.AdmitRaftMuLocked(5, term:50, admitted:[LowPri:26,NormalPri:26,AboveNormalPri:26,HighPri:26])
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
@@ -777,13 +616,6 @@ handle-raft-ready-and-admit entries=none/i27/t45/pri0/time2/len100 leader-term=5
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 28
- RaftNode.LeaderLocked() = 5
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 50
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
  RangeController.HandleRaftEventRaftMuLocked([27])
 .....
 AdmitRaftEntries:
@@ -799,13 +631,6 @@ handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 28
- RaftNode.LeaderLocked() = 5
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 50
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
  RangeController.AdmitRaftMuLocked(5, term:50, admitted:[LowPri:27,NormalPri:27,AboveNormalPri:27,HighPri:27])
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
@@ -828,12 +653,5 @@ handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  Replica.RaftMuAssertHeld
- Replica.MuRLock
- RaftNode.NextUnstableIndexLocked() = 28
- RaftNode.LeaderLocked() = 0
- Replica.LeaseholderMuRLocked
- RaftNode.TermLocked() = 51
- RaftNode.ReplicasStateLocked
- Replica.MuRUnlock
  RangeController.CloseRaftMuLocked
 .....

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -326,8 +326,10 @@ type Replica struct {
 
 		flowControlLevel kvflowcontrol.V2EnabledWhenLeaderLevel
 
-		// Scratch for populating RaftEvent for flowControlV2.
+		// Scratch for populating rac2.RaftEvent.MsgApps for flowControlV2.
 		msgAppScratchForFlowControl map[roachpb.ReplicaID][]raftpb.Message
+		// Scratch for populating rac2.RaftEvent.ReplicaSateInfo for flowContrlV2.
+		replicaStateScratchForFlowControl map[roachpb.ReplicaID]rac2.ReplicaStateInfo
 	}
 
 	// localMsgs contains a collection of raftpb.Message that target the local

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -225,6 +225,7 @@ func newUninitializedReplicaWithoutRaftGroup(
 	r.raftMu.flowControlLevel = kvflowcontrol.GetV2EnabledWhenLeaderLevel(
 		r.raftCtx, store.ClusterSettings(), store.TestingKnobs().FlowControlTestingKnobs)
 	r.raftMu.msgAppScratchForFlowControl = map[roachpb.ReplicaID][]raftpb.Message{}
+	r.raftMu.replicaStateScratchForFlowControl = map[roachpb.ReplicaID]rac2.ReplicaStateInfo{}
 	r.flowControlV2 = replica_rac2.NewProcessor(replica_rac2.ProcessorOptions{
 		NodeID:                 store.NodeID(),
 		StoreID:                r.StoreID(),
@@ -324,7 +325,8 @@ func (r *Replica) initRaftGroupRaftMuLockedReplicaMuLocked() error {
 		return err
 	}
 	r.mu.internalRaftGroup = rg
-	r.flowControlV2.InitRaftLocked(ctx, replica_rac2.NewRaftNode(rg, (*replicaForRACv2)(r)))
+	r.flowControlV2.InitRaftLocked(
+		ctx, replica_rac2.NewRaftNode(rg, (*replicaForRACv2)(r)), rg.LogMark())
 	return nil
 }
 


### PR DESCRIPTION
The replica_rac2.RaftNode interface is no more, and is replaced by RaftNodeBasicState that is passed in to Processor by the caller.

The rac2.RaftInterface remains, and is solely for use by RangeController. Various methods on replica_rac2.Replica are also removed.

kvserver.Replica is responsible for populating RaftNodeBasicState and RaftEvent.ReplicasStateInfo (the latter was previously being populated in processorImpl).

For the raft state accessed by RAC2 code during Replica.handleRaftReady, this centralizes all Raft state access to when
Replica.handleRaftReadyRaftMuLocked locks the Replica.mu.

Epic: CRDB-37515

Release note: None