### PR TITLE
release-24.2: sql: properly annotate errors in the internal executor in some cases

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -550,7 +550,7 @@ func (r *rowsIterator) Next(ctx context.Context) (_ bool, retErr error) {
 			// r.lastErr if necessary.
 			_ /* err */ = r.Close()
 		}
-		if r.errCallback != nil {
+		if r.lastErr != nil && r.errCallback != nil {
 			r.lastErr = r.errCallback(r.lastErr)
 			r.errCallback = nil
 		}


### PR DESCRIPTION
While reviewing a recent change to clean up the `rowsIterator` struct that is used to paginate results of the internally executed query I noticed that the change fixed a bug. Namely, since introduction of the streaming internal executor a few years ago, we would unconditionally call `errCallback` and unset it if it was provided, even if there was no error so far. This meant that if we happened to return some rows before encountering an error, the callback wouldn't get called on that error (because it had already been called on the first row when `lastErr` was nil, and the callback had been reset). This commit fixes that oversight and is made directly against 24.2 branch since 24.3 and master have the cleaner version with correct behavior.

Epic: None
Release note: None

Release justification: low-risk bug fix.