### PR TITLE
sql: add test cases for blind writes to RC implicit partitioning tests

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit_read_committed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit_read_committed
@@ -160,7 +160,15 @@ SET tracing = kv
 
 # Test a blind write.
 statement ok
-UPSERT INTO overwrite VALUES (1, 'two', 3);
+UPSERT INTO overwrite VALUES (1, 'two', 3)
+
+# Test a blind rewrite. No tombstones because the PK doesn't change.
+statement ok
+UPSERT INTO overwrite VALUES (1, 'two', 4)
+
+# Test a blind overwrite.
+statement ok
+UPSERT INTO overwrite VALUES (1, 'three', 5)
 
 query T
 SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE 'CPut%'
@@ -170,6 +178,16 @@ CPut /Table/111/1/" "/1/0 -> nil (tombstone)
 CPut /Table/111/1/"\x80"/1/0 -> nil (tombstone)
 CPut /Table/111/1/"\xa0"/1/0 -> nil (tombstone)
 CPut /Table/111/1/"\xc0"/1/0 -> nil (tombstone)
+CPut /Table/111/1/"\x80"/1/0 -> /TUPLE/3:3:Int/5
+CPut /Table/111/1/" "/1/0 -> nil (tombstone)
+CPut /Table/111/1/"@"/1/0 -> nil (tombstone)
+CPut /Table/111/1/"\xa0"/1/0 -> nil (tombstone)
+CPut /Table/111/1/"\xc0"/1/0 -> nil (tombstone)
+
+query ITI
+SELECT * FROM overwrite ORDER BY pk
+----
+1  three  5
 
 statement ok
 INSERT INTO t VALUES (1, 'two', 3, 4, 5)
@@ -204,6 +222,11 @@ SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE 'CPut%'
 CPut /Table/111/1/"@"/1/0 -> /TUPLE/3:3:Int/3
 CPut /Table/111/1/" "/1/0 -> nil (tombstone)
 CPut /Table/111/1/"\x80"/1/0 -> nil (tombstone)
+CPut /Table/111/1/"\xa0"/1/0 -> nil (tombstone)
+CPut /Table/111/1/"\xc0"/1/0 -> nil (tombstone)
+CPut /Table/111/1/"\x80"/1/0 -> /TUPLE/3:3:Int/5
+CPut /Table/111/1/" "/1/0 -> nil (tombstone)
+CPut /Table/111/1/"@"/1/0 -> nil (tombstone)
 CPut /Table/111/1/"\xa0"/1/0 -> nil (tombstone)
 CPut /Table/111/1/"\xc0"/1/0 -> nil (tombstone)
 CPut /Table/110/1/"@"/1/0 -> /TUPLE/3:3:Int/3/1:4:Int/4/1:5:Int/5

--- a/pkg/sql/mutation_test.go
+++ b/pkg/sql/mutation_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
+	"reflect"
 	"sync"
 	"testing"
 
@@ -263,8 +264,9 @@ PARTITION ALL BY LIST (r) (
 			if err := rows.Scan(&id, &k, &r, &a); err != nil {
 				t.Fatal(err)
 			}
-			if id != tc.expectedOutput[0] || k != tc.expectedOutput[1] || r != tc.expectedOutput[2] || a != tc.expectedOutput[3] {
-				t.Fatalf("%d: expected %v, got %v", idx, tc.expectedOutput, []string{id, k, r, a})
+			res := []string{id, k, r, a}
+			if !reflect.DeepEqual(tc.expectedOutput, res) {
+				t.Fatalf("%d: expected %v, got %v", idx, tc.expectedOutput, res)
 			}
 		}
 		rows.Close()


### PR DESCRIPTION
Previously, we didn't test blind overwrite using UPSERT into an implicitly partitioned table under read committed isolation. The behavior here is a bit unexpected because the PK isn't always rewritten, resulting in fewer tombstones than we might naively expect. This test makes note of what is supposed to happen.

Additionally, a cleanup of the UPSERT unit test didn't make it into the previous patch, so it's included here.

Release note: None