### PR TITLE
kvserver/rangefeed: minor test helper refactor

### DIFF
--- a/pkg/kv/kvserver/rangefeed/registry_helper_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_helper_test.go
@@ -182,7 +182,7 @@ func (s *testStream) SetSendErr(err error) {
 	s.mu.sendErr = err
 }
 
-func (s *testStream) Events() []*kvpb.RangeFeedEvent {
+func (s *testStream) GetAndClearEvents() []*kvpb.RangeFeedEvent {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	es := s.mu.events

--- a/pkg/kv/kvserver/rangefeed/sender_helper_test.go
+++ b/pkg/kv/kvserver/rangefeed/sender_helper_test.go
@@ -35,8 +35,8 @@ func (c *testRangefeedCounter) UpdateMetricsOnRangefeedDisconnect() {
 	c.count.Add(-1)
 }
 
-func (c *testRangefeedCounter) get() int32 {
-	return c.count.Load()
+func (c *testRangefeedCounter) get() int {
+	return int(c.count.Load())
 }
 
 // testServerStream mocks grpc server stream for testing.

--- a/pkg/kv/kvserver/rangefeed/unbuffered_sender_test.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_sender_test.go
@@ -58,10 +58,10 @@ func TestUnbufferedSenderDisconnect(t *testing.T) {
 		streamCtx, cancel := context.WithCancel(context.Background())
 		ubs.AddStream(streamID, cancel)
 		// Note that kvpb.NewError(nil) == nil.
-		require.Equal(t, testRangefeedCounter.get(), int32(1))
+		require.Equal(t, 1, testRangefeedCounter.get())
 		ubs.SendBufferedError(makeMuxRangefeedErrorEvent(streamID, rangeID,
 			kvpb.NewError(nil)))
-		require.Equal(t, testRangefeedCounter.get(), int32(0))
+		require.Equal(t, 0, testRangefeedCounter.get())
 		require.Equal(t, context.Canceled, streamCtx.Err())
 		expectedErrEvent := &kvpb.MuxRangeFeedEvent{
 			StreamID: streamID,
@@ -92,13 +92,13 @@ func TestUnbufferedSenderDisconnect(t *testing.T) {
 			{2, 2, &kvpb.NodeUnavailableError{}},
 		}
 
-		require.Equal(t, testRangefeedCounter.get(), int32(0))
+		require.Equal(t, 0, testRangefeedCounter.get())
 
 		for _, muxError := range testRangefeedCompletionErrors {
 			ubs.AddStream(muxError.streamID, func() {})
 		}
 
-		require.Equal(t, testRangefeedCounter.get(), int32(3))
+		require.Equal(t, 3, testRangefeedCounter.get())
 
 		var wg sync.WaitGroup
 		for _, muxError := range testRangefeedCompletionErrors {
@@ -125,7 +125,7 @@ func TestUnbufferedSenderDisconnect(t *testing.T) {
 				return errors.Newf("expected error %v not found", muxError)
 			})
 		}
-		require.Equal(t, testRangefeedCounter.get(), int32(0))
+		require.Equal(t, 0, testRangefeedCounter.get())
 	})
 }
 
@@ -203,7 +203,7 @@ func TestUnbufferedSenderWithConcurrentSend(t *testing.T) {
 	defer ubs.Stop()
 
 	ubs.AddStream(1, func() {})
-	require.Equal(t, testRangefeedCounter.get(), int32(1))
+	require.Equal(t, 1, testRangefeedCounter.get())
 
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
**kvserver/rangefeed: rename testStream.Events to GetAndClearEvents**

This patch renames testStream.Events to testStream.GetAndClearEvents for
better clarity. We also plan to introduce GetEvents() in a future commit.

Epic: none
Release note: none

----

**kvserver/rangefeed: change testRangefeedCounter.get to return int**

This patch changes testRangefeedCounter.get() is changed to return an int
instead of int32, making require.Equal() easier in tests.

Epic: none
Release note: none