### PR TITLE
roachtest: move metamorphic perturbation tests to their own suite

### DIFF
--- a/build/teamcity/cockroach/nightlies/perturbation_nightly_metamorphic_impl.sh
+++ b/build/teamcity/cockroach/nightlies/perturbation_nightly_metamorphic_impl.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+set -exuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+set -a
+source "$dir/teamcity-support.sh"
+set +a
+
+if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
+  ssh-keygen -q -C "roachtest-nightly-bazel $(date)" -N "" -f ~/.ssh/id_rsa
+fi
+
+source $root/build/teamcity/util/roachtest_util.sh
+
+artifacts=/artifacts
+
+arch=amd64
+$root/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh $arch
+
+build/teamcity-roachtest-invoke.sh \
+  --suite perturbation \
+  --cloud "gce" \
+  --cluster-id "${TC_BUILD_ID}" \
+  --artifacts=/artifacts \
+  --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
+  --parallelism="${PARALLELISM}" \
+  --cpu-quota="${CPUQUOTA}" \
+  --use-spot="${USE_SPOT:-auto}" \
+  --slack-token="${SLACK_TOKEN}" \
+  --side-eye-token="${SIDE_EYE_API_TOKEN}"

--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_gce_perturbation.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_gce_perturbation.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
+set -exuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e LITERAL_ARTIFACTS_DIR=$root/artifacts -e BUILD_VCS_NUMBER -e CLOUD -e COCKROACH_DEV_LICENSE -e TESTS -e COUNT -e GITHUB_API_TOKEN -e GITHUB_ORG -e GITHUB_REPO -e GOOGLE_EPHEMERAL_CREDENTIALS -e GOOGLE_KMS_KEY_A -e GOOGLE_KMS_KEY_B -e GOOGLE_CREDENTIALS_ASSUME_ROLE -e GOOGLE_SERVICE_ACCOUNT -e SLACK_TOKEN -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL -e SELECT_PROBABILITY -e COCKROACH_RANDOM_SEED -e ROACHTEST_ASSERTIONS_ENABLED_SEED -e ROACHTEST_FORCE_RUN_INVALID_RELEASE_BRANCH -e GRAFANA_SERVICE_ACCOUNT_JSON -e GRAFANA_SERVICE_ACCOUNT_AUDIENCE -e USE_SPOT -e SFUSER -e SFPASSWORD -e SIDE_EYE_API_TOKEN -e COCKROACH_EA_PROBABILITY" \
+			       run_bazel build/teamcity/cockroach/nightlies/perturbation_nightly_metamorphic_impl.sh

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -366,11 +366,13 @@ const (
 	PebbleNightlyYCSBRace = "pebble_nightly_ycsb_race"
 	Roachtest             = "roachtest"
 	Acceptance            = "acceptance"
+	Perturbation          = "perturbation"
 )
 
 var allSuites = []string{
 	Nightly, Weekly, ReleaseQualification, ORM, Driver, Tool, Smoketest, Quick, Fixtures,
 	Pebble, PebbleNightlyWrite, PebbleNightlyYCSB, PebbleNightlyYCSBRace, Roachtest, Acceptance,
+	Perturbation,
 }
 
 // SuiteSet represents a set of suites.

--- a/pkg/cmd/roachtest/registry/testdata/filter/errors
+++ b/pkg/cmd/roachtest/registry/testdata/filter/errors
@@ -6,11 +6,11 @@ error: invalid owner "badowner"
 
 filter suite=badsuite
 ----
-error: invalid suite "badsuite"; valid suites are nightly,weekly,release_qualification,orm,driver,tool,smoketest,quick,fixtures,pebble,pebble_nightly_write,pebble_nightly_ycsb,pebble_nightly_ycsb_race,roachtest,acceptance
+error: invalid suite "badsuite"; valid suites are nightly,weekly,release_qualification,orm,driver,tool,smoketest,quick,fixtures,pebble,pebble_nightly_write,pebble_nightly_ycsb,pebble_nightly_ycsb_race,roachtest,acceptance,perturbation
 
 filter owner=badowner suite=badsuite
 ----
-error: invalid suite "badsuite"; valid suites are nightly,weekly,release_qualification,orm,driver,tool,smoketest,quick,fixtures,pebble,pebble_nightly_write,pebble_nightly_ycsb,pebble_nightly_ycsb_race,roachtest,acceptance
+error: invalid suite "badsuite"; valid suites are nightly,weekly,release_qualification,orm,driver,tool,smoketest,quick,fixtures,pebble,pebble_nightly_write,pebble_nightly_ycsb,pebble_nightly_ycsb_race,roachtest,acceptance,perturbation
 
 # Filters with one field leading to no matches.
 

--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -259,7 +259,7 @@ func addMetamorphic(r registry.Registry, p perturbation, acceptableChange float6
 	r.Add(registry.TestSpec{
 		Name:             fmt.Sprintf("perturbation/metamorphic/%s", v.perturbationName()),
 		CompatibleClouds: v.cloud,
-		Suites:           registry.Suites(registry.Nightly),
+		Suites:           registry.Suites(registry.Perturbation),
 		Owner:            registry.OwnerKV,
 		Cluster:          v.makeClusterSpec(),
 		Leases:           v.leaseType,


### PR DESCRIPTION
The metamorphic perturbation tests are intended to find new bugs in existing code. They are not a regression test against existing code. As such they have funadmentally different properties that typical regression roachtests and instead are more like the DRT cluster. These tests already have a complex set of conditions they work around and it would be even more complex to try and backport those conditions to older releases.

Epic: none

Release note: None