### PR TITLE
lint: fix `TestForbiddenImports`

### DIFF
--- a/pkg/ccl/crosscluster/logical/BUILD.bazel
+++ b/pkg/ccl/crosscluster/logical/BUILD.bazel
@@ -86,7 +86,6 @@ go_library(
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_cockroachdb_errors//issuelink",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_lib_pq//oid",

--- a/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
@@ -38,7 +38,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/errors/issuelink"
 )
 
 func init() {
@@ -94,7 +93,7 @@ func createLogicalReplicationStreamPlanHook(
 		}
 
 		if stmt.From.Database != "" {
-			return errors.UnimplementedErrorf(issuelink.IssueLink{}, "logical replication streams on databases are unsupported")
+			return errors.UnimplementedErrorf(errors.IssueLink{}, "logical replication streams on databases are unsupported")
 		}
 		if len(stmt.From.Tables) != len(stmt.Into.Tables) {
 			return pgerror.New(pgcode.InvalidParameterValue, "the same number of source and destination tables must be specified")

--- a/pkg/ccl/crosscluster/streamclient/BUILD.bazel
+++ b/pkg/ccl/crosscluster/streamclient/BUILD.bazel
@@ -38,7 +38,6 @@ go_library(
         "@com_github_golang_snappy//:snappy",
         "@com_github_jackc_pgconn//:pgconn",
         "@com_github_jackc_pgx_v4//:pgx",
-        "@com_github_pkg_errors//:errors",
     ],
 )
 

--- a/pkg/ccl/crosscluster/streamclient/client_helpers.go
+++ b/pkg/ccl/crosscluster/streamclient/client_helpers.go
@@ -11,9 +11,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/crosscluster"
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
 	"github.com/golang/snappy"
 	"github.com/jackc/pgx/v4"
-	"github.com/pkg/errors"
 )
 
 func subscribeInternal(

--- a/pkg/raft/BUILD.bazel
+++ b/pkg/raft/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/raft/raftstoreliveness",
         "//pkg/raft/tracker",
         "//pkg/util/hlc",
+        "@com_github_cockroachdb_errors//:errors",
         "@org_golang_x_exp//maps",
     ],
 )

--- a/pkg/raft/bootstrap.go
+++ b/pkg/raft/bootstrap.go
@@ -18,9 +18,8 @@
 package raft
 
 import (
-	"errors"
-
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/errors"
 )
 
 // Bootstrap initializes the RawNode for first use by appending configuration

--- a/pkg/raft/confchange/BUILD.bazel
+++ b/pkg/raft/confchange/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/raft/quorum",
         "//pkg/raft/raftpb",
         "//pkg/raft/tracker",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 
@@ -29,5 +30,6 @@ go_test(
         "//pkg/raft/raftpb",
         "//pkg/raft/tracker",
         "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/raft/confchange/confchange.go
+++ b/pkg/raft/confchange/confchange.go
@@ -18,13 +18,13 @@
 package confchange
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/raft/quorum"
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
+	"github.com/cockroachdb/errors"
 )
 
 // Changer facilitates configuration changes. It exposes methods to handle

--- a/pkg/raft/confchange/datadriven_test.go
+++ b/pkg/raft/confchange/datadriven_test.go
@@ -18,7 +18,6 @@
 package confchange
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -28,6 +27,7 @@ import (
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 )
 
 func TestConfChangeDataDriven(t *testing.T) {

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
-	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -36,6 +35,7 @@ import (
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftstoreliveness"
 	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
+	"github.com/cockroachdb/errors"
 	"golang.org/x/exp/maps"
 )
 

--- a/pkg/raft/rafttest/interaction_env_handler_add_nodes.go
+++ b/pkg/raft/rafttest/interaction_env_handler_add_nodes.go
@@ -19,7 +19,6 @@ package rafttest
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -31,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 )
 
 func (env *InteractionEnv) handleAddNodes(t *testing.T, d datadriven.TestData) error {

--- a/pkg/raft/rafttest/interaction_env_handler_process_append_thread.go
+++ b/pkg/raft/rafttest/interaction_env_handler_process_append_thread.go
@@ -18,13 +18,13 @@
 package rafttest
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 )
 
 func (env *InteractionEnv) handleProcessAppendThread(t *testing.T, d datadriven.TestData) error {

--- a/pkg/raft/rafttest/interaction_env_handler_report_unreachable.go
+++ b/pkg/raft/rafttest/interaction_env_handler_report_unreachable.go
@@ -18,10 +18,10 @@
 package rafttest
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 )
 
 func (env *InteractionEnv) handleReportUnreachable(t *testing.T, d datadriven.TestData) error {

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -18,10 +18,9 @@
 package raft
 
 import (
-	"errors"
-
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
+	"github.com/cockroachdb/errors"
 )
 
 // ErrStepLocalMsg is returned when try to step a local raft message

--- a/pkg/raft/storage.go
+++ b/pkg/raft/storage.go
@@ -18,11 +18,11 @@
 package raft
 
 import (
-	"errors"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/raft/raftlogger"
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/errors"
 )
 
 // ErrCompacted is returned by Storage.Entries/Compact when a requested

--- a/pkg/sql/tablemetadatacache/BUILD.bazel
+++ b/pkg/sql/tablemetadatacache/BUILD.bazel
@@ -64,6 +64,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/tablemetadatacache/cluster_settings.go
+++ b/pkg/sql/tablemetadatacache/cluster_settings.go
@@ -6,10 +6,10 @@
 package tablemetadatacache
 
 import (
-	"errors"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/errors"
 )
 
 const defaultDataValidDuration = time.Minute * 20

--- a/pkg/sql/tablemetadatacache/table_metadata_batch_iterator.go
+++ b/pkg/sql/tablemetadatacache/table_metadata_batch_iterator.go
@@ -7,13 +7,13 @@ package tablemetadatacache
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/errors"
 )
 
 const (

--- a/pkg/sql/tablemetadatacache/update_table_metadata_cache_job_test.go
+++ b/pkg/sql/tablemetadatacache/update_table_metadata_cache_job_test.go
@@ -7,7 +7,6 @@ package tablemetadatacache
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -22,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
We need to set `Dir` in the `packages.Load()` call or else the whole thing doesn't work. It would be really nice if it threw an error instead of simply doing nothing, but it is what it is. To guard against this in the future I added an error if the list is empty.

Fix the test then all existing violations, except for `raftlogger` and `rafttest` which will need some extra TLC by the owning team (see #132262)

Closes #132258

Epic: none
Release note: None