### PR TITLE
roachtest: Add support for multliple workload nodes

### DIFF
--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -28,6 +28,9 @@ import (
 
 func TestClusterNodes(t *testing.T) {
 	c := &clusterImpl{spec: spec.MakeClusterSpec(10, spec.WorkloadNode())}
+	c2 := &clusterImpl{spec: spec.MakeClusterSpec(10, spec.WorkloadNodeCount(0))}
+	c3 := &clusterImpl{spec: spec.MakeClusterSpec(10, spec.WorkloadNodeCount(1))}
+	c4 := &clusterImpl{spec: spec.MakeClusterSpec(10, spec.WorkloadNodeCount(4))}
 	opts := func(opts ...option.Option) []option.Option {
 		return opts
 	}
@@ -46,6 +49,12 @@ func TestClusterNodes(t *testing.T) {
 		{opts(c.Node(2), c.Node(3), c.Node(4)), ":2-4"},
 		{opts(c.CRDBNodes()), ":1-9"},
 		{opts(c.WorkloadNode()), ":10"},
+		{opts(c2.CRDBNodes()), ":1-10"},
+		{opts(c2.WorkloadNode()), ""},
+		{opts(c3.CRDBNodes()), ":1-9"},
+		{opts(c3.WorkloadNode()), ":10"},
+		{opts(c4.CRDBNodes()), ":1-6"},
+		{opts(c4.WorkloadNode()), ":7-10"},
 	}
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {

--- a/pkg/cmd/roachtest/option/node_lister.go
+++ b/pkg/cmd/roachtest/option/node_lister.go
@@ -7,9 +7,9 @@ package option
 
 // NodeLister is a helper to create `option.NodeListOption`s.
 type NodeLister struct {
-	NodeCount               int
-	WorkloadNodeProvisioned bool
-	Fatalf                  func(string, ...interface{})
+	NodeCount         int
+	WorkloadNodeCount int
+	Fatalf            func(string, ...interface{})
 }
 
 // All returns a list of all nodes.
@@ -19,10 +19,7 @@ func (l NodeLister) All() NodeListOption {
 
 // CRDBNodes returns a list of all CRDB nodes, i.e, non workload nodes.
 func (l NodeLister) CRDBNodes() NodeListOption {
-	if l.WorkloadNodeProvisioned {
-		return l.Range(1, l.NodeCount-1)
-	}
-	return l.Range(1, l.NodeCount)
+	return l.Range(1, l.NodeCount-l.WorkloadNodeCount)
 }
 
 // Range returns only the nodes [begin, ..., end].
@@ -59,8 +56,8 @@ func (l NodeLister) Node(n int) NodeListOption {
 // WorkloadNode returns the workload node—it assumes that one has
 // been created through the cluster spec WorkloadNode option.
 func (l NodeLister) WorkloadNode() NodeListOption {
-	if !l.WorkloadNodeProvisioned {
+	if l.WorkloadNodeCount == 0 {
 		l.Fatalf("workload node specified but no workload nodes were provisioned by the cluster")
 	}
-	return l.Nodes(l.NodeCount)
+	return l.Range(l.NodeCount-l.WorkloadNodeCount+1, l.NodeCount)
 }

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -94,11 +94,14 @@ const (
 type ClusterSpec struct {
 	Arch      vm.CPUArch // CPU architecture; auto-chosen if left empty
 	NodeCount int
-	// WorkloadNode indicates that the last node of the cluster should be a
-	// workload node. Defaults to a VM with 4 CPUs if not specified by
-	// WorkloadNodeCPUs.
-	WorkloadNode     bool
-	WorkloadNodeCPUs int
+	// WorkloadNode indicates if we are using workload nodes.
+	// WorkloadNodeCount indicates count of the last few node of the cluster
+	// treated as workload node. Defaults to a VM with 4 CPUs if not specified
+	// by WorkloadNodeCPUs.
+	// TODO(GouravKumar): remove use of WorkloadNode, use WorkloadNodeCount instead
+	WorkloadNode      bool
+	WorkloadNodeCount int
+	WorkloadNodeCPUs  int
 	// CPUs is the number of CPUs per node.
 	CPUs                 int
 	Mem                  MemPerCPU
@@ -562,5 +565,5 @@ func (s *ClusterSpec) TotalCPUs() int {
 	if !s.WorkloadNode {
 		return s.NodeCount * s.CPUs
 	}
-	return (s.NodeCount-1)*s.CPUs + s.WorkloadNodeCPUs
+	return (s.NodeCount-s.WorkloadNodeCount)*s.CPUs + (s.WorkloadNodeCPUs * s.WorkloadNodeCount)
 }

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -33,11 +33,21 @@ func CPU(n int) Option {
 	}
 }
 
-// WorkloadNode indicates that the last node is a workload node.
-// Defaults to a VM with 4 CPUs if not specified by WorkloadNodeCPUs.
+// WorkloadNodeCount indicates the count of last nodes in cluster to be treated
+// as workload node. Defaults to a VM with 4 CPUs if not specified by
+// WorkloadNodeCPUs.
+func WorkloadNodeCount(n int) Option {
+	return func(spec *ClusterSpec) {
+		spec.WorkloadNodeCount = n
+		spec.WorkloadNode = true
+	}
+}
+
+// TODO(GouravKumar): remove use of WorkloadNode, use WorkloadNodeCount instead
 func WorkloadNode() Option {
 	return func(spec *ClusterSpec) {
 		spec.WorkloadNode = true
+		spec.WorkloadNodeCount = 1
 	}
 }
 


### PR DESCRIPTION
This changes allows roachtests to specify multiple workload nodes in test.
Before this, we could add only one workload node.

Epic: none
Release note: None