### PR TITLE
rac2: fix race on token watcher handle

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -1830,6 +1830,11 @@ func (rs *replicaState) createReplicaSendStream(
 	// RangeController.
 	rss.mu.sendQueue.approxMeanSizeBytes = 500
 	if mode == MsgAppPull && !rs.sendStream.isEmptySendQueueLocked() {
+		// NB: need to lock rss.mu since
+		// startAttemptingToEmptySendQueueViaWatcherLocked can hand a reference to
+		// rss to a different goroutine, which can start running immediately.
+		rss.mu.Lock()
+		defer rss.mu.Unlock()
 		rss.startAttemptingToEmptySendQueueViaWatcherLocked(ctx)
 	}
 }


### PR DESCRIPTION
When creating a send stream, the range controller did not lock it before calling methods which require a lock.

Lock the send stream upon creation.

Part of: #128040
Release note: None