### PR TITLE
sql/schemachanger: Support enum types for DSC impl of ALTER COLUMN … ALTER TYPE

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1009,8 +1009,21 @@ statement ok
 SET enable_experimental_alter_column_type_general = true;
 
 statement ok
-CREATE TABLE enum_data_type (x STRING);
+CREATE TABLE enum_data_type (x STRING, y INT);
 INSERT INTO enum_data_type VALUES ('hello'), ('howdy');
+
+skipif config local-legacy-schema-changer "legacy doesn't hydrate the type name in the message"
+skipif config local-mixed-24.1 "same as above. 24.1 doesn't have any ALTER TYPE support in the DSC, so it's legacy"
+statement error pq: column "y" cannot be cast automatically to type public.greeting\nHINT: You might need to specify "USING y::public.greeting".
+ALTER TABLE enum_data_type ALTER COLUMN y SET DATA TYPE greeting;
+
+statement error pq: invalid cast: int -> greeting
+ALTER TABLE enum_data_type ALTER COLUMN y SET DATA TYPE greeting USING y::greeting;
+
+skipif config local-legacy-schema-changer "legacy doesn't hydrate the type name in the message"
+skipif config local-mixed-24.1 "same as above. 24.1 doesn't have any ALTER TYPE support in the DSC, so it's legacy"
+statement error pq: column "x" cannot be cast automatically to type public.greeting\nHINT: You might need to specify "USING x::public.greeting".
+ALTER TABLE enum_data_type ALTER COLUMN x SET DATA TYPE greeting;
 
 statement ok
 ALTER TABLE enum_data_type ALTER COLUMN x SET DATA TYPE greeting USING x::greeting;
@@ -1019,7 +1032,7 @@ statement ok
 INSERT INTO enum_data_type VALUES ('hi')
 
 query T rowsort
-SELECT * FROM enum_data_type
+SELECT x FROM enum_data_type
 ----
 hello
 howdy
@@ -1090,7 +1103,7 @@ statement ok
 CREATE TABLE enum_data_type (x STRING);
 INSERT INTO enum_data_type VALUES ('notagreeting')
 
-statement error pq: invalid input value for enum greeting: "notagreeting"
+statement error pq: .*invalid input value for enum greeting: "notagreeting"
 ALTER TABLE enum_data_type ALTER COLUMN x SET DATA TYPE greeting USING x::greeting
 
 statement ok


### PR DESCRIPTION
Previously, attempts to alter a column's type to an enum were blocked due to failures during the backfill process, resulting in the error: "cannot resolve types in DistSQL by name." This change addresses that issue by ensuring all type names are fully resolved when populating the USING expression for the alteration.

Additionally, I've corrected an error message for column type conversions involving an enum type without a USING clause. The previous message included a hint with an unhydrated type name, which was confusing for users. The hint used to look like this:
```
HINT: You might need to specify "USING: x::@100117".
```

This fix now provides a more meaningful hint by displaying the correct type name.

Epic: CRDB-25314
Closes #132936
Release note: none