### PR TITLE
kvserver: introduce longer suspect duration for longer unavailability

### DIFF
--- a/pkg/kv/kvserver/asim/state/liveness.go
+++ b/pkg/kv/kvserver/asim/state/liveness.go
@@ -93,9 +93,11 @@ func convertNodeStatusToNodeVitality(
 		now,               /* now */
 		hlc.Timestamp{},   /* descUpdateTime */
 		hlc.Timestamp{},   /* descUnavailableTime */
+		hlc.Timestamp{},   /* descUnavailableTimeBegin */
 		true,              /* connected */
 		timeUntilNodeDead, /* timeUntilNodeDead */
 		0,                 /* timeAfterNodeSuspect */
+		1.0,               /* timeAfterNodeSuspectLongMult */
 	)
 	return entry
 }

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -36,11 +36,6 @@ import (
 	"github.com/cockroachdb/redact"
 )
 
-const (
-	timeUntilNodeDeadSettingName    = "server.time_until_store_dead"
-	timeAfterNodeSuspectSettingName = "server.time_after_store_suspect"
-)
-
 // Setting this to less than the interval for gossiping stores is a big
 // no-no, since this value is compared to the age of the most recent gossip
 // from each store to determine whether that store is live. Put a buffer of
@@ -50,7 +45,7 @@ const minTimeUntilNodeDead = gossip.StoresInterval + 15*time.Second
 // TimeUntilNodeDead wraps "server.time_until_store_dead".
 var TimeUntilNodeDead = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,
-	timeUntilNodeDeadSettingName,
+	"server.time_until_store_dead",
 	"the time after which if there is no new gossiped information about a store, it is considered dead",
 	5*time.Minute,
 	settings.DurationWithMinimum(minTimeUntilNodeDead),
@@ -71,7 +66,7 @@ const maxTimeAfterNodeSuspect = 5 * time.Minute
 // it's last failure.
 var TimeAfterNodeSuspect = settings.RegisterDurationSetting(
 	settings.SystemOnly,
-	timeAfterNodeSuspectSettingName,
+	"server.time_after_store_suspect",
 	"the amount of time we consider a node suspect for after it becomes unavailable."+
 		" A suspect node is typically treated the same as an unavailable node.",
 	30*time.Second,

--- a/pkg/kv/kvserver/liveness/livenesspb/liveness_test_helper.go
+++ b/pkg/kv/kvserver/liveness/livenesspb/liveness_test_helper.go
@@ -50,9 +50,27 @@ func TestCreateNodeVitality(ids ...roachpb.NodeID) TestNodeVitality {
 func (e testNodeVitalityEntry) convert() NodeVitality {
 	now := e.clock.Now()
 	if e.Alive {
-		return e.Liveness.CreateNodeVitality(now, now, hlc.Timestamp{}, true, time.Second, time.Second)
+		return e.Liveness.CreateNodeVitality(
+			now,             /* now */
+			now,             /* descUpdateTime */
+			hlc.Timestamp{}, /* descUnavailableTime */
+			hlc.Timestamp{}, /* descUnavailableTimeBegin */
+			true,            /* connected */
+			time.Second,     /* timeUntilNodeDead */
+			time.Second,     /* timeAfterNodeSuspect */
+			1.0,             /* timeAfterNodeSuspectLongMult */
+		)
 	} else {
-		return e.Liveness.CreateNodeVitality(now, now.AddDuration(-time.Hour), hlc.Timestamp{}, false, time.Second, time.Second)
+		return e.Liveness.CreateNodeVitality(
+			now,                         /* now */
+			now.AddDuration(-time.Hour), /* descUpdateTime */
+			now.AddDuration(-time.Hour), /* descUnavailableTime */
+			hlc.Timestamp{},             /* descUnavailableTimeBegin */
+			false,                       /* connected */
+			time.Second,                 /* timeUntilNodeDead */
+			time.Second,                 /* timeAfterNodeSuspect */
+			1.0,                         /* timeAfterNodeSuspectLongMult */
+		)
 	}
 }
 


### PR DESCRIPTION
Introduce a new system only cluster setting:

```
server.time_after_store_suspect.long_failure_multiplier
```

Which multiplies the suspect duration
('server.time_after_store_suspect') applied to nodes which have been
marked as unavailable for at least `server.time_after_store_suspect`
duration.

The default multiplier is `2.0`, meaning that unavailability longer than
`server.time_after_store_suspect` will be penalized with a 2 times
longer suspect duration.

The multiplier therefore only targets nodes which have been unavailable
for a longer time, knowing that these nodes will have a larger amount of
catch up work to perform upon becoming available.

Resolves: https://github.com/cockroachdb/cockroach/issues/132796
Release note: None