### PR TITLE
replica_rac2: check raft state instead of lead==self

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -51,6 +51,9 @@ type RaftScheduler interface {
 type RaftNodeBasicState struct {
 	// Term is the current term of this replica.
 	Term uint64
+	// IsLeader is true if the RawNode is the leader of the Term, and acts in
+	// StateLeader. We are interested in transitions in and out of StateLeader.
+	IsLeader bool
 	// Leader is the current known leader, or zero if Raft does not know the
 	// leader. This state can advance past the group membership state, so the
 	// leader may not be known as a current group member.
@@ -391,8 +394,12 @@ type processorImpl struct {
 	// cycle. It is used to notice transitions out of leadership and back, to
 	// recreate leader.rc.
 	term uint64
+	// isLeader is true if this replica is the leader of the term, and acts as
+	// one, i.e. raft RawNode is in StateLeader.
+	isLeader bool
 	// leaderID is the ID of the current term leader. Can be zero if unknown.
 	leaderID roachpb.ReplicaID
+
 	// leaderNodeID and leaderStoreID are a function of leaderID and replicas
 	// fields. They are set when leaderID is non-zero and replicas contains
 	// leaderID, else are 0.
@@ -615,26 +622,36 @@ func (p *processorImpl) makeStateConsistentRaftMuLocked(
 	}
 	termChanged := state.Term > p.term
 	if termChanged {
+		// NB: always keep the term up-to-date, even if there are no other changes
+		// to act on below.
 		p.term = state.Term
 	}
+	leadChanged := state.Leader != p.leaderID
+	leaseChanged := state.Leaseholder != p.leaseholderID
 	replicasChanged := p.desc.replicasChanged
+
+	// Detect when we leave or enter leadership. Note that leftLeader and
+	// becameLeader can be true simultaneously, meaning that we left being leader
+	// of the previous term, and became the leader of state.Term.
+	leftLeader := p.isLeader && (termChanged || !state.IsLeader)
+	becameLeader := (!p.isLeader || termChanged) && state.IsLeader
+
+	// Check the common case: nothing changed.
+	if !leftLeader && !becameLeader && !leadChanged && !leaseChanged && !replicasChanged && !force {
+		// There is no observed change, and force is false, so return.
+		return
+	}
+	// At least one thing has changed, or the initialization is forced.
+
+	p.isLeader = state.IsLeader
+	p.leaderID = state.Leader
+	p.leaseholderID = state.Leaseholder
 	if replicasChanged {
 		p.desc.replicasChanged = false
 	}
-	if !replicasChanged && state.Leader == p.leaderID && state.Leaseholder == p.leaseholderID &&
-		(p.leader.rc == nil || !termChanged) && !force {
-		// Common case.
-		//
-		// NB: if termChanged is the only observed change, and RangeController is
-		// nil, everything has already been made consistent (since we updated
-		// p.term above), so we will fall here and return.
-		return
-	}
-	// The leader or leaseholder or replicas or term changed. We set everything.
-	p.leaderID = state.Leader
-	p.leaseholderID = state.Leaseholder
+
 	// Set leaderNodeID, leaderStoreID.
-	if p.leaderID == 0 {
+	if state.Leader == 0 {
 		p.leaderNodeID = 0
 		p.leaderStoreID = 0
 	} else {
@@ -659,22 +676,17 @@ func (p *processorImpl) makeStateConsistentRaftMuLocked(
 			p.leaderStoreID = rd.StoreID
 		}
 	}
-	if p.leaderID != p.opts.ReplicaID {
-		if p.leader.rc != nil {
-			// Transition from leader to follower.
-			p.closeLeaderStateRaftMuLocked(ctx)
-		}
-		return
-	}
-	// Is the leader.
+
 	if p.enabledWhenLeader == kvflowcontrol.V2NotEnabledWhenLeader {
 		return
 	}
-	if p.leader.rc != nil && termChanged {
-		// Need to recreate the RangeController.
+	if leftLeader {
 		p.closeLeaderStateRaftMuLocked(ctx)
 	}
-	if p.leader.rc == nil {
+	if !state.IsLeader {
+		return
+	}
+	if p.leader.rc == nil { // becameLeader || force
 		p.createLeaderStateRaftMuLocked(ctx, state.Term, state.NextUnstableIndex)
 		return
 	}

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -82,8 +82,9 @@ type testRaftNode struct {
 	b *strings.Builder
 	r *testReplica
 
-	term   uint64
-	leader roachpb.ReplicaID
+	isLeader bool
+	term     uint64
+	leader   roachpb.ReplicaID
 
 	mark              rac2.LogMark
 	nextUnstableIndex uint64
@@ -253,6 +254,8 @@ func TestProcessorBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	const replicaID = 5
+
 	ctx := context.Background()
 	var b strings.Builder
 	var r *testReplica
@@ -276,7 +279,7 @@ func TestProcessorBasic(t *testing.T) {
 			NodeID:                 1,
 			StoreID:                2,
 			RangeID:                3,
-			ReplicaID:              5,
+			ReplicaID:              replicaID,
 			Replica:                r,
 			RaftScheduler:          &sched,
 			AdmittedPiggybacker:    &piggybacker,
@@ -323,6 +326,7 @@ func TestProcessorBasic(t *testing.T) {
 				if d.HasArg("leader") {
 					var leaderID int
 					d.ScanArgs(t, "leader", &leaderID)
+					r.raftNode.isLeader = leaderID == replicaID
 					r.raftNode.leader = roachpb.ReplicaID(leaderID)
 				}
 				if d.HasArg("next-unstable-index") {
@@ -367,6 +371,7 @@ func TestProcessorBasic(t *testing.T) {
 				if r.raftNode != nil {
 					state = RaftNodeBasicState{
 						Term:              r.raftNode.term,
+						IsLeader:          r.raftNode.isLeader,
 						Leader:            r.raftNode.leader,
 						NextUnstableIndex: r.raftNode.nextUnstableIndex,
 						Leaseholder:       r.leaseholder,
@@ -403,6 +408,7 @@ func TestProcessorBasic(t *testing.T) {
 				if r.raftNode != nil {
 					state = RaftNodeBasicState{
 						Term:              r.raftNode.term,
+						IsLeader:          r.raftNode.isLeader,
 						Leader:            r.raftNode.leader,
 						NextUnstableIndex: r.raftNode.nextUnstableIndex,
 						Leaseholder:       r.leaseholder,

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/raft_node.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/raft_node.go
@@ -20,6 +20,7 @@ func MakeRaftNodeBasicStateLocked(
 ) RaftNodeBasicState {
 	return RaftNodeBasicState{
 		Term:              rn.Term(),
+		IsLeader:          rn.State() == raftpb.StateLeader,
 		Leader:            roachpb.ReplicaID(rn.Lead()),
 		NextUnstableIndex: rn.NextUnstableIndex(),
 		Leaseholder:       leaseholderID,

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -558,7 +558,17 @@ func (rn *RawNode) Term() uint64 {
 	return rn.raft.Term
 }
 
+// State returns the current role of the RawNode.
+func (rn *RawNode) State() pb.StateType {
+	return rn.raft.state
+}
+
 // Lead returns the leader of Term(), or None if the leader is unknown.
+//
+// NB: it is possible that Lead() returns this node's ID, yet State() does not
+// return StateLeader. It means this node was the leader, but it has stepped
+// down. If the caller needs to know whether this node is acting as the leader,
+// it should check the State() instead of Lead() == ID.
 func (rn *RawNode) Lead() pb.PeerID {
 	return rn.raft.lead
 }


### PR DESCRIPTION
Raft `RawNode` can step down from leadership, and yet retain a record that it was the leader of the current term. This makes the `Lead() == self.ID` check not robust to step downs. To understand whether the `RawNode` is acting as the leader, we must consult its raft state explicitly.

Epic: none
Release note: none