### PR TITLE
util/stop: fix recover comment

### DIFF
--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -216,7 +216,7 @@ func NewStopper(options ...Option) *Stopper {
 	return s
 }
 
-// recover reports the current panic, if any, any panics again.
+// recover reports the current panic, if any, and panics again.
 //
 // Note: this function _must_ be called with `defer s.recover()`, otherwise
 // the panic recovery won't work.


### PR DESCRIPTION
Spotted a small mistake in one of the comments while passing by.

Epic: None
Release note: None