### PR TITLE
server/license: Change how trial license usage is tracked

### DIFF
--- a/pkg/ccl/utilccl/license_check.go
+++ b/pkg/ccl/utilccl/license_check.go
@@ -26,9 +26,9 @@ import (
 	"github.com/cockroachdb/redact"
 )
 
-// trialLicenseUsageCount keeps track of the number of times a free trial
-// license has already been installed on this cluster.
-var trialLicenseUsageCount atomic.Int64
+// trialLicenseExpiryTimestamp tracks the expiration timestamp of any trial licenses
+// that have been installed on this cluster (past or present).
+var trialLicenseExpiryTimestamp atomic.Int64
 
 var enterpriseLicense = settings.RegisterStringSetting(
 	settings.SystemVisible,
@@ -45,7 +45,8 @@ var enterpriseLicense = settings.RegisterStringSetting(
 				return nil
 			}
 
-			if l.Type == licenseccl.License_Trial && trialLicenseUsageCount.Load() > 0 {
+			if l.Type == licenseccl.License_Trial && trialLicenseExpiryTimestamp.Load() > 0 &&
+				l.ValidUntilUnixSec != trialLicenseExpiryTimestamp.Load() {
 				return errors.WithHint(errors.Newf("a trial license has previously been installed on this cluster"),
 					"Please install a non-trial license to continue")
 			}
@@ -378,12 +379,12 @@ func RegisterCallbackOnLicenseChange(
 		}
 		licenseEnforcer.RefreshForLicenseChange(ctx, licenseType, licenseExpiry)
 
-		cnt, err := licenseEnforcer.CalculateTrialUsageCount(ctx, licenseType, isChange)
+		expiry, err := licenseEnforcer.UpdateTrialLicenseExpiry(ctx, licenseType, isChange, licenseExpiry.Unix())
 		if err != nil {
-			log.Errorf(ctx, "unable to calculate trial license usage count: %v", err)
+			log.Errorf(ctx, "unable to update trial license expiry: %v", err)
 			return
 		}
-		trialLicenseUsageCount.Store(cnt)
+		trialLicenseExpiryTimestamp.Store(expiry)
 	}
 	// Install the hook so that we refresh license details when the license changes.
 	enterpriseLicense.SetOnChange(&st.SV,

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -300,9 +300,8 @@ var (
 	// set during cluster initialization, by which a license must be installed to avoid
 	// throttling. The value is stored as the number of seconds since the Unix epoch.
 	ClusterInitGracePeriodTimestamp = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("lic-gpi-ts")))
-	// TrialLicenseUsageCount is used to keep track of the number of times a trial
-	// license was installed on the cluster.
-	TrialLicenseUsageCount = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("lic-tluc")))
+	// TrialLicenseExpiry is used to track the expiry of any trial license (past or present)
+	TrialLicenseExpiry = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("lic-tle")))
 	//
 	// NodeIDGenerator is the global node ID generator sequence.
 	NodeIDGenerator = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("node-idgen")))

--- a/pkg/keys/doc.go
+++ b/pkg/keys/doc.go
@@ -244,7 +244,7 @@ var _ = [...]interface{}{
 	NodeLivenessPrefix,              // "\x00liveness-"
 	BootstrapVersionKey,             // "bootstrap-version"
 	ClusterInitGracePeriodTimestamp, // "lic-gpi-ts"
-	TrialLicenseUsageCount,          // "lic-tluc"
+	TrialLicenseExpiry,              // "lic-tle"
 	NodeIDGenerator,                 // "node-idgen"
 	RangeIDGenerator,                // "range-idgen"
 	StatusPrefix,                    // "status-"


### PR DESCRIPTION
There’s a race condition when updating the enterprise.license config setting and checking the trial usage count. If a node starts up while a new trial license is being applied, it can encounter an issue where it sees the updated trial usage count in KV before receiving the corresponding enterprise.license config setting. This causes the license update to be rejected, as it incorrectly assumes a trial license has already been used.

This change addresses the issue by modifying what is stored in the KV for the trial license. Instead of tracking the number of trial licenses used, which would ever be 0 or 1, we now store the expiry timestamp of any active or past trial license. The enterprise.license validation function will compare the expiry of the new license against the cached value from KV. If the expiry timestamp is not set or matches the expiry of the new license, the validation will proceed. Otherwise, it will fail as before.

This change will be backported to 24.2, 24.1, 23.2 and 23.1.

Epic: CRDB-39988
Closes #131968
Release note: none