### PR TITLE
cluster-ui: convert api v2 responses from server

### DIFF
--- a/pkg/sql/tablemetadatacache/table_metadata_updater.go
+++ b/pkg/sql/tablemetadatacache/table_metadata_updater.go
@@ -266,8 +266,6 @@ func (q *tableMetadataBatchUpsertQuery) addRow(
 		livePercentage = float64(liveBytes) / float64(total)
 	}
 
-	// TODO (xinhaoz): Get store ids from span stats after
-	// https://github.com/cockroachdb/cockroach/issues/129060 is complete.
 	storeIds := make([]int, len(stats.StoreIDs))
 	for i, id := range stats.StoreIDs {
 		storeIds[i] = int(id)

--- a/pkg/ui/workspaces/cluster-ui/src/api/databases/grantsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databases/grantsApi.ts
@@ -6,10 +6,12 @@
 import useSWRImmutable from "swr/immutable";
 
 import { fetchDataJSON } from "../fetchData";
+import { ResultsWithPagination, PaginationRequest } from "../types";
+
 import {
-  APIV2ResponseWithPaginationState,
-  SimplePaginationState,
-} from "../types";
+  convertServerPaginationToClientPagination,
+  DatabaseGrantsResponseServer,
+} from "./serverTypes";
 
 export type DatabaseGrant = {
   grantee: string;
@@ -25,12 +27,8 @@ type DatabaseGrantsRequest = {
   dbId: number;
   sortBy?: GrantsSortOptions;
   sortOrder?: "asc" | "desc";
-  pagination?: SimplePaginationState;
+  pagination?: PaginationRequest;
 };
-
-export type DatabaseGrantsResponse = APIV2ResponseWithPaginationState<
-  DatabaseGrant[]
->;
 
 const createDbGrantsPath = (req: DatabaseGrantsRequest): string => {
   const { dbId, pagination, sortBy, sortOrder } = req;
@@ -50,11 +48,23 @@ const createDbGrantsPath = (req: DatabaseGrantsRequest): string => {
   return `api/v2/grants/databases/${dbId}/?` + urlParams.toString();
 };
 
+type DatabaseGrantsResponse = ResultsWithPagination<DatabaseGrant[]>;
+
 const fetchDbGrants = (
   req: DatabaseGrantsRequest,
 ): Promise<DatabaseGrantsResponse> => {
   const path = createDbGrantsPath(req);
-  return fetchDataJSON(path);
+  return fetchDataJSON<DatabaseGrantsResponseServer, null>(path).then(resp => {
+    return {
+      results: resp.results.map(r => ({
+        grantee: r.grantee,
+        privilege: r.privilege,
+      })),
+      pagination: convertServerPaginationToClientPagination(
+        resp.pagination_info,
+      ),
+    };
+  });
 };
 
 export const useDatabaseGrantsImmutable = (req: DatabaseGrantsRequest) => {
@@ -65,7 +75,6 @@ export const useDatabaseGrantsImmutable = (req: DatabaseGrantsRequest) => {
 
   return {
     databaseGrants: data?.results,
-    pagination: data?.pagination_info,
     isLoading,
     error: error,
   };
@@ -75,12 +84,10 @@ type TableGrantsRequest = {
   tableId: number;
   sortBy?: GrantsSortOptions;
   sortOrder?: "asc" | "desc";
-  pagination?: SimplePaginationState;
+  pagination?: PaginationRequest;
 };
 
-export type TableGrantsResponse = APIV2ResponseWithPaginationState<
-  DatabaseGrant[]
->;
+export type TableGrantsResponse = ResultsWithPagination<DatabaseGrant[]>;
 
 const createTableGrantsPath = (req: TableGrantsRequest): string => {
   const { tableId, pagination, sortBy, sortOrder } = req;
@@ -100,11 +107,19 @@ const createTableGrantsPath = (req: TableGrantsRequest): string => {
   return `api/v2/grants/tables/${tableId}/?` + urlParams.toString();
 };
 
-const fetchTableGrants = (
+const fetchTableGrants = async (
   req: TableGrantsRequest,
 ): Promise<TableGrantsResponse> => {
   const path = createTableGrantsPath(req);
-  return fetchDataJSON(path);
+  const resp = await fetchDataJSON<DatabaseGrantsResponseServer, null>(path);
+  return {
+    results: resp.results,
+    pagination: {
+      pageSize: resp.pagination_info?.page_size ?? 0,
+      pageNum: resp.pagination_info?.page_num ?? 0,
+      totalResults: resp.pagination_info?.total_results ?? 0,
+    },
+  };
 };
 
 export const useTableGrantsImmutable = (req: TableGrantsRequest) => {
@@ -115,7 +130,6 @@ export const useTableGrantsImmutable = (req: TableGrantsRequest) => {
 
   return {
     tableGrants: data?.results,
-    pagination: data?.pagination_info,
     isLoading,
     error: error,
   };

--- a/pkg/ui/workspaces/cluster-ui/src/api/databases/serverTypes.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databases/serverTypes.ts
@@ -1,0 +1,97 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// ------------------------------------------------------------------------------------
+// This file contains the types for the server api responses from /api/v2/ endpoints.
+// ------------------------------------------------------------------------------------
+
+import { PaginationState } from "../types";
+
+// ------------------------------------------------------------------------------------
+// Response with pagination.
+// ------------------------------------------------------------------------------------
+type APIV2PaginationResponse = {
+  total_results: number;
+  page_size: number;
+  page_num: number;
+};
+
+type APIV2ResponseWithPaginationState<T> = {
+  results: T[];
+  pagination_info: APIV2PaginationResponse;
+};
+
+export const convertServerPaginationToClientPagination = (
+  pagination: APIV2PaginationResponse,
+): PaginationState => {
+  return {
+    pageNum: pagination?.page_num ?? 0,
+    pageSize: pagination?.page_size ?? 0,
+    totalResults: pagination?.total_results ?? 0,
+  };
+};
+
+// ------------------------------------------------------------------------------------
+// /api/v2/table_metadata/ response.
+// ------------------------------------------------------------------------------------
+export type TableMetadataServer = {
+  db_id: number;
+  db_name: string;
+  table_id: number;
+  schema_name: string;
+  table_name: string;
+  replication_size_bytes: number;
+  range_count: number;
+  column_count: number;
+  index_count: number;
+  percent_live_data: number;
+  total_live_data_bytes: number;
+  total_data_bytes: number;
+  store_ids: number[];
+  last_updated: string;
+  last_update_error: string | null;
+  auto_stats_enabled: boolean;
+  // Optimizer stats.
+  stats_last_updated: string | null;
+};
+
+export type TableMetadataResponseServer =
+  APIV2ResponseWithPaginationState<TableMetadataServer>;
+
+// ------------------------------------------------------------------------------------
+// /api/v2/table_metadata/:tableId/ response.
+// ------------------------------------------------------------------------------------
+export type TableDetailsResponseServer = {
+  metadata: TableMetadataServer;
+  create_statement: string;
+};
+
+// ------------------------------------------------------------------------------------
+// /api/v2/database_metadata/ response.
+// ------------------------------------------------------------------------------------
+export type DatabaseMetadataServer = {
+  db_id: number;
+  db_name: string;
+  size_bytes: number;
+  table_count: number;
+  store_ids: number[];
+  last_updated: string;
+};
+
+export type DatabaseMetadataResponseServer =
+  APIV2ResponseWithPaginationState<DatabaseMetadataServer>;
+
+// ------------------------------------------------------------------------------------
+// /api/v2/grants/tabless/:tableId/ response.
+// /api/v2/grants/databases/:dbId/ response.
+// ------------------------------------------------------------------------------------
+
+export type DatabaseGrantServer = {
+  grantee: string;
+  privilege: string;
+};
+
+export type DatabaseGrantsResponseServer =
+  APIV2ResponseWithPaginationState<DatabaseGrantServer>;

--- a/pkg/ui/workspaces/cluster-ui/src/api/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/types.ts
@@ -26,18 +26,18 @@ export function createInitialState<T>(
   };
 }
 
-export type SimplePaginationState = {
+export type PaginationRequest = {
   pageSize: number;
   pageNum: number;
 };
 
-export type APIV2PaginationResponse = {
-  total_results: number;
-  page_size: number;
-  page_num: number;
+export type PaginationState = {
+  pageSize: number;
+  pageNum: number;
+  totalResults: number;
 };
 
-export type APIV2ResponseWithPaginationState<T> = {
+export type ResultsWithPagination<T> = {
   results: T;
-  pagination_info: APIV2PaginationResponse;
+  pagination: PaginationState;
 };

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/index.tsx
@@ -60,7 +60,7 @@ export const DatabaseDetailsPageV2 = () => {
   const dbName =
     error?.status === 404 || !data
       ? "Database Not Found"
-      : data.metadata.db_name;
+      : data.metadata.dbName;
 
   const breadCrumbItems = [
     { name: "Databases", link: DB_PAGE_PATH },

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
@@ -40,7 +40,7 @@ import {
 
 import { TableColName } from "./constants";
 import { TableRow } from "./types";
-import { rawTableMetadataToRows } from "./utils";
+import { tableMetadataToRows } from "./utils";
 
 const COLUMNS: (TableColumnProps<TableRow> & { sortKey?: TableSortOption })[] =
   [
@@ -49,10 +49,10 @@ const COLUMNS: (TableColumnProps<TableRow> & { sortKey?: TableSortOption })[] =
         <Tooltip title={"The name of the table."}>{TableColName.NAME}</Tooltip>
       ),
       width: "15%",
-      sorter: (a, b) => a.name.localeCompare(b.name),
+      sorter: (a, b) => a.tableName.localeCompare(b.tableName),
       render: (t: TableRow) => {
         return (
-          <Link to={`/table/${t.tableID}`}>{t.qualifiedNameWithSchema}</Link>
+          <Link to={`/table/${t.tableId}`}>{t.qualifiedNameWithSchema}</Link>
         );
       },
       sortKey: TableSortOption.NAME,
@@ -131,9 +131,9 @@ const COLUMNS: (TableColumnProps<TableRow> & { sortKey?: TableSortOption })[] =
       render: (t: TableRow) => {
         return (
           <div>
-            <div>{t.liveDataPercentage * 100}%</div>
+            <div>{t.percentLiveData * 100}%</div>
             <div>
-              {Bytes(t.liveDataBytes)} / {Bytes(t.totalDataBytes)}
+              {Bytes(t.totalLiveDataBytes)} / {Bytes(t.totalDataBytes)}
             </div>
           </div>
         );
@@ -227,7 +227,6 @@ export const TablesPageV2 = () => {
     createTableMetadataRequestFromParams(dbID, params),
   );
   const nodesResp = useNodeStatuses();
-  const paginationState = data?.pagination_info;
 
   const onNodeRegionsChange = (storeIDs: StoreID[]) => {
     setFilters({
@@ -236,19 +235,18 @@ export const TablesPageV2 = () => {
   };
 
   const tableList = data?.results;
-
   const tableData = useMemo(
     () =>
-      rawTableMetadataToRows(tableList ?? [], {
+      tableMetadataToRows(tableList ?? [], {
         nodeIDToRegion: nodesResp.nodeIDToRegion,
         storeIDToNodeID: nodesResp.storeIDToNodeID,
         isLoading: nodesResp.isLoading,
       }),
     [
       tableList,
-      nodesResp.isLoading,
       nodesResp.nodeIDToRegion,
       nodesResp.storeIDToNodeID,
+      nodesResp.isLoading,
     ],
   );
 
@@ -309,7 +307,7 @@ export const TablesPageV2 = () => {
         <PageCount
           page={params.pagination.page}
           pageSize={params.pagination.pageSize}
-          total={data?.pagination_info?.total_results ?? 0}
+          total={data?.pagination.totalResults ?? 0}
           entity="tables"
         />
         <Table
@@ -326,7 +324,7 @@ export const TablesPageV2 = () => {
             pageSize: params.pagination.pageSize,
             showSizeChanger: false,
             position: ["bottomCenter"],
-            total: paginationState?.total_results,
+            total: data?.pagination.totalResults,
           }}
           onChange={onTableChange}
         />

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/types.ts
@@ -3,24 +3,11 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import { Moment } from "moment-timezone";
-
+import { TableMetadata } from "src/api/databases/getTableMetadataApi";
 import { NodeID } from "src/types/clusterTypes";
 
-export type TableRow = {
+export type TableRow = TableMetadata & {
   qualifiedNameWithSchema: string;
-  name: string;
-  dbName: string;
-  tableID: number;
-  dbID: number;
-  replicationSizeBytes: number;
-  rangeCount: number;
-  columnCount: number;
   nodesByRegion: Record<string, NodeID[]>;
-  liveDataPercentage: number;
-  liveDataBytes: number;
-  totalDataBytes: number;
-  statsLastUpdated: Moment;
-  autoStatsEnabled: boolean;
   key: string;
 };

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/utils.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/utils.tsx
@@ -3,14 +3,12 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import moment from "moment-timezone";
-
 import { TableMetadata } from "src/api/databases/getTableMetadataApi";
 import { NodeID, StoreID } from "src/types/clusterTypes";
 
 import { TableRow } from "./types";
 
-export const rawTableMetadataToRows = (
+export const tableMetadataToRows = (
   tables: TableMetadata[],
   nodesInfo: {
     nodeIDToRegion: Record<NodeID, string>;
@@ -21,7 +19,7 @@ export const rawTableMetadataToRows = (
   return tables.map(table => {
     const nodesByRegion: Record<string, NodeID[]> = {};
     if (!nodesInfo.isLoading) {
-      table.store_ids?.forEach(storeID => {
+      table.storeIds?.forEach(storeID => {
         const nodeID = nodesInfo.storeIDToNodeID[storeID as StoreID];
         const region = nodesInfo.nodeIDToRegion[nodeID];
         if (!nodesByRegion[region]) {
@@ -31,21 +29,10 @@ export const rawTableMetadataToRows = (
       });
     }
     return {
-      name: table.table_name,
-      dbName: table.db_name,
-      tableID: table.table_id,
-      dbID: table.db_id,
-      replicationSizeBytes: table.replication_size_bytes,
-      rangeCount: table.range_count,
-      columnCount: table.column_count,
+      ...table,
       nodesByRegion: nodesByRegion,
-      liveDataPercentage: table.percent_live_data,
-      liveDataBytes: table.total_live_data_bytes,
-      totalDataBytes: table.total_data_bytes,
-      statsLastUpdated: moment.utc(table.stats_last_updated),
-      autoStatsEnabled: table.auto_stats_enabled,
-      key: table.table_id.toString(),
-      qualifiedNameWithSchema: `${table.schema_name}.${table.table_name}`,
+      key: table.tableId.toString(),
+      qualifiedNameWithSchema: `${table.schemaName}.${table.tableName}`,
     };
   });
 };

--- a/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
@@ -142,8 +142,6 @@ export const DatabasesPageV2 = () => {
   );
   const nodesResp = useNodeStatuses();
 
-  const paginationState = data?.pagination_info;
-
   const onNodeRegionsChange = (storeIDs: StoreID[]) => {
     setFilters({
       storeIDs: storeIDs.map(sid => sid.toString()),
@@ -212,9 +210,9 @@ export const DatabasesPageV2 = () => {
       </PageSection>
       <PageSection>
         <PageCount
-          page={params.pagination.page ?? 0}
-          pageSize={params.pagination.pageSize ?? 0}
-          total={paginationState?.total_results ?? 0}
+          page={params.pagination.page}
+          pageSize={params.pagination.pageSize}
+          total={data?.pagination.totalResults ?? 0}
           entity="databases"
         />
         <Table
@@ -231,7 +229,7 @@ export const DatabasesPageV2 = () => {
             pageSize: params.pagination.pageSize,
             showSizeChanger: false,
             position: ["bottomCenter"],
-            total: paginationState?.total_results,
+            total: data?.pagination.totalResults,
           }}
           onChange={onTableChange}
         />

--- a/pkg/ui/workspaces/cluster-ui/src/databasesV2/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesV2/utils.ts
@@ -19,7 +19,7 @@ export const rawDatabaseMetadataToDatabaseRows = (
   return raw.map((db: DatabaseMetadata): DatabaseRow => {
     const nodesByRegion: Record<string, NodeID[]> = {};
     if (!nodesInfo.isLoading) {
-      db.store_ids?.forEach(storeID => {
+      db.storeIds?.forEach(storeID => {
         const nodeID = nodesInfo.storeIDToNodeID[storeID as StoreID];
         const region = nodesInfo.nodeIDToRegion[nodeID];
         if (!nodesByRegion[region]) {
@@ -29,13 +29,13 @@ export const rawDatabaseMetadataToDatabaseRows = (
       });
     }
     return {
-      name: db.db_name,
-      id: db.db_id,
-      tableCount: db.table_count ?? 0,
-      approximateDiskSizeBytes: db.size_bytes ?? 0,
-      rangeCount: db.table_count ?? 0,
+      name: db.dbName,
+      id: db.dbId,
+      tableCount: db.tableCount ?? 0,
+      approximateDiskSizeBytes: db.sizeBytes ?? 0,
+      rangeCount: db.tableCount ?? 0,
       schemaInsightsCount: 0,
-      key: db.db_id.toString(),
+      key: db.dbId.toString(),
       nodesByRegion: {
         isLoading: nodesInfo.isLoading,
         data: nodesByRegion,

--- a/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/index.tsx
@@ -34,15 +34,15 @@ export const TableDetailsPageV2 = () => {
 
   const partiallyQualifiedTableName = !tableNotFound
     ? data
-      ? data.metadata.schema_name + "." + data.metadata.table_name
+      ? data.metadata.schemaName + "." + data.metadata.tableName
       : ""
     : "Table not found";
 
   const breadCrumbItems = [
     { link: `/databases`, name: "Databases" },
     {
-      link: `/databases/${data?.metadata.db_id}`,
-      name: data?.metadata.db_name,
+      link: `/databases/${data?.metadata.dbId}`,
+      name: data?.metadata.dbName,
     },
     {
       link: null,
@@ -66,9 +66,9 @@ export const TableDetailsPageV2 = () => {
       label: "Indexes",
       children: (
         <TableIndexesView
-          dbName={data?.metadata.db_name}
-          schemaName={data?.metadata.schema_name}
-          tableName={data?.metadata.table_name}
+          dbName={data?.metadata.dbName}
+          schemaName={data?.metadata.schemaName}
+          tableName={data?.metadata.tableName}
         />
       ),
     },

--- a/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/tableOverview.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/tableOverview.tsx
@@ -9,7 +9,7 @@ import moment from "moment-timezone";
 import React from "react";
 
 import { useNodeStatuses } from "src/api";
-import { TableDetailsResponse } from "src/api/databases/getTableMetadataApi";
+import { TableDetails } from "src/api/databases/getTableMetadataApi";
 import { PageSection } from "src/layouts";
 import { SqlBox, SqlBoxSize } from "src/sql";
 import { SummaryCard, SummaryCardItem } from "src/summaryCard";
@@ -18,7 +18,7 @@ import { StoreID } from "src/types/clusterTypes";
 import { Bytes, DATE_WITH_SECONDS_FORMAT_24_TZ } from "src/util";
 
 type TableOverviewProps = {
-  tableDetails: TableDetailsResponse;
+  tableDetails: TableDetails;
 };
 
 export const TableOverview: React.FC<TableOverviewProps> = ({
@@ -38,7 +38,7 @@ export const TableOverview: React.FC<TableOverviewProps> = ({
       return "";
     }
     const nodesByRegion: Record<string, number[]> = {};
-    metadata.store_ids.forEach(storeID => {
+    metadata.storeIds.forEach(storeID => {
       const nodeID = storeIDToNodeID[storeID as StoreID];
       const region = nodeIDToRegion[nodeID];
       if (!nodesByRegion[region]) {
@@ -54,35 +54,32 @@ export const TableOverview: React.FC<TableOverviewProps> = ({
       .join(", ");
   };
 
-  const percentLiveDataWithPrecision = (
-    metadata.percent_live_data * 100
-  ).toFixed(2);
+  const percentLiveDataWithPrecision = (metadata.percentLiveData * 100).toFixed(
+    2,
+  );
 
-  const formattedErrorText = metadata.last_update_error
-    ? "Update error: " + metadata.last_update_error
+  const formattedErrorText = metadata.lastUpdateError
+    ? "Update error: " + metadata.lastUpdateError
     : "";
 
   return (
     <>
       <PageSection>
-        <SqlBox
-          value={tableDetails.create_statement}
-          size={SqlBoxSize.CUSTOM}
-        />
+        <SqlBox value={tableDetails.createStatement} size={SqlBoxSize.CUSTOM} />
       </PageSection>
       <PageSection>
         <Row justify={"end"}>
           <Col>
             <Tooltip title={formattedErrorText}>
               <Row gutter={8} align={"middle"} justify={"center"}>
-                {metadata.last_update_error && (
+                {metadata.lastUpdateError && (
                   <Icon fill="warning" iconName={"Caution"} />
                 )}
                 <Col>
                   Last updated:{" "}
                   <Timestamp
                     format={DATE_WITH_SECONDS_FORMAT_24_TZ}
-                    time={moment.utc(metadata.last_updated)}
+                    time={moment.utc(metadata.lastUpdated)}
                     fallback={"Never"}
                   />
                 </Col>
@@ -95,9 +92,9 @@ export const TableOverview: React.FC<TableOverviewProps> = ({
             <SummaryCard>
               <SummaryCardItem
                 label="Size"
-                value={Bytes(metadata.replication_size_bytes)}
+                value={Bytes(metadata.replicationSizeBytes)}
               />
-              <SummaryCardItem label="Ranges" value={metadata.range_count} />
+              <SummaryCardItem label="Ranges" value={metadata.rangeCount} />
               <SummaryCardItem
                 label="Regions / Nodes"
                 value={
@@ -116,21 +113,21 @@ export const TableOverview: React.FC<TableOverviewProps> = ({
                   <div>
                     <div>{percentLiveDataWithPrecision}% </div>
                     <div>
-                      {Bytes(metadata.total_live_data_bytes)} /{" "}
-                      {Bytes(metadata.total_live_data_bytes)}
+                      {Bytes(metadata.totalLiveDataBytes)} /{" "}
+                      {Bytes(metadata.totalLiveDataBytes)}
                     </div>
                   </div>
                 }
               />
               <SummaryCardItem
                 label="Auto stats collections"
-                value={metadata.auto_stats_enabled ? "Enabled" : "Disabled"}
+                value={metadata.autoStatsEnabled ? "Enabled" : "Disabled"}
               />
               <SummaryCardItem
                 label="Stats last updated"
                 value={
                   <Timestamp
-                    time={moment.utc(metadata.stats_last_updated)}
+                    time={metadata.statsLastUpdated}
                     format={DATE_WITH_SECONDS_FORMAT_24_TZ}
                     fallback={"Never"}
                   />


### PR DESCRIPTION
Convert the server responses from api v2 to a more client friendly type where we don't have to assume all fields are nullable.

This also makes any future api changes easier as we may want to switch back to using protobufs.

Epic: none
Release note: None