### PR TITLE
roachprod: VMs are annotated with both _sanitized_ and original test_…

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1865,7 +1865,9 @@ func (c *clusterImpl) doDestroy(ctx context.Context, l *logger.Logger) <-chan st
 }
 
 func (c *clusterImpl) addLabels(labels map[string]string) error {
-	return roachprod.AddLabels(c.l, c.name, labels)
+	// N.B. we must sanitize the values; e.g., some test names can exceed the maximum length (63 chars in GCE).
+	// N.B. we don't sanitize the keys; unlike values, they are typically _not_ (dynamically) generated.
+	return roachprod.AddLabels(c.l, c.name, vm.SanitizeLabelValues(labels))
 }
 
 func (c *clusterImpl) removeLabels(labels []string) error {

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1510,6 +1510,8 @@ func cleanupFailedCreate(l *logger.Logger, clusterName string) error {
 	return cloud.DestroyCluster(l, c)
 }
 
+// AddLabels adds (or updates) the given labels to the VMs corresponding to the given cluster.
+// N.B. If a VM contains a label with the same key, its value will be updated.
 func AddLabels(l *logger.Logger, clusterName string, labels map[string]string) error {
 	c, err := getClusterFromCache(l, clusterName)
 	if err != nil {

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -576,7 +576,7 @@ func (p *Provider) editLabels(
 		if remove {
 			tagArgs = append(tagArgs, fmt.Sprintf("Key=%s", key))
 		} else {
-			tagArgs = append(tagArgs, fmt.Sprintf("Key=%s,Value=%s", key, vm.SanitizeLabel(value)))
+			tagArgs = append(tagArgs, fmt.Sprintf("Key=%s,Value=%s", key, value))
 		}
 	}
 	args = append(args, tagArgs...)
@@ -602,7 +602,8 @@ func (p *Provider) editLabels(
 	return g.Wait()
 }
 
-// AddLabels adds the given labels to the given VMs.
+// AddLabels adds (or updates) the given labels to the given VMs.
+// N.B. If a VM contains a label with the same key, its value will be updated.
 func (p *Provider) AddLabels(l *logger.Logger, vms vm.List, labels map[string]string) error {
 	return p.editLabels(l, vms, labels, false)
 }

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -209,6 +209,8 @@ func getAzureDefaultLabelMap(opts vm.CreateOpts) map[string]string {
 	return m
 }
 
+// AddLabels adds (or updates) the given labels to the given VMs.
+// N.B. If a VM contains a label with the same key, its value will be updated.
 func (p *Provider) AddLabels(l *logger.Logger, vms vm.List, labels map[string]string) error {
 	return p.editLabels(l, vms, labels, false /*removeLabels*/)
 }

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -1190,7 +1190,7 @@ func (p *Provider) editLabels(
 		if remove {
 			tagArgs = append(tagArgs, key)
 		} else {
-			tagArgs = append(tagArgs, fmt.Sprintf("%s=%s", key, vm.SanitizeLabel(value)))
+			tagArgs = append(tagArgs, fmt.Sprintf("%s=%s", key, value))
 		}
 	}
 	tagArgsString := strings.Join(tagArgs, ",")
@@ -1216,7 +1216,8 @@ func (p *Provider) editLabels(
 	return g.Wait()
 }
 
-// AddLabels adds the given labels to the given VMs.
+// AddLabels adds (or updates) the given labels to the given VMs.
+// N.B. If a VM contains a label with the same key, its value will be updated.
 func (p *Provider) AddLabels(l *logger.Logger, vms vm.List, labels map[string]string) error {
 	return p.editLabels(l, vms, labels, false /* remove */)
 }

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -483,10 +483,11 @@ type Provider interface {
 	// Return the account name associated with the provider
 	FindActiveAccount(l *logger.Logger) (string, error)
 	List(l *logger.Logger, opts ListOptions) (List, error)
-	// The name of the Provider, which will also surface in the top-level Providers map.
-
+	// AddLabels adds (or updates) the given labels to the given VMs.
+	// N.B. If a VM contains a label with the same key, its value will be updated.
 	AddLabels(l *logger.Logger, vms List, labels map[string]string) error
 	RemoveLabels(l *logger.Logger, vms List, labels []string) error
+	// The name of the Provider, which will also surface in the top-level Providers map.
 	Name() string
 
 	// Active returns true if the provider is properly installed and capable of
@@ -753,7 +754,7 @@ func DNSSafeName(name string) string {
 	return regexp.MustCompile(`-+`).ReplaceAllString(name, "-")
 }
 
-// SanitizeLabel returns a version of the string that can be used as a label.
+// SanitizeLabel returns a version of the string that can be used as a (resource) label.
 // This takes the lowest common denominator of the label requirements;
 // GCE: "The value can only contain lowercase letters, numeric characters, underscores and dashes.
 // The value can be at most 63 characters long"
@@ -770,4 +771,13 @@ func SanitizeLabel(label string) string {
 	// Remove any leading or trailing hyphens
 	label = strings.Trim(label, "-")
 	return label
+}
+
+// SanitizeLabelValues returns the same set of keys with sanitized values.
+func SanitizeLabelValues(labels map[string]string) map[string]string {
+	sanitized := map[string]string{}
+	for k, v := range labels {
+		sanitized[k] = SanitizeLabel(v)
+	}
+	return sanitized
 }


### PR DESCRIPTION
Fixes a regression added in https://github.com/cockroachdb/cockroach/issues/133773, wherein the cached labels were
added unsanitized. This change enforces `SanitizeLabelValues` at
the roachtest/roachprod API boundary. Thus, both cached and
propagated label values (from roachtest) are always
sanitized.

Epic: none
Fixes: #133773

Release note: None