### PR TITLE
kvserver: unskip v2 flow control integration tests under duress 

### DIFF
--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -68,9 +68,6 @@ import (
 func TestFlowControlBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	testutils.RunTrueAndFalse(t, "always-enqueue", func(t *testing.T, alwaysEnqueue bool) {
 		ctx := context.Background()
@@ -223,9 +220,6 @@ ORDER BY streams DESC;
 func TestFlowControlRangeSplitMerge(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 3
@@ -341,9 +335,6 @@ ORDER BY streams DESC;
 func TestFlowControlBlockedAdmission(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 3
@@ -455,9 +446,6 @@ ORDER BY name ASC;
 func TestFlowControlAdmissionPostSplitMerge(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 3
@@ -594,9 +582,6 @@ ORDER BY streams DESC;
 func TestFlowControlCrashedNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 2
@@ -714,9 +699,6 @@ func TestFlowControlCrashedNode(t *testing.T) {
 func TestFlowControlRaftSnapshot(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	const numServers int = 5
 	stickyServerArgs := make(map[int]base.TestServerArgs)
@@ -1014,9 +996,6 @@ SELECT store_id,
 func TestFlowControlRaftTransportBreak(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 3
@@ -1129,9 +1108,6 @@ func TestFlowControlRaftTransportBreak(t *testing.T) {
 func TestFlowControlRaftTransportCulled(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 3
@@ -1268,9 +1244,6 @@ func TestFlowControlRaftTransportCulled(t *testing.T) {
 func TestFlowControlRaftMembership(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
@@ -1401,9 +1374,6 @@ ORDER BY name ASC;
 func TestFlowControlRaftMembershipRemoveSelf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	testutils.RunTrueAndFalse(t, "transfer-lease-first", func(t *testing.T, transferLeaseFirst bool) {
 		ctx := context.Background()
@@ -1532,9 +1502,6 @@ ORDER BY name ASC;
 func TestFlowControlClassPrioritization(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 5
@@ -1618,9 +1585,6 @@ func TestFlowControlClassPrioritization(t *testing.T) {
 func TestFlowControlQuiescedRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 3
@@ -1761,9 +1725,6 @@ ORDER BY name ASC;
 func TestFlowControlUnquiescedRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 3
@@ -1917,9 +1878,6 @@ ORDER BY name ASC;
 func TestFlowControlTransferLease(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 5
@@ -2008,9 +1966,6 @@ ORDER BY name ASC;
 func TestFlowControlLeaderNotLeaseholder(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 5
@@ -2144,9 +2099,6 @@ ORDER BY name ASC;
 func TestFlowControlGranterAdmitOneByOne(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TOOD(kvoli,pav-kv,sumeerbhola): Enable this test under all conditions
-	// after fixing the flakiness introduced by #132121.
-	skip.UnderDuressWithIssue(t, 132310)
 
 	ctx := context.Background()
 	const numNodes = 3

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
@@ -2207,7 +2206,6 @@ func TestFlowControlGranterAdmitOneByOne(t *testing.T) {
 func TestFlowControlBasicV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderDuressWithIssue(t, 132272, "non-determinism under duress: stress/race/deadlock")
 
 	testutils.RunValues(t, "v2_enabled_when_leader_level", []kvflowcontrol.V2EnabledWhenLeaderLevel{
 		kvflowcontrol.V2EnabledWhenLeaderV1Encoding,
@@ -2302,7 +2300,6 @@ ORDER BY streams DESC;
 func TestFlowControlRangeSplitMergeV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderDuressWithIssue(t, 132272, "non-determinism under duress: stress/race/deadlock")
 
 	testutils.RunValues(t, "v2_enabled_when_leader_level", []kvflowcontrol.V2EnabledWhenLeaderLevel{
 		kvflowcontrol.V2EnabledWhenLeaderV1Encoding,
@@ -2417,7 +2414,6 @@ ORDER BY streams DESC;
 func TestFlowControlBlockedAdmissionV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderDuressWithIssue(t, 132272, "non-determinism under duress: stress/race/deadlock")
 
 	testutils.RunValues(t, "v2_enabled_when_leader_level", []kvflowcontrol.V2EnabledWhenLeaderLevel{
 		kvflowcontrol.V2EnabledWhenLeaderV1Encoding,
@@ -2519,7 +2515,6 @@ func TestFlowControlBlockedAdmissionV2(t *testing.T) {
 func TestFlowControlAdmissionPostSplitMergeV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderDuressWithIssue(t, 132272, "non-determinism under duress: stress/race/deadlock")
 
 	testutils.RunValues(t, "v2_enabled_when_leader_level", []kvflowcontrol.V2EnabledWhenLeaderLevel{
 		kvflowcontrol.V2EnabledWhenLeaderV1Encoding,
@@ -2670,7 +2665,6 @@ ORDER BY streams DESC;
 func TestFlowControlCrashedNodeV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderDuressWithIssue(t, 132272, "non-determinism under duress: stress/race/deadlock")
 
 	testutils.RunValues(t, "v2_enabled_when_leader_level", []kvflowcontrol.V2EnabledWhenLeaderLevel{
 		kvflowcontrol.V2EnabledWhenLeaderV1Encoding,
@@ -2775,7 +2769,6 @@ func TestFlowControlCrashedNodeV2(t *testing.T) {
 func TestFlowControlRaftSnapshotV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderDuressWithIssue(t, 132272, "non-determinism under duress: stress/race/deadlock")
 
 	const numServers int = 5
 
@@ -3043,7 +3036,6 @@ SELECT store_id,
 func TestFlowControlRaftMembershipV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderDuressWithIssue(t, 132272, "non-determinism under duress: stress/race/deadlock")
 
 	testutils.RunValues(t, "v2_enabled_when_leader_level", []kvflowcontrol.V2EnabledWhenLeaderLevel{
 		kvflowcontrol.V2EnabledWhenLeaderV1Encoding,
@@ -3176,7 +3168,6 @@ func TestFlowControlRaftMembershipV2(t *testing.T) {
 func TestFlowControlRaftMembershipRemoveSelfV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderDuressWithIssue(t, 132272, "non-determinism under duress: stress/race/deadlock")
 
 	testutils.RunValues(t, "v2_enabled_when_leader_level", []kvflowcontrol.V2EnabledWhenLeaderLevel{
 		kvflowcontrol.V2EnabledWhenLeaderV1Encoding,
@@ -3313,7 +3304,6 @@ ORDER BY streams DESC;
 func TestFlowControlClassPrioritizationV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderDuressWithIssue(t, 132272, "non-determinism under duress: stress/race/deadlock")
 
 	testutils.RunValues(t, "v2_enabled_when_leader_level", []kvflowcontrol.V2EnabledWhenLeaderLevel{
 		kvflowcontrol.V2EnabledWhenLeaderV1Encoding,
@@ -3404,7 +3394,6 @@ func TestFlowControlClassPrioritizationV2(t *testing.T) {
 func TestFlowControlUnquiescedRangeV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderDuressWithIssue(t, 132272, "non-determinism under duress: stress/race/deadlock")
 
 	testutils.RunValues(t, "v2_enabled_when_leader_level", []kvflowcontrol.V2EnabledWhenLeaderLevel{
 		kvflowcontrol.V2EnabledWhenLeaderV1Encoding,
@@ -3423,7 +3412,6 @@ func TestFlowControlUnquiescedRangeV2(t *testing.T) {
 			settings := cluster.MakeTestingClusterSettings()
 			// Override metamorphism to allow range quiescence.
 			kvserver.ExpirationLeasesOnly.Override(ctx, &settings.SV, false)
-			pinnedLease := kvserver.NewPinnedLeases()
 			tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
 				ReplicationMode: base.ReplicationManual,
 				ServerArgs: base.TestServerArgs{
@@ -3435,10 +3423,6 @@ func TestFlowControlUnquiescedRangeV2(t *testing.T) {
 					},
 					Knobs: base.TestingKnobs{
 						Store: &kvserver.StoreTestingKnobs{
-							// Pin the lease to the first store to prevent lease and leader
-							// moves which disrupt this test.
-							PinnedLeases: pinnedLease,
-
 							FlowControlTestingKnobs: &kvflowcontrol.TestingKnobs{
 								UseOnlyForScratchRanges: true,
 								OverrideV2EnabledWhenLeaderLevel: func() kvflowcontrol.V2EnabledWhenLeaderLevel {
@@ -3475,7 +3459,6 @@ func TestFlowControlUnquiescedRangeV2(t *testing.T) {
 			k := tc.ScratchRange(t)
 			desc, err := tc.LookupRange(k)
 			require.NoError(t, err)
-			pinnedLease.PinLease(desc.RangeID, tc.GetFirstStoreFromServer(t, 0).StoreID())
 
 			tc.AddVotersOrFatal(t, k, tc.Targets(1, 2)...)
 			h := newFlowControlTestHelperV2(t, tc, v2EnabledWhenLeaderLevel)
@@ -3539,7 +3522,6 @@ func TestFlowControlUnquiescedRangeV2(t *testing.T) {
 func TestFlowControlTransferLeaseV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderDuressWithIssue(t, 132272, "non-determinism under duress: stress/race/deadlock")
 
 	testutils.RunValues(t, "v2_enabled_when_leader_level", []kvflowcontrol.V2EnabledWhenLeaderLevel{
 		kvflowcontrol.V2EnabledWhenLeaderV1Encoding,
@@ -3628,7 +3610,6 @@ func TestFlowControlTransferLeaseV2(t *testing.T) {
 func TestFlowControlLeaderNotLeaseholderV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderDuressWithIssue(t, 132272, "non-determinism under duress: stress/race/deadlock")
 
 	testutils.RunValues(t, "v2_enabled_when_leader_level", []kvflowcontrol.V2EnabledWhenLeaderLevel{
 		kvflowcontrol.V2EnabledWhenLeaderV1Encoding,
@@ -3741,7 +3722,6 @@ func TestFlowControlLeaderNotLeaseholderV2(t *testing.T) {
 func TestFlowControlGranterAdmitOneByOneV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderDuressWithIssue(t, 132272, "non-determinism under duress: stress/race/deadlock")
 
 	testutils.RunValues(t, "v2_enabled_when_leader_level", []kvflowcontrol.V2EnabledWhenLeaderLevel{
 		kvflowcontrol.V2EnabledWhenLeaderV1Encoding,

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -176,6 +176,9 @@ type StoreTestingKnobs struct {
 	DisableReplicaGCQueue bool
 	// DisableReplicateQueue disables the replication queue.
 	DisableReplicateQueue bool
+	// DisableStoreRebalancer turns off the store rebalancer which moves replicas
+	// and leases.
+	DisableStoreRebalancer bool
 	// DisableLoadBasedSplitting turns off LBS so no splits happen because of load.
 	DisableLoadBasedSplitting bool
 	// LoadBasedSplittingOverrideKey returns a key which should be used for load

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -581,6 +581,7 @@ func (tc *TestCluster) AddServer(
 		stkCopy.DisableSplitQueue = true
 		stkCopy.DisableMergeQueue = true
 		stkCopy.DisableReplicateQueue = true
+		stkCopy.DisableStoreRebalancer = true
 		serverArgs.Knobs.Store = &stkCopy
 	}
 


### PR DESCRIPTION
Similar to the prior commit, un-skip the v2 flow control integration
tests under duress.

These were disabled due to flakiness.

Resolves: https://github.com/cockroachdb/cockroach/issues/132272
Release note: None