### PR TITLE
changefeedccl: add PTS to system.users

### DIFF
--- a/pkg/ccl/changefeedccl/protected_timestamps.go
+++ b/pkg/ccl/changefeedccl/protected_timestamps.go
@@ -48,7 +48,8 @@ var systemTablesToProtect = []descpb.ID{
 	keys.ZonesTableID,
 	// Required for CDC Queries.
 	keys.RoleMembersTableID,
-	// TODO(#128806): identify and add any more required tables (such as, possibly, `keys.UsersTableID`)
+	keys.UsersTableID,
+	// TODO(#128806, #133566): identify and add any more required tables
 }
 
 func makeTargetToProtect(targets changefeedbase.Targets) *ptpb.Target {


### PR DESCRIPTION
Add `system.users` to the list of system tables
that changefeeds protect with PTS. This table is
required for CDC Queries.

Part of: #128806

Release note (enterprise change): Add
`system.users` to the list of system tables that
changefeeds protect with PTS. This table is
required for CDC Queries.
