### PR TITLE
kvserver: store.Enqueue shouldn't start verbose tracing

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -323,6 +323,7 @@ go_test(
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "//pkg/util/tracing",
         "//pkg/util/uuid",
         "//pkg/util/version",
         "//pkg/workload",

--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -385,7 +385,7 @@ SET CLUSTER SETTING kv.allocator.min_lease_transfer_interval = '5m'
 						return errors.New(`could not find replica`)
 					}
 					for _, queueName := range []string{"split", "replicate", "raftsnapshot"} {
-						_, processErr, err := store.Enqueue(
+						processErr, err := store.Enqueue(
 							ctx, queueName, repl, true /* skipShouldQueue */, false, /* async */
 						)
 						if processErr != nil {

--- a/pkg/kv/kvserver/kvserverbase/BUILD.bazel
+++ b/pkg/kv/kvserver/kvserverbase/BUILD.bazel
@@ -27,7 +27,6 @@ go_library(
         "//pkg/util/quotapool",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
-        "//pkg/util/tracing/tracingpb",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/kv/kvserver/kvserverbase/stores.go
+++ b/pkg/kv/kvserver/kvserverbase/stores.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 )
 
 // StoresIterator is able to iterate over all stores on a given node.
@@ -30,7 +29,7 @@ type Store interface {
 		queue string,
 		rangeID roachpb.RangeID,
 		skipShouldQueue bool,
-	) (tracingpb.Recording, error)
+	) error
 
 	// SetQueueActive disables/enables the named queue.
 	SetQueueActive(active bool, queue string) error

--- a/pkg/kv/kvserver/lease_queue_test.go
+++ b/pkg/kv/kvserver/lease_queue_test.go
@@ -466,9 +466,9 @@ func TestLeaseQueueRaceReplicateQueue(t *testing.T) {
 	// replica in the replicate queue synchronously. The lease queue processing
 	// should block on the block mutex above, causing the replicate queue to
 	// return a AllocatorTokenErr trying to process the replica.
-	_, _, _ = repl.Store().Enqueue(ctx, "lease", repl, true /* skipShouldQueue */, true /* async */)
+	_, _ = repl.Store().Enqueue(ctx, "lease", repl, true /* skipShouldQueue */, true /* async */)
 	<-blocked
-	_, processErr, _ := repl.Store().Enqueue(ctx, "replicate", repl, true /* skipShouldQueue */, false /* async */)
+	processErr, _ := repl.Store().Enqueue(ctx, "replicate", repl, true /* skipShouldQueue */, false /* async */)
 	require.ErrorIs(t, processErr, plan.NewErrAllocatorToken("lease"))
 }
 

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -989,7 +989,8 @@ func testRaftSnapshotsToNonVoters(t *testing.T, drainReceivingNode bool) {
 		// Manually enqueue the leaseholder replica into its store's raft snapshot
 		// queue. We expect it to pick up on the fact that the non-voter on its range
 		// needs a snapshot.
-		recording, pErr, err := leaseholderStore.Enqueue(
+		ctx, rec := tracing.ContextWithRecordingSpan(ctx, leaseholderStore.GetStoreConfig().Tracer(), "trace-enqueue")
+		pErr, err := leaseholderStore.Enqueue(
 			ctx,
 			"raftsnapshot",
 			leaseholderRepl,
@@ -1002,7 +1003,7 @@ func testRaftSnapshotsToNonVoters(t *testing.T, drainReceivingNode bool) {
 		if err != nil {
 			return err
 		}
-		matched, err := regexp.MatchString("streamed snapshot.*to.*NON_VOTER", recording.String())
+		matched, err := regexp.MatchString("streamed snapshot.*to.*NON_VOTER", rec().String())
 		if err != nil {
 			return err
 		}
@@ -1266,13 +1267,14 @@ func TestReplicateQueueSeesLearnerOrJointConfig(t *testing.T) {
 	{
 		require.Equal(t, int64(0), getFirstStoreMetric(t, tc.Server(0), `queue.replicate.removelearnerreplica`))
 		store.TestingSetReplicateQueueActive(true)
-		trace, processErr, err := store.Enqueue(
-			ctx, "replicate", repl, true /* skipShouldQueue */, false, /* async */
+		traceCtx, finish := tracing.ContextWithRecordingSpan(ctx, store.GetStoreConfig().Tracer(), "trace-enqueue")
+		processErr, err := store.Enqueue(
+			traceCtx, "replicate", repl, true /* skipShouldQueue */, false, /* async */
 		)
 		require.NoError(t, err)
 		require.NoError(t, processErr)
 		action := "next replica action: remove learner"
-		require.NoError(t, testutils.MatchInOrder(trace.String(), []string{action}...))
+		require.NoError(t, testutils.MatchInOrder(finish().String(), []string{action}...))
 		require.Equal(t, int64(1), getFirstStoreMetric(t, tc.Server(0), `queue.replicate.removelearnerreplica`))
 
 		testutils.SucceedsSoon(t, func() error {
@@ -1294,13 +1296,14 @@ func TestReplicateQueueSeesLearnerOrJointConfig(t *testing.T) {
 		desc := tc.RemoveVotersOrFatal(t, scratchStartKey, tc.Target(2))
 		require.True(t, desc.Replicas().InAtomicReplicationChange(), desc)
 		store.TestingSetReplicateQueueActive(true)
-		trace, processErr, err := store.Enqueue(
-			ctx, "replicate", repl, true /* skipShouldQueue */, false, /* async */
+		traceCtx, finish := tracing.ContextWithRecordingSpan(ctx, store.GetStoreConfig().Tracer(), "trace-enqueue")
+		processErr, err := store.Enqueue(
+			traceCtx, "replicate", repl, true /* skipShouldQueue */, false, /* async */
 		)
 		require.NoError(t, err)
 		require.NoError(t, processErr)
 		action := "next replica action: finalize conf change"
-		require.NoError(t, testutils.MatchInOrder(trace.String(), []string{action}...))
+		require.NoError(t, testutils.MatchInOrder(finish().String(), []string{action}...))
 
 		testutils.SucceedsSoon(t, func() error {
 			desc = tc.LookupRangeOrFatal(t, scratchStartKey)
@@ -1334,13 +1337,14 @@ func TestReplicaGCQueueSeesLearnerOrJointConfig(t *testing.T) {
 	// Run the replicaGC queue.
 	checkNoGC := func() roachpb.RangeDescriptor {
 		store, repl := getFirstStoreReplica(t, tc.Server(1), scratchStartKey)
-		trace, processErr, err := store.Enqueue(
-			ctx, "replicaGC", repl, true /* skipShouldQueue */, false, /* async */
+		traceCtx, rec := tracing.ContextWithRecordingSpan(ctx, store.GetStoreConfig().Tracer(), "trace-enqueue")
+		processErr, err := store.Enqueue(
+			traceCtx, "replicaGC", repl, true /* skipShouldQueue */, false, /* async */
 		)
 		require.NoError(t, err)
 		require.NoError(t, processErr)
 		const msg = `not gc'able, replica is still in range descriptor: (n2,s2):`
-		require.Contains(t, trace.String(), msg)
+		require.Contains(t, rec().String(), msg)
 		return tc.LookupRangeOrFatal(t, scratchStartKey)
 	}
 	desc := checkNoGC()
@@ -1396,8 +1400,9 @@ func TestRaftSnapshotQueueSeesLearner(t *testing.T) {
 	// raft to figure out that the replica needs a snapshot.
 	store, repl := getFirstStoreReplica(t, tc.Server(0), scratchStartKey)
 	testutils.SucceedsSoon(t, func() error {
-		trace, processErr, err := store.Enqueue(
-			ctx, "raftsnapshot", repl, true /* skipShouldQueue */, false, /* async */
+		traceCtx, rec := tracing.ContextWithRecordingSpan(ctx, store.GetStoreConfig().Tracer(), "trace-enqueue")
+		processErr, err := store.Enqueue(
+			traceCtx, "raftsnapshot", repl, true /* skipShouldQueue */, false, /* async */
 		)
 		if err != nil {
 			return err
@@ -1406,7 +1411,7 @@ func TestRaftSnapshotQueueSeesLearner(t *testing.T) {
 			return processErr
 		}
 		const msg = `skipping snapshot; replica is likely a LEARNER in the process of being added: (n2,s2):2LEARNER`
-		formattedTrace := trace.String()
+		formattedTrace := rec().String()
 		if !strings.Contains(formattedTrace, msg) {
 			return errors.Errorf(`expected "%s" in trace got:\n%s`, msg, formattedTrace)
 		}
@@ -1548,8 +1553,9 @@ func TestLearnerReplicateQueueRace(t *testing.T) {
 	queue1ErrCh := make(chan error, 1)
 	go func() {
 		queue1ErrCh <- func() error {
-			trace, processErr, err := store.Enqueue(
-				ctx, "replicate", repl, true /* skipShouldQueue */, false, /* async */
+			traceCtx, rec := tracing.ContextWithRecordingSpan(ctx, store.GetStoreConfig().Tracer(), "trace-enqueue")
+			processErr, err := store.Enqueue(
+				traceCtx, "replicate", repl, true /* skipShouldQueue */, false, /* async */
 			)
 			if err != nil {
 				return err
@@ -1557,7 +1563,7 @@ func TestLearnerReplicateQueueRace(t *testing.T) {
 			if processErr == nil || !strings.Contains(processErr.Error(), `descriptor changed`) {
 				return errors.Wrap(processErr, `expected "descriptor changed" error got: %+v`)
 			}
-			formattedTrace := trace.String()
+			formattedTrace := rec().String()
 			expectedMessages := []string{
 				`could not promote .*?n3,s3.*? to voter, rolling back:.*?change replicas of r\d+ failed: descriptor changed`,
 				`learner to roll back not found`,
@@ -2044,7 +2050,7 @@ func TestMergeQueueDoesNotInterruptReplicationChange(t *testing.T) {
 	// ensure that the merge correctly notices that there is a snapshot in
 	// flight and ignores the range.
 	store, repl := getFirstStoreReplica(t, tc.Server(0), scratchKey)
-	_, processErr, enqueueErr := store.Enqueue(
+	processErr, enqueueErr := store.Enqueue(
 		ctx, "merge", repl, true /* skipShouldQueue */, false, /* async */
 	)
 	require.NoError(t, enqueueErr)
@@ -2090,12 +2096,13 @@ func TestMergeQueueSeesLearnerOrJointConfig(t *testing.T) {
 		})
 
 		store, repl := getFirstStoreReplica(t, tc.Server(0), scratchStartKey)
-		trace, processErr, err := store.Enqueue(
-			ctx, "merge", repl, true /* skipShouldQueue */, false, /* async */
+		traceCtx, rec := tracing.ContextWithRecordingSpan(ctx, store.GetStoreConfig().Tracer(), "trace-enqueue")
+		processErr, err := store.Enqueue(
+			traceCtx, "merge", repl, true /* skipShouldQueue */, false, /* async */
 		)
 		require.NoError(t, err)
 		require.NoError(t, processErr)
-		formattedTrace := trace.String()
+		formattedTrace := rec().String()
 		expectedMessages := []string{
 			`removing learner replicas \[n2,s2\]`,
 			`merging to produce range: /Table/Max-/Max`,
@@ -2127,12 +2134,13 @@ func TestMergeQueueSeesLearnerOrJointConfig(t *testing.T) {
 		checkTransitioningOut := func() {
 			t.Helper()
 			store, repl := getFirstStoreReplica(t, tc.Server(0), scratchStartKey)
-			trace, processErr, err := store.Enqueue(
-				ctx, "merge", repl, true /* skipShouldQueue */, false, /* async */
+			traceCtx, rec := tracing.ContextWithRecordingSpan(ctx, store.GetStoreConfig().Tracer(), "trace-enqueue")
+			processErr, err := store.Enqueue(
+				traceCtx, "merge", repl, true /* skipShouldQueue */, false, /* async */
 			)
 			require.NoError(t, err)
 			require.NoError(t, processErr)
-			formattedTrace := trace.String()
+			formattedTrace := rec().String()
 			expectedMessages := []string{
 				`transitioning out of joint configuration`,
 				`merging to produce range: /Table/Max-/Max`,

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -4097,7 +4097,7 @@ func TestManuallyEnqueueUninitializedReplica(t *testing.T) {
 		StoreID:   tc.store.StoreID(),
 		ReplicaID: 7,
 	})
-	_, _, err := tc.store.Enqueue(
+	_, err := tc.store.Enqueue(
 		ctx, "replicaGC", repl, true /* skipShouldQueue */, false, /* async */
 	)
 	require.Error(t, err)

--- a/pkg/kv/kvserver/stores_base.go
+++ b/pkg/kv/kvserver/stores_base.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
 )
 
@@ -51,21 +50,21 @@ func (s *baseStore) StoreID() roachpb.StoreID {
 // Enqueue is part of kvserverbase.Store.
 func (s *baseStore) Enqueue(
 	ctx context.Context, queue string, rangeID roachpb.RangeID, skipShouldQueue bool,
-) (tracingpb.Recording, error) {
+) error {
 	store := (*Store)(s)
 	repl, err := store.GetReplica(rangeID)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	trace, processErr, enqueueErr := store.Enqueue(ctx, queue, repl, skipShouldQueue, false /* async */)
+	processErr, enqueueErr := store.Enqueue(ctx, queue, repl, skipShouldQueue, false /* async */)
 	if processErr != nil {
-		return nil, processErr
+		return processErr
 	}
 	if enqueueErr != nil {
-		return nil, enqueueErr
+		return enqueueErr
 	}
-	return trace, nil
+	return nil
 }
 
 // SetQueueActive is part of kvserverbase.Store.

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -3202,9 +3202,11 @@ func (s *systemAdminServer) enqueueRangeLocal(
 		queueName = "mvccGC"
 	}
 
-	traceSpans, processErr, err := store.Enqueue(
-		ctx, queueName, repl, req.SkipShouldQueue, false, /* async */
+	traceCtx, rec := tracing.ContextWithRecordingSpan(ctx, store.GetStoreConfig().Tracer(), "trace-enqueue")
+	processErr, err := store.Enqueue(
+		traceCtx, queueName, repl, req.SkipShouldQueue, false, /* async */
 	)
+	traceSpans := rec()
 	if err != nil {
 		response.Details[0].Error = err.Error()
 		return response, nil

--- a/pkg/server/decommission.go
+++ b/pkg/server/decommission.go
@@ -71,7 +71,7 @@ func (t *decommissioningNodeMap) makeOnNodeDecommissioningCallback(
 					if !shouldEnqueue {
 						return true /* wantMore */
 					}
-					_, processErr, enqueueErr := store.Enqueue(
+					processErr, enqueueErr := store.Enqueue(
 						// NB: We elide the shouldQueue check since we _know_ that the
 						// range being enqueued has replicas on a decommissioning node.
 						// Unfortunately, until

--- a/pkg/spanconfig/spanconfigkvsubscriber/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigkvsubscriber/BUILD.bazel
@@ -76,6 +76,7 @@ go_test(
         "//pkg/util/protoutil",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "//pkg/util/tracing",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -250,6 +250,7 @@ go_test(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/timeutil/pgdate",
+        "//pkg/util/tracing",
         "//pkg/workload",
         "//pkg/workload/bank",
         "//pkg/workload/tpcc",


### PR DESCRIPTION
Previously in server.Enqueue, we unconditionally started verbose
tracing. This is expensive and unnessary since most traces were never
processed. Additionally, with the new raft level logging for verbose
traces this resulted in unnecessary traces being created and logged to
the main cockroach.log. This change removes the automatic tracing inside
Enqueue and instead converts tests and callers to explicitly start a
span prior to calling the queue.

As part of this change the Enqueue method no longer returns a Recording.

Epic: none

Release note: None