### PR TITLE
backupccl: remove old backup/restore syntax from backup_test

### DIFF
--- a/pkg/ccl/backupccl/alter_backup_test.go
+++ b/pkg/ccl/backupccl/alter_backup_test.go
@@ -111,10 +111,10 @@ func TestAlterBackupRestore(t *testing.T) {
 	// Tests to see that show backup correctly recognizes the new encryption-info
 	// file when SHOW BACKUP is called on an altered encrypted backup.
 	t.Run("alter-backup-show-backup", func(t *testing.T) {
-		query = fmt.Sprintf("SHOW BACKUP LATEST IN %s WITH KMS = %s", userfile, newURI)
+		query = fmt.Sprintf("SHOW BACKUP FROM LATEST IN %s WITH KMS = %s", userfile, newURI)
 		sqlDB.Exec(t, query)
 
-		query = fmt.Sprintf("SHOW BACKUP LATEST IN %s WITH KMS = %s", userfile, oldURI)
+		query = fmt.Sprintf("SHOW BACKUP FROM LATEST IN %s WITH KMS = %s", userfile, oldURI)
 		sqlDB.Exec(t, query)
 	})
 

--- a/pkg/ccl/backupccl/backup_tenant_test.go
+++ b/pkg/ccl/backupccl/backup_tenant_test.go
@@ -145,7 +145,7 @@ func TestBackupTenantImportingTable(t *testing.T) {
 
 	// tenant now has a fully ingested, paused import, so back them up.
 	const dst = "userfile:///t"
-	if _, err := sqlDB.DB.ExecContext(ctx, `BACKUP TENANT 10 TO $1`, dst); err != nil {
+	if _, err := sqlDB.DB.ExecContext(ctx, `BACKUP TENANT 10 INTO $1`, dst); err != nil {
 		t.Fatal(err)
 	}
 	// Destroy the tenant, then restore it.
@@ -156,7 +156,7 @@ func TestBackupTenantImportingTable(t *testing.T) {
 	if _, err := sqlDB.DB.ExecContext(ctx, "DROP TENANT [10] IMMEDIATE"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := sqlDB.DB.ExecContext(ctx, "RESTORE TENANT 10 FROM $1", dst); err != nil {
+	if _, err := sqlDB.DB.ExecContext(ctx, "RESTORE TENANT 10 FROM LATEST IN $1", dst); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/ccl/backupccl/backupinfo/BUILD.bazel
+++ b/pkg/ccl/backupccl/backupinfo/BUILD.bazel
@@ -84,6 +84,7 @@ go_test(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/isql",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/bulk",
         "//pkg/util/hlc",

--- a/pkg/ccl/backupccl/backupinfo/backup_metadata_test.go
+++ b/pkg/ccl/backupccl/backupinfo/backup_metadata_test.go
@@ -7,6 +7,7 @@ package backupinfo_test
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"testing"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/bulk"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -54,8 +56,9 @@ func TestMetadataSST(t *testing.T) {
 	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulkio.write_metadata_sst.enabled = true`)
 
 	// Check that backup metadata is correct on full cluster backup.
-	sqlDB.Exec(t, `BACKUP TO $1`, userfile)
-	checkMetadata(ctx, t, tc, userfile)
+	sqlDB.Exec(t, `BACKUP INTO $1`, userfile)
+	backupPath := userfile + getBackupPath(t, sqlDB, userfile)
+	checkMetadata(ctx, t, tc, backupPath)
 
 	// Check for correct backup metadata on incremental backup with revision
 	// history.
@@ -65,25 +68,28 @@ func TestMetadataSST(t *testing.T) {
 	sqlDB.Exec(t, `CREATE TABLE emptydb.bar(k INT, v INT)`)
 	sqlDB.Exec(t, `DROP DATABASE emptydb`)
 
-	sqlDB.Exec(t, `BACKUP TO $1 WITH revision_history`, userfile)
-	checkMetadata(ctx, t, tc, userfile)
+	sqlDB.Exec(t, `BACKUP INTO $1 WITH revision_history`, userfile)
+	checkMetadata(ctx, t, tc, backupPath)
 
 	//  Check for correct backup metadata on single table backups.
 	userfile1 := "userfile:///1"
-	sqlDB.Exec(t, `BACKUP TABLE data.bank TO $1 WITH revision_history`, userfile1)
-	checkMetadata(ctx, t, tc, userfile1)
+	sqlDB.Exec(t, `BACKUP TABLE data.bank INTO $1 WITH revision_history`, userfile1)
+	backupPath1 := userfile1 + getBackupPath(t, sqlDB, userfile1)
+	checkMetadata(ctx, t, tc, backupPath1)
 
 	// Check for correct backup metadata on tenant backups.
 	userfile2 := "userfile:///2"
 	_, err := tc.Servers[0].TenantController().StartTenant(ctx, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)})
 	require.NoError(t, err)
-	sqlDB.Exec(t, `BACKUP TENANT 10 TO $1`, userfile2)
-	checkMetadata(ctx, t, tc, userfile2)
+	sqlDB.Exec(t, `BACKUP TENANT 10 INTO $1`, userfile2)
+	backupPath2 := userfile2 + getBackupPath(t, sqlDB, userfile2)
+	checkMetadata(ctx, t, tc, backupPath2)
 }
 
 func checkMetadata(
 	ctx context.Context, t *testing.T, tc *testcluster.TestCluster, backupLoc string,
 ) {
+	t.Helper()
 	store, err := cloud.ExternalStorageFromURI(
 		ctx,
 		backupLoc,
@@ -296,6 +302,16 @@ func checkStats(
 	}
 
 	require.Equal(t, expectedStats, metaStats)
+}
+
+// Gets the first backup path in a userfile path.
+// Note: the tests in this file expects only one backup in the path so only fetches the first backup
+func getBackupPath(t *testing.T, db *sqlutils.SQLRunner, userfile string) string {
+	rows := db.Query(t, "SHOW BACKUPS IN $1", userfile)
+	var result struct{ path string }
+	require.True(t, rows.Next(), fmt.Sprintf("Could not find backup path in %s", userfile))
+	require.NoError(t, rows.Scan(&result.path))
+	return result.path
 }
 
 func testingReadBackupManifest(

--- a/pkg/ccl/backupccl/backupresolver/targets_test.go
+++ b/pkg/ccl/backupccl/backupresolver/targets_test.go
@@ -250,7 +250,7 @@ func TestDescriptorsMatchingTargets(t *testing.T) {
 	searchPath := sessiondata.MakeSearchPath([]string{"public", "pg_catalog"})
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%d/%s/%s", i, test.sessionDatabase, test.pattern), func(t *testing.T) {
-			sql := fmt.Sprintf(`BACKUP %s TO 'ignored'`, test.pattern)
+			sql := fmt.Sprintf(`BACKUP %s INTO 'ignored'`, test.pattern)
 			stmt, err := parser.ParseOne(sql)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/ccl/backupccl/restore_mid_schema_change_test.go
+++ b/pkg/ccl/backupccl/restore_mid_schema_change_test.go
@@ -270,7 +270,7 @@ func restoreMidSchemaChange(
 		if isSchemaOnly {
 			restoreQuery = restoreQuery + ", schema_only"
 		}
-		log.Infof(context.Background(), "%+v", sqlDB.QueryStr(t, "SHOW BACKUP LATEST IN $1", localFoo))
+		log.Infof(context.Background(), "%+v", sqlDB.QueryStr(t, "SHOW BACKUP FROM LATEST IN $1", localFoo))
 		sqlDB.Exec(t, restoreQuery, localFoo)
 		// Wait for all jobs to terminate. Some may fail since we don't restore
 		// adding spans.

--- a/pkg/ccl/backupccl/restore_old_versions_test.go
+++ b/pkg/ccl/backupccl/restore_old_versions_test.go
@@ -346,7 +346,7 @@ func fullClusterRestoreSystemRoleMembersWithoutIDs(exportDir string) func(t *tes
 		// manifest version is always less than the MinSupportedVersion which will
 		// in turn fail the restore unless we pass in the specified option to elide
 		// the compatibility check.
-		sqlDB.Exec(t, fmt.Sprintf("RESTORE FROM '%s' WITH UNSAFE_RESTORE_INCOMPATIBLE_VERSION", localFoo))
+		sqlDB.Exec(t, fmt.Sprintf("RESTORE FROM '/' IN '%s' WITH UNSAFE_RESTORE_INCOMPATIBLE_VERSION", localFoo))
 
 		sqlDB.CheckQueryResults(t, "SELECT * FROM system.role_members", [][]string{
 			{"admin", "root", "true", "2", "1"},
@@ -381,7 +381,7 @@ func fullClusterRestoreSystemPrivilegesWithoutIDs(exportDir string) func(t *test
 		// manifest version is always less than the MinSupportedVersion which will
 		// in turn fail the restore unless we pass in the specified option to elide
 		// the compatibility check.
-		sqlDB.Exec(t, fmt.Sprintf("RESTORE FROM '%s' WITH UNSAFE_RESTORE_INCOMPATIBLE_VERSION", localFoo))
+		sqlDB.Exec(t, fmt.Sprintf("RESTORE FROM '/' IN '%s' WITH UNSAFE_RESTORE_INCOMPATIBLE_VERSION", localFoo))
 
 		sqlDB.CheckQueryResults(t, "SELECT * FROM system.privileges", [][]string{
 			{"public", "/vtable/crdb_internal/tables", "{}", "{}", "4"},
@@ -416,7 +416,7 @@ func fullClusterRestoreSystemDatabaseRoleSettingsWithoutIDs(exportDir string) fu
 		// manifest version is always less than the MinSupportedVersion which will
 		// in turn fail the restore unless we pass in the specified option to elide
 		// the compatibility check.
-		sqlDB.Exec(t, fmt.Sprintf("RESTORE FROM '%s' WITH UNSAFE_RESTORE_INCOMPATIBLE_VERSION", localFoo))
+		sqlDB.Exec(t, fmt.Sprintf("RESTORE FROM '/' IN '%s' WITH UNSAFE_RESTORE_INCOMPATIBLE_VERSION", localFoo))
 
 		sqlDB.CheckQueryResults(t, "SELECT * FROM system.database_role_settings", [][]string{
 			{"0", "", "{timezone=America/New_York}", "0"},
@@ -451,7 +451,7 @@ func fullClusterRestoreSystemExternalConnectionsWithoutIDs(exportDir string) fun
 		// manifest version is always less than the MinSupportedVersion which will
 		// in turn fail the restore unless we pass in the specified option to elide
 		// the compatibility check.
-		sqlDB.Exec(t, fmt.Sprintf("RESTORE FROM '%s' WITH UNSAFE_RESTORE_INCOMPATIBLE_VERSION", localFoo))
+		sqlDB.Exec(t, fmt.Sprintf("RESTORE FROM '/' IN '%s' WITH UNSAFE_RESTORE_INCOMPATIBLE_VERSION", localFoo))
 
 		sqlDB.CheckQueryResults(t, "SELECT * FROM system.external_connections", [][]string{
 			{"connection1", "2023-03-20 01:26:50.174781 +0000 +0000", "2023-03-20 01:26:50.174781 +0000 +0000", "STORAGE",

--- a/pkg/ccl/backupccl/restore_online_test.go
+++ b/pkg/ccl/backupccl/restore_online_test.go
@@ -101,11 +101,11 @@ func TestOnlineRestorePartitioned(t *testing.T) {
 	)
 	defer cleanupFn()
 
-	sqlDB.Exec(t, `BACKUP DATABASE data TO ('nodelocal://1/a?COCKROACH_LOCALITY=default',
+	sqlDB.Exec(t, `BACKUP DATABASE data INTO ('nodelocal://1/a?COCKROACH_LOCALITY=default',
 		'nodelocal://1/b?COCKROACH_LOCALITY=dc%3Ddc2',
 		'nodelocal://1/c?COCKROACH_LOCALITY=dc%3Ddc3')`)
 
-	j := sqlDB.QueryStr(t, `RESTORE DATABASE data FROM ('nodelocal://1/a?COCKROACH_LOCALITY=default',
+	j := sqlDB.QueryStr(t, `RESTORE DATABASE data FROM LATEST IN ('nodelocal://1/a?COCKROACH_LOCALITY=default',
 		'nodelocal://1/b?COCKROACH_LOCALITY=dc%3Ddc2',
 		'nodelocal://1/c?COCKROACH_LOCALITY=dc%3Ddc3') WITH new_db_name='d2', EXPERIMENTAL DEFERRED COPY`)
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/backup-permissions-deprecated
+++ b/pkg/ccl/backupccl/testdata/backup-restore/backup-permissions-deprecated
@@ -143,7 +143,7 @@ GRANT CONNECT ON DATABASE d TO testuser;
 ----
 
 exec-sql cluster=s3 user=testuser
-SHOW BACKUP 'http://COCKROACH_TEST_HTTP_SERVER/'
+SHOW BACKUP FROM LATEST IN 'http://COCKROACH_TEST_HTTP_SERVER/'
 ----
 pq: only users with the admin role or the EXTERNALIOIMPLICITACCESS system privilege are allowed to access the specified http URI
 
@@ -161,6 +161,6 @@ CREATE USER testuser
 ----
 
 exec-sql cluster=s4 user=testuser
-SHOW BACKUP 'http://COCKROACH_TEST_HTTP_SERVER/'
+SHOW BACKUP FROM LATEST IN 'http://COCKROACH_TEST_HTTP_SERVER/'
 ----
-pq: make storage: external http access disabled
+pq: read LATEST path: external http access disabled

--- a/pkg/ccl/backupccl/utils_test.go
+++ b/pkg/ccl/backupccl/utils_test.go
@@ -577,3 +577,16 @@ func requireRecoveryEvent(
 		return nil
 	})
 }
+
+// getFullBackupPaths finds all full backups in the given URI and returns their paths using SHOW BACKUPS IN
+func getFullBackupPaths(t *testing.T, sqlDB *sqlutils.SQLRunner, uri string) []string {
+	t.Helper()
+	var fullBackupPaths []string
+	rows := sqlDB.Query(t, `SELECT path FROM [SHOW BACKUPS IN $1]`, uri)
+	for rows.Next() {
+		var path string
+		require.NoError(t, rows.Scan(&path))
+		fullBackupPaths = append(fullBackupPaths, path)
+	}
+	return fullBackupPaths
+}


### PR DESCRIPTION
`backup_test.go` contains a lot of the deprecated backup/restore syntax. This updates all tests to use the new `BACKUP INTO/RESTORE FROM ... IN` syntax.

Epic: None

Release note: None