### PR TITLE
release-24.3: roachtest: deflake Test_updateSpecForSelectiveTests

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -121,6 +121,7 @@ go_test(
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/echotest",
+        "//pkg/util",
         "//pkg/util/randutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",


### PR DESCRIPTION
Backport 1/1 commits from #132860.

/cc @cockroachdb/release

---

This change reduces the amount of iterations the randomized test takes from 1000 to 100, as each iteration spins up a goroutine that can lead to OOM issues. On race builds, it further decreases it to 10.

It also switches the tests to log using t.Log instead of logging to stdout.

Fixes: #133438
Release note: none
Epic: none

Release justification: test only change
