### PR TITLE
logictest: revert "logictest: add kv tracing to testcase for 131869"

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/column_families
+++ b/pkg/sql/logictest/testdata/logic_test/column_families
@@ -85,32 +85,22 @@ fetched: /t/t_pkey/1/2/z -> /1
 statement ok
 CREATE TABLE abc (a INT NOT NULL, b FLOAT NOT NULL, c INT, FAMILY (a), FAMILY (b), FAMILY (c))
 
-query T regexp,kvtrace(prefix=/Table/109)
+statement ok
 INSERT INTO abc VALUES (4, -0, 6)
-----
-CPut /Table/109/1/\d+/0 -> /TUPLE/1:1:Int/4
-CPut /Table/109/1/\d+/1/1 -> /FLOAT/-0
-CPut /Table/109/1/\d+/2/1 -> /INT/6
 
 statement ok
 ALTER TABLE abc ADD PRIMARY KEY (a, b)
 
-query T kvtrace(prefix=/Table/109)
+statement ok
 UPDATE abc SET c = NULL WHERE a = 4 AND b = -0
-----
-Scan /Table/109/4/4/0{-/PrefixEnd} lock Exclusive (Block, Unreplicated)
-Del /Table/109/4/4/0/2/1
 
 query IFI
 SELECT * FROM abc
 ----
 4  -0  NULL
 
-query T kvtrace(prefix=/Table/109)
-UPDATE abc SET b = 0 WHERE a = 4 AND b = -0
-----
-Scan /Table/109/4/4/0{-/PrefixEnd} lock Exclusive (Block, Unreplicated)
-Del /Table/109/4/4/0/1/1
+statement ok
+UPDATE abc SET b = 0 WHERE a = 4 AND b = -0;
 
 query IFI
 SELECT * FROM abc


### PR DESCRIPTION
This reverts part of commit 90f4a30b9dbdb2ddbe5d43abc4d7073ba48387ed. The tracing sometimes varies due to txnKVFetcher resuming a span after a partial result, and we don't need the tracing to show correctness anyway, as long as `SELECT * FROM abc` returns the correct result.

(But this keeps the enhancement to the "kvtrace" logictest command.)

Fixes: #133451

Release note: None