### PR TITLE
sql/randgen: disable crazy names in most randomized tests

### DIFF
--- a/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
@@ -707,9 +707,7 @@ func TestRandomTables(t *testing.T) {
 			rng,
 			tableName,
 			1,
-			false, /* isMultiregion */
-			// We do not have full support for column families.
-			randgen.SkipColumnFamilyMutation())
+			randgen.TableOptSkipColumnFamilyMutations)
 		stmt := tree.SerializeForDisplay(createStmt)
 		t.Log(stmt)
 		runnerA.Exec(t, stmt)

--- a/pkg/ccl/crosscluster/logical/udf_row_processor_test.go
+++ b/pkg/ccl/crosscluster/logical/udf_row_processor_test.go
@@ -60,10 +60,7 @@ func TestUDFWithRandomTables(t *testing.T) {
 		rng,
 		tableName,
 		1,
-		false, /* isMultiregion */
-		// We do not have full support for column families.
-		randgen.SkipColumnFamilyMutation(),
-		randgen.RequirePrimaryIndex(),
+		randgen.TableOptPrimaryIndexRequired|randgen.TableOptSkipColumnFamilyMutations,
 	)
 	stmt := tree.SerializeForDisplay(createStmt)
 	t.Log(stmt)

--- a/pkg/internal/sqlsmith/alter.go
+++ b/pkg/internal/sqlsmith/alter.go
@@ -113,7 +113,7 @@ func makeCreateSchema(s *Smither) (tree.Statement, bool) {
 }
 
 func makeCreateTable(s *Smither) (tree.Statement, bool) {
-	table := randgen.RandCreateTable(context.Background(), s.rnd, "", 0, false /* isMultiRegion */)
+	table := randgen.RandCreateTable(context.Background(), s.rnd, "", 0, randgen.TableOptNone)
 	schemaOrd := s.rnd.Intn(len(s.schemas))
 	schema := s.schemas[schemaOrd]
 	table.Table = tree.MakeTableNameWithSchema(tree.Name(s.dbName), schema.SchemaName, s.name("tab"))

--- a/pkg/internal/sqlsmith/setup.go
+++ b/pkg/internal/sqlsmith/setup.go
@@ -125,8 +125,12 @@ func randTablesN(r *rand.Rand, n int, prefix string, isMultiRegion bool) []strin
 	stmts = append(stmts, `SET CLUSTER SETTING sql.stats.histogram_collection.enabled = false;`)
 
 	// Create the random tables.
+	opt := randgen.TableOptNone
+	if isMultiRegion {
+		opt |= randgen.TableOptMultiRegion
+	}
 	createTableStatements := randgen.RandCreateTables(
-		context.Background(), r, "table", n, isMultiRegion, randgen.StatisticsMutator,
+		context.Background(), r, "table", n, opt, randgen.StatisticsMutator,
 		randgen.PartialIndexMutator, randgen.ForeignKeyMutator,
 	)
 

--- a/pkg/internal/sqlsmith/setup.go
+++ b/pkg/internal/sqlsmith/setup.go
@@ -125,7 +125,7 @@ func randTablesN(r *rand.Rand, n int, prefix string, isMultiRegion bool) []strin
 	stmts = append(stmts, `SET CLUSTER SETTING sql.stats.histogram_collection.enabled = false;`)
 
 	// Create the random tables.
-	opt := randgen.TableOptNone
+	opt := randgen.TableOptCrazyNames
 	if isMultiRegion {
 		opt |= randgen.TableOptMultiRegion
 	}

--- a/pkg/sql/colenc/encode_test.go
+++ b/pkg/sql/colenc/encode_test.go
@@ -262,7 +262,7 @@ func TestEncoderEqualityRand(t *testing.T) {
 	rng, _ := randutil.NewTestRand()
 	for i := 0; i < 100; i++ {
 		tableName := fmt.Sprintf("t%d", i)
-		ct := randgen.RandCreateTableWithName(ctx, rng, tableName, i, false /* isMultiRegion */)
+		ct := randgen.RandCreateTableWithName(ctx, rng, tableName, i, randgen.TableOptNone)
 		tableDef := tree.Serialize(ct)
 		r := sqlutils.MakeSQLRunner(db)
 		r.Exec(t, tableDef)

--- a/pkg/sql/importer/exportparquet_test.go
+++ b/pkg/sql/importer/exportparquet_test.go
@@ -199,7 +199,7 @@ func TestRandomParquetExports(t *testing.T) {
 		)
 
 		stmts := randgen.RandCreateTables(
-			ctx, rng, tablePrefix, numTables, false, /* isMultiRegion */
+			ctx, rng, tablePrefix, numTables, randgen.TableOptNone,
 			randgen.PartialIndexMutator, randgen.ForeignKeyMutator,
 		)
 

--- a/pkg/sql/randgen/schema.go
+++ b/pkg/sql/randgen/schema.go
@@ -109,6 +109,7 @@ const (
 	TableOptSkipColumnFamilyMutations
 	TableOptMultiRegion
 	TableOptAllowPartiallyVisibleIndex
+	TableOptCrazyNames
 )
 
 func (t TableOpt) IsSet(o TableOpt) bool {
@@ -162,8 +163,13 @@ func RandCreateTableWithColumnIndexNumberGenerator(
 	opt TableOpt,
 	generateColumnIndexSuffix func() string,
 ) *tree.CreateTable {
-	g := randident.NewNameGenerator(&nameGenCfg, rng, prefix)
-	name := g.GenerateOne(strconv.Itoa(tableIdx))
+	var name string
+	if opt.IsSet(TableOptCrazyNames) {
+		g := randident.NewNameGenerator(&nameGenCfg, rng, prefix)
+		name = g.GenerateOne(strconv.Itoa(tableIdx))
+	} else {
+		name = fmt.Sprintf("%s%d", prefix, tableIdx)
+	}
 	return randCreateTableWithColumnIndexNumberGeneratorAndName(
 		ctx, rng, name, tableIdx, opt, generateColumnIndexSuffix,
 	)
@@ -204,7 +210,7 @@ func randCreateTableWithColumnIndexNumberGeneratorAndName(
 	nComputedColumns := randutil.RandIntInRange(rng, 0, (nColumns+1)/2)
 	nNormalColumns := nColumns - nComputedColumns
 	for i := 0; i < nNormalColumns; i++ {
-		columnDef := randColumnTableDef(rng, tableIdx, colSuffix(i))
+		columnDef := randColumnTableDef(rng, tableIdx, colSuffix(i), opt)
 		columnDefs = append(columnDefs, columnDef)
 		defs = append(defs, columnDef)
 	}
@@ -212,7 +218,7 @@ func randCreateTableWithColumnIndexNumberGeneratorAndName(
 	// Make defs for computed columns.
 	normalColDefs := columnDefs
 	for i := nNormalColumns; i < nColumns; i++ {
-		columnDef := randComputedColumnTableDef(rng, normalColDefs, tableIdx, colSuffix(i))
+		columnDef := randComputedColumnTableDef(rng, normalColDefs, tableIdx, colSuffix(i), opt)
 		columnDefs = append(columnDefs, columnDef)
 		defs = append(defs, columnDef)
 	}
@@ -454,13 +460,20 @@ func PopulateTableWithRandData(
 
 // randColumnTableDef produces a random ColumnTableDef for a non-computed
 // column, with a random type and nullability.
-func randColumnTableDef(rng *rand.Rand, tableIdx int, colSuffix string) *tree.ColumnTableDef {
-	g := randident.NewNameGenerator(&nameGenCfg, rng, fmt.Sprintf("col%d", tableIdx))
-	colName := g.GenerateOne(colSuffix)
+func randColumnTableDef(
+	rng *rand.Rand, tableIdx int, colSuffix string, opt TableOpt,
+) *tree.ColumnTableDef {
+	var colName tree.Name
+	if opt.IsSet(TableOptCrazyNames) {
+		g := randident.NewNameGenerator(&nameGenCfg, rng, fmt.Sprintf("col%d", tableIdx))
+		colName = tree.Name(g.GenerateOne(colSuffix))
+	} else {
+		colName = tree.Name(fmt.Sprintf("col%d_%s", tableIdx, colSuffix))
+	}
 	columnDef := &tree.ColumnTableDef{
 		// We make a unique name for all columns by prefixing them with the table
 		// index to make it easier to reference columns from different tables.
-		Name: tree.Name(colName),
+		Name: colName,
 		Type: RandColumnType(rng),
 	}
 	// Slightly prefer non-nullable columns
@@ -482,9 +495,13 @@ func randColumnTableDef(rng *rand.Rand, tableIdx int, colSuffix string) *tree.Co
 // column (either STORED or VIRTUAL). The computed expressions refer to columns
 // in normalColDefs.
 func randComputedColumnTableDef(
-	rng *rand.Rand, normalColDefs []*tree.ColumnTableDef, tableIdx int, colSuffix string,
+	rng *rand.Rand,
+	normalColDefs []*tree.ColumnTableDef,
+	tableIdx int,
+	colSuffix string,
+	opt TableOpt,
 ) *tree.ColumnTableDef {
-	newDef := randColumnTableDef(rng, tableIdx, colSuffix)
+	newDef := randColumnTableDef(rng, tableIdx, colSuffix, opt)
 	newDef.Computed.Computed = true
 	newDef.Computed.Virtual = rng.Intn(2) == 0
 
@@ -647,7 +664,11 @@ func randIndexTableDefFromCols(
 		numExpressions := rng.Intn(10) + 1
 		for i := 0; i < numPartitions; i++ {
 			var partition tree.ListPartition
-			partition.Name = tree.Name(g.GenerateOne(strconv.Itoa(i)))
+			if opt.IsSet(TableOptCrazyNames) {
+				partition.Name = tree.Name(g.GenerateOne(strconv.Itoa(i)))
+			} else {
+				partition.Name = tree.Name(fmt.Sprintf("%s_part_%d", tableName, i))
+			}
 			// Add up to 10 expressions in each partition.
 			for j := 0; j < numExpressions; j++ {
 				// Use a tuple to contain the expressions in case there are multiple

--- a/pkg/sql/randgen/schema_test.go
+++ b/pkg/sql/randgen/schema_test.go
@@ -46,7 +46,7 @@ func TestPopulateTableWithRandData(t *testing.T) {
 	numTables := 10
 
 	stmts := randgen.RandCreateTables(
-		ctx, rng, tablePrefix, numTables, false, /* isMultiRegion */
+		ctx, rng, tablePrefix, numTables, randgen.TableOptNone,
 		randgen.PartialIndexMutator, randgen.ForeignKeyMutator,
 	)
 

--- a/pkg/sql/tests/random_schema_test.go
+++ b/pkg/sql/tests/random_schema_test.go
@@ -58,7 +58,7 @@ func TestCreateRandomSchema(t *testing.T) {
 
 	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
 	for i := 0; i < 100; i++ {
-		createTable := randgen.RandCreateTable(ctx, rng, "table", i, false /* isMultiRegion */)
+		createTable := randgen.RandCreateTable(ctx, rng, "table", i, randgen.TableOptNone)
 		setDb(t, db, "test")
 		_, err := db.Exec(toStr(createTable))
 		if err != nil {

--- a/pkg/workload/rand/rand.go
+++ b/pkg/workload/rand/rand.go
@@ -97,7 +97,7 @@ func (w *random) Tables() []workload.Table {
 	tables := make([]workload.Table, w.tables)
 	rng := rand.New(rand.NewSource(RandomSeed.Seed()))
 	for i := 0; i < w.tables; i++ {
-		createTable := randgen.RandCreateTable(context.Background(), rng, "table", rng.Int(), false /* isMultiRegion */)
+		createTable := randgen.RandCreateTable(context.Background(), rng, "table", rng.Int(), randgen.TableOptNone)
 		ctx := tree.NewFmtCtx(tree.FmtParsable)
 		createTable.FormatBody(ctx)
 		tables[i] = workload.Table{

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1260,9 +1260,12 @@ func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opSt
 		return nil, err
 	}
 
+	opt := randgen.TableOptAllowPartiallyVisibleIndex
+	if databaseHasMultiRegion {
+		opt |= randgen.TableOptMultiRegion
+	}
 	stmt := randgen.RandCreateTableWithColumnIndexNumberGenerator(
-		ctx, og.params.rng, "table", tableIdx, databaseHasMultiRegion,
-		true /* allowPartiallyVisibleIndex */, og.newUniqueSeqNumSuffix,
+		ctx, og.params.rng, "table", tableIdx, opt, og.newUniqueSeqNumSuffix,
 	)
 	stmt.Table = *tableName
 	stmt.IfNotExists = og.randIntn(2) == 0

--- a/pkg/workload/sqlsmith/sqlsmith.go
+++ b/pkg/workload/sqlsmith/sqlsmith.go
@@ -79,7 +79,7 @@ func (g *sqlSmith) Tables() []workload.Table {
 	rng := rand.New(rand.NewSource(RandomSeed.Seed()))
 	var tables []workload.Table
 	for idx := 0; idx < g.tables; idx++ {
-		schema := randgen.RandCreateTable(context.Background(), rng, "table", idx, false /* isMultiRegion */)
+		schema := randgen.RandCreateTable(context.Background(), rng, "table", idx, randgen.TableOptNone)
 		// workload expects the schema to be missing the 'CREATE TABLE "name"', so
 		// we only want to format the schema, not the whole statement.
 		fmtCtx := tree.NewFmtCtx(tree.FmtSerializable)


### PR DESCRIPTION
#### sql/randgen: unify table options

Options for generating random tables have been unified into the
`TableOpt` type. Prior to this commit, options were specified with a
mixture of boolean arguments and the `tableGenerationOptions` type.

Release note: None

#### sql/randgen: add TableOptCrazyNames

The `randgen.TableOptCrazyNames` option has been added, which instructs
`randgen` functions to use the `randident` package to generate table,
column, and partition names with special and interesting characters.

This setting is only used for sqlsmith tests where it is most likely to
catch problems. It not used for other forms of randomized tests because
it makes it more difficult to reduce those test failures.

Epic: None

Release note: None
