### PR TITLE
release-24.1: opt: check type and composite sensitivity before remapping computed expressions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -1578,3 +1578,26 @@ query I
 SELECT count(v) FROM l_101823 LEFT LOOKUP JOIN r_101823 ON a = u AND b = v;
 ----
 1
+
+# Regression test for incorrectly remapping equal columns with non-identical
+# types (#124732).
+statement ok
+CREATE TABLE table_1_124732 (col1_6 REGCLASS);
+
+statement ok
+CREATE TABLE table_3_124732 (
+  col3_0 OID,
+  col3_7 STRING AS (col3_0::STRING) VIRTUAL PRIMARY KEY
+);
+
+statement ok
+INSERT INTO table_1_124732 (col1_6) VALUES (0);
+INSERT INTO table_3_124732 (col3_0) VALUES (0);
+
+query T
+SELECT col1_6 FROM table_1_124732 INNER HASH JOIN table_3_124732 ON col3_0 = col1_6;
+----
+-
+
+statement error pgcode XXUUU pq: could not produce a query plan conforming to the LOOKUP JOIN hint
+SELECT col1_6 FROM table_1_124732 INNER LOOKUP JOIN table_3_124732 ON col3_0 = col1_6;

--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -1579,6 +1579,8 @@ SELECT count(v) FROM l_101823 LEFT LOOKUP JOIN r_101823 ON a = u AND b = v;
 ----
 1
 
+subtest regression_124732
+
 # Regression test for incorrectly remapping equal columns with non-identical
 # types (#124732).
 statement ok
@@ -1601,3 +1603,27 @@ SELECT col1_6 FROM table_1_124732 INNER HASH JOIN table_3_124732 ON col3_0 = col
 
 statement error pgcode XXUUU pq: could not produce a query plan conforming to the LOOKUP JOIN hint
 SELECT col1_6 FROM table_1_124732 INNER LOOKUP JOIN table_3_124732 ON col3_0 = col1_6;
+
+# Regression test for incorrectly remapping columns in a composite-sensitive
+# expression to produce a lookup join (#124732).
+statement ok
+CREATE TABLE t_124732 (
+  i DECIMAL,
+  v STRING AS (i::STRING) VIRTUAL,
+  PRIMARY KEY (v, i)
+);
+
+statement ok
+INSERT INTO t_124732 VALUES (1.000);
+
+statement error pgcode XXUUU pq: could not produce a query plan conforming to the LOOKUP JOIN hint
+SELECT * FROM (VALUES (1::DECIMAL)) AS v(i)
+INNER LOOKUP JOIN t_124732 ON v.i = t_124732.i;
+
+query RRT
+SELECT * FROM (VALUES (1::DECIMAL)) AS v(i)
+INNER HASH JOIN t_124732 ON v.i = t_124732.i;
+----
+1  1.000  1.000
+
+subtest end

--- a/pkg/sql/opt/lookupjoin/constraint_builder.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder.go
@@ -455,6 +455,8 @@ func (b *ConstraintBuilder) Build(
 //  2. col is a computed column.
 //  3. Columns referenced in the computed expression are a subset of columns
 //     that already have equality constraints.
+//  4. The computed column expression is not composite-sensitive to the set of
+//     referenced columns.
 //
 // For example, consider the table and query:
 //
@@ -509,6 +511,14 @@ func (b *ConstraintBuilder) findComputedColJoinEquality(
 	}
 	expr, ok := tabMeta.ComputedColExpr(col)
 	if !ok {
+		return nil, false
+	}
+	if memo.CanBeCompositeSensitive(expr) {
+		// Composite-typed values might compare equally without being exactly the
+		// same (e.g. 2.0::DECIMAL vs 2.000::DECIMAL). We must ensure that the
+		// computed column expression produces equivalent (but not necessarily
+		// identical) results if its columns are swapped out with equivalent
+		// columns.
 		return nil, false
 	}
 	var sharedProps props.Shared

--- a/pkg/sql/opt/lookupjoin/constraint_builder.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder.go
@@ -160,7 +160,6 @@ func (b *ConstraintBuilder) Build(
 	// Extract the equality columns from the ON and derived FK filters.
 	leftEq, rightEq, eqFilterOrds :=
 		memo.ExtractJoinEqualityColumnsWithFilterOrds(b.leftCols, b.rightCols, b.allFilters)
-	rightEqSet := rightEq.ToSet()
 
 	// Retrieve the inequality columns from the ON and derived FK filters.
 	var rightCmp opt.ColList
@@ -185,7 +184,7 @@ func (b *ConstraintBuilder) Build(
 	// columns, but it avoids unnecessary work in most cases.
 	firstIdxCol := b.table.IndexColumnID(index, 0)
 	if _, ok := rightEq.Find(firstIdxCol); !ok {
-		if _, ok := b.findComputedColJoinEquality(b.table, firstIdxCol, rightEqSet); !ok {
+		if _, ok := b.findComputedColJoinEquality(b.table, firstIdxCol, rightEq.ToSet()); !ok {
 			if !HasJoinFilterConstants(b.allFilters, firstIdxCol, b.evalCtx) {
 				if _, ok := rightCmp.Find(firstIdxCol); !ok {
 					return Constraint{}, false
@@ -261,6 +260,17 @@ func (b *ConstraintBuilder) Build(
 		keyCols = nil
 	}
 
+	// rightEqIdenticalTypeCols is the set of columns in rightEq that have
+	// identical types to the corresponding columns in leftEq. This is used to
+	// determine if a computed column can be synthesized for a column in the
+	// index in order to allow a lookup join.
+	var rightEqIdenticalTypeCols opt.ColSet
+	for i := range rightEq {
+		if b.md.ColumnMeta(rightEq[i]).Type.Identical(b.md.ColumnMeta(leftEq[i]).Type) {
+			rightEqIdenticalTypeCols.Add(rightEq[i])
+		}
+	}
+
 	// All the lookup conditions must apply to the prefix of the index and so
 	// the projected columns created must be created in order.
 	for j := 0; j < numIndexKeyCols; j++ {
@@ -281,7 +291,10 @@ func (b *ConstraintBuilder) Build(
 		// and construct a Project expression that wraps the join's input
 		// below. See findComputedColJoinEquality for the requirements to
 		// synthesize a computed column equality constraint.
-		if expr, ok := b.findComputedColJoinEquality(b.table, idxCol, rightEqSet); ok {
+		//
+		// NOTE: we must only consider equivalent columns with identical types,
+		// since column remapping is otherwise not valid.
+		if expr, ok := b.findComputedColJoinEquality(b.table, idxCol, rightEqIdenticalTypeCols); ok {
 			colMeta := b.md.ColumnMeta(idxCol)
 			compEqCol := b.md.AddColumn(fmt.Sprintf("%s_eq", colMeta.Alias), colMeta.Type)
 

--- a/pkg/sql/opt/lookupjoin/testdata/computed
+++ b/pkg/sql/opt/lookupjoin/testdata/computed
@@ -120,3 +120,10 @@ input projections:
   v_eq = a + 10
 lookup expression:
   ((v_eq = v) AND (a = x)) AND (y > 0)
+
+# Regression test for #124732: Computed columns cannot be remapped unless the
+# column types are identical.
+lookup-constraints left=(a regclass, b int) right=(x oid, v string not null as (x::string) stored) index=(v, x)
+x = a
+----
+lookup join not possible

--- a/pkg/sql/opt/lookupjoin/testdata/computed
+++ b/pkg/sql/opt/lookupjoin/testdata/computed
@@ -127,3 +127,19 @@ lookup-constraints left=(a regclass, b int) right=(x oid, v string not null as (
 x = a
 ----
 lookup join not possible
+
+# Computed columns cannot be remapped if the expression is composite-sensitive.
+lookup-constraints left=(a decimal, b int) right=(x decimal, v int not null as (x::int) stored) index=(v, x)
+x = a
+----
+lookup join not possible
+
+# Case with a composite-insensitive computed column expression.
+lookup-constraints left=(a decimal, b int) right=(x decimal, v decimal not null as (x + 2.5) stored) index=(v, x)
+x = a
+----
+key cols:
+  v = v_eq
+  x = a
+input projections:
+  v_eq = a + 2.5


### PR DESCRIPTION
Backport 2/2 commits from #126345.

/cc @cockroachdb/release

---

#### opt: don't remap non-identical cols when building a lookup join

It is possible in some cases to infer an equality constraint for a
computed column in order to allow a lookup join. This requires remapping
the columns in the computed column expression to columns from the join's
left input. Previously, this logic did not check that the remapped columns
all have identical types. This could result in incorrect results.
This commit fixes the issue by only remapping columns that are identical.

Fixes #124732

Release note (bug fix): Fixed a bug existing since before v23.1 which
could lead to incorrect results in rare cases. The bug requires a join
between two tables, with an equality between columns with equivalent but
not identical types (e.g. OID and REGCLASS). In addition, the join must
lookup into an index that includes a computed column that references one
of the equivalent columns.

#### opt: don't remap composite-sensitive computed cols when building a lookup join

Similar to the prior fix for remapping non-identical columns when
projecting a computed columns expression for a lookup join, this commit
adds a check to ensure that the computed column expression is composite
insensitive. Without this check, differences in a composite-typed column
(e.g. `2.0::DECIMAL` vs `2.0000::DECIMAL`) could cause the lookup join
to produce incorrect results.

Informs #124732

Release note (bug fix): Fixed a bug existing since before v23.1 which
could lead to incorrect results in rare cases. The bug requires a
lookup join into a table with a computed index column, where the
computed column expression is composite sensitive. A composite sensitive
expression can compare differently if supplied non-identical but
equivalent input values (e.g. `2.0::DECIMAL` vs `2.00::DECIMAL`).

---

Release justification: correctness bug fix
