### PR TITLE
roachprod-microbench: add microbench dashboard links

### DIFF
--- a/pkg/cmd/roachprod-microbench/compare.go
+++ b/pkg/cmd/roachprod-microbench/compare.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod-microbench/google"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod-microbench/model"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod-microbench/util"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
@@ -69,7 +70,6 @@ var defaultInfluxMetadata = map[string]string{
 }
 
 const (
-	packageSeparator         = "→"
 	slackPercentageThreshold = 20.0
 	slackReportMax           = 3
 	skipComparison           = math.MaxFloat64
@@ -264,9 +264,9 @@ func (c *compare) postToSlack(
 					comparison.Delta == 0 {
 					continue
 				}
-				nameSplit := strings.Split(detail.BenchmarkName, packageSeparator)
+				nameSplit := strings.Split(detail.BenchmarkName, util.PackageSeparator)
 				ci := changeInfo{
-					BenchmarkName: nameSplit[0] + packageSeparator + truncateBenchmarkName(nameSplit[1], 32),
+					BenchmarkName: nameSplit[0] + util.PackageSeparator + truncateBenchmarkName(nameSplit[1], 32),
 					PercentChange: fmt.Sprintf("%.2f%%", comparison.Delta),
 				}
 				if math.Abs(comparison.Delta) > highestPercentChange {
@@ -415,7 +415,7 @@ func (c *compare) createBenchSeries() ([]*benchseries.ComparisonSeries, error) {
 					cmp = string(config.Value)
 				}
 			}
-			key := pkg + packageSeparator + string(rec.Name)
+			key := pkg + util.PackageSeparator + string(rec.Name)
 			// Update the name to include the package name. This is a workaround for
 			// `benchseries`, that currently does not support package names.
 			rec.Name = benchfmt.Name(key)
@@ -485,8 +485,8 @@ func (c *compare) pushToInfluxDB() error {
 				"experiment-commit": cs.HashPairs[experimentTime].NumHash,
 				"benchmarks-commit": residues["benchmarks-commit"],
 			}
-			pkg := strings.Split(benchmarkName, packageSeparator)[0]
-			benchmarkName = strings.Split(benchmarkName, packageSeparator)[1]
+			pkg := strings.Split(benchmarkName, util.PackageSeparator)[0]
+			benchmarkName = strings.Split(benchmarkName, util.PackageSeparator)[1]
 			tags := map[string]string{
 				"name":         benchmarkName,
 				"unit":         cs.Unit,
@@ -527,7 +527,7 @@ func processReportFile(builder *model.Builder, id, pkg, path string) error {
 	}
 	defer file.Close()
 	reader := benchfmt.NewReader(file, path)
-	return builder.AddMetrics(id, pkg+packageSeparator, reader)
+	return builder.AddMetrics(id, pkg+util.PackageSeparator, reader)
 }
 
 func truncateBenchmarkName(text string, maxLen int) string {

--- a/pkg/cmd/roachprod-microbench/google/BUILD.bazel
+++ b/pkg/cmd/roachprod-microbench/google/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/cmd/roachprod-microbench/model",
+        "//pkg/cmd/roachprod-microbench/util",
         "@com_github_cockroachdb_errors//:errors",
         "@org_golang_google_api//drive/v3:drive",
         "@org_golang_google_api//googleapi",

--- a/pkg/cmd/roachprod-microbench/google/service.go
+++ b/pkg/cmd/roachprod-microbench/google/service.go
@@ -160,7 +160,7 @@ func (srv *Service) createRawSheet(
 
 		// Column: Benchmark name.
 		vals = append(vals, strCell("name"))
-		metadata = append(metadata, withSize(400))
+		metadata = append(metadata, withSize(600))
 
 		// Columns: Metric names.
 		for _, run := range runs {
@@ -269,7 +269,7 @@ func (srv *Service) createOverviewSheet(rawInfos []rawSheetInfo) *sheets.Sheet {
 		if len(info.nonZeroVals) == 0 {
 			noChanges := fmt.Sprintf("no change in %s", info.metric.Name)
 			vals = append(vals, strCell(noChanges))
-			metadata = append(metadata, withSize(200))
+			metadata = append(metadata, withSize(400))
 			continue
 		}
 
@@ -308,7 +308,7 @@ func (srv *Service) createOverviewSheet(rawInfos []rawSheetInfo) *sheets.Sheet {
 			},
 		})
 		vals = append(vals, &sheets.CellData{})
-		metadata = append(metadata, withSize(200), withSize(100))
+		metadata = append(metadata, withSize(400), withSize(100))
 
 		deltaCol := int64(len(vals)) - 1
 		cf := condFormatting(props.SheetId, deltaCol, smallerBetter)

--- a/pkg/cmd/roachprod-microbench/google/service.go
+++ b/pkg/cmd/roachprod-microbench/google/service.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod-microbench/model"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod-microbench/util"
 	"github.com/cockroachdb/errors"
 	"golang.org/x/exp/maps"
 	"google.golang.org/api/drive/v3"
@@ -22,6 +23,8 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/sheets/v4"
 )
+
+const dashboardURL = "https://microbench.testeng.crdb.io/dashboard/"
 
 // Service is capable of communicating with the Google Drive API and the Google
 // Sheets API to create new spreadsheets and populate them from benchstat
@@ -198,7 +201,7 @@ func (srv *Service) createRawSheet(
 		entry := metric.BenchmarkEntries[name]
 		comparison := comparisons[name]
 		var vals []*sheets.CellData
-		vals = append(vals, strCell(name))
+		vals = append(vals, strCellWithLink(name, dashboardLink(name)))
 		for _, run := range runs {
 			vals = append(vals, numCell(entry.Summaries[run].Center))
 		}
@@ -367,6 +370,29 @@ func strCell(s string) *sheets.CellData {
 			StringValue: &s,
 		},
 	}
+}
+
+func strCellWithLink(s string, link string) *sheets.CellData {
+	return &sheets.CellData{
+		UserEnteredValue: &sheets.ExtendedValue{
+			StringValue: &s,
+		},
+		TextFormatRuns: []*sheets.TextFormatRun{
+			{
+				StartIndex: 0,
+				Format: &sheets.TextFormat{
+					Link: &sheets.Link{
+						Uri: link,
+					},
+				},
+			},
+		},
+	}
+}
+
+func dashboardLink(name string) string {
+	parts := strings.Split(name, util.PackageSeparator)
+	return dashboardURL + "?benchmark=" + parts[1] + "&package=" + parts[0]
 }
 
 func numCell(f float64) *sheets.CellData {

--- a/pkg/cmd/roachprod-microbench/util/util.go
+++ b/pkg/cmd/roachprod-microbench/util/util.go
@@ -22,6 +22,7 @@ import (
 
 // TimeFormat defines a constant format for time-related strings, using underscores instead of colons in the time portion.
 const TimeFormat = "2006-01-02T15_04_05"
+const PackageSeparator = "→"
 
 var (
 	// invalidCharRegex matches


### PR DESCRIPTION
Add dashboard links for the benchmarks on the sheet. No dates are passed, and it
will point to the latest metrics regarding the benchmark on the dashboard. This
is for convenience to inspect a benchmark's history.

Epic: None
Release note: None