### PR TITLE
raftlog: don't use protoutil.Unmarshal for RaftAdmissionMeta

### DIFF
--- a/pkg/kv/kvserver/raftlog/encoding.go
+++ b/pkg/kv/kvserver/raftlog/encoding.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -245,7 +244,9 @@ func DecodeRaftAdmissionMeta(data []byte) (kvflowcontrolpb.RaftAdmissionMeta, er
 	// present at the start of the marshaled raft command. This could speed it
 	// up slightly.
 	var raftAdmissionMeta kvflowcontrolpb.RaftAdmissionMeta
-	if err := protoutil.Unmarshal(data[RaftCommandPrefixLen:], &raftAdmissionMeta); err != nil {
+	// NB: we don't use protoutil.Unmarshal to avoid passing raftAdmissionMeta
+	// through an interface, which would cause a heap allocation.
+	if err := raftAdmissionMeta.Unmarshal(data[RaftCommandPrefixLen:]); err != nil {
 		return kvflowcontrolpb.RaftAdmissionMeta{}, err
 	}
 	if buildutil.CrdbTestBuild {

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1458,6 +1458,7 @@ func TestLint(t *testing.T) {
 			":!util/protoutil/marshaler.go",
 			":!util/encoding/encoding.go",
 			":!util/hlc/timestamp.go",
+			":!kv/kvserver/raftlog/encoding.go",
 			":!rpc/codec.go",
 			":!rpc/codec_test.go",
 			":!storage/mvcc_value.go",


### PR DESCRIPTION
This saves an unnecessary allocation. These allocations are a significant fraction of the RACv2 allocations when the system is not overloaded.

Epic: CRDB-37515

Release note: None