### PR TITLE
release-24.2: lint: require license headers for all scss files

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -258,7 +258,7 @@ func TestLint(t *testing.T) {
 
 		// These extensions identify source files that should have copyright headers.
 		extensions := []string{
-			"*.go", "*.cc", "*.h", "*.js", "*.ts", "*.tsx", "*.s", "*.S", "*.styl", "*.proto", "*.rl",
+			"*.go", "*.cc", "*.h", "*.js", "*.ts", "*.tsx", "*.s", "*.S", "*.scss", "*.styl", "*.proto", "*.rl",
 		}
 		fullExtensions := make([]string, len(extensions)*2)
 		for i, extension := range extensions {

--- a/pkg/ui/workspaces/cluster-ui/src/NotificationMessage/notificationMessage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/NotificationMessage/notificationMessage.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module.scss";
 
 .notification-message {

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/executionStatusIcon.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/executionStatusIcon.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "src/core/index.module";
 
 .status-icon {

--- a/pkg/ui/workspaces/cluster-ui/src/anchor/anchor.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/anchor/anchor.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module.scss";
 
 .crl-anchor {

--- a/pkg/ui/workspaces/cluster-ui/src/badge/badge.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/badge/badge.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module.scss";
 @import "~@cockroachlabs/design-tokens/dist/web/_tokens.scss";
 

--- a/pkg/ui/workspaces/cluster-ui/src/barCharts/barCharts.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/barCharts/barCharts.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module";
 
 .bar-chart {

--- a/pkg/ui/workspaces/cluster-ui/src/button/button.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/button/button.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module.scss";
 
 @mixin icon-color($color: $colors--neutral-7) {

--- a/pkg/ui/workspaces/cluster-ui/src/columnsSelector/columnsSelector.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/columnsSelector/columnsSelector.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module";
 
 .apply-btn {

--- a/pkg/ui/workspaces/cluster-ui/src/common/styles.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/common/styles.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "src/core/index.module";
 
 .cockroach--tabs {

--- a/pkg/ui/workspaces/cluster-ui/src/core/base.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/core/base.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "typography.module";
 
 @mixin base {

--- a/pkg/ui/workspaces/cluster-ui/src/core/colors.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/core/colors.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 $colors--neutral-0: #ffffff;
 $colors--neutral-1: #f5f7fa;
 $colors--neutral-2: #e7ecf3;

--- a/pkg/ui/workspaces/cluster-ui/src/core/index.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/core/index.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "./typography.module";
 @import "./colors.module";
 @import "./base.module";

--- a/pkg/ui/workspaces/cluster-ui/src/core/typography.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/core/typography.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @mixin font-face($name) {
   @font-face {
     font-family: $name;

--- a/pkg/ui/workspaces/cluster-ui/src/dateRangeMenu/dateRangeMenu.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/dateRangeMenu/dateRangeMenu.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module";
 
 .popup-content {

--- a/pkg/ui/workspaces/cluster-ui/src/dropdown/dropdown.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/dropdown/dropdown.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module";
 
 .crl-dropdown {

--- a/pkg/ui/workspaces/cluster-ui/src/empty/emptyPanel/emptyPanel.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/empty/emptyPanel/emptyPanel.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../../core/index.module";
 
 .cl-empty-view {

--- a/pkg/ui/workspaces/cluster-ui/src/empty/emptyTable/emptyTable.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/empty/emptyTable/emptyTable.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../../core/index.module.scss";
 
 .root {

--- a/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/bargraph.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/bargraph.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 :global {
   @import "uplot/dist/uPlot.min";
 }

--- a/pkg/ui/workspaces/cluster-ui/src/highlightedText/highlightedText.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/highlightedText/highlightedText.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module";
 
 ._text-bold {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "src/core/index.module";
 
 .alert-area {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightsDetails.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightsDetails.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 .section {
   padding: 12px 24px 12px 0px;
   display: flex;

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "src/core/index.module";
 
 .insight-type {

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "src/core/index.module";
 
 .crl-job-profiler-view {

--- a/pkg/ui/workspaces/cluster-ui/src/loading/loading.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/loading/loading.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module";
 
 .loading-indicator {

--- a/pkg/ui/workspaces/cluster-ui/src/modal/modal.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/modal/modal.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module";
 
 .crl-modal {

--- a/pkg/ui/workspaces/cluster-ui/src/multiSelectCheckbox/multiSelectCheckbox.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/multiSelectCheckbox/multiSelectCheckbox.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module";
 
 .checkbox {

--- a/pkg/ui/workspaces/cluster-ui/src/outsideEventHandler/outsideEventHandler.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/outsideEventHandler/outsideEventHandler.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 .outside-event-handler {
   position: initial;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/pageConfig/pageConfig.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/pageConfig/pageConfig.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module";
 
 .page-config {

--- a/pkg/ui/workspaces/cluster-ui/src/pagination/pagination.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/pagination/pagination.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module";
 
 ._pg-jump {

--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module";
 
 $dropdown-hover-color: darken($colors--background, 2.5%);

--- a/pkg/ui/workspaces/cluster-ui/src/search/search.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/search/search.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module";
 
 .root {

--- a/pkg/ui/workspaces/cluster-ui/src/searchCriteria/searchCriteria.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/searchCriteria/searchCriteria.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module";
 
 :global(.ant-dropdown-menu-submenu-popup ul) {

--- a/pkg/ui/workspaces/cluster-ui/src/settings/booleanSetting.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/settings/booleanSetting.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "src/core/index.module";
 
 .crl-hover-text {

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/sortedtable.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module.scss";
 @import "./table.module.scss";
 

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/table.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/table.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module.scss";
 
 $table-cell-border: 1px solid $colors--neutral-2;

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/tableHead/tableHead.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/tableHead/tableHead.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../../core/index.module.scss";
 @import "../table.module.scss";
 

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/tableRow/tableRow.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/tableRow/tableRow.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../../core/index.module.scss";
 @import "../table.module.scss";
 

--- a/pkg/ui/workspaces/cluster-ui/src/sortedtable/tableSpinner/tableSpinner.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sortedtable/tableSpinner/tableSpinner.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../../core/index.module.scss";
 
 .table__loading {

--- a/pkg/ui/workspaces/cluster-ui/src/sqlActivity/sqlActivity.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sqlActivity/sqlActivity.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "src/core/index.module";
 
 .tooltip-info {

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "src/core/index.module";
 
 .crl-statements-diagnostics-view {

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "src/core/index.module";
 
 .bold-link {

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planView/planView.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planView/planView.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "src/core/index.module";
 @import "src/sortedtable/table.module.scss";
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "src/core/index.module";
 
 .text-link {

--- a/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/activateStatementDiagnosticsModal.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/activateStatementDiagnosticsModal.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module";
 
 .root {

--- a/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/diagnosticStatusBadge.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/diagnosticStatusBadge.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "src/core/index.module";
 
 .diagnostic-status-badge {

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementTypeSelect.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementTypeSelect.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "src/core/index.module";
 
 .statement-select {

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "src/core/index.module";
 
 cl-table-container {

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "src/core/index.module";
 
 .numeric-stats-table {

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "src/core/index.module";
 
 .cl-table-link__description {

--- a/pkg/ui/workspaces/cluster-ui/src/summaryCard/summaryCard.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/summaryCard/summaryCard.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module";
 
 .summary--card {

--- a/pkg/ui/workspaces/cluster-ui/src/table/table.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/table/table.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "src/core/index.module";
 @import "src/sortedtable/tableHead/tableHead.module";
 

--- a/pkg/ui/workspaces/cluster-ui/src/tableStatistics/tableStatistics.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/tableStatistics/tableStatistics.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "src/core/index.module";
 
 .flex-display {

--- a/pkg/ui/workspaces/cluster-ui/src/text/text.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/text/text.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module.scss";
 
 .text {

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/rangeSelector.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/rangeSelector.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "src/core/index.module";
 
 .custom-menu {

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeFrameControls.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeFrameControls.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "src/core/index.module";
 
 .controls-content {

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScale.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScale.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "src/core/index.module";
 
 .timescale {

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.modules.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.modules.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../core/index.module.scss";
 
 .summary-columns {

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsCells/transactionsCells.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsCells/transactionsCells.module.scss
@@ -1,3 +1,8 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
 @import "../../core/index.module.scss";
 
 .hover-area {


### PR DESCRIPTION
Backport 1/1 commits from #131794.

/cc @cockroachdb/release

---

All scss files should have license headers. This commit requires the CSL license header on all scss files via the license header linter and adds the header to the files that were missing it.

Part of RE-658

Release note (general change): Change the license cockroach is distributed under to the new CockroachDB Software License (CSL).

---

Release justification: Change the license cockroach is distributed under to the new CockroachDB Software License (CSL).