### PR TITLE
ui: remove "Range Count" column from db page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/databaseDetailsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databaseDetailsApi.ts
@@ -83,7 +83,6 @@ function newDatabaseDetailsSpanStatsResponse(): DatabaseDetailsSpanStatsResponse
       approximate_disk_bytes: 0,
       live_bytes: 0,
       total_bytes: 0,
-      range_count: 0,
     },
     error: undefined,
   };
@@ -332,7 +331,6 @@ export type DatabaseSpanStatsRow = {
   approximate_disk_bytes: number;
   live_bytes: number;
   total_bytes: number;
-  range_count: number;
 };
 
 function formatSpanStatsExecutionResult(
@@ -357,7 +355,6 @@ function formatSpanStatsExecutionResult(
   if (txnResult.rows.length === 1) {
     const row = txnResult.rows[0];
     out.spanStats.approximate_disk_bytes = row.approximate_disk_bytes;
-    out.spanStats.range_count = row.range_count;
     out.spanStats.live_bytes = row.live_bytes;
     out.spanStats.total_bytes = row.total_bytes;
   } else {
@@ -511,7 +508,6 @@ export function createDatabaseDetailsSpanStatsReq(
 ): SqlExecutionRequest {
   const statement = {
     sql: `SELECT
-            sum(range_count) as range_count,
             sum(approximate_disk_bytes) as approximate_disk_bytes,
             sum(live_bytes) as live_bytes,
             sum(total_bytes) as total_bytes

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
@@ -575,29 +575,6 @@ export class DatabasesPage extends React.Component<
         title: (
           <Tooltip
             placement="bottom"
-            title="The total number of ranges across all tables in the database."
-          >
-            Range Count
-          </Tooltip>
-        ),
-        cell: database => (
-          <LoadingCell
-            requestError={database.spanStatsRequestError}
-            queryError={database.spanStats?.error}
-            loading={database.spanStatsLoading}
-            errorClassName={cx("databases-table__cell-error")}
-          >
-            {database.spanStats?.range_count}
-          </LoadingCell>
-        ),
-        sort: database => database.spanStats?.range_count,
-        className: cx("databases-table__col-range-count"),
-        name: "rangeCount",
-      },
-      {
-        title: (
-          <Tooltip
-            placement="bottom"
             title="Regions/Nodes on which the database tables are located."
           >
             {this.props.isTenant ? "Regions" : "Regions/Nodes"}

--- a/pkg/ui/workspaces/cluster-ui/src/store/databaseDetails/databaseDetailsSpanStats.saga.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/databaseDetails/databaseDetailsSpanStats.saga.spec.ts
@@ -41,7 +41,6 @@ describe("DatabaseDetails sagas", () => {
       spanStats: {
         approximate_disk_bytes: 100,
         live_bytes: 200,
-        range_count: 300,
         total_bytes: 400,
         error: undefined,
       },

--- a/pkg/ui/workspaces/db-console/src/util/api.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.spec.ts
@@ -119,7 +119,6 @@ describe("rest api", function () {
                 approximate_disk_bytes: 100,
                 live_bytes: 200,
                 total_bytes: 300,
-                range_count: 400,
               },
             ],
           },
@@ -130,7 +129,6 @@ describe("rest api", function () {
         expect(res.results.spanStats.approximate_disk_bytes).toEqual(100);
         expect(res.results.spanStats.live_bytes).toEqual(200);
         expect(res.results.spanStats.total_bytes).toEqual(300);
-        expect(res.results.spanStats.range_count).toEqual(400);
       });
     });
   });


### PR DESCRIPTION
The legacy databases page calculates the "Range Count" column by summing  the range counts of every table in said database. This is not an accurate value because multiple tables can share a range, resulting in potential double counting when doing a sum at the database level. As a result, there are discrepancies between the "Range Count" on the "Databases" page and the results of a `SHOW RANGES` query.

Since getting unique ranges, as per the `SHOW RANGES` query, is a relatively expensive operation, we are opting to remove this column from the "Databases" page.

Epic: CRDB-37558
Resolves: #116691
Release note (ui change): Due to the inaccuracy of the "Range Count" column on the "Databases" page and the cost incurred to fetch the correct range count for every database in a cluster, this data will no longer be visible. This data is still available via a `SHOW RANGES` query.