### PR TITLE
 workload/schemachanger: fix failure in foreign key operation generation

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -216,7 +216,7 @@ func (og *operationGenerator) randOp(
 			if errors.Is(err, ErrSchemaChangesDisallowedDueToPkSwap) {
 				continue
 			}
-			return nil, err
+			return nil, errors.Wrapf(err, "failed generating operation: %s", op)
 		}
 
 		// Screen for schema change after write in the same transaction.


### PR DESCRIPTION
Certain errors were supposed to be ignored when validating foreign keys,
when column types are not comparable. These are meant to be ignored and
when foreign keys refer to the table itself we were also using the wrong
column information when running queries. To address this, the error
detection for foreign key validation has been updated and the correct
column information is passed. This could lead to intermittent failures
in the workload.

Fixes: #131365

Release note: None