### PR TITLE
kvserver/rangefeed: remove context 

### DIFF
--- a/pkg/kv/kvclient/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvclient/rangefeed/BUILD.bazel
@@ -70,6 +70,7 @@ go_test(
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/kvserverbase",
+        "//pkg/kv/kvserver/rangefeed",
         "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -1456,7 +1456,7 @@ func TestRangeFeedIntentResolutionRace(t *testing.T) {
 	}
 	eventC := make(chan *kvpb.RangeFeedEvent)
 	sink := newChannelSink(ctx, eventC)
-	require.NoError(t, s3.RangeFeed(&req, sink)) // check if we've errored yet
+	require.NoError(t, s3.RangeFeed(sink.ctx, &req, sink)) // check if we've errored yet
 	require.NoError(t, sink.Error())
 	t.Logf("started rangefeed on %s", repl3)
 
@@ -1626,10 +1626,6 @@ type channelSink struct {
 
 func newChannelSink(ctx context.Context, ch chan<- *kvpb.RangeFeedEvent) *channelSink {
 	return &channelSink{ctx: ctx, ch: ch, done: make(chan *kvpb.Error, 1)}
-}
-
-func (c *channelSink) Context() context.Context {
-	return c.ctx
 }
 
 func (c *channelSink) SendUnbufferedIsThreadSafe() {}

--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
+	kvrangefeed "github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
@@ -1650,11 +1651,12 @@ func (c *channelSink) Error() error {
 	}
 }
 
-// Disconnect implements the Stream interface. It mocks the disconnect behavior
-// by sending the error to the done channel.
-func (c *channelSink) Disconnect(err *kvpb.Error) {
+// SendError implements the Stream interface.
+func (c *channelSink) SendError(err *kvpb.Error) {
 	c.done <- err
 }
+
+func (c *channelSink) AddRegistration(r kvrangefeed.Disconnector) {}
 
 // TestRangeFeedMetadataManualSplit tests that a spawned rangefeed emits a
 // metadata event which indicates if it spawned to due a manual split. The

--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -2520,8 +2520,6 @@ func (s *ScanStats) String() string {
 
 // RangeFeedEventSink is an interface for sending a single rangefeed event.
 type RangeFeedEventSink interface {
-	// Context returns the context for this stream.
-	Context() context.Context
 	// SendUnbuffered blocks until it sends the RangeFeedEvent, the stream is
 	// done, or the stream breaks. Send must be safe to call on the same stream in
 	// different goroutines.

--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -457,10 +457,6 @@ func newDummyStream(ctx context.Context, name string) *dummyStream {
 	}
 }
 
-func (s *dummyStream) Context() context.Context {
-	return s.ctx
-}
-
 func (s *dummyStream) SendUnbufferedIsThreadSafe() {}
 
 func (s *dummyStream) SendUnbuffered(ev *kvpb.RangeFeedEvent) error {
@@ -493,7 +489,7 @@ func waitReplicaRangeFeed(
 		return stream.SendUnbuffered(&event)
 	}
 
-	err := r.RangeFeed(req, stream, nil /* pacer */)
+	err := r.RangeFeed(stream.ctx, req, stream, nil /* pacer */)
 	if err != nil {
 		return sendErrToStream(kvpb.NewError(err))
 	}

--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -472,11 +473,12 @@ func (s *dummyStream) SendUnbuffered(ev *kvpb.RangeFeedEvent) error {
 	}
 }
 
-// Disconnect implements the Stream interface. It mocks the disconnect behavior
-// by sending the error to the done channel.
-func (s *dummyStream) Disconnect(err *kvpb.Error) {
+// SendError implements the Stream interface.
+func (s *dummyStream) SendError(err *kvpb.Error) {
 	s.done <- err
 }
+
+func (s *dummyStream) AddRegistration(d rangefeed.Disconnector) {}
 
 func waitReplicaRangeFeed(
 	ctx context.Context, r *kvserver.Replica, req *kvpb.RangeFeedRequest, stream *dummyStream,

--- a/pkg/kv/kvserver/rangefeed/bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/bench_test.go
@@ -192,10 +192,6 @@ type noopStream struct {
 	done   chan *kvpb.Error
 }
 
-func (s *noopStream) Context() context.Context {
-	return s.ctx
-}
-
 func (s *noopStream) SendUnbuffered(*kvpb.RangeFeedEvent) error {
 	s.events++
 	return nil

--- a/pkg/kv/kvserver/rangefeed/bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/bench_test.go
@@ -202,10 +202,13 @@ func (s *noopStream) SendUnbuffered(*kvpb.RangeFeedEvent) error {
 // thread-safety.
 func (s *noopStream) SendUnbufferedIsThreadSafe() {}
 
-// Disconnect implements the Stream interface. It mocks the disconnect behavior
-// by sending the error to the done channel.
-func (s *noopStream) Disconnect(error *kvpb.Error) {
+// SendError implements the Stream interface.
+func (s *noopStream) SendError(error *kvpb.Error) {
 	s.done <- error
+}
+
+func (s *noopStream) AddRegistration(r Disconnector) {
+
 }
 
 // WaitForError waits for the rangefeed to complete and returns the error sent

--- a/pkg/kv/kvserver/rangefeed/buffered_registration.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_registration.go
@@ -212,8 +212,6 @@ func (br *bufferedRegistration) outputLoop(ctx context.Context) error {
 			}
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-br.stream.Context().Done():
-			return br.stream.Context().Err()
 		}
 	}
 }

--- a/pkg/kv/kvserver/rangefeed/buffered_registration.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_registration.go
@@ -146,10 +146,10 @@ func (br *bufferedRegistration) publish(
 	}
 }
 
-// disconnect cancels the output loop context for the registration and passes an
+// Disconnect cancels the output loop context for the registration and passes an
 // error to the output error stream for the registration.
 // Safe to run multiple times, but subsequent errors would be discarded.
-func (br *bufferedRegistration) disconnect(pErr *kvpb.Error) {
+func (br *bufferedRegistration) Disconnect(pErr *kvpb.Error) {
 	br.mu.Lock()
 	defer br.mu.Unlock()
 	if !br.mu.disconnected {
@@ -161,7 +161,7 @@ func (br *bufferedRegistration) disconnect(pErr *kvpb.Error) {
 			br.mu.outputLoopCancelFn()
 		}
 		br.mu.disconnected = true
-		br.stream.Disconnect(pErr)
+		br.stream.SendError(pErr)
 	}
 }
 
@@ -226,7 +226,7 @@ func (br *bufferedRegistration) runOutputLoop(ctx context.Context, _forStacks ro
 	ctx, br.mu.outputLoopCancelFn = context.WithCancel(ctx)
 	br.mu.Unlock()
 	err := br.outputLoop(ctx)
-	br.disconnect(kvpb.NewError(err))
+	br.Disconnect(kvpb.NewError(err))
 }
 
 // drainAllocations should be done after registration is disconnected from

--- a/pkg/kv/kvserver/rangefeed/buffered_sender.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_sender.go
@@ -87,7 +87,11 @@ func (bs *BufferedSender) SendBufferedError(ev *kvpb.MuxRangeFeedEvent) {
 	panic("unimplemented: buffered sender for rangefeed #126560")
 }
 
-func (bs *BufferedSender) AddStream(streamID int64, cancel context.CancelFunc) {
+func (bs *BufferedSender) Disconnect(ev *kvpb.MuxRangeFeedEvent) bool {
+	panic("unimplemented: buffered sender for rangefeed #126560")
+}
+
+func (bs *BufferedSender) AddStream(streamID int64, r Disconnector) {
 	panic("unimplemented: buffered sender for rangefeed #126560")
 }
 

--- a/pkg/kv/kvserver/rangefeed/buffered_stream.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_stream.go
@@ -6,8 +6,6 @@
 package rangefeed
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 )
@@ -27,17 +25,15 @@ type BufferedStream interface {
 // similar to PerRangeEventSink but buffers events in BufferedSender before
 // forwarding events to the underlying grpc stream.
 type BufferedPerRangeEventSink struct {
-	ctx      context.Context
 	rangeID  roachpb.RangeID
 	streamID int64
 	wrapped  *BufferedSender
 }
 
 func NewBufferedPerRangeEventSink(
-	ctx context.Context, rangeID roachpb.RangeID, streamID int64, wrapped *BufferedSender,
+	rangeID roachpb.RangeID, streamID int64, wrapped *BufferedSender,
 ) *BufferedPerRangeEventSink {
 	return &BufferedPerRangeEventSink{
-		ctx:      ctx,
 		rangeID:  rangeID,
 		streamID: streamID,
 		wrapped:  wrapped,
@@ -47,10 +43,6 @@ func NewBufferedPerRangeEventSink(
 var _ kvpb.RangeFeedEventSink = (*BufferedPerRangeEventSink)(nil)
 var _ Stream = (*BufferedPerRangeEventSink)(nil)
 var _ BufferedStream = (*BufferedPerRangeEventSink)(nil)
-
-func (s *BufferedPerRangeEventSink) Context() context.Context {
-	return s.ctx
-}
 
 // SendUnbufferedIsThreadSafe is a no-op declaration method. It is a contract
 // that the SendUnbuffered method is thread-safe. Note that

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -460,7 +460,7 @@ func (p *LegacyProcessor) run(
 				}
 			}
 			if err := stopper.RunAsyncTask(ctx, "rangefeed: output loop", runOutputLoop); err != nil {
-				r.disconnect(kvpb.NewError(err))
+				r.Disconnect(kvpb.NewError(err))
 				p.reg.Unregister(ctx, r)
 			}
 
@@ -578,7 +578,7 @@ func (p *LegacyProcessor) sendStop(pErr *kvpb.Error) {
 	}
 }
 
-// Register  implements Processor interface.
+// Register implements Processor interface.
 func (p *LegacyProcessor) Register(
 	span roachpb.RSpan,
 	startTS hlc.Timestamp,
@@ -602,7 +602,9 @@ func (p *LegacyProcessor) Register(
 	select {
 	case p.regC <- r:
 		// Wait for response.
-		return true, <-p.filterResC
+		f := <-p.filterResC
+		stream.AddRegistration(r)
+		return true, f
 	case <-p.stoppedC:
 		return false, nil
 	}

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -304,7 +304,7 @@ func TestProcessorBasic(t *testing.T) {
 		// its own context and we don't have that registration any more. Maybe this
 		// is a hint that we should return registration from p.Register? Or maybe we
 		// should adjust our testing framework for this
-		r1Stream.Disconnect(kvpb.NewError(fmt.Errorf("disconnection error")))
+		r1Stream.SendError(kvpb.NewError(fmt.Errorf("disconnection error")))
 		require.NotNil(t, r1Stream.WaitForError(t))
 
 		// Stop the processor with an error.
@@ -1368,10 +1368,13 @@ func (c *consumer) WaitBlock() {
 	<-c.blocked
 }
 
-// Disconnect implements the Stream interface. It mocks the disconnect behavior
-// by sending the error to the done channel.
-func (c *consumer) Disconnect(error *kvpb.Error) {
+// SendError implements the Stream interface.
+func (c *consumer) SendError(error *kvpb.Error) {
 	c.done <- error
+}
+
+func (c *consumer) AddRegistration(r Disconnector) {
+
 }
 
 // WaitForError waits for the rangefeed to complete and returns the error sent

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -299,7 +299,12 @@ func TestProcessorBasic(t *testing.T) {
 		// r2Stream should not see the event.
 
 		// Cancel the first registration.
-		r1Stream.Cancel()
+		// TODO(ssd,wenyi): this is tricky we are losing some test coverage here by not
+		// having a context handle on the registration since registration now has
+		// its own context and we don't have that registration any more. Maybe this
+		// is a hint that we should return registration from p.Register? Or maybe we
+		// should adjust our testing framework for this
+		r1Stream.Disconnect(kvpb.NewError(fmt.Errorf("disconnection error")))
 		require.NotNil(t, r1Stream.WaitForError(t))
 
 		// Stop the processor with an error.
@@ -1353,10 +1358,6 @@ func (c *consumer) SendUnbuffered(e *kvpb.RangeFeedEvent) error {
 		}
 	}
 	return nil
-}
-
-func (c *consumer) Context() context.Context {
-	return c.ctx
 }
 
 func (c *consumer) Cancel() {

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -20,13 +20,12 @@ import (
 // registration defines an interface for registration that can be added to a
 // processor registry. Implemented by bufferedRegistration.
 type registration interface {
+	Disconnector
+
 	// publish sends the provided event to the registration. It is up to the
 	// registration implementation to decide how to handle the event and how to
 	// prevent missing events.
 	publish(ctx context.Context, event *kvpb.RangeFeedEvent, alloc *SharedBudgetAllocation)
-	// disconnect disconnects the registration with the provided error. Safe to
-	// run multiple times, but subsequent errors would be discarded.
-	disconnect(pErr *kvpb.Error)
 	// runOutputLoop runs the output loop for the registration. The output loop is
 	// meant to be run in a separate goroutine.
 	runOutputLoop(ctx context.Context, forStacks roachpb.RangeID)
@@ -57,6 +56,12 @@ type registration interface {
 	// getUnreg returns the unregisterFn call back of the registration. It should
 	// be called when being unregistered from processor.
 	getUnreg() func()
+}
+
+type Disconnector interface {
+	// Disconnect disconnects the registration with the provided error. Safe to
+	// run multiple times, but subsequent errors would be discarded.
+	Disconnect(pErr *kvpb.Error)
 }
 
 // baseRegistration is a common base for all registration types. It is intended
@@ -379,7 +384,7 @@ func (reg *registry) forOverlappingRegs(
 		r := i.(registration)
 		dis, pErr := fn(r)
 		if dis {
-			r.disconnect(pErr)
+			r.Disconnect(pErr)
 			toDelete = append(toDelete, i)
 		}
 		return false

--- a/pkg/kv/kvserver/rangefeed/registry_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_test.go
@@ -53,10 +53,6 @@ func newTestStream() *testStream {
 	return &testStream{ctx: ctx, ctxDone: done, done: make(chan *kvpb.Error, 1)}
 }
 
-func (s *testStream) Context() context.Context {
-	return s.ctx
-}
-
 func (s *testStream) Cancel() {
 	s.ctxDone()
 }
@@ -256,9 +252,9 @@ func TestRegistrationBasic(t *testing.T) {
 		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
 
 	streamCancelReg.Cancel()
-	go streamCancelReg.runOutputLoop(ctx, 0)
+	go streamCancelReg.runOutputLoop(streamCancelReg.ctx, 0)
 	require.NoError(t, streamCancelReg.waitForCaughtUp(ctx))
-	require.Equal(t, streamCancelReg.stream.Context().Err(), streamCancelReg.WaitForError(t))
+	require.Equal(t, streamCancelReg.ctx.Err(), streamCancelReg.WaitForError(t))
 }
 
 func TestRegistrationCatchUpScan(t *testing.T) {

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -320,6 +320,7 @@ func (p *ScheduledProcessor) Register(
 			span.AsRawSpanWithNoLocals(), startTS, catchUpIter, withDiff, withFiltering, withOmitRemote,
 			p.Config.EventChanCap, blockWhenFull, p.Metrics, stream, disconnectFn,
 		)
+
 	}
 
 	filter := runRequest(p, func(ctx context.Context, p *ScheduledProcessor) *Filter {
@@ -330,6 +331,7 @@ func (p *ScheduledProcessor) Register(
 			log.Fatalf(ctx, "registration %s not in Processor's key range %v", r, p.Span)
 		}
 
+		stream.AddRegistration(r)
 		// Add the new registration to the registry.
 		p.reg.Register(ctx, r)
 
@@ -359,7 +361,7 @@ func (p *ScheduledProcessor) Register(
 			// If we can't schedule internally, processor is already stopped which
 			// could only happen on shutdown. Disconnect stream and just remove
 			// registration.
-			r.disconnect(kvpb.NewError(err))
+			r.Disconnect(kvpb.NewError(err))
 			p.reg.Unregister(ctx, r)
 		}
 		return f

--- a/pkg/kv/kvserver/rangefeed/sender_helper_test.go
+++ b/pkg/kv/kvserver/rangefeed/sender_helper_test.go
@@ -35,9 +35,9 @@ func (c *testRangefeedCounter) UpdateMetricsOnRangefeedDisconnect() {
 	c.count.Add(-1)
 }
 
-func (c *testRangefeedCounter) get() int32 {
-	return c.count.Load()
-}
+//func (c *testRangefeedCounter) get() int32 {
+//	return c.count.Load()
+//}
 
 // testServerStream mocks grpc server stream for testing.
 type testServerStream struct {

--- a/pkg/kv/kvserver/rangefeed/stream.go
+++ b/pkg/kv/kvserver/rangefeed/stream.go
@@ -6,8 +6,6 @@
 package rangefeed
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 )
@@ -26,17 +24,15 @@ type Stream interface {
 // PerRangeEventSink is an implementation of Stream which annotates each
 // response with rangeID and streamID. It is used by MuxRangeFeed.
 type PerRangeEventSink struct {
-	ctx      context.Context
 	rangeID  roachpb.RangeID
 	streamID int64
 	wrapped  *UnbufferedSender
 }
 
 func NewPerRangeEventSink(
-	ctx context.Context, rangeID roachpb.RangeID, streamID int64, wrapped *UnbufferedSender,
+	rangeID roachpb.RangeID, streamID int64, wrapped *UnbufferedSender,
 ) *PerRangeEventSink {
 	return &PerRangeEventSink{
-		ctx:      ctx,
 		rangeID:  rangeID,
 		streamID: streamID,
 		wrapped:  wrapped,
@@ -45,10 +41,6 @@ func NewPerRangeEventSink(
 
 var _ kvpb.RangeFeedEventSink = (*PerRangeEventSink)(nil)
 var _ Stream = (*PerRangeEventSink)(nil)
-
-func (s *PerRangeEventSink) Context() context.Context {
-	return s.ctx
-}
 
 // SendUnbufferedIsThreadSafe is a no-op declaration method. It is a contract
 // that the SendUnbuffered method is thread-safe. Note that

--- a/pkg/kv/kvserver/rangefeed/stream.go
+++ b/pkg/kv/kvserver/rangefeed/stream.go
@@ -6,19 +6,55 @@
 package rangefeed
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
+
+// StreamManager manages one or more streams.
+//
+// Implemented by BufferedSender and UnbufferedSender.
+type StreamManager interface {
+	// SendBufferedError sends an error back to client. This call is
+	// non-blocking.
+	SendBufferedError(ev *kvpb.MuxRangeFeedEvent)
+
+	// Disconnect disconnects the stream with the ev.StreamID. This call is
+	// non-blocking, and additional clean-up takes place async. Caller cannot
+	// expect immediate disconnection. The returned bool indicates whether the
+	// given stream was previously registered with this manager.
+	Disconnect(ev *kvpb.MuxRangeFeedEvent) bool
+
+	// AddStream adds a new per-range stream for the streamManager to manage.
+	AddStream(streamID int64, r Disconnector)
+
+	// Start starts the streamManager background job to manage all active streams.
+	// It continues until it errors or Stop is called. It is not valid to call
+	// Start multiple times or restart after Stop.
+	Start(ctx context.Context, stopper *stop.Stopper) error
+
+	// Stop streamManager background job if it is still running.
+	Stop()
+
+	// Error returns a channel that will be non-empty if the streamManager
+	// encounters an error and a node level shutdown is required.
+	Error() chan error
+}
 
 // Stream is an object capable of transmitting RangeFeedEvents from a server
 // rangefeed to a client.
 type Stream interface {
 	kvpb.RangeFeedEventSink
-	// Disconnect disconnects the stream with the provided error. Note that this
-	// function can be called by the processor worker while holding raftMu, so it
-	// is important that this function doesn't block IO or try acquiring locks
-	// that could lead to deadlocks.
-	Disconnect(err *kvpb.Error)
+	// SendError sends an error to the stream. Since this function can be called by
+	// the processor worker while holding raftMu as part of
+	// registration.Disconnect(), it is important that this function doesn't block
+	// IO or try acquiring locks that could lead to deadlocks.
+	SendError(err *kvpb.Error)
+
+	AddRegistration(Disconnector)
 }
 
 // PerRangeEventSink is an implementation of Stream which annotates each
@@ -27,6 +63,7 @@ type PerRangeEventSink struct {
 	rangeID  roachpb.RangeID
 	streamID int64
 	wrapped  *UnbufferedSender
+	manager  StreamManager
 }
 
 func NewPerRangeEventSink(
@@ -36,6 +73,7 @@ func NewPerRangeEventSink(
 		rangeID:  rangeID,
 		streamID: streamID,
 		wrapped:  wrapped,
+		manager:  wrapped,
 	}
 }
 
@@ -56,11 +94,8 @@ func (s *PerRangeEventSink) SendUnbuffered(event *kvpb.RangeFeedEvent) error {
 	return s.wrapped.SendUnbuffered(response)
 }
 
-// Disconnect implements the Stream interface. It requests the UnbufferedSender
-// to detach the stream. The UnbufferedSender is then responsible for handling
-// the actual disconnection and additional cleanup. Note that Caller should not
-// rely on immediate disconnection as cleanup takes place async.
-func (s *PerRangeEventSink) Disconnect(err *kvpb.Error) {
+// Disconnect implements the Stream interface.
+func (s *PerRangeEventSink) SendError(err *kvpb.Error) {
 	ev := &kvpb.MuxRangeFeedEvent{
 		RangeID:  s.rangeID,
 		StreamID: s.streamID,
@@ -68,7 +103,12 @@ func (s *PerRangeEventSink) Disconnect(err *kvpb.Error) {
 	ev.MustSetValue(&kvpb.RangeFeedError{
 		Error: *transformRangefeedErrToClientError(err),
 	})
+	log.Infof(context.Background(), "s.wrapped.SendBufferedErr(%v)", ev)
 	s.wrapped.SendBufferedError(ev)
+}
+
+func (s *PerRangeEventSink) AddRegistration(r Disconnector) {
+	s.manager.AddStream(s.streamID, r)
 }
 
 // transformRangefeedErrToClientError converts a rangefeed error to a client

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -233,7 +233,10 @@ func (tp *rangefeedTxnPusher) Barrier(ctx context.Context) error {
 // complete. The surrounding store's ConcurrentRequestLimiter is used to limit
 // the number of rangefeeds using catch-up iterators at the same time.
 func (r *Replica) RangeFeed(
-	streamCtx context.Context, args *kvpb.RangeFeedRequest, stream rangefeed.Stream, pacer *admission.Pacer,
+	streamCtx context.Context,
+	args *kvpb.RangeFeedRequest,
+	stream rangefeed.Stream,
+	pacer *admission.Pacer,
 ) error {
 	streamCtx = r.AnnotateCtx(streamCtx)
 
@@ -507,7 +510,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 
 		scanner, err := rangefeed.NewSeparatedIntentScanner(ctx, r.store.TODOEngine(), desc.RSpan())
 		if err != nil {
-			stream.Disconnect(kvpb.NewError(err))
+			stream.SendError(kvpb.NewError(err))
 			return nil
 		}
 		return scanner

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -65,10 +65,6 @@ func (s *testStream) SetHeader(metadata.MD) error  { panic("unimplemented") }
 func (s *testStream) SendHeader(metadata.MD) error { panic("unimplemented") }
 func (s *testStream) SetTrailer(metadata.MD)       { panic("unimplemented") }
 
-func (s *testStream) Context() context.Context {
-	return s.ctx
-}
-
 func (s *testStream) Cancel() {
 	s.cancel()
 }
@@ -110,7 +106,7 @@ func (s *testStream) WaitForError(t *testing.T) error {
 func waitRangeFeed(
 	t *testing.T, store *kvserver.Store, req *kvpb.RangeFeedRequest, stream *testStream,
 ) error {
-	if err := store.RangeFeed(req, stream); err != nil {
+	if err := store.RangeFeed(stream.ctx, req, stream); err != nil {
 		return err
 	}
 	return stream.WaitForError(t)

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -84,11 +84,12 @@ func (s *testStream) Events() []*kvpb.RangeFeedEvent {
 	return s.mu.events
 }
 
-// Disconnect implements the Stream interface. It mocks the disconnect behavior
-// by sending the error to the done channel.
-func (s *testStream) Disconnect(error *kvpb.Error) {
+// SendError implements the Stream interface.
+func (s *testStream) SendError(error *kvpb.Error) {
 	s.done <- error
 }
+
+func (s *testStream) AddRegistration(rangefeed.Disconnector) {}
 
 // WaitForError waits for the rangefeed to complete and returns the error sent
 // to the done channel. It fails the test if rangefeed cannot complete within 30

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3232,7 +3232,7 @@ func (s *Store) Descriptor(ctx context.Context, useCached bool) (*roachpb.StoreD
 // RangeFeed registers a rangefeed over the specified span. It sends updates to
 // the provided stream and returns a future with an optional error when the rangefeed is
 // complete.
-func (s *Store) RangeFeed(args *kvpb.RangeFeedRequest, stream rangefeed.Stream) error {
+func (s *Store) RangeFeed(streamCtx context.Context, args *kvpb.RangeFeedRequest, stream rangefeed.Stream) error {
 	if filter := s.TestingKnobs().TestingRangefeedFilter; filter != nil {
 		if pErr := filter(args, stream); pErr != nil {
 			return pErr.GoError()
@@ -3259,7 +3259,7 @@ func (s *Store) RangeFeed(args *kvpb.RangeFeedRequest, stream rangefeed.Stream) 
 
 	tenID, _ := repl.TenantID()
 	pacer := s.cfg.KVAdmissionController.AdmitRangefeedRequest(tenID, args)
-	return repl.RangeFeed(args, stream, pacer)
+	return repl.RangeFeed(streamCtx, args, stream, pacer)
 }
 
 // updateReplicationGauges counts a number of simple replication statistics for

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3232,7 +3232,9 @@ func (s *Store) Descriptor(ctx context.Context, useCached bool) (*roachpb.StoreD
 // RangeFeed registers a rangefeed over the specified span. It sends updates to
 // the provided stream and returns a future with an optional error when the rangefeed is
 // complete.
-func (s *Store) RangeFeed(streamCtx context.Context, args *kvpb.RangeFeedRequest, stream rangefeed.Stream) error {
+func (s *Store) RangeFeed(
+	streamCtx context.Context, args *kvpb.RangeFeedRequest, stream rangefeed.Stream,
+) error {
 	if filter := s.TestingKnobs().TestingRangefeedFilter; filter != nil {
 		if pErr := filter(args, stream); pErr != nil {
 			return pErr.GoError()

--- a/pkg/kv/kvserver/stores.go
+++ b/pkg/kv/kvserver/stores.go
@@ -204,12 +204,11 @@ func (ls *Stores) SendWithWriteBytes(
 // RangeFeed registers a rangefeed over the specified span. It sends
 // updates to the provided stream and returns a future with an optional error
 // when the rangefeed is complete.
-func (ls *Stores) RangeFeed(args *kvpb.RangeFeedRequest, stream rangefeed.Stream) error {
-	ctx := stream.Context()
+func (ls *Stores) RangeFeed(streamCtx context.Context, args *kvpb.RangeFeedRequest, stream rangefeed.Stream) error {
 	if args.RangeID == 0 {
-		log.Fatal(ctx, "rangefeed request missing range ID")
+		log.Fatal(streamCtx, "rangefeed request missing range ID")
 	} else if args.Replica.StoreID == 0 {
-		log.Fatal(ctx, "rangefeed request missing store ID")
+		log.Fatal(streamCtx, "rangefeed request missing store ID")
 	}
 
 	store, err := ls.GetStore(args.Replica.StoreID)
@@ -217,7 +216,7 @@ func (ls *Stores) RangeFeed(args *kvpb.RangeFeedRequest, stream rangefeed.Stream
 		return err
 	}
 
-	return store.RangeFeed(args, stream)
+	return store.RangeFeed(streamCtx, args, stream)
 }
 
 // ReadBootstrapInfo implements the gossip.Storage interface. Read

--- a/pkg/kv/kvserver/stores.go
+++ b/pkg/kv/kvserver/stores.go
@@ -204,7 +204,9 @@ func (ls *Stores) SendWithWriteBytes(
 // RangeFeed registers a rangefeed over the specified span. It sends
 // updates to the provided stream and returns a future with an optional error
 // when the rangefeed is complete.
-func (ls *Stores) RangeFeed(streamCtx context.Context, args *kvpb.RangeFeedRequest, stream rangefeed.Stream) error {
+func (ls *Stores) RangeFeed(
+	streamCtx context.Context, args *kvpb.RangeFeedRequest, stream rangefeed.Stream,
+) error {
 	if args.RangeID == 0 {
 		log.Fatal(streamCtx, "rangefeed request missing range ID")
 	} else if args.Replica.StoreID == 0 {

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -283,10 +283,6 @@ type rangefeedEventSink struct {
 
 var _ kvpb.RangeFeedEventSink = (*rangefeedEventSink)(nil)
 
-func (s *rangefeedEventSink) Context() context.Context {
-	return s.ctx
-}
-
 // Note that SendUnbuffered itself is not thread-safe (grpc stream is not
 // thread-safe), but tests were written in a way that sends sequentially,
 // ensuring thread-safety for SendUnbuffered.

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -2043,27 +2043,6 @@ func (s *lockedMuxStream) Send(e *kvpb.MuxRangeFeedEvent) error {
 	return s.wrapped.Send(e)
 }
 
-// streamManager is an interface that defines the methods required to manage a
-// rangefeed.Stream at the node level. Implemented by rangefeed.BufferedSender
-// and rangefeed.UnbufferedSender.
-type streamManager interface {
-	// SendBufferedError disconnects the stream with the ev.StreamID and sends
-	// error back to client. This call is un-blocking, and additional clean-up
-	// takes place async. Caller cannot expect immediate disconnection.
-	SendBufferedError(ev *kvpb.MuxRangeFeedEvent)
-	// AddStream adds a new per-range stream for the streamManager to manage.
-	AddStream(streamID int64, cancel context.CancelFunc)
-	// Start starts the streamManager background job to manage all active streams.
-	// It continues until it errors or Stop is called. It is not valid to call
-	// Start multiple times or restart after Stop.
-	Start(ctx context.Context, stopper *stop.Stopper) error
-	// Stop streamManager background job if it is still running.
-	Stop()
-	// Error returns a channel that will be non-empty if the streamManager
-	// encounters an error and a node level shutdown is required.
-	Error() chan error
-}
-
 // MuxRangeFeed implements the roachpb.InternalServer interface.
 func (n *Node) MuxRangeFeed(muxStream kvpb.Internal_MuxRangeFeedServer) error {
 	lockedMuxStream := &lockedMuxStream{wrapped: muxStream}
@@ -2073,7 +2052,7 @@ func (n *Node) MuxRangeFeed(muxStream kvpb.Internal_MuxRangeFeedServer) error {
 	ctx, cancel := context.WithCancel(n.AnnotateCtx(muxStream.Context()))
 	defer cancel()
 
-	var sm streamManager
+	var sm rangefeed.StreamManager
 	if kvserver.RangefeedUseBufferedSender.Get(&n.storeCfg.Settings.SV) {
 		sm = rangefeed.NewBufferedSender(lockedMuxStream, n.metrics)
 		log.Fatalf(ctx, "unimplemented: buffered sender for rangefeed #126560")
@@ -2114,19 +2093,12 @@ func (n *Node) MuxRangeFeed(muxStream kvpb.Internal_MuxRangeFeedServer) error {
 			}
 
 			if req.CloseStream {
-				// For client close stream requests, we now shut down at a later time. Check if that is okay.
-				// Note that we will call DisconnectStreamWithError again when
-				// registration.disconnect happens, but DisconnectStreamWithError will
-				// ignore subsequent errors.
-				// TODO(ssd): to follow up in next pr cancelling streamCtx no longer
-				// works from here now
-				sm.SendBufferedError(makeMuxRangefeedErrorEvent(req.StreamID, req.RangeID,
+				sm.Disconnect(makeMuxRangefeedErrorEvent(req.StreamID, req.RangeID,
 					kvpb.NewError(kvpb.NewRangeFeedRetryError(kvpb.RangeFeedRetryError_REASON_RANGEFEED_CLOSED))))
 				continue
 			}
 
-			streamCtx, cancel := context.WithCancel(ctx)
-			streamCtx = logtags.AddTag(streamCtx, "r", req.RangeID)
+			streamCtx := logtags.AddTag(ctx, "r", req.RangeID)
 			streamCtx = logtags.AddTag(streamCtx, "sm", req.Replica.StoreID)
 			streamCtx = logtags.AddTag(streamCtx, "sid", req.StreamID)
 
@@ -2138,7 +2110,6 @@ func (n *Node) MuxRangeFeed(muxStream kvpb.Internal_MuxRangeFeedServer) error {
 			} else {
 				log.Fatalf(streamCtx, "unknown sender type %T", sm)
 			}
-			sm.AddStream(req.StreamID, cancel)
 
 			// Rangefeed attempts to register rangefeed a request over the specified
 			// span. If registration fails, it returns an error. Otherwise, it returns
@@ -2146,11 +2117,8 @@ func (n *Node) MuxRangeFeed(muxStream kvpb.Internal_MuxRangeFeedServer) error {
 			// the provided streamSink. If the rangefeed disconnects after being
 			// successfully registered, it calls streamSink.Disconnect with the error.
 			if err := n.stores.RangeFeed(streamCtx, req, streamSink); err != nil {
-				// TODO(ssd): to follow up in next pr cancelling streamCtx no longer
-				// works from here now; but it should be fine since r.disconnect should
-				// be happening down below? ssd can double check my thoughts
-				sm.SendBufferedError(
-					makeMuxRangefeedErrorEvent(req.StreamID, req.RangeID, kvpb.NewError(err)))
+				err := makeMuxRangefeedErrorEvent(req.StreamID, req.RangeID, kvpb.NewError(err))
+				sm.SendBufferedError(err)
 			}
 		}
 	}


### PR DESCRIPTION
TODO: make sure that there is nothing spun up from stores.Rangefeed watching for streamContext since we now do not do streamCtx cancellation during per registration disconnect

Epic: none