### PR TITLE
cluster-ui: add context to provide tenant status to db pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "24.3.0-prerelease.1",
+  "version": "24.3.0-prerelease.2",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",

--- a/pkg/ui/workspaces/cluster-ui/src/api/nodesApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/nodesApi.ts
@@ -4,12 +4,13 @@
 // included in the /LICENSE file.
 
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
-import { useMemo } from "react";
+import { useContext, useMemo } from "react";
 import useSWR from "swr";
 
 import { fetchData } from "src/api";
 import { getRegionFromLocality } from "src/store/nodes";
 
+import { ClusterDetailsContext } from "../contexts";
 import { NodeID, StoreID } from "../types/clusterTypes";
 
 const NODES_PATH = "_status/nodes_ui";
@@ -20,10 +21,16 @@ export const getNodes =
   };
 
 export const useNodeStatuses = () => {
-  const { data, isLoading, error } = useSWR(NODES_PATH, getNodes, {
-    revalidateOnFocus: false,
-    dedupingInterval: 10000, // 10 seconds.
-  });
+  const clusterDetails = useContext(ClusterDetailsContext);
+  const isTenant = clusterDetails.isTenant;
+  const { data, isLoading, error } = useSWR(
+    NODES_PATH,
+    !isTenant ? getNodes : null,
+    {
+      revalidateOnFocus: false,
+      dedupingInterval: 10000, // 10 seconds.
+    },
+  );
 
   const { storeIDToNodeID, nodeIDToRegion } = useMemo(() => {
     const nodeIDToRegion: Record<NodeID, string> = {};

--- a/pkg/ui/workspaces/cluster-ui/src/contexts/clusterDetailsContext.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/contexts/clusterDetailsContext.tsx
@@ -1,0 +1,15 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { createContext } from "react";
+
+type ClusterDetailsContextType = {
+  isTenant?: boolean;
+};
+
+// This is used by CC to fill in details such as whether we have a tenant or not.
+export const ClusterDetailsContext = createContext<ClusterDetailsContextType>({
+  isTenant: false,
+});

--- a/pkg/ui/workspaces/cluster-ui/src/contexts/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/contexts/index.ts
@@ -5,3 +5,4 @@
 
 export * from "./cockroachCloudContext";
 export * from "./timezoneContext";
+export * from "./clusterDetailsContext";

--- a/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/tableOverview.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/tableOverview.tsx
@@ -4,12 +4,14 @@
 // included in the /LICENSE file.
 
 import { Icon } from "@cockroachlabs/ui-components";
-import { Col, Row, Skeleton, Tooltip } from "antd";
+import { Col, Row, Skeleton } from "antd";
 import moment from "moment-timezone";
-import React from "react";
+import React, { useContext } from "react";
 
 import { useNodeStatuses } from "src/api";
 import { TableDetails } from "src/api/databases/getTableMetadataApi";
+import { Tooltip } from "src/components/tooltip";
+import { ClusterDetailsContext } from "src/contexts";
 import { PageSection } from "src/layouts";
 import { SqlBox, SqlBoxSize } from "src/sql";
 import { SummaryCard, SummaryCardItem } from "src/summaryCard";
@@ -24,6 +26,8 @@ type TableOverviewProps = {
 export const TableOverview: React.FC<TableOverviewProps> = ({
   tableDetails,
 }) => {
+  const clusterDetails = useContext(ClusterDetailsContext);
+  const isTenant = clusterDetails.isTenant;
   const { metadata } = tableDetails;
   const {
     nodeIDToRegion,
@@ -96,14 +100,16 @@ export const TableOverview: React.FC<TableOverviewProps> = ({
               />
               <SummaryCardItem label="Ranges" value={metadata.rangeCount} />
               <SummaryCardItem label="Replicas" value={metadata.replicaCount} />
-              <SummaryCardItem
-                label="Regions / Nodes"
-                value={
-                  <Skeleton loading={nodesLoading}>
-                    {getNodesByRegionDisplayStr()}
-                  </Skeleton>
-                }
-              />
+              {!isTenant && (
+                <SummaryCardItem
+                  label="Regions / Nodes"
+                  value={
+                    <Skeleton loading={nodesLoading}>
+                      {getNodesByRegionDisplayStr()}
+                    </Skeleton>
+                  }
+                />
+              )}
             </SummaryCard>
           </Col>
           <Col span={12}>


### PR DESCRIPTION
Cluster UI now exports a context to be used to fill in whether or not the cluster is a tenant. This is to support the existing behaviour on the old db pages where we hide the node/region column for tenant clusters.

Epic: none

Release note: None