### PR TITLE
roachtest: various minor perturbation cleanups

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -116,7 +116,7 @@ var leases = []registry.LeaseType{
 func (v variations) String() string {
 	return fmt.Sprintf("seed: %d, fillDuration: %s, maxBlockBytes: %d, perturbationDuration: %s, "+
 		"validationDuration: %s, ratioOfMax: %f, splits: %d, numNodes: %d, numWorkloadNodes: %d, "+
-		"vcpu: %d, disks: %d, memory: %s, leaseType: %s, cloud: %v, perturbation: %s",
+		"vcpu: %d, disks: %d, memory: %s, leaseType: %s, cloud: %v, perturbation: %+v",
 		v.seed, v.fillDuration, v.maxBlockBytes,
 		v.perturbationDuration, v.validationDuration, v.ratioOfMax, v.splits, v.numNodes, v.numWorkloadNodes,
 		v.vcpu, v.disks, v.mem, v.leaseType, v.cloud, v.perturbation)
@@ -439,10 +439,6 @@ func (s *slowDisk) setupMetamorphic(rng *rand.Rand) {
 	s.walFailover = rng.Intn(2) == 0
 }
 
-func (s *slowDisk) String() string {
-	return fmt.Sprintf("slowDisk{slowLiveness: %t, walFailover: %t}", s.slowLiveness, s.walFailover)
-}
-
 // startTargetNode implements perturbation.
 func (s *slowDisk) startTargetNode(ctx context.Context, t test.Test, v variations) {
 	extraArgs := []string{}
@@ -490,9 +486,6 @@ type restart struct {
 
 var _ perturbation = &restart{}
 
-func (r *restart) String() string {
-	return fmt.Sprintf("restart{cleanRestart: %t}", r.cleanRestart)
-}
 
 func (r *restart) setupMetamorphic(rng *rand.Rand) {
 	r.cleanRestart = rng.Intn(2) == 0
@@ -546,10 +539,6 @@ type partition struct {
 }
 
 var _ perturbation = &partition{}
-
-func (p *partition) String() string {
-	return fmt.Sprintf("partition{partitionSite: %t}", p.partitionSite)
-}
 
 func (p *partition) setupMetamorphic(rng *rand.Rand) {
 	p.partitionSite = rng.Intn(2) == 0
@@ -622,10 +611,6 @@ type decommission struct {
 }
 
 var _ perturbation = &decommission{}
-
-func (d *decommission) String() string {
-	return fmt.Sprintf("decommission{drain: %t}", d.drain)
-}
 
 func (d *decommission) setupMetamorphic(rng *rand.Rand) {
 	d.drain = rng.Intn(2) == 0

--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -69,8 +69,6 @@ import (
 // baseline. In some variations there is a small window immediately after the
 // perturbation is started where we don't measure the latency since we expect an
 // impact (such as after a network partition or unexpected node crash)
-//
-// TODO(baptist): Add a timeline describing the test in more detail.
 type variations struct {
 	// cluster is set up at the start of the test run.
 	cluster.Cluster
@@ -259,8 +257,6 @@ func addMetamorphic(r registry.Registry, p perturbation, acceptableChange float6
 	v := p.setupMetamorphic(rng)
 	v.seed = seed
 	v.acceptableChange = acceptableChange
-	// TODO(baptist): Make the cloud be metamorphic for repeatable results with
-	// a given seed.
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("perturbation/metamorphic/%s", v.perturbationName()),
 		CompatibleClouds: v.cloud,
@@ -617,7 +613,9 @@ func (addNode) endPerturbation(ctx context.Context, t test.Test, v variations) t
 	return v.validationDuration
 }
 
-// restart will gracefully stop and then restart a node after a custom duration.
+// decommission will decommission the target node during the start phase. It
+// allows optionally calling drain first. Draining first is the best practice
+// recommendation, however it should not cause a latency impact either way.
 type decommission struct {
 	drain bool
 }
@@ -945,8 +943,8 @@ func (v variations) validateTokensReturned(ctx context.Context, t test.Test) {
 }
 
 // trackedStat is a collection of the relevant values from the histogram. The
-// score is a unitless composite measure representing the throughput and latency
-// of a histogram. Lower scores are better.
+// score is computed based on the time per operation per core and blended
+// latency of P50 and P99. Lower scores are better.
 type trackedStat struct {
 	cli.Tick
 	score time.Duration

--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -235,8 +235,15 @@ func registerLatencyTests(r registry.Registry) {
 }
 
 func (v variations) makeClusterSpec() spec.ClusterSpec {
-	// TODO(baptist): Allow the non-disk tests to reuse the cluster.
-	return spec.MakeClusterSpec(v.numNodes+v.numWorkloadNodes, spec.CPU(v.vcpu), spec.SSD(v.disks), spec.Mem(v.mem), spec.ReuseNone())
+	opts := []spec.Option{spec.CPU(v.vcpu), spec.SSD(v.disks), spec.Mem(v.mem)}
+	// TODO(baptist): This is ugly to use reflection here. The better change
+	// would be to have the perturbation expose the options it wants to add to
+	// the cluster spec. If there is any additional instances where we need to
+	// differentiate the tests, convert to that.
+	if reflect.TypeOf(v.perturbation) == reflect.TypeOf(&slowDisk{}) {
+		opts = append(opts, spec.ReuseNone())
+	}
+	return spec.MakeClusterSpec(v.numNodes+v.numWorkloadNodes, opts...)
 }
 
 func (v variations) perturbationName() string {

--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -230,13 +230,13 @@ func registerLatencyTests(r registry.Registry) {
 
 	// NB: These tests will never fail and are not enabled, but they are useful
 	// for development.
-	addDev(r, &restart{cleanRestart: true}, math.Inf(1))
-	addDev(r, &partition{partitionSite: true}, math.Inf(1))
-	addDev(r, addNode{}, math.Inf(1))
-	addDev(r, &decommission{drain: true}, math.Inf(1))
-	addDev(r, backfill{}, math.Inf(1))
-	addDev(r, &slowDisk{slowLiveness: true, walFailover: true}, math.Inf(1))
-	addDev(r, elasticWorkload{}, math.Inf(1))
+	addDev(r, &restart{cleanRestart: true})
+	addDev(r, &partition{partitionSite: true})
+	addDev(r, addNode{})
+	addDev(r, &decommission{drain: true})
+	addDev(r, backfill{})
+	addDev(r, &slowDisk{slowLiveness: true, walFailover: true})
+	addDev(r, elasticWorkload{})
 }
 
 func (v variations) makeClusterSpec() spec.ClusterSpec {
@@ -284,9 +284,10 @@ func addFull(r registry.Registry, p perturbation, acceptableChange float64) {
 	})
 }
 
-func addDev(r registry.Registry, p perturbation, acceptableChange float64) {
+func addDev(r registry.Registry, p perturbation) {
 	v := setupDev(p)
-	v.acceptableChange = acceptableChange
+	// Dev tests never fail on latency increases.
+	v.acceptableChange = math.Inf(1)
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("perturbation/dev/%s", v.perturbationName()),
 		CompatibleClouds: v.cloud,


### PR DESCRIPTION
Various minor cleanups to the perturbation tests. These changes don't impact anything functional but make it slightly easier to write new perturbations.