### PR TITLE
schemachanger: disable dsc zone config by default

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -533,7 +533,6 @@ ALTER INDEX a@bar CONFIGURE ZONE USING gc.ttlseconds = 15000
 # verify zone config changes are logged
 ##################
 skipif config 3node-tenant-default-configs
-skipif config local-mixed-24.1
 query IT
 SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID' - 'Statement'
 FROM system.eventlog

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -303,6 +303,10 @@ onlyif config local-legacy-schema-changer
 statement error pq: user root does not have CREATE or ZONECONFIG privilege on relation columns
 ALTER TABLE information_schema.columns CONFIGURE ZONE USING gc.ttlseconds = 100000
 
+# TODO(annie): remove this override once CONFIGURE ZONE is enabled by default in the DSC
+statement ok
+SET CLUSTER SETTING sql.schema.force_declarative_statements = "+CONFIGURE ZONE"
+
 skipif config local-mixed-24.1
 skipif config local-legacy-schema-changer
 statement error pq: pg_type is a system catalog
@@ -312,6 +316,9 @@ skipif config local-mixed-24.1
 skipif config local-legacy-schema-changer
 statement error pq: columns is a virtual object and cannot be modified
 ALTER TABLE information_schema.columns CONFIGURE ZONE USING gc.ttlseconds = 100000
+
+statement ok
+RESET CLUSTER SETTING sql.schema.force_declarative_statements
 
 statement ok
 CREATE TABLE roachie(i int)

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
@@ -63,7 +63,7 @@ var supportedStatements = map[reflect.Type]supportedStatement{
 	reflect.TypeOf((*tree.CreateSchema)(nil)):        {fn: CreateSchema, statementTags: []string{tree.CreateSchemaTag}, on: true, checks: nil},
 	reflect.TypeOf((*tree.CreateSequence)(nil)):      {fn: CreateSequence, statementTags: []string{tree.CreateSequenceTag}, on: true, checks: isV241Active},
 	reflect.TypeOf((*tree.CreateDatabase)(nil)):      {fn: CreateDatabase, statementTags: []string{tree.CreateDatabaseTag}, on: true, checks: isV241Active},
-	reflect.TypeOf((*tree.SetZoneConfig)(nil)):       {fn: SetZoneConfig, statementTags: []string{tree.ConfigureZoneTag}, on: true, checks: isV242Active},
+	reflect.TypeOf((*tree.SetZoneConfig)(nil)):       {fn: SetZoneConfig, statementTags: []string{tree.ConfigureZoneTag}, on: false, checks: isV242Active},
 	reflect.TypeOf((*tree.CreateTrigger)(nil)):       {fn: CreateTrigger, statementTags: []string{tree.CreateTriggerTag}, on: true, checks: isV243Active},
 	reflect.TypeOf((*tree.DropTrigger)(nil)):         {fn: DropTrigger, statementTags: []string{tree.DropTriggerTag}, on: true, checks: isV243Active},
 }


### PR DESCRIPTION
This patch disables zone config statements in the declarative schema changer by default.

Release note: None
Epic: None