### PR TITLE
ui,server: hook up index details breadcrumb to new db pages

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -4951,6 +4951,7 @@ Response object returned by TableIndexStatsResponse.
 | statistics | [TableIndexStatsResponse.ExtendedCollectedIndexUsageStatistics](#cockroach.server.serverpb.TableIndexStatsResponse-cockroach.server.serverpb.TableIndexStatsResponse.ExtendedCollectedIndexUsageStatistics) | repeated |  | [reserved](#support-status) |
 | last_reset | [google.protobuf.Timestamp](#cockroach.server.serverpb.TableIndexStatsResponse-google.protobuf.Timestamp) |  | Timestamp of the latest reset index usage statistics request. | [reserved](#support-status) |
 | index_recommendations | [cockroach.sql.IndexRecommendation](#cockroach.server.serverpb.TableIndexStatsResponse-cockroach.sql.IndexRecommendation) | repeated |  | [reserved](#support-status) |
+| database_id | [int32](#cockroach.server.serverpb.TableIndexStatsResponse-int32) |  | database_id is the ID of the database that contains the table. | [reserved](#support-status) |
 
 
 

--- a/pkg/server/index_usage_stats_test.go
+++ b/pkg/server/index_usage_stats_test.go
@@ -351,17 +351,18 @@ CREATE TABLE schema.test_table (
 
 	for _, tc := range testCases {
 		tableName := fmt.Sprintf("%s.%s", tc.schema, tc.table)
-		tableID, err := getTableIDFromDatabaseAndTableName(ctx, tc.database, tableName, s.InternalExecutor().(*sql.InternalExecutor), userName)
+		tableID, databaseID, err := getIDFromDatabaseAndTableName(ctx, tc.database, tableName, s.InternalExecutor().(*sql.InternalExecutor), userName)
 		require.NoError(t, err)
 
 		// Get actual Table ID.
 		actualTableID := db.QueryStr(t, `
-SELECT table_id 
+SELECT table_id, parent_id
 FROM crdb_internal.tables 
 WHERE database_name=$1 AND schema_name=$2 AND name=$3`,
 			tc.database, tc.schema, tc.table)
 
 		// Assert Table ID is correct.
 		require.Equal(t, fmt.Sprint(tableID), actualTableID[0][0])
+		require.Equal(t, fmt.Sprint(databaseID), actualTableID[0][1])
 	}
 }

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -2032,6 +2032,9 @@ message TableIndexStatsResponse {
   // Timestamp of the latest reset index usage statistics request.
   google.protobuf.Timestamp last_reset = 2 [(gogoproto.stdtime) = true];
   repeated cockroach.sql.IndexRecommendation index_recommendations = 3;
+
+  // database_id is the ID of the database that contains the table.
+  int32 database_id  = 4 [(gogoproto.customname) = "DatabaseID"];
 }
 
 // Request object for issuing a index usage stats reset request.

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsConnected.ts
@@ -120,6 +120,7 @@ const mapStateToProps = (
       lastRead: TimestampToMoment(details?.statistics?.stats?.last_read),
       lastReset: TimestampToMoment(stats?.data?.last_reset),
       indexRecommendations,
+      databaseID: stats?.data?.database_id,
     },
   };
 };

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.spec.tsx
@@ -35,6 +35,7 @@ describe("IndexDetailsPage", () => {
       indexID: undefined,
       lastRead: util.minDate,
       lastReset: util.minDate,
+      databaseID: 1,
     },
     breadcrumbItems: null,
     isTenant: false,

--- a/pkg/ui/workspaces/cluster-ui/src/store/indexStats/indexStats.sagas.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/indexStats/indexStats.sagas.spec.ts
@@ -77,6 +77,7 @@ describe("IndexStats sagas", () => {
           created_at: null,
         },
       ],
+      database_id: 10,
       last_reset: null,
       index_recommendations: [
         {

--- a/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.spec.ts
@@ -153,6 +153,7 @@ describe("Index Details Page", function () {
           indexID: undefined,
           lastRead: util.minDate,
           lastReset: util.minDate,
+          databaseID: undefined,
         },
         breadcrumbItems: null,
       },
@@ -185,6 +186,7 @@ describe("Index Details Page", function () {
         },
       ],
       last_reset: util.stringToTimestamp("2021-11-12T20:18:22.167627Z"),
+      database_id: 10,
     });
 
     await driver.refreshIndexStats();
@@ -213,6 +215,7 @@ describe("Index Details Page", function () {
           util.stringToTimestamp("2021-11-12T20:18:22.167627Z"),
         ),
         indexRecommendations: [],
+        databaseID: 10,
       },
       breadcrumbItems: null,
     });

--- a/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.ts
@@ -90,6 +90,7 @@ export const mapStateToProps = (
       ),
       lastReset: util.TimestampToMoment(stats?.data?.last_reset, util.minDate),
       indexRecommendations,
+      databaseID: stats?.data?.database_id,
     },
     breadcrumbItems: null,
   };


### PR DESCRIPTION
This commit hooks up the breadcrumb navigation in the db console's index details page to route to the new db details page. Currently it does this for DB console shipped with the binary and not for cloud since the routes haven't been set up there yet.

To accomplish the above we add `databaseID` to the response for the TableIndexStats api which is used by the index details page.

Epic: none
Fixes: #132090

Release note: None