### PR TITLE
storage: enable FormatFlushableIngestExcises

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -2512,6 +2512,7 @@ func (p *Pebble) CreateCheckpoint(dir string, spans []roachpb.Span) error {
 // version associated with it, since they did so during the fence version.
 var pebbleFormatVersionMap = map[clusterversion.Key]pebble.FormatMajorVersion{
 	clusterversion.V24_1: pebble.FormatSyntheticPrefixSuffix,
+	clusterversion.V24_3: pebble.FormatFlushableIngestExcises,
 }
 
 // pebbleFormatVersionKeys contains the keys in the map above, in descending order.


### PR DESCRIPTION
Future work will bump the format major version further to FormatColumnarBlocks, but that work is blocked on a regression associated with the recent Pebble version bump.

Epic: none
Release note: none