### PR TITLE
pkg/cli: optimise the upload of logs from debug zip

### DIFF
--- a/pkg/cli/testdata/upload/logs
+++ b/pkg/cli/testdata/upload/logs
@@ -16,7 +16,7 @@ upload-logs
   }
 }
 ----
-ABC/123/dt=20240716/hour=17:
+ABC/123/dt=20240716/hour=17/1/cockroach.hostname.username.2024-07-16T17_51_43Z.048498.log:
 Upload ID: 123
 debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=logs
 {"data":{"type":"archives","attributes":{"name":"123","query":"-*","destination":{"type":"gcs","path":"ABC/123","bucket":"debugzip-archives","integration":{"project_id":"arjun-sandbox-424904","client_email":"datadog-archive@arjun-sandbox-424904.iam.gserviceaccount.com"}}}}}
@@ -76,7 +76,8 @@ upload-logs log-format=crdb-v1
   }
 }
 ----
-ABC/123/dt=20240716/hour=17:
+ABC/123/dt=20240716/hour=17/1/cockroach.node1.username.2024-07-16T17_51_43Z.048498.log:
+ABC/123/dt=20240716/hour=17/2/cockroach.node2.username.2024-07-16T17_51_43Z.048498.log:
 Upload ID: 123
 debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=logs --log-format=crdb-v1
 {"data":{"type":"archives","attributes":{"name":"123","query":"-*","destination":{"type":"gcs","path":"ABC/123","bucket":"debugzip-archives","integration":{"project_id":"arjun-sandbox-424904","client_email":"datadog-archive@arjun-sandbox-424904.iam.gserviceaccount.com"}}}}}

--- a/pkg/cli/tsdump_upload.go
+++ b/pkg/cli/tsdump_upload.go
@@ -311,7 +311,7 @@ func (d *datadogWriter) upload(fileName string) error {
 				err := d.emitDataDogMetrics(data)
 				if err != nil {
 					errorsInDDUpload = append(errorsInDDUpload,
-						fmt.Sprintf("retries exhausted for datadog upload for series %s with error %v", data[0].Metric, err))
+						fmt.Sprintf("retries exhausted for datadog upload for series %s with error %v\n", data[0].Metric, err))
 					wg.Done()
 					return
 				}

--- a/pkg/cli/zip_upload.go
+++ b/pkg/cli/zip_upload.go
@@ -22,12 +22,15 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/system"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -86,6 +89,9 @@ const (
 	ddArchiveQuery           = "-*" // will make sure to not archive any live logs
 	ddArchiveBucketName      = "debugzip-archives"
 	ddArchiveDefaultClient   = "datadog-archive" // TODO(arjunmahishi): make this a flag also
+
+	gcsPathTimeFormat = "dt=20060102/hour=15"
+	zipUploadRetries  = 5
 )
 
 var debugZipUploadOpts = struct {
@@ -99,10 +105,8 @@ var debugZipUploadOpts = struct {
 	from, to             timestampValue
 	logFormat            string
 	maxConcurrentUploads int
-	reporter             *zipUploadReporter
 }{
-	maxConcurrentUploads: system.NumCPU(),
-	reporter:             newReporter(os.Stderr),
+	maxConcurrentUploads: system.NumCPU() * 4,
 }
 
 // This is the list of all supported artifact types. The "possible values" part
@@ -223,21 +227,30 @@ func uploadZipProfiles(ctx context.Context, uploadID string, debugDirPath string
 		pathsByNode[nodeID] = append(pathsByNode[nodeID], path)
 	}
 
+	retryOpts := base.DefaultRetryOptions()
+	retryOpts.MaxRetries = zipUploadRetries
+	var req *http.Request
 	for nodeID, paths := range pathsByNode {
-		req, err := newProfileUploadReq(
-			ctx, paths, appendUserTags(
-				append(
-					defaultDDTags, makeDDTag(nodeIDTag, nodeID), makeDDTag(uploadIDTag, uploadID),
-					makeDDTag(clusterTag, debugZipUploadOpts.clusterName),
-				), // system generated tags
-				debugZipUploadOpts.tags..., // user provided tags
-			),
-		)
-		if err != nil {
-			return err
+		for retry := retry.Start(retryOpts); retry.Next(); {
+			req, err = newProfileUploadReq(
+				ctx, paths, appendUserTags(
+					append(
+						defaultDDTags, makeDDTag(nodeIDTag, nodeID), makeDDTag(uploadIDTag, uploadID),
+						makeDDTag(clusterTag, debugZipUploadOpts.clusterName),
+					), // system generated tags
+					debugZipUploadOpts.tags..., // user provided tags
+				),
+			)
+			if err != nil {
+				continue
+			}
+
+			if _, err = doUploadReq(req); err == nil {
+				break
+			}
 		}
 
-		if _, err := doUploadReq(req); err != nil {
+		if err != nil {
 			return fmt.Errorf("failed to upload profiles of node %s: %w", nodeID, err)
 		}
 
@@ -315,10 +328,94 @@ func newProfileUploadReq(
 	return req, nil
 }
 
-func uploadZipLogs(ctx context.Context, uploadID string, debugDirPath string) error {
+func processLogFile(
+	uploadID, debugDirPath string, file fileInfo, uploadFn func(logUploadSig),
+) (time.Time, time.Time, error) {
+	var (
+		pathParts                            = strings.Split(strings.TrimPrefix(file.path, debugDirPath), "/")
+		inputEditMode                        = log.SelectEditMode(false /* redactable */, false /* redactInput */)
+		nodeID                               = pathParts[2]
+		fileName                             = path.Base(file.path)
+		logBuffer                            = &bytes.Buffer{}
+		localMinTimestamp, localMaxTimestamp = time.Time{}, time.Time{}
+		prevTargetPath                       = ""
+	)
+
+	stream, err := newFileLogStream(
+		file, time.Time(debugZipUploadOpts.from), time.Time(debugZipUploadOpts.to),
+		inputEditMode, debugZipUploadOpts.logFormat,
+	)
+	if err != nil {
+		return localMinTimestamp, localMaxTimestamp, err
+	}
+
+	for e, ok := stream.peek(); ok; e, ok = stream.peek() {
+		currentTimestamp := timeutil.Unix(0, e.Time)
+		if localMinTimestamp.IsZero() || currentTimestamp.Before(localMinTimestamp) {
+			localMinTimestamp = currentTimestamp
+		}
+		localMaxTimestamp = currentTimestamp
+
+		// The target path is constructed like this:
+		// <cluster-name>/<upload-id>/dt=20210901/hour=15/<node_id>/<filename>
+		currTargetPath := path.Join(
+			debugZipUploadOpts.clusterName, uploadID,
+			timeutil.Unix(0, e.Time).Format(gcsPathTimeFormat), nodeID, fileName,
+		)
+
+		if prevTargetPath != "" && prevTargetPath != currTargetPath {
+			// we've found a new hour, so we need to send the logs of the
+			// previous hour for upload
+			uploadFn(logUploadSig{
+				key:    prevTargetPath,
+				nodeID: nodeID,
+				data:   logBuffer.Bytes(),
+			})
+
+			logBuffer.Reset()
+		}
+
+		rawLine, err := logEntryToJSON(e, appendUserTags(
+			append(
+				defaultDDTags, makeDDTag(uploadIDTag, uploadID), makeDDTag(nodeIDTag, nodeID),
+				makeDDTag(clusterTag, debugZipUploadOpts.clusterName),
+			), // system generated tags
+			debugZipUploadOpts.tags..., // user provided tags
+		))
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+
+		_, err = logBuffer.Write(append(rawLine, []byte("\n")...))
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+
+		stream.pop()
+		prevTargetPath = currTargetPath
+	}
+
+	// upload the remaining logs
+	if logBuffer.Len() > 0 {
+		uploadFn(logUploadSig{
+			key:    prevTargetPath,
+			data:   logBuffer.Bytes(),
+			nodeID: nodeID,
+		})
+		logBuffer.Reset()
+	}
+
+	return localMinTimestamp, localMaxTimestamp, nil
+}
+
+func logReaderPool(
+	size int, debugDirPath, uploadID string, uploadFn func(logUploadSig),
+) (func() (time.Time, time.Time), error) {
 	paths, err := expandPatterns([]string{path.Join(debugDirPath, zippedLogsPattern)})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	filePattern := regexp.MustCompile(logFilePattern)
@@ -326,74 +423,128 @@ func uploadZipLogs(ctx context.Context, uploadID string, debugDirPath string) er
 		paths, filePattern, nil, groupIndex(filePattern, "program"),
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	// chunkMap holds the mapping of target path names to the chunks of log lines
-	chunkMap := make(map[string][][]byte)
-	firstEventTime, lastEventTime := time.Time{}, time.Time{}
-	gcsPathPrefix := path.Join(debugZipUploadOpts.clusterName, uploadID)
+	filesChan := make(chan fileInfo, len(files))
+	wg := sync.WaitGroup{}
 	for _, file := range files {
-		pathParts := strings.Split(strings.TrimPrefix(file.path, debugDirPath), "/")
-		inputEditMode := log.SelectEditMode(false /* redactable */, false /* redactInput */)
-		stream, err := newFileLogStream(
-			file, time.Time(debugZipUploadOpts.from), time.Time(debugZipUploadOpts.to),
-			inputEditMode, debugZipUploadOpts.logFormat,
-		)
-		if err != nil {
-			return err
-		}
+		filesChan <- file
+	}
+	wg.Add(len(files))
 
-		for e, ok := stream.peek(); ok; e, ok = stream.peek() {
-			if firstEventTime.IsZero() {
-				firstEventTime = timeutil.Unix(0, e.Time) // from the first log entry
+	logTimeRange := struct {
+		syncutil.Mutex
+		min, max time.Time
+	}{}
+
+	for i := 0; i < size; i++ {
+		go func() {
+			for file := range filesChan {
+				fileMinTimestamp, fileMaxTimestamp, err := processLogFile(
+					uploadID, debugDirPath, file, uploadFn,
+				)
+				if err != nil {
+					fmt.Println("Failed to upload logs:", err)
+				} else {
+					if !fileMinTimestamp.IsZero() && !fileMaxTimestamp.IsZero() {
+						// consolidate the min and max timestamps. This is done in an
+						// anonymous function because the lock + update + unlock has to be
+						// done atomically. The linter will complain if there are if conditions
+						// in between the lock and unlock.
+						func() {
+							logTimeRange.Lock()
+							defer logTimeRange.Unlock()
+
+							if logTimeRange.min.IsZero() || fileMinTimestamp.Before(logTimeRange.min) {
+								logTimeRange.min = fileMinTimestamp
+							}
+
+							if fileMaxTimestamp.After(logTimeRange.max) {
+								logTimeRange.max = fileMaxTimestamp
+							}
+						}()
+					}
+				}
+
+				wg.Done()
 			}
-			lastEventTime = timeutil.Unix(0, e.Time) // from the last log entry
-
-			// The target path is constructed like this: <cluster-name>/<upload-id>/dt=20210901/hour=15
-			targetPath := path.Join(
-				gcsPathPrefix, timeutil.Unix(0, e.Time).Format("dt=20060102/hour=15"),
-			)
-			rawLine, err := logEntryToJSON(e, appendUserTags(
-				append(
-					defaultDDTags, makeDDTag(uploadIDTag, uploadID), makeDDTag(nodeIDTag, pathParts[2]),
-					makeDDTag(clusterTag, debugZipUploadOpts.clusterName),
-				), // system generated tags
-				debugZipUploadOpts.tags..., // user provided tags
-			))
-			if err != nil {
-				return err
-			}
-
-			if _, ok := chunkMap[targetPath]; !ok {
-				chunkMap[targetPath] = [][]byte{}
-			}
-
-			// TODO(arjunmahishi): Can this map hold all the data? We might be able
-			// to start the upload here itself. So that we don't have to keep
-			// everything in memory. But since we are running this on our mac books
-			// for now, we can afford to keep everything in memory.
-			chunkMap[targetPath] = append(chunkMap[targetPath], rawLine)
-			stream.pop()
-		}
-
-		if err := stream.error(); err != nil {
-			if err.Error() == "EOF" {
-				continue
-			}
-			return err
-		}
+		}()
 	}
 
-	if err := writeLogsToGCS(ctx, chunkMap); err != nil {
+	wait := func() (time.Time, time.Time) {
+		wg.Wait() // wait for all the reads to complete
+		close(filesChan)
+		return logTimeRange.min, logTimeRange.max
+	}
+
+	return wait, nil
+}
+
+func uploadZipLogs(ctx context.Context, uploadID string, debugDirPath string) error {
+	var (
+		// both the channels are buffered to keep the workers busy
+		gcsWorkChan = make(chan logUploadSig, debugZipUploadOpts.maxConcurrentUploads*2)
+		doneChan    = make(chan logUploadStatus, debugZipUploadOpts.maxConcurrentUploads*2)
+		writerGroup = sync.WaitGroup{}
+		totalSize   = 0
+		nodeLookup  = make(map[string]struct{})
+	)
+
+	go func() {
+		for sig := range doneChan {
+			if _, ok := nodeLookup[sig.nodeID]; !ok {
+				nodeLookup[sig.nodeID] = struct{}{}
+				fmt.Fprintf(os.Stderr, "Uploading logs for node %s\n", sig.nodeID)
+			}
+
+			if sig.err != nil {
+				fmt.Fprintln(os.Stderr, "error while uploading logs:", sig.err)
+			} else {
+				totalSize += sig.uploadSize
+			}
+
+			writerGroup.Done()
+		}
+	}()
+
+	// queueForUpload is responsible for receiving the logs from the
+	// logReaderPool and queuing them for upload. Currently, it just adds the
+	// logs to the gcsWorkChan but this can be extended to add work to more than
+	// on worker pool. In the near future, this will extend support to datadog
+	// logs API
+	queueForUpload := func(sig logUploadSig) {
+		writerGroup.Add(1)
+		gcsWorkChan <- sig
+	}
+
+	startGCSWriterPool(debugZipUploadOpts.maxConcurrentUploads, gcsWorkChan, doneChan)
+	waitForReads, err := logReaderPool(
+		debugZipUploadOpts.maxConcurrentUploads, debugDirPath, uploadID, queueForUpload,
+	)
+	if err != nil {
 		return err
 	}
 
-	if err := setupDDArchive(ctx, gcsPathPrefix, uploadID); err != nil {
-		return errors.Wrap(err, "failed to setup datadog archive")
+	// block until all the logs queued for upload
+	firstEventTime, lastEventTime := waitForReads()
+
+	writerGroup.Wait()
+	close(gcsWorkChan)
+	close(doneChan)
+
+	if totalSize != 0 {
+		fmt.Fprintf(os.Stderr, "Upload complete! Total size: %s\n", humanReadableSize(totalSize))
+
+		if err := setupDDArchive(
+			ctx, path.Join(debugZipUploadOpts.clusterName, uploadID), uploadID,
+		); err != nil {
+			return errors.Wrap(err, "failed to setup datadog archive")
+		}
+
+		printRehydrationSteps(uploadID, uploadID, firstEventTime, lastEventTime)
 	}
 
-	printRehydrationSteps(uploadID, uploadID, firstEventTime, lastEventTime)
 	return nil
 }
 
@@ -466,91 +617,80 @@ func setupDDArchive(ctx context.Context, pathPrefix, archiveName string) error {
 	return nil
 }
 
-type gcsWorkerSig struct {
-	key  string
-	data []byte
+type logUploadSig struct {
+	key    string
+	nodeID string
+	data   []byte
 }
 
-// writeLogsToGCS is a function that concurrently writes the logs to GCS.
-// The chunkMap is expected to be a map of time-base paths to luist of log lines.
+type logUploadStatus struct {
+	err        error
+	uploadSize int
+	nodeID     string
+}
+
+// startGCSWriterPool creates a worker pool that can concurrently write the
+// logs to GCS. This function only orchestrates the upload process. This pool
+// is terminated when the workChan is closed
+func startGCSWriterPool(size int, workChan <-chan logUploadSig, doneChan chan<- logUploadStatus) {
+	for i := 0; i < size; i++ {
+		go func() {
+			for sig := range workChan {
+				doneChan <- logUploadStatus{
+					err:        writeLogsToGCS(context.Background(), sig),
+					uploadSize: len(sig.data),
+					nodeID:     sig.nodeID,
+				}
+			}
+		}()
+	}
+}
+
+// writeLogsToGCS is a function that writes the logs to GCS.
+// The key in the gcsWorkerSig is the target path where the logs should be
+// uploaded.
 //
-//	Example: {
-//	  "dt=20210901/hour=15": [[]byte, []byte, ...],
-//	}
+//	Example: "<cluster-name>/<upload-id>/dt=20210901/hour=15/<node_id>/<filename>"
 //
 // Each path will be uploaded as a separate file. The final file name will be
-// randomly generated just be for uploading.
-var writeLogsToGCS = func(ctx context.Context, chunkMap map[string][][]byte) error {
+// randomly generated just be for uploading. This function only does the actual
+// writing to GCS. The concurrency has to be handled by the caller.
+var writeLogsToGCS = func(ctx context.Context, sig logUploadSig) error {
 	gcsClient, closeGCSClient, err := newGCSClient(ctx)
 	if err != nil {
 		return err
 	}
 	defer closeGCSClient()
 
-	// The concurrency can be easily managed with something like sync/errors.Group
-	// But using channels gives us two advantages:
-	// 1. We can fail fast i.e exit as soon as one upload fails
-	// 2. We can monitor the progress as the uploads happen and report it to the
-	// CLI user (this seem like a non-feature but this is super useful when the
-	// upload times are long)
-	workChan := make(chan gcsWorkerSig, len(chunkMap))
-	doneChan := make(chan error, len(chunkMap))
-	for key, lines := range chunkMap {
-		workChan <- gcsWorkerSig{key, bytes.Join(lines, []byte("\n"))}
-	}
+	filename := path.Join(sig.key, fmt.Sprintf(
+		"archive_%s_%s_%s.json.gz",
+		newRandStr(6, true /* numericOnly */), newRandStr(4, true), newRandStr(22, false),
+	))
 
-	// we can aggressively schedule the number of workers. Because this is a
-	// network IO bound workload. We will be waiting for the GCS API to complete
-	// the upload most of the time
-	noOfWorkers := min(system.NumCPU()*4, len(chunkMap))
-	for i := 0; i < noOfWorkers; i++ {
-		go func() {
-			for sig := range workChan {
-				filename := path.Join(sig.key, fmt.Sprintf(
-					"archive_%s_%s_%s.json.gz",
-					newRandStr(6, true /* numericOnly */), newRandStr(4, true), newRandStr(22, false),
-				))
+	retryOpts := base.DefaultRetryOptions()
+	retryOpts.MaxRetries = zipUploadRetries
 
-				objectWriter := gcsClient.Bucket(ddArchiveBucketName).Object(filename).NewWriter(ctx)
-				w := gzip.NewWriter(objectWriter)
-				_, err := w.Write(sig.data)
-				if err != nil {
-					doneChan <- err
-					return
-				}
-
-				if err := w.Close(); err != nil {
-					doneChan <- err
-					return
-				}
-
-				if err := objectWriter.Close(); err != nil {
-					doneChan <- err
-					return
-				}
-
-				doneChan <- nil
-			}
-		}()
-	}
-
-	report := newReporter(os.Stderr).newReport("logs")
-	doneCount := 0.0
-	for i := 0; i < len(chunkMap); i++ {
-		if err := <-doneChan; err != nil {
-			// stop everything and return the error
-			close(workChan)
-			close(doneChan)
-			return err
+	for retry := retry.Start(retryOpts); retry.Next(); {
+		objectWriter := gcsClient.Bucket(ddArchiveBucketName).Object(filename).NewWriter(ctx)
+		w := gzip.NewWriter(objectWriter)
+		_, err = w.Write(sig.data)
+		if err != nil {
+			continue
 		}
 
-		doneCount++
-		report((doneCount / float64(len(chunkMap))) * 100)
+		if err = w.Close(); err != nil {
+			continue
+		}
+
+		if err = objectWriter.Close(); err != nil {
+			continue
+		}
+
+		// if there was no error, we can break out of this loop
+		break
 	}
 
-	close(workChan)
-	close(doneChan)
-	return nil
+	return err
 }
 
 func newGCSClient(ctx context.Context) (*storage.Client, func(), error) {
@@ -767,67 +907,17 @@ func makeDDURL(tmpl string) string {
 	return fmt.Sprintf(tmpl, ddSiteToHostMap[debugZipUploadOpts.ddSite])
 }
 
-// zipUploadReporter is a simple concurrency-safe logger that can be used to
-// report the progress on the upload of each artifact type in the debug zip.
-// The log printed by this is updated in-place as the progress changes.
-// Usage pattern:
-//
-//	reporter := newReporter(os.Stderr)
-//	report := reporter.newReport("profiles")
-//	report(50) // 50% progress
-//	report(75) // 50% progress
-//	report(100) // 100% progress
-type zipUploadReporter struct {
-	syncutil.RWMutex
-	reports   map[string]float64
-	output    string
-	logWriter io.Writer
-}
-
-func (r *zipUploadReporter) print() {
-	r.RLock()
-	defer r.RUnlock()
-
-	// move the cursor to the top
-	currentLines := strings.Count(r.output, "\n")
-	if currentLines > 0 {
-		fmt.Fprintf(r.logWriter, "\033[%dA", currentLines)
+// humanReadableSize converts the given number of bytes to a human readable
+// format. Lowest unit is bytes and the highest unit is petabytes.
+func humanReadableSize(bytes int) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
 	}
-
-	reports := []string{}
-	for name := range r.reports {
-		reports = append(reports, name)
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
 	}
-	sort.Strings(reports)
-
-	var outputBuilder strings.Builder
-	for _, name := range reports {
-		progress := r.reports[name]
-		outputBuilder.WriteString(fmt.Sprintf("%s upload progress: %.2f%%\n", name, progress))
-	}
-
-	r.output = outputBuilder.String()
-	fmt.Fprint(r.logWriter, r.output)
-}
-
-func (r *zipUploadReporter) newReport(name string) func(float64) {
-	r.Lock()
-	defer r.print()
-	defer r.Unlock()
-
-	r.reports[name] = 0
-	return func(progress float64) {
-		r.Lock()
-		defer r.print()
-		defer r.Unlock()
-
-		r.reports[name] = progress
-	}
-}
-
-func newReporter(logWriter io.Writer) *zipUploadReporter {
-	return &zipUploadReporter{
-		reports:   make(map[string]float64),
-		logWriter: logWriter,
-	}
+	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
 }


### PR DESCRIPTION
Currently, the log upload works by loading all the logs into memory. This works in most cases. But is extreamly slow. This commit fixes that by reading the log files in batches (of 1 hour) and queues them for upload.

Both the read and upload happen concurrently using individual worker pools. This significantly improves speed and resource usage of the overall process.

This commit also adds retries for any upload related errors (This change was taken from https://github.com/cockroachdb/cockroach/pull/131654).

Part of: CC-29714
Release note: None