### PR TITLE
crosscluster: remove crdb_replication_origin_timestamp SQL column

### DIFF
--- a/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
@@ -155,28 +155,6 @@ func createLogicalReplicationStreamPlanHook(
 			repPairs[i].DstDescriptorID = int32(td.GetID())
 			dstTableDescs[i] = td
 
-			// TODO(dt): remove when we support this via KV metadata.
-			var foundTSCol bool
-			for _, col := range td.GetColumns() {
-				if col.Name == originTimestampColumnName {
-					foundTSCol = true
-					if col.Type.Family() != types.DecimalFamily {
-						return errors.Newf(
-							"%s column must be type DECIMAL for use by logical replication", originTimestampColumnName,
-						)
-					}
-					break
-				}
-			}
-			if !foundTSCol {
-				return errors.WithHintf(errors.Newf(
-					"tables written to by logical replication currently require a %q DECIMAL column",
-					originTimestampColumnName,
-				), "try 'ALTER TABLE %s ADD COLUMN %s DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL'",
-					dstObjName.String(), originTimestampColumnName,
-				)
-			}
-
 			tbNameWithSchema := tree.MakeTableNameWithSchema(
 				tree.Name(prefix.Database.GetName()),
 				tree.Name(prefix.Schema.GetName()),

--- a/pkg/ccl/crosscluster/logical/lww_kv_processor_test.go
+++ b/pkg/ccl/crosscluster/logical/lww_kv_processor_test.go
@@ -46,9 +46,6 @@ func TestKVWriterUpdateEncoding(t *testing.T) {
 	createTable := func(t *testing.T, schema string) string {
 		tableName := fmt.Sprintf("tab%d", tableNumber)
 		runner.Exec(t, fmt.Sprintf(schema, tableName))
-		runner.Exec(t, fmt.Sprintf(
-			"ALTER TABLE %s "+lwwColumnAdd,
-			tableName))
 		tableNumber++
 		return tableName
 	}

--- a/pkg/ccl/crosscluster/logical/lww_row_processor.go
+++ b/pkg/ccl/crosscluster/logical/lww_row_processor.go
@@ -38,12 +38,6 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-const (
-	// oldOriginTimestampColumnName is the name of the table
-	// column where the origin timestamp used to be stored.
-	oldOriginTimestampColumnName = "crdb_replication_origin_timestamp"
-)
-
 // A sqlRowProcessor is a RowProcessor that handles rows using the
 // provided querier.
 type sqlRowProcessor struct {
@@ -614,21 +608,10 @@ func insertColumnNamesForFamily(
 		if col.IsComputed() && !includeComputed {
 			return nil
 		}
-		colName := col.GetName()
-		// We will set crdb_replication_origin_timestamp ourselves from
-		// the MVCC timestamp of the incoming datum. We should never see
-		// this on the rangefeed as a non-null value as that would imply
-		// we've looped data around.
-		//
-		// TODO(ssd): If we aren't going to support a migration path, we
-		// can probably remove this completely.
-		if colName == oldOriginTimestampColumnName {
-			return nil
-		}
 		if _, seen := seenIds[colID]; seen {
 			return nil
 		}
-		inputColumnNames = append(inputColumnNames, colName)
+		inputColumnNames = append(inputColumnNames, col.GetName())
 		seenIds[colID] = struct{}{}
 		return nil
 	}

--- a/pkg/ccl/crosscluster/logical/lww_row_processor.go
+++ b/pkg/ccl/crosscluster/logical/lww_row_processor.go
@@ -39,7 +39,9 @@ import (
 )
 
 const (
-	originTimestampColumnName = "crdb_replication_origin_timestamp"
+	// oldOriginTimestampColumnName is the name of the table
+	// column where the origin timestamp used to be stored.
+	oldOriginTimestampColumnName = "crdb_replication_origin_timestamp"
 )
 
 // A sqlRowProcessor is a RowProcessor that handles rows using the
@@ -71,8 +73,7 @@ type queryBuilder struct {
 
 	// TODO(ssd): It would almost surely be better to track this by column IDs than name.
 	//
-	// TODO(ssd): The management of MVCC Origin Timestamp column is a bit messy. The mess
-	// is caused by column families that don't have that row in the datum.
+	// TODO(ssd): The management of MVCC Origin Timestamp column is a bit messy.
 	//
 	// If the query requires the origin timestamp column, inputColumns should not include the column.
 	// Rather, the query should set needsOriginTimestamp.
@@ -442,22 +443,15 @@ func (m *muxQuerier) RequiresParsedBeforeRow(id catid.DescID) bool {
 	return m.shouldUseUDF[id]
 }
 
-// lwwQuerier is a querier that implements partial
-// last-write-wins semantics using SQL queries. We assume that the table has an
-// crdb_replication_origin_timestamp column defined as:
-//
-//	crdb_replication_origin_timestamp DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL
-//
-// This row is explicitly set by the INSERT query using the MVCC timestamp of
-// the inbound write.
+// lwwQuerier is a querier that implements partial last-write-wins
+// semantics using SQL queries.
 //
 // Known issues:
 //
 //  1. An UPDATE and a DELETE may be applied out of order because we have no way
 //     from SQL of knowing the write timestamp of the deletion tombstone.
-//  2. The crdb_replication_origin_timestamp requires modifying the user's schema.
 //
-// See the design document for possible solutions to both of these problems.
+// See the design document for possible solutions to these problems.
 type lwwQuerier struct {
 	settings    *cluster.Settings
 	queryBuffer queryBuffer
@@ -512,7 +506,10 @@ func (lww *lwwQuerier) InsertRow(
 		if err != nil {
 			return batchStats{}, err
 		}
-		if _, err = ie.ExecParsed(ctx, replicatedOptimisticInsertOpName, kvTxn, lww.ieOverrideOptimisticInsert, stmt, datums...); err != nil {
+
+		sess := lww.ieOverrideOptimisticInsert
+		sess.OriginTimestampForLogicalDataReplication = row.MvccTimestamp
+		if _, err = ie.ExecParsed(ctx, replicatedOptimisticInsertOpName, kvTxn, sess, stmt, datums...); err != nil {
 			// If the optimistic insert failed with unique violation, we have to
 			// fall back to the pessimistic path. If we got a different error,
 			// then we bail completely.
@@ -531,7 +528,9 @@ func (lww *lwwQuerier) InsertRow(
 	if err != nil {
 		return batchStats{}, err
 	}
-	if _, err = ie.ExecParsed(ctx, replicatedInsertOpName, kvTxn, lww.ieOverrideInsert, stmt, datums...); err != nil {
+	sess := lww.ieOverrideInsert
+	sess.OriginTimestampForLogicalDataReplication = row.MvccTimestamp
+	if _, err = ie.ExecParsed(ctx, replicatedInsertOpName, kvTxn, sess, stmt, datums...); err != nil {
 		log.Warningf(ctx, "replicated insert failed (query: %s): %s", stmt.SQL, err.Error())
 		return batchStats{}, err
 	}
@@ -559,7 +558,9 @@ func (lww *lwwQuerier) DeleteRow(
 		return batchStats{}, err
 	}
 
-	if _, err := ie.ExecParsed(ctx, replicatedDeleteOpName, kvTxn, lww.ieOverrideDelete, stmt, datums...); err != nil {
+	sess := lww.ieOverrideDelete
+	sess.OriginTimestampForLogicalDataReplication = row.MvccTimestamp
+	if _, err := ie.ExecParsed(ctx, replicatedDeleteOpName, kvTxn, sess, stmt, datums...); err != nil {
 		log.Warningf(ctx, "replicated delete failed (query: %s): %s", stmt.SQL, err.Error())
 		return batchStats{}, err
 	}
@@ -574,10 +575,10 @@ VALUES (%s)
 ON CONFLICT (%s)
 DO UPDATE SET
 %s
-WHERE (t.crdb_internal_mvcc_timestamp <= excluded.crdb_replication_origin_timestamp
-     AND t.crdb_replication_origin_timestamp IS NULL)
- OR (t.crdb_replication_origin_timestamp <= excluded.crdb_replication_origin_timestamp
-     AND t.crdb_replication_origin_timestamp IS NOT NULL)`
+WHERE (t.crdb_internal_mvcc_timestamp <= $%[6]d
+    AND t.crdb_internal_origin_timestamp IS NULL)
+ OR (t.crdb_internal_origin_timestamp <= $%[6]d
+ 	AND t.crdb_internal_origin_timestamp IS NOT NULL)`
 )
 
 func sqlEscapedJoin(parts []string, sep string) string {
@@ -614,17 +615,20 @@ func insertColumnNamesForFamily(
 			return nil
 		}
 		colName := col.GetName()
-		// We will set crdb_replication_origin_timestamp ourselves from the MVCC timestamp of the incoming datum.
-		// We should never see this on the rangefeed as a non-null value as that would imply we've looped data around.
-		if colName == originTimestampColumnName {
+		// We will set crdb_replication_origin_timestamp ourselves from
+		// the MVCC timestamp of the incoming datum. We should never see
+		// this on the rangefeed as a non-null value as that would imply
+		// we've looped data around.
+		//
+		// TODO(ssd): If we aren't going to support a migration path, we
+		// can probably remove this completely.
+		if colName == oldOriginTimestampColumnName {
 			return nil
 		}
 		if _, seen := seenIds[colID]; seen {
 			return nil
 		}
-		if colName != originTimestampColumnName {
-			inputColumnNames = append(inputColumnNames, colName)
-		}
+		inputColumnNames = append(inputColumnNames, colName)
 		seenIds[colID] = struct{}{}
 		return nil
 	}
@@ -684,8 +688,7 @@ func makeLWWInsertQueries(
 			addColToQueryParts(name)
 		}
 
-		addColToQueryParts(originTimestampColumnName)
-		valStr := valueStringForNumItems(len(inputColumnNames)+1, 1)
+		valStr := valueStringForNumItems(len(inputColumnNames), 1)
 		parsedOptimisticQuery, err := parser.ParseOne(fmt.Sprintf(insertQueryOptimistic,
 			dstTableDescID,
 			columnNames.String(),
@@ -695,12 +698,14 @@ func makeLWWInsertQueries(
 			return err
 		}
 
+		originTSIdx := len(inputColumnNames) + 1
 		parsedPessimisticQuery, err := parser.ParseOne(fmt.Sprintf(insertQueryPessimistic,
 			dstTableDescID,
 			columnNames.String(),
 			valStr,
 			sqlEscapedJoin(td.TableDesc().PrimaryIndex.KeyColumnNames, ","),
 			onConflictUpdateClause.String(),
+			originTSIdx,
 		))
 		if err != nil {
 			return err
@@ -737,9 +742,9 @@ func makeLWWDeleteQuery(dstTableDescID int32, td catalog.TableDescriptor) (query
 	baseQuery := `
 DELETE FROM [%d as t] WHERE %s
    AND ((t.crdb_internal_mvcc_timestamp < $%[3]d
-        AND t.crdb_replication_origin_timestamp IS NULL)
-    OR (t.crdb_replication_origin_timestamp < $%[3]d
-        AND t.crdb_replication_origin_timestamp IS NOT NULL))`
+        AND t.crdb_internal_origin_timestamp IS NULL)
+    OR (t.crdb_internal_origin_timestamp < $%[3]d
+        AND t.crdb_internal_origin_timestamp IS NOT NULL))`
 	stmt, err := parser.ParseOne(
 		fmt.Sprintf(baseQuery, dstTableDescID, whereClause.String(), originTSIdx))
 	if err != nil {

--- a/pkg/ccl/crosscluster/logical/lww_row_processor_test.go
+++ b/pkg/ccl/crosscluster/logical/lww_row_processor_test.go
@@ -73,9 +73,6 @@ func TestLWWInsertQueryGeneration(t *testing.T) {
 	createTable := func(t *testing.T, stmt string) string {
 		tableName := fmt.Sprintf("tab%d", tableNumber)
 		runner.Exec(t, fmt.Sprintf(stmt, tableName))
-		runner.Exec(t, fmt.Sprintf(
-			"ALTER TABLE %s "+lwwColumnAdd,
-			tableName))
 		tableNumber++
 		return tableName
 	}
@@ -149,7 +146,6 @@ func BenchmarkLWWInsertBatch(b *testing.B) {
 	runner := sqlutils.MakeSQLRunner(sqlDB)
 	tableName := "tab"
 	runner.Exec(b, "CREATE TABLE tab (pk INT PRIMARY KEY, payload STRING)")
-	runner.Exec(b, "ALTER TABLE tab "+lwwColumnAdd)
 
 	desc := desctestutils.TestingGetPublicTableDescriptor(kvDB, s.Codec(), "defaultdb", tableName)
 	// Simulate how we set up the row processor on the main code path.
@@ -325,9 +321,6 @@ func TestLWWConflictResolution(t *testing.T) {
 	createTable := func(t *testing.T) string {
 		tableName := fmt.Sprintf("tab%d", tableNumber)
 		runner.Exec(t, fmt.Sprintf(`CREATE TABLE %s (pk int primary key, payload string)`, tableName))
-		runner.Exec(t, fmt.Sprintf(
-			"ALTER TABLE %s "+lwwColumnAdd,
-			tableName))
 		tableNumber++
 		return tableName
 	}
@@ -403,7 +396,6 @@ func TestLWWConflictResolution(t *testing.T) {
 
 				keyValue2 := encoder(timeOneDayBackward, row2...)
 				require.NoError(t, insertRow(rp, keyValue2, roachpb.Value{}))
-
 				expectedRows := [][]string{
 					{"1", "row1"},
 				}

--- a/pkg/ccl/crosscluster/logical/udf_row_processor_test.go
+++ b/pkg/ccl/crosscluster/logical/udf_row_processor_test.go
@@ -85,10 +85,6 @@ func TestUDFWithRandomTables(t *testing.T) {
 		sqlA, tableName, numInserts, nil)
 	require.NoError(t, err)
 
-	addCol := fmt.Sprintf(`ALTER TABLE %s `+lwwColumnAdd, tableName)
-	runnerA.Exec(t, addCol)
-	runnerB.Exec(t, addCol)
-
 	dbAURL, cleanup := s.PGUrl(t, serverutils.DBName("a"))
 	defer cleanup()
 
@@ -130,10 +126,6 @@ func TestUDFInsertOnly(t *testing.T) {
 		END
 		$$ LANGUAGE plpgsql
 		`)
-
-	addCol := fmt.Sprintf(`ALTER TABLE %s `+lwwColumnAdd, tableName)
-	runnerA.Exec(t, addCol)
-	runnerB.Exec(t, addCol)
 
 	dbAURL, cleanup := s.PGUrl(t, serverutils.DBName("a"))
 	defer cleanup()
@@ -184,10 +176,6 @@ func TestUDFPreviousValue(t *testing.T) {
 		END
 		$$ LANGUAGE plpgsql
 		`)
-
-	addCol := fmt.Sprintf(`ALTER TABLE %s `+lwwColumnAdd, tableName)
-	runnerA.Exec(t, addCol)
-	runnerB.Exec(t, addCol)
 
 	dbAURL, cleanup := s.PGUrl(t, serverutils.DBName("a"))
 	defer cleanup()

--- a/pkg/ccl/crosscluster/streamclient/randclient/random_stream_client.go
+++ b/pkg/ccl/crosscluster/streamclient/randclient/random_stream_client.go
@@ -703,12 +703,8 @@ func randDatumsForTable(rng *rand.Rand, td catalog.TableDescriptor) ([]tree.Datu
 		if c.IsComputed() {
 			return nil, errors.Errorf("unable to generate random datums for table with computed column %q", c.GetName())
 		}
-		if c.GetName() == "crdb_replication_origin_timestamp" {
-			datums = append(datums, tree.DNull)
-		} else {
-			datums = append(datums,
-				randgen.RandDatum(rng, c.GetType(), c.IsNullable()))
-		}
+		datums = append(datums,
+			randgen.RandDatum(rng, c.GetType(), c.IsNullable()))
 	}
 	return datums, nil
 }

--- a/pkg/cmd/roachtest/tests/logical_data_replication.go
+++ b/pkg/cmd/roachtest/tests/logical_data_replication.go
@@ -679,11 +679,6 @@ func setupLDR(
 
 	dbName, tableName := ldrWorkload.dbName, ldrWorkload.tableName
 
-	// Setup LDR-specific columns
-	timestampQuery := fmt.Sprintf("ALTER TABLE %s.%s ADD COLUMN crdb_replication_origin_timestamp DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL", dbName, tableName)
-	setup.left.sysSQL.Exec(t, timestampQuery)
-	setup.right.sysSQL.Exec(t, timestampQuery)
-
 	startLDR := func(targetDB *sqlutils.SQLRunner, sourceURL string) int {
 		targetDB.Exec(t, fmt.Sprintf("USE %s", dbName))
 		r := targetDB.QueryRow(t,
@@ -728,7 +723,7 @@ func VerifyCorrectness(
 
 	m := c.NewMonitor(context.Background(), setup.CRDBNodes())
 	var leftFingerprint, rightFingerprint [][]string
-	queryStmt := fmt.Sprintf("SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE %s.%s WITH EXCLUDE COLUMNS = ('crdb_replication_origin_timestamp')", ldrWorkload.dbName, ldrWorkload.tableName)
+	queryStmt := fmt.Sprintf("SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE %s.%s", ldrWorkload.dbName, ldrWorkload.tableName)
 	m.Go(func(ctx context.Context) error {
 		leftFingerprint = setup.left.sysSQL.QueryStr(t, queryStmt)
 		return nil

--- a/scripts/drtprod
+++ b/scripts/drtprod
@@ -568,11 +568,9 @@ EOF"
         $0 sql drt-ldr1:1 -- -e "ALTER TABLE ycsb.public.usertable ADD COLUMN expired_at TIMESTAMPTZ NOT NULL DEFAULT now() + '30 minutes';"
         # set row level ttl
         $0 sql drt-ldr1:1 -- -e "ALTER TABLE ycsb.public.usertable SET (ttl_expiration_expression = 'expired_at', ttl_job_cron = '*/30 * * * *');"
-        $0 sql drt-ldr1:1 -- -e "ALTER TABLE ycsb.public.usertable ADD COLUMN crdb_replication_origin_timestamp DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL;"
 
         $0 sql drt-ldr2:1 -- -e "ALTER TABLE ycsb.public.usertable ADD COLUMN expired_at TIMESTAMPTZ NOT NULL DEFAULT now() + '30 minutes';"
         $0 sql drt-ldr2:1 -- -e "ALTER TABLE ycsb.public.usertable SET (ttl_expiration_expression = 'expired_at', ttl_job_cron = '*/30 * * * *');"
-        $0 sql drt-ldr2:1 -- -e "ALTER TABLE ycsb.public.usertable ADD COLUMN crdb_replication_origin_timestamp DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL;"
 
         roachprod sql drt-ldr1:1 -- -e "CREATE LOGICAL REPLICATION STREAM FROM TABLE usertable ON 'external://drt-ldr2' INTO TABLE ycsb.public.usertable;"
         roachprod sql drt-ldr2:1 -- -e "CREATE LOGICAL REPLICATION STREAM FROM TABLE usertable ON 'external://drt-ldr1' INTO TABLE ycsb.public.usertable;"

--- a/scripts/ldr
+++ b/scripts/ldr
@@ -131,8 +131,6 @@ case $1 in
       "init")
         roachprod run $A:1 "./workload init ycsb --drop --families=false --splits 1000 $(roachprod pgurl $A)"
         roachprod run $B:1 "./workload init ycsb --drop --families=false --splits 1000 $(roachprod pgurl $B)"
-        roachprod sql $A:1 -- -e "ALTER TABLE ycsb.public.usertable ADD COLUMN crdb_replication_origin_timestamp DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL"
-        roachprod sql $B:1 -- -e "ALTER TABLE ycsb.public.usertable ADD COLUMN crdb_replication_origin_timestamp DECIMAL NOT VISIBLE DEFAULT NULL ON UPDATE NULL"
         roachprod sql $A:1 -- -e "ALTER TABLE ycsb.public.usertable SET (ttl_expire_after = '3 hours');"
         roachprod sql $B:1 -- -e "ALTER TABLE ycsb.public.usertable SET (ttl_expire_after = '3 hours');"
         ;;


### PR DESCRIPTION
The LDR SQL write path now writes the origin timestamp to the MVCCValueHeader and reads it out using the
`crdb_internal_origin_timestamp` system column.

Note that this change represents a hard incompatibility for anyone running LDR from master and we may need to coordinate its rollout with those small number of internal users.

Epic: none
Release note None