### PR TITLE
storage: fix temp engine key schema initialization

### DIFF
--- a/pkg/storage/temp_engine.go
+++ b/pkg/storage/temp_engine.go
@@ -106,6 +106,8 @@ func newPebbleTempEngine(
 			// pebbleMap.makeKey and pebbleMap.makeKeyWithSequence on how this works.
 			// Use the default bytes.Compare-like comparer.
 			cfg.opts.Comparer = pebble.DefaultComparer
+			cfg.opts.KeySchemas = nil
+			cfg.opts.KeySchema = ""
 			cfg.opts.DisableWAL = true
 			cfg.opts.Experimental.KeyValidationFunc = nil
 			cfg.opts.BlockPropertyCollectors = nil


### PR DESCRIPTION
We weren't clearing out the key schema from the options, resulting in
using the CRDB key schema with non-CRDB keys and the default comparer.

Fixes: #133082
Release note: None