### PR TITLE
release-24.2: lint: fix `TestForbiddenImports`

### DIFF
--- a/pkg/ccl/crosscluster/logical/BUILD.bazel
+++ b/pkg/ccl/crosscluster/logical/BUILD.bazel
@@ -77,7 +77,6 @@ go_library(
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_cockroachdb_errors//issuelink",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_lib_pq//oid",

--- a/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/errors/issuelink"
 )
 
 func init() {
@@ -90,7 +89,7 @@ func createLogicalReplicationStreamPlanHook(
 		}
 
 		if stmt.From.Database != "" {
-			return errors.UnimplementedErrorf(issuelink.IssueLink{}, "logical replication streams on databases are unsupported")
+			return errors.UnimplementedErrorf(errors.IssueLink{}, "logical replication streams on databases are unsupported")
 		}
 		if len(stmt.From.Tables) != len(stmt.Into.Tables) {
 			return pgerror.New(pgcode.InvalidParameterValue, "the same number of source and destination tables must be specified")

--- a/pkg/ccl/crosscluster/streamclient/BUILD.bazel
+++ b/pkg/ccl/crosscluster/streamclient/BUILD.bazel
@@ -38,7 +38,6 @@ go_library(
         "@com_github_golang_snappy//:snappy",
         "@com_github_jackc_pgconn//:pgconn",
         "@com_github_jackc_pgx_v4//:pgx",
-        "@com_github_pkg_errors//:errors",
     ],
 )
 

--- a/pkg/ccl/crosscluster/streamclient/client_helpers.go
+++ b/pkg/ccl/crosscluster/streamclient/client_helpers.go
@@ -11,9 +11,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/crosscluster"
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
 	"github.com/golang/snappy"
 	"github.com/jackc/pgx/v4"
-	"github.com/pkg/errors"
 )
 
 func subscribeInternal(

--- a/pkg/raft/BUILD.bazel
+++ b/pkg/raft/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/raft/raftpb",
         "//pkg/raft/raftstoreliveness",
         "//pkg/raft/tracker",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 

--- a/pkg/raft/bootstrap.go
+++ b/pkg/raft/bootstrap.go
@@ -18,9 +18,8 @@
 package raft
 
 import (
-	"errors"
-
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/errors"
 )
 
 // Bootstrap initializes the RawNode for first use by appending configuration

--- a/pkg/raft/confchange/BUILD.bazel
+++ b/pkg/raft/confchange/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/raft/quorum",
         "//pkg/raft/raftpb",
         "//pkg/raft/tracker",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 
@@ -28,5 +29,6 @@ go_test(
         "//pkg/raft/raftpb",
         "//pkg/raft/tracker",
         "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/raft/confchange/confchange.go
+++ b/pkg/raft/confchange/confchange.go
@@ -18,13 +18,13 @@
 package confchange
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/raft/quorum"
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
+	"github.com/cockroachdb/errors"
 )
 
 // Changer facilitates configuration changes. It exposes methods to handle

--- a/pkg/raft/confchange/datadriven_test.go
+++ b/pkg/raft/confchange/datadriven_test.go
@@ -18,7 +18,6 @@
 package confchange
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -27,6 +26,7 @@ import (
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 )
 
 func TestConfChangeDataDriven(t *testing.T) {

--- a/pkg/raft/node.go
+++ b/pkg/raft/node.go
@@ -19,9 +19,9 @@ package raft
 
 import (
 	"context"
-	"errors"
 
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/errors"
 )
 
 type SnapshotStatus int

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -20,7 +20,6 @@ package raft
 import (
 	"bytes"
 	"crypto/rand"
-	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -33,6 +32,7 @@ import (
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftstoreliveness"
 	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
+	"github.com/cockroachdb/errors"
 )
 
 const (

--- a/pkg/raft/rafttest/BUILD.bazel
+++ b/pkg/raft/rafttest/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//pkg/raft/raftpb",
         "//pkg/raft/tracker",
         "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/raft/rafttest/interaction_env_handler_add_nodes.go
+++ b/pkg/raft/rafttest/interaction_env_handler_add_nodes.go
@@ -18,7 +18,6 @@
 package rafttest
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -26,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/raft"
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 )
 
 func (env *InteractionEnv) handleAddNodes(t *testing.T, d datadriven.TestData) error {

--- a/pkg/raft/rafttest/interaction_env_handler_process_append_thread.go
+++ b/pkg/raft/rafttest/interaction_env_handler_process_append_thread.go
@@ -18,13 +18,13 @@
 package rafttest
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 )
 
 func (env *InteractionEnv) handleProcessAppendThread(t *testing.T, d datadriven.TestData) error {

--- a/pkg/raft/rafttest/interaction_env_handler_report_unreachable.go
+++ b/pkg/raft/rafttest/interaction_env_handler_report_unreachable.go
@@ -18,10 +18,10 @@
 package rafttest
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 )
 
 func (env *InteractionEnv) handleReportUnreachable(t *testing.T, d datadriven.TestData) error {

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -18,10 +18,9 @@
 package raft
 
 import (
-	"errors"
-
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
+	"github.com/cockroachdb/errors"
 )
 
 // ErrStepLocalMsg is returned when try to step a local raft message

--- a/pkg/raft/storage.go
+++ b/pkg/raft/storage.go
@@ -18,10 +18,10 @@
 package raft
 
 import (
-	"errors"
 	"sync"
 
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/errors"
 )
 
 // ErrCompacted is returned by Storage.Entries/Compact when a requested

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1801,11 +1801,18 @@ func TestLint(t *testing.T) {
 			pkgs, err := packages.Load(
 				&packages.Config{
 					Mode: packages.NeedImports | packages.NeedName,
+					Dir:  crdbDir,
 				},
 				pkgPath,
 			)
 			if err != nil {
 				return errors.Wrapf(err, "error loading package %s", pkgPath)
+			}
+			// NB: if no packages were found, this API confusingly
+			// returns no error, so we need to explicitly check that
+			// something was returned.
+			if len(pkgs) == 0 {
+				return errors.Newf("could not list packages under %s", pkgPath)
 			}
 			for _, pkg := range pkgs {
 				for _, s := range pkg.Imports {
@@ -1826,6 +1833,7 @@ func TestLint(t *testing.T) {
 			stream.GrepNot(`cockroach/pkg/util/sysutil: syscall$`),
 			stream.GrepNot(`cockroachdb/cockroach/pkg/build/bazel/util/tinystringer: errors$`),
 			stream.GrepNot(`cockroachdb/cockroach/pkg/build/engflow: github\.com/golang/protobuf/proto$`),
+			stream.GrepNot(`cockroachdb/cockroach/pkg/build/engflow: log$`),
 			stream.GrepNot(`cockroachdb/cockroach/pkg/util/grpcutil: github\.com/cockroachdb\/errors\/errbase$`),
 			stream.GrepNot(`cockroachdb/cockroach/pkg/util/future: github\.com/cockroachdb\/errors\/errbase$`),
 			stream.GrepNot(`cockroach/pkg/roachprod/install: syscall$`), // TODO: switch to sysutil
@@ -1839,6 +1847,11 @@ func TestLint(t *testing.T) {
 			stream.GrepNot(`cockroachdb/cockroach/pkg/kv/kvpb/gen: log$`),
 			stream.GrepNot(`cockroachdb/cockroach/pkg/util/log/gen: log$`),
 			stream.GrepNot(`cockroach/pkg/util/uuid: github\.com/satori/go\.uuid$`),
+			// See #132262.
+			stream.GrepNot(`github.com/cockroachdb/cockroach/pkg/raft: log$`),
+			stream.GrepNot(`github.com/cockroachdb/cockroach/pkg/raft/raftlogger: log$`),
+			stream.GrepNot(`github.com/cockroachdb/cockroach/pkg/raft/rafttest: log$`),
+			stream.GrepNot(`github.com/cockroachdb/cockroach/pkg/workload/debug: log$`),
 		), func(s string) {
 			pkgStr := strings.Split(s, ": ")
 			importingPkg, importedPkg := pkgStr[0], pkgStr[1]


### PR DESCRIPTION
Backport 1/1 commits from #132263.

/cc @cockroachdb/release

Release justification: Non-production code changes

---

We need to set `Dir` in the `packages.Load()` call or else the whole thing doesn't work. It would be really nice if it threw an error instead of simply doing nothing, but it is what it is. To guard against this in the future I added an error if the list is empty.

Fix the test then all existing violations, except for `raftlogger` and `rafttest` which will need some extra TLC by the owning team (see #132262)

Closes #132258

Epic: none
Release note: None
