### PR TITLE
roachtest: disable 23.1 -> 23.2 testing for follower reads

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -1008,6 +1008,13 @@ func runFollowerReadsMixedVersionGlobalTableTest(
 		// Use a longer upgrade timeout to give the migrations enough time to finish
 		// considering the cross-region latency.
 		mixedversion.UpgradeTimeout(60*time.Minute),
+
+		// This test is flaky when upgrading from v23.1 to v23.2 for follower
+		// reads in shared-process deployments. There were a number of changes
+		// to tenant health checks since then which appear to have addressed
+		// this issue.
+		mixedversion.MinimumSupportedVersion("v23.2.0"),
+
 		// This test does not currently work with shared-process
 		// deployments (#129167), so we do not run it in separate-process
 		// mode either to reduce noise. We should reevaluate once the test


### PR DESCRIPTION
After introducing shared process testing of follower reads, the tests follower-reads/mixed-version/* have been flaky. This commit starts testing from 23.2 to make sure that any other failures are caught and triaged correctly.

Epic: none
Fixes: #133000
Fixes: #132999
Fixes: #129546
Fixes: #129167

Release note: None