### PR TITLE
sql: fix TestAuthenticationAndHBARules stress tests SSL issue

### DIFF
--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -61,6 +61,7 @@ go_library(
         "//pkg/sql/sqltelemetry",
         "//pkg/sql/types",
         "//pkg/util",
+        "//pkg/util/buildutil",
         "//pkg/util/ctxlog",
         "//pkg/util/duration",
         "//pkg/util/envutil",

--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -572,7 +572,17 @@ func hbaRunTest(t *testing.T, insecure bool) {
 						defer dbSQL.Close()
 					}
 					if err != nil {
-						return "", err
+						if !errors.Is(err, pq.ErrSSLNotSupported) {
+							return "", err
+						}
+						// Retry: server might fail to respond for upgrade conn under stress
+						dbSQL, err = gosql.Open("postgres", dsn)
+						if dbSQL != nil {
+							defer dbSQL.Close()
+						}
+						if err != nil {
+							return "", err
+						}
 					}
 					row := dbSQL.QueryRow("SELECT current_catalog")
 					var result string


### PR DESCRIPTION
sql: fix TestAuthenticationAndHBARules stress tests SSL issue

informs #131532
informs #131110
informs #130253
informs #127745
Epic CRDB-41958

TestAuthenticationAndHBARules fails for `special_cases`, `hba_default_equivalence`, `empty_hba` data driven tests for secure mode. The failures occur when root user is trying to authenticate with cert-password auth method and `sslmode` is set to `verify-ca` with `sslcert` being empty. The expected behavior is root authentication defaults to password method and fails as no password is set for root, but instead we get:
```
pq: SSL is not enabled on the server
```
Since the failures are there only under stress, it might be because db server shutdown or paused before responding to request for upgrade connection to SSL from lib/pq client from here
https://github.com/lib/pq/blob/3d613208bca2e74f2a20e04126ed30bcb5c4cc27/conn.go#L1116-L1130. Retrying connection establishment when this specific error is obtained might fix the problem as this logic seems faulty(it checks for absence of 'S' in server response whereas the correct check should be for 'N' in response).

----

pgwire: add test build logs for upgrade secure conn

Additional test build logs are added to verify the step for which
`maybeUpgradeToSecureConn` fails.

Release note: None