### PR TITLE
schemachanger: cleanup unused indexID

### DIFF
--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_index_configure_zone/alter_index_configure_zone.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_index_configure_zone/alter_index_configure_zone.explain
@@ -11,7 +11,7 @@ Schema change plan for ALTER INDEX ‹defaultdb›.‹public›.‹t›@‹foo�
  │         ├── 1 element transitioning toward PUBLIC
  │         │    └── ABSENT → PUBLIC IndexZoneConfig:{DescID: 104 (t), IndexID: 2 (foo), SeqNum: 1}
  │         └── 1 Mutation operation
- │              └── AddIndexZoneConfig {"IndexID":2,"TableID":104}
+ │              └── AddIndexZoneConfig {"TableID":104}
  └── PreCommitPhase
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 1 element transitioning toward PUBLIC
@@ -22,4 +22,4 @@ Schema change plan for ALTER INDEX ‹defaultdb›.‹public›.‹t›@‹foo�
            ├── 1 element transitioning toward PUBLIC
            │    └── ABSENT → PUBLIC IndexZoneConfig:{DescID: 104 (t), IndexID: 2 (foo), SeqNum: 1}
            └── 1 Mutation operation
-                └── AddIndexZoneConfig {"IndexID":2,"TableID":104}
+                └── AddIndexZoneConfig {"TableID":104}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_index_configure_zone_multiple/alter_index_configure_zone_multiple__statement_1_of_3.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_index_configure_zone_multiple/alter_index_configure_zone_multiple__statement_1_of_3.explain
@@ -11,7 +11,7 @@ Schema change plan for ALTER INDEX ‹defaultdb›.‹public›.‹t›@‹foo�
  │         ├── 1 element transitioning toward PUBLIC
  │         │    └── ABSENT → PUBLIC IndexZoneConfig:{DescID: 104 (t), IndexID: 2 (foo), SeqNum: 1}
  │         └── 1 Mutation operation
- │              └── AddIndexZoneConfig {"IndexID":2,"TableID":104}
+ │              └── AddIndexZoneConfig {"TableID":104}
  └── PreCommitPhase
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 1 element transitioning toward PUBLIC
@@ -22,4 +22,4 @@ Schema change plan for ALTER INDEX ‹defaultdb›.‹public›.‹t›@‹foo�
            ├── 1 element transitioning toward PUBLIC
            │    └── ABSENT → PUBLIC IndexZoneConfig:{DescID: 104 (t), IndexID: 2 (foo), SeqNum: 1}
            └── 1 Mutation operation
-                └── AddIndexZoneConfig {"IndexID":2,"TableID":104}
+                └── AddIndexZoneConfig {"TableID":104}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_index_configure_zone_multiple/alter_index_configure_zone_multiple__statement_2_of_3.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_index_configure_zone_multiple/alter_index_configure_zone_multiple__statement_2_of_3.explain
@@ -12,7 +12,7 @@ Schema change plan for ALTER INDEX ‹defaultdb›.‹public›.‹t›@‹foo�
  │         ├── 1 element transitioning toward PUBLIC
  │         │    └── ABSENT → PUBLIC IndexZoneConfig:{DescID: 104 (t), IndexID: 2 (foo), SeqNum: 2}
  │         └── 1 Mutation operation
- │              └── AddIndexZoneConfig {"IndexID":2,"TableID":104}
+ │              └── AddIndexZoneConfig {"TableID":104}
  └── PreCommitPhase
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 2 elements transitioning toward PUBLIC
@@ -25,5 +25,5 @@ Schema change plan for ALTER INDEX ‹defaultdb›.‹public›.‹t›@‹foo�
            │    ├── ABSENT → PUBLIC IndexZoneConfig:{DescID: 104 (t), IndexID: 2 (foo), SeqNum: 1}
            │    └── ABSENT → PUBLIC IndexZoneConfig:{DescID: 104 (t), IndexID: 2 (foo), SeqNum: 2}
            └── 2 Mutation operations
-                ├── AddIndexZoneConfig {"IndexID":2,"TableID":104}
-                └── AddIndexZoneConfig {"IndexID":2,"TableID":104}
+                ├── AddIndexZoneConfig {"TableID":104}
+                └── AddIndexZoneConfig {"TableID":104}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_index_configure_zone_multiple/alter_index_configure_zone_multiple__statement_3_of_3.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_index_configure_zone_multiple/alter_index_configure_zone_multiple__statement_3_of_3.explain
@@ -13,7 +13,7 @@ Schema change plan for ALTER INDEX ‹defaultdb›.‹public›.‹t›@‹foo�
  │         ├── 1 element transitioning toward PUBLIC
  │         │    └── ABSENT → PUBLIC IndexZoneConfig:{DescID: 104 (t), IndexID: 2 (foo), SeqNum: 3}
  │         └── 1 Mutation operation
- │              └── AddIndexZoneConfig {"IndexID":2,"TableID":104}
+ │              └── AddIndexZoneConfig {"TableID":104}
  └── PreCommitPhase
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 3 elements transitioning toward PUBLIC
@@ -28,6 +28,6 @@ Schema change plan for ALTER INDEX ‹defaultdb›.‹public›.‹t›@‹foo�
            │    ├── ABSENT → PUBLIC IndexZoneConfig:{DescID: 104 (t), IndexID: 2 (foo), SeqNum: 2}
            │    └── ABSENT → PUBLIC IndexZoneConfig:{DescID: 104 (t), IndexID: 2 (foo), SeqNum: 3}
            └── 3 Mutation operations
-                ├── AddIndexZoneConfig {"IndexID":2,"TableID":104}
-                ├── AddIndexZoneConfig {"IndexID":2,"TableID":104}
-                └── AddIndexZoneConfig {"IndexID":2,"TableID":104}
+                ├── AddIndexZoneConfig {"TableID":104}
+                ├── AddIndexZoneConfig {"TableID":104}
+                └── AddIndexZoneConfig {"TableID":104}

--- a/pkg/sql/schemachanger/scop/immediate_mutation.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation.go
@@ -1006,7 +1006,6 @@ type AddTableZoneConfig struct {
 type AddIndexZoneConfig struct {
 	immediateMutationOp
 	TableID      descpb.ID
-	IndexID      descpb.IndexID
 	Subzone      zonepb.Subzone
 	SubzoneSpans []zonepb.SubzoneSpan
 }

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_index_zone_config.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_index_zone_config.go
@@ -19,7 +19,6 @@ func init() {
 
 					return &scop.AddIndexZoneConfig{
 						TableID:      this.TableID,
-						IndexID:      this.IndexID,
 						Subzone:      this.Subzone,
 						SubzoneSpans: this.SubzoneSpans,
 					}


### PR DESCRIPTION
We don't use the indexID in `scop.AddIndexZoneConfig`; we can remove it.

Epic: None

Release note: None