### PR TITLE
release-24.3: server: handle create table statement error in table_metadata api

### DIFF
--- a/pkg/server/api_v2_databases_metadata.go
+++ b/pkg/server/api_v2_databases_metadata.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/tablemetadatacache"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/safesql"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -323,7 +324,9 @@ func (a *apiV2Server) getTableCreateStatement(
 	row, types, err := a.sqlServer.internalExecutor.QueryRowExWithCols(ctx, "get-table-create-statement", nil,
 		sessiondata.NodeUserSessionDataOverride, query.String(), query.QueryArguments()...)
 	if err != nil {
-		return "", err
+		statementError := fmt.Sprintf("Unable to retrieve create statement for %s.%s", escDbName, escTableName)
+		log.Warningf(ctx, "%v", errors.Wrapf(err, "%s", statementError))
+		return statementError, nil
 	}
 	scanner := makeResultScanner(types)
 	var createStatement string


### PR DESCRIPTION
Backport 1/1 commits from #132871.

/cc @cockroachdb/release

---

Errors in the retrieval of create table statements in the GetTableMetadataWithDetails API was resulting in a 500 internal exception. This could manifest itself in many ways, but was observed when a table descriptor was in the "offline" state during an import operation.

Instead of failing the request due to an error, a
error message will be returned in place of the
create statement and an error log will be emitted.

Epic: CRDB-37558
Release note: None

<img width="1791" alt="image" src="https://github.com/user-attachments/assets/d6b4e924-249d-468d-bc3a-e3c0a347280d">

