### PR TITLE
raft,kvserver: handle MsgSnap with outdated term

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -679,20 +679,6 @@ func (r *Replica) stepRaftGroupRaftMuLocked(req *kvserverpb.RaftMessageRequest) 
 			// If we receive a (pre)vote request, and we find our leader to be dead or
 			// removed, forget it so we can grant the (pre)votes.
 			r.maybeForgetLeaderOnVoteRequestLocked()
-		case raftpb.MsgSnap:
-			// Occasionally a snapshot message may arrive under an outdated term,
-			// which would lead to Raft discarding the snapshot. This should be
-			// really rare in practice, but it does happen in tests and in particular
-			// can happen to the synchronous snapshots on the learner path, which
-			// will then have to wait for the raft snapshot queue to send another
-			// snapshot. However, in some tests it is desirable to disable the
-			// raft snapshot queue. This workaround makes that possible.
-			//
-			// See TestReportUnreachableRemoveRace for the test that prompted
-			// this addition.
-			if term := raftGroup.BasicStatus().Term; term > req.Message.Term {
-				req.Message.Term = term
-			}
 		case raftpb.MsgApp:
 			if n := len(req.Message.Entries); n > 0 {
 				sideChannelInfo = replica_rac2.SideChannelInfoUsingRaftMessageRequest{


### PR DESCRIPTION
A snapshot message may arrive under an outdated term. Since it carries committed state, we can safely process it regardless of the term. The message term means the snapshot is committed as of this term (or could be committed earlier). By raft invariants, all committed state under a particular term will be committed under later terms as well.

Part of #127348
Related to #133169