### PR TITLE
kvflowinspectpb: add stream string method

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb/kvflowinspect.go
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb/kvflowinspect.go
@@ -10,11 +10,15 @@ import (
 	"github.com/cockroachdb/redact"
 )
 
+func (s Stream) String() string {
+	return redact.StringWithoutMarkers(s)
+}
+
 // SafeFormat implements the redact.SafeFormatter interface.
 func (s Stream) SafeFormat(w redact.SafePrinter, _ rune) {
 	w.Printf("s%v/t%v eval_regular=%v eval_elastic=%v send_regular=%v send_elastic=%v",
-		s.TenantID,
 		s.StoreID,
+		s.TenantID,
 		humanizeutil.IBytes(s.AvailableEvalRegularTokens),
 		humanizeutil.IBytes(s.AvailableEvalElasticTokens),
 		humanizeutil.IBytes(s.AvailableSendRegularTokens),

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb/kvflowinspect.proto
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb/kvflowinspect.proto
@@ -78,6 +78,7 @@ message ConnectedStream {
 // available for it (as maintained by the node-level kvflowcontrol.Controller,
 // or in >= v24.3, by the node level StreamTokenCounterProvider).
 message Stream {
+  option (gogoproto.goproto_stringer) = false;
   roachpb.TenantID tenant_id = 1 [
     (gogoproto.nullable) = false,
     (gogoproto.customname) = "TenantID"];


### PR DESCRIPTION
A prior commit created a safe format method, however in tests the safe
format value is unused. Also create a `String` method which returns the
unredacted `SafeFormat` string.

Also, fix the ordering of `StoreID` and `TenantID` which was incorrectly
swapped.

Part of: https://github.com/cockroachdb/cockroach/issues/128040
Release note: None