### PR TITLE
sql/schemachanger: Preserving column family order for complex column type changes

### DIFF
--- a/pkg/ccl/schemachangerccl/testdata/decomp/multiregion
+++ b/pkg/ccl/schemachangerccl/testdata/decomp/multiregion
@@ -232,6 +232,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 1
     computeExpr: null
     elementCreationMetadata:
@@ -261,6 +262,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 2
     computeExpr: null
     elementCreationMetadata:
@@ -290,6 +292,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967292e+09
     computeExpr: null
     elementCreationMetadata:
@@ -319,6 +322,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967293e+09
     computeExpr: null
     elementCreationMetadata:
@@ -348,6 +352,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967294e+09
     computeExpr: null
     elementCreationMetadata:
@@ -377,6 +382,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967295e+09
     computeExpr: null
     elementCreationMetadata:
@@ -627,6 +633,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 1
     computeExpr: null
     elementCreationMetadata:
@@ -656,6 +663,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 2
     computeExpr: null
     elementCreationMetadata:
@@ -685,6 +693,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967292e+09
     computeExpr: null
     elementCreationMetadata:
@@ -714,6 +723,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967293e+09
     computeExpr: null
     elementCreationMetadata:
@@ -743,6 +753,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967294e+09
     computeExpr: null
     elementCreationMetadata:
@@ -772,6 +783,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967295e+09
     computeExpr: null
     elementCreationMetadata:
@@ -1064,6 +1076,7 @@ ElementState:
     closedTypeIds:
     - 106
     - 107
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 3
     computeExpr: null
     elementCreationMetadata:
@@ -1094,6 +1107,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 1
     computeExpr: null
     elementCreationMetadata:
@@ -1123,6 +1137,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 2
     computeExpr: null
     elementCreationMetadata:
@@ -1152,6 +1167,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967292e+09
     computeExpr: null
     elementCreationMetadata:
@@ -1181,6 +1197,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967293e+09
     computeExpr: null
     elementCreationMetadata:
@@ -1210,6 +1227,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967294e+09
     computeExpr: null
     elementCreationMetadata:
@@ -1239,6 +1257,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967295e+09
     computeExpr: null
     elementCreationMetadata:

--- a/pkg/ccl/schemachangerccl/testdata/decomp/partitioning
+++ b/pkg/ccl/schemachangerccl/testdata/decomp/partitioning
@@ -164,6 +164,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 1
     computeExpr: null
     elementCreationMetadata:
@@ -193,6 +194,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 2
     computeExpr: null
     elementCreationMetadata:
@@ -222,6 +224,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 3
     computeExpr: null
     elementCreationMetadata:
@@ -251,6 +254,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967292e+09
     computeExpr: null
     elementCreationMetadata:
@@ -280,6 +284,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967293e+09
     computeExpr: null
     elementCreationMetadata:
@@ -309,6 +314,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967294e+09
     computeExpr: null
     elementCreationMetadata:
@@ -338,6 +344,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967295e+09
     computeExpr: null
     elementCreationMetadata:
@@ -666,6 +673,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 1
     computeExpr: null
     elementCreationMetadata:
@@ -695,6 +703,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 2
     computeExpr: null
     elementCreationMetadata:
@@ -724,6 +733,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967292e+09
     computeExpr: null
     elementCreationMetadata:
@@ -753,6 +763,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967293e+09
     computeExpr: null
     elementCreationMetadata:
@@ -782,6 +793,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967294e+09
     computeExpr: null
     elementCreationMetadata:
@@ -811,6 +823,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967295e+09
     computeExpr: null
     elementCreationMetadata:

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -205,7 +205,7 @@ INSERT INTO t2 VALUES ('5')
 # Verify ALTER COLUMN TYPE from INT to STRING works correctly.
 # Column order should stay the same.
 statement ok
-CREATE TABLE t3 (id int, id2 int, id3 int)
+CREATE TABLE t3 (id int, id2 int, id3 int, family f1 (id3, id2, id))
 
 statement ok
 INSERT INTO t3 VALUES (1,1,1), (2,2,2), (3,3,3)
@@ -220,6 +220,19 @@ id     INT8    true   NULL            ·  {t3_pkey}  false
 id2    STRING  true   NULL            ·  {t3_pkey}  false
 id3    INT8    true   NULL            ·  {t3_pkey}  false
 rowid  INT8    false  unique_rowid()  ·  {t3_pkey}  true
+
+query TT colnames
+show create table t3
+----
+table_name  create_statement
+t3          CREATE TABLE public.t3 (
+              id INT8 NULL,
+              id2 STRING NULL,
+              id3 INT8 NULL,
+              rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+              CONSTRAINT t3_pkey PRIMARY KEY (rowid ASC),
+              FAMILY f1 (id3, id2, id, rowid)
+            )
 
 statement ok
 INSERT INTO t3 VALUES (4,'4',4)
@@ -985,6 +998,19 @@ c2     CHAR(4) true   NULL            ·  {t_bytes_pkey}  false
 c3     UUID    true   NULL            ·  {t_bytes_pkey}  false
 rowid  INT8    false  unique_rowid()  ·  {t_bytes_pkey}  true
 
+query TT colnames
+show create table t_bytes
+----
+table_name  create_statement
+t_bytes     CREATE TABLE public.t_bytes (
+              c1 STRING NULL,
+              c2 CHAR(4) NULL,
+              c3 UUID NULL,
+              rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+              CONSTRAINT t_bytes_pkey PRIMARY KEY (rowid ASC),
+              FAMILY f1 (c1, c2, c3, rowid)
+            )
+
 statement ok
 DROP TABLE t_bytes;
 
@@ -1047,6 +1073,18 @@ SHOW COLUMNS FROM t_decimal;
 c1     DECIMAL(7,2)  true   NULL            ·  {t_decimal_pkey}  false
 c2     DECIMAL(10,2) true   NULL            ·  {t_decimal_pkey}  false
 rowid  INT8          false  unique_rowid()  ·  {t_decimal_pkey}  true
+
+query TT colnames
+show create table t_decimal
+----
+table_name  create_statement
+t_decimal   CREATE TABLE public.t_decimal (
+              c1 DECIMAL(7,2) NULL,
+              c2 DECIMAL(10,2) NULL,
+              rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+              CONSTRAINT t_decimal_pkey PRIMARY KEY (rowid ASC),
+              FAMILY f1 (c1, c2, rowid)
+            )
 
 statement ok
 DROP TABLE t_decimal;

--- a/pkg/sql/schemachanger/dml_injection_test.go
+++ b/pkg/sql/schemachanger/dml_injection_test.go
@@ -169,9 +169,22 @@ func TestAlterTableDMLInjection(t *testing.T) {
 			expectedErr:  "cannot evaluate scalar expressions containing sequence operations in this context",
 		},
 		{
-			desc:         "alter column type",
+			desc:         "alter column type trivial",
 			setup:        []string{"ALTER TABLE tbl ADD COLUMN new_col SMALLINT NOT NULL DEFAULT 100"},
 			schemaChange: "ALTER TABLE tbl ALTER COLUMN new_col SET DATA TYPE BIGINT",
+		},
+		{
+			desc:         "alter column type validate",
+			setup:        []string{"ALTER TABLE tbl ADD COLUMN new_col BIGINT NOT NULL DEFAULT 100"},
+			schemaChange: "ALTER TABLE tbl ALTER COLUMN new_col SET DATA TYPE SMALLINT",
+		},
+		{
+			desc: "alter column type general",
+			setup: []string{
+				"SET enable_experimental_alter_column_type_general=TRUE",
+				"ALTER TABLE tbl ADD COLUMN new_col BIGINT",
+			},
+			schemaChange: "ALTER TABLE tbl ALTER COLUMN new_col SET DATA TYPE TEXT",
 		},
 		{
 			desc:         "add column default udf",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_type.go
@@ -313,6 +313,11 @@ func handleGeneralColumnConversion(
 	b.Drop(oldColType)
 	handleDropColumnPrimaryIndexes(b, tbl, col)
 
+	// The new column is replacing an existing one, so we want to insert it into the
+	// column family at the same position as the old column. Normally, when adding a new
+	// column, it is appended to the end of the column family.
+	newColType.ColumnFamilyOrderFollowsColumnID = oldColType.ColumnID
+
 	// Add the spec for the new column. It will be identical to the column it is replacing,
 	// except the type will differ, and it will have a transient computed expression.
 	// This expression will reference the original column to facilitate the backfill.
@@ -340,11 +345,8 @@ func handleGeneralColumnConversion(
 		},
 		transientCompute: true,
 		notNull:          retrieveColumnNotNull(b, tbl.TableID, col.ColumnID) != nil,
-		// TODO(#133040): The new column will be placed in the same column family as the
-		// one it's replacing, so there's no need to specify a family. However, the new
-		// column will be added to the end of the family's column ID list, which changes
-		// its internal ordering. This needs to be revisited as CDC may have a dependency
-		// on the same ordering (see TestEventColumnOrderingWithSchemaChanges).
+		// The new column will be placed in the same column family as the one
+		// it's replacing, so there's no need to specify a family.
 		fam: nil,
 	}
 	addColumn(b, spec, t)

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_table_alter_column_type
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_table_alter_column_type
@@ -96,7 +96,7 @@ ALTER TABLE t ALTER COLUMN c2 SET DATA TYPE BIGINT USING c2::BIGINT
 - [[ColumnName:{DescID: 104, Name: c2, ColumnID: 4}, PUBLIC], ABSENT]
   {columnId: 4, name: c2, tableId: 104}
 - [[ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 4, TypeName: INT8}, PUBLIC], ABSENT]
-  {columnId: 4, elementCreationMetadata: {in231OrLater: true, in243OrLater: true}, isNullable: true, tableId: 104, type: {family: IntFamily, oid: 20, width: 64}, typeName: INT8}
+  {columnFamilyOrderFollowsColumnId: 2, columnId: 4, elementCreationMetadata: {in231OrLater: true, in243OrLater: true}, isNullable: true, tableId: 104, type: {family: IntFamily, oid: 20, width: 64}, typeName: INT8}
 - [[ColumnComputeExpression:{DescID: 104, ColumnID: 4}, TRANSIENT_ABSENT], ABSENT]
   {columnId: 4, expr: 'c2::INT8', referencedColumnIds: [2], tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 4, IndexID: 2}, TRANSIENT_ABSENT], ABSENT]

--- a/pkg/sql/schemachanger/scdecomp/testdata/other
+++ b/pkg/sql/schemachanger/scdecomp/testdata/other
@@ -316,6 +316,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 1
     computeExpr: null
     elementCreationMetadata:
@@ -345,6 +346,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967292e+09
     computeExpr: null
     elementCreationMetadata:
@@ -374,6 +376,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967293e+09
     computeExpr: null
     elementCreationMetadata:
@@ -403,6 +406,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967294e+09
     computeExpr: null
     elementCreationMetadata:
@@ -432,6 +436,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967295e+09
     computeExpr: null
     elementCreationMetadata:
@@ -602,6 +607,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 1
     computeExpr: null
     elementCreationMetadata:
@@ -631,6 +637,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 2
     computeExpr: null
     elementCreationMetadata:
@@ -660,6 +667,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967292e+09
     computeExpr: null
     elementCreationMetadata:
@@ -689,6 +697,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967293e+09
     computeExpr: null
     elementCreationMetadata:
@@ -718,6 +727,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967294e+09
     computeExpr: null
     elementCreationMetadata:
@@ -747,6 +757,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967295e+09
     computeExpr: null
     elementCreationMetadata:

--- a/pkg/sql/schemachanger/scdecomp/testdata/sequence
+++ b/pkg/sql/schemachanger/scdecomp/testdata/sequence
@@ -237,6 +237,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 1
     computeExpr: null
     elementCreationMetadata:
@@ -266,6 +267,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 2
     computeExpr: null
     elementCreationMetadata:
@@ -295,6 +297,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967292e+09
     computeExpr: null
     elementCreationMetadata:
@@ -324,6 +327,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967293e+09
     computeExpr: null
     elementCreationMetadata:
@@ -353,6 +357,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967294e+09
     computeExpr: null
     elementCreationMetadata:
@@ -382,6 +387,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967295e+09
     computeExpr: null
     elementCreationMetadata:
@@ -627,6 +633,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 1
     computeExpr: null
     elementCreationMetadata:
@@ -656,6 +663,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 2
     computeExpr: null
     elementCreationMetadata:
@@ -685,6 +693,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967292e+09
     computeExpr: null
     elementCreationMetadata:
@@ -714,6 +723,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967293e+09
     computeExpr: null
     elementCreationMetadata:
@@ -743,6 +753,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967294e+09
     computeExpr: null
     elementCreationMetadata:
@@ -772,6 +783,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967295e+09
     computeExpr: null
     elementCreationMetadata:

--- a/pkg/sql/schemachanger/scdecomp/testdata/table
+++ b/pkg/sql/schemachanger/scdecomp/testdata/table
@@ -121,6 +121,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 1
     computeExpr: null
     elementCreationMetadata:
@@ -150,6 +151,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967292e+09
     computeExpr: null
     elementCreationMetadata:
@@ -179,6 +181,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967293e+09
     computeExpr: null
     elementCreationMetadata:
@@ -208,6 +211,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967294e+09
     computeExpr: null
     elementCreationMetadata:
@@ -237,6 +241,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967295e+09
     computeExpr: null
     elementCreationMetadata:
@@ -514,6 +519,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 1
     computeExpr: null
     elementCreationMetadata:
@@ -543,6 +549,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 2
     computeExpr: null
     elementCreationMetadata:
@@ -572,6 +579,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 3
     computeExpr: null
     elementCreationMetadata:
@@ -601,6 +609,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967292e+09
     computeExpr: null
     elementCreationMetadata:
@@ -630,6 +639,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967293e+09
     computeExpr: null
     elementCreationMetadata:
@@ -659,6 +669,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967294e+09
     computeExpr: null
     elementCreationMetadata:
@@ -688,6 +699,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967295e+09
     computeExpr: null
     elementCreationMetadata:
@@ -1102,6 +1114,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 1
     computeExpr: null
     elementCreationMetadata:
@@ -1131,6 +1144,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 2
     computeExpr: null
     elementCreationMetadata:
@@ -1160,6 +1174,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967292e+09
     computeExpr: null
     elementCreationMetadata:
@@ -1189,6 +1204,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967293e+09
     computeExpr: null
     elementCreationMetadata:
@@ -1218,6 +1234,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967294e+09
     computeExpr: null
     elementCreationMetadata:
@@ -1247,6 +1264,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967295e+09
     computeExpr: null
     elementCreationMetadata:
@@ -1491,6 +1509,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 1
     computeExpr: null
     elementCreationMetadata:
@@ -1520,6 +1539,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 2
     computeExpr: null
     elementCreationMetadata:
@@ -1549,6 +1569,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967292e+09
     computeExpr: null
     elementCreationMetadata:
@@ -1578,6 +1599,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967293e+09
     computeExpr: null
     elementCreationMetadata:
@@ -1607,6 +1629,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967294e+09
     computeExpr: null
     elementCreationMetadata:
@@ -1636,6 +1659,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967295e+09
     computeExpr: null
     elementCreationMetadata:

--- a/pkg/sql/schemachanger/scdecomp/testdata/type
+++ b/pkg/sql/schemachanger/scdecomp/testdata/type
@@ -274,6 +274,7 @@ ElementState:
     closedTypeIds:
     - 104
     - 105
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 2
     computeExpr: null
     elementCreationMetadata:
@@ -306,6 +307,7 @@ ElementState:
     closedTypeIds:
     - 104
     - 105
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4
     computeExpr: null
     elementCreationMetadata:
@@ -353,6 +355,7 @@ ElementState:
     closedTypeIds:
     - 106
     - 107
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 3
     computeExpr: null
     elementCreationMetadata:
@@ -383,6 +386,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 1
     computeExpr: null
     elementCreationMetadata:
@@ -412,6 +416,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967292e+09
     computeExpr: null
     elementCreationMetadata:
@@ -441,6 +446,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967293e+09
     computeExpr: null
     elementCreationMetadata:
@@ -470,6 +476,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967294e+09
     computeExpr: null
     elementCreationMetadata:
@@ -499,6 +506,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967295e+09
     computeExpr: null
     elementCreationMetadata:
@@ -528,6 +536,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 5
     computeExpr: null
     elementCreationMetadata:
@@ -1079,6 +1088,7 @@ ElementState:
     closedTypeIds:
     - 109
     - 110
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 3
     computeExpr: null
     elementCreationMetadata:
@@ -1157,6 +1167,7 @@ ElementState:
 - ColumnType:
     closedTypeIds:
     - 109
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 2
     computeExpr: null
     elementCreationMetadata:
@@ -1220,6 +1231,7 @@ ElementState:
 - ColumnType:
     closedTypeIds:
     - 109
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4
     computeExpr: null
     elementCreationMetadata:
@@ -1283,6 +1295,7 @@ ElementState:
 - ColumnType:
     closedTypeIds:
     - 109
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 5
     computeExpr: null
     elementCreationMetadata:
@@ -1345,6 +1358,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 1
     computeExpr: null
     elementCreationMetadata:
@@ -1374,6 +1388,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967292e+09
     computeExpr: null
     elementCreationMetadata:
@@ -1403,6 +1418,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967293e+09
     computeExpr: null
     elementCreationMetadata:
@@ -1432,6 +1448,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967294e+09
     computeExpr: null
     elementCreationMetadata:
@@ -1461,6 +1478,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 4.294967295e+09
     computeExpr: null
     elementCreationMetadata:
@@ -1490,6 +1508,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 6
     computeExpr: null
     elementCreationMetadata:
@@ -1519,6 +1538,7 @@ ElementState:
   Status: PUBLIC
 - ColumnType:
     closedTypeIds: []
+    columnFamilyOrderFollowsColumnId: 0
     columnId: 7
     computeExpr: null
     elementCreationMetadata:

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -237,6 +237,10 @@ message ColumnType {
   // It can be used in a similar way to version gates to ensure compatibility
   // in mixed version state.
   ElementCreationMetadata element_creation_metadata= 11;
+  // If non-zero, the column will be added to the column family after the column with
+  // this ID. This is used for operations like 'ALTER COLUMN .. TYPE', where
+  // maintaining column family order is necessary when replacing columns.
+  uint32 column_family_order_follows_column_id = 12 [(gogoproto.customname) = "ColumnFamilyOrderFollowsColumnID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.ColumnID"];
 }
 
 message ColumnComputeExpression {

--- a/pkg/sql/schemachanger/scpb/uml/table.puml
+++ b/pkg/sql/schemachanger/scpb/uml/table.puml
@@ -85,6 +85,7 @@ ColumnType :  IsNullable
 ColumnType :  ComputeExpr
 ColumnType :  IsVirtual
 ColumnType :  ElementCreationMetadata
+ColumnType :  ColumnFamilyOrderFollowsColumnID
 
 object CompositeType
 

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_column_type
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_column_type
@@ -202,6 +202,7 @@ StatementPhase stage 1 of 1 with 16 MutationType ops
       TableID: 104
     *scop.UpsertColumnType
       ColumnType:
+        ColumnFamilyOrderFollowsColumnID: 2
         ColumnID: 3
         ElementCreationMetadata:
           in231OrLater: true
@@ -342,6 +343,7 @@ PreCommitPhase stage 2 of 2 with 21 MutationType ops
       TableID: 104
     *scop.UpsertColumnType
       ColumnType:
+        ColumnFamilyOrderFollowsColumnID: 2
         ColumnID: 3
         ElementCreationMetadata:
           in231OrLater: true

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general.explain
@@ -32,7 +32,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER CO
  │         └── 16 Mutation operations
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":3,"PgAttributeNum":2,"TableID":104}}
  │              ├── SetColumnName {"ColumnID":3,"Name":"j","TableID":104}
- │              ├── UpsertColumnType {"ColumnType":{"ColumnID":3,"IsNullable":true,"TableID":104}}
+ │              ├── UpsertColumnType {"ColumnType":{"ColumnFamilyOrderFollowsColumnID":2,"ColumnID":3,"IsNullable":true,"TableID":104}}
  │              ├── AddColumnComputeExpression {"ComputeExpression":{"ColumnID":3,"TableID":104}}
  │              ├── SetColumnName {"ColumnID":2,"Name":"j_shadow","TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":2,"IndexID":2,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":3}}
@@ -94,7 +94,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER CO
  │         └── 21 Mutation operations
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":3,"PgAttributeNum":2,"TableID":104}}
  │              ├── SetColumnName {"ColumnID":3,"Name":"j","TableID":104}
- │              ├── UpsertColumnType {"ColumnType":{"ColumnID":3,"IsNullable":true,"TableID":104}}
+ │              ├── UpsertColumnType {"ColumnType":{"ColumnFamilyOrderFollowsColumnID":2,"ColumnID":3,"IsNullable":true,"TableID":104}}
  │              ├── AddColumnComputeExpression {"ComputeExpression":{"ColumnID":3,"TableID":104}}
  │              ├── SetColumnName {"ColumnID":2,"Name":"j_shadow","TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":2,"IndexID":2,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":3}}


### PR DESCRIPTION
When altering a column’s type in a way that requires a backfill, we drop the old column and add a new one. Previously, the new column was always added to the end of the column family. This change ensures the column family order is preserved.

In the DSC, the column family is updated when a new ColumnType element is added. I introduced a new field to this element to control the order, which requires specifying the column ID that the new column should follow.

Epic: CRDB-25314
Closes #133040
Release note: none