### PR TITLE
drtprod: use ROACHPROD_GCE_DEFAULT_PROJECT to avoid warning

### DIFF
--- a/pkg/cmd/drt/scripts/roachtest_operations_run.sh
+++ b/pkg/cmd/drt/scripts/roachtest_operations_run.sh
@@ -7,7 +7,7 @@
 
 cd /home/ubuntu
 
-export GCE_PROJECT=cockroach-drt
+export ROACHPROD_GCE_DEFAULT_PROJECT=cockroach-drt
 export ROACHPROD_DNS="drt.crdb.io"
 ./roachprod sync
 sleep 20

--- a/pkg/cmd/drtprod/configs/drt_test.yaml
+++ b/pkg/cmd/drtprod/configs/drt_test.yaml
@@ -1,6 +1,6 @@
 # Yaml to create a test-cluster. Please make sure that you change the cluster names to avoid conflicts.
 environment:
-  GCE_PROJECT: cockroach-ephemeral
+  ROACHPROD_GCE_DEFAULT_PROJECT: cockroach-ephemeral
   CLUSTER: drt-test
   WORKLOAD_CLUSTER: workload-test
 

--- a/scripts/drtprod
+++ b/scripts/drtprod
@@ -6,7 +6,7 @@ set -euo pipefail
 # clusters that ensures consistent use of the correct project-assignment vars
 # and done some additional sanity check enforcement on some flags.
 
-export GCE_PROJECT=cockroach-drt
+export ROACHPROD_GCE_DEFAULT_PROJECT=cockroach-drt
 export ROACHPROD_DNS="drt.crdb.io"
 
 if [ "$#" -lt 1 ]; then


### PR DESCRIPTION
This PR replaces all instances of `GCE_PROJECT` with `ROACHPROD_GCE_DEFAULT_PROJECT` to avoid the warning `WARNING: `GCE_PROJECT` is deprecated; please, use `ROACHPROD_GCE_DEFAULT_PROJECT` instead`

Epic: none
Release note: None