### PR TITLE
server/license: Suppress NOTICE during license grace period

### DIFF
--- a/pkg/server/license/enforcer.go
+++ b/pkg/server/license/enforcer.go
@@ -155,7 +155,7 @@ type MetadataAccessor interface {
 func NewEnforcer(tk *TestingKnobs) *Enforcer {
 	e := &Enforcer{
 		startTime:      timeutil.Now(),
-		throttleLogger: log.Every(5 * time.Minute),
+		throttleLogger: log.Every(12 * time.Hour),
 		testingKnobs:   tk,
 	}
 	return e

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -502,10 +502,8 @@ func (ex *connExecutor) execStmtInOpenState(
 		// Enforce license policies. Throttling can occur if there is no valid
 		// license or if the existing one has expired.
 		if isSQLOkayToThrottle(ast) {
-			if notice, err := ex.server.cfg.LicenseEnforcer.MaybeFailIfThrottled(ctx, curOpen); err != nil {
+			if _, err := ex.server.cfg.LicenseEnforcer.MaybeFailIfThrottled(ctx, curOpen); err != nil {
 				return makeErrEvent(err)
-			} else if notice != nil {
-				res.BufferNotice(notice)
 			}
 		}
 	}


### PR DESCRIPTION
Previously, a NOTICE was sent to the client while in the license grace period to warn of imminent throttling. Based on feedback, we will no longer send this NOTICE to the client. Additionally, we have reduced the frequency of log messages in cockroach.log, changing the interval from every 5 minutes to every 12 hours. The MaybeFailIfThrottled function still returns a notice output parameter, allowing us to test the log message.

Epic: CRDB-39988
Closes #133050
Release note: none