### PR TITLE
sql/parser: update CREATE VIRTUAL CLUSTER to support a direct tenant ID

### DIFF
--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
@@ -596,14 +596,19 @@ func TestRefreshThrottling(t *testing.T) {
 func createTenant(tc serverutils.TestClusterInterface, id roachpb.TenantID) error {
 	srv := tc.Server(0)
 	conn := srv.InternalExecutor().(*sql.InternalExecutor)
-	if _, err := conn.Exec(
-		context.Background(),
-		"testserver-create-tenant",
-		nil, /* txn */
-		"SELECT crdb_internal.create_tenant($1)",
-		id.ToUint64(),
-	); err != nil {
-		return err
+	for _, stmt := range []string{
+		`CREATE VIRTUAL CLUSTER [$1]`,
+		`ALTER VIRTUAL CLUSTER [$1] START SERVICE EXTERNAL`,
+	} {
+		if _, err := conn.Exec(
+			context.Background(),
+			"testserver-create-tenant",
+			nil, /* txn */
+			stmt,
+			id.ToUint64(),
+		); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/crosscluster/physical/BUILD.bazel
+++ b/pkg/crosscluster/physical/BUILD.bazel
@@ -111,6 +111,7 @@ go_test(
         "stream_ingestion_frontier_processor_test.go",
         "stream_ingestion_job_test.go",
         "stream_ingestion_manager_test.go",
+        "stream_ingestion_planning_test.go",
         "stream_ingestion_processor_test.go",
     ],
     data = glob(["testdata/**"]),

--- a/pkg/crosscluster/physical/stream_ingestion_planning_test.go
+++ b/pkg/crosscluster/physical/stream_ingestion_planning_test.go
@@ -1,0 +1,71 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package physical
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateTenantFromReplicationUsingID(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	serverA, aDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
+	})
+	defer serverA.Stopper().Stop(ctx)
+	serverB, bDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
+	})
+	defer serverB.Stopper().Stop(ctx)
+
+	sqlA := sqlutils.MakeSQLRunner(aDB)
+	sqlB := sqlutils.MakeSQLRunner(bDB)
+
+	serverAURL, cleanupURLA := sqlutils.PGUrl(t, serverA.SQLAddr(), t.Name(), url.User(username.RootUser))
+	defer cleanupURLA()
+
+	verifyCreatedTenant := func(t *testing.T, db *sqlutils.SQLRunner, id int64, fn func()) {
+		const query = "SELECT count(*), count(CASE WHEN id = $1 THEN 1 END) FROM system.tenants"
+		var rowCountPrev, hasTenant int64
+		db.QueryRow(t, query, id).Scan(&rowCountPrev, &hasTenant)
+		require.Zero(t, hasTenant)
+		fn()
+		var rowCountNext int64
+		db.QueryRow(t, query, id).Scan(&rowCountNext, &hasTenant)
+		require.Equal(t, rowCountPrev+1, rowCountNext)
+		require.Equal(t, int64(1), hasTenant)
+	}
+
+	verifyCreatedTenant(t, sqlA, 50, func() {
+		t.Logf("creating tenant [50]")
+		sqlA.Exec(t, "CREATE VIRTUAL CLUSTER [50]")
+		sqlA.Exec(t, "ALTER VIRTUAL CLUSTER [50] START SERVICE SHARED")
+	})
+
+	verifyCreatedTenant(t, sqlB, 51, func() {
+		t.Logf("starting replication [50]->[51]")
+		sqlB.Exec(t, "CREATE VIRTUAL CLUSTER [51] FROM REPLICATION OF 'cluster-50' ON $1", serverAURL.String())
+	})
+}

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4741,39 +4741,39 @@ logical_replication_options:
 // CREATE VIRTUAL CLUSTER [ IF NOT EXISTS ] name [ <replication> ]
 //
 // Replication option:
-//    FROM REPLICATION OF <virtual_cluster_spec> ON <location> [ WITH OPTIONS ... ]
+//    FROM REPLICATION OF name ON <location> [ WITH OPTIONS ... ]
 create_virtual_cluster_stmt:
-  CREATE virtual_cluster d_expr
+  CREATE virtual_cluster virtual_cluster_spec
   {
     /* SKIP DOC */
     $$.val = &tree.CreateTenant{
-      TenantSpec: &tree.TenantSpec{IsName: true, Expr: $3.expr()},
+      TenantSpec: $3.tenantSpec(),
     }
   }
-| CREATE virtual_cluster IF NOT EXISTS d_expr
+| CREATE virtual_cluster IF NOT EXISTS virtual_cluster_spec
   {
     /* SKIP DOC */
     $$.val = &tree.CreateTenant{
       IfNotExists: true,
-      TenantSpec: &tree.TenantSpec{IsName: true, Expr: $6.expr()},
+      TenantSpec: $6.tenantSpec(),
     }
   }
-| CREATE virtual_cluster d_expr FROM REPLICATION OF d_expr ON d_expr opt_with_replication_options
+| CREATE virtual_cluster virtual_cluster_spec FROM REPLICATION OF d_expr ON d_expr opt_with_replication_options
   {
     /* SKIP DOC */
     $$.val = &tree.CreateTenantFromReplication{
-      TenantSpec: &tree.TenantSpec{IsName: true, Expr: $3.expr()},
+      TenantSpec: $3.tenantSpec(),
       ReplicationSourceTenantName: &tree.TenantSpec{IsName: true, Expr: $7.expr()},
       ReplicationSourceAddress: $9.expr(),
       Options: *$10.tenantReplicationOptions(),
     }
   }
-| CREATE virtual_cluster IF NOT EXISTS d_expr FROM REPLICATION OF d_expr ON d_expr opt_with_replication_options
+| CREATE virtual_cluster IF NOT EXISTS virtual_cluster_spec FROM REPLICATION OF d_expr ON d_expr opt_with_replication_options
   {
     /* SKIP DOC */
     $$.val = &tree.CreateTenantFromReplication{
       IfNotExists: true,
-      TenantSpec: &tree.TenantSpec{IsName: true, Expr: $6.expr()},
+      TenantSpec: $6.tenantSpec(),
       ReplicationSourceTenantName: &tree.TenantSpec{IsName: true, Expr: $10.expr()},
       ReplicationSourceAddress: $12.expr(),
       Options: *$13.tenantReplicationOptions(),

--- a/pkg/sql/parser/testdata/create_virtual_cluster
+++ b/pkg/sql/parser/testdata/create_virtual_cluster
@@ -7,6 +7,14 @@ CREATE VIRTUAL CLUSTER bar -- literals removed
 CREATE VIRTUAL CLUSTER _ -- identifiers removed
 
 parse
+CREATE VIRTUAL CLUSTER [123::INT]
+----
+CREATE VIRTUAL CLUSTER [123::INT8] -- normalized!
+CREATE VIRTUAL CLUSTER [((123)::INT8)] -- fully parenthesized
+CREATE VIRTUAL CLUSTER [_::INT8] -- literals removed
+CREATE VIRTUAL CLUSTER [123::INT8] -- identifiers removed
+
+parse
 CREATE TENANT bar
 ----
 CREATE VIRTUAL CLUSTER bar -- normalized!
@@ -31,12 +39,28 @@ CREATE VIRTUAL CLUSTER IF NOT EXISTS bar -- literals removed
 CREATE VIRTUAL CLUSTER IF NOT EXISTS _ -- identifiers removed
 
 parse
+CREATE VIRTUAL CLUSTER IF NOT EXISTS [123::INT]
+----
+CREATE VIRTUAL CLUSTER IF NOT EXISTS [123::INT8] -- normalized!
+CREATE VIRTUAL CLUSTER IF NOT EXISTS [((123)::INT8)] -- fully parenthesized
+CREATE VIRTUAL CLUSTER IF NOT EXISTS [_::INT8] -- literals removed
+CREATE VIRTUAL CLUSTER IF NOT EXISTS [123::INT8] -- identifiers removed
+
+parse
 CREATE VIRTUAL CLUSTER destination FROM REPLICATION OF source ON 'pgurl'
 ----
 CREATE VIRTUAL CLUSTER destination FROM REPLICATION OF source ON 'pgurl'
 CREATE VIRTUAL CLUSTER (destination) FROM REPLICATION OF (source) ON ('pgurl') -- fully parenthesized
 CREATE VIRTUAL CLUSTER destination FROM REPLICATION OF source ON '_' -- literals removed
 CREATE VIRTUAL CLUSTER _ FROM REPLICATION OF _ ON 'pgurl' -- identifiers removed
+
+parse
+CREATE VIRTUAL CLUSTER [123::INT] FROM REPLICATION OF source ON 'pgurl'
+----
+CREATE VIRTUAL CLUSTER [123::INT8] FROM REPLICATION OF source ON 'pgurl' -- normalized!
+CREATE VIRTUAL CLUSTER [((123)::INT8)] FROM REPLICATION OF (source) ON ('pgurl') -- fully parenthesized
+CREATE VIRTUAL CLUSTER [_::INT8] FROM REPLICATION OF source ON '_' -- literals removed
+CREATE VIRTUAL CLUSTER [123::INT8] FROM REPLICATION OF _ ON 'pgurl' -- identifiers removed
 
 parse
 CREATE VIRTUAL CLUSTER IF NOT EXISTS destination FROM REPLICATION OF source ON 'pgurl'

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -1069,9 +1069,22 @@ func (n *AlterTenantReplication) walkStmt(v Visitor) Statement {
 	return ret
 }
 
+// copyNode makes a copy of this Statement without recursing in any child Statements.
+func (n *CreateTenant) copyNode() *CreateTenant {
+	stmtCopy := *n
+	return &stmtCopy
+}
+
 // walkStmt is part of the walkableStmt interface.
 func (n *CreateTenant) walkStmt(v Visitor) Statement {
 	ret := n
+	ts, changed := walkTenantSpec(v, n.TenantSpec)
+	if changed {
+		if ret == n {
+			ret = n.copyNode()
+		}
+		ret.TenantSpec = ts
+	}
 	return ret
 }
 
@@ -1084,6 +1097,13 @@ func (n *CreateTenantFromReplication) copyNode() *CreateTenantFromReplication {
 // walkStmt is part of the walkableStmt interface.
 func (n *CreateTenantFromReplication) walkStmt(v Visitor) Statement {
 	ret := n
+	ts, changed := walkTenantSpec(v, n.TenantSpec)
+	if changed {
+		if ret == n {
+			ret = n.copyNode()
+		}
+		ret.TenantSpec = ts
+	}
 	e, changed := WalkExpr(v, n.ReplicationSourceTenantName.Expr)
 	if changed {
 		if ret == n {


### PR DESCRIPTION
Previously, the CREATE VIRTUAL CLUSTER (or CREATE TENANT) syntax only accepted
a tenant name for creating a virtual cluster, with the system automatically
generating the tenant ID. However, this approach doesn't work with CockroachDB
Cloud's (CC) PCR setup, as we need to create a replication stream using an
existing tenant ID. An existing tenant ID has to be used because CC currently
manages and assigns tenant IDs to all Serverless clusters, and we have not
migrated to use tenant names yet.

To address this, this commit modifies the CREATE VIRTUAL CLUSTER
syntax to allow for a direct tenant ID input, enabling the creation of a
tenant with a specific ID. While we have crdb_internal.create_tenant(ID) for
this purpose, there's no equivalent built-in for creating a replication stream,
so we will have to resort to using the CREATE VIRTUAL CLUSTER ... FROM
REPLICATION syntax.

No release note as this is meant to be used internally only. This change can
be removed once we transition away from using tenant IDs in CockroachDB Cloud.

Epic: none

Release note: None