### PR TITLE
rac2: fix token return behaviour

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -1776,8 +1776,8 @@ func (rss *replicaSendStream) admit(ctx context.Context, av AdmittedVector) {
 	rss.mu.Lock()
 	defer rss.mu.Unlock()
 
-	returnedSend, returnedEval := rss.mu.tracker.Untrack(
-		av.Term, av.Admitted, rss.mu.nextRaftIndexInitial)
+	returnedSend, returnedEval := rss.mu.tracker.Untrack(av,
+		rss.mu.nextRaftIndexInitial)
 	rss.returnSendTokens(ctx, returnedSend, false /* disconnect */)
 	rss.returnEvalTokensLocked(ctx, returnedEval)
 }

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -791,8 +791,8 @@ func constructRaftEventForReplica(
 ) (_ raftEventForReplica, scratch []entryFCState) {
 	firstNewEntryIndex, lastNewEntryIndex := uint64(math.MaxUint64), uint64(math.MaxUint64)
 	if n := len(raftEventAppendState.newEntries); n > 0 {
-		firstNewEntryIndex = raftEventAppendState.newEntries[0].index
-		lastNewEntryIndex = raftEventAppendState.newEntries[n-1].index + 1
+		firstNewEntryIndex = raftEventAppendState.newEntries[0].id.index
+		lastNewEntryIndex = raftEventAppendState.newEntries[n-1].id.index + 1
 		// The rewoundNextRaftIndex + newEntries should never lag behind Next.
 		if latestReplicaStateInfo.Next > lastNewEntryIndex {
 			panic(errors.AssertionFailedf("unexpected next=%v > last_new_entry_index=%v",
@@ -1848,7 +1848,7 @@ func (rs *replicaState) isStateReplicateAndSendQ() (isStateReplicate, hasSendQ b
 }
 
 type entryFCState struct {
-	term, index     uint64
+	id              entryID
 	usesFlowControl bool
 	tokens          kvflowcontrol.Tokens
 	pri             raftpb.Priority
@@ -1871,8 +1871,7 @@ func getEntryFCStateOrFatal(ctx context.Context, entry raftpb.Entry) entryFCStat
 	}
 
 	return entryFCState{
-		index:           entry.Index,
-		term:            entry.Term,
+		id:              entryID{index: entry.Index, term: entry.Term},
 		usesFlowControl: enc.UsesAdmissionControl(),
 		tokens:          kvflowcontrol.Tokens(len(entry.Data)),
 		pri:             pri,
@@ -2217,18 +2216,18 @@ func (rss *replicaSendStream) handleReadyEntriesLocked(
 	// Common behavior for updating state using sendingEntries and newEntries
 	// for MsgAppPush and MsgAppPull.
 	if n := len(event.sendingEntries); n > 0 {
-		if event.sendingEntries[0].index != rss.mu.sendQueue.indexToSend {
+		if event.sendingEntries[0].id.index != rss.mu.sendQueue.indexToSend {
 			panic(errors.AssertionFailedf("first send entry %d does not match indexToSend %d",
-				event.sendingEntries[0].index, rss.mu.sendQueue.indexToSend))
+				event.sendingEntries[0].id.index, rss.mu.sendQueue.indexToSend))
 		}
-		rss.mu.sendQueue.indexToSend = event.sendingEntries[n-1].index + 1
+		rss.mu.sendQueue.indexToSend = event.sendingEntries[n-1].id.index + 1
 		for _, entry := range event.sendingEntries {
 			if !entry.usesFlowControl {
 				continue
 			}
 			var pri raftpb.Priority
 			inSendQueue := false
-			if entry.index >= rss.mu.sendQueue.nextRaftIndex {
+			if entry.id.index >= rss.mu.sendQueue.nextRaftIndex {
 				// Was never in the send-queue.
 				pri = entry.pri
 			} else {
@@ -2246,7 +2245,7 @@ func (rss *replicaSendStream) handleReadyEntriesLocked(
 					tokens = fn(tokens)
 				}
 			}
-			if inSendQueue && entry.index >= rss.mu.nextRaftIndexInitial {
+			if inSendQueue && entry.id.index >= rss.mu.nextRaftIndexInitial {
 				// Was in send-queue and had eval tokens deducted for it.
 				rss.mu.sendQueue.originalEvalTokens[WorkClassFromRaftPriority(entry.pri)] -= tokens
 				rss.mu.sendQueue.preciseSizeSum -= tokens
@@ -2256,25 +2255,25 @@ func (rss *replicaSendStream) handleReadyEntriesLocked(
 				flag = AdjPreventSendQueue
 			}
 			rss.parent.sendTokenCounter.Deduct(ctx, WorkClassFromRaftPriority(pri), tokens, flag)
-			rss.mu.tracker.Track(ctx, entry.term, entry.index, pri, tokens)
+			rss.mu.tracker.Track(ctx, entry.id, pri, tokens)
 		}
 		if directive.preventSendQNoForceFlush {
 			rss.parent.parent.opts.RangeControllerMetrics.SendQueue.PreventionCount.Inc(1)
 		}
 	}
 	if n := len(event.newEntries); n > 0 {
-		if event.newEntries[0].index != rss.mu.sendQueue.nextRaftIndex {
+		if event.newEntries[0].id.index != rss.mu.sendQueue.nextRaftIndex {
 			panic(errors.AssertionFailedf("append %d does not match nextRaftIndex %d",
-				event.newEntries[0].index, rss.mu.sendQueue.nextRaftIndex))
+				event.newEntries[0].id.index, rss.mu.sendQueue.nextRaftIndex))
 		}
-		rss.mu.sendQueue.nextRaftIndex = event.newEntries[n-1].index + 1
+		rss.mu.sendQueue.nextRaftIndex = event.newEntries[n-1].id.index + 1
 		for _, entry := range event.newEntries {
 			if !entry.usesFlowControl {
 				continue
 			}
 			var pri raftpb.Priority
 			inSendQueue := false
-			if entry.index >= rss.mu.sendQueue.indexToSend {
+			if entry.id.index >= rss.mu.sendQueue.indexToSend {
 				// Being added to the send-queue.
 				inSendQueue = true
 				if event.mode == MsgAppPush {
@@ -2298,7 +2297,7 @@ func (rss *replicaSendStream) handleReadyEntriesLocked(
 					tokens = fn(tokens)
 				}
 			}
-			if inSendQueue && entry.index >= rss.mu.nextRaftIndexInitial {
+			if inSendQueue && entry.id.index >= rss.mu.nextRaftIndexInitial {
 				// Is in send-queue and will have eval tokens deducted for it.
 				rss.mu.sendQueue.originalEvalTokens[WorkClassFromRaftPriority(entry.pri)] += tokens
 			}
@@ -2312,7 +2311,7 @@ func (rss *replicaSendStream) handleReadyEntriesLocked(
 		// NB: this will not do IO since everything here is in the unstable log
 		// (see raft.LogSnapshot.unstable).
 		slice, err := event.logSnapshot.LogSlice(
-			event.sendingEntries[0].index, event.sendingEntries[n-1].index+1, math.MaxInt64)
+			event.sendingEntries[0].id.index, event.sendingEntries[n-1].id.index+1, math.MaxInt64)
 		if err != nil {
 			return false, err
 		}
@@ -2395,17 +2394,17 @@ func (rss *replicaSendStream) dequeueFromQueueAndSendLocked(
 	var tokensNeeded kvflowcontrol.Tokens
 	for _, entry := range msg.Entries {
 		entryState := getEntryFCStateOrFatal(ctx, entry)
-		if entryState.index != rss.mu.sendQueue.indexToSend {
+		if entryState.id.index != rss.mu.sendQueue.indexToSend {
 			panic(errors.AssertionFailedf("index %d != indexToSend %d",
-				entryState.index, rss.mu.sendQueue.indexToSend))
+				entryState.id.index, rss.mu.sendQueue.indexToSend))
 		}
-		if entryState.index >= rss.mu.sendQueue.nextRaftIndex {
-			panic(errors.AssertionFailedf("index %d >= nextRaftIndex %d", entryState.index,
+		if entryState.id.index >= rss.mu.sendQueue.nextRaftIndex {
+			panic(errors.AssertionFailedf("index %d >= nextRaftIndex %d", entryState.id.index,
 				rss.mu.sendQueue.nextRaftIndex))
 		}
 		rss.mu.sendQueue.indexToSend++
 		if entryState.usesFlowControl {
-			if entryState.index >= rss.mu.nextRaftIndexInitial {
+			if entryState.id.index >= rss.mu.nextRaftIndexInitial {
 				rss.mu.sendQueue.preciseSizeSum -= entryState.tokens
 				rss.mu.sendQueue.originalEvalTokens[WorkClassFromRaftPriority(entryState.pri)] -=
 					entryState.tokens
@@ -2413,7 +2412,7 @@ func (rss *replicaSendStream) dequeueFromQueueAndSendLocked(
 			// TODO(sumeer): use knowledge from entries < nextRaftIndexInitial to
 			// adjust approxMeanSizeBytes.
 			tokensNeeded += entryState.tokens
-			rss.mu.tracker.Track(ctx, entryState.term, entryState.index, raftpb.LowPri, entryState.tokens)
+			rss.mu.tracker.Track(ctx, entryState.id, raftpb.LowPri, entryState.tokens)
 		}
 	}
 	if !rss.mu.sendQueue.forceFlushScheduled {

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
@@ -326,6 +326,7 @@ func (s *testingRCState) getOrInitRange(
 		}
 
 		init := RangeControllerInitState{
+			Term:          1,
 			ReplicaSet:    r.replicas(),
 			Leaseholder:   r.localReplicaID,
 			NextRaftIndex: r.nextRaftIndex,

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
@@ -1414,8 +1414,7 @@ func TestGetEntryFCState(t *testing.T) {
 				tokens: 100,
 			},
 			expectedFCState: entryFCState{
-				term:            1,
-				index:           1,
+				id:              entryID{index: 1, term: 1},
 				pri:             raftpb.LowPri,
 				usesFlowControl: true,
 				tokens:          100,
@@ -1432,8 +1431,7 @@ func TestGetEntryFCState(t *testing.T) {
 				tokens: 200,
 			},
 			expectedFCState: entryFCState{
-				term:            2,
-				index:           2,
+				id:              entryID{index: 2, term: 2},
 				pri:             raftpb.LowPri,
 				usesFlowControl: true,
 				tokens:          200,
@@ -1448,8 +1446,7 @@ func TestGetEntryFCState(t *testing.T) {
 				tokens: 300,
 			},
 			expectedFCState: entryFCState{
-				term:            3,
-				index:           3,
+				id:              entryID{index: 3, term: 3},
 				usesFlowControl: false,
 				tokens:          300,
 			},
@@ -1465,8 +1462,7 @@ func TestGetEntryFCState(t *testing.T) {
 				tokens: 400,
 			},
 			expectedFCState: entryFCState{
-				term:            4,
-				index:           4,
+				id:              entryID{index: 4, term: 4},
 				pri:             raftpb.NormalPri,
 				usesFlowControl: true,
 				tokens:          400,
@@ -1483,8 +1479,7 @@ func TestGetEntryFCState(t *testing.T) {
 				tokens: 500,
 			},
 			expectedFCState: entryFCState{
-				term:            5,
-				index:           5,
+				id:              entryID{index: 5, term: 5},
 				pri:             raftpb.AboveNormalPri,
 				usesFlowControl: true,
 				tokens:          500,
@@ -1642,8 +1637,7 @@ func TestConstructRaftEventForReplica(t *testing.T) {
 		var entries []entryFCState
 		for i := 0; i < n; i++ {
 			entries = append(entries, entryFCState{
-				term:            startingTerm,
-				index:           startingIndex + uint64(i),
+				id:              entryID{index: startingIndex + uint64(i), term: startingTerm},
 				usesFlowControl: defaultUseFC,
 				tokens:          kvflowcontrol.Tokens((i + 1) * tokenMult),
 				pri:             defaultPri,
@@ -1860,8 +1854,8 @@ func TestConstructRaftEventForReplica(t *testing.T) {
 			name: "msgapps with entries before new entries",
 			raftEventAppendState: raftEventAppendState{
 				newEntries: []entryFCState{
-					{index: 12, term: 1, usesFlowControl: true, tokens: 300, pri: raftpb.NormalPri},
-					{index: 13, term: 1, usesFlowControl: true, tokens: 400, pri: raftpb.NormalPri},
+					{id: entryID{index: 12, term: 1}, usesFlowControl: true, tokens: 300, pri: raftpb.NormalPri},
+					{id: entryID{index: 13, term: 1}, usesFlowControl: true, tokens: 400, pri: raftpb.NormalPri},
 				},
 				rewoundNextRaftIndex: 12,
 			},
@@ -1890,8 +1884,8 @@ func TestConstructRaftEventForReplica(t *testing.T) {
 				},
 				nextRaftIndex: 12,
 				newEntries: []entryFCState{
-					{index: 12, term: 1, usesFlowControl: true, tokens: 300, pri: raftpb.NormalPri},
-					{index: 13, term: 1, usesFlowControl: true, tokens: 400, pri: raftpb.NormalPri},
+					{id: entryID{index: 12, term: 1}, usesFlowControl: true, tokens: 300, pri: raftpb.NormalPri},
+					{id: entryID{index: 13, term: 1}, usesFlowControl: true, tokens: 400, pri: raftpb.NormalPri},
 				},
 				sendingEntries:     makeEntryFCStates(t, 4),
 				recreateSendStream: false,
@@ -1902,9 +1896,9 @@ func TestConstructRaftEventForReplica(t *testing.T) {
 			name: "msgapps with entries before new entries and send-queue after sending",
 			raftEventAppendState: raftEventAppendState{
 				newEntries: []entryFCState{
-					{index: 12, term: 1, usesFlowControl: true, tokens: 300, pri: raftpb.NormalPri},
-					{index: 13, term: 1, usesFlowControl: true, tokens: 400, pri: raftpb.NormalPri},
-					{index: 14, term: 1, usesFlowControl: true, tokens: 400, pri: raftpb.NormalPri},
+					{id: entryID{index: 12, term: 1}, usesFlowControl: true, tokens: 300, pri: raftpb.NormalPri},
+					{id: entryID{index: 13, term: 1}, usesFlowControl: true, tokens: 400, pri: raftpb.NormalPri},
+					{id: entryID{index: 14, term: 1}, usesFlowControl: true, tokens: 400, pri: raftpb.NormalPri},
 				},
 				rewoundNextRaftIndex: 12,
 			},
@@ -1933,9 +1927,9 @@ func TestConstructRaftEventForReplica(t *testing.T) {
 				},
 				nextRaftIndex: 12,
 				newEntries: []entryFCState{
-					{index: 12, term: 1, usesFlowControl: true, tokens: 300, pri: raftpb.NormalPri},
-					{index: 13, term: 1, usesFlowControl: true, tokens: 400, pri: raftpb.NormalPri},
-					{index: 14, term: 1, usesFlowControl: true, tokens: 400, pri: raftpb.NormalPri},
+					{id: entryID{index: 12, term: 1}, usesFlowControl: true, tokens: 300, pri: raftpb.NormalPri},
+					{id: entryID{index: 13, term: 1}, usesFlowControl: true, tokens: 400, pri: raftpb.NormalPri},
+					{id: entryID{index: 14, term: 1}, usesFlowControl: true, tokens: 400, pri: raftpb.NormalPri},
 				},
 				sendingEntries:     makeEntryFCStates(t, 4),
 				recreateSendStream: false,

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/simulation_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/simulation_test.go
@@ -1139,7 +1139,7 @@ func (r *testingRCRange) testingReturnTokens(
 	for _, deduction := range rs.sendStream.mu.tracker.tracked[raftPri] {
 		if r.mu.outstandingReturns[rid]-deduction.tokens >= 0 {
 			r.mu.outstandingReturns[rid] -= deduction.tokens
-			returnIndex = deduction.index
+			returnIndex = deduction.id.index
 		}
 	}
 	if returnIndex != 0 {
@@ -1223,7 +1223,7 @@ func (t *Tracker) testingString() string {
 		buf.WriteString(fmt.Sprintf("pri=%s\n", RaftToAdmissionPriority(raftpb.Priority(pri))))
 		for _, deduction := range deductions {
 			buf.WriteString(fmt.Sprintf("  tokens=%s log-position=%v/%v\n",
-				testingPrintTrimmedTokens(deduction.tokens), deduction.term, deduction.index))
+				testingPrintTrimmedTokens(deduction.tokens), deduction.id.term, deduction.id.index))
 		}
 	}
 

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/token_tracker
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/token_tracker
@@ -1,3 +1,7 @@
+init term=5
+----
+ok
+
 track
 term=1 index=10 tokens=100 pri=LowPri
 term=1 index=20 tokens=200 pri=NormalPri
@@ -112,14 +116,25 @@ HighPri:
   term=1 index=30 tokens=300
   term=3 index=60 tokens=600
 
-untrack term=2 eval-tokens-ge-index=40
+# Stale leader term, untrack returns nothing.
+untrack term=4 eval-tokens-ge-index=40
+LowPri=45
+----
+
+# Newer leader term. Currently we return nothing, but we could also return all
+# the tokens.
+untrack term=6 eval-tokens-ge-index=40
+LowPri=45
+----
+
+# For the right-term admitted vector, untrack returns only the tokens covered by
+# the admitted indices at the corresponding priorities.
+untrack term=5 eval-tokens-ge-index=40
 LowPri=45
 NormalPri=0
 HighPri=0
 ----
 send returned: tokens=500  pri=LowPri
-send returned: tokens=200  pri=NormalPri
-send returned: tokens=300  pri=HighPri
 eval returned: tokens=400  pri=LowPri
 
 state
@@ -128,29 +143,37 @@ LowPri:
   term=2 index=51 tokens=400
   term=3 index=70 tokens=700
 NormalPri:
+  term=1 index=20 tokens=200
   term=2 index=50 tokens=500
 HighPri:
+  term=1 index=30 tokens=300
   term=3 index=60 tokens=600
 
-# Untrack with a higher term.
-untrack term=3 eval-tokens-ge-index=51
+untrack term=5 eval-tokens-ge-index=51
 NormalPri=60
 HighPri=60
 ----
-send returned: tokens=400  pri=LowPri
-send returned: tokens=500  pri=NormalPri
-send returned: tokens=600  pri=HighPri
-eval returned: tokens=400  pri=LowPri
+send returned: tokens=700  pri=NormalPri
+send returned: tokens=900  pri=HighPri
 eval returned: tokens=600  pri=HighPri
 
 state
 ----
 LowPri:
+  term=2 index=51 tokens=400
   term=3 index=70 tokens=700
 
 # The inspect state should match up with the formatted state printed above.
 inspect
 ----
+{
+  "priority": -128,
+  "tokens": "400",
+  "raft_log_position": {
+    "term": "2",
+    "index": "51"
+  }
+}
 {
   "priority": -128,
   "tokens": "700",
@@ -160,19 +183,19 @@ inspect
   }
 }
 
-state
-----
-LowPri:
-  term=3 index=70 tokens=700
-
 untrack_all
 ----
-send returned: tokens=700  pri=LowPri
+send returned: tokens=1100 pri=LowPri
 
+# Everything is returned.
 state
 ----
 
 # Test tracking and untracking with different terms
+init term=5
+----
+ok
+
 track
 term=4 index=80 tokens=800 pri=NormalPri
 term=4 index=85 tokens=800 pri=NormalPri
@@ -193,23 +216,20 @@ NormalPri:
 HighPri:
   term=5 index=100 tokens=999
 
-untrack term=4 eval-tokens-ge-index=80
+untrack term=5 eval-tokens-ge-index=80
 NormalPri=95
 HighPri=95
 ----
-send returned: tokens=1600 pri=NormalPri
-eval returned: tokens=1600 pri=NormalPri
+send returned: tokens=2500 pri=NormalPri
+eval returned: tokens=2500 pri=NormalPri
 
 state
 ----
-NormalPri:
-  term=5 index=90 tokens=900
 HighPri:
   term=5 index=100 tokens=999
 
 untrack_all
 ----
-send returned: tokens=900  pri=NormalPri
 send returned: tokens=999  pri=HighPri
 
 state

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker.go
@@ -33,8 +33,8 @@ type tracked struct {
 	index, term uint64
 }
 
-func (dt *Tracker) Init(stream kvflowcontrol.Stream) {
-	*dt = Tracker{
+func (t *Tracker) Init(stream kvflowcontrol.Stream) {
+	*t = Tracker{
 		tracked: [raftpb.NumPriorities][]tracked{},
 		stream:  stream,
 	}

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker.go
@@ -92,14 +92,13 @@ func (t *Tracker) Track(
 // equal to the leader term. evalTokensGEIndex is used to separately count the
 // untracked (eval) tokens that are for indices >= evalTokensGEIndex.
 func (t *Tracker) Untrack(
-	term uint64, admitted [raftpb.NumPriorities]uint64, evalTokensGEIndex uint64,
+	av AdmittedVector, evalTokensGEIndex uint64,
 ) (returnedSend, returnedEval [raftpb.NumPriorities]kvflowcontrol.Tokens) {
-	for pri := range admitted {
-		uptoIndex := admitted[pri]
+	for pri, uptoIndex := range av.Admitted {
 		var untracked int
 		for n := len(t.tracked[pri]); untracked < n; untracked++ {
 			deduction := t.tracked[pri][untracked]
-			if deduction.term > term || (deduction.term == term && deduction.index > uptoIndex) {
+			if deduction.term > av.Term || (deduction.term == av.Term && deduction.index > uptoIndex) {
 				break
 			}
 			returnedSend[pri] += deduction.tokens

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker.go
@@ -26,7 +26,11 @@ type entryID struct {
 // deducted for an in-flight log entry identified by its raft entryID, with
 // a given priority.
 type Tracker struct {
+	// term is the raft leader term owning this tracker. Does not change during
+	// the lifetime of this tracker, after Init is called.
+	term uint64
 	// tracked contains the per-priority tracked log entries ordered by log index.
+	// All the tracked entries are in the term's leader log.
 	tracked [raftpb.NumPriorities][]tracked
 
 	stream kvflowcontrol.Stream // used for logging only
@@ -38,8 +42,9 @@ type tracked struct {
 	tokens kvflowcontrol.Tokens
 }
 
-func (t *Tracker) Init(stream kvflowcontrol.Stream) {
+func (t *Tracker) Init(term uint64, stream kvflowcontrol.Stream) {
 	*t = Tracker{
+		term:    term,
 		tracked: [raftpb.NumPriorities][]tracked{},
 		stream:  stream,
 	}
@@ -91,15 +96,22 @@ func (t *Tracker) Track(
 func (t *Tracker) Untrack(
 	av AdmittedVector, evalTokensGEIndex uint64,
 ) (returnedSend, returnedEval [raftpb.NumPriorities]kvflowcontrol.Tokens) {
-	// TODO(pav-kv): the logic below is not correct. We need to check av.Term to
-	// be the same as this leader's term. If it's below, ignore. If above, release
-	// all tokens. If same, release a prefix up to the given index.
+	if av.Term != t.term {
+		// If av.Term < t.term, this is an admission vector for a stale leader, and
+		// we should ignore it. The current-term log is not guaranteed to be
+		// consistent with the av.Term log.
+		//
+		// TODO(pav-kv): if av.Term > t.term, we should return all tokens instead of
+		// returning here. However, raft will know about the term bump soon enough,
+		// exit StateLeader, and the tokens will be returned anyway.
+		return
+	}
+
 	for pri, uptoIndex := range av.Admitted {
 		var untracked int
 		for n := len(t.tracked[pri]); untracked < n; untracked++ {
 			deduction := t.tracked[pri][untracked]
-			if deduction.id.term > av.Term ||
-				deduction.id.term == av.Term && deduction.id.index > uptoIndex {
+			if deduction.id.index > uptoIndex {
 				break
 			}
 			returnedSend[pri] += deduction.tokens
@@ -113,8 +125,8 @@ func (t *Tracker) Untrack(
 	return returnedSend, returnedEval
 }
 
-// UntrackAll iterates through all tracked token deductions, untracking all of them
-// and returning the sum of tokens for each priority.
+// UntrackAll removes all tracked deductions, and returns the total amount of
+// previously tracked tokens for each priority.
 func (t *Tracker) UntrackAll() (returned [raftpb.NumPriorities]kvflowcontrol.Tokens) {
 	for pri, deductions := range t.tracked {
 		for _, deduction := range deductions {
@@ -122,7 +134,6 @@ func (t *Tracker) UntrackAll() (returned [raftpb.NumPriorities]kvflowcontrol.Tok
 		}
 	}
 	t.tracked = [raftpb.NumPriorities][]tracked{}
-
 	return returned
 }
 

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker_test.go
@@ -28,7 +28,7 @@ func formatTrackerState(t *Tracker) string {
 			result.WriteString(fmt.Sprintf("%v:\n", raftpb.Priority(pri)))
 			for _, tr := range tracked {
 				result.WriteString(fmt.Sprintf("  term=%d index=%-2d tokens=%-3d\n",
-					tr.term, tr.index, tr.tokens))
+					tr.id.term, tr.id.index, tr.tokens))
 			}
 		}
 	}

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker_test.go
@@ -100,11 +100,10 @@ func TestTokenTracker(t *testing.T) {
 			return buf.String()
 
 		case "untrack":
-			var term uint64
-			d.ScanArgs(t, "term", &term)
+			var av AdmittedVector
+			d.ScanArgs(t, "term", &av.Term)
 			var evalTokensGEIndex uint64
 			d.ScanArgs(t, "eval-tokens-ge-index", &evalTokensGEIndex)
-			var admitted [raftpb.NumPriorities]uint64
 			for _, line := range strings.Split(d.Input, "\n") {
 				line = strings.TrimSpace(line)
 				if line == "" {
@@ -117,9 +116,9 @@ func TestTokenTracker(t *testing.T) {
 				pri := AdmissionToRaftPriority(parsePriority(t, priStr))
 				index, err := strconv.ParseUint(indexStr, 10, 64)
 				require.NoError(t, err)
-				admitted[pri] = index
+				av.Admitted[pri] = index
 			}
-			returnedSend, returnedEval := tracker.Untrack(term, admitted, evalTokensGEIndex)
+			returnedSend, returnedEval := tracker.Untrack(av, evalTokensGEIndex)
 			return fmt.Sprintf("%s%s", formatUntracked("send", returnedSend),
 				formatUntracked("eval", returnedEval))
 

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker_test.go
@@ -52,7 +52,6 @@ func TestTokenTracker(t *testing.T) {
 
 	ctx := context.Background()
 	tracker := &Tracker{}
-	tracker.Init(kvflowcontrol.Stream{})
 
 	// Used to marshal the output of the Inspect() method into a human-readable
 	// formatted JSON string. See case "inspect" below.
@@ -63,6 +62,12 @@ func TestTokenTracker(t *testing.T) {
 	}
 	datadriven.RunTest(t, "testdata/token_tracker", func(t *testing.T, d *datadriven.TestData) string {
 		switch d.Cmd {
+		case "init":
+			var term uint64
+			d.ScanArgs(t, "term", &term)
+			tracker.Init(term, kvflowcontrol.Stream{})
+			return "ok"
+
 		case "track":
 			var buf strings.Builder
 			for _, line := range strings.Split(d.Input, "\n") {

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker_test.go
@@ -93,7 +93,8 @@ func TestTokenTracker(t *testing.T) {
 				parts[3] = strings.TrimPrefix(parts[3], "pri=")
 				pri := AdmissionToRaftPriority(parsePriority(t, parts[3]))
 
-				tracker.Track(ctx, term, index, pri, kvflowcontrol.Tokens(tokens))
+				tracker.Track(ctx, entryID{index: index, term: term}, pri,
+					kvflowcontrol.Tokens(tokens))
 				buf.WriteString(fmt.Sprintf("tracked: term=%d index=%-2d tokens=%-3d pri=%v\n",
 					term, index, tokens, pri))
 			}

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -116,6 +116,7 @@ type ACWorkQueue interface {
 }
 
 type rangeControllerInitState struct {
+	term          uint64
 	replicaSet    rac2.ReplicaSet
 	leaseholder   roachpb.ReplicaID
 	nextRaftIndex uint64
@@ -707,6 +708,7 @@ func (p *processorImpl) createLeaderStateRaftMuLocked(
 	}
 	p.term = term
 	rc := p.opts.RangeControllerFactory.New(ctx, rangeControllerInitState{
+		term:           term,
 		replicaSet:     p.desc.replicas,
 		leaseholder:    p.leaseholderID,
 		nextRaftIndex:  nextUnstableIndex,
@@ -1204,6 +1206,7 @@ func (f RangeControllerFactoryImpl) New(
 			Knobs:                  f.knobs,
 		},
 		rac2.RangeControllerInitState{
+			Term:          state.term,
 			ReplicaSet:    state.replicaSet,
 			Leaseholder:   state.leaseholder,
 			NextRaftIndex: state.nextRaftIndex,


### PR DESCRIPTION
This PR converts the raw `index, term` pairs in `rac2` package to ones that carry raft log semantics:

- `AdmittedVector` is per leader term, and should be passed around wholesale.
- The entries in `Tracker` are identified by log entry ID, which should be passed around wholesale, to carry the appropriate semantics. These should not be confused with `LogMark`.

---

The last commit fixes premature flow token returns in the token tracker.

Our log (at leader `term`) is:
```
prefix=[other term entries] + suffix=[entryID.term == term]
```

The old code, in the common case (receiving `AdmittedVector` for the current leader `term`), would return tokens for the entire `prefix`, and everything from the `suffix` up to the corresponding admitted index. The problem with this is when the admitted index is in the `prefix` part. Regardless of how low the index is, we will return everything from the
`prefix`. This effectively turns RACv2 into no-op after a leader change. We would "recover" only when admitted indices reach the leader's own entries.

On a stale `AdmittedVector.Term`, we similarly would return a whole prefix of entries < `av.Term`, and maybe a suffix of `av.Term` entries if the index is high enough.

---

Epic: CRDB-37515