### PR TITLE
vector: add vector.Set implementation

### DIFF
--- a/pkg/gen/protobuf.bzl
+++ b/pkg/gen/protobuf.bzl
@@ -90,6 +90,7 @@ PROTOBUF_SRCS = [
     "//pkg/util/timeutil/pgdate:pgdate_go_proto",
     "//pkg/util/tracing/tracingpb:tracingpb_go_proto",
     "//pkg/util/tracing/tracingservicepb:tracingservicepb_go_proto",
+    "//pkg/util/vector:vector_go_proto",
     "//pkg/util:util_go_proto",
     "//pkg/workload/histogram:histogram_go_proto",
 ]

--- a/pkg/testutils/lint/gcassert_paths.txt
+++ b/pkg/testutils/lint/gcassert_paths.txt
@@ -34,3 +34,4 @@ util/admission
 util/hlc
 util/intsets
 util/mon
+util/vector

--- a/pkg/util/vector/BUILD.bazel
+++ b/pkg/util/vector/BUILD.bazel
@@ -1,23 +1,51 @@
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "vector",
-    srcs = ["vector.go"],
+    srcs = [
+        "vector.go",
+        "vector_set.go",
+    ],
+    embed = [":vector_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/vector",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/util/encoding",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 
 go_test(
     name = "vector_test",
-    srcs = ["vector_test.go"],
+    srcs = [
+        "vector_set_test.go",
+        "vector_test.go",
+    ],
     embed = [":vector"],
     deps = [
         "//pkg/util/randutil",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
+)
+
+proto_library(
+    name = "vector_proto",
+    srcs = ["vector.proto"],
+    strip_import_prefix = "/pkg",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_gogo_protobuf//gogoproto:gogo_proto"],
+)
+
+go_proto_library(
+    name = "vector_go_proto",
+    compilers = ["//pkg/cmd/protoc-gen-gogoroach:protoc-gen-gogoroach_compiler"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/util/vector",
+    proto = ":vector_proto",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_gogo_protobuf//gogoproto"],
 )

--- a/pkg/util/vector/vector.go
+++ b/pkg/util/vector/vector.go
@@ -63,6 +63,15 @@ func ParseVector(input string) (T, error) {
 	return vector, nil
 }
 
+// AsSet returns this vector a set of one vector.
+func (v T) AsSet() Set {
+	return Set{
+		Dims:  len(v),
+		Count: 1,
+		Data:  v[:len(v):len(v)],
+	}
+}
+
 // String implements the fmt.Stringer interface.
 func (v T) String() string {
 	var sb strings.Builder

--- a/pkg/util/vector/vector.proto
+++ b/pkg/util/vector/vector.proto
@@ -1,0 +1,27 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+syntax = "proto3";
+package cockroach.util.vector;
+option go_package = "github.com/cockroachdb/cockroach/pkg/util/vector";
+
+import "gogoproto/gogo.proto";
+
+option (gogoproto.goproto_getters_all) = false;
+
+// Set is a set of float32 vectors of equal dimension. Vectors in the set are
+// stored contiguously in a slice, in row-wise order. They are assumed to be
+// unordered; some methods do not preserve ordering.
+message Set {
+  // Dims is the number of dimensions of each vector in the set.
+  int64 dims = 1 [(gogoproto.casttype) = "int"];
+  // Count is the number of vectors in the set.
+  int64 count = 2 [(gogoproto.casttype) = "int"];
+  // Data is a float32 slice that contains all vectors, laid out contiguously in
+  // row-wise order in memory.
+  // NB: Avoid using this field directly, instead preferring to use the At
+  // function to access individual vectors.
+  repeated float data = 3;
+}

--- a/pkg/util/vector/vector_set.go
+++ b/pkg/util/vector/vector_set.go
@@ -1,0 +1,121 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package vector
+
+import (
+	"slices"
+
+	"github.com/cockroachdb/errors"
+)
+
+// MakeSet constructs a new empty vector set with the given number of
+// dimensions. New vectors can be added via the Add or AddSet methods.
+func MakeSet(dims int) Set {
+	return Set{Dims: dims}
+}
+
+// MakeSetFromRawData constructs a new vector set from a raw slice of vectors.
+// The vectors in the slice have the given number of dimensions and are laid out
+// contiguously in row-wise order.
+// NB: The data slice is directly used rather than copied; any outside changes
+// to it will be reflected in the vector set.
+func MakeSetFromRawData(data []float32, dims int) Set {
+	if len(data)%dims != 0 {
+		panic(errors.AssertionFailedf(
+			"data length %d is not a multiple of %d dimensions", len(data), dims))
+	}
+	return Set{
+		Dims:  dims,
+		Count: len(data) / dims,
+		Data:  data,
+	}
+}
+
+// At returns the vector at the given offset in the set.
+//
+//gcassert:inline
+func (vs *Set) At(offset int) T {
+	start := offset * vs.Dims
+	end := start + vs.Dims
+	return vs.Data[start:end:end]
+}
+
+// SplitAt divides the vector set into two subsets at the given offset. This
+// vector set is updated to contain only the vectors before the split point, and
+// the returned set contains only the vectors on or after the split point.
+func (vs *Set) SplitAt(offset int) Set {
+	if offset > vs.Count {
+		panic(errors.AssertionFailedf(
+			"split point %d cannot be greater than set size %d", offset, vs.Count))
+	}
+
+	split := offset * vs.Dims
+	other := Set{
+		Dims:  vs.Dims,
+		Count: vs.Count - offset,
+		Data:  vs.Data[split:],
+	}
+
+	// Specify capacity of the slice so that it's safe to add vectors to this
+	// set without impacting the returned set.
+	vs.Data = vs.Data[:split:split]
+	vs.Count = offset
+	return other
+}
+
+// Add appends a new vector to the set.
+func (vs *Set) Add(v T) {
+	if vs.Dims != len(v) {
+		panic(errors.AssertionFailedf(
+			"cannot add vector with %d dimensions to a set with %d dimensions", len(v), vs.Dims))
+	}
+	vs.Data = append(vs.Data, v...)
+	vs.Count++
+}
+
+// AddSet appends all vectors from the given set to this set.
+func (vs *Set) AddSet(vectors *Set) {
+	if vs.Dims != vectors.Dims {
+		panic(errors.AssertionFailedf(
+			"cannot add vector set with %d dimensions to a set with %d dimensions",
+			vectors.Dims, vs.Dims))
+	}
+	vs.Data = append(vs.Data, vectors.Data...)
+	vs.Count += vectors.Count
+}
+
+// AddZero adds the given count of zero vectors to this set.
+func (vs *Set) AddZero(count int) {
+	vs.Data = slices.Grow(vs.Data, count*vs.Dims)
+	vs.Count += count
+	start := len(vs.Data)
+	end := vs.Count * vs.Dims
+	vs.Data = vs.Data[:end]
+	for i := start; i < end; i++ {
+		vs.Data[i] = 0
+	}
+}
+
+// Remove removes the vector at the given offset from the set. This is an O(1)
+// operation.
+// NB: This operation changes the ordering of vectors in the set, with the last
+// vector moved to the removed vector's offset.
+func (vs *Set) Remove(offset int) {
+	targetStart := offset * vs.Dims
+	sourceEnd := len(vs.Data)
+	copy(vs.Data[targetStart:targetStart+vs.Dims], vs.Data[sourceEnd-vs.Dims:sourceEnd])
+	vs.Data = vs.Data[:sourceEnd-vs.Dims]
+	vs.Count--
+}
+
+// EnsureCapacity grows the underlying data slice if needed to ensure the
+// requested capacity. This is useful to prevent unnecessary resizing when it's
+// known up-front how big the vector set will need to get.
+func (vs *Set) EnsureCapacity(capacity int) {
+	if vs.Count < capacity {
+		vs.Data = slices.Grow(vs.Data, (capacity-vs.Count)*vs.Dims)
+	}
+}

--- a/pkg/util/vector/vector_set_test.go
+++ b/pkg/util/vector/vector_set_test.go
@@ -1,0 +1,108 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package vector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVectorSet(t *testing.T) {
+	vs := MakeSet(2)
+	require.Equal(t, 2, vs.Dims)
+	require.Equal(t, 0, vs.Count)
+
+	// Add methods.
+	v1 := T{1, 2}
+	v2 := T{5, 3}
+	v3 := T{6, 6}
+	vs.Add(v1)
+	vs.Add(v2)
+	vs.Add(v3)
+	require.Equal(t, 3, vs.Count)
+	require.Equal(t, []float32{1, 2, 5, 3, 6, 6}, vs.Data)
+
+	vs.AddSet(&vs)
+	require.Equal(t, 6, vs.Count)
+	require.Equal(t, []float32{1, 2, 5, 3, 6, 6, 1, 2, 5, 3, 6, 6}, vs.Data)
+
+	vs.AddZero(2)
+	vs.AddZero(0)
+	require.Equal(t, 8, vs.Count)
+	require.Equal(t, []float32{1, 2, 5, 3, 6, 6, 1, 2, 5, 3, 6, 6, 0, 0, 0, 0}, vs.Data)
+
+	// Remove.
+	vs.Remove(1)
+	vs.Remove(4)
+	vs.Remove(5)
+	require.Equal(t, 5, vs.Count)
+	require.Equal(t, []float32{1, 2, 0, 0, 6, 6, 1, 2, 0, 0}, vs.Data)
+
+	// Add zero again, to ensure that reusing memory still zeroes it.
+	vs.AddZero(1)
+	require.Equal(t, []float32{1, 2, 0, 0, 6, 6, 1, 2, 0, 0, 0, 0}, vs.Data)
+
+	vs3 := MakeSetFromRawData(vs.Data, 2)
+	require.Equal(t, vs, vs3)
+
+	// Ensure capacity.
+	vs4 := MakeSet(3)
+	vs4.EnsureCapacity(5)
+	require.Equal(t, 0, len(vs4.Data))
+	require.GreaterOrEqual(t, cap(vs4.Data), 15)
+	vs4.AddZero(2)
+	require.Equal(t, 2, vs4.Count)
+	require.Equal(t, 6, len(vs4.Data))
+
+	// AsSet.
+	vs5 := T{1, 2, 3}.AsSet()
+	require.Equal(t, 3, cap(vs5.Data))
+	vs4.AddSet(&vs5)
+	require.Equal(t, 3, vs4.Count)
+	require.Equal(t, []float32{0, 0, 0, 0, 0, 0, 1, 2, 3}, vs4.Data)
+
+	// SplitAt.
+	vs6 := MakeSetFromRawData([]float32{1, 2, 3, 4, 5, 6}, 2)
+	vs7 := vs6.SplitAt(0)
+	require.Equal(t, 0, vs6.Count)
+	require.Equal(t, []float32{}, vs6.Data)
+	require.Equal(t, 3, vs7.Count)
+	require.Equal(t, []float32{1, 2, 3, 4, 5, 6}, vs7.Data)
+
+	// Append to vs6 and ensure that it does not affect vs7.
+	vs6.Add([]float32{7, 8})
+	require.Equal(t, []float32{1, 2, 3, 4, 5, 6}, vs7.Data)
+
+	vs8 := vs7.SplitAt(2)
+	require.Equal(t, 2, vs7.Count)
+	require.Equal(t, []float32{1, 2, 3, 4}, vs7.Data)
+	require.Equal(t, 1, vs8.Count)
+	require.Equal(t, []float32{5, 6}, vs8.Data)
+
+	vs9 := vs7.SplitAt(2)
+	require.Equal(t, 2, vs7.Count)
+	require.Equal(t, []float32{1, 2, 3, 4}, vs7.Data)
+	require.Equal(t, 0, vs9.Count)
+	require.Equal(t, []float32{}, vs9.Data)
+
+	// Check that invalid operations will panic.
+	vs11 := MakeSetFromRawData([]float32{1, 2, 3, 4, 5, 6}, 2)
+	require.Panics(t, func() { vs11.At(-1) })
+	require.Panics(t, func() { vs11.SplitAt(-1) })
+	require.Panics(t, func() { vs11.AddZero(-1) })
+	require.Panics(t, func() { vs11.AddSet(nil) })
+	require.Panics(t, func() { vs11.Remove(-1) })
+
+	vs12 := MakeSet(2)
+	require.Panics(t, func() { vs12.At(0) })
+	require.Panics(t, func() { vs12.SplitAt(1) })
+	require.Panics(t, func() { vs12.Remove(0) })
+
+	vs13 := MakeSet(-1)
+	require.Panics(t, func() { vs13.Add(v1) })
+	require.Panics(t, func() { vs13.AddZero(1) })
+}


### PR DESCRIPTION
Implement vector.Set, which is a set of float32 vectors of equal dimension. Vectors in the set are stored contiguously in a slice, in row-wise order. Future PR's will take advantage of this layout to implement fast set operations.

Epic: CRDB-42943

Release note: None