### PR TITLE
changefeedccl: add jitter to changefeed retry delays

### DIFF
--- a/pkg/ccl/changefeedccl/retry.go
+++ b/pkg/ccl/changefeedccl/retry.go
@@ -20,9 +20,10 @@ var useFastRetry = envutil.EnvOrDefaultBool(
 // getRetry returns retry object for changefeed.
 func getRetry(ctx context.Context) Retry {
 	opts := retry.Options{
-		InitialBackoff: 5 * time.Second,
-		Multiplier:     2,
-		MaxBackoff:     10 * time.Minute,
+		InitialBackoff:      5 * time.Second,
+		Multiplier:          2,
+		MaxBackoff:          10 * time.Minute,
+		RandomizationFactor: 0.1,
 	}
 
 	if useFastRetry {


### PR DESCRIPTION
Add 10% jitter to changefeed retries, to mitigate
thundering herd PTS updates in <v24.1.

Fixes: #132602

Release note (enterprise change): Added 10% jitter to changefeed retry delays.
