### PR TITLE
release-24.1: sql/colexec: fix projection and selections with constant NULL values

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -2699,6 +2699,7 @@ func planProjectionExpr(
 		resultIdx = len(typs)
 		// The projection result will be outputted to a new column which is
 		// appended to the input batch.
+		// TODO(#127814): We may need to handle the case when the left is DNull.
 		op, err = colexecprojconst.GetProjectionLConstOperator(
 			allocator, typs, left.ResolvedType(), outputType, projOp, input,
 			rightIdx, lConstArg, resultIdx, evalCtx, binOp, cmpExpr, calledOnNullInput,
@@ -2741,7 +2742,12 @@ func planProjectionExpr(
 			// The projection result will be outputted to a new column which is
 			// appended to the input batch.
 			resultIdx = len(typs)
-			if isCmpProjOp {
+			if !calledOnNullInput && right == tree.DNull {
+				// If the right is NULL and the operator is not called on NULL,
+				// simply project NULL.
+				op = colexecbase.NewConstNullOp(allocator, input, resultIdx)
+			} else if isCmpProjOp {
+				// Use optimized operators for special cases.
 				switch cmpProjOp.Symbol {
 				case treecmp.Like, treecmp.NotLike, treecmp.ILike, treecmp.NotILike:
 					negate, caseInsensitive := examineLikeOp(cmpProjOp)

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -2086,6 +2086,13 @@ func planSelectionOperators(
 		}
 		lTyp := ct[leftIdx]
 		if constArg, ok := t.Right.(tree.Datum); ok {
+			if !t.Op.CalledOnNullInput && constArg == tree.DNull {
+				// If the RHS is NULL and the operator is not called on NULL,
+				// the result will be NULL and the selection vector will always
+				// be empty. So we can simply plan a zero operator.
+				op = colexecutils.NewZeroOp(input)
+				return op, resultIdx, ct, err
+			}
 			switch cmpOp.Symbol {
 			case treecmp.Like, treecmp.NotLike, treecmp.ILike, treecmp.NotILike:
 				negate, caseInsensitive := examineLikeOp(cmpOp)

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -1054,3 +1054,23 @@ query B
 SELECT o NOT IN ((SELECT NULL FROM t127814_empty),) FROM t127814
 ----
 NULL
+
+# Regression test for #130759. The vectorized engine should correctly evaluate
+# IN expressions where the tuple on the RHS contains a single NULL value.
+statement ok
+CREATE TABLE t130759 (
+  i INT
+);
+
+statement ok
+INSERT INTO t130759 VALUES (0);
+
+query I
+SELECT 1
+FROM t130759
+WHERE NOT (
+  ('127.0.0.1'::INET - i) IN (
+    (SELECT NULL FROM (VALUES (0)) v(i) WHERE false),
+  )
+)
+----

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -1039,4 +1039,18 @@ LEFT JOIN LATERAL (
 row-1  row-1  {row-1}  1
 row-2  row-2  {row-2}  1
 
-subtest end
+# Regression test for #127814. The vectorized engine should correctly project
+# expressions operating on NULL.
+statement ok
+CREATE TABLE t127814_empty (i INT)
+
+statement ok
+CREATE TABLE t127814 (o OID)
+
+statement ok
+INSERT INTO t127814 VALUES (0)
+
+query B
+SELECT o NOT IN ((SELECT NULL FROM t127814_empty),) FROM t127814
+----
+NULL


### PR DESCRIPTION
Backport:
  * 1/1 commits from "colexec: fix projections with constant NULL values" (#128123)
  * 1/1 commits from "sql/colexec: fix selection comparisons with NULL" (#132261)

Please see individual PRs for details.

/cc @cockroachdb/release

---

Release justification: Low-risk bug fixes.
