### PR TITLE
kvserver/rangefeed: remove context from kvpb.RangeFeedEventSink

### DIFF
--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -1456,7 +1456,7 @@ func TestRangeFeedIntentResolutionRace(t *testing.T) {
 	}
 	eventC := make(chan *kvpb.RangeFeedEvent)
 	sink := newChannelSink(ctx, eventC)
-	require.NoError(t, s3.RangeFeed(&req, sink)) // check if we've errored yet
+	require.NoError(t, s3.RangeFeed(sink.ctx, &req, sink)) // check if we've errored yet
 	require.NoError(t, sink.Error())
 	t.Logf("started rangefeed on %s", repl3)
 
@@ -1626,10 +1626,6 @@ type channelSink struct {
 
 func newChannelSink(ctx context.Context, ch chan<- *kvpb.RangeFeedEvent) *channelSink {
 	return &channelSink{ctx: ctx, ch: ch, done: make(chan *kvpb.Error, 1)}
-}
-
-func (c *channelSink) Context() context.Context {
-	return c.ctx
 }
 
 func (c *channelSink) SendUnbufferedIsThreadSafe() {}

--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -2520,8 +2520,6 @@ func (s *ScanStats) String() string {
 
 // RangeFeedEventSink is an interface for sending a single rangefeed event.
 type RangeFeedEventSink interface {
-	// Context returns the context for this stream.
-	Context() context.Context
 	// SendUnbuffered blocks until it sends the RangeFeedEvent, the stream is
 	// done, or the stream breaks. Send must be safe to call on the same stream in
 	// different goroutines.

--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -457,10 +457,6 @@ func newDummyStream(ctx context.Context, name string) *dummyStream {
 	}
 }
 
-func (s *dummyStream) Context() context.Context {
-	return s.ctx
-}
-
 func (s *dummyStream) SendUnbufferedIsThreadSafe() {}
 
 func (s *dummyStream) SendUnbuffered(ev *kvpb.RangeFeedEvent) error {
@@ -493,7 +489,7 @@ func waitReplicaRangeFeed(
 		return stream.SendUnbuffered(&event)
 	}
 
-	err := r.RangeFeed(req, stream, nil /* pacer */)
+	err := r.RangeFeed(stream.ctx, req, stream, nil /* pacer */)
 	if err != nil {
 		return sendErrToStream(kvpb.NewError(err))
 	}

--- a/pkg/kv/kvserver/rangefeed/bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/bench_test.go
@@ -103,7 +103,7 @@ func runBenchmarkRangefeed(b *testing.B, opts benchmarkRangefeedOpts) {
 		// extra data.
 		const withFiltering = false
 		streams[i] = &noopStream{ctx: ctx, done: make(chan *kvpb.Error, 1)}
-		ok, _ := p.Register(span, hlc.MinTimestamp, nil,
+		ok, _ := p.Register(ctx, span, hlc.MinTimestamp, nil,
 			withDiff, withFiltering, false, /* withOmitRemote */
 			streams[i], nil)
 		require.True(b, ok)
@@ -190,10 +190,6 @@ type noopStream struct {
 	ctx    context.Context
 	events int
 	done   chan *kvpb.Error
-}
-
-func (s *noopStream) Context() context.Context {
-	return s.ctx
 }
 
 func (s *noopStream) SendUnbuffered(*kvpb.RangeFeedEvent) error {

--- a/pkg/kv/kvserver/rangefeed/buffered_registration.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_registration.go
@@ -70,6 +70,7 @@ type bufferedRegistration struct {
 var _ registration = &bufferedRegistration{}
 
 func newBufferedRegistration(
+	streamCtx context.Context,
 	span roachpb.Span,
 	startTS hlc.Timestamp,
 	catchUpIter *CatchUpIterator,
@@ -84,6 +85,7 @@ func newBufferedRegistration(
 ) *bufferedRegistration {
 	br := &bufferedRegistration{
 		baseRegistration: baseRegistration{
+			streamCtx:        streamCtx,
 			span:             span,
 			catchUpTimestamp: startTS,
 			withDiff:         withDiff,
@@ -212,8 +214,8 @@ func (br *bufferedRegistration) outputLoop(ctx context.Context) error {
 			}
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-br.stream.Context().Done():
-			return br.stream.Context().Err()
+		case <-br.streamCtx.Done():
+			return br.streamCtx.Err()
 		}
 	}
 }

--- a/pkg/kv/kvserver/rangefeed/buffered_stream.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_stream.go
@@ -6,8 +6,6 @@
 package rangefeed
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 )
@@ -27,17 +25,15 @@ type BufferedStream interface {
 // similar to PerRangeEventSink but buffers events in BufferedSender before
 // forwarding events to the underlying grpc stream.
 type BufferedPerRangeEventSink struct {
-	ctx      context.Context
 	rangeID  roachpb.RangeID
 	streamID int64
 	wrapped  *BufferedSender
 }
 
 func NewBufferedPerRangeEventSink(
-	ctx context.Context, rangeID roachpb.RangeID, streamID int64, wrapped *BufferedSender,
+	rangeID roachpb.RangeID, streamID int64, wrapped *BufferedSender,
 ) *BufferedPerRangeEventSink {
 	return &BufferedPerRangeEventSink{
-		ctx:      ctx,
 		rangeID:  rangeID,
 		streamID: streamID,
 		wrapped:  wrapped,
@@ -47,10 +43,6 @@ func NewBufferedPerRangeEventSink(
 var _ kvpb.RangeFeedEventSink = (*BufferedPerRangeEventSink)(nil)
 var _ Stream = (*BufferedPerRangeEventSink)(nil)
 var _ BufferedStream = (*BufferedPerRangeEventSink)(nil)
-
-func (s *BufferedPerRangeEventSink) Context() context.Context {
-	return s.ctx
-}
 
 // SendUnbufferedIsThreadSafe is a no-op declaration method. It is a contract
 // that the SendUnbuffered method is thread-safe. Note that

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -198,6 +198,7 @@ type Processor interface {
 	//
 	// NB: startTS is exclusive; the first possible event will be at startTS.Next().
 	Register(
+		streamCtx context.Context,
 		span roachpb.RSpan,
 		startTS hlc.Timestamp, // exclusive
 		catchUpIter *CatchUpIterator,
@@ -582,6 +583,7 @@ func (p *LegacyProcessor) sendStop(pErr *kvpb.Error) {
 
 // Register  implements Processor interface.
 func (p *LegacyProcessor) Register(
+	streamCtx context.Context,
 	span roachpb.RSpan,
 	startTS hlc.Timestamp,
 	catchUpIter *CatchUpIterator,
@@ -598,7 +600,7 @@ func (p *LegacyProcessor) Register(
 
 	blockWhenFull := p.Config.EventChanTimeout == 0 // for testing
 	r := newBufferedRegistration(
-		span.AsRawSpanWithNoLocals(), startTS, catchUpIter, withDiff, withFiltering, withOmitRemote,
+		streamCtx, span.AsRawSpanWithNoLocals(), startTS, catchUpIter, withDiff, withFiltering, withOmitRemote,
 		p.Config.EventChanCap, blockWhenFull, p.Metrics, stream, disconnectFn,
 	)
 	select {

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -62,6 +62,7 @@ type registration interface {
 // baseRegistration is a common base for all registration types. It is intended
 // to be embedded in an actual registration struct.
 type baseRegistration struct {
+	streamCtx        context.Context
 	span             roachpb.Span
 	withDiff         bool
 	withFiltering    bool

--- a/pkg/kv/kvserver/rangefeed/registry_helper_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_helper_test.go
@@ -256,6 +256,7 @@ func newTestRegistration(
 ) *testRegistration {
 	s := newTestStream()
 	r := newBufferedRegistration(
+		s.ctx,
 		span,
 		ts,
 		makeCatchUpIterator(catchup, span, ts),

--- a/pkg/kv/kvserver/rangefeed/registry_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_test.go
@@ -105,9 +105,9 @@ func TestRegistrationBasic(t *testing.T) {
 		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
 
 	streamCancelReg.Cancel()
-	go streamCancelReg.runOutputLoop(ctx, 0)
+	go streamCancelReg.runOutputLoop(streamCancelReg.ctx, 0)
 	require.NoError(t, streamCancelReg.waitForCaughtUp(ctx))
-	require.Equal(t, streamCancelReg.stream.Context().Err(), streamCancelReg.WaitForError(t))
+	require.Equal(t, streamCancelReg.ctx.Err(), streamCancelReg.WaitForError(t))
 }
 
 func TestRegistrationCatchUpScan(t *testing.T) {

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -296,6 +296,7 @@ func (p *ScheduledProcessor) sendStop(pErr *kvpb.Error) {
 //
 // NB: startTS is exclusive; the first possible event will be at startTS.Next().
 func (p *ScheduledProcessor) Register(
+	streamCtx context.Context,
 	span roachpb.RSpan,
 	startTS hlc.Timestamp,
 	catchUpIter *CatchUpIterator,
@@ -317,6 +318,7 @@ func (p *ScheduledProcessor) Register(
 			"unimplemented: unbuffered registrations for rangefeed, see #126560")
 	} else {
 		r = newBufferedRegistration(
+			streamCtx,
 			span.AsRawSpanWithNoLocals(), startTS, catchUpIter, withDiff, withFiltering, withOmitRemote,
 			p.Config.EventChanCap, blockWhenFull, p.Metrics, stream, disconnectFn,
 		)

--- a/pkg/kv/kvserver/rangefeed/stream.go
+++ b/pkg/kv/kvserver/rangefeed/stream.go
@@ -6,8 +6,6 @@
 package rangefeed
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 )
@@ -26,17 +24,15 @@ type Stream interface {
 // PerRangeEventSink is an implementation of Stream which annotates each
 // response with rangeID and streamID. It is used by MuxRangeFeed.
 type PerRangeEventSink struct {
-	ctx      context.Context
 	rangeID  roachpb.RangeID
 	streamID int64
 	wrapped  *UnbufferedSender
 }
 
 func NewPerRangeEventSink(
-	ctx context.Context, rangeID roachpb.RangeID, streamID int64, wrapped *UnbufferedSender,
+	rangeID roachpb.RangeID, streamID int64, wrapped *UnbufferedSender,
 ) *PerRangeEventSink {
 	return &PerRangeEventSink{
-		ctx:      ctx,
 		rangeID:  rangeID,
 		streamID: streamID,
 		wrapped:  wrapped,
@@ -45,10 +41,6 @@ func NewPerRangeEventSink(
 
 var _ kvpb.RangeFeedEventSink = (*PerRangeEventSink)(nil)
 var _ Stream = (*PerRangeEventSink)(nil)
-
-func (s *PerRangeEventSink) Context() context.Context {
-	return s.ctx
-}
 
 // SendUnbufferedIsThreadSafe is a no-op declaration method. It is a contract
 // that the SendUnbuffered method is thread-safe. Note that

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -65,10 +65,6 @@ func (s *testStream) SetHeader(metadata.MD) error  { panic("unimplemented") }
 func (s *testStream) SendHeader(metadata.MD) error { panic("unimplemented") }
 func (s *testStream) SetTrailer(metadata.MD)       { panic("unimplemented") }
 
-func (s *testStream) Context() context.Context {
-	return s.ctx
-}
-
 func (s *testStream) Cancel() {
 	s.cancel()
 }
@@ -110,7 +106,7 @@ func (s *testStream) WaitForError(t *testing.T) error {
 func waitRangeFeed(
 	t *testing.T, store *kvserver.Store, req *kvpb.RangeFeedRequest, stream *testStream,
 ) error {
-	if err := store.RangeFeed(req, stream); err != nil {
+	if err := store.RangeFeed(stream.ctx, req, stream); err != nil {
 		return err
 	}
 	return stream.WaitForError(t)

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3240,7 +3240,9 @@ func (s *Store) Descriptor(ctx context.Context, useCached bool) (*roachpb.StoreD
 // RangeFeed registers a rangefeed over the specified span. It sends updates to
 // the provided stream and returns a future with an optional error when the rangefeed is
 // complete.
-func (s *Store) RangeFeed(args *kvpb.RangeFeedRequest, stream rangefeed.Stream) error {
+func (s *Store) RangeFeed(
+	streamCtx context.Context, args *kvpb.RangeFeedRequest, stream rangefeed.Stream,
+) error {
 	if filter := s.TestingKnobs().TestingRangefeedFilter; filter != nil {
 		if pErr := filter(args, stream); pErr != nil {
 			return pErr.GoError()
@@ -3267,7 +3269,7 @@ func (s *Store) RangeFeed(args *kvpb.RangeFeedRequest, stream rangefeed.Stream) 
 
 	tenID, _ := repl.TenantID()
 	pacer := s.cfg.KVAdmissionController.AdmitRangefeedRequest(tenID, args)
-	return repl.RangeFeed(args, stream, pacer)
+	return repl.RangeFeed(streamCtx, args, stream, pacer)
 }
 
 // updateReplicationGauges counts a number of simple replication statistics for

--- a/pkg/kv/kvserver/stores.go
+++ b/pkg/kv/kvserver/stores.go
@@ -204,12 +204,13 @@ func (ls *Stores) SendWithWriteBytes(
 // RangeFeed registers a rangefeed over the specified span. It sends
 // updates to the provided stream and returns a future with an optional error
 // when the rangefeed is complete.
-func (ls *Stores) RangeFeed(args *kvpb.RangeFeedRequest, stream rangefeed.Stream) error {
-	ctx := stream.Context()
+func (ls *Stores) RangeFeed(
+	streamCtx context.Context, args *kvpb.RangeFeedRequest, stream rangefeed.Stream,
+) error {
 	if args.RangeID == 0 {
-		log.Fatal(ctx, "rangefeed request missing range ID")
+		log.Fatal(streamCtx, "rangefeed request missing range ID")
 	} else if args.Replica.StoreID == 0 {
-		log.Fatal(ctx, "rangefeed request missing store ID")
+		log.Fatal(streamCtx, "rangefeed request missing store ID")
 	}
 
 	store, err := ls.GetStore(args.Replica.StoreID)
@@ -217,7 +218,7 @@ func (ls *Stores) RangeFeed(args *kvpb.RangeFeedRequest, stream rangefeed.Stream
 		return err
 	}
 
-	return store.RangeFeed(args, stream)
+	return store.RangeFeed(streamCtx, args, stream)
 }
 
 // ReadBootstrapInfo implements the gossip.Storage interface. Read

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -283,10 +283,6 @@ type rangefeedEventSink struct {
 
 var _ kvpb.RangeFeedEventSink = (*rangefeedEventSink)(nil)
 
-func (s *rangefeedEventSink) Context() context.Context {
-	return s.ctx
-}
-
 // Note that SendUnbuffered itself is not thread-safe (grpc stream is not
 // thread-safe), but tests were written in a way that sends sequentially,
 // ensuring thread-safety for SendUnbuffered.

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -2131,9 +2131,9 @@ func (n *Node) MuxRangeFeed(muxStream kvpb.Internal_MuxRangeFeedServer) error {
 
 			var streamSink rangefeed.Stream
 			if ubs, ok := sm.(*rangefeed.UnbufferedSender); ok {
-				streamSink = rangefeed.NewPerRangeEventSink(streamCtx, req.RangeID, req.StreamID, ubs)
+				streamSink = rangefeed.NewPerRangeEventSink(req.RangeID, req.StreamID, ubs)
 			} else if bs, ok := sm.(*rangefeed.BufferedSender); ok {
-				streamSink = rangefeed.NewBufferedPerRangeEventSink(streamCtx, req.RangeID, req.StreamID, bs)
+				streamSink = rangefeed.NewBufferedPerRangeEventSink(req.RangeID, req.StreamID, bs)
 			} else {
 				log.Fatalf(streamCtx, "unknown sender type %T", sm)
 			}
@@ -2144,7 +2144,7 @@ func (n *Node) MuxRangeFeed(muxStream kvpb.Internal_MuxRangeFeedServer) error {
 			// nil without blocking on rangefeed completion. Events are then sent to
 			// the provided streamSink. If the rangefeed disconnects after being
 			// successfully registered, it calls streamSink.Disconnect with the error.
-			if err := n.stores.RangeFeed(req, streamSink); err != nil {
+			if err := n.stores.RangeFeed(streamCtx, req, streamSink); err != nil {
 				sm.SendBufferedError(
 					makeMuxRangefeedErrorEvent(req.StreamID, req.RangeID, kvpb.NewError(err)))
 			}


### PR DESCRIPTION
Previously, `node.MuxRangefeed` created a child context for each rangefeed
request, storing it in the stream interface to allow the node level to be able
to shut down registration goroutines. This patch simplifies the approach by
passing the stream context directly to `p.Register`, eliminating the need to
store context in `streamSink` or return context via the interface. So this patch
also removes context from `kvpb.RangeFeedEventSink`.

Epic: none
Release note: none