### PR TITLE
sql/catalog: fix panic inside sequence expression parsing

### DIFF
--- a/pkg/sql/catalog/seqexpr/sequence.go
+++ b/pkg/sql/catalog/seqexpr/sequence.go
@@ -80,10 +80,10 @@ func GetSequenceFromFunc(funcExpr *tree.FuncExpr) (*SeqIdentifier, error) {
 			if len(funcExpr.Exprs) == overload.Types.Length() {
 				paramTypes, ok := overload.Types.(tree.ParamTypes)
 				if !ok {
-					panic(pgerror.Newf(
+					return nil, pgerror.Newf(
 						pgcode.InvalidFunctionDefinition,
 						"%s has invalid argument types", funcExpr.Func.String(),
-					))
+					)
 				}
 				found = true
 				for i := 0; i < len(paramTypes); i++ {
@@ -98,10 +98,10 @@ func GetSequenceFromFunc(funcExpr *tree.FuncExpr) (*SeqIdentifier, error) {
 			}
 		}
 		if !found {
-			panic(pgerror.New(
+			return nil, pgerror.New(
 				pgcode.DatatypeMismatch,
 				"could not find matching function overload for given arguments",
-			))
+			)
 		}
 	}
 	return nil, nil

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -1097,3 +1097,16 @@ statement ok
 SET inject_retry_errors_enabled=false
 
 subtest end
+
+
+# Addresses a bug where parsing nextval expressions with extra values could end
+# end up with a panic when rewriting sequence expressions.
+subtest 133399
+
+statement ok
+CREATE TABLE v_133399 (c01 INT);
+
+statement error pgcode 42804 could not find matching function overload for given arguments
+CREATE TABLE t_133399 AS (SELECT * FROM v_133399 WINDOW window_name AS (ROWS c01 BETWEEN nextval ('abc', 'abc', 'abc') AND c01 PRECEDING));
+
+subtest end


### PR DESCRIPTION
Previously, if the correct overloads were not found for sequence builtins it was possible for the server to panic. This could happen when rewriting a CREATE TABLE expression with an invalid sequence builtin call. To address this, this patch updates the sequence logic to return the error instead of panicking on it.

Fixes: #133399

Release note (bug fix): Address a panic inside CREATE TABLE AS if sequence builtin expressions had invalid function overloads.