### PR TITLE
roachtest: add validation for version binary override flag

### DIFF
--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -365,7 +365,7 @@ var (
 			List of <version>=<path to cockroach binary>. If a certain version <ver>
 			is present in the list, the respective binary will be used when a
 			mixed-version test asks for the respective binary, instead of roachprod
-			stage <ver>. Example: 20.1.4=cockroach-20.1,20.2.0=cockroach-20.2.`,
+			stage <ver>. Example: v20.1.4=cockroach-20.1,v20.2.0=cockroach-20.2.`,
 	})
 
 	SlackToken string

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/cockroachdb/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
@@ -303,6 +304,12 @@ func initRunFlagsBinariesAndLibraries(cmd *cobra.Command) error {
 
 	if roachtestflags.SelectProbability > 0 && roachtestflags.SelectProbability < 1 {
 		fmt.Printf("Matching tests will be selected with probability %.2f\n", roachtestflags.SelectProbability)
+	}
+
+	for override := range roachtestflags.VersionsBinaryOverride {
+		if _, err := version.Parse(override); err != nil {
+			return errors.Wrapf(err, "binary version override %s is not a valid version", override)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Previously the help message for this flag had an incorrect example usage that listed the version without the leading `v`. Doing this would cause the override to never be used as the override checked for version with the leading `v`.

This change fixes the usage message as well as adds validation that overrided versions are parseable.

Release note: none
Fixes: none
Epic: none