### PR TITLE
storageccl: forward timestamps to min in BenchmarkTimeBoundIterate

### DIFF
--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -94,6 +94,9 @@ func loadTestData(
 				minWallTime = minSStableTimestamps[i/scaled]
 			}
 			timestamp := hlc.Timestamp{WallTime: minWallTime + rand.Int63n(int64(batchTimeSpan))}
+			if timestamp.Less(hlc.MinTimestamp) {
+				timestamp = hlc.MinTimestamp
+			}
 			value := roachpb.MakeValueFromBytes(randutil.RandBytes(rng, valueBytes))
 			value.InitChecksum(key)
 			if _, err := storage.MVCCPut(ctx, batch, key, timestamp, value, storage.MVCCWriteOptions{}); err != nil {


### PR DESCRIPTION
Previously, we left the possibility open for the random number generator to return a zero WallTime, which would put a key's timestamp as being below hlc.MinTimestamp which is WallTime 0 Logical 1. This would put it outside the bounds of the TBI, resulting in missing keys seen by the TBI variant of this benchmark.

Fixes #133605.

Epic: none

Release note: None