### PR TITLE
sql: allow stats collection on tables only with virtual computed cols

### DIFF
--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -529,6 +529,12 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 
 	// Create the table readers; for this we initialize a dummy scanNode.
 	scan := scanNode{desc: desc}
+	if colCfg.wantedColumns == nil {
+		// wantedColumns cannot be left nil, and if it is nil at this point,
+		// then we only have virtual computed columns, so we'll allocate an
+		// empty slice.
+		colCfg.wantedColumns = []tree.ColumnID{}
+	}
 	err := scan.initDescDefaults(colCfg)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -2869,6 +2869,14 @@ upper_bound            range_rows  distinct_range_rows  equal_rows
 '{"bar": {"baz": 2}}'  0           0                    1
 '{"bar": {"baz": 3}}'  0           0                    1
 
+# Regression test for collecting stats on a table only with virtual computed
+# columns (#130817).
+statement ok
+CREATE TABLE t130817 (k INT PRIMARY KEY AS (NULL) VIRTUAL);
+
+statement ok
+ANALYZE t130817;
+
 # Test partial stats using extremes on indexed virtual computed columns.
 statement ok
 INSERT INTO t68254 (a, b, c) VALUES (5, '5', '{"foo": {"bar": {"baz": 5}}}')


### PR DESCRIPTION
Previously, we would violate the contract of `scanColumnsConfig.wantedColumns` for tables only with virtual computed columns - that field is not allowed to be nil while we would it leave it so. This would result in an assertion failure when trying to collect stats on such tables, and this is now fixed by simply allocating an empty slice (which represents the empty set of columns to be scanned from disk).

This seems like an edge case so I omitted the release note.

Fixes: #130817.

Release note: None