### PR TITLE
cluster-ui: fix index details page stories

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.stories.tsx
@@ -20,6 +20,7 @@ const withData: IndexDetailsPageProps = {
   nodeRegions: {},
   timeScale: null,
   details: {
+    databaseID: 1,
     loading: false,
     loaded: true,
     createStatement: `


### PR DESCRIPTION
Add `databaseID` prop to index page in story file. This error was preventing the cluster-ui publish
action from completing.

Epic: none

Release note: None