### PR TITLE
roachtest: change lease type for perturbation tests

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -154,7 +154,11 @@ func setupMetamorphic(p perturbation) variations {
 func setupFull(p perturbation) variations {
 	v := variations{}
 	v.workload = kvWorkload{}
-	v.leaseType = registry.ExpirationLeases
+	v.leaseType = registry.EpochLeases
+	// TODO(baptist): Inject this in a better way.
+	if reflect.TypeOf(p) == reflect.TypeOf(&partition{}) {
+		v.leaseType = registry.ExpirationLeases
+	}
 	v.maxBlockBytes = 4096
 	v.splits = 10000
 	v.numNodes = 12
@@ -174,7 +178,11 @@ func setupFull(p perturbation) variations {
 func setupDev(p perturbation) variations {
 	v := variations{}
 	v.workload = kvWorkload{}
-	v.leaseType = registry.ExpirationLeases
+	v.leaseType = registry.EpochLeases
+	// TODO(baptist): Inject this in a better way.
+	if reflect.TypeOf(p) == reflect.TypeOf(&partition{}) {
+		v.leaseType = registry.ExpirationLeases
+	}
 	v.maxBlockBytes = 1024
 	v.splits = 1
 	v.numNodes = 4


### PR DESCRIPTION
Previously the perturbation/full/* tests were all run under expiration leases. This wasn't the default cluster setting and only the partition test required epoch leases to pass successfully. This commit changes the default to epoch for all the non-partition tests.

Epic: none

Release note: None