### PR TITLE
plpgsql: allow assigning to an element of a composite-typed variable

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_assign
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_assign
@@ -1,0 +1,124 @@
+statement ok
+CREATE TABLE xy (x INT, y INT);
+INSERT INTO xy VALUES (1, 2), (3, 4);
+
+subtest assign_elem
+
+# It is possible to assign to an element of a composite-typed variable.
+statement ok
+CREATE FUNCTION f(val xy) RETURNS xy AS $$
+  BEGIN
+    val.x := (val).x + 100;
+    RETURN val;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query TTT
+SELECT f(ROW(1, 2)), f(ROW(NULL, -1)), f(NULL::xy);
+----
+(101,2)  (,-1)  (,)
+
+query T rowsort
+SELECT f(ROW(x, y)) FROM xy;
+----
+(101,2)
+(103,4)
+
+statement ok
+DROP FUNCTION f;
+
+statement ok
+CREATE PROCEDURE p() LANGUAGE PLpgSQL AS $$
+  DECLARE
+    foo xy; -- Starts off as NULL.
+  BEGIN
+    foo.x := 1;
+    RAISE NOTICE '%', foo;
+    foo.y := 2;
+    RAISE NOTICE '%', foo;
+    foo.x := (foo).x + (foo).y;
+    RAISE NOTICE '%', foo;
+    foo.x = NULL;
+    RAISE NOTICE '%', foo;
+  END
+$$;
+
+query T noticetrace
+CALL p();
+----
+NOTICE: (1,)
+NOTICE: (1,2)
+NOTICE: (3,2)
+NOTICE: (,2)
+
+statement ok
+DROP PROCEDURE p;
+
+# The assigned value will be coerced to the type of the tuple element.
+# The coercion may fail at execution time if the type is wrong.
+statement ok
+CREATE FUNCTION f(val xy) RETURNS xy AS $$
+  BEGIN
+    val.x := ROW(100, 200);
+    RETURN val;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pgcode 22P02 pq: could not parse "\(100,200\)" as type int: strconv.ParseInt: parsing "\(100,200\)": invalid syntax
+SELECT f(ROW(1, 2));
+
+statement ok
+DROP FUNCTION f;
+
+# Qualifying variable names with a block label is still not supported (#122322).
+statement error pgcode 42601 pq: "b" is not a known variable
+CREATE PROCEDURE p() LANGUAGE PLpgSQL AS $$
+  <<b>>
+  DECLARE
+    x INT;
+  BEGIN
+    b.x := 5;
+  END
+$$;
+
+# Prefer to resolve as a variable with an indirection over a block-qualified
+# variable reference.
+statement ok
+CREATE PROCEDURE p() LANGUAGE PLpgSQL AS $$
+  <<b>>
+  DECLARE
+    b xy;
+  BEGIN
+    b.x := 5;
+    RAISE NOTICE '%', b;
+  END
+$$;
+
+query T noticetrace
+CALL p();
+----
+NOTICE: (5,)
+
+statement ok
+DROP PROCEDURE p;
+
+# The type of the variable must be a tuple. NOTE: this is the same error as the
+# one Postgres gives.
+statement error pgcode 42601 pq: "val.x" is not a known variable
+CREATE FUNCTION f(val INT) RETURNS INT AS $$
+  BEGIN
+    val.x := 5;
+    RETURN val;
+  END
+$$ LANGUAGE PLpgSQL;
+
+# The referenced element must be a field of the tuple.
+statement error pgcode 42703 pq: record "val" has no field "z"
+CREATE FUNCTION f(val xy) RETURNS xy AS $$
+  BEGIN
+    val.z := 5;
+    RETURN val;
+  END
+$$ LANGUAGE PLpgSQL;
+
+subtest end

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2689,6 +2689,13 @@ func TestTenantLogicCCL_pgcrypto_builtins(
 	runCCLLogicTest(t, "pgcrypto_builtins")
 }
 
+func TestTenantLogicCCL_plpgsql_assign(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_assign")
+}
+
 func TestTenantLogicCCL_plpgsql_block(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 30,
+    shard_count = 31,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
@@ -124,6 +124,13 @@ func TestCCLLogic_pgcrypto_builtins(
 	runCCLLogicTest(t, "pgcrypto_builtins")
 }
 
+func TestCCLLogic_plpgsql_assign(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_assign")
+}
+
 func TestCCLLogic_plpgsql_block(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 30,
+    shard_count = 31,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
@@ -124,6 +124,13 @@ func TestCCLLogic_pgcrypto_builtins(
 	runCCLLogicTest(t, "pgcrypto_builtins")
 }
 
+func TestCCLLogic_plpgsql_assign(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_assign")
+}
+
 func TestCCLLogic_plpgsql_block(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 31,
+    shard_count = 32,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
@@ -131,6 +131,13 @@ func TestCCLLogic_pgcrypto_builtins(
 	runCCLLogicTest(t, "pgcrypto_builtins")
 }
 
+func TestCCLLogic_plpgsql_assign(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_assign")
+}
+
 func TestCCLLogic_plpgsql_block(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 29,
+    shard_count = 30,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/generated_test.go
@@ -124,6 +124,13 @@ func TestCCLLogic_pgcrypto_builtins(
 	runCCLLogicTest(t, "pgcrypto_builtins")
 }
 
+func TestCCLLogic_plpgsql_assign(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_assign")
+}
+
 func TestCCLLogic_plpgsql_block(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-mixed-24.1/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-mixed-24.1/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 28,
+    shard_count = 29,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-mixed-24.1/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-mixed-24.1/generated_test.go
@@ -124,6 +124,13 @@ func TestCCLLogic_pgcrypto_builtins(
 	runCCLLogicTest(t, "pgcrypto_builtins")
 }
 
+func TestCCLLogic_plpgsql_assign(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_assign")
+}
+
 func TestCCLLogic_plpgsql_block(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-mixed-24.2/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-mixed-24.2/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 29,
+    shard_count = 30,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-mixed-24.2/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-mixed-24.2/generated_test.go
@@ -124,6 +124,13 @@ func TestCCLLogic_pgcrypto_builtins(
 	runCCLLogicTest(t, "pgcrypto_builtins")
 }
 
+func TestCCLLogic_plpgsql_assign(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_assign")
+}
+
 func TestCCLLogic_plpgsql_block(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -2638,6 +2638,13 @@ func TestReadCommittedLogicCCL_pgcrypto_builtins(
 	runCCLLogicTest(t, "pgcrypto_builtins")
 }
 
+func TestReadCommittedLogicCCL_plpgsql_assign(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_assign")
+}
+
 func TestReadCommittedLogicCCL_plpgsql_block(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
@@ -2631,6 +2631,13 @@ func TestRepeatableReadLogicCCL_pgcrypto_builtins(
 	runCCLLogicTest(t, "pgcrypto_builtins")
 }
 
+func TestRepeatableReadLogicCCL_plpgsql_assign(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_assign")
+}
+
 func TestRepeatableReadLogicCCL_plpgsql_block(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 30,
+    shard_count = 31,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
@@ -124,6 +124,13 @@ func TestCCLLogic_pgcrypto_builtins(
 	runCCLLogicTest(t, "pgcrypto_builtins")
 }
 
+func TestCCLLogic_plpgsql_assign(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_assign")
+}
+
 func TestCCLLogic_plpgsql_block(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local/generated_test.go
@@ -229,6 +229,13 @@ func TestCCLLogic_pgcrypto_builtins(
 	runCCLLogicTest(t, "pgcrypto_builtins")
 }
 
+func TestCCLLogic_plpgsql_assign(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_assign")
+}
+
 func TestCCLLogic_plpgsql_block(
 	t *testing.T,
 ) {

--- a/pkg/sql/plpgsql/parser/plpgsql.y
+++ b/pkg/sql/plpgsql/parser/plpgsql.y
@@ -785,6 +785,19 @@ stmt_assign: IDENT assign_operator expr_until_semi ';'
       Value: expr,
     }
   }
+| IDENT '.' IDENT assign_operator expr_until_semi ';'
+  {
+    // TODO(#91779, #122322): allow arbitrary nesting of indirection.
+    expr, err := plpgsqllex.(*lexer).ParseExpr($5)
+    if err != nil {
+      return setErr(plpgsqllex, err)
+    }
+    $$.val = &plpgsqltree.Assignment{
+      Var: plpgsqltree.Variable($1),
+      Value: expr,
+      Indirection: tree.Name($3),
+    }
+  }
 ;
 
 stmt_getdiag: GET getdiag_area_opt DIAGNOSTICS getdiag_list ';'

--- a/pkg/sql/plpgsql/parser/testdata/stmt_assign
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_assign
@@ -89,6 +89,41 @@ _ := 100;
 END;
  -- identifiers removed
 
+# We support assignment with indirection.
+parse
+BEGIN
+  a.b := 100;
+END
+----
+BEGIN
+a.b := 100;
+END;
+ -- normalized!
+BEGIN
+a.b := (100);
+END;
+ -- fully parenthesized
+BEGIN
+a.b := _;
+END;
+ -- literals removed
+BEGIN
+_._ := 100;
+END;
+ -- identifiers removed
+
+# We do not currently support more than one indirection.
+error
+BEGIN
+  a.b.c := 100;
+END
+----
+at or near ".": syntax error
+DETAIL: source SQL:
+BEGIN
+  a.b.c := 100;
+     ^
+
 error
 DECLARE
 BEGIN

--- a/pkg/sql/sem/plpgsqltree/statements.go
+++ b/pkg/sql/sem/plpgsqltree/statements.go
@@ -220,6 +220,10 @@ type Assignment struct {
 	StatementImpl
 	Var   Variable
 	Value Expr
+
+	// Indirection is the optional name of a field in a composite variable. For
+	// example, in the assignment "foo.bar := 1", Indirection would be "bar".
+	Indirection tree.Name
 }
 
 func (s *Assignment) CopyNode() *Assignment {
@@ -233,6 +237,10 @@ func (s *Assignment) PlpgSQLStatementTag() string {
 
 func (s *Assignment) Format(ctx *tree.FmtCtx) {
 	ctx.FormatNode(&s.Var)
+	if s.Indirection != "" {
+		ctx.WriteByte('.')
+		ctx.FormatNode(&s.Indirection)
+	}
 	ctx.WriteString(" := ")
 	ctx.FormatNode(s.Value)
 	ctx.WriteString(";\n")


### PR DESCRIPTION
#### plpgsql/parser: parse assign statements with indirection

This commit add support in the PL/pgSQL parser for an assignment
statement that assigns to an element of a variable, like `a.b := 5`.

Informs #132627

Release note: None

#### plpgsql: allow assigning to an element of a composite-typed variable

This patch adds support for assign statements that assign to an element of
a composite-typed variable, rather than just to the variable itself. Under
the hood, the other elements of the variable are copied into a new tuple
with the assigned value, and the result used to update the variable. This
is particularly useful for trigger functions, since users may want to update
rows in row-level BEFORE triggers like this example:
```
CREATE FUNCTION f() RETURNS TRIGGER AS $$
  BEGIN
    NEW.x = 100;
    RETURN NEW;
  END
$$ LANGUAGE PLpgSQL;

CREATE TRIGGER t BEFORE INSERT ON xy FOR EACH ROW EXECUTE FUNCTION f();
```
With this example, all inserts to table `xy` will now set `x` to 100.

Fixes #132627

Release note (sql change): It is now possible to assign to an element
of a composite typed varialbe in PL/pgSQL. For example, given a variable
`foo` with two integer elements `x` and `y`, the following assignment
statement is allowed: `foo.x := 100;`.