### PR TITLE
crosscluster/logical: writer loses timestamp tie

### DIFF
--- a/pkg/ccl/crosscluster/logical/lww_kv_processor.go
+++ b/pkg/ccl/crosscluster/logical/lww_kv_processor.go
@@ -411,7 +411,7 @@ func (p *kvTableWriter) insertRow(ctx context.Context, b *kv.Batch, after cdceve
 		OriginTimestamp: after.MvccTimestamp,
 		// TODO(ssd): We should choose this based by comparing the cluster IDs of the source
 		// and destination clusters.
-		ShouldWinTie: true,
+		// ShouldWinTie: true,
 	}
 	return p.ri.InsertRow(ctx, &row.KVBatchAdapter{Batch: b}, p.newVals, ph, oth, false, false)
 }
@@ -432,7 +432,7 @@ func (p *kvTableWriter) updateRow(
 		OriginTimestamp: after.MvccTimestamp,
 		// TODO(ssd): We should choose this based by comparing the cluster IDs of the source
 		// and destination clusters.
-		ShouldWinTie: true,
+		// ShouldWinTie: true,
 	}
 	_, err := p.ru.UpdateRow(ctx, b, p.oldVals, p.newVals, ph, oth, false)
 	return err
@@ -452,7 +452,7 @@ func (p *kvTableWriter) deleteRow(
 		OriginTimestamp:    after.MvccTimestamp,
 		// TODO(ssd): We should choose this based by comparing the cluster IDs of the source
 		// and destination clusters.
-		ShouldWinTie: true,
+		// ShouldWinTie: true,
 	}
 
 	return p.rd.DeleteRow(ctx, b, p.oldVals, ph, oth, false)

--- a/pkg/ccl/crosscluster/logical/lww_row_processor.go
+++ b/pkg/ccl/crosscluster/logical/lww_row_processor.go
@@ -588,9 +588,9 @@ VALUES (%s)
 ON CONFLICT (%s)
 DO UPDATE SET
 %s
-WHERE (t.crdb_internal_mvcc_timestamp <= $%[6]d
+WHERE (t.crdb_internal_mvcc_timestamp < $%[6]d
     AND t.crdb_internal_origin_timestamp IS NULL)
- OR (t.crdb_internal_origin_timestamp <= $%[6]d
+ OR (t.crdb_internal_origin_timestamp < $%[6]d
  	AND t.crdb_internal_origin_timestamp IS NOT NULL)`
 )
 


### PR DESCRIPTION
While the KV write path has the ability to choose a consistent winner of timestamp ties, for now we are saying the writer always loses such a tie. The reasoning here is that such ties are very unlikely and as a result most of the time we are seeing a tie, it is actually a re-transmission and eliding the write makes more sense.

Epic: none
Release note: None