### PR TITLE
rac2: use LogSlice semantics consistent with raft

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -156,16 +156,22 @@ type RaftLogSnapshot interface {
 	// only be called in MsgAppPull mode for followers. The maxSize is required
 	// to be > 0.
 	//
-	// If the sum of all entries in [start,end) are <= maxSize, all will be
-	// returned. Else, entries will be returned until, and including, the first
-	// entry that causes maxSize to be equaled or exceeded. This implies at
-	// least one entry will be returned in the slice on success.
+	// Returns the longest prefix of entries in the [start, end) interval such
+	// that the total size of the entries does not exceed maxSize. The limit can
+	// only be exceeded if the first entry is larger than maxSize, in which case
+	// only this first entry is returned.
 	//
-	// Returns an error if the log is truncated, or there is some other
-	// transient problem.
+	// Returns an error if the log is truncated beyond the start index, or there
+	// is some other transient problem.
 	//
 	// NB: the [start, end) interval is different from RawNode.LogSlice which
 	// accepts an open-closed interval.
+	//
+	// TODO(#132789): change the semantics so that maxSize can be exceeded not
+	// only if the first entry is large. It should be ok to exceed maxSize if the
+	// last entry makes it so. In the underlying storage implementation, we have
+	// paid the cost of fetching this entry anyway, so there is no need to drop it
+	// from the result.
 	LogSlice(start, end uint64, maxSize uint64) (raft.LogSlice, error)
 }
 

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/do_force_flush
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/do_force_flush
@@ -247,20 +247,19 @@ NormalPri:
   term=1 index=5  tokens=3145728
   term=1 index=6  tokens=3145728
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[4,6) send_queue=[6,7) precise_q_size=+3.0 MiB force-flushing
+(n2,s2):2: state=replicate closed=false inflight=[4,5) send_queue=[5,7) precise_q_size=+6.0 MiB force-flushing
 eval deducted: reg=+0 B ela=+12 MiB
-eval original in send-q: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+6.0 MiB ela=+0 B
 LowPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
   term=1 index=4  tokens=3145728
-  term=1 index=5  tokens=3145728
 ++++
 (n3,s3):3: closed
 ++++
 MsgApps sent in pull mode:
- to: 2, lowPri: true entries: [4 5]
+ to: 2, lowPri: true entries: [4]
 ++++
 schedule-controller-event-count: 3
 scheduled-replicas: 2
@@ -279,20 +278,20 @@ NormalPri:
   term=1 index=5  tokens=3145728
   term=1 index=6  tokens=3145728
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[6,7) send_queue=[7,7) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[5,6) send_queue=[6,7) precise_q_size=+3.0 MiB force-flushing
 eval deducted: reg=+0 B ela=+12 MiB
-eval original in send-q: reg=+0 B ela=+0 B
+eval original in send-q: reg=+3.0 MiB ela=+0 B
 LowPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
   term=1 index=4  tokens=3145728
   term=1 index=5  tokens=3145728
-  term=1 index=6  tokens=3145728
 ++++
 (n3,s3):3: closed
 ++++
 MsgApps sent in pull mode:
- to: 2, lowPri: true entries: [6]
+ to: 2, lowPri: true entries: [5]
 ++++
-schedule-controller-event-count: 3
+schedule-controller-event-count: 4
+scheduled-replicas: 2

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/do_force_flush
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/do_force_flush
@@ -151,45 +151,45 @@ schedule-controller-event-count: 1
 raft_event pull-mode
 range_id=1
   entries
-    term=1 index=4 pri=NormalPri size=3MiB
-    term=1 index=5 pri=NormalPri size=3MiB
-    term=1 index=6 pri=NormalPri size=3MiB
+    term=1 index=4 pri=NormalPri size=1.5MiB
+    term=1 index=5 pri=NormalPri size=1.5MiB
+    term=1 index=6 pri=NormalPri size=1.5MiB
 ----
-t1/s1: eval reg=-12 MiB/+16 MiB ela=-12 MiB/+8.0 MiB
-       send reg=-12 MiB/+16 MiB ela=-12 MiB/+8.0 MiB
-t1/s2: eval reg=+0 B/+16 MiB ela=-12 MiB/+8.0 MiB
+t1/s1: eval reg=-7.5 MiB/+16 MiB ela=-7.5 MiB/+8.0 MiB
+       send reg=-7.5 MiB/+16 MiB ela=-7.5 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-7.5 MiB/+8.0 MiB
        send reg=+0 B/+16 MiB ela=-3.0 MiB/+8.0 MiB
-t1/s3: eval reg=-9.0 MiB/+16 MiB ela=-9.0 MiB/+8.0 MiB
-       send reg=-9.0 MiB/+16 MiB ela=-9.0 MiB/+8.0 MiB
+t1/s3: eval reg=-4.5 MiB/+16 MiB ela=-4.5 MiB/+8.0 MiB
+       send reg=-4.5 MiB/+16 MiB ela=-4.5 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
 (n1,s1):1: state=replicate closed=false inflight=[4,7) send_queue=[7,7) precise_q_size=+0 B
-eval deducted: reg=+12 MiB ela=+0 B
+eval deducted: reg=+7.5 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
-  term=1 index=4  tokens=3145728
-  term=1 index=5  tokens=3145728
-  term=1 index=6  tokens=3145728
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+  term=1 index=6  tokens=1572864
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,7) precise_q_size=+9.0 MiB watching-for-tokens
-eval deducted: reg=+0 B ela=+12 MiB
-eval original in send-q: reg=+9.0 MiB ela=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,7) precise_q_size=+4.5 MiB watching-for-tokens
+eval deducted: reg=+0 B ela=+7.5 MiB
+eval original in send-q: reg=+4.5 MiB ela=+0 B
 LowPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
 (n3,s3):3: state=replicate closed=false inflight=[4,7) send_queue=[7,7) precise_q_size=+0 B
-eval deducted: reg=+9.0 MiB ela=+0 B
+eval deducted: reg=+4.5 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
-  term=1 index=4  tokens=3145728
-  term=1 index=5  tokens=3145728
-  term=1 index=6  tokens=3145728
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+  term=1 index=6  tokens=1572864
 ++++
 MsgApps sent in pull mode:
  to: 3, lowPri: false entries: [4 5 6]
@@ -208,19 +208,19 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 stream_state range_id=1
 ----
 (n1,s1):1: state=replicate closed=false inflight=[1,7) send_queue=[7,7) precise_q_size=+0 B
-eval deducted: reg=+12 MiB ela=+0 B
+eval deducted: reg=+7.5 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
-  term=1 index=4  tokens=3145728
-  term=1 index=5  tokens=3145728
-  term=1 index=6  tokens=3145728
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+  term=1 index=6  tokens=1572864
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,7) precise_q_size=+9.0 MiB force-flushing
-eval deducted: reg=+0 B ela=+12 MiB
-eval original in send-q: reg=+9.0 MiB ela=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,7) precise_q_size=+4.5 MiB force-flushing
+eval deducted: reg=+0 B ela=+7.5 MiB
+eval original in send-q: reg=+4.5 MiB ela=+0 B
 LowPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
@@ -231,35 +231,36 @@ LowPri:
 schedule-controller-event-count: 2
 scheduled-replicas: 2
 
-# Scheduler event. Only two entries are dequeued from the send-queue since 3+3
-# = 6MiB exceeds the 4MiB threshold for sending in one scheduler event.
-# Replica 2 schedules itself again.
+# Scheduler event. Only two entries are dequeued from the send-queue since 1.5 +
+# 1.5 + 1.5 = 4.5 MiB exceeds the 4MiB threshold for sending in one scheduler
+# event. Replica 2 schedules itself again.
 handle_scheduler_event range_id=1
 ----
 (n1,s1):1: state=replicate closed=false inflight=[1,7) send_queue=[7,7) precise_q_size=+0 B
-eval deducted: reg=+12 MiB ela=+0 B
+eval deducted: reg=+7.5 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
-  term=1 index=4  tokens=3145728
-  term=1 index=5  tokens=3145728
-  term=1 index=6  tokens=3145728
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+  term=1 index=6  tokens=1572864
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[4,5) send_queue=[5,7) precise_q_size=+6.0 MiB force-flushing
-eval deducted: reg=+0 B ela=+12 MiB
-eval original in send-q: reg=+6.0 MiB ela=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[4,6) send_queue=[6,7) precise_q_size=+1.5 MiB force-flushing
+eval deducted: reg=+0 B ela=+7.5 MiB
+eval original in send-q: reg=+1.5 MiB ela=+0 B
 LowPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
-  term=1 index=4  tokens=3145728
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
 ++++
 (n3,s3):3: closed
 ++++
 MsgApps sent in pull mode:
- to: 2, lowPri: true entries: [4]
+ to: 2, lowPri: true entries: [4 5]
 ++++
 schedule-controller-event-count: 3
 scheduled-replicas: 2
@@ -268,30 +269,30 @@ scheduled-replicas: 2
 handle_scheduler_event range_id=1
 ----
 (n1,s1):1: state=replicate closed=false inflight=[1,7) send_queue=[7,7) precise_q_size=+0 B
-eval deducted: reg=+12 MiB ela=+0 B
+eval deducted: reg=+7.5 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
-  term=1 index=4  tokens=3145728
-  term=1 index=5  tokens=3145728
-  term=1 index=6  tokens=3145728
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+  term=1 index=6  tokens=1572864
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[5,6) send_queue=[6,7) precise_q_size=+3.0 MiB force-flushing
-eval deducted: reg=+0 B ela=+12 MiB
-eval original in send-q: reg=+3.0 MiB ela=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[6,7) send_queue=[7,7) precise_q_size=+0 B
+eval deducted: reg=+0 B ela=+7.5 MiB
+eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
-  term=1 index=4  tokens=3145728
-  term=1 index=5  tokens=3145728
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+  term=1 index=6  tokens=1572864
 ++++
 (n3,s3):3: closed
 ++++
 MsgApps sent in pull mode:
- to: 2, lowPri: true entries: [5]
+ to: 2, lowPri: true entries: [6]
 ++++
-schedule-controller-event-count: 4
-scheduled-replicas: 2
+schedule-controller-event-count: 3

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/send_q_watcher
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/send_q_watcher
@@ -13,7 +13,6 @@ t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
 t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
        send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
 
-
 # Append three entries. Replica 2 has a send-queue.
 raft_event pull-mode
 range_id=1
@@ -178,8 +177,10 @@ NormalPri:
 schedule-controller-event-count: 2
 scheduled-replicas: 2
 
-# Scheduler event. Both entries in the send-queue are sent, and an extra
-# 512KiB needed to be deducted.
+# Scheduler event. Only the first entry in the send-queue is sent, because the
+# second entry would exceed the max size limit.
+# Replica 2 still has 512KiB of deducted tokens that are not used, and is
+# waiting for a scheduler event.
 handle_scheduler_event range_id=1
 ----
 (n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
@@ -211,6 +212,39 @@ MsgApps sent in pull mode:
 schedule-controller-event-count: 3
 scheduled-replicas: 2
 
+# The second entry is sent, and empties the send-queue. Extra 512KiB needed to
+# be deducted.
+handle_scheduler_event range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B
+eval deducted: reg=+0 B ela=+3.0 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+eval deducted: reg=+3.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
+++++
+MsgApps sent in pull mode:
+ to: 2, lowPri: true entries: [3]
+++++
+schedule-controller-event-count: 3
+
 # s2 has -512KiB of elastic send tokens.
 adjust_tokens send
   store_id=2 pri=HighPri tokens=0
@@ -218,7 +252,7 @@ adjust_tokens send
 t1/s1: eval reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
        send reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
 t1/s2: eval reg=+0 B/+16 MiB ela=-3.0 MiB/+8.0 MiB
-       send reg=+2.5 MiB/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+2.5 MiB/+16 MiB ela=-512 KiB/+8.0 MiB
 t1/s3: eval reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
        send reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
 
@@ -242,15 +276,18 @@ NormalPri:
   term=1 index=3  tokens=1048576
 ++++
 (n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
-eval deducted: reg=+0 B ela=+0 B
+eval deducted: reg=+0 B ela=+3.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
 ++++
 (n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+0 B watching-for-tokens
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
 schedule-controller-event-count: 3
-scheduled-replicas: 2
 
 # Noop. Note that s3 has 0 send tokens.
 adjust_tokens send
@@ -258,8 +295,8 @@ adjust_tokens send
 ----
 t1/s1: eval reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
        send reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
-t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
-       send reg=+2.5 MiB/+16 MiB ela=+2.5 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-3.0 MiB/+8.0 MiB
+       send reg=+2.5 MiB/+16 MiB ela=-512 KiB/+8.0 MiB
 t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
        send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
 
@@ -271,8 +308,8 @@ adjust_tokens send
 ----
 t1/s1: eval reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
        send reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
-t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
-       send reg=+2.5 MiB/+16 MiB ela=+2.5 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-3.0 MiB/+8.0 MiB
+       send reg=+2.5 MiB/+16 MiB ela=-512 KiB/+8.0 MiB
 t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
        send reg=+10 KiB/+16 MiB ela=+6.0 KiB/+8.0 MiB
 
@@ -288,15 +325,19 @@ NormalPri:
   term=1 index=3  tokens=1048576
 ++++
 (n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
-eval deducted: reg=+0 B ela=+0 B
+eval deducted: reg=+0 B ela=+3.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
 ++++
 (n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+0 B deducted=+4.0 KiB
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
-schedule-controller-event-count: 3
-scheduled-replicas: 2 3
+schedule-controller-event-count: 4
+scheduled-replicas: 3
 
 # Scheduler event. Replica 3 deducts 1MiB-4KiB without waiting since the entry
 # was actually 1MiB.
@@ -311,8 +352,12 @@ NormalPri:
   term=1 index=3  tokens=1048576
 ++++
 (n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
-eval deducted: reg=+0 B ela=+0 B
+eval deducted: reg=+0 B ela=+3.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
 ++++
 (n3,s3):3: state=replicate closed=false inflight=[2,3) send_queue=[3,4) precise_q_size=+0 B watching-for-tokens
 eval deducted: reg=+0 B ela=+0 B
@@ -323,7 +368,7 @@ LowPri:
 MsgApps sent in pull mode:
  to: 3, lowPri: true entries: [2]
 ++++
-schedule-controller-event-count: 3
+schedule-controller-event-count: 4
 
 # Add 3MiB of elastic send tokens, to return to 2MiB+10KiB of tokens. The
 # send-stream now has an estimate of 1MiB needed per entry, and deduct 1.1 x
@@ -333,8 +378,8 @@ adjust_tokens send
 ----
 t1/s1: eval reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
        send reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
-t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
-       send reg=+2.5 MiB/+16 MiB ela=+2.5 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-3.0 MiB/+8.0 MiB
+       send reg=+2.5 MiB/+16 MiB ela=-512 KiB/+8.0 MiB
 t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
        send reg=+3.0 MiB/+16 MiB ela=+932 KiB/+8.0 MiB
 
@@ -351,8 +396,12 @@ NormalPri:
   term=1 index=3  tokens=1048576
 ++++
 (n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
-eval deducted: reg=+0 B ela=+0 B
+eval deducted: reg=+0 B ela=+3.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
 ++++
 (n3,s3):3: state=replicate closed=false inflight=[2,3) send_queue=[3,4) precise_q_size=+0 B deducted=+1.1 MiB
 eval deducted: reg=+0 B ela=+0 B
@@ -360,7 +409,7 @@ eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
   term=1 index=2  tokens=1048576
 ++++
-schedule-controller-event-count: 4
+schedule-controller-event-count: 5
 scheduled-replicas: 3
 
 # Scheduler event. Replica 3 returns 0.1MiB since the entry was actually 1MiB.
@@ -376,8 +425,12 @@ NormalPri:
   term=1 index=3  tokens=1048576
 ++++
 (n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
-eval deducted: reg=+0 B ela=+0 B
+eval deducted: reg=+0 B ela=+3.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
 ++++
 (n3,s3):3: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
@@ -389,7 +442,7 @@ LowPri:
 MsgApps sent in pull mode:
  to: 3, lowPri: true entries: [3]
 ++++
-schedule-controller-event-count: 4
+schedule-controller-event-count: 5
 
 # Noop, to see current token values.
 adjust_tokens send
@@ -397,7 +450,7 @@ adjust_tokens send
 ----
 t1/s1: eval reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
        send reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
-t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
-       send reg=+2.5 MiB/+16 MiB ela=+2.5 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-3.0 MiB/+8.0 MiB
+       send reg=+2.5 MiB/+16 MiB ela=-512 KiB/+8.0 MiB
 t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
        send reg=+3.0 MiB/+16 MiB ela=+1.0 MiB/+8.0 MiB

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/send_q_watcher
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/send_q_watcher
@@ -190,13 +190,12 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[2,4) send_queue=[4,4) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[2,3) send_queue=[3,4) precise_q_size=+1.0 MiB deducted=+512 KiB
 eval deducted: reg=+0 B ela=+3.0 MiB
-eval original in send-q: reg=+0 B ela=+0 B
+eval original in send-q: reg=+1.0 MiB ela=+0 B
 LowPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
-  term=1 index=3  tokens=1048576
 ++++
 (n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
@@ -207,9 +206,10 @@ NormalPri:
   term=1 index=3  tokens=1048576
 ++++
 MsgApps sent in pull mode:
- to: 2, lowPri: true entries: [2 3]
+ to: 2, lowPri: true entries: [2]
 ++++
-schedule-controller-event-count: 2
+schedule-controller-event-count: 3
+scheduled-replicas: 2
 
 # s2 has -512KiB of elastic send tokens.
 adjust_tokens send
@@ -218,7 +218,7 @@ adjust_tokens send
 t1/s1: eval reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
        send reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
 t1/s2: eval reg=+0 B/+16 MiB ela=-3.0 MiB/+8.0 MiB
-       send reg=+2.5 MiB/+16 MiB ela=-512 KiB/+8.0 MiB
+       send reg=+2.5 MiB/+16 MiB ela=+0 B/+8.0 MiB
 t1/s3: eval reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
        send reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
 
@@ -242,18 +242,15 @@ NormalPri:
   term=1 index=3  tokens=1048576
 ++++
 (n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
-eval deducted: reg=+0 B ela=+3.0 MiB
+eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
-LowPri:
-  term=1 index=1  tokens=1048576
-  term=1 index=2  tokens=1048576
-  term=1 index=3  tokens=1048576
 ++++
 (n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+0 B watching-for-tokens
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
-schedule-controller-event-count: 2
+schedule-controller-event-count: 3
+scheduled-replicas: 2
 
 # Noop. Note that s3 has 0 send tokens.
 adjust_tokens send
@@ -261,8 +258,8 @@ adjust_tokens send
 ----
 t1/s1: eval reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
        send reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
-t1/s2: eval reg=+0 B/+16 MiB ela=-3.0 MiB/+8.0 MiB
-       send reg=+2.5 MiB/+16 MiB ela=-512 KiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+2.5 MiB/+16 MiB ela=+2.5 MiB/+8.0 MiB
 t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
        send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
 
@@ -274,8 +271,8 @@ adjust_tokens send
 ----
 t1/s1: eval reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
        send reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
-t1/s2: eval reg=+0 B/+16 MiB ela=-3.0 MiB/+8.0 MiB
-       send reg=+2.5 MiB/+16 MiB ela=-512 KiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+2.5 MiB/+16 MiB ela=+2.5 MiB/+8.0 MiB
 t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
        send reg=+10 KiB/+16 MiB ela=+6.0 KiB/+8.0 MiB
 
@@ -291,19 +288,15 @@ NormalPri:
   term=1 index=3  tokens=1048576
 ++++
 (n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
-eval deducted: reg=+0 B ela=+3.0 MiB
+eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
-LowPri:
-  term=1 index=1  tokens=1048576
-  term=1 index=2  tokens=1048576
-  term=1 index=3  tokens=1048576
 ++++
 (n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+0 B deducted=+4.0 KiB
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
 schedule-controller-event-count: 3
-scheduled-replicas: 3
+scheduled-replicas: 2 3
 
 # Scheduler event. Replica 3 deducts 1MiB-4KiB without waiting since the entry
 # was actually 1MiB.
@@ -318,12 +311,8 @@ NormalPri:
   term=1 index=3  tokens=1048576
 ++++
 (n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
-eval deducted: reg=+0 B ela=+3.0 MiB
+eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
-LowPri:
-  term=1 index=1  tokens=1048576
-  term=1 index=2  tokens=1048576
-  term=1 index=3  tokens=1048576
 ++++
 (n3,s3):3: state=replicate closed=false inflight=[2,3) send_queue=[3,4) precise_q_size=+0 B watching-for-tokens
 eval deducted: reg=+0 B ela=+0 B
@@ -344,8 +333,8 @@ adjust_tokens send
 ----
 t1/s1: eval reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
        send reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
-t1/s2: eval reg=+0 B/+16 MiB ela=-3.0 MiB/+8.0 MiB
-       send reg=+2.5 MiB/+16 MiB ela=-512 KiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+2.5 MiB/+16 MiB ela=+2.5 MiB/+8.0 MiB
 t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
        send reg=+3.0 MiB/+16 MiB ela=+932 KiB/+8.0 MiB
 
@@ -362,12 +351,8 @@ NormalPri:
   term=1 index=3  tokens=1048576
 ++++
 (n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
-eval deducted: reg=+0 B ela=+3.0 MiB
+eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
-LowPri:
-  term=1 index=1  tokens=1048576
-  term=1 index=2  tokens=1048576
-  term=1 index=3  tokens=1048576
 ++++
 (n3,s3):3: state=replicate closed=false inflight=[2,3) send_queue=[3,4) precise_q_size=+0 B deducted=+1.1 MiB
 eval deducted: reg=+0 B ela=+0 B
@@ -391,12 +376,8 @@ NormalPri:
   term=1 index=3  tokens=1048576
 ++++
 (n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
-eval deducted: reg=+0 B ela=+3.0 MiB
+eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
-LowPri:
-  term=1 index=1  tokens=1048576
-  term=1 index=2  tokens=1048576
-  term=1 index=3  tokens=1048576
 ++++
 (n3,s3):3: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
@@ -416,7 +397,7 @@ adjust_tokens send
 ----
 t1/s1: eval reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
        send reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
-t1/s2: eval reg=+0 B/+16 MiB ela=-3.0 MiB/+8.0 MiB
-       send reg=+2.5 MiB/+16 MiB ela=-512 KiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+2.5 MiB/+16 MiB ela=+2.5 MiB/+8.0 MiB
 t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
        send reg=+3.0 MiB/+16 MiB ela=+1.0 MiB/+8.0 MiB

--- a/pkg/raft/storage.go
+++ b/pkg/raft/storage.go
@@ -64,6 +64,12 @@ type LogStorage interface {
 	// TODO(pav-kv): all log slices in raft are constructed in context of being
 	// appended after a particular log index, so (lo, hi] semantics fits better
 	// than [lo, hi).
+	//
+	// TODO(#132789): change the semantics so that maxSize can be exceeded not
+	// only if the first entry is large. It should be ok to exceed maxSize if the
+	// last entry makes it so. In the underlying storage implementation, we have
+	// paid the cost of fetching this entry anyway, so there is no need to drop it
+	// from the result.
 	Entries(lo, hi, maxSize uint64) ([]pb.Entry, error)
 
 	// Term returns the term of the entry at the given index, which must be in the


### PR DESCRIPTION
This PR converts the test-only implementation of the `LogSlice` method to behave exactly as the raft's `LogStorage` does. Specifically:

- The entry size is the proto `Size()` rather than `len(entry.Data)`
- The `maxSize` can not be exceeded unless the first entry is large

Both semantics can/should be changed in the future to what RACv2 previously assumed, but this PR eliminates the diff between the two in the short term so that the `rac2` tests are reflective of the real behaviour.

Epic: none
Release note: none