### PR TITLE
drtprod: move drt-large to spot vms

### DIFF
--- a/pkg/cmd/drtprod/configs/drt_large.yaml
+++ b/pkg/cmd/drtprod/configs/drt_large.yaml
@@ -17,6 +17,7 @@ targets:
         flags:
           clouds: gce
           gce-managed: true
+          gce-use-spot: true
           gce-enable-multiple-stores: true
           gce-zones: "northamerica-northeast2-a:2,northamerica-northeast2-b:2,northamerica-northeast2-c:1,us-east5-a:2,us-east5-b:2,us-east5-c:1,us-east1-b:2,us-east1-c:2,us-east1-d:1"
           nodes: 15


### PR DESCRIPTION
move drt-large to spot VMs

Epic: none

Release note: None