### PR TITLE
kvserver: bring TestRequestsOnLaggingReplica to a leader leases world 

### DIFF
--- a/pkg/kv/kvserver/client_raft_epoch_leases_test.go
+++ b/pkg/kv/kvserver/client_raft_epoch_leases_test.go
@@ -7,13 +7,18 @@ package kvserver_test
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -23,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,8 +67,7 @@ func TestRaftCheckQuorumEpochLeases(t *testing.T) {
 
 			// Only run the test with epoch based leases.
 			st := cluster.MakeTestingClusterSettings()
-			kvserver.TransferExpirationLeasesFirstEnabled.Override(ctx, &st.SV, false)
-			kvserver.ExpirationLeasesOnly.Override(ctx, &st.SV, false)
+			alwaysRunWithEpochLeases(ctx, st)
 
 			tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
 				ReplicationMode: base.ReplicationManual,
@@ -204,4 +209,258 @@ func TestRaftCheckQuorumEpochLeases(t *testing.T) {
 			require.Equal(t, leaderStatus.Term, finalStatus.Term)
 		})
 	})
+}
+
+// TestRequestsOnLaggingReplicaEpochLeases tests that requests sent to a replica
+// that's behind in log application don't block. The test indirectly verifies
+// that a replica that's not the leader does not attempt to acquire a lease and,
+// thus, does not block until it figures out that it cannot, in fact, take the
+// lease.
+//
+// This test relies on follower replicas refusing to forward lease acquisition
+// requests to the leader, thereby refusing to acquire a lease. The point of
+// this behavior is to prevent replicas that are behind from trying to acquire
+// the lease and then blocking traffic for a long time until they find out
+// whether they successfully took the lease or not.
+//
+// The test is run only with epoch based leases.
+func TestRequestsOnLaggingReplicaEpochLeases(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	st := cluster.MakeTestingClusterSettings()
+	alwaysRunWithEpochLeases(ctx, st)
+
+	clusterArgs := base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+		ServerArgs: base.TestServerArgs{
+			// Reduce the election timeout some to speed up the test.
+			RaftConfig: base.RaftConfig{RaftElectionTimeoutTicks: 10},
+			Knobs: base.TestingKnobs{
+				NodeLiveness: kvserver.NodeLivenessTestingKnobs{
+					// This test waits for an epoch-based lease to expire, so we're
+					// setting the liveness duration as low as possible while still
+					// keeping the test stable.
+					LivenessDuration: 3000 * time.Millisecond,
+					RenewalDuration:  1500 * time.Millisecond,
+				},
+				Store: &kvserver.StoreTestingKnobs{
+					// We eliminate clock offsets in order to eliminate the stasis period
+					// of leases, in order to speed up the test.
+					MaxOffset: time.Nanosecond,
+				},
+			},
+		},
+	}
+
+	tc := testcluster.StartTestCluster(t, 3, clusterArgs)
+	defer tc.Stopper().Stop(ctx)
+
+	_, rngDesc, err := tc.Servers[0].ScratchRangeEx()
+	require.NoError(t, err)
+	key := rngDesc.StartKey.AsRawKey()
+	// Add replicas on all the stores.
+	tc.AddVotersOrFatal(t, rngDesc.StartKey.AsRawKey(), tc.Target(1), tc.Target(2))
+
+	{
+		// Write a value so that the respective key is present in all stores and we
+		// can increment it again later.
+		_, err := tc.Server(0).DB().Inc(ctx, key, 1)
+		require.NoError(t, err)
+		log.Infof(ctx, "test: waiting for initial values...")
+		tc.WaitForValues(t, key, []int64{1, 1, 1})
+		log.Infof(ctx, "test: waiting for initial values... done")
+	}
+
+	// Partition the original leader from its followers. We do this by installing
+	// unreliableRaftHandler listeners on all three Stores. The handler on the
+	// partitioned store filters out all messages while the handler on the other
+	// two stores only filters out messages from the partitioned store. The
+	// configuration looks like:
+	//
+	//           [0]
+	//          x  x
+	//         /    \
+	//        x      x
+	//      [1]<---->[2]
+	//
+	log.Infof(ctx, "test: partitioning node")
+	const partitionNodeIdx = 0
+	partitionStore := tc.GetFirstStoreFromServer(t, partitionNodeIdx)
+	partRepl, err := partitionStore.GetReplica(rngDesc.RangeID)
+	require.NoError(t, err)
+	partReplDesc, err := partRepl.GetReplicaDescriptor()
+	require.NoError(t, err)
+	partitionedStoreSender := partitionStore.TestSender()
+	const otherStoreIdx = 1
+	otherStore := tc.GetFirstStoreFromServer(t, otherStoreIdx)
+	otherRepl, err := otherStore.GetReplica(rngDesc.RangeID)
+	require.NoError(t, err)
+
+	for _, i := range []int{0, 1, 2} {
+		store := tc.GetFirstStoreFromServer(t, i)
+		h := &unreliableRaftHandler{
+			name:                       fmt.Sprintf("store %d", i),
+			rangeID:                    rngDesc.RangeID,
+			IncomingRaftMessageHandler: store,
+		}
+		if i != partitionNodeIdx {
+			// Only filter messages from the partitioned store on the other two
+			// stores.
+			h.dropReq = func(req *kvserverpb.RaftMessageRequest) bool {
+				return req.FromReplica.StoreID == partRepl.StoreID()
+			}
+			h.dropHB = func(hb *kvserverpb.RaftHeartbeat) bool {
+				return hb.FromReplicaID == partReplDesc.ReplicaID
+			}
+		}
+		store.Transport().ListenIncomingRaftMessages(store.Ident.StoreID, h)
+	}
+
+	// Stop the heartbeats so that n1's lease can expire.
+	log.Infof(ctx, "test: suspending heartbeats for n1")
+	resumeN1Heartbeats := partitionStore.GetStoreConfig().NodeLiveness.PauseAllHeartbeatsForTest()
+
+	// Wait until another replica campaigns and becomes leader, replacing the
+	// partitioned one.
+	log.Infof(ctx, "test: waiting for leadership transfer")
+	testutils.SucceedsSoon(t, func() error {
+		// Make sure this replica has not inadvertently quiesced. We need the
+		// replica ticking so that it campaigns.
+		if otherRepl.IsQuiescent() {
+			otherRepl.MaybeUnquiesce()
+		}
+		lead := otherRepl.RaftStatus().Lead
+		if lead == raft.None {
+			return errors.New("no leader yet")
+		}
+		if roachpb.ReplicaID(lead) == partReplDesc.ReplicaID {
+			return errors.New("partitioned replica is still leader")
+		}
+		return nil
+	})
+
+	leaderReplicaID := roachpb.ReplicaID(otherRepl.RaftStatus().Lead)
+	log.Infof(ctx, "test: the leader is replica ID %d", leaderReplicaID)
+	if leaderReplicaID != 2 && leaderReplicaID != 3 {
+		t.Fatalf("expected leader to be 1 or 2, was: %d", leaderReplicaID)
+	}
+	leaderNodeIdx := int(leaderReplicaID - 1)
+	leaderNode := tc.Server(leaderNodeIdx)
+	leaderStore, err := leaderNode.GetStores().(*kvserver.Stores).GetStore(leaderNode.GetFirstStoreID())
+	require.NoError(t, err)
+
+	// Wait until the lease expires.
+	log.Infof(ctx, "test: waiting for lease expiration")
+	partitionedReplica, err := partitionStore.GetReplica(rngDesc.RangeID)
+	require.NoError(t, err)
+	testutils.SucceedsSoon(t, func() error {
+		status := partitionedReplica.CurrentLeaseStatus(ctx)
+		require.True(t,
+			status.Lease.OwnedBy(partitionStore.StoreID()), "someone else got the lease: %s", status)
+		if status.State == kvserverpb.LeaseState_VALID {
+			return errors.New("lease still valid")
+		}
+		// We need to wait for the stasis state to pass too; during stasis other
+		// replicas can't take the lease.
+		if status.State == kvserverpb.LeaseState_UNUSABLE {
+			return errors.New("lease still in stasis")
+		}
+		return nil
+	})
+	log.Infof(ctx, "test: lease expired")
+
+	{
+		// Write something to generate some Raft log entries and then truncate the log.
+		log.Infof(ctx, "test: incrementing")
+		incArgs := incrementArgs(key, 1)
+		sender := leaderStore.TestSender()
+		_, pErr := kv.SendWrapped(ctx, sender, incArgs)
+		require.Nil(t, pErr)
+	}
+
+	tc.WaitForValues(t, key, []int64{1, 2, 2})
+	index := otherRepl.GetLastIndex()
+
+	// Truncate the log at index+1 (log entries < N are removed, so this includes
+	// the increment). This means that the partitioned replica will need a
+	// snapshot to catch up.
+	log.Infof(ctx, "test: truncating log...")
+	truncArgs := &kvpb.TruncateLogRequest{
+		RequestHeader: kvpb.RequestHeader{
+			Key: key,
+		},
+		Index:   index,
+		RangeID: rngDesc.RangeID,
+	}
+	{
+		_, pErr := kv.SendWrapped(ctx, leaderStore.TestSender(), truncArgs)
+		require.NoError(t, pErr.GoError())
+	}
+
+	// Resume n1's heartbeats and wait for it to become live again. This is to
+	// ensure that the rest of the test does not somehow fool itself because n1 is
+	// not live.
+	log.Infof(ctx, "test: resuming n1 heartbeats")
+	resumeN1Heartbeats()
+
+	// Resolve the partition, but continue blocking snapshots destined for the
+	// previously-partitioned replica. The point of blocking the snapshots is to
+	// prevent the respective replica from catching up and becoming eligible to
+	// become the leader/leaseholder. The point of resolving the partition is to
+	// allow the replica in question to figure out that it's not the leader any
+	// more. As long as it is completely partitioned, the replica continues
+	// believing that it is the leader, and lease acquisition requests block.
+	log.Infof(ctx, "test: removing partition")
+	slowSnapHandler := &slowSnapRaftHandler{
+		rangeID:                    rngDesc.RangeID,
+		waitCh:                     make(chan struct{}),
+		IncomingRaftMessageHandler: partitionStore,
+	}
+	defer slowSnapHandler.unblock()
+	partitionStore.Transport().ListenIncomingRaftMessages(partitionStore.Ident.StoreID, slowSnapHandler)
+	// Remove the unreliable transport from the other stores, so that messages
+	// sent by the partitioned store can reach them.
+	for _, i := range []int{0, 1, 2} {
+		if i == partitionNodeIdx {
+			// We've handled the partitioned store above.
+			continue
+		}
+		store := tc.GetFirstStoreFromServer(t, i)
+		store.Transport().ListenIncomingRaftMessages(store.Ident.StoreID, store)
+	}
+
+	// Now we're going to send a request to the behind replica, and we expect it
+	// to not block; we expect a redirection to the leader.
+	log.Infof(ctx, "test: sending request")
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	for {
+		getRequest := getArgs(key)
+		_, pErr := kv.SendWrapped(timeoutCtx, partitionedStoreSender, getRequest)
+		require.Error(t, pErr.GoError(), "unexpected success")
+		nlhe := &kvpb.NotLeaseHolderError{}
+		require.ErrorAs(t, pErr.GetDetail(), &nlhe)
+		// Someone else (e.g. the Raft scheduler) may have attempted to acquire the
+		// lease in the meanwhile, bumping the node's epoch and causing an
+		// ErrEpochIncremented, so we ignore these and try again.
+		if strings.Contains(nlhe.Error(), liveness.ErrEpochIncremented.Error()) { // no cause chain
+			t.Logf("got %s, retrying", nlhe)
+			continue
+		}
+		// When the old leader is partitioned, it will step down due to CheckQuorum.
+		// Immediately after the partition is healed, the replica will not know who
+		// the new leader is, so it will return a NotLeaseholderError with an empty
+		// lease. This is expected and better than blocking. Still, we have the test
+		// retry to make sure that the new leader is eventually discovered and that
+		// after that point, the NotLeaseholderErrors start including a lease which
+		// points to the new leader.
+		if nlhe.Lease.Empty() {
+			t.Logf("got %s, retrying", nlhe)
+			continue
+		}
+		require.Equal(t, leaderReplicaID, nlhe.Lease.Replica.ReplicaID)
+		break
+	}
 }

--- a/pkg/kv/kvserver/client_raft_helpers_test.go
+++ b/pkg/kv/kvserver/client_raft_helpers_test.go
@@ -499,3 +499,10 @@ func alwaysRunWithLeaderLeases(ctx context.Context, st *cluster.Settings) {
 	kvserver.LeaderLeasesEnabled.Override(ctx, &st.SV, true)
 	kvserver.RaftLeaderFortificationFractionEnabled.Override(ctx, &st.SV, 1.0)
 }
+
+func alwaysRunWithEpochLeases(ctx context.Context, st *cluster.Settings) {
+	// Only run the test with epoch based leases.
+	kvserver.TransferExpirationLeasesFirstEnabled.Override(ctx, &st.SV, false)
+	kvserver.ExpirationLeasesOnly.Override(ctx, &st.SV, false)
+	kvserver.RaftLeaderFortificationFractionEnabled.Override(ctx, &st.SV, 0.0)
+}

--- a/pkg/kv/kvserver/client_raft_helpers_test.go
+++ b/pkg/kv/kvserver/client_raft_helpers_test.go
@@ -437,7 +437,7 @@ func dropRaftMessagesFrom(
 		dropFrom[id] = true
 		rep, ok := desc.GetReplicaDescriptorByID(id)
 		if !ok {
-			t.Fatalf("replica %d not found in range descriptor %v", id, desc)
+			t.Fatalf("replica %d not found in range descriptor: %v", id, desc)
 		}
 		t.Logf("from store %d; adding replica %s to drop list", store.StoreID(), id)
 		t.Logf("from store %d; adding store %s to drop list", store.StoreID(), rep.StoreID)
@@ -498,6 +498,10 @@ func alwaysRunWithLeaderLeases(ctx context.Context, st *cluster.Settings) {
 	kvserver.ExpirationLeasesOnly.Override(ctx, &st.SV, false)
 	kvserver.LeaderLeasesEnabled.Override(ctx, &st.SV, true)
 	kvserver.RaftLeaderFortificationFractionEnabled.Override(ctx, &st.SV, 1.0)
+	// TODO(arul): Once https://github.com/cockroachdb/cockroach/issues/118435 we
+	// can remove this. Leader leases require us to reject lease requests on
+	// replicas that are not the leader.
+	kvserver.RejectLeaseOnLeaderUnknown.Override(ctx, &st.SV, true)
 }
 
 func alwaysRunWithEpochLeases(ctx context.Context, st *cluster.Settings) {

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/split"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness"
 	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -52,6 +53,10 @@ import (
 
 func (s *Store) Transport() *RaftTransport {
 	return s.cfg.Transport
+}
+
+func (s *Store) StoreLivenessTransport() *storeliveness.Transport {
+	return s.cfg.StoreLivenessTransport
 }
 
 func (s *Store) FindTargetAndTransferLease(

--- a/pkg/kv/kvserver/storeliveness/unreliable_store_liveness_handler.go
+++ b/pkg/kv/kvserver/storeliveness/unreliable_store_liveness_handler.go
@@ -22,7 +22,7 @@ var _ MessageHandler = &UnreliableHandler{}
 
 // HandleMessage implements the MessageHandler interface.
 func (h *UnreliableHandler) HandleMessage(msg *storelivenesspb.Message) error {
-	if h.DropStoreLivenessMsg(msg) {
+	if h.DropStoreLivenessMsg != nil && h.DropStoreLivenessMsg(msg) {
 		return nil
 	}
 


### PR DESCRIPTION
This patch reworks TestRequestsOnLaggingReplica to always use leader
leases. While here, we also improve the test in a few ways:

- Previously, the test would only create an assymetric partition. We
introduce a symmetric variant as well. Arguably, this is a more apt
test case after https://github.com/cockroachdb/cockroach/commit/58004827905fbec8926a51ea6f751823b1991fa4.
- We add a step to send a request to the lagging replica before healing
the partition. This serves as a test for RejectLeaseOnLeaderUnknown.
- We're able to make stronger guarantees about lease expiration.

Epic: none

Release note: None