### PR TITLE
pgwire: add test build logs for upgrade secure conn

### DIFF
--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -61,6 +61,7 @@ go_library(
         "//pkg/sql/sqltelemetry",
         "//pkg/sql/types",
         "//pkg/util",
+        "//pkg/util/buildutil",
         "//pkg/util/ctxlog",
         "//pkg/util/duration",
         "//pkg/util/envutil",


### PR DESCRIPTION
Epic CRDB-41958

Additional test build logs are added to verify the step for which `maybeUpgradeToSecureConn` fails for `TestAuthenticationAndHBARules`.

Release note: None