### PR TITLE
ui,server: add ReplicaCount to table details

### DIFF
--- a/pkg/roachpb/span_stats.proto
+++ b/pkg/roachpb/span_stats.proto
@@ -69,7 +69,11 @@ message SpanStats {
   // Unique store ids for the requested span.
   repeated int32 store_ids = 8 [(gogoproto.customname) = "StoreIDs", (gogoproto.casttype) = "StoreID"];
 
-  // NEXT ID: 9.
+  // ReplicaCount is the total number of `voting_replicas` and `non_voting_replicas`
+  // for the span's ranges. It does not include `learner_replicas`.
+  int32 replica_count = 9;
+
+  // NEXT ID: 10.
 }
 
 message SpanStatsResponse {

--- a/pkg/server/api_v2_databases_metadata.go
+++ b/pkg/server/api_v2_databases_metadata.go
@@ -453,6 +453,7 @@ func getTableMetadataBaseQuery(userName string) *safesql.Query {
 			tbm.store_ids, 
 			COALESCE((tbm.details->>'auto_stats_enabled')::BOOL, csc.auto_stats_enabled) as auto_stats_enabled,
 			parse_timestamp(tbm.details->>'stats_last_updated') as stats_last_updated,
+			COALESCE((tbm.details->>'replica_count')::INT, 0) as replica_count,
 			COALESCE(tbm.last_update_error, '') as last_update_error,
 			tbm.last_updated,
 			count(*) OVER() as total_row_count
@@ -522,6 +523,9 @@ func rowToTableMetadata(scanner resultScanner, row tree.Datums) (tmd tableMetada
 		return tmd, err
 	}
 	if err = scanner.Scan(row, "stats_last_updated", &tmd.StatsLastUpdated); err != nil {
+		return tmd, err
+	}
+	if err = scanner.Scan(row, "replica_count", &tmd.ReplicaCount); err != nil {
 		return tmd, err
 	}
 
@@ -1090,6 +1094,7 @@ type tableMetadata struct {
 	StatsLastUpdated     *time.Time `json:"stats_last_updated"`
 	LastUpdateError      string     `json:"last_update_error,omitempty"`
 	LastUpdated          time.Time  `json:"last_updated"`
+	ReplicaCount         int64      `json:"replica_count"`
 }
 
 type dbMetadata struct {

--- a/pkg/sql/tablemetadatacache/table_metadata_updater.go
+++ b/pkg/sql/tablemetadatacache/table_metadata_updater.go
@@ -48,6 +48,9 @@ type tableMetadataDetails struct {
 	// the table. This can be nil if table stats haven't been
 	// updated yet.
 	StatsLastUpdated *time.Time `json:"stats_last_updated"`
+	// ReplicaCount is the number of voter and non-voter replicas
+	// containing data for the table.
+	ReplicaCount int32 `json:"replica_count"`
 }
 
 var _ tablemetadatacacheutil.ITableMetadataUpdater = &tableMetadataUpdater{}
@@ -286,7 +289,11 @@ func (q *tableMetadataBatchUpsertQuery) addRow(
 		storeIds[i] = int(id)
 	}
 
-	details := tableMetadataDetails{AutoStatsEnabled: row.autoStatsEnabled, StatsLastUpdated: row.statsLastUpdated}
+	details := tableMetadataDetails{
+		AutoStatsEnabled: row.autoStatsEnabled,
+		StatsLastUpdated: row.statsLastUpdated,
+		ReplicaCount:     stats.ReplicaCount,
+	}
 	detailsStr, err := gojson.Marshal(details)
 	if err != nil {
 		log.Errorf(ctx, "failed to encode details: %v", err)

--- a/pkg/sql/tablemetadatacache/testdata/update_table_metadata_errors
+++ b/pkg/sql/tablemetadatacache/testdata/update_table_metadata_errors
@@ -11,63 +11,63 @@ query
 SELECT * FROM system.table_metadata
 ORDER BY (db_name, table_name)
 ----
-1 24 system public comments 4 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 44 system public database_role_settings 4 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 3 system public descriptor 2 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 7 system public descriptor_id_seq 1 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC SEQUENCE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 12 system public eventlog 6 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 53 system public external_connections 7 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 54 system public job_info 4 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 15 system public jobs 12 4 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 41 system public join_tokens 3 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 11 system public lease 5 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 21 system public locations 4 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 40 system public migrations 5 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 64 system public mvcc_statistics 6 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 30 system public namespace 4 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 52 system public privileges 5 2 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 31 system public protected_ts_meta 5 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 32 system public protected_ts_records 8 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 13 system public rangelog 7 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 9 system public region_liveness 2 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 25 system public replication_constraint_stats 7 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 26 system public replication_critical_localities 5 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 27 system public replication_stats 7 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 28 system public reports_meta 2 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 48 system public role_id_seq 1 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC SEQUENCE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 23 system public role_members 5 5 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 33 system public role_options 4 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 37 system public scheduled_jobs 10 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 6 system public settings 4 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 47 system public span_configurations 3 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 51 system public span_count 2 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 56 system public span_stats_buckets 5 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 57 system public span_stats_samples 2 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 58 system public span_stats_tenant_boundaries 2 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 55 system public span_stats_unique_keys 2 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 46 system public sql_instances 8 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 39 system public sqlliveness 3 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 61 system public statement_activity 17 7 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 34 system public statement_bundle_chunks 3 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 36 system public statement_diagnostics 7 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 35 system public statement_diagnostics_requests 11 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 66 system public statement_execution_insights 29 4 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 42 system public statement_statistics 19 8 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 67 system public table_metadata 18 10 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 20 system public table_statistics 12 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 59 system public task_payloads 8 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 63 system public tenant_id_seq 1 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC SEQUENCE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 50 system public tenant_settings 6 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 60 system public tenant_tasks 7 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 45 system public tenant_usage 14 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 8 system public tenants 6 2 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 62 system public transaction_activity 14 7 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 65 system public transaction_execution_insights 23 2 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 43 system public transaction_statistics 14 7 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 14 system public ui 3 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 4 system public users 4 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 19 system public web_sessions 9 4 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
-1 5 system public zones 2 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "stats_last_updated": null}
+1 24 system public comments 4 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 44 system public database_role_settings 4 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 3 system public descriptor 2 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 7 system public descriptor_id_seq 1 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC SEQUENCE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 12 system public eventlog 6 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 53 system public external_connections 7 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 54 system public job_info 4 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 15 system public jobs 12 4 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 41 system public join_tokens 3 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 11 system public lease 5 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 21 system public locations 4 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 40 system public migrations 5 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 64 system public mvcc_statistics 6 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 30 system public namespace 4 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 52 system public privileges 5 2 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 31 system public protected_ts_meta 5 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 32 system public protected_ts_records 8 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 13 system public rangelog 7 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 9 system public region_liveness 2 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 25 system public replication_constraint_stats 7 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 26 system public replication_critical_localities 5 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 27 system public replication_stats 7 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 28 system public reports_meta 2 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 48 system public role_id_seq 1 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC SEQUENCE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 23 system public role_members 5 5 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 33 system public role_options 4 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 37 system public scheduled_jobs 10 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 6 system public settings 4 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 47 system public span_configurations 3 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 51 system public span_count 2 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 56 system public span_stats_buckets 5 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 57 system public span_stats_samples 2 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 58 system public span_stats_tenant_boundaries 2 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 55 system public span_stats_unique_keys 2 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 46 system public sql_instances 8 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 39 system public sqlliveness 3 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 61 system public statement_activity 17 7 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 34 system public statement_bundle_chunks 3 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 36 system public statement_diagnostics 7 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 35 system public statement_diagnostics_requests 11 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 66 system public statement_execution_insights 29 4 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 42 system public statement_statistics 19 8 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 67 system public table_metadata 18 10 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 20 system public table_statistics 12 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 59 system public task_payloads 8 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 63 system public tenant_id_seq 1 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC SEQUENCE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 50 system public tenant_settings 6 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 60 system public tenant_tasks 7 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 45 system public tenant_usage 14 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 8 system public tenants 6 2 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 62 system public transaction_activity 14 7 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 65 system public transaction_execution_insights 23 2 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 43 system public transaction_statistics 14 7 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 14 system public ui 3 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 4 system public users 4 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 19 system public web_sessions 9 4 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 5 system public zones 2 0 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
 
 
 set-time unixSecs=1710000000

--- a/pkg/ui/workspaces/cluster-ui/src/api/databases/getTableMetadataApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databases/getTableMetadataApi.ts
@@ -49,6 +49,7 @@ export type TableMetadata = {
   autoStatsEnabled: boolean;
   // Optimizer stats.
   statsLastUpdated: moment.Moment | null;
+  replicaCount: number;
 };
 
 export type ListTableMetadataRequest = {
@@ -85,6 +86,7 @@ const convertTableMetadataFromServer = (
     statsLastUpdated: resp.stats_last_updated
       ? moment(resp.stats_last_updated)
       : null,
+    replicaCount: resp.replica_count ?? 0,
   };
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/api/databases/serverTypes.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databases/serverTypes.ts
@@ -55,6 +55,7 @@ export type TableMetadataServer = {
   auto_stats_enabled: boolean;
   // Optimizer stats.
   stats_last_updated: string | null;
+  replica_count: number;
 };
 
 export type TableMetadataResponseServer =

--- a/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/tableOverview.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/tableOverview.tsx
@@ -95,6 +95,7 @@ export const TableOverview: React.FC<TableOverviewProps> = ({
                 value={Bytes(metadata.replicationSizeBytes)}
               />
               <SummaryCardItem label="Ranges" value={metadata.rangeCount} />
+              <SummaryCardItem label="Replicas" value={metadata.replicaCount} />
               <SummaryCardItem
                 label="Regions / Nodes"
                 value={


### PR DESCRIPTION
Add the replica count to the span stats proto.
ReplicaCount is the count of voter and non-voter
replicas for ranges in the span.

This commit also fixes a bug where the StoreIDs
field in spanstats was being incorrectly overpopulated.
Instead of filling hte array based on the replica descriptors,
all store ids for the node were being included.

Epic: CRDB-37558
Part of: #131755

---------------------------------------------

cluster-ui: add Replicas field to table details page
This commit adds the replica count to the v2 table
details page.

Fixes: https://github.com/cockroachdb/cockroach/issues/131755
Epic: CRDB-37558

Release note: None