### PR TITLE
release-24.3: sql: simplify generic query plans

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/generic
+++ b/pkg/ccl/logictestccl/testdata/logic_test/generic
@@ -1193,3 +1193,30 @@ quality of service: regular
           regions: <hidden>
           actual row count: 1
           size: 1 column, 1 row
+
+statement ok
+DEALLOCATE p
+
+# Regression test for #132963. Do not cache non-reusable plans.
+statement ok
+SET plan_cache_mode = auto
+
+statement ok
+CREATE TABLE a (a INT PRIMARY KEY)
+
+statement ok
+PREPARE p AS SELECT create_statement FROM [SHOW CREATE TABLE a]
+
+query T
+EXECUTE p
+----
+CREATE TABLE public.a (
+  a INT8 NOT NULL,
+  CONSTRAINT a_pkey PRIMARY KEY (a ASC)
+)
+
+statement ok
+ALTER TABLE a RENAME TO b
+
+statement error pgcode 42P01 pq: relation \"a\" does not exist
+EXECUTE p

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -530,9 +530,7 @@ func (opc *optPlanningCtx) buildReusableMemo(
 //
 // The returned memo is only safe to use in one thread, during execution of the
 // current statement.
-func (opc *optPlanningCtx) reuseMemo(
-	ctx context.Context, cachedMemo *memo.Memo,
-) (*memo.Memo, error) {
+func (opc *optPlanningCtx) reuseMemo(cachedMemo *memo.Memo) (*memo.Memo, error) {
 	opc.incPlanTypeTelemetry(cachedMemo)
 	if cachedMemo.IsOptimized() {
 		// The query could have been already fully optimized in
@@ -713,7 +711,7 @@ func (opc *optPlanningCtx) fetchPreparedMemo(ctx context.Context) (_ *memo.Memo,
 	}
 	if validMemo != nil {
 		opc.log(ctx, "reusing cached memo")
-		return opc.reuseMemo(ctx, validMemo)
+		return opc.reuseMemo(validMemo)
 	}
 
 	// Otherwise, we need to rebuild the memo.
@@ -754,7 +752,7 @@ func (opc *optPlanningCtx) fetchPreparedMemo(ctx context.Context) (_ *memo.Memo,
 	}
 
 	// Re-optimize the memo, if necessary.
-	return opc.reuseMemo(ctx, newMemo)
+	return opc.reuseMemo(newMemo)
 }
 
 // buildExecMemo creates a fully optimized memo, possibly reusing a previously
@@ -768,7 +766,7 @@ func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ e
 		// rollback its transaction. Use resumeProc to resume execution in a new
 		// transaction where the control statement left off.
 		opc.log(ctx, "resuming stored procedure execution in a new transaction")
-		return opc.reuseMemo(ctx, resumeProc)
+		return opc.reuseMemo(resumeProc)
 	}
 
 	// Fetch and reuse a memo if a valid one is available.
@@ -802,7 +800,7 @@ func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ e
 				opc.log(ctx, "query cache hit")
 				opc.flags.Set(planFlagOptCacheHit)
 			}
-			return opc.reuseMemo(ctx, cachedData.Memo)
+			return opc.reuseMemo(cachedData.Memo)
 		}
 		opc.flags.Set(planFlagOptCacheMiss)
 		opc.log(ctx, "query cache miss")

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -52,22 +52,17 @@ type PreparedStatement struct {
 
 	// BaseMemo is the memoized data structure constructed by the cost-based
 	// optimizer during prepare of a SQL statement.
-	//
-	// It may be a fully-optimized memo if it contains an "ideal generic plan"
-	// that is guaranteed to be optimal across all executions of the prepared
-	// statement. Ideal generic plans are generated when the statement has no
-	// placeholders nor fold-able stable expressions, or when the placeholder
-	// fast-path is utilized.
-	//
-	// If it is not an ideal generic plan, it is an unoptimized, normalized
-	// memo that is used as a starting point for optimization of custom plans.
 	BaseMemo *memo.Memo
 
 	// GenericMemo, if present, is a fully-optimized memo that can be executed
 	// as-is.
-	// TODO(mgartner): Put all fully-optimized plans in the GenericMemo field to
-	// reduce confusion.
 	GenericMemo *memo.Memo
+
+	// IdealGenericPlan is true if GenericMemo is guaranteed to be optimal
+	// across all executions of the prepared statement. Ideal generic plans are
+	// generated when the statement has no placeholders nor fold-able stable
+	// expressions, or when the placeholder fast-path is utilized.
+	IdealGenericPlan bool
 
 	// Costs tracks the costs of previously optimized custom and generic plans.
 	Costs planCosts


### PR DESCRIPTION
Backport 4/4 commits from #131791.

/cc @cockroachdb/release

---

#### sql: do not cache non-reusable plans

Fixes #132963

Release note (bug fix): A bug has been fixed that caused non-reusable
query plans, e.g., plans for DDL and `SHOW ...` statements, to be cached
and reused in future executions, possibly causing stale results to be
returned. This bug only occurred when `plan_cache_mode` was set to
`auto` or `force_generic_plan`, both of which are not currently the
default settings.

#### sql: remove legacy planning code path

An optimization code path from before the introduction of generic query
plans has been removed. This code path remained in the codebase to
de-risk the generic query plans backports. It is not needed in future
versions.

Release note: None

#### sql: remove unused context parameter in `reuseMemo`

Release note: None

#### sql: simplify generic query plans

All fully-optimized memos that can be reused without re-optimization are
now stored in `PreparedStatement.GenericMemo`. Prior to this commit,
some fully-optimized memos were stored in `PreparedStatement.BaseMemo`.

Release note: None

---

Release justification: Refactoring that narrowly missed branch-cut.

