### PR TITLE
release-23.1: server: Fix NPE in spanStatsFanOut

### DIFF
--- a/pkg/server/span_stats_server.go
+++ b/pkg/server/span_stats_server.go
@@ -41,8 +41,6 @@ func (s *systemStatusServer) spanStatsFanOut(
 		res.SpanToStats[sp.String()] = &roachpb.SpanStats{}
 	}
 
-	responses := make(map[string]struct{})
-
 	spansPerNode, err := s.getSpansPerNode(ctx, req)
 	if err != nil {
 		return nil, err
@@ -91,33 +89,6 @@ func (s *systemStatusServer) spanStatsFanOut(
 		return resp, err
 	}
 
-	responseFn := func(nodeID roachpb.NodeID, resp interface{}) {
-		// Noop if nil response (returned from skipped node).
-		if resp == nil {
-			return
-		}
-
-		nodeResponse := resp.(*roachpb.SpanStatsResponse)
-
-		// Values of ApproximateDiskBytes should be physical values, but
-		// TotalStats (MVCC stats) should be the logical, pre-replicated value.
-		// Note: This implementation can return arbitrarily stale values, because instead of getting
-		// MVCC stats from the leaseholder, MVCC stats are taken from the node that responded first.
-		// See #108779.
-		for spanStr, spanStats := range nodeResponse.SpanToStats {
-			// Accumulate physical values across all replicas:
-			res.SpanToStats[spanStr].ApproximateDiskBytes += spanStats.ApproximateDiskBytes
-
-			// Logical values: take the values from the node that responded first.
-			// TODO: This should really be read from the leaseholder.
-			if _, ok := responses[spanStr]; !ok {
-				res.SpanToStats[spanStr].TotalStats = spanStats.TotalStats
-				res.SpanToStats[spanStr].RangeCount = spanStats.RangeCount
-				responses[spanStr] = struct{}{}
-			}
-		}
-	}
-
 	errorFn := func(nodeID roachpb.NodeID, err error) {
 		log.Errorf(ctx, nodeErrorMsgPlaceholder, nodeID, err)
 		errorMessage := fmt.Sprintf("%v", err)
@@ -131,13 +102,58 @@ func (s *systemStatusServer) spanStatsFanOut(
 		timeout,
 		smartDial,
 		nodeFn,
-		responseFn,
+		collectSpanStatsResponses(ctx, res),
 		errorFn,
 	); err != nil {
 		return nil, err
 	}
 
 	return res, nil
+}
+
+// collectSpanStatsResponses takes a *roachpb.SpanStatsResponse and creates a closure around it
+// to provide as a callback to fanned out SpanStats requests.
+func collectSpanStatsResponses(
+	ctx context.Context, res *roachpb.SpanStatsResponse,
+) func(nodeID roachpb.NodeID, resp interface{}) {
+	responses := make(map[string]struct{})
+	return func(nodeID roachpb.NodeID, resp interface{}) {
+		// Noop if nil response (returned from skipped node).
+		if resp == nil {
+			return
+		}
+
+		nodeResponse := resp.(*roachpb.SpanStatsResponse)
+
+		// Values of ApproximateDiskBytes should be physical values, but
+		// TotalStats (MVCC stats) should be the logical, pre-replicated value.
+		// Note: This implementation can return arbitrarily stale values, because instead of getting
+		// MVCC stats from the leaseholder, MVCC stats are taken from the node that responded first.
+		// See #108779.
+		for spanStr, spanStats := range nodeResponse.SpanToStats {
+			if spanStats == nil {
+				log.Errorf(ctx, "Span stats for %s from node response is nil", spanStr)
+				continue
+			}
+
+			_, ok := res.SpanToStats[spanStr]
+			if !ok {
+				log.Warningf(ctx, "Received Span not in original request: %s", spanStr)
+				res.SpanToStats[spanStr] = &roachpb.SpanStats{}
+			}
+
+			// Accumulate physical values across all replicas:
+			res.SpanToStats[spanStr].ApproximateDiskBytes += spanStats.ApproximateDiskBytes
+
+			// Logical values: take the values from the node that responded first.
+			// TODO: This should really be read from the leaseholder.
+			if _, ok := responses[spanStr]; !ok {
+				res.SpanToStats[spanStr].TotalStats = spanStats.TotalStats
+				res.SpanToStats[spanStr].RangeCount = spanStats.RangeCount
+				responses[spanStr] = struct{}{}
+			}
+		}
+	}
 }
 
 func (s *systemStatusServer) getLocalStats(

--- a/pkg/server/span_stats_server_test.go
+++ b/pkg/server/span_stats_server_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
@@ -101,4 +102,185 @@ func TestSpanStatsBatching(t *testing.T) {
 		require.Equal(t, len(tcase.expectedBatches), len(res.Errors))
 	}
 
+}
+
+func TestCollectSpanStatsResponses(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	type nodeResponse struct {
+		nodeID roachpb.NodeID
+		resp   *roachpb.SpanStatsResponse
+	}
+	type testCase struct {
+		actualRes     *roachpb.SpanStatsResponse
+		nodeResponses []nodeResponse
+		expectedRes   *roachpb.SpanStatsResponse
+	}
+
+	var testCases []testCase
+
+	// test case 1
+	tc1 := testCase{
+		actualRes: createSpanStatsResponse("span1", "span2"),
+		nodeResponses: []nodeResponse{
+			{nodeID: 1, resp: &roachpb.SpanStatsResponse{
+				SpanToStats: map[string]*roachpb.SpanStats{
+					"span1": {RangeCount: 1,
+						ApproximateDiskBytes: 1,
+					},
+				},
+			}},
+			{nodeID: 2, resp: &roachpb.SpanStatsResponse{
+				SpanToStats: map[string]*roachpb.SpanStats{
+					"span2": {RangeCount: 1,
+						ApproximateDiskBytes: 1,
+					},
+				},
+			}},
+		},
+		expectedRes: &roachpb.SpanStatsResponse{
+			SpanToStats: map[string]*roachpb.SpanStats{
+				"span1": {RangeCount: 1,
+					ApproximateDiskBytes: 1,
+				},
+				"span2": {RangeCount: 1,
+					ApproximateDiskBytes: 1,
+				},
+			},
+		},
+	}
+	testCases = append(testCases, tc1)
+
+	// test case 2 - span is replicated in node 1 and 2
+	totalStats1 := enginepb.MVCCStats{LiveBytes: 1}
+	totalStats2 := enginepb.MVCCStats{LiveBytes: 2}
+	expectedApproxTotalStats := enginepb.MVCCStats{}
+	expectedApproxTotalStats.Add(totalStats1)
+	expectedApproxTotalStats.Add(totalStats2)
+	tc2 := testCase{
+		actualRes: createSpanStatsResponse("span1", "span2"),
+		nodeResponses: []nodeResponse{
+			{nodeID: 1, resp: &roachpb.SpanStatsResponse{
+				SpanToStats: map[string]*roachpb.SpanStats{
+					"span1": {
+						TotalStats:           totalStats1,
+						RangeCount:           1,
+						ApproximateDiskBytes: 1,
+					},
+				},
+			}},
+			{nodeID: 2, resp: &roachpb.SpanStatsResponse{
+				SpanToStats: map[string]*roachpb.SpanStats{
+					"span1": {
+						TotalStats:           totalStats2,
+						RangeCount:           1,
+						ApproximateDiskBytes: 1,
+					},
+				},
+			}},
+		},
+		expectedRes: &roachpb.SpanStatsResponse{
+			SpanToStats: map[string]*roachpb.SpanStats{
+				"span1": {
+					TotalStats:           totalStats1,
+					RangeCount:           1,
+					ApproximateDiskBytes: 2,
+				},
+			},
+		},
+	}
+	testCases = append(testCases, tc2)
+
+	// test case 3 - node response spanToStats value is nil for span2
+	tc3 := testCase{
+		actualRes: createSpanStatsResponse("span1", "span2"),
+		nodeResponses: []nodeResponse{
+			{nodeID: 1, resp: &roachpb.SpanStatsResponse{
+				SpanToStats: map[string]*roachpb.SpanStats{
+					"span1": {
+						RangeCount:           1,
+						ApproximateDiskBytes: 1,
+					},
+				},
+			}},
+			{nodeID: 2, resp: &roachpb.SpanStatsResponse{
+				SpanToStats: map[string]*roachpb.SpanStats{
+					"span2": nil,
+				},
+			}},
+		},
+		expectedRes: &roachpb.SpanStatsResponse{
+			SpanToStats: map[string]*roachpb.SpanStats{
+				"span1": {
+					RangeCount:           1,
+					ApproximateDiskBytes: 1,
+				},
+				"span2": {},
+			},
+		},
+	}
+	testCases = append(testCases, tc3)
+
+	// test case 4 - node response contains span not in original response struct
+	tc4 := testCase{
+		actualRes: createSpanStatsResponse("span1"),
+		nodeResponses: []nodeResponse{
+			{nodeID: 1, resp: &roachpb.SpanStatsResponse{
+				SpanToStats: map[string]*roachpb.SpanStats{
+					"span1": {
+						RangeCount:           1,
+						ApproximateDiskBytes: 1,
+					},
+				},
+			}},
+			{nodeID: 2, resp: &roachpb.SpanStatsResponse{
+				SpanToStats: map[string]*roachpb.SpanStats{
+					"span2": {
+						RangeCount:           1,
+						ApproximateDiskBytes: 1,
+					},
+				},
+			}},
+		},
+		expectedRes: &roachpb.SpanStatsResponse{
+			SpanToStats: map[string]*roachpb.SpanStats{
+				"span1": {
+					RangeCount:           1,
+					ApproximateDiskBytes: 1,
+				},
+				"span2": {
+					RangeCount:           1,
+					ApproximateDiskBytes: 1,
+				},
+			},
+		},
+	}
+	testCases = append(testCases, tc4)
+
+	ctx := context.Background()
+	for _, tc := range testCases {
+		cb := collectSpanStatsResponses(ctx, tc.actualRes)
+		for _, nodeResp := range tc.nodeResponses {
+			cb(nodeResp.nodeID, nodeResp.resp)
+		}
+
+		for spanStr, spanStats := range tc.expectedRes.SpanToStats {
+			actualSpanStat, ok := tc.actualRes.SpanToStats[spanStr]
+			require.True(t, ok)
+			require.NotNil(t, actualSpanStat)
+			require.Equal(t, spanStats.TotalStats, actualSpanStat.TotalStats)
+			require.Equal(t, spanStats.RangeCount, actualSpanStat.RangeCount)
+			require.Equal(t, spanStats.ApproximateDiskBytes, actualSpanStat.ApproximateDiskBytes)
+		}
+	}
+}
+
+func createSpanStatsResponse(spanStrs ...string) *roachpb.SpanStatsResponse {
+	resp := &roachpb.SpanStatsResponse{}
+	resp.SpanToStats = make(map[string]*roachpb.SpanStats)
+	for _, str := range spanStrs {
+		resp.SpanToStats[str] = &roachpb.SpanStats{}
+	}
+	return resp
 }


### PR DESCRIPTION
Backport 1/1 commits from #132349.

/cc @cockroachdb/release

---

a NPE was surfaced when doing a spanstats request on an unfinalized (mixed version) cluster.

To fix, defensive checks are added to defend against potential nil responses and references to non-existant map entries for a request span stat

Fixes: #132130
Release note (bug fix): Fixes a bug where a span stats request on a mixed version cluster resulted in an NPE
