### PR TITLE
release-24.1: *: update kv teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -267,9 +267,9 @@
 /pkg/kv/bulk/                           @cockroachdb/disaster-recovery
 /pkg/kv/kvbase/                         @cockroachdb/kv-prs
 /pkg/kv/kvclient/                       @cockroachdb/kv-prs
-/pkg/kv/kvclient/kvcoord/*rangefeed*    @cockroachdb/repl-prs
+/pkg/kv/kvclient/kvcoord/*rangefeed*    @cockroachdb/kv-prs
 /pkg/kv/kvclient/kvstreamer             @cockroachdb/sql-queries-prs
-/pkg/kv/kvclient/rangefeed/             @cockroachdb/repl-prs
+/pkg/kv/kvclient/rangefeed/             @cockroachdb/kv-prs
 /pkg/kv/kvnemesis/                      @cockroachdb/kv-prs
 /pkg/kv/kvpb/                           @cockroachdb/kv-prs
 /pkg/kv/kvpb/.gitattributes             @cockroachdb/dev-inf
@@ -287,24 +287,24 @@
 /pkg/kv/kvprober/                       @cockroachdb/kv-prs
 # Same subdirectory rule as above for `/pkg/kv`
 /pkg/kv/kvserver/*.*                    @cockroachdb/kv-prs
-/pkg/kv/kvserver/*circuit*.go           @cockroachdb/repl-prs
-/pkg/kv/kvserver/*closed*ts*.go         @cockroachdb/repl-prs
-/pkg/kv/kvserver/*_app*.go              @cockroachdb/repl-prs
-/pkg/kv/kvserver/*closed_timestamp*.go  @cockroachdb/repl-prs
-/pkg/kv/kvserver/*consistency*.go       @cockroachdb/repl-prs
-/pkg/kv/kvserver/*probe*.go             @cockroachdb/repl-prs
-/pkg/kv/kvserver/*proposal*.go          @cockroachdb/repl-prs
-/pkg/kv/kvserver/*raft*.go              @cockroachdb/repl-prs
-/pkg/kv/kvserver/*raft*/                @cockroachdb/repl-prs
-/pkg/kv/kvserver/*rangefeed*.go         @cockroachdb/repl-prs
-/pkg/kv/kvserver/*sideload*.go          @cockroachdb/repl-prs
+/pkg/kv/kvserver/*circuit*.go           @cockroachdb/kv-prs
+/pkg/kv/kvserver/*closed*ts*.go         @cockroachdb/kv-prs
+/pkg/kv/kvserver/*_app*.go              @cockroachdb/kv-prs
+/pkg/kv/kvserver/*closed_timestamp*.go  @cockroachdb/kv-prs
+/pkg/kv/kvserver/*consistency*.go       @cockroachdb/kv-prs
+/pkg/kv/kvserver/*probe*.go             @cockroachdb/kv-prs
+/pkg/kv/kvserver/*proposal*.go          @cockroachdb/kv-prs
+/pkg/kv/kvserver/*raft*.go              @cockroachdb/kv-prs
+/pkg/kv/kvserver/*raft*/                @cockroachdb/kv-prs
+/pkg/kv/kvserver/*rangefeed*.go         @cockroachdb/kv-prs
+/pkg/kv/kvserver/*sideload*.go          @cockroachdb/kv-prs
 /pkg/kv/kvserver/abortspan/             @cockroachdb/kv-prs
 /pkg/kv/kvserver/allocator/             @cockroachdb/kv-prs
-/pkg/kv/kvserver/apply/                 @cockroachdb/repl-prs
+/pkg/kv/kvserver/apply/                 @cockroachdb/kv-prs
 /pkg/kv/kvserver/asim/                  @cockroachdb/kv-prs
 /pkg/kv/kvserver/batcheval/             @cockroachdb/kv-prs
 /pkg/kv/kvserver/benignerror/           @cockroachdb/kv-prs
-/pkg/kv/kvserver/closedts/              @cockroachdb/repl-prs
+/pkg/kv/kvserver/closedts/              @cockroachdb/kv-prs
 /pkg/kv/kvserver/concurrency/           @cockroachdb/kv-prs
 /pkg/kv/kvserver/constraint/            @cockroachdb/kv-prs
 /pkg/kv/kvserver/diskmap/               @cockroachdb/kv-prs
@@ -315,17 +315,17 @@
 /pkg/kv/kvserver/kvflowcontrol/         @cockroachdb/admission-control
 /pkg/kv/kvserver/kvserverbase/          @cockroachdb/kv-prs
 /pkg/kv/kvserver/kvserverpb/            @cockroachdb/kv-prs
-/pkg/kv/kvserver/kvstorage/             @cockroachdb/repl-prs
+/pkg/kv/kvserver/kvstorage/             @cockroachdb/kv-prs
 /pkg/kv/kvserver/liveness/              @cockroachdb/kv-prs
 /pkg/kv/kvserver/load/                  @cockroachdb/kv-prs
 /pkg/kv/kvserver/lockspanset/           @cockroachdb/kv-prs
-/pkg/kv/kvserver/logstore/              @cockroachdb/repl-prs
-/pkg/kv/kvserver/loqrecovery/           @cockroachdb/repl-prs
+/pkg/kv/kvserver/logstore/              @cockroachdb/kv-prs
+/pkg/kv/kvserver/loqrecovery/           @cockroachdb/kv-prs
 /pkg/kv/kvserver/multiqueue/            @cockroachdb/kv-prs
 /pkg/kv/kvserver/protectedts/           @cockroachdb/kv-prs
-/pkg/kv/kvserver/rangefeed/             @cockroachdb/repl-prs
+/pkg/kv/kvserver/rangefeed/             @cockroachdb/kv-prs
 /pkg/kv/kvserver/rangelog/              @cockroachdb/kv-prs
-/pkg/kv/kvserver/rditer/                @cockroachdb/repl-prs
+/pkg/kv/kvserver/rditer/                @cockroachdb/kv-prs
 /pkg/kv/kvserver/readsummary/           @cockroachdb/kv-prs
 /pkg/kv/kvserver/replicastats/          @cockroachdb/kv-prs
 /pkg/kv/kvserver/reports/               @cockroachdb/kv-prs
@@ -340,9 +340,9 @@
 /pkg/kv/kvserver/txnwait/               @cockroachdb/kv-prs
 /pkg/kv/kvserver/uncertainty/           @cockroachdb/kv-prs
 
-# KV/replication team owns integration with raft.
+# The KV team owns integration with raft.
 #
-/pkg/raft/ @cockroachdb/repl-prs
+/pkg/raft/ @cockroachdb/kv-prs
 
 /pkg/ccl/spanconfigccl/                            @cockroachdb/kv-prs @cockroachdb/sql-foundations
 /pkg/ccl/spanconfigccl/spanconfigkvaccessorccl/    @cockroachdb/kv-prs

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -44,10 +44,6 @@ cockroachdb/kv:
     cockroachdb/kv-prs: other
   triage_column_id: 14242655
   label: T-kv
-cockroachdb/replication:
-  aliases:
-    cockroachdb/repl-prs: other
-  label: T-kv-replication
 cockroachdb/spatial:
   triage_column_id: 9487269
   label: T-spatial

--- a/pkg/cmd/roachtest/registry/filter_test.go
+++ b/pkg/cmd/roachtest/registry/filter_test.go
@@ -16,9 +16,8 @@ import (
 
 func init() {
 	OverrideTeams(team.Map{
-		OwnerCDC.ToTeamAlias():         {},
-		OwnerKV.ToTeamAlias():          {},
-		OwnerReplication.ToTeamAlias(): {},
+		OwnerCDC.ToTeamAlias(): {},
+		OwnerKV.ToTeamAlias():  {},
 	})
 }
 

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -22,7 +22,6 @@ const (
 	OwnerCDC              Owner = `cdc`
 	OwnerDisasterRecovery Owner = `disaster-recovery`
 	OwnerKV               Owner = `kv`
-	OwnerReplication      Owner = `replication`
 	OwnerAdmissionControl Owner = `admission-control`
 	OwnerObservability    Owner = `obs-prs`
 	OwnerServer           Owner = `server` // not currently staffed

--- a/pkg/cmd/roachtest/registry/testdata/filter/describe
+++ b/pkg/cmd/roachtest/registry/testdata/filter/describe
@@ -24,9 +24,9 @@ describe cloud=gce suite=nightly
 ----
 tests which are compatible with cloud "gce" and are part of the "nightly" suite
 
-describe cloud=local owner=replication benchmarks
+describe cloud=local owner=kv benchmarks
 ----
-benchmarks which are compatible with cloud "local" and have owner "replication"
+benchmarks which are compatible with cloud "local" and have owner "kv"
 
 describe cloud=gce suite=nightly
 foo

--- a/pkg/cmd/roachtest/registry/testdata/filter/errors
+++ b/pkg/cmd/roachtest/registry/testdata/filter/errors
@@ -27,10 +27,6 @@ filter suite=orm
 ----
 error: no tests in suite "orm"
 
-filter owner=replication
-----
-error: no tests with owner "replication"
-
 filter benchmarks
 component_blargle
 ----

--- a/pkg/cmd/roachtest/tests/inconsistency.go
+++ b/pkg/cmd/roachtest/tests/inconsistency.go
@@ -20,7 +20,7 @@ import (
 func registerInconsistency(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "inconsistency",
-		Owner:            registry.OwnerReplication,
+		Owner:            registry.OwnerKV,
 		Cluster:          r.MakeClusterSpec(3),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -425,7 +425,7 @@ func registerKVContention(r registry.Registry) {
 func registerKVQuiescenceDead(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:                "kv/quiescence/nodes=3",
-		Owner:               registry.OwnerReplication,
+		Owner:               registry.OwnerKV,
 		Cluster:             r.MakeClusterSpec(4, spec.WorkloadNode()),
 		CompatibleClouds:    registry.AllExceptAWS,
 		Suites:              registry.Suites(registry.Nightly),

--- a/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
+++ b/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
@@ -66,7 +66,7 @@ func registerLOQRecovery(r registry.Registry) {
 		testSpec := s
 		r.Add(registry.TestSpec{
 			Name:             s.testName(""),
-			Owner:            registry.OwnerReplication,
+			Owner:            registry.OwnerKV,
 			Benchmark:        true,
 			CompatibleClouds: registry.AllExceptAWS,
 			Suites:           registry.Suites(registry.Nightly),
@@ -81,7 +81,7 @@ func registerLOQRecovery(r registry.Registry) {
 		})
 		r.Add(registry.TestSpec{
 			Name:             s.testName("half-online"),
-			Owner:            registry.OwnerReplication,
+			Owner:            registry.OwnerKV,
 			Benchmark:        true,
 			CompatibleClouds: registry.AllExceptAWS,
 			Suites:           registry.Suites(registry.Nightly),

--- a/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
@@ -26,7 +26,7 @@ import (
 func registerChangeReplicasMixedVersion(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "change-replicas/mixed-version",
-		Owner:            registry.OwnerReplication,
+		Owner:            registry.OwnerKV,
 		Cluster:          r.MakeClusterSpec(4),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),

--- a/pkg/cmd/roachtest/tests/replicagc.go
+++ b/pkg/cmd/roachtest/tests/replicagc.go
@@ -26,7 +26,7 @@ func registerReplicaGC(r registry.Registry) {
 	for _, restart := range []bool{true, false} {
 		r.Add(registry.TestSpec{
 			Name:             fmt.Sprintf("replicagc-changed-peers/restart=%t", restart),
-			Owner:            registry.OwnerReplication,
+			Owner:            registry.OwnerKV,
 			Cluster:          r.MakeClusterSpec(6),
 			CompatibleClouds: registry.AllExceptAWS,
 			Suites:           registry.Suites(registry.Nightly),

--- a/pkg/internal/team/TEAMS.yaml
+++ b/pkg/internal/team/TEAMS.yaml
@@ -44,10 +44,6 @@ cockroachdb/kv:
     cockroachdb/kv-prs: other
   triage_column_id: 14242655
   label: T-kv
-cockroachdb/replication:
-  aliases:
-    cockroachdb/repl-prs: other
-  label: T-kv-replication
 cockroachdb/spatial:
   triage_column_id: 9487269
   label: T-spatial


### PR DESCRIPTION
Backport of #126692 and #129362 to 24.1.

Release justification: Infra only change.

---

**github: update codeowners**

Update all instances of `repl-prs` to `kv-prs`.

---

**team: remove replication from teams.yaml**

The `replication` team was merged into `kv`.

Update the `TEAMS.yaml` files (parts `ii` and `iii` from [this doc][1]).

[1]: https://cockroachlabs.atlassian.net/wiki/spaces/devinf/pages/3692167169/Merging+teams+into+KV+-+2024-06#GitHub

---

**roachtest: move replication into kv; remove replication**

The Replication team was merged with KV.

Update the owners of various tests from `OwnerReplication` to `OwnerKV`.

Epic: CRDB-37617.