### PR TITLE
cluster-ui: misc v2 db pages styling adjustments

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/common/styles.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/common/styles.module.scss
@@ -13,8 +13,6 @@
 
   :global(.crl-ant-tabs-tab) {
     font-family: $font-family--base;
-    font-size: 16px;
-    line-height: 1.5;
     letter-spacing: normal;
     color: $colors--neutral-7;
   }

--- a/pkg/ui/workspaces/cluster-ui/src/components/liveDataPercent/liveDataPercent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/components/liveDataPercent/liveDataPercent.tsx
@@ -1,0 +1,28 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import { Row } from "antd";
+import React from "react";
+
+import { Bytes, Percentage } from "src/util";
+
+type Props = {
+  // Float between 0-1.
+  liveBytes: number;
+  totalBytes: number;
+};
+
+export const LiveDataPercent: React.FC<Props> = ({ liveBytes, totalBytes }) => {
+  return (
+    <div>
+      <Row justify={"end"}>
+        {totalBytes ? Percentage(liveBytes, totalBytes, 1) : "0.0%"}
+      </Row>
+      <Row justify={"end"}>
+        {Bytes(liveBytes)} live data / {Bytes(totalBytes)} total
+      </Row>
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/components/regionNodesLabel/components/regionLabel.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/components/regionNodesLabel/components/regionLabel.module.scss
@@ -8,6 +8,10 @@
 .container {
   margin: 0.5rem;
   width: fit-content;
+  min-width: 100px;
+  &:hover {
+    cursor: pointer;
+  }
 }
 
 

--- a/pkg/ui/workspaces/cluster-ui/src/components/regionNodesLabel/components/regionLabel.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/components/regionNodesLabel/components/regionLabel.tsx
@@ -31,9 +31,7 @@ export const RegionLabel: React.FC<Props> = ({
         <div className={styles["label-body"]}>
           <Text strong>{region.label || "Unknown Region"}</Text>
           {showCode && <Text>({region.code})</Text>}
-          <div>
-            <Badge count={nodes.length} className={styles.badge} />
-          </div>
+          <Badge count={nodes.length} className={styles.badge} />
         </div>
       </Tooltip>
     </div>

--- a/pkg/ui/workspaces/cluster-ui/src/components/tableMetadataLastUpdated/tableMetadataJobControl.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/components/tableMetadataLastUpdated/tableMetadataJobControl.spec.tsx
@@ -48,7 +48,7 @@ describe("TableMetadataJobControl", () => {
     jest.clearAllMocks();
   });
 
-  it("renders the last refreshed time", () => {
+  it("renders the relative last refreshed time", () => {
     render(
       <TimezoneContext.Provider value="UTC">
         <TableMetadataJobControl onJobComplete={mockOnJobComplete} />
@@ -56,8 +56,9 @@ describe("TableMetadataJobControl", () => {
     );
 
     expect(screen.getByText(/Last refreshed:/)).toBeInTheDocument();
+    const lastCompletedRelativeTime = mockLastCompletedTime.fromNow();
     expect(
-      screen.getByText(/Jan 01, 2024 at 12:00:00 UTC/),
+      screen.getByText(new RegExp(lastCompletedRelativeTime)),
     ).toBeInTheDocument();
   });
 

--- a/pkg/ui/workspaces/cluster-ui/src/components/tableMetadataLastUpdated/tableMetadataJobProgress.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/components/tableMetadataLastUpdated/tableMetadataJobProgress.module.scss
@@ -3,9 +3,6 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-export enum DatabaseColName {
-  NAME = "Name",
-  SIZE = "Size",
-  TABLE_COUNT = "Tables",
-  NODE_REGIONS = "Regions / Nodes",
+.progress-list {
+  list-style-position: inside;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/components/tableMetadataLastUpdated/tableMetadataJobProgress.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/components/tableMetadataLastUpdated/tableMetadataJobProgress.tsx
@@ -1,0 +1,40 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import moment from "moment-timezone";
+import React from "react";
+
+import { Timestamp } from "src/timestamp";
+import { DATE_WITH_SECONDS_FORMAT_24_TZ } from "src/util";
+
+import styles from "./tableMetadataJobProgress.module.scss";
+
+type Props = {
+  jobStartedTime: moment.Moment;
+  jobProgressFraction: number; // Between 0 and 1.
+};
+
+// This message is meant to be displayed when the job is running.
+export const TableMetadataJobProgress: React.FC<Props> = ({
+  jobStartedTime,
+  jobProgressFraction,
+}) => {
+  const percentDone = Math.round(jobProgressFraction * 100);
+  return (
+    <div>
+      Refreshing data
+      <ul className={styles["progress-list"]}>
+        <li>{percentDone}% done</li>
+        <li>
+          Started at{" "}
+          <Timestamp
+            time={jobStartedTime}
+            format={DATE_WITH_SECONDS_FORMAT_24_TZ}
+          />
+        </li>
+      </ul>
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/components/tooltip/tooltip.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/components/tooltip/tooltip.module.scss
@@ -17,7 +17,7 @@
 
 .title {
  a {
-   font-size: inherit;
+   font: inherit;
    color: inherit;
  }
 }

--- a/pkg/ui/workspaces/cluster-ui/src/components/tooltipMessages/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/components/tooltipMessages/index.tsx
@@ -2,10 +2,11 @@
 //
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
+
 import Link from "antd/es/typography/Link";
 import React from "react";
 
-import { tableStatsClusterSetting } from "src/util";
+import { tableStatsClusterSetting } from "../../util";
 
 export const AUTO_STATS_COLLECTION_HELP = (
   <span>
@@ -17,5 +18,4 @@ export const AUTO_STATS_COLLECTION_HELP = (
   </span>
 );
 
-export const TABLE_METADATA_LAST_UPDATED_HELP =
-  "Data is last refreshed automatically (per cluster setting) or manually.";
+export * from "./tableMetadataLastUpdatedTooltip";

--- a/pkg/ui/workspaces/cluster-ui/src/components/tooltipMessages/tableMetadataLastUpdatedTooltip.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/components/tooltipMessages/tableMetadataLastUpdatedTooltip.module.scss
@@ -3,9 +3,6 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-export enum DatabaseColName {
-  NAME = "Name",
-  SIZE = "Size",
-  TABLE_COUNT = "Tables",
-  NODE_REGIONS = "Regions / Nodes",
+.table-metadata-tooltip-content {
+  column-gap: 8px;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/components/tooltipMessages/tableMetadataLastUpdatedTooltip.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/components/tooltipMessages/tableMetadataLastUpdatedTooltip.tsx
@@ -1,0 +1,90 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+import { Icon } from "@cockroachlabs/ui-components";
+import { Row } from "antd";
+import moment from "moment-timezone";
+import React from "react";
+
+import { Timestamp } from "../../timestamp";
+import { DATE_WITH_SECONDS_FORMAT_24_TZ } from "../../util";
+import { Tooltip } from "../tooltip";
+
+import styles from "./tableMetadataLastUpdatedTooltip.module.scss";
+
+const TABLE_METADATA_LAST_UPDATED_HELP =
+  "Data was last refreshed automatically (per cluster setting) or manually.";
+
+type Props = {
+  timestamp?: moment.Moment | null;
+  children: (
+    formattedRelativeTime: string,
+    icon?: JSX.Element,
+  ) => React.ReactNode;
+  errorMessage?: string;
+};
+
+const formatErrorMessage = (
+  errorMessage: string | null,
+  lastUpdatedTime: moment.Moment | null,
+) => {
+  if (!errorMessage) {
+    return null;
+  }
+
+  return (
+    <>
+      Last refresh failed to retrieve data about this table. The data shown is
+      as of{" "}
+      <Timestamp
+        format={DATE_WITH_SECONDS_FORMAT_24_TZ}
+        time={lastUpdatedTime}
+        fallback={"Never"}
+      />
+      .
+      <br />
+      Last refresh error: {errorMessage}
+    </>
+  );
+};
+
+export const TableMetadataLastUpdatedTooltip = ({
+  timestamp,
+  errorMessage,
+  children,
+}: Props) => {
+  const durationText = timestamp?.fromNow() ?? "Never";
+  const icon = errorMessage ? (
+    <Icon fill={"warning"} iconName={"Caution"} />
+  ) : (
+    <Icon fill="info" iconName={"InfoCircle"} />
+  );
+
+  const formattedErr = formatErrorMessage(errorMessage, timestamp);
+  return (
+    <Tooltip
+      title={
+        <div>
+          {formattedErr ?? (
+            <>
+              {timestamp && (
+                <Timestamp
+                  format={DATE_WITH_SECONDS_FORMAT_24_TZ}
+                  time={timestamp}
+                  fallback={"Never"}
+                />
+              )}
+              <br />
+              {TABLE_METADATA_LAST_UPDATED_HELP}
+            </>
+          )}
+        </div>
+      }
+    >
+      <Row className={styles["table-metadata-tooltip-content"]} align="middle">
+        {children(durationText, icon)}
+      </Row>
+    </Tooltip>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/dbGrantsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/dbGrantsView.tsx
@@ -27,7 +27,7 @@ export const DbGrantsView: React.FC = () => {
   }, [databaseGrants]);
 
   return (
-    <PageSection heading={"Grants"}>
+    <PageSection>
       <GrantsTable data={dataWithKey ?? []} loading={isLoading} error={error} />
     </PageSection>
   );

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/index.tsx
@@ -26,7 +26,7 @@ enum TabKeys {
 export const DatabaseDetailsPageV2 = () => {
   const { dbID: dbIdRouteParam } = useRouteParams();
   const dbId = parseInt(dbIdRouteParam, 10);
-  const { data, isLoading, error } = useDatabaseMetadataByID(dbId);
+  const { data, isLoading } = useDatabaseMetadataByID(dbId);
   const history = useHistory();
   const location = useLocation();
   const tab = queryByName(location, tabAttr) ?? TabKeys.TABLES;
@@ -57,25 +57,23 @@ export const DatabaseDetailsPageV2 = () => {
     },
   ];
 
-  const dbName =
-    error?.status === 404 || !data
-      ? "Database Not Found"
-      : data.metadata.dbName;
+  const dbName = isLoading ? (
+    <Skeleton paragraph={false} title={{ width: 100 }} />
+  ) : (
+    data?.metadata.dbName ?? "Database Not Found"
+  );
 
   const breadCrumbItems = [
     { name: "Databases", link: DB_PAGE_PATH },
     {
-      name: dbName,
-      link: null,
+      name: <>Database: {dbName}</>,
+      link: "",
     },
   ];
 
   return (
     <PageLayout>
-      <PageHeader
-        breadcrumbItems={breadCrumbItems}
-        title={<Skeleton loading={isLoading}>{dbName}</Skeleton>}
-      />
+      <PageHeader breadcrumbItems={breadCrumbItems} title={dbName} />
       <Tabs
         defaultActiveKey={TabKeys.TABLES}
         className={commonStyles("cockroach--tabs")}

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
@@ -3,6 +3,7 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
+import { Row } from "antd";
 import React, { useContext, useMemo } from "react";
 import { Link } from "react-router-dom";
 
@@ -13,11 +14,13 @@ import {
   useTableMetadata,
 } from "src/api/databases/getTableMetadataApi";
 import { Badge } from "src/badge";
+import { LiveDataPercent } from "src/components/liveDataPercent/liveDataPercent";
 import { NodeRegionsSelector } from "src/components/nodeRegionsSelector/nodeRegionsSelector";
 import { RegionNodesLabel } from "src/components/regionNodesLabel";
 import { TableMetadataJobControl } from "src/components/tableMetadataLastUpdated/tableMetadataJobControl";
 import { Tooltip } from "src/components/tooltip";
-import { AUTO_STATS_COLLECTION_HELP } from "src/constants/tooltipMessages";
+import { AUTO_STATS_COLLECTION_HELP } from "src/components/tooltipMessages";
+import { ClusterDetailsContext } from "src/contexts";
 import { useRouteParams } from "src/hooks/useRouteParams";
 import { PageSection } from "src/layouts";
 import { PageConfig, PageConfigItem } from "src/pageConfig";
@@ -33,8 +36,6 @@ import useTable, { TableParams } from "src/sharedFromCloud/useTable";
 import { Timestamp } from "src/timestamp";
 import { StoreID } from "src/types/clusterTypes";
 import { Bytes, DATE_WITH_SECONDS_FORMAT_24_TZ, tabAttr } from "src/util";
-
-import { ClusterDetailsContext } from "../contexts";
 
 import { TableColName } from "./constants";
 import { TableRow } from "./types";
@@ -67,6 +68,7 @@ const COLUMNS: (TableColumnProps<TableRow> & {
       </Tooltip>
     ),
     sorter: (a, b) => a.replicationSizeBytes - b.replicationSizeBytes,
+    align: "right",
     render: (t: TableRow) => {
       return Bytes(t.replicationSizeBytes);
     },
@@ -74,27 +76,38 @@ const COLUMNS: (TableColumnProps<TableRow> & {
   },
   {
     title: (
-      <Tooltip title={"The number of ranges the table."}>
+      <Tooltip title={"The number of ranges in the table."}>
         {TableColName.RANGE_COUNT}
       </Tooltip>
     ),
     sorter: true,
+    align: "right",
     render: (t: TableRow) => {
       return t.rangeCount;
     },
     sortKey: TableSortOption.RANGES,
   },
   {
-    title: TableColName.COLUMN_COUNT,
+    title: (
+      <Tooltip title={"The number of columns the table."}>
+        {TableColName.COLUMN_COUNT}
+      </Tooltip>
+    ),
     sorter: true,
+    align: "right",
     render: (t: TableRow) => {
       return t.columnCount;
     },
     sortKey: TableSortOption.COLUMNS,
   },
   {
-    title: TableColName.INDEX_COUNT,
+    title: (
+      <Tooltip title={"The number of indexes in the table."}>
+        {TableColName.INDEX_COUNT}
+      </Tooltip>
+    ),
     sorter: true,
+    align: "right",
     render: (t: TableRow) => {
       // We always include the primary index.
       return t.indexCount;
@@ -108,6 +121,7 @@ const COLUMNS: (TableColumnProps<TableRow> & {
       </Tooltip>
     ),
     hideIfTenant: true,
+    width: "fit-content",
     render: (t: TableRow) => (
       <RegionNodesLabel nodesByRegion={t.nodesByRegion} />
     ),
@@ -123,15 +137,14 @@ const COLUMNS: (TableColumnProps<TableRow> & {
       </Tooltip>
     ),
     sorter: true,
+    align: "right",
     sortKey: TableSortOption.LIVE_DATA,
     render: (t: TableRow) => {
       return (
-        <div>
-          <div>{(t.percentLiveData * 100).toFixed(2)}%</div>
-          <div>
-            {Bytes(t.totalLiveDataBytes)} / {Bytes(t.totalDataBytes)}
-          </div>
-        </div>
+        <LiveDataPercent
+          liveBytes={t.totalLiveDataBytes}
+          totalBytes={t.totalDataBytes}
+        />
       );
     },
   },
@@ -142,6 +155,7 @@ const COLUMNS: (TableColumnProps<TableRow> & {
       </Tooltip>
     ),
     sorter: false,
+    align: "center",
     render: (t: TableRow) => {
       const type = t.autoStatsEnabled ? "success" : "default";
       const text = t.autoStatsEnabled ? "ENABLED" : "DISABLED";
@@ -294,18 +308,18 @@ export const TablesPageV2 = () => {
         </PageConfig>
       </PageSection>
       <PageSection>
-        <PageCount
-          page={params.pagination.page}
-          pageSize={params.pagination.pageSize}
-          total={data?.pagination.totalResults ?? 0}
-          entity="tables"
-        />
+        <Row align={"middle"} justify={"space-between"}>
+          <PageCount
+            page={params.pagination.page}
+            pageSize={params.pagination.pageSize}
+            total={data?.pagination.totalResults ?? 0}
+            entity="tables"
+          />
+          <TableMetadataJobControl onJobComplete={refreshTables} />
+        </Row>
         <Table
           loading={isLoading}
           error={error}
-          actionButton={
-            <TableMetadataJobControl onJobComplete={refreshTables} />
-          }
           columns={colsWithSort}
           dataSource={tableData}
           pagination={{

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
@@ -48,7 +48,6 @@ const COLUMNS: (TableColumnProps<TableRow> & {
     title: (
       <Tooltip title={"The name of the table."}>{TableColName.NAME}</Tooltip>
     ),
-    width: "15%",
     sorter: (a, b) => a.tableName.localeCompare(b.tableName),
     render: (t: TableRow) => {
       return (
@@ -67,7 +66,6 @@ const COLUMNS: (TableColumnProps<TableRow> & {
         {TableColName.REPLICATION_SIZE}
       </Tooltip>
     ),
-    width: "fit-content",
     sorter: (a, b) => a.replicationSizeBytes - b.replicationSizeBytes,
     render: (t: TableRow) => {
       return Bytes(t.replicationSizeBytes);
@@ -80,7 +78,6 @@ const COLUMNS: (TableColumnProps<TableRow> & {
         {TableColName.RANGE_COUNT}
       </Tooltip>
     ),
-    width: "fit-content",
     sorter: true,
     render: (t: TableRow) => {
       return t.rangeCount;
@@ -89,7 +86,6 @@ const COLUMNS: (TableColumnProps<TableRow> & {
   },
   {
     title: TableColName.COLUMN_COUNT,
-    width: "fit-content",
     sorter: true,
     render: (t: TableRow) => {
       return t.columnCount;
@@ -98,7 +94,6 @@ const COLUMNS: (TableColumnProps<TableRow> & {
   },
   {
     title: TableColName.INDEX_COUNT,
-    width: "fit-content",
     sorter: true,
     render: (t: TableRow) => {
       // We always include the primary index.
@@ -113,7 +108,6 @@ const COLUMNS: (TableColumnProps<TableRow> & {
       </Tooltip>
     ),
     hideIfTenant: true,
-    width: "20%",
     render: (t: TableRow) => (
       <RegionNodesLabel nodesByRegion={t.nodesByRegion} />
     ),
@@ -129,7 +123,6 @@ const COLUMNS: (TableColumnProps<TableRow> & {
       </Tooltip>
     ),
     sorter: true,
-    width: "fit-content",
     sortKey: TableSortOption.LIVE_DATA,
     render: (t: TableRow) => {
       return (

--- a/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
@@ -3,7 +3,7 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import { Skeleton } from "antd";
+import { Row, Skeleton } from "antd";
 import React, { useContext, useMemo } from "react";
 import { Link } from "react-router-dom";
 
@@ -18,6 +18,8 @@ import { NodeRegionsSelector } from "src/components/nodeRegionsSelector/nodeRegi
 import { RegionNodesLabel } from "src/components/regionNodesLabel";
 import { TableMetadataJobControl } from "src/components/tableMetadataLastUpdated/tableMetadataJobControl";
 import { Tooltip } from "src/components/tooltip";
+import { AUTO_STATS_COLLECTION_HELP } from "src/components/tooltipMessages";
+import { ClusterDetailsContext } from "src/contexts";
 import { PageLayout, PageSection } from "src/layouts";
 import { PageConfig, PageConfigItem } from "src/pageConfig";
 import { BooleanSetting } from "src/settings";
@@ -33,9 +35,6 @@ import {
 import useTable, { TableParams } from "src/sharedFromCloud/useTable";
 import { StoreID } from "src/types/clusterTypes";
 import { Bytes } from "src/util";
-
-import { AUTO_STATS_COLLECTION_HELP } from "../constants/tooltipMessages";
-import { ClusterDetailsContext } from "../contexts";
 
 import { DatabaseColName } from "./constants";
 import { DatabaseRow } from "./databaseTypes";
@@ -71,6 +70,7 @@ const COLUMNS: (TableColumnProps<DatabaseRow> & {
     ),
     sortKey: DatabaseSortOptions.REPLICATION_SIZE,
     sorter: (a, b) => a.approximateDiskSizeBytes - b.approximateDiskSizeBytes,
+    align: "right",
     render: (db: DatabaseRow) => {
       return Bytes(db.approximateDiskSizeBytes);
     },
@@ -83,6 +83,7 @@ const COLUMNS: (TableColumnProps<DatabaseRow> & {
     ),
     sortKey: DatabaseSortOptions.TABLE_COUNT,
     sorter: true,
+    align: "right",
     render: (db: DatabaseRow) => {
       return db.tableCount;
     },
@@ -213,34 +214,32 @@ export const DatabasesPageV2 = () => {
           </Skeleton>
         }
       />
-      <PageSection>
-        <PageConfig>
-          <PageConfigItem>
-            <Search placeholder="Search databases" onSubmit={setSearch} />
+      <PageConfig>
+        <PageConfigItem>
+          <Search placeholder="Search databases" onSubmit={setSearch} />
+        </PageConfigItem>
+        {!isTenant && (
+          <PageConfigItem minWidth={"200px"}>
+            <NodeRegionsSelector
+              value={nodeRegionsValue}
+              onChange={onNodeRegionsChange}
+            />
           </PageConfigItem>
-          {!isTenant && (
-            <PageConfigItem minWidth={"200px"}>
-              <NodeRegionsSelector
-                value={nodeRegionsValue}
-                onChange={onNodeRegionsChange}
-              />
-            </PageConfigItem>
-          )}
-        </PageConfig>
-      </PageSection>
+        )}
+      </PageConfig>
       <PageSection>
-        <PageCount
-          page={params.pagination.page}
-          pageSize={params.pagination.pageSize}
-          total={data?.pagination.totalResults ?? 0}
-          entity="databases"
-        />
+        <Row align={"middle"} justify={"space-between"}>
+          <PageCount
+            page={params.pagination.page}
+            pageSize={params.pagination.pageSize}
+            total={data?.pagination.totalResults ?? 0}
+            entity="databases"
+          />
+          <TableMetadataJobControl onJobComplete={refreshDatabases} />
+        </Row>
         <Table
           loading={isLoading}
           error={error}
-          actionButton={
-            <TableMetadataJobControl onJobComplete={refreshDatabases} />
-          }
           columns={colsWithSort}
           dataSource={tableData}
           pagination={{

--- a/pkg/ui/workspaces/cluster-ui/src/sharedFromCloud/pageHeader.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sharedFromCloud/pageHeader.module.scss
@@ -3,6 +3,9 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
+@import "src/core/index.module";
+@import "application.module.scss";
+
 .page-header {
   width: 100%;
   margin-bottom: crl-gutters(2);
@@ -18,7 +21,14 @@
   align-items: center; // Allows the text to center vertically.
   margin-bottom: 0;
   gap: crl-gutters(2);
+  color: $colors--neutral-7;
+  font-family: $font-family--semi-bold;
+  font-style: normal;
+  font-stretch: normal;
+  font-size: $font-size--large;
+  padding-bottom: 12px;
 }
+
 
 .header-breadcrumbs {
   margin-top: crl-gutters(1);
@@ -47,3 +57,4 @@
 .loader {
   margin-left: crl-gutters(1);
 }
+

--- a/pkg/ui/workspaces/cluster-ui/src/sharedFromCloud/search.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sharedFromCloud/search.scss
@@ -7,6 +7,7 @@
 
 .search {
   width: 280px;
+  margin: 2px;
 
   &__button {
     background-color: transparent;

--- a/pkg/ui/workspaces/cluster-ui/src/summaryCard/summaryCard.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/summaryCard/summaryCard.module.scss
@@ -75,7 +75,7 @@
     &--value {
       font-family: $font-family--base;
       font-size: 14px;
-      font-weight: $font-weight--bold;
+      font-weight: $font-weight--medium;
       line-height: 1.71;
       letter-spacing: 0.1px;
       color: $popover-color;

--- a/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/index.tsx
@@ -3,7 +3,7 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import { Tabs } from "antd";
+import { Skeleton, Tabs } from "antd";
 import React, { useState } from "react";
 
 import { useTableDetails } from "src/api/databases/getTableMetadataApi";
@@ -29,20 +29,20 @@ export const TableDetailsPageV2 = () => {
   const { data, error, isLoading } = useTableDetails({
     tableId: parseInt(tableID, 10),
   });
-  // The table name is undefined if the table does not exist.
-  const tableNotFound = error?.status === 404;
 
-  const partiallyQualifiedTableName = !tableNotFound
-    ? data
-      ? data.metadata.schemaName + "." + data.metadata.tableName
-      : ""
-    : "Table not found";
+  const partiallyQualifiedTableName = isLoading ? (
+    <Skeleton loading={true} paragraph={false} title={{ width: 100 }} />
+  ) : data ? (
+    data.metadata.schemaName + "." + data.metadata.tableName
+  ) : (
+    "Table not found"
+  );
 
   const breadCrumbItems = [
     { link: `/databases`, name: "Databases" },
     {
-      link: `/databases/${data?.metadata.dbId}`,
-      name: data?.metadata.dbName,
+      link: data ? `/databases/${data?.metadata.dbId}` : "",
+      name: `Database: ${data?.metadata?.dbName ?? ""}`,
     },
     {
       link: null,

--- a/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/tableGrantsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/tableGrantsView.tsx
@@ -27,7 +27,7 @@ export const TableGrantsView: React.FC = () => {
   }, [tableGrants]);
 
   return (
-    <PageSection heading={"Grants"}>
+    <PageSection>
       <GrantsTable error={error} loading={isLoading} data={dataWithKey ?? []} />
     </PageSection>
   );

--- a/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/tableIndexesView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/tableIndexesView.tsx
@@ -4,7 +4,7 @@
 // included in the /LICENSE file.
 
 import { Row, Tag } from "antd";
-import React from "react";
+import React, { useContext } from "react";
 
 import {
   resetIndexStatsApi,
@@ -19,90 +19,94 @@ import { Table, TableColumnProps } from "src/sharedFromCloud/table";
 import { Timestamp } from "src/timestamp";
 import { DATE_WITH_SECONDS_FORMAT_24_TZ } from "src/util";
 
+import { CockroachCloudContext } from "../contexts";
+
 type TableIndexRow = TableIndex & {
   key: React.Key;
 };
 
-const COLUMNS: TableColumnProps<TableIndexRow>[] = [
-  {
-    title: "Index Name",
-    render: (idx: TableIndexRow) => (
-      <IndexStatsLink
-        dbName={idx.dbName}
-        escSchemaQualifiedTableName={idx.escSchemaQualifiedTableName}
-        indexName={idx.indexName}
-      />
-    ),
-  },
-  {
-    title: "Last Read",
-    render: (idx: TableIndexRow) => (
-      <Timestamp
-        time={idx.lastRead}
-        format={DATE_WITH_SECONDS_FORMAT_24_TZ}
-        fallback={"Never"}
-      />
-    ),
-  },
-  {
-    title: "Total Reads",
-    sorter: true,
-    render: (idx: TableIndexRow) => idx.totalReads,
-  },
-  {
-    title: (
-      <Tooltip
-        text={`
+const COLUMNS: (TableColumnProps<TableIndexRow> & { hideIfCloud?: boolean })[] =
+  [
+    {
+      title: "Index Name",
+      render: (idx: TableIndexRow) => (
+        <IndexStatsLink
+          dbName={idx.dbName}
+          escSchemaQualifiedTableName={idx.escSchemaQualifiedTableName}
+          indexName={idx.indexName}
+        />
+      ),
+    },
+    {
+      title: "Last Read",
+      render: (idx: TableIndexRow) => (
+        <Timestamp
+          time={idx.lastRead}
+          format={DATE_WITH_SECONDS_FORMAT_24_TZ}
+          fallback={"Never"}
+        />
+      ),
+    },
+    {
+      title: "Total Reads",
+      sorter: true,
+      render: (idx: TableIndexRow) => idx.totalReads,
+    },
+    {
+      title: (
+        <Tooltip
+          text={`
     Index recommendations will appear if the system detects improper index usage, 
     such as the occurrence of unused indexes. Following index recommendations may 
     help improve query performance.
     `}
-      >
-        Recommendations
-      </Tooltip>
-    ),
-    sorter: true,
-    render: (idx: TableIndexRow) => {
-      if (idx.indexRecs.length === 0 || idx.indexType === "primary") {
-        return "None";
-      }
-      const recs = idx.indexRecs.map((rec, i) => {
-        // The only rec right now is "DROP_UNUSED".
-        return (
-          <Tooltip noUnderline key={i} title={rec.reason}>
-            <Tag color="blue">Drop unused index</Tag>
-          </Tooltip>
-        );
-      });
-      return <span>{recs}</span>;
+        >
+          Recommendations
+        </Tooltip>
+      ),
+      sorter: true,
+      render: (idx: TableIndexRow) => {
+        if (idx.indexRecs.length === 0 || idx.indexType === "primary") {
+          return "None";
+        }
+        const recs = idx.indexRecs.map((rec, i) => {
+          // The only rec right now is "DROP_UNUSED".
+          return (
+            <Tooltip noUnderline key={i} title={rec.reason}>
+              <Tag color="blue">Drop unused index</Tag>
+            </Tooltip>
+          );
+        });
+        return <span>{recs}</span>;
+      },
     },
-  },
-  {
-    title: "Action",
-    sorter: false,
-    render: (idx: TableIndexRow) => {
-      if (idx.indexRecs.length === 0 || idx.indexType === "primary") {
-        return null;
-      }
+    {
+      title: "Action",
+      sorter: false,
+      hideIfCloud: true,
+      render: (idx: TableIndexRow) => {
+        if (idx.indexRecs.length === 0 || idx.indexType === "primary") {
+          return null;
+        }
 
-      const stat = {
-        indexName: idx.indexName,
-        indexRecommendations: idx.indexRecs.map(rec => ({
-          type: "DROP_UNUSED" as const,
-          reason: rec.reason,
-        })),
-      };
-      // The action button expects an escaped schema qualified table name.
-      return (
-        <ActionCell
-          indexStat={stat}
-          tableName={idx.escSchemaQualifiedTableName}
-          databaseName={idx.dbName}
-        />
-      );
+        const stat = {
+          indexName: idx.indexName,
+          indexRecommendations: idx.indexRecs.map(rec => ({
+            type: "DROP_UNUSED" as const,
+            reason: rec.reason,
+          })),
+        };
+        // The action button expects an escaped schema qualified table name.
+        return (
+          <ActionCell
+            indexStat={stat}
+            tableName={idx.escSchemaQualifiedTableName}
+            databaseName={idx.dbName}
+          />
+        );
+      },
     },
-  },
-];
+  ];
 
 type Props = {
   dbName: string;
@@ -120,6 +124,7 @@ export const TableIndexesView: React.FC<Props> = ({
     tableName: tableName,
     schemaName: schemaName,
   });
+  const isCloud = useContext(CockroachCloudContext);
 
   const tableIndexRows = indexStats.tableIndexes.map((idx, i) => ({
     ...idx,
@@ -131,34 +136,35 @@ export const TableIndexesView: React.FC<Props> = ({
     return refreshIndexStats();
   };
 
-  const lastResetAction = (
-    <Row align={"middle"}>
-      <Tooltip
-        title={`Index stats accumulate from the time the index was created or had its stats reset. 
-          Clicking ‘Reset all index stats’ will reset index stats for the entire cluster. Last 
-          reset is the timestamp at which the last reset started.`}
-      >
-        Last reset:{" "}
-        <Timestamp
-          format={DATE_WITH_SECONDS_FORMAT_24_TZ}
-          time={indexStats.lastReset}
-          fallback={"Never"}
-        />
-      </Tooltip>
-      <Button
-        category={"tertiary"}
-        onClick={resetAllIndexStats}
-        text={"Reset all index stats"}
-      />
-    </Row>
-  );
+  const filteredCols = COLUMNS.filter(col => !isCloud || !col.hideIfCloud);
 
   return (
-    <Table
-      actionButton={lastResetAction}
-      loading={isLoading}
-      columns={COLUMNS}
-      dataSource={tableIndexRows}
-    />
+    <div>
+      <Row align={"middle"} justify={"end"}>
+        <Tooltip
+          title={`Index stats accumulate from the time the index was created or had its stats reset. 
+          Clicking ‘Reset all index stats’ will reset index stats for the entire cluster. Last 
+          reset is the timestamp at which the last reset started.`}
+        >
+          Last reset:{" "}
+          <Timestamp
+            format={DATE_WITH_SECONDS_FORMAT_24_TZ}
+            time={indexStats.lastReset}
+            fallback={"Never"}
+          />
+        </Tooltip>
+        <Button
+          category={"tertiary"}
+          onClick={resetAllIndexStats}
+          text={"Reset all index stats"}
+        />
+      </Row>
+
+      <Table
+        loading={isLoading}
+        columns={filteredCols}
+        dataSource={tableIndexRows}
+      />
+    </div>
   );
 };

--- a/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/tableOverview.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/tableOverview.tsx
@@ -3,15 +3,13 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import { Icon } from "@cockroachlabs/ui-components";
 import { Col, Row, Skeleton } from "antd";
-import moment from "moment-timezone";
 import React, { useContext } from "react";
 
 import { useNodeStatuses } from "src/api";
 import { TableDetails } from "src/api/databases/getTableMetadataApi";
-import { Tooltip } from "src/components/tooltip";
-import { TABLE_METADATA_LAST_UPDATED_HELP } from "src/constants/tooltipMessages";
+import { LiveDataPercent } from "src/components/liveDataPercent/liveDataPercent";
+import { TableMetadataLastUpdatedTooltip } from "src/components/tooltipMessages/tableMetadataLastUpdatedTooltip";
 import { ClusterDetailsContext } from "src/contexts";
 import { PageSection } from "src/layouts";
 import { SqlBox, SqlBoxSize } from "src/sql";
@@ -55,14 +53,6 @@ export const TableOverview: React.FC<TableOverviewProps> = ({
       .join(", ");
   };
 
-  const percentLiveDataWithPrecision = (metadata.percentLiveData * 100).toFixed(
-    2,
-  );
-
-  const formattedErrorText = metadata.lastUpdateError
-    ? "Update error: " + metadata.lastUpdateError
-    : null;
-
   return (
     <>
       <PageSection>
@@ -71,28 +61,21 @@ export const TableOverview: React.FC<TableOverviewProps> = ({
       <PageSection>
         <Row justify={"end"}>
           <Col>
-            <Tooltip
-              title={formattedErrorText ?? TABLE_METADATA_LAST_UPDATED_HELP}
+            <TableMetadataLastUpdatedTooltip
+              errorMessage={metadata.lastUpdateError}
+              timestamp={metadata.lastUpdated}
             >
-              <Row gutter={8} align={"middle"} justify={"center"}>
-                {metadata.lastUpdateError ? (
-                  <Icon fill={"warning"} iconName={"Caution"} />
-                ) : (
-                  <Icon fill="info" iconName={"InfoCircle"} />
-                )}
-                <Col>
-                  {" "}
-                  Last updated:{" "}
-                  <Timestamp
-                    format={DATE_WITH_SECONDS_FORMAT_24_TZ}
-                    time={moment.utc(metadata.lastUpdated)}
-                    fallback={"Never"}
-                  />
-                </Col>
-              </Row>
-            </Tooltip>
+              {(durationText, icon) => (
+                <>
+                  {icon}
+                  <span> Last updated: {durationText} </span>
+                </>
+              )}
+            </TableMetadataLastUpdatedTooltip>
           </Col>
         </Row>
+      </PageSection>
+      <PageSection>
         <Row gutter={8}>
           <Col span={12}>
             <SummaryCard>
@@ -119,13 +102,10 @@ export const TableOverview: React.FC<TableOverviewProps> = ({
               <SummaryCardItem
                 label="% of Live data"
                 value={
-                  <div>
-                    <div>{percentLiveDataWithPrecision}% </div>
-                    <div>
-                      {Bytes(metadata.totalLiveDataBytes)} /{" "}
-                      {Bytes(metadata.totalLiveDataBytes)}
-                    </div>
-                  </div>
+                  <LiveDataPercent
+                    liveBytes={metadata.totalLiveDataBytes}
+                    totalBytes={metadata.totalLiveDataBytes}
+                  />
                 }
               />
               <SummaryCardItem


### PR DESCRIPTION
ui: regions label adjustments

- Ensure the regions label text isn't condensed to
1 character per row by providing a min width.
- Remove unnecessary widths on tables

Epic: none
Release note: None

------------------------------------------------------------

cluster-ui: misc v2 db pages styling adjustments

Misc formatting
- Fix page heading font styling
- Fix search bar on focus border being cut off
- Add `database` suffix to breadcrumb for db details page
- Format live data percentage by adding `live data` and
`total` as suffixes to numerator / denom respectively
- Don't show db and table breadcrumb as not found when
data is still being loaded
- Put reset index action in row outside / on top of table
- Add spinner state to refresh button when cached data is
refreshing

Table last updated/refreshed message & tooltip:
- Align data last refreshed time with page count
- Move full timestamp in table metadata tooltip
- Better error message formatting
- Show job progress when running

Grants
- Remove "Grants" header

Epic: [CRDB-37558](https://cockroachlabs.atlassian.net/browse/CRDB-37558)
Fixes: https://github.com/cockroachdb/cockroach/issues/132595

Release note (ui change): In the v2 database and db details
pages, the refresh button tooltip will now include the cache
refresh progress when the job is running as well as when the
update started.