### PR TITLE
release-24.3: sql: fix erroneous NOT NULL constraint violations in UPSERTs and refactor upsert logic

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -1357,3 +1357,73 @@ query III
 SELECT * FROM arbiter_index
 ----
 1  2  10
+
+subtest regression_133146
+
+# Regression test for #133146. Columns that are not updated in an UPSERT should
+# not cause not-null constraint violations.
+statement ok
+CREATE TABLE t133146 (
+  id INT PRIMARY KEY,
+  a INT NOT NULL,
+  b INT
+)
+
+statement ok
+INSERT INTO t133146 (id, a, b) VALUES (1, 2, 3)
+
+# This should not cause a not-null constraint violation of column "a" because
+# the value of "a" is not being updated to NULL in the existing row.
+statement ok
+UPSERT INTO t133146 (id, b) VALUES (1, 30)
+
+query III
+SELECT * FROM t133146
+----
+1  2  30
+
+statement ok
+INSERT INTO t133146 (id, b) VALUES (1, 40) ON CONFLICT (id) DO UPDATE SET b = 40
+
+query III
+SELECT * FROM t133146
+----
+1  2  40
+
+statement error pgcode 23502 pq: null value in column \"a\" violates not-null constraint
+UPSERT INTO t133146 (id, a) VALUES (1, NULL)
+
+statement error pgcode 23502 pq: null value in column \"a\" violates not-null constraint
+INSERT INTO t133146 (id, b) VALUES (1, 50) ON CONFLICT (id) DO UPDATE SET a = NULL
+
+statement ok
+CREATE TABLE t133146b (
+  a INT,
+  b INT NOT NULL,
+  id INT PRIMARY KEY
+)
+
+statement ok
+INSERT INTO t133146b (id, a, b) VALUES (1, 2, 3)
+
+statement ok
+UPSERT INTO t133146b (id, b) VALUES (1, 30)
+
+query III
+SELECT * FROM t133146b
+----
+2  30  1
+
+statement ok
+INSERT INTO t133146b (id, b) VALUES (1, 40) ON CONFLICT (id) DO UPDATE SET b = 40
+
+query III
+SELECT * FROM t133146b
+----
+2  40  1
+
+statement error pgcode 23502 pq: null value in column \"b\" violates not-null constraint
+UPSERT INTO t133146b (id, b) VALUES (1, NULL)
+
+statement error pgcode 23502 pq: null value in column \"b\" violates not-null constraint
+INSERT INTO t133146b (id, a) VALUES (1, 20) ON CONFLICT (id) DO UPDATE SET b = NULL

--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -255,17 +255,6 @@ func (tu *optTableUpserter) updateConflictingRow(
 	pm row.PartialIndexUpdateHelper,
 	traceKV bool,
 ) error {
-	// Enforce the column constraints.
-	// Note: the column constraints are already enforced for fetchRow,
-	// because:
-	// - for the insert part, they were checked upstream in upsertNode
-	//   via GenerateInsertRow().
-	// - for the fetched part, we assume that the data in the table is
-	//   correct already.
-	if err := enforceNotNullConstraints(updateValues, tu.updateCols); err != nil {
-		return err
-	}
-
 	// Queue the update in KV. This also returns an "update row"
 	// containing the updated values for every column in the
 	// table. This is useful for RETURNING, which we collect below.

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -134,8 +134,26 @@ func (n *upsertNode) BatchedNext(params runParams) (bool, error) {
 // processSourceRow processes one row from the source for upsertion.
 // The table writer is in charge of accumulating the result rows.
 func (n *upsertNode) processSourceRow(params runParams, rowVals tree.Datums) error {
-	if err := enforceNotNullConstraints(rowVals, n.run.insertCols); err != nil {
-		return err
+	// Check for NOT NULL constraint violations.
+	if n.run.tw.canaryOrdinal != -1 && rowVals[n.run.tw.canaryOrdinal] != tree.DNull {
+		// When there is a canary column and its value is not NULL, then an
+		// existing row is being updated, so check only the update columns for
+		// NOT NULL constraint violations.
+		offset := len(n.run.insertCols) + len(n.run.tw.fetchCols)
+		vals := rowVals[offset : offset+len(n.run.tw.updateCols)]
+		if err := enforceNotNullConstraints(vals, n.run.tw.updateCols); err != nil {
+			return err
+		}
+	} else {
+		// Otherwise, there is no canary column (i.e., canaryOrdinal is -1,
+		// which is the case for "blind" upsert which overwrites existing rows
+		// without performing a read) or it is NULL, indicating that a new row
+		// is being inserted. In this case, check the insert columns for a NOT
+		// NULL constraint violation.
+		vals := rowVals[:len(n.run.insertCols)]
+		if err := enforceNotNullConstraints(vals, n.run.insertCols); err != nil {
+			return err
+		}
 	}
 
 	// Create a set of partial index IDs to not add or remove entries from.


### PR DESCRIPTION
Backport 1/6 commits from #133671.

/cc @cockroachdb/release

---

#### sql: fix erroneous NOT NULL constraint violations in UPSERTs

Fixes #133146

Release note (bug fix): A bug has been fixed that caused incorrect NOT
NULL constraint violation errors on `UPSERT` and `INSERT .. ON CONFLICT
.. DO UPDATE` statements when those statements updated an existing row
and a subset of columns which did not include a `NOT NULL` column of the
table. This bug has been present since at least version 20.1.0.

---

Release justification: Major bug fix.

