### PR TITLE
logconfig: update file sink log validation config

### DIFF
--- a/pkg/util/log/logconfig/testdata/validate
+++ b/pkg/util/log/logconfig/testdata/validate
@@ -868,3 +868,15 @@ file-defaults:
     max-buffer-size: 50MiB
 ----
 ERROR: Unable to use "buffered-writes" in conjunction with a "buffering" configuration. These configuration options are mutually exclusive.
+
+# Check that auditable and buffered-writes are incompatible together.
+yaml
+file-defaults:
+  buffered-writes: false
+  auditable: true
+  buffering:
+    max-staleness: 5s
+    flush-trigger-size: 1.0MiB
+    max-buffer-size: 50MiB
+----
+ERROR: File-based audit logging cannot coexist with buffering configuration. Disable either the "buffering" (buffered-writes) or "auditable" log (auditable) configuration.

--- a/pkg/util/log/logconfig/validate.go
+++ b/pkg/util/log/logconfig/validate.go
@@ -372,6 +372,10 @@ func (c *Config) validateFileSinkConfig(fc *FileSinkConfig) error {
 			return errors.Newf(`Unable to use "buffered-writes" in conjunction with a "buffering" configuration. ` +
 				`These configuration options are mutually exclusive.`)
 		}
+		if *fc.Auditable {
+			return errors.Newf(`File-based audit logging cannot coexist with buffering configuration. ` +
+				`Disable either the "buffering" (buffered-writes) or "auditable" log (auditable) configuration.`)
+		}
 		// To preserve the format of log files, avoid additional formatting in the
 		// buffering configuration.
 		fmtNone := BufferFmtNone


### PR DESCRIPTION
Previously, you can configure auditable & buffered sink at once in file sink log config. These configuration shouldn't co-exist. To address this, we have added a validation that both these configuration shouldn't co-exist.

Epic: CRDB-37534
-------------------------------
 Sample onfiguration & error message:
`file-defaults:
  dir: cockroach-data/logs
  max-file-size: 10MiB
  max-group-size: 100MiB
  buffered-writes: false
  filter: INFO
  format: crdb-v2
  redact: false
  redactable: true
  exit-on-error: true
  auditable: true
  buffering:
    max-staleness: 1s
    flush-trigger-size: 256KiB
    max-buffer-size: 50MiB`

![Screenshot 2024-10-16 at 8 30 03 PM](https://github.com/user-attachments/assets/7e6b8f65-1e00-4426-b9b7-1dc89fe12e8d)

