### PR TITLE
tablemetadatacache: mock job execution in TestUpdateTableMetadataCacheJobRunsOnRPCTrigger

### DIFF
--- a/pkg/sql/tablemetadatacache/BUILD.bazel
+++ b/pkg/sql/tablemetadatacache/BUILD.bazel
@@ -46,11 +46,9 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/jobs",
-        "//pkg/jobs/jobspb",
         "//pkg/kv/kvserver",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
-        "//pkg/security/username",
         "//pkg/server",
         "//pkg/server/serverpb",
         "//pkg/sql",

--- a/pkg/sql/tablemetadatacache/table_metadata_updater.go
+++ b/pkg/sql/tablemetadatacache/table_metadata_updater.go
@@ -13,7 +13,6 @@ import (
 	"math"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -48,18 +47,17 @@ type tableMetadataDetails struct {
 var _ tablemetadatacacheutil.ITableMetadataUpdater = &tableMetadataUpdater{}
 
 // newTableMetadataUpdater creates a new tableMetadataUpdater.
-var newTableMetadataUpdater = func(
-	job *jobs.Job,
+func newTableMetadataUpdater(
+	onProgressUpdated func(ctx context.Context, progress float32),
 	metrics *TableMetadataUpdateJobMetrics,
 	ie isql.Executor,
-	testKnobs *tablemetadatacacheutil.TestingKnobs) *tableMetadataUpdater {
+	testKnobs *tablemetadatacacheutil.TestingKnobs,
+) *tableMetadataUpdater {
 	return &tableMetadataUpdater{
-		ie:      ie,
-		metrics: metrics,
-		updateProgress: func(ctx context.Context, progress float32) {
-			updateProgress(ctx, job, progress)
-		},
-		testKnobs: testKnobs,
+		ie:             ie,
+		metrics:        metrics,
+		updateProgress: onProgressUpdated,
+		testKnobs:      testKnobs,
 	}
 }
 

--- a/pkg/sql/tablemetadatacache/update_table_metadata_cache_job.go
+++ b/pkg/sql/tablemetadatacache/update_table_metadata_cache_job.go
@@ -59,7 +59,7 @@ func (j *tableMetadataUpdateJobResumer) Resume(ctx context.Context, execCtxI int
 	}
 
 	if updater == nil {
-		updater = newTableMetadataUpdater(j.job, &metrics, execCtx.ExecCfg().InternalDB.Executor(), testKnobs)
+		updater = newTableMetadataUpdater(j.updateProgress, &metrics, execCtx.ExecCfg().InternalDB.Executor(), testKnobs)
 	}
 	// We must reset the job's num runs to 0 so that it doesn't get
 	// delayed by the job system's exponential backoff strategy.
@@ -130,8 +130,8 @@ func (j *tableMetadataUpdateJobResumer) Resume(ctx context.Context, execCtxI int
 	}
 }
 
-func updateProgress(ctx context.Context, job *jobs.Job, progress float32) {
-	if err := job.NoTxn().FractionProgressed(ctx, jobs.FractionUpdater(progress)); err != nil {
+func (j *tableMetadataUpdateJobResumer) updateProgress(ctx context.Context, progress float32) {
+	if err := j.job.NoTxn().FractionProgressed(ctx, jobs.FractionUpdater(progress)); err != nil {
 		log.Errorf(ctx, "Error updating table metadata log progress. error: %s", err.Error())
 	}
 }

--- a/pkg/sql/tablemetadatacache/update_table_metadata_cache_job_test.go
+++ b/pkg/sql/tablemetadatacache/update_table_metadata_cache_job_test.go
@@ -9,13 +9,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
-	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	tablemetadatacacheutil "github.com/cockroachdb/cockroach/pkg/sql/tablemetadatacache/util"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -34,8 +32,20 @@ func TestUpdateTableMetadataCacheJobRunsOnRPCTrigger(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	jobCompleteCh := make(chan struct{})
 	ctx := context.Background()
-	tc := serverutils.StartCluster(t, 3, base.TestClusterArgs{})
+	tc := serverutils.StartCluster(t, 3, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				TableMetadata: &tablemetadatacacheutil.TestingKnobs{
+					TableMetadataUpdater: &noopUpdater{},
+					OnJobComplete: func() {
+						jobCompleteCh <- struct{}{}
+					},
+				},
+			},
+		},
+	})
 	defer tc.Stopper().Stop(context.Background())
 
 	conn := sqlutils.MakeSQLRunner(tc.ServerConn(0))
@@ -63,25 +73,20 @@ WHERE id = $1 AND claim_instance_id IS NOT NULL`, jobs.UpdateTableMetadataCacheJ
 		return nil
 	})
 
-	metrics := tc.Server(0).JobRegistry().(*jobs.Registry).MetricsStruct().
-		JobSpecificMetrics[jobspb.TypeUpdateTableMetadataCache].(TableMetadataUpdateJobMetrics)
-	testutils.SucceedsSoon(t, func() error {
-		if metrics.NumRuns.Count() != 1 {
-			return errors.New("job hasn't run yet")
-		}
-		row := conn.Query(t,
-			`SELECT running_status FROM crdb_internal.jobs WHERE job_id = $1 AND running_status IS NOT NULL`,
-			jobs.UpdateTableMetadataCacheJobID)
-		if !row.Next() {
-			return errors.New("last_run_time not updated")
-		}
-		var runningStatus string
-		require.NoError(t, row.Scan(&runningStatus))
-		if !strings.Contains(runningStatus, "Job completed at") {
-			return errors.New("running_status not updated")
-		}
-		return nil
-	})
+	// Wait for the job to complete.
+	t.Log("waiting for job to complete")
+	<-jobCompleteCh
+	t.Log("job completed")
+
+	row := conn.Query(t,
+		`SELECT running_status FROM crdb_internal.jobs WHERE job_id = $1 AND running_status IS NOT NULL`,
+		jobs.UpdateTableMetadataCacheJobID)
+	if !row.Next() {
+		t.Fatal("last_run_time not updated")
+	}
+	var runningStatus string
+	require.NoError(t, row.Scan(&runningStatus))
+	require.Containsf(t, runningStatus, "Job completed at", "running_status not updated: %s", runningStatus)
 }
 
 // TestUpdateTableMetadataCacheAutomaticUpdates tests that:
@@ -96,7 +101,7 @@ func TestUpdateTableMetadataCacheAutomaticUpdates(t *testing.T) {
 	ctx := context.Background()
 
 	jobRunCh := make(chan struct{})
-	updater := mockUpdater{jobRunCh: jobRunCh}
+	updater := mockUpdaterWithSignal{jobRunCh: jobRunCh}
 
 	// Server setup.
 	s := serverutils.StartServerOnly(t, base.TestServerArgs{
@@ -177,12 +182,15 @@ func TestUpdateTableMetadataCacheAutomaticUpdates(t *testing.T) {
 	})
 }
 
-type mockUpdater struct {
+// mockUpdaterWithSignal is a mock implementation of ITableMetadataUpdater that
+// records the time of each call to RunUpdater and signals when the job
+// is complete.
+type mockUpdaterWithSignal struct {
 	mockCalls []time.Time
 	jobRunCh  chan struct{}
 }
 
-func (m *mockUpdater) RunUpdater(ctx context.Context) error {
+func (m *mockUpdaterWithSignal) RunUpdater(ctx context.Context) error {
 	log.Info(ctx, "mockUpdater.RunUpdater started")
 	m.mockCalls = append(m.mockCalls, time.Now())
 	m.jobRunCh <- struct{}{}
@@ -190,4 +198,12 @@ func (m *mockUpdater) RunUpdater(ctx context.Context) error {
 	return nil
 }
 
-var _ tablemetadatacacheutil.ITableMetadataUpdater = &mockUpdater{}
+var _ tablemetadatacacheutil.ITableMetadataUpdater = &mockUpdaterWithSignal{}
+
+type noopUpdater struct{}
+
+func (nu *noopUpdater) RunUpdater(_ctx context.Context) error {
+	return nil
+}
+
+var _ tablemetadatacacheutil.ITableMetadataUpdater = &noopUpdater{}


### PR DESCRIPTION
Mock the update job's execution for the test
TestUpdateTableMetadataCacheJobRunsOnRPCTrigger since
this test is just to validate that we can trigger the job
via an RPC. Allowing the update job to run normally can
lead to flakiness due to timeouts.

We also modify the signature of the newTableMetadataUpdater
such that it doesn't need a job.


Fixes: #132138

Release note: None