### PR TITLE
raft: remove apply pacing

### DIFF
--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -78,13 +78,6 @@ type raftLog struct {
 	// returned from calls to nextCommittedEnts that have not been acknowledged
 	// by a call to appliedTo.
 	maxApplyingEntsSize entryEncodingSize
-	// applyingEntsSize is the current outstanding byte size of the messages
-	// returned from calls to nextCommittedEnts that have not been acknowledged
-	// by a call to appliedTo.
-	applyingEntsSize entryEncodingSize
-	// applyingEntsPaused is true when entry application has been paused until
-	// enough progress is acknowledged.
-	applyingEntsPaused bool
 }
 
 // newLog returns log using the given storage and default options. It
@@ -263,14 +256,18 @@ func (l *raftLog) hasNextUnstableEnts() bool {
 	return len(l.nextUnstableEnts()) > 0
 }
 
+func (l *raftLog) applyingEntsPaused() bool {
+	return l.applying > l.applied
+}
+
 // nextCommittedEnts returns all the available entries for execution.
 // Entries can be committed even when the local raft instance has not durably
 // appended them to the local raft log yet. If allowUnstable is true, committed
 // entries from the unstable log may be returned; otherwise, only entries known
 // to reside locally on stable storage will be returned.
 func (l *raftLog) nextCommittedEnts(allowUnstable bool) (ents []pb.Entry) {
-	if l.applyingEntsPaused {
-		// Entry application outstanding size limit reached.
+	if l.applyingEntsPaused() {
+		// Some entries are still being applied.
 		return nil
 	}
 	if l.hasNextOrInProgressSnapshot() {
@@ -282,12 +279,7 @@ func (l *raftLog) nextCommittedEnts(allowUnstable bool) (ents []pb.Entry) {
 		// Nothing to apply.
 		return nil
 	}
-	maxSize := l.maxApplyingEntsSize - l.applyingEntsSize
-	if maxSize <= 0 {
-		l.logger.Panicf("applying entry size (%d-%d)=%d not positive",
-			l.maxApplyingEntsSize, l.applyingEntsSize, maxSize)
-	}
-	ents, err := l.slice(lo, hi, maxSize)
+	ents, err := l.slice(lo, hi, l.maxApplyingEntsSize)
 	if err != nil {
 		l.logger.Panicf("unexpected error when getting unapplied entries (%v)", err)
 	}
@@ -297,8 +289,8 @@ func (l *raftLog) nextCommittedEnts(allowUnstable bool) (ents []pb.Entry) {
 // hasNextCommittedEnts returns if there is any available entries for execution.
 // This is a fast check without heavy raftLog.slice() in nextCommittedEnts().
 func (l *raftLog) hasNextCommittedEnts(allowUnstable bool) bool {
-	if l.applyingEntsPaused {
-		// Entry application outstanding size limit reached.
+	if l.applyingEntsPaused() {
+		// Some entries are still being applied.
 		return false
 	}
 	if l.hasNextOrInProgressSnapshot() {
@@ -377,39 +369,19 @@ func (l *raftLog) commitTo(mark LogMark) {
 	}
 }
 
-func (l *raftLog) appliedTo(i uint64, size entryEncodingSize) {
+func (l *raftLog) appliedTo(i uint64) {
 	if l.committed < i || i < l.applied {
 		l.logger.Panicf("applied(%d) is out of range [prevApplied(%d), committed(%d)]", i, l.applied, l.committed)
 	}
 	l.applied = i
 	l.applying = max(l.applying, i)
-	if l.applyingEntsSize > size {
-		l.applyingEntsSize -= size
-	} else {
-		// Defense against underflow.
-		l.applyingEntsSize = 0
-	}
-	l.applyingEntsPaused = l.applyingEntsSize >= l.maxApplyingEntsSize
 }
 
-func (l *raftLog) acceptApplying(i uint64, size entryEncodingSize, allowUnstable bool) {
+func (l *raftLog) acceptApplying(i uint64) {
 	if l.committed < i {
 		l.logger.Panicf("applying(%d) is out of range [prevApplying(%d), committed(%d)]", i, l.applying, l.committed)
 	}
 	l.applying = i
-	l.applyingEntsSize += size
-	// Determine whether to pause entry application until some progress is
-	// acknowledged. We pause in two cases:
-	// 1. the outstanding entry size equals or exceeds the maximum size.
-	// 2. the outstanding entry size does not equal or exceed the maximum size,
-	//    but we determine that the next entry in the log will push us over the
-	//    limit. We determine this by comparing the last entry returned from
-	//    raftLog.nextCommittedEnts to the maximum entry that the method was
-	//    allowed to return had there been no size limit. If these indexes are
-	//    not equal, then the returned entries slice must have been truncated to
-	//    adhere to the memory limit.
-	l.applyingEntsPaused = l.applyingEntsSize >= l.maxApplyingEntsSize ||
-		i < l.maxAppliableIndex(allowUnstable)
 }
 
 func (l *raftLog) stableTo(mark LogMark) { l.unstable.stableTo(mark) }

--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -315,14 +315,14 @@ func TestNextCommittedEnts(t *testing.T) {
 		snap          bool
 		want          []pb.Entry
 	}{
-		{applied: 3, applying: 3, allowUnstable: true, want: init.entries[:2]},
-		{applied: 3, applying: 4, allowUnstable: true, want: init.entries[1:2]},
+		{applied: 3, applying: 3, allowUnstable: true, want: init.sub(3, 5)},
+		{applied: 3, applying: 4, allowUnstable: true, want: init.sub(4, 5)},
 		{applied: 3, applying: 5, allowUnstable: true, want: nil},
-		{applied: 4, applying: 4, allowUnstable: true, want: init.entries[1:2]},
+		{applied: 4, applying: 4, allowUnstable: true, want: init.sub(4, 5)},
 		{applied: 4, applying: 5, allowUnstable: true, want: nil},
 		{applied: 5, applying: 5, allowUnstable: true, want: nil},
 		// Don't allow unstable entries.
-		{applied: 3, applying: 3, allowUnstable: false, want: init.entries[:1]},
+		{applied: 3, applying: 3, allowUnstable: false, want: init.sub(3, 4)},
 		{applied: 3, applying: 4, allowUnstable: false, want: nil},
 		{applied: 3, applying: 5, allowUnstable: false, want: nil},
 		{applied: 4, applying: 4, allowUnstable: false, want: nil},

--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -352,7 +352,7 @@ func TestNextCommittedEnts(t *testing.T) {
 			}
 
 			hasNext := raftLog.hasNextCommittedEnts(tt.allowUnstable)
-			next := raftLog.nextCommittedEnts(tt.allowUnstable)
+			next := raftLog.nextCommittedEnts(noLimit, tt.allowUnstable)
 			require.Equal(t, next != nil, hasNext)
 			require.Equal(t, tt.want, next)
 		})
@@ -360,7 +360,6 @@ func TestNextCommittedEnts(t *testing.T) {
 }
 
 func TestAcceptApplying(t *testing.T) {
-	maxSize := entryEncodingSize(100)
 	snap := pb.Snapshot{
 		Metadata: pb.SnapshotMetadata{Term: 1, Index: 3},
 	}
@@ -376,7 +375,7 @@ func TestAcceptApplying(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			storage := NewMemoryStorage()
 			require.NoError(t, storage.ApplySnapshot(snap))
-			raftLog := newLogWithSize(storage, raftlogger.DiscardLogger, maxSize)
+			raftLog := newLog(storage, raftlogger.DiscardLogger)
 			require.True(t, raftLog.append(init))
 			require.NoError(t, storage.Append(init.entries[:1]))
 
@@ -392,7 +391,6 @@ func TestAcceptApplying(t *testing.T) {
 }
 
 func TestAppliedTo(t *testing.T) {
-	maxSize := entryEncodingSize(100)
 	snap := pb.Snapshot{
 		Metadata: pb.SnapshotMetadata{Term: 1, Index: 3},
 	}
@@ -409,7 +407,7 @@ func TestAppliedTo(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			storage := NewMemoryStorage()
 			require.NoError(t, storage.ApplySnapshot(snap))
-			raftLog := newLogWithSize(storage, raftlogger.DiscardLogger, maxSize)
+			raftLog := newLog(storage, raftlogger.DiscardLogger)
 			require.True(t, raftLog.append(init))
 			require.NoError(t, storage.Append(init.entries[:1]))
 

--- a/pkg/raft/raft_paper_test.go
+++ b/pkg/raft/raft_paper_test.go
@@ -438,7 +438,7 @@ func TestLeaderCommitEntry(t *testing.T) {
 	assert.Equal(t, li+1, r.raftLog.committed)
 	assert.Equal(t, []pb.Entry{
 		{Index: li + 1, Term: 1, Data: []byte("some data")},
-	}, r.raftLog.nextCommittedEnts(true))
+	}, r.raftLog.nextCommittedEnts(noLimit, true))
 	msgs := r.readMessages()
 	slices.SortFunc(msgs, cmpMessages)
 	for i, m := range msgs {
@@ -515,7 +515,7 @@ func TestLeaderCommitPrecedingEntries(t *testing.T) {
 		assert.Equal(t, append(tt,
 			pb.Entry{Term: 3, Index: li + 1},
 			pb.Entry{Term: 3, Index: li + 2, Data: []byte("some data")},
-		), r.raftLog.nextCommittedEnts(true), "#%d", i)
+		), r.raftLog.nextCommittedEnts(noLimit, true), "#%d", i)
 	}
 }
 
@@ -562,7 +562,7 @@ func TestFollowerCommitEntry(t *testing.T) {
 		r.Step(pb.Message{From: 2, To: 1, Type: pb.MsgApp, Term: 1, Entries: tt.ents, Commit: tt.commit})
 
 		assert.Equal(t, tt.commit, r.raftLog.committed, "#%d", i)
-		assert.Equal(t, tt.ents[:int(tt.commit)], r.raftLog.nextCommittedEnts(true), "#%d", i)
+		assert.Equal(t, tt.ents[:int(tt.commit)], r.raftLog.nextCommittedEnts(noLimit, true), "#%d", i)
 	}
 }
 

--- a/pkg/raft/raft_paper_test.go
+++ b/pkg/raft/raft_paper_test.go
@@ -822,7 +822,7 @@ func commitNoopEntry(r *raft, s *MemoryStorage) {
 	// ignore further messages to refresh followers' commit index
 	r.readMessages()
 	s.Append(r.raftLog.nextUnstableEnts())
-	r.raftLog.appliedTo(r.raftLog.committed, 0 /* size */)
+	r.raftLog.appliedTo(r.raftLog.committed)
 	r.raftLog.stableTo(r.raftLog.unstable.mark())
 }
 

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -45,7 +45,7 @@ func nextEnts(r *raft, s *MemoryStorage) (ents []pb.Entry) {
 
 	// Return committed entries.
 	ents = r.raftLog.nextCommittedEnts(true)
-	r.raftLog.appliedTo(r.raftLog.committed, 0 /* size */)
+	r.raftLog.appliedTo(r.raftLog.committed)
 	return ents
 }
 

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -44,7 +44,7 @@ func nextEnts(r *raft, s *MemoryStorage) (ents []pb.Entry) {
 	r.advanceMessagesAfterAppend()
 
 	// Return committed entries.
-	ents = r.raftLog.nextCommittedEnts(true)
+	ents = r.raftLog.nextCommittedEnts(noLimit, true)
 	r.raftLog.appliedTo(r.raftLog.committed)
 	return ents
 }

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -499,7 +499,7 @@ func (rn *RawNode) acceptReady(rd Ready) {
 	if len(rd.CommittedEntries) > 0 {
 		ents := rd.CommittedEntries
 		index := ents[len(ents)-1].Index
-		rn.raft.raftLog.acceptApplying(index, entsSize(ents), rn.applyUnstableEntries())
+		rn.raft.raftLog.acceptApplying(index)
 	}
 }
 

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -230,7 +230,7 @@ func (rn *RawNode) readyWithoutAccept() Ready {
 
 	rd := Ready{
 		Entries:          r.raftLog.nextUnstableEnts(),
-		CommittedEntries: r.raftLog.nextCommittedEnts(rn.applyUnstableEntries()),
+		CommittedEntries: r.raftLog.nextCommittedEnts(r.maxApplyingEntsSize, rn.applyUnstableEntries()),
 		Messages:         r.msgs,
 	}
 	if softSt := r.softState(); !softSt.equal(rn.prevSoftSt) {

--- a/pkg/raft/testdata/async_storage_writes.txt
+++ b/pkg/raft/testdata/async_storage_writes.txt
@@ -505,8 +505,6 @@ process-ready 1 2 3
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   Entries:
   1/15 EntryNormal "prop_4"
-  CommittedEntries:
-  1/13 EntryNormal "prop_2"
   Messages:
   1->2 MsgApp Term:1 Log:1/14 Commit:13
   1->3 MsgApp Term:1 Log:1/14 Commit:13
@@ -515,9 +513,6 @@ process-ready 1 2 3
   1->AppendThread MsgStorageAppend Term:1 Log:1/15 Commit:13 Vote:1 Lead:1 LeadEpoch:1 Entries:[1/15 EntryNormal "prop_4"] Responses:[
     1->1 MsgAppResp Term:1 Log:0/15 Commit:13
     AppendThread->1 MsgStorageAppendResp Term:0 Log:1/15
-  ]
-  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
-    ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
   ]
 > 2 handling Ready
   <empty Ready>
@@ -540,32 +535,22 @@ process-ready 1 2 3
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   Entries:
   1/15 EntryNormal "prop_4"
-  CommittedEntries:
-  1/13 EntryNormal "prop_2"
   Messages:
   2->AppendThread MsgStorageAppend Term:1 Log:1/15 Commit:13 Vote:1 Lead:1 LeadEpoch:1 Entries:[1/15 EntryNormal "prop_4"] Responses:[
     2->1 MsgAppResp Term:1 Log:0/14 Commit:13
     2->1 MsgAppResp Term:1 Log:0/15 Commit:13
     AppendThread->2 MsgStorageAppendResp Term:0 Log:1/15
   ]
-  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
-    ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
-  ]
 > 3 handling Ready
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   Entries:
   1/15 EntryNormal "prop_4"
-  CommittedEntries:
-  1/13 EntryNormal "prop_2"
   Messages:
   3->AppendThread MsgStorageAppend Term:1 Log:1/15 Commit:13 Vote:1 Lead:1 LeadEpoch:1 Entries:[1/15 EntryNormal "prop_4"] Responses:[
     3->1 MsgAppResp Term:1 Log:0/14 Commit:13
     3->1 MsgAppResp Term:1 Log:0/15 Commit:13
     AppendThread->3 MsgStorageAppendResp Term:0 Log:1/15
-  ]
-  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
-    ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
   ]
 
 process-append-thread 1 2 3
@@ -629,18 +614,37 @@ process-ready 1 2 3
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:14 Lead:1 LeadEpoch:1
   CommittedEntries:
+  1/13 EntryNormal "prop_2"
   1/14 EntryNormal "prop_3"
   Messages:
   1->2 MsgApp Term:1 Log:1/15 Commit:14
   1->3 MsgApp Term:1 Log:1/15 Commit:14
   1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:14 Vote:1 Lead:1 LeadEpoch:1
-  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"] Responses:[
-    ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
+  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[
+    1/13 EntryNormal "prop_2"
+    1/14 EntryNormal "prop_3"
+  ] Responses:[
+    ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[
+      1/13 EntryNormal "prop_2"
+      1/14 EntryNormal "prop_3"
+    ]
   ]
 > 2 handling Ready
-  <empty Ready>
+  Ready MustSync=false:
+  CommittedEntries:
+  1/13 EntryNormal "prop_2"
+  Messages:
+  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
+    ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
+  ]
 > 3 handling Ready
-  <empty Ready>
+  Ready MustSync=false:
+  CommittedEntries:
+  1/13 EntryNormal "prop_2"
+  Messages:
+  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"] Responses:[
+    ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
+  ]
 
 deliver-msgs 1 2 3
 ----
@@ -654,26 +658,16 @@ process-ready 1 2 3
 > 2 handling Ready
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:14 Lead:1 LeadEpoch:1
-  CommittedEntries:
-  1/14 EntryNormal "prop_3"
   Messages:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:14 Vote:1 Lead:1 LeadEpoch:1 Responses:[
     2->1 MsgAppResp Term:1 Log:0/15 Commit:14
   ]
-  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"] Responses:[
-    ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
-  ]
 > 3 handling Ready
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:14 Lead:1 LeadEpoch:1
-  CommittedEntries:
-  1/14 EntryNormal "prop_3"
   Messages:
   3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:14 Vote:1 Lead:1 LeadEpoch:1 Responses:[
     3->1 MsgAppResp Term:1 Log:0/15 Commit:14
-  ]
-  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"] Responses:[
-    ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
   ]
 
 process-append-thread 1 2 3
@@ -703,9 +697,15 @@ process-apply-thread 1 2 3
 ----
 > 1 processing apply thread
   Processing:
-  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
+  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[
+    1/13 EntryNormal "prop_2"
+    1/14 EntryNormal "prop_3"
+  ]
   Responses:
-  ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
+  ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[
+    1/13 EntryNormal "prop_2"
+    1/14 EntryNormal "prop_3"
+  ]
 > 2 processing apply thread
   Processing:
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
@@ -725,7 +725,10 @@ AppendThread->1 MsgStorageAppendResp Term:0 Log:1/15
 2->1 MsgAppResp Term:1 Log:0/15 Commit:13
 3->1 MsgAppResp Term:1 Log:0/14 Commit:13
 3->1 MsgAppResp Term:1 Log:0/15 Commit:13
-ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
+ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[
+  1/13 EntryNormal "prop_2"
+  1/14 EntryNormal "prop_3"
+]
 AppendThread->2 MsgStorageAppendResp Term:0 Log:1/15
 ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
 AppendThread->3 MsgStorageAppendResp Term:0 Log:1/15
@@ -746,9 +749,21 @@ process-ready 1 2 3
     ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
   ]
 > 2 handling Ready
-  <empty Ready>
+  Ready MustSync=false:
+  CommittedEntries:
+  1/14 EntryNormal "prop_3"
+  Messages:
+  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"] Responses:[
+    ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
+  ]
 > 3 handling Ready
-  <empty Ready>
+  Ready MustSync=false:
+  CommittedEntries:
+  1/14 EntryNormal "prop_3"
+  Messages:
+  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"] Responses:[
+    ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
+  ]
 
 deliver-msgs 1 2 3
 ----
@@ -762,26 +777,16 @@ process-ready 1 2 3
 > 2 handling Ready
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:15 Lead:1 LeadEpoch:1
-  CommittedEntries:
-  1/15 EntryNormal "prop_4"
   Messages:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:15 Vote:1 Lead:1 LeadEpoch:1 Responses:[
     2->1 MsgAppResp Term:1 Log:0/15 Commit:15
   ]
-  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"] Responses:[
-    ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
-  ]
 > 3 handling Ready
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:15 Lead:1 LeadEpoch:1
-  CommittedEntries:
-  1/15 EntryNormal "prop_4"
   Messages:
   3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:15 Vote:1 Lead:1 LeadEpoch:1 Responses:[
     3->1 MsgAppResp Term:1 Log:0/15 Commit:15
-  ]
-  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"] Responses:[
-    ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
   ]
 
 process-append-thread 2 3
@@ -801,9 +806,9 @@ process-apply-thread 1 2 3
 ----
 > 1 processing apply thread
   Processing:
-  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
+  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
   Responses:
-  ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
+  ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
 > 2 processing apply thread
   Processing:
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
@@ -819,7 +824,7 @@ deliver-msgs 1 2 3
 ----
 2->1 MsgAppResp Term:1 Log:0/15 Commit:14
 3->1 MsgAppResp Term:1 Log:0/15 Commit:14
-ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
+ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
 ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
 ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
 
@@ -828,9 +833,21 @@ process-ready 1 2 3
 > 1 handling Ready
   <empty Ready>
 > 2 handling Ready
-  <empty Ready>
+  Ready MustSync=false:
+  CommittedEntries:
+  1/15 EntryNormal "prop_4"
+  Messages:
+  2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"] Responses:[
+    ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
+  ]
 > 3 handling Ready
-  <empty Ready>
+  Ready MustSync=false:
+  CommittedEntries:
+  1/15 EntryNormal "prop_4"
+  Messages:
+  3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"] Responses:[
+    ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
+  ]
 
 process-append-thread 2 3
 ----
@@ -848,10 +865,7 @@ process-append-thread 2 3
 process-apply-thread 1 2 3
 ----
 > 1 processing apply thread
-  Processing:
-  1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
-  Responses:
-  ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
+  no apply work to perform
 > 2 processing apply thread
   Processing:
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
@@ -867,7 +881,6 @@ deliver-msgs 1 2 3
 ----
 2->1 MsgAppResp Term:1 Log:0/15 Commit:15
 3->1 MsgAppResp Term:1 Log:0/15 Commit:15
-ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
 ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
 ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
 


### PR DESCRIPTION
This commit removes the committed entries application pacing from the `raftLog` type. This is done for a few reasons:

- CRDB does not use this capability. Entries are applied immediately in the `Ready` handler, so there are no times when two `MsgStorageApply` messages are in-flight.
- If we re-introduce this pacing, it will be done outside the `raft` package. Instead of having the per-range in-flight limit, we are going to need a node/store level limit, to help avoid OOMs.
- We are moving away from doing IO from within the `RawNode`. Fetching committed entries from log storage will be done via the `LogSnapshot` at some point. It will be natural for the caller to implement the size policies at its level.
- This change separates the concerns of `raftLog` being a data structure, vs flow control / pacing policies. Before this change, the two were coupled in the `raftLog` type.

Related to #105850