### PR TITLE
roachtest: enable basic node drain for multitenant environment

### DIFF
--- a/pkg/cmd/roachtest/tests/drain.go
+++ b/pkg/cmd/roachtest/tests/drain.go
@@ -358,7 +358,20 @@ func runClusterNotAtQuorum(ctx context.Context, t test.Test, c cluster.Cluster) 
 // runDrainAndShutdown is to verify that we can use the --shutdown flag so the
 // process quits after draining is complete.
 func runDrainAndShutdown(ctx context.Context, t test.Test, c cluster.Cluster) {
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.All())
+	runDrainAndShutdownInternal(ctx, t, c, false /* runAsShared */)
+}
+
+func runDrainAndShutdownInternal(
+	ctx context.Context, t test.Test, c cluster.Cluster, runAsShared bool,
+) {
+	clusterSettings := install.MakeClusterSettings()
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), clusterSettings, c.All())
+
+	if runAsShared {
+		startOpts := option.StartSharedVirtualClusterOpts(appTenantName)
+		c.StartServiceForVirtualCluster(ctx, t.L(), startOpts, clusterSettings)
+	}
+
 	db := c.Conn(ctx, t.L(), 1)
 	defer func() { _ = db.Close() }()
 

--- a/pkg/cmd/roachtest/tests/multitenant_shared_process.go
+++ b/pkg/cmd/roachtest/tests/multitenant_shared_process.go
@@ -54,4 +54,17 @@ func registerMultiTenantSharedProcess(r registry.Registry) {
 			c.Run(ctx, option.WithNodes(c.WorkloadNode()), runCmd)
 		},
 	})
+
+	r.Add(registry.TestSpec{
+		Name:                "multitenant/shared-process/drain",
+		Owner:               registry.OwnerServer,
+		Cluster:             r.MakeClusterSpec(crdbNodeCount+1, spec.WorkloadNode()),
+		Leases:              registry.MetamorphicLeases,
+		SkipPostValidations: registry.PostValidationNoDeadNodes,
+		CompatibleClouds:    registry.AllExceptAWS,
+		Suites:              registry.Suites(registry.Nightly),
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runDrainAndShutdownInternal(ctx, t, c, true /* runAsShared */)
+		},
+	})
 }


### PR DESCRIPTION
We should be enabling all the tests in `roachtest/tests/drain.go` and beyond for multitenant environment modes (shared & external). This is already planned in [CRDB-38970](https://cockroachlabs.atlassian.net/browse/CRDB-38970) but for now, I'm enabling one roachtest for shared process mode to ensure we don't break even the basic drain. We will revisit enabling the rest as part of above-linked epic.

Informs: #133165

Epic: CRDB-43488