### PR TITLE
replica_rac2: optimize logTracker.admitted

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -1050,8 +1050,8 @@ func (p *processorImpl) AdmittedLogEntry(
 
 // AdmittedState implements Processor.
 func (p *processorImpl) AdmittedState() rac2.AdmittedVector {
-	admitted, _ := p.logTracker.admitted(false /* sched */)
-	return admitted
+	av, _ := p.logTracker.admitted(false /* sched */)
+	return av
 }
 
 // AdmitRaftMuLocked implements Processor.


### PR DESCRIPTION
Improve cache friendliness by checking the `dirty` and scheduling bits before resetting them. Cache the latest admitted vector to avoid computing it on every call. Instead, it is recomputed only if `dirty` bit is true.

Informs #128033