### PR TITLE
release-23.2: catalog: validate/repair default privs with orphan roles

### DIFF
--- a/pkg/sql/catalog/dbdesc/database_desc_builder.go
+++ b/pkg/sql/catalog/dbdesc/database_desc_builder.go
@@ -183,6 +183,16 @@ func (ddb *databaseDescriptorBuilder) StripDanglingBackReferences(
 func (ddb *databaseDescriptorBuilder) StripNonExistentRoles(
 	roleExists func(role username.SQLUsername) bool,
 ) error {
+	// Remove any non-existent roles from default privileges.
+	defaultPrivs := ddb.original.GetDefaultPrivileges()
+	if defaultPrivs != nil {
+		err := ddb.stripNonExistentRolesOnDefaultPrivs(ddb.original.DefaultPrivileges.DefaultPrivilegesPerRole, roleExists)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Remove any non-existent roles from the privileges.
 	newPrivs := make([]catpb.UserPrivileges, 0, len(ddb.maybeModified.Privileges.Users))
 	for _, priv := range ddb.maybeModified.Privileges.Users {
 		exists := roleExists(priv.UserProto.Decode())
@@ -192,6 +202,54 @@ func (ddb *databaseDescriptorBuilder) StripNonExistentRoles(
 	}
 	if len(newPrivs) != len(ddb.maybeModified.Privileges.Users) {
 		ddb.maybeModified.Privileges.Users = newPrivs
+		ddb.changes.Add(catalog.StrippedNonExistentRoles)
+	}
+	return nil
+}
+
+func (ddb *databaseDescriptorBuilder) stripNonExistentRolesOnDefaultPrivs(
+	defaultPrivs []catpb.DefaultPrivilegesForRole, roleExists func(role username.SQLUsername) bool,
+) error {
+	hasChanges := false
+	newDefaultPrivs := make([]catpb.DefaultPrivilegesForRole, 0, len(defaultPrivs))
+	for _, dp := range defaultPrivs {
+		// Skip adding if we are dealing with an explicit role and the role does
+		// not exist.
+		if dp.IsExplicitRole() && !roleExists(dp.GetExplicitRole().UserProto.Decode()) {
+			hasChanges = true
+			continue
+		}
+
+		newDefaultPrivilegesPerObject := make(map[privilege.TargetObjectType]catpb.PrivilegeDescriptor, len(dp.DefaultPrivilegesPerObject))
+
+		for objTyp, privDesc := range dp.DefaultPrivilegesPerObject {
+			newUserPrivs := make([]catpb.UserPrivileges, 0, len(privDesc.Users))
+			for _, userPriv := range privDesc.Users {
+				// Only add users where the role exists.
+				if roleExists(userPriv.UserProto.Decode()) {
+					newUserPrivs = append(newUserPrivs, userPriv)
+				} else {
+					hasChanges = true
+				}
+			}
+			// If we have not filtered out all user privileges, update the privilege
+			// descriptor with our newUserPrivs -- along with our map.
+			if len(newUserPrivs) != 0 {
+				privDesc.Users = newUserPrivs
+				newDefaultPrivilegesPerObject[objTyp] = privDesc
+			}
+		}
+
+		// If we have not filtered out our map of default privileges, update the
+		// default privileges for role and add that to our list of newDefaultPrivs.
+		if len(newDefaultPrivilegesPerObject) != 0 {
+			dp.DefaultPrivilegesPerObject = newDefaultPrivilegesPerObject
+			newDefaultPrivs = append(newDefaultPrivs, dp)
+		}
+	}
+
+	if hasChanges {
+		ddb.maybeModified.DefaultPrivileges.DefaultPrivilegesPerRole = newDefaultPrivs
 		ddb.changes.Add(catalog.StrippedNonExistentRoles)
 	}
 	return nil

--- a/pkg/sql/catalog/schemadesc/schema_desc_builder.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc_builder.go
@@ -138,6 +138,15 @@ func (sdb *schemaDescriptorBuilder) StripDanglingBackReferences(
 func (sdb *schemaDescriptorBuilder) StripNonExistentRoles(
 	roleExists func(role username.SQLUsername) bool,
 ) error {
+	// Remove any non-existent roles from default privileges.
+	defaultPrivs := sdb.original.GetDefaultPrivileges()
+	if defaultPrivs != nil {
+		err := sdb.stripNonExistentRolesOnDefaultPrivs(sdb.original.DefaultPrivileges.DefaultPrivilegesPerRole, roleExists)
+		if err != nil {
+			return err
+		}
+	}
+
 	newPrivs := make([]catpb.UserPrivileges, 0, len(sdb.maybeModified.Privileges.Users))
 	for _, priv := range sdb.maybeModified.Privileges.Users {
 		exists := roleExists(priv.UserProto.Decode())
@@ -147,6 +156,54 @@ func (sdb *schemaDescriptorBuilder) StripNonExistentRoles(
 	}
 	if len(newPrivs) != len(sdb.maybeModified.Privileges.Users) {
 		sdb.maybeModified.Privileges.Users = newPrivs
+		sdb.changes.Add(catalog.StrippedNonExistentRoles)
+	}
+	return nil
+}
+
+func (sdb *schemaDescriptorBuilder) stripNonExistentRolesOnDefaultPrivs(
+	defaultPrivs []catpb.DefaultPrivilegesForRole, roleExists func(role username.SQLUsername) bool,
+) error {
+	hasChanges := false
+	newDefaultPrivs := make([]catpb.DefaultPrivilegesForRole, 0, len(defaultPrivs))
+	for _, dp := range defaultPrivs {
+		// Skip adding if we are dealing with an explicit role and the role does
+		// not exist.
+		if dp.IsExplicitRole() && !roleExists(dp.GetExplicitRole().UserProto.Decode()) {
+			hasChanges = true
+			continue
+		}
+
+		newDefaultPrivilegesPerObject := make(map[privilege.TargetObjectType]catpb.PrivilegeDescriptor, len(dp.DefaultPrivilegesPerObject))
+
+		for objTyp, privDesc := range dp.DefaultPrivilegesPerObject {
+			newUserPrivs := make([]catpb.UserPrivileges, 0, len(privDesc.Users))
+			for _, userPriv := range privDesc.Users {
+				// Only add users where the role exists.
+				if roleExists(userPriv.UserProto.Decode()) {
+					newUserPrivs = append(newUserPrivs, userPriv)
+				} else {
+					hasChanges = true
+				}
+			}
+			// If we have not filtered out all user privileges, update the privilege
+			// descriptor with our newUserPrivs -- along with our map.
+			if len(newUserPrivs) != 0 {
+				privDesc.Users = newUserPrivs
+				newDefaultPrivilegesPerObject[objTyp] = privDesc
+			}
+		}
+
+		// If we have not filtered out our map of default privileges, update the
+		// default privileges for role and add that to our list of newDefaultPrivs.
+		if len(newDefaultPrivilegesPerObject) != 0 {
+			dp.DefaultPrivilegesPerObject = newDefaultPrivilegesPerObject
+			newDefaultPrivs = append(newDefaultPrivs, dp)
+		}
+	}
+
+	if hasChanges {
+		sdb.maybeModified.DefaultPrivileges.DefaultPrivilegesPerRole = newDefaultPrivs
 		sdb.changes.Add(catalog.StrippedNonExistentRoles)
 	}
 	return nil

--- a/pkg/sql/catalog/validate.go
+++ b/pkg/sql/catalog/validate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/errors"
 )
@@ -194,6 +195,48 @@ func ValidateRolesInDescriptor(
 				descriptor.GetID(),
 				priv.User())
 		}
+	}
+	return nil
+}
+
+// ValidateRolesInDefaultPrivilegeDescriptor validates roles within a
+// catalog.DefaultPrivilegeDescriptor.
+func ValidateRolesInDefaultPrivilegeDescriptor(
+	defaultDesc DefaultPrivilegeDescriptor, roleExists func(username.SQLUsername) (bool, error),
+) error {
+	err := defaultDesc.ForEachDefaultPrivilegeForRole(func(defaultPriv catpb.DefaultPrivilegesForRole) error {
+		// If we have a default privilege on a specific role, validate whether the
+		// role exists.
+		if defaultPriv.IsExplicitRole() {
+			user := defaultPriv.GetExplicitRole().UserProto.Decode()
+			exists, err := roleExists(user)
+			if err != nil {
+				return err
+			}
+			if !exists {
+				return errors.AssertionFailedf("a default privilege exists on a role %q that doesn't exist",
+					user)
+			}
+		}
+		// Loop through to find which users have a default privilege assigned to
+		// them. If any user does not exist, return an error.
+		for _, privDesc := range defaultPriv.DefaultPrivilegesPerObject {
+			for _, userPriv := range privDesc.Users {
+				user := userPriv.User()
+				exists, err := roleExists(user)
+				if err != nil {
+					return err
+				}
+				if !exists {
+					return errors.AssertionFailedf("a default privilege exists for a role %q that doesn't exist",
+						user)
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -6146,7 +6146,7 @@ CREATE TABLE crdb_internal.invalid_objects (
 			for _, validationError := range ve {
 				doError(validationError)
 			}
-			doError(catalog.ValidateRolesInDescriptor(descriptor, func(username username.SQLUsername) (bool, error) {
+			roleExists := func(username username.SQLUsername) (bool, error) {
 				if username.IsRootUser() ||
 					username.IsAdminRole() ||
 					username.IsNodeUser() ||
@@ -6161,7 +6161,17 @@ CREATE TABLE crdb_internal.invalid_objects (
 					return false, err
 				}
 				return true, nil
-			}))
+			}
+			doError(catalog.ValidateRolesInDescriptor(descriptor, roleExists))
+			if dbDesc, ok := descriptor.(catalog.DatabaseDescriptor); ok {
+				doError(
+					catalog.ValidateRolesInDefaultPrivilegeDescriptor(
+						dbDesc.GetDefaultPrivilegeDescriptor(), roleExists))
+			} else if schemaDesc, ok := descriptor.(catalog.SchemaDescriptor); ok {
+				doError(
+					catalog.ValidateRolesInDefaultPrivilegeDescriptor(
+						schemaDesc.GetDefaultPrivilegeDescriptor(), roleExists))
+			}
 			jobs.ValidateJobReferencesInDescriptor(descriptor, jmg, doError)
 			return err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_default_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_default_privileges
@@ -1106,3 +1106,134 @@ test2          NULL         testuser  false          routines     public    EXEC
 test2          NULL         NULL      true           tables       foo       SELECT          false
 test2          NULL         NULL      true           types        public    USAGE           false
 test2          NULL         NULL      true           routines     public    EXECUTE         false
+
+subtest corrupt_default_privilege
+
+statement ok
+CREATE ROLE roach_a;
+CREATE ROLE roach_b;
+SET ROLE roach_b;
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE roach_b GRANT SELECT ON TABLES TO roach_a;
+
+statement ok
+SET ROLE root;
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT SELECT ON TABLES TO roach_a;
+
+statement ok
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT INSERT ON TABLES TO roach_a;
+
+# Create some descriptor corruptions with an orphaned role that is being granted
+# a default privilege.
+statement ok
+DELETE FROM system.users WHERE username = 'roach_a';
+
+query TTTBTTTB colnames
+SELECT * FROM crdb_internal.default_privileges WHERE grantee = 'roach_a'
+ORDER BY role;
+----
+database_name  schema_name  role     for_all_roles  object_type  grantee  privilege_type  is_grantable
+test2          NULL         NULL     true           tables       roach_a  SELECT          false
+test2          NULL         roach_b  false          tables       roach_a  SELECT          false
+test2          public       root     false          tables       roach_a  INSERT          false
+
+statement ok
+CREATE ROLE roach_c;
+CREATE ROLE roach_d;
+SET ROLE roach_d;
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE roach_d GRANT SELECT ON TABLES TO roach_b;
+
+statement ok
+SET ROLE roach_c;
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE roach_c GRANT SELECT ON TABLES TO roach_d;
+
+statement ok
+SET ROLE root;
+
+# Create a descriptor corruption with an orphaned role that is granting a
+# default privilege.
+statement ok
+DELETE FROM system.users WHERE username = 'roach_d';
+
+# Create a descriptor corruption with all orphaned roles.
+statement ok
+DELETE FROM system.users WHERE username = 'roach_c';
+
+# We see that roach_c and roach_d still exist in our default privileges on our
+# database descriptor.
+query TT colnames
+WITH t AS (
+   SELECT json_array_elements(crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor)
+     -> 'database'
+     -> 'defaultPrivileges'
+     -> 'defaultPrivilegesPerRole') AS default_privs_per_role
+   FROM system.descriptor
+   WHERE id = (SELECT oid FROM pg_database WHERE datname = 'test2')
+) SELECT
+  default_privs_per_role->'defaultPrivilegesPerObject'->'1'->'users' AS grantees,
+  default_privs_per_role->'explicitRole'->'userProto' AS role
+ FROM t
+ORDER BY role;
+----
+grantees                                                                                  role
+[{"privileges": "32", "userProto": "foo"}, {"privileges": "32", "userProto": "roach_a"}]  NULL
+[{"privileges": "32", "userProto": "roach_a"}]                                            "roach_b"
+[{"privileges": "32", "userProto": "roach_d"}]                                            "roach_c"
+[{"privileges": "32", "userProto": "roach_b"}]                                            "roach_d"
+[{"privileges": "1032", "userProto": "foo", "withGrantOption": "1032"}]                   "root"
+
+# Invalidate the role membership cache (validation uses the cache).
+statement ok
+CREATE ROLE invalidate;
+
+query TTTT colnames
+SELECT database_name, schema_name, obj_name, error FROM crdb_internal.invalid_objects
+ORDER BY schema_name;
+----
+database_name  schema_name  obj_name  error
+test2          ·            ·         a default privilege exists for a role "roach_a" that doesn't exist
+test2          public       ·         a default privilege exists for a role "roach_a" that doesn't exist
+
+query TT colnames
+SELECT name, corruption FROM crdb_internal.kv_repairable_catalog_corruptions
+ORDER BY name;
+----
+name    corruption
+public  descriptor
+test2   descriptor
+
+statement ok
+SELECT crdb_internal.repair_catalog_corruption(id, corruption) FROM "".crdb_internal.kv_repairable_catalog_corruptions;
+
+query I
+SELECT count(*) FROM crdb_internal.invalid_objects;
+----
+0
+
+# Our default privileges are now properly cleaned up.
+query TT colnames
+WITH t AS (
+   SELECT json_array_elements(crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor)
+     -> 'database'
+     -> 'defaultPrivileges'
+     -> 'defaultPrivilegesPerRole') AS default_privs_per_role
+   FROM system.descriptor
+   WHERE id = (SELECT oid FROM pg_database WHERE datname = 'test2')
+) SELECT
+  default_privs_per_role->'defaultPrivilegesPerObject'->'1'->'users' AS grantees,
+  default_privs_per_role->'explicitRole'->'userProto' AS role
+ FROM t
+ORDER BY role;
+----
+grantees                                                                 role
+[{"privileges": "32", "userProto": "foo"}]                               NULL
+[{"privileges": "1032", "userProto": "foo", "withGrantOption": "1032"}]  "root"
+
+subtest end


### PR DESCRIPTION
Backport 2/2 commits from #131782.

/cc @cockroachdb/release

---

### sql/catalog: check default privs during desc validation

This patch adds an additional step for our invalid objects
virtual table that checks if default privilege descriptors
are invalid. A default privilege descriptor is considered
invalid if it meets at least one of the following:

1. The role that the default privilege is granted *on* does
not exist
2. The role that the default privilege is has been granted *to*
does not exist

Release note: None

---

### sql/catalog: add default priv repair step

This patch adds a repair step to strip away any
non-existent roles in default privileges.

Fixes: #130243

Release note (bug fix): Add automated clean-up/validation
for dropped roles inside of default privileges.

---

Release justification: low risk fix that prevents corrupt descriptors from granting orphaned default privs to a newly created (but previously existing) role