### PR TITLE
release-24.2: roachprod: preserve error object in Get

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2221,13 +2221,10 @@ func (c *SyncedCluster) Put(
 		close(results)
 	}()
 
-	var errOnce sync.Once
 	var finalErr error
 	setErr := func(e error) {
-		if e != nil {
-			errOnce.Do(func() {
-				finalErr = e
-			})
+		if finalErr != nil {
+			finalErr = e
 		}
 	}
 
@@ -2571,15 +2568,21 @@ func (c *SyncedCluster) Get(
 		close(results)
 	}()
 
+	var finalErr error
+	setErr := func(e error) {
+		if finalErr != nil {
+			finalErr = e
+		}
+	}
+
 	defer spinner.Start()()
-	haveErr := false
 	for {
 		r, ok := <-results
 		if !ok {
 			break
 		}
 		if r.err != nil {
-			haveErr = true
+			setErr(r.err)
 			nodeTaskStatus(nodes[r.index], r.err.Error(), true)
 		} else {
 			nodeTaskStatus(nodes[r.index], "done", true)
@@ -2587,8 +2590,8 @@ func (c *SyncedCluster) Get(
 	}
 	spinner.MaybeLogTasks(l)
 
-	if haveErr {
-		return errors.Newf("get %s failed", src)
+	if finalErr != nil {
+		return errors.Wrapf(finalErr, "get %s failed", src)
 	}
 	return nil
 }


### PR DESCRIPTION
Backport 1/1 commits from #132478.

/cc @cockroachdb/release

---

We need to keep the error object so our ssh flake detection works.

Fixes: #132434
Release note: none
Epic: none

Release Justification: Test infra only change