### PR TITLE
release-24.2: pgwire: add test build logs for upgrade secure conn

### DIFF
--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -58,6 +58,7 @@ go_library(
         "//pkg/sql/sqltelemetry",
         "//pkg/sql/types",
         "//pkg/util",
+        "//pkg/util/buildutil",
         "//pkg/util/ctxlog",
         "//pkg/util/duration",
         "//pkg/util/envutil",


### PR DESCRIPTION
Backport 1/1 commits from #133224.

/cc @cockroachdb/release

---

Epic CRDB-41958

Additional test build logs are added to verify the step for which `maybeUpgradeToSecureConn` fails for `TestAuthenticationAndHBARules`.

Release note: None

---
Release justification: test only change