### PR TITLE
rac2,replica_rac2: add CircularBuffer to replace some uses of a slice

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "rac2",
     srcs = [
+        "circular_buffer.go",
         "log_tracker.go",
         "metrics.go",
         "priority.go",
@@ -42,6 +43,7 @@ go_library(
 go_test(
     name = "rac2_test",
     srcs = [
+        "circular_buffer_test.go",
         "log_tracker_test.go",
         "priority_test.go",
         "range_controller_test.go",

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/circular_buffer.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/circular_buffer.go
@@ -1,0 +1,165 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package rac2
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/errors"
+)
+
+// CircularBuffer provides functionality akin to a []T, for cases that usually
+// push to the back and pop from the front, and would like to reduce
+// allocations. The assumption made here is that the capacity needed for
+// holding the live entries is somewhat stable. The circular buffer grows as
+// needed, and over time will shrink. Liveness of shrinking depends on new
+// entries being pushed.
+type CircularBuffer[T any] struct {
+	// len(buf) == cap(buf). These are powers of 2 and >= minCap.
+	buf []T
+	// first is in [0, len(buf)).
+	first int
+	// len is in [0, len(buf)].
+	len int
+	// pushesSinceCheck counts the number of push calls since the last time we
+	// considered shrinking the buffer.
+	pushesSinceCheck int64
+	// maxObservedLen is the maximum observed len value since the last time we
+	// considered shrinking the buffer.
+	maxObservedLen int
+}
+
+// minCap is the smallest capacity and must be a power of 2. The choice of 32
+// is arbitrary.
+const minCap = 32
+
+// 2^shrinkCheckInterval * cap is the threshold for checking whether the cap
+// should be shrunk. This is used to amortize the cost of the check. The
+// choice of 2^3 = 8 is arbitrary.
+const shrinkCheckInterval = 3
+
+// Push adds an entry to the end of the buffer.
+func (cb *CircularBuffer[T]) Push(a T) {
+	needed := cb.len + 1
+	cap := len(cb.buf)
+	if needed > cap {
+		// cap is a power of 2.
+		cap = max(minCap, cap*2)
+		// TODO(sumeer): panic if size is > math.MaxInt/2, since cb.first + cb.len
+		// could overflow.
+		cb.reallocate(cap)
+	} else if cb.pushesSinceCheck > int64(cap)<<shrinkCheckInterval {
+		// NB: don't bother with bit arithmetic since this conditional is rarely
+		// evaluated. The constants here are arbitrary.
+		//
+		// This heuristic is subjective and arbitrary: for instance it doesn't
+		// shrink if cap/2 is exactly what is needed, since that doesn't leave any
+		// headroom. Also, the maxObservedLen is > needed-1 in this case, so that
+		// part of the predicate may already disqualify from shrinking.
+		if cap > minCap && cap > 3*cb.maxObservedLen && cap/2 > needed {
+			// Shrink.
+			cap = cap / 2
+			cb.reallocate(cap)
+		}
+		cb.pushesSinceCheck = 0
+		cb.maxObservedLen = 0
+	}
+	// NB: &(cap-1) is equivalent to %cap.
+	cb.buf[(cb.first+cb.len)&(cap-1)] = a
+	cb.len++
+	cb.pushesSinceCheck++
+	if cb.maxObservedLen < cb.len {
+		cb.maxObservedLen = cb.len
+	}
+}
+
+// Pop removes the first num entries.
+//
+// REQUIRES: num <= cb.len.
+func (cb *CircularBuffer[T]) Pop(num int) {
+	if buildutil.CrdbTestBuild && num > cb.len {
+		panic(errors.AssertionFailedf("num %d > cb.len %d", num, cb.len))
+	}
+	if num == 0 {
+		// It is possible cb.cap is 0, so returning here avoids doing a possibly
+		// incorrect <something> % cb.cap (though with two's complement the bit
+		// operation below would happen to be correct).
+		return
+	}
+	cb.len -= num
+	// NB: &(len(cb.buf)-1) is equivalent to %len(cb.buf).
+	cb.first = (cb.first + num) & (len(cb.buf) - 1)
+}
+
+// ShrinkToPrefix shrinks the buffer to retain the first num entries.
+//
+// REQUIRES: num <= cb.len.
+func (cb *CircularBuffer[T]) ShrinkToPrefix(num int) {
+	if buildutil.CrdbTestBuild && num > cb.len {
+		panic(errors.AssertionFailedf("num %d > cb.len %d", num, cb.len))
+	}
+	cb.len = num
+}
+
+// At returns the entry at index.
+//
+// REQUIRES: index < cb.len.
+func (cb *CircularBuffer[T]) At(index int) T {
+	if buildutil.CrdbTestBuild && index >= cb.len {
+		panic(errors.AssertionFailedf("index %d >= cb.len %d", index, cb.len))
+	}
+	// NB: &(len(cb.buf)-1) is equivalent to %len(cb.buf).
+	return cb.buf[(cb.first+index)&(len(cb.buf)-1)]
+}
+
+// SetLast overwrites the last entry.
+//
+// REQUIRES: Length() > 0.
+func (cb *CircularBuffer[T]) SetLast(a T) {
+	if buildutil.CrdbTestBuild && cb.len == 0 {
+		panic(errors.AssertionFailedf("buffer is empty"))
+	}
+	// NB: &(len(cb.buf)-1) is equivalent to %len(cb.buf).
+	cb.buf[(cb.first+cb.len-1)&(len(cb.buf)-1)] = a
+}
+
+// SetFirst overwrites the first entry.
+//
+// REQUIRES: Length() > 0.
+func (cb *CircularBuffer[T]) SetFirst(a T) {
+	if buildutil.CrdbTestBuild && cb.len == 0 {
+		panic(errors.AssertionFailedf("buffer is empty"))
+	}
+	cb.buf[cb.first] = a
+}
+
+// Length returns the current length.
+func (cb *CircularBuffer[T]) Length() int {
+	return cb.len
+}
+
+func (cb *CircularBuffer[T]) reallocate(size int) {
+	buf := make([]T, size)
+	capacity := len(cb.buf)
+	// cb.buf is split into a prefix and suffix, where the prefix is
+	// cb.buf[first:first+n1] and the suffix is cb.buf[:n2].
+	n1 := capacity - cb.first
+	n2 := 0
+	if n1 < cb.len {
+		// Suffix is non-empty.
+		n2 = cb.len - n1
+	} else {
+		// Suffix is empty.
+		n1 = cb.len
+	}
+	if n1 > 0 {
+		copy(buf, cb.buf[cb.first:cb.first+n1])
+	}
+	if n2 > 0 {
+		copy(buf[n1:], cb.buf[:n2])
+	}
+	cb.first = 0
+	cb.buf = buf
+}

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/circular_buffer_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/circular_buffer_test.go
@@ -1,0 +1,125 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package rac2
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/datadriven"
+)
+
+func TestCircularBuffer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	cb := CircularBuffer[int]{}
+	cbString := func() string {
+		var b strings.Builder
+		printStats := func() {
+			fmt.Fprintf(&b, "first: %d len: %d cap: %d pushes: %d, max-len: %d\n",
+				cb.first, cb.len, len(cb.buf), cb.pushesSinceCheck, cb.maxObservedLen)
+		}
+		fmt.Fprintf(&b, "buf:")
+		if cb.Length() == 0 {
+			fmt.Fprintf(&b, " empty\n")
+			printStats()
+			return b.String()
+		}
+		// We collapse the entries into intervals that represent a dense ascending
+		// sequence. The interval is [first, first+count).
+		var first, count int
+		printIntervalAndReset := func() {
+			if count == 0 {
+				return
+			}
+			if count == 1 {
+				// Don't use interval notation.
+				fmt.Fprintf(&b, " %d", first)
+			} else {
+				fmt.Fprintf(&b, " [%d, %d]", first, first+count-1)
+			}
+			first = 0
+			count = 0
+		}
+		for i := 0; i < cb.Length(); i++ {
+			if count > 0 && cb.At(i) != (first+count) {
+				// Cannot extend the current interval since the next entry is not
+				// equal to first + count which is the exclusive end of the current
+				// interval. So print the current interval and reset it to empty.
+				printIntervalAndReset()
+			}
+			if count == 0 {
+				// Start a new interval.
+				first = cb.At(i)
+			}
+			// Add to the current interval.
+			count++
+		}
+		// If there is an accumulated interval, print it.
+		printIntervalAndReset()
+		fmt.Fprintf(&b, "\n")
+		printStats()
+		return b.String()
+	}
+	datadriven.RunTest(t, "testdata/circular_buffer",
+		func(t *testing.T, d *datadriven.TestData) string {
+			switch d.Cmd {
+			case "init":
+				cb = CircularBuffer[int]{}
+				return ""
+
+			case "push":
+				var entry int
+				d.ScanArgs(t, "entry", &entry)
+				count := 1
+				if d.HasArg("count") {
+					d.ScanArgs(t, "count", &count)
+				}
+				pop := false
+				if d.HasArg("pop-after-each-push-except-last") {
+					pop = true
+				}
+				for i := 0; i < count; i++ {
+					cb.Push(entry + i)
+					if pop && i != count-1 {
+						cb.Pop(1)
+					}
+				}
+				return cbString()
+
+			case "pop":
+				var num int
+				d.ScanArgs(t, "num", &num)
+				cb.Pop(num)
+				return cbString()
+
+			case "shrink-to-prefix":
+				var num int
+				d.ScanArgs(t, "num", &num)
+				cb.ShrinkToPrefix(num)
+				return cbString()
+
+			case "set-first":
+				var entry int
+				d.ScanArgs(t, "entry", &entry)
+				cb.SetFirst(entry)
+				return cbString()
+
+			case "set-last":
+				var entry int
+				d.ScanArgs(t, "entry", &entry)
+				cb.SetLast(entry)
+				return cbString()
+
+			default:
+				return fmt.Sprintf("unknown command: %s", d.Cmd)
+			}
+		})
+}

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/log_tracker.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/log_tracker.go
@@ -109,7 +109,7 @@ type LogTracker struct {
 	//	- waiting[pri][i].Term <= last.Term
 	//	- waiting[pri][i].Index < waiting[pri][i+1].Index
 	//	- waiting[pri][i].Term <= waiting[pri][i+1].Term
-	waiting [raftpb.NumPriorities][]LogMark
+	waiting [raftpb.NumPriorities]CircularBuffer[LogMark]
 }
 
 // NewLogTracker returns a LogTracker initialized to the given log mark. The
@@ -137,10 +137,10 @@ func (l *LogTracker) Stable() LogMark {
 //   - indices converge to the stable index which converges to the last index.
 func (l *LogTracker) Admitted() AdmittedVector {
 	a := AdmittedVector{Term: l.last.Term}
-	for pri, marks := range l.waiting {
+	for pri := range l.waiting {
 		index := l.stable
-		if len(marks) != 0 {
-			index = min(index, marks[0].Index-1)
+		if l.waiting[pri].Length() != 0 {
+			index = min(index, l.waiting[pri].At(0).Index-1)
 		}
 		a.Admitted[pri] = index
 	}
@@ -203,8 +203,8 @@ func (l *LogTracker) Append(ctx context.Context, after uint64, to LogMark) bool 
 	// This happens when a new leader overwrites a suffix of the log.
 	l.stable = min(l.stable, after)
 	// Entries at index > after.Index from previous terms are now obsolete.
-	for pri, marks := range l.waiting {
-		l.waiting[pri] = truncate(marks, after)
+	for pri := range l.waiting {
+		truncate(&l.waiting[pri], after)
 	}
 	// The leader term was bumped, so the admitted vector is new for this term,
 	// and is considered "changed".
@@ -225,12 +225,12 @@ func (l *LogTracker) Register(ctx context.Context, at LogMark, pri raftpb.Priori
 		l.errorf(ctx, "admission register %+v [pri=%v] out of order", at, pri)
 		return
 	}
-	ln := len(l.waiting[pri])
-	if ln != 0 && at.Index <= l.waiting[pri][ln-1].Index {
+	ln := l.waiting[pri].Length()
+	if ln != 0 && at.Index <= l.waiting[pri].At(ln-1).Index {
 		l.errorf(ctx, "admission register %+v [pri=%v] out of order", at, pri)
 		return
 	}
-	l.waiting[pri] = append(l.waiting[pri], at)
+	l.waiting[pri].Push(at)
 }
 
 // LogSynced informs the tracker that the log up to the given LogMark has been
@@ -256,12 +256,13 @@ func (l *LogTracker) LogSynced(ctx context.Context, stable LogMark) bool {
 	l.stable = stable.Index
 	// The admitted index at a priority has advanced if its queue was empty or
 	// leading the stable index by more than one.
-	for _, marks := range l.waiting {
+	for pri := range l.waiting {
+		marks := &l.waiting[pri]
 		// Example: stable index was 5 before this call. If marks[0].Index <= 6 then
 		// we can't advance past 5 even if stable index advances to a higher value.
 		// But if marks[0].Index >= 7 we can advance to marks[0].Index-1 which is
 		// greater than the old stable index.
-		if len(marks) == 0 || marks[0].Index > maybeAdmitted {
+		if marks.Length() == 0 || marks.At(0).Index > maybeAdmitted {
 			return true
 		}
 	}
@@ -289,25 +290,26 @@ func (l *LogTracker) LogAdmitted(ctx context.Context, at LogMark, pri raftpb.Pri
 		l.errorf(ctx, "admitting mark %+v before appending it", at)
 		return false
 	}
-	waiting := l.waiting[pri]
+	waiting := &l.waiting[pri]
+	ln := waiting.Length()
 	// There is nothing to admit, or it's a stale admission.
-	if len(waiting) == 0 || waiting[0].After(at) {
+	if ln == 0 || waiting.At(0).After(at) {
 		return false
 	}
 	// At least one waiting entry can be admitted. The admitted index was at
 	// min(l.stable, waiting[0].Index-1). If waiting[0].Index-1 < l.stable, the
 	// min increases after the first entry is removed from the queue.
-	updated := waiting[0].Index <= l.stable
+	updated := waiting.At(0).Index <= l.stable
 	// Remove all entries up to the admitted mark. Due to invariants, this is
 	// always a prefix of the queue.
-	for i, ln := 1, len(waiting); i < ln; i++ {
-		if waiting[i].After(at) {
-			l.waiting[pri] = waiting[i:]
+	for i := 1; i < ln; i++ {
+		if waiting.At(i).After(at) {
+			waiting.Pop(i)
 			return updated
 		}
 	}
 	// The entire queue is admitted, clear it.
-	l.waiting[pri] = waiting[len(waiting):]
+	waiting.ShrinkToPrefix(0)
 	return updated
 }
 
@@ -326,13 +328,15 @@ func (l *LogTracker) SafeFormat(w redact.SafePrinter, _ rune) {
 func (l *LogTracker) DebugString() string {
 	var b strings.Builder
 	fmt.Fprint(&b, l.String())
-	for pri, marks := range l.waiting {
-		if len(marks) == 0 {
+	for pri := range l.waiting {
+		marks := &l.waiting[pri]
+		n := marks.Length()
+		if n == 0 {
 			continue
 		}
 		fmt.Fprintf(&b, "\n%s:", raftpb.Priority(pri))
-		for _, mark := range marks {
-			fmt.Fprintf(&b, " %+v", mark)
+		for i := 0; i < n; i++ {
+			fmt.Fprintf(&b, " %+v", marks.At(i))
 		}
 	}
 	return b.String()
@@ -348,13 +352,15 @@ func (l *LogTracker) errorf(ctx context.Context, format string, args ...any) {
 	}
 }
 
-// truncate returns a prefix of the ordered log marks slice, with all marks at
-// index > after removed from it.
-func truncate(marks []LogMark, after uint64) []LogMark {
-	for i := len(marks); i > 0; i-- {
-		if marks[i-1].Index <= after {
-			return marks[:i]
+// truncate updates the slice to be a prefix of the ordered log marks slice,
+// with all marks at index > after removed from it.
+func truncate(marks *CircularBuffer[LogMark], after uint64) {
+	n := marks.Length()
+	for i := n; i > 0; i-- {
+		if marks.At(i-1).Index <= after {
+			marks.ShrinkToPrefix(i)
+			return
 		}
 	}
-	return marks[:0]
+	marks.ShrinkToPrefix(0)
 }

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/log_tracker_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/log_tracker_test.go
@@ -26,13 +26,13 @@ func (l *LogTracker) check(t *testing.T) {
 	stable := l.Stable()
 	require.Equal(t, l.last.Term, stable.Term)
 	for _, waiting := range l.waiting {
-		if ln := len(waiting); ln != 0 {
-			require.LessOrEqual(t, waiting[ln-1].Index, l.last.Index)
-			require.LessOrEqual(t, waiting[ln-1].Term, l.last.Term)
+		if ln := waiting.Length(); ln != 0 {
+			require.LessOrEqual(t, waiting.At(ln-1).Index, l.last.Index)
+			require.LessOrEqual(t, waiting.At(ln-1).Term, l.last.Term)
 		}
-		for i, ln := 1, len(waiting); i < ln; i++ {
-			require.Less(t, waiting[i-1].Index, waiting[i].Index)
-			require.LessOrEqual(t, waiting[i-1].Term, waiting[i].Term)
+		for i, ln := 1, waiting.Length(); i < ln; i++ {
+			require.Less(t, waiting.At(i-1).Index, waiting.At(i).Index)
+			require.LessOrEqual(t, waiting.At(i-1).Term, waiting.At(i).Term)
 		}
 	}
 	a := l.Admitted()
@@ -239,7 +239,8 @@ func TestLogTracker(t *testing.T) {
 		case "snap":
 			mark := readMark(t, d, "index")
 			updated := tracker.Snap(ctx, mark)
-			return state(updated)
+			str := state(updated)
+			return str
 
 		case "sync": // Example: sync term=10 index=100
 			mark := readMark(t, d, "index")

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/simulation_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/simulation_test.go
@@ -1136,7 +1136,9 @@ func (r *testingRCRange) testingReturnTokens(
 	raftPri := AdmissionToRaftPriority(pri)
 	returnIndex := uint64(0)
 	r.mu.outstandingReturns[rid] += tokens
-	for _, deduction := range rs.sendStream.mu.tracker.tracked[raftPri] {
+	n := rs.sendStream.mu.tracker.tracked[raftPri].Length()
+	for i := 0; i < n; i++ {
+		deduction := rs.sendStream.mu.tracker.tracked[raftPri].At(i)
 		if r.mu.outstandingReturns[rid]-deduction.tokens >= 0 {
 			r.mu.outstandingReturns[rid] -= deduction.tokens
 			returnIndex = deduction.id.index
@@ -1217,11 +1219,13 @@ func (r *testingRCRange) testingDisconnectStream(
 func (t *Tracker) testingString() string {
 	var buf strings.Builder
 	for pri, deductions := range t.tracked {
-		if len(deductions) == 0 {
+		n := deductions.Length()
+		if n == 0 {
 			continue
 		}
 		buf.WriteString(fmt.Sprintf("pri=%s\n", RaftToAdmissionPriority(raftpb.Priority(pri))))
-		for _, deduction := range deductions {
+		for i := 0; i < n; i++ {
+			deduction := deductions.At(i)
 			buf.WriteString(fmt.Sprintf("  tokens=%s log-position=%v/%v\n",
 				testingPrintTrimmedTokens(deduction.tokens), deduction.id.term, deduction.id.index))
 		}

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/circular_buffer
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/circular_buffer
@@ -1,0 +1,178 @@
+init
+----
+
+# Grows to capacity of 64. Note that [5, 54] represents a sequence of integers
+# 5 ... 54 in the buffer.
+push entry=5 count=50
+----
+buf: [5, 54]
+first: 0 len: 50 cap: 64 pushes: 50, max-len: 50
+
+# Regarding the notation below in the output, the buffer contains 90, 6, 7,
+# ..., 54.
+set-first entry=90
+----
+buf: 90 [6, 54]
+first: 0 len: 50 cap: 64 pushes: 50, max-len: 50
+
+set-last entry=2
+----
+buf: 90 [6, 53] 2
+first: 0 len: 50 cap: 64 pushes: 50, max-len: 50
+
+pop num=5
+----
+buf: [10, 53] 2
+first: 5 len: 45 cap: 64 pushes: 50, max-len: 50
+
+shrink-to-prefix num=30
+----
+buf: [10, 39]
+first: 5 len: 30 cap: 64 pushes: 50, max-len: 50
+
+push entry=50 count=34
+----
+buf: [10, 39] [50, 83]
+first: 5 len: 64 cap: 64 pushes: 84, max-len: 64
+
+# Grows from 64 to 128 to ... 512.
+push entry=90 count=200
+----
+buf: [10, 39] [50, 83] [90, 289]
+first: 0 len: 264 cap: 512 pushes: 284, max-len: 264
+
+pop num=10
+----
+buf: [20, 39] [50, 83] [90, 289]
+first: 10 len: 254 cap: 512 pushes: 284, max-len: 264
+
+shrink-to-prefix num=100
+----
+buf: [20, 39] [50, 83] [90, 135]
+first: 10 len: 100 cap: 512 pushes: 284, max-len: 264
+
+shrink-to-prefix num=0
+----
+buf: empty
+first: 10 len: 0 cap: 512 pushes: 284, max-len: 264
+
+# Push and pop entries. The max-len of 264 prevents it from shrinking when we
+# cross the threshold of 4096 pushes. But now that the threshold is crossed
+# and the push count reset, the max-len drops to 1.
+push entry=100 count=4000 pop-after-each-push-except-last
+----
+buf: 4099
+first: 425 len: 1 cap: 512 pushes: 187, max-len: 1
+
+# The max-len grows again.
+push entry=100 count=160
+----
+buf: 4099 [100, 259]
+first: 425 len: 161 cap: 512 pushes: 347, max-len: 161
+
+# Push and pop entries. The max-len is small enough that after the threshold
+# of 4096 pushes is crossed, the buffer shrinks to a capacity of 256. Shrinks
+# from 512 to 256.
+push entry=100 count=4000 pop-after-each-push-except-last
+----
+buf: [3938, 4099]
+first: 249 len: 162 cap: 256 pushes: 250, max-len: 162
+
+shrink-to-prefix num=100
+----
+buf: [3938, 4037]
+first: 249 len: 100 cap: 256 pushes: 250, max-len: 162
+
+# The max-len is too high to shrink.
+push entry=100 count=2000 pop-after-each-push-except-last
+----
+buf: [1999, 2099]
+first: 200 len: 101 cap: 256 pushes: 201, max-len: 101
+
+pop num=20
+----
+buf: [2019, 2099]
+first: 220 len: 81 cap: 256 pushes: 201, max-len: 101
+
+# Push and pop entries. When the threshold of 2048 pushes is crossed, the
+# buffer does not shrink since the previous max-len of 101 was too high. But
+# the new max-len shrinks to 82.
+push entry=100 count=2000 pop-after-each-push-except-last
+----
+buf: [2018, 2099]
+first: 171 len: 82 cap: 256 pushes: 152, max-len: 82
+
+# Push and pop entries. The buffer shrinks to 128.
+push entry=100 count=2000 pop-after-each-push-except-last
+----
+buf: [2017, 2099]
+first: 102 len: 83 cap: 128 pushes: 103, max-len: 83
+
+pop num=63
+----
+buf: [2080, 2099]
+first: 37 len: 20 cap: 128 pushes: 103, max-len: 83
+
+push entry=100 count=1000 pop-after-each-push-except-last
+----
+buf: [1079, 1099]
+first: 12 len: 21 cap: 128 pushes: 78, max-len: 21
+
+# Push and pop entries. After the threshold of 1024 pushes is crossed, the
+# buffer shrinks to a capacity of 64.
+push entry=100 count=2000 pop-after-each-push-except-last
+----
+buf: [2078, 2099]
+first: 28 len: 22 cap: 64 pushes: 27, max-len: 22
+
+pop num=14
+----
+buf: [2092, 2099]
+first: 42 len: 8 cap: 64 pushes: 27, max-len: 22
+
+push entry=100 count=500 pop-after-each-push-except-last
+----
+buf: [591, 599]
+first: 29 len: 9 cap: 64 pushes: 14, max-len: 9
+
+# Push and pop entries. The buffer shrinks to a capacity of 32.
+push entry=100 count=500 pop-after-each-push-except-last
+----
+buf: [590, 599]
+first: 0 len: 10 cap: 32 pushes: 1, max-len: 10
+
+# Noop pop.
+pop num=0
+----
+buf: [590, 599]
+first: 0 len: 10 cap: 32 pushes: 1, max-len: 10
+
+# Pop everything.
+pop num=10
+----
+buf: empty
+first: 10 len: 0 cap: 32 pushes: 1, max-len: 10
+
+# Noop pop.
+pop num=0
+----
+buf: empty
+first: 10 len: 0 cap: 32 pushes: 1, max-len: 10
+
+# Noop shrink-to-prefix.
+shrink-to-prefix num=0
+----
+buf: empty
+first: 10 len: 0 cap: 32 pushes: 1, max-len: 10
+
+# Push and pop entries. The buffer cannot shrink below a capacity of 32.
+push entry=100 count=300 pop-after-each-push-except-last
+----
+buf: 399
+first: 21 len: 1 cap: 32 pushes: 44, max-len: 1
+
+# Push and pop entries. The buffer cannot shrink below a capacity of 32.
+push entry=100 count=500 pop-after-each-push-except-last
+----
+buf: [598, 599]
+first: 8 len: 2 cap: 32 pushes: 30, max-len: 2

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_tracker_test.go
@@ -24,9 +24,10 @@ import (
 func formatTrackerState(t *Tracker) string {
 	var result strings.Builder
 	for pri, tracked := range t.tracked {
-		if len(tracked) > 0 {
+		if n := tracked.Length(); n > 0 {
 			result.WriteString(fmt.Sprintf("%v:\n", raftpb.Priority(pri)))
-			for _, tr := range tracked {
+			for i := 0; i < n; i++ {
+				tr := tracked.At(i)
 				result.WriteString(fmt.Sprintf("  term=%d index=%-2d tokens=%-3d\n",
 					tr.id.term, tr.id.index, tr.tokens))
 			}

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/admission.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/admission.go
@@ -5,7 +5,10 @@
 
 package replica_rac2
 
-import "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+import (
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/rac2"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+)
 
 // lowPriOverrideState records which raft log entries have their priority
 // overridden to be raftpb.LowPri. Used at follower replicas.
@@ -66,7 +69,7 @@ type lowPriOverrideState struct {
 	//
 	// A call to getEffectivePriority for index i causes a prefix of indices <=
 	// i to be discarded.
-	intervals []interval
+	intervals rac2.CircularBuffer[interval]
 	// Highest term observed so far.
 	leaderTerm uint64
 }
@@ -97,32 +100,35 @@ func (p *lowPriOverrideState) sideChannelForLowPriOverride(
 	if leaderTerm < p.leaderTerm {
 		return false
 	}
-	n := len(p.intervals)
+	n := p.intervals.Length()
 	if leaderTerm > p.leaderTerm {
 		p.leaderTerm = leaderTerm
 		// Drop all intervals starting at or after the first index. Do it from the
 		// back, so that the append-only case is the fast path. When a suffix of
 		// entries is overwritten, the cost of this loop is an amortized O(1).
-		for ; n > 0 && p.intervals[n-1].first >= first; n-- {
+		for ; n > 0 && p.intervals.At(n-1).first >= first; n-- {
 		}
-		p.intervals = p.intervals[:n]
+		p.intervals.ShrinkToPrefix(n)
 		// INVARIANT: n > 0 => p.intervals[n-1].first < first.
 
 		// Adjust the last interval if it overlaps with the one being added.
-		if n > 0 && p.intervals[n-1].last >= first {
+		if n > 0 && p.intervals.At(n-1).last >= first {
+			lastInterval := p.intervals.At(n - 1)
 			// Truncate the last interval.
-			p.intervals[n-1].last = first - 1
+			lastInterval.last = first - 1
+			p.intervals.SetLast(lastInterval)
 		}
 	} else {
 		// Common case: existing leader.
 		if n > 0 {
-			if p.intervals[n-1].last >= last {
+			lastInterval := p.intervals.At(n - 1)
+			if lastInterval.last >= last {
 				return true
 			}
-			// INVARIANT: p.intervals[n-1].last < last, so p.intervals[n-1].last + 1 <= last.
-			if p.intervals[n-1].last >= first {
+			// INVARIANT: lastInterval.last < last, so lastInterval.last + 1 <= last.
+			if lastInterval.last >= first {
 				// Adjust first to not overlap with the last interval.
-				first = p.intervals[n-1].last + 1
+				first = lastInterval.last + 1
 			}
 		}
 	}
@@ -132,14 +138,16 @@ func (p *lowPriOverrideState) sideChannelForLowPriOverride(
 	// - The last interval, if any, does not overlap with [first,last].
 
 	// Append to, or extend the existing last interval
-	if n > 0 && p.intervals[n-1].lowPriOverride == lowPriOverride &&
-		p.intervals[n-1].last+1 >= first {
-		// Extend the last interval.
-		p.intervals[n-1].last = last
-		return true
+	if n > 0 {
+		lastInterval := p.intervals.At(n - 1)
+		if lastInterval.lowPriOverride == lowPriOverride && lastInterval.last+1 >= first {
+			// Extend the last interval.
+			lastInterval.last = last
+			p.intervals.SetLast(lastInterval)
+			return true
+		}
 	}
-	p.intervals = append(p.intervals,
-		interval{first: first, last: last, lowPriOverride: lowPriOverride})
+	p.intervals.Push(interval{first: first, last: last, lowPriOverride: lowPriOverride})
 	return true
 }
 
@@ -149,7 +157,7 @@ func (p *lowPriOverrideState) sideChannelForV1Leader(leaderTerm uint64) bool {
 		return false
 	}
 	p.leaderTerm = leaderTerm
-	p.intervals = p.intervals[:0]
+	p.intervals.ShrinkToPrefix(0)
 	return true
 }
 
@@ -158,25 +166,30 @@ func (p *lowPriOverrideState) getEffectivePriority(
 ) raftpb.Priority {
 	// Garbage collect intervals ending before the given index.
 	drop := 0
-	for n := len(p.intervals); drop < n && p.intervals[drop].last < index; drop++ {
+	for n := p.intervals.Length(); drop < n && p.intervals.At(drop).last < index; drop++ {
 	}
-	p.intervals = p.intervals[drop:]
-	n := len(p.intervals)
+	p.intervals.Pop(drop)
+	n := p.intervals.Length()
 	// INVARIANT: if n > 0, p.intervals[0].last >= index.
 
 	// If there is no interval containing the index, return the original
 	// priority. We need to tolerate this since this may be case C1, and this is
 	// index 9, so we ignored when sideChannelForLowPriOverride provided
 	// information for 9.
-	if n == 0 || p.intervals[0].first > index {
+	if n == 0 {
 		return pri
 	}
-	lowPriOverride := p.intervals[0].lowPriOverride
+	firstInterval := p.intervals.At(0)
+	if firstInterval.first > index {
+		return pri
+	}
+	lowPriOverride := firstInterval.lowPriOverride
 	// Remove the prefix of indices <= index.
-	if p.intervals[0].last > index {
-		p.intervals[0].first = index + 1
+	if firstInterval.last > index {
+		firstInterval.first = index + 1
+		p.intervals.SetFirst(firstInterval)
 	} else {
-		p.intervals = p.intervals[1:]
+		p.intervals.Pop(1)
 	}
 	if lowPriOverride {
 		return raftpb.LowPri

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/admission_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/admission_test.go
@@ -25,9 +25,10 @@ func TestLowPriOverrideState(t *testing.T) {
 	lposString := func() string {
 		var b strings.Builder
 		fmt.Fprintf(&b, "leader-term: %d", lpos.leaderTerm)
-		if len(lpos.intervals) > 0 {
+		if n := lpos.intervals.Length(); n > 0 {
 			fmt.Fprintf(&b, "\nintervals:")
-			for _, i := range lpos.intervals {
+			for j := 0; j < n; j++ {
+				i := lpos.intervals.At(j)
 				fmt.Fprintf(&b, "\n [%3d, %3d] => %t", i.first, i.last, i.lowPriOverride)
 			}
 		}


### PR DESCRIPTION
It is used to replace uses where we are pushing into the back and popping from the front, to eliminate allocations.

Epic: CRDB-37515

Release note: None