### PR TITLE
kvserver: disable follower pausing during RAC2 pull mode

### DIFF
--- a/pkg/kv/kvserver/replica_proposal_quota.go
+++ b/pkg/kv/kvserver/replica_proposal_quota.go
@@ -107,7 +107,8 @@ func (r *Replica) getQuotaPoolEnabledRLocked(ctx context.Context) bool {
 
 // shouldReplicationAdmissionControlUsePullMode returns whether replication
 // admission/flow control should use pull mode, which allows for a send-queue
-// and disabled raft's own flow control.
+// and disables raft's own flow control. If replication admission/flow control
+// is completely disabled, it returns false.
 func (r *Replica) shouldReplicationAdmissionControlUsePullMode(ctx context.Context) bool {
 	if knobs := r.store.cfg.TestingKnobs.FlowControlTestingKnobs; knobs != nil &&
 		knobs.OverridePullPushMode != nil {
@@ -121,9 +122,9 @@ func (r *Replica) shouldReplicationAdmissionControlUsePullMode(ctx context.Conte
 		versionEnabled = r.store.cfg.Settings.Version.IsActive(ctx, clusterversion.V24_3_UseRACV2Full)
 	}
 
-	return (versionEnabled &&
+	return versionEnabled &&
 		kvflowcontrol.Mode.Get(&r.store.cfg.Settings.SV) == kvflowcontrol.ApplyToAll &&
-		kvflowcontrol.Enabled.Get(&r.store.cfg.Settings.SV))
+		kvflowcontrol.Enabled.Get(&r.store.cfg.Settings.SV)
 }
 
 func (r *Replica) replicationAdmissionControlModeToUse(ctx context.Context) rac2.RaftMsgAppMode {

--- a/pkg/kv/kvserver/replica_raft_overload.go
+++ b/pkg/kv/kvserver/replica_raft_overload.go
@@ -308,6 +308,13 @@ func (r *Replica) updatePausedFollowersLocked(ctx context.Context, ioThresholdMa
 		return
 	}
 
+	if r.shouldReplicationAdmissionControlUsePullMode(ctx) {
+		// Replication admission control is enabled and is using pull-mode which
+		// allows for formation of a send-queue. The send-queue and pull-mode
+		// behavior is RAC2 subsumes follower pausing, so do not pause.
+		return
+	}
+
 	if !quotaPoolEnabledForRange(desc) {
 		// If the quota pool isn't enabled (like for the liveness range), play it
 		// safe. The range is unlikely to be a major contributor to any follower's


### PR DESCRIPTION
RAC2 pull mode subsumes follower pausing by maintaining a send-queue and ensuring there is a quorum without a send-queue. NB: follower pausing is already disabled by default, and not widely enabled.

Fixes https://github.com/cockroachdb/cockroach/issues/132617

Epic: CRDB-37515

Release note: None