### PR TITLE
roachprod: update default CockroachDB logging configuration

### DIFF
--- a/pkg/roachprod/install/files/cockroachdb-logging.yaml
+++ b/pkg/roachprod/install/files/cockroachdb-logging.yaml
@@ -35,13 +35,13 @@ sinks:
       channels: [STORAGE]
     security:
       channels: [PRIVILEGES, USER_ADMIN]
-      auditable: true
+      auditable: false
     sql-audit:
       channels: [SENSITIVE_ACCESS]
-      auditable: true
+      auditable: false
     sql-auth:
       channels: [SESSIONS]
-      auditable: true
+      auditable: false
     sql-exec:
       channels: [SQL_EXEC]
     sql-slow:


### PR DESCRIPTION
Update the default logging configuration used for roachprod clusters to disable auditable logs on logs going to file sinks. Some roachtests use the buffered:true configuration to withstand disk stall events. This setting is incompatible with auditable logs on file sinks and recently introduced validation (#132742) prohibits the settings from being used together.

Release note: none
Informs #129922.
Informs #132988.
Epic: none