### PR TITLE
roachtest: allow decommissioned error in decommission/drains test

### DIFF
--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -1056,10 +1056,11 @@ func runDecommissionDrains(ctx context.Context, t test.Test, c cluster.Cluster) 
 			return err
 		}
 
-		// Check to see if the node has been drained.
+		// Check to see if the node has been drained or decomissioned.
 		// If not, queries should not fail.
 		if err = run(decommNodeDB, `SHOW DATABASES`); err != nil {
-			if strings.Contains(err.Error(), "not accepting clients") { // drained
+			if strings.Contains(err.Error(), "not accepting clients") || // drained
+				strings.Contains(err.Error(), "node is decommissioned") { // decommissioned
 				return nil
 			}
 			t.Fatal(err)


### PR DESCRIPTION
Previously the test would only succeed if the returned error was a SQL error due to an inability to connect. Since the test is racy due to specifying `--wait=none` the query can also hit a decommssioned errror. This change additionally checks for that error.

Fixes: https://github.com/cockroachdb/cockroach/issues/132559

Release note: None