### PR TITLE
rac2: remove leftover log.Infof in replicaSendStream

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -2223,7 +2223,6 @@ func (rss *replicaSendStream) closeLocked(ctx context.Context) {
 	rss.stopAttemptingToEmptySendQueueLocked(ctx, true)
 	if rss.mu.sendQueue.forceFlushScheduled {
 		rss.parent.parent.opts.RangeControllerMetrics.SendQueue.ForceFlushedScheduledCount.Dec(1)
-		log.Infof(ctx, "r%v:%v stream %v force-flushing -1", rss.parent.parent.opts.RangeID, rss.parent.desc, rss.parent.stream)
 	}
 	rss.mu.closed = true
 }


### PR DESCRIPTION
Epic: CRDB-37515

Release note: None