### PR TITLE
release-24.2: roachtest: mixedversion runner comments

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
@@ -191,9 +191,9 @@ func (tr *testRunner) run() (retErr error) {
 	defer func() { tr.teardown(stepsErr, retErr != nil) }()
 	defer func() {
 		if retErr != nil {
-			// If the test failed an we haven't run any user hooks up to this
-			// point, redirect the failure to Test Eng, as this indicates a
-			// setup problem that should be investigated separately.
+			// If the test failed, and we haven't run any user hooks up to this point,
+			// redirect the failure to Test Eng, as this indicates a setup problem
+			// that should be investigated separately.
 			if !tr.ranUserHooks.Load() {
 				retErr = registry.ErrorWithOwner(registry.OwnerTestEng, retErr)
 			}
@@ -375,7 +375,7 @@ func (tr *testRunner) stepError(
 }
 
 // testFailure generates a `testFailure` for failures that happened
-// due to the given error.  It logs the error to the logger passed,
+// due to the given error. It logs the error to the logger passed,
 // and renames the underlying file to include the "FAILED" prefix to
 // help in debugging.
 func (tr *testRunner) testFailure(
@@ -950,10 +950,9 @@ func loadAtomicVersions(v *atomic.Value) []roachpb.Version {
 	return v.Load().([]roachpb.Version)
 }
 
-// panicAsError ensures that the any panics that might happen while
-// the function passed runs are captured and returned as regular
-// errors. A stack trace is included in the logs when that happens to
-// facilitate debugging.
+// panicAsError ensures that any panics that might happen while the function
+// passed runs are captured and returned as regular errors. A stack trace is
+// included in the logs when that happens to facilitate debugging.
 func panicAsError(l *logger.Logger, f func() error) (retErr error) {
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
Backport 1/1 commits from #132707.

/cc @cockroachdb/release

---

Fix up a few small comments.

Epic: None
Release note: None

Release justification: Test only change.