### PR TITLE
jobs: only show progress for LDR if job has progress

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/jobs/util/jobOptions.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/util/jobOptions.tsx
@@ -22,13 +22,13 @@ export function jobToVisual(job: Job): JobStatusVisual {
   if (job.type === "CHANGEFEED") {
     return JobStatusVisual.BadgeOnly;
   }
-  if (
-    job.type === "REPLICATION STREAM PRODUCER" ||
-    job.type === "LOGICAL REPLICATION INGESTION"
-  ) {
+  if (job.type === "REPLICATION STREAM PRODUCER") {
     return JobStatusVisual.BadgeOnly;
   }
-  if (job.type === "REPLICATION STREAM INGESTION") {
+  if (
+    job.type === "REPLICATION STREAM INGESTION" ||
+    job.type === "LOGICAL REPLICATION"
+  ) {
     return jobToVisualForReplicationIngestion(job);
   }
   switch (job.status) {


### PR DESCRIPTION
This change was extracted from a larger change that adds a working progress bar for LDR jobs. It allows the UI to show a progress bar if progress is available and fixes a typo that causes the current version of LDR to show a useless progress bar.

Part of: #130367
Release Note (bug fix): Fixes a minor UI bug in the jobs status page for LDR jobs.