### PR TITLE
logictest: use high priority txn in partial_index and synthetic_privileges tests

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -564,10 +564,11 @@ SELECT * FROM h@a_b_foo_idx WHERE b = 'foo'
 1  foo
 
 # Backfill a partial index with a user defined type when a new table is created
-# in the same transaction.
+# in the same transaction. Use a high priority to make it less likely for the
+# transaction to be aborted.
 
 statement ok
-BEGIN
+BEGIN PRIORITY HIGH
 
 statement ok
 CREATE TABLE i (a INT, b enum)

--- a/pkg/sql/logictest/testdata/logic_test/synthetic_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/synthetic_privileges
@@ -296,8 +296,9 @@ SELECT has_table_privilege('testuser4', 'crdb_internal.feature_usage', 'SELECT')
 ----
 false
 
+# Use a high priority transaction to avoid this transaction being aborted.
 statement ok
-BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+BEGIN TRANSACTION PRIORITY HIGH ISOLATION LEVEL SERIALIZABLE;
 
 statement ok
 GRANT SELECT ON crdb_internal.feature_usage TO testuser4


### PR DESCRIPTION
This should make it less likely for the transaction to be aborted.

fixes https://github.com/cockroachdb/cockroach/issues/126763
fixes https://github.com/cockroachdb/cockroach/issues/132919
Release note: None