### PR TITLE
release-24.2: testccl: fix TestAuthenticationAndHBARules due to updated HBA options format

### DIFF
--- a/pkg/ccl/testccl/authccl/testdata/ldap
+++ b/pkg/ccl/testccl/authccl/testdata/ldap
@@ -72,12 +72,12 @@ host  all ldap_user 127.0.0.1/32 ldap ldapserver=localhost ldapport=636 "ldapbas
 ERROR: LDAP option "ldapbinddn" is set to invalid value: "bindDN": failed to parse distinguished name bindDN: DN ended with incomplete type, value pair
 
 set_hba
-host  all ldap_user 127.0.0.1/32 ldap ldapserver=localhost ldapport=636 "ldapbasedn=O=security org,DC=localhost" "ldapbinddn=CN=service_account,O=security org,DC=localhost" "ldapbindpasswd=" ldapsearchattribute=sAMAccountName "ldapsearchfilter=(memberOf=*)"
+host  all ldap_user 127.0.0.1/32 ldap ldapserver=localhost ldapport=636 "ldapbasedn=O=security org,DC=localhost" "ldapbinddn=CN=service_account,O=security org,DC=localhost" ldapbindpasswd="" ldapsearchattribute=sAMAccountName "ldapsearchfilter=(memberOf=*)"
 ----
 ERROR: LDAP option "ldapbindpasswd" is set to invalid value: "": "ldapbindpasswd" is set to empty
 
 set_hba
-host  all ldap_user 127.0.0.1/32 ldap ldapserver=localhost ldapport=636 "ldapbasedn=O=security org,DC=localhost" "ldapbinddn=CN=service_account,O=security org,DC=localhost" ldapbindpasswd=ldap_pwd "ldapsearchattribute=" "ldapsearchfilter=(memberOf=*)"
+host  all ldap_user 127.0.0.1/32 ldap ldapserver=localhost ldapport=636 "ldapbasedn=O=security org,DC=localhost" "ldapbinddn=CN=service_account,O=security org,DC=localhost" ldapbindpasswd=ldap_pwd ldapsearchattribute="" "ldapsearchfilter=(memberOf=*)"
 ----
 ERROR: LDAP option "ldapsearchattribute" is set to invalid value: "": "ldapsearchattribute" is set to empty
 


### PR DESCRIPTION
Closes CRDB-41624
Epic CRDB-33829

The TestAuthenticationAndHBARules is failing now, as we updated the HBA options
to handle double quotes in v24.2 as well. The change is to fix the failing test
due to incorrect input format.

Release note: None

----
Release justification: test only.