### PR TITLE
logictest: add kv tracing to testcase for 131869

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -325,7 +325,8 @@ import (
 //            if kvtrace(CPut,Del,prefix=/Table/54,prefix=/Table/55), the
 //            results will be filtered to contain messages starting with
 //            CPut /Table/54, CPut /Table/55, Del /Table/54, Del /Table/55.
-//            Cannot be combined with noticetrace.
+//            Tenant IDs do not need to be included in prefixes and will be
+//            removed from results. Cannot be combined with noticetrace.
 //      - noticetrace: runs the query and compares only the notices that
 //						appear. Cannot be combined with kvtrace.
 //      - nodeidx=N: runs the query on node N of the cluster.
@@ -2800,6 +2801,9 @@ func (t *logicTest) processSubtest(
 							for _, c := range strings.Split(s, ",") {
 								if strings.HasPrefix(c, "prefix=") {
 									matched := strings.TrimPrefix(c, "prefix=")
+									if len(t.tenantApps) != 0 || t.cluster.StartedDefaultTestTenant() {
+										matched = "/Tenant/%" + matched
+									}
 									query.keyPrefixFilters = append(query.keyPrefixFilters, matched)
 								} else if isAllowedKVOp(c) {
 									query.kvOpTypes = append(query.kvOpTypes, c)
@@ -2981,7 +2985,11 @@ func (t *logicTest) processSubtest(
 						return err
 					}
 
-					queryPrefix := `SELECT message FROM [SHOW KV TRACE FOR SESSION] `
+					projection := `message`
+					if len(t.tenantApps) != 0 || t.cluster.StartedDefaultTestTenant() {
+						projection = `regexp_replace(message, '/Tenant/\d+', '')`
+					}
+					queryPrefix := fmt.Sprintf(`SELECT %s FROM [SHOW KV TRACE FOR SESSION] `, projection)
 					buildQuery := func(ops []string, keyFilters []string) string {
 						var sb strings.Builder
 						sb.WriteString(queryPrefix)
@@ -2995,7 +3003,7 @@ func (t *logicTest) processSubtest(
 								} else {
 									sb.WriteString("OR ")
 								}
-								sb.WriteString(fmt.Sprintf("message like '%s %s%%'", c, f))
+								sb.WriteString(fmt.Sprintf("message like '%s %s%%' ", c, f))
 							}
 						}
 						return sb.String()

--- a/pkg/sql/logictest/testdata/logic_test/column_families
+++ b/pkg/sql/logictest/testdata/logic_test/column_families
@@ -85,22 +85,32 @@ fetched: /t/t_pkey/1/2/z -> /1
 statement ok
 CREATE TABLE abc (a INT NOT NULL, b FLOAT NOT NULL, c INT, FAMILY (a), FAMILY (b), FAMILY (c))
 
-statement ok
+query T regexp,kvtrace(prefix=/Table/109)
 INSERT INTO abc VALUES (4, -0, 6)
+----
+CPut /Table/109/1/\d+/0 -> /TUPLE/1:1:Int/4
+CPut /Table/109/1/\d+/1/1 -> /FLOAT/-0
+CPut /Table/109/1/\d+/2/1 -> /INT/6
 
 statement ok
 ALTER TABLE abc ADD PRIMARY KEY (a, b)
 
-statement ok
+query T kvtrace(prefix=/Table/109)
 UPDATE abc SET c = NULL WHERE a = 4 AND b = -0
+----
+Scan /Table/109/4/4/0{-/PrefixEnd} lock Exclusive (Block, Unreplicated)
+Del /Table/109/4/4/0/2/1
 
 query IFI
 SELECT * FROM abc
 ----
 4  -0  NULL
 
-statement ok
-UPDATE abc SET b = 0 WHERE a = 4 AND b = -0;
+query T kvtrace(prefix=/Table/109)
+UPDATE abc SET b = 0 WHERE a = 4 AND b = -0
+----
+Scan /Table/109/4/4/0{-/PrefixEnd} lock Exclusive (Block, Unreplicated)
+Del /Table/109/4/4/0/1/1
 
 query IFI
 SELECT * FROM abc


### PR DESCRIPTION
This helps show what is happening. Also make the kvtrace option handle keys with tenant prefixes.

Informs: #131860

Release note: None