### PR TITLE
sql/schemachanger: add more checks for schema changes during LDR

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -2330,8 +2330,17 @@ func checkSchemaChangeIsAllowed(desc catalog.TableDescriptor, n tree.Statement) 
 	if desc.IsSchemaLocked() && !tree.IsSetOrResetSchemaLocked(n) {
 		return sqlerrors.NewSchemaChangeOnLockedTableErr(desc.GetName())
 	}
-	if len(desc.TableDesc().LDRJobIDs) > 0 && !tree.IsAllowedLDRSchemaChange(n) {
-		return sqlerrors.NewDisallowedSchemaChangeOnLDRTableErr(desc.GetName(), desc.TableDesc().LDRJobIDs)
+	if len(desc.TableDesc().LDRJobIDs) > 0 {
+		var virtualColNames []string
+		for _, col := range desc.NonDropColumns() {
+			if col.IsVirtual() {
+				virtualColNames = append(virtualColNames, col.GetName())
+			}
+		}
+		if !tree.IsAllowedLDRSchemaChange(n, virtualColNames) {
+			return sqlerrors.NewDisallowedSchemaChangeOnLDRTableErr(desc.GetName(), desc.TableDesc().LDRJobIDs)
+
+		}
 	}
 	return nil
 }

--- a/pkg/sql/sem/tree/schema_helpers.go
+++ b/pkg/sql/sem/tree/schema_helpers.go
@@ -32,14 +32,51 @@ func IsSetOrResetSchemaLocked(n Statement) bool {
 // IsAllowedLDRSchemaChange returns true if the schema change statement is
 // allowed to occur while the table is being referenced by a logical data
 // replication job as a destination table.
-func IsAllowedLDRSchemaChange(n Statement) bool {
+func IsAllowedLDRSchemaChange(n Statement, virtualColNames []string) bool {
 	switch s := n.(type) {
 	case *CreateIndex:
-		// Only allow non-unique and non-partial indexes to be created. A unique or
-		// partial index on a destination table could cause inserts to fail.
-		return !s.Unique && s.Predicate == nil
+		// Don't allow creating an index on a virtual column.
+		for _, col := range s.Columns {
+			if slices.Contains(virtualColNames, string(col.Column)) {
+				return false
+			}
+		}
+		// Disallow unique, partial, or hash-sharded indexes. Having these indexes
+		// on a destination table could cause inserts to fail.
+		// NB: hash-sharded indexes are disallowed since they create an index on a
+		// virtual column. Since it also implicitly creates the virtual column
+		// at the same time, the check above on virtualColNames would not block it.
+		return !s.Unique && s.Predicate == nil && s.Sharded == nil
 	case *DropIndex:
 		return true
+	case *SetZoneConfig:
+		return true
+	case *AlterTable:
+		onlySafeStorageParams := true
+		for _, cmd := range s.Cmds {
+			switch c := cmd.(type) {
+			// Allow safe storage parameter changes.
+			case *AlterTableSetStorageParams:
+				// ttl_expire_after is not safe since it creates a new column and
+				// backfills it.
+				if c.StorageParams.GetVal("ttl_expire_after") != nil {
+					onlySafeStorageParams = false
+				}
+			case *AlterTableResetStorageParams:
+				if slices.Contains(c.Params, "ttl_expire_after") {
+					// Resetting `ttl_expire_after` is not safe since it drops a column
+					// and rebuilds the primary index.
+					onlySafeStorageParams = false
+				} else if slices.Contains(c.Params, "ttl") {
+					// Resetting `ttl` can also result in the expiration column being
+					// dropped.
+					onlySafeStorageParams = false
+				}
+			default:
+				onlySafeStorageParams = false
+			}
+		}
+		return onlySafeStorageParams
 	}
 	return false
 }

--- a/pkg/sql/sem/tree/schema_helpers_test.go
+++ b/pkg/sql/sem/tree/schema_helpers_test.go
@@ -58,13 +58,31 @@ func TestIsAllowedLDRSchemaChange(t *testing.T) {
 			stmt:      "ALTER TABLE t ADD COLUMN a INT, DROP COLUMN b",
 			isAllowed: false,
 		},
+		{
+			stmt:      "ALTER TABLE t ADD COLUMN a INT, SET (ttl = 'on', ttl_expiration_expression = 'expires_at')",
+			isAllowed: false,
+		},
+		{
+			stmt:      "ALTER TABLE t SET (ttl = 'on', ttl_expire_after = '5m')",
+			isAllowed: false,
+		},
+		{
+			stmt:      "ALTER TABLE t SET (ttl = 'on', ttl_expiration_expression = 'expires_at')",
+			isAllowed: true,
+		},
+		{
+			stmt:      "ALTER TABLE t RESET (ttl, ttl_expiration_expression)",
+			isAllowed: false,
+		},
 	} {
 		t.Run(tc.stmt, func(t *testing.T) {
 			stmt, err := parser.ParseOne(tc.stmt)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got := tree.IsAllowedLDRSchemaChange(stmt.AST); got != tc.isAllowed {
+			// Tests for virtual column checks are in
+			// TestLogicalReplicationCreationChecks.
+			if got := tree.IsAllowedLDRSchemaChange(stmt.AST, nil /* virtualColNames */); got != tc.isAllowed {
 				t.Errorf("expected %v, got %v", tc.isAllowed, got)
 			}
 		})


### PR DESCRIPTION
We now will disallow creating an index on a virtual column, and creating
a hash-sharded index.

Setting a zone config is always allowed, as is adding COMMENT.

Setting table storage parameters are allowed, except for the TTL-related
parameters that cause the primary index to be rewritten.

End-to-end tests were added for the above.

fixes https://github.com/cockroachdb/cockroach/issues/131989

Release note (sql change): If a table is the destination of a logical
replication stream, then only schema change statements that are deemed
safe are allowed on the table. Safe statements are those that do not
result in a rebuild of the primary index, and do not create an index on
a virtual computed column.
