### PR TITLE
sql/colexec: fix selection comparisons with NULL

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -1054,3 +1054,23 @@ query B
 SELECT o NOT IN ((SELECT NULL FROM t127814_empty),) FROM t127814
 ----
 NULL
+
+# Regression test for #130759. The vectorized engine should correctly evaluate
+# IN expressions where the tuple on the RHS contains a single NULL value.
+statement ok
+CREATE TABLE t130759 (
+  i INT
+);
+
+statement ok
+INSERT INTO t130759 VALUES (0);
+
+query I
+SELECT 1
+FROM t130759
+WHERE NOT (
+  ('127.0.0.1'::INET - i) IN (
+    (SELECT NULL FROM (VALUES (0)) v(i) WHERE false),
+  )
+)
+----


### PR DESCRIPTION
This commit fixes a bug in the vectorized engine that caused incorrect
results when selections operated on constant NULL values. The selection
operators, like `selNEDatumDatumConstOp`, do not correctly handle NULL
inputs. So, we avoid these code paths when an operator should not be
called on NULL values by constructing a zero operator.

Fixes #130759

Release note (bug fix): A bug has been fixed that could cause incorrect
evaluation of scalar expressions involving NULL values in rare cases.
