### PR TITLE
release-24.2: sql: simplify generic query plans

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/generic
+++ b/pkg/ccl/logictestccl/testdata/logic_test/generic
@@ -1193,3 +1193,30 @@ quality of service: regular
           regions: <hidden>
           actual row count: 1
           size: 1 column, 1 row
+
+statement ok
+DEALLOCATE p
+
+# Regression test for #132963. Do not cache non-reusable plans.
+statement ok
+SET plan_cache_mode = auto
+
+statement ok
+CREATE TABLE a (a INT PRIMARY KEY)
+
+statement ok
+PREPARE p AS SELECT create_statement FROM [SHOW CREATE TABLE a]
+
+query T
+EXECUTE p
+----
+CREATE TABLE public.a (
+  a INT8 NOT NULL,
+  CONSTRAINT a_pkey PRIMARY KEY (a ASC)
+)
+
+statement ok
+ALTER TABLE a RENAME TO b
+
+statement error pgcode 42P01 pq: relation \"a\" does not exist
+EXECUTE p


### PR DESCRIPTION
Backport 1/4 commits from #131791.

/cc @cockroachdb/release

---

#### sql: do not cache non-reusable plans

Fixes #132963

Release note (bug fix): A bug has been fixed that caused non-reusable
query plans, e.g., plans for DDL and `SHOW ...` statements, to be cached
and reused in future executions, possibly causing stale results to be
returned. This bug only occurred when `plan_cache_mode` was set to
`auto` or `force_generic_plan`, both of which are not currently the
default settings.

---

Release justification: Bug fix.



