### PR TITLE
kvserver: skip empty RACv1 dispatches

### DIFF
--- a/pkg/kv/kvserver/raft_transport.go
+++ b/pkg/kv/kvserver/raft_transport.go
@@ -885,10 +885,12 @@ func (t *RaftTransport) processQueue(
 				dispatchPendingFlowTokensTimer.Reset(0)
 			}
 
-			req := newRaftMessageRequest()
-			maybeAnnotateWithAdmittedRaftLogEntries(req, pendingDispatches)
-			batch.Requests = append(batch.Requests, *req)
-			releaseRaftMessageRequest(req)
+			if len(pendingDispatches) != 0 {
+				req := newRaftMessageRequest()
+				maybeAnnotateWithAdmittedRaftLogEntries(req, pendingDispatches)
+				batch.Requests = append(batch.Requests, *req)
+				releaseRaftMessageRequest(req)
+			}
 
 			maybeAnnotateWithStoreIDs(batch)
 			annotateWithClockTimestamp(batch)


### PR DESCRIPTION
This commit skips creating a `RaftMessageRequest` in the fallback RAC admission dispatch code if there are no pending RACv1 dispatches. Previously, it would send an empty `RaftMessageRequest` which would cause an error in the receiver's `handleRaftRequest`, [message drops](https://github.com/cockroachdb/cockroach/blob/9e12f67ff4ad860651c40dcef489a1556d1d11b7/pkg/kv/kvserver/raft_transport.go#L451-L456), and the receiver's message queue to restart after the following warning:

```
unable to accept Raft message from (n0,s0):?: no handler registered for (n0,s0):?
```

Related to #129508