### PR TITLE
kvserver: unskip v1 flow control integration tests under duress

### DIFF
--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -68,9 +68,6 @@ import (
 func TestFlowControlBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	testutils.RunTrueAndFalse(t, "always-enqueue", func(t *testing.T, alwaysEnqueue bool) {
 		ctx := context.Background()
@@ -223,9 +220,6 @@ ORDER BY streams DESC;
 func TestFlowControlRangeSplitMerge(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 3
@@ -341,9 +335,6 @@ ORDER BY streams DESC;
 func TestFlowControlBlockedAdmission(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 3
@@ -455,9 +446,6 @@ ORDER BY name ASC;
 func TestFlowControlAdmissionPostSplitMerge(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 3
@@ -594,9 +582,6 @@ ORDER BY streams DESC;
 func TestFlowControlCrashedNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 2
@@ -714,9 +699,6 @@ func TestFlowControlCrashedNode(t *testing.T) {
 func TestFlowControlRaftSnapshot(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	const numServers int = 5
 	stickyServerArgs := make(map[int]base.TestServerArgs)
@@ -1014,9 +996,6 @@ SELECT store_id,
 func TestFlowControlRaftTransportBreak(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 3
@@ -1129,9 +1108,6 @@ func TestFlowControlRaftTransportBreak(t *testing.T) {
 func TestFlowControlRaftTransportCulled(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 3
@@ -1268,9 +1244,6 @@ func TestFlowControlRaftTransportCulled(t *testing.T) {
 func TestFlowControlRaftMembership(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
@@ -1401,9 +1374,6 @@ ORDER BY name ASC;
 func TestFlowControlRaftMembershipRemoveSelf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	testutils.RunTrueAndFalse(t, "transfer-lease-first", func(t *testing.T, transferLeaseFirst bool) {
 		ctx := context.Background()
@@ -1532,9 +1502,6 @@ ORDER BY name ASC;
 func TestFlowControlClassPrioritization(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 5
@@ -1618,9 +1585,6 @@ func TestFlowControlClassPrioritization(t *testing.T) {
 func TestFlowControlQuiescedRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 3
@@ -1761,9 +1725,6 @@ ORDER BY name ASC;
 func TestFlowControlUnquiescedRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 3
@@ -1917,9 +1878,6 @@ ORDER BY name ASC;
 func TestFlowControlTransferLease(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 5
@@ -2008,9 +1966,6 @@ ORDER BY name ASC;
 func TestFlowControlLeaderNotLeaseholder(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 5
@@ -2144,9 +2099,6 @@ ORDER BY name ASC;
 func TestFlowControlGranterAdmitOneByOne(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 3

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -176,6 +176,9 @@ type StoreTestingKnobs struct {
 	DisableReplicaGCQueue bool
 	// DisableReplicateQueue disables the replication queue.
 	DisableReplicateQueue bool
+	// DisableStoreRebalancer turns off the store rebalancer which moves replicas
+	// and leases.
+	DisableStoreRebalancer bool
 	// DisableLoadBasedSplitting turns off LBS so no splits happen because of load.
 	DisableLoadBasedSplitting bool
 	// LoadBasedSplittingOverrideKey returns a key which should be used for load

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -581,6 +581,7 @@ func (tc *TestCluster) AddServer(
 		stkCopy.DisableSplitQueue = true
 		stkCopy.DisableMergeQueue = true
 		stkCopy.DisableReplicateQueue = true
+		stkCopy.DisableStoreRebalancer = true
 		serverArgs.Knobs.Store = &stkCopy
 	}
 


### PR DESCRIPTION
Only the last commit is relevant.

---

These were skipped to unblock merging https://github.com/cockroachdb/cockroach/pull/132125 and later (presumed to
be) fixed by https://github.com/cockroachdb/cockroach/pull/132563.

Un-skip all `TestFlowControl.*` v1 integration tests under duress.

Resolves: https://github.com/cockroachdb/cockroach/issues/132310
Release note: None