### PR TITLE
kvserver/rangefeed: change rangefeed tests

### DIFF
--- a/pkg/kv/kvserver/rangefeed/processor_helpers_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_helpers_test.go
@@ -233,13 +233,15 @@ func (h *processorTestHelper) triggerTxnPushUntilPushed(t *testing.T, pushedC <-
 	}
 }
 
-type rangefeedTestType struct{}
+type rangefeedTestType bool
 
 var (
-	scheduledProcessorWithBufferedReg = rangefeedTestType{}
+	scheduledProcessorWithUnbufferedSender rangefeedTestType
 )
 
-var testTypes = []rangefeedTestType{}
+var testTypes = []rangefeedTestType{
+	scheduledProcessorWithUnbufferedSender,
+}
 
 // NB: When adding new types, please keep make sure existing
 // benchmarks will keep their old name.


### PR DESCRIPTION
This patch adjusts the existing rangefeed tests to simplify
setting up the test framework for buffered sender in future tests.

Release note: none
Epic: none