### PR TITLE
pebble_nightly_metamorphic: show sizes of artifacts

### DIFF
--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic.sh
@@ -36,3 +36,5 @@ echo "Pebble module Git SHA: $PEBBLE_SHA"
 
 BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e BUILD_VCS_NUMBER=$PEBBLE_SHA -e GITHUB_API_TOKEN -e GITHUB_REPO -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL" \
                                run_bazel build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_impl.sh
+
+du -a -h artifacts | sort -hr


### PR DESCRIPTION
We're seeing OOM's when trying to upload artifacts. Print out the sizes so we can validate our assumption the artifacts are very large.

Epic: none
Release note: None