### PR TITLE
roachpb: handle MVCC extended value encoding in roachpb.Value

### DIFF
--- a/pkg/gossip/util_test.go
+++ b/pkg/gossip/util_test.go
@@ -43,7 +43,7 @@ func addKV(rng *rand.Rand, cfg *config.SystemConfig, key int) {
 		}
 	}
 	rawBytes := randutil.RandBytes(rng, 100)
-	// Ensure we don't accidentally make this look like an extended encoding sentinal.
+	// Ensure we don't accidentally make this look like an extended encoding sentinel.
 	rawBytes[4] = byte(roachpb.ValueType_MVCC_EXTENDED_ENCODING_SENTINEL + 1)
 	newKVs = append(newKVs, roachpb.KeyValue{
 		Key: newKey,

--- a/pkg/gossip/util_test.go
+++ b/pkg/gossip/util_test.go
@@ -42,10 +42,13 @@ func addKV(rng *rand.Rand, cfg *config.SystemConfig, key int) {
 			}
 		}
 	}
+	rawBytes := randutil.RandBytes(rng, 100)
+	// Ensure we don't accidentally make this look like an extended encoding sentinal.
+	rawBytes[4] = byte(roachpb.ValueType_MVCC_EXTENDED_ENCODING_SENTINEL + 1)
 	newKVs = append(newKVs, roachpb.KeyValue{
 		Key: newKey,
 		Value: roachpb.Value{
-			RawBytes: randutil.RandBytes(rng, 100),
+			RawBytes: rawBytes,
 		},
 	})
 	sort.Sort(roachpb.KeyValueByKey(newKVs))

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -280,11 +280,16 @@ func (v Value) checksum() uint32 {
 		return 0
 	}
 
-	if len(v.RawBytes) < headerSize || v.RawBytes[tagPos] == byte(ValueType_MVCC_EXTENDED_ENCODING_SENTINEL) {
-		return 0
+	checksumStart := 0
+	if v.usesExtendedEncoding() {
+		extendedHeaderSize := int(extendedMVCCValLenSize + binary.BigEndian.Uint32(v.RawBytes))
+		if len(v.RawBytes) < extendedHeaderSize+headerSize {
+			return 0
+		}
+		checksumStart = extendedHeaderSize + 1
 	}
 
-	_, u, err := encoding.DecodeUint32Ascending(v.RawBytes[:checksumSize])
+	_, u, err := encoding.DecodeUint32Ascending(v.RawBytes[checksumStart : checksumStart+checksumSize])
 	if err != nil {
 		panic(err)
 	}
@@ -295,6 +300,10 @@ func (v *Value) setChecksum(cksum uint32) {
 	if len(v.RawBytes) >= checksumSize {
 		encoding.EncodeUint32Ascending(v.RawBytes[:0], cksum)
 	}
+}
+
+func (v *Value) usesExtendedEncoding() bool {
+	return len(v.RawBytes) > headerSize && v.RawBytes[tagPos] == byte(ValueType_MVCC_EXTENDED_ENCODING_SENTINEL)
 }
 
 // InitChecksum initializes a checksum based on the provided key and
@@ -363,11 +372,11 @@ func (v *Value) IsPresent() bool {
 	// then case we'll hit this case if the 5th character of that string
 	// happens to be `e` (ascii 101). There aren't _that_ many callers to
 	// IsPresent(). We may just need to audit them all.
-	if len(v.RawBytes) >= extendedPreludeSize && v.RawBytes[tagPos] == byte(ValueType_MVCC_EXTENDED_ENCODING_SENTINEL) {
-		headerSize := extendedPreludeSize + binary.BigEndian.Uint32(v.RawBytes)
-		return len(v.RawBytes) > int(headerSize)
+	if v.usesExtendedEncoding() {
+		extendedHeaderSize := extendedPreludeSize + binary.BigEndian.Uint32(v.RawBytes)
+		return len(v.RawBytes) > int(extendedHeaderSize)
 	}
-	return len(v.RawBytes) >= 0
+	return true
 }
 
 // MakeValueFromString returns a value with bytes and tag set.
@@ -413,13 +422,12 @@ func (v Value) GetMVCCValueHeader() (enginepb.MVCCValueHeader, error) {
 		return enginepb.MVCCValueHeader{}, nil
 	}
 	if v.RawBytes[tagPos] == byte(ValueType_MVCC_EXTENDED_ENCODING_SENTINEL) {
-		headerLen := binary.BigEndian.Uint32(v.RawBytes)
-		headerSize := extendedPreludeSize + headerLen
-		if len(v.RawBytes) < int(headerSize) {
+		extendedHeaderSize := extendedPreludeSize + binary.BigEndian.Uint32(v.RawBytes)
+		if len(v.RawBytes) < int(extendedHeaderSize) {
 			return enginepb.MVCCValueHeader{}, nil
 		}
 
-		parseBytes := v.RawBytes[extendedPreludeSize:headerSize]
+		parseBytes := v.RawBytes[extendedPreludeSize:extendedHeaderSize]
 		var vh enginepb.MVCCValueHeader
 		// NOTE: we don't use protoutil to avoid passing header through an interface,
 		// which would cause a heap allocation and incur the cost of dynamic dispatch.
@@ -442,7 +450,7 @@ func (v Value) extendedSimpleTagPos() int {
 }
 
 func (v Value) dataBytes() []byte {
-	if v.RawBytes[tagPos] == byte(ValueType_MVCC_EXTENDED_ENCODING_SENTINEL) {
+	if v.usesExtendedEncoding() {
 		simpleTagPos := v.extendedSimpleTagPos()
 		return v.RawBytes[simpleTagPos+1:]
 	}
@@ -452,7 +460,7 @@ func (v Value) dataBytes() []byte {
 // TagAndDataBytes returns the value's tag and data (no checksum, no timestamp).
 // This is suitable to be used as the expected value in a CPut.
 func (v Value) TagAndDataBytes() []byte {
-	if len(v.RawBytes) > tagPos && v.RawBytes[tagPos] == byte(ValueType_MVCC_EXTENDED_ENCODING_SENTINEL) {
+	if v.usesExtendedEncoding() {
 		simpleTagPos := v.extendedSimpleTagPos()
 		return v.RawBytes[simpleTagPos:]
 	}
@@ -849,6 +857,15 @@ func computeChecksum(key, rawBytes []byte, crc hash.Hash32) uint32 {
 	if len(rawBytes) < headerSize {
 		return 0
 	}
+
+	if rawBytes[tagPos] == byte(ValueType_MVCC_EXTENDED_ENCODING_SENTINEL) {
+		simpleValueStart := extendedMVCCValLenSize + binary.BigEndian.Uint32(rawBytes) + 1
+		rawBytes = rawBytes[simpleValueStart:]
+		if len(rawBytes) < headerSize {
+			return 0
+		}
+	}
+
 	if _, err := crc.Write(key); err != nil {
 		panic(err)
 	}

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -7,6 +7,7 @@ package roachpb
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"math"
 	"math/rand"
@@ -1936,6 +1937,61 @@ func BenchmarkValueGetTuple(b *testing.B) {
 		if _, err := v.GetTuple(); err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+func TestExtendedDecoding(t *testing.T) {
+	// A bit of duplication to avoid import cycles.
+	encodeWithValueHeader := func(v Value, vh enginepb.MVCCValueHeader) []byte {
+		// Extended encoding. Wrap the roachpb.Value encoding with a header containing
+		// MVCC-level metadata. Requires a re-allocation and copy.
+		headerLen := vh.Size()
+		headerSize := extendedPreludeSize + headerLen
+		valueSize := headerSize + len(v.RawBytes)
+		buf := make([]byte, valueSize)
+		// Extended encoding. Wrap the roachpb.Value encoding with a header containing
+		// MVCC-level metadata. Requires a copy.
+		// 4-byte-header-len
+		binary.BigEndian.PutUint32(buf, uint32(headerLen))
+		// 1-byte-sentinel
+		buf[tagPos] = byte(ValueType_MVCC_EXTENDED_ENCODING_SENTINEL)
+		_, err := protoutil.MarshalTo(&vh, buf[extendedPreludeSize:headerSize])
+		require.NoError(t, err)
+		// <4-byte-checksum><1-byte-tag><encoded-data> or empty for tombstone
+		copy(buf[headerSize:], v.RawBytes)
+		return buf
+	}
+
+	var boolValue Value
+	boolValue.SetBool(true)
+
+	testValues := map[string]Value{
+		"bool":      boolValue,
+		"tombstone": {Timestamp: hlc.Timestamp{WallTime: 1}},
+		"untagged":  {RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 1}},
+	}
+	for name, tv := range testValues {
+		t.Run(name, func(t *testing.T) {
+			extendedValueBytes := encodeWithValueHeader(tv, enginepb.MVCCValueHeader{OriginID: 1})
+			extendedValue := Value{RawBytes: extendedValueBytes, Timestamp: tv.Timestamp}
+
+			require.Equal(t, tv.IsPresent(), extendedValue.IsPresent())
+			require.Equal(t, tv.GetTag(), extendedValue.GetTag())
+			vh, err := tv.GetMVCCValueHeader()
+			require.NoError(t, err)
+			require.Equal(t, uint32(0), vh.OriginID)
+
+			vh, err = extendedValue.GetMVCCValueHeader()
+			require.NoError(t, err)
+			require.Equal(t, uint32(1), vh.OriginID)
+
+			// These methods crash if called on tombstones or degenerate values.
+			if len(tv.RawBytes) > tagPos {
+				require.Equal(t, tv.TagAndDataBytes(), extendedValue.TagAndDataBytes())
+				require.True(t, tv.EqualTagAndData(extendedValue))
+				require.True(t, extendedValue.EqualTagAndData(tv))
+			}
+		})
 	}
 }
 

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -1962,6 +1962,7 @@ func TestExtendedDecoding(t *testing.T) {
 		return buf
 	}
 
+	key := Key("hello")
 	var boolValue Value
 	boolValue.SetBool(true)
 
@@ -1972,8 +1973,18 @@ func TestExtendedDecoding(t *testing.T) {
 	}
 	for name, tv := range testValues {
 		t.Run(name, func(t *testing.T) {
+			tv.InitChecksum(key)
 			extendedValueBytes := encodeWithValueHeader(tv, enginepb.MVCCValueHeader{OriginID: 1})
 			extendedValue := Value{RawBytes: extendedValueBytes, Timestamp: tv.Timestamp}
+
+			// These methods error on degenerate values.
+			if len(tv.RawBytes) >= headerSize {
+				require.NoError(t, tv.Verify(key))
+				require.NoError(t, extendedValue.Verify(key))
+			}
+
+			require.Equal(t, tv.checksum(), extendedValue.checksum())
+			require.Equal(t, tv.computeChecksum(key), tv.computeChecksum(key))
 
 			require.Equal(t, tv.IsPresent(), extendedValue.IsPresent())
 			require.Equal(t, tv.GetTag(), extendedValue.GetTag())

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1478,6 +1478,7 @@ func TestLint(t *testing.T) {
 			":!rpc/codec.go",
 			":!rpc/codec_test.go",
 			":!storage/mvcc_value.go",
+			":!roachpb/data.go",
 			":!sql/types/types_jsonpb.go",
 		)
 		if err != nil {


### PR DESCRIPTION
Previously, values encoded with the extended encoding would never
escape pkg/storage.

Now, requests made with the new ReturnRawMVCCValues option will return
roachpb.Value structs with their RawBytes containing the full extended
encoded value.

Here, we extended the following method on roachpb.Value to handle this
encoding:

- GetTag: Reads past the value header and returns the underlying tag.

- Get[Type]: Reads past the value header and returns the underlying
  data.

- IsPresent(): Now additionally returns false if RawBytes is non-nil but _only_
  contains the MVCC Value header.

- TagAndDataBytes(): Reads past the value header and returns the
  underlying tag and data.

- checksum/computeCheckum/Verify(): Reads past the value header to return/compute the checksum.

We additionally add GetMVCCValueHeader which returns the
MVCCValueHeader if one exists.

Epic: none
Release note: None