### PR TITLE
release-24.1: opt: prevent stack overflow when deriving computed column filters

### DIFF
--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -640,22 +640,22 @@ func (c *indexConstraintCtx) makeSpansForExpr(
 				// Attempt to convert the constraint into a disjunction of ANDed IS
 				// predicates, with additional derived IS conjuncts on computed
 				// columns based on columns in the constraint spans.
-				// TODO(msirek/mgartner): Modify CombineComputedColFilters to build a
-				// `Constraint` or `constraint.Set` directly instead of building a
-				// filter and calling `makeSpansForExpr`.
-				computedColumnFilters := norm.CombineComputedColFilters(
+				// TODO(mgartner): Modify CombineComputedColFilters to build a
+				// `Constraint` or `constraint.Set` directly instead of building
+				// a filter and calling `makeSpansForExpr`.
+				disjunctions := norm.CombineComputedColFilters(
 					c.computedCols,
 					c.keyCols,
 					c.colsInComputedColsExpressions,
 					constraints.Constraint(0),
 					c.factory,
 				)
-				if len(computedColumnFilters) == 1 {
-					// All predicates in `computedColumnFilters[0].Condition` fully
-					// represent the original condition plus derived predicates, so we
-					// only have to make spans on the new condition.
+				if len(disjunctions) > 0 {
+					// All disjunctions fully represent the original condition
+					// plus derived predicates, so we only have to make spans on
+					// the list of disjunctions.
 					c.skipComputedColPredDerivation = true
-					localTight := c.makeSpansForExpr(offset, computedColumnFilters[0].Condition, out)
+					localTight := c.binaryMergeSpansForOr(offset, disjunctions, out)
 					c.skipComputedColPredDerivation = false
 					return localTight
 				}

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/arith"
-	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/errors"
 )
 
@@ -1036,7 +1035,9 @@ func (c *CustomFuncs) tryFoldComputedCol(
 // which seeks to fold computed column expressions using values from single-key
 // constraint spans in order to build new predicates on those computed columns
 // and AND them with predicates built from the constraint span key used to
-// compute the computed column value.
+// compute the computed column value. If successful, it returns a list of
+// expressions representing disjunctions, with a length equal to the number of
+// spans in the constraint. If unsuccessful, nil is returned.
 //
 // New derived keys cannot be saved for the filters as a whole, for later
 // processing, because a given combination of span key values is only applicable
@@ -1090,22 +1091,19 @@ func CombineComputedColFilters(
 	colsInComputedColsExpressions opt.ColSet,
 	cons *constraint.Constraint,
 	f *Factory,
-) memo.FiltersExpr {
+) (disjunctions []opt.ScalarExpr) {
 	if len(computedCols) == 0 {
 		return nil
 	}
 	if !f.evalCtx.SessionData().OptimizerUseImprovedComputedColumnFiltersDerivation {
 		return nil
 	}
-	var combinedComputedColFilters memo.FiltersExpr
-	var orOp opt.ScalarExpr
 	if !cons.Columns.ColSet().Intersects(colsInComputedColsExpressions) {
 		// If this constraint doesn't involve any columns used to construct a
 		// computed column value, no need to process it further.
 		return nil
 	}
 	for k := 0; k < cons.Spans.Count(); k++ {
-		filterAdded := false
 		span := cons.Spans.Get(k)
 		if !span.HasSingleKey(f.evalCtx) {
 			// If we don't have a single value, or combination of single values
@@ -1119,40 +1117,22 @@ func CombineComputedColFilters(
 		if !ok {
 			return nil
 		}
-		var newOp opt.ScalarExpr
-		// Build a new ANDed predicate involving the computed column and columns in
-		// the computed column expression.
-		newOp, filterAdded =
-			buildConjunctionOfEqualityPredsOnComputedAndNonComputedCols(
-				initialConjunction, computedCols, constFilterCols, indexKeyCols, f)
-		// Only build a new disjunct if terms were derived for this span.
-		if filterAdded {
-			if orOp == nil {
-				// The case of the first span or only one span.
-				orOp = newOp
-			} else {
-				// The spans in a constraint represent a disjunction, so OR them
-				// together.
-				constructOr := func() {
-					orOp = f.ConstructOr(orOp, newOp)
-				}
-				var disabledRules intsets.Fast
-				// Disable this rule as it disallows finding tight constraints in
-				// some cases when a conjunct can be factored out, e.g.,
-				// `(a=3 AND b=4) OR (a=3 AND b=6)` --> `a=3 AND (b=4 OR b=6)`
-				disabledRules.Add(int(opt.ExtractRedundantConjunct))
-				f.DisableOptimizationRulesTemporarily(disabledRules, constructOr)
-			}
-		} else {
+		// Build a new ANDed predicate involving the computed column and columns
+		// in the computed column expression.
+		conjunct, ok := buildConjunctionOfEqualityPredsOnComputedAndNonComputedCols(
+			initialConjunction, computedCols, constFilterCols, indexKeyCols, f,
+		)
+		if !ok {
 			// If we failed to build any of the disjuncts, we must give up.
 			return nil
 		}
+		if disjunctions == nil {
+			// Lazily allocate the slice of disjunctions.
+			disjunctions = make([]opt.ScalarExpr, 0, cons.Spans.Count())
+		}
+		disjunctions = append(disjunctions, conjunct)
 	}
-	if orOp != nil {
-		combinedComputedColFilters =
-			append(combinedComputedColFilters, f.ConstructFiltersItem(orOp))
-	}
-	return combinedComputedColFilters
+	return disjunctions
 }
 
 // buildConstColsMapFromConstraint converts a constraint on one or more columns

--- a/pkg/sql/opt/testutils/opttester/BUILD.bazel
+++ b/pkg/sql/opt/testutils/opttester/BUILD.bazel
@@ -60,6 +60,7 @@ go_library(
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
+        "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_pmezard_go_difflib//difflib",
     ],
 )

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -69,6 +70,7 @@ import (
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
+	"github.com/dustin/go-humanize"
 	"github.com/pmezard/go-difflib/difflib"
 )
 
@@ -265,6 +267,10 @@ type Flags struct {
 
 	// TxnIsoLevel is the isolation level to plan for.
 	TxnIsoLevel isolation.Level
+
+	// MaxStackBytes specifies the number of bytes to limit the stack size to.
+	// If it is zero, the stack size has the default Go limit.
+	MaxStackBytes int
 }
 
 // New constructs a new instance of the OptTester for the given SQL statement.
@@ -572,6 +578,9 @@ func New(catalog cat.Catalog, sqlStr string) *OptTester {
 //     full path or a relative path to testdata.
 //
 //   - isolation: sets the isolation level to plan for.
+//
+//   - max-stack: sets the maximum stack size for the goroutine that optimizes
+//     the query. See debug.SetMaxStack.
 func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 	// Allow testcases to override the flags.
 	for _, a := range d.CmdArgs {
@@ -594,6 +603,11 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 	ot.evalCtx.OriginalLocality = ot.Flags.Locality
 	ot.evalCtx.Placeholders = nil
 	ot.evalCtx.TxnIsoLevel = ot.Flags.TxnIsoLevel
+
+	if ot.Flags.MaxStackBytes > 0 {
+		originalMaxStack := debug.SetMaxStack(ot.Flags.MaxStackBytes)
+		defer debug.SetMaxStack(originalMaxStack)
+	}
 
 	switch d.Cmd {
 	case "exec-ddl":
@@ -1180,6 +1194,16 @@ func (f *Flags) Set(arg datadriven.CmdArg) error {
 			)
 		}
 		f.TxnIsoLevel = isolation.Level(level)
+
+	case "max-stack":
+		if len(arg.Vals) != 1 {
+			return fmt.Errorf("max-stack requires one argument")
+		}
+		bytes, err := humanize.ParseBytes(arg.Vals[0])
+		if err != nil {
+			return err
+		}
+		f.MaxStackBytes = int(bytes)
 
 	default:
 		return fmt.Errorf("unknown argument: %s", arg.Key)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -2772,6 +2772,89 @@ scan singleton_check
  ├── key: ()
  └── fd: ()-->(1,2)
 
+# Regression test for #125422. An equality between with two variables implies
+# that either variable is not null, allowing a scan over a partial index with an
+# IS NOT NULL predicate.
+exec-ddl
+CREATE TABLE t125422 (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  INDEX t125422_a_idx (a) WHERE a IS NOT NULL
+)
+----
+
+opt
+SELECT k FROM t125422@t125422_a_idx WHERE a = b
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null a:2!null b:3!null
+      ├── key: (1)
+      ├── fd: (1)-->(2,3), (2)==(3), (3)==(2)
+      ├── scan t125422
+      │    ├── columns: k:1!null a:2 b:3
+      │    ├── partial index predicates
+      │    │    └── t125422_a_idx: filters
+      │    │         └── a:2 IS NOT NULL [outer=(2), constraints=(/2: (/NULL - ]; tight)]
+      │    ├── flags: force-index=t125422_a_idx
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2,3)
+      └── filters
+           └── a:2 = b:3 [outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ]), fd=(2)==(3), (3)==(2)]
+
+# Regression test for #132669. Deriving computed column constraints should not
+# cause the stack to grow excessively.
+exec-ddl
+CREATE TABLE t132669 (
+  a INT,
+  b INT NOT NULL AS (mod(a, 16)) VIRTUAL,
+  INDEX (b, a)
+)
+----
+
+# Optimize the query with a significantly reduced max stack size. This allows
+# unnecessary recursion to trigger a stack overflow without having to make the
+# `IN` list below huge - triggering a stack overflow with Go's default max stack
+# size requires a list of ~1.6 million elements.
+opt max-stack=50KB format=hide-all
+SELECT * FROM t132669
+WHERE a IN (
+    1,  2,  3,  4,  5,  6,  7, 8, 9, 10,
+   11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+   21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+   31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+   41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
+   51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+   61, 62, 63, 64, 65, 66, 67, 68, 69, 70,
+   71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
+   81, 82, 83, 84, 85, 86, 87, 88, 89, 90,
+   91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
+  101, 102, 103, 104, 105, 106, 107, 108, 109, 110,
+  111, 112, 113, 114, 115, 116, 117, 118, 119, 120,
+  121, 122, 123, 124, 125, 126, 127, 128, 129, 130,
+  131, 132, 133, 134, 135, 136, 137, 138, 139, 140,
+  141, 142, 143, 144, 145, 146, 147, 148, 149, 150,
+  151, 152, 153, 154, 155, 156, 157, 158, 159, 160,
+  161, 162, 163, 164, 165, 166, 167, 168, 169, 170,
+  171, 172, 173, 174, 175, 176, 177, 178, 179, 180,
+  181, 182, 183, 184, 185, 186, 187, 188, 189, 190,
+  191, 192, 193, 194, 195, 196, 197, 198, 199, 200
+)
+----
+project
+ ├── select
+ │    ├── scan t132669
+ │    │    └── computed column expressions
+ │    │         └── b
+ │    │              └── mod(a, 16)
+ │    └── filters
+ │         └── a IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200)
+ └── projections
+      └── mod(a, 16)
+
 # --------------------------------------------------
 # GenerateInvertedIndexScans
 # --------------------------------------------------


### PR DESCRIPTION
Backport 2/2 commits from #132701.

/cc @cockroachdb/release

---

#### opt: add max-stack opttest option

This commit adds the `max-stack` option for opttests, allowing tests to
alter the maximum stack size for the goroutine that optimizes the query.

Release note: None

#### opt: prevent stack overflow when deriving computed column filters

Previously, a filter of the form `col IN (elem0, elem1, ..., elemN)`
could result in a stack overflow in the optimizer when `N` is very
large, e.g., 1.6 million or more . The problem would occur when trying
to derive constraints for indexes on computed column, specifically when
those computed columns are dependent on the column in the filter, e.g.,
`col` in the example.

The current implementation builds an `OrExpr` tree with depth equal to
the length of the `IN` list. It then constructs a `FiltersItem` with the
`OrExpr` tree as the condition, causing logical properties to be built
for the expression. When building logical properties, the `OrExpr` tree
is traversed recursively, which causes the stack to overflow when the
tree is very deep.

Now, an `OrExpr` tree is never built. Instead,
`CombineComputedColFilters` returns a slice of `ScalarExpr`s that
represents a disjunction of expressions. This effectively eliminates the
possibility of stack overflows in code that recursively traverses the
derived expressions. It also simplified the logic.

Fixes #132669

Release note (bug fix): A bug in the query optimizer which could cause
CockroachDB nodes to crash in rare cases has been fixed. The bug could
occur when a query contains a filter in the form
`col IN (elem0, elem1, ..., elemN)` only when `N` is very large, e.g.,
1.6+ million, and when `col` exists in a hash-sharded index or exists a
table with an indexed, computed column dependent on `col`.

---

Release justification: Low-risk bug fix for bug causing nodes to crash.

