### PR TITLE
release-24.3: kv: redirect requests to raft leader who holds leader lease

### DIFF
--- a/pkg/kv/kvserver/kvserverpb/lease_status.proto
+++ b/pkg/kv/kvserver/kvserverpb/lease_status.proto
@@ -14,7 +14,27 @@ import "util/hlc/timestamp.proto";
 import "gogoproto/gogo.proto";
 
 enum LeaseState {
-  // ERROR indicates that the lease can't be used or acquired.
+  // ERROR indicates that the lease can't be used or acquired. The state is
+  // not a definitive indication of the lease's validity. Rather, it is an
+  // indication that the validity is indeterminate; it may be valid or it
+  // may not be.
+  //
+  // The ERROR state is returned in the following cases:
+  // 1. An epoch lease has a reference to a node liveness record which the
+  //    lease status evaluator is not aware of. This can happen when gossip
+  //    is down and node liveness information is not available for the lease
+  //    holder. In such cases, it would be unsafe to use the lease because
+  //    the evaluator cannot determine the lease's expiration, so it may
+  //    have expired. However, it would also be unsafe to replace the lease,
+  //    because it may still be valid.
+  // 2. A leader lease is evaluated on a replica that is not the raft leader
+  //    and is not aware of a successor raft leader at a future term (either
+  //    itself or some other replica). In such cases, the lease may be valid
+  //    or it may have expired. The raft leader (+leaseholder) itself would
+  //    be able to tell, but the only way for a follower replica to tell is
+  //    for it to try to become the raft leader, while respecting raft
+  //    fortification rules. In the meantime, it is best for the follower
+  //    replica to redirect any requests to the raft leader (+leaseholder).
   ERROR = 0;
   // VALID indicates that the lease is not expired at the current clock
   // time and can be used to serve a given request.

--- a/pkg/kv/kvserver/leases/status.go
+++ b/pkg/kv/kvserver/leases/status.go
@@ -178,9 +178,6 @@ func Status(ctx context.Context, nl NodeLiveness, i StatusInput) kvserverpb.Leas
 				// to replace it.
 				knownSuccessor := i.RaftStatus.Term > lease.Term && i.RaftStatus.Lead != raft.None
 				if !knownSuccessor {
-					// TODO(nvanbenschoten): we could introduce a new INDETERMINATE state
-					// for this case, instead of using ERROR. This would look a bit less
-					// unexpected.
 					status.State = kvserverpb.LeaseState_ERROR
 					status.ErrInfo = "leader lease is not held locally, cannot determine validity"
 					return status

--- a/pkg/kv/kvserver/replica_store_liveness.go
+++ b/pkg/kv/kvserver/replica_store_liveness.go
@@ -21,7 +21,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
-var raftLeaderFortificationFractionEnabled = settings.RegisterFloatSetting(
+// RaftLeaderFortificationFractionEnabled controls the fraction of ranges for
+// which the raft leader fortification protocol is enabled.
+var RaftLeaderFortificationFractionEnabled = settings.RegisterFloatSetting(
 	settings.SystemOnly,
 	"kv.raft.leader_fortification.fraction_enabled",
 	"controls the fraction of ranges for which the raft leader fortification "+
@@ -87,7 +89,7 @@ func (r *replicaRLockedStoreLiveness) SupportFromEnabled() bool {
 	if !r.store.storeLiveness.SupportFromEnabled(context.TODO()) {
 		return false
 	}
-	fracEnabled := raftLeaderFortificationFractionEnabled.Get(&r.store.ClusterSettings().SV)
+	fracEnabled := RaftLeaderFortificationFractionEnabled.Get(&r.store.ClusterSettings().SV)
 	fortifyEnabled := raftFortificationEnabledForRangeID(fracEnabled, r.RangeID)
 	return fortifyEnabled
 }


### PR DESCRIPTION
Backport 1/1 commits from #133573.

/cc @cockroachdb/release

---

Informs #132762.

This commit updates the lease status logic to redirect requests to the raft leader who holds a leader lease when evaluating a request on a follower. Previously, the follower would return a NotLeaseHolderError, but it would not include the lease in the response, so the client would not be immediately redirected to the leader. Instead, it would continue trying each replica in order, eventually throwing a `sending to all replicas failed` error.

Furthermore, since no lease was included, request proxying would never be used. This explains why the `failover/partial/lease-gateway` test was failing to recover. With this change, the test now observes recovery in in 7.650s.

| test                                         | lease=epoch (ms) | lease=expiration (ms) | lease=leader (ms) | parity with expiration |
|:---------------------------------------------|-----------------:|----------------------:|------------------:|:----------------------:|
| failover/partial/lease-gateway               | 8,589            | 19,327           | 7,650            | ✔                      |

**Key _(comparing leader vs. expiration)_**:
✔ = parity
❌ = minor regression
❌❌ = major regression
❌❌❌ = unavailability

To further demonstrate that this change works as expected, the commit also ports over two unit test that exercise request proxying to run with leader leases. Without this change, they fail. With it, they pass.

----

Release note: None

Release justification: needed for leader leases.