### PR TITLE
raft: move StateType from raft into raftpb

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -186,7 +186,7 @@ go_test(
         "//pkg/kv/kvserver/tscache",
         "//pkg/kv/kvserver/txnwait",
         "//pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer",
-        "//pkg/raft",
+        "//pkg/raft/raftpb",
         "//pkg/roachpb",
         "//pkg/rpc",
         "//pkg/rpc/nodedialer",

--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
-	"github.com/cockroachdb/cockroach/pkg/raft"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
@@ -4771,7 +4771,7 @@ func TestPartialPartition(t *testing.T) {
 					store, err := sl.GetStores().(*kvserver.Stores).GetStore(sl.GetFirstStoreID())
 					require.NoError(t, err)
 					status := store.LookupReplica(roachpb.RKey(scratchKey)).RaftStatus()
-					if status == nil || status.RaftState != raft.StateLeader {
+					if status == nil || status.RaftState != raftpb.StateLeader {
 						return errors.Newf("Leader leaseholder split %v", status)
 					}
 					return nil

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
@@ -1917,7 +1917,7 @@ func (r *mockRepl) RaftStatus() *raft.Status {
 	raftStatus := &raft.Status{
 		Progress: make(map[raftpb.PeerID]tracker.Progress),
 	}
-	raftStatus.RaftState = raft.StateLeader
+	raftStatus.RaftState = raftpb.StateLeader
 	for i := int32(1); i <= r.replicationFactor; i++ {
 		state := tracker.StateReplicate
 		if _, ok := r.replsInNeedOfSnapshot[roachpb.ReplicaID(i)]; ok {
@@ -8290,7 +8290,7 @@ func TestFilterBehindReplicas(t *testing.T) {
 				Progress: make(map[raftpb.PeerID]tracker.Progress),
 			}
 			status.Lead = c.leader
-			status.RaftState = raft.StateLeader
+			status.RaftState = raftpb.StateLeader
 			status.Commit = c.commit
 			var replicas []roachpb.ReplicaDescriptor
 			for j, v := range c.progress {
@@ -8363,7 +8363,7 @@ func TestFilterUnremovableReplicas(t *testing.T) {
 			// Use an invalid replica ID for the leader. TestFilterBehindReplicas covers
 			// valid replica IDs.
 			status.Lead = 99
-			status.RaftState = raft.StateLeader
+			status.RaftState = raftpb.StateLeader
 			status.Commit = c.commit
 			var replicas []roachpb.ReplicaDescriptor
 			for j, v := range c.progress {
@@ -8421,7 +8421,7 @@ func TestSimulateFilterUnremovableReplicas(t *testing.T) {
 			// Use an invalid replica ID for the leader. TestFilterBehindReplicas covers
 			// valid replica IDs.
 			status.Lead = 99
-			status.RaftState = raft.StateLeader
+			status.RaftState = raftpb.StateLeader
 			status.Commit = c.commit
 			var replicas []roachpb.ReplicaDescriptor
 			for j, v := range c.progress {

--- a/pkg/kv/kvserver/allocator/plan/replicate.go
+++ b/pkg/kv/kvserver/allocator/plan/replicate.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/rac2"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/raft"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -534,7 +535,7 @@ func (rp ReplicaPlanner) findRemoveVoter(
 			lastReplAdded = 0
 		}
 		raftStatus := repl.RaftStatus()
-		if raftStatus == nil || raftStatus.RaftState != raft.StateLeader {
+		if raftStatus == nil || raftStatus.RaftState != raftpb.StateLeader {
 			// If requested, assume all replicas are up-to-date.
 			if rp.knobs.AllowVoterRemovalWhenNotLeader {
 				candidates = allocatorimpl.FilterUnremovableReplicasWithoutRaftStatus(

--- a/pkg/kv/kvserver/allocator_impl_test.go
+++ b/pkg/kv/kvserver/allocator_impl_test.go
@@ -303,7 +303,7 @@ func TestAllocatorRebalanceTarget(t *testing.T) {
 		Progress: make(map[raftpb.PeerID]tracker.Progress),
 	}
 	status.Lead = 1
-	status.RaftState = raft.StateLeader
+	status.RaftState = raftpb.StateLeader
 	status.Commit = 10
 	for _, replica := range replicas {
 		status.Progress[raftpb.PeerID(replica.ReplicaID)] = tracker.Progress{

--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -1203,7 +1203,7 @@ func (s *state) RaftStatus(rangeID RangeID, storeID StoreID) *raft.Status {
 	// TODO(kvoli): The raft leader will always be the current leaseholder
 	// here. This should change to enable testing this scenario.
 	status.Lead = raftpb.PeerID(leader.ReplicaID())
-	status.RaftState = raft.StateLeader
+	status.RaftState = raftpb.StateLeader
 	status.Commit = 2
 	// TODO(kvoli): A replica is never behind on their raft log, this should
 	// change to enable testing this scenario where replicas fall behind. e.g.

--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
-	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -431,7 +430,7 @@ func TestTransferLeaseDuringJointConfigWithDeadIncomingVoter(t *testing.T) {
 		require.NoError(t, repl0.RaftReportUnreachable(4))
 		// Check the Raft progress.
 		s := repl0.RaftStatus()
-		require.Equal(t, raft.StateLeader, s.RaftState)
+		require.Equal(t, raftpb.StateLeader, s.RaftState)
 		p := s.Progress
 		require.Len(t, p, 4)
 		require.Contains(t, p, raftpb.PeerID(4))

--- a/pkg/kv/kvserver/leases/BUILD.bazel
+++ b/pkg/kv/kvserver/leases/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/kv/kvserver/raftutil",
         "//pkg/raft",
+        "//pkg/raft/raftpb",
         "//pkg/roachpb",
         "//pkg/util/hlc",
         "//pkg/util/log",

--- a/pkg/kv/kvserver/leases/build.go
+++ b/pkg/kv/kvserver/leases/build.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/raft"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
@@ -383,7 +384,7 @@ func leaseType(st Settings, i BuildInput) roachpb.LeaseType {
 		// construct an epoch-based lease.
 		return roachpb.LeaseEpoch
 	}
-	if i.RaftStatus.RaftState != raft.StateLeader || i.RaftStatus.LeadTransferee != raft.None {
+	if i.RaftStatus.RaftState != raftpb.StateLeader || i.RaftStatus.LeadTransferee != raft.None {
 		// If this range wants to use a leader lease, but the local replica is not
 		// currently the raft leader, we construct an expiration-based lease. It is
 		// highly likely that the lease acquisition will be rejected before being
@@ -541,7 +542,7 @@ func leaseTerm(i BuildInput, nextType roachpb.LeaseType) uint64 {
 	if nextType != roachpb.LeaseLeader {
 		panic("leaseTerm called for non-leader lease")
 	}
-	if i.RaftStatus.RaftState != raft.StateLeader {
+	if i.RaftStatus.RaftState != raftpb.StateLeader {
 		panic("leaseTerm called when not leader")
 	}
 	if i.RaftStatus.Term == 0 {

--- a/pkg/kv/kvserver/leases/build_test.go
+++ b/pkg/kv/kvserver/leases/build_test.go
@@ -206,13 +206,13 @@ func raftStatusFollower(replicaID roachpb.ReplicaID) *raft.Status {
 	s := &raft.Status{}
 	s.ID = raftpb.PeerID(replicaID)
 	s.Term = 5
-	s.RaftState = raft.StateFollower
+	s.RaftState = raftpb.StateFollower
 	return s
 }
 
 func raftStatusLeader(replicaID roachpb.ReplicaID) *raft.Status {
 	s := raftStatusFollower(replicaID)
-	s.RaftState = raft.StateLeader
+	s.RaftState = raftpb.StateLeader
 	s.LeadSupportUntil = ts30
 	return s
 }

--- a/pkg/kv/kvserver/leases/status_test.go
+++ b/pkg/kv/kvserver/leases/status_test.go
@@ -69,12 +69,12 @@ func TestStatus(t *testing.T) {
 	leaderLeaseRemote := leaderLease
 	leaderLeaseRemote.Replica = repl2
 
-	raftStatus := func(state raft.StateType, term uint64, leadSupport hlc.Timestamp) raft.LeadSupportStatus {
+	raftStatus := func(state raftpb.StateType, term uint64, leadSupport hlc.Timestamp) raft.LeadSupportStatus {
 		var s raft.LeadSupportStatus
 		s.ID = raftpb.PeerID(repl1.ReplicaID)
 		s.RaftState = state
 		s.Term = term
-		if state == raft.StateLeader {
+		if state == raftpb.StateLeader {
 			s.Lead = raftpb.PeerID(repl1.ReplicaID)
 		} else {
 			s.Lead = raftpb.PeerID(repl2.ReplicaID)
@@ -83,15 +83,15 @@ func TestStatus(t *testing.T) {
 		return s
 	}
 	// Basic case.
-	leaderStatus := raftStatus(raft.StateLeader, 5, ts[4].ToTimestamp())
+	leaderStatus := raftStatus(raftpb.StateLeader, 5, ts[4].ToTimestamp())
 	// Advanced cases.
-	followerStatus := raftStatus(raft.StateFollower, 5, hlc.Timestamp{})
-	unfortifiedLeaderStatus := raftStatus(raft.StateLeader, 5, hlc.Timestamp{})
-	steppingDownFollowerStatus := raftStatus(raft.StateFollower, 5, ts[4].ToTimestamp())
-	followerNewTermUnknownLeadStatus := raftStatus(raft.StateFollower, 6, hlc.Timestamp{})
+	followerStatus := raftStatus(raftpb.StateFollower, 5, hlc.Timestamp{})
+	unfortifiedLeaderStatus := raftStatus(raftpb.StateLeader, 5, hlc.Timestamp{})
+	steppingDownFollowerStatus := raftStatus(raftpb.StateFollower, 5, ts[4].ToTimestamp())
+	followerNewTermUnknownLeadStatus := raftStatus(raftpb.StateFollower, 6, hlc.Timestamp{})
 	followerNewTermUnknownLeadStatus.Lead = raft.None
-	followerNewTermKnownLeadStatus := raftStatus(raft.StateFollower, 6, hlc.Timestamp{})
-	leaderNewTermKnownLeadStatus := raftStatus(raft.StateLeader, 6, ts[4].ToTimestamp())
+	followerNewTermKnownLeadStatus := raftStatus(raftpb.StateFollower, 6, hlc.Timestamp{})
+	leaderNewTermKnownLeadStatus := raftStatus(raftpb.StateLeader, 6, ts[4].ToTimestamp())
 
 	for _, tc := range []struct {
 		lease         roachpb.Lease

--- a/pkg/kv/kvserver/leases/verify.go
+++ b/pkg/kv/kvserver/leases/verify.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftutil"
 	"github.com/cockroachdb/cockroach/pkg/raft"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -117,7 +118,7 @@ func verifyAcquisition(ctx context.Context, st Settings, i VerifyInput) error {
 	// the leader.
 	leader := roachpb.ReplicaID(i.RaftStatus.Lead)
 	leaderKnown := leader != roachpb.ReplicaID(raft.None)
-	iAmTheLeader := i.RaftStatus.RaftState == raft.StateLeader
+	iAmTheLeader := i.RaftStatus.RaftState == raftpb.StateLeader
 	if (leader == i.LocalReplicaID) != iAmTheLeader {
 		log.Fatalf(ctx, "inconsistent Raft state: %s", i.RaftStatus)
 	}
@@ -213,7 +214,7 @@ func verifyExtension(ctx context.Context, st Settings, i VerifyInput) error {
 	if i.PrevLeaseExpired {
 		return verifyAcquisition(ctx, st, i)
 	}
-	iAmTheLeader := i.RaftStatus.RaftState == raft.StateLeader
+	iAmTheLeader := i.RaftStatus.RaftState == raftpb.StateLeader
 	if !iAmTheLeader {
 		log.VEventf(ctx, 2, "proposing lease extension even though we're not the leader; we hold the current lease")
 	}

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -288,7 +288,7 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 
 	// Is this the raft leader? We only propose log truncation on the raft
 	// leader which has the up to date info on followers.
-	if raftStatus.RaftState != raft.StateLeader {
+	if raftStatus.RaftState != raftpb.StateLeader {
 		return truncateDecision{}, nil
 	}
 

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -205,7 +205,7 @@ func TestComputeTruncateDecision(t *testing.T) {
 			assert.False(t, recompute)
 			assert.Equal(t, decision.ShouldTruncate(), prio != 0)
 			input.LogSizeTrusted = false
-			input.RaftStatus.RaftState = raft.StateLeader
+			input.RaftStatus.RaftState = raftpb.StateLeader
 			if input.LastIndex <= input.FirstIndex {
 				input.LastIndex = input.FirstIndex + 1
 			}

--- a/pkg/kv/kvserver/raftutil/util.go
+++ b/pkg/kv/kvserver/raftutil/util.go
@@ -22,7 +22,7 @@ func ReplicaIsBehind(st *raft.Status, replicaID roachpb.ReplicaID) bool {
 		// Testing only.
 		return true
 	}
-	if st.RaftState != raft.StateLeader {
+	if st.RaftState != raftpb.StateLeader {
 		// If we aren't the Raft leader, we aren't tracking the replica's progress,
 		// so we can't be sure it's not behind.
 		return true
@@ -131,7 +131,7 @@ func ReplicaMayNeedSnapshot(
 		// Testing only.
 		return NoRaftStatusAvailable
 	}
-	if st.RaftState != raft.StateLeader {
+	if st.RaftState != raftpb.StateLeader {
 		// If we aren't the Raft leader, we aren't tracking the replica's progress,
 		// so we can't be sure it does not need a snapshot.
 		return LocalReplicaNotLeader

--- a/pkg/kv/kvserver/raftutil/util_test.go
+++ b/pkg/kv/kvserver/raftutil/util_test.go
@@ -32,28 +32,28 @@ func TestReplicaIsBehind(t *testing.T) {
 		{
 			name: "local follower",
 			st: makeStatus(func(st *raft.Status) {
-				st.RaftState = raft.StateFollower
+				st.RaftState = raftpb.StateFollower
 			}),
 			expect: true,
 		},
 		{
 			name: "local candidate",
 			st: makeStatus(func(st *raft.Status) {
-				st.RaftState = raft.StateCandidate
+				st.RaftState = raftpb.StateCandidate
 			}),
 			expect: true,
 		},
 		{
 			name: "local leader, no progress for peer",
 			st: makeStatus(func(st *raft.Status) {
-				st.RaftState = raft.StateLeader
+				st.RaftState = raftpb.StateLeader
 			}),
 			expect: true,
 		},
 		{
 			name: "local leader, peer leader",
 			st: makeStatus(func(st *raft.Status) {
-				st.RaftState = raft.StateLeader
+				st.RaftState = raftpb.StateLeader
 				st.Progress[replicaID] = tracker.Progress{State: tracker.StateReplicate}
 				st.Lead = replicaID
 			}),
@@ -62,7 +62,7 @@ func TestReplicaIsBehind(t *testing.T) {
 		{
 			name: "local leader, peer state probe",
 			st: makeStatus(func(st *raft.Status) {
-				st.RaftState = raft.StateLeader
+				st.RaftState = raftpb.StateLeader
 				st.Progress[replicaID] = tracker.Progress{State: tracker.StateProbe}
 			}),
 			expect: true,
@@ -70,7 +70,7 @@ func TestReplicaIsBehind(t *testing.T) {
 		{
 			name: "local leader, peer state snapshot",
 			st: makeStatus(func(st *raft.Status) {
-				st.RaftState = raft.StateLeader
+				st.RaftState = raftpb.StateLeader
 				st.Progress[replicaID] = tracker.Progress{State: tracker.StateSnapshot}
 			}),
 			expect: true,
@@ -78,7 +78,7 @@ func TestReplicaIsBehind(t *testing.T) {
 		{
 			name: "local leader, peer state replicate, match < commit",
 			st: makeStatus(func(st *raft.Status) {
-				st.RaftState = raft.StateLeader
+				st.RaftState = raftpb.StateLeader
 				st.Progress[replicaID] = tracker.Progress{State: tracker.StateReplicate, Match: 9}
 			}),
 			expect: true,
@@ -86,7 +86,7 @@ func TestReplicaIsBehind(t *testing.T) {
 		{
 			name: "local leader, peer state replicate, match == commit",
 			st: makeStatus(func(st *raft.Status) {
-				st.RaftState = raft.StateLeader
+				st.RaftState = raftpb.StateLeader
 				st.Progress[replicaID] = tracker.Progress{State: tracker.StateReplicate, Match: 10}
 			}),
 			expect: false,
@@ -94,7 +94,7 @@ func TestReplicaIsBehind(t *testing.T) {
 		{
 			name: "local leader, peer state replicate, match > commit",
 			st: makeStatus(func(st *raft.Status) {
-				st.RaftState = raft.StateLeader
+				st.RaftState = raftpb.StateLeader
 				st.Progress[replicaID] = tracker.Progress{State: tracker.StateReplicate, Match: 11}
 			}),
 			expect: false,
@@ -131,28 +131,28 @@ func TestReplicaMayNeedSnapshot(t *testing.T) {
 		{
 			name: "local follower",
 			st: makeStatus(func(st *raft.Status) {
-				st.RaftState = raft.StateFollower
+				st.RaftState = raftpb.StateFollower
 			}),
 			expect: LocalReplicaNotLeader,
 		},
 		{
 			name: "local candidate",
 			st: makeStatus(func(st *raft.Status) {
-				st.RaftState = raft.StateCandidate
+				st.RaftState = raftpb.StateCandidate
 			}),
 			expect: LocalReplicaNotLeader,
 		},
 		{
 			name: "local leader, no progress for peer",
 			st: makeStatus(func(st *raft.Status) {
-				st.RaftState = raft.StateLeader
+				st.RaftState = raftpb.StateLeader
 			}),
 			expect: ReplicaUnknown,
 		},
 		{
 			name: "local leader, peer state probe",
 			st: makeStatus(func(st *raft.Status) {
-				st.RaftState = raft.StateLeader
+				st.RaftState = raftpb.StateLeader
 				st.Progress[replicaID] = tracker.Progress{State: tracker.StateProbe}
 			}),
 			expect: ReplicaStateProbe,
@@ -160,7 +160,7 @@ func TestReplicaMayNeedSnapshot(t *testing.T) {
 		{
 			name: "local leader, peer state snapshot",
 			st: makeStatus(func(st *raft.Status) {
-				st.RaftState = raft.StateLeader
+				st.RaftState = raftpb.StateLeader
 				st.Progress[replicaID] = tracker.Progress{State: tracker.StateSnapshot}
 			}),
 			expect: ReplicaStateSnapshot,
@@ -168,7 +168,7 @@ func TestReplicaMayNeedSnapshot(t *testing.T) {
 		{
 			name: "local leader, peer state replicate, match+1 < firstIndex",
 			st: makeStatus(func(st *raft.Status) {
-				st.RaftState = raft.StateLeader
+				st.RaftState = raftpb.StateLeader
 				st.Progress[replicaID] = tracker.Progress{State: tracker.StateReplicate, Match: 8}
 			}),
 			expect: ReplicaMatchBelowLeadersFirstIndex,
@@ -176,7 +176,7 @@ func TestReplicaMayNeedSnapshot(t *testing.T) {
 		{
 			name: "local leader, peer state replicate, match+1 == firstIndex",
 			st: makeStatus(func(st *raft.Status) {
-				st.RaftState = raft.StateLeader
+				st.RaftState = raftpb.StateLeader
 				st.Progress[replicaID] = tracker.Progress{State: tracker.StateReplicate, Match: 9}
 			}),
 			expect: NoSnapshotNeeded,
@@ -184,7 +184,7 @@ func TestReplicaMayNeedSnapshot(t *testing.T) {
 		{
 			name: "local leader, peer state replicate, match+1 == firstIndex",
 			st: makeStatus(func(st *raft.Status) {
-				st.RaftState = raft.StateLeader
+				st.RaftState = raftpb.StateLeader
 				st.Progress[replicaID] = tracker.Progress{State: tracker.StateReplicate, Match: 10}
 			}),
 			expect: NoSnapshotNeeded,

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/readsummary/rspb"
-	"github.com/cockroachdb/cockroach/pkg/raft"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -582,7 +582,7 @@ func (r *Replica) handleChangeReplicasResult(
 
 	// This is currently executed before the conf change is applied to the Raft
 	// node, so we still see ourselves as the leader.
-	if r.raftBasicStatusRLocked().RaftState == raft.StateLeader {
+	if r.raftBasicStatusRLocked().RaftState == raftpb.StateLeader {
 		r.store.metrics.RangeRaftLeaderRemovals.Inc(1)
 	}
 

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -136,7 +136,7 @@ func maybeDescriptorChangedError(
 
 func splitSnapshotWarningStr(rangeID roachpb.RangeID, status *raft.Status) redact.RedactableString {
 	var s redact.RedactableString
-	if status != nil && status.RaftState == raft.StateLeader {
+	if status != nil && status.RaftState == raftpb.StateLeader {
 		for replicaID, pr := range status.Progress {
 			if replicaID == status.Lead {
 				// TODO(tschottdorf): remove this line once we have picked up

--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
-	"github.com/cockroachdb/cockroach/pkg/raft"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -168,7 +168,7 @@ func replicaIsSuspect(repl *Replica) bool {
 	switch raftStatus.SoftState.RaftState {
 	// If a replica is a candidate, then by definition it has lost contact with
 	// its leader and possibly the rest of the Raft group, so consider it suspect.
-	case raft.StateCandidate, raft.StatePreCandidate:
+	case raftpb.StateCandidate, raftpb.StatePreCandidate:
 		return true
 
 	// If the replica is a follower, check that the leader is in our range
@@ -177,7 +177,7 @@ func replicaIsSuspect(repl *Replica) bool {
 	// a quiesced follower which was partitioned away from the Raft group during
 	// its own removal from the range -- this case is vulnerable to race
 	// conditions, but if it fails it will be GCed within 12 hours anyway.
-	case raft.StateFollower:
+	case raftpb.StateFollower:
 		leadDesc, ok := repl.Desc().GetReplicaDescriptorByID(roachpb.ReplicaID(raftStatus.Lead))
 		if !ok || !livenessMap[leadDesc.NodeID].IsLive {
 			return true
@@ -186,7 +186,7 @@ func replicaIsSuspect(repl *Replica) bool {
 	// If the replica is a leader, check that it has a quorum. This handles e.g.
 	// a stuck leader with a lost quorum being replaced via Node.ResetQuorum,
 	// which must cause the stale leader to relinquish its lease and GC itself.
-	case raft.StateLeader:
+	case raftpb.StateLeader:
 		if !repl.Desc().Replicas().CanMakeProgress(func(d roachpb.ReplicaDescriptor) bool {
 			return livenessMap[d.NodeID].IsLive
 		}) {

--- a/pkg/kv/kvserver/replica_metrics.go
+++ b/pkg/kv/kvserver/replica_metrics.go
@@ -174,7 +174,7 @@ func calcReplicaMetrics(d calcReplicaMetricsInput) ReplicaMetrics {
 
 	// The raft leader computes the number of raft entries that replicas are
 	// behind.
-	leader := d.raftStatus != nil && d.raftStatus.RaftState == raft.StateLeader
+	leader := d.raftStatus != nil && d.raftStatus.RaftState == raftpb.StateLeader
 	var leaderBehindCount, leaderPausedFollowerCount int64
 	if leader {
 		leaderBehindCount = calcBehindCount(d.raftStatus, d.desc, d.vitalityMap)

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -125,7 +125,7 @@ type admitEntHandle struct {
 type singleBatchProposer interface {
 	getReplicaID() roachpb.ReplicaID
 	flowControlHandle(ctx context.Context) kvflowcontrol.Handle
-	onErrProposalDropped([]raftpb.Entry, []*ProposalData, raft.StateType)
+	onErrProposalDropped([]raftpb.Entry, []*ProposalData, raftpb.StateType)
 }
 
 // A proposer is an object that uses a propBuf to coordinate Raft proposals.
@@ -1185,11 +1185,11 @@ func (rp *replicaProposer) withGroupLocked(fn func(raftGroup proposerRaft) error
 }
 
 func (rp *replicaProposer) onErrProposalDropped(
-	ents []raftpb.Entry, _ []*ProposalData, stateType raft.StateType,
+	ents []raftpb.Entry, _ []*ProposalData, stateType raftpb.StateType,
 ) {
 	n := int64(len(ents))
 	rp.store.metrics.RaftProposalsDropped.Inc(n)
-	if stateType == raft.StateLeader {
+	if stateType == raftpb.StateLeader {
 		rp.store.metrics.RaftProposalsDroppedLeader.Inc(n)
 	}
 }

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -60,7 +60,7 @@ type testProposer struct {
 	onRejectProposalWithErrLocked func(err error)
 	// If not nil, this is called by onErrProposalDropped.
 	onProposalsDropped func(
-		ents []raftpb.Entry, proposalData []*ProposalData, stateType raft.StateType,
+		ents []raftpb.Entry, proposalData []*ProposalData, stateType raftpb.StateType,
 	)
 	// validLease is returned by ownsValidLease.
 	validLease bool
@@ -189,7 +189,7 @@ func (t *testProposer) withGroupLocked(fn func(proposerRaft) error) error {
 }
 
 func (rp *testProposer) onErrProposalDropped(
-	ents []raftpb.Entry, props []*ProposalData, typ raft.StateType,
+	ents []raftpb.Entry, props []*ProposalData, typ raftpb.StateType,
 ) {
 	if rp.onProposalsDropped == nil {
 		return
@@ -516,7 +516,7 @@ func TestProposalBufferRejectLeaseAcqOnFollower(t *testing.T) {
 	// scenario. Some proposals should be allowed, some should be rejected.
 	for _, tc := range []struct {
 		name  string
-		state raft.StateType
+		state raftpb.StateType
 		// raft.None means there's no leader, or the leader is unknown.
 		leader raftpb.PeerID
 		// Empty means VOTER_FULL.
@@ -535,14 +535,14 @@ func TestProposalBufferRejectLeaseAcqOnFollower(t *testing.T) {
 	}{
 		{
 			name:   "leader",
-			state:  raft.StateLeader,
+			state:  raftpb.StateLeader,
 			leader: self,
 			// No rejection. The leader can request a lease.
 			expRejection: false,
 		},
 		{
 			name:  "follower, known eligible leader",
-			state: raft.StateFollower,
+			state: raftpb.StateFollower,
 			// Someone else is leader.
 			leader: self + 1,
 			// Rejection - a follower can't request a lease.
@@ -550,7 +550,7 @@ func TestProposalBufferRejectLeaseAcqOnFollower(t *testing.T) {
 		},
 		{
 			name:  "follower, lease extension despite known eligible leader",
-			state: raft.StateFollower,
+			state: raftpb.StateFollower,
 			// Someone else is leader, but we're the leaseholder.
 			leader:         self + 1,
 			ownsValidLease: true,
@@ -559,7 +559,7 @@ func TestProposalBufferRejectLeaseAcqOnFollower(t *testing.T) {
 		},
 		{
 			name:  "follower, known ineligible leader",
-			state: raft.StateFollower,
+			state: raftpb.StateFollower,
 			// Someone else is leader.
 			leader: self + 1,
 			// The leader type makes it ineligible to get the lease. Thus, the local
@@ -571,7 +571,7 @@ func TestProposalBufferRejectLeaseAcqOnFollower(t *testing.T) {
 			// Here we simulate the leader being known by Raft, but the local replica
 			// is so far behind that it doesn't contain the leader replica.
 			name:  "follower, known leader not in range descriptor",
-			state: raft.StateFollower,
+			state: raftpb.StateFollower,
 			// Someone else is leader.
 			leader:             self + 1,
 			leaderNotInRngDesc: true,
@@ -580,7 +580,7 @@ func TestProposalBufferRejectLeaseAcqOnFollower(t *testing.T) {
 		},
 		{
 			name:  "follower, unknown leader",
-			state: raft.StateFollower,
+			state: raftpb.StateFollower,
 			// Unknown leader.
 			leader: raft.None,
 			// No rejection if the leader is unknown. See comments in
@@ -589,7 +589,7 @@ func TestProposalBufferRejectLeaseAcqOnFollower(t *testing.T) {
 		},
 		{
 			name:  "follower, known eligible non-live leader",
-			state: raft.StateFollower,
+			state: raftpb.StateFollower,
 			// Someone else is leader.
 			leader:        self + 1,
 			leaderNotLive: true,
@@ -686,7 +686,7 @@ func TestProposalBufferRejectUnsafeLeaseTransfer(t *testing.T) {
 	// scenario. Some proposals should be allowed, some should be rejected.
 	for _, tc := range []struct {
 		name          string
-		proposerState raft.StateType
+		proposerState raftpb.StateType
 		// math.MaxUint64 if the target is not in the raft group.
 		targetState rafttracker.StateType
 		targetMatch kvpb.RaftIndex
@@ -696,40 +696,40 @@ func TestProposalBufferRejectUnsafeLeaseTransfer(t *testing.T) {
 	}{
 		{
 			name:               "follower",
-			proposerState:      raft.StateFollower,
+			proposerState:      raftpb.StateFollower,
 			expRejection:       true,
 			expRejectionReason: raftutil.LocalReplicaNotLeader,
 		},
 		{
 			name:               "candidate",
-			proposerState:      raft.StateCandidate,
+			proposerState:      raftpb.StateCandidate,
 			expRejection:       true,
 			expRejectionReason: raftutil.LocalReplicaNotLeader,
 		},
 		{
 			name:               "leader, no progress for target",
-			proposerState:      raft.StateLeader,
+			proposerState:      raftpb.StateLeader,
 			targetState:        math.MaxUint64,
 			expRejection:       true,
 			expRejectionReason: raftutil.ReplicaUnknown,
 		},
 		{
 			name:               "leader, target state probe",
-			proposerState:      raft.StateLeader,
+			proposerState:      raftpb.StateLeader,
 			targetState:        rafttracker.StateProbe,
 			expRejection:       true,
 			expRejectionReason: raftutil.ReplicaStateProbe,
 		},
 		{
 			name:               "leader, target state snapshot",
-			proposerState:      raft.StateLeader,
+			proposerState:      raftpb.StateLeader,
 			targetState:        rafttracker.StateSnapshot,
 			expRejection:       true,
 			expRejectionReason: raftutil.ReplicaStateSnapshot,
 		},
 		{
 			name:               "leader, target state replicate, match+1 < firstIndex",
-			proposerState:      raft.StateLeader,
+			proposerState:      raftpb.StateLeader,
 			targetState:        rafttracker.StateReplicate,
 			targetMatch:        proposerFirstIndex - 2,
 			expRejection:       true,
@@ -737,14 +737,14 @@ func TestProposalBufferRejectUnsafeLeaseTransfer(t *testing.T) {
 		},
 		{
 			name:          "leader, target state replicate, match+1 == firstIndex",
-			proposerState: raft.StateLeader,
+			proposerState: raftpb.StateLeader,
 			targetState:   rafttracker.StateReplicate,
 			targetMatch:   proposerFirstIndex - 1,
 			expRejection:  false,
 		},
 		{
 			name:          "leader, target state replicate, match+1 > firstIndex",
-			proposerState: raft.StateLeader,
+			proposerState: raftpb.StateLeader,
 			targetState:   rafttracker.StateReplicate,
 			targetMatch:   proposerFirstIndex,
 			expRejection:  false,
@@ -773,7 +773,7 @@ func TestProposalBufferRejectUnsafeLeaseTransfer(t *testing.T) {
 			var raftStatus raft.Status
 			raftStatus.ID = proposer
 			raftStatus.RaftState = tc.proposerState
-			if tc.proposerState == raft.StateLeader {
+			if tc.proposerState == raftpb.StateLeader {
 				raftStatus.Lead = proposer
 				raftStatus.Progress = map[raftpb.PeerID]rafttracker.Progress{
 					proposer: {State: rafttracker.StateReplicate, Match: uint64(proposerFirstIndex)},
@@ -831,7 +831,7 @@ func TestProposalBufferLinesUpEntriesAndProposals(t *testing.T) {
 
 	var matchingDroppedProposalsSeen int
 	p := testProposer{
-		onProposalsDropped: func(ents []raftpb.Entry, props []*ProposalData, _ raft.StateType) {
+		onProposalsDropped: func(ents []raftpb.Entry, props []*ProposalData, _ raftpb.StateType) {
 			require.Equal(t, len(ents), len(props))
 			for i := range ents {
 				if ents[i].Type == raftpb.EntryNormal {
@@ -1097,7 +1097,7 @@ func TestProposalBufferClosedTimestamp(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			r := &testProposerRaft{}
 			r.status.Lead = 1
-			r.status.RaftState = raft.StateLeader
+			r.status.RaftState = raftpb.StateLeader
 			r.status.Progress = map[raftpb.PeerID]rafttracker.Progress{
 				1: {State: rafttracker.StateReplicate},
 			}

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -87,11 +87,11 @@ func (r *Replica) maybeUnquiesceLocked(wakeLeader, mayCampaign bool) bool {
 	r.store.unquiescedReplicas.Unlock()
 
 	st := r.raftSparseStatusRLocked()
-	if st.RaftState == raft.StateLeader {
+	if st.RaftState == raftpb.StateLeader {
 		r.mu.lastUpdateTimes.updateOnUnquiesce(
 			r.shMu.state.Desc.Replicas().Descriptors(), st.Progress, r.Clock().PhysicalTime())
 
-	} else if st.RaftState == raft.StateFollower && st.Lead != raft.None && wakeLeader {
+	} else if st.RaftState == raftpb.StateFollower && st.Lead != raft.None && wakeLeader {
 		// Propose an empty command which will wake the leader.
 		if log.V(3) {
 			log.Infof(ctx, "waking r%d leader", r.RangeID)
@@ -371,7 +371,7 @@ func shouldReplicaQuiesceRaftMuLockedReplicaMuLocked(
 		}
 		return nil, nil, false
 	}
-	if status.SoftState.RaftState != raft.StateLeader {
+	if status.SoftState.RaftState != raftpb.StateLeader {
 		if log.V(4) {
 			log.Infof(ctx, "not quiescing: not leader")
 		}

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed"
-	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -1092,7 +1091,7 @@ func TestReplicaRangefeedErrors(t *testing.T) {
 				return err
 			}
 			raftStatus := repl.RaftStatus()
-			if raftStatus != nil && raftStatus.RaftState == raft.StateFollower {
+			if raftStatus != nil && raftStatus.RaftState == raftpb.StateFollower {
 				return nil
 			}
 			err = repl.AdminTransferLease(ctx, roachpb.StoreID(1), false /* bypassSafetyChecks */)

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -133,7 +133,7 @@ func upToDateRaftStatus(repls []roachpb.ReplicaDescriptor) *raft.Status {
 	return &raft.Status{
 		BasicStatus: raft.BasicStatus{
 			HardState: raftpb.HardState{Commit: 100, Lead: 1},
-			SoftState: raft.SoftState{RaftState: raft.StateLeader},
+			SoftState: raft.SoftState{RaftState: raftpb.StateLeader},
 		},
 		Progress: prs,
 	}
@@ -8995,9 +8995,9 @@ func TestReplicaMetrics(t *testing.T) {
 		// and 2 is ok.
 		status.HardState.Commit = 12
 		if lead == 1 {
-			status.SoftState.RaftState = raft.StateLeader
+			status.SoftState.RaftState = raftpb.StateLeader
 		} else {
-			status.SoftState.RaftState = raft.StateFollower
+			status.SoftState.RaftState = raftpb.StateFollower
 		}
 		status.HardState.Lead = lead
 		return status
@@ -9886,7 +9886,7 @@ func (q *testQuiescer) descRLocked() *roachpb.RangeDescriptor {
 }
 
 func (q *testQuiescer) isRaftLeaderRLocked() bool {
-	return q.status != nil && q.status.RaftState == raft.StateLeader
+	return q.status != nil && q.status.RaftState == raftpb.StateLeader
 }
 
 func (q *testQuiescer) raftSparseStatusRLocked() *raft.SparseStatus {
@@ -9960,7 +9960,7 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 							Commit: logIndex,
 						},
 						SoftState: raft.SoftState{
-							RaftState: raft.StateLeader,
+							RaftState: raftpb.StateLeader,
 						},
 						Applied:        logIndex,
 						LeadTransferee: 0,
@@ -10034,8 +10034,8 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 	test(false, func(q *testQuiescer) { q.mergeInProgress = true })
 	test(false, func(q *testQuiescer) { q.isDestroyed = true })
 	test(false, func(q *testQuiescer) { q.status = nil })
-	test(false, func(q *testQuiescer) { q.status.RaftState = raft.StateFollower })
-	test(false, func(q *testQuiescer) { q.status.RaftState = raft.StateCandidate })
+	test(false, func(q *testQuiescer) { q.status.RaftState = raftpb.StateFollower })
+	test(false, func(q *testQuiescer) { q.status.RaftState = raftpb.StateCandidate })
 	test(false, func(q *testQuiescer) { q.status.LeadTransferee = 1 })
 	test(false, func(q *testQuiescer) { q.status.Commit = invalidIndex })
 	test(false, func(q *testQuiescer) { q.status.Applied = invalidIndex })
@@ -11507,7 +11507,7 @@ func TestReplicaShouldCampaignOnWake(t *testing.T) {
 		},
 		raftStatus: raft.BasicStatus{
 			SoftState: raft.SoftState{
-				RaftState: raft.StateFollower,
+				RaftState: raftpb.StateFollower,
 			},
 			HardState: raftpb.HardState{
 				Lead: 2,
@@ -11533,15 +11533,15 @@ func TestReplicaShouldCampaignOnWake(t *testing.T) {
 			p.leaseStatus.Lease.Replica.StoreID = 1
 		}},
 		"pre-candidate": {false, func(p *params) {
-			p.raftStatus.SoftState.RaftState = raft.StatePreCandidate
+			p.raftStatus.SoftState.RaftState = raftpb.StatePreCandidate
 			p.raftStatus.Lead = raft.None
 		}},
 		"candidate": {false, func(p *params) {
-			p.raftStatus.SoftState.RaftState = raft.StateCandidate
+			p.raftStatus.SoftState.RaftState = raftpb.StateCandidate
 			p.raftStatus.Lead = raft.None
 		}},
 		"leader": {false, func(p *params) {
-			p.raftStatus.SoftState.RaftState = raft.StateLeader
+			p.raftStatus.SoftState.RaftState = raftpb.StateLeader
 			p.raftStatus.Lead = 1
 		}},
 		"unknown leader": {true, func(p *params) {
@@ -11627,7 +11627,7 @@ func TestReplicaShouldCampaignOnLeaseRequestRedirect(t *testing.T) {
 		},
 		raftStatus: raft.BasicStatus{
 			SoftState: raft.SoftState{
-				RaftState: raft.StateFollower,
+				RaftState: raftpb.StateFollower,
 			},
 			HardState: raftpb.HardState{
 				Lead: 2,
@@ -11648,15 +11648,15 @@ func TestReplicaShouldCampaignOnLeaseRequestRedirect(t *testing.T) {
 	}{
 		"dead leader": {true, func(p *params) {}},
 		"pre-candidate": {false, func(p *params) {
-			p.raftStatus.SoftState.RaftState = raft.StatePreCandidate
+			p.raftStatus.SoftState.RaftState = raftpb.StatePreCandidate
 			p.raftStatus.Lead = raft.None
 		}},
 		"candidate": {false, func(p *params) {
-			p.raftStatus.SoftState.RaftState = raft.StateCandidate
+			p.raftStatus.SoftState.RaftState = raftpb.StateCandidate
 			p.raftStatus.Lead = raft.None
 		}},
 		"leader": {false, func(p *params) {
-			p.raftStatus.SoftState.RaftState = raft.StateLeader
+			p.raftStatus.SoftState.RaftState = raftpb.StateLeader
 			p.raftStatus.Lead = 1
 		}},
 		"unknown leader": {true, func(p *params) {
@@ -11744,7 +11744,7 @@ func TestReplicaShouldForgetLeaderOnVoteRequest(t *testing.T) {
 		},
 		raftStatus: raft.BasicStatus{
 			SoftState: raft.SoftState{
-				RaftState: raft.StateFollower,
+				RaftState: raftpb.StateFollower,
 			},
 			HardState: raftpb.HardState{
 				Lead: 2,
@@ -11764,15 +11764,15 @@ func TestReplicaShouldForgetLeaderOnVoteRequest(t *testing.T) {
 	}{
 		"dead leader": {true, func(p *params) {}},
 		"pre-candidate": {false, func(p *params) {
-			p.raftStatus.SoftState.RaftState = raft.StatePreCandidate
+			p.raftStatus.SoftState.RaftState = raftpb.StatePreCandidate
 			p.raftStatus.Lead = raft.None
 		}},
 		"candidate": {false, func(p *params) {
-			p.raftStatus.SoftState.RaftState = raft.StateCandidate
+			p.raftStatus.SoftState.RaftState = raftpb.StateCandidate
 			p.raftStatus.Lead = raft.None
 		}},
 		"leader": {false, func(p *params) {
-			p.raftStatus.SoftState.RaftState = raft.StateLeader
+			p.raftStatus.SoftState.RaftState = raftpb.StateLeader
 			p.raftStatus.Lead = 1
 		}},
 		"unknown leader": {false, func(p *params) {
@@ -11848,7 +11848,7 @@ func TestReplicaShouldTransferRaftLeadershipToLeaseholder(t *testing.T) {
 		raftStatus: raft.SparseStatus{
 			BasicStatus: raft.BasicStatus{
 				SoftState: raft.SoftState{
-					RaftState: raft.StateLeader,
+					RaftState: raftpb.StateLeader,
 				},
 				HardState: raftpb.HardState{
 					Lead:   localID,
@@ -11878,15 +11878,15 @@ func TestReplicaShouldTransferRaftLeadershipToLeaseholder(t *testing.T) {
 			true, func(p *params) {},
 		},
 		"follower": {false, func(p *params) {
-			p.raftStatus.SoftState.RaftState = raft.StateFollower
+			p.raftStatus.SoftState.RaftState = raftpb.StateFollower
 			p.raftStatus.Lead = remoteID
 		}},
 		"pre-candidate": {false, func(p *params) {
-			p.raftStatus.SoftState.RaftState = raft.StatePreCandidate
+			p.raftStatus.SoftState.RaftState = raftpb.StatePreCandidate
 			p.raftStatus.Lead = raft.None
 		}},
 		"candidate": {false, func(p *params) {
-			p.raftStatus.SoftState.RaftState = raft.StateCandidate
+			p.raftStatus.SoftState.RaftState = raftpb.StateCandidate
 			p.raftStatus.Lead = raft.None
 		}},
 		"invalid lease": {false, func(p *params) {

--- a/pkg/kv/kvserver/split_delay_helper.go
+++ b/pkg/kv/kvserver/split_delay_helper.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/raft"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -86,7 +87,7 @@ func maybeDelaySplitToAvoidSnapshot(
 		problems = problems[:0]
 		rangeID, raftStatus := sdh.RaftStatus(ctx)
 
-		if raftStatus == nil || raftStatus.RaftState == raft.StateFollower {
+		if raftStatus == nil || raftStatus.RaftState == raftpb.StateFollower {
 			// Don't delay on followers (we don't have information about the
 			// peers in that state and thus can't determine when it is safe
 			// to continue). This case is hit rarely enough to not matter,
@@ -145,7 +146,7 @@ func maybeDelaySplitToAvoidSnapshot(
 		//
 		// See TestSplitBurstWithSlowFollower for end-to-end verification of this
 		// mechanism.
-		if raftStatus.RaftState != raft.StateLeader {
+		if raftStatus.RaftState != raftpb.StateLeader {
 			problems = append(problems, redact.Sprintf("not leader (%s)", redact.Safe(raftStatus.RaftState)))
 		}
 

--- a/pkg/kv/kvserver/split_delay_helper_test.go
+++ b/pkg/kv/kvserver/split_delay_helper_test.go
@@ -68,7 +68,7 @@ func TestSplitDelayToAvoidSnapshot(t *testing.T) {
 		assert.EqualValues(t, 0, h.slept)
 	})
 
-	statusWithState := func(status raft.StateType) *raft.Status {
+	statusWithState := func(status raftpb.StateType) *raft.Status {
 		return &raft.Status{
 			BasicStatus: raft.BasicStatus{
 				SoftState: raft.SoftState{
@@ -95,14 +95,14 @@ func TestSplitDelayToAvoidSnapshot(t *testing.T) {
 		h := &testSplitDelayHelper{
 			numAttempts: 5,
 			rangeID:     1,
-			raftStatus:  statusWithState(raft.StateFollower),
+			raftStatus:  statusWithState(raftpb.StateFollower),
 		}
 		s := maybeDelaySplitToAvoidSnapshot(ctx, h)
 		assert.EqualValues(t, "; delayed by 0.0s to resolve: replica is raft follower (without success)", s)
 		assert.EqualValues(t, 0, h.slept)
 	})
 
-	for _, state := range []raft.StateType{raft.StatePreCandidate, raft.StateCandidate} {
+	for _, state := range []raftpb.StateType{raftpb.StatePreCandidate, raftpb.StateCandidate} {
 		t.Run(state.String(), func(t *testing.T) {
 			h := &testSplitDelayHelper{
 				numAttempts: 5,
@@ -115,7 +115,7 @@ func TestSplitDelayToAvoidSnapshot(t *testing.T) {
 	}
 
 	t.Run("inactive", func(t *testing.T) {
-		st := statusWithState(raft.StateLeader)
+		st := statusWithState(raftpb.StateLeader)
 		st.Progress = map[raftpb.PeerID]tracker.Progress{
 			2: {State: tracker.StateProbe},
 		}
@@ -132,7 +132,7 @@ func TestSplitDelayToAvoidSnapshot(t *testing.T) {
 
 	for _, state := range []tracker.StateType{tracker.StateProbe, tracker.StateSnapshot} {
 		t.Run(state.String(), func(t *testing.T) {
-			st := statusWithState(raft.StateLeader)
+			st := statusWithState(raftpb.StateLeader)
 			st.Progress = map[raftpb.PeerID]tracker.Progress{
 				2: {
 					State:              state,
@@ -155,7 +155,7 @@ func TestSplitDelayToAvoidSnapshot(t *testing.T) {
 	}
 
 	t.Run("immediately-replicating", func(t *testing.T) {
-		st := statusWithState(raft.StateLeader)
+		st := statusWithState(raftpb.StateLeader)
 		st.Progress = map[raftpb.PeerID]tracker.Progress{
 			2: {State: tracker.StateReplicate}, // intentionally not recently active
 		}
@@ -170,7 +170,7 @@ func TestSplitDelayToAvoidSnapshot(t *testing.T) {
 	})
 
 	t.Run("becomes-replicating", func(t *testing.T) {
-		st := statusWithState(raft.StateLeader)
+		st := statusWithState(raftpb.StateLeader)
 		st.Progress = map[raftpb.PeerID]tracker.Progress{
 			2: {State: tracker.StateProbe, RecentActive: true, Inflights: &tracker.Inflights{}},
 		}

--- a/pkg/kv/kvserver/store_rebalancer_test.go
+++ b/pkg/kv/kvserver/store_rebalancer_test.go
@@ -1562,7 +1562,7 @@ func TestNoLeaseTransferToBehindReplicas(t *testing.T) {
 		require.True(t, ok, "Could not find replica descriptor for replica on store with id %d", storeID)
 
 		status.Lead = raftpb.PeerID(replDesc.ReplicaID)
-		status.RaftState = raft.StateLeader
+		status.RaftState = raftpb.StateLeader
 		status.Commit = 2
 		for _, replica := range desc.InternalReplicas {
 			match := uint64(2)
@@ -1850,7 +1850,7 @@ func TestingRaftStatusFn(desc *roachpb.RangeDescriptor, storeID roachpb.StoreID)
 	}
 
 	status.Lead = raftpb.PeerID(replDesc.ReplicaID)
-	status.RaftState = raft.StateLeader
+	status.RaftState = raftpb.StateLeader
 	status.Commit = 2
 	for _, replica := range desc.InternalReplicas {
 		status.Progress[raftpb.PeerID(replica.ReplicaID)] = tracker.Progress{

--- a/pkg/raft/node.go
+++ b/pkg/raft/node.go
@@ -31,7 +31,7 @@ var emptyState = pb.HardState{}
 // SoftState provides state that is useful for logging and debugging.
 // The state is volatile and does not need to be persisted to the WAL.
 type SoftState struct {
-	RaftState StateType
+	RaftState pb.StateType
 }
 
 func (a *SoftState) equal(b *SoftState) bool {

--- a/pkg/raft/node_test.go
+++ b/pkg/raft/node_test.go
@@ -462,7 +462,7 @@ func TestSoftStateEqual(t *testing.T) {
 		we bool
 	}{
 		{&SoftState{}, true},
-		{&SoftState{RaftState: StateLeader}, false},
+		{&SoftState{RaftState: raftpb.StateLeader}, false},
 	}
 	for i, tt := range tests {
 		assert.Equal(t, tt.we, tt.st.equal(&SoftState{}), "#%d", i)

--- a/pkg/raft/raftpb/raft.go
+++ b/pkg/raft/raftpb/raft.go
@@ -5,7 +5,11 @@
 
 package raftpb
 
-import "github.com/cockroachdb/redact"
+import (
+	"fmt"
+
+	"github.com/cockroachdb/redact"
+)
 
 // PeerID is a custom type for peer IDs in a raft group.
 type PeerID uint64
@@ -75,4 +79,31 @@ func (p Priority) SafeFormat(w redact.SafePrinter, _ rune) {
 	default:
 		panic("invalid raft priority")
 	}
+}
+
+// StateType represents the role of a node in a cluster.
+type StateType uint64
+
+// Possible values for StateType.
+const (
+	StateFollower StateType = iota
+	StateCandidate
+	StateLeader
+	StatePreCandidate
+	NumStates
+)
+
+var stmap = [...]string{
+	"StateFollower",
+	"StateCandidate",
+	"StateLeader",
+	"StatePreCandidate",
+}
+
+func (st StateType) String() string {
+	return stmap[st]
+}
+
+func (st StateType) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("%q", st.String())), nil
 }

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -169,7 +169,7 @@ func (rn *RawNode) SetLazyReplication(lazy bool) {
 	}
 	// The lazy mode was disabled. We need to check whether any replication flows
 	// are unblocked and can be saturated.
-	if r.state == StateLeader {
+	if r.state == pb.StateLeader {
 		// TODO(pav-kv): this sends at most one MsgApp message per peer. It may not
 		// completely saturate the flow. Consider looping while maybeSendAppend()
 		// returns true.

--- a/pkg/raft/rawnode_test.go
+++ b/pkg/raft/rawnode_test.go
@@ -473,7 +473,7 @@ func TestRawNodeStart(t *testing.T) {
 		{Term: 1, Index: 3, Data: []byte("foo")}, // non-empty entry
 	}
 	want := Ready{
-		SoftState:        &SoftState{RaftState: StateLeader},
+		SoftState:        &SoftState{RaftState: pb.StateLeader},
 		HardState:        pb.HardState{Term: 1, Commit: 3, Vote: 1, Lead: 1, LeadEpoch: 1},
 		Entries:          nil, // emitted & checked in intermediate Ready cycle
 		CommittedEntries: entries,
@@ -582,7 +582,7 @@ func TestRawNodeRestart(t *testing.T) {
 	assert.Equal(t, uint64(1), rawNode.raft.Term)
 	assert.Equal(t, uint64(1), rawNode.raft.raftLog.committed)
 	assert.Equal(t, pb.PeerID(1), rawNode.raft.lead)
-	assert.True(t, rawNode.raft.state == StateFollower)
+	assert.True(t, rawNode.raft.state == pb.StateFollower)
 	assert.Equal(t, pb.Epoch(1), rawNode.raft.leadEpoch)
 
 	// Ensure we campaign after the election timeout has elapsed.
@@ -592,7 +592,7 @@ func TestRawNodeRestart(t *testing.T) {
 		rawNode.raft.leadEpoch = 0
 		rawNode.raft.tick()
 	}
-	assert.Equal(t, StateCandidate, rawNode.raft.state)
+	assert.Equal(t, pb.StateCandidate, rawNode.raft.state)
 	assert.Equal(t, uint64(2), rawNode.raft.Term) // this should in-turn bump the term
 }
 
@@ -643,7 +643,7 @@ func TestRawNodeStatus(t *testing.T) {
 	rn.Advance(rd)
 	status := rn.Status()
 	require.Equal(t, pb.PeerID(1), status.Lead)
-	require.Equal(t, StateLeader, status.RaftState)
+	require.Equal(t, pb.StateLeader, status.RaftState)
 	require.Equal(t, *rn.raft.trk.Progress(1), status.Progress[1])
 
 	expCfg := quorum.Config{Voters: quorum.JointConfig{

--- a/pkg/raft/status.go
+++ b/pkg/raft/status.go
@@ -101,7 +101,7 @@ func getBasicStatus(r *raft) BasicStatus {
 	s.HardState = r.hardState()
 	s.SoftState = r.softState()
 	s.Applied = r.raftLog.applied
-	if s.RaftState == StateFollower && s.Lead == r.id {
+	if s.RaftState == pb.StateFollower && s.Lead == r.id {
 		// A raft leader's term ends when it is shut down. It'll rejoin its peers as
 		// a follower when it comes back up, but its Lead and Term field may still
 		// correspond to its pre-restart leadership term. We expect this to quickly
@@ -125,7 +125,7 @@ func getBasicStatus(r *raft) BasicStatus {
 func getStatus(r *raft) Status {
 	var s Status
 	s.BasicStatus = getBasicStatus(r)
-	if s.RaftState == StateLeader {
+	if s.RaftState == pb.StateLeader {
 		s.Progress = getProgressCopy(r)
 	}
 	s.Config = r.config.Clone()
@@ -142,7 +142,7 @@ func getStatus(r *raft) Status {
 func getSparseStatus(r *raft) SparseStatus {
 	var s SparseStatus
 	s.BasicStatus = getBasicStatus(r)
-	if s.RaftState == StateLeader {
+	if s.RaftState == pb.StateLeader {
 		s.Progress = make(map[pb.PeerID]tracker.Progress, r.trk.Len())
 		withProgress(r, func(id pb.PeerID, _ ProgressType, pr tracker.Progress) {
 			s.Progress[id] = pr

--- a/pkg/raft/util.go
+++ b/pkg/raft/util.go
@@ -26,10 +26,6 @@ import (
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 )
 
-func (st StateType) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("%q", st.String())), nil
-}
-
 var isLocalMsg = [...]bool{
 	pb.MsgHup:               true,
 	pb.MsgBeat:              true,

--- a/pkg/testutils/testcluster/BUILD.bazel
+++ b/pkg/testutils/testcluster/BUILD.bazel
@@ -14,7 +14,7 @@ go_library(
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/multitenant/tenantcapabilities",
-        "//pkg/raft",
+        "//pkg/raft/raftpb",
         "//pkg/roachpb",
         "//pkg/rpc",
         "//pkg/rpc/nodedialer",

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
-	"github.com/cockroachdb/cockroach/pkg/raft"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
@@ -1855,7 +1855,7 @@ func (tc *TestCluster) GetRaftLeader(
 					// invalid.
 					raftLeaderRepl = nil
 					latestTerm = raftStatus.Term
-					if raftStatus.RaftState == raft.StateLeader {
+					if raftStatus.RaftState == raftpb.StateLeader {
 						raftLeaderRepl = repl
 					}
 				}


### PR DESCRIPTION
We'll need this to avoid a circular dependency when we use StateType in the FortificationTracker.

Epic: none

Release note: None