### PR TITLE
drtprod: control tpcc execution

### DIFF
--- a/pkg/cmd/drtprod/configs/drt_chaos.yaml
+++ b/pkg/cmd/drtprod/configs/drt_chaos.yaml
@@ -88,5 +88,9 @@ targets:
           - workload
       - script: "pkg/cmd/drtprod/scripts/setup_datadog_workload"
       - script: "pkg/cmd/drtprod/scripts/tpcc_init.sh"
+        args:
+          - cct_tpcc # suffix added to script name tpcc_init_cct_tpcc.sh
+          - true # determines whether to execute the script immediately on workload node
         flags:
           warehouses: 12000
+          db: cct_tpcc

--- a/pkg/cmd/drtprod/configs/drt_large.yaml
+++ b/pkg/cmd/drtprod/configs/drt_large.yaml
@@ -101,5 +101,9 @@ targets:
           - workload
       - script: "pkg/cmd/drtprod/scripts/setup_datadog_workload"
       - script: "pkg/cmd/drtprod/scripts/tpcc_init.sh"
+        args:
+          - cct_tpcc # suffix added to script name tpcc_init_cct_tpcc.sh
+          - true # determines whether to execute the script immediately on workload node
         flags:
           warehouses: 15000
+          db: cct_tpcc

--- a/pkg/cmd/drtprod/configs/drt_scale.yaml
+++ b/pkg/cmd/drtprod/configs/drt_scale.yaml
@@ -123,6 +123,16 @@ targets:
           - pkg/cmd/drt/scripts/roachtest_operations_run.sh
           - roachtest_operations_run.sh
       - script: "pkg/cmd/drtprod/scripts/tpcc_init.sh"
+        args:
+          - cct_tpcc_320k # suffix added to script name tpcc_init_cct_tpcc_320k.sh
+          - true # determines whether to execute the script immediately on workload node
         flags:
-          warehouses: 100000
+          warehouses: 320000
           db: cct_tpcc
+      - script: "pkg/cmd/drtprod/scripts/tpcc_init.sh"
+        args:
+          - cct_tpcc_640k # suffix added to script name tpcc_init_cct_tpcc_640k.sh
+          - false # determines whether to execute the script immediately on workload node
+        flags:
+          warehouses: 640000
+          db: cct_tpcc_big

--- a/pkg/cmd/drtprod/configs/drt_scale_operations.yaml
+++ b/pkg/cmd/drtprod/configs/drt_scale_operations.yaml
@@ -13,5 +13,5 @@ targets:
     steps:
       - script: "pkg/cmd/drtprod/scripts/create_run_operation.sh"
         args:
-          - "schema_change,add-column|add-index,0 0 * * *" # runs every day at 12 AM
+          - "schema_change,add-column|add-index"
           - "kill_stall,disk-stall|network-partition|node-kill,0 * * * *" # runs every 1 hour

--- a/pkg/cmd/drtprod/scripts/tpcc_init.sh
+++ b/pkg/cmd/drtprod/scripts/tpcc_init.sh
@@ -9,6 +9,23 @@
 # The --warehouses and other flags for import are passed as argument to this script
 # NOTE - This uses CLUSTER and WORKLOAD_CLUSTER environment variable, if not set the script fails
 
+# The first argument is the name suffix that is added to the script as tpcc_init_<suffix>.sh
+if [ "$#" -lt 4 ]; then
+  echo "Usage: $0 <script_suffix> <execute:true|false> <flags to init:--warehouses,--db>"
+  exit 1
+fi
+suffix=$1
+shift
+# The second argument represents whether the init process should be started in the workload cluster
+# The value is true or false
+if [ "$1" != "true" ] && [ "$1" != "false" ]; then
+  # $1 is used again because of the shift
+  echo "Error: The second argument must be 'true' or 'false' which implies whether the script should be started in background or not."
+  exit 1
+fi
+execute_script=$1
+shift
+
 if [ -z "${CLUSTER}" ]; then
   echo "environment CLUSTER is not set"
   exit 1
@@ -19,19 +36,22 @@ if [ -z "${WORKLOAD_CLUSTER}" ]; then
   exit 1
 fi
 
-absolute_path=$(roachprod run "${WORKLOAD_CLUSTER}":1 -- "realpath ./tpcc_init.sh")
+absolute_path=$(roachprod run "${WORKLOAD_CLUSTER}":1 -- "realpath ./tpcc_init_${suffix}.sh")
 pwd=$(roachprod run "${WORKLOAD_CLUSTER}":1 -- "dirname ${absolute_path}")
+PGURLS=$(roachprod pgurl "${CLUSTER}")
 
 # script is responsible for importing the tpcc database for workload
-roachprod ssh "${WORKLOAD_CLUSTER}":1 -- "tee tpcc_init.sh > /dev/null << 'EOF'
+roachprod ssh "${WORKLOAD_CLUSTER}":1 -- "tee tpcc_init_${suffix}.sh > /dev/null << 'EOF'
 #!/bin/bash
 
 export ROACHPROD_GCE_DEFAULT_PROJECT=${ROACHPROD_GCE_DEFAULT_PROJECT}
 export ROACHPROD_DNS=${ROACHPROD_DNS}
 ${pwd}/roachprod sync
 sleep 20
-PGURLS=\$(${pwd}/roachprod pgurl ${CLUSTER} | sed s/\'//g)
-${pwd}/cockroach workload init tpcc $@ --secure --families \$PGURLS
+${pwd}/cockroach workload init tpcc $@ --secure --families $PGURLS
 EOF"
-roachprod ssh "${WORKLOAD_CLUSTER}":1 -- "chmod +x tpcc_init.sh"
-roachprod run "${WORKLOAD_CLUSTER}":1 -- "sudo systemd-run --unit tpccinit --same-dir --uid \$(id -u) --gid \$(id -g) bash ${pwd}/tpcc_init.sh"
+roachprod ssh "${WORKLOAD_CLUSTER}":1 -- "chmod +x tpcc_init_${suffix}.sh"
+
+if [ "$execute_script" = "true" ]; then
+  roachprod run "${WORKLOAD_CLUSTER}":1 -- "sudo systemd-run --unit tpccinit_${suffix} --same-dir --uid \$(id -u) --gid \$(id -g) bash ${pwd}/tpcc_init_${suffix}.sh"
+fi


### PR DESCRIPTION
In the tpcc init script, there is no option to control whether the script should be executed in the workload node immediately after creation or not. Today it just executes it as a background process immediately after creation.

This control is needed because we will need to create multiple tpcc databases with different names and not all scripts should be executed immediately.

So, this PR has a control that allows you to decide whether the script should be executed immediately or not after creation.
Also, as we need to create multiple scripts in the same workload node, this PR has a change to put a suffix to the script name.

Epic: None
Release note: None