### PR TITLE
ui: table details bug fixes

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/index.tsx
@@ -55,8 +55,8 @@ export const TableDetailsPageV2 = () => {
       key: TabKeys.OVERVIEW,
       label: "Overview",
       children: (
-        <Loading page="TableDetailsOverview" loading={isLoading}>
-          <TableOverview tableDetails={data} />
+        <Loading error={error} page="TableDetailsOverview" loading={isLoading}>
+          {data && <TableOverview tableDetails={data} />}
         </Loading>
       ),
     },


### PR DESCRIPTION
- Only render table overview when data is non-null
- Render table details resp error if it occurs
- Dedup node ids in table overview

Epic: CRDB-37558
Release note: None

<img width="1310" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/ef71321f-e87a-4237-b138-f8303f2d3b36">
<img width="629" alt="Replicas" src="https://github.com/user-attachments/assets/3f3d607e-20a7-4b2f-9074-4da3593bad29">
