### PR TITLE
multiregionccl: update tests to new `BACKUP`/`RESTORE` syntax

### DIFF
--- a/pkg/ccl/multiregionccl/region_test.go
+++ b/pkg/ccl/multiregionccl/region_test.go
@@ -932,8 +932,8 @@ func testRegionAddDropWithConcurrentBackupOps(
 	}{
 		{
 			name:      "backup-database",
-			backupOp:  `BACKUP DATABASE db TO 'nodelocal://1/db_backup'`,
-			restoreOp: `RESTORE DATABASE db FROM 'nodelocal://1/db_backup'`,
+			backupOp:  `BACKUP DATABASE db INTO 'nodelocal://1/db_backup'`,
+			restoreOp: `RESTORE DATABASE db FROM LATEST IN 'nodelocal://1/db_backup'`,
 		},
 	}
 


### PR DESCRIPTION
Several tests still use the old `BACKUP`/`RESTORE` syntax. This patch updates some of the tests to the new `BACKUP INTO` and `RESTORE FROM ... IN ...` syntax.

Epic: none

Release note: None