### PR TITLE
workload/schemachange: setColumnType operations will occasionally fail

### DIFF
--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -268,7 +268,7 @@ var opWeights = []int{
 	alterTableAddColumn:               1,
 	alterTableAddConstraintForeignKey: 1,
 	alterTableAddConstraintUnique:     1,
-	alterTableAlterColumnType:         0, // Disabled and tracked with #66662.
+	alterTableAlterColumnType:         1,
 	alterTableAlterPrimaryKey:         1,
 	alterTableDropColumn:              1,
 	alterTableDropColumnDefault:       1,


### PR DESCRIPTION
Previously this test would fail due to 0A000 and 2BP01 even though those failures are expected.
In these code changes we properly handle these errors.

Epic: CRDB-25314

Fixes: #66662
Release note: None