### PR TITLE
changefeedccl: deflake TestChangefeedSchemaChangeBackfillCheckpoint

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2352,7 +2352,7 @@ func TestChangefeedSchemaChangeBackfillCheckpoint(t *testing.T) {
 
 		// Checkpoint progress frequently, and set the checkpoint size limit.
 		changefeedbase.FrontierCheckpointFrequency.Override(
-			context.Background(), &s.Server.ClusterSettings().SV, 10*time.Millisecond)
+			context.Background(), &s.Server.ClusterSettings().SV, 1)
 		changefeedbase.FrontierCheckpointMaxBytes.Override(
 			context.Background(), &s.Server.ClusterSettings().SV, maxCheckpointSize)
 


### PR DESCRIPTION
This patch deflakes `TestChangefeedSchemaChangeBackfillCheckpoint` by
decreasing the value of `changefeed.frontier_checkpoint_frequency` to
1 nanosecond so that we always checkpoint even when the change frontier
processes multiple resolved spans in quick succession.

Fixes #132548

Release note: None