### PR TITLE
drtprod: add support for run operation with cron

### DIFF
--- a/pkg/cmd/drtprod/configs/drt_scale.yaml
+++ b/pkg/cmd/drtprod/configs/drt_scale.yaml
@@ -125,3 +125,4 @@ targets:
       - script: "pkg/cmd/drtprod/scripts/tpcc_init.sh"
         flags:
           warehouses: 100000
+          db: cct_tpcc

--- a/pkg/cmd/drtprod/configs/drt_scale_operations.yaml
+++ b/pkg/cmd/drtprod/configs/drt_scale_operations.yaml
@@ -1,0 +1,17 @@
+# Yaml for creating and configuring operations scripts for drt-scale cluster.
+environment:
+  ROACHPROD_GCE_DEFAULT_SERVICE_ACCOUNT: 622274581499-compute@developer.gserviceaccount.com
+  ROACHPROD_DNS: drt.crdb.io
+  ROACHPROD_GCE_DNS_DOMAIN: drt.crdb.io
+  ROACHPROD_GCE_DNS_ZONE: drt
+  ROACHPROD_GCE_DEFAULT_PROJECT: cockroach-drt
+  CLUSTER: drt-scale
+  WORKLOAD_CLUSTER: workload-scale
+
+targets:
+  - target_name: operations
+    steps:
+      - script: "pkg/cmd/drtprod/scripts/create_run_operation.sh"
+        args:
+          - "schema_change,add-column|add-index,0 0 * * *" # runs every day at 12 AM
+          - "kill_stall,disk-stall|network-partition|node-kill,0 * * * *" # runs every 1 hour

--- a/pkg/cmd/drtprod/scripts/create_run_operation.sh
+++ b/pkg/cmd/drtprod/scripts/create_run_operation.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# This script sets up the tpcc import workload script in the workload node and starts the same in nohup
+# NOTE - This uses CLUSTER and WORKLOAD_CLUSTER environment variable, if not set the script fails
+
+# Check if at least one argument is provided
+if [ "$#" -lt 1 ]; then
+  echo "Usage: $0 \"identifier,operation_regex,cron_config\" \"identifier,operation_regex,cron_config\" ..."
+  exit 1
+fi
+
+if [ -z "${CLUSTER}" ]; then
+  echo "environment CLUSTER is not set"
+  exit 1
+fi
+
+if [ -z "${WORKLOAD_CLUSTER}" ]; then
+  echo "environment CLUSTER is not set"
+  exit 1
+fi
+
+dd_api_key="$(gcloud --project=cockroach-drt secrets versions access latest --secret datadog-api-key)"
+
+if [ -z "${dd_api_key}" ]; then
+  echo "Missing Datadog API key!"
+  exit 1
+fi
+
+# the ssh keys of all workload nodes should be setup on the crdb nodes for the operations
+roachprod ssh ${CLUSTER} -- "echo \"$(roachprod run ${WORKLOAD_CLUSTER} -- cat ./.ssh/id_rsa.pub|grep ssh-rsa)\" >> ./.ssh/authorized_keys"
+
+absolute_path=$(roachprod run "${WORKLOAD_CLUSTER}":1 -- "realpath ./roachtest-operations")
+pwd=$(roachprod run "${WORKLOAD_CLUSTER}":1 -- "dirname ${absolute_path}")
+# Loop over all the passed arguments
+for entry in "$@"; do
+  # Split the entry into identifier, cron_config, and operation_regex using IFS and comma
+  IFS=',' read -r identifier operation_regex cron_config <<< "$entry"
+
+  # Check if all 3 parts are provided
+  if [ -z "$identifier" ] || [ -z "$operation_regex" ]; then
+    echo "Error: Each argument must have an identifier and operation_regex separated by commas."
+    exit 1
+  fi
+  filename=run_ops_${identifier}.sh
+  # Create a file with the name "run_ops_<identifier>.sh" and add the entry of roachtest run-operation
+  roachprod ssh "${WORKLOAD_CLUSTER}":1 -- "tee ${pwd}/${filename} > /dev/null << EOF
+#!/bin/bash
+
+export ROACHPROD_GCE_DEFAULT_PROJECT=${ROACHPROD_GCE_DEFAULT_PROJECT}
+export ROACHPROD_DNS=${ROACHPROD_DNS}
+${pwd}/roachtest-operations run-operation ${CLUSTER} \"${operation_regex}\" --datadog-api-key ${dd_api_key} \
+--datadog-tags env:development,cluster:${WORKLOAD_CLUSTER},team:drt,service:drt-cockroachdb \
+--datadog-app-key 1 --certs-dir ./certs  | tee -a roachtest_ops_${identifier}.log
+EOF"
+  roachprod ssh "${WORKLOAD_CLUSTER}":1 -- chmod +x "${pwd}"/"${filename}"
+  if [ "$cron_config" ]; then
+    roachprod run "${WORKLOAD_CLUSTER}":1 -- "(crontab -l; echo \"${cron_config} /usr/bin/flock -n /tmp/lock_${identifier} ${pwd}/${filename}\") | crontab -"
+  fi
+done
+
+# unmask and start cron
+roachprod ssh "${WORKLOAD_CLUSTER}":1 -- sudo systemctl unmask cron
+roachprod ssh "${WORKLOAD_CLUSTER}":1 -- sudo systemctl start cron

--- a/pkg/cmd/drtprod/scripts/setup_datadog_cluster
+++ b/pkg/cmd/drtprod/scripts/setup_datadog_cluster
@@ -8,10 +8,7 @@ if [ -z "${CLUSTER}" ]; then
   exit 1
 fi
 
-# TODO - this command does not work. We need to replace this with the actual dd_api_key for the script to work
-
 dd_api_key="$(gcloud --project=cockroach-drt secrets versions access latest --secret datadog-api-key)"
-
 
 if [ -z "${dd_api_key}" ]; then
   echo "Missing Datadog API key!"

--- a/pkg/cmd/drtprod/scripts/setup_datadog_workload
+++ b/pkg/cmd/drtprod/scripts/setup_datadog_workload
@@ -8,9 +8,7 @@ if [ -z "${WORKLOAD_CLUSTER}" ]; then
   exit 1
 fi
 
-# TODO - this command does not work. We need to replace this with the actual dd_api_key for the script to work
 dd_api_key="$(gcloud --project=cockroach-drt secrets versions access latest --secret datadog-api-key)"
-
 
 if [ -z "${dd_api_key}" ]; then
   echo "Missing Datadog API key!"


### PR DESCRIPTION
drt-scale has a requirement to run operations with specific schedules. To achieve this, this PR has a script that takes input of different operation regular expressions along with a crontab configuration. These are given as input from the YAML file. The script creates an entry for each configured operation combinations and also makes a crontab entry.

the PR also has a fix for the tpcc_init.sh script which ensures that the tpcc init can run asynchronously and the drtprod execute can exit gracefully.

Epic: None
Release note: None