### PR TITLE
sql: fix erroneous NOT NULL constraint violations in UPSERTs and refactor upsert logic

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -253,7 +253,7 @@ go_library(
         "tablewriter_delete.go",
         "tablewriter_insert.go",
         "tablewriter_update.go",
-        "tablewriter_upsert_opt.go",
+        "tablewriter_upsert.go",
         "telemetry.go",
         "telemetry_logging.go",
         "temporary_schema.go",

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -1357,3 +1357,73 @@ query III
 SELECT * FROM arbiter_index
 ----
 1  2  10
+
+subtest regression_133146
+
+# Regression test for #133146. Columns that are not updated in an UPSERT should
+# not cause not-null constraint violations.
+statement ok
+CREATE TABLE t133146 (
+  id INT PRIMARY KEY,
+  a INT NOT NULL,
+  b INT
+)
+
+statement ok
+INSERT INTO t133146 (id, a, b) VALUES (1, 2, 3)
+
+# This should not cause a not-null constraint violation of column "a" because
+# the value of "a" is not being updated to NULL in the existing row.
+statement ok
+UPSERT INTO t133146 (id, b) VALUES (1, 30)
+
+query III
+SELECT * FROM t133146
+----
+1  2  30
+
+statement ok
+INSERT INTO t133146 (id, b) VALUES (1, 40) ON CONFLICT (id) DO UPDATE SET b = 40
+
+query III
+SELECT * FROM t133146
+----
+1  2  40
+
+statement error pgcode 23502 pq: null value in column \"a\" violates not-null constraint
+UPSERT INTO t133146 (id, a) VALUES (1, NULL)
+
+statement error pgcode 23502 pq: null value in column \"a\" violates not-null constraint
+INSERT INTO t133146 (id, b) VALUES (1, 50) ON CONFLICT (id) DO UPDATE SET a = NULL
+
+statement ok
+CREATE TABLE t133146b (
+  a INT,
+  b INT NOT NULL,
+  id INT PRIMARY KEY
+)
+
+statement ok
+INSERT INTO t133146b (id, a, b) VALUES (1, 2, 3)
+
+statement ok
+UPSERT INTO t133146b (id, b) VALUES (1, 30)
+
+query III
+SELECT * FROM t133146b
+----
+2  30  1
+
+statement ok
+INSERT INTO t133146b (id, b) VALUES (1, 40) ON CONFLICT (id) DO UPDATE SET b = 40
+
+query III
+SELECT * FROM t133146b
+----
+2  40  1
+
+statement error pgcode 23502 pq: null value in column \"b\" violates not-null constraint
+UPSERT INTO t133146b (id, b) VALUES (1, NULL)
+
+statement error pgcode 23502 pq: null value in column \"b\" violates not-null constraint
+INSERT INTO t133146b (id, a) VALUES (1, 20) ON CONFLICT (id) DO UPDATE SET b = NULL

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1694,7 +1694,7 @@ func (ef *execFactory) ConstructUpsert(
 		run: upsertRun{
 			checkOrds:  checks,
 			insertCols: ri.InsertCols,
-			tw: optTableUpserter{
+			tw: tableUpserter{
 				ri:            ri,
 				canaryOrdinal: int(canaryCol),
 				fetchCols:     fetchCols,

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -76,10 +76,6 @@ type tableWriter interface {
 	// close frees all resources held by the tableWriter.
 	close(context.Context)
 
-	// desc returns a name suitable for describing the table writer in
-	// the output of EXPLAIN.
-	desc() string
-
 	// enable auto commit in call to finalize().
 	enableAutoCommit()
 }

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -27,13 +27,6 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// expressionCarrier handles visiting sub-expressions.
-type expressionCarrier interface {
-	// walkExprs explores all sub-expressions held by this object, if
-	// any.
-	walkExprs(func(desc string, index int, expr tree.TypedExpr))
-}
-
 // tableWriter handles writing kvs and forming table rows.
 //
 // Usage:
@@ -48,8 +41,6 @@ type expressionCarrier interface {
 //	err := tw.finalize()
 //	// Handle err.
 type tableWriter interface {
-	expressionCarrier
-
 	// init provides the tableWriter with a Txn and optional monitor to write to
 	// and returns an error if it was misconfigured.
 	init(context.Context, *kv.Txn, *eval.Context) error

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
@@ -26,59 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
-
-// tableWriter handles writing kvs and forming table rows.
-//
-// Usage:
-//
-//	err := tw.init(txn, evalCtx)
-//	// Handle err.
-//	for {
-//	   values := ...
-//	   row, err := tw.row(values)
-//	   // Handle err.
-//	}
-//	err := tw.finalize()
-//	// Handle err.
-type tableWriter interface {
-	// init provides the tableWriter with a Txn and optional monitor to write to
-	// and returns an error if it was misconfigured.
-	init(context.Context, *kv.Txn, *eval.Context) error
-
-	// row performs a sql row modification (tableInserter performs an insert,
-	// etc). It batches up writes to the init'd txn and periodically sends them.
-	//
-	// The passed Datums is not used after `row` returns.
-	//
-	// The PartialIndexUpdateHelper is used to determine which partial indexes
-	// to avoid updating when performing row modification. This is necessary
-	// because not all rows are indexed by partial indexes.
-	//
-	// The traceKV parameter determines whether the individual K/V operations
-	// should be logged to the context. We use a separate argument here instead
-	// of a Value field on the context because Value access in context.Context
-	// is rather expensive and the tableWriter interface is used on the
-	// inner loop of table accesses.
-	row(context.Context, tree.Datums, row.PartialIndexUpdateHelper, bool /* traceKV */) error
-
-	// flushAndStartNewBatch is called at the end of each batch but the last.
-	// This should flush the current batch.
-	flushAndStartNewBatch(context.Context) error
-
-	// finalize flushes out any remaining writes. It is called after all calls
-	// to row.
-	finalize(context.Context) error
-
-	// tableDesc returns the TableDescriptor for the table that the tableWriter
-	// will modify.
-	tableDesc() catalog.TableDescriptor
-
-	// close frees all resources held by the tableWriter.
-	close(context.Context)
-
-	// enable auto commit in call to finalize().
-	enableAutoCommit()
-}
 
 type autoCommitOpt int
 
@@ -149,6 +95,7 @@ var maxBatchBytes = settings.RegisterByteSizeSetting(
 	4<<20,
 )
 
+// init initializes the tableWriterBase with a Txn.
 func (tb *tableWriterBase) init(
 	txn *kv.Txn, tableDesc catalog.TableDescriptor, evalCtx *eval.Context,
 ) error {

--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -28,9 +28,6 @@ type tableDeleter struct {
 
 var _ tableWriter = &tableDeleter{}
 
-// desc is part of the tableWriter interface.
-func (*tableDeleter) desc() string { return "deleter" }
-
 // init is part of the tableWriter interface.
 func (td *tableDeleter) init(_ context.Context, txn *kv.Txn, evalCtx *eval.Context) error {
 	return td.tableWriterBase.init(txn, td.tableDesc(), evalCtx)

--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -31,9 +31,6 @@ var _ tableWriter = &tableDeleter{}
 // desc is part of the tableWriter interface.
 func (*tableDeleter) desc() string { return "deleter" }
 
-// walkExprs is part of the tableWriter interface.
-func (td *tableDeleter) walkExprs(_ func(desc string, index int, expr tree.TypedExpr)) {}
-
 // init is part of the tableWriter interface.
 func (td *tableDeleter) init(_ context.Context, txn *kv.Txn, evalCtx *eval.Context) error {
 	return td.tableWriterBase.init(txn, td.tableDesc(), evalCtx)

--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -26,14 +26,23 @@ type tableDeleter struct {
 	alloc *tree.DatumAlloc
 }
 
-var _ tableWriter = &tableDeleter{}
-
-// init is part of the tableWriter interface.
+// init initializes the tableDeleter with a Txn.
 func (td *tableDeleter) init(_ context.Context, txn *kv.Txn, evalCtx *eval.Context) error {
 	return td.tableWriterBase.init(txn, td.tableDesc(), evalCtx)
 }
 
-// row is part of the tableWriter interface.
+// row performs a delete.
+//
+// The passed Datums is not used after `row` returns.
+//
+// The PartialIndexUpdateHelper is used to determine which partial indexes
+// to avoid updating when performing row modification. This is necessary
+// because not all rows are indexed by partial indexes.
+//
+// The traceKV parameter determines whether the individual K/V operations
+// should be logged to the context. We use a separate argument here instead
+// of a Value field on the context because Value access in context.Context
+// is rather expensive.
 func (td *tableDeleter) row(
 	ctx context.Context, values tree.Datums, pm row.PartialIndexUpdateHelper, traceKV bool,
 ) error {
@@ -71,6 +80,8 @@ func (td *tableDeleter) deleteIndex(
 	return td.b.Results[0].ResumeSpanAsValue(), nil
 }
 
+// tableDesc returns the TableDescriptor for the table that the tableDeleter
+// will modify.
 func (td *tableDeleter) tableDesc() catalog.TableDescriptor {
 	return td.rd.Helper.TableDesc
 }

--- a/pkg/sql/tablewriter_insert.go
+++ b/pkg/sql/tablewriter_insert.go
@@ -43,6 +43,3 @@ func (ti *tableInserter) row(
 func (ti *tableInserter) tableDesc() catalog.TableDescriptor {
 	return ti.ri.Helper.TableDesc
 }
-
-// walkExprs is part of the tableWriter interface.
-func (ti *tableInserter) walkExprs(_ func(desc string, index int, expr tree.TypedExpr)) {}

--- a/pkg/sql/tablewriter_insert.go
+++ b/pkg/sql/tablewriter_insert.go
@@ -21,14 +21,23 @@ type tableInserter struct {
 	ri row.Inserter
 }
 
-var _ tableWriter = &tableInserter{}
-
-// init is part of the tableWriter interface.
+// init initializes the tableInserter with a Txn.
 func (ti *tableInserter) init(_ context.Context, txn *kv.Txn, evalCtx *eval.Context) error {
 	return ti.tableWriterBase.init(txn, ti.tableDesc(), evalCtx)
 }
 
-// row is part of the tableWriter interface.
+// row performs an insert.
+//
+// The passed Datums is not used after `row` returns.
+//
+// The PartialIndexUpdateHelper is used to determine which partial indexes
+// to avoid updating when performing row modification. This is necessary
+// because not all rows are indexed by partial indexes.
+//
+// The traceKV parameter determines whether the individual K/V operations
+// should be logged to the context. We use a separate argument here instead
+// of a Value field on the context because Value access in context.Context
+// is rather expensive.
 func (ti *tableInserter) row(
 	ctx context.Context, values tree.Datums, pm row.PartialIndexUpdateHelper, traceKV bool,
 ) error {
@@ -36,7 +45,8 @@ func (ti *tableInserter) row(
 	return ti.ri.InsertRow(ctx, &ti.putter, values, pm, nil, false /* overwrite */, traceKV)
 }
 
-// tableDesc is part of the tableWriter interface.
+// tableDesc returns the TableDescriptor for the table that the tableInserter
+// will modify.
 func (ti *tableInserter) tableDesc() catalog.TableDescriptor {
 	return ti.ri.Helper.TableDesc
 }

--- a/pkg/sql/tablewriter_insert.go
+++ b/pkg/sql/tablewriter_insert.go
@@ -23,9 +23,6 @@ type tableInserter struct {
 
 var _ tableWriter = &tableInserter{}
 
-// desc is part of the tableWriter interface.
-func (*tableInserter) desc() string { return "inserter" }
-
 // init is part of the tableWriter interface.
 func (ti *tableInserter) init(_ context.Context, txn *kv.Txn, evalCtx *eval.Context) error {
 	return ti.tableWriterBase.init(txn, ti.tableDesc(), evalCtx)

--- a/pkg/sql/tablewriter_update.go
+++ b/pkg/sql/tablewriter_update.go
@@ -56,6 +56,3 @@ func (tu *tableUpdater) rowForUpdate(
 func (tu *tableUpdater) tableDesc() catalog.TableDescriptor {
 	return tu.ru.Helper.TableDesc
 }
-
-// walkExprs is part of the tableWriter interface.
-func (tu *tableUpdater) walkExprs(_ func(desc string, index int, expr tree.TypedExpr)) {}

--- a/pkg/sql/tablewriter_update.go
+++ b/pkg/sql/tablewriter_update.go
@@ -21,24 +21,23 @@ type tableUpdater struct {
 	ru row.Updater
 }
 
-var _ tableWriter = &tableUpdater{}
-
-// init is part of the tableWriter interface.
+// init initializes the tableUpdater with a Txn.
 func (tu *tableUpdater) init(_ context.Context, txn *kv.Txn, evalCtx *eval.Context) error {
 	return tu.tableWriterBase.init(txn, tu.tableDesc(), evalCtx)
 }
 
-// row is part of the tableWriter interface.
-// We don't implement this because tu.ru.UpdateRow wants two slices
-// and it would be a shame to split the incoming slice on every call.
-// Instead provide a separate rowForUpdate() below.
-func (tu *tableUpdater) row(
-	context.Context, tree.Datums, row.PartialIndexUpdateHelper, bool,
-) error {
-	panic("unimplemented")
-}
-
-// rowForUpdate extends row() from the tableWriter interface.
+// rowForUpdate performs an update.
+//
+// The passed Datums is not used after `rowForUpdate` returns.
+//
+// The PartialIndexUpdateHelper is used to determine which partial indexes
+// to avoid updating when performing row modification. This is necessary
+// because not all rows are indexed by partial indexes.
+//
+// The traceKV parameter determines whether the individual K/V operations
+// should be logged to the context. We use a separate argument here instead
+// of a Value field on the context because Value access in context.Context
+// is rather expensive.
 func (tu *tableUpdater) rowForUpdate(
 	ctx context.Context,
 	oldValues, updateValues tree.Datums,
@@ -49,7 +48,8 @@ func (tu *tableUpdater) rowForUpdate(
 	return tu.ru.UpdateRow(ctx, tu.b, oldValues, updateValues, pm, nil, traceKV)
 }
 
-// tableDesc is part of the tableWriter interface.
+// tableDesc returns the TableDescriptor for the table that the tableUpdater
+// will modify.
 func (tu *tableUpdater) tableDesc() catalog.TableDescriptor {
 	return tu.ru.Helper.TableDesc
 }

--- a/pkg/sql/tablewriter_update.go
+++ b/pkg/sql/tablewriter_update.go
@@ -23,9 +23,6 @@ type tableUpdater struct {
 
 var _ tableWriter = &tableUpdater{}
 
-// desc is part of the tableWriter interface.
-func (*tableUpdater) desc() string { return "updater" }
-
 // init is part of the tableWriter interface.
 func (tu *tableUpdater) init(_ context.Context, txn *kv.Txn, evalCtx *eval.Context) error {
 	return tu.tableWriterBase.init(txn, tu.tableDesc(), evalCtx)

--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -255,17 +255,6 @@ func (tu *optTableUpserter) updateConflictingRow(
 	pm row.PartialIndexUpdateHelper,
 	traceKV bool,
 ) error {
-	// Enforce the column constraints.
-	// Note: the column constraints are already enforced for fetchRow,
-	// because:
-	// - for the insert part, they were checked upstream in upsertNode
-	//   via GenerateInsertRow().
-	// - for the fetched part, we assume that the data in the table is
-	//   correct already.
-	if err := enforceNotNullConstraints(updateValues, tu.updateCols); err != nil {
-		return err
-	}
-
 	// Queue the update in KV. This also returns an "update row"
 	// containing the updated values for every column in the
 	// table. This is useful for RETURNING, which we collect below.

--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -152,9 +152,6 @@ func (tu *optTableUpserter) makeResultFromRow(
 	return resultRow
 }
 
-// desc is part of the tableWriter interface.
-func (*optTableUpserter) desc() string { return "opt upserter" }
-
 // row is part of the tableWriter interface.
 func (tu *optTableUpserter) row(
 	ctx context.Context, row tree.Datums, pm row.PartialIndexUpdateHelper, traceKV bool,

--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -300,7 +300,3 @@ func (tu *optTableUpserter) updateConflictingRow(
 func (tu *optTableUpserter) tableDesc() catalog.TableDescriptor {
 	return tu.ri.Helper.TableDesc
 }
-
-// walkExprs is part of the tableWriter interface.
-func (tu *optTableUpserter) walkExprs(walk func(desc string, index int, expr tree.TypedExpr)) {
-}

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -37,7 +37,7 @@ var _ mutationPlanNode = &upsertNode{}
 
 // upsertRun contains the run-time state of upsertNode during local execution.
 type upsertRun struct {
-	tw        optTableUpserter
+	tw        tableUpserter
 	checkOrds checkSet
 
 	// insertCols are the columns being inserted/upserted into.

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -134,8 +134,26 @@ func (n *upsertNode) BatchedNext(params runParams) (bool, error) {
 // processSourceRow processes one row from the source for upsertion.
 // The table writer is in charge of accumulating the result rows.
 func (n *upsertNode) processSourceRow(params runParams, rowVals tree.Datums) error {
-	if err := enforceNotNullConstraints(rowVals, n.run.insertCols); err != nil {
-		return err
+	// Check for NOT NULL constraint violations.
+	if n.run.tw.canaryOrdinal != -1 && rowVals[n.run.tw.canaryOrdinal] != tree.DNull {
+		// When there is a canary column and its value is not NULL, then an
+		// existing row is being updated, so check only the update columns for
+		// NOT NULL constraint violations.
+		offset := len(n.run.insertCols) + len(n.run.tw.fetchCols)
+		vals := rowVals[offset : offset+len(n.run.tw.updateCols)]
+		if err := enforceNotNullConstraints(vals, n.run.tw.updateCols); err != nil {
+			return err
+		}
+	} else {
+		// Otherwise, there is no canary column (i.e., canaryOrdinal is -1,
+		// which is the case for "blind" upsert which overwrites existing rows
+		// without performing a read) or it is NULL, indicating that a new row
+		// is being inserted. In this case, check the insert columns for a NOT
+		// NULL constraint violation.
+		vals := rowVals[:len(n.run.insertCols)]
+		if err := enforceNotNullConstraints(vals, n.run.insertCols); err != nil {
+			return err
+		}
 	}
 
 	// Create a set of partial index IDs to not add or remove entries from.


### PR DESCRIPTION
#### sql: fix erroneous NOT NULL constraint violations in UPSERTs

Fixes #133146

Release note (bug fix): A bug has been fixed that caused incorrect NOT
NULL constraint violation errors on `UPSERT` and `INSERT .. ON CONFLICT
.. DO UPDATE` statements when those statements updated an existing row
and a subset of columns which did not include a `NOT NULL` column of the
table. This bug has been present since at least version 20.1.0.

#### sql: remove `expressionCarrier` interface

This commit removes the unused `expressionCarrier` interface and the
implementations of its single method, `walkExprs`.

Release note: None

#### sql: remove unused `desc` method from `tableWriter` interface

This commit removes the unused `desc` method from the `tableWriter`
interface and its implementations.

Release note: None

#### sql: remove `tableWriter` interface

The `tableWriter` interface was never used. All types implementing this
interface were always used directly.

Release note: None

#### sql: add assertion for `enforceNotNullConstraints`

The `enforceNotNullConstraints` function now has an assertion enforcing
the lengths of its input to prevent incorrect usage.

Release note: None

#### sql: refactor upsert table writer

This commit refactors the upsert table writer which had names and
references to logic implementation details that no longer exist because
they were made obsolete by the cost-based optimizer.

Release note: None
