### PR TITLE
drtprod: put tpcc init and run scripts on workload-scale

### DIFF
--- a/pkg/cmd/drt/scripts/roachtest_operations_run.sh
+++ b/pkg/cmd/drt/scripts/roachtest_operations_run.sh
@@ -7,7 +7,7 @@
 
 cd /home/ubuntu
 
-export GCE_PROJECT=cockroach-drt
+export ROACHPROD_GCE_DEFAULT_PROJECT=cockroach-drt
 export ROACHPROD_DNS="drt.crdb.io"
 ./roachprod sync
 sleep 20

--- a/pkg/cmd/drt/scripts/tpcc_init.sh
+++ b/pkg/cmd/drt/scripts/tpcc_init.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
+set -o pipefail
+
+TPCC_DB=cct_tpcc
+export ROACHPROD_GCE_DEFAULT_PROJECT=cockroach-drt
+export ROACHPROD_DNS="drt.crdb.io"
+./roachprod sync
+sleep 20
+PGURLS=$(./roachprod pgurl drt-scale:1-150 | sed s/\'//g)
+
+./cockroach workload init tpcc \
+  --warehouses 3000 \
+  --db $TPCC_DB \
+  --secure \
+  --families \
+  $PGURLS

--- a/pkg/cmd/drt/scripts/tpcc_run.sh
+++ b/pkg/cmd/drt/scripts/tpcc_run.sh
@@ -11,9 +11,11 @@ set -o pipefail
 TPCC_DB=cct_tpcc
 TPCC_USER=cct_tpcc_user
 TPCC_PASSWORD=tpcc
-PGURLS=$(./roachprod pgurl cct-232 --external --secure --cluster application | sed s/\'//g)
-
-read -r -a PGURLS_ARR <<< "$PGURLS"
+export ROACHPROD_GCE_DEFAULT_PROJECT=cockroach-drt
+export ROACHPROD_DNS="drt.crdb.io"
+./roachprod sync
+sleep 20
+PGURLS=$(./roachprod pgurl drt-scale | sed s/\'//g)
 
 j=0
 while true; do
@@ -34,7 +36,7 @@ while true; do
       --tolerate-errors \
       --password tpcc \
       --families \
-        "${PGURLS_ARR[@]}" | tee $LOG
+      $PGURLS | tee $LOG
     if [ $? -eq 0 ]; then
         rm "$LOG"
     fi

--- a/pkg/cmd/drtprod/configs/drt_scale.yaml
+++ b/pkg/cmd/drtprod/configs/drt_scale.yaml
@@ -122,3 +122,13 @@ targets:
           - $WORKLOAD_CLUSTER
           - pkg/cmd/drt/scripts/roachtest_operations_run.sh
           - roachtest_operations_run.sh
+      - command: put
+        args:
+          - $WORKLOAD_CLUSTER
+          - pkg/cmd/drt/scripts/tpcc_init.sh
+          - tpcc_init.sh
+      - command: put
+        args:
+          - $WORKLOAD_CLUSTER
+          - pkg/cmd/drt/scripts/tpcc_run.sh
+          - tpcc_run.sh

--- a/scripts/drtprod
+++ b/scripts/drtprod
@@ -6,7 +6,7 @@ set -euo pipefail
 # clusters that ensures consistent use of the correct project-assignment vars
 # and done some additional sanity check enforcement on some flags.
 
-export GCE_PROJECT=cockroach-drt
+export ROACHPROD_GCE_DEFAULT_PROJECT=cockroach-drt
 export ROACHPROD_DNS="drt.crdb.io"
 
 if [ "$#" -lt 1 ]; then


### PR DESCRIPTION
This patch ensures that we put the `tpcc_init.sh`
and `tpcc_run.sh` file while creating `workload-scale`

Epic: none
Release note: None