### PR TITLE
roachprod: option to create multiple PDs in create

### DIFF
--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -125,6 +125,7 @@ type ClusterSpec struct {
 		MachineType    string
 		MinCPUPlatform string
 		VolumeType     string
+		VolumeCount    int // volume count is only supported for GCE. This can be moved up if we start supporting other clouds
 		Zones          string
 	} `cloud:"gce"`
 
@@ -237,6 +238,7 @@ func getGCEOpts(
 	minCPUPlatform string,
 	arch vm.CPUArch,
 	volumeType string,
+	volumeCount int,
 	useSpot bool,
 ) vm.ProviderOpts {
 	opts := gce.DefaultProviderOpts()
@@ -249,6 +251,9 @@ func getGCEOpts(
 	}
 	if volumeSize != 0 {
 		opts.PDVolumeSize = volumeSize
+	}
+	if volumeCount != 0 {
+		opts.PDVolumeCount = volumeCount
 	}
 	opts.SSDCount = localSSDCount
 	if localSSD && localSSDCount > 0 {
@@ -461,11 +466,11 @@ func (s *ClusterSpec) RoachprodOpts(
 	case GCE:
 		providerOpts = getGCEOpts(machineType, s.VolumeSize, ssdCount,
 			createVMOpts.SSDOpts.UseLocalSSD, s.RAID0, s.TerminateOnMigration,
-			s.GCE.MinCPUPlatform, vm.ParseArch(createVMOpts.Arch), s.GCE.VolumeType, s.UseSpotVMs,
+			s.GCE.MinCPUPlatform, vm.ParseArch(createVMOpts.Arch), s.GCE.VolumeType, s.GCE.VolumeCount, s.UseSpotVMs,
 		)
 		workloadProviderOpts = getGCEOpts(workloadMachineType, s.VolumeSize, ssdCount,
 			createVMOpts.SSDOpts.UseLocalSSD, s.RAID0, s.TerminateOnMigration,
-			s.GCE.MinCPUPlatform, vm.ParseArch(createVMOpts.Arch), s.GCE.VolumeType, s.UseSpotVMs,
+			s.GCE.MinCPUPlatform, vm.ParseArch(createVMOpts.Arch), s.GCE.VolumeType, s.GCE.VolumeCount, s.UseSpotVMs,
 		)
 	case Azure:
 		providerOpts = getAzureOpts(machineType, s.VolumeSize)


### PR DESCRIPTION
`roachprod create` does not have an option to create a cluster with multiple stores per node using persistent disks.
There can be only 1 PD per node.
This change adds a new flag as `--gce-pd-volume-count` which enables us to create a cluster with multiple stores per node using PDs. The option is considered when `--local-ssd` is `false`. The default value of the `gce-pd-volume-count` is  set to 1 to ensure backward compatibility.

To create a cluster with multiple PDs:
`roachprod create -n 2 --gce-machine-type=n2-standard-2 --gce-use-spot=true --local-ssd=false --gce-enable-multiple-stores --gce-pd-volume-count=2`

To use the multiple stores at start does not change:
`roachprod start --store-count=2`

Fixes: #133424
Epic: None
Release note: None