### PR TITLE
ui, tablemetadatacache: disable sorting on auto stats collection columns, expose batch size as a cluster setting

### DIFF
--- a/pkg/sql/tablemetadatacache/cluster_settings.go
+++ b/pkg/sql/tablemetadatacache/cluster_settings.go
@@ -12,7 +12,12 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-const defaultDataValidDuration = time.Minute * 20
+const (
+	defaultDataValidDuration = time.Minute * 20
+	// defaultTableBatchSize is the number of tables to fetch in a
+	// single batch from the system tables.
+	defaultTableBatchSize = 20
+)
 
 var AutomaticCacheUpdatesEnabledSetting = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
@@ -34,3 +39,12 @@ var DataValidDurationSetting = settings.RegisterDurationSetting(
 		return nil
 	}),
 	settings.WithPublic)
+
+var updateJobBatchSizeSetting = settings.RegisterIntSetting(
+	settings.ApplicationLevel,
+	"obs.tablemetadata.update_job_batch_size",
+	"the number of tables the update table metadata job will attempt to update "+
+		"in a single batch",
+	defaultTableBatchSize,
+	settings.NonNegativeInt,
+)

--- a/pkg/sql/tablemetadatacache/update_table_metadata_cache_job.go
+++ b/pkg/sql/tablemetadatacache/update_table_metadata_cache_job.go
@@ -65,6 +65,7 @@ func (j *tableMetadataUpdateJobResumer) Resume(ctx context.Context, execCtxI int
 			execCtx.ExecCfg().TenantStatusServer,
 			execCtx.ExecCfg().InternalDB.Executor(),
 			timeutil.DefaultTimeSource{},
+			updateJobBatchSizeSetting.Get(&execCtx.ExecCfg().Settings.SV),
 			testKnobs)
 	}
 	// We must reset the job's num runs to 0 so that it doesn't get

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
@@ -119,7 +119,7 @@ const COLUMNS: (TableColumnProps<TableRow> & { sortKey?: TableSortOption })[] =
       render: (t: TableRow) => {
         return (
           <div>
-            <div>{t.percentLiveData * 100}%</div>
+            <div>{(t.percentLiveData * 100).toFixed(2)}%</div>
             <div>
               {Bytes(t.totalLiveDataBytes)} / {Bytes(t.totalDataBytes)}
             </div>
@@ -133,7 +133,7 @@ const COLUMNS: (TableColumnProps<TableRow> & { sortKey?: TableSortOption })[] =
           {TableColName.AUTO_STATS_ENABLED}
         </Tooltip>
       ),
-      sorter: true,
+      sorter: false,
       render: (t: TableRow) => {
         const type = t.autoStatsEnabled ? "success" : "error";
         const text = t.autoStatsEnabled ? "ENABLED" : "DISABLED";
@@ -150,7 +150,7 @@ const COLUMNS: (TableColumnProps<TableRow> & { sortKey?: TableSortOption })[] =
           {TableColName.STATS_LAST_UPDATED}
         </Tooltip>
       ),
-      sorter: true,
+      sorter: false,
       render: (t: TableRow) => (
         <Timestamp
           time={t.statsLastUpdated}


### PR DESCRIPTION
cluster-ui: disable sorting on auto stats columns

In the table overview page disable sorting on the
columns pertaining to auto stats collection. These
columns are not sortable.

Epic: CRDB-37558
Release note: None

------------------

tablemetadatacache: make the update job table batch size a CS

This commit makes the update job batch size adjustable
via a cluster setting.

Epic: none
Release note: None
@xinhaoz