### PR TITLE
raft: don't ignore MsgTimeoutNow as candidate

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -2060,7 +2060,11 @@ func stepCandidate(r *raft, m pb.Message) error {
 			r.becomeFollower(r.Term, r.lead)
 		}
 	case pb.MsgTimeoutNow:
-		r.logger.Debugf("%x [term %d state %v] ignored MsgTimeoutNow from %x", r.id, r.Term, r.state, m.From)
+		r.becomeFollower(m.Term, m.From) // always m.Term == r.Term
+		// TODO(nvanbenschoten): this is temporarily duplicating logic from
+		// stepFollower. Unify.
+		r.logger.Infof("%x [term %d] received MsgTimeoutNow from %x and starts an election to get leadership", r.id, r.Term, m.From)
+		r.hup(campaignTransfer)
 	}
 	return nil
 }

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -3099,6 +3099,31 @@ func TestLeaderTransferToSlowFollower(t *testing.T) {
 	checkLeaderTransferState(t, lead, pb.StateFollower, 3)
 }
 
+func TestLeaderTransferToCandidate(t *testing.T) {
+	nt := newNetworkWithConfig(preVoteConfigWithFortificationDisabled, nil, nil, nil)
+	n3 := nt.peers[3].(*raft)
+
+	// Elect node 1 as the leader of term 1.
+	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgHup})
+	require.Equal(t, uint64(1), n3.Term)
+
+	// Isolate node 3 so that it decides to become a pre-candidate.
+	nt.isolate(3)
+	for i := 0; i < n3.randomizedElectionTimeout; i++ {
+		nt.tick(n3)
+	}
+	require.Equal(t, pb.StatePreCandidate, n3.state)
+	require.Equal(t, uint64(1), n3.Term)
+
+	// Reconnect node 3 and initiate a transfer of leadership from node 1 to node
+	// 3, all before node 3 steps back to a follower. This will instruct node 3 to
+	// call an election at the next term, which it can and does win.
+	nt.recover()
+	nt.send(pb.Message{From: 3, To: 1, Type: pb.MsgTransferLeader})
+	require.Equal(t, pb.StateLeader, n3.state)
+	require.Equal(t, uint64(2), n3.Term)
+}
+
 func TestLeaderTransferAfterSnapshot(t *testing.T) {
 	nt := newNetwork(nil, nil, nil)
 	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgHup})


### PR DESCRIPTION
This commit updates `stepCandidate` to not ignore `MsgTimeoutNow` messages from the leader. These messages not only teach the candidate who the leader is, but they also allow the candidate to call a new election at the _next_ term. Furthermore, they allow the candidate to perform a "force" election. So we don't want to drop these messages if at all possible.

This is a pretty rare case because a leader will only transfer leadership to a peer that it knows has an up-to-date log, but it is possible, as demonstrated by the test.

Epic: None
Release note: None