### PR TITLE
kvserver: use the context from the proposal buf

### DIFF
--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -440,6 +440,7 @@ func (b *propBuf) FlushLockedWithRaftGroup(
 			log.Fatalf(ctx, "unexpected nil proposal in buffer")
 			return 0, nil // unreachable, for linter
 		}
+		ctx := p.Context()
 		reproposal := !p.tok.stillTracked()
 
 		// Conditionally reject the proposal based on the state of the raft group.


### PR DESCRIPTION
Previously the code in FlushLockedWithRaftGroup used the generic context for the replica rather than a specific one for the proposal. We have the proposal buffer in this method so we should use it instead. This will make SQL traces more meaningful.

Epic: none

Release note: None