### PR TITLE
testcat: merge implicit type resolution for ResolveType & friends

### DIFF
--- a/pkg/sql/opt/testutils/testcat/types.go
+++ b/pkg/sql/opt/testutils/testcat/types.go
@@ -51,46 +51,12 @@ func (tc *Catalog) CreateType(c *tree.CreateType) {
 	tc.enumTypes[c.TypeName.Object()] = typ
 }
 
-// ResolveType part of the cat.Catalog interface and the
-// tree.TypeReferenceResolver interface.
-func (tc *Catalog) ResolveType(
-	ctx context.Context, name *tree.UnresolvedObjectName,
-) (*types.T, error) {
-	// First look for a matching user-defined enum type.
-	if typ := tc.enumTypes[name.Object()]; typ != nil {
-		return typ, nil
-	}
-	// Otherwise look for a matching implicit record type.
-	for _, ds := range tc.testSchema.dataSources {
-		if tab, ok := ds.(*Table); ok && tab.TabName.Object() == name.Object() {
-			contents := make([]*types.T, 0, tab.ColumnCount())
-			labels := make([]string, 0, tab.ColumnCount())
-			for i, n := 0, tab.ColumnCount(); i < n; i++ {
-				col := tab.Column(i)
-				if col.Kind() == cat.Ordinary && col.Visibility() == cat.Visible {
-					contents = append(contents, col.DatumType())
-					labels = append(labels, string(col.ColName()))
-				}
-			}
-			return types.MakeLabeledTuple(contents, labels), nil
-		}
-	}
-	return nil, errors.Newf("type %q does not exist", name)
-}
-
-// ResolveTypeByOID is part of the cat.Catalog interface.
-func (tc *Catalog) ResolveTypeByOID(ctx context.Context, typID oid.Oid) (*types.T, error) {
-	// First look for a matching user-defined enum type.
-	for _, typ := range tc.enumTypes {
-		if typ.Oid() == typID {
-			return typ, nil
-		}
-	}
-	// Otherwise look for a matching implicit record type.
+// Look for a matching implicit record type, skipping tables that don't match
+// the filter functor's criteria.
+func (tc *Catalog) resolveTypeImplicit(skipme func(tab *Table) bool) *types.T {
 	for _, ds := range tc.testSchema.dataSources {
 		if tab, ok := ds.(*Table); ok {
-			implicitTypID := typedesc.TableIDToImplicitTypeOID(descpb.ID(tab.ID()))
-			if implicitTypID != typID {
+			if skipme(tab) {
 				continue
 			}
 			contents := make([]*types.T, 0, tab.ColumnCount())
@@ -102,8 +68,48 @@ func (tc *Catalog) ResolveTypeByOID(ctx context.Context, typID oid.Oid) (*types.
 					labels = append(labels, string(col.ColName()))
 				}
 			}
-			return types.MakeLabeledTuple(contents, labels), nil
+			return types.MakeLabeledTuple(contents, labels)
 		}
 	}
-	return nil, errors.Newf("type %d does not exist", typID)
+
+	return nil
+}
+
+// ResolveType is part of the cat.Catalog interface and the
+// tree.TypeReferenceResolver interface.
+func (tc *Catalog) ResolveType(
+	ctx context.Context, name *tree.UnresolvedObjectName,
+) (*types.T, error) {
+	// First look for a matching user-defined enum type.
+	if typ := tc.enumTypes[name.Object()]; typ != nil {
+		return typ, nil
+	}
+
+	// Otherwise look for a matching implicit record type.
+	typ := tc.resolveTypeImplicit(func(tab *Table) bool {
+		return tab.TabName.Object() != name.Object()
+	})
+	if typ == nil {
+		return nil, errors.Newf("type %q does not exist", name)
+	}
+	return typ, nil
+}
+
+// ResolveTypeByOID is part of the cat.Catalog interface.
+func (tc *Catalog) ResolveTypeByOID(ctx context.Context, typID oid.Oid) (*types.T, error) {
+	// First look for a matching user-defined enum type.
+	for _, typ := range tc.enumTypes {
+		if typ.Oid() == typID {
+			return typ, nil
+		}
+	}
+
+	// Otherwise look for a matching implicit record type.
+	typ := tc.resolveTypeImplicit(func(tab *Table) bool {
+		return typedesc.TableIDToImplicitTypeOID(descpb.ID(tab.ID())) != typID
+	})
+	if typ == nil {
+		return nil, errors.Newf("type %q does not exist", typID)
+	}
+	return typ, nil
 }


### PR DESCRIPTION
Previously, testcat.ResolveType() and ResolveTypeByOID()  were completely separate functions with nearly identical implementations. This patch breaks out the identical component and parameterizes it to reduce code duplication.

Epic: none