### PR TITLE
acceptance: build image with podman

### DIFF
--- a/pkg/acceptance/compose/gss/build-push-gss.sh
+++ b/pkg/acceptance/compose/gss/build-push-gss.sh
@@ -9,5 +9,10 @@ set -xeuo pipefail
 
 TARGET=$1
 TAG=$(date +%Y%m%d-%H%M%S)
-docker buildx create --use
-docker buildx build --push --platform linux/amd64,linux/arm64 -t us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-$TARGET:$TAG ./$TARGET
+if which podman; then
+  podman build --platform linux/amd64,linux/arm64 --manifest us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-$TARGET:$TAG ./$TARGET
+  podman manifest push us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-$TARGET:$TAG us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-$TARGET:$TAG
+else
+  docker buildx create --use
+  docker buildx build --push --platform linux/amd64,linux/arm64 -t us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-$TARGET:$TAG ./$TARGET
+fi


### PR DESCRIPTION
Previously, the only option to build acceptance images was to use `docker buildx`, which is not supported by podman.

This PR adds support for podman.

Epic: none
Release note: None