### PR TITLE
roachtest: default sysbench to --rand-type=uniform

### DIFF
--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -60,6 +60,7 @@ func (w sysbenchWorkload) String() string {
 
 type sysbenchOptions struct {
 	workload     sysbenchWorkload
+	distribution string // default `uniform`
 	duration     time.Duration
 	concurrency  int
 	tables       int
@@ -74,6 +75,10 @@ func (o *sysbenchOptions) cmd(haproxy bool) string {
 		pghost = "127.0.0.1"
 		pgport = "26257"
 	}
+	distribution := "uniform"
+	if o.distribution != "" {
+		distribution = o.distribution
+	}
 	return fmt.Sprintf(`sysbench \
 		--db-driver=pgsql \
 		--pgsql-host=%s \
@@ -82,6 +87,7 @@ func (o *sysbenchOptions) cmd(haproxy bool) string {
 		--pgsql-password=%s \
 		--pgsql-db=sysbench \
 		--report-interval=1 \
+		--rand-type=%s \
 		--time=%d \
 		--threads=%d \
 		--tables=%d \
@@ -92,6 +98,7 @@ func (o *sysbenchOptions) cmd(haproxy bool) string {
 		pgport,
 		install.DefaultUser,
 		install.DefaultPassword,
+		distribution,
 		int(o.duration.Seconds()),
 		o.concurrency,
 		o.tables,


### PR DESCRIPTION
`sysbench` at 1.0.20 (the latest release) uses its own "special"
built-in rand-type. This has hotspots and is generally unpleasant
and poorly understood.

Vendors generally recommend using `uniform`[^1], which we now default to
(I'll add a roachperf annotation). In addition, the next release of
sysbench - should it ever come, it's been four years - will _remove_ the
"special" distribution and default to uniform as well.

[^1]: https://docs.pingcap.com/tidb/stable/benchmark-tidb-using-sysbench

Epic: none
Release note: None
