### PR TITLE
drtprod: remove rollback for drt-scale

### DIFF
--- a/pkg/cmd/drtprod/configs/drt_scale.yaml
+++ b/pkg/cmd/drtprod/configs/drt_scale.yaml
@@ -29,10 +29,6 @@ targets:
           username: drt
           lifetime: 8760h
           gce-image: "ubuntu-2204-jammy-v20240319"
-        on_rollback:
-          - command: destroy
-            args:
-              - $CLUSTER
       - command: sync
         flags:
           clouds: gce
@@ -90,6 +86,10 @@ targets:
           - $WORKLOAD_CLUSTER
           - workload
       - script: "pkg/cmd/drtprod/scripts/setup_datadog_workload"
+      - script: rm
+        args:
+          - -rf
+          - certs-$CLUSTER
       - command: get
         args:
           - $CLUSTER:1


### PR DESCRIPTION
This PR removes rollback in case of any failures
in the `drt_scale.yaml`. We want to see the error
logs and check in the fixes. Also, added a fail safe to remove 
`certs-$CLUSTER` to avoid putting any old certs on the machine.

Epic: none
Release note: None