### PR TITLE
server/license: Allow silencing of license grace period NOTICE

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -505,7 +505,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			if notice, err := ex.server.cfg.LicenseEnforcer.MaybeFailIfThrottled(ctx, curOpen); err != nil {
 				return makeErrEvent(err)
 			} else if notice != nil {
-				res.BufferNotice(notice)
+				p.BufferClientNotice(ctx, notice)
 			}
 		}
 	}


### PR DESCRIPTION
Previously, we were unable to silence the notice emitted during the license grace period because we were using an incorrect API, which bypassed checks that respect environment settings. This fix ensures the notice can be silenced if the `client_min_messages variable` is set or the `sql.notices.enabled` cluster setting is configured, but the notice will still be displayed by default.

Epic: CRDB-39988
Closes #133050
Release note: none