### PR TITLE
admission: fix snapshot queue bug, returning item to wrong pool 

### DIFF
--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/util/grunning",
         "//pkg/util/humanizeutil",
         "//pkg/util/log",
+        "//pkg/util/metamorphic",
         "//pkg/util/metric",
         "//pkg/util/queue",
         "//pkg/util/schedulerlatency",

--- a/pkg/util/admission/snapshot_queue.go
+++ b/pkg/util/admission/snapshot_queue.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/queue"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -51,8 +52,9 @@ var DiskBandwidthForSnapshotIngest = settings.RegisterBoolSetting(
 	settings.SystemOnly, "kvadmission.store.snapshot_ingest_bandwidth_control.enabled",
 	"if set to true, snapshot ingests will be subject to disk write control in AC",
 	// TODO(aaditya): Enable by default once enough experimentation is done.
-	false,
-	settings.WithPublic)
+	metamorphic.ConstantWithTestBool("kvadmission.store.snapshot_ingest_bandwidth_control.enabled", false),
+	settings.WithPublic,
+)
 
 var snapshotWaitDur = metric.Metadata{
 	Name:        "admission.wait_durations.snapshot_ingest",

--- a/pkg/util/admission/snapshot_queue.go
+++ b/pkg/util/admission/snapshot_queue.go
@@ -240,7 +240,7 @@ func releaseSnapshotWorkItem(sw *snapshotWorkItem) {
 	*sw = snapshotWorkItem{
 		admitCh: ch,
 	}
-	waitingWorkPool.Put(sw)
+	snapshotWorkItemPool.Put(sw)
 }
 
 func newSnapshotWorkItem(count int64) *snapshotWorkItem {


### PR DESCRIPTION
PR includes two commits:

----
[admission: fix snapshot queue bug, returning item to wrong pool](https://github.com/cockroachdb/cockroach/commit/fad053c8228315896373231c92a9e2a06bf9b626) 

Fixes https://github.com/cockroachdb/cockroach/issues/132534.

Release note: None

----

[admission: make snapshot ingest AC setting metamorphic for tests](https://github.com/cockroachdb/cockroach/commit/a515b3c080f3e6cf5af734e91d738f60082cfba2) 

Part of: [CRDB-36837](https://cockroachlabs.atlassian.net/browse/CRDB-36837)

Release note: None