### PR TITLE
sql/schema_changer_test: Improve reliability of TestRaceWithBackfill

### DIFF
--- a/pkg/sql/sqltestutils/sql_test_utils.go
+++ b/pkg/sql/sqltestutils/sql_test_utils.go
@@ -33,8 +33,17 @@ import (
 // AddImmediateGCZoneConfig set the GC TTL to 0 for the given table ID. One must
 // make sure to disable strict GC TTL enforcement when using this.
 func AddImmediateGCZoneConfig(sqlDB *gosql.DB, id descpb.ID) (zonepb.ZoneConfig, error) {
+	return UpdateGCZoneConfig(sqlDB, id, 0)
+}
+
+// UpdateGCZoneConfig sets the GC TTL to a custom value for the given table ID.
+// If setting the value to 0, one must make sure to disable strict GC TTL
+// enforcement when using this.
+func UpdateGCZoneConfig(
+	sqlDB *gosql.DB, id descpb.ID, ttlSeconds int32,
+) (zonepb.ZoneConfig, error) {
 	cfg := zonepb.DefaultZoneConfig()
-	cfg.GC.TTLSeconds = 0
+	cfg.GC.TTLSeconds = ttlSeconds
 	buf, err := protoutil.Marshal(&cfg)
 	if err != nil {
 		return cfg, err


### PR DESCRIPTION
The TestRaceWithBackfill test sets the GC TTL threshold to 0, which causes everything to be garbage collected immediately. Occasionally, this leads to test failures with errors like:

```
pq: batch timestamp 1729337275.789296372,0 must be after replica GC threshold 1729337288.197835522,0 (r73: /Table/106/{1/160-4/40})
```
Previously, we added retries using SucceedsSoon, but this approach felt like a game of whack-a-mole, as new failure points kept emerging. Instead, I’ve set the GC TTL threshold to 1, so it's no longer immediate. The goal is to reduce the likelihood of the replica GC threshold advancing past the batch timestamp.

Fixes #132986
Epic: None
Release note: None