### PR TITLE
sql,util: fix incorrect logtags.Buffer usage

### DIFF
--- a/pkg/sql/type_change.go
+++ b/pkg/sql/type_change.go
@@ -1373,8 +1373,8 @@ func (t *typeSchemaChanger) execWithRetry(ctx context.Context) error {
 
 func (t *typeSchemaChanger) logTags() *logtags.Buffer {
 	buf := &logtags.Buffer{}
-	buf.Add("typeChangeExec", nil)
-	buf.Add("type", t.typeID)
+	buf = buf.Add("typeChangeExec", nil)
+	buf = buf.Add("type", t.typeID)
 	return buf
 }
 

--- a/pkg/util/tracing/bench_test.go
+++ b/pkg/util/tracing/bench_test.go
@@ -25,8 +25,8 @@ func BenchmarkTracer_StartSpanCtx(b *testing.B) {
 	skip.UnderDeadlock(b, "span reuse triggers false-positives in the deadlock detector")
 	ctx := context.Background()
 
-	staticLogTags := logtags.Buffer{}
-	staticLogTags.Add("foo", "bar")
+	staticLogTags := &logtags.Buffer{}
+	staticLogTags = staticLogTags.Add("foo", "bar")
 	mockListener := &mockEventListener{}
 
 	for _, tc := range []struct {
@@ -39,7 +39,7 @@ func BenchmarkTracer_StartSpanCtx(b *testing.B) {
 		{name: "none", defaultMode: TracingModeOnDemand},
 		{name: "real", defaultMode: TracingModeActiveSpansRegistry},
 		{name: "real,logtag", defaultMode: TracingModeActiveSpansRegistry,
-			opts: []SpanOption{WithLogTags(&staticLogTags)}},
+			opts: []SpanOption{WithLogTags(staticLogTags)}},
 		{name: "real,autoparent", defaultMode: TracingModeActiveSpansRegistry, parent: true},
 		{name: "real,manualparent", defaultMode: TracingModeActiveSpansRegistry, parent: true,
 			opts: []SpanOption{WithDetachedRecording()}},


### PR DESCRIPTION
(*logtags.Buffer).Add creates a new Buffer, copies the log tags from the receiver, adds the new tag to the new Buffer, and return the buffer. These callers weren't doing anything with the response so they weren't actually adding the tags they thought they were adding.

This seems like some wasted work, but I suppose the more common case is `(*logtags.Buffer).Merge` which is more efficient. (Note repeated calls with `logtags.AddTag(ctx, key, val)` is similarly unfortunate, but also rare in the codebase from what I can see).

Epic: none
Release note: None