### PR TITLE
cluster-ui: use react-router-dom

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "24.3.0-prerelease.2",
+  "version": "24.3.0-prerelease.3",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/index.tsx
@@ -5,7 +5,7 @@
 
 import { Skeleton, Tabs } from "antd";
 import React from "react";
-import { useHistory, useLocation } from "react-router";
+import { useHistory, useLocation } from "react-router-dom";
 
 import { useDatabaseMetadataByID } from "src/api/databases/getDatabaseMetadataApi";
 import { commonStyles } from "src/common";

--- a/pkg/ui/workspaces/cluster-ui/src/hooks/useRouteParams.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/hooks/useRouteParams.ts
@@ -3,7 +3,7 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import { useParams } from "react-router";
+import { useParams } from "react-router-dom";
 
 import { databaseIDAttr, tableIdAttr } from "src/util";
 

--- a/pkg/ui/workspaces/cluster-ui/src/sharedFromCloud/useTable.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/sharedFromCloud/useTable.ts
@@ -5,7 +5,7 @@
 
 import { DateTime } from "luxon";
 import { useEffect, useMemo, useReducer } from "react";
-import { useHistory } from "react-router";
+import { useHistory } from "react-router-dom";
 
 import { parseURLParams, updateURLParams } from "./handleURLParams";
 


### PR DESCRIPTION
Use utilities from react-router-dom instead
of react-router for CC compatibility.
This allows a parent context not to have to
be defined.

Epic: none
Release note: None