### PR TITLE
roachtest: add test for elasticWorkload

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -215,6 +215,7 @@ func registerLatencyTests(r registry.Registry) {
 	addMetamorphic(r, &decommission{}, 5.0)
 	addMetamorphic(r, backfill{}, 40.0)
 	addMetamorphic(r, &slowDisk{}, math.Inf(1))
+	addMetamorphic(r, elasticWorkload{}, 5.0)
 
 	// NB: If these tests fail, it likely signals a regression. Investigate the
 	// history of the test on roachperf to see what changed.
@@ -224,6 +225,7 @@ func registerLatencyTests(r registry.Registry) {
 	addFull(r, &decommission{drain: true}, 5.0)
 	addFull(r, backfill{}, 40.0)
 	addFull(r, &slowDisk{slowLiveness: true, walFailover: true}, math.Inf(1))
+	addFull(r, elasticWorkload{}, 5.0)
 
 	// NB: These tests will never fail and are not enabled, but they are useful
 	// for development.
@@ -233,6 +235,7 @@ func registerLatencyTests(r registry.Registry) {
 	addDev(r, &decommission{drain: true}, math.Inf(1))
 	addDev(r, backfill{}, math.Inf(1))
 	addDev(r, &slowDisk{slowLiveness: true, walFailover: true}, math.Inf(1))
+	addDev(r, elasticWorkload{}, math.Inf(1))
 }
 
 func (v variations) makeClusterSpec() spec.ClusterSpec {
@@ -311,6 +314,48 @@ type perturbation interface {
 	// endPerturbation ends the system change. Not all perturbations do anything on stop.
 	// It returns the duration looking backwards to collect performance stats.
 	endPerturbation(ctx context.Context, t test.Test, v variations) time.Duration
+}
+
+// elasticWorkload will start a workload with elastic priority. It uses the same
+// characteristics as the normal workload. However since the normal workload
+// runs at 50% CPU this adds another 2x the stable rate so it will be slowed
+// down by AC.
+// TODO(baptist): Run against the same database to hit transaction conflicts and
+// priority inversions.
+type elasticWorkload struct{}
+
+var _ perturbation = elasticWorkload{}
+
+func (e elasticWorkload) setupMetamorphic(rng *rand.Rand) {}
+
+func (e elasticWorkload) startTargetNode(ctx context.Context, t test.Test, v variations) {
+	v.startNoBackup(ctx, t, v.targetNodes())
+	initCmd := fmt.Sprintf("./cockroach workload init kv --db elastic --splits %d {pgurl:1}", v.splits)
+	v.Run(ctx, option.WithNodes(v.Node(1)), initCmd)
+}
+
+func (e elasticWorkload) startPerturbation(
+	ctx context.Context, t test.Test, v variations,
+) time.Duration {
+	startTime := timeutil.Now()
+	runCmd := fmt.Sprintf(
+		"./cockroach workload run kv --db elastic --txn-qos=background --duration=%s --max-block-bytes=%d --min-block-bytes=%d --concurrency=500 {pgurl%s}",
+		v.perturbationDuration, v.maxBlockBytes, v.maxBlockBytes, v.stableNodes())
+	v.Run(ctx, option.WithNodes(v.workloadNodes()), runCmd)
+
+	// Wait a few seconds to allow the latency to resume after stopping the
+	// workload. This makes it easier to separate the perturbation from the
+	// validation phases.
+	waitDuration(ctx, 5*time.Second)
+	return timeutil.Since(startTime)
+}
+
+// endPerturbation implements perturbation.
+func (e elasticWorkload) endPerturbation(
+	ctx context.Context, t test.Test, v variations,
+) time.Duration {
+	waitDuration(ctx, v.validationDuration)
+	return v.validationDuration
 }
 
 // backfill will create a backfill table during the startup and an index on it


### PR DESCRIPTION
This commit adds three new perturbation tests:
perturbation/metamorphic/elasticWorkload
perturbation/full/elasticWorkload
perturbation/dev/elasticWorkload
The tests run an elastic workload as the perturbation.

Epic: none

Release note: None