### PR TITLE
raft: fix raft mixedversion forget_leader tests

### DIFF
--- a/pkg/raft/testdata/mixedversions/forget_leader.txt
+++ b/pkg/raft/testdata/mixedversions/forget_leader.txt
@@ -6,15 +6,10 @@ log-level none
 ----
 ok
 
-# Start 4 nodes, two of them has the older version 24.2.
-add-nodes 2 voters=(1,2,3) learners=(4) index=10 crdb-version=24.2
+# Start 4 nodes that have the older version 24.2.
+add-nodes 4 voters=(1,2,3) learners=(4) index=10 crdb-version=24.2
 ----
 ok
-
-add-nodes 2 voters=(1,2,3) learners=(4) index=10 crdb-version=24.3
-----
-ok
-
 
 campaign 1
 ----

--- a/pkg/raft/testdata/mixedversions/forget_leader_prevote_checkquorum.txt
+++ b/pkg/raft/testdata/mixedversions/forget_leader_prevote_checkquorum.txt
@@ -12,12 +12,8 @@ log-level none
 ----
 ok
 
-# Start 3 nodes, two of them has the older version 24.2.
-add-nodes 2 voters=(1,2,3) index=10 prevote=true checkquorum=true crdb-version=24.2
-----
-ok
-
-add-nodes 1 voters=(1,2,3) index=10 prevote=true checkquorum=true crdb-version=24.3
+# Start 3 nodes that have the older version 24.2.
+add-nodes 3 voters=(1,2,3) index=10 prevote=true checkquorum=true crdb-version=24.2
 ----
 ok
 


### PR DESCRIPTION
Right now, the tests campaign a leader with a newer version (24.3). This means that followers with older versions (24.2) which have store liveness disabled would panic when receiving a MsgFortify from the leader.

Note that this scenario should not happen in reality because the leader would only send MsgFortify if it knows that everyone is at least at 24.3.

This commit fixes this by making all nodes have the same older version 24.2.

Epic: None

Release note: None