### PR TITLE
[dnm] add repro for mangled caller paths

### DIFF
--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -14,6 +14,8 @@ import (
 	"math/rand"
 	"reflect"
 	"regexp"
+	"runtime"
+	"runtime/debug"
 	"slices"
 	"sort"
 	"strconv"
@@ -15048,4 +15050,19 @@ func TestLockAcquisitions1PCInteractions(t *testing.T) {
 			})
 		})
 	})
+}
+
+func TestBoo(t *testing.T) {
+	callers := make([]uintptr, 5)
+	n := runtime.Callers(0, callers)
+	callers = callers[:n]
+	frames := runtime.CallersFrames(callers)
+	debug.PrintStack()
+	for {
+		fr, ok := frames.Next()
+		require.NotContains(t, fr.File, "kvserver/pkg")
+		if !ok {
+			break
+		}
+	}
 }


### PR DESCRIPTION
This passes:

```
go test ./pkg/kv/kvserver/ -run TestBoo
```

This fails:

```
$ ./dev test ./pkg/kv/kvserver/ --filter TestBoo --stream-output
--- FAIL: TestBoo (0.00s)
    replica_test.go:15061:
        	Error Trace:	github.com/cockroachdb/cockroach/pkg/kv/kvserver/pkg/kv/kvserver/replica_test.go:15061
        	Error:      	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/pkg/kv/kvserver/replica_test.go" should not contain "kvserver/pkg"
        	Test:       	TestBoo
```

I looked into this because cpu profiles taken from a sysbench roachprod cluster (cockroach binary built off recent master using `./dev build cockroach --cross=linux`) can't be `list`ed due to referencing these incorrect paths; this reduces the value of these profiles.

This problem is rampant throughout many bazel builds, slack has tons of hits if you search for `pkg/kv/kvserver/pkg/kv/kvserver` just inside of random snippets folks are posting; the github issue poster also nicely shows it here[^1] for example. We also see it in the `cockroach` binary you get with `roachprod stage cockroach`. Release binaries are also affected; I tried `roachprod stage tobias-sbrw:4 release v24.2.2`.

[^1]: https://github.com/cockroachdb/cockroach/issues/132579#issue-2586410841

Confusingly though, the paths aren't consistently incorrect. In fact, some are correct:

```
ROUTINE ======================== github.com/cockroachdb/cockroach/pkg/raft.(*raft).maybeSendAppend in github.com/cockroachdb/cockroach/pkg/raft/raft.go
```

```
ROUTINE ======================== github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/replica_rac2.(*processorImpl).maybeSendAdmittedRaftMuLocked in github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
```

Most are incorrect, though, and in various ways. Classic is the `pkg/..../pkg` pattern:

```
ROUTINE ======================== github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*Stores).SendWithWriteBytes in github.com/cockroachdb/cockroach/pkg/kv/kvserver/pkg/kv/kvserver/stores.go
```

```
ROUTINE ======================== github.com/cockroachdb/cockroach/pkg/sql/stats.(*TableStatisticsCache).lookupStatsLocked in github.com/cockroachdb/cockroach/pkg/sql/stats/pkg/sql/stats/stats_cache.go
```

but there are also wilder ones like this:

```
ROUTINE ======================== github.com/cockroachdb/cockroach/pkg/sql/execinfrapb.(*distSQLFlowStreamServer).Send in github.com/cockroachdb/cockroach/pkg/sql/execinfrapb/bazel-out/k8-opt/bin/pkg/sql/execinfrapb/execinfrapb_go_proto_/github.com/cockroachdb/cockroach/pkg/sql/execinfrapb/api.pb.go
```

Release note: None
Epic: None
