### PR TITLE
sql/delegate: refactor comments table code and remove usage of `system.comments` table

### DIFF
--- a/pkg/sql/delegate/BUILD.bazel
+++ b/pkg/sql/delegate/BUILD.bazel
@@ -45,7 +45,6 @@ go_library(
         "//pkg/jobs/jobspb",
         "//pkg/security/username",
         "//pkg/settings",
-        "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/decodeusername",
         "//pkg/sql/lexbase",

--- a/pkg/sql/delegate/delegate.go
+++ b/pkg/sql/delegate/delegate.go
@@ -7,6 +7,7 @@ package delegate
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -269,4 +270,24 @@ func (d *delegator) resolveAndModifyTableIndexName(
 		(*name).Table = resName.ToUnresolvedObjectName().ToTableName()
 	}
 	return dataSource, resName, nil
+}
+
+func (d *delegator) getCommentQuery(
+	commentTableName string, classOidType int, objIdColumn string,
+) (string, string) {
+	commentColumn := `, comment`
+	commentJoin := fmt.Sprintf(`
+			LEFT JOIN
+				(
+					SELECT 
+						objoid, description as comment
+					FROM
+						%s
+					WHERE
+						classoid = %d
+				) c
+			ON
+				%s = c.objoid`, commentTableName, classOidType, objIdColumn)
+
+	return commentColumn, commentJoin
 }

--- a/pkg/sql/delegate/show_databases.go
+++ b/pkg/sql/delegate/show_databases.go
@@ -8,40 +8,29 @@ package delegate
 import (
 	"fmt"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
+	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
 func (d *delegator) delegateShowDatabases(stmt *tree.ShowDatabases) (tree.Statement, error) {
-	query := `SELECT
-	name AS database_name, owner, primary_region, secondary_region, regions, survival_goal`
 
+	commentColumn, commentJoin := ``, ``
 	if stmt.WithComment {
-		query += `, comment`
+		commentTableName := lexbase.EscapeSQLIdent(d.evalCtx.SessionData().Database) + ".pg_catalog.pg_shdescription"
+		commentColumn, commentJoin = d.getCommentQuery(commentTableName, catconstants.PgCatalogDatabaseTableID, "d.id")
 	}
 
-	query += `
-FROM
-  "".crdb_internal.databases d
-`
-	if stmt.WithComment {
-		query += fmt.Sprintf(`
-LEFT JOIN
-	(
-		SELECT 
-			object_id, type, comment
-		FROM
-			system.comments
-		WHERE
-			type = %d
-	) c
-ON
-	c.object_id = d.id`, catalogkeys.DatabaseCommentType)
-	}
-
-	query += `
-ORDER BY
-	database_name`
+	query := fmt.Sprintf(`
+			SELECT
+				name AS database_name, 
+				owner, 
+				primary_region, 
+				secondary_region, 
+				regions,
+				survival_goal %s
+			FROM "".crdb_internal.databases d %s
+			ORDER BY database_name`, commentColumn, commentJoin)
 
 	return d.parse(query)
 }

--- a/pkg/sql/delegate/show_schemas.go
+++ b/pkg/sql/delegate/show_schemas.go
@@ -8,9 +8,9 @@ package delegate
 import (
 	"fmt"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 )
@@ -23,21 +23,12 @@ func (d *delegator) delegateShowSchemas(n *tree.ShowSchemas) (tree.Statement, er
 	if err != nil {
 		return nil, err
 	}
+
 	commentColumn, commentJoin := ``, ``
 	if n.WithComment {
-		commentColumn = `, comment`
-		commentJoin = fmt.Sprintf(`
-			LEFT JOIN
-				(
-					SELECT 
-						object_id, type, comment
-					FROM
-						system.comments
-					WHERE
-						type = %d
-				) c
-			ON
-				c.object_id = n.oid`, catalogkeys.SchemaCommentType)
+		commentTableName := name.String() + ".pg_catalog.pg_description"
+		commentColumn, commentJoin = d.getCommentQuery(commentTableName, catconstants.PgCatalogNamespaceTableID, "n.oid")
+
 	}
 
 	getSchemasQuery := fmt.Sprintf(`

--- a/pkg/sql/delegate/show_types.go
+++ b/pkg/sql/delegate/show_types.go
@@ -19,19 +19,8 @@ func (d *delegator) delegateShowTypes(n *tree.ShowTypes) (tree.Statement, error)
 	dbName := lexbase.EscapeSQLIdent(d.evalCtx.SessionData().Database)
 	commentColumn, commentJoin := ``, ``
 	if n.WithComment {
-		commentColumn = `, comment`
-		commentJoin = fmt.Sprintf(`
-			LEFT JOIN
-				(
-					SELECT 
-						objoid, description as comment
-					FROM
-						%s.pg_catalog.pg_description
-					WHERE
-						classoid = %d
-				) c
-			ON
-				 	(types.oid::int - 100000) = c.objoid`, dbName, catconstants.PgCatalogTypeTableID)
+		commentTableName := dbName + ".pg_catalog.pg_description"
+		commentColumn, commentJoin = d.getCommentQuery(commentTableName, catconstants.PgCatalogTypeTableID, "(types.oid::int - 100000)")
 	}
 
 	// Query all enum and composite types. Two explanations about the WHERE


### PR DESCRIPTION
Show schemas with comment and show databases with comment rely on
system.comments table.

system.comments which is currently being used is a low level internal
table so it's possible that it can be changed in the future. This change
aims to use the `pg_catalog.pg_description` and
`pg_catalog.pg_shdescription` table

Fixes: https://github.com/cockroachdb/cockroach/issues/132201 
Release note: None
