### PR TITLE
rac2,kvserver: do not quiesce if send tokens held

### DIFF
--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -3371,20 +3371,10 @@ func TestFlowControlQuiescedRangeV2(t *testing.T) {
 `)
 		h.query(n1, v2FlowTokensQueryStr)
 
-		// TODO(pav-kv,kvoli): When #129581 is complete, this test will fail
-		// because the range won't quiesce with a lagging admitted vector. Update
-		// the test to assert that the range doesn't quiesce then.
-		//
-		// Wait for the range to quiesce.
-		h.comment(`-- (Wait for range to quiesce.)`)
-		testutils.SucceedsSoon(t, func() error {
-			leader := tc.GetRaftLeader(t, roachpb.RKey(k))
-			require.NotNil(t, leader)
-			if !leader.IsQuiescent() {
-				return errors.Errorf("%s not quiescent", leader)
-			}
-			return nil
-		})
+		// The range must not quiesce because the leader holds send tokens.
+		leader := tc.GetRaftLeader(t, roachpb.RKey(k))
+		require.NotNil(t, leader)
+		require.False(t, leader.IsQuiescent())
 
 		h.comment(`
 -- (Allow below-raft admission to proceed. We've disabled the fallback token
@@ -3409,6 +3399,15 @@ func TestFlowControlQuiescedRangeV2(t *testing.T) {
 -- are returned through the fallback mechanism. 
 `)
 		h.query(n1, v2FlowTokensQueryStr)
+
+		// The range eventually quiesces because all the tokens have been returned.
+		h.comment(`-- (Wait for range to quiesce.)`)
+		testutils.SucceedsSoon(t, func() error {
+			if !leader.IsQuiescent() {
+				return errors.Errorf("%s not quiescent", leader)
+			}
+			return nil
+		})
 	})
 }
 
@@ -3503,20 +3502,10 @@ func TestFlowControlUnquiescedRangeV2(t *testing.T) {
 `)
 		h.query(n1, v2FlowTokensQueryStr)
 
-		// TODO(pav-kv,kvoli): When #129581 is complete, this test will fail
-		// because the range won't quiesce with a lagging admitted vector. Update
-		// the test to assert that the range doesn't quiesce then.
-		//
-		// Wait for the range to quiesce.
-		h.comment(`-- (Wait for range to quiesce.)`)
-		testutils.SucceedsSoon(t, func() error {
-			leader := tc.GetRaftLeader(t, roachpb.RKey(k))
-			require.NotNil(t, leader)
-			if !leader.IsQuiescent() {
-				return errors.Errorf("%s not quiescent", leader)
-			}
-			return nil
-		})
+		// The range must not quiesce because the leader holds send tokens.
+		leader := tc.GetRaftLeader(t, roachpb.RKey(k))
+		require.NotNil(t, leader)
+		require.False(t, leader.IsQuiescent())
 
 		h.comment(`
 -- (Allow below-raft admission to proceed. We've disabled the fallback token
@@ -3547,6 +3536,15 @@ func TestFlowControlUnquiescedRangeV2(t *testing.T) {
 -- are returned through the piggyback mechanism. 
 `)
 		h.query(n1, v2FlowTokensQueryStr)
+
+		// The range eventually quiesces because all the tokens have been returned.
+		h.comment(`-- (Wait for range to quiesce.)`)
+		testutils.SucceedsSoon(t, func() error {
+			if !leader.IsQuiescent() {
+				return errors.Errorf("%s not quiescent", leader)
+			}
+			return nil
+		})
 	})
 }
 

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -217,6 +217,11 @@ func (c *testRangeController) MaybeSendPingsRaftMuLocked() {
 	fmt.Fprintf(c.b, " RangeController.MaybeSendPingsRaftMuLocked()\n")
 }
 
+func (c *testRangeController) HoldsSendTokensRaftMuLocked() bool {
+	fmt.Fprintf(c.b, " RangeController.HoldsSendTokensRaftMuLocked()\n")
+	return false
+}
+
 func (c *testRangeController) SetReplicasRaftMuLocked(
 	ctx context.Context, replicas rac2.ReplicaSet,
 ) error {

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1392,112 +1392,110 @@ func (r *Replica) tick(
 ) (exists bool, err error) {
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()
-	exists, err = func() (bool, error) {
-		r.mu.Lock()
-		defer r.mu.Unlock()
-
-		// If the replica has been destroyed, don't tick it.
-		if r.mu.internalRaftGroup == nil {
-			return false, nil
+	defer func() {
+		if exists && err == nil {
+			// NB: since we are returning true, there will be a Ready handling
+			// immediately after this call, so any pings stashed in raft will be sent.
+			// NB: Replica.mu must not be held here.
+			r.flowControlV2.MaybeSendPingsRaftMuLocked()
 		}
-
-		if r.mu.quiescent {
-			return false, nil
-		}
-
-		r.unreachablesMu.Lock()
-		remotes := r.unreachablesMu.remotes
-		r.unreachablesMu.remotes = nil
-		r.unreachablesMu.Unlock()
-		bypassFn := r.store.TestingKnobs().RaftReportUnreachableBypass
-		for remoteReplica := range remotes {
-			if bypassFn != nil && bypassFn(remoteReplica) {
-				continue
-			}
-			r.mu.internalRaftGroup.ReportUnreachable(raftpb.PeerID(remoteReplica))
-		}
-
-		r.updatePausedFollowersLocked(ctx, ioThresholdMap)
-
-		storeClockTimestamp := r.store.Clock().NowAsClockTimestamp()
-		leaseStatus := r.leaseStatusAtRLocked(ctx, storeClockTimestamp)
-		// TODO(pav-kv): modify the quiescence criterion so that we don't quiesce if
-		// RACv2 holds some send tokens.
-		if r.maybeQuiesceRaftMuLockedReplicaMuLocked(ctx, leaseStatus, livenessMap) {
-			return false, nil
-		}
-
-		r.maybeTransferRaftLeadershipToLeaseholderLocked(ctx, leaseStatus)
-
-		// Eagerly acquire or extend leases. This only works for unquiesced ranges. We
-		// never quiesce expiration leases, but for epoch leases we fall back to the
-		// replicate queue which will do this within 10 minutes.
-		if !r.store.cfg.TestingKnobs.DisableAutomaticLeaseRenewal {
-			if shouldRequest, isExtension := r.shouldRequestLeaseRLocked(leaseStatus); shouldRequest {
-				if _, requestPending := r.mu.pendingLeaseRequest.RequestPending(); !requestPending {
-					var limiter *quotapool.IntPool
-					if !isExtension { // don't limit lease extensions
-						limiter = r.store.eagerLeaseAcquisitionLimiter
-					}
-					// Check quota first to avoid wasted work.
-					if limiter == nil || limiter.ApproximateQuota() > 0 {
-						_ = r.requestLeaseLocked(ctx, leaseStatus, limiter)
-					}
-				}
-			}
-		}
-
-		// For followers, we update lastUpdateTimes when we step a message from them
-		// into the local Raft group. The leader won't hit that path, so we update
-		// it whenever it ticks. In effect, this makes sure it always sees itself as
-		// alive.
-		//
-		// Note that in a workload where the leader doesn't have inflight requests
-		// "most of the time" (i.e. occasional writes only on this range), it's quite
-		// likely that we'll never reach this line, since we'll return in the
-		// maybeQuiesceRaftMuLockedReplicaMuLocked branch above.
-		//
-		// This is likely unintentional, and the leader should likely consider itself
-		// live even when quiesced.
-		if r.isRaftLeaderRLocked() {
-			r.mu.lastUpdateTimes.update(r.replicaID, r.Clock().PhysicalTime())
-			// We also update lastUpdateTimes for replicas that provide store liveness
-			// support to the leader.
-			r.updateLastUpdateTimesUsingStoreLivenessRLocked(storeClockTimestamp)
-		}
-
-		r.mu.ticks++
-		preTickState := r.mu.internalRaftGroup.BasicStatus().RaftState
-		r.mu.internalRaftGroup.Tick()
-		postTickState := r.mu.internalRaftGroup.BasicStatus().RaftState
-		if preTickState != postTickState {
-			if postTickState == raft.StatePreCandidate {
-				r.store.Metrics().RaftTimeoutCampaign.Inc(1)
-				if k := r.store.TestingKnobs(); k != nil && k.OnRaftTimeoutCampaign != nil {
-					k.OnRaftTimeoutCampaign(r.RangeID)
-				}
-			}
-		}
-
-		refreshAtDelta := r.store.cfg.RaftReproposalTimeoutTicks
-		if knob := r.store.TestingKnobs().RefreshReasonTicksPeriod; knob > 0 {
-			refreshAtDelta = knob
-		}
-		if !r.store.TestingKnobs().DisableRefreshReasonTicks && r.mu.ticks%refreshAtDelta == 0 {
-			// The combination of the above condition and passing refreshAtDelta to
-			// refreshProposalsLocked means that commands will be refreshed when they
-			// have been pending for 1 to 2 reproposal timeouts.
-			r.refreshProposalsLocked(ctx, refreshAtDelta, reasonTicks)
-		}
-		return true, nil
 	}()
-	if !exists || err != nil {
-		return exists, err
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// If the replica has been destroyed or is quiesced, don't tick it.
+	if r.mu.internalRaftGroup == nil {
+		return false, nil
+	}
+	if r.mu.quiescent {
+		return false, nil
 	}
 
-	// NB: since we are returning true below, there will be a Ready handling
-	// immediately after this call, so any pings stashed in raft will be sent.
-	r.flowControlV2.MaybeSendPingsRaftMuLocked()
+	r.unreachablesMu.Lock()
+	remotes := r.unreachablesMu.remotes
+	r.unreachablesMu.remotes = nil
+	r.unreachablesMu.Unlock()
+	bypassFn := r.store.TestingKnobs().RaftReportUnreachableBypass
+	for remoteReplica := range remotes {
+		if bypassFn != nil && bypassFn(remoteReplica) {
+			continue
+		}
+		r.mu.internalRaftGroup.ReportUnreachable(raftpb.PeerID(remoteReplica))
+	}
+
+	r.updatePausedFollowersLocked(ctx, ioThresholdMap)
+
+	storeClockTimestamp := r.store.Clock().NowAsClockTimestamp()
+	leaseStatus := r.leaseStatusAtRLocked(ctx, storeClockTimestamp)
+	// TODO(pav-kv): modify the quiescence criterion so that we don't quiesce if
+	// RACv2 holds some send tokens.
+	if r.maybeQuiesceRaftMuLockedReplicaMuLocked(ctx, leaseStatus, livenessMap) {
+		return false, nil
+	}
+
+	r.maybeTransferRaftLeadershipToLeaseholderLocked(ctx, leaseStatus)
+
+	// Eagerly acquire or extend leases. This only works for unquiesced ranges. We
+	// never quiesce expiration leases, but for epoch leases we fall back to the
+	// replicate queue which will do this within 10 minutes.
+	if !r.store.cfg.TestingKnobs.DisableAutomaticLeaseRenewal {
+		if shouldRequest, isExtension := r.shouldRequestLeaseRLocked(leaseStatus); shouldRequest {
+			if _, requestPending := r.mu.pendingLeaseRequest.RequestPending(); !requestPending {
+				var limiter *quotapool.IntPool
+				if !isExtension { // don't limit lease extensions
+					limiter = r.store.eagerLeaseAcquisitionLimiter
+				}
+				// Check quota first to avoid wasted work.
+				if limiter == nil || limiter.ApproximateQuota() > 0 {
+					_ = r.requestLeaseLocked(ctx, leaseStatus, limiter)
+				}
+			}
+		}
+	}
+
+	// For followers, we update lastUpdateTimes when we step a message from them
+	// into the local Raft group. The leader won't hit that path, so we update
+	// it whenever it ticks. In effect, this makes sure it always sees itself as
+	// alive.
+	//
+	// Note that in a workload where the leader doesn't have inflight requests
+	// "most of the time" (i.e. occasional writes only on this range), it's quite
+	// likely that we'll never reach this line, since we'll return in the
+	// maybeQuiesceRaftMuLockedReplicaMuLocked branch above.
+	//
+	// This is likely unintentional, and the leader should likely consider itself
+	// live even when quiesced.
+	if r.isRaftLeaderRLocked() {
+		r.mu.lastUpdateTimes.update(r.replicaID, r.Clock().PhysicalTime())
+		// We also update lastUpdateTimes for replicas that provide store liveness
+		// support to the leader.
+		r.updateLastUpdateTimesUsingStoreLivenessRLocked(storeClockTimestamp)
+	}
+
+	r.mu.ticks++
+	preTickState := r.mu.internalRaftGroup.BasicStatus().RaftState
+	r.mu.internalRaftGroup.Tick()
+	postTickState := r.mu.internalRaftGroup.BasicStatus().RaftState
+	if preTickState != postTickState {
+		if postTickState == raft.StatePreCandidate {
+			r.store.Metrics().RaftTimeoutCampaign.Inc(1)
+			if k := r.store.TestingKnobs(); k != nil && k.OnRaftTimeoutCampaign != nil {
+				k.OnRaftTimeoutCampaign(r.RangeID)
+			}
+		}
+	}
+
+	refreshAtDelta := r.store.cfg.RaftReproposalTimeoutTicks
+	if knob := r.store.TestingKnobs().RefreshReasonTicksPeriod; knob > 0 {
+		refreshAtDelta = knob
+	}
+	if !r.store.TestingKnobs().DisableRefreshReasonTicks && r.mu.ticks%refreshAtDelta == 0 {
+		// The combination of the above condition and passing refreshAtDelta to
+		// refreshProposalsLocked means that commands will be refreshed when they
+		// have been pending for 1 to 2 reproposal timeouts.
+		r.refreshProposalsLocked(ctx, refreshAtDelta, reasonTicks)
+	}
 	return true, nil
 }
 

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -573,6 +573,15 @@ func (r *Replica) hasPendingProposalQuotaRLocked() bool {
 	return !r.mu.proposalQuota.Full()
 }
 
+// hasSendTokensRaftMuLocked is part of the quiescer interface. It returns true
+// if RACv2 holds any send tokens for this range.
+//
+// We can't quiesce while any send tokens are held because this could lead to
+// never releasing them. Tokens must be released.
+func (r *Replica) hasSendTokensRaftMuLocked() bool {
+	return r.flowControlV2.HoldsSendTokensRaftMuLocked()
+}
+
 // ticksSinceLastProposalRLocked returns the number of ticks since the last
 // proposal.
 func (r *Replica) ticksSinceLastProposalRLocked() int {

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -6,8 +6,9 @@
 package kvserver
 
 import (
+	"cmp"
 	"context"
-	"sort"
+	"slices"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
@@ -249,11 +250,6 @@ func (s laggingReplicaSet) AnyMemberStale(livenessMap livenesspb.IsLiveMap) bool
 	return false
 }
 
-// Implement Sort.Interface.
-func (s laggingReplicaSet) Len() int           { return len(s) }
-func (s laggingReplicaSet) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-func (s laggingReplicaSet) Less(i, j int) bool { return s[i].NodeID < s[j].NodeID }
-
 // shouldReplicaQuiesceRaftMuLockedReplicaMuLocked determines if a replica should be quiesced. All the
 // access to Replica internals is gated by the quiescer interface to facilitate
 // testing. Returns the raft.Status and true on success, and (nil, false) on
@@ -447,7 +443,9 @@ func shouldReplicaQuiesceRaftMuLockedReplicaMuLocked(
 			return nil, nil, false
 		}
 	}
-	sort.Sort(lagging)
+	slices.SortFunc(lagging, func(a, b livenesspb.Liveness) int {
+		return cmp.Compare(a.NodeID, b.NodeID)
+	})
 	if !foundSelf {
 		if log.V(4) {
 			log.Infof(ctx, "not quiescing: %d not found in progress: %+v",

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -192,7 +192,8 @@ func (r *Replica) maybeQuiesceRaftMuLockedReplicaMuLocked(
 	if r.store.cfg.TestingKnobs.DisableQuiescence {
 		return false
 	}
-	status, lagging, ok := shouldReplicaQuiesce(ctx, r, leaseStatus, livenessMap, r.mu.pausedFollowers)
+	status, lagging, ok := shouldReplicaQuiesceRaftMuLockedReplicaMuLocked(
+		ctx, r, leaseStatus, livenessMap, r.mu.pausedFollowers)
 	if !ok {
 		return false
 	}
@@ -253,7 +254,7 @@ func (s laggingReplicaSet) Len() int           { return len(s) }
 func (s laggingReplicaSet) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s laggingReplicaSet) Less(i, j int) bool { return s[i].NodeID < s[j].NodeID }
 
-// shouldReplicaQuiesce determines if a replica should be quiesced. All the
+// shouldReplicaQuiesceRaftMuLockedReplicaMuLocked determines if a replica should be quiesced. All the
 // access to Replica internals is gated by the quiescer interface to facilitate
 // testing. Returns the raft.Status and true on success, and (nil, false) on
 // failure.
@@ -282,7 +283,7 @@ func (s laggingReplicaSet) Less(i, j int) bool { return s[i].NodeID < s[j].NodeI
 // failovers can take longer.
 //
 // NOTE: The last 3 conditions are fairly, but not completely, overlapping.
-func shouldReplicaQuiesce(
+func shouldReplicaQuiesceRaftMuLockedReplicaMuLocked(
 	ctx context.Context,
 	q quiescer,
 	leaseStatus kvserverpb.LeaseStatus,
@@ -576,7 +577,7 @@ func shouldFollowerQuiesceOnNotify(
 	//
 	// The other two checks that combine to provide this guarantee are:
 	// 1. a leader will not quiesce if it believes any lagging replicas
-	//    are alive (see shouldReplicaQuiesce).
+	//    are alive (see shouldReplicaQuiesceRaftMuLockedReplicaMuLocked).
 	// 2. any up-to-date replica that learns that a lagging replica is
 	//    alive will unquiesce the range (see Store.nodeIsLiveCallback).
 	//

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -9938,7 +9938,7 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 
 	const logIndex = 10
 	const invalidIndex = 11
-	test := func(expected bool, transform func(q *testQuiescer) *testQuiescer) {
+	test := func(expected bool, transform func(q *testQuiescer)) {
 		t.Run("", func(t *testing.T) {
 			// A testQuiescer initialized so that shouldReplicaQuiesce will return
 			// true. The transform function is intended to perform one mutation to
@@ -9992,7 +9992,7 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 					3: {IsLive: true},
 				},
 			}
-			q = transform(q)
+			transform(q)
 			_, lagging, ok := shouldReplicaQuiesceRaftMuLockedReplicaMuLocked(
 				context.Background(), q, q.leaseStatus, q.livenessMap, q.paused)
 			require.Equal(t, expected, ok)
@@ -10012,191 +10012,121 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 		})
 	}
 
-	test(true, func(q *testQuiescer) *testQuiescer {
-		return q
-	})
-	test(false, func(q *testQuiescer) *testQuiescer {
-		q.numProposals = 1
-		return q
-	})
-	test(false, func(q *testQuiescer) *testQuiescer {
-		q.pendingQuota = true
-		return q
-	})
-	test(false, func(q *testQuiescer) *testQuiescer {
-		q.sendTokens = true
-		return q
-	})
-	test(true, func(q *testQuiescer) *testQuiescer {
+	test(true, func(q *testQuiescer) {})
+	test(false, func(q *testQuiescer) { q.numProposals = 1 })
+	test(false, func(q *testQuiescer) { q.pendingQuota = true })
+	test(false, func(q *testQuiescer) { q.sendTokens = true })
+	test(true, func(q *testQuiescer) {
 		q.ticksSinceLastProposal = quiesceAfterTicks // quiesce on quiesceAfterTicks
-		return q
 	})
-	test(true, func(q *testQuiescer) *testQuiescer {
+	test(true, func(q *testQuiescer) {
 		q.ticksSinceLastProposal = quiesceAfterTicks + 1 // quiesce above quiesceAfterTicks
-		return q
 	})
-	test(false, func(q *testQuiescer) *testQuiescer {
+	test(false, func(q *testQuiescer) {
 		q.ticksSinceLastProposal = quiesceAfterTicks - 1 // don't quiesce below quiesceAfterTicks
-		return q
 	})
-	test(false, func(q *testQuiescer) *testQuiescer {
+	test(false, func(q *testQuiescer) {
 		q.ticksSinceLastProposal = 0 // don't quiesce on 0
-		return q
 	})
-	test(false, func(q *testQuiescer) *testQuiescer {
+	test(false, func(q *testQuiescer) {
 		q.ticksSinceLastProposal = -1 // don't quiesce on negative (shouldn't happen)
-		return q
 	})
-	test(false, func(q *testQuiescer) *testQuiescer {
-		q.mergeInProgress = true
-		return q
-	})
-	test(false, func(q *testQuiescer) *testQuiescer {
-		q.isDestroyed = true
-		return q
-	})
-	test(false, func(q *testQuiescer) *testQuiescer {
-		q.status = nil
-		return q
-	})
-	test(false, func(q *testQuiescer) *testQuiescer {
-		q.status.RaftState = raft.StateFollower
-		return q
-	})
-	test(false, func(q *testQuiescer) *testQuiescer {
-		q.status.RaftState = raft.StateCandidate
-		return q
-	})
-	test(false, func(q *testQuiescer) *testQuiescer {
-		q.status.LeadTransferee = 1
-		return q
-	})
-	test(false, func(q *testQuiescer) *testQuiescer {
-		q.status.Commit = invalidIndex
-		return q
-	})
-	test(false, func(q *testQuiescer) *testQuiescer {
-		q.status.Applied = invalidIndex
-		return q
-	})
-	test(false, func(q *testQuiescer) *testQuiescer {
-		q.lastIndex = invalidIndex
-		return q
-	})
+	test(false, func(q *testQuiescer) { q.mergeInProgress = true })
+	test(false, func(q *testQuiescer) { q.isDestroyed = true })
+	test(false, func(q *testQuiescer) { q.status = nil })
+	test(false, func(q *testQuiescer) { q.status.RaftState = raft.StateFollower })
+	test(false, func(q *testQuiescer) { q.status.RaftState = raft.StateCandidate })
+	test(false, func(q *testQuiescer) { q.status.LeadTransferee = 1 })
+	test(false, func(q *testQuiescer) { q.status.Commit = invalidIndex })
+	test(false, func(q *testQuiescer) { q.status.Applied = invalidIndex })
+	test(false, func(q *testQuiescer) { q.lastIndex = invalidIndex })
 	for _, i := range []raftpb.PeerID{1, 2, 3} {
-		test(false, func(q *testQuiescer) *testQuiescer {
+		test(false, func(q *testQuiescer) {
 			q.status.Progress[i] = tracker.Progress{Match: invalidIndex}
-			return q
 		})
 	}
-	test(false, func(q *testQuiescer) *testQuiescer {
+	test(false, func(q *testQuiescer) {
 		delete(q.status.Progress, q.status.ID)
-		return q
 	})
-	test(false, func(q *testQuiescer) *testQuiescer {
-		q.storeID = 9
-		return q
-	})
-	test(false, func(q *testQuiescer) *testQuiescer {
-		q.leaseStatus.State = kvserverpb.LeaseState_ERROR
-		return q
-	})
-	test(false, func(q *testQuiescer) *testQuiescer {
-		q.leaseStatus.State = kvserverpb.LeaseState_UNUSABLE
-		return q
-	})
-	test(false, func(q *testQuiescer) *testQuiescer {
-		q.leaseStatus.State = kvserverpb.LeaseState_EXPIRED
-		return q
-	})
-	test(false, func(q *testQuiescer) *testQuiescer {
-		q.leaseStatus.State = kvserverpb.LeaseState_PROSCRIBED
-		return q
-	})
-	test(false, func(q *testQuiescer) *testQuiescer {
-		q.raftReady = true
-		return q
-	})
-	test(false, func(q *testQuiescer) *testQuiescer {
+	test(false, func(q *testQuiescer) { q.storeID = 9 })
+
+	for _, leaseState := range []kvserverpb.LeaseState{
+		kvserverpb.LeaseState_ERROR,
+		kvserverpb.LeaseState_UNUSABLE,
+		kvserverpb.LeaseState_EXPIRED,
+		kvserverpb.LeaseState_PROSCRIBED,
+	} {
+		test(false, func(q *testQuiescer) { q.leaseStatus.State = leaseState })
+	}
+	test(false, func(q *testQuiescer) { q.raftReady = true })
+	test(false, func(q *testQuiescer) {
 		pr := q.status.Progress[2]
 		pr.State = tracker.StateProbe
 		q.status.Progress[2] = pr
-		return q
 	})
 	// Create a mismatch between the raft progress replica IDs and the
 	// replica IDs in the range descriptor.
 	for i := 0; i < 3; i++ {
-		test(false, func(q *testQuiescer) *testQuiescer {
+		test(false, func(q *testQuiescer) {
 			q.desc.InternalReplicas[i].ReplicaID = roachpb.ReplicaID(4 + i)
-			return q
 		})
 	}
 	// Pass a nil liveness map.
-	test(true, func(q *testQuiescer) *testQuiescer {
-		q.livenessMap = nil
-		return q
-	})
+	test(true, func(q *testQuiescer) { q.livenessMap = nil })
 	// Verify quiesce even when replica progress doesn't match, if
 	// the replica is on a non-live node.
 	for _, i := range []raftpb.PeerID{1, 2, 3} {
-		test(true, func(q *testQuiescer) *testQuiescer {
+		test(true, func(q *testQuiescer) {
 			nodeID := roachpb.NodeID(i)
 			q.livenessMap[nodeID] = livenesspb.IsLiveMapEntry{
 				Liveness: livenesspb.Liveness{NodeID: nodeID},
 				IsLive:   false,
 			}
 			q.status.Progress[i] = tracker.Progress{Match: invalidIndex}
-			return q
 		})
 	}
 	// Verify no quiescence when replica progress doesn't match, if
 	// given a nil liveness map.
 	for _, i := range []raftpb.PeerID{1, 2, 3} {
-		test(false, func(q *testQuiescer) *testQuiescer {
+		test(false, func(q *testQuiescer) {
 			q.livenessMap = nil
 			q.status.Progress[i] = tracker.Progress{Match: invalidIndex}
-			return q
 		})
 	}
 	// Verify no quiescence when replica progress doesn't match, if
 	// liveness map does not contain the lagging replica.
 	for _, i := range []raftpb.PeerID{1, 2, 3} {
-		test(false, func(q *testQuiescer) *testQuiescer {
+		test(false, func(q *testQuiescer) {
 			delete(q.livenessMap, roachpb.NodeID(i))
 			q.status.Progress[i] = tracker.Progress{Match: invalidIndex}
-			return q
 		})
 	}
 	// Verify no quiescence when a follower is paused.
-	test(false, func(q *testQuiescer) *testQuiescer {
+	test(false, func(q *testQuiescer) {
 		q.paused = map[roachpb.ReplicaID]struct{}{
 			q.desc.Replicas().Descriptors()[0].ReplicaID: {},
 		}
-		return q
 	})
 	// Verify no quiescence with expiration-based leases, regardless
 	// of kv.expiration_leases_only.enabled.
-	test(false, func(q *testQuiescer) *testQuiescer {
+	test(false, func(q *testQuiescer) {
 		ExpirationLeasesOnly.Override(context.Background(), &q.st.SV, true)
 		q.leaseStatus.Lease.Epoch = 0
 		q.leaseStatus.Lease.Expiration = &hlc.Timestamp{
 			WallTime: timeutil.Now().Add(time.Minute).Unix(),
 		}
-		return q
 	})
-	test(false, func(q *testQuiescer) *testQuiescer {
+	test(false, func(q *testQuiescer) {
 		ExpirationLeasesOnly.Override(context.Background(), &q.st.SV, false)
 		q.leaseStatus.Lease.Epoch = 0
 		q.leaseStatus.Lease.Expiration = &hlc.Timestamp{
 			WallTime: timeutil.Now().Add(time.Minute).Unix(),
 		}
-		return q
 	})
 	// Verify no quiescence with leader leases.
-	test(false, func(q *testQuiescer) *testQuiescer {
+	test(false, func(q *testQuiescer) {
 		q.leaseStatus.Lease.Epoch = 0
 		q.leaseStatus.Lease.Term = 1
-		return q
 	})
 }
 

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -9859,6 +9859,7 @@ type testQuiescer struct {
 	desc                   roachpb.RangeDescriptor
 	numProposals           int
 	pendingQuota           bool
+	sendTokens             bool
 	ticksSinceLastProposal int
 	status                 *raft.SparseStatus
 	lastIndex              kvpb.RaftIndex
@@ -9910,6 +9911,10 @@ func (q *testQuiescer) hasPendingProposalsRLocked() bool {
 
 func (q *testQuiescer) hasPendingProposalQuotaRLocked() bool {
 	return q.pendingQuota
+}
+
+func (q *testQuiescer) hasSendTokensRaftMuLocked() bool {
+	return q.sendTokens
 }
 
 func (q *testQuiescer) ticksSinceLastProposalRLocked() int {
@@ -10016,6 +10021,10 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 	})
 	test(false, func(q *testQuiescer) *testQuiescer {
 		q.pendingQuota = true
+		return q
+	})
+	test(false, func(q *testQuiescer) *testQuiescer {
+		q.sendTokens = true
 		return q
 	})
 	test(true, func(q *testQuiescer) *testQuiescer {

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -7,12 +7,14 @@ package kvserver
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"fmt"
 	"math"
 	"math/rand"
 	"reflect"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -9997,7 +9999,9 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 						expLagging = append(expLagging, l.Liveness)
 					}
 				}
-				sort.Sort(expLagging)
+				slices.SortFunc(expLagging, func(a, b livenesspb.Liveness) int {
+					return cmp.Compare(a.NodeID, b.NodeID)
+				})
 				require.Equal(t, expLagging, lagging)
 			}
 		})

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -9986,7 +9986,8 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 				},
 			}
 			q = transform(q)
-			_, lagging, ok := shouldReplicaQuiesce(context.Background(), q, q.leaseStatus, q.livenessMap, q.paused)
+			_, lagging, ok := shouldReplicaQuiesceRaftMuLockedReplicaMuLocked(
+				context.Background(), q, q.leaseStatus, q.livenessMap, q.paused)
 			require.Equal(t, expected, ok)
 			if ok {
 				// Any non-live replicas should be in the laggingReplicaSet.

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/quiesced_range
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/quiesced_range
@@ -37,9 +37,6 @@ ORDER BY name ASC;
   kvflowcontrol.tokens.send.regular.unaccounted                     | 0 B      
 
 
--- (Wait for range to quiesce.)
-
-
 -- (Allow below-raft admission to proceed. We've disabled the fallback token
 -- dispatch mechanism so no tokens are returned yet -- quiesced ranges don't
 -- use the piggy-backed token return mechanism since there's no raft traffic.)
@@ -111,6 +108,9 @@ ORDER BY name ASC;
   kvflowcontrol.tokens.send.regular.returned                        | 0 B      
   kvflowcontrol.tokens.send.regular.returned.disconnect             | 0 B      
   kvflowcontrol.tokens.send.regular.unaccounted                     | 0 B      
+
+
+-- (Wait for range to quiesce.)
 ----
 ----
 

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/quiesced_range_v1_encoding
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/quiesced_range_v1_encoding
@@ -44,9 +44,6 @@ ORDER BY name ASC;
   kvflowcontrol.tokens.send.regular.unaccounted                     | 0 B      
 
 
--- (Wait for range to quiesce.)
-
-
 -- (Allow below-raft admission to proceed. We've disabled the fallback token
 -- dispatch mechanism so no tokens are returned yet -- quiesced ranges don't
 -- use the piggy-backed token return mechanism since there's no raft traffic.)
@@ -118,6 +115,9 @@ ORDER BY name ASC;
   kvflowcontrol.tokens.send.regular.returned                        | 0 B      
   kvflowcontrol.tokens.send.regular.returned.disconnect             | 0 B      
   kvflowcontrol.tokens.send.regular.unaccounted                     | 0 B      
+
+
+-- (Wait for range to quiesce.)
 ----
 ----
 

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/unquiesced_range
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/unquiesced_range
@@ -37,9 +37,6 @@ ORDER BY name ASC;
   kvflowcontrol.tokens.send.regular.unaccounted                     | 0 B      
 
 
--- (Wait for range to quiesce.)
-
-
 -- (Allow below-raft admission to proceed. We've disabled the fallback token
 -- dispatch mechanism so no tokens are returned yet -- quiesced ranges don't
 -- use the piggy-backed token return mechanism since there's no raft traffic.)
@@ -114,6 +111,9 @@ ORDER BY name ASC;
   kvflowcontrol.tokens.send.regular.returned                        | 0 B      
   kvflowcontrol.tokens.send.regular.returned.disconnect             | 0 B      
   kvflowcontrol.tokens.send.regular.unaccounted                     | 0 B      
+
+
+-- (Wait for range to quiesce.)
 ----
 ----
 

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/unquiesced_range_v1_encoding
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/unquiesced_range_v1_encoding
@@ -44,9 +44,6 @@ ORDER BY name ASC;
   kvflowcontrol.tokens.send.regular.unaccounted                     | 0 B      
 
 
--- (Wait for range to quiesce.)
-
-
 -- (Allow below-raft admission to proceed. We've disabled the fallback token
 -- dispatch mechanism so no tokens are returned yet -- quiesced ranges don't
 -- use the piggy-backed token return mechanism since there's no raft traffic.)
@@ -121,6 +118,9 @@ ORDER BY name ASC;
   kvflowcontrol.tokens.send.regular.returned                        | 0 B      
   kvflowcontrol.tokens.send.regular.returned.disconnect             | 0 B      
   kvflowcontrol.tokens.send.regular.unaccounted                     | 0 B      
+
+
+-- (Wait for range to quiesce.)
 ----
 ----
 


### PR DESCRIPTION
This PR prevents range quiescence if RACv2 holds any send tokens for this range. Quiescence would prevent `MsgApp` pings which ensure that the leader reliably learns about the follower store admitting log entries, and causes it to release tokens accordingly. We do not want to end up holding tokens permanently.

Resolves #129581