### PR TITLE
backupccl: ignore non-required backup layers in restore

### DIFF
--- a/pkg/ccl/backupccl/backupdest/backup_destination.go
+++ b/pkg/ccl/backupccl/backupdest/backup_destination.go
@@ -485,7 +485,9 @@ func ListFullBackupsInCollection(
 // manifests and metadata required to RESTORE. If only one layer is explicitly
 // provided, it is inspected to see if it contains "appended" layers internally
 // that are then expanded into the result layers returned, similar to if those
-// layers had been specified in `from` explicitly.
+// layers had been specified in `from` explicitly. If `includeSkipped` is true,
+// layers that do not actually contribute to the path from the base to the end
+// timestamp are included in the result, otherwise they are elided.
 func ResolveBackupManifests(
 	ctx context.Context,
 	mem *mon.BoundAccount,
@@ -498,6 +500,7 @@ func ResolveBackupManifests(
 	encryption *jobspb.BackupEncryptionOptions,
 	kmsEnv cloud.KMSEnv,
 	user username.SQLUsername,
+	includeSkipped bool,
 ) (
 	defaultURIs []string,
 	// mainBackupManifests contains the manifest located at each defaultURI in the backup chain.
@@ -608,7 +611,7 @@ func ResolveBackupManifests(
 	ownedMemSize = 0
 
 	validatedDefaultURIs, validatedMainBackupManifests, validatedLocalityInfo, err := backupinfo.ValidateEndTimeAndTruncate(
-		defaultURIs, mainBackupManifests, localityInfo, endTime)
+		defaultURIs, mainBackupManifests, localityInfo, endTime, includeSkipped)
 
 	if err != nil {
 		return nil, nil, nil, 0, err

--- a/pkg/ccl/backupccl/backupinfo/BUILD.bazel
+++ b/pkg/ccl/backupccl/backupinfo/BUILD.bazel
@@ -73,6 +73,7 @@ go_test(
         "//pkg/ccl/backupccl/backuppb",
         "//pkg/ccl/backupccl/backuptestutils",
         "//pkg/cloud",
+        "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/multitenant/mtinfopb",
         "//pkg/roachpb",

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1789,8 +1789,9 @@ func doRestorePlan(
 	// localities. Incrementals will be searched for automatically.
 	defaultURIs, mainBackupManifests, localityInfo, memReserved, err := backupdest.ResolveBackupManifests(
 		ctx, &mem, baseStores, incStores, mkStore, fullyResolvedBaseDirectory,
-		fullyResolvedIncrementalsDirectory, endTime, encryption, &kmsEnv, p.User(),
+		fullyResolvedIncrementalsDirectory, endTime, encryption, &kmsEnv, p.User(), false,
 	)
+
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -475,7 +475,7 @@ you must pass the 'encryption_info_dir' parameter that points to the directory o
 		info.defaultURIs, info.manifests, info.localityInfo, memReserved,
 			err = backupdest.ResolveBackupManifests(
 			ctx, &mem, baseStores, incStores, mkStore, fullyResolvedDest,
-			fullyResolvedIncrementalsDirectory, hlc.Timestamp{}, encryption, &kmsEnv, p.User())
+			fullyResolvedIncrementalsDirectory, hlc.Timestamp{}, encryption, &kmsEnv, p.User(), true)
 		defer func() {
 			mem.Shrink(ctx, memReserved)
 		}()


### PR DESCRIPTION
Previously we would attempt to restore all layers in a backup, even if some of those layers were fully covered with other layers, i.e. were redundant, such as when concurrent incremental backups start from the same timestamp and then only one of them is used when the chain is later extended. In such cases, the "spur" backup is not required to restore the main chain.

This change ensures restore elides layers from the chain that it does not require. This could be useful in the future if we intentionally were to produce layers later in a chain that somehow -- either by picking an earlier layer than the immediate successor as their start time or by 'compacting' prior layers -- and wished to benefit from that during the restore process.

Elided redundant layers are still included in SHOW BACKUP as one may wish to restore to the timestamps provided by the backups on the spur, rather than to those on the rest of the chain, in which case the spur's end times are good to know.

Release note: none.
Epic: none.