### PR TITLE
raft: implement SafeFormatter on Progress

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -852,7 +852,7 @@ func (m *WALFailoverMode) String() string {
 	return redact.StringWithoutMarkers(m)
 }
 
-// SafeFormat implements the refact.SafeFormatter interface.
+// SafeFormat implements the redact.SafeFormatter interface.
 func (m *WALFailoverMode) SafeFormat(p redact.SafePrinter, _ rune) {
 	switch *m {
 	case WALFailoverDefault:
@@ -905,7 +905,7 @@ func (c *WALFailoverConfig) String() string {
 	return redact.StringWithoutMarkers(c)
 }
 
-// SafeFormat implements the refact.SafeFormatter interface.
+// SafeFormat implements the redact.SafeFormatter interface.
 func (c *WALFailoverConfig) SafeFormat(p redact.SafePrinter, _ rune) {
 	switch c.Mode {
 	case WALFailoverDefault:

--- a/pkg/raft/tracker/BUILD.bazel
+++ b/pkg/raft/tracker/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/raft/raftstoreliveness",
         "//pkg/util/hlc",
         "//pkg/util/syncutil",
+        "@com_github_cockroachdb_redact//:redact",
         "@org_golang_x_exp//maps",
     ],
 )
@@ -39,6 +40,7 @@ go_test(
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/raft/tracker/progress_test.go
+++ b/pkg/raft/tracker/progress_test.go
@@ -20,10 +20,11 @@ package tracker
 import (
 	"testing"
 
+	"github.com/cockroachdb/redact"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestProgressString(t *testing.T) {
+func TestProgressStringAndSafeFormat(t *testing.T) {
 	ins := NewInflights(1, 0)
 	ins.Add(123, 1)
 	pr := &Progress{
@@ -40,7 +41,12 @@ func TestProgressString(t *testing.T) {
 	}
 	const exp = "StateSnapshot match=3 next=4 sentCommit=2 matchCommit=1 learner paused " +
 		"pendingSnap=123 inactive inflight=1[full]"
+	// String.
 	assert.Equal(t, exp, pr.String())
+	// Redactable string.
+	assert.EqualValues(t, exp, redact.Sprint(pr))
+	// Redacted string.
+	assert.EqualValues(t, exp, redact.Sprint(pr).Redact())
 }
 
 func TestProgressIsPaused(t *testing.T) {

--- a/pkg/raft/tracker/state.go
+++ b/pkg/raft/tracker/state.go
@@ -1,3 +1,6 @@
+// This code has been modified from its original form by The Cockroach Authors.
+// All modifications are Copyright 2024 The Cockroach Authors.
+//
 // Copyright 2019 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,3 +43,4 @@ var prstmap = [...]string{
 }
 
 func (st StateType) String() string { return prstmap[st] }
+func (st StateType) SafeValue()     {}

--- a/pkg/storage/enginepb/engine.go
+++ b/pkg/storage/enginepb/engine.go
@@ -17,7 +17,7 @@ func (e *EngineType) Type() string { return "string" }
 // String implements the pflag.Value interface.
 func (e *EngineType) String() string { return redact.StringWithoutMarkers(e) }
 
-// SafeFormat implements the refact.SafeFormatter interface.
+// SafeFormat implements the redact.SafeFormatter interface.
 func (e *EngineType) SafeFormat(p redact.SafePrinter, _ rune) {
 	switch *e {
 	case EngineTypeDefault:

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -145,6 +145,9 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 						"ConfChangeType":       {},
 						"ConfChangeTransition": {},
 					},
+					"github.com/cockroachdb/cockroach/pkg/raft/tracker": {
+						"StateType": {},
+					},
 					"github.com/cockroachdb/cockroach/pkg/repstream/streampb": {
 						"StreamID": {},
 					},


### PR DESCRIPTION
This commit implements the `redact.SafeFormatter` interface on `tracker.Progress` so that it will never be redacted when logged.

Epic: None
Release note: None