### PR TITLE
sql: default disallow_full_table_scans to true

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2321,10 +2321,9 @@ func (ex *connExecutor) makeExecPlan(ctx context.Context, planner *planner) erro
 				// - the query is not an internal query.
 				ex.metrics.EngineMetrics.FullTableOrIndexScanRejectedCount.Inc(1)
 				return errors.WithHint(
-					pgerror.Newf(pgcode.TooManyRows,
-						"query `%s` contains a full table/index scan which is explicitly disallowed",
-						planner.stmt.SQL),
-					"try overriding the `disallow_full_table_scans` or increasing the `large_full_scan_rows` cluster/session settings",
+					errors.WithMessage(pgerror.Newf(pgcode.TooManyRows,
+						"query requires a full table/index scan"), "rejected (disallow_full_table_scans = true)"),
+					"ensure WHERE or LIMIT clause is present with appropriate index. If a full scan is needed, override disallow_full_table_scans or increase large_full_scan_rows",
 				)
 			}
 		}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -632,7 +632,7 @@ var disallowFullTableScans = settings.RegisterBoolSetting(
 	"setting to true rejects queries that have planned a full table scan; set "+
 		"large_full_scan_rows > 0 to allow small full table scans estimated to "+
 		"read fewer than large_full_scan_rows",
-	false,
+	true,
 	settings.WithPublic)
 
 // intervalStyle controls intervals representation.


### PR DESCRIPTION
Also update the error message to suggest adding a `WHERE`/`LIMIT` clause with appropriate index.

Informs #79683

Release note (sql change): session setting `disallow_full_table_scans` and the cluster setting `sql.defaults.disallow_full_table_scans.enabled` now default to true.