### PR TITLE
kv: deflake TestMergeQueue, control merge queue directly

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -3171,7 +3171,6 @@ func TestMergeQueueWithExternalFiles(t *testing.T) {
 			store, err := s.GetStores().(*kvserver.Stores).GetStore(s.GetFirstStoreID())
 			require.NoError(t, err)
 
-			store.SetMergeQueueActive(true)
 			if skipExternal {
 				verifyUnmergedSoon(t, store, lhsDesc.StartKey, rhsDesc.StartKey)
 			} else {
@@ -4293,6 +4292,11 @@ func TestStoreRangeMergeDuringShutdown(t *testing.T) {
 
 func verifyMergedSoon(t *testing.T, store *kvserver.Store, lhsStartKey, rhsStartKey roachpb.RKey) {
 	t.Helper()
+	store.SetMergeQueueActive(true)
+	defer func() {
+		store.SetMergeQueueActive(false)
+		store.MustForceMergeScanAndProcess() // drain any merges that might already be queued
+	}()
 	testutils.SucceedsSoon(t, func() error {
 		store.MustForceMergeScanAndProcess()
 		repl := store.LookupReplica(rhsStartKey)
@@ -4310,6 +4314,11 @@ func verifyUnmergedSoon(
 	t *testing.T, store *kvserver.Store, lhsStartKey, rhsStartKey roachpb.RKey,
 ) {
 	t.Helper()
+	store.SetMergeQueueActive(true)
+	defer func() {
+		store.SetMergeQueueActive(false)
+		store.MustForceMergeScanAndProcess() // drain any merges that might already be queued
+	}()
 	testutils.SucceedsSoon(t, func() error {
 		store.MustForceMergeScanAndProcess()
 		repl := store.LookupReplica(rhsStartKey)
@@ -4344,9 +4353,6 @@ func TestMergeQueue(t *testing.T) {
 						WallClock:                 manualClock,
 						DefaultZoneConfigOverride: &zoneConfig,
 					},
-					Store: &kvserver.StoreTestingKnobs{
-						DisableScanner: true,
-					},
 				},
 			},
 		})
@@ -4354,11 +4360,6 @@ func TestMergeQueue(t *testing.T) {
 
 	conf := zoneConfig.AsSpanConfig()
 	store := tc.GetFirstStoreFromServer(t, 0)
-	// The cluster with manual replication disables the merge queue,
-	// so we need to re-enable.
-	_, err := tc.ServerConn(0).Exec(`SET CLUSTER SETTING kv.range_merge.queue.enabled = true`)
-	require.NoError(t, err)
-	store.SetMergeQueueActive(true)
 
 	split := func(t *testing.T, key roachpb.Key, expirationTime hlc.Timestamp) {
 		t.Helper()
@@ -4429,6 +4430,7 @@ func TestMergeQueue(t *testing.T) {
 			kvserver.SplitByLoadEnabled.Override(ctx, &s.ClusterSettings().SV, false)
 		}
 
+		store.SetMergeQueueActive(false)     // reset merge queue to inactive
 		store.MustForceMergeScanAndProcess() // drain any merges that might already be queued
 		split(t, rhsStartKey.AsRawKey(), hlc.Timestamp{} /* expirationTime */)
 	}
@@ -4818,7 +4820,8 @@ func TestMergeQueueSeesNonVoters(t *testing.T) {
 	}
 
 	var clusterArgs = base.TestClusterArgs{
-		// We dont want the replicate queue mucking with our test, so disable it.
+		// We don't want the replicate queue mucking with our test, so disable it.
+		// This also disables the merge queue, until it is manually enabled.
 		ReplicationMode: base.ReplicationManual,
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
@@ -4841,10 +4844,6 @@ func TestMergeQueueSeesNonVoters(t *testing.T) {
 
 			store, err := tc.Server(0).GetStores().(*kvserver.Stores).GetStore(1)
 			require.Nil(t, err)
-			// We're going to split the dummy range created above with an empty
-			// expiration time. Disable the merge queue before splitting so that the
-			// split ranges aren't immediately merged.
-			store.SetMergeQueueActive(false)
 			leftDesc, rightDesc := splitDummyRangeInTestCluster(
 				t, tc, dbName, "kv" /* tableName */, hlc.Timestamp{} /* splitExpirationTime */)
 
@@ -4887,7 +4886,6 @@ func TestMergeQueueSeesNonVoters(t *testing.T) {
 			tc.RemoveVotersOrFatal(t, rightDesc.StartKey.AsRawKey(), tc.Target(0))
 			rightDesc = tc.LookupRangeOrFatal(t, rightDesc.StartKey.AsRawKey())
 
-			store.SetMergeQueueActive(true)
 			verifyMergedSoon(t, store, leftDesc.StartKey, rightDesc.StartKey)
 		})
 	}
@@ -4909,7 +4907,8 @@ func TestMergeQueueWithSlowNonVoterSnaps(t *testing.T) {
 	ctx := context.Background()
 	var delaySnapshotTrap atomic.Value
 	var clusterArgs = base.TestClusterArgs{
-		// We dont want the replicate queue mucking with our test, so disable it.
+		// We don't want the replicate queue mucking with our test, so disable it.
+		// This also disables the merge queue, until it is manually enabled.
 		ReplicationMode: base.ReplicationManual,
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
@@ -4945,17 +4944,9 @@ func TestMergeQueueWithSlowNonVoterSnaps(t *testing.T) {
 	numNodes := 3
 	tc, _ := setupTestClusterWithDummyRange(t, clusterArgs, dbName, tableName, numNodes)
 	defer tc.Stopper().Stop(ctx)
-	// We're controlling merge queue operation via
-	// `store.SetMergeQueueActive`, so enable the cluster setting here.
-	_, err := tc.ServerConn(0).Exec(`SET CLUSTER SETTING kv.range_merge.queue.enabled=true`)
-	require.NoError(t, err)
 
 	store, err := tc.Server(0).GetStores().(*kvserver.Stores).GetStore(1)
 	require.Nil(t, err)
-	// We're going to split the dummy range created above with an empty
-	// expiration time. Disable the merge queue before splitting so that the
-	// split ranges aren't immediately merged.
-	store.SetMergeQueueActive(false)
 	leftDesc, rightDesc := splitDummyRangeInTestCluster(
 		t, tc, dbName, tableName, hlc.Timestamp{}, /* splitExpirationTime */
 	)
@@ -4972,7 +4963,6 @@ func TestMergeQueueWithSlowNonVoterSnaps(t *testing.T) {
 		time.Sleep(5 * time.Second)
 		return nil
 	})
-	store.SetMergeQueueActive(true)
 	verifyMergedSoon(t, store, leftDesc.StartKey, rightDesc.StartKey)
 }
 


### PR DESCRIPTION
Fixes #132831.

This commit deflakes TestMergeQueue by changing how it disables the merge queue. Previously, it attempted to disable the merge queue by disabling the replica scanner. This was insufficient to prevent the merge queue from running at unexpected times, because there are other reactive reasons for the merge queue to run (e.g. gossip updates).

This commit switches the test to directly setting the merge queue as active or inactive when needed. This is more reliable because it prevents unexpected background activity causing the merge queue to run at inopportune times.

Release note: None