### PR TITLE
server, ui: tweak language for throttling, remove obsolete alerts, add test probe

### DIFF
--- a/pkg/server/license/enforcer.go
+++ b/pkg/server/license/enforcer.go
@@ -352,6 +352,11 @@ func (e *Enforcer) GetTelemetryDeadline() (deadline, lastPing time.Time, ok bool
 	}
 
 	lastTelemetryDataReceived := e.telemetryStatusReporter.GetLastSuccessfulTelemetryPing()
+	pingOverrideForTesting := envutil.EnvOrDefaultInt64("COCKROACH_LAST_SUCCESSFUL_TELEMETRY_PING", lastTelemetryDataReceived.Unix())
+	if pingOverrideForTesting < lastTelemetryDataReceived.Unix() {
+		lastTelemetryDataReceived = timeutil.Unix(pingOverrideForTesting, 0)
+	}
+
 	throttleTS := lastTelemetryDataReceived.Add(e.getMaxTelemetryInterval())
 	return throttleTS, lastTelemetryDataReceived, true
 }

--- a/pkg/ui/workspaces/db-console/src/redux/alerts.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/alerts.spec.ts
@@ -12,7 +12,6 @@ import * as protos from "src/js/protos";
 import { cockroach } from "src/js/protos";
 import { versionsSelector } from "src/redux/nodes";
 import { API_PREFIX } from "src/util/api";
-import { setDataFromServer } from "src/util/dataFromServer";
 import fetchMock from "src/util/fetch-mock";
 
 import {
@@ -28,7 +27,6 @@ import {
   emailSubscriptionAlertSelector,
   clusterPreserveDowngradeOptionDismissedSetting,
   clusterPreserveDowngradeOptionOvertimeSelector,
-  licenseUpdateNotificationSelector,
 } from "./alerts";
 import {
   livenessReducerObj,
@@ -43,7 +41,6 @@ import { AdminUIState, AppDispatch, createAdminUIStore } from "./state";
 import {
   VERSION_DISMISSED_KEY,
   INSTRUCTIONS_BOX_COLLAPSED_KEY,
-  LICENSE_UPDATE_DISMISSED_KEY,
   setUIDataKey,
   isInFlight,
 } from "./uiData";
@@ -253,31 +250,6 @@ describe("alerts", function () {
         const numAlert = staggeredVersionWarningSelector(state());
         numAlert.dismiss(dispatch, state);
         expect(staggeredVersionDismissedSetting.selector(state())).toBe(true);
-      });
-    });
-
-    describe("licence update notification", function () {
-      it("displays the alert when nothing is done", function () {
-        dispatch(setUIDataKey(LICENSE_UPDATE_DISMISSED_KEY, null));
-        const alert = licenseUpdateNotificationSelector(state());
-        expect(typeof alert).toBe("object");
-        expect(alert.level).toEqual(AlertLevel.INFORMATION);
-        expect(alert.text).toEqual(
-          "Important changes to CockroachDB’s licensing model.",
-        );
-      });
-
-      it("hides the alert when dismissed timestamp is present", function () {
-        dispatch(setUIDataKey(LICENSE_UPDATE_DISMISSED_KEY, moment()));
-        expect(licenseUpdateNotificationSelector(state())).toBeUndefined();
-      });
-
-      it("hides the alert when license is enterprise", function () {
-        dispatch(setUIDataKey(LICENSE_UPDATE_DISMISSED_KEY, null));
-        setDataFromServer({
-          LicenseType: "Enterprise",
-        } as any);
-        expect(licenseUpdateNotificationSelector(state())).toBeUndefined();
       });
     });
 
@@ -653,7 +625,6 @@ describe("alerts", function () {
       );
       dispatch(setUIDataKey(VERSION_DISMISSED_KEY, "blank"));
       dispatch(setUIDataKey(INSTRUCTIONS_BOX_COLLAPSED_KEY, false));
-      dispatch(setUIDataKey(LICENSE_UPDATE_DISMISSED_KEY, moment()));
       dispatch(
         versionReducerObj.receiveData({
           details: [],

--- a/pkg/ui/workspaces/db-console/src/redux/uiData.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/uiData.ts
@@ -57,11 +57,6 @@ export class OptInAttributes {
 // was last dismissed.
 export const VERSION_DISMISSED_KEY = "version_dismissed";
 
-// LICENSE_UPDATE_DISMISSED_KEY is the uiData key on the server that tracks when the licence
-// update banner was last dismissed. This banner notifies the user that we've changed our
-// licensing if they're deployed without an active license.
-export const LICENSE_UPDATE_DISMISSED_KEY = "license_update_dismissed";
-
 // INSTRUCTIONS_BOX_COLLAPSED_KEY is the uiData key on the server that tracks whether the
 // instructions box on the cluster viz has been collapsed or not.
 export const INSTRUCTIONS_BOX_COLLAPSED_KEY =

--- a/pkg/ui/workspaces/db-console/src/util/docs.ts
+++ b/pkg/ui/workspaces/db-console/src/util/docs.ts
@@ -59,8 +59,6 @@ export let licensingFaqs: string;
 export let throttlingFaqs: string;
 // Note that these explicitly don't use the current version, since we want to
 // link to the most up-to-date documentation available.
-export const enterpriseLicenseUpdate =
-  "https://www.cockroachlabs.com/enterprise-license-update/";
 export const upgradeCockroachVersion =
   "https://www.cockroachlabs.com/docs/stable/upgrade-cockroach-version.html";
 export const enterpriseLicensing =

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.spec.tsx
@@ -75,7 +75,7 @@ describe("AlertBar", () => {
 
     expect(wrapper.text()).toContain(
       "Your license key expired on September 15th, 2024. " +
-        `The cluster will be throttled on ${gracePeriodEnd.format("MMMM Do, YYYY")} unless the license is renewed. Learn more`,
+        `The cluster will be throttled on ${gracePeriodEnd.format("MMMM Do, YYYY")} unless a new license key is added. Learn more`,
     );
   });
 

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.tsx
@@ -131,8 +131,8 @@ export const AlertBar = ({
         <div className={cx("alert-bar", "alert--warning")}>
           Your license key expired on{" "}
           {licenseExpiryDate.format("MMMM Do, YYYY")}. The cluster will be
-          throttled on {gracePeriodEnd.format("MMMM Do, YYYY")} unless the
-          license is renewed. <a href={throttlingFaqs}>Learn more</a>
+          throttled on {gracePeriodEnd.format("MMMM Do, YYYY")} unless a new
+          license key is added. <a href={throttlingFaqs}>Learn more</a>
         </div>
       );
     }


### PR DESCRIPTION
_Note: these 3 small changes are grouped for easy review + backporting_

----

[server: allow env var override for telemetry ping](https://github.com/cockroachdb/cockroach/commit/6f44b589f9c3978ce092cc0e94a008a8f2a3ffca) 

When testing the license throttling behavior, it's helpful to easily
override the telemetry ping timestamp. This timestamp will only be
accepted if it's smaller than the current recorded timestamp, which
reduces the chance that this ability can be used to extend the grace
period.

Epic: [CRDB-40209](https://cockroachlabs.atlassian.net/browse/CRDB-40209)
Release note: None
@[dhartunian](https://github.com/cockroachdb/cockroach/commits?author=dhartunian)
dhartunian committed 2 minutes ago

----
[ui: tweak license expiration text for throttle bar](https://github.com/cockroachdb/cockroach/commit/be48767a6108b8a98dbc01615e47e387ac62b783) 

Instead of asking a user to "renew" we tell them to "add" a new
license, which matches other language we've used.

Epic: [CRDB-40853](https://cockroachlabs.atlassian.net/browse/CRDB-40853)
Release note: None
@[dhartunian](https://github.com/cockroachdb/cockroach/commits?author=dhartunian)
dhartunian committed 1 minute ago

----
[ui: remove core deprecation notification](https://github.com/cockroachdb/cockroach/commit/3190cf8d2bf4c292c4afcddfade03c84612498c3) 

Prior to 24.3 release, we added a notification in the DB Console to
alert customers to the licensing changes and give them time to
prepare. Now that they'll be rolling out, the notice is removed since
it's no longer in the future.

Epic: [CRDB-40853](https://cockroachlabs.atlassian.net/browse/CRDB-40853)
Release note: None