### PR TITLE
admission: do not create snapshot pacer for nil queue

### DIFF
--- a/pkg/util/admission/snapshot_queue_test.go
+++ b/pkg/util/admission/snapshot_queue_test.go
@@ -136,12 +136,9 @@ func TestSnapshotPacer(t *testing.T) {
 	var pacer *SnapshotPacer = nil
 	// Should not panic on nil pacer.
 	require.NoError(t, pacer.Pace(ctx, 1, false))
-	// Should not panic on nil pacer.
-	pacer.Close()
 
 	q := &testingSnapshotQueue{}
-	pacer = NewSnapshotPacer(q, 1)
-	defer pacer.Close()
+	pacer = NewSnapshotPacer(q)
 
 	// Should not ask for admission since write bytes = burst size.
 	writeBytes := int64(SnapshotBurstSize)


### PR DESCRIPTION
Even though `Pace()` was checking for nil snapshot queue, it was asserting on the `snapshotRequester` interface, which would be non-nil even if the underlying queue was nil.

This patch moves the nil check outside of the pacer, and we don't create a pacer if the snapshot queue is nil.

Also, the `Close()` func was not doing any real work, so we remove that.

Fixes #132905.

Release note: None