### PR TITLE
kvserver: add rac2 send queue functionality test

### DIFF
--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -988,7 +988,7 @@ SELECT store_id,
 	   crdb_internal.humanize_bytes(available_elastic_tokens)
   FROM crdb_internal.kv_flow_controller
  ORDER BY store_id ASC;
-`, "range_id", "regular_available", "elastic_available")
+`, "store_id", "regular_available", "elastic_available")
 }
 
 // TestFlowControlRaftTransportBreak tests flow token behavior when the raft
@@ -3051,7 +3051,7 @@ SELECT store_id,
 	   crdb_internal.humanize_bytes(available_eval_elastic_tokens)
   FROM crdb_internal.kv_flow_controller_v2
  ORDER BY store_id ASC;
-`, "range_id", "eval_regular_available", "eval_elastic_available")
+`, "store_id", "eval_regular_available", "eval_elastic_available")
 		})
 	})
 }

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -4507,6 +4507,416 @@ ORDER BY streams DESC;
 	h.query(n2, v2FlowTokensQueryStr)
 }
 
+type testGeneratedPut struct{}
+
+func contextWithTestGeneratedPut(ctx context.Context) context.Context {
+	return context.WithValue(ctx, testGeneratedPut{}, &testGeneratedPut{})
+}
+
+func isTestGeneratedPut(ctx context.Context) bool {
+	val := ctx.Value(testGeneratedPut{})
+	_, ok := val.(*testGeneratedPut)
+	return ok
+}
+
+// TestFlowControlSendQueue exercises the send queue formation, prevention and
+// flushing via selective (logical) admission of entries and token return. See
+// the initial comment for an overview of the test structure.
+func TestFlowControlSendQueue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	const numNodes = 5
+	var noopWaitForEval atomic.Bool
+	disableWorkQueueGrantingServers := make([]atomic.Bool, numNodes)
+	setTokenReturnEnabled := func(enabled bool, serverIdxs ...int) {
+		for _, serverIdx := range serverIdxs {
+			disableWorkQueueGrantingServers[serverIdx].Store(!enabled)
+		}
+	}
+
+	mkStream := func(serverIdx int) kvflowcontrol.Stream {
+		return kvflowcontrol.Stream{
+			StoreID:  roachpb.StoreID(serverIdx + 1),
+			TenantID: roachpb.SystemTenantID,
+		}
+	}
+
+	settings := cluster.MakeTestingClusterSettings()
+	kvflowcontrol.Mode.Override(ctx, &settings.SV, kvflowcontrol.ApplyToAll)
+	// We want to exhaust tokens but not overload the test, so we set the limits
+	// lower (8 and 16 MiB default).
+	kvflowcontrol.ElasticTokensPerStream.Override(ctx, &settings.SV, 2<<20)
+	kvflowcontrol.RegularTokensPerStream.Override(ctx, &settings.SV, 4<<20)
+
+	stickyArgsPerServer := make(map[int]base.TestServerArgs)
+	for i := range disableWorkQueueGrantingServers {
+		// Start with admission (logical token return) disabled across all nodes.
+		disableWorkQueueGrantingServers[i].Store(true)
+		stickyArgsPerServer[i] = base.TestServerArgs{
+			Settings: settings,
+			StoreSpecs: []base.StoreSpec{
+				{
+					InMemory:    true,
+					StickyVFSID: strconv.FormatInt(int64(i), 10),
+				},
+			},
+			RaftConfig: base.RaftConfig{
+				// Suppress timeout-based elections. This test doesn't want to deal
+				// with leadership changing hands unintentionally.
+				RaftElectionTimeoutTicks: 1000000,
+			},
+			Knobs: base.TestingKnobs{
+				Server: &server.TestingKnobs{
+					StickyVFSRegistry: fs.NewStickyRegistry(),
+				},
+				Store: &kvserver.StoreTestingKnobs{
+					FlowControlTestingKnobs: &kvflowcontrol.TestingKnobs{
+						UseOnlyForScratchRanges: true,
+						OverrideTokenDeduction: func(tokens kvflowcontrol.Tokens) kvflowcontrol.Tokens {
+							// This test sends several puts, with each put potentially
+							// diverging by a few bytes between runs, in aggregate this can
+							// accumulate to enough tokens to produce a diff in metrics. In
+							// addition, under stress/race the larger writes may overload the
+							// system with many concurrent tests. Deduct every write as 1
+							// MiB, regardless of how large it actually is.
+							return kvflowcontrol.Tokens(1 << 20)
+						},
+
+						OverrideBypassAdmitWaitForEval: func(ctx context.Context) (bypass bool, waited bool) {
+							bypassAndWaited := noopWaitForEval.Load()
+							if bypassAndWaited {
+								return true, true
+							}
+							if !isTestGeneratedPut(ctx) {
+								return true, false
+							}
+							return false, false
+						},
+						// We want to test the behavior of the send queue, so we want to
+						// always have up-to-date stats. This ensures that the send queue
+						// stats are always refreshed on each call to
+						// RangeController.HandleRaftEventRaftMuLocked.
+						OverrideAlwaysRefreshSendStreamStats: true,
+					},
+				},
+				AdmissionControl: &admission.TestingKnobs{
+					DisableWorkQueueFastPath: true,
+					DisableWorkQueueGranting: func() bool {
+						idx := i
+						return disableWorkQueueGrantingServers[idx].Load()
+					},
+				},
+			},
+		}
+	}
+
+	tc := testcluster.StartTestCluster(t, 5, base.TestClusterArgs{
+		ReplicationMode:   base.ReplicationManual,
+		ServerArgsPerNode: stickyArgsPerServer,
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	// We setup 3 voters initially on n1, n2, n3. Later, we add n4, n5.
+	k := tc.ScratchRange(t)
+	tc.AddVotersOrFatal(t, k, tc.Targets(1, 2)...)
+
+	h := newFlowControlTestHelper(
+		t, tc, "flow_control_integration_v2", /* testdata */
+		kvflowcontrol.V2EnabledWhenLeaderV2Encoding, true, /* isStatic */
+	)
+	h.init(kvflowcontrol.ApplyToAll)
+	defer h.close("send_queue")
+
+	desc, err := tc.LookupRange(k)
+	require.NoError(t, err)
+	h.enableVerboseRaftMsgLoggingForRange(desc.RangeID)
+	n1 := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+
+	h.waitForConnectedStreams(ctx, desc.RangeID, 3, 0 /* serverIdx */)
+	// We shouldn't need this, since we use contextWithTestGeneratedPut to only
+	// subject the test's puts to RAC. But there was a test failure that had
+	// 4KiB of tokens deducted and returned, so a send-queue must have formed,
+	// possibly because the replica was not in StateReplicate when some entries
+	// not subject to RAC were processed.
+	h.resetV2TokenMetrics(ctx)
+
+	h.comment(`
+-- This test exercises send queue formation, prevention and flushing.
+-- The structure roughly follows:
+--   Start with three voters on [n1,n2,n3], where n1 is the leader+leaseholder.
+--   Large regular write -4 MiB.
+--   Allow admission [n1,n2].
+--   - Tokens should be returned for n1 and n2.
+--   Block admission [n2].
+--   Regular write -1 MiB.
+--   - Shouldn't be blocked on wait-for-eval because of quorum [n1,n2].
+--   - Metrics should reflect send queue formation on n3.
+--   Stop n2.
+--   Regular write -1 MiB.
+--   - Blocks on wait-for-eval, however the test bypasses this instance.
+--   - Metrics should reflect n3 being force flushed.
+--   Allow admission [n1,n2,n3].
+--   Start n2.
+--   Add n4, n5, the voters now are [n1,n2,n3,n4,n5].
+--   Block admission [n4,n5] (already blocked)
+--   Regular write -4 MiB.
+--   Regular write -1  MiB.
+--   - Shouldn't be blocked on wait-for-eval because of quorum [n1,n2,n3]
+--   - Metrics should reflect send queue formation on n4,n5.
+--   Unblock admission [n4,n5].
+--   - Wait for tokens to be returned.
+--   Block admission [n2,n3,n4,n5].
+--   Regular write -4 MiB.
+--   Regular write -1  MiB.
+--   - Blocks on wait-for-eval, however the test bypasses this instance.    
+--   - Metrics should reflect 2 streams being prevented from forming a send queue.
+--   Allow admission [n1,n2,n3,n4,n5] (all).
+--   Assert all tokens returned.
+--
+-- Start by printing the relevant metrics on n1, first the flow token metrics.
+`)
+	h.query(n1, v2FlowTokensQueryStr)
+	h.comment(`-- Send queue metrics from n1.`)
+	h.query(n1, flowSendQueueQueryStr)
+	h.comment(`-- Per-store tokens available from n1.`)
+	h.query(n1, flowPerStoreTokenQueryStr, flowPerStoreTokenQueryHeaderStrs...)
+
+	h.comment(`-- (Issuing 4x1MiB regular, 3x replicated write that's not admitted.)`)
+	h.put(contextWithTestGeneratedPut(ctx), k, 1, admissionpb.NormalPri)
+	h.put(contextWithTestGeneratedPut(ctx), k, 1, admissionpb.NormalPri)
+	h.put(contextWithTestGeneratedPut(ctx), k, 1, admissionpb.NormalPri)
+	h.put(contextWithTestGeneratedPut(ctx), k, 1, admissionpb.NormalPri)
+	h.waitForTotalTrackedTokens(ctx, desc.RangeID, 12<<20 /* 12MiB */, 0 /* serverIdx */)
+	h.comment(`-- Observe the total tracked tokens per-stream on n1.`)
+	h.query(n1, `
+  SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::INT8)
+    FROM crdb_internal.kv_flow_control_handles_v2
+`, "range_id", "store_id", "total_tracked_tokens")
+	h.comment(`-- And, the per-store tokens available post-write from n1.`)
+	h.query(n1, flowPerStoreTokenQueryStr, flowPerStoreTokenQueryHeaderStrs...)
+
+	h.comment(`
+-- (Allowing below-raft admission to proceed on n1 and n2.)
+-- [n1(enabled),n2(enabled),n3(blocked)]`)
+	setTokenReturnEnabled(true /* enabled */, 0, 1)
+	// Wait for token return on n1, n2. We should only be tracking the tokens for
+	// n3 now.
+	h.waitForAllTokensReturnedForStreamsV2(ctx, 0 /* serverIdx */, mkStream(0), mkStream(1))
+	h.waitForTotalTrackedTokens(ctx, desc.RangeID, 4<<20 /* 4MiB */, 0 /* serverIdx */)
+	h.comment(`-- Observe the total tracked tokens per-stream on n1.`)
+	h.query(n1, `
+  SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::INT8)
+    FROM crdb_internal.kv_flow_control_handles_v2
+`, "range_id", "store_id", "total_tracked_tokens")
+	h.comment(`-- Per-store tokens available from n1.`)
+	h.query(n1, flowPerStoreTokenQueryStr, flowPerStoreTokenQueryHeaderStrs...)
+
+	// Re-disable admission on n2. This is to track a write to n2 that won't be
+	// admitted before it's stopped.
+	h.comment(`-- (Blocking below-raft admission on n2.)`)
+	setTokenReturnEnabled(false /* enabled */, 1)
+
+	h.comment(`-- (Issuing 1x1MiB regular, 3x replicated write that's not admitted.)`)
+	h.put(contextWithTestGeneratedPut(ctx), k, 1, admissionpb.NormalPri)
+	// NB: The write won't be tracked because the quorum [n1,n2] have tokens for
+	// eval.
+	h.waitForTotalTrackedTokens(ctx, desc.RangeID, 5<<20 /* 5 MiB */, 0 /* serverIdx */)
+	h.waitForAllTokensReturnedForStreamsV2(ctx, 0 /* serverIdx */, mkStream(0))
+	h.waitForSendQueueSize(ctx, desc.RangeID, 1<<20 /* 1MiB expSize */, 0 /* serverIdx */)
+	h.comment(`
+-- The send queue metrics from n1 should reflect the 1 MiB write being queued
+-- for n3 and 1 MiB tracked for n2 that is yet to be admitted.
+`)
+	h.query(n1, flowSendQueueQueryStr)
+	h.comment(`-- Per-store tokens available from n1.`)
+	h.query(n1, flowPerStoreTokenQueryStr, flowPerStoreTokenQueryHeaderStrs...)
+
+	h.comment(`-- (Stopping n2.)`)
+	tc.StopServer(1 /* n2 */)
+	// There should now be 2 connected streams (n1,n3).
+	h.waitForConnectedStreams(ctx, desc.RangeID, 2, 0 /* serverIdx */)
+	// There should also be 5 MiB of tracked tokens for n1->n3, 4 + 1 MiB.
+	h.waitForTotalTrackedTokens(ctx, desc.RangeID, 5<<20 /* 5 MiB */, 0 /* serverIdx */)
+	h.waitForAllTokensReturnedForStreamsV2(ctx, 0 /* serverIdx */, mkStream(0), mkStream(1))
+	h.waitForSendQueueSize(ctx, desc.RangeID, 0 /* expSize */, 0 /* serverIdx */)
+	h.comment(`
+-- Flow token metrics from n1, the disconnect should be reflected in the metrics.`)
+	h.query(n1, v2FlowTokensQueryStr)
+
+	h.comment(`
+-- Send queue metrics from n1, n3's send queue should have been force-flushed.`)
+	h.query(n1, flowSendQueueQueryStr)
+	h.comment(`
+-- Observe the total tracked tokens per-stream on n1, n3's flushed entries 
+-- will also be tracked here.`)
+	h.query(n1, `
+  SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::INT8)
+    FROM crdb_internal.kv_flow_control_handles_v2
+`, "range_id", "store_id", "total_tracked_tokens")
+	h.comment(`
+-- Per-store tokens available from n1, these should reflect the deducted 
+-- tokens from force-flushing n3.`)
+	h.query(n1, flowPerStoreTokenQueryStr, flowPerStoreTokenQueryHeaderStrs...)
+
+	h.comment(`-- (Enabling wait-for-eval bypass.)`)
+	noopWaitForEval.Store(true)
+	h.comment(`-- (Issuing 1x1MiB regular, 3x replicated write that's not admitted.)`)
+	h.put(contextWithTestGeneratedPut(ctx), k, 1, admissionpb.NormalPri)
+	h.comment(`-- (Disabling wait-for-eval bypass.)`)
+	noopWaitForEval.Store(false)
+	h.waitForTotalTrackedTokens(ctx, desc.RangeID, 6<<20 /* 6 MiB */, 0 /* serverIdx */)
+	h.waitForAllTokensReturnedForStreamsV2(ctx, 0 /* serverIdx */, mkStream(0), mkStream(1))
+
+	h.comment(`
+-- Send queue metrics from n1, n3's should not be allowed to form a send queue.`)
+	h.query(n1, flowSendQueueQueryStr)
+	h.comment(`
+-- Observe the total tracked tokens per-stream on n1, n3's should track the latest write
+-- as well.`)
+	h.query(n1, `
+  SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::INT8)
+    FROM crdb_internal.kv_flow_control_handles_v2
+`, "range_id", "store_id", "total_tracked_tokens")
+
+	h.comment(`
+-- (Allowing below-raft admission to proceed on n1, n2, and n3. Note that n2 is still down.)
+-- [n1(enabled),n2(enabled),n3(enabled)]`)
+	setTokenReturnEnabled(true /* enabled */, 0, 1, 2)
+	h.waitForAllTokensReturned(ctx, 3, 0 /* serverIdx */)
+	h.comment(`-- Flow token metrics from n1.`)
+	h.query(n1, v2FlowTokensQueryStr)
+	h.comment(`-- Per-store tokens available from n1.`)
+	h.query(n1, flowPerStoreTokenQueryStr, flowPerStoreTokenQueryHeaderStrs...)
+
+	h.comment(`-- (Starting n2.)`)
+	require.NoError(t, tc.RestartServer(1))
+	h.waitForConnectedStreams(ctx, desc.RangeID, 3, 0 /* serverIdx */)
+	h.comment(`-- There should now be 3 connected streams again.`)
+	h.query(n1, `
+  SELECT range_id, count(*) AS streams
+    FROM crdb_internal.kv_flow_control_handles_v2
+GROUP BY (range_id)
+ORDER BY streams DESC;
+`, "range_id", "stream_count")
+
+	h.comment(`-- (Adding VOTER to n4 and n5.)`)
+	tc.AddVotersOrFatal(t, k, tc.Targets(3, 4)...)
+	h.waitForConnectedStreams(ctx, desc.RangeID, 5, 0 /* serverIdx */)
+	h.waitForAllTokensReturned(ctx, 5, 0 /* serverIdx */)
+	h.comment(`
+-- Now, after adding n4,n5, there should be 5 connected streams.
+-- [n1,n2,n3,n4,n5]
+`)
+	h.query(n1, `
+  SELECT range_id, count(*) AS streams
+    FROM crdb_internal.kv_flow_control_handles_v2
+GROUP BY (range_id)
+ORDER BY streams DESC;
+`, "range_id", "stream_count")
+	h.comment(`-- Per-store tokens available from n1.`)
+	h.query(n1, flowPerStoreTokenQueryStr, flowPerStoreTokenQueryHeaderStrs...)
+
+	h.comment(`-- (Issuing 4x1MiB regular, 5x replicated write that's not admitted.)`)
+	h.put(contextWithTestGeneratedPut(ctx), k, 1, admissionpb.NormalPri)
+	h.put(contextWithTestGeneratedPut(ctx), k, 1, admissionpb.NormalPri)
+	h.put(contextWithTestGeneratedPut(ctx), k, 1, admissionpb.NormalPri)
+	h.put(contextWithTestGeneratedPut(ctx), k, 1, admissionpb.NormalPri)
+	// Expect the unblocked streams (n1,n2,n3) to track, then untrack quickly as
+	// admission is allowed. While n4,n5 will continue to track as they are
+	// blocked from admitting.
+	h.waitForTotalTrackedTokens(ctx, desc.RangeID, 8<<20 /* 8 MiB */, 0 /* serverIdx */)
+	h.waitForAllTokensReturnedForStreamsV2(ctx, 0 /* serverIdx */, mkStream(0), mkStream(1), mkStream(2))
+	h.comment(`
+-- From n1. We should expect to see the unblocked streams quickly
+-- untrack as admission is allowed (so not observed here), while n4,n5 will continue
+-- to track as they are blocked from admitting (logically).
+`)
+	h.query(n1, flowPerStoreTokenQueryStr, flowPerStoreTokenQueryHeaderStrs...)
+	h.query(n1, `
+  SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::INT8)
+    FROM crdb_internal.kv_flow_control_handles_v2
+`, "range_id", "store_id", "total_tracked_tokens")
+
+	h.comment(`-- (Issuing 1x1MiB regular, 5x replicated write that's not admitted.)`)
+	h.put(contextWithTestGeneratedPut(ctx), k, 1, admissionpb.NormalPri)
+	// The total tracked tokens should not change, as the quorum (n1,n2,n3)
+	// quickly admits and untracks. While n4,n5 queue the write, not sending the
+	// msg, deducting and tracking the entry tokens.
+	h.waitForTotalTrackedTokens(ctx, desc.RangeID, 8<<20 /* 8 MiB */, 0 /* serverIdx */)
+	h.waitForAllTokensReturnedForStreamsV2(ctx, 0 /* serverIdx */, mkStream(0), mkStream(1), mkStream(2))
+	h.comment(`
+-- Send queue and flow token metrics from n1. The 1 MiB write should be queued
+-- for n4,n5, while the quorum (n1,n2,n3) proceeds.
+`)
+	h.query(n1, flowSendQueueQueryStr)
+	h.query(n1, flowPerStoreTokenQueryStr, flowPerStoreTokenQueryHeaderStrs...)
+
+	h.comment(`
+-- (Allowing below-raft admission to proceed on n4 and n5.)
+-- [n1(enabled),n2(enabled),n3(enabled),n4(enabled),n5(enabled)]`)
+	setTokenReturnEnabled(true /* enabled */, 0, 1, 2, 3, 4)
+	h.waitForAllTokensReturned(ctx, 5, 0 /* serverIdx */)
+	h.comment(`
+-- Per-store tokens available from n1. Expect these to return to the same as 
+-- the initial state.
+`)
+	h.query(n1, flowPerStoreTokenQueryStr, flowPerStoreTokenQueryHeaderStrs...)
+
+	h.comment(`-- (Blocking below-raft admission on [n2,n3,n4,n5].)`)
+	setTokenReturnEnabled(false /* enabled */, 1, 2, 3, 4)
+
+	h.comment(`-- (Issuing 4x1MiB regular, 5x replicated write that's not admitted.)`)
+	h.put(contextWithTestGeneratedPut(ctx), k, 1, admissionpb.NormalPri)
+	h.put(contextWithTestGeneratedPut(ctx), k, 1, admissionpb.NormalPri)
+	h.put(contextWithTestGeneratedPut(ctx), k, 1, admissionpb.NormalPri)
+	h.put(contextWithTestGeneratedPut(ctx), k, 1, admissionpb.NormalPri)
+	// XXX:
+	h.waitForTotalTrackedTokens(ctx, desc.RangeID, 16<<20 /* 16 MiB */, 0 /* serverIdx */)
+	h.comment(`
+-- Send queue and flow token metrics from n1. The 4 MiB write should not be
+-- queued, but instead exhaust all available regular eval and send tokens across
+-- each stream, except s1 (as admission is not blocked).
+`)
+	h.query(n1, flowSendQueueQueryStr)
+	h.query(n1, flowPerStoreTokenQueryStr, flowPerStoreTokenQueryHeaderStrs...)
+
+	h.comment(`-- (Enabling wait-for-eval bypass.)`)
+	noopWaitForEval.Store(true)
+	h.comment(`-- (Issuing 1x1MiB regular, 5x replicated write that's not admitted.)`)
+	h.put(contextWithTestGeneratedPut(ctx), k, 1, admissionpb.NormalPri)
+	h.comment(`-- (Disabling wait-for-eval bypass.)`)
+	noopWaitForEval.Store(false)
+	// Expect 4 x 4 MiB tracked tokens for the 4 MiB write = 16 MiB.
+	// Expect 2 x 1 MiB tracked tokens for the 1 MiB write =  2 MiB.
+	h.waitForTotalTrackedTokens(ctx, desc.RangeID, 18<<20 /* 18MiB */, 0 /* serverIdx */)
+	h.waitForAllTokensReturnedForStreamsV2(ctx, 0 /* serverIdx */, mkStream(0))
+	h.comment(`
+-- Observe the total tracked tokens per-stream on n1. We should expect to see the
+-- 1 MiB write being tracked across a quorum of streams, while the 4 MiB write
+-- is tracked across each stream (except s1). Two(/4 non-leader) replica send 
+-- streams should be prevented from forming a send queue and have higher tracked
+-- tokens than the other two.
+`)
+	h.query(n1, `
+  SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::INT8)
+    FROM crdb_internal.kv_flow_control_handles_v2
+`, "range_id", "store_id", "total_tracked_tokens")
+	h.comment(`-- Send queue and flow token metrics from n1.`)
+	h.query(n1, flowSendQueueQueryStr)
+	h.query(n1, flowPerStoreTokenQueryStr, flowPerStoreTokenQueryHeaderStrs...)
+
+	h.comment(`-- (Allowing below-raft admission on [n1,n2,n3,n4,n5].)`)
+	setTokenReturnEnabled(true /* enabled */, 0, 1, 2, 3, 4)
+
+	h.waitForAllTokensReturned(ctx, 5, 0 /* serverIdx */)
+	h.comment(`
+-- Send queue and flow token metrics from n1. All tokens should be returned.`)
+	h.query(n1, flowSendQueueQueryStr)
+	h.query(n1, flowPerStoreTokenQueryStr, flowPerStoreTokenQueryHeaderStrs...)
+}
+
 type flowControlTestHelper struct {
 	t             testing.TB
 	tc            *testcluster.TestCluster
@@ -4593,6 +5003,37 @@ func (h *flowControlTestHelper) waitForAllTokensReturned(
 	})
 }
 
+// waitForAllTokensReturnedForStreamsV2 waits for all tokens to be returned
+// across the specified streams. This only works for RACv2.
+func (h *flowControlTestHelper) waitForAllTokensReturnedForStreamsV2(
+	ctx context.Context, serverIdx int, streamIDs ...kvflowcontrol.Stream,
+) {
+	testutils.SucceedsSoon(h.t, func() error {
+		return h.checkTokensAvailableForStreamsV2(ctx, len(streamIDs), serverIdx,
+			h.tokensAvailableLimitWithDelta(kvflowinspectpb.Stream{}), streamIDs...)
+	})
+}
+
+func (h *flowControlTestHelper) waitForSendQueueSize(
+	ctx context.Context, rangeID roachpb.RangeID, expSize int64, serverIdx int,
+) {
+	testutils.SucceedsSoon(h.t, func() error {
+		return h.checkSendQueueSize(ctx, rangeID, expSize, serverIdx)
+	})
+}
+
+func (h *flowControlTestHelper) checkSendQueueSize(
+	ctx context.Context, rangeID roachpb.RangeID, expSize int64, serverIdx int,
+) error {
+	stats := rac2.RangeSendStreamStats{}
+	h.tc.GetFirstStoreFromServer(h.t, serverIdx).GetReplicaIfExists(rangeID).SendStreamStats(&stats)
+	_, sizeBytes := stats.SumSendQueues()
+	if sizeBytes != expSize {
+		return errors.Errorf("expected send queue size %d, got %d [%v]", expSize, sizeBytes, stats)
+	}
+	return nil
+}
+
 // checkAllTokensReturned checks that all tokens have been returned across all
 // streams. It also checks that the expected number of streams are present. The
 // protocol level is passed in as an argument, in order to allow switching
@@ -4600,7 +5041,7 @@ func (h *flowControlTestHelper) waitForAllTokensReturned(
 func (h *flowControlTestHelper) checkAllTokensReturned(
 	ctx context.Context, expStreamCount, serverIdx int, lvl ...kvflowcontrol.V2EnabledWhenLeaderLevel,
 ) error {
-	return h.checkTokensAvailable(
+	return h.checkTokensAvailableWithLevel(
 		ctx, expStreamCount, serverIdx, h.tokensAvailableLimitWithDelta(kvflowinspectpb.Stream{}), lvl...)
 }
 
@@ -4653,15 +5094,36 @@ func (h *flowControlTestHelper) waitForAllTokensAvailable(
 	lvl ...kvflowcontrol.V2EnabledWhenLeaderLevel,
 ) {
 	testutils.SucceedsSoon(h.t, func() error {
-		return h.checkTokensAvailable(ctx, expStreamCount, serverIdx, expTokensStream, lvl...)
+		return h.checkTokensAvailableWithLevel(ctx, expStreamCount, serverIdx, expTokensStream, lvl...)
 	})
 }
 
-// checkTokensAvailable checks that the expected number of tokens are available
-// across all streams. The expected number of streams and protocol level is
-// passed in as an argument, in order to allow switching between v1 and v2 flow
-// control.
-func (h *flowControlTestHelper) checkTokensAvailable(
+// checkTokensAvailableForStreamsV2 checks that the expected number of tokens
+// are available across the specified streams. This only works for RACv2.
+func (h *flowControlTestHelper) checkTokensAvailableForStreamsV2(
+	ctx context.Context,
+	expStreamCount, serverIdx int,
+	expTokensStream kvflowinspectpb.Stream,
+	streamIDs ...kvflowcontrol.Stream,
+) error {
+	streams := h.tc.GetFirstStoreFromServer(h.t, serverIdx).GetStoreConfig().KVFlowStreamTokenProvider.Inspect(ctx)
+	filteredStreams := make([]kvflowinspectpb.Stream, 0, len(streams))
+	for _, stream := range streams {
+		for _, s := range streamIDs {
+			if s.TenantID == stream.TenantID && s.StoreID == stream.StoreID {
+				filteredStreams = append(filteredStreams, stream)
+				break
+			}
+		}
+	}
+	return h.checkTokensAvailable(
+		ctx, expStreamCount, serverIdx, expTokensStream, filteredStreams, h.level)
+}
+
+// checkTokensAvailableWithLevel checks that the expected number of tokens are
+// available across all streams. The V2EnabledWhenLeaderLevel may be passed in
+// as an argument, in order to allow switching between v1 and v2 flow control.
+func (h *flowControlTestHelper) checkTokensAvailableWithLevel(
 	ctx context.Context,
 	expStreamCount, serverIdx int,
 	expTokensStream kvflowinspectpb.Stream,
@@ -4677,7 +5139,20 @@ func (h *flowControlTestHelper) checkTokensAvailable(
 	default:
 		h.t.Fatalf("unknown level: %v", level)
 	}
+	return h.checkTokensAvailable(ctx, expStreamCount, serverIdx, expTokensStream, streams, level)
+}
 
+// checkTokensAvailable checks that the expected number of tokens are available
+// across all streams. The expected number of streams and protocol level is
+// passed in as an argument, in order to allow switching between v1 and v2 flow
+// control.
+func (h *flowControlTestHelper) checkTokensAvailable(
+	ctx context.Context,
+	expStreamCount, serverIdx int,
+	expTokensStream kvflowinspectpb.Stream,
+	streams []kvflowinspectpb.Stream,
+	level kvflowcontrol.V2EnabledWhenLeaderLevel,
+) error {
 	if len(streams) != expStreamCount {
 		return fmt.Errorf("expected %d replication streams, got %d [%+v]", expStreamCount, len(streams), streams)
 	}
@@ -4688,7 +5163,7 @@ func (h *flowControlTestHelper) checkTokensAvailable(
 		typName string,
 	) error {
 		if actualTokens != expTokens {
-			return fmt.Errorf("expected %v of %v flow tokens for %v, got %v [level=%+v stream=%v]",
+			return fmt.Errorf("expected %v of %v flow tokens for %v, got %v [level=%v stream=%v]",
 				humanize.IBytes(uint64(expTokens)), typName, stream,
 				humanize.IBytes(uint64(actualTokens)),
 				level,
@@ -4837,13 +5312,50 @@ const v2FlowTokensQueryStr = `
 ORDER BY name ASC;
 `
 
+// flowSendQueueQueryStr is the query string to fetch flow control send queue
+// metrics from the node metrics table.
+const flowSendQueueQueryStr = `
+
+  SELECT name, crdb_internal.humanize_bytes(value::INT8)
+    FROM crdb_internal.node_metrics
+   WHERE name LIKE '%kvflowcontrol%send_queue%'
+     AND name != 'kvflowcontrol.send_queue.count'
+ORDER BY name ASC;
+`
+
+// flowPerStoreTokenQueryStr is the query string to fetch per-store flow tokens
+// metrics from the kv_flow_controller_v2 table.
+const flowPerStoreTokenQueryStr = `
+  SELECT store_id,
+     crdb_internal.humanize_bytes(available_eval_regular_tokens),
+     crdb_internal.humanize_bytes(available_eval_elastic_tokens),
+     crdb_internal.humanize_bytes(available_send_regular_tokens),
+     crdb_internal.humanize_bytes(available_send_elastic_tokens)
+  FROM crdb_internal.kv_flow_controller_v2
+  ORDER BY store_id ASC;
+`
+
+// flowPerStoreTokenQueryHeaderStrs are the headers for the per-store flow
+// token query.
+var flowPerStoreTokenQueryHeaderStrs = []string{
+	"store_id",
+	"eval_regular_available", "eval_elastic_available",
+	"send_regular_available", "send_elastic_available",
+}
+
 // query runs the given SQL query against the given SQLRunner, and appends the
 // output to the testdata file buffer.
 func (h *flowControlTestHelper) query(runner *sqlutils.SQLRunner, sql string, headers ...string) {
 	// NB: We update metric gauges here to ensure that periodically updated
 	// metrics (via the node metrics loop) are up-to-date.
-	for _, server := range h.tc.Servers {
+	for idx, server := range h.tc.Servers {
+		if h.tc.ServerStopped(idx) {
+			// The test has explicitly stopped this server, so we should skip it.
+			continue
+		}
 		require.NoError(h.t, server.GetStores().(*kvserver.Stores).VisitStores(func(s *kvserver.Store) error {
+			_, err := s.ComputeMetricsPeriodically(context.Background(), nil, 0)
+			require.NoError(h.t, err)
 			s.GetStoreConfig().KVFlowStreamTokenProvider.UpdateMetricGauges()
 			return nil
 		}))

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"reflect"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
@@ -696,13 +697,23 @@ func (rc *rangeController) WaitForEval(
 	rc.opts.EvalWaitMetrics.OnWaiting(wc)
 	waitCategory, waitCategoryChangeCh := rc.opts.WaitForEvalConfig.Current()
 	bypass := waitCategory.Bypass(wc)
+	if knobs := rc.opts.Knobs; knobs != nil &&
+		knobs.OverrideBypassAdmitWaitForEval != nil {
+		// This is used by some tests to bypass the wait for eval, for two different
+		// purposes:
+		// - to get the entry into HandleRaftEventRaftMuLocked, where normally the
+		//   request would block here.
+		// - to prevent the entry from being subject to replication admission
+		//   control.
+		bypass, waited = rc.opts.Knobs.OverrideBypassAdmitWaitForEval(ctx)
+	}
 	if bypass {
 		if expensiveLoggingEnabled {
 			log.VEventf(ctx, 2, "r%v/%v bypassed request (pri=%v)",
 				rc.opts.RangeID, rc.opts.LocalReplicaID, pri)
 		}
 		rc.opts.EvalWaitMetrics.OnBypassed(wc, 0 /* duration */)
-		return false, nil
+		return waited, nil
 	}
 	waitForAllReplicateHandles := false
 	if wc == admissionpb.ElasticWorkClass {
@@ -1584,7 +1595,8 @@ func (rc *rangeController) maybeUpdateSendQueueStatsRaftMuLocked() {
 		rc.mu.Lock()
 		defer rc.mu.Unlock()
 		if nextUpdateTime := rc.mu.lastSendQueueStatRefresh.Add(
-			sendQueueStatRefreshInterval); now.After(nextUpdateTime) {
+			sendQueueStatRefreshInterval); now.After(nextUpdateTime) ||
+			(rc.opts.Knobs != nil && rc.opts.Knobs.OverrideAlwaysRefreshSendStreamStats) {
 			// We should update the stats, it has been longer than
 			// sendQueueStatRefreshInterval.
 			updateStats = true
@@ -2062,15 +2074,41 @@ func (rss *replicaSendStream) holdsTokensRaftMuLocked() bool {
 
 func (rss *replicaSendStream) admitRaftMuLocked(ctx context.Context, av AdmittedVector) {
 	rss.parent.parent.opts.ReplicaMutexAsserter.RaftMuAssertHeld()
-	if log.V(2) {
-		log.VInfof(ctx, 2, "r%v:%v stream %v admit %v",
-			rss.parent.parent.opts.RangeID, rss.parent.desc, rss.parent.stream, av)
-	}
 	rss.mu.Lock()
 	defer rss.mu.Unlock()
 
 	returnedSend, returnedEval := rss.raftMu.tracker.Untrack(av,
 		rss.mu.nextRaftIndexInitial)
+	if log.V(2) {
+		returnedSomething := false
+		for _, tokenArray := range [2][raftpb.NumPriorities]kvflowcontrol.Tokens{returnedSend, returnedEval} {
+			for _, t := range tokenArray {
+				if t > 0 {
+					returnedSomething = true
+				}
+			}
+		}
+		if returnedSomething {
+			var b strings.Builder
+			printReturned := func(prefix string, returned [raftpb.NumPriorities]kvflowcontrol.Tokens) {
+				first := true
+				for pri, tokens := range returned {
+					if tokens > 0 {
+						if first {
+							fmt.Fprintf(&b, "%s:", prefix)
+							first = false
+						}
+						fmt.Fprintf(&b, "%v:%v", raftpb.Priority(pri), tokens)
+					}
+				}
+			}
+			printReturned("send", returnedSend)
+			printReturned(" eval", returnedEval)
+			log.VInfof(ctx, 2, "r%v:%v stream %v admit %v returned %s",
+				rss.parent.parent.opts.RangeID, rss.parent.desc, rss.parent.stream, av,
+				redact.SafeString(b.String()))
+		}
+	}
 	rss.returnSendTokensRaftMuAndStreamLocked(ctx, returnedSend, false /* disconnect */)
 	rss.returnEvalTokensRaftMuAndStreamLocked(ctx, returnedEval)
 }
@@ -2494,6 +2532,26 @@ func (rss *replicaSendStream) closeRaftMuAndStreamLocked(ctx context.Context) {
 	rss.mu.closed = true
 }
 
+func (rss *replicaSendStream) applySendQueuePreciseSizeDeltaRaftMuAndStreamLocked(
+	ctx context.Context, delta kvflowcontrol.Tokens,
+) {
+	rss.parent.parent.opts.ReplicaMutexAsserter.RaftMuAssertHeld()
+	rss.mu.AssertHeld()
+
+	before := rss.mu.sendQueue.preciseSizeSum
+	after := before + delta
+	rss.mu.sendQueue.preciseSizeSum = after
+	if rss.isEmptySendQueueStreamLocked() && after != 0 {
+		panic(errors.AssertionFailedf(
+			"empty send-queue with non-zero precise size: "+
+				"before=%v after=%v delta=%v [queue_len=%v, queue_approx_size=%v]",
+			before, after, delta,
+			rss.queueLengthRaftMuAndStreamLocked(),
+			rss.approxQueueSizeStreamLocked(),
+		))
+	}
+}
+
 func (rss *replicaSendStream) handleReadyEntriesRaftMuAndStreamLocked(
 	ctx context.Context, event raftEventForReplica, directive replicaDirective,
 ) (transitionedSendQState bool, err error) {
@@ -2566,7 +2624,7 @@ func (rss *replicaSendStream) handleReadyEntriesRaftMuAndStreamLocked(
 			if inSendQueue && entry.id.index >= rss.mu.nextRaftIndexInitial {
 				// Was in send-queue and had eval tokens deducted for it.
 				rss.mu.sendQueue.originalEvalTokens[WorkClassFromRaftPriority(entry.pri)] -= tokens
-				rss.mu.sendQueue.preciseSizeSum -= tokens
+				rss.applySendQueuePreciseSizeDeltaRaftMuAndStreamLocked(ctx, -tokens)
 			}
 			rss.raftMu.tracker.Track(ctx, entry.id, pri, tokens)
 			sendTokensToDeduct[WorkClassFromRaftPriority(pri)] += tokens
@@ -2597,6 +2655,12 @@ func (rss *replicaSendStream) handleReadyEntriesRaftMuAndStreamLocked(
 			}
 			var pri raftpb.Priority
 			inSendQueue := false
+			tokens := entry.tokens
+			if rss.parent.parent.opts.Knobs != nil {
+				if fn := rss.parent.parent.opts.Knobs.OverrideTokenDeduction; fn != nil {
+					tokens = fn(tokens)
+				}
+			}
 			if entry.id.index >= rss.mu.sendQueue.indexToSend {
 				// Being added to the send-queue.
 				inSendQueue = true
@@ -2611,15 +2675,9 @@ func (rss *replicaSendStream) handleReadyEntriesRaftMuAndStreamLocked(
 				} else {
 					pri = raftpb.LowPri
 				}
-				rss.mu.sendQueue.preciseSizeSum += entry.tokens
+				rss.applySendQueuePreciseSizeDeltaRaftMuAndStreamLocked(ctx, +tokens)
 			} else {
 				pri = entry.pri
-			}
-			tokens := entry.tokens
-			if rss.parent.parent.opts.Knobs != nil {
-				if fn := rss.parent.parent.opts.Knobs.OverrideTokenDeduction; fn != nil {
-					tokens = fn(tokens)
-				}
 			}
 			if inSendQueue && entry.id.index >= rss.mu.nextRaftIndexInitial {
 				// Is in send-queue and will have eval tokens deducted for it.
@@ -2738,22 +2796,28 @@ func (rss *replicaSendStream) dequeueFromQueueAndSendRaftMuAndStreamLocked(
 			panic(errors.AssertionFailedf("index %d >= nextRaftIndex %d", entryState.id.index,
 				rss.mu.sendQueue.nextRaftIndex))
 		}
+		tokens := entryState.tokens
+		if rss.parent.parent.opts.Knobs != nil {
+			if fn := rss.parent.parent.opts.Knobs.OverrideTokenDeduction; fn != nil {
+				tokens = fn(tokens)
+			}
+		}
 		rss.mu.sendQueue.indexToSend++
 		isApproximatedEntry := entryState.id.index < rss.mu.nextRaftIndexInitial
 		if isApproximatedEntry {
 			approximatedNumEntries++
 			if entryState.usesFlowControl {
-				approximatedNumActualTokens += entryState.tokens
+				approximatedNumActualTokens += tokens
 			}
 		}
 		if entryState.usesFlowControl {
 			if !isApproximatedEntry {
-				rss.mu.sendQueue.preciseSizeSum -= entryState.tokens
+				rss.applySendQueuePreciseSizeDeltaRaftMuAndStreamLocked(ctx, -tokens)
 				rss.mu.sendQueue.originalEvalTokens[WorkClassFromRaftPriority(entryState.pri)] -=
-					entryState.tokens
+					tokens
 			}
-			tokensNeeded += entryState.tokens
-			rss.raftMu.tracker.Track(ctx, entryState.id, raftpb.LowPri, entryState.tokens)
+			tokensNeeded += tokens
+			rss.raftMu.tracker.Track(ctx, entryState.id, raftpb.LowPri, tokens)
 		}
 	}
 	if approximatedNumEntries > 0 {

--- a/pkg/kv/kvserver/kvflowcontrol/testing_knobs.go
+++ b/pkg/kv/kvserver/kvflowcontrol/testing_knobs.go
@@ -6,6 +6,8 @@
 package kvflowcontrol
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb"
 )
@@ -32,6 +34,16 @@ type TestingKnobs struct {
 	// mode, while also having the ability to switch between the two
 	// apply_to_(elastic|all) modes.
 	OverridePullPushMode func() bool
+	// OverrideBypassAdmitWaitForEval is used to override the behavior of
+	// WaitForEval. When bypass is set to true, WaitForEval will return
+	// immediately and return the waited value. Otherwise, when bypass is set
+	// to false, or unset, WaitForEval will behave normally.
+	OverrideBypassAdmitWaitForEval func(ctx context.Context) (bypass bool, waited bool)
+	// OverrideAlwaysRefreshSendStreamStats is used to override the behavior of
+	// the send stream stats refresh. When set to true, the send stream stats
+	// will always be refreshed on a HandleRaftEventRaftMuLocked call. Otherwise,
+	// when set to false, the default behavior will be used.
+	OverrideAlwaysRefreshSendStreamStats bool
 }
 
 // TestingKnobsV1 are the testing knobs that appply to replication flow control

--- a/pkg/kv/kvserver/testdata/flow_control_integration/raft_snapshot
+++ b/pkg/kv/kvserver/testdata/flow_control_integration/raft_snapshot
@@ -178,7 +178,7 @@ SELECT store_id,
   FROM crdb_internal.kv_flow_controller
  ORDER BY store_id ASC;
 
-  range_id | regular_available | elastic_available  
+  store_id | regular_available | elastic_available  
 -----------+-------------------+--------------------
   1        | 16 MiB            | 8.0 MiB            
   2        | 16 MiB            | 8.0 MiB            

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/raft_snapshot_v1_encoding_apply_to_all
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/raft_snapshot_v1_encoding_apply_to_all
@@ -231,7 +231,7 @@ SELECT store_id,
   FROM crdb_internal.kv_flow_controller_v2
  ORDER BY store_id ASC;
 
-  range_id | eval_regular_available | eval_elastic_available  
+  store_id | eval_regular_available | eval_elastic_available  
 -----------+------------------------+-------------------------
   1        | 16 MiB                 | 8.0 MiB                 
   2        | 16 MiB                 | 8.0 MiB                 

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/raft_snapshot_v1_encoding_apply_to_elastic
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/raft_snapshot_v1_encoding_apply_to_elastic
@@ -231,7 +231,7 @@ SELECT store_id,
   FROM crdb_internal.kv_flow_controller_v2
  ORDER BY store_id ASC;
 
-  range_id | eval_regular_available | eval_elastic_available  
+  store_id | eval_regular_available | eval_elastic_available  
 -----------+------------------------+-------------------------
   1        | 16 MiB                 | 8.0 MiB                 
   2        | 16 MiB                 | 8.0 MiB                 

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/raft_snapshot_v2_encoding_apply_to_all
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/raft_snapshot_v2_encoding_apply_to_all
@@ -224,7 +224,7 @@ SELECT store_id,
   FROM crdb_internal.kv_flow_controller_v2
  ORDER BY store_id ASC;
 
-  range_id | eval_regular_available | eval_elastic_available  
+  store_id | eval_regular_available | eval_elastic_available  
 -----------+------------------------+-------------------------
   1        | 16 MiB                 | 8.0 MiB                 
   2        | 16 MiB                 | 8.0 MiB                 

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/raft_snapshot_v2_encoding_apply_to_elastic
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/raft_snapshot_v2_encoding_apply_to_elastic
@@ -224,7 +224,7 @@ SELECT store_id,
   FROM crdb_internal.kv_flow_controller_v2
  ORDER BY store_id ASC;
 
-  range_id | eval_regular_available | eval_elastic_available  
+  store_id | eval_regular_available | eval_elastic_available  
 -----------+------------------------+-------------------------
   1        | 16 MiB                 | 8.0 MiB                 
   2        | 16 MiB                 | 8.0 MiB                 

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue
@@ -1,0 +1,633 @@
+echo
+----
+----
+-- This test exercises send queue formation, prevention and flushing.
+-- The structure roughly follows:
+--   Start with three voters on [n1,n2,n3], where n1 is the leader+leaseholder.
+--   Large regular write -4 MiB.
+--   Allow admission [n1,n2].
+--   - Tokens should be returned for n1 and n2.
+--   Block admission [n2].
+--   Regular write -1 MiB.
+--   - Shouldn't be blocked on wait-for-eval because of quorum [n1,n2].
+--   - Metrics should reflect send queue formation on n3.
+--   Stop n2.
+--   Regular write -1 MiB.
+--   - Blocks on wait-for-eval, however the test bypasses this instance.
+--   - Metrics should reflect n3 being force flushed.
+--   Allow admission [n1,n2,n3].
+--   Start n2.
+--   Add n4, n5, the voters now are [n1,n2,n3,n4,n5].
+--   Block admission [n4,n5] (already blocked)
+--   Regular write -4 MiB.
+--   Regular write -1  MiB.
+--   - Shouldn't be blocked on wait-for-eval because of quorum [n1,n2,n3]
+--   - Metrics should reflect send queue formation on n4,n5.
+--   Unblock admission [n4,n5].
+--   - Wait for tokens to be returned.
+--   Block admission [n2,n3,n4,n5].
+--   Regular write -4 MiB.
+--   Regular write -1  MiB.
+--   - Blocks on wait-for-eval, however the test bypasses this instance.    
+--   - Metrics should reflect 2 streams being prevented from forming a send queue.
+--   Allow admission [n1,n2,n3,n4,n5] (all).
+--   Assert all tokens returned.
+--
+-- Start by printing the relevant metrics on n1, first the flow token metrics.
+SELECT name, crdb_internal.humanize_bytes(value::INT8)
+    FROM crdb_internal.node_metrics
+   WHERE name LIKE '%kvflowcontrol%tokens%'
+ORDER BY name ASC;
+
+  kvflowcontrol.tokens.eval.elastic.available                       | 6.0 MiB  
+  kvflowcontrol.tokens.eval.elastic.deducted                        | 0 B      
+  kvflowcontrol.tokens.eval.elastic.returned                        | 0 B      
+  kvflowcontrol.tokens.eval.elastic.returned.disconnect             | 0 B      
+  kvflowcontrol.tokens.eval.elastic.unaccounted                     | 0 B      
+  kvflowcontrol.tokens.eval.regular.available                       | 12 MiB   
+  kvflowcontrol.tokens.eval.regular.deducted                        | 0 B      
+  kvflowcontrol.tokens.eval.regular.returned                        | 0 B      
+  kvflowcontrol.tokens.eval.regular.returned.disconnect             | 0 B      
+  kvflowcontrol.tokens.eval.regular.unaccounted                     | 0 B      
+  kvflowcontrol.tokens.send.elastic.available                       | 6.0 MiB  
+  kvflowcontrol.tokens.send.elastic.deducted                        | 0 B      
+  kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 0 B      
+  kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 0 B      
+  kvflowcontrol.tokens.send.elastic.returned                        | 0 B      
+  kvflowcontrol.tokens.send.elastic.returned.disconnect             | 0 B      
+  kvflowcontrol.tokens.send.elastic.unaccounted                     | 0 B      
+  kvflowcontrol.tokens.send.regular.available                       | 12 MiB   
+  kvflowcontrol.tokens.send.regular.deducted                        | 0 B      
+  kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 0 B      
+  kvflowcontrol.tokens.send.regular.returned                        | 0 B      
+  kvflowcontrol.tokens.send.regular.returned.disconnect             | 0 B      
+  kvflowcontrol.tokens.send.regular.unaccounted                     | 0 B      
+
+
+-- Send queue metrics from n1.
+SELECT name, crdb_internal.humanize_bytes(value::INT8)
+    FROM crdb_internal.node_metrics
+   WHERE name LIKE '%kvflowcontrol%send_queue%'
+     AND name != 'kvflowcontrol.send_queue.count'
+ORDER BY name ASC;
+
+  kvflowcontrol.send_queue.bytes                                    | 0 B  
+  kvflowcontrol.send_queue.prevent.count                            | 0 B  
+  kvflowcontrol.send_queue.scheduled.deducted_bytes                 | 0 B  
+  kvflowcontrol.send_queue.scheduled.force_flush                    | 0 B  
+  kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 0 B  
+  kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 0 B  
+  kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 0 B  
+
+
+-- Per-store tokens available from n1.
+SELECT store_id,
+     crdb_internal.humanize_bytes(available_eval_regular_tokens),
+     crdb_internal.humanize_bytes(available_eval_elastic_tokens),
+     crdb_internal.humanize_bytes(available_send_regular_tokens),
+     crdb_internal.humanize_bytes(available_send_elastic_tokens)
+  FROM crdb_internal.kv_flow_controller_v2
+  ORDER BY store_id ASC;
+
+  store_id | eval_regular_available | eval_elastic_available | send_regular_available | send_elastic_available  
+-----------+------------------------+------------------------+------------------------+-------------------------
+  1        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  2        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  3        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+
+
+-- (Issuing 4x1MiB regular, 3x replicated write that's not admitted.)
+
+
+-- Observe the total tracked tokens per-stream on n1.
+SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::INT8)
+    FROM crdb_internal.kv_flow_control_handles_v2
+
+  range_id | store_id | total_tracked_tokens  
+-----------+----------+-----------------------
+  70       | 1        | 4.0 MiB               
+  70       | 2        | 4.0 MiB               
+  70       | 3        | 4.0 MiB               
+
+
+-- And, the per-store tokens available post-write from n1.
+SELECT store_id,
+     crdb_internal.humanize_bytes(available_eval_regular_tokens),
+     crdb_internal.humanize_bytes(available_eval_elastic_tokens),
+     crdb_internal.humanize_bytes(available_send_regular_tokens),
+     crdb_internal.humanize_bytes(available_send_elastic_tokens)
+  FROM crdb_internal.kv_flow_controller_v2
+  ORDER BY store_id ASC;
+
+  store_id | eval_regular_available | eval_elastic_available | send_regular_available | send_elastic_available  
+-----------+------------------------+------------------------+------------------------+-------------------------
+  1        | 0 B                    | -2.0 MiB               | 0 B                    | -2.0 MiB                
+  2        | 0 B                    | -2.0 MiB               | 0 B                    | -2.0 MiB                
+  3        | 0 B                    | -2.0 MiB               | 0 B                    | -2.0 MiB                
+
+
+-- (Allowing below-raft admission to proceed on n1 and n2.)
+-- [n1(enabled),n2(enabled),n3(blocked)]
+
+
+-- Observe the total tracked tokens per-stream on n1.
+SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::INT8)
+    FROM crdb_internal.kv_flow_control_handles_v2
+
+  range_id | store_id | total_tracked_tokens  
+-----------+----------+-----------------------
+  70       | 1        | 0 B                   
+  70       | 2        | 0 B                   
+  70       | 3        | 4.0 MiB               
+
+
+-- Per-store tokens available from n1.
+SELECT store_id,
+     crdb_internal.humanize_bytes(available_eval_regular_tokens),
+     crdb_internal.humanize_bytes(available_eval_elastic_tokens),
+     crdb_internal.humanize_bytes(available_send_regular_tokens),
+     crdb_internal.humanize_bytes(available_send_elastic_tokens)
+  FROM crdb_internal.kv_flow_controller_v2
+  ORDER BY store_id ASC;
+
+  store_id | eval_regular_available | eval_elastic_available | send_regular_available | send_elastic_available  
+-----------+------------------------+------------------------+------------------------+-------------------------
+  1        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  2        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  3        | 0 B                    | -2.0 MiB               | 0 B                    | -2.0 MiB                
+
+
+-- (Blocking below-raft admission on n2.)
+
+
+-- (Issuing 1x1MiB regular, 3x replicated write that's not admitted.)
+
+
+-- The send queue metrics from n1 should reflect the 1 MiB write being queued
+-- for n3 and 1 MiB tracked for n2 that is yet to be admitted.
+SELECT name, crdb_internal.humanize_bytes(value::INT8)
+    FROM crdb_internal.node_metrics
+   WHERE name LIKE '%kvflowcontrol%send_queue%'
+     AND name != 'kvflowcontrol.send_queue.count'
+ORDER BY name ASC;
+
+  kvflowcontrol.send_queue.bytes                                    | 1.0 MiB  
+  kvflowcontrol.send_queue.prevent.count                            | 0 B      
+  kvflowcontrol.send_queue.scheduled.deducted_bytes                 | 0 B      
+  kvflowcontrol.send_queue.scheduled.force_flush                    | 0 B      
+  kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 0 B      
+  kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 0 B      
+  kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 0 B      
+
+
+-- Per-store tokens available from n1.
+SELECT store_id,
+     crdb_internal.humanize_bytes(available_eval_regular_tokens),
+     crdb_internal.humanize_bytes(available_eval_elastic_tokens),
+     crdb_internal.humanize_bytes(available_send_regular_tokens),
+     crdb_internal.humanize_bytes(available_send_elastic_tokens)
+  FROM crdb_internal.kv_flow_controller_v2
+  ORDER BY store_id ASC;
+
+  store_id | eval_regular_available | eval_elastic_available | send_regular_available | send_elastic_available  
+-----------+------------------------+------------------------+------------------------+-------------------------
+  1        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  2        | 3.0 MiB                | 1.0 MiB                | 3.0 MiB                | 1.0 MiB                 
+  3        | 0 B                    | -3.0 MiB               | 0 B                    | -2.0 MiB                
+
+
+-- (Stopping n2.)
+
+
+-- Flow token metrics from n1, the disconnect should be reflected in the metrics.
+SELECT name, crdb_internal.humanize_bytes(value::INT8)
+    FROM crdb_internal.node_metrics
+   WHERE name LIKE '%kvflowcontrol%tokens%'
+ORDER BY name ASC;
+
+  kvflowcontrol.tokens.eval.elastic.available                       | 1.0 MiB  
+  kvflowcontrol.tokens.eval.elastic.deducted                        | 15 MiB   
+  kvflowcontrol.tokens.eval.elastic.returned                        | 10 MiB   
+  kvflowcontrol.tokens.eval.elastic.returned.disconnect             | 1.0 MiB  
+  kvflowcontrol.tokens.eval.elastic.unaccounted                     | 0 B      
+  kvflowcontrol.tokens.eval.regular.available                       | 8.0 MiB  
+  kvflowcontrol.tokens.eval.regular.deducted                        | 14 MiB   
+  kvflowcontrol.tokens.eval.regular.returned                        | 10 MiB   
+  kvflowcontrol.tokens.eval.regular.returned.disconnect             | 1.0 MiB  
+  kvflowcontrol.tokens.eval.regular.unaccounted                     | 0 B      
+  kvflowcontrol.tokens.send.elastic.available                       | 1.0 MiB  
+  kvflowcontrol.tokens.send.elastic.deducted                        | 15 MiB   
+  kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 1.0 MiB  
+  kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 0 B      
+  kvflowcontrol.tokens.send.elastic.returned                        | 10 MiB   
+  kvflowcontrol.tokens.send.elastic.returned.disconnect             | 1.0 MiB  
+  kvflowcontrol.tokens.send.elastic.unaccounted                     | 0 B      
+  kvflowcontrol.tokens.send.regular.available                       | 8.0 MiB  
+  kvflowcontrol.tokens.send.regular.deducted                        | 14 MiB   
+  kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 0 B      
+  kvflowcontrol.tokens.send.regular.returned                        | 10 MiB   
+  kvflowcontrol.tokens.send.regular.returned.disconnect             | 1.0 MiB  
+  kvflowcontrol.tokens.send.regular.unaccounted                     | 0 B      
+
+
+-- Send queue metrics from n1, n3's send queue should have been force-flushed.
+SELECT name, crdb_internal.humanize_bytes(value::INT8)
+    FROM crdb_internal.node_metrics
+   WHERE name LIKE '%kvflowcontrol%send_queue%'
+     AND name != 'kvflowcontrol.send_queue.count'
+ORDER BY name ASC;
+
+  kvflowcontrol.send_queue.bytes                                    | 0 B      
+  kvflowcontrol.send_queue.prevent.count                            | 0 B      
+  kvflowcontrol.send_queue.scheduled.deducted_bytes                 | 0 B      
+  kvflowcontrol.send_queue.scheduled.force_flush                    | 0 B      
+  kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 1.0 MiB  
+  kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 0 B      
+  kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 0 B      
+
+
+-- Observe the total tracked tokens per-stream on n1, n3's flushed entries 
+-- will also be tracked here.
+SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::INT8)
+    FROM crdb_internal.kv_flow_control_handles_v2
+
+  range_id | store_id | total_tracked_tokens  
+-----------+----------+-----------------------
+  70       | 1        | 0 B                   
+  70       | 3        | 5.0 MiB               
+
+
+-- Per-store tokens available from n1, these should reflect the deducted 
+-- tokens from force-flushing n3.
+SELECT store_id,
+     crdb_internal.humanize_bytes(available_eval_regular_tokens),
+     crdb_internal.humanize_bytes(available_eval_elastic_tokens),
+     crdb_internal.humanize_bytes(available_send_regular_tokens),
+     crdb_internal.humanize_bytes(available_send_elastic_tokens)
+  FROM crdb_internal.kv_flow_controller_v2
+  ORDER BY store_id ASC;
+
+  store_id | eval_regular_available | eval_elastic_available | send_regular_available | send_elastic_available  
+-----------+------------------------+------------------------+------------------------+-------------------------
+  1        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  2        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  3        | 0 B                    | -3.0 MiB               | 0 B                    | -3.0 MiB                
+
+
+-- (Enabling wait-for-eval bypass.)
+
+
+-- (Issuing 1x1MiB regular, 3x replicated write that's not admitted.)
+
+
+-- (Disabling wait-for-eval bypass.)
+
+
+-- Send queue metrics from n1, n3's should not be allowed to form a send queue.
+SELECT name, crdb_internal.humanize_bytes(value::INT8)
+    FROM crdb_internal.node_metrics
+   WHERE name LIKE '%kvflowcontrol%send_queue%'
+     AND name != 'kvflowcontrol.send_queue.count'
+ORDER BY name ASC;
+
+  kvflowcontrol.send_queue.bytes                                    | 0 B      
+  kvflowcontrol.send_queue.prevent.count                            | 1 B      
+  kvflowcontrol.send_queue.scheduled.deducted_bytes                 | 0 B      
+  kvflowcontrol.send_queue.scheduled.force_flush                    | 0 B      
+  kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 1.0 MiB  
+  kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 1.0 MiB  
+  kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 1.0 MiB  
+
+
+-- Observe the total tracked tokens per-stream on n1, n3's should track the latest write
+-- as well.
+SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::INT8)
+    FROM crdb_internal.kv_flow_control_handles_v2
+
+  range_id | store_id | total_tracked_tokens  
+-----------+----------+-----------------------
+  70       | 1        | 0 B                   
+  70       | 3        | 6.0 MiB               
+
+
+-- (Allowing below-raft admission to proceed on n1, n2, and n3. Note that n2 is still down.)
+-- [n1(enabled),n2(enabled),n3(enabled)]
+
+
+-- Flow token metrics from n1.
+SELECT name, crdb_internal.humanize_bytes(value::INT8)
+    FROM crdb_internal.node_metrics
+   WHERE name LIKE '%kvflowcontrol%tokens%'
+ORDER BY name ASC;
+
+  kvflowcontrol.tokens.eval.elastic.available                       | 6.0 MiB  
+  kvflowcontrol.tokens.eval.elastic.deducted                        | 17 MiB   
+  kvflowcontrol.tokens.eval.elastic.returned                        | 17 MiB   
+  kvflowcontrol.tokens.eval.elastic.returned.disconnect             | 1.0 MiB  
+  kvflowcontrol.tokens.eval.elastic.unaccounted                     | 0 B      
+  kvflowcontrol.tokens.eval.regular.available                       | 12 MiB   
+  kvflowcontrol.tokens.eval.regular.deducted                        | 16 MiB   
+  kvflowcontrol.tokens.eval.regular.returned                        | 16 MiB   
+  kvflowcontrol.tokens.eval.regular.returned.disconnect             | 1.0 MiB  
+  kvflowcontrol.tokens.eval.regular.unaccounted                     | 0 B      
+  kvflowcontrol.tokens.send.elastic.available                       | 6.0 MiB  
+  kvflowcontrol.tokens.send.elastic.deducted                        | 17 MiB   
+  kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 1.0 MiB  
+  kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 1.0 MiB  
+  kvflowcontrol.tokens.send.elastic.returned                        | 17 MiB   
+  kvflowcontrol.tokens.send.elastic.returned.disconnect             | 1.0 MiB  
+  kvflowcontrol.tokens.send.elastic.unaccounted                     | 0 B      
+  kvflowcontrol.tokens.send.regular.available                       | 12 MiB   
+  kvflowcontrol.tokens.send.regular.deducted                        | 16 MiB   
+  kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 1.0 MiB  
+  kvflowcontrol.tokens.send.regular.returned                        | 16 MiB   
+  kvflowcontrol.tokens.send.regular.returned.disconnect             | 1.0 MiB  
+  kvflowcontrol.tokens.send.regular.unaccounted                     | 0 B      
+
+
+-- Per-store tokens available from n1.
+SELECT store_id,
+     crdb_internal.humanize_bytes(available_eval_regular_tokens),
+     crdb_internal.humanize_bytes(available_eval_elastic_tokens),
+     crdb_internal.humanize_bytes(available_send_regular_tokens),
+     crdb_internal.humanize_bytes(available_send_elastic_tokens)
+  FROM crdb_internal.kv_flow_controller_v2
+  ORDER BY store_id ASC;
+
+  store_id | eval_regular_available | eval_elastic_available | send_regular_available | send_elastic_available  
+-----------+------------------------+------------------------+------------------------+-------------------------
+  1        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  2        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  3        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+
+
+-- (Starting n2.)
+
+
+-- There should now be 3 connected streams again.
+SELECT range_id, count(*) AS streams
+    FROM crdb_internal.kv_flow_control_handles_v2
+GROUP BY (range_id)
+ORDER BY streams DESC;
+
+  range_id | stream_count  
+-----------+---------------
+  70       | 3             
+
+
+-- (Adding VOTER to n4 and n5.)
+
+
+-- Now, after adding n4,n5, there should be 5 connected streams.
+-- [n1,n2,n3,n4,n5]
+SELECT range_id, count(*) AS streams
+    FROM crdb_internal.kv_flow_control_handles_v2
+GROUP BY (range_id)
+ORDER BY streams DESC;
+
+  range_id | stream_count  
+-----------+---------------
+  70       | 5             
+
+
+-- Per-store tokens available from n1.
+SELECT store_id,
+     crdb_internal.humanize_bytes(available_eval_regular_tokens),
+     crdb_internal.humanize_bytes(available_eval_elastic_tokens),
+     crdb_internal.humanize_bytes(available_send_regular_tokens),
+     crdb_internal.humanize_bytes(available_send_elastic_tokens)
+  FROM crdb_internal.kv_flow_controller_v2
+  ORDER BY store_id ASC;
+
+  store_id | eval_regular_available | eval_elastic_available | send_regular_available | send_elastic_available  
+-----------+------------------------+------------------------+------------------------+-------------------------
+  1        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  2        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  3        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  4        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  5        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+
+
+-- (Issuing 4x1MiB regular, 5x replicated write that's not admitted.)
+
+
+-- From n1. We should expect to see the unblocked streams quickly
+-- untrack as admission is allowed (so not observed here), while n4,n5 will continue
+-- to track as they are blocked from admitting (logically).
+SELECT store_id,
+     crdb_internal.humanize_bytes(available_eval_regular_tokens),
+     crdb_internal.humanize_bytes(available_eval_elastic_tokens),
+     crdb_internal.humanize_bytes(available_send_regular_tokens),
+     crdb_internal.humanize_bytes(available_send_elastic_tokens)
+  FROM crdb_internal.kv_flow_controller_v2
+  ORDER BY store_id ASC;
+
+  store_id | eval_regular_available | eval_elastic_available | send_regular_available | send_elastic_available  
+-----------+------------------------+------------------------+------------------------+-------------------------
+  1        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  2        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  3        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  4        | 0 B                    | -2.0 MiB               | 0 B                    | -2.0 MiB                
+  5        | 0 B                    | -2.0 MiB               | 0 B                    | -2.0 MiB                
+SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::INT8)
+    FROM crdb_internal.kv_flow_control_handles_v2
+
+  range_id | store_id | total_tracked_tokens  
+-----------+----------+-----------------------
+  70       | 1        | 0 B                   
+  70       | 2        | 0 B                   
+  70       | 3        | 0 B                   
+  70       | 4        | 4.0 MiB               
+  70       | 5        | 4.0 MiB               
+
+
+-- (Issuing 1x1MiB regular, 5x replicated write that's not admitted.)
+
+
+-- Send queue and flow token metrics from n1. The 1 MiB write should be queued
+-- for n4,n5, while the quorum (n1,n2,n3) proceeds.
+SELECT name, crdb_internal.humanize_bytes(value::INT8)
+    FROM crdb_internal.node_metrics
+   WHERE name LIKE '%kvflowcontrol%send_queue%'
+     AND name != 'kvflowcontrol.send_queue.count'
+ORDER BY name ASC;
+
+  kvflowcontrol.send_queue.bytes                                    | 2.0 MiB  
+  kvflowcontrol.send_queue.prevent.count                            | 1 B      
+  kvflowcontrol.send_queue.scheduled.deducted_bytes                 | 0 B      
+  kvflowcontrol.send_queue.scheduled.force_flush                    | 0 B      
+  kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 1.0 MiB  
+  kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 1.0 MiB  
+  kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 1.0 MiB  
+SELECT store_id,
+     crdb_internal.humanize_bytes(available_eval_regular_tokens),
+     crdb_internal.humanize_bytes(available_eval_elastic_tokens),
+     crdb_internal.humanize_bytes(available_send_regular_tokens),
+     crdb_internal.humanize_bytes(available_send_elastic_tokens)
+  FROM crdb_internal.kv_flow_controller_v2
+  ORDER BY store_id ASC;
+
+  store_id | eval_regular_available | eval_elastic_available | send_regular_available | send_elastic_available  
+-----------+------------------------+------------------------+------------------------+-------------------------
+  1        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  2        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  3        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  4        | 0 B                    | -3.0 MiB               | 0 B                    | -2.0 MiB                
+  5        | 0 B                    | -3.0 MiB               | 0 B                    | -2.0 MiB                
+
+
+-- (Allowing below-raft admission to proceed on n4 and n5.)
+-- [n1(enabled),n2(enabled),n3(enabled),n4(enabled),n5(enabled)]
+
+
+-- Per-store tokens available from n1. Expect these to return to the same as 
+-- the initial state.
+SELECT store_id,
+     crdb_internal.humanize_bytes(available_eval_regular_tokens),
+     crdb_internal.humanize_bytes(available_eval_elastic_tokens),
+     crdb_internal.humanize_bytes(available_send_regular_tokens),
+     crdb_internal.humanize_bytes(available_send_elastic_tokens)
+  FROM crdb_internal.kv_flow_controller_v2
+  ORDER BY store_id ASC;
+
+  store_id | eval_regular_available | eval_elastic_available | send_regular_available | send_elastic_available  
+-----------+------------------------+------------------------+------------------------+-------------------------
+  1        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  2        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  3        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  4        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  5        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+
+
+-- (Blocking below-raft admission on [n2,n3,n4,n5].)
+
+
+-- (Issuing 4x1MiB regular, 5x replicated write that's not admitted.)
+
+
+-- Send queue and flow token metrics from n1. The 4 MiB write should not be
+-- queued, but instead exhaust all available regular eval and send tokens across
+-- each stream, except s1 (as admission is not blocked).
+SELECT name, crdb_internal.humanize_bytes(value::INT8)
+    FROM crdb_internal.node_metrics
+   WHERE name LIKE '%kvflowcontrol%send_queue%'
+     AND name != 'kvflowcontrol.send_queue.count'
+ORDER BY name ASC;
+
+  kvflowcontrol.send_queue.bytes                                    | 0 B      
+  kvflowcontrol.send_queue.prevent.count                            | 1 B      
+  kvflowcontrol.send_queue.scheduled.deducted_bytes                 | 0 B      
+  kvflowcontrol.send_queue.scheduled.force_flush                    | 0 B      
+  kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 1.0 MiB  
+  kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 1.0 MiB  
+  kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 1.0 MiB  
+SELECT store_id,
+     crdb_internal.humanize_bytes(available_eval_regular_tokens),
+     crdb_internal.humanize_bytes(available_eval_elastic_tokens),
+     crdb_internal.humanize_bytes(available_send_regular_tokens),
+     crdb_internal.humanize_bytes(available_send_elastic_tokens)
+  FROM crdb_internal.kv_flow_controller_v2
+  ORDER BY store_id ASC;
+
+  store_id | eval_regular_available | eval_elastic_available | send_regular_available | send_elastic_available  
+-----------+------------------------+------------------------+------------------------+-------------------------
+  1        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  2        | 0 B                    | -2.0 MiB               | 0 B                    | -2.0 MiB                
+  3        | 0 B                    | -2.0 MiB               | 0 B                    | -2.0 MiB                
+  4        | 0 B                    | -2.0 MiB               | 0 B                    | -2.0 MiB                
+  5        | 0 B                    | -2.0 MiB               | 0 B                    | -2.0 MiB                
+
+
+-- (Enabling wait-for-eval bypass.)
+
+
+-- (Issuing 1x1MiB regular, 5x replicated write that's not admitted.)
+
+
+-- (Disabling wait-for-eval bypass.)
+
+
+-- Observe the total tracked tokens per-stream on n1. We should expect to see the
+-- 1 MiB write being tracked across a quorum of streams, while the 4 MiB write
+-- is tracked across each stream (except s1). Two(/4 non-leader) replica send 
+-- streams should be prevented from forming a send queue and have higher tracked
+-- tokens than the other two.
+SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::INT8)
+    FROM crdb_internal.kv_flow_control_handles_v2
+
+  range_id | store_id | total_tracked_tokens  
+-----------+----------+-----------------------
+  70       | 1        | 0 B                   
+  70       | 2        | 4.0 MiB               
+  70       | 3        | 4.0 MiB               
+  70       | 4        | 5.0 MiB               
+  70       | 5        | 5.0 MiB               
+
+
+-- Send queue and flow token metrics from n1.
+SELECT name, crdb_internal.humanize_bytes(value::INT8)
+    FROM crdb_internal.node_metrics
+   WHERE name LIKE '%kvflowcontrol%send_queue%'
+     AND name != 'kvflowcontrol.send_queue.count'
+ORDER BY name ASC;
+
+  kvflowcontrol.send_queue.bytes                                    | 2.0 MiB  
+  kvflowcontrol.send_queue.prevent.count                            | 3 B      
+  kvflowcontrol.send_queue.scheduled.deducted_bytes                 | 0 B      
+  kvflowcontrol.send_queue.scheduled.force_flush                    | 0 B      
+  kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 1.0 MiB  
+  kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 3.0 MiB  
+  kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 3.0 MiB  
+SELECT store_id,
+     crdb_internal.humanize_bytes(available_eval_regular_tokens),
+     crdb_internal.humanize_bytes(available_eval_elastic_tokens),
+     crdb_internal.humanize_bytes(available_send_regular_tokens),
+     crdb_internal.humanize_bytes(available_send_elastic_tokens)
+  FROM crdb_internal.kv_flow_controller_v2
+  ORDER BY store_id ASC;
+
+  store_id | eval_regular_available | eval_elastic_available | send_regular_available | send_elastic_available  
+-----------+------------------------+------------------------+------------------------+-------------------------
+  1        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  2        | 0 B                    | -3.0 MiB               | 0 B                    | -2.0 MiB                
+  3        | 0 B                    | -3.0 MiB               | 0 B                    | -2.0 MiB                
+  4        | -1.0 MiB               | -3.0 MiB               | -1.0 MiB               | -3.0 MiB                
+  5        | -1.0 MiB               | -3.0 MiB               | -1.0 MiB               | -3.0 MiB                
+
+
+-- (Allowing below-raft admission on [n1,n2,n3,n4,n5].)
+
+
+-- Send queue and flow token metrics from n1. All tokens should be returned.
+SELECT name, crdb_internal.humanize_bytes(value::INT8)
+    FROM crdb_internal.node_metrics
+   WHERE name LIKE '%kvflowcontrol%send_queue%'
+     AND name != 'kvflowcontrol.send_queue.count'
+ORDER BY name ASC;
+
+  kvflowcontrol.send_queue.bytes                                    | 0 B      
+  kvflowcontrol.send_queue.prevent.count                            | 3 B      
+  kvflowcontrol.send_queue.scheduled.deducted_bytes                 | 0 B      
+  kvflowcontrol.send_queue.scheduled.force_flush                    | 0 B      
+  kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 1.0 MiB  
+  kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 3.0 MiB  
+  kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 3.0 MiB  
+SELECT store_id,
+     crdb_internal.humanize_bytes(available_eval_regular_tokens),
+     crdb_internal.humanize_bytes(available_eval_elastic_tokens),
+     crdb_internal.humanize_bytes(available_send_regular_tokens),
+     crdb_internal.humanize_bytes(available_send_elastic_tokens)
+  FROM crdb_internal.kv_flow_controller_v2
+  ORDER BY store_id ASC;
+
+  store_id | eval_regular_available | eval_elastic_available | send_regular_available | send_elastic_available  
+-----------+------------------------+------------------------+------------------------+-------------------------
+  1        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  2        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  3        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  4        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+  5        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
+----
+----
+
+# vim:ft=sql


### PR DESCRIPTION
This commit introduces two testing knobs:

```go
// OverrideBypassAdmitWaitForEval is used to override the behavior of
// WaitForEval. When bypass is set to true, WaitForEval will return
// immediately and return the waited value. Otherwise, when bypass is set
// to false, or unset, WaitForEval will behave normally.
OverrideBypassAdmitWaitForEval func() bool
// OverrideAlwaysRefreshSendStreamStats is used to override the behavior of
// the send stream stats refresh. When set to true, the send stream stats
// will always be refreshed on a HandleRaftEventRaftMuLocked call. Otherwise,
// when set to false, the default behavior will be used.
OverrideAlwaysRefreshSendStreamStats bool
```

Also:

- Thread send queue precise size adjustments via a method which also
  asserts that the size is consistent between the count and bytes.
- Change the logging in `replicaSendStream.admitRaftMuLocked` to log
  when some tokens were actually returned. The existing logging was very
  spammy and made it hard to debug.


---


The header was incorrectly `range_id` rather than `store_id` for some
`TestFlowControl.*` integration tests. Amend the header to be
`store_id`.

---

Introduce `TestFlowControlSendQueue`, which exercises:

1. Send queue formation via send token exhaustion
2. Send queue force-flushing via a node disconnect
3. Send queue formation prevention via a testing knob to skip
   wait-for-eval

More specifically, the test has the following structure:

```sql
-- This test exercises send queue formation, prevention and flushing.
-- The structure roughly follows:
--   Start with three voters on [n1,n2,n3], where n1 is the leader+leaseholder.
--   Large regular write -4 MiB.
--   Allow admission [n1,n2].
--   - Tokens should be returned for n1 and n2.
--   Block admission [n2].
--   Regular write -1 MiB.
--   - Shouldn't be blocked on wait-for-eval because of quorum [n1,n2].
--   - Metrics should reflect send queue formation on n3.
--   Stop n2.
--   Regular write -1 MiB.
--   - Blocks on wait-for-eval, however the test bypasses this instance.
--   - Metrics should reflect n3 being force flushed.
--   Allow admission [n1,n2,n3].
--   Start n2.
--   Add n4, n5, the voters now are [n1,n2,n3,n4,n5].
--   Block admission [n4,n5] (already blocked)
--   Regular write -4 MiB.
--   Regular write -1  MiB.
--   - Shouldn't be blocked on wait-for-eval because of quorum [n1,n2,n3]
--   - Metrics should reflect send queue formation on n4,n5.
--   Unblock admission [n4,n5].
--   - Wait for tokens to be returned.
--   Block admission [n2,n3,n4,n5].
--   Regular write -4 MiB.
--   Regular write -1  MiB.
--   - Blocks on wait-for-eval, however the test bypasses this instance.
--   - Metrics should reflect 2 streams being prevented from forming a send queue.
--   Allow admission [n1,n2,n3,n4,n5] (all).
--   Assert all tokens returned.
```

Part of: https://github.com/cockroachdb/cockroach/issues/132614
Release note: None