### PR TITLE
workload/schemachange: improved comments for logging structs

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -3025,17 +3025,18 @@ const (
 
 type opStmtQueryResultCallback func(ctx context.Context, rows pgx.Rows) error
 
-// opStmt a generated statement that is either DDL or DML, including the potential
-// set of execution errors this statement can generate.
+// opStmt encapsulates a generated SQL statement, its type (DDL or DML),
+// expected and potential execution errors, and a callback for handling query results.
 type opStmt struct {
 	// sql the query being executed.
 	sql string
-	// queryType family of the query type being executed (DML or DDL).
+	// queryType indicates whether the type being executed is DDL or DML.
 	queryType opStmtType
 	// expectedExecErrors expected set of execution errors.
 	expectedExecErrors errorCodeSet
 	// potentialExecErrors errors that could be potentially seen on execution.
 	potentialExecErrors errorCodeSet
+	// queryResultCallback handles the results of the query execution.
 	queryResultCallback opStmtQueryResultCallback
 }
 

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -401,15 +401,23 @@ var (
 	errRunInTxnRbkSentinel   = errors.New("txn needs to rollback")
 )
 
-// LogEntry and its fields must be public so that the json package can encode this struct.
+// LogEntry is used to log information about the operations performed, expected errors,
+// the worker ID, the corresponding timestamp, and any additional messages or error states.
+// Note: LogEntry and its fields must be public so that the json package can encode this struct.
 type LogEntry struct {
-	WorkerID             int           `json:"workerId"`
-	ClientTimestamp      string        `json:"clientTimestamp"`
-	Ops                  []interface{} `json:"ops"`
-	ExpectedExecErrors   string        `json:"expectedExecErrors"`
-	ExpectedCommitErrors string        `json:"expectedCommitErrors"`
+	// WorkerID identifies the worker executing the operations.
+	WorkerID int `json:"workerId"`
+	// ClientTimestamp tracks when the operation was executed.
+	ClientTimestamp string `json:"clientTimestamp"`
+	// Ops a collection of the various types of operations performed.
+	Ops []interface{} `json:"ops"`
+	// ExpectedExecErrors errors which occur as soon as you run the statement.
+	ExpectedExecErrors string `json:"expectedExecErrors"`
+	// ExpectedCommitErrors errors which occur only during commit.
+	ExpectedCommitErrors string `json:"expectedCommitErrors"`
 	// Optional message for errors or if a hook was called.
-	Message    string      `json:"message"`
+	Message string `json:"message"`
+	// ErrorState holds information on the error's state when an error occurs.
 	ErrorState *ErrorState `json:"errorState,omitempty"`
 }
 


### PR DESCRIPTION
The previous comments on the LogEntry and opStmt struct may have not been clear enough for someone newer to the Random Schema Changer Workload. These comments help to clarify some of the details in our logging.

Epic: none
Release note: None