### PR TITLE
roachtest: use latest versions for mixed-version rebalance test

### DIFF
--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -104,6 +104,9 @@ func registerRebalanceLoad(r registry.Registry) {
 					mixedversion.SystemOnlyDeployment,
 					mixedversion.SharedProcessDeployment,
 				),
+
+				// Only use the latest version of each release to work around #127029.
+				mixedversion.AlwaysUseLatestPredecessors,
 			)
 			mvt.OnStartup("maybe enable split/scatter on tenant",
 				func(ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper) error {


### PR DESCRIPTION
Previously, the mixed rebalance/by-load/*/mixed-version roachtest could use random versions of each release. This caused the test to flake due to #127029, so this commit prevents the flakes by making the test use the latest versions.

Fixes #132045

Release note: None