### PR TITLE
changefeedccl: fix data race in tests

### DIFF
--- a/pkg/ccl/changefeedccl/sink_external_connection.go
+++ b/pkg/ccl/changefeedccl/sink_external_connection.go
@@ -65,9 +65,10 @@ func validateExternalConnectionSinkURI(
 	}
 
 	if knobs, ok := serverCfg.TestingKnobs.Changefeed.(*TestingKnobs); ok && knobs.WrapSink != nil {
-		wrapSink := knobs.WrapSink
-		knobs.WrapSink = nil
-		defer func() { knobs.WrapSink = wrapSink }()
+		// Make a new copy of the knobs so we don't cause a data race.
+		newKnobs := *knobs
+		newKnobs.WrapSink = nil
+		serverCfg.TestingKnobs.Changefeed = &newKnobs
 	}
 
 	// Validate the URI by creating a canary sink.


### PR DESCRIPTION
Fix data race in unit tests caused by mutating testing knobs.

Fixes: #132537

Release note: none
