### PR TITLE
release: update versions should properly handle errors

### DIFF
--- a/pkg/cmd/release/update_versions.go
+++ b/pkg/cmd/release/update_versions.go
@@ -282,7 +282,8 @@ func updateVersions(_ *cobra.Command, _ []string) error {
 	var prs []string
 	var workOnRepoErrors []error
 	for _, repo := range reposToWorkOn {
-		repo.workOnRepoError = workOnRepo(repo)
+		err := workOnRepo(repo)
+		repo.workOnRepoError = err
 		if repo.workOnRepoError != nil {
 			err = fmt.Errorf("workOnRepo: error occurred while working on repo %s: %w", repo.name(), err)
 			workOnRepoErrors = append(workOnRepoErrors, err)


### PR DESCRIPTION
Previously, the update versions script was wrongly using the `err` variable to set the status of a command execution results.

This PR fixes the issue, where a command fails, but the script ignores the error.

Epic: none
Release note: None