### PR TITLE
changefeedccl: deflake TestChangefeedPrimaryKeyChangeWorks

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -6646,8 +6646,6 @@ INSERT INTO foo VALUES (1, 'f');
 		assertPayloads(t, foo, []string{
 			`foo: [6, "a"]->{"after": {"a": 6, "b": "a"}}`,
 			`foo: [14, "e"]->{"after": {"a": 5, "b": "e"}}`,
-		})
-		assertPayloads(t, foo, []string{
 			`foo: [1]->{"after": {"a": 1, "b": "f"}}`,
 		})
 	}


### PR DESCRIPTION
This patch deflakes `TestChangefeedPrimaryKeyChangeWorks` by removing an
erroneous assumption regarding the order of messages for different keys.

Fixes #133045

Release note: None