### PR TITLE
raft: stop resetting electionElapsed when attempting to campaign

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -220,7 +220,7 @@ var (
 	// defaultRaftHeartbeatIntervalTicks is the default value for
 	// RaftHeartbeatIntervalTicks, which determines the number of ticks between
 	// each heartbeat.
-	defaultRaftHeartbeatIntervalTicks = envutil.EnvOrDefaultInt(
+	defaultRaftHeartbeatIntervalTicks = envutil.EnvOrDefaultInt64(
 		"COCKROACH_RAFT_HEARTBEAT_INTERVAL_TICKS", 2)
 
 	// defaultRaftElectionTimeoutTicks specifies the minimum number of Raft ticks
@@ -233,12 +233,12 @@ var (
 	// sufficient for a full network roundtrip. Raft heartbeats are also sent via
 	// SystemClass, avoiding head-of-line blocking by general RPC traffic. The 1-2
 	// random factor provides an additional buffer.
-	defaultRaftElectionTimeoutTicks = envutil.EnvOrDefaultInt(
+	defaultRaftElectionTimeoutTicks = envutil.EnvOrDefaultInt64(
 		"COCKROACH_RAFT_ELECTION_TIMEOUT_TICKS", 4)
 
 	// defaultRaftReproposalTimeoutTicks is the number of ticks before reproposing
 	// a Raft command.
-	defaultRaftReproposalTimeoutTicks = envutil.EnvOrDefaultInt(
+	defaultRaftReproposalTimeoutTicks = envutil.EnvOrDefaultInt64(
 		"COCKROACH_RAFT_REPROPOSAL_TIMEOUT_TICKS", 6)
 
 	// defaultRaftEnableCheckQuorum specifies whether to enable CheckQuorum in
@@ -524,15 +524,15 @@ type RaftConfig struct {
 	// an election. The actual election timeout is randomized by each replica to
 	// between 1-2 election timeouts. This value is inherited by individual stores
 	// unless overridden.
-	RaftElectionTimeoutTicks int
+	RaftElectionTimeoutTicks int64
 
 	// RaftReproposalTimeoutTicks is the number of ticks before reproposing a Raft
 	// command. This also specifies the number of ticks between each reproposal
 	// check, so the actual timeout is 1-2 times this value.
-	RaftReproposalTimeoutTicks int
+	RaftReproposalTimeoutTicks int64
 
 	// RaftHeartbeatIntervalTicks is the number of ticks that pass between heartbeats.
-	RaftHeartbeatIntervalTicks int
+	RaftHeartbeatIntervalTicks int64
 
 	// RangeLeaseRaftElectionTimeoutMultiplier specifies the range lease duration.
 	RangeLeaseDuration time.Duration

--- a/pkg/base/testdata/raft_config
+++ b/pkg/base/testdata/raft_config
@@ -2,9 +2,9 @@ echo
 ----
 (base.RaftConfig) {
  RaftTickInterval: (time.Duration) 500ms,
- RaftElectionTimeoutTicks: (int) 4,
- RaftReproposalTimeoutTicks: (int) 6,
- RaftHeartbeatIntervalTicks: (int) 2,
+ RaftElectionTimeoutTicks: (int64) 4,
+ RaftReproposalTimeoutTicks: (int64) 6,
+ RaftHeartbeatIntervalTicks: (int64) 2,
  RangeLeaseDuration: (time.Duration) 6s,
  RangeLeaseRenewalFraction: (float64) 0.5,
  RaftEnableCheckQuorum: (bool) true,

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -2817,7 +2817,7 @@ func TestRaftHeartbeats(t *testing.T) {
 	// Wait for several ticks to elapse.
 	ticksToWait := 2 * store.GetStoreConfig().RaftElectionTimeoutTicks
 	ticks := store.Metrics().RaftTicks.Count
-	for targetTicks := ticks() + int64(ticksToWait); ticks() < targetTicks; {
+	for targetTicks := ticks() + ticksToWait; ticks() < targetTicks; {
 		time.Sleep(time.Millisecond)
 	}
 
@@ -2872,7 +2872,7 @@ func TestReportUnreachableHeartbeats(t *testing.T) {
 
 	ticksToWait := 2 * leaderStore.GetStoreConfig().RaftElectionTimeoutTicks
 	ticks := leaderStore.Metrics().RaftTicks.Count
-	for targetTicks := ticks() + int64(ticksToWait); ticks() < targetTicks; {
+	for targetTicks := ticks() + ticksToWait; ticks() < targetTicks; {
 		time.Sleep(time.Millisecond)
 	}
 
@@ -4390,7 +4390,7 @@ func TestRangeQuiescence(t *testing.T) {
 	// Wait for a bunch of ticks to occur which will allow the follower time to
 	// campaign.
 	ticks := tc.GetFirstStoreFromServer(t, followerIdx).Metrics().RaftTicks.Count
-	for targetTicks := ticks() + int64(2*tc.GetFirstStoreFromServer(t, followerIdx).GetStoreConfig().RaftElectionTimeoutTicks); ticks() < targetTicks; {
+	for targetTicks := ticks() + 2*tc.GetFirstStoreFromServer(t, followerIdx).GetStoreConfig().RaftElectionTimeoutTicks; ticks() < targetTicks; {
 		time.Sleep(time.Millisecond)
 	}
 

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -811,10 +811,10 @@ type Replica struct {
 		quotaReleaseQueue []*quotapool.IntAlloc
 
 		// Counts calls to Replica.tick()
-		ticks int
+		ticks int64
 
 		// lastProposalAtTicks tracks the time of the last proposal, in ticks.
-		lastProposalAtTicks int
+		lastProposalAtTicks int64
 
 		// Counts Raft messages refused due to queue congestion.
 		droppedMessages int

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -138,11 +138,11 @@ type ProposalData struct {
 
 	// proposedAtTicks is the (logical) time at which this command was
 	// last (re-)proposed.
-	proposedAtTicks int
+	proposedAtTicks int64
 
 	// createdAtTicks is the (logical) time at which this command was
 	// *first* proposed.
-	createdAtTicks int
+	createdAtTicks int64
 
 	// command is the log entry that is encoded into encodedCommand and proposed
 	// to raft. Never mutated.

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -612,7 +612,7 @@ func (r *Replica) hasSendTokensRaftMuLockedReplicaMuLocked() bool {
 
 // ticksSinceLastProposalRLocked returns the number of ticks since the last
 // proposal.
-func (r *Replica) ticksSinceLastProposalRLocked() int {
+func (r *Replica) ticksSinceLastProposalRLocked() int64 {
 	return r.mu.ticks - r.mu.lastProposalAtTicks
 }
 
@@ -1611,7 +1611,7 @@ const (
 // ticks of an election timeout (affect only proposals that have had ample time
 // to apply but didn't).
 func (r *Replica) refreshProposalsLocked(
-	ctx context.Context, refreshAtDelta int, reason refreshRaftReason,
+	ctx context.Context, refreshAtDelta int64, reason refreshRaftReason,
 ) {
 	if refreshAtDelta != 0 && reason != reasonTicks {
 		log.Fatalf(ctx, "refreshAtDelta specified for reason %s != reasonTicks", reason)

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -27,7 +27,7 @@ import (
 // should quiesce. Unquiescing incurs a raft proposal which has a non-neglible
 // cost, and low-latency clusters may otherwise (un)quiesce very frequently,
 // e.g. on every tick.
-var quiesceAfterTicks = envutil.EnvOrDefaultInt("COCKROACH_QUIESCE_AFTER_TICKS", 6)
+var quiesceAfterTicks = envutil.EnvOrDefaultInt64("COCKROACH_QUIESCE_AFTER_TICKS", 6)
 
 // raftDisableQuiescence disables raft quiescence.
 var raftDisableQuiescence = envutil.EnvOrDefaultBool("COCKROACH_DISABLE_QUIESCENCE", false)
@@ -213,7 +213,7 @@ type quiescer interface {
 	hasPendingProposalsRLocked() bool
 	hasPendingProposalQuotaRLocked() bool
 	hasSendTokensRaftMuLockedReplicaMuLocked() bool
-	ticksSinceLastProposalRLocked() int
+	ticksSinceLastProposalRLocked() int64
 	mergeInProgressRLocked() bool
 	isDestroyedRLocked() (DestroyReason, error)
 }

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -8189,7 +8189,7 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 	r.mu.Unlock()
 
 	// We tick the replica 3*RaftReproposalTimeoutTicks.
-	for i := 0; i < 3*reproposalTicks; i++ {
+	for i := int64(0); i < 3*reproposalTicks; i++ {
 		// Add another pending command on each iteration.
 		id := fmt.Sprintf("%08d", i)
 		ba := &kvpb.BatchRequest{}
@@ -8245,7 +8245,7 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 		// time, this will be 1 reproposal (the one at ticks=0 for the reproposal at
 		// ticks=reproposalTicks), then +reproposalTicks reproposals each time.
 		if (ticks % reproposalTicks) == 0 {
-			if exp := i + 2 - reproposalTicks; len(reproposed) != exp { // +1 to offset i, +1 for inclusive
+			if exp := i + 2 - reproposalTicks; int64(len(reproposed)) != exp { // +1 to offset i, +1 for inclusive
 				t.Fatalf("%d: expected %d reproposed commands, but found %d", i, exp, len(reproposed))
 			}
 		} else {
@@ -9860,7 +9860,7 @@ type testQuiescer struct {
 	numProposals           int
 	pendingQuota           bool
 	sendTokens             bool
-	ticksSinceLastProposal int
+	ticksSinceLastProposal int64
 	status                 *raft.SparseStatus
 	lastIndex              kvpb.RaftIndex
 	raftReady              bool
@@ -9917,7 +9917,7 @@ func (q *testQuiescer) hasSendTokensRaftMuLockedReplicaMuLocked() bool {
 	return q.sendTokens
 }
 
-func (q *testQuiescer) ticksSinceLastProposalRLocked() int {
+func (q *testQuiescer) ticksSinceLastProposalRLocked() int64 {
 	return q.ticksSinceLastProposal
 }
 

--- a/pkg/kv/kvserver/scheduler.go
+++ b/pkg/kv/kvserver/scheduler.go
@@ -149,7 +149,7 @@ type raftScheduleState struct {
 	// TODO(pavelkalinnikov): add a node health metric for the ticks.
 	//
 	// INVARIANT: flags&stateRaftTick == 0 iff ticks == 0.
-	ticks int
+	ticks int64
 }
 
 var raftSchedulerBatchPool = sync.Pool{
@@ -230,7 +230,7 @@ type raftSchedulerShard struct {
 	queue      rangeIDQueue
 	state      map[roachpb.RangeID]raftScheduleState
 	numWorkers int
-	maxTicks   int
+	maxTicks   int64
 	stopped    bool
 }
 
@@ -241,7 +241,7 @@ func newRaftScheduler(
 	numWorkers int,
 	shardSize int,
 	priorityWorkers int,
-	maxTicks int,
+	maxTicks int64,
 ) *raftScheduler {
 	s := &raftScheduler{
 		ambientContext: ambient,
@@ -273,7 +273,7 @@ func newRaftScheduler(
 	return s
 }
 
-func newRaftSchedulerShard(numWorkers, maxTicks int) *raftSchedulerShard {
+func newRaftSchedulerShard(numWorkers int, maxTicks int64) *raftSchedulerShard {
 	shard := &raftSchedulerShard{
 		state:      map[roachpb.RangeID]raftScheduleState{},
 		numWorkers: numWorkers,
@@ -465,7 +465,7 @@ func (s *raftScheduler) NewEnqueueBatch() *raftSchedulerBatch {
 func (ss *raftSchedulerShard) enqueue1Locked(
 	addFlags raftScheduleFlags, id roachpb.RangeID, now int64,
 ) int {
-	ticks := int((addFlags & stateRaftTick) / stateRaftTick) // 0 or 1
+	ticks := int64((addFlags & stateRaftTick) / stateRaftTick) // 0 or 1
 
 	prevState := ss.state[id]
 	if prevState.flags&addFlags == addFlags && ticks == 0 {

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -279,7 +279,7 @@ type StoreTestingKnobs struct {
 	// RefreshReasonTicksPeriod overrides the default period over which
 	// pending commands are refreshed. The period is specified as a multiple
 	// of Raft group ticks.
-	RefreshReasonTicksPeriod int
+	RefreshReasonTicksPeriod int64
 	// DisableProcessRaft disables the process raft loop.
 	DisableProcessRaft func(roachpb.StoreID) bool
 	// DisableLastProcessedCheck disables checking on replica queue last processed times.

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -390,10 +390,11 @@ type raft struct {
 	// term changes.
 	uncommittedSize entryPayloadSize
 
-	// electionElapsed is the number of ticks since we last reached the
-	// electionTimeout. Tracked by both leaders and followers alike. Additionally,
-	// followers also reset this field whenever they receive a valid message from
-	// the current leader or if the leader is fortified when ticked.
+	// electionElapsed is tracked by both leaders and followers. For followers, it
+	// is the number of ticks since they last received a valid message from the
+	// from the current leader, unless the follower is fortifying a leader
+	// (leadEpoch != 0), in which case it is always set to 0. For leaders, it is
+	// the number of ticks since the last time it performed a checkQuorum.
 	//
 	// Invariant: electionElapsed = 0 when r.leadEpoch != 0 on a follower.
 	electionElapsed int64
@@ -1174,7 +1175,7 @@ func (r *raft) tickElection() {
 		// 2. But we do want to take advantage of randomized election timeouts built
 		//    into raft to prevent hung elections.
 		// We achieve both of these goals by "forwarding" electionElapsed to begin
-		// at r.electionTimeout. Also see pastElectionTimeout.
+		// at r.electionTimeout. Also see atRandomizedElectionTimeout.
 		r.logger.Debugf(
 			"%d setting election elapsed to start from %d ticks after store liveness support expired",
 			r.id, r.electionTimeout,
@@ -1184,8 +1185,7 @@ func (r *raft) tickElection() {
 		r.electionElapsed++
 	}
 
-	if r.pastElectionTimeout() {
-		r.electionElapsed = 0
+	if r.atRandomizedElectionTimeout() {
 		if err := r.Step(pb.Message{From: r.id, Type: pb.MsgHup}); err != nil {
 			r.logger.Debugf("error occurred during election: %v", err)
 		}
@@ -2647,11 +2647,11 @@ func (r *raft) loadState(state pb.HardState) {
 	r.setLeadEpoch(state.LeadEpoch)
 }
 
-// pastElectionTimeout returns true if r.electionElapsed is greater
-// than or equal to the randomized election timeout in
-// [electiontimeout, 2 * electiontimeout - 1].
-func (r *raft) pastElectionTimeout() bool {
-	return r.electionElapsed >= r.randomizedElectionTimeout
+// atRandomizedElectionTimeout returns true if r.electionElapsed modulo the
+// r.randomizedElectionTimeout is equal to 0. This means that at every
+// r.randomizedElectionTimeout period, this method will return true once.
+func (r *raft) atRandomizedElectionTimeout() bool {
+	return r.electionElapsed != 0 && r.electionElapsed%r.randomizedElectionTimeout == 0
 }
 
 func (r *raft) resetRandomizedElectionTimeout() {

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1184,7 +1184,7 @@ func (r *raft) tickElection() {
 		r.electionElapsed++
 	}
 
-	if r.promotable() && r.pastElectionTimeout() {
+	if r.pastElectionTimeout() {
 		r.electionElapsed = 0
 		if err := r.Step(pb.Message{From: r.id, Type: pb.MsgHup}); err != nil {
 			r.logger.Debugf("error occurred during election: %v", err)
@@ -1344,7 +1344,7 @@ func (r *raft) hup(t CampaignType) {
 		return
 	}
 	if !r.promotable() {
-		r.logger.Warningf("%x is unpromotable and can not campaign", r.id)
+		r.logger.Infof("%x is unpromotable and can not campaign", r.id)
 		return
 	}
 	// NB: The leader is allowed to bump its term by calling an election. Note that

--- a/pkg/raft/raft_paper_test.go
+++ b/pkg/raft/raft_paper_test.go
@@ -110,7 +110,7 @@ func TestStartAsFollower(t *testing.T) {
 // every heartbeat interval, but it won't send a MsgHeartbeat.
 func TestLeaderBcastBeat(t *testing.T) {
 	// heartbeat interval
-	hi := 3
+	hi := int64(3)
 
 	testutils.RunTrueAndFalse(t, "store-liveness-enabled",
 		func(t *testing.T, storeLivenessEnabled bool) {
@@ -129,7 +129,7 @@ func TestLeaderBcastBeat(t *testing.T) {
 				mustAppendEntry(r, pb.Entry{Index: uint64(i) + 1})
 			}
 
-			for i := 0; i < hi; i++ {
+			for i := int64(0); i < hi; i++ {
 				require.Empty(t, r.readMessages())
 				r.tick()
 			}
@@ -171,7 +171,7 @@ func TestCandidateStartNewElection(t *testing.T) {
 // Reference: section 5.2
 func testNonleaderStartElection(t *testing.T, state pb.StateType) {
 	// election timeout
-	et := 10
+	et := int64(10)
 	r := newTestRaft(1, et, 1, newTestMemoryStorage(withPeers(1, 2, 3)))
 	switch state {
 	case pb.StateFollower:
@@ -180,7 +180,7 @@ func testNonleaderStartElection(t *testing.T, state pb.StateType) {
 		r.becomeCandidate()
 	}
 
-	for i := 1; i < 2*et; i++ {
+	for i := int64(1); i < 2*et; i++ {
 		r.tick()
 	}
 	r.advanceMessagesAfterAppend()
@@ -307,10 +307,10 @@ func TestCandidateElectionTimeoutRandomized(t *testing.T) {
 // follower or candidate is randomized.
 // Reference: section 5.2
 func testNonleaderElectionTimeoutRandomized(t *testing.T, state pb.StateType) {
-	et := 10
+	et := int64(10)
 	r := newTestRaft(1, et, 1, newTestMemoryStorage(withPeers(1, 2, 3)))
-	timeouts := make(map[int]bool)
-	for round := 0; round < 50*et; round++ {
+	timeouts := make(map[int64]bool)
+	for round := int64(0); round < 50*et; round++ {
 		switch state {
 		case pb.StateFollower:
 			r.becomeFollower(r.Term+1, 2)
@@ -318,7 +318,7 @@ func testNonleaderElectionTimeoutRandomized(t *testing.T, state pb.StateType) {
 			r.becomeCandidate()
 		}
 
-		time := 0
+		time := int64(0)
 		for len(r.readMessages()) == 0 {
 			r.tick()
 			time++
@@ -347,7 +347,7 @@ func TestCandidatesElectionTimeoutNonconflict(t *testing.T) {
 // likelihood of split vote in the new election.
 // Reference: section 5.2
 func testNonleadersElectionTimeoutNonconflict(t *testing.T, state pb.StateType) {
-	et := 10
+	et := int64(10)
 	size := 5
 	rs := make([]*raft, size)
 	ids := idsBySize(size)
@@ -712,7 +712,7 @@ func TestVoteRequest(t *testing.T) {
 		})
 		r.readMessages()
 
-		for i := 1; i < r.electionTimeout*2; i++ {
+		for i := int64(1); i < r.electionTimeout*2; i++ {
 			r.tickElection()
 		}
 

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -346,7 +346,7 @@ func TestLearnerElectionTimeout(t *testing.T) {
 
 	// n2 is learner. Learner should not start election even when times out.
 	setRandomizedElectionTimeout(n2, n2.electionTimeout)
-	for i := 0; i < n2.electionTimeout; i++ {
+	for i := int64(0); i < n2.electionTimeout; i++ {
 		n2.tick()
 	}
 
@@ -370,7 +370,7 @@ func TestLearnerPromotion(t *testing.T) {
 
 	// n1 should become leader
 	setRandomizedElectionTimeout(n1, n1.electionTimeout)
-	for i := 0; i < n1.electionTimeout; i++ {
+	for i := int64(0); i < n1.electionTimeout; i++ {
 		n1.tick()
 	}
 	n1.advanceMessagesAfterAppend()
@@ -386,7 +386,7 @@ func TestLearnerPromotion(t *testing.T) {
 
 	// n2 start election, should become leader
 	setRandomizedElectionTimeout(n2, n2.electionTimeout)
-	for i := 0; i < n2.electionTimeout; i++ {
+	for i := int64(0); i < n2.electionTimeout; i++ {
 		n2.tick()
 	}
 	n2.advanceMessagesAfterAppend()
@@ -636,7 +636,7 @@ func TestLearnerLogReplication(t *testing.T) {
 	n2.becomeFollower(1, None)
 
 	setRandomizedElectionTimeout(n1, n1.electionTimeout)
-	for i := 0; i < n1.electionTimeout; i++ {
+	for i := int64(0); i < n1.electionTimeout; i++ {
 		n1.tick()
 	}
 	n1.advanceMessagesAfterAppend()
@@ -1083,7 +1083,7 @@ func TestCommit(t *testing.T) {
 
 func TestPastElectionTimeout(t *testing.T) {
 	tests := []struct {
-		elapse       int
+		elapse       int64
 		wprobability float64
 		round        bool
 	}{
@@ -1569,7 +1569,7 @@ func testCandidateResetTerm(t *testing.T, mt pb.MessageType) {
 
 	// trigger campaign in isolated c
 	c.resetRandomizedElectionTimeout()
-	for i := 0; i < c.randomizedElectionTimeout; i++ {
+	for i := int64(0); i < c.randomizedElectionTimeout; i++ {
 		c.tick()
 	}
 	c.advanceMessagesAfterAppend()
@@ -1688,7 +1688,7 @@ func TestLeaderStepdownWhenQuorumActive(t *testing.T) {
 	sm.becomeCandidate()
 	sm.becomeLeader()
 
-	for i := 0; i < sm.electionTimeout+1; i++ {
+	for i := int64(0); i < sm.electionTimeout+1; i++ {
 		sm.Step(pb.Message{From: 2, Type: pb.MsgHeartbeatResp, Term: sm.Term})
 		sm.tick()
 	}
@@ -1705,7 +1705,7 @@ func TestLeaderStepdownWhenQuorumLost(t *testing.T) {
 	sm.becomeCandidate()
 	sm.becomeLeader()
 
-	for i := 0; i < sm.electionTimeout+1; i++ {
+	for i := int64(0); i < sm.electionTimeout+1; i++ {
 		sm.tick()
 	}
 
@@ -1727,7 +1727,7 @@ func TestLeaderSupersedingWithCheckQuorum(t *testing.T) {
 	nt := newNetwork(a, b, c)
 	setRandomizedElectionTimeout(b, b.electionTimeout+1)
 
-	for i := 0; i < b.electionTimeout; i++ {
+	for i := int64(0); i < b.electionTimeout; i++ {
 		b.tick()
 	}
 	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgHup})
@@ -1741,7 +1741,7 @@ func TestLeaderSupersedingWithCheckQuorum(t *testing.T) {
 	assert.Equal(t, pb.StateCandidate, c.state)
 
 	// Letting b's electionElapsed reach to electionTimeout
-	for i := 0; i < b.electionTimeout; i++ {
+	for i := int64(0); i < b.electionTimeout; i++ {
 		b.tick()
 	}
 	nt.send(pb.Message{From: 3, To: 3, Type: pb.MsgHup})
@@ -1776,10 +1776,10 @@ func TestLeaderElectionWithCheckQuorum(t *testing.T) {
 	// because the value might be reset to electionTimeout since the last state changes
 	setRandomizedElectionTimeout(a, a.electionTimeout+1)
 	setRandomizedElectionTimeout(b, b.electionTimeout+2)
-	for i := 0; i < a.electionTimeout; i++ {
+	for i := int64(0); i < a.electionTimeout; i++ {
 		a.tick()
 	}
-	for i := 0; i < b.electionTimeout; i++ {
+	for i := int64(0); i < b.electionTimeout; i++ {
 		b.tick()
 	}
 	nt.send(pb.Message{From: 3, To: 3, Type: pb.MsgHup})
@@ -1806,7 +1806,7 @@ func TestFreeStuckCandidateWithCheckQuorum(t *testing.T) {
 	nt := newNetwork(a, b, c)
 	setRandomizedElectionTimeout(b, b.electionTimeout+1)
 
-	for i := 0; i < b.electionTimeout; i++ {
+	for i := int64(0); i < b.electionTimeout; i++ {
 		b.tick()
 	}
 	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgHup})
@@ -1852,7 +1852,7 @@ func TestNonPromotableVoterWithCheckQuorum(t *testing.T) {
 
 	require.False(t, b.promotable())
 
-	for i := 0; i < b.electionTimeout; i++ {
+	for i := int64(0); i < b.electionTimeout; i++ {
 		b.tick()
 	}
 	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgHup})
@@ -1897,7 +1897,7 @@ func TestDisruptiveFollower(t *testing.T) {
 	// election timeouts (e.g. multi-datacenter deploy)
 	// Or leader messages are being delayed while ticks elapse
 	setRandomizedElectionTimeout(n3, n3.electionTimeout+2)
-	for i := 0; i < n3.randomizedElectionTimeout-1; i++ {
+	for i := int64(0); i < n3.randomizedElectionTimeout-1; i++ {
 		n3.tick()
 	}
 
@@ -2245,7 +2245,7 @@ func TestSendAppendForProgressProbeStoreLivenessDisabled(t *testing.T) {
 		}
 
 		// do a heartbeat
-		for j := 0; j < r.heartbeatTimeout; j++ {
+		for j := int64(0); j < r.heartbeatTimeout; j++ {
 			r.tick()
 		}
 		assert.True(t, r.trk.Progress(2).MsgAppProbesPaused)
@@ -2303,7 +2303,7 @@ func TestSendAppendForProgressProbeStoreLivenessEnabled(t *testing.T) {
 		}
 
 		// The next heartbeat timeout will allow another message to be sent.
-		for j := 0; j < r.heartbeatTimeout; j++ {
+		for j := int64(0); j < r.heartbeatTimeout; j++ {
 			r.tick()
 		}
 		assert.True(t, r.trk.Progress(2).MsgAppProbesPaused)
@@ -2386,7 +2386,7 @@ func TestRestore(t *testing.T) {
 	assert.Equal(t, s.snap.Metadata.ConfState.Voters, sm.trk.VoterNodes())
 
 	require.False(t, sm.restore(s))
-	for i := 0; i < sm.randomizedElectionTimeout; i++ {
+	for i := int64(0); i < sm.randomizedElectionTimeout; i++ {
 		sm.tick()
 	}
 	assert.Equal(t, pb.StateFollower, sm.state)
@@ -2448,7 +2448,7 @@ func TestRestoreWithVotersOutgoing(t *testing.T) {
 	require.False(t, sm.restore(s))
 
 	// It should not campaign before actually applying data.
-	for i := 0; i < sm.randomizedElectionTimeout; i++ {
+	for i := int64(0); i < sm.randomizedElectionTimeout; i++ {
 		sm.tick()
 	}
 	assert.Equal(t, pb.StateFollower, sm.state)
@@ -2524,7 +2524,7 @@ func TestLearnerReceiveSnapshot(t *testing.T) {
 	nt := newNetwork(n1, n2)
 
 	setRandomizedElectionTimeout(n1, n1.electionTimeout)
-	for i := 0; i < n1.electionTimeout; i++ {
+	for i := int64(0); i < n1.electionTimeout; i++ {
 		n1.tick()
 	}
 
@@ -2764,7 +2764,7 @@ func TestAddNodeCheckQuorum(t *testing.T) {
 	r.becomeCandidate()
 	r.becomeLeader()
 
-	for i := 0; i < r.electionTimeout-1; i++ {
+	for i := int64(0); i < r.electionTimeout-1; i++ {
 		r.tick()
 	}
 
@@ -2778,7 +2778,7 @@ func TestAddNodeCheckQuorum(t *testing.T) {
 
 	// After another electionTimeout ticks without hearing from node 2,
 	// node 1 should step down.
-	for i := 0; i < r.electionTimeout; i++ {
+	for i := int64(0); i < r.electionTimeout; i++ {
 		r.tick()
 	}
 
@@ -3049,7 +3049,7 @@ func TestLeaderTransferLeaderStepsDownImmediately(t *testing.T) {
 
 	// Eventually, the previous leader gives up on waiting and calls an election
 	// to reestablish leadership at the next term.
-	for i := 0; i < lead.randomizedElectionTimeout; i++ {
+	for i := int64(0); i < lead.randomizedElectionTimeout; i++ {
 		lead.tick()
 	}
 	nt.send(lead.readMessages()...)
@@ -3062,7 +3062,7 @@ func TestLeaderTransferLeaderStepsDownImmediately(t *testing.T) {
 // even the current leader is still under its leader lease.
 func TestLeaderTransferWithCheckQuorum(t *testing.T) {
 	nt := newNetwork(nil, nil, nil)
-	for i := 1; i < 4; i++ {
+	for i := int64(1); i < 4; i++ {
 		r := nt.peers[pb.PeerID(i)].(*raft)
 		r.checkQuorum = true
 		setRandomizedElectionTimeout(r, r.electionTimeout+i)
@@ -3070,7 +3070,7 @@ func TestLeaderTransferWithCheckQuorum(t *testing.T) {
 
 	// Letting peer 2 electionElapsed reach to timeout so that it can vote for peer 1
 	f := nt.peers[2].(*raft)
-	for i := 0; i < f.electionTimeout; i++ {
+	for i := int64(0); i < f.electionTimeout; i++ {
 		f.tick()
 	}
 
@@ -3126,7 +3126,7 @@ func TestLeaderTransferToCandidate(t *testing.T) {
 
 	// Isolate node 3 so that it decides to become a pre-candidate.
 	nt.isolate(3)
-	for i := 0; i < n3.randomizedElectionTimeout; i++ {
+	for i := int64(0); i < n3.randomizedElectionTimeout; i++ {
 		nt.tick(n3)
 	}
 	require.Equal(t, pb.StatePreCandidate, n3.state)
@@ -3218,12 +3218,12 @@ func TestLeaderTransferTimeout(t *testing.T) {
 	nt.send(pb.Message{From: 3, To: 1, Type: pb.MsgTransferLeader})
 	require.Equal(t, pb.PeerID(3), lead.leadTransferee)
 
-	for i := 0; i < lead.heartbeatTimeout; i++ {
+	for i := int64(0); i < lead.heartbeatTimeout; i++ {
 		lead.tick()
 	}
 	require.Equal(t, pb.PeerID(3), lead.leadTransferee)
 
-	for i := 0; i < lead.electionTimeout-lead.heartbeatTimeout; i++ {
+	for i := int64(0); i < lead.electionTimeout-lead.heartbeatTimeout; i++ {
 		lead.tick()
 	}
 
@@ -3398,13 +3398,13 @@ func TestLeaderTransferSecondTransferToSameNode(t *testing.T) {
 	nt.send(pb.Message{From: 3, To: 1, Type: pb.MsgTransferLeader})
 	require.Equal(t, pb.PeerID(3), lead.leadTransferee)
 
-	for i := 0; i < lead.heartbeatTimeout; i++ {
+	for i := int64(0); i < lead.heartbeatTimeout; i++ {
 		lead.tick()
 	}
 	// Second transfer leadership request to the same node.
 	nt.send(pb.Message{From: 3, To: 1, Type: pb.MsgTransferLeader})
 
-	for i := 0; i < lead.electionTimeout-lead.heartbeatTimeout; i++ {
+	for i := int64(0); i < lead.electionTimeout-lead.heartbeatTimeout; i++ {
 		lead.tick()
 	}
 
@@ -3501,7 +3501,7 @@ func TestLeaderTransferStaleFollower(t *testing.T) {
 	// Eventually, the previous leader gives up on waiting and calls an election
 	// to reestablish leadership at the next term. Node 3 does not hear about this
 	// either.
-	for i := 0; i < n1.randomizedElectionTimeout; i++ {
+	for i := int64(0); i < n1.randomizedElectionTimeout; i++ {
 		n1.tick()
 	}
 	nt.send(nt.filter(n1.readMessages())...)
@@ -3870,7 +3870,7 @@ func testConfChangeCheckBeforeCampaign(t *testing.T, v2 bool) {
 	})
 
 	// Trigger campaign in node 2
-	for i := 0; i < n2.randomizedElectionTimeout; i++ {
+	for i := int64(0); i < n2.randomizedElectionTimeout; i++ {
 		n2.tick()
 	}
 	// It's still follower because committed conf change is not applied.
@@ -3890,7 +3890,7 @@ func testConfChangeCheckBeforeCampaign(t *testing.T, v2 bool) {
 
 	// Advance apply on node 1 and re-establish leadership.
 	nextEnts(n1, nt.storage[1])
-	for i := 0; i < n1.randomizedElectionTimeout; i++ {
+	for i := int64(0); i < n1.randomizedElectionTimeout; i++ {
 		n1.tick()
 	}
 	nt.send(n1.readMessages()...)
@@ -4363,13 +4363,13 @@ func idsBySize(size int) []pb.PeerID {
 // setRandomizedElectionTimeout set up the value by caller instead of choosing
 // by system, in some test scenario we need to fill in some expected value to
 // ensure the certainty
-func setRandomizedElectionTimeout(r *raft, v int) {
+func setRandomizedElectionTimeout(r *raft, v int64) {
 	r.randomizedElectionTimeout = v
 }
 
 // SetRandomizedElectionTimeout is like setRandomizedElectionTimeout, but
 // exported for use by tests that are not in the raft package, using RawNode.
-func SetRandomizedElectionTimeout(r *RawNode, v int) {
+func SetRandomizedElectionTimeout(r *RawNode, v int64) {
 	setRandomizedElectionTimeout(r.raft, v)
 }
 
@@ -4395,7 +4395,7 @@ func withStoreLiveness(storeLiveness raftstoreliveness.StoreLiveness) testConfig
 }
 
 func newTestConfig(
-	id pb.PeerID, election, heartbeat int, storage Storage, opts ...testConfigModifierOpt,
+	id pb.PeerID, election, heartbeat int64, storage Storage, opts ...testConfigModifierOpt,
 ) *Config {
 	modifiers := testConfigModifiers{}
 	for _, opt := range opts {
@@ -4442,13 +4442,13 @@ func newTestMemoryStorage(opts ...testMemoryStorageOptions) *MemoryStorage {
 }
 
 func newTestRaft(
-	id pb.PeerID, election, heartbeat int, storage Storage, opts ...testConfigModifierOpt,
+	id pb.PeerID, election, heartbeat int64, storage Storage, opts ...testConfigModifierOpt,
 ) *raft {
 	return newRaft(newTestConfig(id, election, heartbeat, storage, opts...))
 }
 
 func newTestLearnerRaft(
-	id pb.PeerID, election, heartbeat int, storage Storage, opts ...testConfigModifierOpt,
+	id pb.PeerID, election, heartbeat int64, storage Storage, opts ...testConfigModifierOpt,
 ) *raft {
 	cfg := newTestConfig(id, election, heartbeat, storage, opts...)
 	return newRaft(cfg)
@@ -4456,7 +4456,7 @@ func newTestLearnerRaft(
 
 // newTestRawNode sets up a RawNode with the given peers. The configuration will
 // not be reflected in the Storage.
-func newTestRawNode(id pb.PeerID, election, heartbeat int, storage Storage) *RawNode {
+func newTestRawNode(id pb.PeerID, election, heartbeat int64, storage Storage) *RawNode {
 	cfg := newTestConfig(id, election, heartbeat, storage)
 	rn, err := NewRawNode(cfg)
 	if err != nil {

--- a/pkg/raft/rafttest/interaction_env.go
+++ b/pkg/raft/rafttest/interaction_env.go
@@ -33,7 +33,7 @@ type InteractionOpts struct {
 
 	// SetRandomizedElectionTimeout is used to plumb this function down from the
 	// raft test package.
-	SetRandomizedElectionTimeout func(node *raft.RawNode, timeout int)
+	SetRandomizedElectionTimeout func(node *raft.RawNode, timeout int64)
 }
 
 // Node is a member of a raft group tested via an InteractionEnv.

--- a/pkg/raft/rafttest/interaction_env_handler_set_randomized_election_timeout.go
+++ b/pkg/raft/rafttest/interaction_env_handler_set_randomized_election_timeout.go
@@ -1,3 +1,6 @@
+// This code has been modified from its original form by The Cockroach Authors.
+// All modifications are Copyright 2024 The Cockroach Authors.
+//
 // Copyright 2023 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +28,7 @@ func (env *InteractionEnv) handleSetRandomizedElectionTimeout(
 	t *testing.T, d datadriven.TestData,
 ) error {
 	idx := firstAsNodeIdx(t, d)
-	var timeout int
+	var timeout int64
 	d.ScanArgs(t, "timeout", &timeout)
 	require.NotZero(t, timeout)
 

--- a/pkg/raft/rafttest/interaction_env_handler_tick.go
+++ b/pkg/raft/rafttest/interaction_env_handler_tick.go
@@ -1,3 +1,6 @@
+// This code has been modified from its original form by The Cockroach Authors.
+// All modifications are Copyright 2024 The Cockroach Authors.
+//
 // Copyright 2019 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,8 +34,8 @@ func (env *InteractionEnv) handleTickHeartbeat(t *testing.T, d datadriven.TestDa
 }
 
 // Tick the node at the given index the given number of times.
-func (env *InteractionEnv) Tick(idx int, num int) error {
-	for i := 0; i < num; i++ {
+func (env *InteractionEnv) Tick(idx int, num int64) error {
+	for i := int64(0); i < num; i++ {
 		env.Nodes[idx].Tick()
 	}
 	return nil

--- a/pkg/raft/rawnode_test.go
+++ b/pkg/raft/rawnode_test.go
@@ -585,7 +585,7 @@ func TestRawNodeRestart(t *testing.T) {
 	assert.Equal(t, pb.Epoch(1), rawNode.raft.leadEpoch)
 
 	// Ensure we campaign after the election timeout has elapsed.
-	for i := 0; i < rawNode.raft.randomizedElectionTimeout; i++ {
+	for i := int64(0); i < rawNode.raft.randomizedElectionTimeout; i++ {
 		// TODO(arul): consider getting rid of this hack to reset the epoch so that
 		// we can call an election without panicking.
 		rawNode.raft.leadEpoch = 0

--- a/pkg/raft/testdata/confchange_v1_remove_leader.txt
+++ b/pkg/raft/testdata/confchange_v1_remove_leader.txt
@@ -212,4 +212,4 @@ raft proposal dropped
 # Nor can it campaign to become leader.
 campaign 1
 ----
-WARN 1 is unpromotable and can not campaign
+INFO 1 is unpromotable and can not campaign

--- a/pkg/raft/testdata/confchange_v2_replace_leader.txt
+++ b/pkg/raft/testdata/confchange_v2_replace_leader.txt
@@ -170,7 +170,7 @@ raft-state
 # Make sure n1 cannot campaign to become leader.
 campaign 1
 ----
-WARN 1 is unpromotable and can not campaign
+INFO 1 is unpromotable and can not campaign
 
 support-expired 1
 ----


### PR DESCRIPTION
This commit changes the current behaviour where we reset electionElapsed when campaigning (to allow us to campaign again on the next randomizedElectionTimeout). This problem with the current behaviour is that if a follower can't campaign (due to store liveness limitations), resetting the electionElapsed will re-arm the inHeartbeatLease, making the follower reject MsgVotes.

This commit changes that by campaigning at every randomizedElectionTimeout interval.

Epic: None

Release note: None