### PR TITLE
logconfig: update file sink log validation message

### DIFF
--- a/pkg/util/log/logconfig/testdata/validate
+++ b/pkg/util/log/logconfig/testdata/validate
@@ -879,4 +879,4 @@ file-defaults:
     flush-trigger-size: 1.0MiB
     max-buffer-size: 50MiB
 ----
-ERROR: File-based audit logging cannot coexist with buffering configuration. Disable either the "buffering" (buffered-writes) or "auditable" log (auditable) configuration.
+ERROR: File-based audit logging cannot coexist with buffering configuration. Disable either the buffering configuration ("buffering") or auditable log ("auditable") configuration.

--- a/pkg/util/log/logconfig/validate.go
+++ b/pkg/util/log/logconfig/validate.go
@@ -374,7 +374,7 @@ func (c *Config) validateFileSinkConfig(fc *FileSinkConfig) error {
 		}
 		if *fc.Auditable {
 			return errors.Newf(`File-based audit logging cannot coexist with buffering configuration. ` +
-				`Disable either the "buffering" (buffered-writes) or "auditable" log (auditable) configuration.`)
+				`Disable either the buffering configuration ("buffering") or auditable log ("auditable") configuration.`)
 		}
 		// To preserve the format of log files, avoid additional formatting in the
 		// buffering configuration.


### PR DESCRIPTION
Previously we added a file sink log validation (#132742). This change updates message so that message is clear to the user.

Epic: CRDB-37534
Release note (ops change): Updated the file sink log validation message. This would give clear indication to user about the expected valid configuration.