### PR TITLE
drtprod: fix drt-scale yaml and tpch script

### DIFF
--- a/pkg/cmd/drtprod/configs/drt_scale.yaml
+++ b/pkg/cmd/drtprod/configs/drt_scale.yaml
@@ -144,10 +144,10 @@ targets:
           duration: 12h
           ramp: 10m
           wait: 0
-      - script: "pkg/cmd/drtprod/scripts/generate_tpch_init.sh"
+      - script: "pkg/cmd/drtprod/scripts/tpch_init.sh"
         args:
           - scale_factor_1000 # suffix added to script name tpch_init_scale_factor_1000.sh
-          - false # determines whether to execute the script immediately on workload node
+          - true # determines whether to execute the script immediately on workload node
         flags:
           scale-factor: 1000
       - script: "pkg/cmd/drtprod/scripts/generate_tpch_run.sh"

--- a/pkg/cmd/drtprod/scripts/tpcc_run_multiregion.sh
+++ b/pkg/cmd/drtprod/scripts/tpcc_run_multiregion.sh
@@ -44,7 +44,7 @@ while true; do
       --max-rate=$MAX_RATE \
       --duration=$RUN_DURATION \
       --wait=false \
-      --partitions$NUM_REGIONS \
+      --partitions=$NUM_REGIONS \
       --partition-affinity=$(($NODE-1)) \
       --tolerate-errors \
       $PGURLS_REGION \

--- a/pkg/cmd/drtprod/scripts/tpch_init.sh
+++ b/pkg/cmd/drtprod/scripts/tpch_init.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 # Copyright 2024 The Cockroach Authors.
 #
 # Use of this software is governed by the CockroachDB Software License
@@ -9,7 +10,7 @@
 # NOTE - This uses CLUSTER and WORKLOAD_CLUSTER environment variable, if not set the script fails
 
 # The first argument is the name suffix that is added to the script as tpch_init_<suffix>.sh
-if [ "$#" -lt 4 ]; then
+if [ "$#" -lt 3 ]; then
   echo "Usage: $0 <script_suffix> <execute:true|false> <flags to init:--scale-factor,--db>"
   exit 1
 fi


### PR DESCRIPTION
Tested out the script and end to end. Found a bug in the `tpch_init.sh` script where we were expecting more parameters than being passed.

Epic: none
Release note: None