### PR TITLE
raft: deflake non-determinisctic raft node tests

### DIFF
--- a/pkg/raft/rafttest/node.go
+++ b/pkg/raft/rafttest/node.go
@@ -49,7 +49,7 @@ func startNode(id raftpb.PeerID, peers []raft.Peer, iface iface) *node {
 	st := raft.NewMemoryStorage()
 	c := &raft.Config{
 		ID:                        id,
-		ElectionTick:              10,
+		ElectionTick:              50,
 		HeartbeatTick:             1,
 		Storage:                   st,
 		MaxSizePerMsg:             1024 * 1024,


### PR DESCRIPTION
We sporadically see that some raft node_test tests fail due to the leader not being stable. This commit should reduce the chances of that happening by increasing the election timeout to 250ms (instead of 50ms).

I couldn't reproduce the bug locally with this change.

If the bug still happens, we can try to force leadership to make it more deterministic.

Fixes: #132992, #131676, #132205, #133048

Release note: None