### PR TITLE
raft,kvserver: add RawNode.WithBasicProgress and BasicProgress struct

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/raft_node.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/raft_node.go
@@ -30,7 +30,7 @@ func MakeRaftNodeBasicStateLocked(
 // held, at least for read.
 func MakeReplicaStateInfos(rn *raft.RawNode, infoMap map[roachpb.ReplicaID]rac2.ReplicaStateInfo) {
 	clear(infoMap)
-	rn.WithProgress(func(peerID raftpb.PeerID, _ raft.ProgressType, progress tracker.Progress) {
+	rn.WithBasicProgress(func(peerID raftpb.PeerID, progress tracker.BasicProgress) {
 		infoMap[roachpb.ReplicaID(peerID)] = rac2.ReplicaStateInfo{
 			Match: progress.Match,
 			Next:  progress.Next,

--- a/pkg/kv/kvserver/replica_proposal_quota.go
+++ b/pkg/kv/kvserver/replica_proposal_quota.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/rac2"
-	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -211,7 +210,7 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 	// to consider progress beyond it as meaningful.
 	minIndex := kvpb.RaftIndex(status.Applied)
 
-	r.mu.internalRaftGroup.WithProgress(func(id raftpb.PeerID, _ raft.ProgressType, progress tracker.Progress) {
+	r.mu.internalRaftGroup.WithBasicProgress(func(id raftpb.PeerID, progress tracker.BasicProgress) {
 		rep, ok := r.shMu.state.Desc.GetReplicaDescriptorByID(roachpb.ReplicaID(id))
 		if !ok {
 			return

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1986,7 +1986,7 @@ func (r *Replica) sendRaftMessage(
 		// below for more context:
 		_ = maybeDropMsgApp
 		// NB: this code is allocation free.
-		r.mu.internalRaftGroup.WithProgress(func(id raftpb.PeerID, _ raft.ProgressType, pr tracker.Progress) {
+		r.mu.internalRaftGroup.WithBasicProgress(func(id raftpb.PeerID, pr tracker.BasicProgress) {
 			if id == msg.To && pr.State == tracker.StateProbe {
 				// It is moderately expensive to attach a full key to the message, but note that
 				// a probing follower will only be appended to once per heartbeat interval (i.e.

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -630,6 +630,12 @@ func (rn *RawNode) WithProgress(visitor func(id pb.PeerID, typ ProgressType, pr 
 	withProgress(rn.raft, visitor)
 }
 
+// WithBasicProgress is a helper to introspect the BasicProgress for this node
+// and its peers.
+func (rn *RawNode) WithBasicProgress(visitor func(id pb.PeerID, pr tracker.BasicProgress)) {
+	rn.raft.trk.WithBasicProgress(visitor)
+}
+
 // ReportUnreachable reports the given node is not reachable for the last send.
 func (rn *RawNode) ReportUnreachable(id pb.PeerID) {
 	_ = rn.raft.Step(pb.Message{Type: pb.MsgUnreachable, From: id})

--- a/pkg/raft/tracker/progress.go
+++ b/pkg/raft/tracker/progress.go
@@ -433,3 +433,13 @@ func (m ProgressMap) String() string {
 	}
 	return buf.String()
 }
+
+// BasicProgress contains a subset of fields from Progress.
+type BasicProgress struct {
+	// Match corresponds to Progress.Match.
+	Match uint64
+	// Next corresponds to Progress.Next.
+	Next uint64
+	// State corresponds to Progress.State.
+	State StateType
+}

--- a/pkg/raft/tracker/progresstracker.go
+++ b/pkg/raft/tracker/progresstracker.go
@@ -137,3 +137,15 @@ func (p *ProgressTracker) LearnerNodes() []pb.PeerID {
 	slices.Sort(nodes)
 	return nodes
 }
+
+// WithBasicProgress is a helper to introspect the BasicProgress for this node
+// and its peers.
+func (p *ProgressTracker) WithBasicProgress(visitor func(id pb.PeerID, pr BasicProgress)) {
+	for id, p := range p.progress {
+		visitor(id, BasicProgress{
+			Match: p.Match,
+			Next:  p.Next,
+			State: p.State,
+		})
+	}
+}


### PR DESCRIPTION
This is a micro-optimization, plus avoids exposing Raft details that the three callers are not interested in. BasicProgress only contains {State, Match, Next} and there is no sorting of peer ids before the visitor is called.

This method consumes 0.6% in kv0 running with RACv2, of which more than half is calls from RACv2 code.

Informs #128033

Epic: CRDB-37515

Release note: None