### PR TITLE
storage: optimize Batch.PutMVCC

### DIFF
--- a/pkg/storage/mvcc_value.go
+++ b/pkg/storage/mvcc_value.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/errors"
@@ -209,6 +210,9 @@ func EncodeMVCCValueToBuf(v MVCCValue, buf []byte) ([]byte, bool, error) {
 		return v.Value.RawBytes, false, nil
 	}
 
+	// NB: This code is duplicated in encodeExtendedMVCCValueToSizedBuf and
+	// edits should be replicated there.
+
 	// Extended encoding. Wrap the roachpb.Value encoding with a header containing
 	// MVCC-level metadata. Requires a re-allocation and copy.
 	headerLen := v.MVCCValueHeader.Size()
@@ -237,6 +241,38 @@ func EncodeMVCCValueToBuf(v MVCCValue, buf []byte) ([]byte, bool, error) {
 	// <4-byte-checksum><1-byte-tag><encoded-data> or empty for tombstone
 	copy(buf[headerSize:], v.Value.RawBytes)
 	return buf, true, nil
+}
+
+func mvccValueSize(v MVCCValue) (size int, extendedEncoding bool) {
+	if v.MVCCValueHeader.IsEmpty() && !disableSimpleValueEncoding {
+		return len(v.Value.RawBytes), false
+	}
+	return extendedPreludeSize + v.MVCCValueHeader.Size() + len(v.Value.RawBytes), true
+}
+
+// encodeExtendedMVCCValueToSizedBuf encodes an MVCCValue into its encoded form
+// in the provided buffer. The provided buf must be exactly sized, matching the
+// value returned by MVCCValue.encodedMVCCValueSize.
+//
+// See EncodeMVCCValueToBuf for detailed comments on the encoding scheme.
+func encodeExtendedMVCCValueToSizedBuf(v MVCCValue, buf []byte) error {
+	if buildutil.CrdbTestBuild {
+		if sz := encodedMVCCValueSize(v); sz != len(buf) {
+			panic(errors.AssertionFailedf("provided buf (len=%d) is not sized correctly; expected %d", len(buf), sz))
+		}
+	}
+	headerSize := len(buf) - len(v.Value.RawBytes)
+	headerLen := headerSize - extendedPreludeSize
+	binary.BigEndian.PutUint32(buf, uint32(headerLen))
+	buf[tagPos] = extendedEncodingSentinel
+	if _, err := v.MVCCValueHeader.MarshalToSizedBuffer(buf[extendedPreludeSize:headerSize]); err != nil {
+		return errors.Wrap(err, "marshaling MVCCValueHeader")
+	}
+	if buildutil.CrdbTestBuild && len(buf[headerSize:]) != len(v.Value.RawBytes) {
+		panic(errors.AssertionFailedf("insufficient space for raw value; expected %d, got %d", len(v.Value.RawBytes), len(buf[headerSize:])))
+	}
+	copy(buf[headerSize:], v.Value.RawBytes)
+	return nil
 }
 
 // DecodeMVCCValue decodes an MVCCKey from its Pebble representation.

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -273,11 +273,7 @@ func (wb *writeBatch) PutMVCC(key MVCCKey, value MVCCValue) error {
 	if key.Timestamp.IsEmpty() {
 		panic("PutMVCC timestamp is empty")
 	}
-	encValue, err := EncodeMVCCValue(value)
-	if err != nil {
-		return err
-	}
-	return wb.put(key, encValue)
+	return wb.putMVCC(key, value)
 }
 
 // PutRawMVCC implements the Writer interface.
@@ -302,13 +298,41 @@ func (wb *writeBatch) PutEngineKey(key EngineKey, value []byte) error {
 	return wb.batch.Set(wb.buf, value, nil)
 }
 
+func (wb *writeBatch) putMVCC(key MVCCKey, value MVCCValue) error {
+	// For performance, this method uses the pebble Batch's deferred operation
+	// API to avoid an extra memcpy. We:
+	// - determine the length of the encoded MVCC key and MVCC value
+	// - reserve space in the pebble Batch using SetDeferred
+	// - encode the MVCC key and MVCC value directly into the Batch
+	// - call Finish on the deferred operation (which will index the key if
+	//   wb.batch is indexed)
+	valueLen, isExtended := mvccValueSize(value)
+	keyLen := encodedMVCCKeyLength(key)
+	o := wb.batch.SetDeferred(keyLen, valueLen)
+	encodeMVCCKeyToBuf(o.Key, key, keyLen)
+	if !isExtended {
+		// Fast path; we don't need to use the extended encoding and can copy
+		// RawBytes in verbatim.
+		copy(o.Value, value.Value.RawBytes)
+	} else {
+		// Slow path; we need the MVCC value header.
+		err := encodeExtendedMVCCValueToSizedBuf(value, o.Value)
+		if err != nil {
+			return err
+		}
+	}
+	return o.Finish()
+}
+
 func (wb *writeBatch) put(key MVCCKey, value []byte) error {
 	if len(key.Key) == 0 {
 		return emptyKeyError()
 	}
-
-	wb.buf = EncodeMVCCKeyToBuf(wb.buf[:0], key)
-	return wb.batch.Set(wb.buf, value, nil)
+	keyLen := encodedMVCCKeyLength(key)
+	o := wb.batch.SetDeferred(keyLen, len(value))
+	encodeMVCCKeyToBuf(o.Key, key, keyLen)
+	copy(o.Value, value)
+	return o.Finish()
 }
 
 // LogData implements the Writer interface.


### PR DESCRIPTION
Use the Pebble Batch's deferred operation API to encode the MVCC key and MVCC value directly into the Batch's memory, avoiding an extra memcpy for each.

```
goos: darwin
goarch: arm64
                │   old.txt    │            deferred.txt             │
                │    sec/op    │   sec/op     vs base                │
BatchBuilderPut   100.10n ± 2%   89.08n ± 8%  -11.01% (p=0.002 n=25)
```

Benchmarks run while rebased over #133275. 

Epic: none
Release note: none