### PR TITLE
build: add scripts to work with patches for dependencies

### DIFF
--- a/build/patches/README.md
+++ b/build/patches/README.md
@@ -22,3 +22,11 @@ examples:
   targets using pre-generated `.pb.go` files under
   `@com_github_golang_protobuf//ptypes`. We do this because the `wkt` rules
   create conflicts in our build.
+
+The `build/scripts` directory contains scripts that can help with development of
+patches:
+* `patch-prepare-repo.sh` generates WORKSPACE and BUILD.bazel files for the
+  dependency;
+* `patch-apply.sh` applies a patch on a prepared repo;
+* `patch-gen.sh` extracts a patch from a prepared repo.
+

--- a/build/scripts/patch-apply.sh
+++ b/build/scripts/patch-apply.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+set -euo pipefail
+
+function usage() {
+  echo "This script runs gazelle and applies a patch to a repository clone."
+  echo ""
+  echo "Assumes that the repository has been prepared using patch-prepare-repo.sh"
+  echo ""
+  echo "Usage: $0 <bazel-repo-name> <repo-directory>"
+  echo ""
+  echo "Example: $0 com_github_cockroachdb_pebble ~/pebble"
+  exit 1
+}
+
+if [ "$#" -ne 2 ]; then
+  usage
+fi
+
+CRDB_ROOT="$(dirname $(dirname $(realpath $0)))"
+
+REPO_NAME="$1"
+REPO_DIR="$2"
+
+PATCH_FILE="$CRDB_ROOT/patches/$REPO_NAME.patch"
+
+# Check if the patch file exists
+if [ ! -f "$PATCH_FILE" ]; then
+  echo "Error: Patch file '$PATCH_FILE' does not exist."
+  exit 1
+fi
+
+# Check if the repository directory exists
+if [ ! -d "$REPO_DIR" ]; then
+  echo "Error: Repository directory '$REPO_DIR' does not exist."
+  exit 1
+fi
+
+cd "$REPO_DIR" || exit 1
+
+# Apply the patch
+echo "Applying patch $PATCH_FILE to directory $REPO_DIR"
+echo ""
+
+if patch -p1 < "$PATCH_FILE"; then
+  echo "Patch applied successfully."
+else
+  echo "Failed to apply patch."
+  echo "Make sure the repository is at the proper commit."
+  exit 1
+fi

--- a/build/scripts/patch-gen.sh
+++ b/build/scripts/patch-gen.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+set -euo pipefail
+
+function usage() {
+  echo "This script will create a patch file from the current git diff from a"
+  echo "repository clone."
+  echo ""
+  echo "Assumes that the repository has been prepared using patch-prepare-repo.sh"
+  echo ""
+  echo "Usage: $0 <bazel-repo-name> <repo-directory>"
+  echo ""
+  echo "Example: $0 com_github_cockroachdb_pebble ~/pebble"
+  exit 1
+}
+
+if [ "$#" -ne 2 ]; then
+  usage
+fi
+
+CRDB_ROOT="$(dirname $(dirname $(realpath $0)))"
+
+REPO_NAME="$1"
+REPO_DIR="$2"
+
+PATCH_FILE="$CRDB_ROOT/patches/$REPO_NAME.patch"
+
+# Check if the repository directory exists
+if [ ! -d "$REPO_DIR" ]; then
+  echo "Error: Repository directory '$REPO_DIR' does not exist."
+  exit 1
+fi
+
+# Check if the directory is a git repository
+if [ ! -d "$REPO_DIR/.git" ]; then
+  echo "Error: '$REPO_DIR' is not a Git repository."
+  exit 1
+fi
+
+echo "Creating $REPO_NAME.patch from the current git diff in $REPO_DIR"
+echo ""
+echo "Note: This diff contains staged changes and unstaged changes to tracked"
+echo "      files. It does not include untracked files."
+echo ""
+
+cd "$REPO_DIR" || exit 1
+if git diff --no-ext-diff HEAD > "$PATCH_FILE"; then
+  echo "Patch file created successfully at $PATCH_FILE"
+
+  echo ""
+  echo "Note that the gazelle invocation does not use all flags that are normally"
+  echo "passed in the bazel build, so the generated files might be different."
+  echo "If the generated patch fails to apply, use:"
+  echo "  bazel query @<bazel-repo-name>//:<library_name> --output=build"
+  echo "without any patch to see the correct \"base\" BUILD.bazel file."
+else
+  echo "Failed to create patch file."
+  exit 1
+fi
+

--- a/build/scripts/patch-prepare-repo.sh
+++ b/build/scripts/patch-prepare-repo.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+set -euo pipefail
+
+function usage() {
+  echo "This script prepares a clone of a dependency for applying and generating"
+  echo "patches. It generates a WORKSPACE file and runs gazelle to generate"
+  echo "BUILD.bazel files and commits these changes."
+  echo ""
+  echo "This script should be used to set up the \"base\" tree before using"
+  echo "patch-apply.sh and patch-gen.sh."
+  echo ""
+  echo "Usage: $0 <bazel-repo-name> <repo-directory> [flags for gazelle]"
+  echo ""
+  echo "Example: $0 com_github_cockroachdb_pebble ~/pebble"
+  exit 1
+}
+
+# Check for required arguments
+if [ "$#" -lt 2 ]; then
+  usage
+fi
+
+CRDB_ROOT="$(dirname $(dirname $(realpath $0)))"
+
+REPO_NAME="$1"
+REPO_DIR="$2"
+
+# Generate the import path from the workspace. For example,
+# com_github_cockroachdb_pebble.patch to github.com/cockroachdb/pebble.
+
+# Split the input string by underscores
+IFS='_' read -r -a fields <<< "$REPO_NAME"
+
+# Extract the first two fields
+field1="${fields[0]}"
+field2="${fields[1]}"
+
+# Join the remaining fields with '/'
+rest=$(IFS=/; echo "${fields[*]:2}")
+
+IMPORT_PATH="${field2}.${field1}/${rest}"
+
+echo "Import path: $IMPORT_PATH"
+
+# Check if the repository directory exists.
+if [ ! -d "$REPO_DIR" ]; then
+  echo "Error: Repository directory '$REPO_DIR' does not exist."
+  exit 1
+fi
+
+cd "$REPO_DIR"
+
+if grep -q -E '^[::space::]*(/WORKSPACE|BUILD.bazel)[::space::]*$' .gitignore; then
+  echo "Removing /WORKSPACE and BUILD.bazel from .gitignore"
+
+  TEMP_FILE=$(mktemp)
+  cp .gitignore $TEMP_FILE
+  sed -E '\#^[::space::]*(/WORKSPACE|BUILD.bazel)[::space::]*$#d' $TEMP_FILE >.gitignore
+
+  git commit .gitignore -m "gitignore: /WORKSPACE and BUILD.bazel"
+  git log -1 HEAD
+fi
+
+if [ ! -f WORKSPACE ]; then
+	echo "Generating WORKSPACE"
+	echo "workspace(name = \"$REPO_NAME\")" > WORKSPACE
+fi
+
+(
+  cd "$CRDB_ROOT"
+  set -x
+  bazel run @bazel_gazelle//cmd/gazelle -- update ${@:3} --go_prefix="$IMPORT_PATH" --repo_root=$REPO_DIR $REPO_DIR
+)
+
+git add -A
+git commit -m "gazelle: generate WORKSPACE and BUILD.bazel"
+git log -1 HEAD
+


### PR DESCRIPTION
This commit adds three scripts:
 - patch-prepare-repo.sh prepares a clone of the dependency by
   generating the `WORKSPACE` and `BUILD.bazel` files (using gazelle).
 - patch-apply.sh: applies an exiting patch to the repository.
 - patch-gen.sh: generates the patch from the current diff in the
   repository.

Epic: none
Release note: None