### PR TITLE
rac2: add Replica mutex assertions to RangeController

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
@@ -59,6 +59,7 @@ go_test(
     deps = [
         "//pkg/kv/kvserver/kvflowcontrol",
         "//pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb",
+        "//pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/kvserverpb",
         "//pkg/kv/kvserver/raftlog",

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -240,25 +240,25 @@ func (c *testRangeController) SendStreamStats(stats *rac2.RangeSendStreamStats) 
 	fmt.Fprintf(c.b, " RangeController.SendStreamStats\n")
 }
 
-func makeTestMutexAsserter() ReplicaMutexAsserter {
+func makeTestMutexAsserter() rac2.ReplicaMutexAsserter {
 	var raftMu syncutil.Mutex
 	var replicaMu syncutil.RWMutex
-	return MakeReplicaMutexAsserter(&raftMu, &replicaMu)
+	return rac2.MakeReplicaMutexAsserter(&raftMu, &replicaMu)
 }
 
-func LockRaftMuAndReplicaMu(mu *ReplicaMutexAsserter) (unlockFunc func()) {
-	mu.raftMu.Lock()
-	mu.replicaMu.Lock()
+func LockRaftMuAndReplicaMu(mu *rac2.ReplicaMutexAsserter) (unlockFunc func()) {
+	mu.RaftMu.Lock()
+	mu.ReplicaMu.Lock()
 	return func() {
-		mu.replicaMu.Unlock()
-		mu.raftMu.Unlock()
+		mu.ReplicaMu.Unlock()
+		mu.RaftMu.Unlock()
 	}
 }
 
-func LockRaftMu(mu *ReplicaMutexAsserter) (unlockFunc func()) {
-	mu.raftMu.Lock()
+func LockRaftMu(mu *rac2.ReplicaMutexAsserter) (unlockFunc func()) {
+	mu.RaftMu.Lock()
 	return func() {
-		mu.raftMu.Unlock()
+		mu.RaftMu.Unlock()
 	}
 }
 

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -238,7 +238,7 @@ func newUninitializedReplicaWithoutRaftGroup(
 		RangeID:           r.RangeID,
 		ReplicaID:         r.replicaID,
 		ReplicaForTesting: (*replicaForRACv2)(r),
-		ReplicaMutexAsserter: replica_rac2.MakeReplicaMutexAsserter(
+		ReplicaMutexAsserter: rac2.MakeReplicaMutexAsserter(
 			&r.raftMu.Mutex, (*syncutil.RWMutex)(&r.mu.ReplicaMutex)),
 		RaftScheduler:          r.store.scheduler,
 		AdmittedPiggybacker:    r.store.cfg.KVFlowAdmittedPiggybacker,

--- a/pkg/testutils/lint/gcassert_paths.txt
+++ b/pkg/testutils/lint/gcassert_paths.txt
@@ -5,7 +5,7 @@ kv/kvclient/kvcoord
 kv/kvclient/rangecache
 kv/kvpb
 kv/kvserver/intentresolver
-kv/kvserver/kvflowcontrol/replica_rac2
+kv/kvserver/kvflowcontrol/rac2
 kv/kvserver/rangefeed
 roachpb
 sql/catalog/descs


### PR DESCRIPTION
As part of this, the ReplicaMutexAsserter is moved to the rac2 package. The replicaSendStream.isEmptySendQueueRaftMuAndStreamLocked method was incorrectly named, in that it is not necessarily called with raftMu held. This is fixed.

Epic: CRDB-37515

Release note: None