### PR TITLE
tracing: remove duplicate branches in a test

### DIFF
--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -935,11 +935,7 @@ func TestSpan_UseAfterFinish(t *testing.T) {
 				// below.
 				for i := 0; i < 20; i++ {
 					t.Run("invoke", func(t *testing.T) {
-						if i == 9 {
-							f.Func.Call(args)
-						} else {
-							f.Func.Call(args)
-						}
+						f.Func.Call(args)
 					})
 				}
 			})


### PR DESCRIPTION
My guess is that duplication was added to allow for setting breakpoint when debugging d0fbf6fd9d88cadab57da0a50ca0096c27ef33c4 and was never removed.

Fixes: #133305.

Release note: None