### PR TITLE
rac2: reduce how long rangeController.mu is held

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
@@ -1323,11 +1323,7 @@ func TestRangeController(t *testing.T) {
 					var sizeCount, sizeBytes int64
 					for _, rcState := range state.ranges {
 						stats := RangeSendStreamStats{}
-						func() {
-							rcState.rc.mu.Lock()
-							defer rcState.rc.mu.Unlock()
-							rcState.rc.updateSendQueueStatsRaftMuRCLocked(state.ts.Now())
-						}()
+						rcState.rc.updateSendQueueStatsRaftMuLocked(state.ts.Now())
 						rcState.rc.SendStreamStats(&stats)
 						count, bytes := stats.SumSendQueues()
 						sizeCount += count
@@ -1371,11 +1367,7 @@ func TestRangeController(t *testing.T) {
 
 				r := state.ranges[roachpb.RangeID(rangeID)]
 				if refresh {
-					func() {
-						r.rc.mu.Lock()
-						defer r.rc.mu.Unlock()
-						r.rc.updateSendQueueStatsRaftMuRCLocked(state.ts.Now())
-					}()
+					r.rc.updateSendQueueStatsRaftMuLocked(state.ts.Now())
 				}
 				stats := RangeSendStreamStats{}
 				r.rc.SendStreamStats(&stats)


### PR DESCRIPTION
Also, never hold it and then acquire replicaSendStream.mu, since the latter is held when doing IO. Additionally, changed some Lock calls to RLock.

Epic: CRDB-37515

Release note: None