### PR TITLE
tablemetadatacache: write span stats failures to last_update_error

### DIFF
--- a/pkg/sql/tablemetadatacache/BUILD.bazel
+++ b/pkg/sql/tablemetadatacache/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
         "//pkg/base",
         "//pkg/jobs",
         "//pkg/kv/kvserver",
+        "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",

--- a/pkg/sql/tablemetadatacache/table_metadata_batch_iterator.go
+++ b/pkg/sql/tablemetadatacache/table_metadata_batch_iterator.go
@@ -7,13 +7,15 @@ package tablemetadatacache
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/errors"
 )
 
 const (
@@ -31,10 +33,10 @@ const (
 	schemaNameIdx
 	columnCountIdx
 	indexCountIdx
-	spanStatsIdx
 	tableTypeIdx
 	autoStatsEnabledIdx
 	statsLastUpdatedIdx
+	spanIdx
 
 	// iterCols is the number of columns returned by the batch iterator.
 	iterCols
@@ -57,7 +59,7 @@ type tableMetadataIterRow struct {
 	schemaName       string
 	columnCount      int
 	indexCount       int
-	spanStatsJSON    []byte
+	spanStats        roachpb.SpanStats
 	tableType        string
 	autoStatsEnabled *bool
 	statsLastUpdated *time.Time
@@ -70,15 +72,17 @@ type tableMetadataBatchIterator struct {
 	// The current batch of rows.
 	batchRows []tableMetadataIterRow
 	// query statement to use for retrieving batches
-	queryStatement string
+	queryStatement   string
+	spanStatsFetcher spanStatsFetcher
 }
 
 func newTableMetadataBatchIterator(
-	ie isql.Executor, aostClause string,
+	ie isql.Executor, spanStatsFetcher spanStatsFetcher, aostClause string,
 ) *tableMetadataBatchIterator {
 	return &tableMetadataBatchIterator{
-		ie:        ie,
-		batchRows: make([]tableMetadataIterRow, 0, tableBatchSize),
+		ie:               ie,
+		spanStatsFetcher: spanStatsFetcher,
+		batchRows:        make([]tableMetadataIterRow, 0, tableBatchSize),
 		lastID: paginationKey{
 			parentID: 1,
 			schemaID: 1,
@@ -106,18 +110,22 @@ func (batchIter *tableMetadataBatchIterator) fetchNextBatch(
 
 	// fetch-table-metadata-batch is a query that fetches a batch of rows
 	// from the system.namespace table according to the pagination key.
-	// We collect the table spans for the tables in the batch and issue
-	// a single SpanStats rpc via crdb_internal.tenant_span_stats to get the
-	// span stats for all the tables in the batch.
 	// Rows are then joined with the system.descirptor table to get the
 	// table descriptor metadata.
+	//
+	// We collect the table spans for the tables in the batch and issue
+	// a single SpanStats rpc via the spanStatsFetcher to get the span
+	// stats for all the tables in the batch.
+	var spans roachpb.Spans
 	for {
 		it, err := batchIter.ie.QueryIteratorEx(
 			ctx,
 			"fetch-table-metadata-batch",
 			nil, /* txn */
-			sessiondata.NodeUserWithBulkLowPriSessionDataOverride, batchIter.queryStatement,
-			batchIter.lastID.parentID, batchIter.lastID.schemaID, batchIter.lastID.name, batchSize,
+			sessiondata.NodeUserWithBulkLowPriSessionDataOverride,
+			batchIter.queryStatement,
+			batchIter.lastID.parentID, batchIter.lastID.schemaID, batchIter.lastID.name,
+			batchSize,
 		)
 		if err != nil {
 			return false, err
@@ -152,16 +160,15 @@ func (batchIter *tableMetadataBatchIterator) fetchNextBatch(
 			}
 
 			iterRow := tableMetadataIterRow{
-				tableID:       int(tree.MustBeDInt(row[idIdx])),
-				tableName:     string(tree.MustBeDString(row[tableNameIdx])),
-				dbID:          int(tree.MustBeDInt(row[parentIDIdx])),
-				dbName:        string(tree.MustBeDString(row[databaseNameIdx])),
-				schemaID:      int(tree.MustBeDInt(row[schemaIDIdx])),
-				schemaName:    string(tree.MustBeDString(row[schemaNameIdx])),
-				columnCount:   int(tree.MustBeDInt(row[columnCountIdx])),
-				indexCount:    int(tree.MustBeDInt(row[indexCountIdx])),
-				spanStatsJSON: []byte(tree.MustBeDJSON(row[spanStatsIdx]).JSON.String()),
-				tableType:     string(tree.MustBeDString(row[tableTypeIdx])),
+				tableID:     int(tree.MustBeDInt(row[idIdx])),
+				tableName:   string(tree.MustBeDString(row[tableNameIdx])),
+				dbID:        int(tree.MustBeDInt(row[parentIDIdx])),
+				dbName:      string(tree.MustBeDString(row[databaseNameIdx])),
+				schemaID:    int(tree.MustBeDInt(row[schemaIDIdx])),
+				schemaName:  string(tree.MustBeDString(row[schemaNameIdx])),
+				columnCount: int(tree.MustBeDInt(row[columnCountIdx])),
+				indexCount:  int(tree.MustBeDInt(row[indexCountIdx])),
+				tableType:   string(tree.MustBeDString(row[tableTypeIdx])),
 			}
 
 			if row[autoStatsEnabledIdx] != tree.DNull {
@@ -174,6 +181,12 @@ func (batchIter *tableMetadataBatchIterator) fetchNextBatch(
 				iterRow.statsLastUpdated = &t.Time
 			}
 
+			dSpan := tree.MustBeDArray(row[spanIdx]).Array
+			spans = append(spans, roachpb.Span{
+				Key:    []byte(tree.MustBeDBytes(dSpan[0])),
+				EndKey: []byte(tree.MustBeDBytes(dSpan[1])),
+			})
+
 			batchIter.batchRows = append(batchIter.batchRows, iterRow)
 		}
 
@@ -184,52 +197,81 @@ func (batchIter *tableMetadataBatchIterator) fetchNextBatch(
 		}
 	}
 
-	return len(batchIter.batchRows) > 0, nil
+	// Collect the span stats for the tables in the batch.
+	res, err := batchIter.spanStatsFetcher.SpanStats(ctx, &roachpb.SpanStatsRequest{
+		Spans:  spans,
+		NodeID: "0", // Fan out.
+	})
+
+	if err != nil {
+		return true, err
+	}
+
+	if len(res.Errors) > 0 {
+		errMsg := strings.Join(res.Errors, " ; ")
+		// For now we won't write partial results to the cache.
+		return true, errors.Newf("%s", errMsg)
+	}
+
+	if res.SpanToStats != nil {
+		for i, row := range batchIter.batchRows {
+			spanStats := res.SpanToStats[spans[i].String()]
+			if spanStats == nil {
+				continue
+			}
+			row.spanStats = *spanStats
+			batchIter.batchRows[i] = row
+		}
+	}
+
+	return true, nil
 }
 
 // newBatchQueryStatement creates a query statement to fetch batches of table metadata to insert into
 // system.table_metadata.
 func newBatchQueryStatement(aostClause string) string {
 	return fmt.Sprintf(`
-WITH tables AS (SELECT n.id,
-                       n.name,
-                       n."parentID",
-                       n."parentSchemaID",
-                       d.descriptor,
-                       crdb_internal.table_span(n.id) as span
-                FROM system.namespace n
-                JOIN system.descriptor d ON n.id = d.id
-								%[1]s
-                WHERE (n."parentID", n."parentSchemaID", n.name) > ($1, $2, $3) AND n."parentSchemaID" != 0
-                ORDER BY (n."parentID", n."parentSchemaID", n.name)
-                LIMIT $4),
-span_array AS (SELECT array_agg((span[1], span[2])) as all_spans FROM tables),
-span_stats AS (SELECT stats, t.id FROM crdb_internal.tenant_span_stats((SELECT all_spans FROM span_array)) s
-               JOIN tables t on t.span[1] = s.start_key and t.span[2] = s.end_key)
+WITH tables AS (
+    SELECT n.id,
+           n.name,
+           n."parentID",
+           n."parentSchemaID",
+           d.descriptor,
+           crdb_internal.table_span(n.id) as span
+    FROM system.namespace n
+    JOIN system.descriptor d ON n.id = d.id
+		%[1]s
+    WHERE (n."parentID", n."parentSchemaID", n.name) > ($1, $2, $3) AND n."parentSchemaID" != 0
+    ORDER BY (n."parentID", n."parentSchemaID", n.name)
+    LIMIT $4
+)
 SELECT t.id,
        t.name,
        t."parentID",
-       db_name.name,
+       db_name.name as db_name,
        t."parentSchemaID",
-       schema_name.name,
+       schema_name.name as schema_name,
        json_array_length(d -> 'table' -> 'columns') as columns,
-       COALESCE(json_array_length(d -> 'table' -> 'indexes'), 0),
-       s.stats,
-			 CASE
-			 		WHEN d->'table'->>'isMaterializedView' = 'true' THEN 'MATERIALIZED_VIEW'
-			 		WHEN d->'table'->>'viewQuery' IS NOT NULL THEN 'VIEW'
-			 		WHEN d->'table'->'sequenceOpts' IS NOT NULL THEN 'SEQUENCE'
-			 		ELSE 'TABLE'
-			 END as table_type,
-			(d->'table'->'autoStatsSettings'->>'enabled')::BOOL as auto_stats_enabled,
-			ts.last_updated as stats_last_updated
+       COALESCE(json_array_length(d -> 'table' -> 'indexes'), 0) as indexes,
+       CASE
+           WHEN d->'table'->>'isMaterializedView' = 'true' THEN 'MATERIALIZED_VIEW'
+           WHEN d->'table'->>'viewQuery' IS NOT NULL THEN 'VIEW'
+           WHEN d->'table'->'sequenceOpts' IS NOT NULL THEN 'SEQUENCE'
+           ELSE 'TABLE'
+           END as table_type,
+       (d->'table'->'autoStatsSettings'->>'enabled')::BOOL as auto_stats_enabled,
+       ts.last_updated as stats_last_updated,
+       t.span as span
 FROM tables t
-LEFT JOIN span_stats s ON t.id = s.id
-LEFT JOIN (select "tableID", max("createdAt") as last_updated from system.table_statistics group by "tableID") ts ON ts."tableID" = t.id
-LEFT JOIN system.namespace db_name ON t."parentID" = db_name.id
-LEFT JOIN system.namespace schema_name ON t."parentSchemaID" = schema_name.id,
+LEFT JOIN (
+    SELECT "tableID", max("createdAt") as last_updated 
+    FROM system.table_statistics 
+    GROUP BY "tableID"
+) ts ON ts."tableID" = t.id
+LEFT JOIN system.namespace db_name ON t."parentID" = db_name.id AND db_name."parentID" = 0
+LEFT JOIN system.namespace schema_name ON t."parentSchemaID" = schema_name.id AND schema_name."parentID" = t."parentID",
 crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', t.descriptor) AS d
 %[1]s
-ORDER BY (t."parentID", t."parentSchemaID", t.name)
+ORDER BY (t."parentID", t."parentSchemaID", t.name);
 `, aostClause)
 }

--- a/pkg/sql/tablemetadatacache/table_metadata_updater_test.go
+++ b/pkg/sql/tablemetadatacache/table_metadata_updater_test.go
@@ -9,10 +9,14 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	tablemetadatacacheutil "github.com/cockroachdb/cockroach/pkg/sql/tablemetadatacache/util"
@@ -28,29 +32,36 @@ import (
 
 // TestDataDrivenTableMetadataCacheUpdater tests the operations performed by
 // tableMetadataCacheUpdater. It reads data written to system.table_metadata
-// by the cache updater to ensure the udpates are valid.
+// by the cache updater to ensure the updates are valid.
 func TestDataDrivenTableMetadataCacheUpdater(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	knobs := tablemetadatacacheutil.CreateTestingKnobs()
-	s := serverutils.StartServerOnly(t, base.TestServerArgs{
-		Knobs: base.TestingKnobs{
-			TableMetadata: knobs,
-		},
-	})
-	defer s.Stopper().Stop(ctx)
-
-	queryConn := s.ApplicationLayer().SQLConn(t)
-	s.ApplicationLayer().DB()
-
 	// We won't check the job progress in this test.
 	mockUpdateProgress := func(ctx context.Context, progress float32) {}
-	metrics := newTableMetadataUpdateJobMetrics().(TableMetadataUpdateJobMetrics)
 	datadriven.Walk(t, datapathutils.TestDataPath(t, ""), func(t *testing.T, path string) {
+		metrics := newTableMetadataUpdateJobMetrics().(TableMetadataUpdateJobMetrics)
+		mockTimeSrc := timeutil.NewManualTime(timeutil.FromUnixMicros(0))
+		s := serverutils.StartServerOnly(t, base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				TableMetadata: knobs,
+			},
+		})
+		defer s.Stopper().Stop(ctx)
+
+		queryConn := s.ApplicationLayer().SQLConn(t)
+		s.ApplicationLayer().DB()
+		spanStatsServer := s.TenantStatusServer().(serverpb.TenantStatusServer)
+
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
+			case "set-time":
+				var unixSecs int64
+				d.ScanArgs(t, "unixSecs", &unixSecs)
+				mockTimeSrc.AdvanceTo(timeutil.FromUnixMicros(unixSecs * 1e6))
+				return ""
 			case "query":
 				rows, err := queryConn.Query(d.Input)
 				if err != nil {
@@ -62,14 +73,42 @@ func TestDataDrivenTableMetadataCacheUpdater(t *testing.T) {
 				}
 				return res
 			case "update-cache":
-				updater := newTableMetadataUpdater(mockUpdateProgress, &metrics, s.InternalExecutor().(isql.Executor), knobs)
-				updated, err := updater.updateCache(ctx)
+				var spanStatsErrors string
+				// The batch number to inject an error on.
+				var spanStatsErrBatch int64
+				var spanStatsSrv spanStatsFetcher = spanStatsServer
+				d.MaybeScanArgs(t, "injectSpanStatsErrors", &spanStatsErrors)
+				d.MaybeScanArgs(t, "spanStatsErrBatch", &spanStatsErrBatch)
+				batchCount := atomic.Int64{}
+				if spanStatsErrors != "" {
+					spanStatsSrv = &mockSpanStatsFetcher{
+						getSpanStats: func(ctx context.Context, request *roachpb.SpanStatsRequest) (*roachpb.SpanStatsResponse, error) {
+							var errs []string
+							batchCount.Add(1)
+							if spanStatsErrBatch == 0 || batchCount.Load() == spanStatsErrBatch {
+								errs = strings.Split(spanStatsErrors, ",")
+							}
+							return &roachpb.SpanStatsResponse{
+								SpanToStats: nil,
+								Errors:      errs,
+							}, nil
+						},
+					}
+				}
+				updater := newTableMetadataUpdater(mockUpdateProgress, &metrics, spanStatsSrv, s.InternalExecutor().(isql.Executor), mockTimeSrc, knobs)
+				prevUpdatedTables := metrics.UpdatedTables.Count()
+				prevErrs := metrics.Errors.Count()
+				err := updater.RunUpdater(ctx)
 				if err != nil {
 					return err.Error()
 				}
-				return fmt.Sprintf("updated %d table(s)", updated)
+				return fmt.Sprintf("updatedTables: %d, errors: %d, run #: %d, duration > 0: %t",
+					metrics.UpdatedTables.Count()-prevUpdatedTables,
+					metrics.Errors.Count()-prevErrs,
+					metrics.NumRuns.Count(),
+					metrics.Duration.CumulativeSnapshot().Mean() > 0)
 			case "prune-cache":
-				updater := newTableMetadataUpdater(mockUpdateProgress, &metrics, s.InternalExecutor().(isql.Executor), knobs)
+				updater := newTableMetadataUpdater(mockUpdateProgress, &metrics, spanStatsServer, s.InternalExecutor().(isql.Executor), mockTimeSrc, knobs)
 				pruned, err := updater.pruneCache(ctx)
 				if err != nil {
 					return err.Error()
@@ -110,16 +149,18 @@ func TestTableMetadataUpdateJobProgressAndMetrics(t *testing.T) {
 	conn := sqlutils.MakeSQLRunner(s.ApplicationLayer().SQLConn(t))
 	metrics := newTableMetadataUpdateJobMetrics().(TableMetadataUpdateJobMetrics)
 	count := 0
-	updater := tableMetadataUpdater{
-		ie:      s.ExecutorConfig().(sql.ExecutorConfig).InternalDB.Executor(),
-		metrics: &metrics,
-		updateProgress: func(ctx context.Context, progress float32) {
+	updater := newTableMetadataUpdater(
+		func(ctx context.Context, progress float32) {
 			require.Greater(t, progress, currentProgress, "progress should be greater than current progress")
 			currentProgress = progress
 			count++
-		},
-		testKnobs: knobs,
-	}
+		}, // onProgressUpdated
+		&metrics,
+		s.TenantStatusServer().(serverpb.TenantStatusServer),
+		s.ExecutorConfig().(sql.ExecutorConfig).InternalDB.Executor(),
+		timeutil.DefaultTimeSource{},
+		knobs,
+	)
 	require.NoError(t, updater.RunUpdater(ctx))
 	updatedTables := metrics.UpdatedTables.Count()
 	require.Greater(t, updatedTables, int64(0))
@@ -153,4 +194,19 @@ func TestTableMetadataUpdateJobProgressAndMetrics(t *testing.T) {
 	require.Equal(t, int64(0), metrics.Errors.Count())
 	require.Equal(t, float32(.99), currentProgress)
 	require.Equal(t, int64(2), metrics.NumRuns.Count())
+}
+
+type mockSpanStatsFetcher struct {
+	getSpanStats func(ctx context.Context, request *roachpb.SpanStatsRequest) (*roachpb.SpanStatsResponse, error)
+}
+
+var _ spanStatsFetcher = &mockSpanStatsFetcher{}
+
+func (m *mockSpanStatsFetcher) SpanStats(
+	ctx context.Context, request *roachpb.SpanStatsRequest,
+) (*roachpb.SpanStatsResponse, error) {
+	if m.getSpanStats == nil {
+		return nil, nil
+	}
+	return m.getSpanStats(ctx, request)
 }

--- a/pkg/sql/tablemetadatacache/testdata/update_table_metadata
+++ b/pkg/sql/tablemetadatacache/testdata/update_table_metadata
@@ -1,3 +1,6 @@
+set-time unixSecs=1610000000
+----
+
 query
 SELECT * FROM system.table_metadata
 ----
@@ -42,7 +45,7 @@ success
 
 update-cache
 ----
-updated 64 table(s)
+updatedTables: 64, errors: 0, run #: 1, duration > 0: true
 
 
 # We're omitting the following columns since they are not deterministic.
@@ -64,74 +67,75 @@ SELECT
   details->'auto_stats_enabled',
   store_ids,
   total_ranges,
+  last_updated,
   last_update_error
 FROM system.table_metadata
 ORDER BY (db_name, table_name)
 ----
-autostats_disabled defaultdb public 100 107 2 0 TABLE false {1} 1 <nil>
-autostats_enabled defaultdb public 100 106 2 0 TABLE true {1} 1 <nil>
-mymaterializedview defaultdb public 100 109 4 0 MATERIALIZED_VIEW null {1} 1 <nil>
-myseq defaultdb public 100 110 1 0 SEQUENCE null {1} 1 <nil>
-mytable defaultdb public 100 104 3 0 TABLE null {1} 1 <nil>
-mytable2 defaultdb public 100 105 4 0 TABLE null {1} 1 <nil>
-myview defaultdb public 100 108 3 0 VIEW null {1} 1 <nil>
-comments system public 1 24 4 0 TABLE null {1} 1 <nil>
-database_role_settings system public 1 44 4 1 TABLE null {1} 1 <nil>
-descriptor system public 1 3 2 0 TABLE null {1} 1 <nil>
-descriptor_id_seq system public 1 7 1 0 SEQUENCE null {1} 1 <nil>
-eventlog system public 1 12 6 0 TABLE null {1} 1 <nil>
-external_connections system public 1 53 7 0 TABLE null {1} 1 <nil>
-job_info system public 1 54 4 0 TABLE null {1} 1 <nil>
-jobs system public 1 15 12 4 TABLE null {1} 1 <nil>
-join_tokens system public 1 41 3 0 TABLE null {1} 1 <nil>
-lease system public 1 11 5 0 TABLE null {1} 1 <nil>
-locations system public 1 21 4 0 TABLE null {1} 1 <nil>
-migrations system public 1 40 5 0 TABLE null {1} 1 <nil>
-mvcc_statistics system public 1 64 6 0 TABLE null {1} 1 <nil>
-namespace system public 1 30 4 0 TABLE null {1} 1 <nil>
-privileges system public 1 52 5 2 TABLE null {1} 1 <nil>
-protected_ts_meta system public 1 31 5 0 TABLE null {1} 1 <nil>
-protected_ts_records system public 1 32 8 0 TABLE null {1} 1 <nil>
-rangelog system public 1 13 7 0 TABLE null {1} 1 <nil>
-region_liveness system public 1 9 2 0 TABLE null {1} 1 <nil>
-replication_constraint_stats system public 1 25 7 0 TABLE null {1} 1 <nil>
-replication_critical_localities system public 1 26 5 0 TABLE null {1} 1 <nil>
-replication_stats system public 1 27 7 0 TABLE null {1} 1 <nil>
-reports_meta system public 1 28 2 0 TABLE null {1} 1 <nil>
-role_id_seq system public 1 48 1 0 SEQUENCE null {1} 1 <nil>
-role_members system public 1 23 5 5 TABLE null {1} 1 <nil>
-role_options system public 1 33 4 1 TABLE null {1} 1 <nil>
-scheduled_jobs system public 1 37 10 1 TABLE null {1} 1 <nil>
-settings system public 1 6 4 0 TABLE null {1} 1 <nil>
-span_configurations system public 1 47 3 0 TABLE null {1} 1 <nil>
-span_count system public 1 51 2 0 TABLE null {1} 1 <nil>
-span_stats_buckets system public 1 56 5 1 TABLE null {1} 1 <nil>
-span_stats_samples system public 1 57 2 1 TABLE null {1} 1 <nil>
-span_stats_tenant_boundaries system public 1 58 2 0 TABLE null {1} 1 <nil>
-span_stats_unique_keys system public 1 55 2 1 TABLE null {1} 1 <nil>
-sql_instances system public 1 46 8 0 TABLE null {1} 1 <nil>
-sqlliveness system public 1 39 3 0 TABLE null {1} 1 <nil>
-statement_activity system public 1 61 17 7 TABLE null {1} 1 <nil>
-statement_bundle_chunks system public 1 34 3 0 TABLE null {1} 1 <nil>
-statement_diagnostics system public 1 36 7 0 TABLE null {1} 1 <nil>
-statement_diagnostics_requests system public 1 35 11 1 TABLE null {1} 1 <nil>
-statement_execution_insights system public 1 66 29 4 TABLE null {1} 1 <nil>
-statement_statistics system public 1 42 19 8 TABLE null {1} 1 <nil>
-table_metadata system public 1 67 18 10 TABLE null {1} 1 <nil>
-table_statistics system public 1 20 12 0 TABLE null {1} 1 <nil>
-task_payloads system public 1 59 8 0 TABLE null {1} 1 <nil>
-tenant_id_seq system public 1 63 1 0 SEQUENCE null {1} 1 <nil>
-tenant_settings system public 1 50 6 0 TABLE null {1} 1 <nil>
-tenant_tasks system public 1 60 7 0 TABLE null {1} 1 <nil>
-tenant_usage system public 1 45 14 0 TABLE null {1} 1 <nil>
-tenants system public 1 8 6 2 TABLE null {1} 1 <nil>
-transaction_activity system public 1 62 14 7 TABLE null {1} 1 <nil>
-transaction_execution_insights system public 1 65 23 2 TABLE null {1} 1 <nil>
-transaction_statistics system public 1 43 14 7 TABLE null {1} 1 <nil>
-ui system public 1 14 3 0 TABLE null {1} 1 <nil>
-users system public 1 4 4 1 TABLE null {1} 1 <nil>
-web_sessions system public 1 19 9 4 TABLE null {1} 1 <nil>
-zones system public 1 5 2 0 TABLE null {1} 1 <nil>
+autostats_disabled defaultdb public 100 107 2 0 TABLE false {1} 1 2021-01-07 06:13:20 +0000 UTC 
+autostats_enabled defaultdb public 100 106 2 0 TABLE true {1} 1 2021-01-07 06:13:20 +0000 UTC 
+mymaterializedview defaultdb public 100 109 4 0 MATERIALIZED_VIEW null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+myseq defaultdb public 100 110 1 0 SEQUENCE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+mytable defaultdb public 100 104 3 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+mytable2 defaultdb public 100 105 4 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+myview defaultdb public 100 108 3 0 VIEW null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+comments system public 1 24 4 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+database_role_settings system public 1 44 4 1 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+descriptor system public 1 3 2 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+descriptor_id_seq system public 1 7 1 0 SEQUENCE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+eventlog system public 1 12 6 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+external_connections system public 1 53 7 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+job_info system public 1 54 4 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+jobs system public 1 15 12 4 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+join_tokens system public 1 41 3 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+lease system public 1 11 5 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+locations system public 1 21 4 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+migrations system public 1 40 5 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+mvcc_statistics system public 1 64 6 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+namespace system public 1 30 4 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+privileges system public 1 52 5 2 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+protected_ts_meta system public 1 31 5 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+protected_ts_records system public 1 32 8 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+rangelog system public 1 13 7 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+region_liveness system public 1 9 2 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+replication_constraint_stats system public 1 25 7 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+replication_critical_localities system public 1 26 5 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+replication_stats system public 1 27 7 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+reports_meta system public 1 28 2 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+role_id_seq system public 1 48 1 0 SEQUENCE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+role_members system public 1 23 5 5 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+role_options system public 1 33 4 1 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+scheduled_jobs system public 1 37 10 1 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+settings system public 1 6 4 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+span_configurations system public 1 47 3 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+span_count system public 1 51 2 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+span_stats_buckets system public 1 56 5 1 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+span_stats_samples system public 1 57 2 1 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+span_stats_tenant_boundaries system public 1 58 2 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+span_stats_unique_keys system public 1 55 2 1 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+sql_instances system public 1 46 8 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+sqlliveness system public 1 39 3 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+statement_activity system public 1 61 17 7 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+statement_bundle_chunks system public 1 34 3 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+statement_diagnostics system public 1 36 7 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+statement_diagnostics_requests system public 1 35 11 1 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+statement_execution_insights system public 1 66 29 4 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+statement_statistics system public 1 42 19 8 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+table_metadata system public 1 67 18 10 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+table_statistics system public 1 20 12 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+task_payloads system public 1 59 8 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+tenant_id_seq system public 1 63 1 0 SEQUENCE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+tenant_settings system public 1 50 6 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+tenant_tasks system public 1 60 7 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+tenant_usage system public 1 45 14 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+tenants system public 1 8 6 2 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+transaction_activity system public 1 62 14 7 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+transaction_execution_insights system public 1 65 23 2 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+transaction_statistics system public 1 43 14 7 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+ui system public 1 14 3 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+users system public 1 4 4 1 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+web_sessions system public 1 19 9 4 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
+zones system public 1 5 2 0 TABLE null {1} 1 2021-01-07 06:13:20 +0000 UTC 
 
 query
 SELECT count(*) FROM system.table_metadata WHERE perc_live_data > 1

--- a/pkg/sql/tablemetadatacache/testdata/update_table_metadata_errors
+++ b/pkg/sql/tablemetadatacache/testdata/update_table_metadata_errors
@@ -1,0 +1,317 @@
+set-time unixSecs=1610000000
+----
+
+update-cache injectSpanStatsErrors=error1
+----
+updatedTables: 57, errors: 3, run #: 1, duration > 0: true
+
+# Since this is the first update and we encountered an error we should see the zero value for
+# the non nullable columns, except for the last updated time which is set to the current time.
+query
+SELECT * FROM system.table_metadata
+ORDER BY (db_name, table_name)
+----
+1 24 system public comments 4 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 44 system public database_role_settings 4 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 3 system public descriptor 2 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 7 system public descriptor_id_seq 1 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC SEQUENCE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 12 system public eventlog 6 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 53 system public external_connections 7 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 54 system public job_info 4 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 15 system public jobs 12 4 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 41 system public join_tokens 3 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 11 system public lease 5 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 21 system public locations 4 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 40 system public migrations 5 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 64 system public mvcc_statistics 6 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 30 system public namespace 4 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 52 system public privileges 5 2 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 31 system public protected_ts_meta 5 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 32 system public protected_ts_records 8 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 13 system public rangelog 7 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 9 system public region_liveness 2 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 25 system public replication_constraint_stats 7 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 26 system public replication_critical_localities 5 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 27 system public replication_stats 7 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 28 system public reports_meta 2 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 48 system public role_id_seq 1 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC SEQUENCE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 23 system public role_members 5 5 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 33 system public role_options 4 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 37 system public scheduled_jobs 10 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 6 system public settings 4 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 47 system public span_configurations 3 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 51 system public span_count 2 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 56 system public span_stats_buckets 5 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 57 system public span_stats_samples 2 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 58 system public span_stats_tenant_boundaries 2 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 55 system public span_stats_unique_keys 2 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 46 system public sql_instances 8 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 39 system public sqlliveness 3 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 61 system public statement_activity 17 7 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 34 system public statement_bundle_chunks 3 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 36 system public statement_diagnostics 7 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 35 system public statement_diagnostics_requests 11 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 66 system public statement_execution_insights 29 4 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 42 system public statement_statistics 19 8 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 67 system public table_metadata 18 10 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 20 system public table_statistics 12 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 59 system public task_payloads 8 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 63 system public tenant_id_seq 1 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC SEQUENCE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 50 system public tenant_settings 6 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 60 system public tenant_tasks 7 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 45 system public tenant_usage 14 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 8 system public tenants 6 2 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 62 system public transaction_activity 14 7 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 65 system public transaction_execution_insights 23 2 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 43 system public transaction_statistics 14 7 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 14 system public ui 3 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 4 system public users 4 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 19 system public web_sessions 9 4 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 5 system public zones 2 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+
+
+set-time unixSecs=1710000000
+----
+
+update-cache
+----
+updatedTables: 57, errors: 0, run #: 2, duration > 0: true
+
+# Now the last_update_error column should be nil and data
+# should be updated.
+query
+SELECT
+  table_name,
+  db_name,
+  schema_name,
+  db_id,
+  table_id,
+  total_columns,
+  total_indexes,
+  table_type,
+  details->'auto_stats_enabled',
+  store_ids,
+  total_ranges,
+  last_updated,
+  last_update_error
+FROM system.table_metadata
+ORDER BY (db_name, table_name)
+----
+comments system public 1 24 4 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+database_role_settings system public 1 44 4 1 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+descriptor system public 1 3 2 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+descriptor_id_seq system public 1 7 1 0 SEQUENCE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+eventlog system public 1 12 6 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+external_connections system public 1 53 7 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+job_info system public 1 54 4 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+jobs system public 1 15 12 4 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+join_tokens system public 1 41 3 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+lease system public 1 11 5 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+locations system public 1 21 4 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+migrations system public 1 40 5 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+mvcc_statistics system public 1 64 6 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+namespace system public 1 30 4 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+privileges system public 1 52 5 2 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+protected_ts_meta system public 1 31 5 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+protected_ts_records system public 1 32 8 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+rangelog system public 1 13 7 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+region_liveness system public 1 9 2 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+replication_constraint_stats system public 1 25 7 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+replication_critical_localities system public 1 26 5 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+replication_stats system public 1 27 7 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+reports_meta system public 1 28 2 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+role_id_seq system public 1 48 1 0 SEQUENCE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+role_members system public 1 23 5 5 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+role_options system public 1 33 4 1 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+scheduled_jobs system public 1 37 10 1 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+settings system public 1 6 4 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+span_configurations system public 1 47 3 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+span_count system public 1 51 2 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+span_stats_buckets system public 1 56 5 1 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+span_stats_samples system public 1 57 2 1 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+span_stats_tenant_boundaries system public 1 58 2 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+span_stats_unique_keys system public 1 55 2 1 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+sql_instances system public 1 46 8 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+sqlliveness system public 1 39 3 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+statement_activity system public 1 61 17 7 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+statement_bundle_chunks system public 1 34 3 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+statement_diagnostics system public 1 36 7 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+statement_diagnostics_requests system public 1 35 11 1 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+statement_execution_insights system public 1 66 29 4 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+statement_statistics system public 1 42 19 8 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+table_metadata system public 1 67 18 10 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+table_statistics system public 1 20 12 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+task_payloads system public 1 59 8 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+tenant_id_seq system public 1 63 1 0 SEQUENCE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+tenant_settings system public 1 50 6 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+tenant_tasks system public 1 60 7 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+tenant_usage system public 1 45 14 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+tenants system public 1 8 6 2 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+transaction_activity system public 1 62 14 7 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+transaction_execution_insights system public 1 65 23 2 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+transaction_statistics system public 1 43 14 7 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+ui system public 1 14 3 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+users system public 1 4 4 1 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+web_sessions system public 1 19 9 4 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+zones system public 1 5 2 0 TABLE null {1} 1 2024-03-09 16:00:00 +0000 UTC <nil>
+
+
+set-time unixSecs=1711000000
+----
+
+# Verify that encountering a new error does not clear the previous row data,
+# including the last_updated time.
+update-cache injectSpanStatsErrors=error2,error3
+----
+updatedTables: 57, errors: 3, run #: 3, duration > 0: true
+
+query
+SELECT
+  db_id,
+  table_id
+  db_name,
+  table_name,
+  total_columns,
+  store_ids,
+  total_ranges,
+  last_updated,
+  last_update_error
+FROM system.table_metadata
+----
+1 3 descriptor 2 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 4 users 4 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 5 zones 2 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 6 settings 4 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 7 descriptor_id_seq 1 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 8 tenants 6 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 9 region_liveness 2 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 11 lease 5 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 12 eventlog 6 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 13 rangelog 7 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 14 ui 3 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 15 jobs 12 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 19 web_sessions 9 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 20 table_statistics 12 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 21 locations 4 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 23 role_members 5 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 24 comments 4 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 25 replication_constraint_stats 7 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 26 replication_critical_localities 5 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 27 replication_stats 7 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 28 reports_meta 2 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 30 namespace 4 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 31 protected_ts_meta 5 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 32 protected_ts_records 8 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 33 role_options 4 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 34 statement_bundle_chunks 3 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 35 statement_diagnostics_requests 11 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 36 statement_diagnostics 7 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 37 scheduled_jobs 10 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 39 sqlliveness 3 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 40 migrations 5 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 41 join_tokens 3 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 42 statement_statistics 19 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 43 transaction_statistics 14 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 44 database_role_settings 4 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 45 tenant_usage 14 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 46 sql_instances 8 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 47 span_configurations 3 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 48 role_id_seq 1 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 50 tenant_settings 6 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 51 span_count 2 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 52 privileges 5 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 53 external_connections 7 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 54 job_info 4 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 55 span_stats_unique_keys 2 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 56 span_stats_buckets 5 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 57 span_stats_samples 2 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 58 span_stats_tenant_boundaries 2 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 59 task_payloads 8 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 60 tenant_tasks 7 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 61 statement_activity 17 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 62 transaction_activity 14 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 63 tenant_id_seq 1 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 64 mvcc_statistics 6 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 65 transaction_execution_insights 23 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 66 statement_execution_insights 29 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 67 table_metadata 18 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+
+
+set-time unixSecs=1810010000
+----
+
+# Test that a span stats rpc error for a single batch does not affect the other batches
+# from being retrieved. We should see tables with an error have the previous date.
+
+update-cache injectSpanStatsErrors=error4 spanStatsErrBatch=1
+----
+updatedTables: 57, errors: 1, run #: 4, duration > 0: true
+
+query
+SELECT
+  last_updated,
+  last_update_error,
+  db_id,
+  table_id
+  db_name,
+  table_name
+FROM system.table_metadata
+ORDER BY last_updated
+----
+2024-03-09 16:00:00 +0000 UTC error4 1 30 namespace
+2024-03-09 16:00:00 +0000 UTC error4 1 64 mvcc_statistics
+2024-03-09 16:00:00 +0000 UTC error4 1 54 job_info
+2024-03-09 16:00:00 +0000 UTC error4 1 53 external_connections
+2024-03-09 16:00:00 +0000 UTC error4 1 7 descriptor_id_seq
+2024-03-09 16:00:00 +0000 UTC error4 1 52 privileges
+2024-03-09 16:00:00 +0000 UTC error4 1 9 region_liveness
+2024-03-09 16:00:00 +0000 UTC error4 1 11 lease
+2024-03-09 16:00:00 +0000 UTC error4 1 12 eventlog
+2024-03-09 16:00:00 +0000 UTC error4 1 13 rangelog
+2024-03-09 16:00:00 +0000 UTC error4 1 44 database_role_settings
+2024-03-09 16:00:00 +0000 UTC error4 1 15 jobs
+2024-03-09 16:00:00 +0000 UTC error4 1 41 join_tokens
+2024-03-09 16:00:00 +0000 UTC error4 1 3 descriptor
+2024-03-09 16:00:00 +0000 UTC error4 1 21 locations
+2024-03-09 16:00:00 +0000 UTC error4 1 40 migrations
+2024-03-09 16:00:00 +0000 UTC error4 1 24 comments
+2024-03-09 16:00:00 +0000 UTC error4 1 25 replication_constraint_stats
+2024-03-09 16:00:00 +0000 UTC error4 1 32 protected_ts_records
+2024-03-09 16:00:00 +0000 UTC error4 1 31 protected_ts_meta
+2027-05-11 04:33:20 +0000 UTC <nil> 1 20 table_statistics
+2027-05-11 04:33:20 +0000 UTC <nil> 1 50 tenant_settings
+2027-05-11 04:33:20 +0000 UTC <nil> 1 27 replication_stats
+2027-05-11 04:33:20 +0000 UTC <nil> 1 26 replication_critical_localities
+2027-05-11 04:33:20 +0000 UTC <nil> 1 33 role_options
+2027-05-11 04:33:20 +0000 UTC <nil> 1 34 statement_bundle_chunks
+2027-05-11 04:33:20 +0000 UTC <nil> 1 35 statement_diagnostics_requests
+2027-05-11 04:33:20 +0000 UTC <nil> 1 36 statement_diagnostics
+2027-05-11 04:33:20 +0000 UTC <nil> 1 37 scheduled_jobs
+2027-05-11 04:33:20 +0000 UTC <nil> 1 39 sqlliveness
+2027-05-11 04:33:20 +0000 UTC <nil> 1 23 role_members
+2027-05-11 04:33:20 +0000 UTC <nil> 1 19 web_sessions
+2027-05-11 04:33:20 +0000 UTC <nil> 1 42 statement_statistics
+2027-05-11 04:33:20 +0000 UTC <nil> 1 43 transaction_statistics
+2027-05-11 04:33:20 +0000 UTC <nil> 1 14 ui
+2027-05-11 04:33:20 +0000 UTC <nil> 1 45 tenant_usage
+2027-05-11 04:33:20 +0000 UTC <nil> 1 46 sql_instances
+2027-05-11 04:33:20 +0000 UTC <nil> 1 47 span_configurations
+2027-05-11 04:33:20 +0000 UTC <nil> 1 48 role_id_seq
+2027-05-11 04:33:20 +0000 UTC <nil> 1 28 reports_meta
+2027-05-11 04:33:20 +0000 UTC <nil> 1 51 span_count
+2027-05-11 04:33:20 +0000 UTC <nil> 1 8 tenants
+2027-05-11 04:33:20 +0000 UTC <nil> 1 6 settings
+2027-05-11 04:33:20 +0000 UTC <nil> 1 5 zones
+2027-05-11 04:33:20 +0000 UTC <nil> 1 55 span_stats_unique_keys
+2027-05-11 04:33:20 +0000 UTC <nil> 1 56 span_stats_buckets
+2027-05-11 04:33:20 +0000 UTC <nil> 1 57 span_stats_samples
+2027-05-11 04:33:20 +0000 UTC <nil> 1 58 span_stats_tenant_boundaries
+2027-05-11 04:33:20 +0000 UTC <nil> 1 59 task_payloads
+2027-05-11 04:33:20 +0000 UTC <nil> 1 60 tenant_tasks
+2027-05-11 04:33:20 +0000 UTC <nil> 1 61 statement_activity
+2027-05-11 04:33:20 +0000 UTC <nil> 1 62 transaction_activity
+2027-05-11 04:33:20 +0000 UTC <nil> 1 63 tenant_id_seq
+2027-05-11 04:33:20 +0000 UTC <nil> 1 4 users
+2027-05-11 04:33:20 +0000 UTC <nil> 1 65 transaction_execution_insights
+2027-05-11 04:33:20 +0000 UTC <nil> 1 66 statement_execution_insights
+2027-05-11 04:33:20 +0000 UTC <nil> 1 67 table_metadata

--- a/pkg/sql/tablemetadatacache/update_table_metadata_cache_job.go
+++ b/pkg/sql/tablemetadatacache/update_table_metadata_cache_job.go
@@ -59,7 +59,13 @@ func (j *tableMetadataUpdateJobResumer) Resume(ctx context.Context, execCtxI int
 	}
 
 	if updater == nil {
-		updater = newTableMetadataUpdater(j.updateProgress, &metrics, execCtx.ExecCfg().InternalDB.Executor(), testKnobs)
+		updater = newTableMetadataUpdater(
+			j.updateProgress,
+			&metrics,
+			execCtx.ExecCfg().TenantStatusServer,
+			execCtx.ExecCfg().InternalDB.Executor(),
+			timeutil.DefaultTimeSource{},
+			testKnobs)
 	}
 	// We must reset the job's num runs to 0 so that it doesn't get
 	// delayed by the job system's exponential backoff strategy.


### PR DESCRIPTION
Only the latest commit is for review in this PR.

----------------------------------------

The span stats rpc fan out can contain errors in the
response. Some examples include node dial errors,
or error responses from different nodes. In those cases
we should write the error for the batch to the
last_update_error column and go on to the next batch.

To support reading the errors from the span stats response
we have now split the span stats request off from the query
fetching descriptor information for the batch. Span stats
are now fetched per batch by issuing an rpc request directly
on the span stats server.

Epic: CRDB-37558
Fixes: https://github.com/cockroachdb/cockroach/issues/130040

Release note: None

Release note: None