### PR TITLE
crosscluster/logical: check UDT equivalency during LDR creation

### DIFF
--- a/pkg/ccl/crosscluster/logical/BUILD.bazel
+++ b/pkg/ccl/crosscluster/logical/BUILD.bazel
@@ -74,6 +74,7 @@ go_library(
         "//pkg/util/admission/admissionpb",
         "//pkg/util/buildutil",
         "//pkg/util/ctxgroup",
+        "//pkg/util/errorutil/unimplemented",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/log/logcrash",

--- a/pkg/ccl/crosscluster/logical/logical_replication_job.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job.go
@@ -360,6 +360,7 @@ func (p *logicalReplicationPlanner) generatePlanImpl(
 	}
 
 	// TODO(msbutler): is this import type resolver kosher? Should put in a new package.
+	// See https://github.com/cockroachdb/cockroach/issues/132164.
 	importResolver := importer.MakeImportTypeResolver(plan.SourceTypes)
 	tableMetadataByDestID := make(map[int32]execinfrapb.TableReplicationMetadata)
 	if err := sql.DescsTxn(ctx, execCfg, func(ctx context.Context, txn isql.Txn, descriptors *descs.Collection) error {

--- a/pkg/ccl/crosscluster/streamclient/partitioned_stream_client.go
+++ b/pkg/ccl/crosscluster/streamclient/partitioned_stream_client.go
@@ -343,8 +343,8 @@ func (p *partitionedStreamClient) PlanLogicalReplication(
 	}
 
 	sourceTypes := make([]*descpb.TypeDescriptor, len(streamSpec.TypeDescriptors))
-	for _, desc := range streamSpec.TypeDescriptors {
-		sourceTypes = append(sourceTypes, &desc)
+	for i, desc := range streamSpec.TypeDescriptors {
+		sourceTypes[i] = &desc
 	}
 
 	return LogicalReplicationPlan{


### PR DESCRIPTION
This check requires that the logical and physical representations of each type are identical. In the future, we may investigate ways to only require logical equivalency.

fixes https://github.com/cockroachdb/cockroach/issues/132167
Release note (ops change): When creating a logical replication stream,
any user-defined types in the source and destination are now checked for
equivalency. This allows for creating a stream that handles user-defined
types without needing to use the `WITH SKIP SCHEMA CHECK` option as long
as the replication stream uses `mode = immediate`.