### PR TITLE
kvprober: reuse TracingEnabled config variable

### DIFF
--- a/pkg/kv/kvprober/kvprober.go
+++ b/pkg/kv/kvprober/kvprober.go
@@ -367,7 +367,8 @@ func (p *Prober) readProbeImpl(ctx context.Context, ops proberOpsI, txns proberT
 	var finishAndGetRecording func() tracingpb.Recording
 	var probeCtx = ctx
 
-	if tracingEnabled.Get(&p.settings.SV) {
+	isTracingEnabled := tracingEnabled.Get(&p.settings.SV)
+	if isTracingEnabled {
 		probeCtx, finishAndGetRecording = tracing.ContextWithRecordingSpan(ctx, p.tracer, "read probe")
 	}
 
@@ -425,7 +426,7 @@ func (p *Prober) readProbeImpl(ctx context.Context, ops proberOpsI, txns proberT
 
 	d := timeutil.Since(start)
 	// Extract leaseholder information from the trace recording if enabled.
-	if tracingEnabled.Get(&p.settings.SV) {
+	if isTracingEnabled {
 		leaseholder := p.returnLeaseholderInfo(finishAndGetRecording())
 		ctx = logtags.AddTag(ctx, "leaseholder", leaseholder)
 		log.Health.Infof(ctx, "kv.Get(%s), r=%v having likely leaseholder=%s returned success in %v", step.Key, step.RangeID, leaseholder, d)
@@ -451,7 +452,8 @@ func (p *Prober) writeProbeImpl(ctx context.Context, ops proberOpsI, txns prober
 	var finishAndGetRecording func() tracingpb.Recording
 	var probeCtx = ctx
 
-	if tracingEnabled.Get(&p.settings.SV) {
+	isTracingEnabled := tracingEnabled.Get(&p.settings.SV)
+	if isTracingEnabled {
 		probeCtx, finishAndGetRecording = tracing.ContextWithRecordingSpan(ctx, p.tracer, "write probe")
 	}
 
@@ -506,7 +508,7 @@ func (p *Prober) writeProbeImpl(ctx context.Context, ops proberOpsI, txns prober
 
 	d := timeutil.Since(start)
 	// Extract leaseholder information from the trace recording if enabled.
-	if tracingEnabled.Get(&p.settings.SV) {
+	if isTracingEnabled {
 		leaseholder := p.returnLeaseholderInfo(finishAndGetRecording())
 		ctx = logtags.AddTag(ctx, "leaseholder", leaseholder)
 		log.Health.Infof(ctx, "kv.Txn(Put(%s); Del(-)), r=%v having likely leaseholder=%s returned success in %v", step.Key, step.RangeID, leaseholder, d)


### PR DESCRIPTION
There was a panic caused due to null reference from variable `finishAndGetRecording` 
see #131672

This was happening because we check the TracingEnabled config twice and in a corner case the flag was false on the first call and enabled when the second call was made causing the null reference.

This PR checks the flag once and reuses it.

Fixes: #131672

Epic: none
Release note: None