### PR TITLE
rac2: lock rc mu for TestRangeController send queue stat calculation

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
@@ -1322,7 +1322,11 @@ func TestRangeController(t *testing.T) {
 					var sizeCount, sizeBytes int64
 					for _, rcState := range state.ranges {
 						stats := RangeSendStreamStats{}
-						rcState.rc.updateSendQueueStatsRaftMuRCLocked(state.ts.Now())
+						func() {
+							rcState.rc.mu.Lock()
+							defer rcState.rc.mu.Unlock()
+							rcState.rc.updateSendQueueStatsRaftMuRCLocked(state.ts.Now())
+						}()
 						rcState.rc.SendStreamStats(&stats)
 						count, bytes := stats.SumSendQueues()
 						sizeCount += count
@@ -1366,7 +1370,11 @@ func TestRangeController(t *testing.T) {
 
 				r := state.ranges[roachpb.RangeID(rangeID)]
 				if refresh {
-					r.rc.updateSendQueueStatsRaftMuRCLocked(state.ts.Now())
+					func() {
+						r.rc.mu.Lock()
+						defer r.rc.mu.Unlock()
+						r.rc.updateSendQueueStatsRaftMuRCLocked(state.ts.Now())
+					}()
 				}
 				stats := RangeSendStreamStats{}
 				r.rc.SendStreamStats(&stats)


### PR DESCRIPTION
Otherwise, we will fail the assertion that `rangeController.mu` is `AssertHeld()`.

This only affected the `TestRangeController` test.

Fixes: #132040
Release note: None