### PR TITLE
ui: use `crl-ant` as antd classname prefix

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/refreshControl/refreshControl.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/refreshControl/refreshControl.module.scss
@@ -21,7 +21,7 @@
   margin-right: 12px;
 }
 
-.ant-switch-checked {
+.crl-ant-switch-checked {
   background-color: $colors--primary-blue-3;
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/common/styles.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/common/styles.module.scss
@@ -7,11 +7,11 @@
 
 .cockroach--tabs {
   overflow: visible !important;
-  :global(.ant-tabs-bar) {
+  :global(.crl-ant-tabs-bar) {
     border-bottom: 1px solid $grey2;
   }
 
-  :global(.ant-tabs-tab) {
+  :global(.crl-ant-tabs-tab) {
     font-family: $font-family--base;
     font-size: 16px;
     line-height: 1.5;
@@ -19,15 +19,15 @@
     color: $colors--neutral-7;
   }
 
-  :global(.ant-tabs-nav .ant-tabs-tab-active) {
+  :global(.crl-ant-tabs-nav .crl-ant-tabs-tab-active) {
     color: $colors--link;
   }
 
-  :global(.ant-tabs-nav .ant-tabs-tab:hover) {
+  :global(.crl-ant-tabs-nav .crl-ant-tabs-tab:hover) {
     color: $colors--link;
   }
 
-  :global(.ant-tabs-ink-bar) {
+  :global(.crl-ant-tabs-ink-bar) {
     height: 3px;
     border-radius: 40px;
     background-color: $blue;

--- a/pkg/ui/workspaces/cluster-ui/src/components/regionNodesLabel/components/regionLabel.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/components/regionNodesLabel/components/regionLabel.module.scss
@@ -23,7 +23,7 @@
 }
 
 .badge {
-  :global(.ant-badge-count) {
+  :global(.crl-ant-badge-count) {
     background-color: $colors--neutral-1;
     font-size: 12px;
     height: 20px;

--- a/pkg/ui/workspaces/cluster-ui/src/dateRangeMenu/dateRangeMenu.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/dateRangeMenu/dateRangeMenu.module.scss
@@ -16,7 +16,7 @@
     padding-bottom: 10px;
 
     a {
-      // Matches the color of .ant-dropdown, needed to override default anchor color. A cleaner way would be to install
+      // Matches the color of .crl-ant-dropdown, needed to override default anchor color. A cleaner way would be to install
       // and set up antd-scss-theme-plugin, and use the antd text-color variable.
       color: rgba(0, 0, 0, 0.65);
     }
@@ -30,7 +30,7 @@
     height: 12px;
   }
 
-  :global(.ant-picker) {
+  :global(.crl-ant-picker) {
     margin-right: 14px;
   }
 }

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobs.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobs.module.scss
@@ -146,7 +146,7 @@
     font-size: $font-size--medium;
     display: flex;
     align-items: center;
-    .ant-divider {
+    .crl-ant-divider {
       height: 20px;
     }
   }
@@ -166,7 +166,7 @@
   .job-status__line--percentage {
     display: flex;
     align-items: center;
-    .ant-divider {
+    .crl-ant-divider {
       height: 20px;
     }
     span {
@@ -178,7 +178,7 @@
       margin: 0;
     }
   }
-  .ant-divider {
+  .crl-ant-divider {
     margin-left: 15px;
     margin-right: 15px;
   }

--- a/pkg/ui/workspaces/cluster-ui/src/modal/modal.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/modal/modal.module.scss
@@ -8,24 +8,24 @@
 .crl-modal {
   @include base;
   :global {
-    .ant-modal-footer {
+    .crl-ant-modal-footer {
       border-top: none;
       padding: 0;
       margin-top: $spacing-large;
     }
 
-    .ant-modal-header {
+    .crl-ant-modal-header {
       margin-bottom: $spacing-medium-small;
     }
 
-    .ant-modal-content {
+    .crl-ant-modal-content {
       padding: $spacing-large;
       box-shadow: 0px 0px 1px rgba(71, 88, 114, 0.47);
       border-radius: 5px;
       min-width: 560px;
     }
 
-    .ant-modal-close {
+    .crl-ant-modal-close {
       top: $spacing-large;
     }
   }

--- a/pkg/ui/workspaces/cluster-ui/src/schedules/schedules.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/schedules/schedules.module.scss
@@ -154,7 +154,7 @@
     font-size: $font-size--medium;
     display: flex;
     align-items: center;
-    .ant-divider {
+    .crl-ant-divider {
       height: 20px;
     }
   }
@@ -174,7 +174,7 @@
   .schedule-status__line--percentage {
     display: flex;
     align-items: center;
-    .ant-divider {
+    .crl-ant-divider {
       height: 20px;
     }
     span {
@@ -186,7 +186,7 @@
       margin: 0;
     }
   }
-  .ant-divider {
+  .crl-ant-divider {
     margin-left: 15px;
     margin-right: 15px;
   }

--- a/pkg/ui/workspaces/cluster-ui/src/search/search.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/search/search.module.scss
@@ -14,7 +14,7 @@
   margin: 2px;
 }
 
-:global(.ant-input-affix-wrapper:not(.ant-input-affix-wrapper-disabled):focus-within) {
+:global(.crl-ant-input-affix-wrapper:not(.crl-ant-input-affix-wrapper-disabled):focus-within) {
   outline: 2px solid $colors--primary-blue-3;
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/searchCriteria/searchCriteria.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/searchCriteria/searchCriteria.module.scss
@@ -5,15 +5,15 @@
 
 @import "../core/index.module";
 
-:global(.ant-dropdown-menu-submenu-popup ul) {
+:global(.crl-ant-dropdown-menu-submenu-popup ul) {
   padding-bottom: 5px;
 }
 
-:global(.ant-dropdown-menu-item:hover) {
+:global(.crl-ant-dropdown-menu-item:hover) {
   background-color: $colors--primary-blue-8;
 }
 
-:global(.ant-dropdown-menu-submenu-title:hover) {
+:global(.crl-ant-dropdown-menu-submenu-title:hover) {
   background-color: $colors--primary-blue-8;
 }
 
@@ -39,7 +39,7 @@
     font-size: $font-size--medium;
     font-weight: $font-weight--light;
 
-    :global(.ant-btn) {
+    :global(.crl-ant-btn) {
       border-color: $colors--neutral-4;
     }
   }

--- a/pkg/ui/workspaces/cluster-ui/src/sql/sqlhighlight.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sql/sqlhighlight.module.scss
@@ -66,12 +66,12 @@
   margin: 15px 0;
 }
 
-:global(.ant-tooltip) {
+:global(.crl-ant-tooltip) {
   &:global(.hljs) {
-    &:global(.ant-tooltip-content) {
+    &:global(.crl-ant-tooltip-content) {
       width: 535px;
     }
-    &:global(.ant-tooltip-inner) {
+    &:global(.crl-ant-tooltip-inner) {
       background-color: $colors--neutral-8;
       padding: 8px;
     }

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementTypeSelect.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementTypeSelect.module.scss
@@ -53,16 +53,16 @@
   transform: scaleY(0);
 }
 
-:global(.ant-radio) {
+:global(.crl-ant-radio) {
   top: 0;
 }
 
-:global(.ant-radio-checked .ant-radio-inner) {
+:global(.crl-ant-radio-checked .crl-ant-radio-inner) {
   background-color: $colors--link;
   border-color: $colors--link;
 }
 
-:global(.ant-radio-checked .ant-radio-inner::after) {
+:global(.crl-ant-radio-checked .crl-ant-radio-inner::after) {
   background-color: white;
   height: 6px;
   width: 6px;

--- a/pkg/ui/workspaces/cluster-ui/src/table/table.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/table/table.module.scss
@@ -7,17 +7,17 @@
 @import "src/sortedtable/tableHead/tableHead.module";
 
 .crl-table-wrapper {
-  :global(.ant-table) {
+  :global(.crl-ant-table) {
     color: $colors--primary-text;
   }
 
   // Table header
-  :global(.ant-table-thead) {
+  :global(.crl-ant-table-thead) {
     @include table-header-text;
     background-color: $colors--neutral-0;
   }
 
-  :global(.ant-table-thead) > tr > th {
+  :global(.crl-ant-table-thead) > tr > th {
     color: $colors--neutral-7;
     background-color: $colors--neutral-0;
     padding: $spacing-smaller $spacing-smaller;
@@ -27,14 +27,14 @@
       @include table-header-text;
     }
     :global {
-      .ant-table-header-column .ant-table-column-sorters:hover::before {
+      .crl-ant-table-header-column .crl-ant-table-column-sorters:hover::before {
         background-color: $colors--neutral-0;
       }
     }
   }
 
   // Sorter icons on table's header
-  :global(.ant-table-thead .ant-table-column-sorter-inner .anticon) {
+  :global(.crl-ant-table-thead .crl-ant-table-column-sorter-inner .anticon) {
     display: flex;
     color: $colors--neutral-4;
     transform: scale(0.91666667) rotate(0deg);
@@ -53,57 +53,57 @@
   // END: Table Column
 
   // Table row
-  :global(.ant-table-row) {
+  :global(.crl-ant-table-row) {
     @include text--body;
     height: $line-height--xxx-large;
   }
 
-  :global(.ant-table-row) .cell--show-on-hover {
+  :global(.crl-ant-table-row) .cell--show-on-hover {
     visibility: hidden;
   }
 
-  :global(.ant-table-row):hover .cell--show-on-hover {
+  :global(.crl-ant-table-row):hover .cell--show-on-hover {
     visibility: visible;
   }
   // END: Table row
 
   // Table cell
-  :global(.ant-table-tbody) > tr > td {
+  :global(.crl-ant-table-tbody) > tr > td {
     padding: $spacing-smaller $spacing-smaller;
     border-bottom-color: $colors--neutral-3;
   }
 
   // Increase right padding for columns aligned by right
-  :global(.ant-table-tbody) > tr > td.column--align-right {
+  :global(.crl-ant-table-tbody) > tr > td.column--align-right {
     padding-right: $spacing-mid-large;
   }
 
   // show column with right border
-  :global(.ant-table-tbody) > tr > td.column--border-right {
+  :global(.crl-ant-table-tbody) > tr > td.column--border-right {
     border-right: $colors--neutral-3 solid 1px;
   }
   // END: Table cell
 
   // Table cell on hover
   :global {
-    .ant-table-thead
-      > tr.ant-table-row-hover:not(.ant-table-expanded-row):not(.ant-table-row-selected)
+    .crl-ant-table-thead
+      > tr.crl-ant-table-row-hover:not(.crl-ant-table-expanded-row):not(.crl-ant-table-row-selected)
       > td,
-    .ant-table-tbody
-      > tr.ant-table-row-hover:not(.ant-table-expanded-row):not(.ant-table-row-selected)
+    .crl-ant-table-tbody
+      > tr.crl-ant-table-row-hover:not(.crl-ant-table-expanded-row):not(.crl-ant-table-row-selected)
       > td,
-    .ant-table-thead
-      > tr:hover:not(.ant-table-expanded-row):not(.ant-table-row-selected)
+    .crl-ant-table-thead
+      > tr:hover:not(.crl-ant-table-expanded-row):not(.crl-ant-table-row-selected)
       > td,
-    .ant-table-tbody
-      > tr:hover:not(.ant-table-expanded-row):not(.ant-table-row-selected)
+    .crl-ant-table-tbody
+      > tr:hover:not(.crl-ant-table-expanded-row):not(.crl-ant-table-row-selected)
       > td {
       background: $colors--neutral-1;
     }
   }
   // END: Table cell on hover
 
-  :global(.ant-table-placeholder) {
+  :global(.crl-ant-table-placeholder) {
     border: $colors--neutral-1 solid 1px;
   }
 
@@ -113,7 +113,7 @@
   }
 
   &__empty {
-    :global(.ant-table-placeholder) {
+    :global(.crl-ant-table-placeholder) {
       border: none;
     }
   }

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/rangeSelector.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/rangeSelector.module.scss
@@ -182,17 +182,17 @@
       align-items: center;
     }
   }
-  .ant-fullcalendar-calendar-body {
+  .crl-ant-fullcalendar-calendar-body {
     padding: 8px 16px;
-    .ant-fullcalendar-column-header {
+    .crl-ant-fullcalendar-column-header {
       font-family: $font-family--bold;
       font-size: 12px;
       line-height: 2;
       letter-spacing: 0.1px;
     }
-    .ant-fullcalendar-tbody {
-      .ant-fullcalendar-cell {
-        .ant-fullcalendar-value {
+    .crl-ant-fullcalendar-tbody {
+      .crl-ant-fullcalendar-cell {
+        .crl-ant-fullcalendar-value {
           width: 24px;
           height: 24px;
           display: flex;
@@ -209,8 +209,8 @@
             background: $background-color;
           }
         }
-        &.ant-fullcalendar-selected-day {
-          .ant-fullcalendar-value {
+        &.crl-ant-fullcalendar-selected-day {
+          .crl-ant-fullcalendar-value {
             background: $colors--primary-blue-1;
             color: $colors--primary-blue-3;
             &:hover {
@@ -219,10 +219,10 @@
             }
           }
         }
-        &.ant-fullcalendar-disabled-cell {
+        &.crl-ant-fullcalendar-disabled-cell {
           background: $background-color;
           color: $colors--neutral-5;
-          .ant-fullcalendar-value {
+          .crl-ant-fullcalendar-value {
             background: $background-color;
             color: $colors--neutral-5;
           }
@@ -231,11 +231,11 @@
             color: $colors--neutral-5;
           }
         }
-        &.ant-fullcalendar-today {
+        &.crl-ant-fullcalendar-today {
           &:hover {
             background: transparent;
           }
-          .ant-fullcalendar-value {
+          .crl-ant-fullcalendar-value {
             width: 24px;
             height: 24px;
             box-shadow: none;
@@ -246,19 +246,19 @@
               background: $colors--primary-blue-1;
             }
           }
-          &.ant-fullcalendar-selected-day {
-            .ant-fullcalendar-value {
+          &.crl-ant-fullcalendar-selected-day {
+            .crl-ant-fullcalendar-value {
               background: $colors--primary-blue-1;
               &:hover {
                 background: #e0efff;
               }
             }
           }
-          &.ant-fullcalendar-disabled-cell {
+          &.crl-ant-fullcalendar-disabled-cell {
             &:hover {
               background: $background-color;
             }
-            .ant-fullcalendar-value {
+            .crl-ant-fullcalendar-value {
               font-family: $font-family--bold;
               color: $colors--neutral-5;
               background: $background-color;

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeFrameControls.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeFrameControls.module.scss
@@ -41,7 +41,7 @@
     }
   }
 
-  :global(.ant-btn-group) {
+  :global(.crl-ant-btn-group) {
     display: flex;
     flex-direction: row;
     ._action,

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -122,8 +122,8 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
           <TimezoneProvider>
             {/* Apply CRL theme twice, with ConfigProvider instance from Db Console and
              imported instance from Cluster UI as it applies theme imported components only. */}
-            <ClusterUIConfigProvider theme={crlTheme}>
-              <ConfigProvider theme={crlTheme}>
+            <ClusterUIConfigProvider theme={crlTheme} prefixCls={"crl-ant"}>
+              <ConfigProvider theme={crlTheme} prefixCls={"crl-ant"}>
                 <Switch>
                   {/* login */}
                   {createLoginRoute()}

--- a/pkg/ui/workspaces/db-console/src/components/modal/modal.styl
+++ b/pkg/ui/workspaces/db-console/src/components/modal/modal.styl
@@ -6,16 +6,16 @@
 @require '~src/components/core/index.styl'
 
 .crl-modal
-  .ant-modal-footer
+  .crl-ant-modal-footer
     border-top none
     padding 0
 
-  .ant-modal-header
+  .crl-ant-modal-header
     border-bottom none
     padding-top unset
     padding-bottom unset
 
-  .ant-modal-content
+  .crl-ant-modal-content
     padding $spacing-medium
     box-shadow 0px 0px 1px rgba(71, 88, 114, 0.47)
     border-radius 5px

--- a/pkg/ui/workspaces/db-console/src/components/select/select.styl
+++ b/pkg/ui/workspaces/db-console/src/components/select/select.styl
@@ -13,15 +13,15 @@
     color $colors--link
     font-weight $font-weight--bold
     letter-spacing $letter-spacing--compact
-    & > .ant-select-selection
+    & > .crl-ant-select-selection
       border none
-      & > .ant-select-arrow
+      & > .crl-ant-select-arrow
         font-size $spacing-base
         color $colors--link
         top 18px
-      & > .ant-select-selection__rendered
+      & > .crl-ant-select-selection__rendered
         margin-right $spacing-large
-    & > .ant-select-selection:focus
+    & > .crl-ant-select-selection:focus
       outline-style none
       box-shadow none
       border-color transparent

--- a/pkg/ui/workspaces/db-console/src/components/tooltip/tooltip.styl
+++ b/pkg/ui/workspaces/db-console/src/components/tooltip/tooltip.styl
@@ -6,21 +6,21 @@
 @require '~src/components/core/index.styl'
 
 .tooltip-overlay
-  .ant-tooltip-content
-    .ant-tooltip-inner
+  .crl-ant-tooltip-content
+    .crl-ant-tooltip-inner
       @extend $text--body
       line-height $line-height--small
       padding $spacing-x-small $spacing-small
       color $colors--white
       background $colors--neutral-8
-    .ant-tooltip-arrow
+    .crl-ant-tooltip-arrow
       color $colors--neutral-8
 
 .tooltip-overlay.crl-tooltip--theme-blue
-  .ant-tooltip-content
-    .ant-tooltip-inner
+  .crl-ant-tooltip-content
+    .crl-ant-tooltip-inner
       background $colors--neutral-6
-    .ant-tooltip-arrow
+    .crl-ant-tooltip-arrow
       color $colors--neutral-6
 
 .tooltip__table--title

--- a/pkg/ui/workspaces/db-console/src/views/app/components/Search/search.module.styl
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/Search/search.module.styl
@@ -9,13 +9,13 @@
 ._search-form
   width 280px
   height 40px
-  :global(.ant-input-affix-wrapper)
+  :global(.crl-ant-input-affix-wrapper)
     height 40px
     &:hover
-      :global(.ant-input:not(.ant-input-disabled))
+      :global(.crl-ant-input:not(.crl-ant-input-disabled))
         border-color $adminui-blue-1-base
         border-right-width 2px !important
-  :global(.ant-btn)
+  :global(.crl-ant-btn)
     margin 0
     padding 0
     width auto
@@ -40,7 +40,7 @@
     line-height 0px !important
     &:hover
       color $adminui-grey-2
-  :global(.ant-input)
+  :global(.crl-ant-input)
     font-size 14px
     font-family $font-family--base
     color $adminui-grey-1
@@ -56,6 +56,6 @@
       padding-left 35px
       padding-right 60px
   ._submitted
-    :global(.ant-input)
+    :global(.crl-ant-input)
       &:not(:first-child)
         padding-right 40px

--- a/pkg/ui/workspaces/db-console/src/views/app/components/modal/styles.styl
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/modal/styles.styl
@@ -11,20 +11,20 @@
   background-color $colors--white
   padding 0
   min-width 905px
-  .ant-modal-close-x
+  .crl-ant-modal-close-x
     font-size 14px
     color $colors--neutral-8
-  .ant-modal-footer
+  .crl-ant-modal-footer
     display flex
     justify-content flex-end
     border-top none
     padding 0 24px 24px
-  .ant-modal-header
+  .crl-ant-modal-header
     border-bottom none
     padding 24px 24px 0
-  .ant-modal-body
+  .crl-ant-modal-body
     padding 0 24px 11px
-  .ant-modal-title
+  .crl-ant-modal-title
     font-family SourceSansPro-Regular
     font-size 20px
     line-height 1.6

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodesOverview/nodes.styl
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodesOverview/nodes.styl
@@ -40,5 +40,5 @@
 .nodes-overview__panel .crl-table-wrapper .nodes-table__link
   color $colors--link
 
-.nodes-overview__panel .crl-table-wrapper .ant-table-row:hover .nodes-table__link
+.nodes-overview__panel .crl-table-wrapper .crl-ant-table-row:hover .nodes-table__link
   text-decoration underline

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/filter/filter.styl
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/filter/filter.styl
@@ -21,24 +21,24 @@
 
 .select__container
   width 100%
-  .ant-select
+  .crl-ant-select
     margin-bottom 18px
-  .ant-select-selection--single
+  .crl-ant-select-selection--single
     height 40px
     display flex
     justify-content flex-start
     align-items center
-  .ant-select-selection--single .ant-select-selection__rendered
+  .crl-ant-select-selection--single .crl-ant-select-selection__rendered
     width 100%
-  .ant-select-selection__placeholder
+  .crl-ant-select-selection__placeholder
     font-family SourceSansPro-Regular
     font-size 14px
     line-height 1.57
     letter-spacing 0.1px
     color $colors--neutral-6
-  .ant-select-arrow
+  .crl-ant-select-arrow
     color #475872
-  .ant-select-selection
+  .crl-ant-select-selection
     &:hover
       border-color $colors--primary-blue-3
     &:focus, &:active

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/latency/latency.styl
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/latency/latency.styl
@@ -79,12 +79,12 @@
   padding: 30px;
 
 
-.ant-tooltip.Chip--tooltip
+.crl-ant-tooltip.Chip--tooltip
   min-width 384px
-  .ant-tooltip-inner
+  .crl-ant-tooltip-inner
     background-color black
     padding 12px 18px
-  .ant-tooltip-content
+  .crl-ant-tooltip-content
     width 100%
   span, p
     font-family $font-family--base
@@ -103,7 +103,7 @@
         margin-right 8px
       &:last-child
         margin-left 8px
-    .ant-divider
+    .crl-ant-divider
       background #3b4a60
       margin 0
     &--item-title, &--item-description

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/alertMessage/alertMessage.styl
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/alertMessage/alertMessage.styl
@@ -25,11 +25,11 @@
     margin-inline-start 4px
     margin-inline-end 12px
 
-  .ant-alert-message
+  .crl-ant-alert-message
     @extends $text--body-strong
     color $colors--neutral-8
 
-  .ant-alert-close-icon
+  .crl-ant-alert-close-icon
     font-weight $font-weight--extra-bold
     align-self start
     margin-top 8px
@@ -37,5 +37,5 @@
       color $colors--neutral-7
 
 
-.ant-alert-success .alert-massage__icon
+.crl-ant-alert-success .alert-massage__icon
   color $colors--primary-green-3

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/drawer/drawer.module.styl
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/drawer/drawer.module.styl
@@ -38,7 +38,7 @@
   ::-webkit-scrollbar-thumb:hover {
     background #5f6c87ad
   }
-  :global(.ant-divider)
+  :global(.crl-ant-divider)
     width 1px
     background #5f6c87
     margin: 0 15px
@@ -53,21 +53,21 @@
       letter-spacing 0.1px
       &:hover
         color #5f6c87
-  :global(.ant-drawer-content)
+  :global(.crl-ant-drawer-content)
     overflow auto
-  :global(.ant-drawer-mask)
+  :global(.crl-ant-drawer-mask)
     background-color transparent
-  :global(.ant-drawer-content-wrapper)
+  :global(.crl-ant-drawer-content-wrapper)
     padding-left 80px
     box-shadow none !important
-  :global(.ant-drawer-content)
+  :global(.crl-ant-drawer-content)
     background #242a35
-  :global(.ant-drawer-header)
+  :global(.crl-ant-drawer-header)
     padding 15px 0
     margin 0 24px
     background transparent
     border-bottom: 1px solid #5f6c87;
-  :global(.ant-drawer-body)
+  :global(.crl-ant-drawer-body)
     padding 15px 20px
     margin 0 4px
     height 190px

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/sql/sqlhighlight.module.styl
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/sql/sqlhighlight.module.styl
@@ -37,12 +37,12 @@
   :global(.hljs-built_in)
     color $colors--functional-orange-3
 
-:global(.ant-tooltip):global(.hljs)
-  :global(.ant-tooltip-content)
+:global(.crl-ant-tooltip):global(.hljs)
+  :global(.crl-ant-tooltip-content)
     width 535px
-  :global(.ant-tooltip-inner), .sql-highlight:global(.hljs)
+  :global(.crl-ant-tooltip-inner), .sql-highlight:global(.hljs)
     background-color $colors--neutral-8
-  :global(.ant-tooltip-inner)
+  :global(.crl-ant-tooltip-inner)
     padding 8px
   .sql-highlight:global(.hljs)
     padding 0

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/toolTip/tooltip.module.styl
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/toolTip/tooltip.module.styl
@@ -6,7 +6,7 @@
 @require '~src/components/core/index.styl'
 
 .tooltip-wrapper
-  :global(.ant-tooltip-arrow)
+  :global(.crl-ant-tooltip-arrow)
     width 20px
     height 20px
     &::before
@@ -16,9 +16,9 @@
       border: solid 1px #e7ecf3;
       box-shadow: none;
 
-:global(.ant-tooltip).tooltip__preset--white
+:global(.crl-ant-tooltip).tooltip__preset--white
   max-width 500px
-  :global(.ant-tooltip-inner)
+  :global(.crl-ant-tooltip-inner)
     padding 10px
     border-radius 3px
     border solid 1px $colors--neutral-2

--- a/pkg/ui/workspaces/db-console/src/views/statements/statements.styl
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statements.styl
@@ -376,5 +376,5 @@ $plan-node-warning-background-color = rgba(209, 135, 55, 0.06)  // light orange
 
 .cl-table-link__statement-tooltip--fixed-width
   max-width max-content
-  .ant-tooltip-content
+  .crl-ant-tooltip-content
     max-width 500px

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsTableContent.module.styl
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsTableContent.module.styl
@@ -15,7 +15,7 @@
 
 .cl-table-link__statement-tooltip--fixed-width
   max-width max-content
-  :global(.ant-tooltip-content)
+  :global(.crl-ant-tooltip-content)
     max-width 500px
 
 .tooltip__table--title

--- a/pkg/ui/workspaces/db-console/styl/shame.styl
+++ b/pkg/ui/workspaces/db-console/styl/shame.styl
@@ -133,15 +133,15 @@
   opacity .6
   font-size 10px
 
-.ant-divider
+.crl-ant-divider
   background $button-border-color
   margin-left 0
   margin-right 22px
-  &.ant-divider-vertical
+  &.crl-ant-divider-vertical
     height auto
 
-.ant-tooltip
-  .ant-tooltip-inner
+.crl-ant-tooltip
+  .crl-ant-tooltip-inner
     font-size 12px
     border-radius 4px
     background-color $body-color
@@ -152,7 +152,7 @@
     min-width 0
     min-height 0
   &.preset-black
-    .ant-tooltip-inner
+    .crl-ant-tooltip-inner
       background-color #000
       pre
         font-family RobotoMono-Medium
@@ -164,7 +164,7 @@
           font-family RobotoMono-Bold
           color #0055ff
 
-.ant-time-picker-input
+.crl-ant-time-picker-input
   height 40px
   padding 0px 11px
   border-radius 3px
@@ -175,72 +175,72 @@
   &:hover
     border-color $link-color
 
-.ant-time-picker-panel-combobox
+.crl-ant-time-picker-panel-combobox
   display flex
 
-.ant-calendar-picker:hover .ant-calendar-picker-input:not(.ant-input-disabled)
+.crl-ant-calendar-picker:hover .crl-ant-calendar-picker-input:not(.crl-ant-input-disabled)
   border-color $link-color
 
-.ant-fullcalendar-header
+.crl-ant-fullcalendar-header
   padding: 10px 4px
   text-align: center
 
-.ant-fullcalendar
+.crl-ant-fullcalendar
   font-size 12px
   font-family Lato-Regular
 
-.ant-fullcalendar-selected-day
-  .ant-fullcalendar-date
+.crl-ant-fullcalendar-selected-day
+  .crl-ant-fullcalendar-date
     background #eff5fe
     color #3a7ce1
     &:hover
       background #e0efff
       color $blue-color
 
-.ant-fullcalendar-today 
-  &.ant-fullcalendar-date
+.crl-ant-fullcalendar-today 
+  &.crl-ant-fullcalendar-date
     color #3a7ce1
     border-color #3a7ce1
     &:hover
       background #eff5fd
-  &.ant-fullcalendar-selected-day
-    .ant-fullcalendar-date
+  &.crl-ant-fullcalendar-selected-day
+    .crl-ant-fullcalendar-date
       background #eff5fd
       &:hover
         background $grey4
         font-weight bold
-  &.ant-fullcalendar-disabled-cell
-    .ant-fullcalendar-date
+  &.crl-ant-fullcalendar-disabled-cell
+    .crl-ant-fullcalendar-date
       background #E7ECF3
       &:hover
         background #E7ECF3
 
-.ant-fullcalendar-date, .ant-time-picker-panel li
+.crl-ant-fullcalendar-date, .crl-ant-time-picker-panel li
   color #5F6C87
   font-family Lato-Regular
   font-size 12px
-  &.ant-time-picker-panel-addon-option-disabled
+  &.crl-ant-time-picker-panel-addon-option-disabled
     color #a3a5af
   &:hover
     background #f6f6f6
   &:focus
     color $link-color
 
-.ant-time-picker-panel li
+.crl-ant-time-picker-panel li
   display flex
   align-items center
 
-.ant-fullcalendar-disabled-cell .ant-fullcalendar-date
+.crl-ant-fullcalendar-disabled-cell .crl-ant-fullcalendar-date
   background #E7ECF3
 
-.ant-fullcalendar-disabled-cell.ant-fullcalendar-today .ant-fullcalendar-date
+.crl-ant-fullcalendar-disabled-cell.crl-ant-fullcalendar-today .crl-ant-fullcalendar-date
   color #a3a5af
   font-weight bold
   border-color transparent
   &:before
     border 1px solid #a3a5af
 
-.ant-calendar-today-btn
+.crl-ant-calendar-today-btn
   width 100%
   font-family Lato-Bold
   color $link-color
@@ -254,13 +254,13 @@
     line-height 1.71
     letter-spacing 0.1px
 
-.ant-btn:focus
+.crl-ant-btn:focus
   color: $link-color
 
-.ant-btn:after
+.crl-ant-btn:after
   display: none !important;
 
-.ant-btn-background-ghost
+.crl-ant-btn-background-ghost
   box-shadow: none
   
 .color
@@ -269,20 +269,20 @@
     &:hover
       text-decoration underline
 
-.ant-checkbox-wrapper
+.crl-ant-checkbox-wrapper
   &:hover
-    .ant-checkbox-inner
+    .crl-ant-checkbox-inner
       border solid 1px $checkbox-border-hover
       background $popover-border-color
-  .ant-checkbox-inner
+  .crl-ant-checkbox-inner
     border solid 1px $checkbox-border
     border-radius 3px
-  .ant-checkbox-checked
+  .crl-ant-checkbox-checked
     &:hover
-      .ant-checkbox-inner
+      .crl-ant-checkbox-inner
         border solid 1px $link
         background $link
-    .ant-checkbox-inner
+    .crl-ant-checkbox-inner
       background-color $link
   span
     font-family SourceSansPro-SemiBold
@@ -291,39 +291,39 @@
     letter-spacing 0.1px
     color $popover-color
 
-.ant-pagination
+.crl-ant-pagination
   display flex
   justify-content center
   align-items flex-end
   margin 40px 0
   &.mini
-    .ant-pagination-item, .ant-pagination-prev, .ant-pagination-next
+    .crl-ant-pagination-item, .crl-ant-pagination-prev, .crl-ant-pagination-next
       margin 0 5px
-  .ant-pagination-item
+  .crl-ant-pagination-item
     a
       color $body-color
       font-size 14px
       font-family Lato-Medium
       &:hover
         color $link-color
-  .ant-pagination-item-active
+  .crl-ant-pagination-item-active
     background transparent
     border-radius 2px
     border 1px solid $link-color
     a
       color $link-color
-  .ant-pagination-next, .ant-pagination-prev
-    .ant-pagination-item-link
+  .crl-ant-pagination-next, .crl-ant-pagination-prev
+    .crl-ant-pagination-item-link
       font-size 12px
       color $body-color
     &:hover
-      .ant-pagination-item-link
+      .crl-ant-pagination-item-link
         color $link-color
-    &.ant-pagination-disabled
-      .ant-pagination-item-link
+    &.crl-ant-pagination-disabled
+      .crl-ant-pagination-item-link
         color #b8bbbc
       &:hover
-        .ant-pagination-item-link
+        .crl-ant-pagination-item-link
           color #b8bbbc
 
 .drawer--preset-black
@@ -350,7 +350,7 @@
   ::-webkit-scrollbar-thumb:hover {
     background #5f6c87ad
   }
-  .ant-divider
+  .crl-ant-divider
     width 1px
     background #5f6c87
     margin: 0 15px
@@ -365,21 +365,21 @@
       letter-spacing 0.1px
       &:hover
         color #5f6c87
-  .ant-drawer-content
+  .crl-ant-drawer-content
     overflow auto
-  .ant-drawer-mask
+  .crl-ant-drawer-mask
     background-color transparent
-  .ant-drawer-content-wrapper
+  .crl-ant-drawer-content-wrapper
     padding-left 80px
     box-shadow none !important
-  .ant-drawer-content
+  .crl-ant-drawer-content
     background #242a35
-  .ant-drawer-header
+  .crl-ant-drawer-header
     padding 15px 0
     margin 0 24px
     background transparent
     border-bottom: 1px solid #5f6c87;
-  .ant-drawer-body
+  .crl-ant-drawer-body
     padding 15px 20px
     margin 0 4px
     height 190px
@@ -395,9 +395,9 @@
       font-family RobotoMono-Bold
 
 .cockroach--tabs
-  .ant-tabs-bar
+  .crl-ant-tabs-bar
     border-bottom 1px solid $grey2
-  .ant-tabs-tab
+  .crl-ant-tabs-tab
     font-family SourceSansPro-Regular
     font-size 16px
     line-height 1.5
@@ -405,9 +405,9 @@
     color $placeholder
     &:hover
       color $adminui-grey-1 
-  .ant-tabs-tab-active
+  .crl-ant-tabs-tab-active
     color $adminui-grey-1 
-  .ant-tabs-ink-bar
+  .crl-ant-tabs-ink-bar
     height 3px
     border-radius 40px
     background-color $blue


### PR DESCRIPTION
Aligns with CC pattern to use `crl-ant` as the antd classname prefix. This fixes styling for components lifted out from CC in `sharedFromCloud` in cluster-ui, which have some scss classes that use this prefix.

Epic: none

Release note: None