### PR TITLE
storage: disable columnar format completely

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1238,6 +1238,10 @@ func newPebble(ctx context.Context, cfg engineConfig) (p *Pebble, err error) {
 		return IngestSplitEnabled.Get(&cfg.settings.SV)
 	}
 	cfg.opts.Experimental.EnableColumnarBlocks = func() bool {
+		// TODO(radu): disable completely for now since the format is not finalized.
+		if true {
+			return false
+		}
 		return columnarBlocksEnabled.Get(&cfg.settings.SV)
 	}
 	cfg.opts.Experimental.EnableDeleteOnlyCompactionExcises = func() bool {


### PR DESCRIPTION
We don't want someone who uses a beta release to try out the new
format and then run into compatibility problems.

Epic: none
Release note: None