### PR TITLE
revert "logictest: deflake TestLogic_union"

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -683,15 +683,11 @@ SELECT a, b AS b1, b AS b2 FROM abc INTERSECT SELECT a, c, b FROM abc ORDER by a
 # synchronizer was causing spurious errors on queries with LIMIT.
 statement ok
 CREATE TABLE t127043_1 (k1 INT, v1 INT, INDEX (k1));
-CREATE TABLE t127043_2 (k2 INT, v2 INT, INDEX (k2));
-CREATE TABLE t127043_3 (k3 INT, v3 INT, INDEX (k3));
-
-statement ok
 INSERT INTO t127043_1 VALUES (1, 1);
+CREATE TABLE t127043_2 (k2 INT, v2 INT, INDEX (k2));
 INSERT INTO t127043_2 VALUES (1, 1);
+CREATE TABLE t127043_3 (k3 INT, v3 INT, INDEX (k3));
 INSERT INTO t127043_3 VALUES (1, 1);
-
-statement ok
 CREATE VIEW v127043 (k, v) AS
   SELECT
     k1 AS k, v1 AS v FROM t127043_1@t127043_1_k1_idx


### PR DESCRIPTION
This reverts commit 6218f23518a73db64b4a8621234626bcfe865f25.

I don't think this commit did anything to remove or reduce flakiness in the union logic test because the error occurs on the SELECT query _after_ the DDL and DML statements modified by this commit. Reverting it to allow for cleaner backports.

Epic: None
Release note: None