### PR TITLE
sql/catalog: reduce allocations when checking for hydratable types

### DIFF
--- a/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
@@ -85,7 +85,7 @@ func (f *dbTableDescFetcher) FetchTableDesc(
 	// Immediately release the lease, since we only need it for the exact
 	// timestamp requested.
 	desc.Release(ctx)
-	if catalog.MaybeRequiresHydration(tableDesc) {
+	if tableDesc.MaybeRequiresTypeHydration() {
 		tableDesc, err = refreshUDT(ctx, tableID, f.db, f.collection, ts)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/catalog/dbdesc/database_desc.go
+++ b/pkg/sql/catalog/dbdesc/database_desc.go
@@ -601,6 +601,9 @@ func (desc *immutable) ForEachUDTDependentForHydration(fn func(t *types.T) error
 	return nil
 }
 
+// MaybeRequiresTypeHydration implements the catalog.Descriptor interface.
+func (desc *immutable) MaybeRequiresTypeHydration() bool { return false }
+
 // GetReplicatedPCRVersion is a part of the catalog.Descriptor
 func (desc *immutable) GetReplicatedPCRVersion() descpb.DescriptorVersion {
 	return desc.ReplicatedPCRVersion

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
@@ -261,6 +260,10 @@ type Descriptor interface {
 	// referenced by this descriptor which must be hydrated prior to using it.
 	// iterutil.StopIteration is supported.
 	ForEachUDTDependentForHydration(func(t *types.T) error) error
+
+	// MaybeRequiresTypeHydration returns false if the descriptor definitely does not
+	// depend on any types.T being hydrated.
+	MaybeRequiresTypeHydration() bool
 
 	// GetReplicatedPCRVersion return the version from the source
 	// tenant if this descriptor is replicated.
@@ -1108,14 +1111,4 @@ func IsSystemDescriptor(desc Descriptor) bool {
 // for the legacy schema changer).
 func HasConcurrentDeclarativeSchemaChange(desc Descriptor) bool {
 	return desc.GetDeclarativeSchemaChangerState() != nil
-}
-
-// MaybeRequiresHydration returns false if the descriptor definitely does not
-// depend on any types.T being hydrated.
-func MaybeRequiresHydration(desc Descriptor) (ret bool) {
-	_ = desc.ForEachUDTDependentForHydration(func(t *types.T) error {
-		ret = true
-		return iterutil.StopIteration()
-	})
-	return ret
 }

--- a/pkg/sql/catalog/descs/hydrate.go
+++ b/pkg/sql/catalog/descs/hydrate.go
@@ -226,7 +226,7 @@ func isHydratable(desc catalog.Descriptor) bool {
 		// Don't hydrate dropped descriptors.
 		return false
 	}
-	return catalog.MaybeRequiresHydration(desc)
+	return desc.MaybeRequiresTypeHydration()
 }
 
 // hydrate ensures that type metadata is present in any type.T objects

--- a/pkg/sql/catalog/funcdesc/func_desc.go
+++ b/pkg/sql/catalog/funcdesc/func_desc.go
@@ -464,6 +464,19 @@ func (desc *immutable) ForEachUDTDependentForHydration(fn func(t *types.T) error
 	return iterutil.Map(fn(desc.ReturnType.Type))
 }
 
+// MaybeRequiresTypeHydration implements the catalog.Descriptor interface.
+func (desc *immutable) MaybeRequiresTypeHydration() bool {
+	if catid.IsOIDUserDefined(desc.ReturnType.Type.Oid()) {
+		return true
+	}
+	for i := range desc.Params {
+		if catid.IsOIDUserDefined(desc.Params[i].Type.Oid()) {
+			return true
+		}
+	}
+	return false
+}
+
 // GetReplicatedPCRVersion is a part of the catalog.Descriptor
 func (desc *immutable) GetReplicatedPCRVersion() descpb.DescriptorVersion {
 	return desc.ReplicatedPCRVersion

--- a/pkg/sql/catalog/hydrateddesccache/hydratedcache.go
+++ b/pkg/sql/catalog/hydrateddesccache/hydratedcache.go
@@ -257,7 +257,7 @@ func (c *Cache) GetHydratedDescriptor(
 
 	// If the table has no user defined types, it is already effectively hydrated,
 	// so just return it.
-	if !catalog.MaybeRequiresHydration(hydratable) {
+	if !hydratable.MaybeRequiresTypeHydration() {
 		return hydratable, nil
 	}
 

--- a/pkg/sql/catalog/schemadesc/schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc.go
@@ -106,6 +106,28 @@ func (desc *immutable) ForEachUDTDependentForHydration(fn func(t *types.T) error
 	return nil
 }
 
+// MaybeRequiresTypeHydration implements the catalog.Descriptor interface.
+func (desc *immutable) MaybeRequiresTypeHydration() bool {
+	for _, f := range desc.Functions {
+		for _, sig := range f.Signatures {
+			if catid.IsOIDUserDefined(sig.ReturnType.Oid()) {
+				return true
+			}
+			for _, typ := range sig.ArgTypes {
+				if catid.IsOIDUserDefined(typ.Oid()) {
+					return true
+				}
+			}
+			for _, typ := range sig.OutParamTypes {
+				if catid.IsOIDUserDefined(typ.Oid()) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
 // SafeMessage makes Mutable a SafeMessager.
 func (desc *Mutable) SafeMessage() string {
 	return formatSafeMessage("schemadesc.Mutable", desc)

--- a/pkg/sql/catalog/schemadesc/synthetic_schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/synthetic_schema_desc.go
@@ -149,6 +149,9 @@ func (p synthetic) ForEachUDTDependentForHydration(fn func(t *types.T) error) er
 	return nil
 }
 
+// MaybeRequiresTypeHydration implements the catalog.Descriptor interface.
+func (p synthetic) MaybeRequiresTypeHydration() bool { return false }
+
 func (p synthetic) GetRawBytesInStorage() []byte {
 	return nil
 }

--- a/pkg/sql/catalog/tabledesc/table_desc.go
+++ b/pkg/sql/catalog/tabledesc/table_desc.go
@@ -656,6 +656,11 @@ func (desc *wrapper) ForEachUDTDependentForHydration(fn func(t *types.T) error) 
 	return nil
 }
 
+// MaybeRequiresTypeHydration implements the catalog.Descriptor interface.
+func (desc *wrapper) MaybeRequiresTypeHydration() bool {
+	return len(desc.UserDefinedTypeColumns()) > 0
+}
+
 // IsSchemaLocked implements the TableDescriptor interface.
 func (desc *wrapper) IsSchemaLocked() bool {
 	return desc.SchemaLocked

--- a/pkg/sql/catalog/typedesc/table_implicit_record_type.go
+++ b/pkg/sql/catalog/typedesc/table_implicit_record_type.go
@@ -187,6 +187,9 @@ func (v *tableImplicitRecordType) ForEachUDTDependentForHydration(_ func(t *type
 	return nil
 }
 
+// MaybeRequiresTypeHydration implements the catalog.Descriptor interface.
+func (v *tableImplicitRecordType) MaybeRequiresTypeHydration() bool { return false }
+
 // TypeDesc implements the catalog.TypeDescriptor interface.
 func (v *tableImplicitRecordType) TypeDesc() *descpb.TypeDescriptor {
 	v.panicNotSupported("TypeDesc")

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -916,6 +916,22 @@ func (desc *immutable) ForEachUDTDependentForHydration(fn func(t *types.T) error
 	return nil
 }
 
+// MaybeRequiresTypeHydration implements the catalog.Descriptor interface.
+func (desc *immutable) MaybeRequiresTypeHydration() bool {
+	if desc.Alias != nil && catid.IsOIDUserDefined(desc.Alias.Oid()) {
+		return true
+	}
+	if desc.Composite == nil {
+		return false
+	}
+	for _, e := range desc.Composite.Elements {
+		if catid.IsOIDUserDefined(e.ElementType.Oid()) {
+			return true
+		}
+	}
+	return false
+}
+
 // GetIDClosure implements the TypeDescriptor interface.
 func (desc *immutable) GetIDClosure() (ret catalog.DescriptorIDSet) {
 	// Collect the descriptor's own ID.

--- a/pkg/sql/regions/region_provider_test.go
+++ b/pkg/sql/regions/region_provider_test.go
@@ -236,6 +236,7 @@ func (d fakeSystemDatabase) Adding() bool               { return false }
 func (d fakeSystemDatabase) ForEachUDTDependentForHydration(func(t *types.T) error) error {
 	return nil
 }
+func (d fakeSystemDatabase) MaybeRequiresTypeHydration() bool { return false }
 
 type fakeLeasedDescriptor struct {
 	catalog.Descriptor
@@ -279,6 +280,7 @@ func (d fakeRegionEnum) Adding() bool               { return false }
 func (d fakeRegionEnum) ForEachUDTDependentForHydration(func(t *types.T) error) error {
 	return nil
 }
+func (d fakeRegionEnum) MaybeRequiresTypeHydration() bool { return false }
 func (d fakeRegionEnum) AsEnumTypeDescriptor() catalog.EnumTypeDescriptor {
 	if d.isNotEnum {
 		return nil


### PR DESCRIPTION
The `catalog.MaybeRequiresHydration` function has been replaced with the
`Descriptor.MaybeRequiresTypeHydration` interface method. This avoids a
heap allocation that was required in `catalog.MaybeRequiresHydration`.
Arguments to interface methods typically escape to the heap, so the
closure passed to `Descriptor.ForEachUDTDependentForHydration` was heap
allocated. The new interface method avoids this.

Epic: None

Release note: None
