### PR TITLE
changefeedccl: fix data race in tests

### DIFF
--- a/pkg/ccl/changefeedccl/sink_external_connection.go
+++ b/pkg/ccl/changefeedccl/sink_external_connection.go
@@ -65,9 +65,11 @@ func validateExternalConnectionSinkURI(
 	}
 
 	if knobs, ok := serverCfg.TestingKnobs.Changefeed.(*TestingKnobs); ok && knobs.WrapSink != nil {
-		wrapSink := knobs.WrapSink
-		knobs.WrapSink = nil
-		defer func() { knobs.WrapSink = wrapSink }()
+		newCfg := *serverCfg
+		newKnobs := *knobs
+		newKnobs.WrapSink = nil
+		newCfg.TestingKnobs.Changefeed = &newKnobs
+		serverCfg = &newCfg
 	}
 
 	// Validate the URI by creating a canary sink.


### PR DESCRIPTION
Fix data race in unit tests caused by mutating testing knobs.

Fixes: #132537

Release note: none
