### PR TITLE
pkg/util/log: assume logging args to be safe by default

### DIFF
--- a/pkg/util/log/BUILD.bazel
+++ b/pkg/util/log/BUILD.bazel
@@ -178,6 +178,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/util/caller",
         "//pkg/util/ctxgroup",
+        "//pkg/util/encoding",
         "//pkg/util/leaktest",
         "//pkg/util/log/channel",
         "//pkg/util/log/logconfig",

--- a/pkg/util/log/log_entry.go
+++ b/pkg/util/log/log_entry.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base/serverident"
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -215,6 +216,42 @@ func makeStructuredEntry(
 	return res
 }
 
+var (
+	// envDefaultSafeRedactionEnabled is the environment variable that controls
+	// if the "default safe" redaction is enabled. If this is set to true, then
+	// all types that do not implement the SafeFormatter or SafeValue interfaces
+	// are assumed to be safe. Enabling this will have some performance degradation
+	// as it will wrap all arguments in a call to redact.Safe. This is still
+	// EXPERIMENTAL and should be used with caution.
+	envDefaultSafeRedactionEnabled = envutil.EnvOrDefaultBool("COCKROACH_DEFAULT_SAFE_REDACTION", false)
+)
+
+// sanitizePrintArgs makes sure that there is no ambiguity in whether an argument is
+// safe or unsafe. This is done by making sure that the types of the arguments
+// either implement the SafeFormatter or SafeValue interfaces. If they do not,
+// the argument is assumed to be safe and is wrapped in a call to redact.Safe.
+func sanitizePrintArgs(args []interface{}) []interface{} {
+	if !envDefaultSafeRedactionEnabled {
+		return args
+	}
+
+	sanitizedArgs := make([]interface{}, len(args))
+	for i, arg := range args {
+		if _, ok := arg.(redact.SafeFormatter); ok {
+			sanitizedArgs[i] = arg
+		}
+
+		if _, ok := arg.(redact.SafeValue); ok {
+			sanitizedArgs[i] = arg
+		}
+
+		// assume that the arg is safe
+		sanitizedArgs[i] = redact.Safe(arg)
+	}
+
+	return sanitizedArgs
+}
+
 // makeUnstructuredEntry creates a logEntry using an unstructured message.
 func makeUnstructuredEntry(
 	ctx context.Context,
@@ -234,11 +271,15 @@ func makeUnstructuredEntry(
 		if len(args) == 0 {
 			// TODO(knz): Remove this legacy case.
 			buf.Print(redact.Safe(format))
-		} else if len(format) == 0 {
-			buf.Print(args...)
 		} else {
-			buf.Printf(format, args...)
+			sArgs := sanitizePrintArgs(args)
+			if len(format) == 0 {
+				buf.Print(sArgs...)
+			} else {
+				buf.Printf(format, sArgs...)
+			}
 		}
+
 		// Collect and append the hints, if any.
 		for _, a := range args {
 			if e, ok := a.(error); ok {
@@ -248,6 +289,7 @@ func makeUnstructuredEntry(
 				}
 			}
 		}
+
 		res.payload = makeRedactablePayload(ctx, buf.RedactableString())
 	} else {
 		var buf strings.Builder

--- a/pkg/util/log/redact_test.go
+++ b/pkg/util/log/redact_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base/serverident"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
@@ -227,4 +228,156 @@ func TestDefaultRedactable(t *testing.T) {
 	if !contains("safe "+startRedactable+"unsafe"+endRedactable, t) {
 		t.Errorf("expected marked data, got %q", contents())
 	}
+
+	t.Run("with defaut safe redaction", func(t *testing.T) {
+		defer capture()()
+		defer setShouldSanitizeArgs(true)()
+
+		// when "default safe" redaction is enabled, we need to explicitly
+		// mark the unsafe arg as unsafe.
+		Infof(context.Background(), "safe %s", encoding.Unsafe("unsafe"))
+		if !contains("safe "+startRedactable+"unsafe"+endRedactable, t) {
+			t.Errorf("expected marked data, got %q", contents())
+		}
+	})
+}
+
+func setShouldSanitizeArgs(val bool) func() {
+	prev := envDefaultSafeRedactionEnabled
+	envDefaultSafeRedactionEnabled = val
+	return func() { envDefaultSafeRedactionEnabled = prev }
+}
+
+// does not implement SafeFormatter
+type sampleSafe struct {
+	a string
+}
+
+func (s sampleSafe) String() string {
+	return s.a
+}
+
+// implements SafeFormatter
+type sampleWithUnsafe struct {
+	a, b string
+}
+
+func (s sampleWithUnsafe) String() string {
+	return fmt.Sprintf("a: %s, b: %s", s.a, s.b)
+}
+
+func (s sampleWithUnsafe) SafeFormat(w redact.SafePrinter, _ rune) {
+	// explicitly marks s.a as safe
+	w.Printf("a: %s, b: %s", redact.Safe(s.a), s.b)
+}
+
+type errWithHint struct {
+	err error
+}
+
+func (e errWithHint) Error() string {
+	return e.err.Error()
+}
+
+func (e errWithHint) ErrorHint() string {
+	return "hint"
+}
+
+func TestDefaultSafeRedaction(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer ScopeWithoutShowLogs(t).Close(t)
+	defer setShouldSanitizeArgs(true)()
+
+	tt := []struct {
+		name     string
+		args     any
+		expected string
+	}{
+		{
+			name:     "does not implement SafeFormatter",
+			args:     sampleSafe{a: "safe"},
+			expected: "safe",
+		},
+		{
+			name:     "implements SafeFormatter",
+			args:     sampleWithUnsafe{a: "safe", b: "unsafe"},
+			expected: "a: safe, b: ‹unsafe›",
+		},
+		{
+			name:     "uses encoding.Unsafe with struct",
+			args:     encoding.Unsafe(sampleSafe{a: "unsafe"}),
+			expected: "‹unsafe›",
+		},
+		{
+			name:     "uses primitive type", // should always be safe
+			args:     "safe",
+			expected: "safe",
+		},
+		{
+			name:     "uses encoding.Unsafe with primitive type",
+			args:     encoding.Unsafe(100),
+			expected: "‹100›",
+		},
+		{
+			name:     "has error hints",
+			args:     errWithHint{err: errors.New("error")},
+			expected: "‹error›\n+HINT: ‹hint›",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			defer capture()()
+			Infof(context.Background(), "%v", tc.args)
+
+			messages := []string{} // there might be more than one log line. Collect all the messages
+			for _, line := range strings.Split(strings.TrimSpace(contents()), "\n") {
+				messages = append(messages, strings.TrimSpace(parseLogEntry(t, line).Message))
+			}
+
+			require.Equal(t, tc.expected, strings.Join(messages, "\n"))
+		})
+	}
+}
+
+func parseLogEntry(t *testing.T, line string) logpb.Entry {
+	t.Helper()
+
+	reader := strings.NewReader(line)
+	decoder, err := NewEntryDecoderWithFormat(reader, WithMarkedSensitiveData, "crdb-v1")
+	require.NoError(t, err)
+
+	var entry logpb.Entry
+	require.NoError(t, decoder.Decode(&entry))
+	return entry
+}
+
+func BenchmarkDefaultSafeRedaction(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	defer ScopeWithoutShowLogs(b).Close(b)
+	defer capture()()
+
+	printLogLines := func() {
+		Info(context.Background(), "safe")
+		Infof(context.Background(), "%s", sampleWithUnsafe{a: "safe", b: "unsafe"})
+		Infof(context.Background(), "%s", sampleSafe{a: "safe"})
+		Infof(
+			context.Background(), "%s %s",
+			sampleWithUnsafe{a: "safe", b: "unsafe"}, sampleSafe{a: "safe"},
+		)
+	}
+
+	b.Run("with default unsafe (current behaviour)", func(b *testing.B) {
+		defer setShouldSanitizeArgs(false)()
+		for i := 0; i < b.N; i++ {
+			printLogLines()
+		}
+	})
+
+	b.Run("with default safe", func(b *testing.B) {
+		defer setShouldSanitizeArgs(true)()
+		for i := 0; i < b.N; i++ {
+			printLogLines()
+		}
+	})
 }


### PR DESCRIPTION
The redact library that we use (cockroach/redact) assumes all type to be unsafe by default, unless specifically marked as "safe". We want to reverse that (assume safe by default). Instead making assumptions about types being logged, we want to mindfully and intentionally mark types are unsafe when they contain sensitive data.

This commits adds an inference logic that looks at each argument of log statements. If the arg's type implements "SafeFormatter" (defined in the redact lib), it leaves the arg as it is. If it doesn't implement SafeFormatter, it explicitly marks the type as "safe for logging". This logic is behind an env variable which is disabled by default. 

More details and rational behind this change, can be found here:
https://docs.google.com/document/d/12HimAj-5zz-4I4QUTzyFxNjwVqg9JKBCA3AXhxU3bSk/edit?tab=t.0#heading=h.9ndo02nsmu

Epic: CRDB-37533
Part of: CRDB-42320
Release note: None