### PR TITLE
tablemetadatacache: skip db and schema entries in table metadata iter…

### DIFF
--- a/pkg/sql/tablemetadatacache/table_metadata_batch_iterator.go
+++ b/pkg/sql/tablemetadatacache/table_metadata_batch_iterator.go
@@ -80,8 +80,8 @@ func newTableMetadataBatchIterator(
 		ie:        ie,
 		batchRows: make([]tableMetadataIterRow, 0, tableBatchSize),
 		lastID: paginationKey{
-			parentID: 0,
-			schemaID: 0,
+			parentID: 1,
+			schemaID: 1,
 			name:     "",
 		},
 		queryStatement: newBatchQueryStatement(aostClause),
@@ -200,7 +200,7 @@ WITH tables AS (SELECT n.id,
                 FROM system.namespace n
                 JOIN system.descriptor d ON n.id = d.id
 								%[1]s
-                WHERE (n."parentID", n."parentSchemaID", n.name) > ($1, $2, $3)
+                WHERE (n."parentID", n."parentSchemaID", n.name) > ($1, $2, $3) AND n."parentSchemaID" != 0
                 ORDER BY (n."parentID", n."parentSchemaID", n.name)
                 LIMIT $4),
 span_array AS (SELECT array_agg((span[1], span[2])) as all_spans FROM tables),

--- a/pkg/sql/tablemetadatacache/table_metadata_updater.go
+++ b/pkg/sql/tablemetadatacache/table_metadata_updater.go
@@ -266,8 +266,6 @@ func (q *tableMetadataBatchUpsertQuery) addRow(
 		livePercentage = float64(liveBytes) / float64(total)
 	}
 
-	// TODO (xinhaoz): Get store ids from span stats after
-	// https://github.com/cockroachdb/cockroach/issues/129060 is complete.
 	storeIds := make([]int, len(stats.StoreIDs))
 	for i, id := range stats.StoreIDs {
 		storeIds[i] = int(id)


### PR DESCRIPTION
…ator

When fetching batches from system.namespace, skip database and schema entries. This commit starts the batch iteration at rows with parentID and parentSchemaID > 0 which skips the db entries in the table, and also adds a filter to the query to skip schema entries. This ensures we don't fetch span stats for either of those.

Epic: CRDB-37558

Release note: None