### PR TITLE
build: delete `test_nogo_configured`

### DIFF
--- a/build/bazelutil/BUILD.bazel
+++ b/build/bazelutil/BUILD.bazel
@@ -1,18 +1,6 @@
 exports_files(["nogo_config.json"])
 
-load("@bazel_skylib//rules:analysis_test.bzl", "analysis_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-
-analysis_test(
-    name = "test_nogo_configured",
-    targets = select(
-        {
-            "//build/toolchains:nogo": [],
-            "//build/toolchains:nonogo_explicit": [],
-        },
-        no_match_error = "must use exactly one of `--config lintonbuild` or `--config nolintonbuild` explicitly",
-    ),
-)
 
 # The output file will be empty unless we're using the force_build_cdeps config.
 genrule(

--- a/pkg/cmd/dev/doctor.go
+++ b/pkg/cmd/dev/doctor.go
@@ -294,8 +294,8 @@ Make sure one of the following lines is in the file %s/.bazelrc.user:
 			configured := d.checkUsingConfig(cfg.workspace, "lintonbuild") ||
 				d.checkUsingConfig(cfg.workspace, "nolintonbuild")
 			if !configured {
-				return "Failed to run `bazel build //build/bazelutil:test_nogo_configured. " + `
-This may be because you haven't configured whether to run lints during builds.
+				return "Failed to find `--config=lintonbuild` or `--config=nolintonbuild` in .bazelrc.user." + `
+
 Put EXACTLY ONE of the following lines in your .bazelrc.user:
     build --config=lintonbuild
         OR


### PR DESCRIPTION
This is unused.

Also correct a bad error message in `dev`.

Epic: none
Release note: None