### PR TITLE
sql: fix pg_catalog.pg_proc(proretset) column

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -1281,6 +1281,9 @@ SELECT (json_populate_record(((1.01, 2, 3) AS d, c, a), '{"a": 3, "c": 10, "d": 
 d
 11.001
 
+statement error argument of json_populate_record must be an object
+SELECT * FROM json_populate_record(((1, 2) AS a, b), '"a"')
+
 statement ok
 CREATE TABLE testtab (
 	i	int,

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2577,6 +2577,27 @@ substring  true         false      i            NULL
 substring  true         false      i            NULL
 substring  true         false      i            NULL
 
+# Verify that proretset is true for set-returning functions.
+query OTBT
+SELECT oid, proname, proretset, prorettype FROM pg_catalog.pg_proc
+WHERE proname IN (
+  'jsonb_object_keys', 'generate_series', 'generate_subscripts',
+  'json_populate_recordset', 'unnest', 'json_each'
+) ORDER BY 1
+----
+317  generate_series          true  20
+318  generate_series          true  20
+319  generate_series          true  1114
+320  generate_series          true  1184
+326  unnest                   true  2283
+327  unnest                   true  2283
+330  generate_subscripts      true  20
+331  generate_subscripts      true  20
+332  generate_subscripts      true  20
+338  jsonb_object_keys        true  25
+339  json_each                true  2283
+345  json_populate_recordset  true  2283
+
 query TIIOTTTT colnames
 SELECT proname, pronargs, pronargdefaults, prorettype, proargtypes, proallargtypes, proargmodes, proargdefaults
 FROM pg_catalog.pg_proc

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2516,11 +2516,10 @@ func addPgProcBuiltinRow(name string, addRow func(...tree.Datum) error) error {
 		}
 
 		var retType tree.Datum
-		isRetSet := false
+		isRetSet := builtin.IsGenerator()
 		if fixedRetType := builtin.FixedReturnType(); fixedRetType != nil {
 			var retOid oid.Oid
 			if fixedRetType.Family() == types.TupleFamily && builtin.IsGenerator() {
-				isRetSet = true
 				// Functions returning tables with zero, or more than one
 				// columns are marked to return "anyelement"
 				// (e.g. `unnest`)


### PR DESCRIPTION
This column was populated incorrectly ever since 3867776 was merged.
It had an overly sensitive condition that made it only get set if the
function returned tuples.

fixes https://github.com/cockroachdb/cockroach/issues/132733
Release note (bug fix): The proretset column of the pg_catalog.pg_proc
table is now properly set to true for set-returning builtin functions.