### PR TITLE
server: add version gating to new metadata APIs

### DIFF
--- a/pkg/server/api_v2.go
+++ b/pkg/server/api_v2.go
@@ -191,7 +191,7 @@ func registerRoutes(
 
 		{"sql/", a.execSQL, true, authserver.RegularRole, true},
 		{"database_metadata/", a.GetDbMetadata, true, authserver.RegularRole, true},
-		{"database_metadata/{database_id:[0-9]+}/", a.GetDbMetadataForId, true, authserver.RegularRole, true},
+		{"database_metadata/{database_id:[0-9]+}/", a.GetDbMetadataWithDetails, true, authserver.RegularRole, true},
 		{"table_metadata/", a.GetTableMetadata, true, authserver.RegularRole, true},
 		{"table_metadata/{table_id:[0-9]+}/", a.GetTableMetadataWithDetails, true, authserver.RegularRole, true},
 		{"table_metadata/updatejob/", a.TableMetadataJob, true, authserver.RegularRole, true},

--- a/pkg/server/api_v2_databases_metadata_test.go
+++ b/pkg/server/api_v2_databases_metadata_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/tablemetadatacache"
 	tablemetadatacache_util "github.com/cockroachdb/cockroach/pkg/sql/tablemetadatacache/util"
@@ -320,7 +321,7 @@ func TestGetTableMetadata(t *testing.T) {
 	})
 }
 
-func TestGetTableMetadataForId(t *testing.T) {
+func TestGetTableMetadataWithDetails(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	testCluster := serverutils.StartCluster(t, 1, base.TestClusterArgs{})
@@ -621,7 +622,7 @@ func TestGetDbMetadata(t *testing.T) {
 	})
 }
 
-func TestGetDbMetadataForId(t *testing.T) {
+func TestGetDbMetadataWithDetails(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	testCluster := serverutils.StartCluster(t, 1, base.TestClusterArgs{})
@@ -835,6 +836,42 @@ func TestTriggerMetadataUpdateJob(t *testing.T) {
 		// completion
 		assertJobTriggered(t, client, ts.AdminURL().WithPath(uri+"?onlyIfStale").String(), jobCompletedChan)
 	})
+}
+
+func TestVersionGating(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ts := serverutils.StartServerOnly(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			Server: &TestingKnobs{
+				DisableAutomaticVersionUpgrade: make(chan struct{}),
+				ClusterVersionOverride:         clusterversion.MinSupported.Version(),
+			},
+		},
+	})
+	defer ts.Stopper().Stop(context.Background())
+	client, err := ts.GetAdminHTTPClient()
+	require.NoError(t, err)
+	var testCases = []struct {
+		name   string
+		url    string
+		method string
+	}{
+		{"table metadata", "/api/v2/table_metadata/?dbId=1", http.MethodGet},
+		{"table metadata details", "/api/v2/table_metadata/1/", http.MethodGet},
+		{"database metadata", "/api/v2/database_metadata/", http.MethodGet},
+		{"database metadata details", "/api/v2/database_metadata/1/", http.MethodGet},
+		{"table metadata update job info", "/api/v2/table_metadata/updatejob/", http.MethodGet},
+		{"table metadata update job trigger", "/api/v2/table_metadata/updatejob/", http.MethodPost},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			resp := makeApiRequest[versionConflictResponse](t, client, ts.AdminURL().WithPath(testCase.url).String(), testCase.method)
+			require.Equal(t, clusterversion.MinSupported.Version().String(), resp.Version)
+		})
+
+	}
 }
 
 func makeApiRequest[T any](


### PR DESCRIPTION
Adds version gating to the new metadata APIs to return a 409 conflict status if `clusterversion.V24_3_AddTableMetadataCols` isn't active.

This is necessary in the case where a cluster is updated to use the 24.3 binary, but the migrations haven't happened yet. In that case, the new APIs will return internal server errors because the migrations creating the new system tables haven't run. One scenario where this happens is in cloud, where nodes may be updated to use the new binary, but the migrations aren't run until the upgrade is finalized.

Epic: CRDB-37558
Release note: None