### PR TITLE
roachtest: add gctrace to perturbation/* tests

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -924,7 +924,8 @@ func (v variations) startNoBackup(
 		opts.RoachprodOpts.ExtraArgs = append(opts.RoachprodOpts.ExtraArgs,
 			fmt.Sprintf("--locality=region=fake-%d", (node-1)/nodesPerRegion))
 		opts.RoachprodOpts.ExtraArgs = append(opts.RoachprodOpts.ExtraArgs, extraArgs...)
-		v.Start(ctx, t.L(), opts, install.MakeClusterSettings(), v.Node(node))
+		settings := install.MakeClusterSettings(install.EnvOption([]string{"GODEBUG=gctrace=1"}))
+		v.Start(ctx, t.L(), opts, settings, v.Node(node))
 	}
 }
 


### PR DESCRIPTION
We have had at least one perturbation test failure where the cause appears to be a ~2s process freeze. We don't have conclusive evidence that this is a GOGC rather than some other type of infra flake, but at least this can help rule out one more potential cause.

Informs: #131822

Epic: none

Release note: None