### PR TITLE
crosscluster: update dlq insert column type

### DIFF
--- a/pkg/ccl/crosscluster/logical/dead_letter_queue_test.go
+++ b/pkg/ccl/crosscluster/logical/dead_letter_queue_test.go
@@ -240,14 +240,11 @@ func TestDLQCreation(t *testing.T) {
 	slices.Sort(actualDQLTables)
 	require.Equal(t, expectedDLQTables, actualDQLTables)
 
-	// Verify enum creation
-	enumRow := [][]string{
-		{dlqSchemaName, "mutation_type", "{insert,update,delete}"},
-	}
+	// Verify that no custom enums were created
 	sqlDB.CheckQueryResults(t,
-		fmt.Sprintf(`SELECT schema, name, values FROM [SHOW ENUMS FROM %s.%s]`, defaultDbName, dlqSchemaName), enumRow)
+		fmt.Sprintf(`SHOW ENUMS FROM %s.%s`, defaultDbName, dlqSchemaName), [][]string{})
 	sqlDB.CheckQueryResults(t,
-		fmt.Sprintf(`SELECT schema, name, values FROM [SHOW ENUMS FROM %s.%s]`, dbAName, dlqSchemaName), enumRow)
+		fmt.Sprintf(`SHOW ENUMS FROM %s.%s`, dbAName, dlqSchemaName), [][]string{})
 }
 
 func TestDLQLogging(t *testing.T) {


### PR DESCRIPTION
Update the `mutation_type` column in DLQ tables
from enum to string type.

Epic: none
Fixes: #133167
Release note: None