### PR TITLE
raft: match MsgFortifyLeaderResp to MsgHeartbeatResp

### DIFF
--- a/pkg/raft/testdata/async_storage_writes.txt
+++ b/pkg/raft/testdata/async_storage_writes.txt
@@ -165,15 +165,19 @@ stabilize
   CommittedEntries:
   1/11 EntryNormal ""
   Messages:
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/11 Commit:11
+  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/11 Commit:11
   1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:11 Vote:1 Lead:1 LeadEpoch:1
   1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/11 EntryNormal ""] Responses:[
     ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
   ]
 > 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/11 Commit:11
 > 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/11 Commit:11
 > 1 processing append thread
   Processing:
@@ -191,6 +195,7 @@ stabilize
   1/11 EntryNormal ""
   Messages:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:11 Vote:1 Lead:1 LeadEpoch:1 Responses:[
+    2->1 MsgAppResp Term:1 Log:0/11 Commit:10
     2->1 MsgAppResp Term:1 Log:0/11 Commit:11
   ]
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/11 EntryNormal ""] Responses:[
@@ -204,6 +209,7 @@ stabilize
   Messages:
   3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:11 Vote:1 Lead:1 LeadEpoch:1 Responses:[
     3->1 MsgAppResp Term:1 Log:0/11 Commit:11
+    3->1 MsgAppResp Term:1 Log:0/11 Commit:11
   ]
   3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/11 EntryNormal ""] Responses:[
     ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
@@ -214,11 +220,13 @@ stabilize
   Processing:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:11 Vote:1 Lead:1 LeadEpoch:1
   Responses:
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 3 processing append thread
   Processing:
   3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:11 Vote:1 Lead:1 LeadEpoch:1
   Responses:
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 2 processing apply thread
   Processing:
@@ -231,7 +239,9 @@ stabilize
   Responses:
   ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
 > 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 2 receiving messages
   ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]

--- a/pkg/raft/testdata/campaign.txt
+++ b/pkg/raft/testdata/campaign.txt
@@ -102,11 +102,15 @@ stabilize
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
+  1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/3 Commit:3
+  1->3 MsgApp Term:1 Log:1/2 Commit:3 Entries:[1/3 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/3 Commit:3
 > 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/3 Commit:3
 > 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/2 Commit:3 Entries:[1/3 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/3 Commit:3
 > 2 handling Ready
   Ready MustSync=true:
@@ -114,6 +118,7 @@ stabilize
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
+  2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 3 handling Ready
   Ready MustSync=true:
@@ -122,6 +127,9 @@ stabilize
   1/3 EntryNormal ""
   Messages:
   3->1 MsgAppResp Term:1 Log:0/3 Commit:3
+  3->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
+  3->1 MsgAppResp Term:1 Log:0/3 Commit:3
   3->1 MsgAppResp Term:1 Log:0/3 Commit:3

--- a/pkg/raft/testdata/campaign_learner_must_vote.txt
+++ b/pkg/raft/testdata/campaign_learner_must_vote.txt
@@ -126,11 +126,14 @@ stabilize 2 3
 > 2 handling Ready
   Ready MustSync=false:
   Messages:
+  2->3 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
   2->3 MsgApp Term:2 Log:1/3 Commit:4 Entries:[
     1/4 EntryConfChangeV2 v3
     2/5 EntryNormal ""
   ]
 > 3 receiving messages
+  2->3 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
+  DEBUG 3 [logterm: 0, index: 4] rejected MsgApp [logterm: 1, index: 4] from 2
   2->3 MsgApp Term:2 Log:1/3 Commit:4 Entries:[
     1/4 EntryConfChangeV2 v3
     2/5 EntryNormal ""
@@ -144,9 +147,12 @@ stabilize 2 3
   CommittedEntries:
   1/4 EntryConfChangeV2 v3
   Messages:
+  3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3) Commit:3
   3->2 MsgAppResp Term:2 Log:0/5 Commit:4
   INFO 3 switched to configuration voters=(1 2 3)
 > 2 receiving messages
+  3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3) Commit:3
+  DEBUG 2 received MsgAppResp(rejected, hint: (index 3, term 1)) from 3 for index 4
   3->2 MsgAppResp Term:2 Log:0/5 Commit:4
 > 2 handling Ready
   Ready MustSync=true:

--- a/pkg/raft/testdata/confchange_v1_add_single.txt
+++ b/pkg/raft/testdata/confchange_v1_add_single.txt
@@ -80,9 +80,12 @@ stabilize
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
+  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChange v2]
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
 > 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChange v2]
+  DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 1]
@@ -94,7 +97,10 @@ stabilize
   HardState Term:1 Commit:4 Lead:1 LeadEpoch:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
+  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
 > 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 sentCommit=4 matchCommit=4 paused pendingSnap=4]

--- a/pkg/raft/testdata/confchange_v2_add_double_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_auto.txt
@@ -104,9 +104,18 @@ stabilize 1 2
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
+  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[
+    1/4 EntryConfChangeV2 v2 v3
+    1/5 EntryConfChangeV2
+  ]
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
 > 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[
+    1/4 EntryConfChangeV2 v2 v3
+    1/5 EntryConfChangeV2
+  ]
+  DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
   INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 1]
@@ -118,8 +127,11 @@ stabilize 1 2
   HardState Term:1 Commit:4 Lead:1 LeadEpoch:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
   Messages:
+  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
 > 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 sentCommit=4 matchCommit=4 paused pendingSnap=4]
 > 1 handling Ready
@@ -189,9 +201,18 @@ stabilize 1 3
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
+  1->3 MsgApp Term:1 Log:1/3 Commit:5 Entries:[
+    1/4 EntryConfChangeV2 v2 v3
+    1/5 EntryConfChangeV2
+  ]
   1->3 MsgSnap Term:1 Log:0/0
     Snapshot: Index:5 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
 > 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/3 Commit:5 Entries:[
+    1/4 EntryConfChangeV2 v2 v3
+    1/5 EntryConfChangeV2
+  ]
+  DEBUG 3 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
   1->3 MsgSnap Term:1 Log:0/0
     Snapshot: Index:5 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 5, term: 1]
@@ -203,8 +224,11 @@ stabilize 1 3
   HardState Term:1 Commit:5 Lead:1 LeadEpoch:1
   Snapshot Index:5 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
+  3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
   3->1 MsgAppResp Term:1 Log:0/5 Commit:5
 > 1 receiving messages
+  3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 3 for index 3
   3->1 MsgAppResp Term:1 Log:0/5 Commit:5
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=5 next=6 sentCommit=5 matchCommit=5 paused pendingSnap=5]
 

--- a/pkg/raft/testdata/confchange_v2_add_double_implicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_implicit.txt
@@ -86,9 +86,18 @@ stabilize 1 2
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
+  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[
+    1/4 EntryConfChangeV2 v2
+    1/5 EntryConfChangeV2
+  ]
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
 > 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[
+    1/4 EntryConfChangeV2 v2
+    1/5 EntryConfChangeV2
+  ]
+  DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
   INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 1]
@@ -100,8 +109,11 @@ stabilize 1 2
   HardState Term:1 Commit:4 Lead:1 LeadEpoch:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
   Messages:
+  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
 > 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 sentCommit=4 matchCommit=4 paused pendingSnap=4]
 > 1 handling Ready

--- a/pkg/raft/testdata/confchange_v2_add_single_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_auto.txt
@@ -81,9 +81,12 @@ stabilize
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
+  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
 > 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
+  DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 1]
@@ -95,7 +98,10 @@ stabilize
   HardState Term:1 Commit:4 Lead:1 LeadEpoch:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
+  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
 > 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 sentCommit=4 matchCommit=4 paused pendingSnap=4]

--- a/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
@@ -81,9 +81,12 @@ stabilize 1 2
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
+  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:false
 > 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
+  DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:false
   INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 1]
@@ -95,8 +98,11 @@ stabilize 1 2
   HardState Term:1 Commit:4 Lead:1 LeadEpoch:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
+  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
 > 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 sentCommit=4 matchCommit=4 paused pendingSnap=4]
 

--- a/pkg/raft/testdata/de_fortification_basic.txt
+++ b/pkg/raft/testdata/de_fortification_basic.txt
@@ -205,6 +205,7 @@ stabilize
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
+  1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/3 Commit:3
   1->3 MsgApp Term:1 Log:1/3 Commit:3
   1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:3 Vote:1 Lead:1 LeadEpoch:3
@@ -212,6 +213,7 @@ stabilize
     ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/3 EntryNormal ""]
   ]
 > 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/3 Commit:3
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/3 Commit:3
@@ -231,6 +233,7 @@ stabilize
   1/3 EntryNormal ""
   Messages:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:3 Vote:1 Lead:1 LeadEpoch:3 Responses:[
+    2->1 MsgAppResp Term:1 Log:0/3 Commit:2
     2->1 MsgAppResp Term:1 Log:0/3 Commit:3
   ]
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/3 EntryNormal ""] Responses:[
@@ -254,6 +257,7 @@ stabilize
   Processing:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:3 Vote:1 Lead:1 LeadEpoch:3
   Responses:
+  2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 3 processing append thread
   Processing:
@@ -271,6 +275,7 @@ stabilize
   Responses:
   ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/3 EntryNormal ""]
 > 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
   3->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 2 receiving messages
@@ -530,15 +535,19 @@ stabilize
   CommittedEntries:
   2/4 EntryNormal ""
   Messages:
+  2->1 MsgApp Term:2 Log:1/3 Commit:3 Entries:[2/4 EntryNormal ""]
   2->1 MsgApp Term:2 Log:2/4 Commit:4
+  2->3 MsgApp Term:2 Log:1/3 Commit:4 Entries:[2/4 EntryNormal ""]
   2->3 MsgApp Term:2 Log:2/4 Commit:4
   2->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:4 Vote:2 Lead:2 LeadEpoch:1
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/4 EntryNormal ""] Responses:[
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/4 EntryNormal ""]
   ]
 > 1 receiving messages
+  2->1 MsgApp Term:2 Log:1/3 Commit:3 Entries:[2/4 EntryNormal ""]
   2->1 MsgApp Term:2 Log:2/4 Commit:4
 > 3 receiving messages
+  2->3 MsgApp Term:2 Log:1/3 Commit:4 Entries:[2/4 EntryNormal ""]
   2->3 MsgApp Term:2 Log:2/4 Commit:4
 > 2 processing append thread
   Processing:
@@ -556,6 +565,7 @@ stabilize
   2/4 EntryNormal ""
   Messages:
   1->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:4 Vote:2 Lead:2 LeadEpoch:1 Responses:[
+    1->2 MsgAppResp Term:2 Log:0/4 Commit:3
     1->2 MsgAppResp Term:2 Log:0/4 Commit:4
   ]
   1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/4 EntryNormal ""] Responses:[
@@ -569,6 +579,7 @@ stabilize
   Messages:
   3->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:4 Vote:2 Lead:2 LeadEpoch:1 Responses:[
     3->2 MsgAppResp Term:2 Log:0/4 Commit:4
+    3->2 MsgAppResp Term:2 Log:0/4 Commit:4
   ]
   3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/4 EntryNormal ""] Responses:[
     ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/4 EntryNormal ""]
@@ -579,11 +590,13 @@ stabilize
   Processing:
   1->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:4 Vote:2 Lead:2 LeadEpoch:1
   Responses:
+  1->2 MsgAppResp Term:2 Log:0/4 Commit:3
   1->2 MsgAppResp Term:2 Log:0/4 Commit:4
 > 3 processing append thread
   Processing:
   3->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:4 Vote:2 Lead:2 LeadEpoch:1
   Responses:
+  3->2 MsgAppResp Term:2 Log:0/4 Commit:4
   3->2 MsgAppResp Term:2 Log:0/4 Commit:4
 > 1 processing apply thread
   Processing:
@@ -598,7 +611,9 @@ stabilize
 > 1 receiving messages
   ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/4 EntryNormal ""]
 > 2 receiving messages
+  1->2 MsgAppResp Term:2 Log:0/4 Commit:3
   1->2 MsgAppResp Term:2 Log:0/4 Commit:4
+  3->2 MsgAppResp Term:2 Log:0/4 Commit:4
   3->2 MsgAppResp Term:2 Log:0/4 Commit:4
 > 3 receiving messages
   ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/4 EntryNormal ""]
@@ -854,15 +869,19 @@ stabilize
   CommittedEntries:
   4/5 EntryNormal ""
   Messages:
+  3->1 MsgApp Term:4 Log:2/4 Commit:4 Entries:[4/5 EntryNormal ""]
   3->1 MsgApp Term:4 Log:4/5 Commit:5
+  3->2 MsgApp Term:4 Log:2/4 Commit:5 Entries:[4/5 EntryNormal ""]
   3->2 MsgApp Term:4 Log:4/5 Commit:5
   3->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:5 Vote:3 Lead:3 LeadEpoch:1
   3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[4/5 EntryNormal ""] Responses:[
     ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[4/5 EntryNormal ""]
   ]
 > 1 receiving messages
+  3->1 MsgApp Term:4 Log:2/4 Commit:4 Entries:[4/5 EntryNormal ""]
   3->1 MsgApp Term:4 Log:4/5 Commit:5
 > 2 receiving messages
+  3->2 MsgApp Term:4 Log:2/4 Commit:5 Entries:[4/5 EntryNormal ""]
   3->2 MsgApp Term:4 Log:4/5 Commit:5
 > 3 processing append thread
   Processing:
@@ -880,6 +899,7 @@ stabilize
   4/5 EntryNormal ""
   Messages:
   1->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:5 Vote:3 Lead:3 LeadEpoch:1 Responses:[
+    1->3 MsgAppResp Term:4 Log:0/5 Commit:4
     1->3 MsgAppResp Term:4 Log:0/5 Commit:5
   ]
   1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[4/5 EntryNormal ""] Responses:[
@@ -893,6 +913,7 @@ stabilize
   Messages:
   2->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:5 Lead:3 LeadEpoch:1 Responses:[
     2->3 MsgAppResp Term:4 Log:0/5 Commit:5
+    2->3 MsgAppResp Term:4 Log:0/5 Commit:5
   ]
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[4/5 EntryNormal ""] Responses:[
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[4/5 EntryNormal ""]
@@ -903,11 +924,13 @@ stabilize
   Processing:
   1->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:5 Vote:3 Lead:3 LeadEpoch:1
   Responses:
+  1->3 MsgAppResp Term:4 Log:0/5 Commit:4
   1->3 MsgAppResp Term:4 Log:0/5 Commit:5
 > 2 processing append thread
   Processing:
   2->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:5 Lead:3 LeadEpoch:1
   Responses:
+  2->3 MsgAppResp Term:4 Log:0/5 Commit:5
   2->3 MsgAppResp Term:4 Log:0/5 Commit:5
 > 1 processing apply thread
   Processing:
@@ -924,7 +947,9 @@ stabilize
 > 2 receiving messages
   ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[4/5 EntryNormal ""]
 > 3 receiving messages
+  1->3 MsgAppResp Term:4 Log:0/5 Commit:4
   1->3 MsgAppResp Term:4 Log:0/5 Commit:5
+  2->3 MsgAppResp Term:4 Log:0/5 Commit:5
   2->3 MsgAppResp Term:4 Log:0/5 Commit:5
 
 raft-state
@@ -1128,15 +1153,19 @@ stabilize
   CommittedEntries:
   5/6 EntryNormal ""
   Messages:
+  2->1 MsgApp Term:5 Log:4/5 Commit:5 Entries:[5/6 EntryNormal ""]
   2->1 MsgApp Term:5 Log:5/6 Commit:6
+  2->3 MsgApp Term:5 Log:4/5 Commit:6 Entries:[5/6 EntryNormal ""]
   2->3 MsgApp Term:5 Log:5/6 Commit:6
   2->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:6 Vote:2 Lead:2 LeadEpoch:1
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[5/6 EntryNormal ""] Responses:[
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[5/6 EntryNormal ""]
   ]
 > 1 receiving messages
+  2->1 MsgApp Term:5 Log:4/5 Commit:5 Entries:[5/6 EntryNormal ""]
   2->1 MsgApp Term:5 Log:5/6 Commit:6
 > 3 receiving messages
+  2->3 MsgApp Term:5 Log:4/5 Commit:6 Entries:[5/6 EntryNormal ""]
   2->3 MsgApp Term:5 Log:5/6 Commit:6
 > 2 processing append thread
   Processing:
@@ -1154,6 +1183,7 @@ stabilize
   5/6 EntryNormal ""
   Messages:
   1->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:6 Vote:2 Lead:2 LeadEpoch:1 Responses:[
+    1->2 MsgAppResp Term:5 Log:0/6 Commit:5
     1->2 MsgAppResp Term:5 Log:0/6 Commit:6
   ]
   1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[5/6 EntryNormal ""] Responses:[
@@ -1167,6 +1197,7 @@ stabilize
   Messages:
   3->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:6 Vote:2 Lead:2 LeadEpoch:1 Responses:[
     3->2 MsgAppResp Term:5 Log:0/6 Commit:6
+    3->2 MsgAppResp Term:5 Log:0/6 Commit:6
   ]
   3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[5/6 EntryNormal ""] Responses:[
     ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[5/6 EntryNormal ""]
@@ -1177,11 +1208,13 @@ stabilize
   Processing:
   1->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:6 Vote:2 Lead:2 LeadEpoch:1
   Responses:
+  1->2 MsgAppResp Term:5 Log:0/6 Commit:5
   1->2 MsgAppResp Term:5 Log:0/6 Commit:6
 > 3 processing append thread
   Processing:
   3->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:6 Vote:2 Lead:2 LeadEpoch:1
   Responses:
+  3->2 MsgAppResp Term:5 Log:0/6 Commit:6
   3->2 MsgAppResp Term:5 Log:0/6 Commit:6
 > 1 processing apply thread
   Processing:
@@ -1196,7 +1229,9 @@ stabilize
 > 1 receiving messages
   ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[5/6 EntryNormal ""]
 > 2 receiving messages
+  1->2 MsgAppResp Term:5 Log:0/6 Commit:5
   1->2 MsgAppResp Term:5 Log:0/6 Commit:6
+  3->2 MsgAppResp Term:5 Log:0/6 Commit:6
   3->2 MsgAppResp Term:5 Log:0/6 Commit:6
 > 3 receiving messages
   ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[5/6 EntryNormal ""]
@@ -1388,6 +1423,7 @@ stabilize
   CommittedEntries:
   6/7 EntryNormal ""
   Messages:
+  1->2 MsgApp Term:6 Log:5/6 Commit:6 Entries:[6/7 EntryNormal ""]
   1->2 MsgApp Term:6 Log:6/7 Commit:7
   1->3 MsgApp Term:6 Log:6/7 Commit:7
   1->AppendThread MsgStorageAppend Term:6 Log:0/0 Commit:7 Vote:1 Lead:1 LeadEpoch:3
@@ -1395,6 +1431,7 @@ stabilize
     ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[6/7 EntryNormal ""]
   ]
 > 2 receiving messages
+  1->2 MsgApp Term:6 Log:5/6 Commit:6 Entries:[6/7 EntryNormal ""]
   1->2 MsgApp Term:6 Log:6/7 Commit:7
 > 3 receiving messages
   1->3 MsgApp Term:6 Log:6/7 Commit:7
@@ -1414,6 +1451,7 @@ stabilize
   6/7 EntryNormal ""
   Messages:
   2->AppendThread MsgStorageAppend Term:6 Log:0/0 Commit:7 Vote:1 Lead:1 LeadEpoch:3 Responses:[
+    2->1 MsgAppResp Term:6 Log:0/7 Commit:6
     2->1 MsgAppResp Term:6 Log:0/7 Commit:7
   ]
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[6/7 EntryNormal ""] Responses:[
@@ -1437,6 +1475,7 @@ stabilize
   Processing:
   2->AppendThread MsgStorageAppend Term:6 Log:0/0 Commit:7 Vote:1 Lead:1 LeadEpoch:3
   Responses:
+  2->1 MsgAppResp Term:6 Log:0/7 Commit:6
   2->1 MsgAppResp Term:6 Log:0/7 Commit:7
 > 3 processing append thread
   Processing:
@@ -1454,6 +1493,7 @@ stabilize
   Responses:
   ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[6/7 EntryNormal ""]
 > 1 receiving messages
+  2->1 MsgAppResp Term:6 Log:0/7 Commit:6
   2->1 MsgAppResp Term:6 Log:0/7 Commit:7
   3->1 MsgAppResp Term:6 Log:0/7 Commit:7
 > 2 receiving messages

--- a/pkg/raft/testdata/fortification_basic.txt
+++ b/pkg/raft/testdata/fortification_basic.txt
@@ -189,14 +189,18 @@ stabilize
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
+  1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/3 Commit:3
   1->3 MsgApp Term:1 Log:1/3 Commit:3
+  1->4 MsgApp Term:1 Log:1/2 Commit:3 Entries:[1/3 EntryNormal ""]
   1->4 MsgApp Term:1 Log:1/3 Commit:3
 > 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/3 Commit:3
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/3 Commit:3
 > 4 receiving messages
+  1->4 MsgApp Term:1 Log:1/2 Commit:3 Entries:[1/3 EntryNormal ""]
   1->4 MsgApp Term:1 Log:1/3 Commit:3
 > 2 handling Ready
   Ready MustSync=true:
@@ -204,6 +208,7 @@ stabilize
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
+  2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 3 handling Ready
   Ready MustSync=true:
@@ -219,7 +224,10 @@ stabilize
   1/3 EntryNormal ""
   Messages:
   4->1 MsgAppResp Term:1 Log:0/3 Commit:3
+  4->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
   3->1 MsgAppResp Term:1 Log:0/3 Commit:3
+  4->1 MsgAppResp Term:1 Log:0/3 Commit:3
   4->1 MsgAppResp Term:1 Log:0/3 Commit:3

--- a/pkg/raft/testdata/fortification_followers_dont_call_election.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_call_election.txt
@@ -105,11 +105,15 @@ stabilize
   CommittedEntries:
   1/11 EntryNormal ""
   Messages:
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/11 Commit:11
+  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/11 Commit:11
 > 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/11 Commit:11
 > 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/11 Commit:11
 > 2 handling Ready
   Ready MustSync=true:
@@ -117,6 +121,7 @@ stabilize
   CommittedEntries:
   1/11 EntryNormal ""
   Messages:
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 3 handling Ready
   Ready MustSync=true:
@@ -125,8 +130,11 @@ stabilize
   1/11 EntryNormal ""
   Messages:
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 
 store-liveness

--- a/pkg/raft/testdata/fortification_followers_dont_call_election_prevote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_call_election_prevote.txt
@@ -135,11 +135,15 @@ stabilize
   CommittedEntries:
   1/11 EntryNormal ""
   Messages:
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/11 Commit:11
+  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/11 Commit:11
 > 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/11 Commit:11
 > 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/11 Commit:11
 > 2 handling Ready
   Ready MustSync=true:
@@ -147,6 +151,7 @@ stabilize
   CommittedEntries:
   1/11 EntryNormal ""
   Messages:
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 3 handling Ready
   Ready MustSync=true:
@@ -155,8 +160,11 @@ stabilize
   1/11 EntryNormal ""
   Messages:
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 
 store-liveness

--- a/pkg/raft/testdata/fortification_followers_dont_prevote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_prevote.txt
@@ -135,11 +135,15 @@ stabilize
   CommittedEntries:
   1/11 EntryNormal ""
   Messages:
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/11 Commit:11
+  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/11 Commit:11
 > 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/11 Commit:11
 > 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/11 Commit:11
 > 2 handling Ready
   Ready MustSync=true:
@@ -147,6 +151,7 @@ stabilize
   CommittedEntries:
   1/11 EntryNormal ""
   Messages:
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 3 handling Ready
   Ready MustSync=true:
@@ -155,8 +160,11 @@ stabilize
   1/11 EntryNormal ""
   Messages:
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 
 withdraw-support 2 1
@@ -316,11 +324,15 @@ stabilize
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
+  2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
   2->1 MsgApp Term:2 Log:2/12 Commit:12
+  2->3 MsgApp Term:2 Log:1/11 Commit:12 Entries:[2/12 EntryNormal ""]
   2->3 MsgApp Term:2 Log:2/12 Commit:12
 > 1 receiving messages
+  2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
   2->1 MsgApp Term:2 Log:2/12 Commit:12
 > 3 receiving messages
+  2->3 MsgApp Term:2 Log:1/11 Commit:12 Entries:[2/12 EntryNormal ""]
   2->3 MsgApp Term:2 Log:2/12 Commit:12
 > 1 handling Ready
   Ready MustSync=true:
@@ -328,6 +340,7 @@ stabilize
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
+  1->2 MsgAppResp Term:2 Log:0/12 Commit:11
   1->2 MsgAppResp Term:2 Log:0/12 Commit:12
 > 3 handling Ready
   Ready MustSync=true:
@@ -336,8 +349,11 @@ stabilize
   2/12 EntryNormal ""
   Messages:
   3->2 MsgAppResp Term:2 Log:0/12 Commit:12
+  3->2 MsgAppResp Term:2 Log:0/12 Commit:12
 > 2 receiving messages
+  1->2 MsgAppResp Term:2 Log:0/12 Commit:11
   1->2 MsgAppResp Term:2 Log:0/12 Commit:12
+  3->2 MsgAppResp Term:2 Log:0/12 Commit:12
   3->2 MsgAppResp Term:2 Log:0/12 Commit:12
 
 raft-state
@@ -474,11 +490,15 @@ stabilize
   CommittedEntries:
   3/13 EntryNormal ""
   Messages:
+  2->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
   2->1 MsgApp Term:3 Log:3/13 Commit:13
+  2->3 MsgApp Term:3 Log:2/12 Commit:13 Entries:[3/13 EntryNormal ""]
   2->3 MsgApp Term:3 Log:3/13 Commit:13
 > 1 receiving messages
+  2->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
   2->1 MsgApp Term:3 Log:3/13 Commit:13
 > 3 receiving messages
+  2->3 MsgApp Term:3 Log:2/12 Commit:13 Entries:[3/13 EntryNormal ""]
   2->3 MsgApp Term:3 Log:3/13 Commit:13
 > 1 handling Ready
   Ready MustSync=true:
@@ -486,6 +506,7 @@ stabilize
   CommittedEntries:
   3/13 EntryNormal ""
   Messages:
+  1->2 MsgAppResp Term:3 Log:0/13 Commit:12
   1->2 MsgAppResp Term:3 Log:0/13 Commit:13
 > 3 handling Ready
   Ready MustSync=true:
@@ -494,8 +515,11 @@ stabilize
   3/13 EntryNormal ""
   Messages:
   3->2 MsgAppResp Term:3 Log:0/13 Commit:13
+  3->2 MsgAppResp Term:3 Log:0/13 Commit:13
 > 2 receiving messages
+  1->2 MsgAppResp Term:3 Log:0/13 Commit:12
   1->2 MsgAppResp Term:3 Log:0/13 Commit:13
+  3->2 MsgAppResp Term:3 Log:0/13 Commit:13
   3->2 MsgAppResp Term:3 Log:0/13 Commit:13
 
 raft-state

--- a/pkg/raft/testdata/fortification_followers_dont_vote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_vote.txt
@@ -105,11 +105,15 @@ stabilize
   CommittedEntries:
   1/11 EntryNormal ""
   Messages:
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/11 Commit:11
+  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/11 Commit:11
 > 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/11 Commit:11
 > 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/11 Commit:11
 > 2 handling Ready
   Ready MustSync=true:
@@ -117,6 +121,7 @@ stabilize
   CommittedEntries:
   1/11 EntryNormal ""
   Messages:
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 3 handling Ready
   Ready MustSync=true:
@@ -125,8 +130,11 @@ stabilize
   1/11 EntryNormal ""
   Messages:
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 
 withdraw-support 2 1
@@ -260,11 +268,15 @@ stabilize
   CommittedEntries:
   3/12 EntryNormal ""
   Messages:
+  2->1 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
   2->1 MsgApp Term:3 Log:3/12 Commit:12
+  2->3 MsgApp Term:3 Log:1/11 Commit:12 Entries:[3/12 EntryNormal ""]
   2->3 MsgApp Term:3 Log:3/12 Commit:12
 > 1 receiving messages
+  2->1 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
   2->1 MsgApp Term:3 Log:3/12 Commit:12
 > 3 receiving messages
+  2->3 MsgApp Term:3 Log:1/11 Commit:12 Entries:[3/12 EntryNormal ""]
   2->3 MsgApp Term:3 Log:3/12 Commit:12
 > 1 handling Ready
   Ready MustSync=true:
@@ -272,6 +284,7 @@ stabilize
   CommittedEntries:
   3/12 EntryNormal ""
   Messages:
+  1->2 MsgAppResp Term:3 Log:0/12 Commit:11
   1->2 MsgAppResp Term:3 Log:0/12 Commit:12
 > 3 handling Ready
   Ready MustSync=true:
@@ -280,8 +293,11 @@ stabilize
   3/12 EntryNormal ""
   Messages:
   3->2 MsgAppResp Term:3 Log:0/12 Commit:12
+  3->2 MsgAppResp Term:3 Log:0/12 Commit:12
 > 2 receiving messages
+  1->2 MsgAppResp Term:3 Log:0/12 Commit:11
   1->2 MsgAppResp Term:3 Log:0/12 Commit:12
+  3->2 MsgAppResp Term:3 Log:0/12 Commit:12
   3->2 MsgAppResp Term:3 Log:0/12 Commit:12
 
 raft-state
@@ -385,11 +401,15 @@ stabilize
   CommittedEntries:
   4/13 EntryNormal ""
   Messages:
+  2->1 MsgApp Term:4 Log:3/12 Commit:12 Entries:[4/13 EntryNormal ""]
   2->1 MsgApp Term:4 Log:4/13 Commit:13
+  2->3 MsgApp Term:4 Log:3/12 Commit:13 Entries:[4/13 EntryNormal ""]
   2->3 MsgApp Term:4 Log:4/13 Commit:13
 > 1 receiving messages
+  2->1 MsgApp Term:4 Log:3/12 Commit:12 Entries:[4/13 EntryNormal ""]
   2->1 MsgApp Term:4 Log:4/13 Commit:13
 > 3 receiving messages
+  2->3 MsgApp Term:4 Log:3/12 Commit:13 Entries:[4/13 EntryNormal ""]
   2->3 MsgApp Term:4 Log:4/13 Commit:13
 > 1 handling Ready
   Ready MustSync=true:
@@ -397,6 +417,7 @@ stabilize
   CommittedEntries:
   4/13 EntryNormal ""
   Messages:
+  1->2 MsgAppResp Term:4 Log:0/13 Commit:12
   1->2 MsgAppResp Term:4 Log:0/13 Commit:13
 > 3 handling Ready
   Ready MustSync=true:
@@ -405,8 +426,11 @@ stabilize
   4/13 EntryNormal ""
   Messages:
   3->2 MsgAppResp Term:4 Log:0/13 Commit:13
+  3->2 MsgAppResp Term:4 Log:0/13 Commit:13
 > 2 receiving messages
+  1->2 MsgAppResp Term:4 Log:0/13 Commit:12
   1->2 MsgAppResp Term:4 Log:0/13 Commit:13
+  3->2 MsgAppResp Term:4 Log:0/13 Commit:13
   3->2 MsgAppResp Term:4 Log:0/13 Commit:13
 
 raft-state

--- a/pkg/raft/testdata/fortification_leader_does_not_support_itself.txt
+++ b/pkg/raft/testdata/fortification_leader_does_not_support_itself.txt
@@ -135,11 +135,15 @@ stabilize
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
+  1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/3 Commit:3
+  1->3 MsgApp Term:1 Log:1/2 Commit:3 Entries:[1/3 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/3 Commit:3
 > 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/3 Commit:3
 > 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/2 Commit:3 Entries:[1/3 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/3 Commit:3
 > 2 handling Ready
   Ready MustSync=true:
@@ -147,6 +151,7 @@ stabilize
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
+  2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 3 handling Ready
   Ready MustSync=true:
@@ -155,8 +160,11 @@ stabilize
   1/3 EntryNormal ""
   Messages:
   3->1 MsgAppResp Term:1 Log:0/3 Commit:3
+  3->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
+  3->1 MsgAppResp Term:1 Log:0/3 Commit:3
   3->1 MsgAppResp Term:1 Log:0/3 Commit:3
 
 # TODO(arul): Consider adding a directive for the leader's support tracker and

--- a/pkg/raft/testdata/fortification_support_tracking.txt
+++ b/pkg/raft/testdata/fortification_support_tracking.txt
@@ -242,11 +242,15 @@ stabilize
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
+  2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
   2->1 MsgApp Term:2 Log:2/12 Commit:12
+  2->3 MsgApp Term:2 Log:1/11 Commit:12 Entries:[2/12 EntryNormal ""]
   2->3 MsgApp Term:2 Log:2/12 Commit:12
 > 1 receiving messages
+  2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
   2->1 MsgApp Term:2 Log:2/12 Commit:12
 > 3 receiving messages
+  2->3 MsgApp Term:2 Log:1/11 Commit:12 Entries:[2/12 EntryNormal ""]
   2->3 MsgApp Term:2 Log:2/12 Commit:12
 > 1 handling Ready
   Ready MustSync=true:
@@ -254,6 +258,7 @@ stabilize
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
+  1->2 MsgAppResp Term:2 Log:0/12 Commit:11
   1->2 MsgAppResp Term:2 Log:0/12 Commit:12
 > 3 handling Ready
   Ready MustSync=true:
@@ -262,8 +267,11 @@ stabilize
   2/12 EntryNormal ""
   Messages:
   3->2 MsgAppResp Term:2 Log:0/12 Commit:12
+  3->2 MsgAppResp Term:2 Log:0/12 Commit:12
 > 2 receiving messages
+  1->2 MsgAppResp Term:2 Log:0/12 Commit:11
   1->2 MsgAppResp Term:2 Log:0/12 Commit:12
+  3->2 MsgAppResp Term:2 Log:0/12 Commit:12
   3->2 MsgAppResp Term:2 Log:0/12 Commit:12
 
 print-fortification-state 2

--- a/pkg/raft/testdata/lagging_commit_no_store_liveness_support.txt
+++ b/pkg/raft/testdata/lagging_commit_no_store_liveness_support.txt
@@ -172,3 +172,15 @@ stabilize
 > 1 receiving messages
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:2
   3->1 MsgAppResp Term:1 Log:0/13 Commit:13
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->3 MsgApp Term:1 Log:1/13 Commit:13
+> 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/13 Commit:13
+> 3 handling Ready
+  Ready MustSync=false:
+  Messages:
+  3->1 MsgAppResp Term:1 Log:0/13 Commit:13
+> 1 receiving messages
+  3->1 MsgAppResp Term:1 Log:0/13 Commit:13

--- a/pkg/raft/testdata/prevote.txt
+++ b/pkg/raft/testdata/prevote.txt
@@ -277,11 +277,15 @@ stabilize
   CommittedEntries:
   2/13 EntryNormal ""
   Messages:
+  2->1 MsgApp Term:2 Log:1/12 Commit:12 Entries:[2/13 EntryNormal ""]
   2->1 MsgApp Term:2 Log:2/13 Commit:13
+  2->3 MsgApp Term:2 Log:1/12 Commit:13 Entries:[2/13 EntryNormal ""]
   2->3 MsgApp Term:2 Log:2/13 Commit:13
 > 1 receiving messages
+  2->1 MsgApp Term:2 Log:1/12 Commit:12 Entries:[2/13 EntryNormal ""]
   2->1 MsgApp Term:2 Log:2/13 Commit:13
 > 3 receiving messages
+  2->3 MsgApp Term:2 Log:1/12 Commit:13 Entries:[2/13 EntryNormal ""]
   2->3 MsgApp Term:2 Log:2/13 Commit:13
 > 1 handling Ready
   Ready MustSync=true:
@@ -289,6 +293,7 @@ stabilize
   CommittedEntries:
   2/13 EntryNormal ""
   Messages:
+  1->2 MsgAppResp Term:2 Log:0/13 Commit:12
   1->2 MsgAppResp Term:2 Log:0/13 Commit:13
 > 3 handling Ready
   Ready MustSync=true:
@@ -297,6 +302,9 @@ stabilize
   2/13 EntryNormal ""
   Messages:
   3->2 MsgAppResp Term:2 Log:0/13 Commit:13
+  3->2 MsgAppResp Term:2 Log:0/13 Commit:13
 > 2 receiving messages
+  1->2 MsgAppResp Term:2 Log:0/13 Commit:12
   1->2 MsgAppResp Term:2 Log:0/13 Commit:13
+  3->2 MsgAppResp Term:2 Log:0/13 Commit:13
   3->2 MsgAppResp Term:2 Log:0/13 Commit:13

--- a/pkg/raft/testdata/prevote_checkquorum.txt
+++ b/pkg/raft/testdata/prevote_checkquorum.txt
@@ -189,11 +189,15 @@ stabilize
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
+  3->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
   3->1 MsgApp Term:2 Log:2/12 Commit:12
+  3->2 MsgApp Term:2 Log:1/11 Commit:12 Entries:[2/12 EntryNormal ""]
   3->2 MsgApp Term:2 Log:2/12 Commit:12
 > 1 receiving messages
+  3->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
   3->1 MsgApp Term:2 Log:2/12 Commit:12
 > 2 receiving messages
+  3->2 MsgApp Term:2 Log:1/11 Commit:12 Entries:[2/12 EntryNormal ""]
   3->2 MsgApp Term:2 Log:2/12 Commit:12
 > 1 handling Ready
   Ready MustSync=true:
@@ -201,6 +205,7 @@ stabilize
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
+  1->3 MsgAppResp Term:2 Log:0/12 Commit:11
   1->3 MsgAppResp Term:2 Log:0/12 Commit:12
 > 2 handling Ready
   Ready MustSync=true:
@@ -209,8 +214,11 @@ stabilize
   2/12 EntryNormal ""
   Messages:
   2->3 MsgAppResp Term:2 Log:0/12 Commit:12
+  2->3 MsgAppResp Term:2 Log:0/12 Commit:12
 > 3 receiving messages
+  1->3 MsgAppResp Term:2 Log:0/12 Commit:11
   1->3 MsgAppResp Term:2 Log:0/12 Commit:12
+  2->3 MsgAppResp Term:2 Log:0/12 Commit:12
   2->3 MsgAppResp Term:2 Log:0/12 Commit:12
 
 withdraw-support 1 3
@@ -370,11 +378,15 @@ stabilize
   CommittedEntries:
   3/13 EntryNormal ""
   Messages:
+  2->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
   2->1 MsgApp Term:3 Log:3/13 Commit:13
+  2->3 MsgApp Term:3 Log:2/12 Commit:13 Entries:[3/13 EntryNormal ""]
   2->3 MsgApp Term:3 Log:3/13 Commit:13
 > 1 receiving messages
+  2->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
   2->1 MsgApp Term:3 Log:3/13 Commit:13
 > 3 receiving messages
+  2->3 MsgApp Term:3 Log:2/12 Commit:13 Entries:[3/13 EntryNormal ""]
   2->3 MsgApp Term:3 Log:3/13 Commit:13
 > 1 handling Ready
   Ready MustSync=true:
@@ -382,6 +394,7 @@ stabilize
   CommittedEntries:
   3/13 EntryNormal ""
   Messages:
+  1->2 MsgAppResp Term:3 Log:0/13 Commit:12
   1->2 MsgAppResp Term:3 Log:0/13 Commit:13
 > 3 handling Ready
   Ready MustSync=true:
@@ -390,6 +403,9 @@ stabilize
   3/13 EntryNormal ""
   Messages:
   3->2 MsgAppResp Term:3 Log:0/13 Commit:13
+  3->2 MsgAppResp Term:3 Log:0/13 Commit:13
 > 2 receiving messages
+  1->2 MsgAppResp Term:3 Log:0/13 Commit:12
   1->2 MsgAppResp Term:3 Log:0/13 Commit:13
+  3->2 MsgAppResp Term:3 Log:0/13 Commit:13
   3->2 MsgAppResp Term:3 Log:0/13 Commit:13

--- a/pkg/raft/testdata/probe_and_replicate.txt
+++ b/pkg/raft/testdata/probe_and_replicate.txt
@@ -538,11 +538,13 @@ stabilize 1 2
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
+  1->2 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
   1->2 MsgApp Term:8 Log:6/19 Commit:18 Entries:[
     6/20 EntryNormal "prop_6_20"
     8/21 EntryNormal ""
   ]
 > 2 receiving messages
+  1->2 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
   1->2 MsgApp Term:8 Log:6/19 Commit:18 Entries:[
     6/20 EntryNormal "prop_6_20"
     8/21 EntryNormal ""
@@ -553,8 +555,10 @@ stabilize 1 2
   6/20 EntryNormal "prop_6_20"
   8/21 EntryNormal ""
   Messages:
+  2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19) Commit:18
   2->1 MsgAppResp Term:8 Log:0/21 Commit:18
 > 1 receiving messages
+  2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19) Commit:18
   2->1 MsgAppResp Term:8 Log:0/21 Commit:18
 
 stabilize 1 3
@@ -574,6 +578,7 @@ stabilize 1 3
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
+  1->3 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
   1->3 MsgApp Term:8 Log:4/14 Commit:18 Entries:[
     4/15 EntryNormal "prop_4_15"
     5/16 EntryNormal ""
@@ -584,6 +589,7 @@ stabilize 1 3
     8/21 EntryNormal ""
   ]
 > 3 receiving messages
+  1->3 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
   1->3 MsgApp Term:8 Log:4/14 Commit:18 Entries:[
     4/15 EntryNormal "prop_4_15"
     5/16 EntryNormal ""
@@ -610,8 +616,10 @@ stabilize 1 3
   5/17 EntryNormal "prop_5_17"
   6/18 EntryNormal ""
   Messages:
+  3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14) Commit:14
   3->1 MsgAppResp Term:8 Log:0/21 Commit:18
 > 1 receiving messages
+  3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14) Commit:14
   3->1 MsgAppResp Term:8 Log:0/21 Commit:18
 
 stabilize 1 4
@@ -640,10 +648,12 @@ stabilize 1 4
   6/20 EntryNormal "prop_6_20"
   8/21 EntryNormal ""
   Messages:
+  1->4 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
   1->2 MsgApp Term:8 Log:8/21 Commit:21
   1->3 MsgApp Term:8 Log:8/21 Commit:21
   1->4 MsgApp Term:8 Log:8/21 Commit:21
 > 4 receiving messages
+  1->4 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
   1->4 MsgApp Term:8 Log:8/21 Commit:21
 > 4 handling Ready
   Ready MustSync=true:
@@ -653,8 +663,10 @@ stabilize 1 4
   6/20 EntryNormal "prop_6_20"
   8/21 EntryNormal ""
   Messages:
+  4->1 MsgAppResp Term:8 Log:0/21 Commit:18
   4->1 MsgAppResp Term:8 Log:0/21 Commit:21
 > 1 receiving messages
+  4->1 MsgAppResp Term:8 Log:0/21 Commit:18
   4->1 MsgAppResp Term:8 Log:0/21 Commit:21
 
 stabilize 1 5
@@ -674,12 +686,14 @@ stabilize 1 5
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
+  1->5 MsgApp Term:8 Log:6/20 Commit:21 Entries:[8/21 EntryNormal ""]
   1->5 MsgApp Term:8 Log:6/18 Commit:21 Entries:[
     6/19 EntryNormal "prop_6_19"
     6/20 EntryNormal "prop_6_20"
     8/21 EntryNormal ""
   ]
 > 5 receiving messages
+  1->5 MsgApp Term:8 Log:6/20 Commit:21 Entries:[8/21 EntryNormal ""]
   1->5 MsgApp Term:8 Log:6/18 Commit:21 Entries:[
     6/19 EntryNormal "prop_6_19"
     6/20 EntryNormal "prop_6_20"
@@ -699,8 +713,10 @@ stabilize 1 5
   6/20 EntryNormal "prop_6_20"
   8/21 EntryNormal ""
   Messages:
+  5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18) Commit:18
   5->1 MsgAppResp Term:8 Log:0/21 Commit:21
 > 1 receiving messages
+  5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18) Commit:18
   5->1 MsgAppResp Term:8 Log:0/21 Commit:21
 
 stabilize 1 6
@@ -720,6 +736,7 @@ stabilize 1 6
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
+  1->6 MsgApp Term:8 Log:6/20 Commit:21 Entries:[8/21 EntryNormal ""]
   1->6 MsgApp Term:8 Log:4/15 Commit:21 Entries:[
     5/16 EntryNormal ""
     5/17 EntryNormal "prop_5_17"
@@ -729,6 +746,7 @@ stabilize 1 6
     8/21 EntryNormal ""
   ]
 > 6 receiving messages
+  1->6 MsgApp Term:8 Log:6/20 Commit:21 Entries:[8/21 EntryNormal ""]
   1->6 MsgApp Term:8 Log:4/15 Commit:21 Entries:[
     5/16 EntryNormal ""
     5/17 EntryNormal "prop_5_17"
@@ -757,72 +775,8 @@ stabilize 1 6
   6/20 EntryNormal "prop_6_20"
   8/21 EntryNormal ""
   Messages:
+  6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17) Commit:15
   6->1 MsgAppResp Term:8 Log:0/21 Commit:21
 > 1 receiving messages
+  6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17) Commit:15
   6->1 MsgAppResp Term:8 Log:0/21 Commit:21
-
-stabilize 1 7
-----
-> 7 receiving messages
-  1->7 MsgFortifyLeader Term:8 Log:0/0
-  1->7 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
-> 7 handling Ready
-  Ready MustSync=true:
-  HardState Term:8 Vote:1 Commit:13 Lead:1 LeadEpoch:2
-  Messages:
-  7->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  7->1 MsgAppResp Term:8 Log:3/20 Rejected (Hint: 20) Commit:13
-> 1 receiving messages
-  7->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  7->1 MsgAppResp Term:8 Log:3/20 Rejected (Hint: 20) Commit:13
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->7 MsgApp Term:8 Log:1/13 Commit:21 Entries:[
-    4/14 EntryNormal ""
-    4/15 EntryNormal "prop_4_15"
-    5/16 EntryNormal ""
-    5/17 EntryNormal "prop_5_17"
-    6/18 EntryNormal ""
-    6/19 EntryNormal "prop_6_19"
-    6/20 EntryNormal "prop_6_20"
-    8/21 EntryNormal ""
-  ]
-> 7 receiving messages
-  1->7 MsgApp Term:8 Log:1/13 Commit:21 Entries:[
-    4/14 EntryNormal ""
-    4/15 EntryNormal "prop_4_15"
-    5/16 EntryNormal ""
-    5/17 EntryNormal "prop_5_17"
-    6/18 EntryNormal ""
-    6/19 EntryNormal "prop_6_19"
-    6/20 EntryNormal "prop_6_20"
-    8/21 EntryNormal ""
-  ]
-  INFO found conflict at index 14 [existing term: 2, conflicting term: 4]
-  INFO replace the unstable entries from index 14
-> 7 handling Ready
-  Ready MustSync=true:
-  HardState Term:8 Vote:1 Commit:21 Lead:1 LeadEpoch:2
-  Entries:
-  4/14 EntryNormal ""
-  4/15 EntryNormal "prop_4_15"
-  5/16 EntryNormal ""
-  5/17 EntryNormal "prop_5_17"
-  6/18 EntryNormal ""
-  6/19 EntryNormal "prop_6_19"
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
-  CommittedEntries:
-  4/14 EntryNormal ""
-  4/15 EntryNormal "prop_4_15"
-  5/16 EntryNormal ""
-  5/17 EntryNormal "prop_5_17"
-  6/18 EntryNormal ""
-  6/19 EntryNormal "prop_6_19"
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
-  Messages:
-  7->1 MsgAppResp Term:8 Log:0/21 Commit:21
-> 1 receiving messages
-  7->1 MsgAppResp Term:8 Log:0/21 Commit:21

--- a/pkg/raft/testdata/refortification_basic.txt
+++ b/pkg/raft/testdata/refortification_basic.txt
@@ -125,9 +125,11 @@ stabilize
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
+  1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/3 Commit:3
   1->3 MsgApp Term:1 Log:1/3 Commit:3
 > 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/3 Commit:3
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/3 Commit:3
@@ -137,6 +139,7 @@ stabilize
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
+  2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 3 handling Ready
   Ready MustSync=true:
@@ -146,6 +149,7 @@ stabilize
   Messages:
   3->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
   3->1 MsgAppResp Term:1 Log:0/3 Commit:3
 

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
@@ -80,24 +80,17 @@ stabilize 3
   Messages:
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
 
-deliver-msgs 1
+stabilize 1
 ----
-3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
-
-# The leader sends a snapshot to the follower on the next heartbeat timeout
-# because the follower is now marked as active.
-# TODO(ibrahim): Call MaybeSendAppend after receiving MsgFortifyLeaderResp.
-tick-heartbeat 1
-----
-DEBUG 1 [firstindex: 12, commit: 11] sent snapshot[index: 11, term: 1] to 3 [StateProbe match=0 next=11 sentCommit=10 matchCommit=0]
-DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=12 sentCommit=11 matchCommit=0 paused pendingSnap=11]
-
-process-ready 1
-----
-Ready MustSync=false:
-Messages:
-1->3 MsgSnap Term:1 Log:0/0
-  Snapshot: Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+> 1 receiving messages
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  DEBUG 1 [firstindex: 12, commit: 11] sent snapshot[index: 11, term: 1] to 3 [StateProbe match=0 next=11 sentCommit=10 matchCommit=0]
+  DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=12 sentCommit=11 matchCommit=0 paused pendingSnap=11]
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->3 MsgSnap Term:1 Log:0/0
+    Snapshot: Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   
 status 1
 ----


### PR DESCRIPTION
When we receive a MsgHeartbeatResp, we attempt to send a MsgApp to the follower because it means that the follower is active.

This commit does the same when we receive a MsgFortifyLeaderResp. If we don't do this, we will need to wait until the next heartbeat timeout to attempt to send the MsgApp, which might increase the latency unnecessarily.

Epic: None

Release note: None