### PR TITLE
logictest: attempt to deflake test by using a different table

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/synthetic_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/synthetic_privileges
@@ -289,10 +289,10 @@ statement ok
 CREATE USER testuser4
 
 statement ok
-REVOKE SELECT ON crdb_internal.tables FROM public
+REVOKE SELECT ON crdb_internal.feature_usage FROM public
 
 query B retry
-SELECT has_table_privilege('testuser4', 'crdb_internal.tables', 'SELECT')
+SELECT has_table_privilege('testuser4', 'crdb_internal.feature_usage', 'SELECT')
 ----
 false
 
@@ -300,24 +300,24 @@ statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 
 statement ok
-GRANT SELECT ON crdb_internal.tables TO testuser4
+GRANT SELECT ON crdb_internal.feature_usage TO testuser4
 
 query TTTT
 SELECT username, path, privileges, grant_options FROM system.privileges ORDER BY 1,2
 ----
-public     /vtable/crdb_internal/tables  {}                                         {}
-root       /global/                      {MODIFYCLUSTERSETTING}                     {}
-testuser   /externalconn/foo             {USAGE}                                    {}
-testuser   /global/                      {MODIFYCLUSTERSETTING}                     {}
-testuser   /vtable/crdb_internal/tables  {SELECT}                                   {}
-testuser2  /externalconn/foo             {USAGE}                                    {}
-testuser2  /global/                      {MODIFYCLUSTERSETTING}                     {}
-testuser3  /global/                      {EXTERNALCONNECTION,MODIFYCLUSTERSETTING}  {}
-testuser4  /vtable/crdb_internal/tables  {SELECT}                                   {}
+public     /vtable/crdb_internal/feature_usage  {}                                         {}
+root       /global/                             {MODIFYCLUSTERSETTING}                     {}
+testuser   /externalconn/foo                    {USAGE}                                    {}
+testuser   /global/                             {MODIFYCLUSTERSETTING}                     {}
+testuser   /vtable/crdb_internal/tables         {SELECT}                                   {}
+testuser2  /externalconn/foo                    {USAGE}                                    {}
+testuser2  /global/                             {MODIFYCLUSTERSETTING}                     {}
+testuser3  /global/                             {EXTERNALCONNECTION,MODIFYCLUSTERSETTING}  {}
+testuser4  /vtable/crdb_internal/feature_usage  {SELECT}                                   {}
 
 # This should not cache the uncommitted privilege.
 query B
-SELECT has_table_privilege('testuser4', 'crdb_internal.tables', 'SELECT')
+SELECT has_table_privilege('testuser4', 'crdb_internal.feature_usage', 'SELECT')
 ----
 true
 
@@ -327,17 +327,17 @@ ROLLBACK
 query TTTT
 SELECT username, path, privileges, grant_options FROM system.privileges ORDER BY 1,2
 ----
-public     /vtable/crdb_internal/tables  {}                                         {}
-root       /global/                      {MODIFYCLUSTERSETTING}                     {}
-testuser   /externalconn/foo             {USAGE}                                    {}
-testuser   /global/                      {MODIFYCLUSTERSETTING}                     {}
-testuser   /vtable/crdb_internal/tables  {SELECT}                                   {}
-testuser2  /externalconn/foo             {USAGE}                                    {}
-testuser2  /global/                      {MODIFYCLUSTERSETTING}                     {}
-testuser3  /global/                      {EXTERNALCONNECTION,MODIFYCLUSTERSETTING}  {}
+public     /vtable/crdb_internal/feature_usage  {}                                         {}
+root       /global/                             {MODIFYCLUSTERSETTING}                     {}
+testuser   /externalconn/foo                    {USAGE}                                    {}
+testuser   /global/                             {MODIFYCLUSTERSETTING}                     {}
+testuser   /vtable/crdb_internal/tables         {SELECT}                                   {}
+testuser2  /externalconn/foo                    {USAGE}                                    {}
+testuser2  /global/                             {MODIFYCLUSTERSETTING}                     {}
+testuser3  /global/                             {EXTERNALCONNECTION,MODIFYCLUSTERSETTING}  {}
 
 query B
-SELECT has_table_privilege('testuser4', 'crdb_internal.tables', 'SELECT')
+SELECT has_table_privilege('testuser4', 'crdb_internal.feature_usage', 'SELECT')
 ----
 false
 


### PR DESCRIPTION
We have seen contention on the synthetic privilege row for crdb_internal.tables. This attempts to deflake the test by using a different table, just in case some other operation is relying on the crdb_internal.tables key.

fixes https://github.com/cockroachdb/cockroach/issues/131998
Release note: None