### PR TITLE
server: don't Fatal in response to cluster setting

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -207,6 +207,7 @@ go_library(
         "//pkg/util/encoding",
         "//pkg/util/envutil",
         "//pkg/util/errorutil",
+        "//pkg/util/errorutil/unimplemented",
         "//pkg/util/growstack",
         "//pkg/util/grpcutil",
         "//pkg/util/grunning",

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -2075,8 +2075,9 @@ func (n *Node) MuxRangeFeed(muxStream kvpb.Internal_MuxRangeFeedServer) error {
 
 	var sm streamManager
 	if kvserver.RangefeedUseBufferedSender.Get(&n.storeCfg.Settings.SV) {
+		// Should be unreachable in production builds.
 		sm = rangefeed.NewBufferedSender(lockedMuxStream, n.metrics)
-		log.Fatalf(ctx, "unimplemented: buffered sender for rangefeed #126560")
+		return kvserver.ErrBufferedSenderNotSupported
 	} else {
 		sm = rangefeed.NewUnbufferedSender(lockedMuxStream, n.metrics)
 	}


### PR DESCRIPTION
This cluster setting is protecting in-development features. While we don't expect users to ever set this, if a user were to happen to find the cluster setting and enable it, we don't want that to result in a process crash.

Here, we add a validation such that the user can't set the relevant setting to true in production and also remove a log.Fatal just in case.

Epic: none
Release note: None