### PR TITLE
opt: relax max stack size in test for stack overflow

### DIFF
--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -2820,7 +2820,7 @@ CREATE TABLE t132669 (
 # unnecessary recursion to trigger a stack overflow without having to make the
 # `IN` list below huge - triggering a stack overflow with Go's default max stack
 # size requires a list of ~1.6 million elements.
-opt max-stack=50KB format=hide-all
+opt max-stack=125KB format=hide-all
 SELECT * FROM t132669
 WHERE a IN (
     1,  2,  3,  4,  5,  6,  7, 8, 9, 10,


### PR DESCRIPTION
This commit relaxes the maximum Go stack size in bytes for a test added
in #132701 from 50KB to 125KB. The very low max stack size was causing
stack overflows to occur in unrelated functions, like parsing, in some
nightly tests. I'm hoping that more than doubling this will eliminate
the flakes.

Fixes #133212

Release note: None
