### PR TITLE
roachtest: elide mode=default in ldr tests

### DIFF
--- a/pkg/cmd/roachtest/tests/logical_data_replication.go
+++ b/pkg/cmd/roachtest/tests/logical_data_replication.go
@@ -736,7 +736,7 @@ func setupLDR(
 
 	startLDR := func(targetDB *sqlutils.SQLRunner, sourceURL string) int {
 		options := ""
-		if mode.String() != "" {
+		if mode != Default {
 			options = fmt.Sprintf("WITH mode='%s'", mode)
 		}
 		targetDB.Exec(t, fmt.Sprintf("USE %s", dbName))


### PR DESCRIPTION
The valid modes are immediate or validated.

Release note: none.
Epic: none.