### PR TITLE
demo: remove copy referring to telemetry disabling env var

### DIFF
--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -38,10 +38,6 @@ subcommands: e.g. "cockroach demo startrek". See --help for a full list.
 
 By default, the 'movr' dataset is pre-loaded. You can also use --no-example-database
 to avoid pre-loading a dataset.
-
-cockroach demo attempts to connect to a Cockroach Labs server to send
-telemetry back to Cockroach Labs. In order to disable this behavior, set the
-environment variable "COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING" to true.
 `,
 	Example: `  cockroach demo`,
 	Args:    cobra.NoArgs,


### PR DESCRIPTION
demo: remove copy referring to telemetry disabling env var

`COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING` can still be used to disable telemetry for CRDB. With the core deprecation happening however, we want to streamline how people enable / disable telemetry in their cluster, so the copy to this variable has been removed.

It will still function as before, the only difference is that it will not show up in the demo startup message.

Epic: CRDB-40209
Fixes: #132688
Release note (general change):
COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING is no longer mentioned in the demo command.