### PR TITLE
rac2,kvserver,raft: use raft LogSnapshot directly

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -168,6 +168,10 @@ type RaftLogSnapshot interface {
 	//
 	// NB: the [start, end) interval is different from RawNode.LogSlice which
 	// accepts an open-closed interval.
+	// TODO(pav-kv): don't do this, since it's bug-prone. Both raft.LogSnapshot
+	// and this interface have the same signature, but different semantics; it is
+	// easy to make a mistake and pass one instead of another. Use the LogSnapshot
+	// directly.
 	//
 	// TODO(#132789): change the semantics so that maxSize can be exceeded not
 	// only if the first entry is large. It should be ok to exceed maxSize if the
@@ -175,6 +179,19 @@ type RaftLogSnapshot interface {
 	// paid the cost of fetching this entry anyway, so there is no need to drop it
 	// from the result.
 	LogSlice(start, end uint64, maxSize uint64) (raft.LogSlice, error)
+}
+
+// NewRaftLogSnapshot returns a RACv2 wrapper around the raft.LogSnapshot.
+func NewRaftLogSnapshot(from raft.LogSnapshot) RaftLogSnapshot {
+	return raftLogSnapshot(from)
+}
+
+// raftLogSnapshot implements RaftLogSnapshot.
+type raftLogSnapshot raft.LogSnapshot
+
+// LogSlice implements RaftLogSnapshot.
+func (l raftLogSnapshot) LogSlice(start, end uint64, maxSize uint64) (raft.LogSlice, error) {
+	return (raft.LogSnapshot(l)).LogSlice(start-1, end-1, maxSize)
 }
 
 // RaftMsgAppMode specifies how Raft (at the leader) generates MsgApps. In

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -71,7 +71,7 @@ type RangeController interface {
 	//
 	// Requires replica.raftMu to be held.
 	HandleSchedulerEventRaftMuLocked(
-		ctx context.Context, mode RaftMsgAppMode, logSnapshot RaftLogSnapshot)
+		ctx context.Context, mode RaftMsgAppMode, logSnapshot raft.LogSnapshot)
 	// AdmitRaftMuLocked handles the notification about the given replica's
 	// admitted vector change. No-op if the replica is not known, or the admitted
 	// vector is stale (either in Term, or the indices).
@@ -150,48 +150,6 @@ type RaftInterface interface {
 	// If it returns true, all the entries in the slice are in the message, and
 	// Next is advanced to be equal to end.
 	SendMsgAppRaftMuLocked(replicaID roachpb.ReplicaID, slice raft.LogSlice) (raftpb.Message, bool)
-}
-
-// RaftLogSnapshot abstract raft.LogSnapshot.
-type RaftLogSnapshot interface {
-	// LogSlice returns a slice containing a prefix of [start, end). It must
-	// only be called in MsgAppPull mode for followers. The maxSize is required
-	// to be > 0.
-	//
-	// Returns the longest prefix of entries in the [start, end) interval such
-	// that the total size of the entries does not exceed maxSize. The limit can
-	// only be exceeded if the first entry is larger than maxSize, in which case
-	// only this first entry is returned.
-	//
-	// Returns an error if the log is truncated beyond the start index, or there
-	// is some other transient problem.
-	//
-	// NB: the [start, end) interval is different from RawNode.LogSlice which
-	// accepts an open-closed interval.
-	// TODO(pav-kv): don't do this, since it's bug-prone. Both raft.LogSnapshot
-	// and this interface have the same signature, but different semantics; it is
-	// easy to make a mistake and pass one instead of another. Use the LogSnapshot
-	// directly.
-	//
-	// TODO(#132789): change the semantics so that maxSize can be exceeded not
-	// only if the first entry is large. It should be ok to exceed maxSize if the
-	// last entry makes it so. In the underlying storage implementation, we have
-	// paid the cost of fetching this entry anyway, so there is no need to drop it
-	// from the result.
-	LogSlice(start, end uint64, maxSize uint64) (raft.LogSlice, error)
-}
-
-// NewRaftLogSnapshot returns a RACv2 wrapper around the raft.LogSnapshot.
-func NewRaftLogSnapshot(from raft.LogSnapshot) RaftLogSnapshot {
-	return raftLogSnapshot(from)
-}
-
-// raftLogSnapshot implements RaftLogSnapshot.
-type raftLogSnapshot raft.LogSnapshot
-
-// LogSlice implements RaftLogSnapshot.
-func (l raftLogSnapshot) LogSlice(start, end uint64, maxSize uint64) (raft.LogSlice, error) {
-	return (raft.LogSnapshot(l)).LogSlice(start-1, end-1, maxSize)
 }
 
 // RaftMsgAppMode specifies how Raft (at the leader) generates MsgApps. In
@@ -389,7 +347,7 @@ type RaftEvent struct {
 	MsgApps map[roachpb.ReplicaID][]raftpb.Message
 	// LogSnapshot must be populated on the leader, when operating in MsgAppPull
 	// mode. It is used (along with RaftInterface) to construct MsgApps.
-	LogSnapshot RaftLogSnapshot
+	LogSnapshot raft.LogSnapshot
 	// ReplicasStateInfo contains the state of all replicas. This is used to
 	// determine if the state of a replica has changed, and if so, to update the
 	// flow control state. It also informs the RangeController of a replica's
@@ -420,7 +378,7 @@ func RaftEventFromMsgStorageAppendAndMsgApps(
 	replicaID roachpb.ReplicaID,
 	appendMsg raftpb.Message,
 	outboundMsgs []raftpb.Message,
-	logSnapshot RaftLogSnapshot,
+	logSnapshot raft.LogSnapshot,
 	msgAppScratch map[roachpb.ReplicaID][]raftpb.Message,
 	replicaStateInfoMap map[roachpb.ReplicaID]ReplicaStateInfo,
 ) RaftEvent {
@@ -836,7 +794,7 @@ type raftEventForReplica struct {
 	newEntries         []entryFCState
 	sendingEntries     []entryFCState
 	recreateSendStream bool
-	logSnapshot        RaftLogSnapshot
+	logSnapshot        raft.LogSnapshot
 }
 
 // raftEventAppendState is the general state computed from RaftEvent that is
@@ -870,7 +828,7 @@ func constructRaftEventForReplica(
 	latestReplicaStateInfo ReplicaStateInfo,
 	existingSendStreamState existingSendStreamState,
 	msgApps []raftpb.Message,
-	logSnapshot RaftLogSnapshot,
+	logSnapshot raft.LogSnapshot,
 	scratchSendingEntries []entryFCState,
 ) (_ raftEventForReplica, scratch []entryFCState) {
 	firstNewEntryIndex, lastNewEntryIndex := uint64(math.MaxUint64), uint64(math.MaxUint64)
@@ -1315,7 +1273,7 @@ func (rc *rangeController) computeVoterDirectives(
 
 // HandleSchedulerEventRaftMuLocked implements RangeController.
 func (rc *rangeController) HandleSchedulerEventRaftMuLocked(
-	ctx context.Context, mode RaftMsgAppMode, logSnapshot RaftLogSnapshot,
+	ctx context.Context, mode RaftMsgAppMode, logSnapshot raft.LogSnapshot,
 ) {
 	var scheduledScratch [5]*replicaState
 	// scheduled will contain all the replicas in scheduledMu.replicas, filtered
@@ -2315,7 +2273,7 @@ func (rs *replicaState) handleReadyStateRaftMuLocked(
 //
 // closedReplica => !scheduleAgain.
 func (rs *replicaState) scheduledRaftMuLocked(
-	ctx context.Context, mode RaftMsgAppMode, logSnapshot RaftLogSnapshot,
+	ctx context.Context, mode RaftMsgAppMode, logSnapshot raft.LogSnapshot,
 ) (scheduleAgain bool, updateWaiterSets bool) {
 	if rs.desc.ReplicaID == rs.parent.opts.LocalReplicaID {
 		panic("scheduled called on the leader replica")
@@ -2358,7 +2316,7 @@ func (rs *replicaState) scheduledRaftMuLocked(
 	// entries not subject to flow control will be tiny. We of course return the
 	// unused tokens for entries not subject to flow control.
 	slice, err := logSnapshot.LogSlice(
-		rss.mu.sendQueue.indexToSend, rss.mu.sendQueue.nextRaftIndex, uint64(bytesToSend))
+		rss.mu.sendQueue.indexToSend-1, rss.mu.sendQueue.nextRaftIndex-1, uint64(bytesToSend))
 	var msg raftpb.Message
 	if err == nil {
 		var sent bool
@@ -2560,7 +2518,7 @@ func (rss *replicaSendStream) handleReadyEntriesRaftMuAndStreamLocked(
 		// NB: this will not do IO since everything here is in the unstable log
 		// (see raft.LogSnapshot.unstable).
 		slice, err := event.logSnapshot.LogSlice(
-			event.sendingEntries[0].id.index, event.sendingEntries[n-1].id.index+1, math.MaxInt64)
+			event.sendingEntries[0].id.index-1, event.sendingEntries[n-1].id.index, math.MaxInt64)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"math"
 	"slices"
 	"sort"
 	"strconv"
@@ -321,6 +322,9 @@ func (s *testingRCState) getOrInitRange(
 		testRC.mu.evals = make(map[string]*testingRCEval)
 		testRC.mu.outstandingReturns = make(map[roachpb.ReplicaID]kvflowcontrol.Tokens)
 		testRC.mu.quorumPosition = kvflowcontrolpb.RaftLogPosition{Term: 1, Index: 0}
+		_ = testRC.raftLog.ApplySnapshot(raftpb.Snapshot{
+			Metadata: raftpb.SnapshotMetadata{Index: r.nextRaftIndex - 1},
+		})
 		options := RangeControllerOptions{
 			RangeID:                r.rangeID,
 			TenantID:               r.tenantID,
@@ -370,7 +374,7 @@ type testingRCRange struct {
 	// snapshots contain snapshots of the tracker state for different replicas,
 	// at various points in time. It is used in TestUsingSimulation.
 	snapshots []testingTrackerSnapshot
-	entries   []raftpb.Entry
+	raftLog   raft.MemoryStorage
 
 	mu struct {
 		syncutil.Mutex
@@ -433,28 +437,8 @@ func (r *testingRCRange) ScheduleControllerEvent(rangeID roachpb.RangeID) {
 	r.scheduleControllerEventCount.Add(1)
 }
 
-func (r *testingRCRange) LogSlice(start, end uint64, maxSize uint64) (raft.LogSlice, error) {
-	if start >= end {
-		panic("start >= end")
-	}
-	var size uint64
-	var entries []raftpb.Entry
-	for _, entry := range r.entries {
-		if entry.Index < start || entry.Index >= end {
-			continue
-		}
-		size += uint64(entry.Size())
-		// Allow exceeding the size limit only if this is the first entry.
-		if size > maxSize && len(entries) != 0 {
-			break
-		}
-		entries = append(entries, entry)
-		if size >= maxSize {
-			break
-		}
-	}
-	// TODO(pav-kv): use a real LogSnapshot and construct a correct LogSlice.
-	return raft.MakeLogSlice(entries), nil
+func (r *testingRCRange) logSnapshot() RaftLogSnapshot {
+	return raftLogSnapshot(raft.MakeLogSnapshot(&r.raftLog))
 }
 
 func (r *testingRCRange) SendMsgAppRaftMuLocked(
@@ -1225,16 +1209,19 @@ func TestRangeController(t *testing.T) {
 					mode = MsgAppPull
 				}
 				for _, event := range parseRaftEvents(t, d.Input) {
+					entries := make([]raftpb.Entry, len(event.entries))
+					for i, entry := range event.entries {
+						entries[i] = testingCreateEntry(t, entry)
+					}
 					testRC := state.ranges[event.rangeID]
+					require.NoError(t, testRC.raftLog.Append(entries))
+
 					raftEvent := RaftEvent{
 						MsgAppMode:        mode,
-						Entries:           make([]raftpb.Entry, len(event.entries)),
+						Entries:           entries,
 						MsgApps:           map[roachpb.ReplicaID][]raftpb.Message{},
-						LogSnapshot:       testRC,
+						LogSnapshot:       testRC.logSnapshot(),
 						ReplicasStateInfo: state.ranges[event.rangeID].replicasStateInfo(),
-					}
-					for i, entry := range event.entries {
-						raftEvent.Entries[i] = testingCreateEntry(t, entry)
 					}
 					msgApp := raftpb.Message{
 						Type: raftpb.MsgApp,
@@ -1243,7 +1230,6 @@ func TestRangeController(t *testing.T) {
 						// suffix of entries that were previously appended, down below.
 						Entries: nil,
 					}
-					testRC.entries = append(testRC.entries, raftEvent.Entries...)
 					func() {
 						testRC.mu.Lock()
 						defer testRC.mu.Unlock()
@@ -1260,11 +1246,9 @@ func TestRangeController(t *testing.T) {
 								} else {
 									fromIndex := event.sendingEntryRange[replicaID].fromIndex
 									toIndex := event.sendingEntryRange[replicaID].toIndex
-									for _, entry := range testRC.entries {
-										if entry.Index >= fromIndex && entry.Index <= toIndex {
-											msgApp.Entries = append(msgApp.Entries, entry)
-										}
-									}
+									entries, err := testRC.raftLog.Entries(fromIndex, toIndex+1, math.MaxUint64)
+									require.NoError(t, err)
+									msgApp.Entries = entries
 								}
 								raftEvent.MsgApps[replicaID] = append([]raftpb.Message(nil), msgApp)
 							}
@@ -1314,7 +1298,7 @@ func TestRangeController(t *testing.T) {
 				if d.HasArg("push-mode") {
 					mode = MsgAppPush
 				}
-				testRC.rc.HandleSchedulerEventRaftMuLocked(ctx, mode, testRC)
+				testRC.rc.HandleSchedulerEventRaftMuLocked(ctx, mode, testRC.logSnapshot())
 				// Sleep for a bit to allow any timers to fire.
 				time.Sleep(20 * time.Millisecond)
 				return state.sendStreamString(roachpb.RangeID(rangeID))
@@ -1565,12 +1549,6 @@ func testingFirst(args ...interface{}) interface{} {
 	return nil
 }
 
-type testLogSnapshot struct{}
-
-func (testLogSnapshot) LogSlice(start, end uint64, maxSize uint64) (raft.LogSlice, error) {
-	return raft.LogSlice{}, nil
-}
-
 func TestRaftEventFromMsgStorageAppendAndMsgAppsBasic(t *testing.T) {
 	// raftpb.Entry and raftpb.Message are only partially populated below, which
 	// could be improved in the future.
@@ -1613,10 +1591,10 @@ func TestRaftEventFromMsgStorageAppendAndMsgAppsBasic(t *testing.T) {
 		},
 	}
 	msgAppScratch := map[roachpb.ReplicaID][]raftpb.Message{}
-	var logSnap testLogSnapshot
+	logSnap := NewRaftLogSnapshot(raft.LogSnapshot{})
 	infoMap := map[roachpb.ReplicaID]ReplicaStateInfo{}
 	checkSnapAndMap := func(event RaftEvent) {
-		require.Equal(t, logSnap, event.LogSnapshot.(testLogSnapshot))
+		require.Equal(t, logSnap, event.LogSnapshot)
 		require.Equal(t, infoMap, event.ReplicasStateInfo)
 	}
 

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
@@ -437,8 +437,8 @@ func (r *testingRCRange) ScheduleControllerEvent(rangeID roachpb.RangeID) {
 	r.scheduleControllerEventCount.Add(1)
 }
 
-func (r *testingRCRange) logSnapshot() RaftLogSnapshot {
-	return raftLogSnapshot(raft.MakeLogSnapshot(&r.raftLog))
+func (r *testingRCRange) logSnapshot() raft.LogSnapshot {
+	return raft.MakeLogSnapshot(&r.raftLog)
 }
 
 func (r *testingRCRange) SendMsgAppRaftMuLocked(
@@ -1591,7 +1591,7 @@ func TestRaftEventFromMsgStorageAppendAndMsgAppsBasic(t *testing.T) {
 		},
 	}
 	msgAppScratch := map[roachpb.ReplicaID][]raftpb.Message{}
-	logSnap := NewRaftLogSnapshot(raft.LogSnapshot{})
+	logSnap := raft.LogSnapshot{}
 	infoMap := map[roachpb.ReplicaID]ReplicaStateInfo{}
 	checkSnapAndMap := func(event RaftEvent) {
 		require.Equal(t, logSnap, event.LogSnapshot)
@@ -1610,7 +1610,7 @@ func TestRaftEventFromMsgStorageAppendAndMsgAppsBasic(t *testing.T) {
 	event = RaftEventFromMsgStorageAppendAndMsgApps(
 		MsgAppPush, 20, raftpb.Message{}, nil, logSnap, msgAppScratch, infoMap)
 	checkSnapAndMap(event)
-	event.LogSnapshot = nil
+	event.LogSnapshot = raft.LogSnapshot{}
 	event.ReplicasStateInfo = nil
 	require.Equal(t, RaftEvent{}, event)
 	// Outbound msgs contains no MsgApps for a follower, since the only MsgApp
@@ -2262,7 +2262,7 @@ func TestConstructRaftEventForReplica(t *testing.T) {
 						tc.latestReplicaStateInfo,
 						tc.existingSendStreamState,
 						tc.msgApps,
-						nil,
+						raft.LogSnapshot{},
 						tc.scratchSendingEntries,
 					)
 				})
@@ -2274,7 +2274,7 @@ func TestConstructRaftEventForReplica(t *testing.T) {
 					tc.latestReplicaStateInfo,
 					tc.existingSendStreamState,
 					tc.msgApps,
-					nil,
+					raft.LogSnapshot{},
 					tc.scratchSendingEntries,
 				)
 				require.Equal(t, tc.expectedRaftEventReplica, gotRaftEventReplica)

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/rac2"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
+	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
@@ -353,7 +354,7 @@ type Processor interface {
 	//
 	// raftMu is held.
 	ProcessSchedulerEventRaftMuLocked(
-		ctx context.Context, mode rac2.RaftMsgAppMode, logSnapshot rac2.RaftLogSnapshot)
+		ctx context.Context, mode rac2.RaftMsgAppMode, logSnapshot raft.LogSnapshot)
 
 	// InspectRaftMuLocked returns a handle to inspect the state of the
 	// underlying range controller. It is used to power /inspectz-style debugging
@@ -1139,7 +1140,7 @@ func (p *processorImpl) AdmitForEval(
 
 // ProcessSchedulerEventRaftMuLocked implements Processor.
 func (p *processorImpl) ProcessSchedulerEventRaftMuLocked(
-	ctx context.Context, mode rac2.RaftMsgAppMode, logSnapshot rac2.RaftLogSnapshot,
+	ctx context.Context, mode rac2.RaftMsgAppMode, logSnapshot raft.LogSnapshot,
 ) {
 	p.opts.Replica.RaftMuAssertHeld()
 	if p.destroyed {

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -203,7 +203,7 @@ func (c *testRangeController) HandleRaftEventRaftMuLocked(
 }
 
 func (c *testRangeController) HandleSchedulerEventRaftMuLocked(
-	ctx context.Context, mode rac2.RaftMsgAppMode, logSnapshot rac2.RaftLogSnapshot,
+	_ context.Context, _ rac2.RaftMsgAppMode, _ raft.LogSnapshot,
 ) {
 	panic("HandleSchedulerEventRaftMuLocked is unimplemented")
 }

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/raft_node.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/raft_node.go
@@ -73,12 +73,3 @@ func (rn raftNodeForRACv2) SendMsgAppRaftMuLocked(
 	defer rn.r.MuUnlock()
 	return rn.RawNode.SendMsgApp(raftpb.PeerID(replicaID), ls)
 }
-
-type RaftLogSnapshot raft.LogSnapshot
-
-var _ rac2.RaftLogSnapshot = RaftLogSnapshot{}
-
-// LogSlice implements rac2.RaftLogSnapshot.
-func (l RaftLogSnapshot) LogSlice(start, end uint64, maxSize uint64) (raft.LogSlice, error) {
-	return (raft.LogSnapshot(l)).LogSlice(start-1, end-1, maxSize)
-}

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1000,7 +1000,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	// replica_rac2.Processor may need to do some work.
 	raftEvent := rac2.RaftEventFromMsgStorageAppendAndMsgApps(
 		rac2ModeForReady, r.ReplicaID(), msgStorageAppend, outboundMsgs,
-		replica_rac2.RaftLogSnapshot(logSnapshot),
+		rac2.NewRaftLogSnapshot(logSnapshot),
 		r.raftMu.msgAppScratchForFlowControl, replicaStateInfoMap)
 	r.flowControlV2.HandleRaftReadyRaftMuLocked(ctx, raftNodeBasicState, raftEvent)
 	if !hasReady {
@@ -1560,7 +1560,7 @@ func (r *Replica) processRACv2RangeController(ctx context.Context) {
 		}
 	}
 	r.flowControlV2.ProcessSchedulerEventRaftMuLocked(
-		ctx, r.mu.currentRACv2Mode, replica_rac2.RaftLogSnapshot(logSnapshot))
+		ctx, r.mu.currentRACv2Mode, rac2.NewRaftLogSnapshot(logSnapshot))
 }
 
 // SendMsgApp implements rac2.MsgAppSender.

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -999,8 +999,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	// Even if we don't have a Ready, or entries in Ready,
 	// replica_rac2.Processor may need to do some work.
 	raftEvent := rac2.RaftEventFromMsgStorageAppendAndMsgApps(
-		rac2ModeForReady, r.ReplicaID(), msgStorageAppend, outboundMsgs,
-		rac2.NewRaftLogSnapshot(logSnapshot),
+		rac2ModeForReady, r.ReplicaID(), msgStorageAppend, outboundMsgs, logSnapshot,
 		r.raftMu.msgAppScratchForFlowControl, replicaStateInfoMap)
 	r.flowControlV2.HandleRaftReadyRaftMuLocked(ctx, raftNodeBasicState, raftEvent)
 	if !hasReady {
@@ -1560,7 +1559,7 @@ func (r *Replica) processRACv2RangeController(ctx context.Context) {
 		}
 	}
 	r.flowControlV2.ProcessSchedulerEventRaftMuLocked(
-		ctx, r.mu.currentRACv2Mode, rac2.NewRaftLogSnapshot(logSnapshot))
+		ctx, r.mu.currentRACv2Mode, logSnapshot)
 }
 
 // SendMsgApp implements rac2.MsgAppSender.

--- a/pkg/raft/node_test.go
+++ b/pkg/raft/node_test.go
@@ -790,25 +790,25 @@ func TestNodeCommitPaginationAfterRestart(t *testing.T) {
 	}
 
 	s.hardState = persistedHardState
-	s.ents = make([]raftpb.Entry, 10)
+	entries := make([]raftpb.Entry, 10)
 	var size uint64
-	for i := range s.ents {
+	for i := range entries {
 		ent := raftpb.Entry{
 			Term:  1,
 			Index: uint64(i + 1),
 			Type:  raftpb.EntryNormal,
 			Data:  []byte("a"),
 		}
-
-		s.ents[i] = ent
+		entries[i] = ent
 		size += uint64(ent.Size())
 	}
+	s.ls = LogSlice{term: 1, entries: entries}
 
 	cfg := newTestConfig(1, 10, 1, s)
 	// Set a MaxSizePerMsg that would suggest to Raft that the last committed entry should
 	// not be included in the initial rd.CommittedEntries. However, our storage will ignore
 	// this and *will* return it (which is how the Commit index ended up being 10 initially).
-	cfg.MaxSizePerMsg = size - uint64(s.ents[len(s.ents)-1].Size()) - 1
+	cfg.MaxSizePerMsg = size - uint64(entries[len(entries)-1].Size()) - 1
 
 	rn, err := NewRawNode(cfg)
 	require.NoError(t, err)

--- a/pkg/raft/storage.go
+++ b/pkg/raft/storage.go
@@ -132,8 +132,9 @@ type inMemStorageCallStats struct {
 	initialState, firstIndex, lastIndex, entries, term, snapshot int
 }
 
-// MemoryStorage implements the Storage interface backed by an
-// in-memory array.
+// MemoryStorage implements the Storage interface backed by an in-memory slice.
+//
+// TODO(pav-kv): split into LogStorage and StateStorage.
 type MemoryStorage struct {
 	// Protects access to all fields. Most methods of MemoryStorage are
 	// run on the raft goroutine, but Append() is run on an application
@@ -142,18 +143,21 @@ type MemoryStorage struct {
 
 	hardState pb.HardState
 	snapshot  pb.Snapshot
-	// ents[i] has raft log position i+snapshot.Metadata.Index
-	ents []pb.Entry
+
+	// ls contains the log entries.
+	//
+	// TODO(pav-kv): the term field of the LogSlice is conservatively populated
+	// to be the last entry term, to keep the LogSlice valid. But it must be
+	// sourced from the upper layer's last accepted term (which is >= the last
+	// entry term).
+	ls LogSlice
 
 	callStats inMemStorageCallStats
 }
 
 // NewMemoryStorage creates an empty MemoryStorage.
 func NewMemoryStorage() *MemoryStorage {
-	return &MemoryStorage{
-		// When starting from scratch populate the list with a dummy entry at term zero.
-		ents: make([]pb.Entry, 1),
-	}
+	return &MemoryStorage{}
 }
 
 // InitialState implements the Storage interface.
@@ -175,22 +179,17 @@ func (ms *MemoryStorage) Entries(lo, hi, maxSize uint64) ([]pb.Entry, error) {
 	ms.Lock()
 	defer ms.Unlock()
 	ms.callStats.entries++
-	offset := ms.ents[0].Index
-	if lo <= offset {
+
+	if lo <= ms.ls.prev.index {
 		return nil, ErrCompacted
-	}
-	if hi > ms.lastIndex()+1 {
-		raftlogger.GetLogger().Panicf("entries' hi(%d) is out of bound lastindex(%d)", hi, ms.lastIndex())
-	}
-	// only contains dummy entries.
-	if len(ms.ents) == 1 {
-		return nil, ErrUnavailable
+	} else if last := ms.ls.lastIndex(); hi > last+1 {
+		raftlogger.GetLogger().Panicf("entries' hi(%d) is out of bound lastindex(%d)", hi, last)
 	}
 
-	ents := limitSize(ms.ents[lo-offset:hi-offset], entryEncodingSize(maxSize))
+	ents := limitSize(ms.ls.sub(lo-1, hi-1), entryEncodingSize(maxSize))
 	// NB: use the full slice expression to limit what the caller can do with the
 	// returned slice. For example, an append will reallocate and copy this slice
-	// instead of corrupting the neighbouring ms.ents.
+	// instead of corrupting the neighbouring entries.
 	return ents[:len(ents):len(ents)], nil
 }
 
@@ -199,14 +198,12 @@ func (ms *MemoryStorage) Term(i uint64) (uint64, error) {
 	ms.Lock()
 	defer ms.Unlock()
 	ms.callStats.term++
-	offset := ms.ents[0].Index
-	if i < offset {
+	if i < ms.ls.prev.index {
 		return 0, ErrCompacted
-	}
-	if int(i-offset) >= len(ms.ents) {
+	} else if i > ms.ls.lastIndex() {
 		return 0, ErrUnavailable
 	}
-	return ms.ents[i-offset].Term, nil
+	return ms.ls.termAt(i), nil
 }
 
 // LastIndex implements the Storage interface.
@@ -214,11 +211,7 @@ func (ms *MemoryStorage) LastIndex() uint64 {
 	ms.Lock()
 	defer ms.Unlock()
 	ms.callStats.lastIndex++
-	return ms.lastIndex()
-}
-
-func (ms *MemoryStorage) lastIndex() uint64 {
-	return ms.ents[0].Index + uint64(len(ms.ents)) - 1
+	return ms.ls.lastIndex()
 }
 
 // FirstIndex implements the Storage interface.
@@ -226,11 +219,7 @@ func (ms *MemoryStorage) FirstIndex() uint64 {
 	ms.Lock()
 	defer ms.Unlock()
 	ms.callStats.firstIndex++
-	return ms.firstIndex()
-}
-
-func (ms *MemoryStorage) firstIndex() uint64 {
-	return ms.ents[0].Index + 1
+	return ms.ls.prev.index + 1
 }
 
 // LogSnapshot implements the LogStorage interface.
@@ -252,16 +241,19 @@ func (ms *MemoryStorage) Snapshot() (pb.Snapshot, error) {
 func (ms *MemoryStorage) ApplySnapshot(snap pb.Snapshot) error {
 	ms.Lock()
 	defer ms.Unlock()
-
-	//handle check for old snapshot being applied
-	msIndex := ms.snapshot.Metadata.Index
-	snapIndex := snap.Metadata.Index
-	if msIndex >= snapIndex {
+	id := entryID{index: snap.Metadata.Index, term: snap.Metadata.Term}
+	// Check whether the snapshot is outdated.
+	if id.index <= ms.snapshot.Metadata.Index {
 		return ErrSnapOutOfDate
 	}
-
+	// The new snapshot represents committed state, so its last entry should be
+	// consistent with the previously committed one.
+	if oldTerm := ms.snapshot.Metadata.Term; id.term < oldTerm {
+		raftlogger.GetLogger().Panicf("snapshot at %+v regresses the term %d", id, oldTerm)
+	}
 	ms.snapshot = snap
-	ms.ents = []pb.Entry{{Term: snap.Metadata.Term, Index: snap.Metadata.Index}}
+	// TODO(pav-kv): the term must be the last accepted term passed in.
+	ms.ls = LogSlice{term: id.term, prev: id}
 	return nil
 }
 
@@ -276,15 +268,12 @@ func (ms *MemoryStorage) CreateSnapshot(
 	defer ms.Unlock()
 	if i <= ms.snapshot.Metadata.Index {
 		return pb.Snapshot{}, ErrSnapOutOfDate
-	}
-
-	offset := ms.ents[0].Index
-	if i > ms.lastIndex() {
-		raftlogger.GetLogger().Panicf("snapshot %d is out of bound lastindex(%d)", i, ms.lastIndex())
+	} else if last := ms.ls.lastIndex(); i > last {
+		raftlogger.GetLogger().Panicf("snapshot %d is out of bound lastindex(%d)", i, last)
 	}
 
 	ms.snapshot.Metadata.Index = i
-	ms.snapshot.Metadata.Term = ms.ents[i-offset].Term
+	ms.snapshot.Metadata.Term = ms.ls.termAt(i)
 	if cs != nil {
 		ms.snapshot.Metadata.ConfState = *cs
 	}
@@ -292,66 +281,49 @@ func (ms *MemoryStorage) CreateSnapshot(
 	return ms.snapshot, nil
 }
 
-// Compact discards all log entries prior to compactIndex.
+// Compact discards all log entries <= index.
 // It is the application's responsibility to not attempt to compact an index
 // greater than raftLog.applied.
-func (ms *MemoryStorage) Compact(compactIndex uint64) error {
+func (ms *MemoryStorage) Compact(index uint64) error {
 	ms.Lock()
 	defer ms.Unlock()
-	offset := ms.ents[0].Index
-	if compactIndex <= offset {
+	if index <= ms.ls.prev.index {
 		return ErrCompacted
+	} else if last := ms.ls.lastIndex(); index > last {
+		raftlogger.GetLogger().Panicf("compact %d is out of bound lastindex(%d)", index, last)
 	}
-	if compactIndex > ms.lastIndex() {
-		raftlogger.GetLogger().Panicf("compact %d is out of bound lastindex(%d)", compactIndex, ms.lastIndex())
-	}
-
-	i := compactIndex - offset
-	// NB: allocate a new slice instead of reusing the old ms.ents. Entries in
-	// ms.ents are immutable, and can be referenced from outside MemoryStorage
-	// through slices returned by ms.Entries().
-	ents := make([]pb.Entry, 1, uint64(len(ms.ents))-i)
-	ents[0].Index = ms.ents[i].Index
-	ents[0].Term = ms.ents[i].Term
-	ents = append(ents, ms.ents[i+1:]...)
-	ms.ents = ents
+	ms.ls = ms.ls.forward(index)
 	return nil
 }
 
 // Append the new entries to storage.
-// TODO (xiangli): ensure the entries are continuous and
-// entries[0].Index > ms.entries[0].Index
+//
+// TODO(pav-kv): pass in a LogSlice which carries correctness semantics.
 func (ms *MemoryStorage) Append(entries []pb.Entry) error {
 	if len(entries) == 0 {
 		return nil
 	}
-
 	ms.Lock()
 	defer ms.Unlock()
 
-	first := ms.firstIndex()
-	last := entries[0].Index + uint64(len(entries)) - 1
-
-	// shortcut if there is no new entry.
-	if last < first {
-		return nil
-	}
-	// truncate compacted entries
-	if first > entries[0].Index {
-		entries = entries[first-entries[0].Index:]
+	first := entries[0].Index
+	if first <= ms.ls.prev.index {
+		// Can not append at indices <= the compacted index.
+		return ErrCompacted
+	} else if last := ms.ls.lastIndex(); first > last+1 {
+		raftlogger.GetLogger().Panicf("missing log entry [last: %d, append at: %d]", last, first)
 	}
 
-	offset := entries[0].Index - ms.ents[0].Index
-	switch {
-	case uint64(len(ms.ents)) > offset:
-		// NB: full slice expression protects ms.ents at index >= offset from
-		// rewrites, as they may still be referenced from outside MemoryStorage.
-		ms.ents = append(ms.ents[:offset:offset], entries...)
-	case uint64(len(ms.ents)) == offset:
-		ms.ents = append(ms.ents, entries...)
-	default:
-		raftlogger.GetLogger().Panicf("missing log entry [last: %d, append at: %d]",
-			ms.lastIndex(), entries[0].Index)
+	// TODO(pav-kv): this must have the correct last accepted term. Pass in the
+	// logSlice to this append method to update it correctly.
+	ms.ls.term = entries[len(entries)-1].Term
+
+	if first == ms.ls.lastIndex()+1 { // appending at the end of the log
+		ms.ls.entries = append(ms.ls.entries, entries...)
+	} else { // first <= lastIndex, after checks above
+		prefix := ms.ls.sub(ms.ls.prev.index, first-1)
+		// NB: protect the suffix of the old slice from rewrites.
+		ms.ls.entries = append(prefix[:len(prefix):len(prefix)], entries...)
 	}
 	return nil
 }

--- a/pkg/raft/storage.go
+++ b/pkg/raft/storage.go
@@ -333,3 +333,14 @@ func (ms *MemoryStorage) Append(entries []pb.Entry) error {
 	}
 	return nil
 }
+
+// MakeLogSnapshot converts the MemoryStorage to a LogSnapshot type serving the
+// log from the MemoryStorage snapshot. Only for testing.
+func MakeLogSnapshot(ms *MemoryStorage) LogSnapshot {
+	return LogSnapshot{
+		first:    ms.FirstIndex(),
+		storage:  ms.LogSnapshot(),
+		unstable: ms.ls.forward(ms.ls.lastIndex()),
+		logger:   raftlogger.DiscardLogger,
+	}
+}

--- a/pkg/raft/storage.go
+++ b/pkg/raft/storage.go
@@ -224,8 +224,14 @@ func (ms *MemoryStorage) FirstIndex() uint64 {
 
 // LogSnapshot implements the LogStorage interface.
 func (ms *MemoryStorage) LogSnapshot() LogStorageSnapshot {
-	// TODO(pav-kv): return an immutable subset of MemoryStorage.
-	return ms
+	// Copy the log slice, and protect MemoryStorage from potential appends to it.
+	// Both MemoryStorage and the caller can append to the slice, but the full
+	// slice expression makes sure the two don't corrupt each other's slices.
+	ls := ms.ls
+	ls.entries = ls.entries[:len(ls.entries):len(ls.entries)]
+	// TODO(pav-kv): we don't need all other fields in MemoryStorage. Factor out a
+	// LogStorage sub-type, and return just the log slice with it.
+	return &MemoryStorage{ls: ls}
 }
 
 // Snapshot implements the Storage interface.

--- a/pkg/raft/storage_test.go
+++ b/pkg/raft/storage_test.go
@@ -26,7 +26,8 @@ import (
 )
 
 func TestStorageTerm(t *testing.T) {
-	ents := index(3).terms(3, 4, 5)
+	prev3 := entryID{index: 3, term: 3}
+	ls := prev3.append(4, 5)
 	tests := []struct {
 		i uint64
 
@@ -43,8 +44,7 @@ func TestStorageTerm(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
-			s := &MemoryStorage{ents: ents}
-
+			s := &MemoryStorage{ls: ls}
 			if tt.wpanic {
 				require.Panics(t, func() {
 					_, _ = s.Term(tt.i)
@@ -58,7 +58,9 @@ func TestStorageTerm(t *testing.T) {
 }
 
 func TestStorageEntries(t *testing.T) {
-	ents := index(3).terms(3, 4, 5, 6)
+	prev3 := entryID{index: 3, term: 3}
+	ls := prev3.append(4, 5, 6)
+	ents := ls.entries
 	tests := []struct {
 		lo, hi, maxsize uint64
 
@@ -73,17 +75,17 @@ func TestStorageEntries(t *testing.T) {
 		// even if maxsize is zero, the first entry should be returned
 		{4, 7, 0, nil, index(4).terms(4)},
 		// limit to 2
-		{4, 7, uint64(ents[1].Size() + ents[2].Size()), nil, index(4).terms(4, 5)},
+		{4, 7, uint64(ents[0].Size() + ents[1].Size()), nil, index(4).terms(4, 5)},
 		// limit to 2
-		{4, 7, uint64(ents[1].Size() + ents[2].Size() + ents[3].Size()/2), nil, index(4).terms(4, 5)},
-		{4, 7, uint64(ents[1].Size() + ents[2].Size() + ents[3].Size() - 1), nil, index(4).terms(4, 5)},
+		{4, 7, uint64(ents[0].Size() + ents[1].Size() + ents[2].Size()/2), nil, index(4).terms(4, 5)},
+		{4, 7, uint64(ents[0].Size() + ents[1].Size() + ents[2].Size() - 1), nil, index(4).terms(4, 5)},
 		// all
-		{4, 7, uint64(ents[1].Size() + ents[2].Size() + ents[3].Size()), nil, index(4).terms(4, 5, 6)},
+		{4, 7, uint64(ents[0].Size() + ents[1].Size() + ents[2].Size()), nil, index(4).terms(4, 5, 6)},
 	}
 
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
-			s := &MemoryStorage{ents: ents}
+			s := &MemoryStorage{ls: ls}
 			entries, err := s.Entries(tt.lo, tt.hi, tt.maxsize)
 			require.Equal(t, tt.werr, err)
 			require.Equal(t, tt.wentries, entries)
@@ -92,23 +94,21 @@ func TestStorageEntries(t *testing.T) {
 }
 
 func TestStorageLastIndex(t *testing.T) {
-	ents := index(3).terms(3, 4, 5)
-	s := &MemoryStorage{ents: ents}
+	s := &MemoryStorage{ls: entryID{index: 3, term: 3}.append(4, 5)}
 	require.Equal(t, uint64(5), s.LastIndex())
 	require.NoError(t, s.Append(index(6).terms(5)))
 	require.Equal(t, uint64(6), s.LastIndex())
 }
 
 func TestStorageFirstIndex(t *testing.T) {
-	ents := index(3).terms(3, 4, 5)
-	s := &MemoryStorage{ents: ents}
+	s := &MemoryStorage{ls: entryID{index: 3, term: 3}.append(4, 5)}
 	require.Equal(t, uint64(4), s.FirstIndex())
 	require.NoError(t, s.Compact(4))
 	require.Equal(t, uint64(5), s.FirstIndex())
 }
 
 func TestStorageCompact(t *testing.T) {
-	ents := index(3).terms(3, 4, 5)
+	ls := entryID{index: 3, term: 3}.append(4, 5)
 	tests := []struct {
 		i uint64
 
@@ -117,25 +117,25 @@ func TestStorageCompact(t *testing.T) {
 		wterm  uint64
 		wlen   int
 	}{
-		{2, ErrCompacted, 3, 3, 3},
-		{3, ErrCompacted, 3, 3, 3},
-		{4, nil, 4, 4, 2},
-		{5, nil, 5, 5, 1},
+		{2, ErrCompacted, 3, 3, 2},
+		{3, ErrCompacted, 3, 3, 2},
+		{4, nil, 4, 4, 1},
+		{5, nil, 5, 5, 0},
 	}
 
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
-			s := &MemoryStorage{ents: ents}
+			s := &MemoryStorage{ls: ls}
 			require.Equal(t, tt.werr, s.Compact(tt.i))
-			require.Equal(t, tt.windex, s.ents[0].Index)
-			require.Equal(t, tt.wterm, s.ents[0].Term)
-			require.Equal(t, tt.wlen, len(s.ents))
+			require.Equal(t, tt.windex, s.ls.prev.index)
+			require.Equal(t, tt.wterm, s.ls.prev.term)
+			require.Equal(t, tt.wlen, len(s.ls.entries))
 		})
 	}
 }
 
 func TestStorageCreateSnapshot(t *testing.T) {
-	ents := index(3).terms(3, 4, 5)
+	ls := entryID{index: 3, term: 3}.append(4, 5)
 	cs := &pb.ConfState{Voters: []pb.PeerID{1, 2, 3}}
 	data := []byte("data")
 
@@ -151,7 +151,7 @@ func TestStorageCreateSnapshot(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
-			s := &MemoryStorage{ents: ents}
+			s := &MemoryStorage{ls: ls}
 			snap, err := s.CreateSnapshot(tt.i, cs, data)
 			require.Equal(t, tt.werr, err)
 			require.Equal(t, tt.wsnap, snap)
@@ -160,7 +160,7 @@ func TestStorageCreateSnapshot(t *testing.T) {
 }
 
 func TestStorageAppend(t *testing.T) {
-	ents := index(3).terms(3, 4, 5)
+	ls := entryID{index: 3, term: 3}.append(4, 5)
 	tests := []struct {
 		entries []pb.Entry
 
@@ -169,49 +169,43 @@ func TestStorageAppend(t *testing.T) {
 	}{
 		{
 			index(1).terms(1, 2),
-			nil,
-			index(3).terms(3, 4, 5),
+			ErrCompacted,
+			index(4).terms(4, 5),
 		},
 		{
 			index(3).terms(3, 4, 5),
-			nil,
-			index(3).terms(3, 4, 5),
+			ErrCompacted,
+			index(4).terms(4, 5),
 		},
 		{
-			index(3).terms(3, 6, 6),
+			index(4).terms(6, 6),
 			nil,
-			index(3).terms(3, 6, 6),
+			index(4).terms(6, 6),
 		},
 		{
-			index(3).terms(3, 4, 5, 5),
+			index(4).terms(4, 5, 5),
 			nil,
-			index(3).terms(3, 4, 5, 5),
-		},
-		// Truncate incoming entries, truncate the existing entries and append.
-		{
-			index(2).terms(3, 3, 5),
-			nil,
-			index(3).terms(3, 5),
+			index(4).terms(4, 5, 5),
 		},
 		// Truncate the existing entries and append.
 		{
 			index(4).terms(5),
 			nil,
-			index(3).terms(3, 5),
+			index(4).terms(5),
 		},
 		// Direct append.
 		{
 			index(6).terms(5),
 			nil,
-			index(3).terms(3, 4, 5, 5),
+			index(4).terms(4, 5, 5),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
-			s := &MemoryStorage{ents: ents}
+			s := &MemoryStorage{ls: ls}
 			require.Equal(t, tt.werr, s.Append(tt.entries))
-			require.Equal(t, tt.wentries, s.ents)
+			require.Equal(t, tt.wentries, s.ls.entries)
 		})
 	}
 }

--- a/pkg/raft/types.go
+++ b/pkg/raft/types.go
@@ -103,15 +103,6 @@ type LogSlice struct {
 	entries []pb.Entry
 }
 
-// MakeLogSlice creates a fake log slice containing the supplied entries. Only
-// for testing.
-//
-// TODO(pav-kv): this is not a correct LogSlice. Remove this function, and help
-// construct a correct one.
-func MakeLogSlice(entries []pb.Entry) LogSlice {
-	return LogSlice{entries: entries}
-}
-
 // Entries returns the log entries covered by this slice. The returned slice
 // must not be mutated.
 func (s LogSlice) Entries() []pb.Entry {

--- a/pkg/raft/types.go
+++ b/pkg/raft/types.go
@@ -90,6 +90,10 @@ func (l LogMark) After(other LogMark) bool {
 // is sourced from a message that was received via transport, or from Storage,
 // or in a test code that manually hard-codes this struct. In these cases, the
 // invariants should be validated using the valid() method.
+//
+// The LogSlice is immutable. The entries slice must not be mutated, but it can
+// be appended to in some cases, when the callee protects its underlying slice
+// by capping the returned entries slice with a full slice expression.
 type LogSlice struct {
 	// term is the leader term containing the given entries in its log.
 	term uint64


### PR DESCRIPTION
This PR:

- refactors `raft.MemoryStorage` to support log snapshots
- converts `rac2` tests to use the real `LogSnapshot` (backed by `MemoryStorage`) instead of a fake one
- converts `rac2` code to pass `raft.LogSnapshot` by value instead of hiding it behind an interface that might allocate

Related to #128779