### PR TITLE
crosscluster: refactor checkpoint event type

### DIFF
--- a/pkg/ccl/cmdccl/clusterrepl/main.go
+++ b/pkg/ccl/cmdccl/clusterrepl/main.go
@@ -251,8 +251,7 @@ func subscriptionConsumer(
 				case crosscluster.DeleteRangeEvent:
 				case crosscluster.CheckpointEvent:
 					fmt.Printf("%s checkpoint\n", timeutil.Now().Format(time.RFC3339))
-					resolved := event.GetResolvedSpans()
-					for _, r := range resolved {
+					for _, r := range event.GetCheckpoint().ResolvedSpans {
 						_, err := frontier.Forward(r.Span, r.Timestamp)
 						if err != nil {
 							return err

--- a/pkg/ccl/crosscluster/BUILD.bazel
+++ b/pkg/ccl/crosscluster/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/crosscluster",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/jobs/jobspb",
         "//pkg/kv/kvpb",
         "//pkg/repstream/streampb",
         "//pkg/roachpb",

--- a/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
@@ -486,7 +486,7 @@ func (lrw *logicalReplicationWriterProcessor) handleEvent(
 			return err
 		}
 	case crosscluster.CheckpointEvent:
-		if err := lrw.maybeCheckpoint(ctx, event.GetResolvedSpans()); err != nil {
+		if err := lrw.maybeCheckpoint(ctx, event.GetCheckpoint().ResolvedSpans); err != nil {
 			return err
 		}
 	case crosscluster.SSTableEvent, crosscluster.DeleteRangeEvent:

--- a/pkg/ccl/crosscluster/physical/stream_ingestion_processor.go
+++ b/pkg/ccl/crosscluster/physical/stream_ingestion_processor.go
@@ -919,7 +919,7 @@ func (sip *streamIngestionProcessor) bufferCheckpoint(event PartitionEvent) erro
 		}
 	}
 
-	resolvedSpans := event.GetResolvedSpans()
+	resolvedSpans := event.GetCheckpoint().ResolvedSpans
 	if resolvedSpans == nil {
 		return errors.New("checkpoint event expected to have resolved spans")
 	}

--- a/pkg/ccl/crosscluster/physical/stream_ingestion_processor_test.go
+++ b/pkg/ccl/crosscluster/physical/stream_ingestion_processor_test.go
@@ -96,8 +96,10 @@ func TestStreamIngestionProcessor(t *testing.T) {
 		v.Timestamp = hlc.Timestamp{WallTime: 1}
 		return []roachpb.KeyValue{{Key: key, Value: v}}
 	}
-	sampleCheckpoint := func(span roachpb.Span, ts int64) []jobspb.ResolvedSpan {
-		return []jobspb.ResolvedSpan{{Span: span, Timestamp: hlc.Timestamp{WallTime: ts}}}
+	sampleCheckpoint := func(span roachpb.Span, ts int64) *streampb.StreamEvent_StreamCheckpoint {
+		return &streampb.StreamEvent_StreamCheckpoint{
+			ResolvedSpans: []jobspb.ResolvedSpan{{Span: span, Timestamp: hlc.Timestamp{WallTime: ts}}},
+		}
 	}
 
 	readRow := func(streamOut execinfra.RowSource) []string {
@@ -778,7 +780,7 @@ func validateFnWithValidator(
 	return func(event crosscluster.Event, spec streamclient.SubscriptionToken) {
 		switch event.Type() {
 		case crosscluster.CheckpointEvent:
-			resolvedTS := resolvedSpansMinTS(event.GetResolvedSpans())
+			resolvedTS := resolvedSpansMinTS(event.GetCheckpoint().ResolvedSpans)
 			err := validator.noteResolved(string(spec), resolvedTS)
 			if err != nil {
 				panic(err.Error())

--- a/pkg/ccl/crosscluster/producer/replication_stream_test.go
+++ b/pkg/ccl/crosscluster/producer/replication_stream_test.go
@@ -106,7 +106,7 @@ func (d *partitionStreamDecoder) pop() crosscluster.Event {
 		// TODO(yevgeniy): Fix checkpoint handling and support backfill checkpoints.
 		// For now, check that we only have one span in the checkpoint, and use that timestamp.
 		require.Equal(d.t, 1, len(d.e.Checkpoint.ResolvedSpans))
-		event := crosscluster.MakeCheckpointEvent(d.e.Checkpoint.ResolvedSpans)
+		event := crosscluster.MakeCheckpointEvent(d.e.Checkpoint)
 		d.e.Checkpoint = nil
 		return event
 	}

--- a/pkg/ccl/crosscluster/replicationtestutils/replication_helpers.go
+++ b/pkg/ccl/crosscluster/replicationtestutils/replication_helpers.go
@@ -76,7 +76,7 @@ func ResolvedAtLeast(lo hlc.Timestamp) FeedEventPredicate {
 		if msg.Type() != crosscluster.CheckpointEvent {
 			return false
 		}
-		return lo.LessEq(minResolvedTimestamp(msg.GetResolvedSpans()))
+		return lo.LessEq(minResolvedTimestamp(msg.GetCheckpoint().ResolvedSpans))
 	}
 }
 
@@ -138,7 +138,7 @@ func (rf *ReplicationFeed) ObserveResolved(ctx context.Context, lo hlc.Timestamp
 	rf.consumeUntil(ctx, ResolvedAtLeast(lo), func(err error) bool {
 		return false
 	})
-	return minResolvedTimestamp(rf.msg.GetResolvedSpans())
+	return minResolvedTimestamp(rf.msg.GetCheckpoint().ResolvedSpans)
 }
 
 // ObserveError consumes the feed until the feed is exhausted, and the final error should

--- a/pkg/ccl/crosscluster/streamclient/client_helpers.go
+++ b/pkg/ccl/crosscluster/streamclient/client_helpers.go
@@ -91,7 +91,7 @@ func parseEvent(streamEvent *streampb.StreamEvent) crosscluster.Event {
 	}
 
 	if streamEvent.Checkpoint != nil {
-		event := crosscluster.MakeCheckpointEvent(streamEvent.Checkpoint.ResolvedSpans)
+		event := crosscluster.MakeCheckpointEvent(streamEvent.Checkpoint)
 		streamEvent.Checkpoint = nil
 		return event
 	}

--- a/pkg/ccl/crosscluster/streamclient/client_test.go
+++ b/pkg/ccl/crosscluster/streamclient/client_test.go
@@ -117,7 +117,9 @@ func (sc testStreamClient) Subscribe(
 
 	events := make(chan crosscluster.Event, 2)
 	events <- crosscluster.MakeKVEventFromKVs([]roachpb.KeyValue{sampleKV})
-	events <- crosscluster.MakeCheckpointEvent([]jobspb.ResolvedSpan{sampleResolvedSpan})
+	events <- crosscluster.MakeCheckpointEvent(&streampb.StreamEvent_StreamCheckpoint{
+		ResolvedSpans: []jobspb.ResolvedSpan{sampleResolvedSpan},
+	})
 	close(events)
 
 	return &testStreamSubscription{
@@ -313,7 +315,7 @@ func ExampleClient() {
 					fmt.Printf("delRange: %s@%d\n", delRange.Span.String(), delRange.Timestamp.WallTime)
 				case crosscluster.CheckpointEvent:
 					minTS := hlc.MaxTimestamp
-					for _, rs := range event.GetResolvedSpans() {
+					for _, rs := range event.GetCheckpoint().ResolvedSpans {
 						if rs.Timestamp.Less(minTS) {
 							minTS = rs.Timestamp
 						}

--- a/pkg/ccl/crosscluster/streamclient/randclient/BUILD.bazel
+++ b/pkg/ccl/crosscluster/streamclient/randclient/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/util/bufalloc",
         "//pkg/util/hlc",
         "//pkg/util/log",
+        "//pkg/util/protoutil",
         "//pkg/util/randutil",
         "//pkg/util/span",
         "//pkg/util/syncutil",

--- a/pkg/ccl/crosscluster/streamclient/randclient/random_stream_client.go
+++ b/pkg/ccl/crosscluster/streamclient/randclient/random_stream_client.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/span"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -296,7 +297,10 @@ func (r *randomEventGenerator) generateNewEvent() (crosscluster.Event, error) {
 		hlcResolvedTime := hlc.Timestamp{WallTime: resolvedTime.UnixNano()}
 		resolvedSpan := jobspb.ResolvedSpan{Span: sp, Timestamp: hlcResolvedTime}
 		r.numEventsSinceLastResolved = 0
-		return crosscluster.MakeCheckpointEvent([]jobspb.ResolvedSpan{resolvedSpan}), nil
+		checkpoint := &streampb.StreamEvent_StreamCheckpoint{
+			ResolvedSpans: []jobspb.ResolvedSpan{resolvedSpan},
+		}
+		return crosscluster.MakeCheckpointEvent(checkpoint), nil
 	}
 
 	// If there are system KVs to emit, prioritize those.
@@ -717,9 +721,8 @@ func duplicateEvent(event crosscluster.Event) crosscluster.Event {
 	var dup crosscluster.Event
 	switch event.Type() {
 	case crosscluster.CheckpointEvent:
-		resolvedSpans := make([]jobspb.ResolvedSpan, len(event.GetResolvedSpans()))
-		copy(resolvedSpans, event.GetResolvedSpans())
-		dup = crosscluster.MakeCheckpointEvent(resolvedSpans)
+		checkpointClone := protoutil.Clone(event.GetCheckpoint()).(*streampb.StreamEvent_StreamCheckpoint)
+		dup = crosscluster.MakeCheckpointEvent(checkpointClone)
 	case crosscluster.KVEvent:
 		kvs := event.GetKVs()
 		res := make([]roachpb.KeyValue, len(kvs))


### PR DESCRIPTION
This change refactors the checkpoint event type so that the event exposes the entire checkpoint proto. This will be used to add range stats to the checkpoint.

Part of: #132336
Release Note: none