### PR TITLE
roachtest: always pass a Context to queries

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -994,7 +994,7 @@ func (v variations) waitForRebalanceToStop(ctx context.Context, t test.Test) {
 		Multiplier:     1,
 	}
 	for r := retry.StartWithCtx(ctx, opts); r.Next(); {
-		if row := db.QueryRow(q); row != nil {
+		if row := db.QueryRowContext(ctx, q); row != nil {
 			var secondsSinceLastEvent int
 			if err := row.Scan(&secondsSinceLastEvent); err != nil && !errors.Is(err, gosql.ErrNoRows) {
 				t.Fatal(err)
@@ -1021,7 +1021,7 @@ func (v variations) waitForIOOverloadToEnd(ctx context.Context, t test.Test) {
 		anyOverloaded := false
 		for _, nodeId := range v.targetNodes() {
 			db := v.Conn(ctx, t.L(), nodeId)
-			if row := db.QueryRow(q); row != nil {
+			if row := db.QueryRowContext(ctx, q); row != nil {
 				var overload float64
 				if err := row.Scan(&overload); err != nil && !errors.Is(err, gosql.ErrNoRows) {
 					db.Close()

--- a/pkg/cmd/roachtest/tests/util.go
+++ b/pkg/cmd/roachtest/tests/util.go
@@ -151,7 +151,7 @@ func profileTopStatements(
 
 	// Enable continuous statement diagnostics rather than just the first one.
 	sql := "SET CLUSTER SETTING sql.stmt_diagnostics.collect_continuously.enabled=true"
-	if _, err := db.Exec(sql); err != nil {
+	if _, err := db.ExecContext(ctx, sql); err != nil {
 		return err
 	}
 
@@ -199,7 +199,7 @@ FROM (
 		dbName,
 		minNumExpectedStmts,
 	)
-	if _, err := db.Exec(sql); err != nil {
+	if _, err := db.ExecContext(ctx, sql); err != nil {
 		return err
 	}
 	return nil
@@ -217,7 +217,7 @@ func downloadProfiles(
 	query := "SELECT id, collected_at FROM system.statement_diagnostics"
 	db := cluster.Conn(ctx, logger, 1)
 	defer db.Close()
-	idRow, err := db.Query(query)
+	idRow, err := db.QueryContext(ctx, query)
 	if err != nil {
 		return err
 	}
@@ -236,7 +236,7 @@ func downloadProfiles(
 			return err
 		}
 		url := urlPrefix + diagID
-		resp, err := client.Get(context.Background(), url)
+		resp, err := client.Get(ctx, url)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Queries can hang if there is no context passed to them. In roachtests, a context can be cancelled if there is a VM preemption. It is always better to use the test context and avoid this risk. This change updates the perturbation/* tests to always pass a context.

Fixes: #133625

Release note: None