### PR TITLE
ldapccl: only attempt LDAP authorization if `ldapgrouplistfilter` is set

### DIFF
--- a/pkg/ccl/ldapccl/authentication_ldap_test.go
+++ b/pkg/ccl/ldapccl/authentication_ldap_test.go
@@ -7,7 +7,6 @@ package ldapccl
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"testing"
 
@@ -27,9 +26,10 @@ func TestLDAPFetchUser(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	// Intercept the call to NewLDAPUtil and return the mocked NewLDAPUtil function
+	_, newMockLDAPUtil := LDAPMocks()
 	defer testutils.TestingHook(
 		&NewLDAPUtil,
-		NewMockLDAPUtil)()
+		newMockLDAPUtil)()
 	ctx := context.Background()
 	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
@@ -129,11 +129,10 @@ func TestLDAPAuthentication(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	// Intercept the call to NewLDAPUtil and return the mocked NewLDAPUtil function
+	_, newMockLDAPUtil := LDAPMocks()
 	defer testutils.TestingHook(
 		&NewLDAPUtil,
-		func(ctx context.Context, conf ldapConfig) (ILDAPUtil, error) {
-			return &mockLDAPUtil{tlsConfig: &tls.Config{}}, nil
-		})()
+		newMockLDAPUtil)()
 	ctx := context.Background()
 	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)

--- a/pkg/ccl/ldapccl/ldap_manager.go
+++ b/pkg/ccl/ldapccl/ldap_manager.go
@@ -32,8 +32,9 @@ var (
 	// ldapSearchRe performs a regex match for ldap search options provided in HBA
 	// configuration. This generally adheres to the format "(key=value)" with
 	// interleaved spaces but could be more flexible as value field could be
-	// provided as a regex string(mail=*@example.com), a key-value distinguished
-	// name(memberOf="CN=test") or a combination of both(memberOf="CN=Sh*").
+	// provided as a wildcard match string(mail=*@example.com), a key-value
+	// distinguished name("memberOf=CN=test") or a combination of
+	// both("memberOf=CN=Sh*").
 	//
 	// The regex string is kept generic as search options could also contain
 	// multiple search entries like "(key1=value1)(key2=value2)".

--- a/pkg/ccl/testccl/authccl/BUILD.bazel
+++ b/pkg/ccl/testccl/authccl/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//pkg/ccl",
         "//pkg/ccl/jwtauthccl",
         "//pkg/ccl/ldapccl",
+        "//pkg/security/distinguishedname",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/security/username",

--- a/pkg/ccl/testccl/authccl/testdata/ldap
+++ b/pkg/ccl/testccl/authccl/testdata/ldap
@@ -5,8 +5,8 @@ config secure
 
 sql
 CREATE USER ldap_user;
-CREATE USER test;
-CREATE USER test2;
+CREATE ROLE ldap_user_parent_1;
+CREATE ROLE ldap_user_parent_2;
 ----
 ok
 
@@ -164,5 +164,67 @@ host     all      unknown_sql_user 127.0.0.1/32 ldap          ldapserver=localho
 connect user=unknown_sql_user password="valid"
 ----
 ERROR: password authentication failed for user unknown_sql_user (SQLSTATE 28P01)
+
+subtest end
+
+subtest no_sync_grouplistfilter_not_set
+
+set_hba
+host  all ldap_user 127.0.0.1/32 ldap ldapserver=localhost ldapport=636 ldapbasedn="O=security org,DC=localhost" ldapbinddn="CN=service_account,O=security org,DC=localhost" ldapbindpasswd=ldap_pwd ldapsearchattribute=sAMAccountName ldapsearchfilter="(memberOf=*)"
+----
+# Active authentication configuration on this node:
+# Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
+# host  all root all cert-password # CockroachDB mandatory rule
+# host  all ldap_user 127.0.0.1/32 ldap ldapserver=localhost ldapport=636 ldapbasedn="O=security org,DC=localhost" ldapbinddn="CN=service_account,O=security org,DC=localhost" ldapbindpasswd=ldap_pwd ldapsearchattribute=sAMAccountName ldapsearchfilter="(memberOf=*)"
+#
+# Interpreted configuration:
+# TYPE   DATABASE USER      ADDRESS      METHOD        OPTIONS
+loopback all      all       all          trust
+host     all      root      all          cert-password
+host     all      ldap_user 127.0.0.1/32 ldap          ldapserver=localhost ldapport=636 "ldapbasedn=O=security org,DC=localhost" "ldapbinddn=CN=service_account,O=security org,DC=localhost" ldapbindpasswd=ldap_pwd ldapsearchattribute=sAMAccountName "ldapsearchfilter=(memberOf=*)"
+
+ldap_mock set_groups=(ldap_user,cn=ldap_user_parent_1,cn=ldap_user_parent_2)
+----
+
+connect user=ldap_user password="ldap_pwd"
+----
+ok defaultdb
+
+query_row
+SELECT pg_has_role('ldap_user', 'ldap_user_parent_1', 'MEMBER')
+----
+false
+
+subtest end
+
+subtest no_membership_grouplistfilter_set
+
+set_hba
+host  all ldap_user 127.0.0.1/32 ldap ldapserver=localhost ldapport=636 ldapbasedn="O=security org,DC=localhost" ldapbinddn="CN=service_account,O=security org,DC=localhost" ldapbindpasswd=ldap_pwd ldapsearchattribute=sAMAccountName ldapsearchfilter="(memberOf=*)" "ldapgrouplistfilter=(objectCategory=CN=Group*)"
+----
+# Active authentication configuration on this node:
+# Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
+# host  all root all cert-password # CockroachDB mandatory rule
+# host  all ldap_user 127.0.0.1/32 ldap ldapserver=localhost ldapport=636 ldapbasedn="O=security org,DC=localhost" ldapbinddn="CN=service_account,O=security org,DC=localhost" ldapbindpasswd=ldap_pwd ldapsearchattribute=sAMAccountName ldapsearchfilter="(memberOf=*)" "ldapgrouplistfilter=(objectCategory=CN=Group*)"
+#
+# Interpreted configuration:
+# TYPE   DATABASE USER      ADDRESS      METHOD        OPTIONS
+loopback all      all       all          trust
+host     all      root      all          cert-password
+host     all      ldap_user 127.0.0.1/32 ldap          ldapserver=localhost ldapport=636 "ldapbasedn=O=security org,DC=localhost" "ldapbinddn=CN=service_account,O=security org,DC=localhost" ldapbindpasswd=ldap_pwd ldapsearchattribute=sAMAccountName "ldapsearchfilter=(memberOf=*)" "ldapgrouplistfilter=(objectCategory=CN=Group*)"
+
+ldap_mock set_groups=(ldap_user,cn=ldap_user_parent_1)
+----
+
+connect user=ldap_user password="ldap_pwd"
+----
+ok defaultdb
+
+query_row
+SELECT pg_has_role('ldap_user', 'ldap_user_parent_1', 'MEMBER')
+----
+true
 
 subtest end


### PR DESCRIPTION
fixes #132170
fixes CRDB-42862
Epic: CRDB-33829

Currently, if LDAP is used for authentication. it will always attempt to
authorize users based on their LDAP groups as well. The authorization behavior
requires `ldapgrouplistfilter` to be set in the host-based auth configuration.
In 24.2, that parameter did not exist.

To allow 24.2 users to move to 24.3 seamlessly, and to offer greater
flexibility, we should make the authorization behavior opt-in.

Release note(enterprise, security, ops): This change ensures authorization via
LDAP only goes through iff `ldapgrouplistfilter`option present in HBA
configuration, else we just proceed with authentication as per provided ldap
auth method options in HBA. This change is to ensure external authorization with
ldap is opt-in rather than enabled by default.