### PR TITLE
kv/kvclient: set activeRangefeed NodeID and ReplicaID earlier

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -496,6 +496,7 @@ func newActiveRangeFeed(
 	rr *rangeFeedRegistry,
 	metrics *DistSenderRangeFeedMetrics,
 	parentMetadata parentRangeFeedMetadata,
+	initialRangeID roachpb.RangeID,
 ) *activeRangeFeed {
 	// Register partial range feed with registry.
 	active := &activeRangeFeed{
@@ -504,6 +505,7 @@ func newActiveRangeFeed(
 			StartAfter:              startAfter,
 			ParentRangefeedMetadata: parentMetadata,
 			CreatedTime:             timeutil.Now(),
+			RangeID:                 initialRangeID,
 		},
 	}
 


### PR DESCRIPTION
Previously, we only set the NodeID and ReplicaID on receipt of the first rangefeed message.

That meant that if a rangefeed was waiting on the catchup iterator semaphore, we couldn't see which node or replica it was running on in the crdb_internal.active_range_feeds table.

Here, we add these fields before making the rangefeed request.

Epic: none
Release note: None