### PR TITLE
release-23.1: sql: fix TestAuthenticationAndHBARules stress tests SSL issue

### DIFF
--- a/build/teamcity/cockroach/nightlies/stress_impl.sh
+++ b/build/teamcity/cockroach/nightlies/stress_impl.sh
@@ -17,7 +17,7 @@ else
     TAGS="bazel,gss,$TAGS"
 fi
 
-GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+GIT_BRANCH="133002"
 if [ "$TC_BUILD_BRANCH" != "$GIT_BRANCH" ]; then
     echo "Skipping test $TARGET, as the expected branch is $TC_BUILD_BRANCH, but actual branch is $GIT_BRANCH"
     exit 0

--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -56,6 +56,7 @@ go_library(
         "//pkg/sql/sqltelemetry",
         "//pkg/sql/types",
         "//pkg/util",
+        "//pkg/util/buildutil",
         "//pkg/util/contextutil",
         "//pkg/util/duration",
         "//pkg/util/envutil",

--- a/pkg/sql/pgwire/pre_serve.go
+++ b/pkg/sql/pgwire/pre_serve.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirecancel"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -446,6 +447,10 @@ func (s *PreServeConnHandler) maybeUpgradeToSecureConn(
 		// non-TLS SQL conns.
 		if !s.cfg.AcceptSQLWithoutTLS && connType != hba.ConnLocal && connType != hba.ConnInternalLoopback {
 			clientErr = pgerror.New(pgcode.ProtocolViolation, ErrSSLRequired)
+			// Extra logs under test to debug TestAuthenticationAndHBARules.
+			if buildutil.CrdbTestBuild {
+				log.Warningf(ctx, "client cannot connect since version=%d AcceptSQLWithoutTLS=false and connType=%s", version, connType)
+			}
 		}
 		return
 	}
@@ -457,6 +462,10 @@ func (s *PreServeConnHandler) maybeUpgradeToSecureConn(
 		// we don't want it.
 		clientErr = pgerror.New(pgcode.ProtocolViolation,
 			"cannot use SSL/TLS over local connections")
+		// Extra logs under test to debug TestAuthenticationAndHBARules.
+		if buildutil.CrdbTestBuild {
+			log.Warningf(ctx, "client cannot connect since version=%d and connType=%s", version, connType)
+		}
 		return
 	}
 
@@ -478,6 +487,10 @@ func (s *PreServeConnHandler) maybeUpgradeToSecureConn(
 	if tlsConfig == nil {
 		// We don't have a TLS configuration available, so we can't honor
 		// the client's request.
+		// Extra logs under test to debug TestAuthenticationAndHBARules.
+		if buildutil.CrdbTestBuild {
+			log.Infof(ctx, "sending sslUnsupported message to client")
+		}
 		n, serverErr = conn.Write(sslUnsupported)
 		if serverErr != nil {
 			return


### PR DESCRIPTION
Backport 2/2 commits from #132729.

/cc @cockroachdb/release

---

sql: fix TestAuthenticationAndHBARules stress tests SSL issue

informs #131532
informs #131110
informs #130253
informs #127745
Epic CRDB-41958

TestAuthenticationAndHBARules fails for `special_cases`, `hba_default_equivalence`, `empty_hba` data driven tests for secure mode. The failures occur when root user is trying to authenticate with cert-password auth method and `sslmode` is set to `verify-ca` with `sslcert` being empty. The expected behavior is root authentication defaults to password method and fails as no password is set for root, but instead we get:
```
pq: SSL is not enabled on the server
```
Since the failures are there only under stress, it might be because db server shutdown or paused before responding to request for upgrade connection to SSL from lib/pq client from here
https://github.com/lib/pq/blob/3d613208bca2e74f2a20e04126ed30bcb5c4cc27/conn.go#L1116-L1130. Retrying connection establishment when this specific error is obtained might fix the problem as this logic seems faulty(it checks for absence of 'S' in server response whereas the correct check should be for 'N' in response).

----

pgwire: add test build logs for upgrade secure conn

Additional test build logs are added to verify the step for which
`maybeUpgradeToSecureConn` fails.

Release note: None

----

Release justification: test only to fix TestAuthenticationAndHBARules under stress