### PR TITLE
kvserver/rangefeed: process unregister requests asyncronously

### DIFF
--- a/pkg/kv/kvserver/rangefeed/bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/bench_test.go
@@ -105,7 +105,7 @@ func runBenchmarkRangefeed(b *testing.B, opts benchmarkRangefeedOpts) {
 		streams[i] = &noopStream{ctx: ctx, done: make(chan *kvpb.Error, 1)}
 		ok, _, _ := p.Register(ctx, span, hlc.MinTimestamp, nil,
 			withDiff, withFiltering, false, /* withOmitRemote */
-			streams[i], nil)
+			streams[i])
 		require.True(b, ok)
 	}
 

--- a/pkg/kv/kvserver/rangefeed/budget.go
+++ b/pkg/kv/kvserver/rangefeed/budget.go
@@ -228,7 +228,7 @@ func (f *FeedBudget) Close(ctx context.Context) {
 	f.closed.Do(func() {
 		f.mu.Lock()
 		f.mu.closed = true
-		f.mu.memBudget.Close(ctx)
+		f.mu.memBudget.Clear(ctx)
 		close(f.stopC)
 		f.mu.Unlock()
 	})

--- a/pkg/kv/kvserver/rangefeed/buffered_registration.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_registration.go
@@ -82,6 +82,7 @@ func newBufferedRegistration(
 	metrics *Metrics,
 	stream Stream,
 	unregisterFn func(),
+	cleanup func(context.Context, registration),
 ) *bufferedRegistration {
 	br := &bufferedRegistration{
 		baseRegistration: baseRegistration{
@@ -91,6 +92,7 @@ func newBufferedRegistration(
 			withDiff:         withDiff,
 			withFiltering:    withFiltering,
 			withOmitRemote:   withOmitRemote,
+			cleanup:          cleanup,
 			unreg:            unregisterFn,
 		},
 		metrics:       metrics,
@@ -172,6 +174,7 @@ func (br *bufferedRegistration) Disconnect(pErr *kvpb.Error) {
 		}
 		br.mu.disconnected = true
 		br.stream.SendError(pErr)
+		br.cleanup(context.Background(), br)
 	}
 }
 

--- a/pkg/kv/kvserver/rangefeed/buffered_registration.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_registration.go
@@ -81,19 +81,17 @@ func newBufferedRegistration(
 	blockWhenFull bool,
 	metrics *Metrics,
 	stream Stream,
-	unregisterFn func(),
-	cleanup func(context.Context, registration),
+	removeRegFromProcessor func(registration),
 ) *bufferedRegistration {
 	br := &bufferedRegistration{
 		baseRegistration: baseRegistration{
-			streamCtx:        streamCtx,
-			span:             span,
-			catchUpTimestamp: startTS,
-			withDiff:         withDiff,
-			withFiltering:    withFiltering,
-			withOmitRemote:   withOmitRemote,
-			cleanup:          cleanup,
-			unreg:            unregisterFn,
+			streamCtx:              streamCtx,
+			span:                   span,
+			catchUpTimestamp:       startTS,
+			withDiff:               withDiff,
+			withFiltering:          withFiltering,
+			withOmitRemote:         withOmitRemote,
+			removeRegFromProcessor: removeRegFromProcessor,
 		},
 		metrics:       metrics,
 		stream:        stream,
@@ -174,7 +172,7 @@ func (br *bufferedRegistration) Disconnect(pErr *kvpb.Error) {
 		}
 		br.mu.disconnected = true
 		br.stream.SendError(pErr)
-		br.cleanup(context.Background(), br)
+		br.removeRegFromProcessor(br)
 	}
 }
 

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -104,6 +104,11 @@ type Config struct {
 	// for low-volume system ranges, since the worker pool is small (default 2).
 	// Only has an effect when Scheduler is used.
 	Priority bool
+
+	// UnregisterFromReplica is a callback provided from the
+	// replica that this processor can call when shutting down to
+	// remove itself from the replica.
+	UnregisterFromReplica func(Processor)
 }
 
 // SetDefaults initializes unset fields in Config to values

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -196,7 +196,6 @@ type Processor interface {
 		withFiltering bool,
 		withOmitRemote bool,
 		stream Stream,
-		disconnectFn func(),
 	) (bool, Disconnector, *Filter)
 
 	// DisconnectSpanWithErr disconnects all rangefeed registrations that overlap

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -70,7 +70,6 @@ func TestProcessorBasic(t *testing.T) {
 			false, /* withFiltering */
 			false, /* withOmitRemote */
 			r1Stream,
-			func() {},
 		)
 		require.True(t, r1OK)
 		h.syncEventAndRegistrations()
@@ -205,7 +204,6 @@ func TestProcessorBasic(t *testing.T) {
 			true,  /* withFiltering */
 			false, /* withOmitRemote */
 			r2Stream,
-			func() {},
 		)
 		require.True(t, r2OK)
 		h.syncEventAndRegistrations()
@@ -314,7 +312,6 @@ func TestProcessorBasic(t *testing.T) {
 			false, /* withFiltering */
 			false, /* withOmitRemote */
 			r3Stream,
-			func() {},
 		)
 		require.True(t, r30K)
 		r3Stream.SendError(kvpb.NewError(fmt.Errorf("disconnection error")))
@@ -336,7 +333,6 @@ func TestProcessorBasic(t *testing.T) {
 			false, /* withFiltering */
 			false, /* withOmitRemote */
 			r4Stream,
-			func() {},
 		)
 		require.False(t, r4OK)
 	})
@@ -362,7 +358,6 @@ func TestProcessorOmitRemote(t *testing.T) {
 			false, /* withFiltering */
 			false, /* withOmitRemote */
 			r1Stream,
-			func() {},
 		)
 		require.True(t, r1OK)
 		h.syncEventAndRegistrations()
@@ -388,7 +383,6 @@ func TestProcessorOmitRemote(t *testing.T) {
 			false, /* withFiltering */
 			true,  /* withOmitRemote */
 			r2Stream,
-			func() {},
 		)
 		require.True(t, r2OK)
 		h.syncEventAndRegistrations()
@@ -442,7 +436,6 @@ func TestProcessorSlowConsumer(t *testing.T) {
 			false, /* withFiltering */
 			false, /* withOmitRemote */
 			r1Stream,
-			func() {},
 		)
 		r2Stream := newTestStream()
 		p.Register(
@@ -454,7 +447,6 @@ func TestProcessorSlowConsumer(t *testing.T) {
 			false, /* withFiltering */
 			false, /* withOmitRemote */
 			r2Stream,
-			func() {},
 		)
 		h.syncEventAndRegistrations()
 		require.Equal(t, 2, p.Len())
@@ -551,7 +543,6 @@ func TestProcessorMemoryBudgetExceeded(t *testing.T) {
 			false, /* withFiltering */
 			false, /* withOmitRemote */
 			r1Stream,
-			func() {},
 		)
 		h.syncEventAndRegistrations()
 
@@ -607,7 +598,6 @@ func TestProcessorMemoryBudgetReleased(t *testing.T) {
 			false, /* withFiltering */
 			false, /* withOmitRemote */
 			r1Stream,
-			func() {},
 		)
 		h.syncEventAndRegistrations()
 
@@ -689,7 +679,6 @@ func TestProcessorInitializeResolvedTimestamp(t *testing.T) {
 			false, /* withFiltering */
 			false, /* withOmitRemote */
 			r1Stream,
-			func() {},
 		)
 		h.syncEventAndRegistrations()
 		require.Equal(t, 1, p.Len())
@@ -996,7 +985,7 @@ func TestProcessorConcurrentStop(t *testing.T) {
 				runtime.Gosched()
 				s := newTestStream()
 				p.Register(s.ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
-					false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, s, func() {})
+					false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, s)
 			}()
 			go func() {
 				defer wg.Done()
@@ -1068,7 +1057,7 @@ func TestProcessorRegistrationObservesOnlyNewEvents(t *testing.T) {
 				s := newTestStream()
 				regs[s] = firstIdx
 				p.Register(s.ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
-					false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, s, func() {})
+					false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, s)
 				regDone <- struct{}{}
 			}
 		}()
@@ -1129,7 +1118,6 @@ func TestBudgetReleaseOnProcessorStop(t *testing.T) {
 			false, /* withFiltering */
 			false, /* withOmitRemote */
 			rStream,
-			func() {},
 		)
 		h.syncEventAndRegistrations()
 
@@ -1210,7 +1198,6 @@ func TestBudgetReleaseOnLastStreamError(t *testing.T) {
 			false, /* withFiltering */
 			false, /* withOmitRemote */
 			rStream,
-			func() {},
 		)
 		h.syncEventAndRegistrations()
 
@@ -1281,7 +1268,6 @@ func TestBudgetReleaseOnOneStreamError(t *testing.T) {
 			false, /* withFiltering */
 			false, /* withOmitRemote */
 			r1Stream,
-			func() {},
 		)
 
 		// Non-blocking registration that would consume all events.
@@ -1295,7 +1281,6 @@ func TestBudgetReleaseOnOneStreamError(t *testing.T) {
 			false, /* withFiltering */
 			false, /* withOmitRemote */
 			r2Stream,
-			func() {},
 		)
 		h.syncEventAndRegistrations()
 
@@ -1463,7 +1448,7 @@ func TestProcessorBackpressure(t *testing.T) {
 		// Add a registration.
 		stream := newTestStream()
 		ok, _, _ := p.Register(stream.ctx, span, hlc.MinTimestamp, nil, /* catchUpIter */
-			false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, stream, nil)
+			false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, stream)
 		require.True(t, ok)
 
 		// Wait for the initial checkpoint.

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -360,9 +360,7 @@ func (reg *registry) PublishToOverlapping(
 // TODO: this should be revisited as part of
 // https://github.com/cockroachdb/cockroach/issues/110634
 func (reg *registry) DisconnectAllOnShutdown(ctx context.Context, pErr *kvpb.Error) {
-	reg.forOverlappingRegs(ctx, all, func(r registration) (bool, *kvpb.Error) {
-		return true /* disconned */, pErr
-	})
+	reg.DisconnectWithErr(ctx, all, pErr)
 }
 
 // DisconnectWithErr disconnects all registrations that overlap the specified

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -67,9 +67,6 @@ type registration interface {
 	Range() interval.Range
 	// ID returns the id field of the registration as a uintptr.
 	ID() uintptr
-	// getUnreg returns the unregisterFn call back of the registration. It should
-	// be called when being unregistered from processor.
-	getUnreg() func()
 
 	// shouldUnregister returns true if this registration should
 	// be unregistered.
@@ -87,10 +84,11 @@ type baseRegistration struct {
 	withDiff       bool
 	withFiltering  bool
 	withOmitRemote bool
-	// TODO(ssd): This unreg can be removed when the LegacyProcess
-	// is removed.
-	unreg   func()
-	cleanup func(context.Context, registration)
+	// removeRegFromProcessor is called to remove the registration from its
+	// processor. This is provided by the creator of the registration and called
+	// during disconnect(). Since it is called during disconnect it must be
+	// non-blocking.
+	removeRegFromProcessor func(registration)
 
 	catchUpTimestamp hlc.Timestamp // exclusive
 	id               int64         // internal
@@ -134,10 +132,6 @@ func (r *baseRegistration) getWithFiltering() bool {
 
 func (r *baseRegistration) getWithOmitRemote() bool {
 	return r.withOmitRemote
-}
-
-func (r *baseRegistration) getUnreg() func() {
-	return r.unreg
 }
 
 func (r *baseRegistration) shouldUnregister() bool {

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -69,20 +70,32 @@ type registration interface {
 	// getUnreg returns the unregisterFn call back of the registration. It should
 	// be called when being unregistered from processor.
 	getUnreg() func()
+
+	// shouldUnregister returns true if this registration should
+	// be unregistered.
+	shouldUnregister() bool
+	// setShouldUnregister sets shouldUnregister to the given
+	// value.
+	setShouldUnregister(bool)
 }
 
 // baseRegistration is a common base for all registration types. It is intended
 // to be embedded in an actual registration struct.
 type baseRegistration struct {
-	streamCtx        context.Context
-	span             roachpb.Span
-	withDiff         bool
-	withFiltering    bool
-	withOmitRemote   bool
-	unreg            func()
+	streamCtx      context.Context
+	span           roachpb.Span
+	withDiff       bool
+	withFiltering  bool
+	withOmitRemote bool
+	// TODO(ssd): This unreg can be removed when the LegacyProcess
+	// is removed.
+	unreg   func()
+	cleanup func(context.Context, registration)
+
 	catchUpTimestamp hlc.Timestamp // exclusive
 	id               int64         // internal
 	keys             interval.Range
+	shouldUnreg      atomic.Bool
 }
 
 // ID implements interval.Interface.
@@ -125,6 +138,14 @@ func (r *baseRegistration) getWithOmitRemote() bool {
 
 func (r *baseRegistration) getUnreg() func() {
 	return r.unreg
+}
+
+func (r *baseRegistration) shouldUnregister() bool {
+	return r.shouldUnreg.Load()
+}
+
+func (r *baseRegistration) setShouldUnregister(b bool) {
+	r.shouldUnreg.Store(b)
 }
 
 func (r *baseRegistration) getWithDiff() bool {
@@ -356,7 +377,10 @@ func (reg *registry) Unregister(ctx context.Context, r registration) {
 // https://github.com/cockroachdb/cockroach/issues/110634
 func (reg *registry) DisconnectAllOnShutdown(ctx context.Context, pErr *kvpb.Error) {
 	reg.metrics.RangeFeedRegistrations.Dec(int64(reg.tree.Len()))
-	reg.DisconnectWithErr(ctx, all, pErr)
+	reg.forOverlappingRegs(ctx, all, func(r registration) (bool, *kvpb.Error) {
+		r.drainAllocations(ctx)
+		return true /* disconned */, pErr
+	})
 }
 
 // Disconnect disconnects all registrations that overlap the specified span with
@@ -398,7 +422,10 @@ func (reg *registry) forOverlappingRegs(
 	} else {
 		reg.tree.DoMatching(matchFn, span.AsRange())
 	}
+	reg.remove(ctx, toDelete)
+}
 
+func (reg *registry) remove(ctx context.Context, toDelete []interval.Interface) {
 	if len(toDelete) == reg.tree.Len() {
 		reg.tree.Clear()
 	} else if len(toDelete) == 1 {
@@ -412,6 +439,21 @@ func (reg *registry) forOverlappingRegs(
 			}
 		}
 		reg.tree.AdjustRanges()
+	}
+}
+
+func (reg *registry) unregisterMarkedRegistrations(ctx context.Context) {
+	var toDelete []interval.Interface
+	reg.tree.Do(func(i interval.Interface) (done bool) {
+		r := i.(registration)
+		if r.shouldUnregister() {
+			toDelete = append(toDelete, i)
+		}
+		return false
+	})
+	reg.remove(ctx, toDelete)
+	for _, i := range toDelete {
+		i.(registration).drainAllocations(ctx)
 	}
 }
 

--- a/pkg/kv/kvserver/rangefeed/registry_helper_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_helper_test.go
@@ -267,8 +267,7 @@ func newTestRegistration(
 		false, /* blockWhenFull */
 		NewMetrics(),
 		s,
-		func() {},
-		func(context.Context, registration) {},
+		func(registration) {},
 	)
 	return &testRegistration{
 		bufferedRegistration: r,

--- a/pkg/kv/kvserver/rangefeed/registry_helper_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_helper_test.go
@@ -268,6 +268,7 @@ func newTestRegistration(
 		NewMetrics(),
 		s,
 		func() {},
+		func(context.Context, registration) {},
 	)
 	return &testRegistration{
 		bufferedRegistration: r,

--- a/pkg/kv/kvserver/rangefeed/registry_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_test.go
@@ -313,7 +313,7 @@ func TestRegistryBasic(t *testing.T) {
 
 	// Unregister the rBC registration as if it was being unregistered via the
 	// processor.
-	rBC.setShouldUnregister(true)
+	rBC.setShouldUnregister()
 	reg.unregisterMarkedRegistrations(ctx)
 	require.Equal(t, 0, reg.Len())
 	require.Equal(t, 0, int(reg.metrics.RangeFeedRegistrations.Value()),

--- a/pkg/kv/kvserver/rangefeed/registry_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_test.go
@@ -360,30 +360,30 @@ func TestRegistryPublishBeneathStartTimestamp(t *testing.T) {
 
 func TestRegistrationString(t *testing.T) {
 	testCases := []struct {
-		r   baseRegistration
+		r   *baseRegistration
 		exp string
 	}{
 		{
-			r: baseRegistration{
+			r: &baseRegistration{
 				span: roachpb.Span{Key: roachpb.Key("a")},
 			},
 			exp: `[a @ 0,0+]`,
 		},
 		{
-			r: baseRegistration{span: roachpb.Span{
+			r: &baseRegistration{span: roachpb.Span{
 				Key: roachpb.Key("a"), EndKey: roachpb.Key("c")},
 			},
 			exp: `[{a-c} @ 0,0+]`,
 		},
 		{
-			r: baseRegistration{
+			r: &baseRegistration{
 				span:             roachpb.Span{Key: roachpb.Key("d")},
 				catchUpTimestamp: hlc.Timestamp{WallTime: 10, Logical: 1},
 			},
 			exp: `[d @ 0.000000010,1+]`,
 		},
 		{
-			r: baseRegistration{span: roachpb.Span{
+			r: &baseRegistration{span: roachpb.Span{
 				Key: roachpb.Key("d"), EndKey: roachpb.Key("z")},
 				catchUpTimestamp: hlc.Timestamp{WallTime: 40, Logical: 9},
 			},

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -7,6 +7,7 @@ package rangefeed
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -64,6 +65,8 @@ type ScheduledProcessor struct {
 	// stopper passed by start that is used for firing up async work from scheduler.
 	stopper       *stop.Stopper
 	txnPushActive bool
+
+	overflowedUnregRequests atomic.Bool
 }
 
 // NewScheduledProcessor creates a new scheduler based rangefeed Processor.
@@ -157,6 +160,10 @@ func (p *ScheduledProcessor) processRequests(ctx context.Context) {
 		case e := <-p.requestQueue:
 			e(ctx)
 		default:
+			if p.overflowedUnregRequests.Swap(false) {
+				log.Warningf(ctx, "request queue overflowed, scanning all registrations")
+				p.reg.unregisterMarkedRegistrations(ctx)
+			}
 			return
 		}
 	}
@@ -239,6 +246,10 @@ func (p *ScheduledProcessor) cleanup() {
 	p.taskCancel()
 	close(p.stoppedC)
 	p.MemBudget.Close(ctx)
+	if p.UnregisterFromReplica != nil {
+		p.UnregisterFromReplica(p)
+	}
+
 }
 
 // Stop shuts down the processor and closes all registrations. Safe to call on
@@ -271,12 +282,16 @@ func (p *ScheduledProcessor) DisconnectSpanWithErr(span roachpb.Span, pErr *kvpb
 
 func (p *ScheduledProcessor) sendStop(pErr *kvpb.Error) {
 	p.enqueueRequest(func(ctx context.Context) {
-		p.reg.DisconnectWithErr(ctx, all, pErr)
-		// First set stopping flag to ensure that once all registrations are removed
-		// processor should stop.
-		p.stopping = true
-		p.scheduler.StopProcessor()
+		p.stopInternal(ctx, pErr)
 	})
+}
+
+func (p *ScheduledProcessor) stopInternal(ctx context.Context, pErr *kvpb.Error) {
+	p.reg.DisconnectAllOnShutdown(ctx, pErr)
+	// First set stopping flag to ensure that once all registrations are removed
+	// processor should stop.
+	p.stopping = true
+	p.scheduler.StopProcessor()
 }
 
 // Register registers the stream over the specified span of keys.
@@ -320,6 +335,9 @@ func (p *ScheduledProcessor) Register(
 		r = newBufferedRegistration(
 			streamCtx, span.AsRawSpanWithNoLocals(), startTS, catchUpIter, withDiff, withFiltering, withOmitRemote,
 			p.Config.EventChanCap, blockWhenFull, p.Metrics, stream, disconnectFn,
+			func(ctx context.Context, r registration) {
+				p.unregisterClientAsync(r)
+			},
 		)
 	}
 
@@ -345,16 +363,7 @@ func (p *ScheduledProcessor) Register(
 		r.publish(ctx, p.newCheckpointEvent(), nil)
 
 		// Run an output loop for the registry.
-		runOutputLoop := func(ctx context.Context) {
-			r.runOutputLoop(ctx, p.RangeID)
-			if p.unregisterClient(r) {
-				// unreg callback is set by replica to tear down processors that have
-				// zero registrations left and to update event filters.
-				if f := r.getUnreg(); f != nil {
-					f()
-				}
-			}
-		}
+		runOutputLoop := func(ctx context.Context) { r.runOutputLoop(ctx, p.RangeID) }
 		// NB: use ctx, not p.taskCtx, as the registry handles teardown itself.
 		if err := p.Stopper.RunAsyncTask(ctx, "rangefeed: output loop", runOutputLoop); err != nil {
 			// If we can't schedule internally, processor is already stopped which
@@ -362,7 +371,6 @@ func (p *ScheduledProcessor) Register(
 			// registration.
 			r.Disconnect(kvpb.NewError(err))
 			r.drainAllocations(ctx)
-			p.reg.Unregister(ctx, r)
 		}
 		return f
 	})
@@ -372,11 +380,24 @@ func (p *ScheduledProcessor) Register(
 	return false, nil, nil
 }
 
-func (p *ScheduledProcessor) unregisterClient(r registration) bool {
-	return runRequest(p, func(ctx context.Context, p *ScheduledProcessor) bool {
-		p.reg.Unregister(ctx, r)
-		return true
-	})
+func (p *ScheduledProcessor) unregisterClientInternal(ctx context.Context, r registration) {
+	p.reg.Unregister(ctx, r)
+	// Assert that we never process requests after stoppedC is closed. This is
+	// necessary to coordinate catchup iter ownership and avoid double-closing.
+	// Note that request/stop processing is always sequential, see process().
+	if buildutil.CrdbTestBuild {
+		select {
+		case <-p.stoppedC:
+			log.Fatalf(ctx, "processing request on stopped processor")
+		default:
+		}
+	}
+
+	// If we have no more registrations, we can stop this
+	// processor.
+	if p.reg.Len() == 0 {
+		p.stopInternal(ctx, nil)
+	}
 }
 
 // ConsumeLogicalOps informs the rangefeed processor of the set of logical
@@ -634,6 +655,33 @@ func (p *ScheduledProcessor) enqueueRequest(req request) {
 	case p.requestQueue <- req:
 		p.scheduler.Enqueue(RequestQueued)
 	case <-p.stoppedC:
+	}
+}
+
+// unregisterClientAsync enqueues an unregister request without
+// blocking. If the request queue is filled, the overflow bool is set
+// which will trigger a scan of all registrations on the next
+// process() call.
+//
+// We are OK with these being processed out of order since these
+// requests originate from a registration cleanup, so the registration
+// in question is no longer processing event.
+func (p *ScheduledProcessor) unregisterClientAsync(r registration) {
+	select {
+	case <-p.stoppedC:
+		return
+	default:
+	}
+	req := func(ctx context.Context) {
+		p.unregisterClientInternal(ctx, r)
+	}
+	select {
+	case p.requestQueue <- req:
+		p.scheduler.Enqueue(RequestQueued)
+	default:
+		r.setShouldUnregister(true)
+		p.overflowedUnregRequests.Store(true)
+		p.scheduler.Enqueue(RequestQueued)
 	}
 }
 

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -66,7 +66,10 @@ type ScheduledProcessor struct {
 	stopper       *stop.Stopper
 	txnPushActive bool
 
-	overflowedUnregRequests atomic.Bool
+	// pendingUnregistrations indicates that the registry may have registrations
+	// that can be unregistered. This is handled outside of the requestQueue to
+	// avoid blocking clients who only need to signal unregistration.
+	pendingUnregistrations atomic.Bool
 }
 
 // NewScheduledProcessor creates a new scheduler based rangefeed Processor.
@@ -160,9 +163,13 @@ func (p *ScheduledProcessor) processRequests(ctx context.Context) {
 		case e := <-p.requestQueue:
 			e(ctx)
 		default:
-			if p.overflowedUnregRequests.Swap(false) {
-				log.Warningf(ctx, "request queue overflowed, scanning all registrations")
+			if p.pendingUnregistrations.Swap(false) {
 				p.reg.unregisterMarkedRegistrations(ctx)
+				// If we have no more registrations, we can stop this
+				// processor.
+				if p.reg.Len() == 0 {
+					p.stopInternal(ctx, nil)
+				}
 			}
 			return
 		}
@@ -373,26 +380,6 @@ func (p *ScheduledProcessor) Register(
 		return true, r, filter
 	}
 	return false, nil, nil
-}
-
-func (p *ScheduledProcessor) unregisterClientInternal(ctx context.Context, r registration) {
-	p.reg.Unregister(ctx, r)
-	// Assert that we never process requests after stoppedC is closed. This is
-	// necessary to coordinate catchup iter ownership and avoid double-closing.
-	// Note that request/stop processing is always sequential, see process().
-	if buildutil.CrdbTestBuild {
-		select {
-		case <-p.stoppedC:
-			log.Fatalf(ctx, "processing request on stopped processor")
-		default:
-		}
-	}
-
-	// If we have no more registrations, we can stop this
-	// processor.
-	if p.reg.Len() == 0 {
-		p.stopInternal(ctx, nil)
-	}
 }
 
 // ConsumeLogicalOps informs the rangefeed processor of the set of logical
@@ -653,31 +640,22 @@ func (p *ScheduledProcessor) enqueueRequest(req request) {
 	}
 }
 
-// unregisterClientAsync enqueues an unregister request without
-// blocking. If the request queue is filled, the overflow bool is set
-// which will trigger a scan of all registrations on the next
-// process() call.
+// unregisterClientAsync instructs the processor to scan the registration for
+// clients to unregister on the next request. This doesn't send and actual
+// request to the request queue to ensure that it is non-blocking.
 //
-// We are OK with these being processed out of order since these
-// requests originate from a registration cleanup, so the registration
-// in question is no longer processing event.
+// We are OK with these being processed out of order since these requests
+// originate from a registration cleanup, so the registration in question is no
+// longer processing event.
 func (p *ScheduledProcessor) unregisterClientAsync(r registration) {
 	select {
 	case <-p.stoppedC:
 		return
 	default:
 	}
-	req := func(ctx context.Context) {
-		p.unregisterClientInternal(ctx, r)
-	}
-	select {
-	case p.requestQueue <- req:
-		p.scheduler.Enqueue(RequestQueued)
-	default:
-		r.setShouldUnregister(true)
-		p.overflowedUnregRequests.Store(true)
-		p.scheduler.Enqueue(RequestQueued)
-	}
+	r.setShouldUnregister(true)
+	p.pendingUnregistrations.Store(true)
+	p.scheduler.Enqueue(RequestQueued)
 }
 
 func (p *ScheduledProcessor) consumeEvent(ctx context.Context, e *event) {

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -319,7 +319,6 @@ func (p *ScheduledProcessor) Register(
 	withFiltering bool,
 	withOmitRemote bool,
 	stream Stream,
-	disconnectFn func(),
 ) (bool, Disconnector, *Filter) {
 	// Synchronize the event channel so that this registration doesn't see any
 	// events that were consumed before this registration was called. Instead,
@@ -334,11 +333,7 @@ func (p *ScheduledProcessor) Register(
 	} else {
 		r = newBufferedRegistration(
 			streamCtx, span.AsRawSpanWithNoLocals(), startTS, catchUpIter, withDiff, withFiltering, withOmitRemote,
-			p.Config.EventChanCap, blockWhenFull, p.Metrics, stream, disconnectFn,
-			func(ctx context.Context, r registration) {
-				p.unregisterClientAsync(r)
-			},
-		)
+			p.Config.EventChanCap, blockWhenFull, p.Metrics, stream, p.unregisterClientAsync)
 	}
 
 	filter := runRequest(p, func(ctx context.Context, p *ScheduledProcessor) *Filter {

--- a/pkg/kv/kvserver/rangefeed/stream_manager_test.go
+++ b/pkg/kv/kvserver/rangefeed/stream_manager_test.go
@@ -221,7 +221,7 @@ func TestStreamManagerErrorHandling(t *testing.T) {
 				stream := sm.NewStream(sID, rID)
 				registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
 					false /* withDiff */, false /* withFiltering */, false, /* withOmitRemote */
-					stream, func() {})
+					stream)
 				require.True(t, registered)
 				go p.StopWithErr(disconnectErr)
 				require.Equal(t, 0, testRangefeedCounter.get())
@@ -235,7 +235,7 @@ func TestStreamManagerErrorHandling(t *testing.T) {
 			defer stopper.Stop(ctx)
 			registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
 				false /* withDiff */, false /* withFiltering */, false, /* withOmitRemote */
-				stream, func() {})
+				stream)
 			require.True(t, registered)
 			sm.AddStream(sID, d)
 			require.Equal(t, 1, p.Len())
@@ -250,7 +250,7 @@ func TestStreamManagerErrorHandling(t *testing.T) {
 			defer stopper.Stop(ctx)
 			registered, d, _ := p.Register(ctx, h.span, hlc.Timestamp{}, nil, /* catchUpIter */
 				false /* withDiff */, false /* withFiltering */, false, /* withOmitRemote */
-				stream, func() {})
+				stream)
 			require.True(t, registered)
 			sm.AddStream(sID, d)
 			require.Equal(t, 1, testRangefeedCounter.get())

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -499,20 +499,21 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 	desc := r.Desc()
 	tp := rangefeedTxnPusher{ir: r.store.intentResolver, r: r, span: desc.RSpan()}
 	cfg := rangefeed.Config{
-		AmbientContext:   r.AmbientContext,
-		Clock:            r.Clock(),
-		Stopper:          r.store.stopper,
-		Settings:         r.store.ClusterSettings(),
-		RangeID:          r.RangeID,
-		Span:             desc.RSpan(),
-		TxnPusher:        &tp,
-		PushTxnsAge:      r.store.TestingKnobs().RangeFeedPushTxnsAge,
-		EventChanCap:     defaultEventChanCap,
-		EventChanTimeout: defaultEventChanTimeout,
-		Metrics:          r.store.metrics.RangeFeedMetrics,
-		MemBudget:        feedBudget,
-		Scheduler:        r.store.getRangefeedScheduler(),
-		Priority:         isSystemSpan, // only takes effect when Scheduler != nil
+		AmbientContext:        r.AmbientContext,
+		Clock:                 r.Clock(),
+		Stopper:               r.store.stopper,
+		Settings:              r.store.ClusterSettings(),
+		RangeID:               r.RangeID,
+		Span:                  desc.RSpan(),
+		TxnPusher:             &tp,
+		PushTxnsAge:           r.store.TestingKnobs().RangeFeedPushTxnsAge,
+		EventChanCap:          defaultEventChanCap,
+		EventChanTimeout:      defaultEventChanTimeout,
+		Metrics:               r.store.metrics.RangeFeedMetrics,
+		MemBudget:             feedBudget,
+		Scheduler:             r.store.getRangefeedScheduler(),
+		Priority:              isSystemSpan, // only takes effect when Scheduler != nil
+		UnregisterFromReplica: r.unsetRangefeedProcessor,
 	}
 	p = rangefeed.NewProcessor(cfg)
 

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -466,7 +466,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 
 	if p != nil {
 		reg, disconnector, filter := p.Register(streamCtx, span, startTS, catchUpIter, withDiff, withFiltering, withOmitRemote,
-			stream, func() { r.maybeDisconnectEmptyRangefeed(p) })
+			stream)
 		if reg {
 			// Registered successfully with an existing processor.
 			// Update the rangefeed filter to avoid filtering ops
@@ -548,7 +548,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 	// this ensures that the only time the registration fails is during
 	// server shutdown.
 	reg, disconnector, filter := p.Register(streamCtx, span, startTS, catchUpIter, withDiff,
-		withFiltering, withOmitRemote, stream, func() { r.maybeDisconnectEmptyRangefeed(p) })
+		withFiltering, withOmitRemote, stream)
 	if !reg {
 		select {
 		case <-r.store.Stopper().ShouldQuiesce():


### PR DESCRIPTION
After the output loop completes, 2 cleanup steps are performed:

1) The registration is removed from the processor's registry, and
2) The process is potentially stopped and removed from the replica.

Before this change, both of these happened syncronously after the output loop finished.

With this change, step (1) happens asyncronously. To facilitate this, an overflow mechanism for requests is provided. This overflow mechanism potentially allocates. Note that we expect that the number of requests is relatively small and should be O(rangefeeds_on_range) so hopefully this mechanism won't be used often.

Step (2) is now handled by the processor itself. After processing an unregister request, if the set of registrations falls to zero, we enqueue a Stop event for ourselves. Then, when processing the Stop, we unregister ourselves from the replica.

Note that this may look like a small semantics change since the previous unregister callback called Stop() which processes all events. However, note that a Stopped event is processed after all other events, so any events in the queue at the point of processing the unregistration that enqueued the stop will be processed.

The motivation for this change is to eventually allow cleanup step (1) to be run as part of registration.disconnect(), which needs to be non-blocking. This is desired for a future change in which there is not a dedicated goroutine to perform this cleanup.

Epic: none
Release note: None