### PR TITLE
roachprod: default to using WAL failover in multi-store roachtests

### DIFF
--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -243,6 +243,15 @@ func NoBackupSchedule(opts interface{}) {
 	}
 }
 
+// DisableWALFailover can be used to generate StartOpts that disable use of WAL
+// failover.
+func DisableWALFailover(opts interface{}) {
+	switch opts := opts.(type) {
+	case *StartOpts:
+		opts.RoachprodOpts.WALFailover = ""
+	}
+}
+
 // Graceful performs a graceful stop of the cockroach process.
 func Graceful(gracePeriodSeconds int) func(interface{}) {
 	return func(opts interface{}) {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/steps.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/steps.go
@@ -636,9 +636,14 @@ func quoteVersionForPresentation(v string) string {
 // regular backups as some tests check for running jobs and the
 // scheduled backup may make things non-deterministic. In the future,
 // we should change the default and add an API for tests to opt-out of
-// the default scheduled backup if necessary.
+// the default scheduled backup if necessary. We disable WAL failover
+// because some versions before v24.1 will early exit since they don't
+// understand the `--wal-failover` flag.
 func startOpts(opts ...option.StartStopOption) option.StartOpts {
 	return option.NewStartOpts(
-		append([]option.StartStopOption{option.NoBackupSchedule}, opts...)...,
+		append([]option.StartStopOption{
+			option.NoBackupSchedule,
+			option.DisableWALFailover,
+		}, opts...)...,
 	)
 }

--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -147,7 +147,7 @@ func (bd *backupDriver) prepareCluster(ctx context.Context) {
 
 	require.NoError(bd.t, clusterupgrade.StartWithSettings(ctx, bd.t.L(), bd.c,
 		bd.sp.hardware.getCRDBNodes(),
-		option.NewStartOpts(option.NoBackupSchedule),
+		option.NewStartOpts(option.NoBackupSchedule, option.DisableWALFailover),
 		install.BinaryOption(binaryPath)))
 
 	bd.assertCorrectCockroachBinary(ctx)

--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -44,14 +44,12 @@ func registerDiskStalledWALFailover(r registry.Registry) {
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		Leases:            registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			runDiskStalledWALFailover(ctx, t, c, "among-stores")
+			runDiskStalledWALFailover(ctx, t, c)
 		},
 	})
 }
 
-func runDiskStalledWALFailover(
-	ctx context.Context, t test.Test, c cluster.Cluster, failoverFlag string,
-) {
+func runDiskStalledWALFailover(ctx context.Context, t test.Test, c cluster.Cluster) {
 	startSettings := install.MakeClusterSettings()
 	// Set a high value for the max sync durations to avoid the disk
 	// stall detector fataling the node.
@@ -68,12 +66,8 @@ func runDiskStalledWALFailover(
 
 	t.Status("starting cluster")
 	startOpts := option.DefaultStartOpts()
-	if failoverFlag == "among-stores" {
-		startOpts.RoachprodOpts.StoreCount = 2
-	}
-	startOpts.RoachprodOpts.ExtraArgs = []string{
-		"--wal-failover=" + failoverFlag,
-	}
+	startOpts.RoachprodOpts.WALFailover = "among-stores"
+	startOpts.RoachprodOpts.StoreCount = 2
 	c.Start(ctx, t.L(), startOpts, startSettings, c.CRDBNodes())
 
 	// Open a SQL connection to n1, the node that will be stalled.

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2455,10 +2455,15 @@ func (u *CommonTestUtils) resetCluster(
 		return fmt.Errorf("failed to wipe cluster: %w", err)
 	}
 
+	var opts = []option.StartStopOption{option.NoBackupSchedule}
+	if !version.AtLeast(clusterupgrade.MustParseVersion("v24.1.0")) {
+		opts = append(opts, option.DisableWALFailover)
+	}
+
 	cockroachPath := clusterupgrade.CockroachPathForVersion(u.t, version)
 	settings = append(settings, install.BinaryOption(cockroachPath), install.SecureOption(true))
 	return clusterupgrade.StartWithSettings(
-		ctx, l, u.cluster, u.roachNodes, option.NewStartOpts(option.NoBackupSchedule), settings...,
+		ctx, l, u.cluster, u.roachNodes, option.NewStartOpts(opts...), settings...,
 	)
 }
 

--- a/pkg/cmd/roachtest/tests/multi_store_remove.go
+++ b/pkg/cmd/roachtest/tests/multi_store_remove.go
@@ -52,6 +52,11 @@ func runMultiStoreRemove(ctx context.Context, t test.Test, c cluster.Cluster) {
 	t.Status("starting cluster")
 	startOpts := option.DefaultStartOpts()
 	startOpts.RoachprodOpts.StoreCount = multiStoreStoresPerNode
+	// TODO(jackson): Allow WAL failover to be enabled once it's able to
+	// tolerate the removal of a store. Today, the mapping of failover
+	// secondaries is fixed, making WAL failover incompatible with the removal
+	// of a store.
+	startOpts.RoachprodOpts.WALFailover = "disabled"
 	startSettings := install.MakeClusterSettings()
 	// Speed up the replicate queue.
 	startSettings.Env = append(startSettings.Env, "COCKROACH_SCAN_INTERVAL=30s")

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -125,6 +125,13 @@ type StartOpts struct {
 	SkipInit        bool
 	StoreCount      int
 	EncryptedStores bool
+	// WALFailover, if non-empty, configures the value to supply to the
+	// --wal-failover start flag.
+	//
+	// In a multi-store configuration, this may be set to "among-stores" to
+	// enable WAL failover among stores. In a single-store configuration, this
+	// should be set to `path=<path>`.
+	WALFailover string
 
 	// -- Options that apply only to the StartServiceForVirtualCluster target --
 	VirtualClusterName     string
@@ -1120,6 +1127,9 @@ func (c *SyncedCluster) generateStartFlagsKV(node Node, startOpts StartOpts) []s
 			encryptArgs = fmt.Sprintf(encryptArgs, storeDir, storeDir)
 			args = append(args, `--enterprise-encryption`, encryptArgs)
 		}
+	}
+	if startOpts.WALFailover != "" {
+		args = append(args, fmt.Sprintf("--wal-failover=%s", startOpts.WALFailover))
 	}
 
 	args = append(args, fmt.Sprintf("--cache=%d%%", c.maybeScaleMem(25)))

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -740,10 +740,15 @@ const DefaultBackupSchedule = `RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WI
 // DefaultStartOpts returns a StartOpts populated with default values.
 func DefaultStartOpts() install.StartOpts {
 	return install.StartOpts{
-		EncryptedStores:    false,
-		NumFilesLimit:      config.DefaultNumFilesLimit,
-		SkipInit:           false,
-		StoreCount:         1,
+		EncryptedStores: false,
+		NumFilesLimit:   config.DefaultNumFilesLimit,
+		SkipInit:        false,
+		StoreCount:      1,
+		// When a node has 1 store, --wal-failover=among-stores has no effect
+		// but is harmless. If a node has multiple stores, it'll allow failover
+		// of WALs between stores. This allows us to exercise WAL failover and
+		// helps insulate us from test failures from disk stalls in roachtests.
+		WALFailover:        "among-stores",
 		VirtualClusterID:   2,
 		ScheduleBackups:    false,
 		ScheduleBackupArgs: DefaultBackupSchedule,


### PR DESCRIPTION
By default set --wal-failover=among-stores in roachprod clusters. This setting has no effect on nodes with a single store. If a node has mutiple stores, it'll enable the failover of WAL writes between stores disks. This is intended to improve test coverage for WAL failover and hopefully provide some insulation to test failures caused by spurious disk stalls.

Epic: none
Release note: none