### PR TITLE
sql: refactor generic query plan logic

### DIFF
--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -530,9 +530,7 @@ func (opc *optPlanningCtx) buildReusableMemo(
 //
 // The returned memo is only safe to use in one thread, during execution of the
 // current statement.
-func (opc *optPlanningCtx) reuseMemo(
-	ctx context.Context, cachedMemo *memo.Memo,
-) (*memo.Memo, error) {
+func (opc *optPlanningCtx) reuseMemo(cachedMemo *memo.Memo) (*memo.Memo, error) {
 	opc.incPlanTypeTelemetry(cachedMemo)
 	if cachedMemo.IsOptimized() {
 		// The query could have been already fully optimized in
@@ -713,7 +711,7 @@ func (opc *optPlanningCtx) fetchPreparedMemo(ctx context.Context) (_ *memo.Memo,
 	}
 	if validMemo != nil {
 		opc.log(ctx, "reusing cached memo")
-		return opc.reuseMemo(ctx, validMemo)
+		return opc.reuseMemo(validMemo)
 	}
 
 	// Otherwise, we need to rebuild the memo.
@@ -752,7 +750,7 @@ func (opc *optPlanningCtx) fetchPreparedMemo(ctx context.Context) (_ *memo.Memo,
 	}
 
 	// Re-optimize the memo, if necessary.
-	return opc.reuseMemo(ctx, newMemo)
+	return opc.reuseMemo(newMemo)
 }
 
 // buildExecMemo creates a fully optimized memo, possibly reusing a previously
@@ -766,7 +764,7 @@ func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ e
 		// rollback its transaction. Use resumeProc to resume execution in a new
 		// transaction where the control statement left off.
 		opc.log(ctx, "resuming stored procedure execution in a new transaction")
-		return opc.reuseMemo(ctx, resumeProc)
+		return opc.reuseMemo(resumeProc)
 	}
 
 	// Fetch and reuse a memo if a valid one is available.
@@ -800,7 +798,7 @@ func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ e
 				opc.log(ctx, "query cache hit")
 				opc.flags.Set(planFlagOptCacheHit)
 			}
-			return opc.reuseMemo(ctx, cachedData.Memo)
+			return opc.reuseMemo(cachedData.Memo)
 		}
 		opc.flags.Set(planFlagOptCacheMiss)
 		opc.log(ctx, "query cache miss")

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -755,34 +755,6 @@ func (opc *optPlanningCtx) fetchPreparedMemo(ctx context.Context) (_ *memo.Memo,
 	return opc.reuseMemo(ctx, newMemo)
 }
 
-// fetchPreparedMemoLegacy attempts to fetch a prepared memo. If a valid (i.e.,
-// non-stale) memo is found, it is used. Otherwise, a new statement will be
-// built. If memo reuse is not allowed, nil is returned.
-func (opc *optPlanningCtx) fetchPreparedMemoLegacy(ctx context.Context) (_ *memo.Memo, err error) {
-	prepared := opc.p.stmt.Prepared
-	p := opc.p
-	if opc.allowMemoReuse && prepared != nil && prepared.BaseMemo != nil {
-		// We are executing a previously prepared statement and a reusable memo is
-		// available.
-
-		// If the prepared memo has been invalidated by schema or other changes,
-		// re-prepare it.
-		if isStale, err := prepared.BaseMemo.IsStale(ctx, p.EvalContext(), opc.catalog); err != nil {
-			return nil, err
-		} else if isStale {
-			opc.log(ctx, "rebuilding cached memo")
-			prepared.BaseMemo, _, err = opc.buildReusableMemo(ctx, false /* buildGeneric */)
-			if err != nil {
-				return nil, err
-			}
-		}
-		opc.log(ctx, "reusing cached memo")
-		return opc.reuseMemo(ctx, prepared.BaseMemo)
-	}
-
-	return nil, nil
-}
-
 // buildExecMemo creates a fully optimized memo, possibly reusing a previously
 // cached memo as a starting point.
 //
@@ -797,29 +769,16 @@ func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ e
 		return opc.reuseMemo(ctx, resumeProc)
 	}
 
-	p := opc.p
-	if p.SessionData().PlanCacheMode == sessiondatapb.PlanCacheModeForceCustom {
-		// Fallback to the legacy logic for reusing memos if plan_cache_mode is
-		// set to force_custom_plan.
-		m, err := opc.fetchPreparedMemoLegacy(ctx)
-		if err != nil {
-			return nil, err
-		}
-		if m != nil {
-			return m, nil
-		}
-	} else {
-		// Use new logic for reusing memos if plan_cache_mode is set to
-		// force_generic_plan or auto.
-		m, err := opc.fetchPreparedMemo(ctx)
-		if err != nil {
-			return nil, err
-		}
-		if m != nil {
-			return m, nil
-		}
+	// Fetch and reuse a memo if a valid one is available.
+	m, err := opc.fetchPreparedMemo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if m != nil {
+		return m, nil
 	}
 
+	p := opc.p
 	if opc.useCache {
 		// Consult the query cache.
 		cachedData, ok := p.execCfg.QueryCache.Find(&p.queryCacheSession, opc.p.stmt.SQL)


### PR DESCRIPTION
#### sql: remove legacy planning code path

An optimization code path from before the introduction of generic query
plans has been removed. This code path remained in the codebase to
de-risk the generic query plans backports. It is not needed in future
versions.

Epic: None

Release note: None

#### sql: remove unused context parameter in `reuseMemo`

Release note: None
