### PR TITLE
raft: only call `SupportFrom` on voters in current config

### DIFF
--- a/pkg/raft/BUILD.bazel
+++ b/pkg/raft/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/raft/tracker",
         "//pkg/util/hlc",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@org_golang_x_exp//maps",
     ],
 )

--- a/pkg/raft/quorum/joint.go
+++ b/pkg/raft/quorum/joint.go
@@ -45,6 +45,20 @@ func (c JointConfig) IDs() map[pb.PeerID]struct{} {
 	return m
 }
 
+// Visit calls the given function for each unique voter ID in the joint
+// configuration.
+func (c JointConfig) Visit(f func(pb.PeerID)) {
+	for id := range c[0] {
+		f(id)
+	}
+	for id := range c[1] {
+		if _, ok := c[0][id]; ok {
+			continue // skip duplicate
+		}
+		f(id)
+	}
+}
+
 // Describe returns a (multi-line) representation of the commit indexes for the
 // given lookuper.
 func (c JointConfig) Describe(l AckedIndexer) string {

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/raft/raftstoreliveness"
 	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"golang.org/x/exp/maps"
 )
 
@@ -1440,14 +1441,14 @@ func (r *raft) Step(m pb.Message) error {
 				// leader it does not update its term or grant its vote.
 				{
 					// Log why we're ignoring the Request{,Pre}Vote.
-					var inHeartbeatLeaseMsg string
-					var inFortifyLeaseMsg string
-					var sep string
+					var inHeartbeatLeaseMsg redact.RedactableString
+					var inFortifyLeaseMsg redact.RedactableString
+					var sep redact.SafeString
 					if inHeartbeatLease {
-						inHeartbeatLeaseMsg = fmt.Sprintf("recently received communication from leader (remaining ticks: %d)", r.electionTimeout-r.electionElapsed)
+						inHeartbeatLeaseMsg = redact.Sprintf("recently received communication from leader (remaining ticks: %d)", r.electionTimeout-r.electionElapsed)
 					}
 					if inFortifyLease {
-						inFortifyLeaseMsg = fmt.Sprintf("supporting fortified leader %d at epoch %d", r.lead, r.leadEpoch)
+						inFortifyLeaseMsg = redact.Sprintf("supporting fortified leader %d at epoch %d", r.lead, r.leadEpoch)
 					}
 					if inFortifyLease && inHeartbeatLease {
 						sep = " and "


### PR DESCRIPTION
Informs #125264.

This commit updates the raft `FortificationTracker` to only call `StoreLiveness.SupportFrom` on voters in the current configuration. This avoids unnecessary calls to the `StoreLiveness` subsystem for non-voters, which can be expensive. It also avoids calling `SupportFrom` on removed voters, which as of #133199, can lead to log warnings.

Release note: None