### PR TITLE
testutils,kvserver: disable store rebalancer when replication manual

### DIFF
--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -176,6 +176,9 @@ type StoreTestingKnobs struct {
 	DisableReplicaGCQueue bool
 	// DisableReplicateQueue disables the replication queue.
 	DisableReplicateQueue bool
+	// DisableStoreRebalancer turns off the store rebalancer which moves replicas
+	// and leases.
+	DisableStoreRebalancer bool
 	// DisableLoadBasedSplitting turns off LBS so no splits happen because of load.
 	DisableLoadBasedSplitting bool
 	// LoadBasedSplittingOverrideKey returns a key which should be used for load

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -581,6 +581,7 @@ func (tc *TestCluster) AddServer(
 		stkCopy.DisableSplitQueue = true
 		stkCopy.DisableMergeQueue = true
 		stkCopy.DisableReplicateQueue = true
+		stkCopy.DisableStoreRebalancer = true
 		serverArgs.Knobs.Store = &stkCopy
 	}
 


### PR DESCRIPTION
`ReplicationManual` can be specified in tests which use a test cluster to prevent lease/replica movements.

This proves vital if the test is asserting exactly on the placement of a range, or its leaseholder.

Also disable the store rebalancer, which could move both leases and replicas under `ReplicationManual` before.

Informs: #132310
Informs: #132272
Release note: None