### PR TITLE
kvserver: extend election timeout ticks in TestControlFlowRaftMembers…

### DIFF
--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -3078,6 +3078,11 @@ func TestFlowControlRaftMembershipV2(t *testing.T) {
 				ReplicationMode: base.ReplicationManual,
 				ServerArgs: base.TestServerArgs{
 					Settings: settings,
+					RaftConfig: base.RaftConfig{
+						// Suppress timeout-based elections. This test doesn't want to deal
+						// with leadership changing hands unless intentional.
+						RaftElectionTimeoutTicks: 1000000,
+					},
 					Knobs: base.TestingKnobs{
 						Store: &kvserver.StoreTestingKnobs{
 							FlowControlTestingKnobs: &kvflowcontrol.TestingKnobs{


### PR DESCRIPTION
…hipV2

The test is susceptible to observing timing issues, such as stream disconnects under CPU exhaustion. This is problematic because the test asserts on the full history of metrics, in that some are counters.

Attempt to paper over these by extending `RaftElectionTimeoutTicks`.

Fixes: #133272
Release note: None