### PR TITLE
sql: support COLLATE expressions on arrays

### DIFF
--- a/docs/generated/sql/operators.md
+++ b/docs/generated/sql/operators.md
@@ -170,6 +170,7 @@
 <tr><td><a href="bytes.html">bytes</a> <code><</code> <a href="bytes.html">bytes</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes[]</a> <code><</code> <a href="bytes.html">bytes[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="collate.html">collatedstring</a> <code><</code> <a href="collate.html">collatedstring</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>collatedstring{*} <code><</code> collatedstring{*}</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code><</code> <a href="date.html">date</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code><</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code><</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
@@ -247,6 +248,7 @@
 <tr><td><a href="bytes.html">bytes</a> <code><=</code> <a href="bytes.html">bytes</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes[]</a> <code><=</code> <a href="bytes.html">bytes[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="collate.html">collatedstring</a> <code><=</code> <a href="collate.html">collatedstring</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>collatedstring{*} <code><=</code> collatedstring{*}</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code><=</code> <a href="date.html">date</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code><=</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code><=</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
@@ -318,6 +320,7 @@
 <tr><td><a href="bytes.html">bytes</a> <code>=</code> <a href="bytes.html">bytes</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes[]</a> <code>=</code> <a href="bytes.html">bytes[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="collate.html">collatedstring</a> <code>=</code> <a href="collate.html">collatedstring</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>collatedstring{*} <code>=</code> collatedstring{*}</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>=</code> <a href="date.html">date</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>=</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>=</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
@@ -451,6 +454,7 @@
 <tr><td><a href="bytes.html">bytes</a> <code>IS NOT DISTINCT FROM</code> <a href="bytes.html">bytes</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes[]</a> <code>IS NOT DISTINCT FROM</code> <a href="bytes.html">bytes[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="collate.html">collatedstring</a> <code>IS NOT DISTINCT FROM</code> <a href="collate.html">collatedstring</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>collatedstring{*} <code>IS NOT DISTINCT FROM</code> collatedstring{*}</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>IS NOT DISTINCT FROM</code> <a href="date.html">date</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>IS NOT DISTINCT FROM</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>IS NOT DISTINCT FROM</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -610,3 +610,118 @@ SELECT string_field FROM test_collate WHERE string_field >= 'baz' ORDER BY id
 Str_Collate_1
 Foo
 Baz
+
+subtest collate_array
+
+# Test collation of string arrays.
+
+query T
+SELECT NULL COLLATE "en_US_u_ks_level2"
+----
+NULL
+
+query T
+SELECT NULL::STRING[] COLLATE "en_US_u_ks_level2"
+----
+NULL
+
+query T
+SELECT ARRAY['a'] COLLATE "en_US_u_ks_level2"
+----
+{a}
+
+query T
+SELECT ARRAY[]::STRING[] COLLATE "en_US_u_ks_level2"
+----
+{}
+
+query T
+SELECT ARRAY[NULL] COLLATE "en_US_u_ks_level2"
+----
+{NULL}
+
+query T
+SELECT ARRAY[NULL]::STRING[] COLLATE "en_US_u_ks_level2"
+----
+{NULL}
+
+query T
+SELECT ARRAY['a', NULL] COLLATE "en_US_u_ks_level2"
+----
+{a,NULL}
+
+query T
+SELECT ARRAY['a' COLLATE "en_US_u_ks_level2"] COLLATE "en_US_u_ks_level2"
+----
+{a}
+
+query T
+SELECT '{}'::STRING[] COLLATE "en_US_u_ks_level2"
+----
+{}
+
+query T
+SELECT '{a}'::STRING[] COLLATE "en_US_u_ks_level2"
+----
+{a}
+
+query T
+SELECT '{a,b,c}'::STRING[] COLLATE "en_US_u_ks_level2"
+----
+{a,b,c}
+
+query T
+SELECT ARRAY['a' COLLATE "en_US_u_ks_level2", 'b' COLLATE "en_US_u_ks_level2", NULL] COLLATE "en_US_u_ks_level2"
+----
+{a,b,NULL}
+
+# TODO(32552): We don't fully support nested arrays, but we can do a hacky check
+# here by turning off DistSQL and only using the ARRAY scalar constructor. These
+# results don't match PostgreSQL, but we're mostly just checking that we don't
+# error or panic when using this syntax.
+
+statement ok
+SET distsql = off
+
+query T
+SELECT ARRAY[ARRAY['a' COLLATE "en_US_u_ks_level2"]]
+----
+{"{a}"}
+
+query T
+SELECT ARRAY[ARRAY['a'] COLLATE "en_US_u_ks_level2"]
+----
+{"{a}"}
+
+query T
+SELECT ARRAY[ARRAY['a']] COLLATE "en_US_u_ks_level2"
+----
+{"{a}"}
+
+statement ok
+RESET distsql
+
+query T
+SELECT string_to_array('a/b/c', '/') COLLATE "en_US_u_ks_level2"
+----
+{a,b,c}
+
+statement ok
+CREATE TABLE str_arr (a STRING[], b STRING COLLATE "en_US_u_ks_level2")
+
+statement ok
+INSERT INTO str_arr VALUES ('{d,e,f}', 'd'), ('{h,i,j}', 'h'), (NULL, NULL)
+
+query T rowsort
+SELECT a COLLATE "en_US_u_ks_level2" FROM str_arr
+----
+{d,e,f}
+{h,i,j}
+NULL
+
+query T
+SELECT b COLLATE "en_US_u_ks_level2" FROM str_arr ORDER BY 1
+----
+NULL
+d
+h

--- a/pkg/sql/opt/memo/typing.go
+++ b/pkg/sql/opt/memo/typing.go
@@ -272,8 +272,9 @@ func typeIndirection(e opt.ScalarExpr) *types.T {
 
 // typeCollate returns the collated string typed with the given locale.
 func typeCollate(e opt.ScalarExpr) *types.T {
+	t := e.Child(0).(opt.ScalarExpr).DataType()
 	locale := e.(*CollateExpr).Locale
-	return types.MakeCollatedString(types.String, locale)
+	return types.MakeCollatedType(t, locale)
 }
 
 // typeArrayFlatten returns the type of the subquery as an array.

--- a/pkg/sql/opt/norm/scalar_funcs.go
+++ b/pkg/sql/opt/norm/scalar_funcs.go
@@ -249,21 +249,39 @@ func (c *CustomFuncs) CastToCollatedString(str opt.ScalarExpr, locale string) op
 		datum = wrap.Wrapped
 	}
 
-	var value string
-	switch t := datum.(type) {
-	case *tree.DString:
-		value = string(*t)
-	case *tree.DCollatedString:
-		value = t.Contents
-	default:
-		panic(errors.AssertionFailedf("unexpected type for COLLATE: %T", t))
+	// buildCollated is a recursive helper function to handle casting arrays.
+	var buildCollated func(datum tree.Datum) tree.Datum
+	buildCollated = func(datum tree.Datum) tree.Datum {
+		if datum == tree.DNull {
+			return tree.DNull
+		}
+		var value string
+		switch t := datum.(type) {
+		case *tree.DString:
+			value = string(*t)
+		case *tree.DCollatedString:
+			value = t.Contents
+		case *tree.DArray:
+			a := tree.NewDArray(types.MakeCollatedType(t.ParamTyp, locale))
+			a.Array = make(tree.Datums, 0, len(t.Array))
+			for _, elem := range t.Array {
+				collatedElem := buildCollated(elem)
+				if err := a.Append(collatedElem); err != nil {
+					panic(err)
+				}
+			}
+			return a
+		default:
+			panic(errors.AssertionFailedf("unexpected type for COLLATE: %T", t))
+		}
+		d, err := tree.NewDCollatedString(value, locale, &c.f.evalCtx.CollationEnv)
+		if err != nil {
+			panic(err)
+		}
+		return d
 	}
 
-	d, err := tree.NewDCollatedString(value, locale, &c.f.evalCtx.CollationEnv)
-	if err != nil {
-		panic(err)
-	}
-	return c.f.ConstructConst(d, types.MakeCollatedString(str.DataType(), locale))
+	return c.f.ConstructConst(buildCollated(datum), types.MakeCollatedType(str.DataType(), locale))
 }
 
 // MakeUnorderedSubquery returns a SubqueryPrivate that specifies no ordering.

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -1490,7 +1490,7 @@ func cmpOpFixups(
 	}
 
 	// Array equality comparisons.
-	for _, t := range append(types.Scalar, types.AnyEnum) {
+	for _, t := range append(types.Scalar, types.AnyEnum, types.AnyCollatedString) {
 		appendCmpOp := func(sym treecmp.ComparisonOperatorSymbol, cmpOp *CmpOp) {
 			s, ok := cmpOps[sym]
 			if !ok {

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -423,7 +423,7 @@ func NewTypedCollateExpr(expr TypedExpr, locale string) *CollateExpr {
 		Expr:   expr,
 		Locale: locale,
 	}
-	node.typ = types.MakeCollatedString(types.String, locale)
+	node.typ = types.MakeCollatedType(expr.ResolvedType(), locale)
 	return node
 }
 

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -971,6 +971,21 @@ func MakeCollatedString(strType *T, locale string) *T {
 	panic(errors.AssertionFailedf("cannot apply collation to non-string type: %s", strType))
 }
 
+// MakeCollatedType is like MakeCollatedString but also handles NULL and arrays
+// of string types that need to become arrays of collated string types.
+//
+// UNKNOWN  => STRING COLLATE EN
+// []STRING => []STRING COLLATE EN
+func MakeCollatedType(typ *T, locale string) *T {
+	if typ.Family() == ArrayFamily {
+		return MakeArray(MakeCollatedType(typ.ArrayContents(), locale))
+	}
+	if typ.Family() == UnknownFamily {
+		return MakeCollatedType(String, locale)
+	}
+	return MakeCollatedString(typ, locale)
+}
+
 // MakeDecimal constructs a new instance of a DECIMAL type (oid = T_numeric)
 // that has at most "precision" # of decimal digits (0 = unspecified number of
 // digits) and at most "scale" # of decimal digits after the decimal point


### PR DESCRIPTION
In PG, COLLATE is a scalar operator that modifies its operand to produce a collated type. This commit adds support for COLLATE on arrays of strings, which marks them as arrays of collated strings.

Epic: None

Release note (sql change): Add support for COLLATE expressions on arrays of strings, to better match PostgreSQL.