### PR TITLE
pkg/acceptance: update gss tests with container built from release branch

### DIFF
--- a/pkg/acceptance/compose/gss/docker-compose-python.yml
+++ b/pkg/acceptance/compose/gss/docker-compose-python.yml
@@ -23,7 +23,7 @@ services:
       timeout: 10s
       retries: 25
   python:
-    image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-python:20241011-132128
+    image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-python:20241015-171248
     user: "${UID}:${GID}"
     depends_on:
       cockroach:

--- a/pkg/acceptance/compose/gss/docker-compose.yml
+++ b/pkg/acceptance/compose/gss/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       timeout: 10s
       retries: 25
   psql:
-    image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-psql:20241011-131822
+    image: us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-psql:20241015-170957
     user: "${UID}:${GID}"
     depends_on:
       cockroach:


### PR DESCRIPTION
I previously updated the GSS acceptance tests using a container built from master. Now that the related backports are in the release branch, I’m updating the container tags to use an image built from the release branch for reproducibility.

Epic: CRDB-39988
Informs CRDB-41998
Release note: none