### PR TITLE
cluster-ui: bump version to 24.3.0-prerelease.1

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "24.3.0-prerelease.0",
+  "version": "24.3.0-prerelease.1",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump the cluster-ui pkg version.

Epic: none

Release note: None