### PR TITLE
pkg/acceptance: update gss tests with container built from master

### DIFF
--- a/pkg/acceptance/compose/gss/docker-compose-python.yml
+++ b/pkg/acceptance/compose/gss/docker-compose-python.yml
@@ -23,7 +23,7 @@ services:
       timeout: 10s
       retries: 25
   python:
-    image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-python:20241004-141441
+    image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-python:20241009-173356
     user: "${UID}:${GID}"
     depends_on:
       cockroach:

--- a/pkg/acceptance/compose/gss/docker-compose.yml
+++ b/pkg/acceptance/compose/gss/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       timeout: 10s
       retries: 25
   psql:
-    image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-psql:20241004-140930
+    image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-psql:20241009-173040
     user: "${UID}:${GID}"
     depends_on:
       cockroach:


### PR DESCRIPTION
I previously updated the GSS acceptance tests using a container built from my fork. Now that the related server changes are in master, I’m updating the container tags to use an image built from master for reproducibility.

This also will refresh the container with one that is built for both arm64 and amd64. This should address #132232.

See this for more context: https://cockroachlabs.slack.com/archives/CJ0H8Q97C/p1728061862175869

Epic: CRDB-39988
Informs CRDB-41998
Closes #132232 
Release note: none