### PR TITLE
release-24.1: changefeedccl: fix failure to updating PTS in retryable errors

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1699,6 +1699,8 @@ func (cf *changeFrontier) maybeCheckpointJob(
 	return false, nil
 }
 
+const changefeedJobProgressTxnName = "changefeed job progress"
+
 func (cf *changeFrontier) checkpointJobProgress(
 	frontier hlc.Timestamp, checkpoint jobspb.ChangefeedProgress_Checkpoint,
 ) (bool, error) {
@@ -1717,10 +1719,12 @@ func (cf *changeFrontier) checkpointJobProgress(
 	}
 	cf.metrics.FrontierUpdates.Inc(1)
 	if cf.js.job != nil {
-		if err := cf.js.job.NoTxn().Update(cf.Ctx(), func(
+		var ptsUpdated bool
+		if err := cf.js.job.DebugNameNoTxn(changefeedJobProgressTxnName).Update(cf.Ctx(), func(
 			txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater,
 		) error {
-			if err := md.CheckRunningOrReverting(); err != nil {
+			var err error
+			if err = md.CheckRunningOrReverting(); err != nil {
 				return err
 			}
 
@@ -1733,7 +1737,7 @@ func (cf *changeFrontier) checkpointJobProgress(
 			changefeedProgress := progress.Details.(*jobspb.Progress_Changefeed).Changefeed
 			changefeedProgress.Checkpoint = &checkpoint
 
-			if err := cf.manageProtectedTimestamps(cf.Ctx(), txn, changefeedProgress); err != nil {
+			if ptsUpdated, err = cf.manageProtectedTimestamps(cf.Ctx(), txn, changefeedProgress); err != nil {
 				log.Warningf(cf.Ctx(), "error managing protected timestamp record: %v", err)
 				return err
 			}
@@ -1756,6 +1760,9 @@ func (cf *changeFrontier) checkpointJobProgress(
 		}); err != nil {
 			return false, err
 		}
+		if ptsUpdated {
+			cf.lastProtectedTimestampUpdate = timeutil.Now()
+		}
 		if log.V(2) {
 			log.Infof(cf.Ctx(), "change frontier persisted highwater=%s and checkpoint=%s", frontier, checkpoint)
 		}
@@ -1770,13 +1777,16 @@ func (cf *changeFrontier) checkpointJobProgress(
 // manageProtectedTimestamps periodically advances the protected timestamp for
 // the changefeed's targets to the current highwater mark.  The record is
 // cleared during changefeedResumer.OnFailOrCancel
+//
+// NOTE: this method may be retried by `txn`, so don't mutate any state that
+// would interfere with that.
 func (cf *changeFrontier) manageProtectedTimestamps(
 	ctx context.Context, txn isql.Txn, progress *jobspb.ChangefeedProgress,
-) error {
+) (updated bool, err error) {
 	ptsUpdateInterval := changefeedbase.ProtectTimestampInterval.Get(&cf.flowCtx.Cfg.Settings.SV)
 	ptsUpdateLag := changefeedbase.ProtectTimestampLag.Get(&cf.FlowCtx.Cfg.Settings.SV)
 	if timeutil.Since(cf.lastProtectedTimestampUpdate) < ptsUpdateInterval {
-		return nil
+		return false, nil
 	}
 
 	pts := cf.flowCtx.Cfg.ProtectedTimestampProvider.WithTxn(txn)
@@ -1792,13 +1802,12 @@ func (cf *changeFrontier) manageProtectedTimestamps(
 			ctx, cf.flowCtx.Codec(), cf.spec.JobID, AllTargets(cf.spec.Feed), highWater,
 		)
 		progress.ProtectedTimestampRecord = ptr.ID.GetUUID()
-		cf.lastProtectedTimestampUpdate = timeutil.Now()
-		return pts.Protect(ctx, ptr)
+		return true, pts.Protect(ctx, ptr)
 	}
 
 	rec, err := pts.GetRecord(ctx, progress.ProtectedTimestampRecord)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	if rec.Target != nil {
@@ -1807,12 +1816,11 @@ func (cf *changeFrontier) manageProtectedTimestamps(
 		// changefeed restarts, which can cause contention and second order effects
 		// on system tables.
 		if !rec.Timestamp.AddDuration(ptsUpdateLag).Less(highWater) {
-			return nil
+			return false, nil
 		}
 
 		log.VEventf(ctx, 2, "updating protected timestamp %v at %v", progress.ProtectedTimestampRecord, highWater)
-		cf.lastProtectedTimestampUpdate = timeutil.Now()
-		return pts.UpdateTimestamp(ctx, progress.ProtectedTimestampRecord, highWater)
+		return true, pts.UpdateTimestamp(ctx, progress.ProtectedTimestampRecord, highWater)
 	}
 
 	// If this changefeed was created in 22.1 or earlier, it may be using a deprecated pts record in which
@@ -1824,19 +1832,18 @@ func (cf *changeFrontier) manageProtectedTimestamps(
 			ctx, cf.flowCtx.Codec(), cf.spec.JobID, AllTargets(cf.spec.Feed), highWater,
 		)
 		if err := pts.Protect(ctx, ptr); err != nil {
-			return err
+			return false, err
 		}
 		progress.ProtectedTimestampRecord = ptr.ID.GetUUID()
 		if err := pts.Release(ctx, prevRecordId); err != nil {
-			return err
+			return false, err
 		}
 
 		log.Eventf(ctx, "created new pts record %v to replace old pts record %v at %v",
 			progress.ProtectedTimestampRecord, prevRecordId, highWater)
 	}
 
-	cf.lastProtectedTimestampUpdate = timeutil.Now()
-	return nil
+	return true, nil
 }
 
 func (cf *changeFrontier) maybeEmitResolved(newResolved hlc.Timestamp) error {

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -34,12 +34,17 @@ import (
 type UpdateFn func(txn isql.Txn, md JobMetadata, ju *JobUpdater) error
 
 type Updater struct {
-	j   *Job
-	txn isql.Txn
+	j            *Job
+	txn          isql.Txn
+	txnDebugName string
 }
 
 func (j *Job) NoTxn() Updater {
 	return Updater{j: j}
+}
+
+func (j *Job) DebugNameNoTxn(txnDebugName string) Updater {
+	return Updater{j: j, txnDebugName: txnDebugName}
 }
 
 func (j *Job) WithTxn(txn isql.Txn) Updater {
@@ -51,6 +56,9 @@ func (u Updater) update(ctx context.Context, updateFn UpdateFn) (retErr error) {
 		return u.j.registry.db.Txn(ctx, func(
 			ctx context.Context, txn isql.Txn,
 		) error {
+			if u.txnDebugName != "" {
+				txn.KV().SetDebugName(u.txnDebugName)
+			}
 			u.txn = txn
 			return u.update(ctx, updateFn)
 		})


### PR DESCRIPTION
Backport 1/1 commits from #132712.

/cc @cockroachdb/release

Release justification: fix for customer incident

---

Previously, in the face of retryable errors
updating PTS records, the records would not be
updated due to mismanagement of state.

Fixes: #132602

Release note (bug fix): Fixed an issue where
changefeeds would fail to update protected
timestamp records in the face of retryable errors.

