### PR TITLE
raft: remove redundant FortificationEnabled checks

### DIFF
--- a/pkg/raft/tracker/fortificationtracker_test.go
+++ b/pkg/raft/tracker/fortificationtracker_test.go
@@ -39,7 +39,7 @@ func TestFortificationEnabled(t *testing.T) {
 	for _, tc := range testCases {
 		cfg := quorum.MakeEmptyConfig()
 		fortificationTracker := NewFortificationTracker(&cfg, tc.storeLiveness, raftlogger.DiscardLogger)
-		require.Equal(t, tc.expectEnabled, fortificationTracker.FortificationEnabled())
+		require.Equal(t, tc.expectEnabled, fortificationTracker.FortificationEnabledForTerm())
 	}
 }
 


### PR DESCRIPTION
Previously, we were checking whether fortification was enabled by consulting StoreLiveness in a few different places. A few of these checks were redundant, which this commit removes. While here, we also start tracking whether fortification was enabled at any point during a leadership term. We'll use this in an upcoming patch to decide whether we should broadcast MsgDeFortifyLeader or not.

Epic: none
Release note: None