### PR TITLE
roachtest: metamorphically enable leader leases

### DIFF
--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -244,9 +244,13 @@ const (
 	LeaderLeases
 	// MetamorphicLeases randomly chooses epoch or expiration
 	// leases (across the entire cluster).
-	// TODO(nvanbenschoten): add leader leases to this mix.
 	MetamorphicLeases
 )
+
+// LeaseTypes contains all lease types.
+//
+// The list does not contain aliases like "default" and "metamorphic".
+var LeaseTypes = []LeaseType{EpochLeases, ExpirationLeases, LeaderLeases}
 
 // CloudSet represents a set of clouds.
 //

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -59,8 +59,7 @@ var rangeLeaseRenewalDuration = func() time.Duration {
 // requests are successful with nominal latencies. See also:
 // https://github.com/cockroachdb/cockroach/issues/103654
 func registerFailover(r registry.Registry) {
-	leaseTypes := []registry.LeaseType{registry.EpochLeases, registry.ExpirationLeases, registry.LeaderLeases}
-	for _, leases := range leaseTypes {
+	for _, leases := range registry.LeaseTypes {
 		var leasesStr string
 		switch leases {
 		case registry.EpochLeases:


### PR DESCRIPTION
Part of #132762.

To increase test coverage of leader leases, this patch adds leader leases to the set of possible lease types when tests opt-in to metamorphic leases. As of fc68b0fe, most roachtests do enable metamorphic leases, so this will provide good coverage of leader leases.

Before merging this, we should manually run all of these tests with leader leases to verify that they pass.

Release note: None