### PR TITLE
kvserver/rangefeed: watch catch up scan context cancellation properly

### DIFF
--- a/pkg/kv/kvserver/rangefeed/buffered_registration.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_registration.go
@@ -268,7 +268,7 @@ func (br *bufferedRegistration) maybeRunCatchUpScan(ctx context.Context) error {
 		br.metrics.RangeFeedCatchUpScanNanos.Inc(timeutil.Since(start).Nanoseconds())
 	}()
 
-	return catchUpIter.CatchUpScan(ctx, br.stream.SendUnbuffered, br.withDiff, br.withFiltering, br.withOmitRemote)
+	return catchUpIter.CatchUpScan(ctx, br.streamCtx, br.stream.SendUnbuffered, br.withDiff, br.withFiltering, br.withOmitRemote)
 }
 
 // Wait for this registration to completely process its internal buffer.

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
@@ -51,7 +51,7 @@ func runCatchUpBenchmark(b *testing.B, emk engineMaker, opts benchOptions) (numE
 			}
 			defer iter.Close()
 			counter := 0
-			err = iter.CatchUpScan(ctx, func(*kvpb.RangeFeedEvent) error {
+			err = iter.CatchUpScan(ctx, context.Background(), func(*kvpb.RangeFeedEvent) error {
 				counter++
 				return nil
 			}, opts.withDiff, false /* withFiltering */, false /* withOmitRemote */)


### PR DESCRIPTION
Previously, catch up scans do not watch for stream context cancellation
properly. This means that - when registration disconnects and server sends an
error back to client notifying rangefeed completion, catch up scans for this
registration may still be running. Although registration would eventually shut
down after the catch up scan completes, it could lead to problems if the scans
take a long time to finish. This patch resolves the issue by ensuring catch-up
scans correctly watch for context cancellation.

Fixes: https://github.com/cockroachdb/cockroach/issues/125953
Release note: none

TODO: add a test for cleanups after catch up scan returns an error (draining memory properly and events are returned in correct order)