### PR TITLE
crosscluster: rename pcr keywords

### DIFF
--- a/pkg/ccl/crosscluster/physical/alter_replication_job.go
+++ b/pkg/ccl/crosscluster/physical/alter_replication_job.go
@@ -42,7 +42,7 @@ const (
 )
 
 var alterReplicationCutoverHeader = colinfo.ResultColumns{
-	{Name: "cutover_time", Typ: types.Decimal},
+	{Name: "failover_time", Typ: types.Decimal},
 }
 
 // ResolvedTenantReplicationOptions represents options from an
@@ -605,12 +605,12 @@ func applyCutoverTime(
 	return job.WithTxn(txn).Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
 		progress := md.Progress.GetStreamIngest()
 		details := md.Payload.GetStreamIngestion()
-		if progress.ReplicationStatus == jobspb.ReplicationCuttingOver {
+		if progress.ReplicationStatus == jobspb.ReplicationFailingOver {
 			return errors.Newf("job %d already started cutting over to timestamp %s",
 				job.ID(), progress.CutoverTime)
 		}
 
-		progress.ReplicationStatus = jobspb.ReplicationPendingCutover
+		progress.ReplicationStatus = jobspb.ReplicationPendingFailover
 		// Update the sentinel being polled by the stream ingestion job to
 		// check if a complete has been signaled.
 		progress.CutoverTime = cutoverTimestamp

--- a/pkg/ccl/crosscluster/physical/replication_random_client_test.go
+++ b/pkg/ccl/crosscluster/physical/replication_random_client_test.go
@@ -210,7 +210,7 @@ func TestStreamIngestionJobWithRandomClient(t *testing.T) {
 	receivedRevertRequest = make(chan struct{})
 	_, err = conn.Exec(`SET CLUSTER SETTING bulkio.stream_ingestion.minimum_flush_interval= '0.0005ms'`)
 	require.NoError(t, err)
-	_, err = conn.Exec(`SET CLUSTER SETTING bulkio.stream_ingestion.cutover_signal_poll_interval='1s'`)
+	_, err = conn.Exec(`SET CLUSTER SETTING bulkio.stream_ingestion.failover_signal_poll_interval='1s'`)
 	require.NoError(t, err)
 	streamAddr := getTestRandomClientURI(roachpb.MustMakeTenantID(oldTenantID), oldTenantName)
 	query := fmt.Sprintf(`CREATE TENANT "30" FROM REPLICATION OF "10" ON '%s'`, streamAddr)

--- a/pkg/ccl/crosscluster/physical/replication_stream_e2e_test.go
+++ b/pkg/ccl/crosscluster/physical/replication_stream_e2e_test.go
@@ -1163,7 +1163,7 @@ func TestTenantStreamingShowTenant(t *testing.T) {
 	c.DestSysSQL.QueryRow(c.T, `ALTER TENANT $1 COMPLETE REPLICATION TO SYSTEM TIME $2::string`,
 		c.Args.DestTenantName, futureTime.AsOfSystemTime()).Scan(&cutoverStr)
 	var showCutover string
-	c.DestSysSQL.QueryRow(c.T, fmt.Sprintf("SELECT cutover_time FROM [SHOW TENANT %s WITH REPLICATION STATUS]",
+	c.DestSysSQL.QueryRow(c.T, fmt.Sprintf("SELECT failover_time FROM [SHOW TENANT %s WITH REPLICATION STATUS]",
 		c.Args.DestTenantName)).Scan(&showCutover)
 	require.Equal(c.T, cutoverStr, showCutover)
 	cutoverOutput := replicationtestutils.DecimalTimeToHLC(c.T, showCutover)

--- a/pkg/ccl/crosscluster/physical/standby_read_ts_poller_job_test.go
+++ b/pkg/ccl/crosscluster/physical/standby_read_ts_poller_job_test.go
@@ -162,7 +162,7 @@ func TestFastFailbackWithReaderTenant(t *testing.T) {
 		"SET CLUSTER SETTING physical_replication.consumer.heartbeat_frequency = '1s'",
 		"SET CLUSTER SETTING physical_replication.consumer.job_checkpoint_frequency = '100ms'",
 		"SET CLUSTER SETTING physical_replication.consumer.minimum_flush_interval = '10ms'",
-		"SET CLUSTER SETTING physical_replication.consumer.cutover_signal_poll_interval = '100ms'",
+		"SET CLUSTER SETTING physical_replication.consumer.failover_signal_poll_interval = '100ms'",
 		"SET CLUSTER SETTING spanconfig.reconciliation_job.checkpoint_interval = '100ms'",
 	} {
 		sqlA.Exec(t, s)

--- a/pkg/ccl/crosscluster/physical/stream_ingestion_job.go
+++ b/pkg/ccl/crosscluster/physical/stream_ingestion_job.go
@@ -117,7 +117,7 @@ func completeIngestion(
 
 	msg := redact.Sprintf("completing the producer job %d in the source cluster",
 		details.StreamID)
-	updateRunningStatus(ctx, ingestionJob, jobspb.ReplicationCuttingOver, msg)
+	updateRunningStatus(ctx, ingestionJob, jobspb.ReplicationFailingOver, msg)
 	completeProducerJob(ctx, ingestionJob, execCtx.ExecCfg().InternalDB, true)
 	evalContext := &execCtx.ExtendedEvalContext().Context
 	if err := startPostCutoverRetentionJob(ctx, execCtx.ExecCfg(), details, evalContext, cutoverTimestamp); err != nil {
@@ -273,7 +273,7 @@ func ingestWithRetries(
 	if err != nil {
 		return err
 	}
-	updateRunningStatus(ctx, ingestionJob, jobspb.ReplicationCuttingOver,
+	updateRunningStatus(ctx, ingestionJob, jobspb.ReplicationFailingOver,
 		"stream ingestion finished successfully")
 	return nil
 }
@@ -466,10 +466,10 @@ func maybeRevertToCutoverTimestamp(
 			shouldRevertToCutover = cutoverTimeIsEligibleForCutover(ctx, cutoverTimestamp, md.Progress)
 
 			if shouldRevertToCutover {
-				updateRunningStatusInternal(md, ju, jobspb.ReplicationCuttingOver,
+				updateRunningStatusInternal(md, ju, jobspb.ReplicationFailingOver,
 					fmt.Sprintf("starting to cut over to the given timestamp %s", cutoverTimestamp))
 			} else {
-				if streamIngestionProgress.ReplicationStatus == jobspb.ReplicationCuttingOver {
+				if streamIngestionProgress.ReplicationStatus == jobspb.ReplicationFailingOver {
 					return errors.AssertionFailedf("cutover already started but cutover time %s is not eligible for cutover",
 						cutoverTimestamp)
 				}

--- a/pkg/ccl/crosscluster/physical/stream_ingestion_job_test.go
+++ b/pkg/ccl/crosscluster/physical/stream_ingestion_job_test.go
@@ -135,7 +135,7 @@ func TestTenantStreamingFailback(t *testing.T) {
 		"SET CLUSTER SETTING physical_replication.consumer.heartbeat_frequency = '1s'",
 		"SET CLUSTER SETTING physical_replication.consumer.job_checkpoint_frequency = '100ms'",
 		"SET CLUSTER SETTING physical_replication.consumer.minimum_flush_interval = '10ms'",
-		"SET CLUSTER SETTING physical_replication.consumer.cutover_signal_poll_interval = '100ms'",
+		"SET CLUSTER SETTING physical_replication.consumer.failover_signal_poll_interval = '100ms'",
 		"SET CLUSTER SETTING spanconfig.reconciliation_job.checkpoint_interval = '100ms'",
 	} {
 		sqlA.Exec(t, s)

--- a/pkg/ccl/crosscluster/physical/stream_ingestion_processor.go
+++ b/pkg/ccl/crosscluster/physical/stream_ingestion_processor.go
@@ -84,11 +84,11 @@ var tooSmallRangeKeySize = settings.RegisterByteSizeSetting(
 // signaled to cutover.
 var cutoverSignalPollInterval = settings.RegisterDurationSetting(
 	settings.SystemOnly,
-	"bulkio.stream_ingestion.cutover_signal_poll_interval",
+	"bulkio.stream_ingestion.failover_signal_poll_interval",
 	"the interval at which the stream ingestion job checks if it has been signaled to cutover",
 	10*time.Second,
 	settings.NonNegativeDuration,
-	settings.WithName("physical_replication.consumer.cutover_signal_poll_interval"),
+	settings.WithName("physical_replication.consumer.failover_signal_poll_interval"),
 )
 
 var quantize = settings.RegisterDurationSettingWithExplicitUnit(

--- a/pkg/ccl/crosscluster/physical/testdata/simple
+++ b/pkg/ccl/crosscluster/physical/testdata/simple
@@ -67,7 +67,7 @@ SHOW TENANTS
 2 destination replicating none
 
 query-sql as=destination-system
-SELECT id, name, source_tenant_name, cutover_time, status FROM [SHOW TENANTS WITH REPLICATION STATUS]
+SELECT id, name, source_tenant_name, failover_time, status FROM [SHOW TENANTS WITH REPLICATION STATUS]
 ----
 1 system <nil> <nil> ready
 2 destination source <nil> replicating

--- a/pkg/ccl/crosscluster/replicationtestutils/testutils.go
+++ b/pkg/ccl/crosscluster/replicationtestutils/testutils.go
@@ -646,13 +646,13 @@ var defaultSrcClusterSetting = map[string]string{
 }
 
 var defaultDestClusterSetting = map[string]string{
-	`stream_replication.consumer_heartbeat_frequency`:      `'1s'`,
-	`stream_replication.job_checkpoint_frequency`:          `'100ms'`,
-	`bulkio.stream_ingestion.minimum_flush_interval`:       `'10ms'`,
-	`bulkio.stream_ingestion.cutover_signal_poll_interval`: `'100ms'`,
-	`jobs.registry.interval.adopt`:                         `'1s'`,
-	`spanconfig.reconciliation_job.checkpoint_interval`:    `'100ms'`,
-	`kv.rangefeed.enabled`:                                 `true`,
+	`stream_replication.consumer_heartbeat_frequency`:       `'1s'`,
+	`stream_replication.job_checkpoint_frequency`:           `'100ms'`,
+	`bulkio.stream_ingestion.minimum_flush_interval`:        `'10ms'`,
+	`bulkio.stream_ingestion.failover_signal_poll_interval`: `'100ms'`,
+	`jobs.registry.interval.adopt`:                          `'1s'`,
+	`spanconfig.reconciliation_job.checkpoint_interval`:     `'100ms'`,
+	`kv.rangefeed.enabled`:                                  `true`,
 }
 
 func ConfigureClusterSettings(setting map[string]string) []string {

--- a/pkg/cli/testdata/explain-bundle/bundle/env.sql
+++ b/pkg/cli/testdata/explain-bundle/bundle/env.sql
@@ -22,7 +22,7 @@
 --   bulkio.backup.read_with_priority_after = 1m0s  (age of read-as-of time above which a BACKUP should read with priority)
 --   bulkio.column_backfill.batch_size = 200  (the number of rows updated at a time to add/remove columns)
 --   bulkio.index_backfill.batch_size = 50000  (the number of rows for which we construct index entries in a single batch)
---   bulkio.stream_ingestion.cutover_signal_poll_interval = 30s  (the interval at which the stream ingestion job checks if it has been signaled to cutover)
+--   bulkio.stream_ingestion.failover_signal_poll_interval = 30s  (the interval at which the stream ingestion job checks if it has been signaled to cutover)
 --   bulkio.stream_ingestion.minimum_flush_interval = 5s  (the minimum timestamp between flushes; flushes may still occur if internal buffers fill up)
 --   changefeed.backfill.concurrent_scan_requests = 0  (number of concurrent scan requests per node issued during a backfill)
 --   changefeed.experimental_poll_interval = 1s  (polling interval for the table descriptors)

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1644,7 +1644,7 @@ func registerClusterReplicationResilience(r registry.Registry) {
 				<-shutdownSetupDone
 
 				// Eagerly listen to cutover signal to exercise node shutdown during actual cutover.
-				rrd.setup.dst.sysSQL.Exec(t, `SET CLUSTER SETTING bulkio.stream_ingestion.cutover_signal_poll_interval='5s'`)
+				rrd.setup.dst.sysSQL.Exec(t, `SET CLUSTER SETTING bulkio.stream_ingestion.failover_signal_poll_interval='5s'`)
 
 				// While executing a node shutdown on either the src or destination
 				// cluster, ensure the destination cluster's stream ingestion job

--- a/pkg/jobs/jobspb/wrap.go
+++ b/pkg/jobs/jobspb/wrap.go
@@ -102,13 +102,13 @@ var _ base.SQLInstanceID
 type ReplicationStatus uint8
 
 const (
-	InitializingReplication   ReplicationStatus = 0
-	CreatingInitialSplits     ReplicationStatus = 6
-	Replicating               ReplicationStatus = 1
-	ReplicationPaused         ReplicationStatus = 2
-	ReplicationPendingCutover ReplicationStatus = 3
-	ReplicationCuttingOver    ReplicationStatus = 4
-	ReplicationError          ReplicationStatus = 5
+	InitializingReplication    ReplicationStatus = 0
+	CreatingInitialSplits      ReplicationStatus = 6
+	Replicating                ReplicationStatus = 1
+	ReplicationPaused          ReplicationStatus = 2
+	ReplicationPendingFailover ReplicationStatus = 3
+	ReplicationFailingOver     ReplicationStatus = 4
+	ReplicationError           ReplicationStatus = 5
 )
 
 // String implements fmt.Stringer.
@@ -120,10 +120,10 @@ func (rs ReplicationStatus) String() string {
 		return "replicating"
 	case ReplicationPaused:
 		return "replication paused"
-	case ReplicationPendingCutover:
-		return "replication pending cutover"
-	case ReplicationCuttingOver:
-		return "replication cutting over"
+	case ReplicationPendingFailover:
+		return "replication pending failover"
+	case ReplicationFailingOver:
+		return "replication failing over"
 	case ReplicationError:
 		return "replication error"
 	case CreatingInitialSplits:

--- a/pkg/sql/catalog/colinfo/result_columns.go
+++ b/pkg/sql/catalog/colinfo/result_columns.go
@@ -310,7 +310,7 @@ var TenantColumnsWithReplication = ResultColumns{
 	// The latest fully replicated time.
 	{Name: "replicated_time", Typ: types.TimestampTZ},
 	{Name: "replication_lag", Typ: types.Interval},
-	{Name: "cutover_time", Typ: types.Decimal},
+	{Name: "failover_time", Typ: types.Decimal},
 	{Name: "status", Typ: types.String},
 }
 


### PR DESCRIPTION
Replace `cutover` with `failover` where `cutover` is used in PCR.

Epic: none
Fixes: #133487
Release note: None