### PR TITLE
release-23.1: roachtest: EveryN util without CRDB log

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log"
 	"math/rand"
 	"net"
 	"net/url"
@@ -45,7 +46,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -934,7 +934,7 @@ func (f *clusterFactory) newCluster(
 		logPath := filepath.Join(f.artifactsDir, runnerLogsDir, "cluster-create", c.name+retryStr+".log")
 		l, err := logger.RootLogger(logPath, teeOpt)
 		if err != nil {
-			log.Fatalf(ctx, "%v", err)
+			log.Fatalf("%v", err)
 		}
 
 		l.PrintfCtx(ctx, "Attempting cluster creation (attempt #%d/%d)", i, maxAttempts)

--- a/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
         "//pkg/testutils/sqlutils",
+        "//pkg/util",
         "//pkg/util/humanizeutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/cmd/roachtest/roachtestutil/utils.go
+++ b/pkg/cmd/roachtest/roachtestutil/utils.go
@@ -5,10 +5,34 @@
 
 package roachtestutil
 
-import "github.com/cockroachdb/cockroach/pkg/roachprod/install"
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
 
 // SystemInterfaceSystemdUnitName is a convenience function that
 // returns the systemd unit name for the system interface
 func SystemInterfaceSystemdUnitName() string {
 	return install.VirtualClusterLabel(install.SystemInterfaceName, 0)
+}
+
+// EveryN provides a way to rate limit noisy log messages. It tracks how
+// recently a given log message has been emitted so that it can determine
+// whether it's worth logging again.
+type EveryN struct {
+	util.EveryN
+}
+
+// Every is a convenience constructor for an EveryN object that allows a log
+// message every n duration.
+func Every(n time.Duration) EveryN {
+	return EveryN{EveryN: util.Every(n)}
+}
+
+// ShouldLog returns whether it's been more than N time since the last event.
+func (e *EveryN) ShouldLog() bool {
+	return e.ShouldProcess(timeutil.Now())
 }

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -35,7 +35,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/util/allstacks"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -516,7 +515,7 @@ func (r *testRunner) runWorker(
 	stdout := lopt.stdout
 
 	ctx = logtags.AddTag(ctx, name, nil /* value */)
-	wStatus := r.addWorker(ctx, name)
+	wStatus := r.addWorker(ctx, l, name)
 	defer func() {
 		r.removeWorker(ctx, name)
 	}()
@@ -575,7 +574,7 @@ func (r *testRunner) runWorker(
 		testToRun := testToRunRes{noWork: true}
 		if c != nil {
 			// Try to reuse cluster.
-			testToRun = work.selectTestForCluster(ctx, c.spec, r.cr)
+			testToRun = work.selectTestForCluster(ctx, l, c.spec, r.cr)
 			if !testToRun.noWork {
 				// We found a test to run on this cluster. Wipe the cluster.
 				if err := c.WipeForReuse(ctx, l, testToRun.spec.Cluster); err != nil {
@@ -1454,12 +1453,12 @@ func (r *testRunner) generateReport() string {
 }
 
 // addWorker updates the bookkeeping for one more worker.
-func (r *testRunner) addWorker(ctx context.Context, name string) *workerStatus {
+func (r *testRunner) addWorker(ctx context.Context, l *logger.Logger, name string) *workerStatus {
 	r.workersMu.Lock()
 	defer r.workersMu.Unlock()
 	w := &workerStatus{name: name}
 	if _, ok := r.workersMu.workers[name]; ok {
-		log.Fatalf(ctx, "worker %q already exists", name)
+		l.FatalfCtx(ctx, "worker %q already exists", name)
 	}
 	r.workersMu.workers[name] = w
 	return w

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -237,7 +237,6 @@ go_library(
         "//pkg/util/httputil",
         "//pkg/util/humanizeutil",
         "//pkg/util/intsets",
-        "//pkg/util/log",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
         "//pkg/util/retry",

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -344,10 +343,10 @@ func registerBackup(r registry.Registry) {
 				// runner copies it into an appropriate directory path.
 				dest := filepath.Join(t.PerfArtifactsDir(), "stats.json")
 				if err := c.RunE(ctx, c.Node(1), "mkdir -p "+filepath.Dir(dest)); err != nil {
-					log.Errorf(ctx, "failed to create perf dir: %+v", err)
+					t.L().ErrorfCtx(ctx, "failed to create perf dir: %+v", err)
 				}
 				if err := c.PutString(ctx, perfBuf.String(), dest, 0755, c.Node(1)); err != nil {
-					log.Errorf(ctx, "failed to upload perf artifacts to node: %s", err.Error())
+					t.L().ErrorfCtx(ctx, "failed to upload perf artifacts to node: %s", err.Error())
 				}
 				return nil
 			})

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/errors"
 )
@@ -151,10 +150,10 @@ func registerImportTPCC(r registry.Registry) {
 			// runner copies it into an appropriate directory path.
 			dest := filepath.Join(t.PerfArtifactsDir(), "stats.json")
 			if err := c.RunE(ctx, c.Node(1), "mkdir -p "+filepath.Dir(dest)); err != nil {
-				log.Errorf(ctx, "failed to create perf dir: %+v", err)
+				t.L().ErrorfCtx(ctx, "failed to create perf dir: %+v", err)
 			}
 			if err := c.PutString(ctx, perfBuf.String(), dest, 0755, c.Node(1)); err != nil {
-				log.Errorf(ctx, "failed to upload perf artifacts to node: %s", err.Error())
+				t.L().ErrorfCtx(ctx, "failed to upload perf artifacts to node: %s", err.Error())
 			}
 			return nil
 		})
@@ -319,10 +318,10 @@ func registerImportTPCH(r registry.Registry) {
 					// runner copies it into an appropriate directory path.
 					dest := filepath.Join(t.PerfArtifactsDir(), "stats.json")
 					if err := c.RunE(ctx, c.Node(1), "mkdir -p "+filepath.Dir(dest)); err != nil {
-						log.Errorf(ctx, "failed to create perf dir: %+v", err)
+						t.L().ErrorfCtx(ctx, "failed to create perf dir: %+v", err)
 					}
 					if err := c.PutString(ctx, perfBuf.String(), dest, 0755, c.Node(1)); err != nil {
-						log.Errorf(ctx, "failed to upload perf artifacts to node: %s", err.Error())
+						t.L().ErrorfCtx(ctx, "failed to upload perf artifacts to node: %s", err.Error())
 					}
 					return nil
 				})

--- a/pkg/cmd/roachtest/tests/latency_verifier.go
+++ b/pkg/cmd/roachtest/tests/latency_verifier.go
@@ -11,9 +11,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/codahale/hdrhistogram"
@@ -41,10 +41,10 @@ type latencyVerifier struct {
 	initialScanHighwater time.Time
 	initialScanLatency   time.Duration
 
-	catchupScanEveryN log.EveryN
+	catchupScanEveryN roachtestutil.EveryN
 
 	maxSeenSteadyLatency time.Duration
-	maxSeenSteadyEveryN  log.EveryN
+	maxSeenSteadyEveryN  roachtestutil.EveryN
 	latencyBecameSteady  bool
 
 	latencyHist *hdrhistogram.Histogram
@@ -74,8 +74,8 @@ func makeLatencyVerifier(
 		setTestStatus:            setTestStatus,
 		latencyHist:              hist,
 		tolerateErrors:           tolerateErrors,
-		maxSeenSteadyEveryN:      log.Every(10 * time.Second),
-		catchupScanEveryN:        log.Every(2 * time.Second),
+		maxSeenSteadyEveryN:      roachtestutil.Every(10 * time.Second),
+		catchupScanEveryN:        roachtestutil.Every(2 * time.Second),
 	}
 }
 

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -1700,6 +1700,7 @@ func (d *BackupRestoreTestDriver) computeTableContents(
 	}
 
 	if err := eg.Wait(); err != nil {
+		l.ErrorfCtx(ctx, "Error loading system table content %s", err)
 		return nil, err
 	}
 

--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -248,7 +247,7 @@ func (cmvt *cdcMixedVersionTester) setupValidator(
 func (cmvt *cdcMixedVersionTester) runKafkaConsumer(
 	ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper,
 ) error {
-	everyN := log.Every(30 * time.Second)
+	everyN := roachtestutil.Every(30 * time.Second)
 
 	// This runs until the test finishes, which will be signaled via
 	// context cancellation. We rely on consumer.Next() to check

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/cockroachdb/errors"
@@ -872,10 +871,10 @@ func exportToRoachperf(
 	// runner copies it into an appropriate directory path.
 	dest := filepath.Join(t.PerfArtifactsDir(), "stats.json")
 	if err := c.RunE(ctx, c.Node(1), "mkdir -p "+filepath.Dir(dest)); err != nil {
-		log.Errorf(ctx, "failed to create perf dir: %+v", err)
+		t.L().ErrorfCtx(ctx, "failed to create perf dir: %+v", err)
 	}
 	if err := c.PutString(ctx, bytesBuf.String(), dest, 0755, c.Node(1)); err != nil {
-		log.Errorf(ctx, "failed to upload perf artifacts to node: %s", err.Error())
+		t.L().ErrorfCtx(ctx, "failed to upload perf artifacts to node: %s", err.Error())
 	}
 }
 

--- a/pkg/cmd/roachtest/work_pool.go
+++ b/pkg/cmd/roachtest/work_pool.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
@@ -83,7 +82,7 @@ func (p *workPool) workRemaining() []testWithCount {
 //
 // cr is used for its information about how many clusters with a given tag currently exist.
 func (p *workPool) selectTestForCluster(
-	ctx context.Context, s spec.ClusterSpec, cr *clusterRegistry,
+	ctx context.Context, l *logger.Logger, s spec.ClusterSpec, cr *clusterRegistry,
 ) testToRunRes {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -101,14 +100,14 @@ func (p *workPool) selectTestForCluster(
 	candidateScore := 0
 	var candidate testWithCount
 	for _, tc := range testsWithCounts {
-		score := scoreTestAgainstCluster(tc, tag, cr)
+		score := scoreTestAgainstCluster(l, tc, tag, cr)
 		if score > candidateScore {
 			candidateScore = score
 			candidate = tc
 		}
 	}
 
-	p.decTestLocked(ctx, candidate.spec.Name)
+	p.decTestLocked(ctx, l, candidate.spec.Name)
 
 	runNum := p.count - candidate.count + 1
 	return testToRunRes{
@@ -177,7 +176,7 @@ func (p *workPool) selectTest(
 
 		tc := p.mu.tests[candidateIdx]
 		runNum := p.count - tc.count + 1
-		p.decTestLocked(ctx, tc.spec.Name)
+		p.decTestLocked(ctx, l, tc.spec.Name)
 		ttr = testToRunRes{
 			spec:            tc.spec,
 			runCount:        p.count,
@@ -206,13 +205,16 @@ func (p *workPool) selectTest(
 //
 // cr is used for its information about how many clusters with a given tag
 // currently exist.
-func scoreTestAgainstCluster(tc testWithCount, tag string, cr *clusterRegistry) int {
+func scoreTestAgainstCluster(
+	l *logger.Logger, tc testWithCount, tag string, cr *clusterRegistry,
+) int {
 	t := tc.spec
 	testPolicy := t.Cluster.ReusePolicy
 	if tag != "" && testPolicy != (spec.ReusePolicyTagged{Tag: tag}) {
-		log.Fatalf(context.TODO(),
+		l.Fatalf(
 			"incompatible test and cluster. Cluster tag: %s. Test policy: %+v",
-			tag, t.Cluster.ReusePolicy)
+			tag, t.Cluster.ReusePolicy,
+		)
 	}
 	score := 0
 	if _, ok := testPolicy.(spec.ReusePolicyAny); ok {
@@ -251,7 +253,7 @@ func (p *workPool) findCompatibleTestsLocked(clusterSpec spec.ClusterSpec) []tes
 
 // decTestLocked decrements a test's remaining count and removes it
 // from the workPool if it was exhausted.
-func (p *workPool) decTestLocked(ctx context.Context, name string) {
+func (p *workPool) decTestLocked(ctx context.Context, l *logger.Logger, name string) {
 	idx := -1
 	for idx = range p.mu.tests {
 		if p.mu.tests[idx].spec.Name == name {
@@ -259,7 +261,7 @@ func (p *workPool) decTestLocked(ctx context.Context, name string) {
 		}
 	}
 	if idx == -1 {
-		log.Fatalf(ctx, "failed to find test: %s", name)
+		l.FatalfCtx(ctx, "failed to find test: %s", name)
 	}
 	tc := &p.mu.tests[idx]
 	tc.count--

--- a/pkg/roachprod/logger/BUILD.bazel
+++ b/pkg/roachprod/logger/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/roachprod/logger",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/cli/exit",
         "//pkg/util/log",
         "//pkg/util/syncutil",
     ],

--- a/pkg/roachprod/logger/log.go
+++ b/pkg/roachprod/logger/log.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	crdblog "github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
@@ -283,6 +284,25 @@ func (l *Logger) PrintfCtx(ctx context.Context, f string, args ...interface{}) {
 // can be passed.
 func (l *Logger) Printf(f string, args ...interface{}) {
 	l.PrintfCtxDepth(context.Background(), 2 /* depth */, f, args...)
+}
+
+// FatalfCtxDepth is like ErrorfCtxDepth, except that it closes the logger after
+// logging the message and then exits the process with status 1.
+func (l *Logger) FatalfCtxDepth(ctx context.Context, depth int, f string, args ...interface{}) {
+	l.ErrorfCtxDepth(ctx, depth, f, args...)
+	l.Close()
+	exit.WithCode(exit.UnspecifiedError())
+}
+
+// FatalfCtx is like FatalfCtxDepth, except without having to pass depth explicitly.
+func (l *Logger) FatalfCtx(ctx context.Context, f string, args ...interface{}) {
+	l.FatalfCtxDepth(ctx, 2 /* depth */, f, args...)
+}
+
+// Fatalf is like FatalfCtx, except it doesn't take a ctx and thus no log tags
+// can be passed.
+func (l *Logger) Fatalf(f string, args ...interface{}) {
+	l.FatalfCtx(context.Background(), f, args...)
 }
 
 // PrintfCtxDepth is like PrintfCtx, except that it allows the caller to control


### PR DESCRIPTION
Backport 4/4 commits from #132594.

/cc @cockroachdb/release

---

This PR removes all references to CRDB log usage in roachtest. There are still a few transitive dependencies that end up calling CRDB log. These are small enough and get redirected to a separate file if they need to be inspected. Ultimately, we want to ensure that the appropriate loggers get used in roachtests, that are supplied by the test framework. After this PR, a linter can be introduced to ban the top-level import of CRDB log from roachtest. The only remaining direct usage in roachtest is to configure CRDB log to use a file sink, but this will be updated by another PR #132586 that moves the redirect functionality alongside the roachprod logger implementation.

Informs: #131412

Epic: None
Release note: None

Release justification: Test only change