### PR TITLE
release-23.2: changefeedccl: fix failure to updating PTS in retryable errors

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -9432,7 +9432,10 @@ func TestChangefeedAvroDecimalColumnWithDiff(t *testing.T) {
 func TestChangefeedProtectedTimestampUpdate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	verifyFunc := func() {}
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		defer verifyFunc()
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
 		// Checkpoint and trigger potential protected timestamp updates frequently.
 		// Make the protected timestamp lag long enough that it shouldn't be
@@ -9497,7 +9500,15 @@ func TestChangefeedProtectedTimestampUpdate(t *testing.T) {
 		require.Less(t, ts, ts2)
 	}
 
-	cdcTest(t, testFn, feedTestForceSink("kafka"))
+	withTxnRetries := withArgsFn(func(args *base.TestServerArgs) {
+		requestFilter, vf := testutils.TestingRequestFilterRetryTxnWithPrefix(t, changefeedJobProgressTxnName, 1)
+		args.Knobs.Store = &kvserver.StoreTestingKnobs{
+			TestingRequestFilter: requestFilter,
+		}
+		verifyFunc = vf
+	})
+
+	cdcTest(t, testFn, feedTestForceSink("kafka"), withTxnRetries)
 }
 
 // TestParallelIOMetrics tests parallel io metrics.

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -37,12 +37,17 @@ import (
 type UpdateFn func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error
 
 type Updater struct {
-	j   *Job
-	txn isql.Txn
+	j            *Job
+	txn          isql.Txn
+	txnDebugName string
 }
 
 func (j *Job) NoTxn() Updater {
 	return Updater{j: j}
+}
+
+func (j *Job) DebugNameNoTxn(txnDebugName string) Updater {
+	return Updater{j: j, txnDebugName: txnDebugName}
 }
 
 func (j *Job) WithTxn(txn isql.Txn) Updater {
@@ -61,6 +66,9 @@ func (u Updater) update(ctx context.Context, useReadLock bool, updateFn UpdateFn
 		return u.j.registry.db.Txn(ctx, func(
 			ctx context.Context, txn isql.Txn,
 		) error {
+			if u.txnDebugName != "" {
+				txn.KV().SetDebugName(u.txnDebugName)
+			}
 			u.txn = txn
 			return u.update(ctx, useReadLock, updateFn)
 		})


### PR DESCRIPTION
Backport 1/1 commits from #132712.

/cc @cockroachdb/release

Release justification: fix for customer incident

---

Previously, in the face of retryable errors
updating PTS records, the records would not be
updated due to mismanagement of state.

Fixes: #132602

Release note (bug fix): Fixed an issue where
changefeeds would fail to update protected
timestamp records in the face of retryable errors.

