### PR TITLE
roachtest: nodekill operation drain fix.

### DIFF
--- a/pkg/cmd/roachtest/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/operations/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//pkg/testutils/fingerprintutils",
         "//pkg/util/hlc",
         "//pkg/util/randutil",
+        "//pkg/util/retry",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
     ],


### PR DESCRIPTION
roachtest operation `node-kill/sigkill/drain=true` run cockroach drain and if drain is successfull then kills cockroach process.Sometimes the cockroach drain commands fails causing the node to reject SQL client connections while remaining healthy for other subsystems. To make the node accept SQL connections again, a manual restart is required.

This PR fixes the issue by not failing the roachtest operation in case of drain failure.

Epic: none

Release note: None