### PR TITLE
kvflowinspectpb: safe format stream

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb/BUILD.bazel
@@ -17,9 +17,14 @@ go_proto_library(
 
 go_library(
     name = "kvflowinspectpb",
+    srcs = ["kvflowinspect.go"],
     embed = [":kvflowinspectpb_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb",
     visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/util/humanizeutil",
+        "@com_github_cockroachdb_redact//:redact",
+    ],
 )
 
 proto_library(

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb/kvflowinspect.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb/kvflowinspect.go
@@ -1,0 +1,23 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvflowinspectpb
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
+	"github.com/cockroachdb/redact"
+)
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (s Stream) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("s%v/t%v eval_regular=%v eval_elastic=%v send_regular=%v send_elastic=%v",
+		s.TenantID,
+		s.StoreID,
+		humanizeutil.IBytes(s.AvailableEvalRegularTokens),
+		humanizeutil.IBytes(s.AvailableEvalElasticTokens),
+		humanizeutil.IBytes(s.AvailableSendRegularTokens),
+		humanizeutil.IBytes(s.AvailableSendElasticTokens),
+	)
+}


### PR DESCRIPTION
The safe formatted string looks like:

```
s1/t1 eval_regular=+16 MiB eval_elastic=+8 MiB send_regular=+16 MiB send_elastic=+8 MiB
```

Part of: #128040
Release note: None