### PR TITLE
sql: add session variable bypassing the PCR reader catalog AOST

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3743,7 +3743,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 // catalog reader, then this function will return an non-zero timestamp
 // to use for all read operations.
 func (ex *connExecutor) GetPCRReaderTimestamp() hlc.Timestamp {
-	if ex.isPCRReaderCatalog {
+	if ex.isPCRReaderCatalog && !ex.sessionData().BypassPCRReaderCatalogAOST {
 		return ex.server.cfg.LeaseManager.GetSafeReplicationTS()
 	}
 	return hlc.Timestamp{}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3888,6 +3888,10 @@ func (m *sessionDataMutator) SetOptimizerPushLimitIntoProjectFilteredScan(val bo
 	m.data.OptimizerPushLimitIntoProjectFilteredScan = val
 }
 
+func (m *sessionDataMutator) SetBypassPCRReaderCatalogAOST(val bool) {
+	m.data.BypassPCRReaderCatalogAOST = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -6221,6 +6221,7 @@ application_name                                           ·
 authentication_method                                      cert-password
 avoid_buffering                                            off
 backslash_quote                                            safe_encoding
+bypass_pcr_reader_catalog_aost                             off
 bytea_output                                               hex
 check_function_bodies                                      on
 client_encoding                                            UTF8

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2869,6 +2869,7 @@ authentication_method                                      cert-password       N
 autocommit_before_ddl                                      off                 NULL      NULL        NULL        string
 avoid_buffering                                            off                 NULL      NULL        NULL        string
 backslash_quote                                            safe_encoding       NULL      NULL        NULL        string
+bypass_pcr_reader_catalog_aost                             off                 NULL      NULL        NULL        string
 bytea_output                                               hex                 NULL      NULL        NULL        string
 check_function_bodies                                      on                  NULL      NULL        NULL        string
 client_encoding                                            UTF8                NULL      NULL        NULL        string
@@ -3062,6 +3063,7 @@ authentication_method                                      cert-password       N
 autocommit_before_ddl                                      off                 NULL  user     NULL      off                 off
 avoid_buffering                                            off                 NULL  user     NULL      off                 off
 backslash_quote                                            safe_encoding       NULL  user     NULL      safe_encoding       safe_encoding
+bypass_pcr_reader_catalog_aost                             off                 NULL  user     NULL      off                 off
 bytea_output                                               hex                 NULL  user     NULL      hex                 hex
 check_function_bodies                                      on                  NULL  user     NULL      on                  on
 client_encoding                                            UTF8                NULL  user     NULL      UTF8                UTF8
@@ -3248,6 +3250,7 @@ authentication_method                                      NULL    NULL     NULL
 autocommit_before_ddl                                      NULL    NULL     NULL     NULL        NULL
 avoid_buffering                                            NULL    NULL     NULL     NULL        NULL
 backslash_quote                                            NULL    NULL     NULL     NULL        NULL
+bypass_pcr_reader_catalog_aost                             NULL    NULL     NULL     NULL        NULL
 bytea_output                                               NULL    NULL     NULL     NULL        NULL
 check_function_bodies                                      NULL    NULL     NULL     NULL        NULL
 client_encoding                                            NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -35,6 +35,7 @@ authentication_method                                      cert-password
 autocommit_before_ddl                                      off
 avoid_buffering                                            off
 backslash_quote                                            safe_encoding
+bypass_pcr_reader_catalog_aost                             off
 bytea_output                                               hex
 check_function_bodies                                      on
 client_encoding                                            UTF8

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -548,6 +548,9 @@ message LocalOnlySessionData {
   // written in this session were originally written with before being
   // replicated via Logical Data Replication.
   util.hlc.Timestamp origin_timestamp_for_logical_data_replication = 140 [(gogoproto.nullable) = false];
+  // BypassPCRReaderCatalogAOST disables the AOST used by all user queries on
+  // the PCR reader catalog.
+  bool bypass_pcr_reader_catalog_aost = 141  [(gogoproto.customname) = "BypassPCRReaderCatalogAOST"];
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3491,6 +3491,21 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+	// CockroachDB extension.
+	`bypass_pcr_reader_catalog_aost`: {
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("bypass_pcr_reader_catalog_aost", s)
+			if err != nil {
+				return err
+			}
+			m.SetBypassPCRReaderCatalogAOST(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().BypassPCRReaderCatalogAOST), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
Previously, when running queries against the PCR reader all user queries would be forced to execute with a AOST. This meant that users would not be able to modify anything within the database, but for certain operations it may be needed in case of emergencies, for example tuning cluster settings. To address this, this patch adds a new session variable "bypass_pcr_reader_catalog_aost", which will disable this implicit AOST.

Fixes: #132343

Release note (sql changes): Allow PCR reader catalogs to bypass AOST timestamps using bypass_pcr_reader_catalog_aost, which can be used to modify cluster settings within the reader.