### PR TITLE
crosscluster/logical: ban all FKs regardless of valid from kv mode

### DIFF
--- a/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
@@ -182,12 +182,8 @@ func createLogicalReplicationStreamPlanHook(
 			}
 
 			if mode != jobspb.LogicalReplicationDetails_Validated {
-				fks := td.OutboundForeignKeys()
-				for _, fk := range append(fks[:len(fks):len(fks)], td.InboundForeignKeys()...) {
-					// TODO(dt): move the constraint to un-validated for them.
-					if fk.IsConstraintValidated() {
-						return pgerror.Newf(pgcode.InvalidParameterValue, "only 'NOT VALID' foreign keys are only supported with MODE = 'validated'")
-					}
+				if len(td.OutboundForeignKeys()) > 0 || len(td.InboundForeignKeys()) > 0 {
+					return pgerror.Newf(pgcode.InvalidParameterValue, "foreign keys are only supported with MODE = 'validated'")
 				}
 			}
 		}

--- a/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
@@ -1264,32 +1264,27 @@ func TestForeignKeyConstraints(t *testing.T) {
 	dbA.Exec(t, "CREATE TABLE test(a int primary key, b int)")
 
 	testutils.RunTrueAndFalse(t, "immediate-mode", func(t *testing.T, immediateMode bool) {
-		testutils.RunTrueAndFalse(t, "valid-foreign-key", func(t *testing.T, validForeignKey bool) {
-			fkStmt := "ALTER TABLE test ADD CONSTRAINT fkc FOREIGN KEY (b) REFERENCES tab(pk)"
-			if !validForeignKey {
-				fkStmt = fkStmt + " NOT VALID"
-			}
-			dbA.Exec(t, fkStmt)
+		fkStmt := "ALTER TABLE test ADD CONSTRAINT fkc FOREIGN KEY (b) REFERENCES tab(pk)"
+		dbA.Exec(t, fkStmt)
 
-			var mode string
-			if immediateMode {
-				mode = "IMMEDIATE"
-			} else {
-				mode = "VALIDATED"
-			}
+		var mode string
+		if immediateMode {
+			mode = "IMMEDIATE"
+		} else {
+			mode = "VALIDATED"
+		}
 
-			var jobID jobspb.JobID
-			stmt := "CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab WITH MODE = " + mode
-			if immediateMode && validForeignKey {
-				dbA.ExpectErr(t, "only 'NOT VALID' foreign keys are only supported with MODE = 'validated'", stmt, dbBURL.String())
-			} else {
-				dbA.QueryRow(t, stmt, dbBURL.String()).Scan(&jobID)
-				dbA.Exec(t, "CANCEL JOB $1", jobID)
-				jobutils.WaitForJobToCancel(t, dbA, jobID)
-			}
+		var jobID jobspb.JobID
+		stmt := "CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab WITH MODE = " + mode
+		if immediateMode {
+			dbA.ExpectErr(t, "foreign keys are only supported with MODE = 'validated'", stmt, dbBURL.String())
+		} else {
+			dbA.QueryRow(t, stmt, dbBURL.String()).Scan(&jobID)
+			dbA.Exec(t, "CANCEL JOB $1", jobID)
+			jobutils.WaitForJobToCancel(t, dbA, jobID)
+		}
 
-			dbA.Exec(t, "ALTER TABLE test DROP CONSTRAINT fkc")
-		})
+		dbA.Exec(t, "ALTER TABLE test DROP CONSTRAINT fkc")
 	})
 }
 


### PR DESCRIPTION
This distinction was too subtle.

Release note: none.
Epic: none.