### PR TITLE
release-23.1: server/license: Change how trial license usage is tracked

### DIFF
--- a/pkg/ccl/utilccl/license_check.go
+++ b/pkg/ccl/utilccl/license_check.go
@@ -27,9 +27,9 @@ import (
 	"github.com/cockroachdb/redact"
 )
 
-// trialLicenseUsageCount keeps track of the number of times a free trial
-// license has already been installed on this cluster.
-var trialLicenseUsageCount atomic.Int64
+// trialLicenseExpiryTimestamp tracks the expiration timestamp of any trial licenses
+// that have been installed on this cluster (past or present).
+var trialLicenseExpiryTimestamp atomic.Int64
 
 var enterpriseLicense = func() *settings.StringSetting {
 	s := settings.RegisterValidatedStringSetting(
@@ -42,11 +42,16 @@ var enterpriseLicense = func() *settings.StringSetting {
 			if err != nil {
 				return err
 			}
-			if l != nil && l.Type == licenseccl.License_Trial && trialLicenseUsageCount.Load() > 0 {
+			if l == nil {
+				return nil
+			}
+
+			if l.Type == licenseccl.License_Trial && trialLicenseExpiryTimestamp.Load() > 0 &&
+				l.ValidUntilUnixSec != trialLicenseExpiryTimestamp.Load() {
 				return errors.WithHint(errors.Newf("a trial license has previously been installed on this cluster"),
 					"Please install a non-trial license to continue")
 			}
-			return err
+			return nil
 		},
 	)
 	// Even though string settings are non-reportable by default, we
@@ -368,12 +373,12 @@ func RegisterCallbackOnLicenseChange(
 		}
 		licenseEnforcer.RefreshForLicenseChange(ctx, licenseType, licenseExpiry)
 
-		cnt, err := licenseEnforcer.CalculateTrialUsageCount(ctx, licenseType, isChange)
+		expiry, err := licenseEnforcer.UpdateTrialLicenseExpiry(ctx, licenseType, isChange, licenseExpiry.Unix())
 		if err != nil {
-			log.Errorf(ctx, "unable to calculate trial license usage count: %v", err)
+			log.Errorf(ctx, "unable to update trial license expiry: %v", err)
 			return
 		}
-		trialLicenseUsageCount.Store(cnt)
+		trialLicenseExpiryTimestamp.Store(expiry)
 	}
 	// Install the hook so that we refresh license details when the license changes.
 	enterpriseLicense.SetOnChange(&st.SV,

--- a/pkg/ccl/utilccl/license_check_test.go
+++ b/pkg/ccl/utilccl/license_check_test.go
@@ -84,6 +84,9 @@ func TestSettingAndCheckingLicense(t *testing.T) {
 
 func TestGetLicenseTypePresent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer func() {
+		trialLicenseExpiryTimestamp.Store(0)
+	}()
 
 	ctx := context.Background()
 	for _, tc := range []struct {
@@ -150,6 +153,9 @@ func TestSettingBadLicenseStrings(t *testing.T) {
 
 func TestTimeToEnterpriseLicenseExpiry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer func() {
+		trialLicenseExpiryTimestamp.Store(0)
+	}()
 
 	ctx := context.Background()
 	id, _ := uuid.FromString("A0000000-0000-0000-0000-00000000000A")
@@ -315,15 +321,21 @@ func TestRefreshLicenseEnforcerOnLicenseChange(t *testing.T) {
 		{[]string{"crl-0-EMDYt8MDGAEiDkNSREIgVW5pdCBUZXN0KAM"}, "", timeutil.UnixEpoch},
 		// No license - 7 days grace period
 		{[]string{""}, "", ts1.Add(30 * 24 * time.Hour)},
-		// Only 1 trial license allowed
+		// Two trial license allowed if they both have the same expiry
 		{[]string{"crl-0-EMDYt8MDGAQiDkNSREIgVW5pdCBUZXN0", "crl-0-EMDYt8MDGAQiDkNSREIgVW5pdCBUZXN0"},
+			"", jan1st2000.Add(7 * 24 * time.Hour)},
+		// A second trial license is not allowed if it has a different expiry (Jan 1st 2000 8:01 AST)
+		{[]string{"crl-0-EMDYt8MDGAQiDkNSREIgVW5pdCBUZXN0KAM", "crl-0-EPzYt8MDGAQiDkNSREIgVW5pdCBUZXN0"},
 			"a trial license has previously been installed on this cluster", timeutil.UnixEpoch},
 	} {
 		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
-			// Reset from prior test unit.
-			cnt, err := enforcer.SetTrialUsageCount(ctx, 0, false /* checkOldCount */)
-			require.NoError(t, err)
-			require.Equal(t, int64(0), cnt)
+			// Reset at the end of the test unit
+			defer func() {
+				err = enforcer.TestingResetTrialUsage(ctx)
+				require.NoError(t, err)
+				trialLicenseExpiryTimestamp.Store(0)
+			}()
+			require.Equal(t, int64(0), trialLicenseExpiryTimestamp.Load())
 
 			tdb := sqlutils.MakeSQLRunner(sqlDB)
 
@@ -333,17 +345,17 @@ func TestRefreshLicenseEnforcerOnLicenseChange(t *testing.T) {
 				tdb.Exec(t, sql)
 
 				// If installing a trial license, we need to wait for the callback to
-				// bump the count before continuing. We depend on the count to cause an
+				// bump the expiry before continuing. We depend on the expiry to cause an
 				// error if another trial license is installed.
 				l, err := decode(tc.licenses[i])
 				require.NoError(t, err)
 				if l.Type == licenseccl.License_Trial {
-					var cnt int64
+					var expiry int64
 					require.Eventually(t, func() bool {
-						cnt = trialLicenseUsageCount.Load()
-						return cnt > 0
+						expiry = trialLicenseExpiryTimestamp.Load()
+						return expiry > 0
 					}, 20*time.Second, time.Millisecond,
-						"trialLicenseUsageCount last returned %t", cnt)
+						"trialLicenseExpiryTimestamp last returned %t", expiry)
 				}
 			}
 
@@ -365,7 +377,7 @@ func TestRefreshLicenseEnforcerOnLicenseChange(t *testing.T) {
 				hasLicense = enforcer.GetHasLicense()
 				return (lastLicense != "") == hasLicense
 			}, 20*time.Second, time.Millisecond,
-				"GetHasLicense() last returned %t", hasLicense)
+				"GetHasLicense() did not return hasLicense of %t in time", lastLicense != "")
 			var ts time.Time
 			var hasGracePeriod bool
 			require.Eventually(t, func() bool {
@@ -375,7 +387,7 @@ func TestRefreshLicenseEnforcerOnLicenseChange(t *testing.T) {
 				}
 				return ts.Equal(tc.expectedGracePeriodEnd)
 			}, 20*time.Second, time.Millisecond,
-				"GetGracePeriodEndTS() last returned %v (%t)", ts, hasGracePeriod)
+				"GetGracePeriodEndTS() did not return grace period of %s in time", tc.expectedGracePeriodEnd.String())
 		})
 	}
 }

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -285,9 +285,8 @@ var (
 	// set during cluster initialization, by which a license must be installed to avoid
 	// throttling. The value is stored as the number of seconds since the Unix epoch.
 	ClusterInitGracePeriodTimestamp = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("lic-gpi-ts")))
-	// TrialLicenseUsageCount is used to keep track of the number of times a trial
-	// license was installed on the cluster.
-	TrialLicenseUsageCount = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("lic-tluc")))
+	// TrialLicenseExpiry is used to track the expiry of any trial license (past or present)
+	TrialLicenseExpiry = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("lic-tle")))
 	//
 	// LegacyDescIDGenerator is the legacy global descriptor ID generator sequence
 	// used for table and namespace IDs for the system tenant in clusters <23.1.

--- a/pkg/keys/doc.go
+++ b/pkg/keys/doc.go
@@ -241,7 +241,7 @@ var _ = [...]interface{}{
 	BootstrapVersionKey,             // "bootstrap-version"
 	LegacyDescIDGenerator,           // "desc-idgen"
 	ClusterInitGracePeriodTimestamp, // "lic-gpi-ts"
-	TrialLicenseUsageCount,          // "lic-tluc"
+	TrialLicenseExpiry,              // "lic-tle"
 	NodeIDGenerator,                 // "node-idgen"
 	RangeIDGenerator,                // "range-idgen"
 	StatusPrefix,                    // "status-"

--- a/pkg/server/license/enforcer.go
+++ b/pkg/server/license/enforcer.go
@@ -83,9 +83,10 @@ type Enforcer struct {
 	// are bypassed. This is typically used to disable enforcement for single-node deployments.
 	isDisabled atomic.Bool
 
-	// trialUsageCount keeps track of the number of times a free trial license has
-	// been used on this cluster.
-	trialUsageCount atomic.Int64
+	// trialUsageExpiry records the expiration timestamp, in seconds, of any
+	// trial license on this cluster (past or present). A value of 0 indicates
+	// that no trial license has ever been installed.
+	trialUsageExpiry atomic.Int64
 
 	// db is a pointer to the database for use for KV read/writes. This is only
 	// set for the system tenant.
@@ -231,17 +232,18 @@ func (e *Enforcer) readClusterMetadata(ctx context.Context, options options) err
 	e.db = options.db
 
 	return options.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		// Cache the current trial usage count.
-		trialUsageCount, err := txn.KV().Get(ctx, keys.TrialLicenseUsageCount)
+		// Cache the current trial license expiry
+		trialUsageCount, err := txn.KV().Get(ctx, keys.TrialLicenseExpiry)
 		if err != nil {
 			return err
 		}
 		if trialUsageCount.Value == nil {
-			e.trialUsageCount.Store(0)
+			e.trialUsageExpiry.Store(0)
 		} else {
-			e.trialUsageCount.Store(trialUsageCount.ValueInt())
+			e.trialUsageExpiry.Store(trialUsageCount.ValueInt())
 		}
-		log.Infof(ctx, "trial license usage count initialized to %d", e.trialUsageCount.Load())
+		log.Infof(ctx, "trial license expiry initialized to %s",
+			timeutil.Unix(e.trialUsageExpiry.Load(), 0))
 
 		// Cache and maybe set the cluster init grace period timestamp. This is the
 		// grace period we will use if the cluster does not have a license installed.
@@ -457,63 +459,60 @@ func (e *Enforcer) RefreshForLicenseChange(
 	log.Infof(ctx, "%s", sb.String())
 }
 
-// CalculateTrialUsageCount returns the number of times a trial license has
-// been used, including the current trial license if a new one is being applied.
-// This function increments the count if the current license is changing and is a trial.
-func (e *Enforcer) CalculateTrialUsageCount(
-	ctx context.Context, currentLicense LicType, isLicenseChange bool,
-) (int64, error) {
+// UpdateTrialLicenseExpiry returns the expiration timestamp of any trial license
+// used on the cluster, including the new trial license if a change is being applied.
+// This function updates the expiry if the current license is changing and is a trial.
+func (e *Enforcer) UpdateTrialLicenseExpiry(
+	ctx context.Context, currentLicense LicType, isLicenseChange bool, expiry int64,
+) (curExpiry int64, err error) {
 	// If we aren't setting a new trial license, return the cached copy. The e.db
 	// check is necessary as that's needed to read/write to the KV. This will be
 	// set for the system tenant, which is where the license can ever be set anyway.
 	if currentLicense != LicTypeTrial || !isLicenseChange || e.db == nil {
-		return e.trialUsageCount.Load(), nil
+		return e.trialUsageExpiry.Load(), nil
 	}
 
-	return e.SetTrialUsageCount(ctx, e.trialUsageCount.Load()+1, true)
-}
-
-// SetTrialUsageCount is an API to set the trial usage count in the enforcer and
-// in the KV. The value in the enforcer is always updated. If checkOldCount is
-// true, the update to the KV is conditional on the old value matching trialUsageCount.
-func (e *Enforcer) SetTrialUsageCount(
-	ctx context.Context, newCount int64, checkOldCount bool,
-) (cnt int64, err error) {
-	if e.db == nil {
-		return 0, errors.AssertionFailedf("no database set")
-	}
 	err = e.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		// If checking the old count, we only do the update in the KV if the
-		// existing value for trialUsageCount matches what's in the KV already
-		// (a missing key is treated as 0). This is necessary to ensure a license
-		// change to use the trial license will only increase the count by 1 when
-		// this function is called for each node.
-		if checkOldCount {
-			oldVal, err := txn.KV().Get(ctx, keys.TrialLicenseUsageCount)
-			if err != nil {
-				return err
-			}
-			if oldVal.Value == nil && e.trialUsageCount.Load() != 0 {
-				e.trialUsageCount.Store(0)
-				return nil
-			} else if oldVal.Value != nil && oldVal.ValueInt() != e.trialUsageCount.Load() {
-				e.trialUsageCount.Store(oldVal.ValueInt())
-				return nil
-			}
-		}
-		err = txn.KV().Put(ctx, keys.TrialLicenseUsageCount, newCount)
+		// We only allow a single trial license to be installed. If one is
+		// already set in the KV, exit and return that expiry value.
+		oldVal, err := txn.KV().Get(ctx, keys.TrialLicenseExpiry)
 		if err != nil {
 			return err
 		}
-		e.trialUsageCount.Store(newCount)
+		if oldVal.Value != nil && oldVal.ValueInt() > 0 {
+			e.trialUsageExpiry.Store(oldVal.ValueInt())
+			return nil
+		}
+		err = txn.KV().Put(ctx, keys.TrialLicenseExpiry, expiry)
+		if err != nil {
+			return err
+		}
+		e.trialUsageExpiry.Store(expiry)
 		return nil
 	})
 	if err != nil {
 		return
 	}
-	cnt = e.trialUsageCount.Load()
-	log.Infof(ctx, "trial license usage count is %d", cnt)
+	curExpiry = e.trialUsageExpiry.Load()
+	log.Infof(ctx, "trial license expiry timestamp is %s", timeutil.Unix(curExpiry, 0))
 	return
+}
+
+// TestingResetTrialUsage is an API to clear the license expiry in the KV. This is only used
+// for test purposes.
+func (e *Enforcer) TestingResetTrialUsage(ctx context.Context) error {
+	if e.db == nil {
+		return errors.AssertionFailedf("no database set")
+	}
+	return e.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		err := txn.KV().Put(ctx, keys.TrialLicenseExpiry, 0)
+		if err != nil {
+			return err
+		}
+		e.trialUsageExpiry.Store(0)
+		log.Infof(ctx, "trial license expiry was reset")
+		return nil
+	})
 }
 
 // Disable turns off all license enforcement for the lifetime of this object.


### PR DESCRIPTION
Backport 1/1 commits from #132177.

/cc @cockroachdb/release

---

There’s a race condition when updating the enterprise.license config setting and checking the trial usage count. If a node starts up while a new trial license is being applied, it can encounter an issue where it sees the updated trial usage count in KV before receiving the corresponding enterprise.license config setting. This causes the license update to be rejected, as it incorrectly assumes a trial license has already been used.

This change addresses the issue by modifying what is stored in the KV for the trial license. Instead of tracking the number of trial licenses used, which would ever be 0 or 1, we now store the expiry timestamp of any active or past trial license. The enterprise.license validation function will compare the expiry of the new license against the cached value from KV. If the expiry timestamp is not set or matches the expiry of the new license, the validation will proceed. Otherwise, it will fail as before.

This change will be backported to 24.2, 24.1, 23.2 and 23.1.

Epic: CRDB-39988
Closes #131968
Release note: none
Release justification: This work is part of the CockroachDB core deprecation.