### PR TITLE
release-23.2: changefeedccl: reduce use of errors during pauseOrResumePolling

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/target.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/target.go
@@ -110,6 +110,19 @@ func (ts *Targets) EachTableID(f func(descpb.ID) error) error {
 	return nil
 }
 
+// EachTableIDWithBool is similar to EachTableID but avoids using
+// iterutil.Map(err) to eliminate the overhead of errors.Is. Thus, f should not
+// return iterutil.StopIteration(). It returns false with error when the
+// callback f returns false or true when the iteration completes.
+func (ts *Targets) EachTableIDWithBool(f func(descpb.ID) (bool, error)) (bool, error) {
+	for id := range ts.m {
+		if b, err := f(id); !b {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
 // EachHavingTableID iterates over each Target with the given id, returning
 // false if there were none.
 func (ts *Targets) EachHavingTableID(id descpb.ID, f func(Target) error) (bool, error) {

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -486,36 +486,42 @@ func (tf *schemaFeed) pauseOrResumePolling(ctx context.Context, atOrBefore hlc.T
 	// Always assume we need to resume polling until we've proven otherwise.
 	tf.mu.pollingPaused = false
 
-	if err := tf.targets.EachTableID(func(id descpb.ID) error {
+	if canPausePolling, err := tf.targets.EachTableIDWithBool(func(id descpb.ID) (bool, error) {
 		// Check if target table is schema-locked at the current highwater.
 		ld1, err := tf.leaseMgr.Acquire(ctx, tf.mu.highWater, id)
 		if err != nil {
-			return err
+			return false, err
 		}
 		defer ld1.Release(ctx)
 		desc1 := ld1.Underlying().(catalog.TableDescriptor)
 		if !desc1.IsSchemaLocked() {
-			return errors.Newf("desc %d not schema-locked at highwater", desc1.GetID())
+			if log.V(2) {
+				log.Infof(ctx, "desc %d not schema-locked at highwater", desc1.GetID())
+			}
+			return false, nil
 		}
 
 		if atOrBefore.LessEq(tf.mu.highWater) {
-			return nil
+			return true, nil
 		}
 
 		// Check if target table remains at the same version at atOrBefore.
 		ld2, err := tf.leaseMgr.Acquire(ctx, atOrBefore, id)
 		if err != nil {
-			return err
+			return false, err
 		}
 		defer ld2.Release(ctx)
 		desc2 := ld2.Underlying().(catalog.TableDescriptor)
 		if desc1.GetVersion() != desc2.GetVersion() {
-			return errors.Newf("desc %d version changed from version %d to %d between highwater and atOrBefore",
-				desc1.GetID(), desc1.GetVersion(), desc2.GetVersion())
+			if log.V(1) {
+				log.Infof(ctx,
+					"desc %d version changed from version %d to %d between highwater and atOrBefore",
+					desc1.GetID(), desc1.GetVersion(), desc2.GetVersion())
+			}
+			return false, nil
 		}
-
-		return nil
-	}); err != nil {
+		return true, nil
+	}); !canPausePolling || err != nil {
 		if errors.Is(err, catalog.ErrDescriptorDropped) {
 			// If a table is dropped and causes Acquire to fail, we mark it as a
 			// terminal error, so that we don't retry, and let the changefeed job

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed_test.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed_test.go
@@ -511,3 +511,66 @@ func TestPauseOrResumePolling(t *testing.T) {
 	require.False(t, sf.pollingPaused())
 	require.Equal(t, hlc.Timestamp{WallTime: 50}, sf.highWater())
 }
+
+// BenchmarkPauseOrResumePolling benchmarks pauseOrResumePolling in cases where
+// there is a non-terminal error early, polling should be paused, and polling
+// should not be paused.
+func BenchmarkPauseOrResumePolling(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
+
+	ctx := context.Background()
+
+	const tableID = 123
+	sf := schemaFeed{
+		leaseMgr: &testLeaseAcquirer{
+			id: tableID,
+			descs: []*testLeasedDescriptor{
+				newTestLeasedDescriptor(tableID, 1, false, hlc.Timestamp{WallTime: 30}),
+				newTestLeasedDescriptor(tableID, 2, true, hlc.Timestamp{WallTime: 40}),
+			},
+		},
+		targets: CreateChangefeedTargets(tableID),
+	}
+	setFrontier := func(ts hlc.Timestamp) error {
+		sf.mu.Lock()
+		defer sf.mu.Unlock()
+		return sf.mu.ts.advanceFrontier(ts)
+	}
+
+	// Set the initial frontier to 10.
+	require.NoError(b, setFrontier(hlc.Timestamp{WallTime: 10}))
+	// Initially, polling should not be paused.
+	require.False(b, sf.pollingPaused())
+
+	b.Run("non-terminal error", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			// We expect a non-terminal error to be swallowed for time 10 since a
+			// valid descriptor does not exist for time 10.
+			require.NoError(b, sf.pauseOrResumePolling(ctx, hlc.Timestamp{WallTime: 10}))
+		}
+		require.False(b, sf.pollingPaused())
+	})
+	b.Run("not schema locked", func(b *testing.B) {
+		// We bump the highwater up to reflect a descriptor being read at time 30.
+		require.NoError(b, setFrontier(hlc.Timestamp{WallTime: 30}))
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			// We do not expect polling to be paused for time 30 since the descriptor
+			// at time 30 is not schema locked.
+			require.NoError(b, sf.pauseOrResumePolling(ctx, hlc.Timestamp{WallTime: 30}))
+		}
+		require.False(b, sf.pollingPaused())
+	})
+	b.Run("schema locked", func(b *testing.B) {
+		// We bump the highwater up to reflect a descriptor being read at time 50.
+		require.NoError(b, setFrontier(hlc.Timestamp{WallTime: 50}))
+		for i := 0; i < b.N; i++ {
+			// We expect polling to be paused for time 50 now that the highwater on a
+			// schema-locked version.
+			require.NoError(b, sf.pauseOrResumePolling(ctx, hlc.Timestamp{WallTime: 50}))
+		}
+		require.True(b, sf.pollingPaused())
+	})
+}


### PR DESCRIPTION
Backport 2/2 commits from #131951.

/cc @cockroachdb/release
 
---

**schemafeed: add BenchmarkPauseOrResumePolling**
This patch introduces a benchmark for pauseOrResumePolling, as it’s an important
function in a hot path that has previously caused performance regressions due to
complex error handling.

Epic: none
Release note: none

---

**changefeedccl: reduce use of errors during pauseOrResumePolling**

Previously, errors were constructed and compared in pauseOrResumePolling solely
to indicate that pausing cannot be stopped and period table history scan is
necessary during pauseOrResumePolling. However, no actual errors were returned
from pauseOrResumePolling. This error handling introduced unnecessary CPU
overhead in this hot path, as observed during escalations and DRT scale testing.
This patch improves performance by replacing error-based communication with a
boolean check.

Fixes: https://github.com/cockroachdb/cockroach/issues/131327
Release note (performance improvement): Enhanced performance when schema_locked
is not in use by improving error handling during periodic table history polling.

```
                                        │  before.txt  │              after.txt               │
                                        │    sec/op    │    sec/op     vs base                │
PauseOrResumePolling/non-terminal_error    5.533µ ± 5%   3.849µ ± 29%  -30.44% (p=0.000 n=10)
PauseOrResumePolling/not_schema_locked    7069.5n ± 4%   176.4n ±  9%  -97.50% (p=0.000 n=10)
PauseOrResumePolling/schema_locked         136.2n ± 4%   131.8n ±  7%        ~ (p=0.306 n=10)
```

---

Release justification: low risk performance improvement