### PR TITLE
tablemetadatacache: add logs to AutomaticUpdatesEnabled test

### DIFF
--- a/pkg/sql/tablemetadatacache/update_table_metadata_cache_job.go
+++ b/pkg/sql/tablemetadatacache/update_table_metadata_cache_job.go
@@ -101,6 +101,7 @@ func (j *tableMetadataUpdateJobResumer) Resume(ctx context.Context, execCtxI int
 		}
 		select {
 		case <-scheduleSettingsCh:
+			log.Info(ctx, "table metadata job settings updated, stopping timer.")
 			timer.Stop()
 			continue
 		case <-timer.C:


### PR DESCRIPTION
Adds logging to mockUpdater.RunUpdater to help debug TestUpdateTableMetadataCacheAutomaticUpdates/AutomaticUpdatesEnabled

Informs: #132042
Release note: None