### PR TITLE
roachprod: default to buffering file sinks in roachprod

### DIFF
--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -73,9 +73,6 @@ func runDiskStalledWALFailover(
 		startOpts.RoachprodOpts.StoreCount = 2
 	}
 	startOpts.RoachprodOpts.ExtraArgs = []string{
-		// Adopt buffering of the file logging to ensure that we don't block on
-		// flushing logs to the stalled device.
-		"--log", fmt.Sprintf(`{file-defaults: {dir: "%s", buffered-writes: false, buffering: {max-staleness: 1s, flush-trigger-size: 256KiB, max-buffer-size: 50MiB}}}`, s.LogDir()),
 		"--wal-failover=" + failoverFlag,
 	}
 	c.Start(ctx, t.L(), startOpts, startSettings, c.CRDBNodes())

--- a/pkg/roachprod/install/files/cockroachdb-logging.yaml
+++ b/pkg/roachprod/install/files/cockroachdb-logging.yaml
@@ -1,7 +1,11 @@
 ---
 file-defaults:
   auditable: false
-  buffered-writes: true
+  buffered-writes: false
+  buffering:
+    max-staleness: 5s
+    flush-trigger-size: 256KiB
+    max-buffer-size: 50MiB
   dir: #{ .LogDir #}
   exit-on-error: false
   filter: INFO


### PR DESCRIPTION
In roachprod clusters, default to using buffering in file sinks. This is required by a subsequent change that will default to using WAL failover in roachprod clusters.

Informs #133248
Informs #129922
Epic: CRDB-37534
Release note: none