### PR TITLE
kvserver: update the send queue size metrics

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3484,6 +3484,8 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		nanos := timeutil.Since(minMaxClosedTS.GoTime()).Nanoseconds()
 		s.metrics.ClosedTimestampMaxBehindNanos.Update(nanos)
 	}
+	s.cfg.KVFlowRangeControllerMetrics.SendQueue.SizeCount.Update(kvflowSendQueueSizeCount)
+	s.cfg.KVFlowRangeControllerMetrics.SendQueue.SizeBytes.Update(kvflowSendQueueSizeBytes)
 
 	if err := s.metrics.RecentReplicaCPUNanosPerSecond.Rotate(); err != nil {
 		return err


### PR DESCRIPTION
This is a tiny bug fix, in that all the plumbing work was already done, and just the update calls were forgotten.

Epic: CRDB-37515

Release note: None