### PR TITLE
kv: return the actual epoch in replicaRLockedStoreLiveness.SupportFrom

### DIFF
--- a/pkg/kv/kvserver/replica_store_liveness.go
+++ b/pkg/kv/kvserver/replica_store_liveness.go
@@ -64,11 +64,6 @@ func (r *replicaRLockedStoreLiveness) SupportFor(replicaID raftpb.PeerID) (raftp
 		log.Warningf(ctx, "store not found for replica %d in SupportFor", replicaID)
 		return 0, false
 	}
-	// TODO(arul): we can remove this once we start to assign storeLiveness in the
-	// Store constructor.
-	if r.store.storeLiveness == nil {
-		return 0, false
-	}
 	epoch, ok := r.store.storeLiveness.SupportFor(storeID)
 	return raftpb.Epoch(epoch), ok
 }

--- a/pkg/kv/kvserver/replica_store_liveness.go
+++ b/pkg/kv/kvserver/replica_store_liveness.go
@@ -67,10 +67,7 @@ func (r *replicaRLockedStoreLiveness) SupportFor(replicaID raftpb.PeerID) (raftp
 		return 0, false
 	}
 	epoch, ok := r.store.storeLiveness.SupportFor(storeID)
-	if !ok {
-		return 0, false
-	}
-	return raftpb.Epoch(epoch), true
+	return raftpb.Epoch(epoch), ok
 }
 
 // SupportFrom implements the raftstoreliveness.StoreLiveness interface.

--- a/pkg/kv/kvserver/replica_store_liveness.go
+++ b/pkg/kv/kvserver/replica_store_liveness.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 var raftLeaderFortificationFractionEnabled = settings.RegisterFloatSetting(
@@ -59,6 +60,8 @@ func (r *replicaRLockedStoreLiveness) getStoreIdent(
 func (r *replicaRLockedStoreLiveness) SupportFor(replicaID raftpb.PeerID) (raftpb.Epoch, bool) {
 	storeID, ok := r.getStoreIdent(replicaID)
 	if !ok {
+		ctx := r.AnnotateCtx(context.TODO())
+		log.Warningf(ctx, "store not found for replica %d in SupportFor", replicaID)
 		return 0, false
 	}
 	// TODO(arul): we can remove this once we start to assign storeLiveness in the
@@ -76,6 +79,8 @@ func (r *replicaRLockedStoreLiveness) SupportFrom(
 ) (raftpb.Epoch, hlc.Timestamp) {
 	storeID, ok := r.getStoreIdent(replicaID)
 	if !ok {
+		ctx := r.AnnotateCtx(context.TODO())
+		log.Warningf(ctx, "store not found for replica %d in SupportFrom", replicaID)
 		return 0, hlc.Timestamp{}
 	}
 	epoch, exp := r.store.storeLiveness.SupportFrom(storeID)


### PR DESCRIPTION
This is needed to complete the intention of https://github.com/cockroachdb/cockroach/pull/131614.

May explain recent `epochs in store liveness shouldn't regress` assertion failures.

Epic: None
Release note: None