### PR TITLE
drtprod: add init/run script for tpch workload

### DIFF
--- a/pkg/cmd/drtprod/configs/drt_large.yaml
+++ b/pkg/cmd/drtprod/configs/drt_large.yaml
@@ -7,6 +7,19 @@ environment:
   ROACHPROD_GCE_DEFAULT_PROJECT: cockroach-drt
   CLUSTER: drt-large
   WORKLOAD_CLUSTER: workload-large
+  STORE_COUNT: 8
+
+  # variables used by tpcc_run_multiregion.sh
+  NUM_REGIONS: 3
+  NODES_PER_REGION: 5
+  REGIONS: northamerica-northeast2,us-east5,us-east1
+  TPCC_WAREHOUSES: 150000
+  DB_NAME: cct_tpcc
+  SURVIVAL_GOAL: region
+  RUN_DURATION: 12h
+  NUM_CONNECTIONS: 500
+  NUM_WORKERS: 500
+  MAX_RATE: 1000
 
 targets:
   - target_name: $CLUSTER
@@ -23,7 +36,7 @@ targets:
           nodes: 15
           gce-machine-type: n2-standard-16
           local-ssd: true
-          gce-local-ssd-count: 4
+          gce-local-ssd-count: $STORE_COUNT
           os-volume-size: 100
           username: drt
           lifetime: 8760h
@@ -46,7 +59,7 @@ targets:
           - "./cockroach"
         flags:
           enable-fluent-sink: true
-          store-count: 4
+          store-count: $STORE_COUNT
           args: --wal-failover=among-stores
           restart: false
           sql-port: 26257
@@ -79,7 +92,7 @@ targets:
         flags:
           clouds: gce
           gce-zones: "northamerica-northeast2-a,us-east5-a,us-east1-b"
-          nodes: 3
+          nodes: $NUM_REGIONS
           gce-machine-type: n2d-standard-4
           os-volume-size: 100
           username: workload
@@ -105,5 +118,9 @@ targets:
           - cct_tpcc # suffix added to script name tpcc_init_cct_tpcc.sh
           - true # determines whether to execute the script immediately on workload node
         flags:
-          warehouses: 15000
-          db: cct_tpcc
+          warehouses: $TPCC_WAREHOUSES
+          partitions: $NUM_REGIONS
+          db: $DB_NAME
+          survival-goal: $SURVIVAL_GOAL
+          regions: $REGIONS
+      - script: "pkg/cmd/drtprod/scripts/tpcc_run_multiregion.sh"

--- a/pkg/cmd/drtprod/configs/drt_scale.yaml
+++ b/pkg/cmd/drtprod/configs/drt_scale.yaml
@@ -144,3 +144,12 @@ targets:
           duration: 12h
           ramp: 10m
           wait: 0
+      - script: "pkg/cmd/drtprod/scripts/generate_tpch_init.sh"
+        args:
+          - scale_factor_1000 # suffix added to script name tpch_init_scale_factor_1000.sh
+          - false # determines whether to execute the script immediately on workload node
+        flags:
+          scale-factor: 1000
+      - script: "pkg/cmd/drtprod/scripts/generate_tpch_run.sh"
+        flags:
+          scale-factor: 1000

--- a/pkg/cmd/drtprod/scripts/generate_tpch_run.sh
+++ b/pkg/cmd/drtprod/scripts/generate_tpch_run.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# This script sets up the tpch run workload script in the workload nodes
+# The --scale-factor and other flags are passed as argument to this script
+# NOTE - This uses CLUSTER and WORKLOAD_CLUSTER environment variable, if not set the script fails
+if [ "$#" -lt 3 ]; then
+  echo "Usage: $0 <script_suffix> <flags to init:--scale-factor,--db>"
+  exit 1
+fi
+suffix=$1
+shift
+
+if [ -z "${CLUSTER}" ]; then
+  echo "environment CLUSTER is not set"
+  exit 1
+fi
+
+if [ -z "${WORKLOAD_CLUSTER}" ]; then
+  echo "environment WORKLOAD_CLUSTER is not set"
+  exit 1
+fi
+
+absolute_path=$(roachprod run "${WORKLOAD_CLUSTER}":1 -- "realpath ./tpch_run_${suffix}.sh")
+pwd=$(roachprod run "${WORKLOAD_CLUSTER}":1 -- "dirname ${absolute_path}")
+PGURLS=$(roachprod pgurl "${CLUSTER}":1)
+
+roachprod ssh "${WORKLOAD_CLUSTER}":1 -- "tee tpch_run_${suffix}.sh > /dev/null << 'EOF'
+#!/bin/bash
+
+${pwd}/cockroach workload run tpch $@ --verbose --prometheus-port 2113 $PGURLS
+EOF"
+roachprod ssh "${WORKLOAD_CLUSTER}":1 -- "chmod +x tpch_run_${suffix}.sh"

--- a/pkg/cmd/drtprod/scripts/setup_datadog_workload
+++ b/pkg/cmd/drtprod/scripts/setup_datadog_workload
@@ -76,6 +76,7 @@ processors:
         expressions:
         - workload_tpcc.*
         - workload_kv_.*
+        - workload_tpch.*
 
 # The */datadog elements are defined in the primary configuration file.
 service:

--- a/pkg/cmd/drtprod/scripts/tpcc_run_multiregion.sh
+++ b/pkg/cmd/drtprod/scripts/tpcc_run_multiregion.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# This script sets up the tpcc multiregion run configuration on the workload node.
+
+env_vars=("CLUSTER" "WORKLOAD_CLUSTER" "NUM_REGIONS" "NODES_PER_REGION" "REGIONS" "TPCC_WAREHOUSES" "DB_NAME" "RUN_DURATION" "NUM_CONNECTIONS" "NUM_WORKERS" "MAX_RATE")
+for var in "${env_vars[@]}"; do
+  if [ -z "${!var}" ]; then
+    echo "$var is not set"
+    exit
+  fi
+done
+
+for NODE in $(seq 1 $NUM_REGIONS)
+do
+  NODE_OFFSET=$(($(($(($NODE - 1))*$NODES_PER_REGION))+1))
+  LAST_NODE_IN_REGION=$(($NODE_OFFSET+$NODES_PER_REGION-1))
+  # Since we're running a number of workers much smaller than the number of
+  # warehouses, we have to do some strange math here. Workers are assigned to
+  # warehouses in order (i.e. worker 1 will target warehouse 1). The
+  # complication is that when we're partitioning the workload such that workers in
+  # region 1 should only target warehouses in region 1, the workload binary will
+  # not assign a worker if the warehouse is not in the specified region. As a
+  # result, we must pass in a number of workers that is large enough to allow
+  #  us to reach the specified region, and then add the actual number of workers
+  #  we want to run.
+  EFFECTIVE_NUM_WORKERS=$(($(($TPCC_WAREHOUSES/$NUM_REGIONS))*$(($NODE-1))+$NUM_WORKERS))
+  PGURLS_REGION=$(./bin/roachprod pgurl $CLUSTER:$NODE_OFFSET-$LAST_NODE_IN_REGION | sed "s/'//g; s/^/'/; s/$/'/")
+  cat <<EOF >/tmp/tpcc_run.sh
+#!/usr/bin/env bash
+j=0
+while true; do
+  echo ">> Starting tpcc workload"
+  ((j++))
+  ./workload run tpcc \
+      --db=$DB_NAME \
+      --ramp=10m \
+      --conns=$NUM_CONNECTIONS \
+      --workers=$EFFECTIVE_NUM_WORKERS \
+      --warehouses=$TPCC_WAREHOUSES \
+      --max-rate=$MAX_RATE \
+      --duration=$RUN_DURATION \
+      --wait=false \
+      --partitions$NUM_REGIONS \
+      --partition-affinity=$(($NODE-1)) \
+      --tolerate-errors \
+      $PGURLS_REGION \
+      --survival-goal region \
+      --regions=$REGIONS
+done
+EOF
+
+  ./bin/drtprod put $WORKLOAD_CLUSTER:$NODE /tmp/tpcc_run.sh
+  ./bin/drtprod ssh $WORKLOAD_CLUSTER:$NODE -- "chmod +x tpcc_run.sh"
+done


### PR DESCRIPTION
Changes as part of this PR:
- Added `generate_tpch_init.sh` script for import tpch workload.
- Added `generate_tpch_run.sh` script for running tpch workload.
- Modified `tpcc_init.sh` to use fixtures for importing data.
- Added `tpcc_run_multiregion.sh` to run tpcc workload on multinode cluster.
- Modified `drt-large.yaml` and `drt-scale.yaml` to use above changes.

Epic: none

Release note: None