### PR TITLE
schemachanger: add support discarding database/table zc

### DIFF
--- a/pkg/ccl/schemachangerccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/backup_base_generated_test.go
@@ -85,6 +85,13 @@ func TestBackupRollbacks_base_alter_database_configure_zone(t *testing.T) {
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_alter_database_configure_zone_discard(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_discard"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_alter_database_configure_zone_multiple(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -607,6 +614,13 @@ func TestBackupRollbacksMixedVersion_base_alter_database_configure_zone(t *testi
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_alter_database_configure_zone_discard(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_discard"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1135,6 +1149,13 @@ func TestBackupSuccess_base_alter_database_configure_zone(t *testing.T) {
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_alter_database_configure_zone_discard(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_discard"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_alter_database_configure_zone_multiple(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1657,6 +1678,13 @@ func TestBackupSuccessMixedVersion_base_alter_database_configure_zone(t *testing
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_alter_database_configure_zone_discard(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_discard"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -551,13 +551,13 @@ ORDER BY "timestamp", info
 
 skipif config 3node-tenant-default-configs
 query IT
-SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID' - 'Statement'
 FROM system.eventlog
 WHERE "eventType" = 'remove_zone_config'
 ORDER BY "timestamp", info
 ----
-1  {"EventType": "remove_zone_config", "Statement": "ALTER DATABASE test CONFIGURE ZONE DISCARD", "Tag": "CONFIGURE ZONE", "Target": "DATABASE test", "User": "root"}
-1  {"EventType": "remove_zone_config", "Statement": "ALTER TABLE \"\".\"\".a CONFIGURE ZONE DISCARD", "Tag": "CONFIGURE ZONE", "Target": "TABLE test.public.a", "User": "root"}
+1  {"EventType": "remove_zone_config", "Tag": "CONFIGURE ZONE", "Target": "DATABASE test", "User": "root"}
+1  {"EventType": "remove_zone_config", "Tag": "CONFIGURE ZONE", "Target": "TABLE test.public.a", "User": "root"}
 
 statement ok
 DROP TABLE a

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -303,10 +303,6 @@ onlyif config local-legacy-schema-changer
 statement error pq: user root does not have CREATE or ZONECONFIG privilege on relation columns
 ALTER TABLE information_schema.columns CONFIGURE ZONE USING gc.ttlseconds = 100000
 
-# TODO(annie): remove this override once CONFIGURE ZONE is enabled by default in the DSC
-statement ok
-SET CLUSTER SETTING sql.schema.force_declarative_statements = "+CONFIGURE ZONE"
-
 skipif config local-mixed-24.1
 skipif config local-mixed-24.2
 skipif config local-legacy-schema-changer
@@ -318,9 +314,6 @@ skipif config local-mixed-24.2
 skipif config local-legacy-schema-changer
 statement error pq: columns is a virtual object and cannot be modified
 ALTER TABLE information_schema.columns CONFIGURE ZONE USING gc.ttlseconds = 100000
-
-statement ok
-RESET CLUSTER SETTING sql.schema.force_declarative_statements
 
 statement ok
 CREATE TABLE roachie(i int)

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -308,11 +308,13 @@ statement ok
 SET CLUSTER SETTING sql.schema.force_declarative_statements = "+CONFIGURE ZONE"
 
 skipif config local-mixed-24.1
+skipif config local-mixed-24.2
 skipif config local-legacy-schema-changer
 statement error pq: pg_type is a system catalog
 ALTER TABLE pg_catalog.pg_type CONFIGURE ZONE USING gc.ttlseconds = 100000
 
 skipif config local-mixed-24.1
+skipif config local-mixed-24.2
 skipif config local-legacy-schema-changer
 statement error pq: columns is a virtual object and cannot be modified
 ALTER TABLE information_schema.columns CONFIGURE ZONE USING gc.ttlseconds = 100000

--- a/pkg/sql/schemachanger/scbuild/event_log.go
+++ b/pkg/sql/schemachanger/scbuild/event_log.go
@@ -467,16 +467,30 @@ func (pb payloadBuilder) build(b buildCtx) logpb.EventPayload {
 			var zcDetails eventpb.CommonZoneConfigDetails
 			var oldConfig string
 			if pb.maybePayload != nil {
-				payload := pb.maybePayload.(*eventpb.SetZoneConfig)
-				zcDetails = eventpb.CommonZoneConfigDetails{
-					Target:  payload.Target,
-					Options: payload.Options,
+				if payload, ok := pb.maybePayload.(*eventpb.SetZoneConfig); ok {
+					zcDetails = eventpb.CommonZoneConfigDetails{
+						Target:  payload.Target,
+						Options: payload.Options,
+					}
+					oldConfig = payload.ResolvedOldConfig
 				}
-				oldConfig = payload.ResolvedOldConfig
 			}
 			return &eventpb.SetZoneConfig{
 				CommonZoneConfigDetails: zcDetails,
 				ResolvedOldConfig:       oldConfig,
+			}
+		} else {
+			var zcDetails eventpb.CommonZoneConfigDetails
+			if pb.maybePayload != nil {
+				if payload, ok := pb.maybePayload.(*eventpb.RemoveZoneConfig); ok {
+					zcDetails = eventpb.CommonZoneConfigDetails{
+						Target:  payload.Target,
+						Options: payload.Options,
+					}
+				}
+			}
+			return &eventpb.RemoveZoneConfig{
+				CommonZoneConfigDetails: zcDetails,
 			}
 		}
 	case *scpb.Trigger:

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/configure_zone.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/configure_zone.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/errors"
 )
 
@@ -83,6 +84,11 @@ func SetZoneConfig(b BuildCtx, n *tree.SetZoneConfig) {
 
 	var elem scpb.Element
 	if n.Discard {
+		// If we are discarding the zone config and a zone config did not previously
+		// exist for us to discard, then no-op.
+		if zco.isNoOp() {
+			return
+		}
 		elem = zco.getZoneConfigElem(b)
 		b.Drop(elem)
 	} else {
@@ -96,16 +102,18 @@ func SetZoneConfig(b BuildCtx, n *tree.SetZoneConfig) {
 		Target:  tree.AsString(&n.ZoneSpecifier),
 		Options: optionsStr,
 	}
-	info := &eventpb.SetZoneConfig{CommonZoneConfigDetails: eventDetails,
-		ResolvedOldConfig: oldZone.String()}
+
+	var info logpb.EventPayload
+	if n.Discard {
+		info = &eventpb.RemoveZoneConfig{CommonZoneConfigDetails: eventDetails}
+	} else {
+		info = &eventpb.SetZoneConfig{CommonZoneConfigDetails: eventDetails,
+			ResolvedOldConfig: oldZone.String()}
+	}
 	b.LogEventForExistingPayload(elem, info)
 }
 
 func astToZoneConfigObject(b BuildCtx, n *tree.SetZoneConfig) (zoneConfigObject, error) {
-	if n.Discard {
-		return nil, scerrors.NotImplementedErrorf(n, "discarding zone configurations is not "+
-			"supported in the DSC")
-	}
 	zs := n.ZoneSpecifier
 	// We are a database object.
 	if n.Database != "" {
@@ -159,6 +167,13 @@ func astToZoneConfigObject(b BuildCtx, n *tree.SetZoneConfig) (zoneConfigObject,
 	// We are a table object.
 	if n.TargetsTable() && !n.TargetsIndex() && !n.TargetsPartition() {
 		return &tzo, nil
+	}
+
+	// TODO(annie): remove this when we add support for discarding subzone
+	// configs.
+	if n.Discard {
+		return nil, scerrors.NotImplementedErrorf(n, "discarding zone configurations on "+
+			"subzones are not supported in the DSC")
 	}
 
 	izo := indexZoneConfigObj{tableZoneConfigObj: tzo}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/configure_zone.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/configure_zone.go
@@ -81,7 +81,15 @@ func SetZoneConfig(b BuildCtx, n *tree.SetZoneConfig) {
 		resolvePhysicalTableName(b, n)
 	}
 
-	elem := zco.addZoneConfigToBuildCtx(b)
+	var elem scpb.Element
+	if n.Discard {
+		elem = zco.getZoneConfigElem(b)
+		b.Drop(elem)
+	} else {
+		zco.incrementSeqNum()
+		elem = zco.getZoneConfigElem(b)
+		b.Add(elem)
+	}
 
 	// Log event for auditing
 	eventDetails := eventpb.CommonZoneConfigDetails{

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/database_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/database_zone_config.go
@@ -31,6 +31,10 @@ func (dzo *databaseZoneConfigObj) incrementSeqNum() {
 	dzo.seqNum += 1
 }
 
+func (dzo *databaseZoneConfigObj) isNoOp() bool {
+	return dzo.zoneConfig == nil
+}
+
 func (dzo *databaseZoneConfigObj) getZoneConfigElem(b BuildCtx) scpb.Element {
 	elem := &scpb.DatabaseZoneConfig{
 		DatabaseID: dzo.databaseID,
@@ -89,7 +93,7 @@ func (dzo *databaseZoneConfigObj) checkZoneConfigChangePermittedForMultiRegion(
 		return nil
 	}
 
-	return maybeMultiregionErrorWithHint(options)
+	return maybeMultiregionErrorWithHint(b, dzo, options)
 }
 
 func (dzo *databaseZoneConfigObj) getTargetID() catid.DescID {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/database_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/database_zone_config.go
@@ -27,14 +27,16 @@ type databaseZoneConfigObj struct {
 
 var _ zoneConfigObject = &databaseZoneConfigObj{}
 
-func (dzo *databaseZoneConfigObj) addZoneConfigToBuildCtx(b BuildCtx) scpb.Element {
+func (dzo *databaseZoneConfigObj) incrementSeqNum() {
 	dzo.seqNum += 1
+}
+
+func (dzo *databaseZoneConfigObj) getZoneConfigElem(b BuildCtx) scpb.Element {
 	elem := &scpb.DatabaseZoneConfig{
 		DatabaseID: dzo.databaseID,
 		ZoneConfig: dzo.zoneConfig,
 		SeqNum:     dzo.seqNum,
 	}
-	b.Add(elem)
 	return elem
 }
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/index_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/index_zone_config.go
@@ -22,7 +22,6 @@ type indexZoneConfigObj struct {
 	tableZoneConfigObj
 	indexID      catid.IndexID
 	indexSubzone *zonepb.Subzone
-	seqNum       uint32
 }
 
 var _ zoneConfigObject = &indexZoneConfigObj{}
@@ -31,8 +30,7 @@ func (izo *indexZoneConfigObj) getTableZoneConfig() *zonepb.ZoneConfig {
 	return izo.tableZoneConfigObj.zoneConfig
 }
 
-func (izo *indexZoneConfigObj) addZoneConfigToBuildCtx(b BuildCtx) scpb.Element {
-	izo.seqNum += 1
+func (izo *indexZoneConfigObj) getZoneConfigElem(b BuildCtx) scpb.Element {
 	subzones := []zonepb.Subzone{*izo.indexSubzone}
 
 	// Merge the new subzones with the old subzones so that we can generate
@@ -55,7 +53,6 @@ func (izo *indexZoneConfigObj) addZoneConfigToBuildCtx(b BuildCtx) scpb.Element 
 		SubzoneSpans: ss,
 		SeqNum:       izo.seqNum,
 	}
-	b.Add(elem)
 	return elem
 }
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/index_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/index_zone_config.go
@@ -26,6 +26,10 @@ type indexZoneConfigObj struct {
 
 var _ zoneConfigObject = &indexZoneConfigObj{}
 
+func (izo *indexZoneConfigObj) isNoOp() bool {
+	return izo.indexSubzone == nil
+}
+
 func (izo *indexZoneConfigObj) getTableZoneConfig() *zonepb.ZoneConfig {
 	return izo.tableZoneConfigObj.zoneConfig
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/partition_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/partition_zone_config.go
@@ -26,7 +26,6 @@ type partitionZoneConfigObj struct {
 	indexZoneConfigObj
 	partitionSubzone *zonepb.Subzone
 	partitionName    string
-	seqNum           uint32
 }
 
 var _ zoneConfigObject = &partitionZoneConfigObj{}
@@ -35,8 +34,7 @@ func (pzo *partitionZoneConfigObj) getTableZoneConfig() *zonepb.ZoneConfig {
 	return pzo.tableZoneConfigObj.zoneConfig
 }
 
-func (pzo *partitionZoneConfigObj) addZoneConfigToBuildCtx(b BuildCtx) scpb.Element {
-	pzo.seqNum += 1
+func (pzo *partitionZoneConfigObj) getZoneConfigElem(b BuildCtx) scpb.Element {
 	subzones := []zonepb.Subzone{*pzo.partitionSubzone}
 
 	// Merge the new subzones with the old subzones so that we can generate
@@ -60,7 +58,6 @@ func (pzo *partitionZoneConfigObj) addZoneConfigToBuildCtx(b BuildCtx) scpb.Elem
 		SubzoneSpans:  ss,
 		SeqNum:        pzo.seqNum,
 	}
-	b.Add(elem)
 	return elem
 }
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/partition_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/partition_zone_config.go
@@ -30,6 +30,10 @@ type partitionZoneConfigObj struct {
 
 var _ zoneConfigObject = &partitionZoneConfigObj{}
 
+func (pzo *partitionZoneConfigObj) isNoOp() bool {
+	return pzo.partitionSubzone == nil
+}
+
 func (pzo *partitionZoneConfigObj) getTableZoneConfig() *zonepb.ZoneConfig {
 	return pzo.tableZoneConfigObj.zoneConfig
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
@@ -63,7 +63,7 @@ var supportedStatements = map[reflect.Type]supportedStatement{
 	reflect.TypeOf((*tree.CreateSchema)(nil)):        {fn: CreateSchema, statementTags: []string{tree.CreateSchemaTag}, on: true, checks: nil},
 	reflect.TypeOf((*tree.CreateSequence)(nil)):      {fn: CreateSequence, statementTags: []string{tree.CreateSequenceTag}, on: true, checks: isV241Active},
 	reflect.TypeOf((*tree.CreateDatabase)(nil)):      {fn: CreateDatabase, statementTags: []string{tree.CreateDatabaseTag}, on: true, checks: isV241Active},
-	reflect.TypeOf((*tree.SetZoneConfig)(nil)):       {fn: SetZoneConfig, statementTags: []string{tree.ConfigureZoneTag}, on: false, checks: isV243Active},
+	reflect.TypeOf((*tree.SetZoneConfig)(nil)):       {fn: SetZoneConfig, statementTags: []string{tree.ConfigureZoneTag}, on: true, checks: isV243Active},
 	reflect.TypeOf((*tree.CreateTrigger)(nil)):       {fn: CreateTrigger, statementTags: []string{tree.CreateTriggerTag}, on: true, checks: isV243Active},
 	reflect.TypeOf((*tree.DropTrigger)(nil)):         {fn: DropTrigger, statementTags: []string{tree.DropTriggerTag}, on: true, checks: isV243Active},
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
@@ -63,7 +63,7 @@ var supportedStatements = map[reflect.Type]supportedStatement{
 	reflect.TypeOf((*tree.CreateSchema)(nil)):        {fn: CreateSchema, statementTags: []string{tree.CreateSchemaTag}, on: true, checks: nil},
 	reflect.TypeOf((*tree.CreateSequence)(nil)):      {fn: CreateSequence, statementTags: []string{tree.CreateSequenceTag}, on: true, checks: isV241Active},
 	reflect.TypeOf((*tree.CreateDatabase)(nil)):      {fn: CreateDatabase, statementTags: []string{tree.CreateDatabaseTag}, on: true, checks: isV241Active},
-	reflect.TypeOf((*tree.SetZoneConfig)(nil)):       {fn: SetZoneConfig, statementTags: []string{tree.ConfigureZoneTag}, on: false, checks: isV242Active},
+	reflect.TypeOf((*tree.SetZoneConfig)(nil)):       {fn: SetZoneConfig, statementTags: []string{tree.ConfigureZoneTag}, on: false, checks: isV243Active},
 	reflect.TypeOf((*tree.CreateTrigger)(nil)):       {fn: CreateTrigger, statementTags: []string{tree.CreateTriggerTag}, on: true, checks: isV243Active},
 	reflect.TypeOf((*tree.DropTrigger)(nil)):         {fn: DropTrigger, statementTags: []string{tree.DropTriggerTag}, on: true, checks: isV243Active},
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/table_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/table_zone_config.go
@@ -28,6 +28,10 @@ type tableZoneConfigObj struct {
 
 var _ zoneConfigObject = &tableZoneConfigObj{}
 
+func (tzo *tableZoneConfigObj) isNoOp() bool {
+	return tzo.zoneConfig == nil
+}
+
 func (tzo *tableZoneConfigObj) getZoneConfigElem(b BuildCtx) scpb.Element {
 	elem := &scpb.TableZoneConfig{
 		TableID:    tzo.tableID,
@@ -88,7 +92,7 @@ func (tzo *tableZoneConfigObj) checkZoneConfigChangePermittedForMultiRegion(
 		return nil
 	}
 
-	return maybeMultiregionErrorWithHint(options)
+	return maybeMultiregionErrorWithHint(b, tzo, options)
 }
 
 func (tzo *tableZoneConfigObj) getTargetID() catid.DescID {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/table_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/table_zone_config.go
@@ -24,19 +24,16 @@ type tableZoneConfigObj struct {
 	databaseZoneConfigObj
 	tableID    catid.DescID
 	zoneConfig *zonepb.ZoneConfig
-	seqNum     uint32
 }
 
 var _ zoneConfigObject = &tableZoneConfigObj{}
 
-func (tzo *tableZoneConfigObj) addZoneConfigToBuildCtx(b BuildCtx) scpb.Element {
-	tzo.seqNum += 1
+func (tzo *tableZoneConfigObj) getZoneConfigElem(b BuildCtx) scpb.Element {
 	elem := &scpb.TableZoneConfig{
 		TableID:    tzo.tableID,
 		ZoneConfig: tzo.zoneConfig,
 		SeqNum:     tzo.seqNum,
 	}
-	b.Add(elem)
 	return elem
 }
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
@@ -74,6 +74,10 @@ type zoneConfigObjBuilder interface {
 
 	// incrementSeqNum increments the seqNum by 1.
 	incrementSeqNum()
+
+	// isNoOp returns true if the zone config object is a no-op. This is defined
+	// by our object having no zone config yet.
+	isNoOp() bool
 }
 
 type zoneConfigRetriever interface {
@@ -156,8 +160,37 @@ func resolvePhysicalTableName(b BuildCtx, n *tree.SetZoneConfig) {
 
 // maybeMultiregionErrorWithHint returns an error if the user is trying to
 // update a zone config value that's protected for multi-region databases.
-func maybeMultiregionErrorWithHint(options tree.KVOptions) error {
+func maybeMultiregionErrorWithHint(b BuildCtx, zco zoneConfigObject, options tree.KVOptions) error {
 	hint := "to override this error, SET override_multi_region_zone_config = true and reissue the command"
+	// The request is to discard the zone configuration. Error in cases where
+	// the zone configuration being discarded was created by the multi-region
+	// abstractions.
+	if options == nil {
+		needToError := false
+		// Determine if this zone config that we're trying to discard is
+		// supposed to be there. zco is either a database or a table.
+		_, isDB := zco.(*databaseZoneConfigObj)
+		if isDB {
+			needToError = true
+		} else {
+			var err error
+			needToError, err = blockDiscardOfZoneConfigForMultiRegionObject(b, zco.getTargetID())
+			if err != nil {
+				return err
+			}
+		}
+
+		if needToError {
+			// User is trying to update a zone config value that's protected for
+			// multi-region databases. Return the constructed error.
+			err := errors.WithDetail(errors.Newf(
+				"attempting to discard the zone configuration of a multi-region entity"),
+				"discarding a multi-region zone configuration may result in sub-optimal performance or behavior",
+			)
+			return errors.WithHint(err, hint)
+		}
+	}
+
 	// This is clearly an n^2 operation, but since there are only a single
 	// digit number of zone config keys, it's likely faster to do it this way
 	// than incur the memory allocation of creating a map.
@@ -174,6 +207,44 @@ func maybeMultiregionErrorWithHint(options tree.KVOptions) error {
 		}
 	}
 	return nil
+}
+
+// blockDiscardOfZoneConfigForMultiRegionObject determines if discarding the
+// zone configuration of a multi-region table, index or partition should be
+// blocked. We only block the discard if the multi-region abstractions have
+// created the zone configuration. Note that this function relies on internal
+// knowledge of which table locality patterns write zone configurations. We do
+// things this way to avoid having to read the zone configurations directly and
+// do a more explicit comparison (with a generated zone configuration). If, down
+// the road, the rules around writing zone configurations change, the tests in
+// multi_region_zone_configs will fail and this function will need updating.
+func blockDiscardOfZoneConfigForMultiRegionObject(b BuildCtx, tblID catid.DescID) (bool, error) {
+	tableElems := b.QueryByID(tblID)
+
+	// It's a table zone config that the user is trying to discard. This
+	// should only be present on GLOBAL and REGIONAL BY TABLE tables in a
+	// specified region.
+	globalElem := tableElems.FilterTableLocalityGlobal().MustGetZeroOrOneElement()
+	primaryRegionElem := tableElems.FilterTableLocalityPrimaryRegion().MustGetZeroOrOneElement()
+	secondaryRegionElem := tableElems.FilterTableLocalitySecondaryRegion().MustGetZeroOrOneElement()
+	RBRElem := tableElems.FilterTableLocalityRegionalByRow().MustGetZeroOrOneElement()
+
+	if globalElem != nil {
+		return true, nil
+	} else if secondaryRegionElem != nil {
+		return true, nil
+	} else if primaryRegionElem != nil {
+		// For REGIONAL BY TABLE tables, no need to error if a user-specified
+		// region does not exist.
+		return false, nil
+	} else if RBRElem != nil {
+		// For REGIONAL BY ROW tables, no need to error if we're setting a
+		// table level zone config.
+		return false, nil
+	} else {
+		return false, errors.AssertionFailedf(
+			"unknown table locality %s", b.QueryByID(tblID))
+	}
 }
 
 // isMultiRegionTable returns True if this table is a multi-region table,
@@ -1020,6 +1091,11 @@ func prepareZoneConfig(
 
 	// No zone was found. Use an empty zone config that inherits from its parent.
 	if partialZone == nil {
+		// If we are trying to discard a zone config that doesn't exist in
+		// system.zones, make this a no-op.
+		if n.Discard {
+			return nil, nil, nil
+		}
 		partialZone = zonepb.NewZoneConfig()
 	}
 	currentZone := protoutil.Clone(partialZone).(*zonepb.ZoneConfig)
@@ -1049,6 +1125,11 @@ func prepareZoneConfig(
 			return nil, nil, err
 		}
 		partialZone.CopyFromZone(zoneInheritedFields, copyFromParentList)
+	}
+
+	if n.Discard {
+		partialZone.DeleteTableConfig()
+		return nil, partialZone, nil
 	}
 
 	// Determine where to load the configuration.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
@@ -52,9 +52,8 @@ type zoneConfigAuthorizer interface {
 }
 
 type zoneConfigObjBuilder interface {
-	// addZoneConfigToBuildCtx adds the zone config to the build context and
-	// returns the added element for logging.
-	addZoneConfigToBuildCtx(b BuildCtx) scpb.Element
+	// getZoneConfigElem retrieves the scpb.Element for the zone config object.
+	getZoneConfigElem(b BuildCtx) scpb.Element
 
 	// getTargetID returns the target ID of the zone config object. This is either
 	// a database or a table ID.
@@ -72,6 +71,9 @@ type zoneConfigObjBuilder interface {
 	// setZoneConfigToWrite fills our object with the zone config/subzone config
 	// we will be writing to KV.
 	setZoneConfigToWrite(zone *zonepb.ZoneConfig)
+
+	// incrementSeqNum increments the seqNum by 1.
+	incrementSeqNum()
 }
 
 type zoneConfigRetriever interface {

--- a/pkg/sql/schemachanger/scexec/scmutationexec/BUILD.bazel
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "stats.go",
         "table.go",
         "trigger.go",
+        "zone_config.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec/scmutationexec",
     visibility = ["//visibility:public"],

--- a/pkg/sql/schemachanger/scexec/scmutationexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/dependencies.go
@@ -78,11 +78,16 @@ type ImmediateMutationStateUpdater interface {
 	// InitSequence initializes a sequence.
 	InitSequence(id descpb.ID, startVal int64)
 
-	// UpdateZoneConfig updates a zone config.
+	// UpdateZoneConfig upserts a zone config.
 	UpdateZoneConfig(id descpb.ID, zc *zonepb.ZoneConfig)
 
-	// UpdateSubzoneConfig updates subzone zone configs.
-	UpdateSubzoneConfig(tableid descpb.ID, subzone zonepb.Subzone, subzoneSpans []zonepb.SubzoneSpan)
+	// UpdateSubzoneConfig upserts a subzone config.
+	UpdateSubzoneConfig(
+		tableid descpb.ID, subzone zonepb.Subzone, subzoneSpans []zonepb.SubzoneSpan,
+	)
+
+	// DeleteZoneConfig deletes the zone config for the given ID.
+	DeleteZoneConfig(id descpb.ID)
 
 	// Reset schedules a reset of the in-txn catalog state
 	// to undo the modifications from earlier stages.

--- a/pkg/sql/schemachanger/scexec/scmutationexec/zone_config.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/zone_config.go
@@ -1,0 +1,22 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package scmutationexec
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
+)
+
+func (i *immediateVisitor) DiscardZoneConfig(ctx context.Context, op scop.DiscardZoneConfig) error {
+	zc := op.ZoneConfig
+	if zc.IsSubzonePlaceholder() && len(zc.Subzones) == 0 {
+		i.ImmediateMutationStateUpdater.DeleteZoneConfig(op.DescID)
+	} else {
+		i.ImmediateMutationStateUpdater.UpdateZoneConfig(op.DescID, zc)
+	}
+	return nil
+}

--- a/pkg/sql/schemachanger/scop/immediate_mutation.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation.go
@@ -995,6 +995,13 @@ type AddDatabaseZoneConfig struct {
 	ZoneConfig *zonepb.ZoneConfig
 }
 
+// DiscardZoneConfig discards the zone config for the given descriptor ID.
+type DiscardZoneConfig struct {
+	immediateMutationOp
+	DescID     descpb.ID
+	ZoneConfig *zonepb.ZoneConfig
+}
+
 // AddTableZoneConfig adds a zone config to a table.
 type AddTableZoneConfig struct {
 	immediateMutationOp

--- a/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
@@ -146,6 +146,7 @@ type ImmediateMutationVisitor interface {
 	InitSequence(context.Context, InitSequence) error
 	CreateDatabaseDescriptor(context.Context, CreateDatabaseDescriptor) error
 	AddDatabaseZoneConfig(context.Context, AddDatabaseZoneConfig) error
+	DiscardZoneConfig(context.Context, DiscardZoneConfig) error
 	AddTableZoneConfig(context.Context, AddTableZoneConfig) error
 	AddIndexZoneConfig(context.Context, AddIndexZoneConfig) error
 	AddPartitionZoneConfig(context.Context, AddPartitionZoneConfig) error
@@ -794,6 +795,11 @@ func (op CreateDatabaseDescriptor) Visit(ctx context.Context, v ImmediateMutatio
 // Visit is part of the ImmediateMutationOp interface.
 func (op AddDatabaseZoneConfig) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
 	return v.AddDatabaseZoneConfig(ctx, op)
+}
+
+// Visit is part of the ImmediateMutationOp interface.
+func (op DiscardZoneConfig) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
+	return v.DiscardZoneConfig(ctx, op)
 }
 
 // Visit is part of the ImmediateMutationOp interface.

--- a/pkg/sql/schemachanger/scpb/element_collection.go
+++ b/pkg/sql/schemachanger/scpb/element_collection.go
@@ -6,6 +6,9 @@
 package scpb
 
 import (
+	"fmt"
+	"reflect"
+
 	"github.com/cockroachdb/cockroach/pkg/util/debugutil"
 	"github.com/cockroachdb/errors"
 )
@@ -272,4 +275,13 @@ func (c *ElementCollection[E]) MustHaveZeroOrOne() *ElementCollection[E] {
 		panic(errors.AssertionFailedf("expected element collection size 0 or 1, not %d", c.Size()))
 	}
 	return c
+}
+
+func (c *ElementCollection[E]) String() string {
+	var result string
+	for _, element := range c.Elements() {
+		elemType := reflect.TypeOf(element).Elem()
+		result += fmt.Sprintf("%s:{%+v}\n", elemType.Name(), element)
+	}
+	return result
 }

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_database_zone_config.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_database_zone_config.go
@@ -26,8 +26,11 @@ func init() {
 		toAbsent(
 			scpb.Status_PUBLIC,
 			to(scpb.Status_ABSENT,
-				emit(func(this *scpb.DatabaseZoneConfig) *scop.NotImplementedForPublicObjects {
-					return notImplementedForPublicObjects(this)
+				emit(func(this *scpb.DatabaseZoneConfig) *scop.DiscardZoneConfig {
+					return &scop.DiscardZoneConfig{
+						DescID:     this.DatabaseID,
+						ZoneConfig: this.ZoneConfig,
+					}
 				}),
 			),
 		),

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_table_zone_config.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_table_zone_config.go
@@ -26,8 +26,11 @@ func init() {
 		toAbsent(
 			scpb.Status_PUBLIC,
 			to(scpb.Status_ABSENT,
-				emit(func(this *scpb.TableZoneConfig) *scop.NotImplementedForPublicObjects {
-					return notImplementedForPublicObjects(this)
+				emit(func(this *scpb.TableZoneConfig) *scop.DiscardZoneConfig {
+					return &scop.DiscardZoneConfig{
+						DescID:     this.TableID,
+						ZoneConfig: this.ZoneConfig,
+					}
 				}),
 			),
 		),

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -85,6 +85,13 @@ func TestEndToEndSideEffects_alter_database_configure_zone(t *testing.T) {
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_alter_database_configure_zone_discard(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_discard"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_alter_database_configure_zone_multiple(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -607,6 +614,13 @@ func TestExecuteWithDMLInjection_alter_database_configure_zone(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_alter_database_configure_zone_discard(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_discard"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1135,6 +1149,13 @@ func TestGenerateSchemaChangeCorpus_alter_database_configure_zone(t *testing.T) 
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_alter_database_configure_zone_discard(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_discard"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_alter_database_configure_zone_multiple(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1657,6 +1678,13 @@ func TestPause_alter_database_configure_zone(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_alter_database_configure_zone_discard(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_discard"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2185,6 +2213,13 @@ func TestPauseMixedVersion_alter_database_configure_zone(t *testing.T) {
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_alter_database_configure_zone_discard(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_discard"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_alter_database_configure_zone_multiple(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2707,6 +2742,13 @@ func TestRollback_alter_database_configure_zone(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_alter_database_configure_zone_discard(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_discard"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_discard/alter_database_configure_zone_discard.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_discard/alter_database_configure_zone_discard.definition
@@ -1,0 +1,8 @@
+setup
+CREATE DATABASE db;
+----
+
+test
+ALTER DATABASE db CONFIGURE ZONE USING num_replicas = 7, gc.ttlseconds = 10000;
+ALTER DATABASE db CONFIGURE ZONE DISCARD;
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_discard/alter_database_configure_zone_discard.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_discard/alter_database_configure_zone_discard.side_effects
@@ -1,0 +1,46 @@
+/* setup */
+CREATE DATABASE db;
+----
+...
++database {0 0 db} -> 104
++schema {104 0 public} -> 105
+
+/* test */
+ALTER DATABASE db CONFIGURE ZONE USING num_replicas = 7, gc.ttlseconds = 10000;
+ALTER DATABASE db CONFIGURE ZONE DISCARD;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: CONFIGURE ZONE
+write *eventpb.SetZoneConfig to event log:
+  config:
+    options:
+    - '"gc.ttlseconds" = 10000'
+    - num_replicas = 7
+    target: DATABASE db
+  resolvedOldConfig: 'range_min_bytes:134217728 range_max_bytes:536870912 gc:<ttl_seconds:14400 > num_replicas:5 inherited_constraints:false null_voter_constraints_is_empty:true inherited_lease_preferences:false '
+  sql:
+    descriptorId: 104
+    statement: ALTER DATABASE ‹db› CONFIGURE ZONE USING ‹num_replicas› = ‹7›, ‹"gc.ttlseconds"› = ‹10000›
+    tag: CONFIGURE ZONE
+    user: root
+## StatementPhase stage 1 of 1 with 1 MutationType op
+upsert zone config for #104
+checking for feature: CONFIGURE ZONE
+write *eventpb.RemoveZoneConfig to event log:
+  config:
+    target: DATABASE db
+  sql:
+    descriptorId: 104
+    statement: ALTER DATABASE ‹db› CONFIGURE ZONE DISCARD
+    tag: CONFIGURE ZONE
+    user: root
+## StatementPhase stage 1 of 1 with 1 MutationType op
+deleting zone config for #104
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 1 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+# end PreCommitPhase
+commit transaction #1

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_discard/alter_database_configure_zone_discard__statement_1_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_discard/alter_database_configure_zone_discard__statement_1_of_2.explain
@@ -1,0 +1,24 @@
+/* setup */
+CREATE DATABASE db;
+
+/* test */
+EXPLAIN (DDL) ALTER DATABASE db CONFIGURE ZONE USING num_replicas = 7, gc.ttlseconds = 10000;
+----
+Schema change plan for ALTER DATABASE ‹db› CONFIGURE ZONE USING ‹num_replicas› = ‹7›, ‹"gc.ttlseconds"› = ‹10000›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → PUBLIC DatabaseZoneConfig:{DescID: 104 (db), SeqNum: 1}
+ │         └── 1 Mutation operation
+ │              └── AddDatabaseZoneConfig {"DatabaseID":104}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── PUBLIC → ABSENT DatabaseZoneConfig:{DescID: 104 (db), SeqNum: 1}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 1 element transitioning toward PUBLIC
+           │    └── ABSENT → PUBLIC DatabaseZoneConfig:{DescID: 104 (db), SeqNum: 1}
+           └── 1 Mutation operation
+                └── AddDatabaseZoneConfig {"DatabaseID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_discard/alter_database_configure_zone_discard__statement_1_of_2.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_discard/alter_database_configure_zone_discard__statement_1_of_2.explain_shape
@@ -1,0 +1,8 @@
+/* setup */
+CREATE DATABASE db;
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER DATABASE db CONFIGURE ZONE USING num_replicas = 7, gc.ttlseconds = 10000;
+----
+Schema change plan for ALTER DATABASE ‹db› CONFIGURE ZONE USING ‹num_replicas› = ‹7›, ‹"gc.ttlseconds"› = ‹10000›;
+ └── execute 1 system table mutations transaction

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_discard/alter_database_configure_zone_discard__statement_2_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_discard/alter_database_configure_zone_discard__statement_2_of_2.explain
@@ -1,0 +1,18 @@
+/* setup */
+CREATE DATABASE db;
+
+/* test */
+ALTER DATABASE db CONFIGURE ZONE USING num_replicas = 7, gc.ttlseconds = 10000;
+EXPLAIN (DDL) ALTER DATABASE db CONFIGURE ZONE DISCARD;
+----
+Schema change plan for ALTER DATABASE ‹db› CONFIGURE ZONE DISCARD; following ALTER DATABASE ‹db› CONFIGURE ZONE USING ‹num_replicas› = ‹7›, ‹"gc.ttlseconds"› = ‹10000›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward ABSENT
+ │         │    └── PUBLIC → ABSENT DatabaseZoneConfig:{DescID: 104 (db), SeqNum: 1}
+ │         └── 1 Mutation operation
+ │              └── DiscardZoneConfig {"DescID":104}
+ └── PreCommitPhase
+      └── Stage 1 of 1 in PreCommitPhase
+           └── 1 Mutation operation
+                └── UndoAllInTxnImmediateMutationOpSideEffects

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_discard/alter_database_configure_zone_discard__statement_2_of_2.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_database_configure_zone_discard/alter_database_configure_zone_discard__statement_2_of_2.explain_shape
@@ -1,0 +1,9 @@
+/* setup */
+CREATE DATABASE db;
+
+/* test */
+ALTER DATABASE db CONFIGURE ZONE USING num_replicas = 7, gc.ttlseconds = 10000;
+EXPLAIN (DDL, SHAPE) ALTER DATABASE db CONFIGURE ZONE DISCARD;
+----
+Schema change plan for ALTER DATABASE ‹db› CONFIGURE ZONE DISCARD; following ALTER DATABASE ‹db› CONFIGURE ZONE USING ‹num_replicas› = ‹7›, ‹"gc.ttlseconds"› = ‹10000›;
+ └── execute 1 system table mutations transaction


### PR DESCRIPTION
### scbuild: version gate SetZoneConfig with isV243Active
New support was added in 24.3 in `SetZoneConfig` for subzone
configs. Since this work was a significant change, we should
gate `SetZoneConfig` to minimize the risk of compatibility
issues with earlier versions.

Epic: none

Release note: None

---

### schemachanger: re-enable dsc zone config
Since 24.3 has been cut, we can turn zone configs
on in the declarative schema changer by default.

Epic: none

Release note: None

---

### scexec: extend UpdateZoneConfig to allow for deletes
This patch extends UpdateZoneConfig to allow for deletes in
the system.zones table.

Epic: None

Release note: None

---

### scbuildstmt: refactor zoneConfigObjBuilder method
This patch refactors the `addZoneConfigToBuildCtx` method
of our `zoneConfigObjBuilder` to be less specific; we pull
the `b.add` out so that we can decide in `SetZoneConfig`
whether to add or drop this element.

Epic: none

Release note: None

---

### schemachanger: add support discarding database/table zc
This patch supports discarding a database/table zone config
in the declarative schema changer.

Informs: https://github.com/cockroachdb/cockroach/issues/133157

Release note: None