### PR TITLE
testccl: update tests to `BACKUP INTO` syntax

### DIFF
--- a/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
+++ b/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
@@ -92,7 +92,7 @@ func TestWorkload(t *testing.T) {
 				FROM system.descriptor
 				LEFT JOIN system.namespace ON namespace.id = descriptor.id
 		`))
-		tdb.Exec(t, "BACKUP DATABASE schemachange TO 'nodelocal://1/backup'")
+		tdb.Exec(t, "BACKUP DATABASE schemachange INTO 'nodelocal://1/backup'")
 		t.Logf("backup, tracing data, and system table dumps in %s", dir)
 	}()
 


### PR DESCRIPTION
Several tests still use the old `BACKUP TO` syntax. This patch updates some of the tests to the new `BACKUP INTO` syntax.

Epic: none

Release note: None