### PR TITLE
sql/row: deflake TestExternalRowDataDistSQL

### DIFF
--- a/pkg/sql/row/external_row_data_test.go
+++ b/pkg/sql/row/external_row_data_test.go
@@ -145,7 +145,9 @@ func TestExternalRowDataDistSQL(t *testing.T) {
 
 	// Place leaseholders on nodes 3, 4, 5.
 	r0.Exec(t, `ALTER TABLE t SPLIT AT VALUES (2), (4)`)
-	r0.Exec(t, `ALTER TABLE t RELOCATE VALUES (ARRAY[3], 1), (ARRAY[4], 3), (ARRAY[5], 5)`)
+	r0.ExecSucceedsSoon(
+		t, `ALTER TABLE t RELOCATE VALUES (ARRAY[3], 1), (ARRAY[4], 3), (ARRAY[5], 5)`,
+	)
 
 	asOf := hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
 


### PR DESCRIPTION
This test runs `ALTER TABLE RELOCATE` to move leaseholders to specific nodes. When running with a secondary tenant, the tenant needs to be given the `can_admin_relocate_range` capability. The test was doing this, but I think it needs to try the ALTER TABLE RELOCATE a few times in case the capability hasn't yet gone into effect.

Fixes: #133598

Release note: None