### PR TITLE
ui: cleanup useNodeStatuses usages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/tablesView.tsx
@@ -240,13 +240,13 @@ export const TablesPageV2 = () => {
   const tableData = useMemo(
     () =>
       tableMetadataToRows(tableList ?? [], {
-        nodeIDToRegion: nodesResp.nodeIDToRegion,
+        nodeStatusByID: nodesResp.nodeStatusByID,
         storeIDToNodeID: nodesResp.storeIDToNodeID,
         isLoading: nodesResp.isLoading,
       }),
     [
       tableList,
-      nodesResp.nodeIDToRegion,
+      nodesResp.nodeStatusByID,
       nodesResp.storeIDToNodeID,
       nodesResp.isLoading,
     ],

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/utils.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsV2/utils.tsx
@@ -3,6 +3,7 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
+import { NodeStatus } from "src/api";
 import { TableMetadata } from "src/api/databases/getTableMetadataApi";
 import { NodeID, StoreID } from "src/types/clusterTypes";
 import { mapStoreIDsToNodeRegions } from "src/util/nodeUtils";
@@ -12,7 +13,7 @@ import { TableRow } from "./types";
 export const tableMetadataToRows = (
   tables: TableMetadata[],
   nodesInfo: {
-    nodeIDToRegion: Record<NodeID, string>;
+    nodeStatusByID: Record<NodeID, NodeStatus>;
     storeIDToNodeID: Record<StoreID, NodeID>;
     isLoading: boolean;
   },
@@ -20,7 +21,7 @@ export const tableMetadataToRows = (
   return tables.map(table => {
     const nodesByRegion = mapStoreIDsToNodeRegions(
       table.storeIds,
-      nodesInfo?.nodeIDToRegion,
+      nodesInfo?.nodeStatusByID,
       nodesInfo?.storeIDToNodeID,
     );
     return {

--- a/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesV2/index.tsx
@@ -159,7 +159,7 @@ export const DatabasesPageV2 = () => {
   const tableData = useMemo(
     () =>
       rawDatabaseMetadataToDatabaseRows(data?.results ?? [], {
-        nodeIDToRegion: nodesResp.nodeIDToRegion,
+        nodeStatusByID: nodesResp.nodeStatusByID,
         storeIDToNodeID: nodesResp.storeIDToNodeID,
         isLoading: nodesResp.isLoading,
       }),

--- a/pkg/ui/workspaces/cluster-ui/src/databasesV2/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesV2/utils.ts
@@ -4,6 +4,7 @@
 // included in the /LICENSE file.
 
 import { DatabaseMetadata } from "src/api/databases/getDatabaseMetadataApi";
+import { NodeStatus } from "src/api/nodesApi";
 import { NodeID, StoreID } from "src/types/clusterTypes";
 import { mapStoreIDsToNodeRegions } from "src/util/nodeUtils";
 
@@ -12,7 +13,7 @@ import { DatabaseRow } from "./databaseTypes";
 export const rawDatabaseMetadataToDatabaseRows = (
   raw: DatabaseMetadata[],
   nodesInfo: {
-    nodeIDToRegion: Record<NodeID, string>;
+    nodeStatusByID: Record<NodeID, NodeStatus>;
     storeIDToNodeID: Record<StoreID, NodeID>;
     isLoading: boolean;
   },
@@ -20,7 +21,7 @@ export const rawDatabaseMetadataToDatabaseRows = (
   return raw.map((db: DatabaseMetadata): DatabaseRow => {
     const nodesByRegion = mapStoreIDsToNodeRegions(
       db.storeIds,
-      nodesInfo?.nodeIDToRegion,
+      nodesInfo?.nodeStatusByID,
       nodesInfo?.storeIDToNodeID,
     );
     return {

--- a/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/tableOverview.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/tableOverview.tsx
@@ -29,7 +29,7 @@ export const TableOverview: React.FC<TableOverviewProps> = ({
   const isTenant = clusterDetails.isTenant;
   const metadata = tableDetails.metadata;
   const {
-    nodeIDToRegion,
+    nodeStatusByID,
     storeIDToNodeID,
     isLoading: nodesLoading,
   } = useNodeStatuses();
@@ -42,7 +42,7 @@ export const TableOverview: React.FC<TableOverviewProps> = ({
     }
     const regionsToNodes = mapStoreIDsToNodeRegions(
       tableDetails.metadata.storeIds,
-      nodeIDToRegion,
+      nodeStatusByID,
       storeIDToNodeID,
     );
     return Object.entries(regionsToNodes)

--- a/pkg/ui/workspaces/cluster-ui/src/util/nodeUtils.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/nodeUtils.spec.ts
@@ -3,7 +3,8 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import { StoreID } from "src/types/clusterTypes";
+import { NodeStatus } from "src/api";
+import { NodeID, StoreID } from "src/types/clusterTypes";
 
 import { mapStoreIDsToNodeRegions } from "./nodeUtils";
 
@@ -12,12 +13,12 @@ describe("nodeUtils", () => {
     it("should return a mapping of regions to the nodes that are present in that region based on the provided storeIDs", () => {
       const stores = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as StoreID[];
       const clusterNodeIDToRegion = {
-        1: "region1",
-        2: "region2",
-        3: "region1",
-        4: "region2",
-        5: "region1",
-      };
+        1: { region: "region1", stores: [1, 6] },
+        2: { region: "region2", stores: [2, 7] },
+        3: { region: "region1", stores: [3, 8] },
+        4: { region: "region2", stores: [4, 9] },
+        5: { region: "region1", stores: [5, 10] },
+      } as Record<NodeID, NodeStatus>;
       const clusterStoreIDToNodeID = {
         1: 1,
         2: 2,

--- a/pkg/ui/workspaces/cluster-ui/src/util/nodeUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/nodeUtils.ts
@@ -3,6 +3,7 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
+import { NodeStatus } from "src/api";
 import { NodeID, StoreID } from "src/types/clusterTypes";
 
 // mapStoreIDsToNodeRegions creates a mapping of regions
@@ -10,7 +11,7 @@ import { NodeID, StoreID } from "src/types/clusterTypes";
 // the provided storeIDs.
 export const mapStoreIDsToNodeRegions = (
   stores: StoreID[],
-  clusterNodeIDToRegion: Record<NodeID, string> = {},
+  clusterNodeIDToRegion: Record<NodeID, NodeStatus> = {},
   clusterStoreIDToNodeID: Record<StoreID, NodeID> = {},
 ): Record<string, NodeID[]> => {
   const nodes = stores.reduce((acc, storeID) => {
@@ -20,7 +21,7 @@ export const mapStoreIDsToNodeRegions = (
 
   const nodesByRegion: Record<string, NodeID[]> = {};
   nodes.forEach(nodeID => {
-    const region = clusterNodeIDToRegion[nodeID];
+    const region = clusterNodeIDToRegion[nodeID].region;
     if (!nodesByRegion[region]) {
       nodesByRegion[region] = [];
     }


### PR DESCRIPTION
This commit cleans up the useNodeStatuses hook. The raw data from the response is no longer returned from the hook.  Instead, callers must use the transformed data.

Epic: none

Release note: None