### PR TITLE
server: Fix NPE in spanStatsFanOut

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -548,6 +548,7 @@ go_test(
         "//pkg/sql/tablemetadatacache/util",
         "//pkg/storage",
         "//pkg/storage/disk",
+        "//pkg/storage/enginepb",
         "//pkg/storage/fs",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",


### PR DESCRIPTION
a NPE was surfaced when doing a spanstats request on an unfinalized (mixed version) cluster.

To fix, defensive checks are added to defend against potential nil responses and references to non-existant map entries for a request span stat

Fixes: #132130
Release note (bug fix): Fixes a bug where a span stats request on a mixed version cluster resulted in an NPE