### PR TITLE
sql: Add SucceedsSoon to TestRaceWithBackfill

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -646,14 +646,17 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 
 	ctx := context.Background()
 
-	// number of keys == 2 * number of rows; 1 column family and 1 index entry
-	// for each row.
-	if err := sqltestutils.CheckTableKeyCount(ctx, kvDB, codec, 2, maxValue); err != nil {
-		t.Fatal(err)
-	}
-	if err := sqlutils.RunScrub(sqlDB, "t", "test"); err != nil {
-		t.Fatal(err)
-	}
+	testutils.SucceedsSoon(t, func() error {
+		// number of keys == 2 * number of rows; 1 column family and 1 index entry
+		// for each row.
+		if err := sqltestutils.CheckTableKeyCount(ctx, kvDB, codec, 2, maxValue); err != nil {
+			return err
+		}
+		if err := sqlutils.RunScrub(sqlDB, "t", "test"); err != nil {
+			return err
+		}
+		return nil
+	})
 
 	// Run some schema changes with operations.
 


### PR DESCRIPTION
We've occasionally seen TestRaceWithBackfill fail with an error like this:
```
pq: scrub-unique: batch timestamp 1727324575.845086785,0 must be after replica GC threshold 1727324575.977490760,0
```

This is likely caused by the test using an excessively aggressive GC TTL setting. To improve the test's stability, I wrapped the scrub-unique operation in a SucceedsSoon block.

Epic: None
Release note: None
Resolves #131401, resolves #130436