### PR TITLE
roachprod: [dnm] add experimental support to specify diff machine-types

### DIFF
--- a/pkg/cmd/roachprod/BUILD.bazel
+++ b/pkg/cmd/roachprod/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/roachprod/ssh",
         "//pkg/roachprod/ui",
         "//pkg/roachprod/vm",
+        "//pkg/roachprod/vm/aws",
         "//pkg/roachprod/vm/gce",
         "//pkg/util/envutil",
         "//pkg/util/flagutil",

--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -82,6 +82,7 @@ var (
 	logsInterval          time.Duration
 	volumeCreateOpts      vm.VolumeCreateOpts
 	listOpts              vm.ListOptions
+	overrideMachineTypes  []string
 
 	monitorOpts        install.MonitorOpts
 	cachedHostsCluster string
@@ -152,6 +153,11 @@ func initFlags() {
 			"and value can't be empty string after trimming space, a value that has space must be quoted by single "+
 			"quotes, gce label name only allows hyphens (-), underscores (_), lowercase characters, numbers and "+
 			"international characters. Examples: usage=cloud-report-2021, namewithspaceinvalue='s o s'")
+	createCmd.Flags().StringSliceVar(&overrideMachineTypes,
+		"override-machine-types", nil,
+		"Override the default machine types for the given cloud provider(s). "+
+			"Format: <machine-type>,<machine-type>,...",
+	)
 
 	// Allow each Provider to inject additional configuration flags
 	for _, providerName := range vm.AllProviderNames() {


### PR DESCRIPTION
Add a new `--override-machine-type` flag to `roachprod create`.

Behavior when specified:

When the cloud is AWS and more than one override machine type is set, we create `len(--override-machine-type` clusters with each cluster using one of the override machine types, otherwise when one machine type override is set, duplicating identical options (including node count). e.g.,

```
roachprod create $USER-aws-hetero-multi-zone
  --nodes 9
  --aws-machine-type=m6g.large,m7g.large,m7g.large
  --aws-zones=eu-west-2b,us-east-1b,us-east-2b
```

Would result in 9 nodes being created, 3 in each of the specified zones, with the first 3 using m6g.large, the next 3 using m7g.large, and the last 3 using m7g.large. e.g.,

```
eu-west-2b: [m6g.large, m6g.large, m6g.large]
us-east-1b: [m7g.large, m7g.large, m7g.large]
us-east-2b: [m7g.large, m7g.large, m7g.large]
```

The single-zone case:

```
roachprod create $USER-aws-hetero-single-zone
  --nodes 9
  --aws-machine-type=m6g.large,m7g.large,m7g.large
  --aws-zones=eu-west-2b
```

Results in:

```
eu-west-2b: [m6g.large, m6g.large, m6g.large,
             m7g.large, m7g.large, m7g.large,
             m7g.large, m7g.large, m7g.large]
```

Note other clouds than AWS are unsupported in this commit.

Epic: none
Release note: None