### PR TITLE
bincheck: bump `max_init_time` for `darwin-amd64`

### DIFF
--- a/build/release/bincheck/.gitignore
+++ b/build/release/bincheck/.gitignore
@@ -1,6 +1,7 @@
 # files created by running cockroach
 cockroach-pid
 cockroach-data/
+cockroach-url
 
 # files created running bincheck
 cockroach.tar.gz

--- a/build/release/bincheck/bincheck
+++ b/build/release/bincheck/bincheck
@@ -19,10 +19,16 @@ readonly pidfile=/tmp/server_pid
 
 # Verify that the startup time is within a reasonable upper-bound. 
 # At the time of writing, the total `init` time is well under 200ms on m1pro.
+max_init_time=500
+if [[ $(uname -sm) == "Darwin x86_64" ]]; then
+  # MacOS Intel GitHub Actions runners are a bit slow
+  max_init_time=3000
+fi
 init_time=`GODEBUG=inittrace=1 $cockroach version 2>&1|awk '/init/ {sum += $5} END {printf("%d\n", sum)}'`
-if [[ $init_time -gt 500 ]]
+if [[ $init_time -gt $max_init_time ]]
 then
   echo "'init' time is unreasonably high: $init_time"
+  GODEBUG=inittrace=1 $cockroach version 2>&1 | grep init | awk '{print $2, $5}' | sort -k2,2 -rn | head
   exit 1
 fi
 


### PR DESCRIPTION
Previously, we started measuring the `init` times of the cockroach binary, but never ran them in GiHub Actions. GitHub Actions runners for darwin-amd64 look a bit slow. Last runs showed values around 1500-2000.

This PR bumps `the max_init_time` value to `3000`.

Epic: none
Release note: None