### PR TITLE
bincheck: tweak macos GitHub runners

### DIFF
--- a/.github/workflows/bincheck.yml
+++ b/.github/workflows/bincheck.yml
@@ -16,13 +16,13 @@ jobs:
     - run: cd build/release/bincheck && ./test-linux ${{ github.ref_name }} ${{ github.sha }}
 
   darwin-amd64:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v3
     - run: cd build/release/bincheck && ./test-macos-amd64 ${{ github.ref_name }} ${{ github.sha }}
 
   darwin-arm64:
-    runs-on: macos-latest-xlarge
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
     - run: cd build/release/bincheck && ./test-macos-arm64 ${{ github.ref_name }} ${{ github.sha }}


### PR DESCRIPTION
Previously, we used `macos-latest` for `darwin-amd64` and `macos-latest-xlarge` for `darwin-arm64`. The former runner type switched to M1 at some point.

This PR adjusts the runner types according to
https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners.

Epic: none
Release note: None