### PR TITLE
cluster-ui: add time since last updated text

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/components/tableMetadataLastUpdated/tableMetadataJobControl.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/components/tableMetadataLastUpdated/tableMetadataJobControl.tsx
@@ -82,6 +82,7 @@ export const TableMetadataJobControl: React.FC<
     // Force refresh.
     triggerUpdateTableMetaJob(false);
   };
+  const durationText = jobStatus?.lastCompletedTime?.fromNow();
 
   const isRunning = jobStatus?.currentStatus === TableMetadataJobStatus.RUNNING;
   return (
@@ -98,6 +99,7 @@ export const TableMetadataJobControl: React.FC<
             time={jobStatus?.lastCompletedTime}
             fallback={"Never"}
           />{" "}
+          {durationText && `(${durationText})`}
         </Tooltip>
       </Skeleton>
       <Tooltip placement="top" title={"Refresh data"}>


### PR DESCRIPTION
This commit adds the time since the last updated to the TableMetadataJobControl component. For example, if the current time was Oct 5 11:00 UTC and the last update was Oct 5 10:50 UTC the component will now
display:
`Last refreshed: [Formatted timestamp] (10 minutes ago)`.

Epic: CRDB-37558
Release note: None