### PR TITLE
release-24.3: scripts: update bump-pebble.sh

### DIFF
--- a/scripts/bump-pebble.sh
+++ b/scripts/bump-pebble.sh
@@ -11,7 +11,7 @@
 # branch name (e.g. crl-release-23.2, etc.). Also update pebble nightly scripts
 # in build/teamcity/cockroach/nightlies to use `@crl-release-xy.z` instead of
 # `@master`.
-BRANCH=master
+BRANCH=release-24.3
 PEBBLE_BRANCH=master
 
 # This script may be used to produce a branch bumping the Pebble version. The


### PR DESCRIPTION
Update the BRANCH. We still use Pebble's master for now - we will
create `crl-release-24.3` when we have a PR that we don't want in
24.2.

Epic: none
Release note: None
Release justification: dev script update

CC @cockroachdb/release 