### PR TITLE
ui, server: trigger cache updates on GET apis for table metadata

### DIFF
--- a/pkg/server/api_v2_databases_metadata.go
+++ b/pkg/server/api_v2_databases_metadata.go
@@ -236,7 +236,7 @@ func (a *apiV2Server) GetTableMetadata(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	apiutil.WriteJSONResponse(ctx, w, http.StatusMultiStatus, resp)
+	apiutil.WriteJSONResponse(ctx, w, http.StatusOK, resp)
 }
 
 // GetTableMetadataWithDetails fetches table metadata for a specific table id.

--- a/pkg/ui/workspaces/cluster-ui/src/api/databases/serverTypes.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databases/serverTypes.ts
@@ -34,6 +34,31 @@ export const convertServerPaginationToClientPagination = (
 };
 
 // ------------------------------------------------------------------------------------
+// /api/v2/updatejob/ response.
+// ------------------------------------------------------------------------------------
+
+export type TableMetaUpdateJobResponseServer = {
+  current_status: string;
+  progress: number;
+  last_start_time: string | null;
+  last_completed_time: string | null;
+  last_updated_time: string | null;
+  data_valid_duration: number;
+  automatic_updates_enabled: boolean;
+};
+
+export type TriggerTableMetaUpdateJobResponseServer = {
+  job_status: TableMetaUpdateJobResponseServer;
+  job_triggered: boolean;
+  message: string;
+};
+
+export type TriggerTableMetaUpdateWithErrorResponseServer = {
+  job_details: TriggerTableMetaUpdateJobResponseServer;
+  error: string;
+};
+
+// ------------------------------------------------------------------------------------
 // /api/v2/table_metadata/ response.
 // ------------------------------------------------------------------------------------
 export type TableMetadataServer = {
@@ -58,11 +83,14 @@ export type TableMetadataServer = {
 };
 
 export type TableMetadataResponseServer =
-  APIV2ResponseWithPaginationState<TableMetadataServer>;
+  APIV2ResponseWithPaginationState<TableMetadataServer> & {
+    job_trigger_response: TriggerTableMetaUpdateWithErrorResponseServer;
+  };
 
 // ------------------------------------------------------------------------------------
 // /api/v2/table_metadata/:tableId/ response.
 // ------------------------------------------------------------------------------------
+
 export type TableDetailsResponseServer = {
   metadata: TableMetadataServer;
   create_statement: string;
@@ -81,7 +109,9 @@ export type DatabaseMetadataServer = {
 };
 
 export type DatabaseMetadataResponseServer =
-  APIV2ResponseWithPaginationState<DatabaseMetadataServer>;
+  APIV2ResponseWithPaginationState<DatabaseMetadataServer> & {
+    job_trigger_response: TriggerTableMetaUpdateWithErrorResponseServer;
+  };
 
 // ------------------------------------------------------------------------------------
 // /api/v2/grants/tabless/:tableId/ response.

--- a/pkg/ui/workspaces/cluster-ui/src/api/databases/tableMetaUpdateJobApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databases/tableMetaUpdateJobApi.ts
@@ -9,6 +9,11 @@ import useSWR from "swr";
 
 import { fetchDataJSON } from "../fetchData";
 
+import {
+  TableMetaUpdateJobResponseServer,
+  TriggerTableMetaUpdateJobResponseServer,
+} from "./serverTypes";
+
 const TABLE_META_JOB_API = "api/v2/table_metadata/updatejob/";
 
 export enum TableMetadataJobStatus {
@@ -16,18 +21,8 @@ export enum TableMetadataJobStatus {
   RUNNING = "RUNNING",
 }
 
-type TableMetaUpdateJobResponse = {
-  current_status: TableMetadataJobStatus;
-  progress: number;
-  last_start_time: string | null;
-  last_completed_time: string | null;
-  last_updated_time: string | null;
-  data_valid_duration: number;
-  automatic_updates_enabled: boolean;
-};
-
-type TableMetaUpdateJobInfo = {
-  currentStatus: TableMetaUpdateJobResponse["current_status"];
+export type TableMetaUpdateJobInfo = {
+  currentStatus: TableMetadataJobStatus;
   progress: number;
   lastStartTime: moment.Moment | null;
   lastCompletedTime: moment.Moment | null;
@@ -37,7 +32,37 @@ type TableMetaUpdateJobInfo = {
 };
 
 const getTableMetaUpdateJobInfo = async () => {
-  return fetchDataJSON<TableMetaUpdateJobResponse, null>(TABLE_META_JOB_API);
+  return fetchDataJSON<TableMetaUpdateJobResponseServer, null>(
+    TABLE_META_JOB_API,
+  );
+};
+
+export const convertTableMetaUpdateJobFromServer = (
+  data: TableMetaUpdateJobResponseServer,
+): TableMetaUpdateJobInfo | null => {
+  if (!data) {
+    return null;
+  }
+
+  return {
+    currentStatus: (data.current_status ??
+      "NOT_RUNNING") as TableMetadataJobStatus,
+    progress: data.progress ?? 0,
+    lastStartTime: data.last_start_time
+      ? moment.utc(data.last_start_time)
+      : null,
+    lastCompletedTime: data.last_completed_time
+      ? moment.utc(data.last_completed_time)
+      : null,
+    lastUpdatedTime: data.last_updated_time
+      ? moment.utc(data.last_updated_time)
+      : null,
+    dataValidDuration: moment.duration(
+      data.data_valid_duration * 1e-6,
+      "millisecond",
+    ),
+    automaticUpdatesEnabled: data.automatic_updates_enabled,
+  };
 };
 
 // useTableMetaUpdateJob is a hook that fetches the current status of the table
@@ -49,7 +74,7 @@ export const useTableMetaUpdateJob = () => {
     getTableMetaUpdateJobInfo,
     {
       focusThrottleInterval: 10000,
-      refreshInterval: (latest: TableMetaUpdateJobResponse) => {
+      refreshInterval: (latest: TableMetaUpdateJobResponseServer) => {
         return latest?.current_status === TableMetadataJobStatus.RUNNING
           ? 3000
           : 0;
@@ -58,30 +83,10 @@ export const useTableMetaUpdateJob = () => {
     },
   );
 
-  const formattedResp: TableMetaUpdateJobInfo = useMemo(() => {
-    if (!data) {
-      return null;
-    }
-
-    return {
-      currentStatus: data.current_status,
-      progress: data.progress,
-      lastStartTime: data.last_start_time
-        ? moment.utc(data.last_start_time)
-        : null,
-      lastCompletedTime: data.last_completed_time
-        ? moment.utc(data.last_completed_time)
-        : null,
-      lastUpdatedTime: data.last_updated_time
-        ? moment.utc(data.last_updated_time)
-        : null,
-      dataValidDuration: moment.duration(
-        data.data_valid_duration * 1e-6,
-        "millisecond",
-      ),
-      automaticUpdatesEnabled: data.automatic_updates_enabled,
-    };
-  }, [data]);
+  const formattedResp: TableMetaUpdateJobInfo = useMemo(
+    () => convertTableMetaUpdateJobFromServer(data),
+    [data],
+  );
 
   const dataValidDurationMs = formattedResp?.dataValidDuration.asMilliseconds();
   // Last completed is only non-null if the job has completed at least once.
@@ -120,20 +125,37 @@ export const useTableMetaUpdateJob = () => {
 type TriggerTableMetaUpdateJobRequest = {
   onlyIfStale?: boolean;
 };
-type TriggerTableMetaUpdateJobResponse = {
-  job_triggered: boolean;
+
+export type TriggerTableMetaUpdateJobResponse = {
+  jobStatus: TableMetaUpdateJobInfo;
+  jobTriggered: boolean;
   message: string;
+};
+
+export const convertTriggerTableMetaUpdateJobResponseFromServer = (
+  data: TriggerTableMetaUpdateJobResponseServer,
+): TriggerTableMetaUpdateJobResponse => ({
+  jobStatus: convertTableMetaUpdateJobFromServer(data?.job_status),
+  jobTriggered: data?.job_triggered ?? false,
+  message: data?.message ?? "",
+});
+
+export type TriggerTableMetaUpdateJobResponseWithErr = {
+  jobTriggerStatus: TriggerTableMetaUpdateJobResponse | null;
+  error: string;
 };
 
 export const triggerUpdateTableMetaJobApi = async (
   req: TriggerTableMetaUpdateJobRequest,
-) => {
+): Promise<TriggerTableMetaUpdateJobResponse> => {
   const urlParams = new URLSearchParams();
   if (req.onlyIfStale) {
     urlParams.append("onlyIfStale", req.onlyIfStale.toString());
   }
   return fetchDataJSON<
-    TriggerTableMetaUpdateJobResponse,
+    TriggerTableMetaUpdateJobResponseServer,
     TriggerTableMetaUpdateJobRequest
-  >(TABLE_META_JOB_API + "?" + urlParams.toString(), req);
+  >(TABLE_META_JOB_API + "?" + urlParams.toString(), req).then(
+    convertTriggerTableMetaUpdateJobResponseFromServer,
+  );
 };

--- a/pkg/ui/workspaces/cluster-ui/src/components/tableMetadataLastUpdated/tableMetadataJobControl.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/components/tableMetadataLastUpdated/tableMetadataJobControl.spec.tsx
@@ -1,10 +1,6 @@
-// Copyright 2024 The Cockroach Authors.
-//
-// Use of this software is governed by the CockroachDB Software License
-// included in the /LICENSE file.
-
 import "@testing-library/jest-dom";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import moment from "moment-timezone";
 import React from "react";
 
@@ -16,30 +12,27 @@ import { TableMetadataJobControl } from "./tableMetadataJobControl";
 jest.mock("src/api/databases/tableMetaUpdateJobApi");
 
 describe("TableMetadataJobControl", () => {
-  const mockOnDataUpdated = jest.fn();
-  const mockRefreshJobStatus = jest.fn();
+  const mockOnJobTriggered = jest.fn();
   const mockLastCompletedTime = moment("2024-01-01T12:00:00Z");
   const mockLastUpdatedTime = moment("2024-01-01T12:05:00Z");
   const mockLastStartTime = moment("2024-01-01T11:59:00Z");
 
+  const defaultJobStatus: api.TableMetaUpdateJobInfo = {
+    dataValidDuration: moment.duration(1, "hour"),
+    currentStatus: api.TableMetadataJobStatus.NOT_RUNNING,
+    progress: 0,
+    lastCompletedTime: mockLastCompletedTime,
+    lastStartTime: mockLastStartTime,
+    lastUpdatedTime: mockLastUpdatedTime,
+    automaticUpdatesEnabled: false,
+  };
+
   beforeEach(() => {
     jest.useFakeTimers();
-    jest.spyOn(api, "useTableMetaUpdateJob").mockReturnValue({
-      jobStatus: {
-        dataValidDuration: moment.duration(1, "hour"),
-        currentStatus: api.TableMetadataJobStatus.NOT_RUNNING,
-        progress: 0,
-        lastCompletedTime: mockLastCompletedTime,
-        lastStartTime: mockLastStartTime,
-        lastUpdatedTime: mockLastUpdatedTime,
-        automaticUpdatesEnabled: false,
-      },
-      refreshJobStatus: mockRefreshJobStatus,
-      isLoading: false,
-    });
     jest.spyOn(api, "triggerUpdateTableMetaJobApi").mockResolvedValue({
       message: "Job triggered",
-      job_triggered: true,
+      jobTriggered: true,
+      jobStatus: defaultJobStatus,
     });
   });
 
@@ -51,7 +44,11 @@ describe("TableMetadataJobControl", () => {
   it("renders the last refreshed time", () => {
     render(
       <TimezoneContext.Provider value="UTC">
-        <TableMetadataJobControl onDataUpdated={mockOnDataUpdated} />
+        <TableMetadataJobControl
+          error={null}
+          jobStatus={defaultJobStatus}
+          onJobTriggered={mockOnJobTriggered}
+        />
       </TimezoneContext.Provider>,
     );
 
@@ -62,23 +59,13 @@ describe("TableMetadataJobControl", () => {
   });
 
   it('renders "Never" when lastCompletedTime is null', () => {
-    jest.spyOn(api, "useTableMetaUpdateJob").mockReturnValue({
-      jobStatus: {
-        lastCompletedTime: null,
-        dataValidDuration: moment.duration(1, "hour"),
-        currentStatus: api.TableMetadataJobStatus.NOT_RUNNING,
-        progress: 0,
-        lastStartTime: mockLastUpdatedTime,
-        lastUpdatedTime: mockLastUpdatedTime,
-        automaticUpdatesEnabled: false,
-      },
-      refreshJobStatus: mockRefreshJobStatus,
-      isLoading: false,
-    });
-
     render(
       <TimezoneContext.Provider value="UTC">
-        <TableMetadataJobControl onDataUpdated={mockOnDataUpdated} />
+        <TableMetadataJobControl
+          error={null}
+          jobStatus={{ ...defaultJobStatus, lastCompletedTime: null }}
+          onJobTriggered={mockOnJobTriggered}
+        />
       </TimezoneContext.Provider>,
     );
 
@@ -88,91 +75,115 @@ describe("TableMetadataJobControl", () => {
   it("triggers update when refresh button is clicked", async () => {
     render(
       <TimezoneContext.Provider value="UTC">
-        <TableMetadataJobControl onDataUpdated={mockOnDataUpdated} />
+        <TableMetadataJobControl
+          error={null}
+          jobStatus={defaultJobStatus}
+          onJobTriggered={mockOnJobTriggered}
+        />
       </TimezoneContext.Provider>,
     );
 
     const refreshButton = screen.getByRole("button");
-    await act(async () => {
-      fireEvent.click(refreshButton);
-    });
+    userEvent.click(refreshButton);
 
     expect(api.triggerUpdateTableMetaJobApi).toHaveBeenCalledWith({
       onlyIfStale: false,
     });
-    expect(mockRefreshJobStatus).toHaveBeenCalled();
-  });
-
-  it("schedules next update after dataValidDuration", async () => {
-    render(
-      <TimezoneContext.Provider value="UTC">
-        <TableMetadataJobControl onDataUpdated={mockOnDataUpdated} />
-      </TimezoneContext.Provider>,
-    );
-
-    await act(async () => {
-      // Advance timer 1 hour and 30s.
-      jest.advanceTimersByTime(3600000 + 30000);
-    });
-
-    expect(api.triggerUpdateTableMetaJobApi).toHaveBeenCalledWith({
-      onlyIfStale: true,
-    });
-  });
-
-  it("calls onDataUpdated when lastCompletedTime changes", () => {
-    const { rerender } = render(
-      <TimezoneContext.Provider value="UTC">
-        <TableMetadataJobControl onDataUpdated={mockOnDataUpdated} />
-      </TimezoneContext.Provider>,
-    );
-
-    // Update the mock to return a new lastCompletedTime
-    jest.spyOn(api, "useTableMetaUpdateJob").mockReturnValue({
-      jobStatus: {
-        lastCompletedTime: moment("2024-01-01T13:00:00Z"),
-        lastStartTime: moment("2024-01-01T13:00:00Z"),
-        lastUpdatedTime: moment.utc(),
-        dataValidDuration: moment.duration(1, "hour"),
-        currentStatus: api.TableMetadataJobStatus.NOT_RUNNING,
-        progress: 0,
-        automaticUpdatesEnabled: false,
-      },
-      refreshJobStatus: mockRefreshJobStatus,
-      isLoading: false,
-    });
-
-    // Rerender the component with the updated mock
-    rerender(
-      <TimezoneContext.Provider value="UTC">
-        <TableMetadataJobControl onDataUpdated={mockOnDataUpdated} />
-      </TimezoneContext.Provider>,
-    );
-
-    expect(mockOnDataUpdated).toHaveBeenCalled();
+    expect(mockOnJobTriggered).toHaveBeenCalled();
   });
 
   it("disables refresh button when job is running", () => {
-    jest.spyOn(api, "useTableMetaUpdateJob").mockReturnValue({
-      jobStatus: {
-        lastCompletedTime: moment("2024-01-01T12:00:00Z"),
-        dataValidDuration: moment.duration(1, "hour"),
-        currentStatus: api.TableMetadataJobStatus.RUNNING,
-        progress: 0,
-        lastStartTime: moment.utc(),
-        lastUpdatedTime: moment.utc(),
-        automaticUpdatesEnabled: false,
-      },
-      refreshJobStatus: mockRefreshJobStatus,
-      isLoading: false,
-    });
-
     render(
       <TimezoneContext.Provider value="UTC">
-        <TableMetadataJobControl onDataUpdated={mockOnDataUpdated} />
+        <TableMetadataJobControl
+          error={null}
+          jobStatus={{
+            ...defaultJobStatus,
+            currentStatus: api.TableMetadataJobStatus.RUNNING,
+          }}
+          onJobTriggered={mockOnJobTriggered}
+        />
       </TimezoneContext.Provider>,
     );
 
     expect(screen.getByRole("button")).toBeDisabled();
+  });
+
+  it("displays correct tooltip for last refreshed time", async () => {
+    render(
+      <TimezoneContext.Provider value="UTC">
+        <TableMetadataJobControl
+          error={null}
+          jobStatus={defaultJobStatus}
+          onJobTriggered={mockOnJobTriggered}
+        />
+      </TimezoneContext.Provider>,
+    );
+
+    const lastRefreshedElement = screen.getByText(/Last refreshed:/);
+    userEvent.hover(lastRefreshedElement);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Data is last refreshed automatically (per cluster setting) or manually.",
+    );
+  });
+
+  it("displays error message in tooltip when error prop is provided", async () => {
+    const errorMessage = "An error occurred";
+    render(
+      <TimezoneContext.Provider value="UTC">
+        <TableMetadataJobControl
+          error={errorMessage}
+          jobStatus={defaultJobStatus}
+          onJobTriggered={mockOnJobTriggered}
+        />
+      </TimezoneContext.Provider>,
+    );
+
+    const lastRefreshedElement = screen.getByText(/Last refreshed:/);
+    userEvent.hover(lastRefreshedElement);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(errorMessage);
+  });
+
+  it("displays correct tooltip for refresh button when not running", async () => {
+    render(
+      <TimezoneContext.Provider value="UTC">
+        <TableMetadataJobControl
+          error={null}
+          jobStatus={defaultJobStatus}
+          onJobTriggered={mockOnJobTriggered}
+        />
+      </TimezoneContext.Provider>,
+    );
+
+    const refreshButton = screen.getByRole("button");
+    userEvent.hover(refreshButton);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Refresh data",
+    );
+  });
+
+  it("displays correct tooltip for refresh button when running", async () => {
+    render(
+      <TimezoneContext.Provider value="UTC">
+        <TableMetadataJobControl
+          error={null}
+          jobStatus={{
+            ...defaultJobStatus,
+            currentStatus: api.TableMetadataJobStatus.RUNNING,
+          }}
+          onJobTriggered={mockOnJobTriggered}
+        />
+      </TimezoneContext.Provider>,
+    );
+
+    const refreshButton = screen.getByRole("button");
+    userEvent.hover(refreshButton);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Data is being refreshed",
+    );
   });
 });

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
@@ -223,7 +223,7 @@ export const TablesPageV2 = () => {
 
   // Get db id from the URL.
   const { dbID } = useRouteParams();
-  const { data, error, isLoading, refreshTables } = useTableMetadata(
+  const { data, error, isLoading, refreshTables, jobStatus } = useTableMetadata(
     createTableMetadataRequestFromParams(dbID, params),
   );
   const nodesResp = useNodeStatuses();
@@ -314,7 +314,11 @@ export const TablesPageV2 = () => {
           loading={isLoading}
           error={error}
           actionButton={
-            <TableMetadataJobControl onDataUpdated={refreshTables} />
+            <TableMetadataJobControl
+              onJobTriggered={() => refreshTables()}
+              error={jobStatus?.error}
+              jobStatus={jobStatus?.jobTriggerStatus?.jobStatus}
+            />
           }
           columns={colsWithSort}
           dataSource={tableData}

--- a/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
@@ -137,9 +137,8 @@ export const DatabasesPageV2 = () => {
   const { params, setFilters, setSort, setSearch, setPagination } = useTable({
     initial: initialParams,
   });
-  const { data, error, isLoading, refreshDatabases } = useDatabaseMetadata(
-    createDatabaseMetadataRequestFromParams(params),
-  );
+  const { data, jobStatus, error, isLoading, refreshDatabases } =
+    useDatabaseMetadata(createDatabaseMetadataRequestFromParams(params));
   const nodesResp = useNodeStatuses();
 
   const onNodeRegionsChange = (storeIDs: StoreID[]) => {
@@ -219,7 +218,11 @@ export const DatabasesPageV2 = () => {
           loading={isLoading}
           error={error}
           actionButton={
-            <TableMetadataJobControl onDataUpdated={refreshDatabases} />
+            <TableMetadataJobControl
+              error={jobStatus?.error}
+              jobStatus={jobStatus?.jobTriggerStatus?.jobStatus}
+              onJobTriggered={() => refreshDatabases()}
+            />
           }
           columns={colsWithSort}
           dataSource={tableData}


### PR DESCRIPTION
Previously we relied on the db console to trigger cache updates
when data is stale. We now bake triggering the job due to staleness
in the server GET apis for table metadata.

The following GET routes can now cause cache refreshes, if the
data is stale. Note that stale data will be returned, meaning we
won't wait for the job to complete. The job's status will be returned
along with the requested page of data. At this time we don't trigger
a cache refresh on the APIs used to get a singular db or table:
- /api/v2/table_metadata/
- /api/v2/database_metadata/

Epic: CRDB-37558
Part of: #132320


--------------------------------------------------------

ui: remove client side table metadata job requests

The list database and tables apis now automatically
issue cache refresh requests on stale reads, so we
don't need to request cache refreshes due to staleness
from the client anymore.

Closes: https://github.com/cockroachdb/cockroach/issues/132320
Epic: CRDB-37558
Release note: None