### PR TITLE
sql: check object type when revoking privilege

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/grant_on_all_tables_in_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_on_all_tables_in_schema
@@ -132,3 +132,12 @@ database_name  schema_name  table_name  grantee   privilege_type  is_grantable
 otherdb        public       tbl         admin     ALL             true
 otherdb        public       tbl         root      ALL             true
 otherdb        public       tbl         testuser  SELECT          false
+
+statement ok
+CREATE TABLE t131157 (c1 INT)
+
+statement ok
+GRANT ALL ON t131157 TO testuser
+
+statement error t131157 is not a sequence
+REVOKE CREATE ON SEQUENCE t131157 FROM testuser

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -538,6 +538,8 @@ func (p *planner) getDescriptorsFromTargetListForPrivilegeChange(
 							objectType: privilege.Sequence,
 						},
 					)
+				} else if targets.Tables.SequenceOnly {
+					return nil, pgerror.Newf(pgcode.WrongObjectType, "%s is not a sequence", tableDesc.GetName())
 				} else {
 					descs = append(
 						descs,


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/131157
Release note (bug fix): Fix an unhandled error that could occur when using `REVOKE ... ON SEQUENCE FROM ... user` on an object that is not a sequence.