### PR TITLE
storeliveness: reduce SupportExpiryInterval to 100ms

### DIFF
--- a/pkg/kv/kvserver/storeliveness/config.go
+++ b/pkg/kv/kvserver/storeliveness/config.go
@@ -35,7 +35,7 @@ func NewOptions(
 	return Options{
 		LivenessInterval:             livenessInterval,
 		HeartbeatInterval:            heartbeatInterval,
-		SupportExpiryInterval:        1 * time.Second,
+		SupportExpiryInterval:        100 * time.Millisecond,
 		IdleSupportFromInterval:      1 * time.Minute,
 		SupportWithdrawalGracePeriod: supportWithdrawalGracePeriod,
 	}

--- a/pkg/kv/kvserver/storeliveness/support_manager.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager.go
@@ -298,6 +298,10 @@ func (sm *SupportManager) withdrawSupport(ctx context.Context) {
 	ssfu := sm.supporterStateHandler.checkOutUpdate()
 	defer sm.supporterStateHandler.finishUpdate(ssfu)
 	numWithdrawn := ssfu.withdrawSupport(now)
+	if numWithdrawn == 0 {
+		// No support to withdraw.
+		return
+	}
 
 	batch := sm.engine.NewBatch()
 	defer batch.Close()


### PR DESCRIPTION
This commit reduces the `SupportExpiryInterval` from 1s to 100ms. This is done to speed up the maximum failover time from a node failure by 900ms, at the cost of running `SupportManager.withdrawSupport` 10x more. To avoid any performance hit, we optimize this method for the common case of no support to withdraw, so that the method is little more than a map iteration over the `supportFor` hash-map.

Epic: None
Release note: None