### PR TITLE
release-23.1: server/license: Enable the License Enforcer

### DIFF
--- a/pkg/ccl/utilccl/license_check_test.go
+++ b/pkg/ccl/utilccl/license_check_test.go
@@ -272,7 +272,6 @@ func TestRefreshLicenseEnforcerOnLicenseChange(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				LicenseTestingKnobs: license.TestingKnobs{
-					Enable:            true,
 					SkipDisable:       true,
 					OverrideStartTime: &ts1,
 				},

--- a/pkg/server/license/enforcer.go
+++ b/pkg/server/license/enforcer.go
@@ -94,14 +94,6 @@ type Enforcer struct {
 }
 
 type TestingKnobs struct {
-	// Enable controls whether the enforcer writes the grace period end time to KV
-	// and performs throttle checks. This is currently opt-in to allow for a gradual
-	// rollout of these changes. It will be removed or changed to opt-out as we near
-	// the final stages of the CockroachDB core licensing deprecation.
-	// TODO(spilchen): Update or remove this knob closer to the completion of the
-	// core licensing deprecation work (CRDB-41758).
-	Enable bool
-
 	// SkipDisable makes the Disable() function a no-op. This is separate from Enable
 	// because we perform additional checks during server startup that may automatically
 	// disable enforcement based on configuration (e.g., for single-node instances).
@@ -140,10 +132,6 @@ func NewEnforcer(tk *TestingKnobs) *Enforcer {
 		throttleLogger: log.Every(5 * time.Minute),
 		testingKnobs:   tk,
 	}
-	// Start is disabled by default unless overridden by testing knobs.
-	if tk == nil || !tk.Enable {
-		e.isDisabled.Store(true)
-	}
 	return e
 }
 
@@ -180,14 +168,11 @@ func (e *Enforcer) Start(ctx context.Context, st *cluster.Settings, opts ...Opti
 	// incomplete, but the server will continue to start. To ensure stability in
 	// that case, we leave throttling disabled.
 	e.isDisabled.Store(true)
-	startDisabled := e.getInitialIsDisabledValue()
 
 	e.maybeLogActiveOverrides(ctx)
 
-	if !startDisabled {
-		if err := e.readClusterMetadata(ctx, options); err != nil {
-			return err
-		}
+	if err := e.initClusterMetadata(ctx, options); err != nil {
+		return err
 	}
 
 	// Initialize assuming there is no license. This seeds necessary values. It
@@ -202,15 +187,15 @@ func (e *Enforcer) Start(ctx context.Context, st *cluster.Settings, opts ...Opti
 	RegisterCallbackOnLicenseChange(ctx, st, e)
 
 	// This should be the final step after all error checks are completed.
-	e.isDisabled.Store(startDisabled)
+	e.isDisabled.Store(false)
 	e.mu.setupComplete = true
 
 	return nil
 }
 
-// readClusterMetadata will read, and maybe write, cluster metadata for license
+// initClusterMetadata will read, and maybe write, cluster metadata for license
 // enforcement. The metadata is stored in the KV system keyspace.
-func (e *Enforcer) readClusterMetadata(ctx context.Context, options options) error {
+func (e *Enforcer) initClusterMetadata(ctx context.Context, options options) error {
 	// Secondary tenants do not have access to the system keyspace where
 	// the cluster init grace period is stored. As a fallback, we apply a 7-day
 	// grace period from the tenant's start time, which is used only when no
@@ -608,21 +593,6 @@ func (e *Enforcer) maybeLogActiveOverrides(ctx context.Context) {
 	if curTelemetryInterval != defaultMaxTelemetryInterval {
 		log.Infof(ctx, "max telemetry interval has changed to %v", curTelemetryInterval)
 	}
-}
-
-// getInitialIsDisabledValue returns bool indicating what the initial value
-// should be for e.isDisabled
-func (e *Enforcer) getInitialIsDisabledValue() bool {
-	// The enforcer is currently opt-in. This will change as we approach the
-	// final stages of CockroachDB core license deprecation.
-	// TODO(spilchen): Enable the enforcer by default in CRDB-41758.
-	tk := e.GetTestingKnobs()
-	if tk == nil {
-		// TODO(spilchen): In CRDB-41758, remove the use of an environment variable
-		// as we want to avoid providing an easy way to disable the enforcer.
-		return !envutil.EnvOrDefaultBool("COCKROACH_ENABLE_LICENSE_ENFORCER", false)
-	}
-	return !tk.Enable
 }
 
 // getIsNewClusterEstimate is a helper to determine if the cluster is a newly

--- a/pkg/server/license/enforcer_test.go
+++ b/pkg/server/license/enforcer_test.go
@@ -49,7 +49,6 @@ func TestClusterInitGracePeriod_NoOverwrite(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				LicenseTestingKnobs: license.TestingKnobs{
-					Enable:            true,
 					OverrideStartTime: &ts1,
 				},
 			},
@@ -63,7 +62,6 @@ func TestClusterInitGracePeriod_NoOverwrite(t *testing.T) {
 	ts2End := ts2.Add(7 * 24 * time.Hour) // Calculate the end of the grace period
 	enforcer := license.NewEnforcer(
 		&license.TestingKnobs{
-			Enable:            true,
 			OverrideStartTime: &ts2,
 		})
 	// Ensure request for the grace period init ts1 before start just returns the start
@@ -91,7 +89,6 @@ func TestClusterInitGracePeriod_NewClusterEstimation(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				LicenseTestingKnobs: license.TestingKnobs{
-					Enable:            true,
 					OverrideStartTime: &ts1,
 				},
 			},
@@ -112,7 +109,6 @@ func TestClusterInitGracePeriod_NewClusterEstimation(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			enforcer := license.NewEnforcer(
 				&license.TestingKnobs{
-					Enable:                            true,
 					OverrideStartTime:                 &ts1,
 					OverwriteClusterInitGracePeriodTS: true,
 				})
@@ -133,7 +129,6 @@ func TestClusterInitGracePeriod_NewClusterEstimation(t *testing.T) {
 				license.WithDB(db),
 				license.WithSystemTenant(true),
 				license.WithTestingKnobs(&license.TestingKnobs{
-					Enable:                            true,
 					OverrideStartTime:                 &ts1,
 					OverwriteClusterInitGracePeriodTS: true,
 				}),
@@ -213,7 +208,6 @@ func TestThrottle(t *testing.T) {
 		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
 			e := license.NewEnforcer(
 				&license.TestingKnobs{
-					Enable:                    true,
 					OverrideStartTime:         &tc.gracePeriodInit,
 					OverrideThrottleCheckTime: &tc.checkTs,
 				})
@@ -280,7 +274,6 @@ func TestThrottleErrorMsg(t *testing.T) {
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{
 				LicenseTestingKnobs: license.TestingKnobs{
-					Enable: true,
 					// The mock server we bring up is single-node, which disables all
 					// throttling checks. We need to avoid that for this test to verify
 					// the throttle message.


### PR DESCRIPTION
Backport 1/1 commits from #131944.

/cc @cockroachdb/release

---

Previously, the license enforcer was disabled by default and only enabled in specific test cases designed for it. This change fully activates the license enforcer and removes the option to disable it.

We still do the enterprise check in this PR. Another PR (#131943) will be opened to remove them as it has quite a bit more test changes needed.

This change will be backported to versions 24.2, 24.1, 23.2, and 23.1.

Epic: CRDB-39988
Closes: CRDB-41758
Release note: none
Release justification: This work is part of the CockroachDB core deprecation.