### PR TITLE
rac2: delete TokenWaitingHandle interface

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/store_stream.go
@@ -541,8 +541,8 @@ func (w *sendStreamTokenWatcher) run(_ context.Context) {
 				select {
 				case <-w.stopper.ShouldQuiesce():
 					return
-				case <-handle.WaitChannel():
-					if handle.ConfirmHaveTokensAndUnblockNextWaiter() {
+				case <-handle.waitChannel():
+					if handle.confirmHaveTokensAndUnblockNextWaiter() {
 						break waiting
 					}
 				}


### PR DESCRIPTION
There is only one implementation, so there is no need to pay for the heap allocation.

Epic: CRDB-37515

Release note: None