### PR TITLE
roachtest: deflake perturbation/metamorphic/backfill

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -351,7 +351,7 @@ func (b backfill) startTargetNode(ctx context.Context, t test.Test, v variations
 	// want the fill to impact the test throughput. We use a larger block size
 	// to create a lot of SSTables and ranges in a short amount of time.
 	runCmd := fmt.Sprintf(
-		"./cockroach workload run kv --db backfill --duration=%s --max-block-bytes=%d --min-block-bytes=%d --concurrency=100 {pgurl%s}",
+		"./cockroach workload run kv --db backfill --duration=%s --max-block-bytes=%d --tolerate-errors --min-block-bytes=%d --concurrency=100 {pgurl%s}",
 		v.perturbationDuration, 10_000, 10_000, v.stableNodes())
 	v.Run(ctx, option.WithNodes(v.workloadNodes()), runCmd)
 


### PR DESCRIPTION
The test runs a `cockroach workload run kv --db backfill ...` workload to set the test up. It can fail if it encounters a transaction retryable error.

This commit adds the `--tolerate-errors` flag to the workload command.

Fixes: #133374

Release note: None