### PR TITLE
drtprod: put roachtest binary and operation script in workload-scale

### DIFF
--- a/pkg/cmd/drt/scripts/roachtest_operations_run.sh
+++ b/pkg/cmd/drt/scripts/roachtest_operations_run.sh
@@ -5,10 +5,15 @@
 # Use of this software is governed by the CockroachDB Software License
 # included in the /LICENSE file.
 
+cd /home/ubuntu
 
-cd ~
+export GCE_PROJECT=cockroach-drt
+export ROACHPROD_DNS="drt.crdb.io"
+./roachprod sync
+sleep 20
 
+# add --datadog-api-key and --datadog-app-key
 while true; do
-  ./roachtest-operations run-operation ".*" --certs-dir ./certs --cluster "cct-232" --cockroach-binary "cockroach" --virtual-cluster "application" | tee -a roachtest_ops.log
-  sleep 10
+  ./roachtest-operations run-operation "drt-scale" ".*" --datadog-tags env:development,cluster:workload-scale,team:drt,service:drt-cockroachdb --certs-dir ./certs  | tee -a roachtest_ops.log
+  sleep 600
 done

--- a/pkg/cmd/drtprod/configs/drt_scale.yaml
+++ b/pkg/cmd/drtprod/configs/drt_scale.yaml
@@ -1,4 +1,5 @@
 # Yaml for creating and configuring the drt-scale cluster. This also configures the datadog.
+# Build the roachprod and roachtest binaries (using --cross) before running this script and delete any certs folder
 environment:
   ROACHPROD_GCE_DEFAULT_SERVICE_ACCOUNT: 622274581499-compute@developer.gserviceaccount.com
   ROACHPROD_DNS: drt.crdb.io
@@ -105,4 +106,19 @@ targets:
           - --
           - chmod
           - 600
-          - ./certs/*
+          - certs/*
+      - command: put
+        args:
+          - $WORKLOAD_CLUSTER
+          - bin/roachprod
+          - roachprod
+      - command: put
+        args:
+          - $WORKLOAD_CLUSTER
+          - bin/roachtest
+          - roachtest-operations
+      - command: put
+        args:
+          - $WORKLOAD_CLUSTER
+          - pkg/cmd/drt/scripts/roachtest_operations_run.sh
+          - roachtest_operations_run.sh


### PR DESCRIPTION
This PR ensures that we put pre-built `roachprod`, `roachtest` binaries and operation runner
script on `workload-scale` cluster upon creation

Epic: none
Release note