### PR TITLE
log: add unsafeWrapper in log package

### DIFF
--- a/pkg/kv/kvpb/BUILD.bazel
+++ b/pkg/kv/kvpb/BUILD.bazel
@@ -74,6 +74,7 @@ go_test(
         "//pkg/storage/enginepb",
         "//pkg/testutils/echotest",
         "//pkg/util/buildutil",
+        "//pkg/util/encoding",
         "//pkg/util/hlc",
         "//pkg/util/protoutil",
         "//pkg/util/timeutil",

--- a/pkg/kv/kvpb/string_test.go
+++ b/pkg/kv/kvpb/string_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -85,7 +86,7 @@ func TestReplicaUnavailableError(t *testing.T) {
 func TestAmbiguousResultError(t *testing.T) {
 	ctx := context.Background()
 
-	wrapped := errors.Errorf("boom with a %s", redact.Unsafe("secret"))
+	wrapped := errors.Errorf("boom with a %s", encoding.Unsafe("secret"))
 	var err error = kvpb.NewAmbiguousResultError(wrapped)
 	err = errors.DecodeError(ctx, errors.EncodeError(ctx, err))
 	require.True(t, errors.Is(err, wrapped), "%+v", err)

--- a/pkg/sql/inverted/expression.go
+++ b/pkg/sql/inverted/expression.go
@@ -167,7 +167,7 @@ func formatSpan(span Span, redactable bool) string {
 	}
 	output := fmt.Sprintf("[%s, %s%c", start, end, spanEndOpenOrClosed)
 	if redactable {
-		output = string(redact.Sprintf("%s", redact.Unsafe(output)))
+		output = string(redact.Sprintf("%s", encoding.Unsafe(output)))
 	}
 	return output
 }

--- a/pkg/sql/opt/cat/BUILD.bazel
+++ b/pkg/sql/opt/cat/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/types",
+        "//pkg/util/encoding",
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -324,7 +325,7 @@ func formatFamily(family Family, buf *bytes.Buffer) {
 // markRedactable is true.
 func MaybeMarkRedactable(unsafe string, markRedactable bool) string {
 	if markRedactable {
-		return string(redact.Sprintf("%s", redact.Unsafe(unsafe)))
+		return string(redact.Sprintf("%s", encoding.Unsafe(unsafe)))
 	}
 	return unsafe
 }

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -3749,3 +3749,19 @@ func BytesPrevish(b []byte, length int) []byte {
 	copy(buf[bLen:], bytes.Repeat([]byte{0xff}, length-bLen))
 	return buf
 }
+
+// unsafeWrapper is implementation of SafeFormatter. This is used to mark
+// arguments as unsafe for redaction. This would make sure that redact.Unsafe() is implementing SafeFormatter interface
+// without affecting invocations.
+// TODO(aa-joshi): This is a temporary solution to mark arguments as unsafe. We should move/update this into cockroachdb/redact package.
+type unsafeWrapper struct {
+	a any
+}
+
+func (uw unsafeWrapper) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Print(redact.Unsafe(uw.a))
+}
+
+func Unsafe(args any) any {
+	return unsafeWrapper{a: args}
+}

--- a/pkg/util/log/redact.go
+++ b/pkg/util/log/redact.go
@@ -135,7 +135,7 @@ func maybeRedactEntry(payload entryPayload, editor redactEditor) (res entryPaylo
 
 func init() {
 	// We consider booleans and numeric values to be always safe for
-	// reporting. A log call can opt out by using redact.Unsafe() around
+	// reporting. A log call can opt out by using encoding.Unsafe() around
 	// a value that would be otherwise considered safe.
 	redact.RegisterSafeType(reflect.TypeOf(true)) // bool
 	redact.RegisterSafeType(reflect.TypeOf(123))  // int


### PR DESCRIPTION
Previously, we are using `redact.Unsafe()` to mark a particular parameter as
unsafe. We are updating log redaction flow as part of CRDB-37533. This change
introduces `unsafeWrapper` which implements `SafeFormatter`. The wrapper is
introduced so that future work can properly infer whether objects which are
being logged are safe or unsafe. This is a `no-op` change which is necessary in
order to mark redaction operation from within CRDB.

Epic: CRDB-37533
Part of: CRDB-42344
Release note: None