### PR TITLE
release-23.1: roachtest: disable zone config evacuation for v22.2 nodes

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
@@ -19,8 +19,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/mixedversion"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/errors"
@@ -225,7 +227,16 @@ func runChangeReplicasMixedVersion(ctx context.Context, t test.Test, c cluster.C
 		})
 
 		for _, node := range nodes {
-			if r.Float64() < 0.5 {
+			// No patch release of v22.2 and earlier has #114365, so they have the
+			// potential to be flaky when evacuating nodes using zone configs. Don't
+			// use zone config movement for these versions.
+			bv, err := clusterupgrade.BinaryVersion(h.Connect(node))
+			if err != nil {
+				return errors.Wrapf(err, "failed to get binary version for node %d", node)
+			}
+			evacuateNodeUsingZoneConfigFlaky := bv.Less(roachpb.Version{Major: 23})
+
+			if r.Float64() < 0.5 && !evacuateNodeUsingZoneConfigFlaky {
 				if err := evacuateNodeUsingZoneConfig(ctx, l, r, h, node); err != nil {
 					return err
 				}


### PR DESCRIPTION
Closes #132546.

No patch release of v22.2 and earlier has #114365, so they have the potential to be flaky when evacuating nodes using zone configs. Don't use zone config movement for these versions.

Release note: None

Release justification: test only.