### PR TITLE
release-24.1: lint: require license headers for .sh, .py, makefiles

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,16 +1,7 @@
 # Copyright 2022 The Cockroach Authors.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied. See the License for the specific language governing
-# permissions and limitations under the License.
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
 
 all: build
 	$(MAKE) help

--- a/build/bazelutil/bazel-generate.sh
+++ b/build/bazelutil/bazel-generate.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 # files_unchanged_from_upstream takes file globs as arguments and checks

--- a/build/bazelutil/check.sh
+++ b/build/bazelutil/check.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 # This script performs assorted checks to make sure there is nothing obviously

--- a/build/bazelutil/gopackagesdriver.sh
+++ b/build/bazelutil/gopackagesdriver.sh
@@ -1,2 +1,8 @@
 #!/bin/bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 exec bazel run -- @io_bazel_rules_go//go/tools/gopackagesdriver "${@}"

--- a/build/bazelutil/stamp.sh
+++ b/build/bazelutil/stamp.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # This command is used by bazel as the workspace_status_command
 # to implement build stamping with git information.
 

--- a/build/bootstrap/autoshutdown.cron.sh
+++ b/build/bootstrap/autoshutdown.cron.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2017 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # This script is intended to be called periodical. If it doesn't detect remote
 # sessions in a given number of consecutive runs, a shutdown is initiated.
 #

--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2017 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 #
 # On a Debian/Ubuntu system, bootstraps a docker install and the cockroach
 # repo.

--- a/build/bootstrap/bootstrap-ssd.sh
+++ b/build/bootstrap/bootstrap-ssd.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2017 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 #
 # Bootstraps Local SSD devices.
 #

--- a/build/bootstrap/bootstrap-unison.sh
+++ b/build/bootstrap/bootstrap-unison.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2018 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 #
 # On a Debian/Ubuntu system, bootstraps the Unison file-syncer.
 

--- a/build/bootstrap/install-azure-cli.sh
+++ b/build/bootstrap/install-azure-cli.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2017 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 #
 # On a Debian/Ubuntu system, installs the Azure CLI.
 

--- a/build/disable-hyperv-timesync.sh
+++ b/build/disable-hyperv-timesync.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2017 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 # Disabling hyper-v time synchronization means unbinding the device.

--- a/build/ghactions/changed-go-pkgs.sh
+++ b/build/ghactions/changed-go-pkgs.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 BASE_SHA="$1"
 HEAD_SHA="$2"
 

--- a/build/ghactions/pr-codecov-run-tests.sh
+++ b/build/ghactions/pr-codecov-run-tests.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 output_json_file="$1"

--- a/build/github/acceptance-test.sh
+++ b/build/github/acceptance-test.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 set +x

--- a/build/github/build.sh
+++ b/build/github/build.sh
@@ -1,3 +1,8 @@
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -euxo pipefail
 
 # Usage: must provide a cross config as argument

--- a/build/github/check-generated-code.sh
+++ b/build/github/check-generated-code.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 # This function dumps the output of the given file to $GITHUB_STEP_SUMMARY

--- a/build/github/cleanup-engflow-keys.sh
+++ b/build/github/cleanup-engflow-keys.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 rm -f /home/agent/engflow.key /home/agent/engflow.crt

--- a/build/github/docker-image.sh
+++ b/build/github/docker-image.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 #!/usr/bin/env bash
 set -euxo pipefail
 

--- a/build/github/engflow-args.sh
+++ b/build/github/engflow-args.sh
@@ -1,3 +1,8 @@
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 # The intention is that you'll execute the script at the end of your Bazel
 # invocation as follows: `bazel test ... $(engflow-args.sh)`. This will add
 # remote execution arguments to the invocation. You must call get-engflow-keys.sh

--- a/build/github/examples-orms.sh
+++ b/build/github/examples-orms.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 pushd cockroach

--- a/build/github/get-engflow-keys.sh
+++ b/build/github/get-engflow-keys.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 gcloud secrets versions access 2 --secret=engflow-mesolite-key > /home/agent/engflow.key

--- a/build/github/lint.sh
+++ b/build/github/lint.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 WORKSPACE=$(bazel info workspace)

--- a/build/github/local-roachtest.sh
+++ b/build/github/local-roachtest.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 CROSSCONFIG=$1

--- a/build/github/prepare-summarize-build.sh
+++ b/build/github/prepare-summarize-build.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 THIS_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)

--- a/build/github/summarize-build.sh
+++ b/build/github/summarize-build.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # You MUST run prepare-summarize-build.sh before running this script.
 
 set -euxo pipefail

--- a/build/github/unit-tests.sh
+++ b/build/github/unit-tests.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 EXTRA_PARAMS=""

--- a/build/go-version-check.sh
+++ b/build/go-version-check.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2018 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # Detect whether the installed version of Go can build this version of
 # CockroachDB.
 #

--- a/build/instrumentation/gen_exclusions.sh
+++ b/build/instrumentation/gen_exclusions.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 
 echo "# Vendor Exclusions"

--- a/build/instrumentation/vendor_antithesis.sh
+++ b/build/instrumentation/vendor_antithesis.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -eo pipefail
 
 # NB: Currently, this script is only intended to work with `make instrument(short)`

--- a/build/node-run.sh
+++ b/build/node-run.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2017 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # node-run.sh runs a command installed by NPM/Yarn. It looks for COMMAND in
 # ./node_modules/bin, where NPM/Yarn install commands by default, then invokes
 # it with the specified ARGS, if any.

--- a/build/packer/setup_filebeat_on_teamcity_agent.sh
+++ b/build/packer/setup_filebeat_on_teamcity_agent.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 export FILEBEAT_CONFIG_PATH=/tmp/filebeat.yml

--- a/build/packer/setup_fips.sh
+++ b/build/packer/setup_fips.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 apt-get update

--- a/build/packer/teamcity-agent-macos.sh
+++ b/build/packer/teamcity-agent-macos.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env zsh
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 write_teamcity_config() {

--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2017 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 write_teamcity_config() {

--- a/build/release/bincheck/download_binary.sh
+++ b/build/release/bincheck/download_binary.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -exuo pipefail
 
 download_and_extract() {

--- a/build/release/teamcity-mark-as-tested.sh
+++ b/build/release/teamcity-mark-as-tested.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 echo "Implement me!"
 

--- a/build/release/teamcity-mark-build-internal-rc.sh
+++ b/build/release/teamcity-mark-build-internal-rc.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 source "$(dirname "${0}")/teamcity-mark-build.sh"

--- a/build/release/teamcity-mark-build-internal-test.sh
+++ b/build/release/teamcity-mark-build-internal-test.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 source "$(dirname "${0}")/teamcity-mark-build.sh"

--- a/build/release/teamcity-mark-build-qualified.sh
+++ b/build/release/teamcity-mark-build-qualified.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 source "$(dirname "${0}")/teamcity-mark-build.sh"

--- a/build/release/teamcity-mark-build.sh
+++ b/build/release/teamcity-mark-build.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 source "$(dirname "${0}")/teamcity-support.sh"
 
 # mark_build marks a build with a given label specified as a parameter on

--- a/build/release/teamcity-publish-redhat-release.sh
+++ b/build/release/teamcity-publish-redhat-release.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 source "$(dirname "${0}")/teamcity-support.sh"

--- a/build/release/teamcity-roachtest-qualification.sh
+++ b/build/release/teamcity-roachtest-qualification.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 echo "Implement me!"
 

--- a/build/release/teamcity-support.sh
+++ b/build/release/teamcity-support.sh
@@ -1,3 +1,8 @@
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 # Common helpers for teamcity-*.sh scripts.
 
 # root is the absolute path to the root directory of the repository.

--- a/build/release/teamcity-update-latest-build.sh
+++ b/build/release/teamcity-update-latest-build.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 echo "Implement me!"
 

--- a/build/shlib.sh
+++ b/build/shlib.sh
@@ -1,3 +1,8 @@
+# Copyright 2017 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 # Shell support functions and variables. Bash-only.
 
 # Terminal color codes.

--- a/build/teamcity-assert-clean.sh
+++ b/build/teamcity-assert-clean.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2017 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 source "$(dirname "${0}")/teamcity-support.sh"

--- a/build/teamcity-bazel-support.sh
+++ b/build/teamcity-bazel-support.sh
@@ -1,3 +1,8 @@
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 if [ -z "${root:-}" ]
 then
     echo '$root is not set; please source teamcity-support.sh'

--- a/build/teamcity-common-support.sh
+++ b/build/teamcity-common-support.sh
@@ -1,3 +1,8 @@
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 # Common logic shared by build/teamcity-support.sh and build/release/teamcity-support.sh.
 
 # Call this to clean up after using any other functions from this file.

--- a/build/teamcity-diagram-generation.sh
+++ b/build/teamcity-diagram-generation.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 source "$(dirname "${0}")/teamcity-support.sh"

--- a/build/teamcity-reset-nightlies.sh
+++ b/build/teamcity-reset-nightlies.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2017 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # Deletes and recreates the nightlies resource group, which contains the Azure
 # VMs, virtual networks, IPs, disks etc. that are automatically created by
 # nightly tests. This is a big hammer, but the nightlies leak resources

--- a/build/teamcity-roachtest-invoke.sh
+++ b/build/teamcity-roachtest-invoke.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -euo pipefail
 
 set +e

--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -1,3 +1,8 @@
+# Copyright 2017 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 # Common helpers for teamcity-*.sh scripts.
 
 # root is the absolute path to the root directory of the repository.

--- a/build/teamcity/cockroach/ci/builds/build_impl.sh
+++ b/build/teamcity/cockroach/ci/builds/build_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 if [ -z "$1" ]

--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64-bigvm/unit_tests.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64-bigvm/unit_tests.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64-bigvm/unit_tests_impl.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64-bigvm/unit_tests_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64/acceptance.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64/acceptance.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64/bench.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64/bench.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 source build/teamcity/cockroach/ci/tests/bench.sh

--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64/local_roachtest.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64/local_roachtest.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -exuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64/maybe_stress.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64/maybe_stress.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 source build/teamcity/cockroach/ci/tests/maybe_stress.sh

--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64/maybe_stressrace.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64/maybe_stressrace.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 source build/teamcity/cockroach/ci/tests/maybe_stressrace.sh

--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64/testrace.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64/testrace.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 source build/teamcity/cockroach/ci/tests/testrace.sh

--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64/ui_test.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64/ui_test.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64/ui_test_impl.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64/ui_test_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 bazel build //pkg/cmd/bazci --config=ci

--- a/build/teamcity/cockroach/ci/tests/bench.sh
+++ b/build/teamcity/cockroach/ci/tests/bench.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/cockroach/ci/tests/bench_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/bench_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/cockroach/ci/tests/check_generated_code_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/check_generated_code_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euox pipefail
 
 if [[ "$(uname -m)" =~ (arm64|aarch64)$ ]]; then

--- a/build/teamcity/cockroach/ci/tests/maybe_stress.sh
+++ b/build/teamcity/cockroach/ci/tests/maybe_stress.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/cockroach/ci/tests/maybe_stress_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/maybe_stress_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -exuo pipefail
 
 if [ -z "$1" ]

--- a/build/teamcity/cockroach/ci/tests/maybe_stressrace.sh
+++ b/build/teamcity/cockroach/ci/tests/maybe_stressrace.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/cockroach/ci/tests/testrace.sh
+++ b/build/teamcity/cockroach/ci/tests/testrace.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/cockroach/ci/tests/testrace_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/testrace_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 # Usage: testrace_impl.sh PKG1 [PKG2 PKG3 PKG4...]

--- a/build/teamcity/cockroach/ci/tests/ui_e2e_test_all.sh
+++ b/build/teamcity/cockroach/ci/tests/ui_e2e_test_all.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -euo pipefail
 
 build="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/cockroach/ci/tests/ui_e2e_test_health.sh
+++ b/build/teamcity/cockroach/ci/tests/ui_e2e_test_health.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -euo pipefail
 
 build="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/cockroach/ci/tests/ui_e2e_test_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/ui_e2e_test_impl.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 function load_cockroach_docker_image() {
   docker load --input upstream_artifacts/cockroach-docker-image.tar.gz &> artifacts/docker-load.log || (cat artifacts/docker-load.log && false)
   rm artifacts/docker-load.log

--- a/build/teamcity/cockroach/coverage/publish_finalize.sh
+++ b/build/teamcity/cockroach/coverage/publish_finalize.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # This script is the final step of the "Publish Coverage" build.
 #
 # It moves the HTML mini-websites into archives, so that it's easy to download

--- a/build/teamcity/cockroach/coverage/publish_gen_html.sh
+++ b/build/teamcity/cockroach/coverage/publish_gen_html.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # This script is the second step of the "Publish Coverage" build.
 #
 # It takes some of the lcov files produced by the previous step and generates

--- a/build/teamcity/cockroach/coverage/publish_gen_lcov.sh
+++ b/build/teamcity/cockroach/coverage/publish_gen_lcov.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # This script is the first step of the "Publish Coverage" build.
 #
 # It takes coverage data from dependent builds and generates lcov files.

--- a/build/teamcity/cockroach/coverage/publish_upload.sh
+++ b/build/teamcity/cockroach/coverage/publish_upload.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # This script is the third step of the "Publish Coverage" build.
 #
 # It takes the HTML mini-websites produced by the previous step and uploads them

--- a/build/teamcity/cockroach/coverage/roachtest_nightly_gce.sh
+++ b/build/teamcity/cockroach/coverage/roachtest_nightly_gce.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -exuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/coverage/roachtest_nightly_gce_impl.sh
+++ b/build/teamcity/cockroach/coverage/roachtest_nightly_gce_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -exuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/coverage/unit_tests.sh
+++ b/build/teamcity/cockroach/coverage/unit_tests.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/coverage/unit_tests_impl.sh
+++ b/build/teamcity/cockroach/coverage/unit_tests_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 bazel build //pkg/cmd/bazci --config=ci

--- a/build/teamcity/cockroach/create-docs-issue.sh
+++ b/build/teamcity/cockroach/create-docs-issue.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # This script is called by the build configuration
 # "Cockroach > Create Docs Issue" in TeamCity.
 

--- a/build/teamcity/cockroach/nightlies/cloud_unit_tests.sh
+++ b/build/teamcity/cockroach/nightlies/cloud_unit_tests.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/cloud_unit_tests_impl.sh
+++ b/build/teamcity/cockroach/nightlies/cloud_unit_tests_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/compose.sh
+++ b/build/teamcity/cockroach/nightlies/compose.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/lint_urls.sh
+++ b/build/teamcity/cockroach/nightlies/lint_urls.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/lint_urls_impl.sh
+++ b/build/teamcity/cockroach/nightlies/lint_urls_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
+++ b/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 #
 # This script runs microbenchmarks across a roachprod cluster.
 # Parameters:

--- a/build/teamcity/cockroach/nightlies/optimizer_tests.sh
+++ b/build/teamcity/cockroach/nightlies/optimizer_tests.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/optimizer_tests_impl.sh
+++ b/build/teamcity/cockroach/nightlies/optimizer_tests_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_build_test_binary.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_build_test_binary.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 #
 # This script is run by pebble_nightly_metamorphic_crossversion.sh to build test
 # binaries of the pebble metamorphic package at different branches. This script

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_common.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_common.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 #
 # This script contains common configuration used by the Pebble Nightly runs.
 

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 #
 # This script is run by the Pebble Nightly Metamorphic - TeamCity build
 # configuration.

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_crossversion.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_crossversion.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 #
 # This script is run by the Pebble Nightly Crossversion Metamorphic - TeamCity
 # build configuration.

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_crossversion_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_crossversion_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
 
 set -euxo pipefail

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
 
 set -euxo pipefail

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 #
 # This script is run by the Pebble Nightly Metamorphic Race - TeamCity build
 # configuration.

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
 
 set -euxo pipefail

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_two_instance.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_two_instance.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 #
 # This script is run by the Pebble Nightly Metamorphic Two Instance - TeamCity
 # build configuration.

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_two_instance_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_two_instance_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
 
 set -euxo pipefail

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_race_common.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_race_common.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 #
 # This script contains common configuration used by the Pebble Nightly race runs.
 

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_write_throughput.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_write_throughput.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 #
 # This script runs the Pebble Nightly write-throughput benchmarks.
 #

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_write_throughput_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_write_throughput_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -eo pipefail
 
 _dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 #
 # This script runs the Pebble Nightly YCSB benchmarks.
 #

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -eo pipefail
 
 _dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb_race.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb_race.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 #
 # This script runs the Pebble Nightly YCSB A benchmark with the race flag.
 # It is used to detect data races which may have been introduced to the latest

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb_race_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb_race_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 _dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"

--- a/build/teamcity/cockroach/nightlies/random_syntax_tests.sh
+++ b/build/teamcity/cockroach/nightlies/random_syntax_tests.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/random_syntax_tests_impl.sh
+++ b/build/teamcity/cockroach/nightlies/random_syntax_tests_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 # N.B. `$root` is defined in build/teamcity-support.sh;

--- a/build/teamcity/cockroach/nightlies/roachtest_compile_component.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_compile_component.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 source $root/build/teamcity/util/roachtest_arch_util.sh

--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_aws.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_aws.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -exuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_aws_fips.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_aws_fips.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -exuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_azure.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_azure.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -exuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_gce.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_gce.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -exuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_gce_fips.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_gce_fips.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -exuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -exuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/roachtest_stress_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_stress_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -exuo pipefail
 
 dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/build/teamcity/cockroach/nightlies/roachtest_weekly.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_weekly.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -exuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/roachtest_weekly_aws.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_weekly_aws.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -exuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -exuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/schema_changer_comparator_nightly.sh
+++ b/build/teamcity/cockroach/nightlies/schema_changer_comparator_nightly.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/schema_changer_comparator_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/schema_changer_comparator_nightly_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/sqlite_logic_test.sh
+++ b/build/teamcity/cockroach/nightlies/sqlite_logic_test.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/sqllogic_backup_restore.sh
+++ b/build/teamcity/cockroach/nightlies/sqllogic_backup_restore.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/sqllogic_backup_restore_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqllogic_backup_restore_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly.sh
+++ b/build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/sqllogic_hi_vmodule_nightly.sh
+++ b/build/teamcity/cockroach/nightlies/sqllogic_hi_vmodule_nightly.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/sqllogic_hi_vmodule_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqllogic_hi_vmodule_nightly_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/stress.sh
+++ b/build/teamcity/cockroach/nightlies/stress.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/stress_engflow.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 export EXTRA_TEST_ARGS="--config use_ci_timeouts"

--- a/build/teamcity/cockroach/nightlies/stress_engflow_deadlock.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow_deadlock.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 export RUNS_PER_TEST=3

--- a/build/teamcity/cockroach/nightlies/stress_engflow_impl.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 google_credentials="$GOOGLE_CREDENTIALS"

--- a/build/teamcity/cockroach/nightlies/stress_engflow_race.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow_race.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 export RUNS_PER_TEST=3

--- a/build/teamcity/cockroach/nightlies/stress_impl.sh
+++ b/build/teamcity/cockroach/nightlies/stress_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/teamcity-roachtest-stress.sh
+++ b/build/teamcity/cockroach/nightlies/teamcity-roachtest-stress.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -exuo pipefail
 
 source "$(dirname "${0}")/../../../teamcity-support.sh"

--- a/build/teamcity/cockroach/nightlies/url_check.sh
+++ b/build/teamcity/cockroach/nightlies/url_check.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -exuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"

--- a/build/teamcity/cockroach/nightlies/url_check_impl.sh
+++ b/build/teamcity/cockroach/nightlies/url_check_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 bazel run //pkg/cmd/urlcheck --config=ci --run_under="cd $PWD && "

--- a/build/teamcity/cockroach/post-merge/publish-bleeding-edge-darwin-amd64.sh
+++ b/build/teamcity/cockroach/post-merge/publish-bleeding-edge-darwin-amd64.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 PLATFORM=darwin-amd64 ./build/teamcity/cockroach/post-merge/publish-bleeding-edge-per-platform.sh

--- a/build/teamcity/cockroach/post-merge/publish-bleeding-edge-darwin-arm64.sh
+++ b/build/teamcity/cockroach/post-merge/publish-bleeding-edge-darwin-arm64.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 PLATFORM=darwin-arm64 ./build/teamcity/cockroach/post-merge/publish-bleeding-edge-per-platform.sh

--- a/build/teamcity/cockroach/post-merge/publish-bleeding-edge-linux-amd64-fips.sh
+++ b/build/teamcity/cockroach/post-merge/publish-bleeding-edge-linux-amd64-fips.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 PLATFORM=linux-amd64-fips ./build/teamcity/cockroach/post-merge/publish-bleeding-edge-per-platform.sh

--- a/build/teamcity/cockroach/post-merge/publish-bleeding-edge-linux-amd64.sh
+++ b/build/teamcity/cockroach/post-merge/publish-bleeding-edge-linux-amd64.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 PLATFORM=linux-amd64 ./build/teamcity/cockroach/post-merge/publish-bleeding-edge-per-platform.sh

--- a/build/teamcity/cockroach/post-merge/publish-bleeding-edge-linux-arm64.sh
+++ b/build/teamcity/cockroach/post-merge/publish-bleeding-edge-linux-arm64.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 PLATFORM=linux-arm64 ./build/teamcity/cockroach/post-merge/publish-bleeding-edge-per-platform.sh

--- a/build/teamcity/cockroach/post-merge/publish-bleeding-edge-per-platform.sh
+++ b/build/teamcity/cockroach/post-merge/publish-bleeding-edge-per-platform.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # This script is called by the build configuration
 # "Cockroach > Post Merge > Publish Bleeding Edge" in TeamCity.
 

--- a/build/teamcity/cockroach/post-merge/publish-bleeding-edge-win-amd64.sh
+++ b/build/teamcity/cockroach/post-merge/publish-bleeding-edge-win-amd64.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 PLATFORM=win-amd64 ./build/teamcity/cockroach/post-merge/publish-bleeding-edge-per-platform.sh
 

--- a/build/teamcity/cockroach/publish-sql-grammar-diagrams-impl.sh
+++ b/build/teamcity/cockroach/publish-sql-grammar-diagrams-impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 bazel build //pkg/cmd/bazci --config=ci

--- a/build/teamcity/internal/cockroach/build/ci/build-and-push-bazel-builder-image-fips.sh
+++ b/build/teamcity/internal/cockroach/build/ci/build-and-push-bazel-builder-image-fips.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"

--- a/build/teamcity/internal/cockroach/build/ci/build-and-push-bazel-builder-image.sh
+++ b/build/teamcity/internal/cockroach/build/ci/build-and-push-bazel-builder-image.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"

--- a/build/teamcity/internal/cockroach/build/ci/nightly-bazel-builder-update-check.sh
+++ b/build/teamcity/internal/cockroach/build/ci/nightly-bazel-builder-update-check.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -xeuo pipefail
 
 # We use a docker image mirror to avoid pulling from 3rd party repos, which sometimes have reliability issues.

--- a/build/teamcity/internal/cockroach/build/ci/open-new-bazel-builder-image-pr.sh
+++ b/build/teamcity/internal/cockroach/build/ci/open-new-bazel-builder-image-pr.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -xeuo pipefail
 
 # This script expects the following env vars to be set:

--- a/build/teamcity/internal/cockroach/nightlies/private_roachtest.sh
+++ b/build/teamcity/internal/cockroach/nightlies/private_roachtest.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -exuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/internal/cockroach/nightlies/private_roachtest_impl.sh
+++ b/build/teamcity/internal/cockroach/nightlies/private_roachtest_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -exuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/internal/cockroach/release/process/cancel_release_date.sh
+++ b/build/teamcity/internal/cockroach/release/process/cancel_release_date.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"

--- a/build/teamcity/internal/cockroach/release/process/cancel_release_date_impl.sh
+++ b/build/teamcity/internal/cockroach/release/process/cancel_release_date_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 to=dev-inf+release-dev@cockroachlabs.com

--- a/build/teamcity/internal/cockroach/release/process/pick_sha.sh
+++ b/build/teamcity/internal/cockroach/release/process/pick_sha.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"

--- a/build/teamcity/internal/cockroach/release/process/pick_sha_impl.sh
+++ b/build/teamcity/internal/cockroach/release/process/pick_sha_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"

--- a/build/teamcity/internal/cockroach/release/process/post_blockers.sh
+++ b/build/teamcity/internal/cockroach/release/process/post_blockers.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"

--- a/build/teamcity/internal/cockroach/release/process/post_blockers_impl.sh
+++ b/build/teamcity/internal/cockroach/release/process/post_blockers_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 to=dev-inf+release-dev@cockroachlabs.com

--- a/build/teamcity/internal/cockroach/release/process/update_versions.sh
+++ b/build/teamcity/internal/cockroach/release/process/update_versions.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"

--- a/build/teamcity/internal/cockroach/release/process/update_versions_impl.sh
+++ b/build/teamcity/internal/cockroach/release/process/update_versions_impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 to=dev-inf+release-dev@cockroachlabs.com

--- a/build/teamcity/internal/cockroach/release/publish/publish-redhat-release.sh
+++ b/build/teamcity/internal/cockroach/release/publish/publish-redhat-release.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"

--- a/build/teamcity/internal/cockroach/release/publish/publish-staged-cockroach-release.sh
+++ b/build/teamcity/internal/cockroach/release/publish/publish-staged-cockroach-release.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"

--- a/build/teamcity/internal/cockroach/release/publish/sign_macos_release.sh
+++ b/build/teamcity/internal/cockroach/release/publish/sign_macos_release.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 KEYCHAIN_NAME=signing

--- a/build/teamcity/internal/cockroach/release/publish/sign_staged_macos_release.sh
+++ b/build/teamcity/internal/cockroach/release/publish/sign_staged_macos_release.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"

--- a/build/teamcity/internal/release/build-and-publish-cdeps.sh
+++ b/build/teamcity/internal/release/build-and-publish-cdeps.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"

--- a/build/teamcity/internal/release/build-and-publish-cross-toolchains.sh
+++ b/build/teamcity/internal/release/build-and-publish-cross-toolchains.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"

--- a/build/teamcity/internal/release/build-and-publish-osx-toolchains.sh
+++ b/build/teamcity/internal/release/build-and-publish-osx-toolchains.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"

--- a/build/teamcity/internal/release/build-and-publish-patched-go.sh
+++ b/build/teamcity/internal/release/build-and-publish-patched-go.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"

--- a/build/teamcity/internal/release/build-and-publish-patched-go/impl-fips.sh
+++ b/build/teamcity/internal/release/build-and-publish-patched-go/impl-fips.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 GO_FIPS_REPO=https://github.com/golang-fips/go

--- a/build/teamcity/internal/release/build-and-publish-patched-go/impl.sh
+++ b/build/teamcity/internal/release/build-and-publish-patched-go/impl.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 # When updating to a new Go version, update all of these variables.

--- a/build/teamcity/internal/release/process/build-cockroach-release-darwin-amd64.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-darwin-amd64.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 PLATFORM=darwin-amd64 ./build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh

--- a/build/teamcity/internal/release/process/build-cockroach-release-darwin-arm64.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-darwin-arm64.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 PLATFORM=darwin-arm64 ./build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh

--- a/build/teamcity/internal/release/process/build-cockroach-release-docker.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-docker.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/internal/release/process/build-cockroach-release-linux-amd64-fips.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-linux-amd64-fips.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 PLATFORM=linux-amd64-fips ./build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh

--- a/build/teamcity/internal/release/process/build-cockroach-release-linux-amd64.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-linux-amd64.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 PLATFORM=linux-amd64 ./build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh

--- a/build/teamcity/internal/release/process/build-cockroach-release-linux-arm64.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-linux-arm64.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 PLATFORM=linux-arm64 ./build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh

--- a/build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/internal/release/process/build-cockroach-release-win-amd64.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-win-amd64.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 PLATFORM=win-amd64 ./build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh

--- a/build/teamcity/internal/release/process/check-gha.sh
+++ b/build/teamcity/internal/release/process/check-gha.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -exuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-darwin-amd64.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-darwin-amd64.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 PLATFORM=darwin-amd64 ./build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-darwin-arm64.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-darwin-arm64.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 PLATFORM=darwin-arm64 ./build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-docker.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-docker.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-linux-amd64-fips.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-linux-amd64-fips.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 PLATFORM=linux-amd64-fips ./build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-linux-amd64.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-linux-amd64.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 PLATFORM=linux-amd64 ./build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-linux-arm64.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-linux-arm64.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 PLATFORM=linux-arm64 ./build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-win-amd64.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-win-amd64.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 PLATFORM=win-amd64 ./build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh

--- a/build/teamcity/internal/release/process/make-and-publish-build-tagging.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-tagging.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/internal/release/process/publish-cockroach-release.sh
+++ b/build/teamcity/internal/release/process/publish-cockroach-release.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/internal/release/process/roachtest-release-qualification.sh
+++ b/build/teamcity/internal/release/process/roachtest-release-qualification.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"

--- a/build/teamcity/internal/release/process/roachtest-release-qualification_fips.sh
+++ b/build/teamcity/internal/release/process/roachtest-release-qualification_fips.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 FIPS_ENABLED=1 ./build/teamcity/internal/release/process/roachtest-release-qualification.sh

--- a/build/teamcity/internal/release/publish-patched-go-for-mac.sh
+++ b/build/teamcity/internal/release/publish-patched-go-for-mac.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"

--- a/build/teamcity/internal/release/sign-patched-go.sh
+++ b/build/teamcity/internal/release/sign-patched-go.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -xeuo pipefail
 
 KEYCHAIN_NAME=signing

--- a/build/teamcity/util.sh
+++ b/build/teamcity/util.sh
@@ -1,3 +1,8 @@
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 # Some common utilities also used by Bazel build configs.
 
 tc_start_block() {

--- a/build/teamcity/util/roachtest_arch_util.sh
+++ b/build/teamcity/util/roachtest_arch_util.sh
@@ -1,3 +1,8 @@
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 # arch_to_config returns the bazel config for the given arch.
 function arch_to_config() {
   case "$1" in

--- a/build/teamcity/util/roachtest_util.sh
+++ b/build/teamcity/util/roachtest_util.sh
@@ -1,3 +1,8 @@
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 # Common logic used by the nightly roachtest scripts (Bazel and non-Bazel).
 
 # Set up Google credentials. Note that we need this for all clouds since we upload

--- a/build/toolchains/toolchainbuild/crosstool-ng/buildtoolchains.sh
+++ b/build/toolchains/toolchainbuild/crosstool-ng/buildtoolchains.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 this_dir="$(cd "$(dirname "${0}")"; pwd)"

--- a/build/toolchains/toolchainbuild/crosstool-ng/perform-build.sh
+++ b/build/toolchains/toolchainbuild/crosstool-ng/perform-build.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 apt-get update \

--- a/build/toolchains/toolchainbuild/osxcross/buildtoolchains.sh
+++ b/build/toolchains/toolchainbuild/osxcross/buildtoolchains.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 this_dir="$(cd "$(dirname "${0}")"; pwd)"

--- a/build/toolchains/toolchainbuild/osxcross/perform-build.sh
+++ b/build/toolchains/toolchainbuild/osxcross/perform-build.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 apt-get update \

--- a/build/vendor_rebuild.sh
+++ b/build/vendor_rebuild.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -Eeoux pipefail
 
 TMP_VENDOR_DIR=.vendor.tmp.$(date +"%Y-%m-%d.%H%M%S")

--- a/build/verify-archive.sh
+++ b/build/verify-archive.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2017 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # This script sanity-checks a source tarball, assuming a Debian-based Linux
 # environment with a Go version capable of building CockroachDB. Source tarballs
 # are expected to build, even after `make clean`, and install a functional

--- a/build/werror.sh
+++ b/build/werror.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2017 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # werror.sh promotes warnings produced by a command to fatal errors, just like
 # GCC's -Werror flag.
 #

--- a/cloud/kubernetes/demo.sh
+++ b/cloud/kubernetes/demo.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2016 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 function sql() {

--- a/cloud/kubernetes/multiregion/setup.py
+++ b/cloud/kubernetes/multiregion/setup.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
 
+# Copyright 2018 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 import distutils.spawn
 import json
 import os

--- a/cloud/kubernetes/multiregion/teardown.py
+++ b/cloud/kubernetes/multiregion/teardown.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
 
+# Copyright 2018 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 from shutil import rmtree
 from subprocess import call
 

--- a/monitoring/demo/config/roach-init.sh
+++ b/monitoring/demo/config/roach-init.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # curl health endpoint
 while ! health=$(curl -s "http://roach1:8080/health?ready=1"); do
   sleep 0.1

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -1,3 +1,8 @@
+# Copyright 2016 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 # This is a convenience Makefile which defers all real work to
 # ../Makefile. The % rule is run for any target specified on the
 # command line. We use the builtin MAKECMDGOALS and MAKEFLAGS

--- a/pkg/acceptance/compose/gss/build-push-gss.sh
+++ b/pkg/acceptance/compose/gss/build-push-gss.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -xeuo pipefail
 
 TARGET=$1

--- a/pkg/acceptance/compose/gss/kdc/start.sh
+++ b/pkg/acceptance/compose/gss/kdc/start.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Copyright 2018 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -e
 
 # The /keytab directory is volume mounted on both kdc and cockroach. kdc

--- a/pkg/acceptance/compose/gss/psql/start.sh
+++ b/pkg/acceptance/compose/gss/psql/start.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Copyright 2018 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -e
 
 echo "Available certs:"

--- a/pkg/acceptance/compose/gss/python/manage.py
+++ b/pkg/acceptance/compose/gss/python/manage.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python
+
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 """Django's command-line utility for administrative tasks."""
 import os
 import sys

--- a/pkg/acceptance/compose/gss/python/python/__init__.py
+++ b/pkg/acceptance/compose/gss/python/python/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.

--- a/pkg/acceptance/compose/gss/python/python/settings.py
+++ b/pkg/acceptance/compose/gss/python/python/settings.py
@@ -1,3 +1,8 @@
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 """
 Django settings for python project.
 

--- a/pkg/acceptance/compose/gss/python/python/urls.py
+++ b/pkg/acceptance/compose/gss/python/python/urls.py
@@ -1,3 +1,8 @@
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 """python URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:

--- a/pkg/acceptance/compose/gss/python/python/wsgi.py
+++ b/pkg/acceptance/compose/gss/python/python/wsgi.py
@@ -1,3 +1,8 @@
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 """
 WSGI config for python project.
 

--- a/pkg/acceptance/compose/gss/python/start.sh
+++ b/pkg/acceptance/compose/gss/python/start.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -e
 
 echo "Available certs:"

--- a/pkg/acceptance/run.sh
+++ b/pkg/acceptance/run.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2016 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 "$(dirname "${0}")"/prepare.sh

--- a/pkg/acceptance/testdata/c/Makefile
+++ b/pkg/acceptance/testdata/c/Makefile
@@ -1,3 +1,8 @@
+# Copyright 2018 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 CC += -std=c99
 CPPFLAGS += -I/usr/include/postgresql
 LDLIBS += -lpq -lpqtypes

--- a/pkg/acceptance/testdata/psql/test-psql-notls.sh
+++ b/pkg/acceptance/testdata/psql/test-psql-notls.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 CERTS_DIR=${CERTS_DIR:-/certs}
 crdb=$1
 trap "set -x; cat /tmp/server_pid | xargs kill -9 || true" EXIT HUP

--- a/pkg/acceptance/testdata/psql/test-psql-unix.sh
+++ b/pkg/acceptance/testdata/psql/test-psql-unix.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 CERTS_DIR=${CERTS_DIR:-/certs}
 crdb=$1
 trap "set -x; cat /tmp/server_pid | xargs kill -9 || true" EXIT HUP

--- a/pkg/acceptance/testdata/psql/test-psql.sh
+++ b/pkg/acceptance/testdata/psql/test-psql.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2018 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 # Check that psql works in the first place.

--- a/pkg/acceptance/testdata/python/test.py
+++ b/pkg/acceptance/testdata/python/test.py
@@ -1,3 +1,8 @@
+# Copyright 2018 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 import decimal
 import sys
 import psycopg2

--- a/pkg/ccl/sqlproxyccl/run_proxy_direct_crdb.sh
+++ b/pkg/ccl/sqlproxyccl/run_proxy_direct_crdb.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -euo pipefail
 
 # This script sets up an sql proxy, test directory server and a host server to help with end to end testing.

--- a/pkg/ccl/sqlproxyccl/run_proxy_indirect_crdb.sh
+++ b/pkg/ccl/sqlproxyccl/run_proxy_indirect_crdb.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -euo pipefail
 
 # This script sets up an sql proxy, test directory server and a host server to help with end to end testing.

--- a/pkg/ccl/sqlproxyccl/run_tenant.sh
+++ b/pkg/ccl/sqlproxyccl/run_tenant.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -euo pipefail
 
 # This script is used by run_proxy_indirect_crdb.sh to start a new tenant sql process. It can be customized to do

--- a/pkg/cli/interactive_tests/netcat.py
+++ b/pkg/cli/interactive_tests/netcat.py
@@ -1,3 +1,8 @@
+# Copyright 2018 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 import socket
 import sys
 

--- a/pkg/cli/interactive_tests/test_auth_cookie.py
+++ b/pkg/cli/interactive_tests/test_auth_cookie.py
@@ -1,3 +1,8 @@
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 import urllib2
 import ssl
 import sys

--- a/pkg/cli/interactive_tests/unzip.py
+++ b/pkg/cli/interactive_tests/unzip.py
@@ -1,3 +1,8 @@
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 import zipfile
 import sys
 

--- a/pkg/cmd/drt/scripts/cct_232_setup.sh
+++ b/pkg/cmd/drt/scripts/cct_232_setup.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -eux
 
 CLUSTER=cct-232

--- a/pkg/cmd/drt/scripts/cct_tpcc_drop.sh
+++ b/pkg/cmd/drt/scripts/cct_tpcc_drop.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 CLUSTER_NAME=cct-232
 PG_URL_N1=$(./roachprod pgurl $CLUSTER_NAME:1 --secure --cluster=application --external | sed s/\'//g)
 PGURLS=$(./roachprod pgurl cct-232 --external --secure --cluster application | sed s/\'//g)

--- a/pkg/cmd/drt/scripts/chaos_test.sh
+++ b/pkg/cmd/drt/scripts/chaos_test.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -u
 set -o pipefail
 

--- a/pkg/cmd/drt/scripts/grafanaAnnotate.sh
+++ b/pkg/cmd/drt/scripts/grafanaAnnotate.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -o errexit
 set -x
 

--- a/pkg/cmd/drt/scripts/kv_run.sh
+++ b/pkg/cmd/drt/scripts/kv_run.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -o pipefail
 
 PGURLS=$(./roachprod pgurl cct-232 --external --secure --cluster application | sed s/\'//g)

--- a/pkg/cmd/drt/scripts/roachtest_operations_run.sh
+++ b/pkg/cmd/drt/scripts/roachtest_operations_run.sh
@@ -1,5 +1,11 @@
 #! /bin/bash
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 cd ~
 
 while true; do

--- a/pkg/cmd/drt/scripts/schemachange_run.sh
+++ b/pkg/cmd/drt/scripts/schemachange_run.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -o pipefail
 
 PGURLS=$(./roachprod pgurl cct-232 --external --secure --cluster application | sed s/\'//g)

--- a/pkg/cmd/drt/scripts/start_all_workloads.sh
+++ b/pkg/cmd/drt/scripts/start_all_workloads.sh
@@ -1,3 +1,8 @@
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 sudo systemd-run --working-directory=/home/ubuntu --service-type exec --collect --unit cct_kv --uid 1000 --gid 1000 ./kv_run.sh
 sudo systemd-run --working-directory=/home/ubuntu --service-type exec --collect --unit cct_tpcc --uid 1000 --gid 1000 ./tpcc_run.sh
 sudo systemd-run --working-directory=/home/ubuntu --service-type exec --collect --unit cct_tpcc_drop --uid 1000 --gid 1000 ./cct_tpcc_drop.sh

--- a/pkg/cmd/drt/scripts/stop_all_workloads.sh
+++ b/pkg/cmd/drt/scripts/stop_all_workloads.sh
@@ -1,3 +1,8 @@
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 sudo systemctl stop cct_schemachange
 sudo systemctl stop cct_kv
 sudo systemctl stop cct_tpcc

--- a/pkg/cmd/drt/scripts/tpcc_run.sh
+++ b/pkg/cmd/drt/scripts/tpcc_run.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -o pipefail
 
 TPCC_DB=cct_tpcc

--- a/pkg/cmd/label-merged-pr/label-merged-pr-wrapper.sh
+++ b/pkg/cmd/label-merged-pr/label-merged-pr-wrapper.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -uo pipefail
 
 this_dir=$(cd "$(dirname "$0")" && pwd)

--- a/pkg/cmd/roachprod/docker/build.sh
+++ b/pkg/cmd/roachprod/docker/build.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 # This script is used to build the docker image.
 
 set -e

--- a/pkg/cmd/roachprod/docker/entrypoint.sh
+++ b/pkg/cmd/roachprod/docker/entrypoint.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -e
 
 # Unpack all of the keys, configs, etc. and then run roachprod

--- a/pkg/cmd/roachprod/docker/push.sh
+++ b/pkg/cmd/roachprod/docker/push.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -euo pipefail
 
 # root is the absolute path to the root directory of the repository.

--- a/pkg/cmd/roachtest/roachstress.sh
+++ b/pkg/cmd/roachtest/roachstress.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -euo pipefail
 
 # This script is an opinionated helper around building binaries and artifacts.

--- a/pkg/compose/run.sh
+++ b/pkg/compose/run.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euxo pipefail
 
 "$(dirname "${0}")"/prepare.sh

--- a/pkg/geo/geomfn/bench.sh
+++ b/pkg/geo/geomfn/bench.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -eux
 
 if [ $# -eq 0 ] || [ "$1" == "" ]; then

--- a/pkg/internal/sqlsmith/Makefile
+++ b/pkg/internal/sqlsmith/Makefile
@@ -1,3 +1,8 @@
+# Copyright 2019 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 # Use FORCE here because we want to regenerate when this makefile changes.
 gen-sampler-gen.go: FORCE
 	genny -in=sampler.tmpl -out=sampler.go gen "element=statement,tableExpr,selectStatement,scalarExpr"

--- a/pkg/security/securitytest/test_certs/regenerate.sh
+++ b/pkg/security/securitytest/test_certs/regenerate.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -eux
 
 dir_n="pkg/security/securitytest/test_certs"

--- a/pkg/sql/lexbase/sql-gen.sh
+++ b/pkg/sql/lexbase/sql-gen.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # This is used through bazel when generating sql.go and plpgsql.go.
 # Look at BUILD.bazel in pkg/sql/parser or pkg/plpgsql/parser for
 # usage.

--- a/pkg/sql/opt/testutils/opttester/testfixtures/rewrite_stats.sh
+++ b/pkg/sql/opt/testutils/opttester/testfixtures/rewrite_stats.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -euo pipefail
 
 if [[ $# < 3 || $# > 4 ]]; then

--- a/pkg/sql/parser/help_gen_test.sh
+++ b/pkg/sql/parser/help_gen_test.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2017 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # Trigger this script by running `make generate PKG=./pkg/sql/parser` from the
 # repository root to ensure your PATH includes vendored binaries.
 

--- a/pkg/sql/pgwire/pgcode/generate.sh
+++ b/pkg/sql/pgwire/pgcode/generate.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Copyright 2019 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -eu
 
 # This script will generate a list of error codes. It will not perform

--- a/pkg/sql/pgwire/pgcode/generate_names.sh
+++ b/pkg/sql/pgwire/pgcode/generate_names.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -eu
 
 # This script will generate a mapping from condition names to error codes.

--- a/pkg/sql/sem/cast/cast_map_gen.sh
+++ b/pkg/sql/sem/cast/cast_map_gen.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # casts_gen.sh generates castMap entries by reading from Postgres's pg_cast
 # table. To use this script, Postgres must be installed with the PostGIS
 # extension and already running.

--- a/pkg/sql/sem/eval/cast_test/testdata/assignment_casts_gen.sh
+++ b/pkg/sql/sem/eval/cast_test/testdata/assignment_casts_gen.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -euo pipefail
 
 # assignment_casts_gen.sh generates a CSV file of test cases for use by

--- a/pkg/sql/sem/eval/cast_test/testdata/explicit_casts_gen.sh
+++ b/pkg/sql/sem/eval/cast_test/testdata/explicit_casts_gen.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -euo pipefail
 
 # explicit_casts_gen.sh generates a CSV file of test cases for use by

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -224,7 +224,7 @@ func TestLint(t *testing.T) {
 		}
 	})
 
-	t.Run("TestCopyrightHeaders", func(t *testing.T) {
+	t.Run("TestCopyrightHeadersWithSlash", func(t *testing.T) {
 		t.Parallel()
 
 		cslHeader := regexp.MustCompile(`// Copyright 20\d\d The Cockroach Authors.
@@ -282,6 +282,59 @@ func TestLint(t *testing.T) {
 			data = data[0:n]
 
 			if cslHeader.Find(data) == nil {
+				t.Errorf("did not find expected CSL license header in %s", filename)
+			}
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cmd.Wait(); err != nil {
+			if out := stderr.String(); len(out) > 0 {
+				t.Fatalf("err=%s, stderr=%s", err, out)
+			}
+		}
+	})
+
+	t.Run("TestCopyrightHeadersWithHash", func(t *testing.T) {
+		t.Parallel()
+
+		cslHeaderHash := regexp.MustCompile(`# Copyright 20\d\d The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+`)
+
+		// These extensions identify source files that should have copyright headers.
+		extensions := []string{"GNUmakefile", "Makefile", "*.py", "*.sh"}
+
+		cmd, stderr, filter, err := dirCmd(crdbDir, "git", append([]string{"ls-files"}, extensions...)...)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := stream.ForEach(stream.Sequence(filter,
+			stream.GrepNot(`^c-deps/.*`),
+			// These files are copied from raft upstream with its own license.
+			stream.GrepNot(`^raft/.*`),
+		), func(filename string) {
+			file, err := os.Open(filepath.Join(crdbDir, filename))
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			defer file.Close()
+			data := make([]byte, 1024)
+			n, err := file.Read(data)
+			if err != nil {
+				t.Errorf("reading start of %s: %s", filename, err)
+			}
+			data = data[0:n]
+
+			if cslHeaderHash.Find(data) == nil {
 				t.Errorf("did not find expected CSL license header in %s", filename)
 			}
 		}); err != nil {

--- a/pkg/ui/Makefile
+++ b/pkg/ui/Makefile
@@ -1,16 +1,7 @@
 # Copyright 2017 The Cockroach Authors.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied. See the License for the specific language governing
-# permissions and limitations under the License.
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
 
 # This is a convenience Makefile which defers all real work to the top-level
 # Makefile. The % rule is run for any target specified on the command line. We

--- a/pkg/ui/workspaces/e2e-tests/build/compose-entrypoint.sh
+++ b/pkg/ui/workspaces/e2e-tests/build/compose-entrypoint.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -uemo pipefail
 
 set -x

--- a/pkg/ui/workspaces/e2e-tests/build/start-crdb-then.sh
+++ b/pkg/ui/workspaces/e2e-tests/build/start-crdb-then.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -ueo pipefail
 
 # Compute the absolute path to the root of the cockroach repo.

--- a/pkg/util/fsm/gen/reports.sh
+++ b/pkg/util/fsm/gen/reports.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2017 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 #
 # reports.sh generates reports about the finite state machine.
 #

--- a/pkg/util/interval/generic/gen.sh
+++ b/pkg/util/interval/generic/gen.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -eu -o pipefail
 
 if [ $# -ne 2 ]; then

--- a/pkg/util/leaktest/add-leaktest.sh
+++ b/pkg/util/leaktest/add-leaktest.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+
+# Copyright 2016 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 #
 # Add leaktest.AfterTest(t) to all tests in the given files.
 # In addition to running this script, add a main_test.go file similar

--- a/pkg/util/leaktest/check-leaktest.sh
+++ b/pkg/util/leaktest/check-leaktest.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Copyright 2016 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -e
 
 pkgs=$(git grep 'go:generate' | grep add-leaktest.sh | awk -F: '{print $1}' | xargs -n1 dirname)

--- a/scripts/authors.sh
+++ b/scripts/authors.sh
@@ -1,5 +1,11 @@
 #! /bin/sh
 
+# Copyright 2017 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # This script produces the list of authors for a given source file,
 # listed in decreasing order of the number of commits by that author
 # that have touched the file.

--- a/scripts/azworker.sh
+++ b/scripts/azworker.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2017 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 #
 # Prerequisites:
 # - Cockroach Labs employees: ask an admin to create an Azure account for you.

--- a/scripts/bump-pebble.sh
+++ b/scripts/bump-pebble.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # NOTE: After a new release has been cut, update this to the appropriate
 # Cockroach branch name (i.e. release-23.2, etc.), and corresponding Pebble
 # branch name (e.g. crl-release-23.2, etc.). Also update pebble nightly scripts

--- a/scripts/deplicense.sh
+++ b/scripts/deplicense.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2017 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 # Output the license info for the current directory's dependencies.

--- a/scripts/diff-example.sh
+++ b/scripts/diff-example.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2017 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # Diff a failed Go example [0] against its expected output.
 #
 # By default, when an example fails, Go prints "got:", followed by the

--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2016 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 cd "$(dirname "${0}")/.."

--- a/scripts/git-blame-stats.sh
+++ b/scripts/git-blame-stats.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Copyright 2017 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # This script produces the list of authors that are "git blame"d for lines in
 # .go files under the current directory.
 #

--- a/scripts/localmetrics/import-csv.sh
+++ b/scripts/localmetrics/import-csv.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 psql 'postgresql://postgres:postgres@127.0.0.1?sslmode=disable' \

--- a/scripts/log2html.sh
+++ b/scripts/log2html.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2016 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # Script that converts a log file to html, using cockroach-specific log syntax
 # highlighting. Requires vim to be installed.
 #

--- a/scripts/ls-files.sh
+++ b/scripts/ls-files.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2017 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # Recursively list all files in this Git checkout, including files in
 # submodules.
 

--- a/scripts/pprof-loop.sh
+++ b/scripts/pprof-loop.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -eu
 
 if [ "$#" -ne 1 ]; then

--- a/scripts/pprof-post.sh
+++ b/scripts/pprof-post.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -euo pipefail
 
 if ! which pprofme; then

--- a/scripts/purge-terraform.sh
+++ b/scripts/purge-terraform.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2017 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # Destroy any Terraform resources found in tfstate files within the repository.
 
 set -euo pipefail

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -1,4 +1,10 @@
 #! /usr/bin/env python3
+
+# Copyright 2018 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 #
 # Show a compact release note summary of a range of Git commits.
 #

--- a/scripts/release-notes/Makefile
+++ b/scripts/release-notes/Makefile
@@ -1,3 +1,8 @@
+# Copyright 2018 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 TESTS := $(wildcard test*.sh)
 BASH ?= /usr/bin/env bash
 PYTHON ?= python

--- a/scripts/release-notes/common.sh
+++ b/scripts/release-notes/common.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Copyright 2018 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # Initialize a test.
 function test_init() {
     PYTHON=${PYTHON:-python}

--- a/scripts/release-notes/test1.sh
+++ b/scripts/release-notes/test1.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+
+# Copyright 2018 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -eux
 
 . common.sh

--- a/scripts/release-notes/test2.sh
+++ b/scripts/release-notes/test2.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+
+# Copyright 2018 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -eux
 
 . common.sh

--- a/scripts/release-notes/test3.sh
+++ b/scripts/release-notes/test3.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+
+# Copyright 2018 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -eux
 
 . common.sh

--- a/scripts/release-notes/test4.sh
+++ b/scripts/release-notes/test4.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+
+# Copyright 2018 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -eux
 
 . common.sh

--- a/scripts/release-notes/test5.sh
+++ b/scripts/release-notes/test5.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+
+# Copyright 2018 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -eux
 
 . common.sh

--- a/scripts/release-notes/test6.sh
+++ b/scripts/release-notes/test6.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+
+# Copyright 2018 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -eux
 
 . common.sh

--- a/scripts/release-notes/test7.sh
+++ b/scripts/release-notes/test7.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+
+# Copyright 2018 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -eux
 
 . common.sh

--- a/scripts/release-notes/test8.sh
+++ b/scripts/release-notes/test8.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+
+# Copyright 2019 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 set -eux
 
 . common.sh

--- a/scripts/roachprod-get-latest.sh
+++ b/scripts/roachprod-get-latest.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # Downloads the _latest_ roachprod binary (on master) from GCS to the specified directory
 # or the current directory if none is specified.
 # Assumes that you have gsutil installed and authenticated; see [1] for those details.

--- a/scripts/roachtest-gobench.sh
+++ b/scripts/roachtest-gobench.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 #
 # Converts roachtest benchmark results (for kv or ycsb workloads) into Go
 # benchmark format, suitable for use with e.g. benchstat.

--- a/scripts/rt-ts-admin.sh
+++ b/scripts/rt-ts-admin.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
 # if you have a roachtest that save tsdump files you can run this from the artifacts dir and it
 # will try to start a admin for each tsdump-gob-run.sh it finds.   It prints out the adminurl.
 # Requirements:

--- a/scripts/tag-custom-build.sh
+++ b/scripts/tag-custom-build.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2020 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # This script makes it easy to make custom builds.
 #
 # It creates a tag for a SHA that triggers a build in the Make and Publish

--- a/scripts/todo_diff.sh
+++ b/scripts/todo_diff.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Copyright 2021 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # The command runs git diff between two refspecs to find all instances of TODO
 # added between them.
 

--- a/scripts/winworker.sh
+++ b/scripts/winworker.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Copyright 2018 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 set -euo pipefail
 
 cd "$(dirname "${0}")/.."

--- a/tools/claim_output_base.sh
+++ b/tools/claim_output_base.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
 # Typically only one bazel server can be running in one output_base at
 # a time, which means if we always use the default base, only one bazel server 
 # can be running for a given workspace at a time. Instead, we'll keep a few 


### PR DESCRIPTION
Backport 1/1 commits from #131799.

/cc @cockroachdb/release

---

Some file types generally did not use license headers before. Now .sh, .py and makefile files will be required to include license headers. The license header linter will enforce the requirement. All non-compliant files are now updated with the correct headers.

Part of RE-658

Release note (general change): Change the license cockroach is distributed under to the new CockroachDB Software License (CSL).

---

Release justification: Change the license cockroach is distributed under to the new CockroachDB Software License (CSL).
