### PR TITLE
cli: don't advertise --tenant-name-scope just yet

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -647,6 +647,7 @@ func init() {
 		if cmd == createClientCertCmd {
 			cliflagcfg.VarFlag(f, &tenantIDSetter{tenantIDs: &certCtx.tenantScope}, cliflags.TenantScope)
 			cliflagcfg.VarFlag(f, &tenantNameSetter{tenantNames: &certCtx.tenantNameScope}, cliflags.TenantScopeByNames)
+			_ = f.MarkHidden(cliflags.TenantScopeByNames.Name)
 
 			// PKCS8 key format is only available for the client cert command.
 			cliflagcfg.BoolFlag(f, &certCtx.generatePKCS8Key, cliflags.GeneratePKCS8Key)


### PR DESCRIPTION
Implementation to authenticate using tenant name scopes from the client certs is not ready yet. Defer advertising the cli flag till it is ready.

Fixes: https://github.com/cockroachdb/cockroach/issues/133168
Epic: CRDB-43487
Release note (multi-tenancy): Hide --tenant-name-scope cli flag until the implementation is ready.