### PR TITLE
storage: add TestKeySchema_RandomKeys

### DIFF
--- a/pkg/storage/engine_key_test.go
+++ b/pkg/storage/engine_key_test.go
@@ -489,3 +489,26 @@ func engineKey(key string, ts int) EngineKey {
 		Version: encodeMVCCTimestamp(wallTS(ts)),
 	}
 }
+
+var possibleVersionLens = []int{
+	engineKeyNoVersion,
+	engineKeyVersionWallTimeLen,
+	engineKeyVersionWallAndLogicalTimeLen,
+	engineKeyVersionWallLogicalAndSyntheticTimeLen,
+	engineKeyVersionLockTableLen,
+}
+
+func randomSerializedEngineKey(r *rand.Rand, maxUserKeyLen int) []byte {
+	userKeyLen := randutil.RandIntInRange(r, 1, maxUserKeyLen)
+	versionLen := possibleVersionLens[r.Intn(len(possibleVersionLens))]
+	serializedLen := userKeyLen + versionLen + 1
+	if versionLen > 0 {
+		serializedLen++ // sentinel
+	}
+	k := randutil.RandBytes(r, serializedLen)
+	k[userKeyLen] = 0x00
+	if versionLen > 0 {
+		k[len(k)-1] = byte(versionLen + 1)
+	}
+	return k
+}

--- a/pkg/storage/testdata/key_schema_key_seeker
+++ b/pkg/storage/testdata/key_schema_key_seeker
@@ -147,3 +147,25 @@ MaterializeUserKey(-1, 3) = hex:6d6f6f0000000000b2d05e00000000010d
 MaterializeUserKey(3, 2) = hex:666f6f0000000000b2d05e00000000010d
 MaterializeUserKey(2, 0) = hex:6261720000000000b2d05e00000000010d
 MaterializeUserKey(0, 1) = hex:6261780000000000b2d05e00000000010d
+
+define-block
+moo@3.000000001,0
+moo@3.000000000,2
+moo@3.000000000,1
+moo@3.000000000,0
+----
+Parse("moo@3.000000001,0") = hex:6d6f6f0000000000b2d05e0109
+Parse("moo@3.000000000,2") = hex:6d6f6f0000000000b2d05e00000000020d
+Parse("moo@3.000000000,1") = hex:6d6f6f0000000000b2d05e00000000010d
+Parse("moo@3.000000000,0") = hex:6d6f6f0000000000b2d05e0009
+
+materialize-user-key
+0
+1
+2
+3
+----
+MaterializeUserKey(-1, 0) = hex:6d6f6f0000000000b2d05e0109
+MaterializeUserKey(0, 1) = hex:6d6f6f0000000000b2d05e00000000020d
+MaterializeUserKey(1, 2) = hex:6d6f6f0000000000b2d05e00000000010d
+MaterializeUserKey(2, 3) = hex:6d6f6f0000000000b2d05e0009


### PR DESCRIPTION
Add a randomized test that constructs random keys, writes them to a Pebble columnar block, iterates over the block and asserts that the keys are semantically equal to the original generated keys.

Epic: none
Release note: none