### PR TITLE
release-23.1: lint: fix `TestForbiddenImports`

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1546,11 +1546,18 @@ func TestLint(t *testing.T) {
 			pkgs, err := packages.Load(
 				&packages.Config{
 					Mode: packages.NeedImports | packages.NeedName,
+					Dir:  crdbDir,
 				},
 				pkgPath,
 			)
 			if err != nil {
 				return errors.Wrapf(err, "error loading package %s", pkgPath)
+			}
+			// NB: if no packages were found, this API confusingly
+			// returns no error, so we need to explicitly check that
+			// something was returned.
+			if len(pkgs) == 0 {
+				return errors.Newf("could not list packages under %s", pkgPath)
 			}
 			for _, pkg := range pkgs {
 				for _, s := range pkg.Imports {
@@ -1583,6 +1590,7 @@ func TestLint(t *testing.T) {
 			stream.GrepNot(`cockroachdb/cockroach/pkg/kv/kvpb/gen: log$`),
 			stream.GrepNot(`cockroachdb/cockroach/pkg/util/log/gen: log$`),
 			stream.GrepNot(`cockroach/pkg/util/uuid: github\.com/satori/go\.uuid$`),
+			stream.GrepNot(`github.com/cockroachdb/cockroach/pkg/workload/debug: log$`),
 		), func(s string) {
 			pkgStr := strings.Split(s, ": ")
 			importingPkg, importedPkg := pkgStr[0], pkgStr[1]


### PR DESCRIPTION
Backport 1/1 commits from #132263.

/cc @cockroachdb/release

Release justification: Non-production code changes

---

We need to set `Dir` in the `packages.Load()` call or else the whole thing doesn't work. It would be really nice if it threw an error instead of simply doing nothing, but it is what it is. To guard against this in the future I added an error if the list is empty.

Fix the test then all existing violations, except for `raftlogger` and `rafttest` which will need some extra TLC by the owning team (see #132262)

Closes #132258

Epic: none
Release note: None
