### PR TITLE
opt: plan row-level BEFORE triggers for cascading mutations

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -2230,24 +2230,28 @@ statement ok
 INSERT INTO parent VALUES (1), (2), (3);
 INSERT INTO child VALUES (1, 1), (2, 2), (3, 2), (4, 3);
 
-# TODO(#132971): We should fire the BEFORE trigger on child.
 query T noticetrace
 UPDATE parent SET k = k * 10 WHERE k = 2 OR k = 3;
 ----
 NOTICE: BEFORE UPDATE ON parent: (2) -> (20)
 NOTICE: BEFORE UPDATE ON parent: (3) -> (30)
+NOTICE: BEFORE UPDATE ON child: (2,2) -> (2,20)
+NOTICE: BEFORE UPDATE ON child: (3,2) -> (3,20)
+NOTICE: BEFORE UPDATE ON child: (4,3) -> (4,30)
 NOTICE: AFTER UPDATE ON parent: (2) -> (20)
 NOTICE: AFTER UPDATE ON parent: (3) -> (30)
 NOTICE: AFTER UPDATE ON child: (2,2) -> (2,20)
 NOTICE: AFTER UPDATE ON child: (3,2) -> (3,20)
 NOTICE: AFTER UPDATE ON child: (4,3) -> (4,30)
 
-# TODO(#132971): We should fire the BEFORE trigger on child.
 query T noticetrace
 DELETE FROM parent WHERE k = 20 OR k = 30;
 ----
 NOTICE: BEFORE DELETE ON parent: (20) -> <NULL>
 NOTICE: BEFORE DELETE ON parent: (30) -> <NULL>
+NOTICE: BEFORE DELETE ON child: (2,20) -> <NULL>
+NOTICE: BEFORE DELETE ON child: (3,20) -> <NULL>
+NOTICE: BEFORE DELETE ON child: (4,30) -> <NULL>
 NOTICE: AFTER DELETE ON parent: (20) -> <NULL>
 NOTICE: AFTER DELETE ON parent: (30) -> <NULL>
 NOTICE: AFTER DELETE ON child: (2,20) -> <NULL>
@@ -2286,31 +2290,35 @@ $$;
 statement ok
 CREATE TRIGGER foo BEFORE INSERT ON ab FOR EACH ROW EXECUTE FUNCTION h();
 
-# TODO(#132971): We should fire the BEFORE trigger on child.
 query T noticetrace
 INSERT INTO ab VALUES (2, 20), (3, 30);
 ----
 NOTICE: update parent.k to 20 in trigger where k = 2
 NOTICE: BEFORE UPDATE ON parent: (2) -> (20)
+NOTICE: BEFORE UPDATE ON child: (2,2) -> (2,20)
+NOTICE: BEFORE UPDATE ON child: (3,2) -> (3,20)
 NOTICE: AFTER UPDATE ON parent: (2) -> (20)
 NOTICE: AFTER UPDATE ON child: (2,2) -> (2,20)
 NOTICE: AFTER UPDATE ON child: (3,2) -> (3,20)
 NOTICE: update parent.k to 30 in trigger where k = 3
 NOTICE: BEFORE UPDATE ON parent: (3) -> (30)
+NOTICE: BEFORE UPDATE ON child: (4,3) -> (4,30)
 NOTICE: AFTER UPDATE ON parent: (3) -> (30)
 NOTICE: AFTER UPDATE ON child: (4,3) -> (4,30)
 
-# TODO(#132971): We should fire the BEFORE trigger on child.
 query T noticetrace
 INSERT INTO ab VALUES (20, NULL), (30, NULL);
 ----
 NOTICE: delete from parent in trigger where k = 20
 NOTICE: BEFORE DELETE ON parent: (20) -> <NULL>
+NOTICE: BEFORE DELETE ON child: (2,20) -> <NULL>
+NOTICE: BEFORE DELETE ON child: (3,20) -> <NULL>
 NOTICE: AFTER DELETE ON parent: (20) -> <NULL>
 NOTICE: AFTER DELETE ON child: (2,20) -> <NULL>
 NOTICE: AFTER DELETE ON child: (3,20) -> <NULL>
 NOTICE: delete from parent in trigger where k = 30
 NOTICE: BEFORE DELETE ON parent: (30) -> <NULL>
+NOTICE: BEFORE DELETE ON child: (4,30) -> <NULL>
 NOTICE: AFTER DELETE ON parent: (30) -> <NULL>
 NOTICE: AFTER DELETE ON child: (4,30) -> <NULL>
 
@@ -2330,31 +2338,35 @@ subtest after_trigger_fires_cascades
 statement ok
 CREATE TRIGGER foo AFTER INSERT OR DELETE ON ab FOR EACH ROW EXECUTE FUNCTION h();
 
-# TODO(#132971): We should fire the BEFORE trigger on child.
 query T noticetrace
 INSERT INTO ab VALUES (2, 20), (3, 30);
 ----
 NOTICE: update parent.k to 20 in trigger where k = 2
 NOTICE: BEFORE UPDATE ON parent: (2) -> (20)
+NOTICE: BEFORE UPDATE ON child: (2,2) -> (2,20)
+NOTICE: BEFORE UPDATE ON child: (3,2) -> (3,20)
 NOTICE: AFTER UPDATE ON parent: (2) -> (20)
 NOTICE: AFTER UPDATE ON child: (2,2) -> (2,20)
 NOTICE: AFTER UPDATE ON child: (3,2) -> (3,20)
 NOTICE: update parent.k to 30 in trigger where k = 3
 NOTICE: BEFORE UPDATE ON parent: (3) -> (30)
+NOTICE: BEFORE UPDATE ON child: (4,3) -> (4,30)
 NOTICE: AFTER UPDATE ON parent: (3) -> (30)
 NOTICE: AFTER UPDATE ON child: (4,3) -> (4,30)
 
-# TODO(#132971): We should fire the BEFORE trigger on child.
 query T noticetrace
 INSERT INTO ab VALUES (20, NULL), (30, NULL);
 ----
 NOTICE: delete from parent in trigger where k = 20
 NOTICE: BEFORE DELETE ON parent: (20) -> <NULL>
+NOTICE: BEFORE DELETE ON child: (2,20) -> <NULL>
+NOTICE: BEFORE DELETE ON child: (3,20) -> <NULL>
 NOTICE: AFTER DELETE ON parent: (20) -> <NULL>
 NOTICE: AFTER DELETE ON child: (2,20) -> <NULL>
 NOTICE: AFTER DELETE ON child: (3,20) -> <NULL>
 NOTICE: delete from parent in trigger where k = 30
 NOTICE: BEFORE DELETE ON parent: (30) -> <NULL>
+NOTICE: BEFORE DELETE ON child: (4,30) -> <NULL>
 NOTICE: AFTER DELETE ON parent: (30) -> <NULL>
 NOTICE: AFTER DELETE ON child: (4,30) -> <NULL>
 
@@ -2415,6 +2427,8 @@ query T noticetrace
 CALL wrap_parent_update(2, NULL);
 ----
 NOTICE: BEFORE DELETE ON parent: (2) -> <NULL>
+NOTICE: BEFORE DELETE ON child: (2,2) -> <NULL>
+NOTICE: BEFORE DELETE ON child: (3,2) -> <NULL>
 NOTICE: FK violation updating parent from 2 to <NULL>
 
 # Try updating a referenced row in the parent table.
@@ -2422,6 +2436,8 @@ query T noticetrace
 CALL wrap_parent_update(2, 10);
 ----
 NOTICE: BEFORE UPDATE ON parent: (2) -> (10)
+NOTICE: BEFORE UPDATE ON child: (2,2) -> (2,10)
+NOTICE: BEFORE UPDATE ON child: (3,2) -> (3,10)
 NOTICE: FK violation updating parent from 2 to 10
 
 # Try inserting a row with no reference into the child2 table.
@@ -2434,10 +2450,147 @@ NOTICE: FK violation inserting (10, 10) into child2
 statement ok
 DROP PROCEDURE wrap_parent_update;
 DROP PROCEDURE wrap_child2_insert;
-DROP TABLE child;
 DROP TABLE child2;
+
+# Unless "unsafe_allow_triggers_modifying_cascades" is set, triggers are not
+# allowed to modify or filter rows the mutation for a cascade.
+subtest triggers_modify_fk_cascades
+
+statement ok
+CREATE FUNCTION h() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    NEW.k := (NEW).k + 100;
+    OLD.k := (OLD).k + 100;
+    RETURN COALESCE(NEW, OLD);
+  END
+$$;
+
+statement ok
+CREATE FUNCTION filter() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN NULL;
+  END
+$$;
+
+statement ok
+DELETE FROM child WHERE True;
+DELETE FROM parent WHERE True;
+INSERT INTO parent VALUES (1), (2), (3);
+INSERT INTO child VALUES (1, 1), (2, 2), (3, 2), (4, 3);
+
+statement ok
+CREATE TRIGGER mod BEFORE INSERT OR UPDATE OR DELETE ON child FOR EACH ROW EXECUTE FUNCTION h();
+
+statement error pgcode 27000 pq: trigger mod attempted to modify or filter a row in a cascade operation: \(1,11\)
+UPDATE parent SET k = k + 10 WHERE k < 3;
+
+statement error pgcode 27000 pq: trigger mod attempted to modify or filter a row in a cascade operation: \(1,1\)
+DELETE FROM parent WHERE k < 3;
+
+statement ok
+SET unsafe_allow_triggers_modifying_cascades = true;
+
+statement ok
+UPDATE parent SET k = k + 10 WHERE k < 3;
+
+statement ok
+DELETE FROM parent WHERE k < 3;
+
+statement ok
+RESET unsafe_allow_triggers_modifying_cascades;
+
+statement ok
+DROP TRIGGER mod ON child;
+
+statement ok
+DELETE FROM child WHERE True;
+DELETE FROM parent WHERE True;
+INSERT INTO parent VALUES (1), (2), (3);
+INSERT INTO child VALUES (1, 1), (2, 2), (3, 2), (4, 3);
+
+statement ok
+CREATE TRIGGER filter BEFORE INSERT OR UPDATE OR DELETE ON child FOR EACH ROW EXECUTE FUNCTION filter();
+
+statement error pgcode 27000 pq: trigger filter attempted to modify or filter a row in a cascade operation: \(1,11\)
+UPDATE parent SET k = k + 10 WHERE k < 3;
+
+statement error pgcode 27000 pq: trigger filter attempted to modify or filter a row in a cascade operation: \(1,1\)
+DELETE FROM parent WHERE k < 3;
+
+statement ok
+SET unsafe_allow_triggers_modifying_cascades = true;
+
+statement ok
+UPDATE parent SET k = k + 10 WHERE k < 3;
+
+statement ok
+DELETE FROM parent WHERE k < 3;
+
+statement ok
+RESET unsafe_allow_triggers_modifying_cascades;
+
+statement ok
+DROP TRIGGER filter ON child;
+
+statement ok
+DELETE FROM child WHERE True;
+DELETE FROM parent WHERE True;
+INSERT INTO parent VALUES (1), (2), (3);
+INSERT INTO child VALUES (1, 1), (2, 2), (3, 2), (4, 3);
+
+# Modifications to mutated rows made by BEFORE triggers are visible to cascades.
+subtest before_trigger_modifies_fk_cascades
+
+statement ok
+CREATE TRIGGER mod BEFORE INSERT OR UPDATE OR DELETE ON parent FOR EACH ROW EXECUTE FUNCTION h();
+
+query T noticetrace
+UPDATE parent SET k = k + 10 WHERE k < 3;
+----
+NOTICE: BEFORE UPDATE ON parent: (1) -> (11)
+NOTICE: BEFORE UPDATE ON parent: (2) -> (12)
+NOTICE: BEFORE UPDATE ON child: (1,1) -> (1,111)
+NOTICE: BEFORE UPDATE ON child: (2,2) -> (2,112)
+NOTICE: BEFORE UPDATE ON child: (3,2) -> (3,112)
+NOTICE: AFTER UPDATE ON parent: (1) -> (111)
+NOTICE: AFTER UPDATE ON parent: (2) -> (112)
+NOTICE: AFTER UPDATE ON child: (1,1) -> (1,111)
+NOTICE: AFTER UPDATE ON child: (2,2) -> (2,112)
+NOTICE: AFTER UPDATE ON child: (3,2) -> (3,112)
+
+query II rowsort
+SELECT * FROM child;
+----
+1  111
+2  112
+3  112
+4  3
+
+query T noticetrace
+DELETE FROM parent WHERE k > 3;
+----
+NOTICE: BEFORE DELETE ON parent: (111) -> <NULL>
+NOTICE: BEFORE DELETE ON parent: (112) -> <NULL>
+NOTICE: BEFORE DELETE ON child: (1,111) -> <NULL>
+NOTICE: BEFORE DELETE ON child: (2,112) -> <NULL>
+NOTICE: BEFORE DELETE ON child: (3,112) -> <NULL>
+NOTICE: AFTER DELETE ON parent: (111) -> <NULL>
+NOTICE: AFTER DELETE ON parent: (112) -> <NULL>
+NOTICE: AFTER DELETE ON child: (1,111) -> <NULL>
+NOTICE: AFTER DELETE ON child: (2,112) -> <NULL>
+NOTICE: AFTER DELETE ON child: (3,112) -> <NULL>
+
+query II rowsort
+SELECT * FROM child;
+----
+4  3
+
+statement ok
+DROP TABLE child;
 DROP TABLE parent;
 DROP FUNCTION g;
+DROP FUNCTION h;
+DROP FUNCTION filter;
 
 # ==============================================================================
 # Test order of execution.

--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -2586,7 +2586,108 @@ SELECT * FROM child;
 4  3
 
 statement ok
+DROP TRIGGER mod ON parent;
+
+subtest cascade_diamond
+
+# Create a diamond cascade structure.
+statement ok
 DROP TABLE child;
+DELETE FROM parent WHERE True;
+
+statement ok
+CREATE TABLE child (k INT PRIMARY KEY, v INT UNIQUE NOT NULL REFERENCES parent(k) ON UPDATE CASCADE ON DELETE CASCADE);
+CREATE TABLE child2 (k INT PRIMARY KEY, v INT UNIQUE NOT NULL REFERENCES parent(k) ON UPDATE CASCADE ON DELETE CASCADE);
+
+statement ok
+CREATE TRIGGER foo BEFORE INSERT OR UPDATE OR DELETE ON child FOR EACH ROW EXECUTE FUNCTION g();
+
+statement ok
+CREATE TRIGGER bar AFTER INSERT OR UPDATE OR DELETE ON child FOR EACH ROW EXECUTE FUNCTION g();
+
+statement ok
+CREATE TRIGGER foo BEFORE INSERT OR UPDATE OR DELETE ON child2 FOR EACH ROW EXECUTE FUNCTION g();
+
+statement ok
+CREATE TRIGGER bar AFTER INSERT OR UPDATE OR DELETE ON child2 FOR EACH ROW EXECUTE FUNCTION g();
+
+statement ok
+CREATE TABLE grandchild (
+  k INT PRIMARY KEY,
+  v INT REFERENCES child(v) ON UPDATE CASCADE ON DELETE CASCADE,
+  v2 INT REFERENCES child2(v) ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+statement ok
+CREATE TRIGGER foo BEFORE INSERT OR UPDATE OR DELETE ON grandchild FOR EACH ROW EXECUTE FUNCTION g();
+
+statement ok
+CREATE TRIGGER bar AFTER INSERT OR UPDATE OR DELETE ON grandchild FOR EACH ROW EXECUTE FUNCTION g();
+
+statement ok
+INSERT INTO parent VALUES (1), (2), (3);
+INSERT INTO child VALUES (1, 1), (2, 2), (3, 3);
+INSERT INTO child2 VALUES (1, 1), (2, 2), (3, 3);
+INSERT INTO grandchild VALUES (1, 1, 1), (2, 2, 2), (3, 2, 2), (4, 3, 3);
+
+# Update the parent table, which should cascade to the children and grandchild.
+# Note that both child tables cascade to the grandchild.
+#
+# Regression test for #133784 and #133792.
+query T noticetrace
+UPDATE parent SET k = k + 10 WHERE k < 3;
+----
+NOTICE: BEFORE UPDATE ON parent: (1) -> (11)
+NOTICE: BEFORE UPDATE ON parent: (2) -> (12)
+NOTICE: BEFORE UPDATE ON child: (1,1) -> (1,11)
+NOTICE: BEFORE UPDATE ON child: (2,2) -> (2,12)
+NOTICE: BEFORE UPDATE ON child2: (1,1) -> (1,11)
+NOTICE: BEFORE UPDATE ON child2: (2,2) -> (2,12)
+NOTICE: AFTER UPDATE ON parent: (1) -> (11)
+NOTICE: AFTER UPDATE ON parent: (2) -> (12)
+NOTICE: AFTER UPDATE ON child: (1,1) -> (1,11)
+NOTICE: AFTER UPDATE ON child: (2,2) -> (2,12)
+NOTICE: AFTER UPDATE ON child2: (1,1) -> (1,11)
+NOTICE: AFTER UPDATE ON child2: (2,2) -> (2,12)
+NOTICE: BEFORE UPDATE ON grandchild: (1,1,1) -> (1,11,1)
+NOTICE: BEFORE UPDATE ON grandchild: (2,2,2) -> (2,12,2)
+NOTICE: BEFORE UPDATE ON grandchild: (3,2,2) -> (3,12,2)
+NOTICE: BEFORE UPDATE ON grandchild: (1,11,1) -> (1,11,11)
+NOTICE: BEFORE UPDATE ON grandchild: (2,12,2) -> (2,12,12)
+NOTICE: BEFORE UPDATE ON grandchild: (3,12,2) -> (3,12,12)
+NOTICE: AFTER UPDATE ON grandchild: (1,1,1) -> (1,11,1)
+NOTICE: AFTER UPDATE ON grandchild: (2,2,2) -> (2,12,2)
+NOTICE: AFTER UPDATE ON grandchild: (3,2,2) -> (3,12,2)
+NOTICE: AFTER UPDATE ON grandchild: (1,11,1) -> (1,11,11)
+NOTICE: AFTER UPDATE ON grandchild: (2,12,2) -> (2,12,12)
+NOTICE: AFTER UPDATE ON grandchild: (3,12,2) -> (3,12,12)
+
+query II rowsort
+SELECT * FROM child;
+----
+1  11
+2  12
+3  3
+
+query II rowsort
+SELECT * FROM child2;
+----
+1  11
+2  12
+3  3
+
+query III rowsort
+SELECT * FROM grandchild;
+----
+1  11  11
+2  12  12
+3  12  12
+4  3   3
+
+statement ok
+DROP TABLE grandchild;
+DROP TABLE child;
+DROP TABLE child2;
 DROP TABLE parent;
 DROP FUNCTION g;
 DROP FUNCTION h;

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3892,6 +3892,10 @@ func (m *sessionDataMutator) SetBypassPCRReaderCatalogAOST(val bool) {
 	m.data.BypassPCRReaderCatalogAOST = val
 }
 
+func (m *sessionDataMutator) SetUnsafeAllowTriggersModifyingCascades(val bool) {
+	m.data.UnsafeAllowTriggersModifyingCascades = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -6394,6 +6394,7 @@ transaction_timeout                                        0
 troubleshooting_mode                                       off
 unbounded_parallel_scans                                   off
 unconstrained_non_covering_index_scan_enabled              off
+unsafe_allow_triggers_modifying_cascades                   off
 variable_inequality_lookup_join_enabled                    on
 xmloption                                                  content
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3039,6 +3039,7 @@ transaction_timeout                                        0                   N
 troubleshooting_mode                                       off                 NULL      NULL        NULL        string
 unbounded_parallel_scans                                   off                 NULL      NULL        NULL        string
 unconstrained_non_covering_index_scan_enabled              off                 NULL      NULL        NULL        string
+unsafe_allow_triggers_modifying_cascades                   off                 NULL      NULL        NULL        string
 use_declarative_schema_changer                             on                  NULL      NULL        NULL        string
 variable_inequality_lookup_join_enabled                    on                  NULL      NULL        NULL        string
 vectorize                                                  on                  NULL      NULL        NULL        string
@@ -3233,6 +3234,7 @@ transaction_timeout                                        0                   N
 troubleshooting_mode                                       off                 NULL  user     NULL      off                 off
 unbounded_parallel_scans                                   off                 NULL  user     NULL      off                 off
 unconstrained_non_covering_index_scan_enabled              off                 NULL  user     NULL      off                 off
+unsafe_allow_triggers_modifying_cascades                   off                 NULL  user     NULL      off                 off
 use_declarative_schema_changer                             on                  NULL  user     NULL      on                  on
 variable_inequality_lookup_join_enabled                    on                  NULL  user     NULL      on                  on
 vectorize                                                  on                  NULL  user     NULL      on                  on
@@ -3427,6 +3429,7 @@ transaction_timeout                                        NULL    NULL     NULL
 troubleshooting_mode                                       NULL    NULL     NULL     NULL        NULL
 unbounded_parallel_scans                                   NULL    NULL     NULL     NULL        NULL
 unconstrained_non_covering_index_scan_enabled              NULL    NULL     NULL     NULL        NULL
+unsafe_allow_triggers_modifying_cascades                   NULL    NULL     NULL     NULL        NULL
 use_declarative_schema_changer                             NULL    NULL     NULL     NULL        NULL
 variable_inequality_lookup_join_enabled                    NULL    NULL     NULL     NULL        NULL
 vectorize                                                  NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -205,6 +205,7 @@ transaction_timeout                                        0
 troubleshooting_mode                                       off
 unbounded_parallel_scans                                   off
 unconstrained_non_covering_index_scan_enabled              off
+unsafe_allow_triggers_modifying_cascades                   off
 use_declarative_schema_changer                             on
 variable_inequality_lookup_join_enabled                    on
 vectorize                                                  on

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -197,6 +197,7 @@ type Memo struct {
 	usePolymorphicParameterFix                 bool
 	useConditionalHoistFix                     bool
 	pushLimitIntoProjectFilteredScan           bool
+	unsafeAllowTriggersModifyingCascades       bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -285,6 +286,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		usePolymorphicParameterFix:                 evalCtx.SessionData().OptimizerUsePolymorphicParameterFix,
 		useConditionalHoistFix:                     evalCtx.SessionData().OptimizerUseConditionalHoistFix,
 		pushLimitIntoProjectFilteredScan:           evalCtx.SessionData().OptimizerPushLimitIntoProjectFilteredScan,
+		unsafeAllowTriggersModifyingCascades:       evalCtx.SessionData().UnsafeAllowTriggersModifyingCascades,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -451,6 +453,7 @@ func (m *Memo) IsStale(
 		m.usePolymorphicParameterFix != evalCtx.SessionData().OptimizerUsePolymorphicParameterFix ||
 		m.useConditionalHoistFix != evalCtx.SessionData().OptimizerUseConditionalHoistFix ||
 		m.pushLimitIntoProjectFilteredScan != evalCtx.SessionData().OptimizerPushLimitIntoProjectFilteredScan ||
+		m.unsafeAllowTriggersModifyingCascades != evalCtx.SessionData().UnsafeAllowTriggersModifyingCascades ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -521,6 +521,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerPushLimitIntoProjectFilteredScan = false
 	notStale()
 
+	// Stale unsafe_allow_triggers_modifying_cascades.
+	evalCtx.SessionData().UnsafeAllowTriggersModifyingCascades = true
+	stale()
+	evalCtx.SessionData().UnsafeAllowTriggersModifyingCascades = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -89,7 +89,7 @@ func (b *Builder) buildDelete(del *tree.Delete, inScope *scope) (outScope *scope
 	mb.buildInputForDelete(inScope, del.Table, del.Where, del.Using, del.Limit, del.OrderBy)
 
 	// Project row-level BEFORE triggers for DELETE.
-	mb.buildRowLevelBeforeTriggers(tree.TriggerEventDelete)
+	mb.buildRowLevelBeforeTriggers(tree.TriggerEventDelete, false /* cascade */)
 
 	// Build the final delete statement, including any returned expressions.
 	if resultsNeeded(del.Returning) {

--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -112,6 +112,10 @@ func (cb *onDeleteCascadeBuilder) Build(
 
 		// Set list of columns that will be fetched by the input expression.
 		mb.setFetchColIDs(mb.outScope.cols)
+
+		// Cascades can fire triggers on the child table.
+		mb.buildRowLevelBeforeTriggers(tree.TriggerEventDelete, true /* cascade */)
+
 		mb.buildDelete(nil /* returning */)
 		return mb.outScope.expr
 	})
@@ -354,6 +358,10 @@ func (cb *onDeleteFastCascadeBuilder) Build(
 
 		// Set list of columns that will be fetched by the input expression.
 		mb.setFetchColIDs(mb.outScope.cols)
+
+		// Cascades can fire triggers on the child table.
+		mb.buildRowLevelBeforeTriggers(tree.TriggerEventInsert, true /* cascade */)
+
 		mb.buildDelete(nil /* returning */)
 		return mb.outScope.expr
 	})
@@ -486,6 +494,9 @@ func (cb *onDeleteSetBuilder) Build(
 			}
 		}
 		mb.addUpdateCols(updateExprs)
+
+		// Cascades can fire triggers on the child table.
+		mb.buildRowLevelBeforeTriggers(tree.TriggerEventUpdate, true /* cascade */)
 
 		// TODO(radu): consider plumbing a flag to prevent building the FK check
 		// against the parent we are cascading from. Need to investigate in which
@@ -728,6 +739,9 @@ func (cb *onUpdateCascadeBuilder) Build(
 			}
 		}
 		mb.addUpdateCols(updateExprs)
+
+		// Cascades can fire triggers on the child table.
+		mb.buildRowLevelBeforeTriggers(tree.TriggerEventUpdate, true /* cascade */)
 
 		mb.buildUpdate(nil /* returning */)
 		return mb.outScope.expr

--- a/pkg/sql/opt/optbuilder/testdata/trigger
+++ b/pkg/sql/opt/optbuilder/testdata/trigger
@@ -3,6 +3,10 @@ CREATE TABLE xy (x INT PRIMARY KEY, y INT);
 ----
 
 exec-ddl
+CREATE TABLE child (k INT PRIMARY KEY, x INT REFERENCES xy(x) ON UPDATE CASCADE ON DELETE CASCADE);
+----
+
+exec-ddl
 CREATE FUNCTION f() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
   BEGIN
     RETURN COALESCE(NEW, OLD);
@@ -16,6 +20,10 @@ $$;
 
 exec-ddl
 CREATE TRIGGER tr BEFORE INSERT OR UPDATE OR DELETE ON xy FOR EACH ROW EXECUTE FUNCTION f();
+----
+
+exec-ddl
+CREATE TRIGGER tr_child BEFORE INSERT OR UPDATE OR DELETE ON child FOR EACH ROW EXECUTE FUNCTION f();
 ----
 
 norm format=(hide-all,show-columns)
@@ -47,211 +55,507 @@ insert xy
            ├── (f:21).x [as=x_new:22]
            └── (f:21).y [as=y_new:23]
 
-norm format=(hide-all,show-columns)
+build-post-queries format=(hide-all,show-columns)
 UPDATE xy SET y = 3 WHERE x = 1;
 ----
-update xy
- ├── columns: <none>
- ├── fetch columns: x:5 y:6
- ├── update-mapping:
- │    ├── x_new:26 => x:1
- │    └── y_new:27 => y:2
- └── project
-      ├── columns: x_new:26 y_new:27 x:5 y:6
-      ├── barrier
-      │    ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8 y_new:9 old:10 new:11 f:25
-      │    └── select
-      │         ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8 y_new:9 old:10 new:11 f:25
-      │         ├── project
-      │         │    ├── columns: f:25 x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8 y_new:9 old:10 new:11
-      │         │    ├── barrier
-      │         │    │    ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8 y_new:9 old:10 new:11
-      │         │    │    └── project
-      │         │    │         ├── columns: new:11 old:10 y_new:9 x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
-      │         │    │         ├── select
-      │         │    │         │    ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
-      │         │    │         │    ├── scan xy
-      │         │    │         │    │    └── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
-      │         │    │         │    └── filters
-      │         │    │         │         └── x:5 = 1
-      │         │    │         └── projections
-      │         │    │              ├── ((x:5, 3) AS x, y) [as=new:11]
-      │         │    │              ├── ((x:5, y:6) AS x, y) [as=old:10]
-      │         │    │              └── 3 [as=y_new:9]
-      │         │    └── projections
-      │         │         └── f(new:11, old:10, 'tr', 'BEFORE', 'ROW', 'UPDATE', 53, 'xy', 'xy', 'public', 0, ARRAY[]) [as=f:25]
-      │         └── filters
-      │              └── f:25 IS DISTINCT FROM NULL
-      └── projections
-           ├── (f:25).x [as=x_new:26]
-           └── (f:25).y [as=y_new:27]
+root
+ ├── update xy
+ │    ├── columns: <none>
+ │    ├── fetch columns: x:5 y:6
+ │    ├── update-mapping:
+ │    │    ├── x_new:26 => x:1
+ │    │    └── y_new:27 => y:2
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── child_x_fkey
+ │    └── project
+ │         ├── columns: x_new:26 y_new:27 x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8 y_new:9 old:10 new:11 f:25
+ │         ├── barrier
+ │         │    ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8 y_new:9 old:10 new:11 f:25
+ │         │    └── select
+ │         │         ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8 y_new:9 old:10 new:11 f:25
+ │         │         ├── project
+ │         │         │    ├── columns: f:25 x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8 y_new:9 old:10 new:11
+ │         │         │    ├── barrier
+ │         │         │    │    ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8 y_new:9 old:10 new:11
+ │         │         │    │    └── project
+ │         │         │    │         ├── columns: new:11 x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8 y_new:9 old:10
+ │         │         │    │         ├── project
+ │         │         │    │         │    ├── columns: old:10 x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8 y_new:9
+ │         │         │    │         │    ├── project
+ │         │         │    │         │    │    ├── columns: y_new:9 x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         │         │    │         │    │    ├── select
+ │         │         │    │         │    │    │    ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         │         │    │         │    │    │    ├── scan xy
+ │         │         │    │         │    │    │    │    └── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         │         │    │         │    │    │    └── filters
+ │         │         │    │         │    │    │         └── x:5 = 1
+ │         │         │    │         │    │    └── projections
+ │         │         │    │         │    │         └── 3 [as=y_new:9]
+ │         │         │    │         │    └── projections
+ │         │         │    │         │         └── ((x:5, y:6) AS x, y) [as=old:10]
+ │         │         │    │         └── projections
+ │         │         │    │              └── ((x:5, y_new:9) AS x, y) [as=new:11]
+ │         │         │    └── projections
+ │         │         │         └── f(new:11, old:10, 'tr', 'BEFORE', 'ROW', 'UPDATE', 53, 'xy', 'xy', 'public', 0, ARRAY[]) [as=f:25]
+ │         │         └── filters
+ │         │              └── f:25 IS DISTINCT FROM NULL
+ │         └── projections
+ │              ├── (f:25).x [as=x_new:26]
+ │              └── (f:25).y [as=y_new:27]
+ └── cascade
+      └── update child
+           ├── columns: <none>
+           ├── fetch columns: k:32 child.x:33
+           ├── update-mapping:
+           │    ├── k_new:55 => k:28
+           │    └── x_new:56 => child.x:29
+           ├── input binding: &2
+           ├── project
+           │    ├── columns: k_new:55 x_new:56 k:32 child.x:33 x_old:36 x_new:37 old:38 new:39 f:53 "check-rows":54
+           │    ├── barrier
+           │    │    ├── columns: k:32 child.x:33 x_old:36 x_new:37 old:38 new:39 f:53 "check-rows":54
+           │    │    └── select
+           │    │         ├── columns: k:32 child.x:33 x_old:36 x_new:37 old:38 new:39 f:53 "check-rows":54
+           │    │         ├── barrier
+           │    │         │    ├── columns: k:32 child.x:33 x_old:36 x_new:37 old:38 new:39 f:53 "check-rows":54
+           │    │         │    └── project
+           │    │         │         ├── columns: "check-rows":54 k:32 child.x:33 x_old:36 x_new:37 old:38 new:39 f:53
+           │    │         │         ├── project
+           │    │         │         │    ├── columns: f:53 k:32 child.x:33 x_old:36 x_new:37 old:38 new:39
+           │    │         │         │    ├── barrier
+           │    │         │         │    │    ├── columns: k:32 child.x:33 x_old:36 x_new:37 old:38 new:39
+           │    │         │         │    │    └── project
+           │    │         │         │    │         ├── columns: new:39 k:32 child.x:33 x_old:36 x_new:37 old:38
+           │    │         │         │    │         ├── project
+           │    │         │         │    │         │    ├── columns: old:38 k:32 child.x:33 x_old:36 x_new:37
+           │    │         │         │    │         │    ├── inner-join (hash)
+           │    │         │         │    │         │    │    ├── columns: k:32 child.x:33 x_old:36 x_new:37
+           │    │         │         │    │         │    │    ├── scan child
+           │    │         │         │    │         │    │    │    └── columns: k:32 child.x:33
+           │    │         │         │    │         │    │    ├── select
+           │    │         │         │    │         │    │    │    ├── columns: x_old:36 x_new:37
+           │    │         │         │    │         │    │    │    ├── with-scan &1
+           │    │         │         │    │         │    │    │    │    ├── columns: x_old:36 x_new:37
+           │    │         │         │    │         │    │    │    │    └── mapping:
+           │    │         │         │    │         │    │    │    │         ├──  xy.x:5 => x_old:36
+           │    │         │         │    │         │    │    │    │         └──  x_new:26 => x_new:37
+           │    │         │         │    │         │    │    │    └── filters
+           │    │         │         │    │         │    │    │         └── x_old:36 IS DISTINCT FROM x_new:37
+           │    │         │         │    │         │    │    └── filters
+           │    │         │         │    │         │    │         └── child.x:33 = x_old:36
+           │    │         │         │    │         │    └── projections
+           │    │         │         │    │         │         └── ((k:32, child.x:33) AS k, x) [as=old:38]
+           │    │         │         │    │         └── projections
+           │    │         │         │    │              └── ((k:32, x_new:37) AS k, x) [as=new:39]
+           │    │         │         │    └── projections
+           │    │         │         │         └── f(new:39, old:38, 'tr_child', 'BEFORE', 'ROW', 'UPDATE', 54, 'child', 'child', 'public', 0, ARRAY[]) [as=f:53]
+           │    │         │         └── projections
+           │    │         │              └── CASE WHEN f:53 IS DISTINCT FROM new:39 THEN crdb_internal.plpgsql_raise('ERROR', 'trigger tr_child attempted to modify or filter a row in a cascade operation: ' || new:39::STRING, e'changing the rows updated or deleted by a foreign-key cascade\n can cause constraint violations, and therefore is not allowed', e'to enable this behavior (with risk of constraint violation), set\nthe session variable \'unsafe_allow_triggers_modifying_cascades\' to true', '27000') ELSE CAST(NULL AS INT8) END [as="check-rows":54]
+           │    │         └── filters
+           │    │              └── f:53 IS DISTINCT FROM NULL
+           │    └── projections
+           │         ├── (f:53).k [as=k_new:55]
+           │         └── (f:53).x [as=x_new:56]
+           └── f-k-checks
+                └── f-k-checks-item: child(x) -> xy(x)
+                     └── anti-join (hash)
+                          ├── columns: x:57
+                          ├── select
+                          │    ├── columns: x:57
+                          │    ├── with-scan &2
+                          │    │    ├── columns: x:57
+                          │    │    └── mapping:
+                          │    │         └──  x_new:56 => x:57
+                          │    └── filters
+                          │         └── x:57 IS NOT NULL
+                          ├── scan xy
+                          │    └── columns: xy.x:58
+                          └── filters
+                               └── x:57 = xy.x:58
 
-norm format=(hide-all,show-columns)
+build-post-queries format=(hide-all,show-columns)
 DELETE FROM xy WHERE x = 1;
 ----
-delete xy
- ├── columns: <none>
- ├── fetch columns: x:5
- └── barrier
-      ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8 old:9 f:23
-      └── select
-           ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8 old:9 f:23
-           ├── project
-           │    ├── columns: f:23 x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8 old:9
-           │    ├── barrier
-           │    │    ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8 old:9
-           │    │    └── project
-           │    │         ├── columns: old:9 x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
-           │    │         ├── select
-           │    │         │    ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
-           │    │         │    ├── scan xy
-           │    │         │    │    └── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
-           │    │         │    └── filters
-           │    │         │         └── x:5 = 1
-           │    │         └── projections
-           │    │              └── ((x:5, y:6) AS x, y) [as=old:9]
-           │    └── projections
-           │         └── f(NULL, old:9, 'tr', 'BEFORE', 'ROW', 'DELETE', 53, 'xy', 'xy', 'public', 0, ARRAY[]) [as=f:23]
-           └── filters
-                └── f:23 IS DISTINCT FROM NULL
+root
+ ├── delete xy
+ │    ├── columns: <none>
+ │    ├── fetch columns: x:5 y:6
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── child_x_fkey
+ │    └── barrier
+ │         ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8 old:9 f:23
+ │         └── select
+ │              ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8 old:9 f:23
+ │              ├── project
+ │              │    ├── columns: f:23 x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8 old:9
+ │              │    ├── barrier
+ │              │    │    ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8 old:9
+ │              │    │    └── project
+ │              │    │         ├── columns: old:9 x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │              │    │         ├── select
+ │              │    │         │    ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │              │    │         │    ├── scan xy
+ │              │    │         │    │    └── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │              │    │         │    └── filters
+ │              │    │         │         └── x:5 = 1
+ │              │    │         └── projections
+ │              │    │              └── ((x:5, y:6) AS x, y) [as=old:9]
+ │              │    └── projections
+ │              │         └── f(NULL, old:9, 'tr', 'BEFORE', 'ROW', 'DELETE', 53, 'xy', 'xy', 'public', 0, ARRAY[]) [as=f:23]
+ │              └── filters
+ │                   └── f:23 IS DISTINCT FROM NULL
+ └── cascade
+      └── delete child
+           ├── columns: <none>
+           ├── fetch columns: k:28 child.x:29
+           └── barrier
+                ├── columns: k:28 child.x:29 old:33 f:47 "check-rows":48
+                └── select
+                     ├── columns: k:28 child.x:29 old:33 f:47 "check-rows":48
+                     ├── barrier
+                     │    ├── columns: k:28 child.x:29 old:33 f:47 "check-rows":48
+                     │    └── project
+                     │         ├── columns: "check-rows":48 k:28 child.x:29 old:33 f:47
+                     │         ├── project
+                     │         │    ├── columns: f:47 k:28 child.x:29 old:33
+                     │         │    ├── barrier
+                     │         │    │    ├── columns: k:28 child.x:29 old:33
+                     │         │    │    └── project
+                     │         │    │         ├── columns: old:33 k:28 child.x:29
+                     │         │    │         ├── semi-join (hash)
+                     │         │    │         │    ├── columns: k:28 child.x:29
+                     │         │    │         │    ├── scan child
+                     │         │    │         │    │    └── columns: k:28 child.x:29
+                     │         │    │         │    ├── with-scan &1
+                     │         │    │         │    │    ├── columns: x:32
+                     │         │    │         │    │    └── mapping:
+                     │         │    │         │    │         └──  xy.x:5 => x:32
+                     │         │    │         │    └── filters
+                     │         │    │         │         └── child.x:29 = x:32
+                     │         │    │         └── projections
+                     │         │    │              └── ((k:28, child.x:29) AS k, x) [as=old:33]
+                     │         │    └── projections
+                     │         │         └── f(NULL, old:33, 'tr_child', 'BEFORE', 'ROW', 'DELETE', 54, 'child', 'child', 'public', 0, ARRAY[]) [as=f:47]
+                     │         └── projections
+                     │              └── CASE WHEN f:47 IS DISTINCT FROM old:33 THEN crdb_internal.plpgsql_raise('ERROR', 'trigger tr_child attempted to modify or filter a row in a cascade operation: ' || old:33::STRING, e'changing the rows updated or deleted by a foreign-key cascade\n can cause constraint violations, and therefore is not allowed', e'to enable this behavior (with risk of constraint violation), set\nthe session variable \'unsafe_allow_triggers_modifying_cascades\' to true', '27000') ELSE CAST(NULL AS INT8) END [as="check-rows":48]
+                     └── filters
+                          └── f:47 IS DISTINCT FROM NULL
 
-norm format=(hide-all,show-columns)
+build-post-queries format=(hide-all,show-columns)
 UPSERT INTO xy VALUES (1, 2);
 ----
-upsert xy
- ├── arbiter indexes: xy_pkey
- ├── columns: <none>
- ├── canary column: x:7
- ├── fetch columns: x:7 y:8
- ├── insert-mapping:
- │    ├── x_new:26 => x:1
- │    └── y_new:27 => y:2
- ├── update-mapping:
- │    ├── upsert_x:46 => x:1
- │    └── upsert_y:47 => y:2
- └── project
-      ├── columns: upsert_x:46 upsert_y:47 x:7 y:8 x_new:26 y_new:27
-      ├── barrier
-      │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28 new:29 f:43
-      │    └── select
-      │         ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28 new:29 f:43
-      │         ├── project
-      │         │    ├── columns: f:43 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28 new:29
-      │         │    ├── barrier
-      │         │    │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28 new:29
-      │         │    │    └── project
-      │         │    │         ├── columns: new:29 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28
-      │         │    │         ├── project
-      │         │    │         │    ├── columns: old:28 x_new:26 y_new:27 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25
-      │         │    │         │    ├── barrier
-      │         │    │         │    │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25
-      │         │    │         │    │    └── select
-      │         │    │         │    │         ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25
-      │         │    │         │    │         ├── project
-      │         │    │         │    │         │    ├── columns: f:25 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11
-      │         │    │         │    │         │    ├── barrier
-      │         │    │         │    │         │    │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11
-      │         │    │         │    │         │    │    └── project
-      │         │    │         │    │         │    │         ├── columns: new:11 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │         │    │         │    │         │    │         ├── left-join (cross)
-      │         │    │         │    │         │    │         │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │         │    │         │    │         │    │         │    ├── values
-      │         │    │         │    │         │    │         │    │    ├── columns: column1:5 column2:6
-      │         │    │         │    │         │    │         │    │    └── (1, 2)
-      │         │    │         │    │         │    │         │    ├── select
-      │         │    │         │    │         │    │         │    │    ├── columns: x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │         │    │         │    │         │    │         │    │    ├── scan xy
-      │         │    │         │    │         │    │         │    │    │    └── columns: x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │         │    │         │    │         │    │         │    │    └── filters
-      │         │    │         │    │         │    │         │    │         └── x:7 = 1
-      │         │    │         │    │         │    │         │    └── filters (true)
-      │         │    │         │    │         │    │         └── projections
-      │         │    │         │    │         │    │              └── ((column1:5, column2:6) AS x, y) [as=new:11]
-      │         │    │         │    │         │    └── projections
-      │         │    │         │    │         │         └── f(new:11, NULL, 'tr', 'BEFORE', 'ROW', 'INSERT', 53, 'xy', 'xy', 'public', 0, ARRAY[]) [as=f:25]
-      │         │    │         │    │         └── filters
-      │         │    │         │    │              └── f:25 IS DISTINCT FROM NULL
-      │         │    │         │    └── projections
-      │         │    │         │         ├── ((x:7, y:8) AS x, y) [as=old:28]
-      │         │    │         │         ├── (f:25).x [as=x_new:26]
-      │         │    │         │         └── (f:25).y [as=y_new:27]
-      │         │    │         └── projections
-      │         │    │              └── ((x:7, y_new:27) AS x, y) [as=new:29]
-      │         │    └── projections
-      │         │         └── CASE WHEN x:7 IS NOT NULL THEN f(new:29, old:28, 'tr', 'BEFORE', 'ROW', 'UPDATE', 53, 'xy', 'xy', 'public', 0, ARRAY[]) ELSE new:29 END [as=f:43]
-      │         └── filters
-      │              └── f:43 IS DISTINCT FROM NULL
-      └── projections
-           ├── CASE WHEN x:7 IS NULL THEN x_new:26 ELSE (f:43).x END [as=upsert_x:46]
-           └── CASE WHEN x:7 IS NULL THEN y_new:27 ELSE (f:43).y END [as=upsert_y:47]
+root
+ ├── upsert xy
+ │    ├── arbiter indexes: xy_pkey
+ │    ├── columns: <none>
+ │    ├── canary column: x:7
+ │    ├── fetch columns: x:7 y:8
+ │    ├── insert-mapping:
+ │    │    ├── x_new:26 => x:1
+ │    │    └── y_new:27 => y:2
+ │    ├── update-mapping:
+ │    │    ├── upsert_x:46 => x:1
+ │    │    └── upsert_y:47 => y:2
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── child_x_fkey
+ │    └── project
+ │         ├── columns: upsert_x:46 upsert_y:47 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28 new:29 f:43 x_new:44 y_new:45
+ │         ├── project
+ │         │    ├── columns: x_new:44 y_new:45 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28 new:29 f:43
+ │         │    ├── barrier
+ │         │    │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28 new:29 f:43
+ │         │    │    └── select
+ │         │    │         ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28 new:29 f:43
+ │         │    │         ├── project
+ │         │    │         │    ├── columns: f:43 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28 new:29
+ │         │    │         │    ├── barrier
+ │         │    │         │    │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28 new:29
+ │         │    │         │    │    └── project
+ │         │    │         │    │         ├── columns: new:29 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28
+ │         │    │         │    │         ├── project
+ │         │    │         │    │         │    ├── columns: old:28 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27
+ │         │    │         │    │         │    ├── project
+ │         │    │         │    │         │    │    ├── columns: x_new:26 y_new:27 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25
+ │         │    │         │    │         │    │    ├── barrier
+ │         │    │         │    │         │    │    │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25
+ │         │    │         │    │         │    │    │    └── select
+ │         │    │         │    │         │    │    │         ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25
+ │         │    │         │    │         │    │    │         ├── project
+ │         │    │         │    │         │    │    │         │    ├── columns: f:25 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11
+ │         │    │         │    │         │    │    │         │    ├── barrier
+ │         │    │         │    │         │    │    │         │    │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11
+ │         │    │         │    │         │    │    │         │    │    └── project
+ │         │    │         │    │         │    │    │         │    │         ├── columns: new:11 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │         │    │         │    │    │         │    │         ├── left-join (hash)
+ │         │    │         │    │         │    │    │         │    │         │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │         │    │         │    │    │         │    │         │    ├── ensure-upsert-distinct-on
+ │         │    │         │    │         │    │    │         │    │         │    │    ├── columns: column1:5 column2:6
+ │         │    │         │    │         │    │    │         │    │         │    │    ├── grouping columns: column1:5
+ │         │    │         │    │         │    │    │         │    │         │    │    ├── values
+ │         │    │         │    │         │    │    │         │    │         │    │    │    ├── columns: column1:5 column2:6
+ │         │    │         │    │         │    │    │         │    │         │    │    │    └── (1, 2)
+ │         │    │         │    │         │    │    │         │    │         │    │    └── aggregations
+ │         │    │         │    │         │    │    │         │    │         │    │         └── first-agg [as=column2:6]
+ │         │    │         │    │         │    │    │         │    │         │    │              └── column2:6
+ │         │    │         │    │         │    │    │         │    │         │    ├── scan xy
+ │         │    │         │    │         │    │    │         │    │         │    │    └── columns: x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │         │    │         │    │    │         │    │         │    └── filters
+ │         │    │         │    │         │    │    │         │    │         │         └── column1:5 = x:7
+ │         │    │         │    │         │    │    │         │    │         └── projections
+ │         │    │         │    │         │    │    │         │    │              └── ((column1:5, column2:6) AS x, y) [as=new:11]
+ │         │    │         │    │         │    │    │         │    └── projections
+ │         │    │         │    │         │    │    │         │         └── f(new:11, NULL, 'tr', 'BEFORE', 'ROW', 'INSERT', 53, 'xy', 'xy', 'public', 0, ARRAY[]) [as=f:25]
+ │         │    │         │    │         │    │    │         └── filters
+ │         │    │         │    │         │    │    │              └── f:25 IS DISTINCT FROM NULL
+ │         │    │         │    │         │    │    └── projections
+ │         │    │         │    │         │    │         ├── (f:25).x [as=x_new:26]
+ │         │    │         │    │         │    │         └── (f:25).y [as=y_new:27]
+ │         │    │         │    │         │    └── projections
+ │         │    │         │    │         │         └── ((x:7, y:8) AS x, y) [as=old:28]
+ │         │    │         │    │         └── projections
+ │         │    │         │    │              └── ((x:7, y_new:27) AS x, y) [as=new:29]
+ │         │    │         │    └── projections
+ │         │    │         │         └── CASE WHEN x:7 IS NOT NULL THEN f(new:29, old:28, 'tr', 'BEFORE', 'ROW', 'UPDATE', 53, 'xy', 'xy', 'public', 0, ARRAY[]) ELSE new:29 END [as=f:43]
+ │         │    │         └── filters
+ │         │    │              └── f:43 IS DISTINCT FROM NULL
+ │         │    └── projections
+ │         │         ├── (f:43).x [as=x_new:44]
+ │         │         └── (f:43).y [as=y_new:45]
+ │         └── projections
+ │              ├── CASE WHEN x:7 IS NULL THEN x_new:26 ELSE x_new:44 END [as=upsert_x:46]
+ │              └── CASE WHEN x:7 IS NULL THEN y_new:27 ELSE y_new:45 END [as=upsert_y:47]
+ └── cascade
+      └── update child
+           ├── columns: <none>
+           ├── fetch columns: k:52 child.x:53
+           ├── update-mapping:
+           │    ├── k_new:75 => k:48
+           │    └── x_new:76 => child.x:49
+           ├── input binding: &2
+           ├── project
+           │    ├── columns: k_new:75 x_new:76 k:52 child.x:53 x_old:56 x_new:57 old:58 new:59 f:73 "check-rows":74
+           │    ├── barrier
+           │    │    ├── columns: k:52 child.x:53 x_old:56 x_new:57 old:58 new:59 f:73 "check-rows":74
+           │    │    └── select
+           │    │         ├── columns: k:52 child.x:53 x_old:56 x_new:57 old:58 new:59 f:73 "check-rows":74
+           │    │         ├── barrier
+           │    │         │    ├── columns: k:52 child.x:53 x_old:56 x_new:57 old:58 new:59 f:73 "check-rows":74
+           │    │         │    └── project
+           │    │         │         ├── columns: "check-rows":74 k:52 child.x:53 x_old:56 x_new:57 old:58 new:59 f:73
+           │    │         │         ├── project
+           │    │         │         │    ├── columns: f:73 k:52 child.x:53 x_old:56 x_new:57 old:58 new:59
+           │    │         │         │    ├── barrier
+           │    │         │         │    │    ├── columns: k:52 child.x:53 x_old:56 x_new:57 old:58 new:59
+           │    │         │         │    │    └── project
+           │    │         │         │    │         ├── columns: new:59 k:52 child.x:53 x_old:56 x_new:57 old:58
+           │    │         │         │    │         ├── project
+           │    │         │         │    │         │    ├── columns: old:58 k:52 child.x:53 x_old:56 x_new:57
+           │    │         │         │    │         │    ├── inner-join (hash)
+           │    │         │         │    │         │    │    ├── columns: k:52 child.x:53 x_old:56 x_new:57
+           │    │         │         │    │         │    │    ├── scan child
+           │    │         │         │    │         │    │    │    └── columns: k:52 child.x:53
+           │    │         │         │    │         │    │    ├── select
+           │    │         │         │    │         │    │    │    ├── columns: x_old:56 x_new:57
+           │    │         │         │    │         │    │    │    ├── with-scan &1
+           │    │         │         │    │         │    │    │    │    ├── columns: x_old:56 x_new:57
+           │    │         │         │    │         │    │    │    │    └── mapping:
+           │    │         │         │    │         │    │    │    │         ├──  xy.x:7 => x_old:56
+           │    │         │         │    │         │    │    │    │         └──  upsert_x:46 => x_new:57
+           │    │         │         │    │         │    │    │    └── filters
+           │    │         │         │    │         │    │    │         └── x_old:56 IS DISTINCT FROM x_new:57
+           │    │         │         │    │         │    │    └── filters
+           │    │         │         │    │         │    │         └── child.x:53 = x_old:56
+           │    │         │         │    │         │    └── projections
+           │    │         │         │    │         │         └── ((k:52, child.x:53) AS k, x) [as=old:58]
+           │    │         │         │    │         └── projections
+           │    │         │         │    │              └── ((k:52, x_new:57) AS k, x) [as=new:59]
+           │    │         │         │    └── projections
+           │    │         │         │         └── f(new:59, old:58, 'tr_child', 'BEFORE', 'ROW', 'UPDATE', 54, 'child', 'child', 'public', 0, ARRAY[]) [as=f:73]
+           │    │         │         └── projections
+           │    │         │              └── CASE WHEN f:73 IS DISTINCT FROM new:59 THEN crdb_internal.plpgsql_raise('ERROR', 'trigger tr_child attempted to modify or filter a row in a cascade operation: ' || new:59::STRING, e'changing the rows updated or deleted by a foreign-key cascade\n can cause constraint violations, and therefore is not allowed', e'to enable this behavior (with risk of constraint violation), set\nthe session variable \'unsafe_allow_triggers_modifying_cascades\' to true', '27000') ELSE CAST(NULL AS INT8) END [as="check-rows":74]
+           │    │         └── filters
+           │    │              └── f:73 IS DISTINCT FROM NULL
+           │    └── projections
+           │         ├── (f:73).k [as=k_new:75]
+           │         └── (f:73).x [as=x_new:76]
+           └── f-k-checks
+                └── f-k-checks-item: child(x) -> xy(x)
+                     └── anti-join (hash)
+                          ├── columns: x:77
+                          ├── select
+                          │    ├── columns: x:77
+                          │    ├── with-scan &2
+                          │    │    ├── columns: x:77
+                          │    │    └── mapping:
+                          │    │         └──  x_new:76 => x:77
+                          │    └── filters
+                          │         └── x:77 IS NOT NULL
+                          ├── scan xy
+                          │    └── columns: xy.x:78
+                          └── filters
+                               └── x:77 = xy.x:78
 
-norm format=(hide-all,show-columns)
+build-post-queries format=(hide-all,show-columns)
 INSERT INTO xy VALUES (1, 2) ON CONFLICT (x) DO UPDATE SET y = 3;
 ----
-upsert xy
- ├── arbiter indexes: xy_pkey
- ├── columns: <none>
- ├── canary column: x:7
- ├── fetch columns: x:7 y:8
- ├── insert-mapping:
- │    ├── x_new:26 => x:1
- │    └── y_new:27 => y:2
- ├── update-mapping:
- │    ├── upsert_x:47 => x:1
- │    └── upsert_y:48 => y:2
- └── project
-      ├── columns: upsert_x:47 upsert_y:48 x:7 y:8 x_new:26 y_new:27
-      ├── barrier
-      │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28 old:29 new:30 f:44
-      │    └── select
-      │         ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28 old:29 new:30 f:44
-      │         ├── project
-      │         │    ├── columns: f:44 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28 old:29 new:30
-      │         │    ├── barrier
-      │         │    │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28 old:29 new:30
-      │         │    │    └── project
-      │         │    │         ├── columns: new:30 old:29 y_new:28 x_new:26 y_new:27 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25
-      │         │    │         ├── barrier
-      │         │    │         │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25
-      │         │    │         │    └── select
-      │         │    │         │         ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25
-      │         │    │         │         ├── project
-      │         │    │         │         │    ├── columns: f:25 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11
-      │         │    │         │         │    ├── barrier
-      │         │    │         │         │    │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11
-      │         │    │         │         │    │    └── project
-      │         │    │         │         │    │         ├── columns: new:11 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │         │    │         │         │    │         ├── left-join (cross)
-      │         │    │         │         │    │         │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │         │    │         │         │    │         │    ├── values
-      │         │    │         │         │    │         │    │    ├── columns: column1:5 column2:6
-      │         │    │         │         │    │         │    │    └── (1, 2)
-      │         │    │         │         │    │         │    ├── select
-      │         │    │         │         │    │         │    │    ├── columns: x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │         │    │         │         │    │         │    │    ├── scan xy
-      │         │    │         │         │    │         │    │    │    └── columns: x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │         │    │         │         │    │         │    │    └── filters
-      │         │    │         │         │    │         │    │         └── x:7 = 1
-      │         │    │         │         │    │         │    └── filters (true)
-      │         │    │         │         │    │         └── projections
-      │         │    │         │         │    │              └── ((column1:5, column2:6) AS x, y) [as=new:11]
-      │         │    │         │         │    └── projections
-      │         │    │         │         │         └── f(new:11, NULL, 'tr', 'BEFORE', 'ROW', 'INSERT', 53, 'xy', 'xy', 'public', 0, ARRAY[]) [as=f:25]
-      │         │    │         │         └── filters
-      │         │    │         │              └── f:25 IS DISTINCT FROM NULL
-      │         │    │         └── projections
-      │         │    │              ├── ((x:7, 3) AS x, y) [as=new:30]
-      │         │    │              ├── ((x:7, y:8) AS x, y) [as=old:29]
-      │         │    │              ├── 3 [as=y_new:28]
-      │         │    │              ├── (f:25).x [as=x_new:26]
-      │         │    │              └── (f:25).y [as=y_new:27]
-      │         │    └── projections
-      │         │         └── CASE WHEN x:7 IS NOT NULL THEN f(new:30, old:29, 'tr', 'BEFORE', 'ROW', 'UPDATE', 53, 'xy', 'xy', 'public', 0, ARRAY[]) ELSE new:30 END [as=f:44]
-      │         └── filters
-      │              └── f:44 IS DISTINCT FROM NULL
-      └── projections
-           ├── CASE WHEN x:7 IS NULL THEN x_new:26 ELSE (f:44).x END [as=upsert_x:47]
-           └── CASE WHEN x:7 IS NULL THEN y_new:27 ELSE (f:44).y END [as=upsert_y:48]
+root
+ ├── upsert xy
+ │    ├── arbiter indexes: xy_pkey
+ │    ├── columns: <none>
+ │    ├── canary column: x:7
+ │    ├── fetch columns: x:7 y:8
+ │    ├── insert-mapping:
+ │    │    ├── x_new:26 => x:1
+ │    │    └── y_new:27 => y:2
+ │    ├── update-mapping:
+ │    │    ├── upsert_x:47 => x:1
+ │    │    └── upsert_y:48 => y:2
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── child_x_fkey
+ │    └── project
+ │         ├── columns: upsert_x:47 upsert_y:48 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28 old:29 new:30 f:44 x_new:45 y_new:46
+ │         ├── project
+ │         │    ├── columns: x_new:45 y_new:46 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28 old:29 new:30 f:44
+ │         │    ├── barrier
+ │         │    │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28 old:29 new:30 f:44
+ │         │    │    └── select
+ │         │    │         ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28 old:29 new:30 f:44
+ │         │    │         ├── project
+ │         │    │         │    ├── columns: f:44 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28 old:29 new:30
+ │         │    │         │    ├── barrier
+ │         │    │         │    │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28 old:29 new:30
+ │         │    │         │    │    └── project
+ │         │    │         │    │         ├── columns: new:30 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28 old:29
+ │         │    │         │    │         ├── project
+ │         │    │         │    │         │    ├── columns: old:29 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28
+ │         │    │         │    │         │    ├── project
+ │         │    │         │    │         │    │    ├── columns: y_new:28 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27
+ │         │    │         │    │         │    │    ├── project
+ │         │    │         │    │         │    │    │    ├── columns: x_new:26 y_new:27 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25
+ │         │    │         │    │         │    │    │    ├── barrier
+ │         │    │         │    │         │    │    │    │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25
+ │         │    │         │    │         │    │    │    │    └── select
+ │         │    │         │    │         │    │    │    │         ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25
+ │         │    │         │    │         │    │    │    │         ├── project
+ │         │    │         │    │         │    │    │    │         │    ├── columns: f:25 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11
+ │         │    │         │    │         │    │    │    │         │    ├── barrier
+ │         │    │         │    │         │    │    │    │         │    │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11
+ │         │    │         │    │         │    │    │    │         │    │    └── project
+ │         │    │         │    │         │    │    │    │         │    │         ├── columns: new:11 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │         │    │         │    │    │    │         │    │         ├── left-join (hash)
+ │         │    │         │    │         │    │    │    │         │    │         │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │         │    │         │    │    │    │         │    │         │    ├── ensure-upsert-distinct-on
+ │         │    │         │    │         │    │    │    │         │    │         │    │    ├── columns: column1:5 column2:6
+ │         │    │         │    │         │    │    │    │         │    │         │    │    ├── grouping columns: column1:5
+ │         │    │         │    │         │    │    │    │         │    │         │    │    ├── values
+ │         │    │         │    │         │    │    │    │         │    │         │    │    │    ├── columns: column1:5 column2:6
+ │         │    │         │    │         │    │    │    │         │    │         │    │    │    └── (1, 2)
+ │         │    │         │    │         │    │    │    │         │    │         │    │    └── aggregations
+ │         │    │         │    │         │    │    │    │         │    │         │    │         └── first-agg [as=column2:6]
+ │         │    │         │    │         │    │    │    │         │    │         │    │              └── column2:6
+ │         │    │         │    │         │    │    │    │         │    │         │    ├── scan xy
+ │         │    │         │    │         │    │    │    │         │    │         │    │    └── columns: x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │         │    │         │    │    │    │         │    │         │    └── filters
+ │         │    │         │    │         │    │    │    │         │    │         │         └── column1:5 = x:7
+ │         │    │         │    │         │    │    │    │         │    │         └── projections
+ │         │    │         │    │         │    │    │    │         │    │              └── ((column1:5, column2:6) AS x, y) [as=new:11]
+ │         │    │         │    │         │    │    │    │         │    └── projections
+ │         │    │         │    │         │    │    │    │         │         └── f(new:11, NULL, 'tr', 'BEFORE', 'ROW', 'INSERT', 53, 'xy', 'xy', 'public', 0, ARRAY[]) [as=f:25]
+ │         │    │         │    │         │    │    │    │         └── filters
+ │         │    │         │    │         │    │    │    │              └── f:25 IS DISTINCT FROM NULL
+ │         │    │         │    │         │    │    │    └── projections
+ │         │    │         │    │         │    │    │         ├── (f:25).x [as=x_new:26]
+ │         │    │         │    │         │    │    │         └── (f:25).y [as=y_new:27]
+ │         │    │         │    │         │    │    └── projections
+ │         │    │         │    │         │    │         └── 3 [as=y_new:28]
+ │         │    │         │    │         │    └── projections
+ │         │    │         │    │         │         └── ((x:7, y:8) AS x, y) [as=old:29]
+ │         │    │         │    │         └── projections
+ │         │    │         │    │              └── ((x:7, y_new:28) AS x, y) [as=new:30]
+ │         │    │         │    └── projections
+ │         │    │         │         └── CASE WHEN x:7 IS NOT NULL THEN f(new:30, old:29, 'tr', 'BEFORE', 'ROW', 'UPDATE', 53, 'xy', 'xy', 'public', 0, ARRAY[]) ELSE new:30 END [as=f:44]
+ │         │    │         └── filters
+ │         │    │              └── f:44 IS DISTINCT FROM NULL
+ │         │    └── projections
+ │         │         ├── (f:44).x [as=x_new:45]
+ │         │         └── (f:44).y [as=y_new:46]
+ │         └── projections
+ │              ├── CASE WHEN x:7 IS NULL THEN x_new:26 ELSE x_new:45 END [as=upsert_x:47]
+ │              └── CASE WHEN x:7 IS NULL THEN y_new:27 ELSE y_new:46 END [as=upsert_y:48]
+ └── cascade
+      └── update child
+           ├── columns: <none>
+           ├── fetch columns: k:53 child.x:54
+           ├── update-mapping:
+           │    ├── k_new:76 => k:49
+           │    └── x_new:77 => child.x:50
+           ├── input binding: &2
+           ├── project
+           │    ├── columns: k_new:76 x_new:77 k:53 child.x:54 x_old:57 x_new:58 old:59 new:60 f:74 "check-rows":75
+           │    ├── barrier
+           │    │    ├── columns: k:53 child.x:54 x_old:57 x_new:58 old:59 new:60 f:74 "check-rows":75
+           │    │    └── select
+           │    │         ├── columns: k:53 child.x:54 x_old:57 x_new:58 old:59 new:60 f:74 "check-rows":75
+           │    │         ├── barrier
+           │    │         │    ├── columns: k:53 child.x:54 x_old:57 x_new:58 old:59 new:60 f:74 "check-rows":75
+           │    │         │    └── project
+           │    │         │         ├── columns: "check-rows":75 k:53 child.x:54 x_old:57 x_new:58 old:59 new:60 f:74
+           │    │         │         ├── project
+           │    │         │         │    ├── columns: f:74 k:53 child.x:54 x_old:57 x_new:58 old:59 new:60
+           │    │         │         │    ├── barrier
+           │    │         │         │    │    ├── columns: k:53 child.x:54 x_old:57 x_new:58 old:59 new:60
+           │    │         │         │    │    └── project
+           │    │         │         │    │         ├── columns: new:60 k:53 child.x:54 x_old:57 x_new:58 old:59
+           │    │         │         │    │         ├── project
+           │    │         │         │    │         │    ├── columns: old:59 k:53 child.x:54 x_old:57 x_new:58
+           │    │         │         │    │         │    ├── inner-join (hash)
+           │    │         │         │    │         │    │    ├── columns: k:53 child.x:54 x_old:57 x_new:58
+           │    │         │         │    │         │    │    ├── scan child
+           │    │         │         │    │         │    │    │    └── columns: k:53 child.x:54
+           │    │         │         │    │         │    │    ├── select
+           │    │         │         │    │         │    │    │    ├── columns: x_old:57 x_new:58
+           │    │         │         │    │         │    │    │    ├── with-scan &1
+           │    │         │         │    │         │    │    │    │    ├── columns: x_old:57 x_new:58
+           │    │         │         │    │         │    │    │    │    └── mapping:
+           │    │         │         │    │         │    │    │    │         ├──  xy.x:7 => x_old:57
+           │    │         │         │    │         │    │    │    │         └──  upsert_x:47 => x_new:58
+           │    │         │         │    │         │    │    │    └── filters
+           │    │         │         │    │         │    │    │         └── x_old:57 IS DISTINCT FROM x_new:58
+           │    │         │         │    │         │    │    └── filters
+           │    │         │         │    │         │    │         └── child.x:54 = x_old:57
+           │    │         │         │    │         │    └── projections
+           │    │         │         │    │         │         └── ((k:53, child.x:54) AS k, x) [as=old:59]
+           │    │         │         │    │         └── projections
+           │    │         │         │    │              └── ((k:53, x_new:58) AS k, x) [as=new:60]
+           │    │         │         │    └── projections
+           │    │         │         │         └── f(new:60, old:59, 'tr_child', 'BEFORE', 'ROW', 'UPDATE', 54, 'child', 'child', 'public', 0, ARRAY[]) [as=f:74]
+           │    │         │         └── projections
+           │    │         │              └── CASE WHEN f:74 IS DISTINCT FROM new:60 THEN crdb_internal.plpgsql_raise('ERROR', 'trigger tr_child attempted to modify or filter a row in a cascade operation: ' || new:60::STRING, e'changing the rows updated or deleted by a foreign-key cascade\n can cause constraint violations, and therefore is not allowed', e'to enable this behavior (with risk of constraint violation), set\nthe session variable \'unsafe_allow_triggers_modifying_cascades\' to true', '27000') ELSE CAST(NULL AS INT8) END [as="check-rows":75]
+           │    │         └── filters
+           │    │              └── f:74 IS DISTINCT FROM NULL
+           │    └── projections
+           │         ├── (f:74).k [as=k_new:76]
+           │         └── (f:74).x [as=x_new:77]
+           └── f-k-checks
+                └── f-k-checks-item: child(x) -> xy(x)
+                     └── anti-join (hash)
+                          ├── columns: x:78
+                          ├── select
+                          │    ├── columns: x:78
+                          │    ├── with-scan &2
+                          │    │    ├── columns: x:78
+                          │    │    └── mapping:
+                          │    │         └──  x_new:77 => x:78
+                          │    └── filters
+                          │         └── x:78 IS NOT NULL
+                          ├── scan xy
+                          │    └── columns: xy.x:79
+                          └── filters
+                               └── x:78 = xy.x:79
 
 # ------------------------------------------------------------------------------
 # Row-level AFTER triggers.
@@ -354,6 +658,8 @@ root
  │    ├── columns: <none>
  │    ├── fetch columns: x:5 y:6
  │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── child_x_fkey
  │    ├── after-triggers
  │    │    └── tr
  │    └── select
@@ -362,26 +668,64 @@ root
  │         │    └── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
  │         └── filters
  │              └── x:5 = 1
+ ├── cascade
+ │    └── delete child
+ │         ├── columns: <none>
+ │         ├── fetch columns: k:13 child.x:14
+ │         └── project
+ │              ├── columns: k_new:33 x_new:34 k:13 child.x:14 new:17 f:31 "check-rows":32
+ │              ├── barrier
+ │              │    ├── columns: k:13 child.x:14 new:17 f:31 "check-rows":32
+ │              │    └── select
+ │              │         ├── columns: k:13 child.x:14 new:17 f:31 "check-rows":32
+ │              │         ├── barrier
+ │              │         │    ├── columns: k:13 child.x:14 new:17 f:31 "check-rows":32
+ │              │         │    └── project
+ │              │         │         ├── columns: "check-rows":32 k:13 child.x:14 new:17 f:31
+ │              │         │         ├── project
+ │              │         │         │    ├── columns: f:31 k:13 child.x:14 new:17
+ │              │         │         │    ├── barrier
+ │              │         │         │    │    ├── columns: k:13 child.x:14 new:17
+ │              │         │         │    │    └── project
+ │              │         │         │    │         ├── columns: new:17 k:13 child.x:14
+ │              │         │         │    │         ├── select
+ │              │         │         │    │         │    ├── columns: k:13 child.x:14
+ │              │         │         │    │         │    ├── scan child
+ │              │         │         │    │         │    │    └── columns: k:13 child.x:14
+ │              │         │         │    │         │    └── filters
+ │              │         │         │    │         │         ├── child.x:14 = 1
+ │              │         │         │    │         │         └── child.x:14 IS DISTINCT FROM CAST(NULL AS INT8)
+ │              │         │         │    │         └── projections
+ │              │         │         │    │              └── ((k:13, child.x:14) AS k, x) [as=new:17]
+ │              │         │         │    └── projections
+ │              │         │         │         └── f(new:17, NULL, 'tr_child', 'BEFORE', 'ROW', 'INSERT', 54, 'child', 'child', 'public', 0, ARRAY[]) [as=f:31]
+ │              │         │         └── projections
+ │              │         │              └── CASE WHEN f:31 IS DISTINCT FROM new:17 THEN crdb_internal.plpgsql_raise('ERROR', 'trigger tr_child attempted to modify or filter a row in a cascade operation: ' || new:17::STRING, e'changing the rows updated or deleted by a foreign-key cascade\n can cause constraint violations, and therefore is not allowed', e'to enable this behavior (with risk of constraint violation), set\nthe session variable \'unsafe_allow_triggers_modifying_cascades\' to true', '27000') ELSE CAST(NULL AS INT8) END [as="check-rows":32]
+ │              │         └── filters
+ │              │              └── f:31 IS DISTINCT FROM NULL
+ │              └── projections
+ │                   ├── (f:31).k [as=k_new:33]
+ │                   └── (f:31).x [as=x_new:34]
  └── after-triggers
       └── barrier
-           ├── columns: x_old:9 y_old:10 old:11 new:12 f:26
+           ├── columns: x_old:35 y_old:36 old:37 new:38 f:52
            └── project
-                ├── columns: f:26 x_old:9 y_old:10 old:11 new:12
+                ├── columns: f:52 x_old:35 y_old:36 old:37 new:38
                 ├── project
-                │    ├── columns: new:12 x_old:9 y_old:10 old:11
+                │    ├── columns: new:38 x_old:35 y_old:36 old:37
                 │    ├── project
-                │    │    ├── columns: old:11 x_old:9 y_old:10
+                │    │    ├── columns: old:37 x_old:35 y_old:36
                 │    │    ├── with-scan &1
-                │    │    │    ├── columns: x_old:9 y_old:10
+                │    │    │    ├── columns: x_old:35 y_old:36
                 │    │    │    └── mapping:
-                │    │    │         ├──  x:5 => x_old:9
-                │    │    │         └──  y:6 => y_old:10
+                │    │    │         ├──  xy.x:5 => x_old:35
+                │    │    │         └──  y:6 => y_old:36
                 │    │    └── projections
-                │    │         └── ((x_old:9, y_old:10) AS x, y) [as=old:11]
+                │    │         └── ((x_old:35, y_old:36) AS x, y) [as=old:37]
                 │    └── projections
-                │         └── NULL [as=new:12]
+                │         └── NULL [as=new:38]
                 └── projections
-                     └── f(new:12, old:11, 'tr', 'AFTER', 'ROW', 'DELETE', 53, 'xy', 'xy', 'public', 0, ARRAY[]) [as=f:26]
+                     └── f(new:38, old:37, 'tr', 'AFTER', 'ROW', 'DELETE', 53, 'xy', 'xy', 'public', 0, ARRAY[]) [as=f:52]
 
 build-post-queries format=(hide-all,show-columns)
 UPSERT INTO xy VALUES (1, 2);
@@ -621,7 +965,7 @@ insert t133329
  │    │         │    │         └── projections
  │    │         │    │              └── ((column1, column2) AS k, a)
  │    │         │    └── projections
- │    │         │         └── f(new, NULL, 'tr', 'BEFORE', 'ROW', 'INSERT', 55, 't133329', 't133329', 'public', 0, ARRAY[])
+ │    │         │         └── f(new, NULL, 'tr', 'BEFORE', 'ROW', 'INSERT', 56, 't133329', 't133329', 'public', 0, ARRAY[])
  │    │         └── filters
  │    │              └── f IS DISTINCT FROM NULL
  │    └── projections

--- a/pkg/sql/opt/optbuilder/testdata/trigger
+++ b/pkg/sql/opt/optbuilder/testdata/trigger
@@ -108,71 +108,65 @@ root
            ├── columns: <none>
            ├── fetch columns: k:32 child.x:33
            ├── update-mapping:
-           │    ├── k_new:55 => k:28
-           │    └── x_new:56 => child.x:29
+           │    └── x_new:37 => child.x:29
            ├── input binding: &2
-           ├── project
-           │    ├── columns: k_new:55 x_new:56 k:32 child.x:33 x_old:36 x_new:37 old:38 new:39 f:53 "check-rows":54
-           │    ├── barrier
-           │    │    ├── columns: k:32 child.x:33 x_old:36 x_new:37 old:38 new:39 f:53 "check-rows":54
-           │    │    └── select
-           │    │         ├── columns: k:32 child.x:33 x_old:36 x_new:37 old:38 new:39 f:53 "check-rows":54
-           │    │         ├── barrier
-           │    │         │    ├── columns: k:32 child.x:33 x_old:36 x_new:37 old:38 new:39 f:53 "check-rows":54
-           │    │         │    └── project
-           │    │         │         ├── columns: "check-rows":54 k:32 child.x:33 x_old:36 x_new:37 old:38 new:39 f:53
-           │    │         │         ├── project
-           │    │         │         │    ├── columns: f:53 k:32 child.x:33 x_old:36 x_new:37 old:38 new:39
-           │    │         │         │    ├── barrier
-           │    │         │         │    │    ├── columns: k:32 child.x:33 x_old:36 x_new:37 old:38 new:39
-           │    │         │         │    │    └── project
-           │    │         │         │    │         ├── columns: new:39 k:32 child.x:33 x_old:36 x_new:37 old:38
-           │    │         │         │    │         ├── project
-           │    │         │         │    │         │    ├── columns: old:38 k:32 child.x:33 x_old:36 x_new:37
-           │    │         │         │    │         │    ├── inner-join (hash)
-           │    │         │         │    │         │    │    ├── columns: k:32 child.x:33 x_old:36 x_new:37
-           │    │         │         │    │         │    │    ├── scan child
-           │    │         │         │    │         │    │    │    └── columns: k:32 child.x:33
-           │    │         │         │    │         │    │    ├── select
-           │    │         │         │    │         │    │    │    ├── columns: x_old:36 x_new:37
-           │    │         │         │    │         │    │    │    ├── with-scan &1
-           │    │         │         │    │         │    │    │    │    ├── columns: x_old:36 x_new:37
-           │    │         │         │    │         │    │    │    │    └── mapping:
-           │    │         │         │    │         │    │    │    │         ├──  xy.x:5 => x_old:36
-           │    │         │         │    │         │    │    │    │         └──  x_new:26 => x_new:37
-           │    │         │         │    │         │    │    │    └── filters
-           │    │         │         │    │         │    │    │         └── x_old:36 IS DISTINCT FROM x_new:37
-           │    │         │         │    │         │    │    └── filters
-           │    │         │         │    │         │    │         └── child.x:33 = x_old:36
-           │    │         │         │    │         │    └── projections
-           │    │         │         │    │         │         └── ((k:32, child.x:33) AS k, x) [as=old:38]
-           │    │         │         │    │         └── projections
-           │    │         │         │    │              └── ((k:32, x_new:37) AS k, x) [as=new:39]
-           │    │         │         │    └── projections
-           │    │         │         │         └── f(new:39, old:38, 'tr_child', 'BEFORE', 'ROW', 'UPDATE', 54, 'child', 'child', 'public', 0, ARRAY[]) [as=f:53]
-           │    │         │         └── projections
-           │    │         │              └── CASE WHEN f:53 IS DISTINCT FROM new:39 THEN crdb_internal.plpgsql_raise('ERROR', 'trigger tr_child attempted to modify or filter a row in a cascade operation: ' || new:39::STRING, e'changing the rows updated or deleted by a foreign-key cascade\n can cause constraint violations, and therefore is not allowed', e'to enable this behavior (with risk of constraint violation), set\nthe session variable \'unsafe_allow_triggers_modifying_cascades\' to true', '27000') ELSE CAST(NULL AS INT8) END [as="check-rows":54]
-           │    │         └── filters
-           │    │              └── f:53 IS DISTINCT FROM NULL
-           │    └── projections
-           │         ├── (f:53).k [as=k_new:55]
-           │         └── (f:53).x [as=x_new:56]
+           ├── barrier
+           │    ├── columns: k:32 child.x:33 x_old:36 x_new:37 old:38 new:39 f:53 "check-rows":54
+           │    └── select
+           │         ├── columns: k:32 child.x:33 x_old:36 x_new:37 old:38 new:39 f:53 "check-rows":54
+           │         ├── barrier
+           │         │    ├── columns: k:32 child.x:33 x_old:36 x_new:37 old:38 new:39 f:53 "check-rows":54
+           │         │    └── project
+           │         │         ├── columns: "check-rows":54 k:32 child.x:33 x_old:36 x_new:37 old:38 new:39 f:53
+           │         │         ├── project
+           │         │         │    ├── columns: f:53 k:32 child.x:33 x_old:36 x_new:37 old:38 new:39
+           │         │         │    ├── barrier
+           │         │         │    │    ├── columns: k:32 child.x:33 x_old:36 x_new:37 old:38 new:39
+           │         │         │    │    └── project
+           │         │         │    │         ├── columns: new:39 k:32 child.x:33 x_old:36 x_new:37 old:38
+           │         │         │    │         ├── project
+           │         │         │    │         │    ├── columns: old:38 k:32 child.x:33 x_old:36 x_new:37
+           │         │         │    │         │    ├── inner-join (hash)
+           │         │         │    │         │    │    ├── columns: k:32 child.x:33 x_old:36 x_new:37
+           │         │         │    │         │    │    ├── scan child
+           │         │         │    │         │    │    │    └── columns: k:32 child.x:33
+           │         │         │    │         │    │    ├── select
+           │         │         │    │         │    │    │    ├── columns: x_old:36 x_new:37
+           │         │         │    │         │    │    │    ├── with-scan &1
+           │         │         │    │         │    │    │    │    ├── columns: x_old:36 x_new:37
+           │         │         │    │         │    │    │    │    └── mapping:
+           │         │         │    │         │    │    │    │         ├──  xy.x:5 => x_old:36
+           │         │         │    │         │    │    │    │         └──  x_new:26 => x_new:37
+           │         │         │    │         │    │    │    └── filters
+           │         │         │    │         │    │    │         └── x_old:36 IS DISTINCT FROM x_new:37
+           │         │         │    │         │    │    └── filters
+           │         │         │    │         │    │         └── child.x:33 = x_old:36
+           │         │         │    │         │    └── projections
+           │         │         │    │         │         └── ((k:32, child.x:33) AS k, x) [as=old:38]
+           │         │         │    │         └── projections
+           │         │         │    │              └── ((k:32, x_new:37) AS k, x) [as=new:39]
+           │         │         │    └── projections
+           │         │         │         └── f(new:39, old:38, 'tr_child', 'BEFORE', 'ROW', 'UPDATE', 54, 'child', 'child', 'public', 0, ARRAY[]) [as=f:53]
+           │         │         └── projections
+           │         │              └── CASE WHEN f:53 IS DISTINCT FROM new:39 THEN crdb_internal.plpgsql_raise('ERROR', 'trigger tr_child attempted to modify or filter a row in a cascade operation: ' || new:39::STRING, e'changing the rows updated or deleted by a foreign-key cascade\n can cause constraint violations, and therefore is not allowed', e'to enable this behavior (with risk of constraint violation), set\nthe session variable \'unsafe_allow_triggers_modifying_cascades\' to true', '27000') ELSE CAST(NULL AS INT8) END [as="check-rows":54]
+           │         └── filters
+           │              └── f:53 IS DISTINCT FROM NULL
            └── f-k-checks
                 └── f-k-checks-item: child(x) -> xy(x)
                      └── anti-join (hash)
-                          ├── columns: x:57
+                          ├── columns: x:55
                           ├── select
-                          │    ├── columns: x:57
+                          │    ├── columns: x:55
                           │    ├── with-scan &2
-                          │    │    ├── columns: x:57
+                          │    │    ├── columns: x:55
                           │    │    └── mapping:
-                          │    │         └──  x_new:56 => x:57
+                          │    │         └──  x_new:37 => x:55
                           │    └── filters
-                          │         └── x:57 IS NOT NULL
+                          │         └── x:55 IS NOT NULL
                           ├── scan xy
-                          │    └── columns: xy.x:58
+                          │    └── columns: xy.x:56
                           └── filters
-                               └── x:57 = xy.x:58
+                               └── x:55 = xy.x:56
 
 build-post-queries format=(hide-all,show-columns)
 DELETE FROM xy WHERE x = 1;
@@ -332,71 +326,65 @@ root
            ├── columns: <none>
            ├── fetch columns: k:52 child.x:53
            ├── update-mapping:
-           │    ├── k_new:75 => k:48
-           │    └── x_new:76 => child.x:49
+           │    └── x_new:57 => child.x:49
            ├── input binding: &2
-           ├── project
-           │    ├── columns: k_new:75 x_new:76 k:52 child.x:53 x_old:56 x_new:57 old:58 new:59 f:73 "check-rows":74
-           │    ├── barrier
-           │    │    ├── columns: k:52 child.x:53 x_old:56 x_new:57 old:58 new:59 f:73 "check-rows":74
-           │    │    └── select
-           │    │         ├── columns: k:52 child.x:53 x_old:56 x_new:57 old:58 new:59 f:73 "check-rows":74
-           │    │         ├── barrier
-           │    │         │    ├── columns: k:52 child.x:53 x_old:56 x_new:57 old:58 new:59 f:73 "check-rows":74
-           │    │         │    └── project
-           │    │         │         ├── columns: "check-rows":74 k:52 child.x:53 x_old:56 x_new:57 old:58 new:59 f:73
-           │    │         │         ├── project
-           │    │         │         │    ├── columns: f:73 k:52 child.x:53 x_old:56 x_new:57 old:58 new:59
-           │    │         │         │    ├── barrier
-           │    │         │         │    │    ├── columns: k:52 child.x:53 x_old:56 x_new:57 old:58 new:59
-           │    │         │         │    │    └── project
-           │    │         │         │    │         ├── columns: new:59 k:52 child.x:53 x_old:56 x_new:57 old:58
-           │    │         │         │    │         ├── project
-           │    │         │         │    │         │    ├── columns: old:58 k:52 child.x:53 x_old:56 x_new:57
-           │    │         │         │    │         │    ├── inner-join (hash)
-           │    │         │         │    │         │    │    ├── columns: k:52 child.x:53 x_old:56 x_new:57
-           │    │         │         │    │         │    │    ├── scan child
-           │    │         │         │    │         │    │    │    └── columns: k:52 child.x:53
-           │    │         │         │    │         │    │    ├── select
-           │    │         │         │    │         │    │    │    ├── columns: x_old:56 x_new:57
-           │    │         │         │    │         │    │    │    ├── with-scan &1
-           │    │         │         │    │         │    │    │    │    ├── columns: x_old:56 x_new:57
-           │    │         │         │    │         │    │    │    │    └── mapping:
-           │    │         │         │    │         │    │    │    │         ├──  xy.x:7 => x_old:56
-           │    │         │         │    │         │    │    │    │         └──  upsert_x:46 => x_new:57
-           │    │         │         │    │         │    │    │    └── filters
-           │    │         │         │    │         │    │    │         └── x_old:56 IS DISTINCT FROM x_new:57
-           │    │         │         │    │         │    │    └── filters
-           │    │         │         │    │         │    │         └── child.x:53 = x_old:56
-           │    │         │         │    │         │    └── projections
-           │    │         │         │    │         │         └── ((k:52, child.x:53) AS k, x) [as=old:58]
-           │    │         │         │    │         └── projections
-           │    │         │         │    │              └── ((k:52, x_new:57) AS k, x) [as=new:59]
-           │    │         │         │    └── projections
-           │    │         │         │         └── f(new:59, old:58, 'tr_child', 'BEFORE', 'ROW', 'UPDATE', 54, 'child', 'child', 'public', 0, ARRAY[]) [as=f:73]
-           │    │         │         └── projections
-           │    │         │              └── CASE WHEN f:73 IS DISTINCT FROM new:59 THEN crdb_internal.plpgsql_raise('ERROR', 'trigger tr_child attempted to modify or filter a row in a cascade operation: ' || new:59::STRING, e'changing the rows updated or deleted by a foreign-key cascade\n can cause constraint violations, and therefore is not allowed', e'to enable this behavior (with risk of constraint violation), set\nthe session variable \'unsafe_allow_triggers_modifying_cascades\' to true', '27000') ELSE CAST(NULL AS INT8) END [as="check-rows":74]
-           │    │         └── filters
-           │    │              └── f:73 IS DISTINCT FROM NULL
-           │    └── projections
-           │         ├── (f:73).k [as=k_new:75]
-           │         └── (f:73).x [as=x_new:76]
+           ├── barrier
+           │    ├── columns: k:52 child.x:53 x_old:56 x_new:57 old:58 new:59 f:73 "check-rows":74
+           │    └── select
+           │         ├── columns: k:52 child.x:53 x_old:56 x_new:57 old:58 new:59 f:73 "check-rows":74
+           │         ├── barrier
+           │         │    ├── columns: k:52 child.x:53 x_old:56 x_new:57 old:58 new:59 f:73 "check-rows":74
+           │         │    └── project
+           │         │         ├── columns: "check-rows":74 k:52 child.x:53 x_old:56 x_new:57 old:58 new:59 f:73
+           │         │         ├── project
+           │         │         │    ├── columns: f:73 k:52 child.x:53 x_old:56 x_new:57 old:58 new:59
+           │         │         │    ├── barrier
+           │         │         │    │    ├── columns: k:52 child.x:53 x_old:56 x_new:57 old:58 new:59
+           │         │         │    │    └── project
+           │         │         │    │         ├── columns: new:59 k:52 child.x:53 x_old:56 x_new:57 old:58
+           │         │         │    │         ├── project
+           │         │         │    │         │    ├── columns: old:58 k:52 child.x:53 x_old:56 x_new:57
+           │         │         │    │         │    ├── inner-join (hash)
+           │         │         │    │         │    │    ├── columns: k:52 child.x:53 x_old:56 x_new:57
+           │         │         │    │         │    │    ├── scan child
+           │         │         │    │         │    │    │    └── columns: k:52 child.x:53
+           │         │         │    │         │    │    ├── select
+           │         │         │    │         │    │    │    ├── columns: x_old:56 x_new:57
+           │         │         │    │         │    │    │    ├── with-scan &1
+           │         │         │    │         │    │    │    │    ├── columns: x_old:56 x_new:57
+           │         │         │    │         │    │    │    │    └── mapping:
+           │         │         │    │         │    │    │    │         ├──  xy.x:7 => x_old:56
+           │         │         │    │         │    │    │    │         └──  upsert_x:46 => x_new:57
+           │         │         │    │         │    │    │    └── filters
+           │         │         │    │         │    │    │         └── x_old:56 IS DISTINCT FROM x_new:57
+           │         │         │    │         │    │    └── filters
+           │         │         │    │         │    │         └── child.x:53 = x_old:56
+           │         │         │    │         │    └── projections
+           │         │         │    │         │         └── ((k:52, child.x:53) AS k, x) [as=old:58]
+           │         │         │    │         └── projections
+           │         │         │    │              └── ((k:52, x_new:57) AS k, x) [as=new:59]
+           │         │         │    └── projections
+           │         │         │         └── f(new:59, old:58, 'tr_child', 'BEFORE', 'ROW', 'UPDATE', 54, 'child', 'child', 'public', 0, ARRAY[]) [as=f:73]
+           │         │         └── projections
+           │         │              └── CASE WHEN f:73 IS DISTINCT FROM new:59 THEN crdb_internal.plpgsql_raise('ERROR', 'trigger tr_child attempted to modify or filter a row in a cascade operation: ' || new:59::STRING, e'changing the rows updated or deleted by a foreign-key cascade\n can cause constraint violations, and therefore is not allowed', e'to enable this behavior (with risk of constraint violation), set\nthe session variable \'unsafe_allow_triggers_modifying_cascades\' to true', '27000') ELSE CAST(NULL AS INT8) END [as="check-rows":74]
+           │         └── filters
+           │              └── f:73 IS DISTINCT FROM NULL
            └── f-k-checks
                 └── f-k-checks-item: child(x) -> xy(x)
                      └── anti-join (hash)
-                          ├── columns: x:77
+                          ├── columns: x:75
                           ├── select
-                          │    ├── columns: x:77
+                          │    ├── columns: x:75
                           │    ├── with-scan &2
-                          │    │    ├── columns: x:77
+                          │    │    ├── columns: x:75
                           │    │    └── mapping:
-                          │    │         └──  x_new:76 => x:77
+                          │    │         └──  x_new:57 => x:75
                           │    └── filters
-                          │         └── x:77 IS NOT NULL
+                          │         └── x:75 IS NOT NULL
                           ├── scan xy
-                          │    └── columns: xy.x:78
+                          │    └── columns: xy.x:76
                           └── filters
-                               └── x:77 = xy.x:78
+                               └── x:75 = xy.x:76
 
 build-post-queries format=(hide-all,show-columns)
 INSERT INTO xy VALUES (1, 2) ON CONFLICT (x) DO UPDATE SET y = 3;
@@ -491,71 +479,65 @@ root
            ├── columns: <none>
            ├── fetch columns: k:53 child.x:54
            ├── update-mapping:
-           │    ├── k_new:76 => k:49
-           │    └── x_new:77 => child.x:50
+           │    └── x_new:58 => child.x:50
            ├── input binding: &2
-           ├── project
-           │    ├── columns: k_new:76 x_new:77 k:53 child.x:54 x_old:57 x_new:58 old:59 new:60 f:74 "check-rows":75
-           │    ├── barrier
-           │    │    ├── columns: k:53 child.x:54 x_old:57 x_new:58 old:59 new:60 f:74 "check-rows":75
-           │    │    └── select
-           │    │         ├── columns: k:53 child.x:54 x_old:57 x_new:58 old:59 new:60 f:74 "check-rows":75
-           │    │         ├── barrier
-           │    │         │    ├── columns: k:53 child.x:54 x_old:57 x_new:58 old:59 new:60 f:74 "check-rows":75
-           │    │         │    └── project
-           │    │         │         ├── columns: "check-rows":75 k:53 child.x:54 x_old:57 x_new:58 old:59 new:60 f:74
-           │    │         │         ├── project
-           │    │         │         │    ├── columns: f:74 k:53 child.x:54 x_old:57 x_new:58 old:59 new:60
-           │    │         │         │    ├── barrier
-           │    │         │         │    │    ├── columns: k:53 child.x:54 x_old:57 x_new:58 old:59 new:60
-           │    │         │         │    │    └── project
-           │    │         │         │    │         ├── columns: new:60 k:53 child.x:54 x_old:57 x_new:58 old:59
-           │    │         │         │    │         ├── project
-           │    │         │         │    │         │    ├── columns: old:59 k:53 child.x:54 x_old:57 x_new:58
-           │    │         │         │    │         │    ├── inner-join (hash)
-           │    │         │         │    │         │    │    ├── columns: k:53 child.x:54 x_old:57 x_new:58
-           │    │         │         │    │         │    │    ├── scan child
-           │    │         │         │    │         │    │    │    └── columns: k:53 child.x:54
-           │    │         │         │    │         │    │    ├── select
-           │    │         │         │    │         │    │    │    ├── columns: x_old:57 x_new:58
-           │    │         │         │    │         │    │    │    ├── with-scan &1
-           │    │         │         │    │         │    │    │    │    ├── columns: x_old:57 x_new:58
-           │    │         │         │    │         │    │    │    │    └── mapping:
-           │    │         │         │    │         │    │    │    │         ├──  xy.x:7 => x_old:57
-           │    │         │         │    │         │    │    │    │         └──  upsert_x:47 => x_new:58
-           │    │         │         │    │         │    │    │    └── filters
-           │    │         │         │    │         │    │    │         └── x_old:57 IS DISTINCT FROM x_new:58
-           │    │         │         │    │         │    │    └── filters
-           │    │         │         │    │         │    │         └── child.x:54 = x_old:57
-           │    │         │         │    │         │    └── projections
-           │    │         │         │    │         │         └── ((k:53, child.x:54) AS k, x) [as=old:59]
-           │    │         │         │    │         └── projections
-           │    │         │         │    │              └── ((k:53, x_new:58) AS k, x) [as=new:60]
-           │    │         │         │    └── projections
-           │    │         │         │         └── f(new:60, old:59, 'tr_child', 'BEFORE', 'ROW', 'UPDATE', 54, 'child', 'child', 'public', 0, ARRAY[]) [as=f:74]
-           │    │         │         └── projections
-           │    │         │              └── CASE WHEN f:74 IS DISTINCT FROM new:60 THEN crdb_internal.plpgsql_raise('ERROR', 'trigger tr_child attempted to modify or filter a row in a cascade operation: ' || new:60::STRING, e'changing the rows updated or deleted by a foreign-key cascade\n can cause constraint violations, and therefore is not allowed', e'to enable this behavior (with risk of constraint violation), set\nthe session variable \'unsafe_allow_triggers_modifying_cascades\' to true', '27000') ELSE CAST(NULL AS INT8) END [as="check-rows":75]
-           │    │         └── filters
-           │    │              └── f:74 IS DISTINCT FROM NULL
-           │    └── projections
-           │         ├── (f:74).k [as=k_new:76]
-           │         └── (f:74).x [as=x_new:77]
+           ├── barrier
+           │    ├── columns: k:53 child.x:54 x_old:57 x_new:58 old:59 new:60 f:74 "check-rows":75
+           │    └── select
+           │         ├── columns: k:53 child.x:54 x_old:57 x_new:58 old:59 new:60 f:74 "check-rows":75
+           │         ├── barrier
+           │         │    ├── columns: k:53 child.x:54 x_old:57 x_new:58 old:59 new:60 f:74 "check-rows":75
+           │         │    └── project
+           │         │         ├── columns: "check-rows":75 k:53 child.x:54 x_old:57 x_new:58 old:59 new:60 f:74
+           │         │         ├── project
+           │         │         │    ├── columns: f:74 k:53 child.x:54 x_old:57 x_new:58 old:59 new:60
+           │         │         │    ├── barrier
+           │         │         │    │    ├── columns: k:53 child.x:54 x_old:57 x_new:58 old:59 new:60
+           │         │         │    │    └── project
+           │         │         │    │         ├── columns: new:60 k:53 child.x:54 x_old:57 x_new:58 old:59
+           │         │         │    │         ├── project
+           │         │         │    │         │    ├── columns: old:59 k:53 child.x:54 x_old:57 x_new:58
+           │         │         │    │         │    ├── inner-join (hash)
+           │         │         │    │         │    │    ├── columns: k:53 child.x:54 x_old:57 x_new:58
+           │         │         │    │         │    │    ├── scan child
+           │         │         │    │         │    │    │    └── columns: k:53 child.x:54
+           │         │         │    │         │    │    ├── select
+           │         │         │    │         │    │    │    ├── columns: x_old:57 x_new:58
+           │         │         │    │         │    │    │    ├── with-scan &1
+           │         │         │    │         │    │    │    │    ├── columns: x_old:57 x_new:58
+           │         │         │    │         │    │    │    │    └── mapping:
+           │         │         │    │         │    │    │    │         ├──  xy.x:7 => x_old:57
+           │         │         │    │         │    │    │    │         └──  upsert_x:47 => x_new:58
+           │         │         │    │         │    │    │    └── filters
+           │         │         │    │         │    │    │         └── x_old:57 IS DISTINCT FROM x_new:58
+           │         │         │    │         │    │    └── filters
+           │         │         │    │         │    │         └── child.x:54 = x_old:57
+           │         │         │    │         │    └── projections
+           │         │         │    │         │         └── ((k:53, child.x:54) AS k, x) [as=old:59]
+           │         │         │    │         └── projections
+           │         │         │    │              └── ((k:53, x_new:58) AS k, x) [as=new:60]
+           │         │         │    └── projections
+           │         │         │         └── f(new:60, old:59, 'tr_child', 'BEFORE', 'ROW', 'UPDATE', 54, 'child', 'child', 'public', 0, ARRAY[]) [as=f:74]
+           │         │         └── projections
+           │         │              └── CASE WHEN f:74 IS DISTINCT FROM new:60 THEN crdb_internal.plpgsql_raise('ERROR', 'trigger tr_child attempted to modify or filter a row in a cascade operation: ' || new:60::STRING, e'changing the rows updated or deleted by a foreign-key cascade\n can cause constraint violations, and therefore is not allowed', e'to enable this behavior (with risk of constraint violation), set\nthe session variable \'unsafe_allow_triggers_modifying_cascades\' to true', '27000') ELSE CAST(NULL AS INT8) END [as="check-rows":75]
+           │         └── filters
+           │              └── f:74 IS DISTINCT FROM NULL
            └── f-k-checks
                 └── f-k-checks-item: child(x) -> xy(x)
                      └── anti-join (hash)
-                          ├── columns: x:78
+                          ├── columns: x:76
                           ├── select
-                          │    ├── columns: x:78
+                          │    ├── columns: x:76
                           │    ├── with-scan &2
-                          │    │    ├── columns: x:78
+                          │    │    ├── columns: x:76
                           │    │    └── mapping:
-                          │    │         └──  x_new:77 => x:78
+                          │    │         └──  x_new:58 => x:76
                           │    └── filters
-                          │         └── x:78 IS NOT NULL
+                          │         └── x:76 IS NOT NULL
                           ├── scan xy
-                          │    └── columns: xy.x:79
+                          │    └── columns: xy.x:77
                           └── filters
-                               └── x:78 = xy.x:79
+                               └── x:76 = xy.x:77
 
 # ------------------------------------------------------------------------------
 # Row-level AFTER triggers.
@@ -672,60 +654,55 @@ root
  │    └── delete child
  │         ├── columns: <none>
  │         ├── fetch columns: k:13 child.x:14
- │         └── project
- │              ├── columns: k_new:33 x_new:34 k:13 child.x:14 new:17 f:31 "check-rows":32
- │              ├── barrier
- │              │    ├── columns: k:13 child.x:14 new:17 f:31 "check-rows":32
- │              │    └── select
- │              │         ├── columns: k:13 child.x:14 new:17 f:31 "check-rows":32
- │              │         ├── barrier
- │              │         │    ├── columns: k:13 child.x:14 new:17 f:31 "check-rows":32
- │              │         │    └── project
- │              │         │         ├── columns: "check-rows":32 k:13 child.x:14 new:17 f:31
- │              │         │         ├── project
- │              │         │         │    ├── columns: f:31 k:13 child.x:14 new:17
- │              │         │         │    ├── barrier
- │              │         │         │    │    ├── columns: k:13 child.x:14 new:17
- │              │         │         │    │    └── project
- │              │         │         │    │         ├── columns: new:17 k:13 child.x:14
- │              │         │         │    │         ├── select
- │              │         │         │    │         │    ├── columns: k:13 child.x:14
- │              │         │         │    │         │    ├── scan child
- │              │         │         │    │         │    │    └── columns: k:13 child.x:14
- │              │         │         │    │         │    └── filters
- │              │         │         │    │         │         ├── child.x:14 = 1
- │              │         │         │    │         │         └── child.x:14 IS DISTINCT FROM CAST(NULL AS INT8)
- │              │         │         │    │         └── projections
- │              │         │         │    │              └── ((k:13, child.x:14) AS k, x) [as=new:17]
- │              │         │         │    └── projections
- │              │         │         │         └── f(new:17, NULL, 'tr_child', 'BEFORE', 'ROW', 'INSERT', 54, 'child', 'child', 'public', 0, ARRAY[]) [as=f:31]
- │              │         │         └── projections
- │              │         │              └── CASE WHEN f:31 IS DISTINCT FROM new:17 THEN crdb_internal.plpgsql_raise('ERROR', 'trigger tr_child attempted to modify or filter a row in a cascade operation: ' || new:17::STRING, e'changing the rows updated or deleted by a foreign-key cascade\n can cause constraint violations, and therefore is not allowed', e'to enable this behavior (with risk of constraint violation), set\nthe session variable \'unsafe_allow_triggers_modifying_cascades\' to true', '27000') ELSE CAST(NULL AS INT8) END [as="check-rows":32]
- │              │         └── filters
- │              │              └── f:31 IS DISTINCT FROM NULL
- │              └── projections
- │                   ├── (f:31).k [as=k_new:33]
- │                   └── (f:31).x [as=x_new:34]
+ │         └── barrier
+ │              ├── columns: k:13 child.x:14 new:17 f:31 "check-rows":32
+ │              └── select
+ │                   ├── columns: k:13 child.x:14 new:17 f:31 "check-rows":32
+ │                   ├── barrier
+ │                   │    ├── columns: k:13 child.x:14 new:17 f:31 "check-rows":32
+ │                   │    └── project
+ │                   │         ├── columns: "check-rows":32 k:13 child.x:14 new:17 f:31
+ │                   │         ├── project
+ │                   │         │    ├── columns: f:31 k:13 child.x:14 new:17
+ │                   │         │    ├── barrier
+ │                   │         │    │    ├── columns: k:13 child.x:14 new:17
+ │                   │         │    │    └── project
+ │                   │         │    │         ├── columns: new:17 k:13 child.x:14
+ │                   │         │    │         ├── select
+ │                   │         │    │         │    ├── columns: k:13 child.x:14
+ │                   │         │    │         │    ├── scan child
+ │                   │         │    │         │    │    └── columns: k:13 child.x:14
+ │                   │         │    │         │    └── filters
+ │                   │         │    │         │         ├── child.x:14 = 1
+ │                   │         │    │         │         └── child.x:14 IS DISTINCT FROM CAST(NULL AS INT8)
+ │                   │         │    │         └── projections
+ │                   │         │    │              └── ((k:13, child.x:14) AS k, x) [as=new:17]
+ │                   │         │    └── projections
+ │                   │         │         └── f(new:17, NULL, 'tr_child', 'BEFORE', 'ROW', 'INSERT', 54, 'child', 'child', 'public', 0, ARRAY[]) [as=f:31]
+ │                   │         └── projections
+ │                   │              └── CASE WHEN f:31 IS DISTINCT FROM new:17 THEN crdb_internal.plpgsql_raise('ERROR', 'trigger tr_child attempted to modify or filter a row in a cascade operation: ' || new:17::STRING, e'changing the rows updated or deleted by a foreign-key cascade\n can cause constraint violations, and therefore is not allowed', e'to enable this behavior (with risk of constraint violation), set\nthe session variable \'unsafe_allow_triggers_modifying_cascades\' to true', '27000') ELSE CAST(NULL AS INT8) END [as="check-rows":32]
+ │                   └── filters
+ │                        └── f:31 IS DISTINCT FROM NULL
  └── after-triggers
       └── barrier
-           ├── columns: x_old:35 y_old:36 old:37 new:38 f:52
+           ├── columns: x_old:33 y_old:34 old:35 new:36 f:50
            └── project
-                ├── columns: f:52 x_old:35 y_old:36 old:37 new:38
+                ├── columns: f:50 x_old:33 y_old:34 old:35 new:36
                 ├── project
-                │    ├── columns: new:38 x_old:35 y_old:36 old:37
+                │    ├── columns: new:36 x_old:33 y_old:34 old:35
                 │    ├── project
-                │    │    ├── columns: old:37 x_old:35 y_old:36
+                │    │    ├── columns: old:35 x_old:33 y_old:34
                 │    │    ├── with-scan &1
-                │    │    │    ├── columns: x_old:35 y_old:36
+                │    │    │    ├── columns: x_old:33 y_old:34
                 │    │    │    └── mapping:
-                │    │    │         ├──  xy.x:5 => x_old:35
-                │    │    │         └──  y:6 => y_old:36
+                │    │    │         ├──  xy.x:5 => x_old:33
+                │    │    │         └──  y:6 => y_old:34
                 │    │    └── projections
-                │    │         └── ((x_old:35, y_old:36) AS x, y) [as=old:37]
+                │    │         └── ((x_old:33, y_old:34) AS x, y) [as=old:35]
                 │    └── projections
-                │         └── NULL [as=new:38]
+                │         └── NULL [as=new:36]
                 └── projections
-                     └── f(new:38, old:37, 'tr', 'AFTER', 'ROW', 'DELETE', 53, 'xy', 'xy', 'public', 0, ARRAY[]) [as=f:52]
+                     └── f(new:36, old:35, 'tr', 'AFTER', 'ROW', 'DELETE', 53, 'xy', 'xy', 'public', 0, ARRAY[]) [as=f:50]
 
 build-post-queries format=(hide-all,show-columns)
 UPSERT INTO xy VALUES (1, 2);

--- a/pkg/sql/opt/optbuilder/trigger.go
+++ b/pkg/sql/opt/optbuilder/trigger.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	plpgsql "github.com/cockroachdb/cockroach/pkg/sql/plpgsql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
@@ -112,6 +113,14 @@ func (mb *mutationBuilder) buildRowLevelBeforeTriggers(
 		// Finally, project a column that invokes the trigger function.
 		triggerFnColID := mb.b.projectColWithMetadataName(triggerScope, def.Name, tableTyp, triggerFn)
 
+		// Don't allow the trigger to modify or filter the row if the mutation is
+		// for a cascade, unless the session variable is set to allow it.
+		if cascade && !mb.b.evalCtx.SessionData().UnsafeAllowTriggersModifyingCascades {
+			mb.ensureNoRowsModifiedByTrigger(
+				triggerScope, triggers[i].Name(), eventType, triggerFnColID, oldColID, newColID,
+			)
+		}
+
 		// BEFORE triggers can return a NULL value to indicate that the row should
 		// be skipped.
 		mb.applyFilterFromTrigger(triggerScope, triggerFnColID)
@@ -142,33 +151,28 @@ func (mb *mutationBuilder) buildOldAndNewCols(
 	triggerScope *scope, eventType tree.TriggerEventType, tableTyp *types.T, visibleColOrds []int,
 ) (oldColID, newColID opt.ColumnID) {
 	f := mb.b.factory
-	makeTuple := func(colIDs opt.OptionalColList, name string) opt.ColumnID {
+	makeTuple := func(colIDs, backupColIDs opt.OptionalColList, name string) opt.ColumnID {
 		elems := make(memo.ScalarListExpr, 0, len(visibleColOrds))
 		for _, i := range visibleColOrds {
-			if colIDs[i] == 0 {
+			col := colIDs[i]
+			if col == 0 && backupColIDs != nil {
+				col = backupColIDs[i]
+			}
+			if col == 0 {
 				panic(errors.AssertionFailedf("missing column for trigger"))
 			}
-			elems = append(elems, f.ConstructVariable(colIDs[i]))
+			elems = append(elems, f.ConstructVariable(col))
 		}
 		tup := f.ConstructTuple(elems, tableTyp)
 		return mb.b.projectColWithMetadataName(triggerScope, name, tableTyp, tup)
 	}
 	if eventType == tree.TriggerEventUpdate || eventType == tree.TriggerEventDelete {
-		oldColID = makeTuple(mb.fetchColIDs, triggerColOld)
+		oldColID = makeTuple(mb.fetchColIDs, nil /* backupColIDs */, triggerColOld)
 	}
 	if eventType == tree.TriggerEventInsert {
-		newColID = makeTuple(mb.insertColIDs, triggerColNew)
+		newColID = makeTuple(mb.insertColIDs, mb.fetchColIDs, triggerColNew)
 	} else if eventType == tree.TriggerEventUpdate {
-		// Build a colIDs slice using updateColIDs, filling in the missing columns
-		// (which are not being updated) with the old column values.
-		colIDs := make(opt.OptionalColList, len(mb.updateColIDs))
-		copy(colIDs, mb.updateColIDs)
-		for i, colID := range colIDs {
-			if colID == 0 {
-				colIDs[i] = mb.fetchColIDs[i]
-			}
-		}
-		newColID = makeTuple(colIDs, triggerColNew)
+		newColID = makeTuple(mb.updateColIDs, mb.fetchColIDs, triggerColNew)
 	}
 	return oldColID, newColID
 }
@@ -273,6 +277,58 @@ func (mb *mutationBuilder) applyChangesFromTriggers(
 		projections[i] = f.ConstructProjectionsItem(elem, elemCol.id)
 	}
 	triggerScope.expr = f.ConstructProject(triggerScope.expr, projections, passThroughCols)
+}
+
+// ensureNoRowsModifiedByTrigger adds a runtime check to the scope that ensures
+// that the trigger function does not modify or filter any rows. This is
+// necessary for cascading operations, where modifications made by the trigger
+// function could cause constraint violations.
+func (mb *mutationBuilder) ensureNoRowsModifiedByTrigger(
+	triggerScope *scope,
+	triggerName tree.Name,
+	eventType tree.TriggerEventType,
+	triggerFnColID opt.ColumnID,
+	oldColID, newColID opt.ColumnID,
+) {
+	makeConstStr := func(str string) opt.ScalarExpr {
+		return mb.b.factory.ConstructConstVal(tree.NewDString(str), types.String)
+	}
+	expectedColID := newColID
+	if eventType == tree.TriggerEventDelete {
+		expectedColID = oldColID
+	}
+	// Construct a call to crdb_internal.plpgsql_raise with the error message.
+	severity := makeConstStr("ERROR")
+	message := mb.b.factory.ConstructConcat(
+		makeConstStr(fmt.Sprintf(
+			"trigger %s attempted to modify or filter a row in a cascade operation: ", triggerName)),
+		mb.b.factory.ConstructCast(mb.b.factory.ConstructVariable(expectedColID), types.String),
+	)
+	detail := makeConstStr("changing the rows updated or deleted by a foreign-key cascade\n" +
+		" can cause constraint violations, and therefore is not allowed")
+	hint := makeConstStr("to enable this behavior (with risk of constraint violation), set\n" +
+		"the session variable 'unsafe_allow_triggers_modifying_cascades' to true")
+	code := makeConstStr(pgcode.TriggeredDataChangeViolation.String())
+	raiseFn := mb.b.makePLpgSQLRaiseFn(memo.ScalarListExpr{severity, message, detail, hint, code})
+
+	// Build a CASE statement to raise the error if the trigger function modified
+	// the row. Add a barrier to ensure the check isn't removed or re-ordered with
+	// a filter.
+	//
+	// TODO(#133787): consider relaxing this check, for example, to ignore updates
+	// to non-FK columns.
+	f := mb.b.factory
+	check := f.ConstructCase(memo.TrueSingleton,
+		memo.ScalarListExpr{
+			f.ConstructWhen(
+				f.ConstructIsNot(f.ConstructVariable(triggerFnColID), f.ConstructVariable(expectedColID)),
+				raiseFn,
+			),
+		},
+		f.ConstructNull(types.Int),
+	)
+	mb.b.projectColWithMetadataName(triggerScope, "check-rows", types.Int, check)
+	triggerScope.expr = f.ConstructBarrier(triggerScope.expr)
 }
 
 // ============================================================================

--- a/pkg/sql/opt/optbuilder/trigger.go
+++ b/pkg/sql/opt/optbuilder/trigger.go
@@ -35,7 +35,9 @@ import (
 // buildRowLevelBeforeTriggers builds any applicable row-level BEFORE triggers
 // based on the event type. It returns true if triggers were built, and false
 // otherwise.
-func (mb *mutationBuilder) buildRowLevelBeforeTriggers(eventType tree.TriggerEventType) bool {
+func (mb *mutationBuilder) buildRowLevelBeforeTriggers(
+	eventType tree.TriggerEventType, cascade bool,
+) bool {
 	var eventsToMatch tree.TriggerEventTypeSet
 	eventsToMatch.Add(eventType)
 	triggers := mb.getRowLevelTriggers(tree.TriggerActionTimeBefore, eventsToMatch)

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -108,7 +108,7 @@ func (b *Builder) buildUpdate(upd *tree.Update, inScope *scope) (outScope *scope
 	mb.addUpdateCols(upd.Exprs)
 
 	// Project row-level BEFORE triggers for UPDATE.
-	mb.buildRowLevelBeforeTriggers(tree.TriggerEventUpdate)
+	mb.buildRowLevelBeforeTriggers(tree.TriggerEventUpdate, false /* cascade */)
 
 	// Build the final update statement, including any returned expressions.
 	if resultsNeeded(upd.Returning) {

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -551,6 +551,11 @@ message LocalOnlySessionData {
   // BypassPCRReaderCatalogAOST disables the AOST used by all user queries on
   // the PCR reader catalog.
   bool bypass_pcr_reader_catalog_aost = 141  [(gogoproto.customname) = "BypassPCRReaderCatalogAOST"];
+  // UnsafeAllowTriggersModifyingCascades, when true, allows row-level BEFORE
+  // triggers to modify or filter rows that are being updated or deleted as
+  // part of a cascading foreign key action. This is unsafe because it can
+  // lead to constraint violations.
+  bool unsafe_allow_triggers_modifying_cascades = 142;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3491,6 +3491,7 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
 	// CockroachDB extension.
 	`bypass_pcr_reader_catalog_aost`: {
 		Set: func(_ context.Context, m sessionDataMutator, s string) error {
@@ -3503,6 +3504,23 @@ var varGen = map[string]sessionVar{
 		},
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return formatBoolAsPostgresSetting(evalCtx.SessionData().BypassPCRReaderCatalogAOST), nil
+		},
+		GlobalDefault: globalFalse,
+	},
+
+	// CockroachDB extension.
+	`unsafe_allow_triggers_modifying_cascades`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`unsafe_allow_triggers_modifying_cascades`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("unsafe_allow_triggers_modifying_cascades", s)
+			if err != nil {
+				return err
+			}
+			m.SetUnsafeAllowTriggersModifyingCascades(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().UnsafeAllowTriggersModifyingCascades), nil
 		},
 		GlobalDefault: globalFalse,
 	},


### PR DESCRIPTION
#### opt: mechanical changes for BEFORE triggers on cascades

This commit consists of the following changes to prepare for adding
support for row-level BEFORE triggers to cascading mutations:
* Added `unsafe_allow_triggers_modifying_cascades` which will determine
  whether a trigger can modify the rows mutated by a cascade, default off.
* Added a "cascade" argument to `buildRowLevelBeforeTriggers` to provide
  the context when building a row-level BEFORE trigger.
* Refactoring the logic for invoking `crdb_internal.plpgsql_raise` to be
  re-used for triggers.

Informs #132971

Release note: None

#### opt: plan row-level BEFORE triggers for cascading mutations

This commit adds logic to invoke the functions for row-level BEFORE
triggers that are fired by a cascade's mutation. This is mostly
straightforward, except for the fact that a row-level BEFORE trigger
can actually modify or filter rows-to-be-mutated. In Postgres, it's
possible to cause constraint violations via this behavior. This commit
adds a runtime check to ensure that trigger functions do not modify
cascading updates/deletes. The check is gated behind
`unsafe_allow_triggers_modifying_cascades`, default off.

Fixes #132971

Release note (sql change): Cascades can now fire row-level BEFORE triggers.
By default, attempting to modify or eliminate the cascading update/delete
will result in a `Triggered Data Change Violation` error. Users that wish
to do this anyway can set `unsafe_allow_triggers_modifying_cascades`.
Note that doing so could result in constraint violations, similar to Postgres.

#### sql: fix queuing behavior for checks and triggers

This commit fixes a bug in `PlanAndRunPostQueries` that could cause
check queries to be run more than once. This would cause problems with
unclosed resources after query completion. This commit also fixes a
minor bug that could cause triggers queued by triggers to be run
before newly-queued checks and cascades, instead of after. The following
commit includes a regression test.

Fixes #133792

Release note: None

#### opt: don't add spurious check queries after BEFORE trigger

This commit fixes a bug that could cause spurious constraint violation
errors when a BEFORE trigger was planned on a cascaded mutation. Since we
don't allow triggers to modify the rows of a cascaded mutation, it is safe
to avoid the extra check entirely. This commit also adds a diamond-pattern
cascade test, with triggers on each table.

Fixes #133784

Release note: None