### PR TITLE
release-23.2: license lint: only lint on the CockroachDB Software License (CSL)

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -204,26 +204,6 @@ func TestLint(t *testing.T) {
 	t.Run("TestCopyrightHeaders", func(t *testing.T) {
 		t.Parallel()
 
-		bslHeader := regexp.MustCompile(`// Copyright 20\d\d The Cockroach Authors.
-//
-// Use of this software is governed by the Business Source License
-// included in the file licenses/BSL.txt.
-//
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0, included in the file
-// licenses/APL.txt.
-`)
-
-		cclHeader := regexp.MustCompile(`// Copyright 20\d\d The Cockroach Authors.
-//
-// Licensed as a CockroachDB Enterprise file under the Cockroach Community
-// License \(the "License"\); you may not use this file except in compliance with
-// the License. You may obtain a copy of the License at
-//
-//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
-`)
-
 		cslHeader := regexp.MustCompile(`// Copyright 20\d\d The Cockroach Authors.
 //
 // Use of this software is governed by the CockroachDB Software License
@@ -284,20 +264,15 @@ func TestLint(t *testing.T) {
 			}
 			data = data[0:n]
 
-			isCCL := strings.Contains(filename, "ccl/")
 			isApache := strings.HasPrefix(filename, "obsservice")
 			switch {
-			case isCCL:
-				if cclHeader.Find(data) == nil && cslHeader.Find(data) == nil {
-					t.Errorf("did not find expected CCL or CSL license header in %s", filename)
-				}
 			case isApache:
 				if apacheHeader.Find(data) == nil {
 					t.Errorf("did not find expected Apache license header in %s", filename)
 				}
 			default:
-				if bslHeader.Find(data) == nil && cslHeader.Find(data) == nil {
-					t.Errorf("did not find expected BSL or CSL license header in %s", filename)
+				if cslHeader.Find(data) == nil {
+					t.Errorf("did not find expected CSL license header in %s", filename)
 				}
 			}
 		}); err != nil {

--- a/pkg/ui/workspaces/db-console/.storybook/config.tsx
+++ b/pkg/ui/workspaces/db-console/.storybook/config.tsx
@@ -1,12 +1,7 @@
 // Copyright 2020 The Cockroach Authors.
 //
-// Use of this software is governed by the Business Source License
-// included in the file licenses/BSL.txt.
-//
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0, included in the file
-// licenses/APL.txt.
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
 
 import { configure } from "@storybook/react";
 


### PR DESCRIPTION
Backport 1/1 commits from #131781.

/cc @cockroachdb/release

---

Given all the headers have been updated to use the CockroachDB Software License (CSL), switch to only linting for CSL headers.

Part of RE-658

Release note: none

---

Release justification: Need to change the cockroach license to the CockroachDB Software License (CSL).