### PR TITLE
cluster-ui: simplify requests for tmj job status and trigger

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/databases/getTableMetadataApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databases/getTableMetadataApi.ts
@@ -146,6 +146,10 @@ export const useTableMetadata = (req: ListTableMetadataRequest) => {
   const { data, error, isLoading, mutate } = useSWR<TableMetadataResponse>(
     key,
     () => getTableMetadata(req),
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    },
   );
 
   return { data, error, isLoading, refreshTables: mutate };

--- a/pkg/ui/workspaces/cluster-ui/src/api/databases/serverTypes.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databases/serverTypes.ts
@@ -95,3 +95,22 @@ export type DatabaseGrantServer = {
 
 export type DatabaseGrantsResponseServer =
   APIV2ResponseWithPaginationState<DatabaseGrantServer>;
+
+// ------------------------------------------------------------------------------------
+// /api/v2/updatejob/ response.
+// ------------------------------------------------------------------------------------
+
+export type TableMetaUpdateJobResponseServer = {
+  current_status: string;
+  progress: number;
+  last_start_time: string | null;
+  last_completed_time: string | null;
+  last_updated_time: string | null;
+  data_valid_duration: number;
+  automatic_updates_enabled: boolean;
+};
+
+export type TriggerTableMetaUpdateJobResponseServer = {
+  job_triggered: boolean;
+  message: string;
+};

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
@@ -300,7 +300,7 @@ export const TablesPageV2 = () => {
           loading={isLoading}
           error={error}
           actionButton={
-            <TableMetadataJobControl onDataUpdated={refreshTables} />
+            <TableMetadataJobControl onJobComplete={refreshTables} />
           }
           columns={colsWithSort}
           dataSource={tableData}

--- a/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
@@ -239,7 +239,7 @@ export const DatabasesPageV2 = () => {
           loading={isLoading}
           error={error}
           actionButton={
-            <TableMetadataJobControl onDataUpdated={refreshDatabases} />
+            <TableMetadataJobControl onJobComplete={refreshDatabases} />
           }
           columns={colsWithSort}
           dataSource={tableData}


### PR DESCRIPTION
This commit removes some unnecessarily complex refresh
logic for the tmj job status and reqs to trigger the job.
We now request both on a 10s interval.

In addition, when data is being refreshed and the refresh
button is disabled, its tooltip text will now display
"Data is currently refreshing".

Epic: CRDB-37558
Release note (ui change): In the new db and tables pages,
when cached data is being refreshed, the refresh button
will be disabled and its tooltip text will display,
"Data is currently refreshing".