### PR TITLE
release-24.2: roachtest: fix ruby test setup

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -146,7 +146,7 @@ func registerActiveRecord(r registry.Registry) {
 			c,
 			node,
 			"installing bundler",
-			`cd /mnt/data1/activerecord-cockroachdb-adapter/ && sudo gem install bundler:2.1.4`,
+			`cd /mnt/data1/activerecord-cockroachdb-adapter/ && sudo gem install bundler:2.4.9`,
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/tests/ruby_pg.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg.go
@@ -146,7 +146,7 @@ func registerRubyPG(r registry.Registry) {
 			c,
 			node,
 			"installing bundler",
-			`cd /mnt/data1/ruby-pg/ && sudo gem install bundler:2.1.4`,
+			`cd /mnt/data1/ruby-pg/ && sudo gem install bundler:2.4.9`,
 		); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Backport 1/2 commits from #133093.

/cc @cockroachdb/release

Release justification: test only change

---

fixes https://github.com/cockroachdb/cockroach/issues/132826
fixes https://github.com/cockroachdb/cockroach/issues/132902
fixes https://github.com/cockroachdb/cockroach/issues/133027
Release note: None
