### PR TITLE
pgwire: reduce allocations when writing CHAR(N) datums

### DIFF
--- a/pkg/sql/pgwire/types_test.go
+++ b/pkg/sql/pgwire/types_test.go
@@ -504,6 +504,10 @@ func benchmarkWriteColumnarString(b *testing.B, format pgwirebase.FormatCode) {
 	benchmarkWriteColumnar(b, getBatch(types.String), format)
 }
 
+func benchmarkWriteColumnarChar(b *testing.B, format pgwirebase.FormatCode) {
+	benchmarkWriteColumnar(b, getBatch(types.MakeChar(16)), format)
+}
+
 func benchmarkWriteDate(b *testing.B, format pgwirebase.FormatCode) {
 	d, _, err := tree.ParseDDate(nil, "2010-09-28")
 	if err != nil {
@@ -669,6 +673,13 @@ func BenchmarkWriteTextColumnarString(b *testing.B) {
 }
 func BenchmarkWriteBinaryColumnarString(b *testing.B) {
 	benchmarkWriteColumnarString(b, pgwirebase.FormatBinary)
+}
+
+func BenchmarkWriteTextColumnarChar(b *testing.B) {
+	benchmarkWriteColumnarChar(b, pgwirebase.FormatText)
+}
+func BenchmarkWriteBinaryColumnarChar(b *testing.B) {
+	benchmarkWriteColumnarChar(b, pgwirebase.FormatBinary)
 }
 
 func BenchmarkWriteTextDate(b *testing.B) {

--- a/pkg/sql/sem/tree/pgwire_encode.go
+++ b/pkg/sql/sem/tree/pgwire_encode.go
@@ -32,17 +32,6 @@ func ResolveBlankPaddedChar(s string, t *types.T) string {
 	return s
 }
 
-// ResolveBlankPaddedCharBytes is similar to ResolveBlankPaddedChar but operates
-// on a slice of bytes instead of a string.
-func ResolveBlankPaddedCharBytes(v []byte, t *types.T) []byte {
-	if t.Oid() == oid.T_bpchar && len(v) < int(t.Width()) {
-		// Pad spaces on the right of the byte slice to make it of length
-		// specified in the type t.
-		return append(v, bytes.Repeat([]byte(" "), int(t.Width())-len(v))...)
-	}
-	return v
-}
-
 func (d *DTuple) pgwireFormat(ctx *FmtCtx) {
 	// When converting a tuple to text in "postgres mode" there is
 	// special behavior: values are printed in "postgres mode" then the


### PR DESCRIPTION
`ResolveBlankPaddedCharBytes` has been replaced with a more efficient
method of padding `CHAR(N)` datums with trailing spaces.

Epic: None

Release note: None
