### PR TITLE
release-23.2: roachtest: skip ruby-pg test

### DIFF
--- a/pkg/cmd/roachtest/tests/ruby_pg.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg.go
@@ -232,6 +232,7 @@ func registerRubyPG(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
+		Skip:    "uses old ruby version",
 		Name:    "ruby-pg",
 		Timeout: 1 * time.Hour,
 		Owner:   registry.OwnerSQLFoundations,


### PR DESCRIPTION
Backport 1/1 commits from #133125.

/cc @cockroachdb/release

---

Skip the test on this branch since it uses an old ruby version.

informs https://github.com/cockroachdb/cockroach/issues/132826
Release note: None
Release justification: test only change

