### PR TITLE
roachprod: add `google_compute_engine` to `DefaultPubKeyNames`

### DIFF
--- a/pkg/roachprod/config/config.go
+++ b/pkg/roachprod/config/config.go
@@ -196,6 +196,7 @@ var DefaultPubKeyNames = []string{
 	"id_ed25519",
 	"id_ed25519_sk",
 	"id_dsa",
+	"google_compute_engine",
 }
 
 // SSHPublicKeyPath returns the path to the default public key expected by


### PR DESCRIPTION
roachprod uses `DefaultPubKeyNames` to look for a public SSH key under $HOME/.ssh. Historically, folks would create an SSH keypair named `google_compute_engine`, so we add it to the list of default keys to scan.

Epic: none

Release note: None