### PR TITLE
opt/exec/explain: gracefully handle decoding negative integers

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
@@ -203,3 +203,9 @@ SELECT crdb_internal.decode_external_plan_gist('AixE')
 ----
 • split
   index: ?@?
+
+# Regression test for #133015. Gracefully handle decoding negative integers.
+query T
+SELECT crdb_internal.decode_external_plan_gist('Aifvzn5p':::STRING)
+----
+• create view

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -332,6 +332,9 @@ func (f *PlanGistFactory) encodeNodeColumnOrdinals(vals []exec.NodeColumnOrdinal
 
 func (f *PlanGistFactory) decodeNodeColumnOrdinals() []exec.NodeColumnOrdinal {
 	l := f.decodeInt()
+	if l < 0 {
+		return nil
+	}
 	vals := make([]exec.NodeColumnOrdinal, l)
 	return vals
 }
@@ -342,6 +345,9 @@ func (f *PlanGistFactory) encodeResultColumns(vals colinfo.ResultColumns) {
 
 func (f *PlanGistFactory) decodeResultColumns() colinfo.ResultColumns {
 	numCols := f.decodeInt()
+	if numCols < 0 {
+		return nil
+	}
 	return make(colinfo.ResultColumns, numCols)
 }
 
@@ -464,6 +470,9 @@ func (f *PlanGistFactory) encodeRows(rows [][]tree.TypedExpr) {
 
 func (f *PlanGistFactory) decodeRows() [][]tree.TypedExpr {
 	numRows := f.decodeInt()
+	if numRows < 0 {
+		return nil
+	}
 	return make([][]tree.TypedExpr, numRows)
 }
 


### PR DESCRIPTION
Fixes #133015

Release note: None