### PR TITLE
release: fix location of THIRD-PARTY-NOTICES.txt

### DIFF
--- a/build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh
@@ -74,7 +74,7 @@ if [[ $platform == "linux-amd64" || $platform == "linux-arm64" || $platform == "
     --ungzip \
     --ignore-zeros \
     --strip-components=1
-  cp LICENSE THIRD-PARTY-NOTICES.txt "build/deploy-${platform}"
+  cp LICENSE licenses/THIRD-PARTY-NOTICES.txt "build/deploy-${platform}"
   # Move the libs where Dockerfile expects them to be
   mv build/deploy-${platform}/lib/* build/deploy-${platform}/
   rmdir build/deploy-${platform}/lib

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh
@@ -99,7 +99,7 @@ if [[ $platform == "linux-amd64" || $platform == "linux-arm64" || $platform == "
     --ungzip \
     --ignore-zeros \
     --strip-components=1
-  cp LICENSE THIRD-PARTY-NOTICES.txt "build/deploy-${platform}"
+  cp LICENSE licenses/THIRD-PARTY-NOTICES.txt "build/deploy-${platform}"
   # Move the libs where Dockerfile expects them to be
   mv build/deploy-${platform}/lib/* build/deploy-${platform}/
   rmdir build/deploy-${platform}/lib


### PR DESCRIPTION
The wrong location for THIRD-PARTY-NOTICES.txt was used in two release scripts. Here we fix this to point at the correct location.

Part of RE-658

Release note: none