### PR TITLE
logic_test: add retry to SHOW CLUSTER SETTING

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -1440,7 +1440,7 @@ SELECT name, value FROM system.settings WHERE name = 'sql.defaults.vectorize'
 ----
 sql.defaults.vectorize  1
 
-query T
+query T retry
 SHOW CLUSTER SETTING sql.defaults.vectorize
 ----
 on
@@ -1468,7 +1468,7 @@ query TT
 SELECT name, value FROM system.settings WHERE name = 'sql.defaults.vectorize'
 ----
 
-query T
+query T retry
 SHOW CLUSTER SETTING sql.defaults.vectorize
 ----
 on


### PR DESCRIPTION
The cluster setting system is not synchronous; sometimes there is a delay between writing to system.settings and seeing the change in SHOW CLUSTER SETTING output.

Fixes: #133429

Release note: None