### PR TITLE
persistedsqlstats: unskip TestSQLStatsCompactor

### DIFF
--- a/pkg/server/application_api/sql_stats_test.go
+++ b/pkg/server/application_api/sql_stats_test.go
@@ -1345,7 +1345,7 @@ func TestCombinedStatementUsesCorrectSourceTable(t *testing.T) {
 		stmt.AggregatedTs = startTs
 		stmt.Key.App = server.CrdbInternalStmtStatsPersisted
 		stmt.Key.TransactionFingerprintID = 1
-		require.NoError(t, sqlstatstestutil.InsertMockedIntoSystemStmtStats(ctx, ie, &stmt, 1 /* nodeId */, nil))
+		require.NoError(t, sqlstatstestutil.InsertMockedIntoSystemStmtStats(ctx, ie, []appstatspb.CollectedStatementStatistics{stmt}, 1))
 
 		stmt.Key.App = server.CrdbInternalStmtStatsCached
 		require.NoError(t, sqlstatstestutil.InsertMockedIntoSystemStmtActivity(ctx, ie, &stmt, nil))
@@ -1355,7 +1355,7 @@ func TestCombinedStatementUsesCorrectSourceTable(t *testing.T) {
 		txn.TransactionFingerprintID = 1
 		txn.AggregatedTs = startTs
 		txn.App = server.CrdbInternalTxnStatsPersisted
-		require.NoError(t, sqlstatstestutil.InsertMockedIntoSystemTxnStats(ctx, ie, &txn, 1, nil))
+		require.NoError(t, sqlstatstestutil.InsertMockedIntoSystemTxnStats(ctx, ie, []appstatspb.CollectedTransactionStatistics{txn}, 1))
 		txn.App = server.CrdbInternalTxnStatsCached
 		require.NoError(t, sqlstatstestutil.InsertMockedIntoSystemTxnActivity(ctx, ie, &txn, nil))
 

--- a/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
@@ -86,7 +86,6 @@ go_test(
         "//pkg/scheduledjobs",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
-        "//pkg/security/username",
         "//pkg/server",
         "//pkg/server/serverpb",
         "//pkg/sql",

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil/BUILD.bazel
@@ -9,8 +9,10 @@ go_library(
         "//pkg/base",
         "//pkg/sql",
         "//pkg/sql/appstatspb",
+        "//pkg/sql/isql",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",
+        "//pkg/util/safesql",
     ],
 )

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil/testutils.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil/testutils.go
@@ -14,9 +14,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil"
+	"github.com/cockroachdb/cockroach/pkg/util/safesql"
 )
 
 // GetRandomizedCollectedStatementStatisticsForTest returns a
@@ -43,52 +45,67 @@ func GetRandomizedCollectedTransactionStatisticsForTest(
 
 func InsertMockedIntoSystemStmtStats(
 	ctx context.Context,
-	ie *sql.InternalExecutor,
-	stmtStats *appstatspb.CollectedStatementStatistics,
+	ie isql.Executor,
+	stmtStatsList []appstatspb.CollectedStatementStatistics,
 	nodeID base.SQLInstanceID,
-	aggInterval *time.Duration,
 ) error {
-	if stmtStats == nil {
+	if len(stmtStatsList) == 0 {
 		return nil
 	}
 
 	aggIntervalVal := time.Hour
-	if aggInterval != nil {
-		aggIntervalVal = *aggInterval
+
+	// Initialize the query builder
+	query := safesql.NewQuery()
+	query.Append("UPSERT INTO system.statement_statistics ")
+	query.Append("(aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, agg_interval, metadata, statistics, plan) VALUES ")
+
+	for i, stmtStats := range stmtStatsList {
+		if i > 0 {
+			query.Append(", ")
+		}
+
+		stmtFingerprint := sqlstatsutil.EncodeUint64ToBytes(uint64(stmtStats.ID))
+		txnFingerprint := sqlstatsutil.EncodeUint64ToBytes(uint64(stmtStats.Key.TransactionFingerprintID))
+		planHash := sqlstatsutil.EncodeUint64ToBytes(stmtStats.Key.PlanHash)
+
+		metadataJSON, err := sqlstatsutil.BuildStmtMetadataJSON(&stmtStats)
+		if err != nil {
+			return err
+		}
+
+		statisticsJSON, err := sqlstatsutil.BuildStmtStatisticsJSON(&stmtStats.Stats)
+		if err != nil {
+			return err
+		}
+		statistics := tree.NewDJSON(statisticsJSON)
+
+		plan := tree.NewDJSON(sqlstatsutil.ExplainTreePlanNodeToJSON(&stmtStats.Stats.SensitiveInfo.MostRecentPlanDescription))
+
+		metadata := tree.NewDJSON(metadataJSON)
+
+		query.Append("($, $, $, $, $, $, $, $, $, $)",
+			stmtStats.AggregatedTs, // aggregated_ts
+			stmtFingerprint,        // fingerprint_id
+			txnFingerprint,         // transaction_fingerprint_id
+			planHash,               // plan_hash
+			stmtStats.Key.App,      // app_name
+			nodeID,                 // node_id
+			aggIntervalVal,         // agg_interval
+			metadata,               // metadata
+			statistics,             // statistics
+			plan,                   // plan
+		)
 	}
 
-	stmtFingerprint := sqlstatsutil.EncodeUint64ToBytes(uint64(stmtStats.ID))
-	txnFingerprint := sqlstatsutil.EncodeUint64ToBytes(uint64(stmtStats.Key.TransactionFingerprintID))
-	planHash := sqlstatsutil.EncodeUint64ToBytes(stmtStats.Key.PlanHash)
-
-	metadataJSON, err := sqlstatsutil.BuildStmtMetadataJSON(stmtStats)
-	if err != nil {
-		return err
-	}
-
-	statisticsJSON, err := sqlstatsutil.BuildStmtStatisticsJSON(&stmtStats.Stats)
-	if err != nil {
-		return err
-	}
-	statistics := tree.NewDJSON(statisticsJSON)
-
-	plan := tree.NewDJSON(sqlstatsutil.ExplainTreePlanNodeToJSON(&stmtStats.Stats.SensitiveInfo.MostRecentPlanDescription))
-
-	metadata := tree.NewDJSON(metadataJSON)
-
-	_, err = ie.ExecEx(ctx, "insert-mock-stmt-stats", nil, sessiondata.NodeUserSessionDataOverride,
-		`UPSERT INTO system.statement_statistics
-VALUES ($1 ,$2, $3, $4, $5, $6, $7, $8, $9, $10)`,
-		stmtStats.AggregatedTs, // aggregated_ts
-		stmtFingerprint,        // fingerprint_id
-		txnFingerprint,         // transaction_fingerprint_id
-		planHash,               // plan_hash
-		stmtStats.Key.App,      // app_name
-		nodeID,                 // node_id
-		aggIntervalVal,         // agg_interval
-		metadata,               // metadata
-		statistics,             // statistics
-		plan,                   // plan
+	// Execute the query
+	_, err := ie.ExecEx(
+		ctx,
+		"insert-mock-stmt-stats-batch",
+		nil,
+		sessiondata.NodeUserSessionDataOverride,
+		query.String(),
+		query.QueryArguments()...,
 	)
 
 	return err
@@ -96,47 +113,59 @@ VALUES ($1 ,$2, $3, $4, $5, $6, $7, $8, $9, $10)`,
 
 func InsertMockedIntoSystemTxnStats(
 	ctx context.Context,
-	ie *sql.InternalExecutor,
-	stats *appstatspb.CollectedTransactionStatistics,
+	ie isql.Executor,
+	statsList []appstatspb.CollectedTransactionStatistics,
 	nodeID base.SQLInstanceID,
-	aggInterval *time.Duration,
 ) error {
-	if stats == nil {
+	if len(statsList) == 0 {
 		return nil
 	}
-
 	aggIntervalVal := time.Hour
-	if aggInterval != nil {
-		aggIntervalVal = *aggInterval
+
+	// Initialize the query builder
+	query := safesql.NewQuery()
+	query.Append("UPSERT INTO system.transaction_statistics ")
+	query.Append("(aggregated_ts, fingerprint_id, app_name, node_id, agg_interval, metadata, statistics) VALUES ")
+
+	for i, stats := range statsList {
+		if i > 0 {
+			query.Append(", ")
+		}
+
+		txnFingerprint := sqlstatsutil.EncodeUint64ToBytes(uint64(stats.TransactionFingerprintID))
+
+		statisticsJSON, err := sqlstatsutil.BuildTxnStatisticsJSON(&stats)
+		if err != nil {
+			return err
+		}
+		statistics := tree.NewDJSON(statisticsJSON)
+
+		metadataJSON, err := sqlstatsutil.BuildTxnMetadataJSON(&stats)
+		if err != nil {
+			return err
+		}
+		metadata := tree.NewDJSON(metadataJSON)
+
+		query.Append("($, $, $, $, $, $, $)",
+			stats.AggregatedTs, // aggregated_ts
+			txnFingerprint,     // fingerprint_id
+			stats.App,          // app_name
+			nodeID,             // node_id
+			aggIntervalVal,     // agg_interval
+			metadata,           // metadata
+			statistics,         // statistics
+		)
 	}
 
-	txnFingerprint := sqlstatsutil.EncodeUint64ToBytes(uint64(stats.TransactionFingerprintID))
-
-	statisticsJSON, err := sqlstatsutil.BuildTxnStatisticsJSON(stats)
-	if err != nil {
-		return err
-	}
-	statistics := tree.NewDJSON(statisticsJSON)
-
-	metadataJSON, err := sqlstatsutil.BuildTxnMetadataJSON(stats)
-	if err != nil {
-		return err
-	}
-	metadata := tree.NewDJSON(metadataJSON)
-	aggregatedTs := stats.AggregatedTs
-
-	_, err = ie.ExecEx(ctx, "insert-mock-txn-stats", nil, sessiondata.NodeUserSessionDataOverride,
-		` UPSERT INTO system.transaction_statistics
-VALUES ($1 ,$2, $3, $4, $5, $6, $7)`,
-		aggregatedTs,   // aggregated_ts
-		txnFingerprint, // fingerprint_id
-		stats.App,      // app_name
-		nodeID,         // node_id
-		aggIntervalVal, // agg_interval
-		metadata,       // metadata
-		statistics,     // statistics
+	// Execute the query
+	_, err := ie.ExecEx(
+		ctx,
+		"insert-mock-txn-stats-batch",
+		nil,
+		sessiondata.NodeUserSessionDataOverride,
+		query.String(),
+		query.QueryArguments()...,
 	)
-
 	return err
 }
 


### PR DESCRIPTION
This commit unskips TestSQLStatsCompactor. Previously
this test was flaky because it compares the number of
actual KV scans on the sql stats tables with the number
of times a sql scan was issued via the compaction job,
tracked via a testing knob. This counting did not
account for potential txn retries leading to more KV
scans than expected in some test runs.

This commit deflakes the test by ensuring a txn is only
counted once. We also now prepopulate the  sql stats tables
directly instead of flushing collected data, since the collected
data from a test cluster can include internal statements which
can change the number of expected scans across test runs.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/120761
Release note: None