### PR TITLE
server: fix merge skew; skip under race

### DIFF
--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -1590,6 +1590,8 @@ func TestThrottlingMetadata(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.UnderRace(t, "times out under race")
+
 	testtime := timeutil.Now()
 
 	s := serverutils.StartCluster(t, 3, base.TestClusterArgs{
@@ -1597,7 +1599,6 @@ func TestThrottlingMetadata(t *testing.T) {
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					LicenseTestingKnobs: license.TestingKnobs{
-						Enable:            true,
 						OverrideStartTime: &testtime,
 					},
 				},


### PR DESCRIPTION
Added skip under race to match other branches.

Release note: None