### PR TITLE
backupccl: remove deprecated restore checkpointing method

### DIFF
--- a/pkg/ccl/backupccl/bench_covering_test.go
+++ b/pkg/ccl/backupccl/bench_covering_test.go
@@ -91,11 +91,10 @@ func BenchmarkRestoreEntryCover(b *testing.B) {
 											filter, err := makeSpanCoveringFilter(
 												backups[numBackups-1].Spans,
 												[]jobspb.RestoreProgress_FrontierEntry{},
-												nil,
 												introducedSpanFrontier,
 												0,
 												defaultMaxFileCount,
-												false)
+											)
 											require.NoError(b, err)
 											defer filter.close()
 

--- a/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
@@ -477,11 +477,9 @@ func runGenerativeSplitAndScatter(
 		filter, err := makeSpanCoveringFilter(
 			spec.Spans,
 			spec.CheckpointedSpans,
-			spec.HighWater,
 			introducedSpanFrontier,
 			spec.TargetSize,
-			spec.MaxFileCount,
-			spec.UseFrontierCheckpointing)
+			spec.MaxFileCount)
 		if err != nil {
 			return errors.Wrap(err, "failed to make span covering filter")
 		}

--- a/pkg/ccl/backupccl/generative_split_and_scatter_processor_test.go
+++ b/pkg/ccl/backupccl/generative_split_and_scatter_processor_test.go
@@ -267,7 +267,6 @@ func makeTestingGenerativeSplitAndScatterSpec(
 		EndTime:            hlc.Timestamp{},
 		Spans:              requiredSpans,
 		BackupLocalityInfo: nil,
-		HighWater:          nil,
 		UserProto:          "",
 		ChunkSize:          1,
 		TargetSize:         1,

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -173,21 +173,17 @@ func distRestore(
 			EndTime:                     md.restoreTime,
 			Spans:                       md.dataToRestore.getSpans(),
 			BackupLocalityInfo:          md.backupLocalityInfo,
-			HighWater:                   md.spanFilter.highWaterMark,
 			UserProto:                   execCtx.User().EncodeProto(),
 			TargetSize:                  md.spanFilter.targetSize,
 			MaxFileCount:                int64(md.spanFilter.maxFileCount),
 			ChunkSize:                   int64(chunkSize),
 			NumEntries:                  int64(md.numImportSpans),
-			UseFrontierCheckpointing:    md.spanFilter.useFrontierCheckpointing,
 			NumNodes:                    int64(numNodes),
 			JobID:                       int64(md.jobID),
 			SQLInstanceIDs:              instanceIDs,
 			ExclusiveFileSpanComparison: md.exclusiveEndKeys,
 		}
-		if md.spanFilter.useFrontierCheckpointing {
-			spec.CheckpointedSpans = persistFrontier(md.spanFilter.checkpointFrontier, 0)
-		}
+		spec.CheckpointedSpans = persistFrontier(md.spanFilter.checkpointFrontier, 0)
 
 		splitAndScatterProc := physicalplan.Processor{
 			SQLInstanceID: execCtx.ExecCfg().NodeInfo.NodeID.SQLInstanceID(),

--- a/pkg/ccl/backupccl/restore_progress_test.go
+++ b/pkg/ccl/backupccl/restore_progress_test.go
@@ -82,7 +82,7 @@ func TestProgressTracker(t *testing.T) {
 		},
 	} {
 		restoreTime := hlc.Timestamp{}
-		pt, err := makeProgressTracker(requiredSpans, persistedSpans, true, 0, restoreTime)
+		pt, err := makeProgressTracker(requiredSpans, persistedSpans, 0, restoreTime)
 		require.NoError(t, err, "step %d", i)
 
 		done, err := pt.ingestUpdate(ctx, mockUpdate(step.update, step.completeUpTo))

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -438,8 +438,7 @@ message GenerativeSplitAndScatterSpec {
   // Spans is the required spans in the restore.
   repeated roachpb.Span spans = 10 [(gogoproto.nullable) = false];
   repeated jobs.jobspb.RestoreDetails.BackupLocalityInfo backup_locality_info = 11 [(gogoproto.nullable) = false];
-  // HighWater is the high watermark of the previous run of restore.
-  optional bytes high_water = 12;
+  reserved 12;
   // User who initiated the restore.
   optional string user_proto = 13 [(gogoproto.nullable) = false, (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/security/username.SQLUsernameProto"];
   // ChunkSize is the number of import spans per chunk.
@@ -451,7 +450,7 @@ message GenerativeSplitAndScatterSpec {
   // NumNodes is the number of nodes available for dist restore.
   optional int64 num_nodes = 17[(gogoproto.nullable) = false];
   optional int64 job_id = 18 [(gogoproto.nullable) = false, (gogoproto.customname) = "JobID"];
-  optional bool use_frontier_checkpointing = 20 [(gogoproto.nullable) = false];
+  reserved 20 ;
   repeated jobs.jobspb.RestoreProgress.FrontierEntry checkpointed_spans = 21 [(gogoproto.nullable) = false];
   // ExclusiveFileSpanComparison is true if the backup can safely use
   // exclusive file span comparison.


### PR DESCRIPTION
The new checkpointing logic has been default since 23.1, so it is safe delete the old checkpointing logic-- we do not expect 25.1 to resume a restore that began pre 23.1.

Epic: none

Release note: non