### PR TITLE
raft: consult store liveness before campaigning

### DIFF
--- a/pkg/kv/kvserver/client_raft_helpers_test.go
+++ b/pkg/kv/kvserver/client_raft_helpers_test.go
@@ -472,6 +472,8 @@ func dropRaftMessagesFrom(
 				drop := shouldDropFromStore(msg.From.StoreID)
 				if drop {
 					t.Logf("dropping msg %s from store %d: to %d", msg.Type, msg.From.StoreID, msg.To.StoreID)
+				} else {
+					t.Logf("allowing msg %s from store %d: to %d", msg.Type, msg.From.StoreID, msg.To.StoreID)
 				}
 				return drop
 			},

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1357,6 +1357,14 @@ func (r *raft) hup(t CampaignType) {
 		r.logger.Debugf("%x ignoring MsgHup due to leader fortification", r.id)
 		return
 	}
+
+	// We shouldn't campaign if we don't have quorum support in store liveness.
+	if r.fortificationTracker.RequireQuorumSupportOnCampaign() &&
+		!r.fortificationTracker.QuorumSupported() {
+		r.logger.Debugf("%x cannot campaign since it's not supported by a quorum in store liveness", r.id)
+		return
+	}
+
 	if r.hasUnappliedConfChanges() {
 		r.logger.Warningf("%x cannot campaign at term %d since there are still pending configuration changes to apply", r.id, r.Term)
 		return

--- a/pkg/raft/testdata/de_fortification_checkquorum.txt
+++ b/pkg/raft/testdata/de_fortification_checkquorum.txt
@@ -46,7 +46,6 @@ withdraw-support 3 1
 2 x 1 1
 3 x 1 1
 
-
 tick-election 1
 ----
 ok
@@ -77,20 +76,16 @@ set-randomized-election-timeout 1 timeout=3
 ----
 ok
 
-# Even though the leader doesn't have store liveness support, it'll still call
-# a pre-vote election until we start checking store liveness before doing so.
+# Since we don't have store liveness support, we can't campaign.
 # However, on this ticker, it'll also broadcast a de-fortify to all peers --
 # which is what we're interested in for this test.
 tick-election 1
 ----
-INFO 1 is starting a new election at term 1
-INFO 1 became pre-candidate at term 1
-INFO 1 [logterm: 1, index: 11] sent MsgPreVote request to 2 at term 1
-INFO 1 [logterm: 1, index: 11] sent MsgPreVote request to 3 at term 1
+DEBUG 1 cannot campaign since it's not supported by a quorum in store liveness
 
 raft-state 1
 ----
-1: StatePreCandidate (Voter) Term:1 Lead:0 LeadEpoch:0
+1: StateFollower (Voter) Term:1 Lead:0 LeadEpoch:0
 2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
 3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
 
@@ -99,8 +94,8 @@ stabilize
 ----
 > 1 handling Ready
   Ready MustSync=true:
-  State:StatePreCandidate
-  HardState Term:1 Vote:1 Commit:11 Lead:0 LeadEpoch:0
+  State:StateFollower
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:0
   Messages:
   1->2 MsgDeFortifyLeader Term:1 Log:0/0
   1->3 MsgDeFortifyLeader Term:1 Log:0/0
@@ -108,26 +103,18 @@ stabilize
   1->3 MsgDeFortifyLeader Term:1 Log:0/0
   1->2 MsgDeFortifyLeader Term:1 Log:0/0
   1->3 MsgDeFortifyLeader Term:1 Log:0/0
-  1->2 MsgPreVote Term:2 Log:1/11
-  1->3 MsgPreVote Term:2 Log:1/11
-  INFO 1 received MsgPreVoteResp from 1 at term 1
-  INFO 1 has received 1 MsgPreVoteResp votes and 0 vote rejections
 > 2 receiving messages
   1->2 MsgDeFortifyLeader Term:1 Log:0/0
   1->2 MsgDeFortifyLeader Term:1 Log:0/0
   DEBUG 2 is not fortifying 1; de-fortification is a no-op
   1->2 MsgDeFortifyLeader Term:1 Log:0/0
   DEBUG 2 is not fortifying 1; de-fortification is a no-op
-  1->2 MsgPreVote Term:2 Log:1/11
-  INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 1 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3)
 > 3 receiving messages
   1->3 MsgDeFortifyLeader Term:1 Log:0/0
   1->3 MsgDeFortifyLeader Term:1 Log:0/0
   DEBUG 3 is not fortifying 1; de-fortification is a no-op
   1->3 MsgDeFortifyLeader Term:1 Log:0/0
   DEBUG 3 is not fortifying 1; de-fortification is a no-op
-  1->3 MsgPreVote Term:2 Log:1/11
-  INFO 3 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 1 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3)
 > 2 handling Ready
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:0
@@ -138,7 +125,7 @@ stabilize
 # All peers have been de-fortified successfully.
 raft-state
 ----
-1: StatePreCandidate (Voter) Term:1 Lead:0 LeadEpoch:0
+1: StateFollower (Voter) Term:1 Lead:0 LeadEpoch:0
 2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:0
 3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:0
 

--- a/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
+++ b/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
@@ -238,6 +238,18 @@ withdraw-support 1 3
 2 x 1 x
 3 x 1 1
 
+# At this point we can't campaign because we are not supported by a quorum.
+campaign 1
+----
+DEBUG 1 cannot campaign since it's not supported by a quorum in store liveness
+
+grant-support 3 1
+----
+  1 2 3
+1 3 1 x
+2 x 1 x
+3 3 1 1
+
 campaign 1
 ----
 INFO 1 is starting a new election at term 2

--- a/pkg/raft/testdata/fortification_support_tracking.txt
+++ b/pkg/raft/testdata/fortification_support_tracking.txt
@@ -23,13 +23,6 @@ withdraw-support 2 1
 2 x 1 1
 3 1 1 1
 
-withdraw-support 3 1
-----
-  1 2 3
-1 1 1 1
-2 x 1 1
-3 x 1 1
-
 campaign 1
 ----
 INFO 1 is starting a new election at term 0
@@ -81,11 +74,13 @@ stabilize
   Entries:
   1/11 EntryNormal ""
   Messages:
+  1->3 MsgFortifyLeader Term:1 Log:0/0
   1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
 > 3 receiving messages
+  1->3 MsgFortifyLeader Term:1 Log:0/0
   1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
 > 2 handling Ready
   Ready MustSync=true:
@@ -96,13 +91,15 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/11 Commit:10
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:0
+  HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   Entries:
   1/11 EntryNormal ""
   Messages:
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   3->1 MsgAppResp Term:1 Log:0/11 Commit:10
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/11 Commit:10
+  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   3->1 MsgAppResp Term:1 Log:0/11 Commit:10
 > 1 handling Ready
   Ready MustSync=true:
@@ -111,10 +108,12 @@ stabilize
   1/11 EntryNormal ""
   Messages:
   1->2 MsgApp Term:1 Log:1/11 Commit:11
+  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/11 Commit:11
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/11 Commit:11
 > 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/11 Commit:11
 > 2 handling Ready
   Ready MustSync=true:
@@ -125,18 +124,28 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:0
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/11 EntryNormal ""
   Messages:
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
+  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 
 print-fortification-state 1
 ----
 1 : 1
+3 : 1
+
+withdraw-support 3 1
+----
+  1 2 3
+1 1 1 1
+2 x 1 1
+3 x 1 1
 
 bump-epoch 2
 ----

--- a/pkg/raft/testdata/prevote_checkquorum.txt
+++ b/pkg/raft/testdata/prevote_checkquorum.txt
@@ -228,6 +228,18 @@ withdraw-support 1 3
 2 x 1 1
 3 x 1 1
 
+# At this point we can't campaign because we are not supported by a quorum.
+campaign 1
+----
+DEBUG 1 cannot campaign since it's not supported by a quorum in store liveness
+
+grant-support 3 1
+----
+  1 2 3
+1 2 1 x
+2 x 1 1
+3 2 1 1
+
 # Node 3 is now the leader. Even though the leader is active, nodes 1 and 2 can
 # still win a prevote and election if they both explicitly campaign, since the
 # PreVote+CheckQuorum recent leader condition only applies to follower voters.
@@ -264,9 +276,9 @@ stabilize
 withdraw-support 2 3
 ----
   1 2 3
-1 1 1 x
+1 2 1 x
 2 x 1 x
-3 x 1 1
+3 2 1 1
 
 campaign 2
 ----

--- a/pkg/raft/tracker/fortificationtracker.go
+++ b/pkg/raft/tracker/fortificationtracker.go
@@ -51,6 +51,10 @@ type FortificationTracker struct {
 	// epochs that they have supported the leader in.
 	fortification map[pb.PeerID]pb.Epoch
 
+	// votersSupported is a map that hangs off the fortificationTracker to prevent
+	// allocations on every call to QuorumSupported.
+	votersSupport map[pb.PeerID]bool
+
 	// leaderMaxSupported is the maximum LeadSupportUntil that the leader has
 	// ever claimed to support. Tracking this ensures that LeadSupportUntil
 	// never regresses for a raft group. Naively, without any tracking, this
@@ -82,6 +86,7 @@ func NewFortificationTracker(
 		config:        config,
 		storeLiveness: storeLiveness,
 		fortification: map[pb.PeerID]pb.Epoch{},
+		votersSupport: map[pb.PeerID]bool{},
 		logger:        logger,
 	}
 	return &st
@@ -318,6 +323,25 @@ func (ft *FortificationTracker) ConfigChangeSafe() bool {
 func (ft *FortificationTracker) QuorumActive() bool {
 	// NB: Only run by the leader.
 	return !ft.storeLiveness.SupportExpired(ft.LeadSupportUntil(pb.StateLeader))
+}
+
+// RequireQuorumSupportOnCampaign returns true if quorum support before
+// campaigning is required.
+func (ft *FortificationTracker) RequireQuorumSupportOnCampaign() bool {
+	return ft.storeLiveness.SupportFromEnabled()
+}
+
+// QuorumSupported returns whether this peer is currently supported by a quorum
+// or not.
+func (ft *FortificationTracker) QuorumSupported() bool {
+	clear(ft.votersSupport)
+
+	ft.config.Voters.Visit(func(id pb.PeerID) {
+		_, isSupported := ft.IsFortifiedBy(id)
+		ft.votersSupport[id] = isSupported
+	})
+
+	return ft.config.Voters.VoteResult(ft.votersSupport) == quorum.VoteWon
 }
 
 // Term returns the leadership term for which the tracker is/was tracking

--- a/pkg/raft/tracker/fortificationtracker.go
+++ b/pkg/raft/tracker/fortificationtracker.go
@@ -51,7 +51,7 @@ type FortificationTracker struct {
 	// epochs that they have supported the leader in.
 	fortification map[pb.PeerID]pb.Epoch
 
-	// votersSupported is a map that hangs off the fortificationTracker to prevent
+	// votersSupport is a map that hangs off the fortificationTracker to prevent
 	// allocations on every call to QuorumSupported.
 	votersSupport map[pb.PeerID]bool
 


### PR DESCRIPTION
This commit makes followers to make sure they are supported by a quorum before campaigning.

Fixes: #132755

Release note: None