### PR TITLE
changefeedccl: fix failure to updating PTS in retryable errors

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -9529,7 +9529,10 @@ func TestChangefeedAvroDecimalColumnWithDiff(t *testing.T) {
 func TestChangefeedProtectedTimestampUpdate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	verifyFunc := func() {}
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		defer verifyFunc()
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
 		// Checkpoint and trigger potential protected timestamp updates frequently.
 		// Make the protected timestamp lag long enough that it shouldn't be
@@ -9594,5 +9597,13 @@ func TestChangefeedProtectedTimestampUpdate(t *testing.T) {
 		require.Less(t, ts, ts2)
 	}
 
-	cdcTest(t, testFn, feedTestForceSink("kafka"))
+	withTxnRetries := withArgsFn(func(args *base.TestServerArgs) {
+		requestFilter, vf := testutils.TestingRequestFilterRetryTxnWithPrefix(t, changefeedJobProgressTxnName, 1)
+		args.Knobs.Store = &kvserver.StoreTestingKnobs{
+			TestingRequestFilter: requestFilter,
+		}
+		verifyFunc = vf
+	})
+
+	cdcTest(t, testFn, feedTestForceSink("kafka"), withTxnRetries)
 }

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -34,12 +34,17 @@ import (
 type UpdateFn func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error
 
 type Updater struct {
-	j   *Job
-	txn isql.Txn
+	j            *Job
+	txn          isql.Txn
+	txnDebugName string
 }
 
 func (j *Job) NoTxn() Updater {
 	return Updater{j: j}
+}
+
+func (j *Job) DebugNameNoTxn(txnDebugName string) Updater {
+	return Updater{j: j, txnDebugName: txnDebugName}
 }
 
 func (j *Job) WithTxn(txn isql.Txn) Updater {
@@ -51,6 +56,9 @@ func (u Updater) update(ctx context.Context, updateFn UpdateFn) (retErr error) {
 		return u.j.registry.db.Txn(ctx, func(
 			ctx context.Context, txn isql.Txn,
 		) error {
+			if u.txnDebugName != "" {
+				txn.KV().SetDebugName(u.txnDebugName)
+			}
 			u.txn = txn
 			return u.update(ctx, updateFn)
 		})


### PR DESCRIPTION
Previously, in the face of retryable errors
updating PTS records, the records would not be
updated due to mismanagement of state.

Fixes: #132602

Release note (bug fix): Fixed an issue where
changefeeds would fail to update protected
timestamp records in the face of retryable errors.
