### PR TITLE
workload: add support for emitting events to Datadog

### DIFF
--- a/pkg/workload/BUILD.bazel
+++ b/pkg/workload/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "connection.go",
         "csv.go",
+        "datadog.go",
         "driver.go",
         "pgx_helpers.go",
         "random.go",
@@ -28,6 +29,8 @@ go_library(
         "//pkg/util/timeutil",
         "//pkg/workload/histogram",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_datadog_datadog_api_client_go_v2//api/datadog",
+        "@com_github_datadog_datadog_api_client_go_v2//api/datadogV1",
         "@com_github_jackc_pgx_v5//:pgx",
         "@com_github_jackc_pgx_v5//pgconn",
         "@com_github_jackc_pgx_v5//pgxpool",

--- a/pkg/workload/cli/BUILD.bazel
+++ b/pkg/workload/cli/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/workload/histogram/exporter",
         "//pkg/workload/workloadsql",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_datadog_datadog_api_client_go_v2//api/datadogV1",
         "@com_github_prometheus_client_golang//prometheus/collectors",
         "@com_github_prometheus_client_golang//prometheus/promhttp",
         "@com_github_spf13_cobra//:cobra",

--- a/pkg/workload/cli/check.go
+++ b/pkg/workload/cli/check.go
@@ -8,13 +8,23 @@ package cli
 import (
 	"context"
 	gosql "database/sql"
+	"fmt"
 	"strings"
 
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
+
+var checkFlags = pflag.NewFlagSet("check", pflag.ContinueOnError)
+var datadogSite = checkFlags.String("datadog-site", "us5.datadoghq.com",
+	"Datadog site to communicate with (e.g., us5.datadoghq.com).")
+var datadogAPIKey = checkFlags.String("datadog-api-key", "",
+	"Datadog API key to emit telemetry data to Datadog.")
+var datadogTags = checkFlags.String("datadog-tags", "",
+	"A comma-separated list of tags to attach to telemetry data (e.g., key1:val1,key2:val2).")
 
 func init() {
 	AddSubCmd(func(userFacing bool) *cobra.Command {
@@ -47,6 +57,7 @@ func init() {
 				Args: cobra.RangeArgs(0, 1),
 			})
 			genCheckCmd.Flags().AddFlagSet(genFlags)
+			genCheckCmd.Flags().AddFlagSet(checkFlags)
 			genCheckCmd.Run = CmdHelper(gen, check)
 			checkCmd.AddCommand(genCheckCmd)
 		}
@@ -73,5 +84,15 @@ func check(gen workload.Generator, urls []string, dbName string) error {
 	if err := sqlDB.Ping(); err != nil {
 		return err
 	}
-	return fn(ctx, sqlDB)
+	err = fn(ctx, sqlDB)
+	if err != nil {
+		// For automated operations running the consistency checker like the DRT team,
+		// there is a need to send an event to Datadog so that a Slack alert can be
+		// configured. Here, we are attempting to emit an error event to Datadog.
+		datadogContext := workload.NewDatadogContext(ctx, *datadogSite, *datadogAPIKey)
+		title := fmt.Sprintf("Consistency check failed for %s", gen.Meta().Name)
+		text := fmt.Sprintf("%v", err)
+		workload.EmitDatadogEvent(datadogContext, title, text, datadogV1.EVENTALERTTYPE_ERROR, *datadogTags)
+	}
+	return err
 }

--- a/pkg/workload/datadog.go
+++ b/pkg/workload/datadog.go
@@ -1,0 +1,69 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package workload
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+var eventsClient = datadogV1.NewEventsApi(datadog.NewAPIClient(datadog.NewConfiguration()))
+
+// NewDatadogContext adds values to the passed in ctx to configure it to
+// communicate with Datadog. If value of site or apiKey is not provided ctx
+// is returned without any changes.
+func NewDatadogContext(ctx context.Context, site, apiKey string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if site == "" || apiKey == "" {
+		return ctx
+	}
+
+	ctx = context.WithValue(ctx, datadog.ContextAPIKeys, map[string]datadog.APIKey{
+		"apiKeyAuth": {
+			Key: apiKey,
+		},
+	})
+
+	ctx = context.WithValue(ctx, datadog.ContextServerVariables, map[string]string{
+		"site": site,
+	})
+	return ctx
+}
+
+// EmitDatadogEvent sends an event to Datadog if the passed in ctx has the necessary values to
+// communicate with Datadog.
+func EmitDatadogEvent(
+	ctx context.Context, title, text string, eventType datadogV1.EventAlertType, tags string,
+) {
+	_, hasAPIKey := ctx.Value(datadog.ContextAPIKeys).(map[string]datadog.APIKey)
+	_, hasServerVariables := ctx.Value(datadog.ContextServerVariables).(map[string]string)
+	if !hasAPIKey && !hasServerVariables {
+		return
+	}
+
+	hostName, _ := os.Hostname()
+	_, _, _ = eventsClient.CreateEvent(ctx, datadogV1.EventCreateRequest{
+		AlertType:      &eventType,
+		DateHappened:   datadog.PtrInt64(timeutil.Now().Unix()),
+		Host:           &hostName,
+		SourceTypeName: datadog.PtrString("workload"),
+		Tags:           getDatadogTags(tags),
+		Text:           text,
+		Title:          title,
+	})
+}
+
+func getDatadogTags(tags string) []string {
+	return strings.Split(tags, ",")
+}


### PR DESCRIPTION
Changes as part of this PR:
- Added support in the workload package to emit events to Datadog if the required environment variables (`DD_SITE`, `DD_API_KEY`, and `DD_TAGS`) are configured.
- Using `EmitDatadogEvent` in the TPC-C consistency checker to emit an event if the consistency check fails.

Epic: none

Release note: None