### PR TITLE
release-24.1: release: use license from its new location

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -42,7 +42,7 @@ To build the image yourself:
 
     ```sh
     cp ./artifacts/{cockroach,libgeos.so,libgeos_c.so} ./build/deploy
-    cp -r ./licenses ./build/deploy
+    cp ./LICENSE ./licenses/THIRD-PARTY-NOTICES.txt ./build/deploy
     ```
 
 1. Build the CockroachDB Docker image.

--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -30,7 +30,7 @@ RUN if [ "$fips_enabled" == "1" ]; then \
 
 RUN mkdir /usr/local/lib/cockroach /cockroach /licenses /docker-entrypoint-initdb.d
 COPY cockroach.sh cockroach /cockroach/
-COPY licenses/* /licenses/
+COPY LICENSE THIRD-PARTY-NOTICES.txt /licenses/
 # Install GEOS libraries.
 COPY libgeos.so libgeos_c.so /usr/local/lib/cockroach/
 

--- a/build/github/docker-image.sh
+++ b/build/github/docker-image.sh
@@ -26,7 +26,7 @@ cp _bazel/bin/pkg/cmd/cockroach/cockroach_/cockroach build/deploy
 cp _bazel/cockroach/external/$ARCHIVEDIR/lib/libgeos.so build/deploy
 cp _bazel/cockroach/external/$ARCHIVEDIR/lib/libgeos_c.so build/deploy
 
-cp -r licenses build/deploy/
+cp LICENSE licenses/THIRD-PARTY-NOTICES.txt build/deploy/
 
 chmod 755 build/deploy/cockroach
 

--- a/build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh
@@ -68,7 +68,7 @@ if [[ $platform == "linux-amd64" || $platform == "linux-arm64" || $platform == "
     --ungzip \
     --ignore-zeros \
     --strip-components=1
-  cp LICENSE THIRD-PARTY-NOTICES.txt "build/deploy-${platform}"
+  cp LICENSE licenses/THIRD-PARTY-NOTICES.txt "build/deploy-${platform}"
   # Move the libs where Dockerfile expects them to be
   mv build/deploy-${platform}/lib/* build/deploy-${platform}/
   rmdir build/deploy-${platform}/lib

--- a/build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh
@@ -68,7 +68,7 @@ if [[ $platform == "linux-amd64" || $platform == "linux-arm64" || $platform == "
     --ungzip \
     --ignore-zeros \
     --strip-components=1
-  cp --recursive licenses "build/deploy-${platform}"
+  cp LICENSE THIRD-PARTY-NOTICES.txt "build/deploy-${platform}"
   # Move the libs where Dockerfile expects them to be
   mv build/deploy-${platform}/lib/* build/deploy-${platform}/
   rmdir build/deploy-${platform}/lib

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh
@@ -93,7 +93,7 @@ if [[ $platform == "linux-amd64" || $platform == "linux-arm64" || $platform == "
     --ungzip \
     --ignore-zeros \
     --strip-components=1
-  cp --recursive licenses "build/deploy-${platform}"
+  cp LICENSE THIRD-PARTY-NOTICES.txt "build/deploy-${platform}"
   # Move the libs where Dockerfile expects them to be
   mv build/deploy-${platform}/lib/* build/deploy-${platform}/
   rmdir build/deploy-${platform}/lib

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh
@@ -93,7 +93,7 @@ if [[ $platform == "linux-amd64" || $platform == "linux-arm64" || $platform == "
     --ungzip \
     --ignore-zeros \
     --strip-components=1
-  cp LICENSE THIRD-PARTY-NOTICES.txt "build/deploy-${platform}"
+  cp LICENSE licenses/THIRD-PARTY-NOTICES.txt "build/deploy-${platform}"
   # Move the libs where Dockerfile expects them to be
   mv build/deploy-${platform}/lib/* build/deploy-${platform}/
   rmdir build/deploy-${platform}/lib

--- a/pkg/cmd/publish-provisional-artifacts/main.go
+++ b/pkg/cmd/publish-provisional-artifacts/main.go
@@ -184,8 +184,8 @@ func run(
 			} else {
 				licenseFiles := []release.ArchiveFile{
 					{
-						LocalAbsolutePath: filepath.Join(o.PkgDir, "licenses", "LICENSE.txt"),
-						ArchiveFilePath:   "LICENSE.txt",
+						LocalAbsolutePath: filepath.Join(o.PkgDir, "LICENSE"),
+						ArchiveFilePath:   "LICENSE",
 					},
 					{
 						LocalAbsolutePath: filepath.Join(o.PkgDir, "licenses", "THIRD-PARTY-NOTICES.txt"),

--- a/pkg/cmd/publish-provisional-artifacts/main_test.go
+++ b/pkg/cmd/publish-provisional-artifacts/main_test.go
@@ -131,7 +131,7 @@ func (r *mockExecRunner) run(c *exec.Cmd) ([]byte, error) {
 			}
 		}
 		paths = append(paths, path, pathSQL)
-		paths = append(paths, filepath.Join(r.pkgDir, "licenses", "LICENSE.txt"))
+		paths = append(paths, filepath.Join(r.pkgDir, "LICENSE"))
 		paths = append(paths, filepath.Join(r.pkgDir, "licenses", "THIRD-PARTY-NOTICES.txt"))
 		ext := release.SharedLibraryExtensionFromPlatform(platform)
 		if platform != release.PlatformMacOSArm && platform != release.PlatformWindows {


### PR DESCRIPTION
Backport:
  * 1/1 commits from "release: use license from its new location" (#132051)
  * 1/1 commits from "release: fix location of THIRD-PARTY-NOTICES.txt" (#132175)

Please see individual PRs for details.

/cc @cockroachdb/release

Part of [RE-658](https://cockroachlabs.atlassian.net/browse/RE-658)

Release note: none

Release justification: The release process needs to use the license from the new location.