### PR TITLE
release-23.1: pgwire: add test build logs for upgrade secure conn

### DIFF
--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -56,6 +56,7 @@ go_library(
         "//pkg/sql/sqltelemetry",
         "//pkg/sql/types",
         "//pkg/util",
+        "//pkg/util/buildutil",
         "//pkg/util/contextutil",
         "//pkg/util/duration",
         "//pkg/util/envutil",

--- a/pkg/sql/pgwire/pre_serve.go
+++ b/pkg/sql/pgwire/pre_serve.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirecancel"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -446,6 +447,10 @@ func (s *PreServeConnHandler) maybeUpgradeToSecureConn(
 		// non-TLS SQL conns.
 		if !s.cfg.AcceptSQLWithoutTLS && connType != hba.ConnLocal && connType != hba.ConnInternalLoopback {
 			clientErr = pgerror.New(pgcode.ProtocolViolation, ErrSSLRequired)
+			// Extra logs under test to debug TestAuthenticationAndHBARules.
+			if buildutil.CrdbTestBuild {
+				log.Warningf(ctx, "client cannot connect since version=%d AcceptSQLWithoutTLS=false and connType=%s", version, connType)
+			}
 		}
 		return
 	}
@@ -457,6 +462,10 @@ func (s *PreServeConnHandler) maybeUpgradeToSecureConn(
 		// we don't want it.
 		clientErr = pgerror.New(pgcode.ProtocolViolation,
 			"cannot use SSL/TLS over local connections")
+		// Extra logs under test to debug TestAuthenticationAndHBARules.
+		if buildutil.CrdbTestBuild {
+			log.Warningf(ctx, "client cannot connect since version=%d and connType=%s", version, connType)
+		}
 		return
 	}
 
@@ -478,6 +487,10 @@ func (s *PreServeConnHandler) maybeUpgradeToSecureConn(
 	if tlsConfig == nil {
 		// We don't have a TLS configuration available, so we can't honor
 		// the client's request.
+		// Extra logs under test to debug TestAuthenticationAndHBARules.
+		if buildutil.CrdbTestBuild {
+			log.Infof(ctx, "sending sslUnsupported message to client")
+		}
 		n, serverErr = conn.Write(sslUnsupported)
 		if serverErr != nil {
 			return


### PR DESCRIPTION
Backport 1/1 commits from #133224.

/cc @cockroachdb/release

---

Epic CRDB-41958

Additional test build logs are added to verify the step for which `maybeUpgradeToSecureConn` fails for `TestAuthenticationAndHBARules`.

Release note: None

---

Release justification: test only change
