### PR TITLE
storage: fix KeySeeker.MaterializeUserKey

### DIFF
--- a/pkg/storage/pebble_key_schema.go
+++ b/pkg/storage/pebble_key_schema.go
@@ -434,10 +434,10 @@ func (ks *cockroachKeySeeker) MaterializeUserKey(
 	}
 
 	// Inline binary.BigEndian.PutUint32.
-	*(*byte)(ptr) = byte(mvccWall >> 24)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 1)) = byte(mvccWall >> 16)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 2)) = byte(mvccWall >> 8)
-	*(*byte)(unsafe.Pointer(uintptr(ptr) + 3)) = byte(mvccWall)
+	*(*byte)(ptr) = byte(mvccLogical >> 24)
+	*(*byte)(unsafe.Pointer(uintptr(ptr) + 1)) = byte(mvccLogical >> 16)
+	*(*byte)(unsafe.Pointer(uintptr(ptr) + 2)) = byte(mvccLogical >> 8)
+	*(*byte)(unsafe.Pointer(uintptr(ptr) + 3)) = byte(mvccLogical)
 	*(*byte)(unsafe.Pointer(uintptr(ptr) + 4)) = 13
 	return ki.Buf[:len(ki.Buf)+14]
 }

--- a/pkg/storage/testdata/key_schema_key_seeker
+++ b/pkg/storage/testdata/key_schema_key_seeker
@@ -27,10 +27,10 @@ foo@3.000000000,0
 foo@3.000000000,2
 zoo@9.000000000,0
 ----
-SeekGE("fax@9.000000000,0", boundRow=-1, searchDir=0) = (row=0, equalPrefix=false) [hex:666f6f0000000000b2d05e00b2d05e000d]
-SeekGE("foo@3.000000000,1", boundRow=-1, searchDir=0) = (row=0, equalPrefix=true) [hex:666f6f0000000000b2d05e00b2d05e000d]
+SeekGE("fax@9.000000000,0", boundRow=-1, searchDir=0) = (row=0, equalPrefix=false) [hex:666f6f0000000000b2d05e00000000010d]
+SeekGE("foo@3.000000000,1", boundRow=-1, searchDir=0) = (row=0, equalPrefix=true) [hex:666f6f0000000000b2d05e00000000010d]
 SeekGE("foo@3.000000000,0", boundRow=-1, searchDir=0) = (row=1, equalPrefix=true) [hex:666f6f0000000000b2d05e0009]
-SeekGE("foo@3.000000000,2", boundRow=-1, searchDir=0) = (row=0, equalPrefix=true) [hex:666f6f0000000000b2d05e00b2d05e000d]
+SeekGE("foo@3.000000000,2", boundRow=-1, searchDir=0) = (row=0, equalPrefix=true) [hex:666f6f0000000000b2d05e00000000010d]
 SeekGE("zoo@9.000000000,0", boundRow=-1, searchDir=0) = (row=2, equalPrefix=false)
 
 define-block
@@ -99,19 +99,19 @@ moo@3.000000000,1
 moo@3.000000000,0
 zoo@9.000000000,0
 ----
-SeekGE("apple@2.000000000,0", boundRow=-1, searchDir=0) = (row=0, equalPrefix=false) [hex:6261720000000000b2d05e00b2d05e000d]
-SeekGE("bar@4.000000000,0", boundRow=-1, searchDir=0) = (row=0, equalPrefix=true) [hex:6261720000000000b2d05e00b2d05e000d]
-SeekGE("bar@3.000000000,0", boundRow=-1, searchDir=0) = (row=1, equalPrefix=true) [hex:6261780000000000b2d05e00b2d05e000d]
-SeekGE("bar@2.000000000,0", boundRow=-1, searchDir=0) = (row=1, equalPrefix=true) [hex:6261780000000000b2d05e00b2d05e000d]
-SeekGE("bax@3.000000000,1", boundRow=-1, searchDir=0) = (row=1, equalPrefix=true) [hex:6261780000000000b2d05e00b2d05e000d]
-SeekGE("bax@3.000000000,0", boundRow=-1, searchDir=0) = (row=2, equalPrefix=true) [hex:666f6f0000000000b2d05e00b2d05e000d]
-SeekGE("fax@9.000000000,0", boundRow=-1, searchDir=0) = (row=2, equalPrefix=false) [hex:666f6f0000000000b2d05e00b2d05e000d]
-SeekGE("foo@3.000000000,2", boundRow=-1, searchDir=0) = (row=2, equalPrefix=true) [hex:666f6f0000000000b2d05e00b2d05e000d]
-SeekGE("foo@3.000000000,1", boundRow=-1, searchDir=0) = (row=2, equalPrefix=true) [hex:666f6f0000000000b2d05e00b2d05e000d]
-SeekGE("foo@3.000000000,0", boundRow=-1, searchDir=0) = (row=3, equalPrefix=true) [hex:6d6f6f0000000000b2d05e00b2d05e000d]
-SeekGE("moo@3.000000001,0", boundRow=-1, searchDir=0) = (row=3, equalPrefix=true) [hex:6d6f6f0000000000b2d05e00b2d05e000d]
-SeekGE("moo@3.000000000,2", boundRow=-1, searchDir=0) = (row=3, equalPrefix=true) [hex:6d6f6f0000000000b2d05e00b2d05e000d]
-SeekGE("moo@3.000000000,1", boundRow=-1, searchDir=0) = (row=3, equalPrefix=true) [hex:6d6f6f0000000000b2d05e00b2d05e000d]
+SeekGE("apple@2.000000000,0", boundRow=-1, searchDir=0) = (row=0, equalPrefix=false) [hex:6261720000000000b2d05e00000000010d]
+SeekGE("bar@4.000000000,0", boundRow=-1, searchDir=0) = (row=0, equalPrefix=true) [hex:6261720000000000b2d05e00000000010d]
+SeekGE("bar@3.000000000,0", boundRow=-1, searchDir=0) = (row=1, equalPrefix=true) [hex:6261780000000000b2d05e00000000010d]
+SeekGE("bar@2.000000000,0", boundRow=-1, searchDir=0) = (row=1, equalPrefix=true) [hex:6261780000000000b2d05e00000000010d]
+SeekGE("bax@3.000000000,1", boundRow=-1, searchDir=0) = (row=1, equalPrefix=true) [hex:6261780000000000b2d05e00000000010d]
+SeekGE("bax@3.000000000,0", boundRow=-1, searchDir=0) = (row=2, equalPrefix=true) [hex:666f6f0000000000b2d05e00000000010d]
+SeekGE("fax@9.000000000,0", boundRow=-1, searchDir=0) = (row=2, equalPrefix=false) [hex:666f6f0000000000b2d05e00000000010d]
+SeekGE("foo@3.000000000,2", boundRow=-1, searchDir=0) = (row=2, equalPrefix=true) [hex:666f6f0000000000b2d05e00000000010d]
+SeekGE("foo@3.000000000,1", boundRow=-1, searchDir=0) = (row=2, equalPrefix=true) [hex:666f6f0000000000b2d05e00000000010d]
+SeekGE("foo@3.000000000,0", boundRow=-1, searchDir=0) = (row=3, equalPrefix=true) [hex:6d6f6f0000000000b2d05e00000000010d]
+SeekGE("moo@3.000000001,0", boundRow=-1, searchDir=0) = (row=3, equalPrefix=true) [hex:6d6f6f0000000000b2d05e00000000010d]
+SeekGE("moo@3.000000000,2", boundRow=-1, searchDir=0) = (row=3, equalPrefix=true) [hex:6d6f6f0000000000b2d05e00000000010d]
+SeekGE("moo@3.000000000,1", boundRow=-1, searchDir=0) = (row=3, equalPrefix=true) [hex:6d6f6f0000000000b2d05e00000000010d]
 SeekGE("moo@3.000000000,0", boundRow=-1, searchDir=0) = (row=4, equalPrefix=true)
 SeekGE("zoo@9.000000000,0", boundRow=-1, searchDir=0) = (row=4, equalPrefix=false)
 
@@ -121,10 +121,10 @@ materialize-user-key
 2
 3
 ----
-MaterializeUserKey(-1, 0) = hex:6261720000000000b2d05e00b2d05e000d
-MaterializeUserKey(0, 1) = hex:6261780000000000b2d05e00b2d05e000d
-MaterializeUserKey(1, 2) = hex:666f6f0000000000b2d05e00b2d05e000d
-MaterializeUserKey(2, 3) = hex:6d6f6f0000000000b2d05e00b2d05e000d
+MaterializeUserKey(-1, 0) = hex:6261720000000000b2d05e00000000010d
+MaterializeUserKey(0, 1) = hex:6261780000000000b2d05e00000000010d
+MaterializeUserKey(1, 2) = hex:666f6f0000000000b2d05e00000000010d
+MaterializeUserKey(2, 3) = hex:6d6f6f0000000000b2d05e00000000010d
 
 materialize-user-key synthetic-suffix=@8.000000000,9
 0
@@ -143,7 +143,7 @@ materialize-user-key
 0
 1
 ----
-MaterializeUserKey(-1, 3) = hex:6d6f6f0000000000b2d05e00b2d05e000d
-MaterializeUserKey(3, 2) = hex:666f6f0000000000b2d05e00b2d05e000d
-MaterializeUserKey(2, 0) = hex:6261720000000000b2d05e00b2d05e000d
-MaterializeUserKey(0, 1) = hex:6261780000000000b2d05e00b2d05e000d
+MaterializeUserKey(-1, 3) = hex:6d6f6f0000000000b2d05e00000000010d
+MaterializeUserKey(3, 2) = hex:666f6f0000000000b2d05e00000000010d
+MaterializeUserKey(2, 0) = hex:6261720000000000b2d05e00000000010d
+MaterializeUserKey(0, 1) = hex:6261780000000000b2d05e00000000010d


### PR DESCRIPTION
The KeySeeker implementation accidentally materialized four bytes of the wall time as the logical time when encoding a MVCC timestamp with a non-zero logical time.

Epic: none
Release note: None