### PR TITLE
schemachanger: refactor subzone config elements

### DIFF
--- a/pkg/ccl/schemachangerccl/ccl_generated_test.go
+++ b/pkg/ccl/schemachangerccl/ccl_generated_test.go
@@ -43,6 +43,13 @@ func TestBackupRollbacks_ccl_alter_partition_configure_zone_multiple(t *testing.
 	sctest.BackupRollbacks(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestBackupRollbacks_ccl_alter_partition_configure_zone_subpartitions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions"
+	sctest.BackupRollbacks(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestBackupRollbacks_ccl_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -117,6 +124,13 @@ func TestBackupRollbacksMixedVersion_ccl_alter_partition_configure_zone_multiple
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple"
+	sctest.BackupRollbacksMixedVersion(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_ccl_alter_partition_configure_zone_subpartitions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions"
 	sctest.BackupRollbacksMixedVersion(t, path, MultiRegionTestClusterFactory{})
 }
 
@@ -197,6 +211,13 @@ func TestBackupSuccess_ccl_alter_partition_configure_zone_multiple(t *testing.T)
 	sctest.BackupSuccess(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestBackupSuccess_ccl_alter_partition_configure_zone_subpartitions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions"
+	sctest.BackupSuccess(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestBackupSuccess_ccl_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -271,6 +292,13 @@ func TestBackupSuccessMixedVersion_ccl_alter_partition_configure_zone_multiple(t
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple"
+	sctest.BackupSuccessMixedVersion(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_ccl_alter_partition_configure_zone_subpartitions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions"
 	sctest.BackupSuccessMixedVersion(t, path, MultiRegionTestClusterFactory{})
 }
 
@@ -351,6 +379,13 @@ func TestEndToEndSideEffects_ccl_alter_partition_configure_zone_multiple(t *test
 	sctest.EndToEndSideEffects(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_ccl_alter_partition_configure_zone_subpartitions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions"
+	sctest.EndToEndSideEffects(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_ccl_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -425,6 +460,13 @@ func TestExecuteWithDMLInjection_ccl_alter_partition_configure_zone_multiple(t *
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple"
+	sctest.ExecuteWithDMLInjection(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_ccl_alter_partition_configure_zone_subpartitions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions"
 	sctest.ExecuteWithDMLInjection(t, path, MultiRegionTestClusterFactory{})
 }
 
@@ -505,6 +547,13 @@ func TestGenerateSchemaChangeCorpus_ccl_alter_partition_configure_zone_multiple(
 	sctest.GenerateSchemaChangeCorpus(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_ccl_alter_partition_configure_zone_subpartitions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions"
+	sctest.GenerateSchemaChangeCorpus(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_ccl_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -579,6 +628,13 @@ func TestPause_ccl_alter_partition_configure_zone_multiple(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple"
+	sctest.Pause(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestPause_ccl_alter_partition_configure_zone_subpartitions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions"
 	sctest.Pause(t, path, MultiRegionTestClusterFactory{})
 }
 
@@ -659,6 +715,13 @@ func TestPauseMixedVersion_ccl_alter_partition_configure_zone_multiple(t *testin
 	sctest.PauseMixedVersion(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_ccl_alter_partition_configure_zone_subpartitions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions"
+	sctest.PauseMixedVersion(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_ccl_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -733,6 +796,13 @@ func TestRollback_ccl_alter_partition_configure_zone_multiple(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_multiple"
+	sctest.Rollback(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestRollback_ccl_alter_partition_configure_zone_subpartitions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions"
 	sctest.Rollback(t, path, MultiRegionTestClusterFactory{})
 }
 

--- a/pkg/ccl/schemachangerccl/testdata/decomp/multiregion
+++ b/pkg/ccl/schemachangerccl/testdata/decomp/multiregion
@@ -1403,7 +1403,10 @@ ElementState:
           numReplicas: 2
       indexId: 1
       partitionName: us-east1
-    subzoneSpans: []
+    subzoneSpans:
+    - endKey: null
+      key: iRJAAAE=
+      subzoneIndex: 0
     tableId: 108
   Status: PUBLIC
 - PartitionZoneConfig:
@@ -1437,7 +1440,10 @@ ElementState:
           numReplicas: 2
       indexId: 1
       partitionName: us-east2
-    subzoneSpans: []
+    subzoneSpans:
+    - endKey: null
+      key: iRKAAAE=
+      subzoneIndex: 1
     tableId: 108
   Status: PUBLIC
 - PartitionZoneConfig:
@@ -1471,7 +1477,10 @@ ElementState:
           numReplicas: 2
       indexId: 1
       partitionName: us-east3
-    subzoneSpans: []
+    subzoneSpans:
+    - endKey: null
+      key: iRLAAAE=
+      subzoneIndex: 2
     tableId: 108
   Status: PUBLIC
 - PrimaryIndex:

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions/alter_partition_configure_zone_subpartitions.definition
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions/alter_partition_configure_zone_subpartitions.definition
@@ -1,0 +1,33 @@
+setup
+CREATE TABLE person (
+    name STRING,
+    country STRING,
+    birth_date DATE,
+    PRIMARY KEY (country, birth_date, name)
+)
+    PARTITION BY LIST (country) (
+            PARTITION australia
+                VALUES IN ('AU', 'NZ')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_au VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_au VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION north_america
+                VALUES IN ('US', 'CA')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_na VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_na VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION default
+                VALUES IN (default)
+        );
+----
+
+test
+ALTER PARTITION australia OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 2;
+ALTER PARTITION old_au OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 4;
+ALTER PARTITION yung_au OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 5;
+ALTER PARTITION old_au OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 6;
+----

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions/alter_partition_configure_zone_subpartitions.side_effects
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions/alter_partition_configure_zone_subpartitions.side_effects
@@ -1,0 +1,103 @@
+/* setup */
+CREATE TABLE person (
+    name STRING,
+    country STRING,
+    birth_date DATE,
+    PRIMARY KEY (country, birth_date, name)
+)
+    PARTITION BY LIST (country) (
+            PARTITION australia
+                VALUES IN ('AU', 'NZ')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_au VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_au VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION north_america
+                VALUES IN ('US', 'CA')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_na VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_na VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION default
+                VALUES IN (default)
+        );
+----
+...
++object {100 101 person} -> 104
+
+/* test */
+ALTER PARTITION australia OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 2;
+ALTER PARTITION old_au OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 4;
+ALTER PARTITION yung_au OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 5;
+ALTER PARTITION old_au OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 6;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: CONFIGURE ZONE
+write *eventpb.SetZoneConfig to event log:
+  config:
+    options:
+    - '"gc.ttlseconds" = 2'
+    target: PARTITION australia OF INDEX defaultdb.public.person@person_pkey
+  resolvedOldConfig: 'inherited_constraints:false null_voter_constraints_is_empty:false inherited_lease_preferences:false '
+  sql:
+    descriptorId: 104
+    statement: ALTER PARTITION ‹australia› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹2›
+    tag: CONFIGURE ZONE
+    user: root
+## StatementPhase stage 1 of 1 with 1 MutationType op
+upsert zone config for #104
+checking for feature: CONFIGURE ZONE
+write *eventpb.SetZoneConfig to event log:
+  config:
+    options:
+    - '"gc.ttlseconds" = 4'
+    target: PARTITION old_au OF INDEX defaultdb.public.person@person_pkey
+  resolvedOldConfig: 'inherited_constraints:false null_voter_constraints_is_empty:false inherited_lease_preferences:false '
+  sql:
+    descriptorId: 104
+    statement: ALTER PARTITION ‹old_au› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹4›
+    tag: CONFIGURE ZONE
+    user: root
+## StatementPhase stage 1 of 1 with 1 MutationType op
+upsert zone config for #104
+checking for feature: CONFIGURE ZONE
+write *eventpb.SetZoneConfig to event log:
+  config:
+    options:
+    - '"gc.ttlseconds" = 5'
+    target: PARTITION yung_au OF INDEX defaultdb.public.person@person_pkey
+  resolvedOldConfig: 'inherited_constraints:false null_voter_constraints_is_empty:false inherited_lease_preferences:false '
+  sql:
+    descriptorId: 104
+    statement: ALTER PARTITION ‹yung_au› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹5›
+    tag: CONFIGURE ZONE
+    user: root
+## StatementPhase stage 1 of 1 with 1 MutationType op
+upsert zone config for #104
+checking for feature: CONFIGURE ZONE
+write *eventpb.SetZoneConfig to event log:
+  config:
+    options:
+    - '"gc.ttlseconds" = 6'
+    target: PARTITION old_au OF INDEX defaultdb.public.person@person_pkey
+  resolvedOldConfig: 'inherited_constraints:false null_voter_constraints_is_empty:false inherited_lease_preferences:false '
+  sql:
+    descriptorId: 104
+    statement: ALTER PARTITION ‹old_au› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹6›
+    tag: CONFIGURE ZONE
+    user: root
+## StatementPhase stage 1 of 1 with 1 MutationType op
+upsert zone config for #104
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 4 MutationType ops
+upsert zone config for #104
+persist all catalog changes to storage
+# end PreCommitPhase
+commit transaction #1

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions/alter_partition_configure_zone_subpartitions__statement_1_of_4.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions/alter_partition_configure_zone_subpartitions__statement_1_of_4.explain
@@ -1,0 +1,47 @@
+/* setup */
+CREATE TABLE person (
+    name STRING,
+    country STRING,
+    birth_date DATE,
+    PRIMARY KEY (country, birth_date, name)
+)
+    PARTITION BY LIST (country) (
+            PARTITION australia
+                VALUES IN ('AU', 'NZ')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_au VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_au VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION north_america
+                VALUES IN ('US', 'CA')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_na VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_na VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION default
+                VALUES IN (default)
+        );
+
+/* test */
+EXPLAIN (DDL) ALTER PARTITION australia OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 2;
+----
+Schema change plan for ALTER PARTITION ‹australia› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹2›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 1, PartitionName: "australia"}
+ │         └── 1 Mutation operation
+ │              └── AddPartitionZoneConfig {"TableID":104}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── PUBLIC → ABSENT PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 1, PartitionName: "australia"}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 1 element transitioning toward PUBLIC
+           │    └── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 1, PartitionName: "australia"}
+           └── 1 Mutation operation
+                └── AddPartitionZoneConfig {"TableID":104}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions/alter_partition_configure_zone_subpartitions__statement_1_of_4.explain_shape
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions/alter_partition_configure_zone_subpartitions__statement_1_of_4.explain_shape
@@ -1,0 +1,31 @@
+/* setup */
+CREATE TABLE person (
+    name STRING,
+    country STRING,
+    birth_date DATE,
+    PRIMARY KEY (country, birth_date, name)
+)
+    PARTITION BY LIST (country) (
+            PARTITION australia
+                VALUES IN ('AU', 'NZ')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_au VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_au VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION north_america
+                VALUES IN ('US', 'CA')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_na VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_na VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION default
+                VALUES IN (default)
+        );
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER PARTITION australia OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 2;
+----
+Schema change plan for ALTER PARTITION ‹australia› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹2›;
+ └── execute 1 system table mutations transaction

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions/alter_partition_configure_zone_subpartitions__statement_2_of_4.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions/alter_partition_configure_zone_subpartitions__statement_2_of_4.explain
@@ -1,0 +1,51 @@
+/* setup */
+CREATE TABLE person (
+    name STRING,
+    country STRING,
+    birth_date DATE,
+    PRIMARY KEY (country, birth_date, name)
+)
+    PARTITION BY LIST (country) (
+            PARTITION australia
+                VALUES IN ('AU', 'NZ')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_au VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_au VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION north_america
+                VALUES IN ('US', 'CA')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_na VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_na VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION default
+                VALUES IN (default)
+        );
+
+/* test */
+ALTER PARTITION australia OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 2;
+EXPLAIN (DDL) ALTER PARTITION old_au OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 4;
+----
+Schema change plan for ALTER PARTITION ‹old_au› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹4›; following ALTER PARTITION ‹australia› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹2›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 1, PartitionName: "old_au"}
+ │         └── 1 Mutation operation
+ │              └── AddPartitionZoneConfig {"TableID":104}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── PUBLIC → ABSENT PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 1, PartitionName: "australia"}
+      │    │    └── PUBLIC → ABSENT PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 1, PartitionName: "old_au"}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 2 elements transitioning toward PUBLIC
+           │    ├── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 1, PartitionName: "australia"}
+           │    └── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 1, PartitionName: "old_au"}
+           └── 2 Mutation operations
+                ├── AddPartitionZoneConfig {"TableID":104}
+                └── AddPartitionZoneConfig {"TableID":104}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions/alter_partition_configure_zone_subpartitions__statement_2_of_4.explain_shape
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions/alter_partition_configure_zone_subpartitions__statement_2_of_4.explain_shape
@@ -1,0 +1,32 @@
+/* setup */
+CREATE TABLE person (
+    name STRING,
+    country STRING,
+    birth_date DATE,
+    PRIMARY KEY (country, birth_date, name)
+)
+    PARTITION BY LIST (country) (
+            PARTITION australia
+                VALUES IN ('AU', 'NZ')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_au VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_au VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION north_america
+                VALUES IN ('US', 'CA')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_na VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_na VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION default
+                VALUES IN (default)
+        );
+
+/* test */
+ALTER PARTITION australia OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 2;
+EXPLAIN (DDL, SHAPE) ALTER PARTITION old_au OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 4;
+----
+Schema change plan for ALTER PARTITION ‹old_au› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹4›; following ALTER PARTITION ‹australia› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹2›;
+ └── execute 1 system table mutations transaction

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions/alter_partition_configure_zone_subpartitions__statement_3_of_4.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions/alter_partition_configure_zone_subpartitions__statement_3_of_4.explain
@@ -1,0 +1,55 @@
+/* setup */
+CREATE TABLE person (
+    name STRING,
+    country STRING,
+    birth_date DATE,
+    PRIMARY KEY (country, birth_date, name)
+)
+    PARTITION BY LIST (country) (
+            PARTITION australia
+                VALUES IN ('AU', 'NZ')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_au VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_au VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION north_america
+                VALUES IN ('US', 'CA')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_na VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_na VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION default
+                VALUES IN (default)
+        );
+
+/* test */
+ALTER PARTITION australia OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 2;
+ALTER PARTITION old_au OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 4;
+EXPLAIN (DDL) ALTER PARTITION yung_au OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 5;
+----
+Schema change plan for ALTER PARTITION ‹yung_au› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹5›; following ALTER PARTITION ‹australia› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹2›; ALTER PARTITION ‹old_au› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹4›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 1, PartitionName: "yung_au"}
+ │         └── 1 Mutation operation
+ │              └── AddPartitionZoneConfig {"TableID":104}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── PUBLIC → ABSENT PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 1, PartitionName: "australia"}
+      │    │    ├── PUBLIC → ABSENT PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 1, PartitionName: "old_au"}
+      │    │    └── PUBLIC → ABSENT PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 1, PartitionName: "yung_au"}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 3 elements transitioning toward PUBLIC
+           │    ├── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 1, PartitionName: "australia"}
+           │    ├── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 1, PartitionName: "old_au"}
+           │    └── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 1, PartitionName: "yung_au"}
+           └── 3 Mutation operations
+                ├── AddPartitionZoneConfig {"TableID":104}
+                ├── AddPartitionZoneConfig {"TableID":104}
+                └── AddPartitionZoneConfig {"TableID":104}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions/alter_partition_configure_zone_subpartitions__statement_3_of_4.explain_shape
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions/alter_partition_configure_zone_subpartitions__statement_3_of_4.explain_shape
@@ -1,0 +1,33 @@
+/* setup */
+CREATE TABLE person (
+    name STRING,
+    country STRING,
+    birth_date DATE,
+    PRIMARY KEY (country, birth_date, name)
+)
+    PARTITION BY LIST (country) (
+            PARTITION australia
+                VALUES IN ('AU', 'NZ')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_au VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_au VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION north_america
+                VALUES IN ('US', 'CA')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_na VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_na VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION default
+                VALUES IN (default)
+        );
+
+/* test */
+ALTER PARTITION australia OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 2;
+ALTER PARTITION old_au OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 4;
+EXPLAIN (DDL, SHAPE) ALTER PARTITION yung_au OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 5;
+----
+Schema change plan for ALTER PARTITION ‹yung_au› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹5›; following ALTER PARTITION ‹australia› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹2›; ALTER PARTITION ‹old_au› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹4›;
+ └── execute 1 system table mutations transaction

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions/alter_partition_configure_zone_subpartitions__statement_4_of_4.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions/alter_partition_configure_zone_subpartitions__statement_4_of_4.explain
@@ -1,0 +1,59 @@
+/* setup */
+CREATE TABLE person (
+    name STRING,
+    country STRING,
+    birth_date DATE,
+    PRIMARY KEY (country, birth_date, name)
+)
+    PARTITION BY LIST (country) (
+            PARTITION australia
+                VALUES IN ('AU', 'NZ')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_au VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_au VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION north_america
+                VALUES IN ('US', 'CA')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_na VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_na VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION default
+                VALUES IN (default)
+        );
+
+/* test */
+ALTER PARTITION australia OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 2;
+ALTER PARTITION old_au OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 4;
+ALTER PARTITION yung_au OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 5;
+EXPLAIN (DDL) ALTER PARTITION old_au OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 6;
+----
+Schema change plan for ALTER PARTITION ‹old_au› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹6›; following ALTER PARTITION ‹australia› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹2›; ALTER PARTITION ‹old_au› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹4›; ALTER PARTITION ‹yung_au› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹5›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 2, PartitionName: "old_au"}
+ │         └── 1 Mutation operation
+ │              └── AddPartitionZoneConfig {"TableID":104}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── PUBLIC → ABSENT PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 1, PartitionName: "australia"}
+      │    │    ├── PUBLIC → ABSENT PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 1, PartitionName: "old_au"}
+      │    │    ├── PUBLIC → ABSENT PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 1, PartitionName: "yung_au"}
+      │    │    └── PUBLIC → ABSENT PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 2, PartitionName: "old_au"}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 4 elements transitioning toward PUBLIC
+           │    ├── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 1, PartitionName: "australia"}
+           │    ├── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 1, PartitionName: "old_au"}
+           │    ├── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 1, PartitionName: "yung_au"}
+           │    └── ABSENT → PUBLIC PartitionZoneConfig:{DescID: 104 (person), IndexID: 1 (person_pkey), SeqNum: 2, PartitionName: "old_au"}
+           └── 4 Mutation operations
+                ├── AddPartitionZoneConfig {"TableID":104}
+                ├── AddPartitionZoneConfig {"TableID":104}
+                ├── AddPartitionZoneConfig {"TableID":104}
+                └── AddPartitionZoneConfig {"TableID":104}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions/alter_partition_configure_zone_subpartitions__statement_4_of_4.explain_shape
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_partition_configure_zone_subpartitions/alter_partition_configure_zone_subpartitions__statement_4_of_4.explain_shape
@@ -1,0 +1,34 @@
+/* setup */
+CREATE TABLE person (
+    name STRING,
+    country STRING,
+    birth_date DATE,
+    PRIMARY KEY (country, birth_date, name)
+)
+    PARTITION BY LIST (country) (
+            PARTITION australia
+                VALUES IN ('AU', 'NZ')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_au VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_au VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION north_america
+                VALUES IN ('US', 'CA')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_na VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_na VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION default
+                VALUES IN (default)
+        );
+
+/* test */
+ALTER PARTITION australia OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 2;
+ALTER PARTITION old_au OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 4;
+ALTER PARTITION yung_au OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 5;
+EXPLAIN (DDL, SHAPE) ALTER PARTITION old_au OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 6;
+----
+Schema change plan for ALTER PARTITION ‹old_au› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹6›; following ALTER PARTITION ‹australia› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹2›; ALTER PARTITION ‹old_au› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹4›; ALTER PARTITION ‹yung_au› OF INDEX ‹defaultdb›.‹public›.‹person›@‹person_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹5›;
+ └── execute 1 system table mutations transaction

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -533,6 +533,8 @@ ALTER INDEX a@bar CONFIGURE ZONE USING gc.ttlseconds = 15000
 # verify zone config changes are logged
 ##################
 skipif config 3node-tenant-default-configs
+skipif config local-mixed-24.1
+skipif config local-mixed-24.2
 query IT
 SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID' - 'Statement'
 FROM system.eventlog
@@ -547,6 +549,7 @@ ORDER BY "timestamp", info
 1  {"EventType": "set_zone_config", "Options": ["range_max_bytes = 67108865", "range_min_bytes = 16777216"], "ResolvedOldConfig": "range_min_bytes:134217728 range_max_bytes:536870912 gc:<ttl_seconds:14400 > num_replicas:3 inherited_constraints:false null_voter_constraints_is_empty:true inherited_lease_preferences:false ", "Tag": "CONFIGURE ZONE", "Target": "DATABASE test", "User": "root"}
 1  {"EventType": "set_zone_config", "Options": ["range_max_bytes = 67108865", "range_min_bytes = 16777216"], "ResolvedOldConfig": "range_min_bytes:134217728 range_max_bytes:536870912 gc:<ttl_seconds:14400 > num_replicas:3 inherited_constraints:false null_voter_constraints_is_empty:true inherited_lease_preferences:false ", "Tag": "CONFIGURE ZONE", "Target": "TABLE test.public.a", "User": "root"}
 1  {"EventType": "set_zone_config", "Options": ["\"gc.ttlseconds\" = 13000"], "ResolvedOldConfig": "range_min_bytes:134217728 range_max_bytes:536870912 gc:<ttl_seconds:14400 > num_replicas:3 inherited_constraints:false null_voter_constraints_is_empty:true inherited_lease_preferences:false ", "Tag": "CONFIGURE ZONE", "Target": "INDEX test.public.a@a_pkey", "User": "root"}
+1  {"EventType": "set_zone_config", "Options": ["\"gc.ttlseconds\" = 15000"], "ResolvedOldConfig": "range_min_bytes:134217728 range_max_bytes:536870912 gc:<ttl_seconds:14400 > num_replicas:3 inherited_constraints:false null_voter_constraints_is_empty:true inherited_lease_preferences:false ", "Tag": "CONFIGURE ZONE", "Target": "INDEX test.public.a@bar", "User": "root"}
 1  {"EventType": "set_zone_config", "Options": ["\"gc.ttlseconds\" = 15000"], "ResolvedOldConfig": "range_min_bytes:134217728 range_max_bytes:536870912 gc:<ttl_seconds:14400 > num_replicas:3 inherited_constraints:false null_voter_constraints_is_empty:true inherited_lease_preferences:false ", "Tag": "CONFIGURE ZONE", "Target": "INDEX test.public.a@bar", "User": "root"}
 
 skipif config 3node-tenant-default-configs

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/database_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/database_zone_config.go
@@ -27,21 +27,30 @@ type databaseZoneConfigObj struct {
 
 var _ zoneConfigObject = &databaseZoneConfigObj{}
 
-func (dzo *databaseZoneConfigObj) incrementSeqNum() {
-	dzo.seqNum += 1
-}
-
 func (dzo *databaseZoneConfigObj) isNoOp() bool {
 	return dzo.zoneConfig == nil
 }
 
-func (dzo *databaseZoneConfigObj) getZoneConfigElem(b BuildCtx) []scpb.Element {
+func (dzo *databaseZoneConfigObj) getZoneConfigElemForAdd(
+	_ BuildCtx,
+) (scpb.Element, []scpb.Element) {
+	elem := &scpb.DatabaseZoneConfig{
+		DatabaseID: dzo.databaseID,
+		ZoneConfig: dzo.zoneConfig,
+		SeqNum:     dzo.seqNum + 1,
+	}
+	return elem, nil
+}
+
+func (dzo *databaseZoneConfigObj) getZoneConfigElemForDrop(
+	_ BuildCtx,
+) (scpb.Element, []scpb.Element) {
 	elem := &scpb.DatabaseZoneConfig{
 		DatabaseID: dzo.databaseID,
 		ZoneConfig: dzo.zoneConfig,
 		SeqNum:     dzo.seqNum,
 	}
-	return []scpb.Element{elem}
+	return elem, nil
 }
 
 func (dzo *databaseZoneConfigObj) checkPrivilegeForSetZoneConfig(

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/database_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/database_zone_config.go
@@ -35,13 +35,13 @@ func (dzo *databaseZoneConfigObj) isNoOp() bool {
 	return dzo.zoneConfig == nil
 }
 
-func (dzo *databaseZoneConfigObj) getZoneConfigElem(b BuildCtx) scpb.Element {
+func (dzo *databaseZoneConfigObj) getZoneConfigElem(b BuildCtx) []scpb.Element {
 	elem := &scpb.DatabaseZoneConfig{
 		DatabaseID: dzo.databaseID,
 		ZoneConfig: dzo.zoneConfig,
 		SeqNum:     dzo.seqNum,
 	}
-	return elem
+	return []scpb.Element{elem}
 }
 
 func (dzo *databaseZoneConfigObj) checkPrivilegeForSetZoneConfig(

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/named_range_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/named_range_zone_config.go
@@ -26,21 +26,30 @@ type namedRangeZoneConfigObj struct {
 
 var _ zoneConfigObject = &namedRangeZoneConfigObj{}
 
-func (rzo *namedRangeZoneConfigObj) incrementSeqNum() {
-	rzo.seqNum += 1
-}
-
 func (rzo *namedRangeZoneConfigObj) isNoOp() bool {
 	return rzo.zoneConfig == nil
 }
 
-func (rzo *namedRangeZoneConfigObj) getZoneConfigElem(b BuildCtx) []scpb.Element {
+func (rzo *namedRangeZoneConfigObj) getZoneConfigElemForAdd(
+	_ BuildCtx,
+) (scpb.Element, []scpb.Element) {
+	elem := &scpb.NamedRangeZoneConfig{
+		RangeID:    rzo.rangeID,
+		ZoneConfig: rzo.zoneConfig,
+		SeqNum:     rzo.seqNum + 1,
+	}
+	return elem, nil
+}
+
+func (rzo *namedRangeZoneConfigObj) getZoneConfigElemForDrop(
+	_ BuildCtx,
+) (scpb.Element, []scpb.Element) {
 	elem := &scpb.NamedRangeZoneConfig{
 		RangeID:    rzo.rangeID,
 		ZoneConfig: rzo.zoneConfig,
 		SeqNum:     rzo.seqNum,
 	}
-	return []scpb.Element{elem}
+	return elem, nil
 }
 
 func (rzo *namedRangeZoneConfigObj) checkPrivilegeForSetZoneConfig(

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/named_range_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/named_range_zone_config.go
@@ -34,13 +34,13 @@ func (rzo *namedRangeZoneConfigObj) isNoOp() bool {
 	return rzo.zoneConfig == nil
 }
 
-func (rzo *namedRangeZoneConfigObj) getZoneConfigElem(b BuildCtx) scpb.Element {
+func (rzo *namedRangeZoneConfigObj) getZoneConfigElem(b BuildCtx) []scpb.Element {
 	elem := &scpb.NamedRangeZoneConfig{
 		RangeID:    rzo.rangeID,
 		ZoneConfig: rzo.zoneConfig,
 		SeqNum:     rzo.seqNum,
 	}
-	return elem
+	return []scpb.Element{elem}
 }
 
 func (rzo *namedRangeZoneConfigObj) checkPrivilegeForSetZoneConfig(

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/partition_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/partition_zone_config.go
@@ -38,7 +38,7 @@ func (pzo *partitionZoneConfigObj) getTableZoneConfig() *zonepb.ZoneConfig {
 	return pzo.tableZoneConfigObj.zoneConfig
 }
 
-func (pzo *partitionZoneConfigObj) getZoneConfigElem(b BuildCtx) scpb.Element {
+func (pzo *partitionZoneConfigObj) getZoneConfigElem(b BuildCtx) []scpb.Element {
 	subzones := []zonepb.Subzone{*pzo.partitionSubzone}
 
 	// Merge the new subzones with the old subzones so that we can generate
@@ -54,15 +54,40 @@ func (pzo *partitionZoneConfigObj) getZoneConfigElem(b BuildCtx) scpb.Element {
 		panic(err)
 	}
 
-	elem := &scpb.PartitionZoneConfig{
-		TableID:       pzo.tableID,
-		IndexID:       pzo.indexID,
-		PartitionName: pzo.partitionName,
-		Subzone:       *pzo.partitionSubzone,
-		SubzoneSpans:  ss,
-		SeqNum:        pzo.seqNum,
+	// TODO(annie): This does a little more work than necessary -- we should be
+	// able to just update the affected subzone spans. This can be done by
+	// comparing the parent's subzone spans with `ss`.
+	//
+	// Update the partition that is represented by pzo, along with all other
+	// subzones.
+	idxToSpansMap := getSubzoneSpansWithIdx(len(subzones), ss)
+	var szCfgsToUpdate []scpb.Element
+	for i, sub := range subzones {
+		if spans, ok := idxToSpansMap[int32(i)]; ok {
+			if len(sub.PartitionName) > 0 {
+				elem := &scpb.PartitionZoneConfig{
+					TableID:       pzo.tableID,
+					IndexID:       catid.IndexID(sub.IndexID),
+					PartitionName: sub.PartitionName,
+					Subzone:       sub,
+					SubzoneSpans:  spans,
+					SeqNum:        pzo.seqNum,
+				}
+				szCfgsToUpdate = append(szCfgsToUpdate, elem)
+			} else {
+				elem := &scpb.IndexZoneConfig{
+					TableID:      pzo.tableID,
+					IndexID:      catid.IndexID(sub.IndexID),
+					Subzone:      sub,
+					SubzoneSpans: spans,
+					SeqNum:       pzo.seqNum,
+				}
+				szCfgsToUpdate = append(szCfgsToUpdate, elem)
+			}
+		}
 	}
-	return elem
+
+	return szCfgsToUpdate
 }
 
 func (pzo *partitionZoneConfigObj) retrievePartialZoneConfig(b BuildCtx) *zonepb.ZoneConfig {
@@ -101,10 +126,6 @@ func (pzo *partitionZoneConfigObj) retrieveCompleteZoneConfig(
 	if getInheritedDefault {
 		zc, err = pzo.getInheritedDefaultZoneConfig(b)
 	} else {
-		//zc, err = pzo.tableZoneConfigObj.getZoneConfig(b, false /* inheritDefaultRange */)
-		//if err != nil {
-		//	return nil, nil, err
-		//}
 		placeholder, err = pzo.getZoneConfig(b, false /* inheritDefaultRange */)
 	}
 	if err != nil {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/table_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/table_zone_config.go
@@ -32,13 +32,13 @@ func (tzo *tableZoneConfigObj) isNoOp() bool {
 	return tzo.zoneConfig == nil
 }
 
-func (tzo *tableZoneConfigObj) getZoneConfigElem(b BuildCtx) scpb.Element {
+func (tzo *tableZoneConfigObj) getZoneConfigElem(b BuildCtx) []scpb.Element {
 	elem := &scpb.TableZoneConfig{
 		TableID:    tzo.tableID,
 		ZoneConfig: tzo.zoneConfig,
 		SeqNum:     tzo.seqNum,
 	}
-	return elem
+	return []scpb.Element{elem}
 }
 
 func (tzo *tableZoneConfigObj) checkPrivilegeForSetZoneConfig(

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/table_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/table_zone_config.go
@@ -32,13 +32,22 @@ func (tzo *tableZoneConfigObj) isNoOp() bool {
 	return tzo.zoneConfig == nil
 }
 
-func (tzo *tableZoneConfigObj) getZoneConfigElem(b BuildCtx) []scpb.Element {
+func (tzo *tableZoneConfigObj) getZoneConfigElemForAdd(_ BuildCtx) (scpb.Element, []scpb.Element) {
+	elem := &scpb.TableZoneConfig{
+		TableID:    tzo.tableID,
+		ZoneConfig: tzo.zoneConfig,
+		SeqNum:     tzo.seqNum + 1,
+	}
+	return elem, nil
+}
+
+func (tzo *tableZoneConfigObj) getZoneConfigElemForDrop(_ BuildCtx) (scpb.Element, []scpb.Element) {
 	elem := &scpb.TableZoneConfig{
 		TableID:    tzo.tableID,
 		ZoneConfig: tzo.zoneConfig,
 		SeqNum:     tzo.seqNum,
 	}
-	return []scpb.Element{elem}
+	return elem, nil
 }
 
 func (tzo *tableZoneConfigObj) checkPrivilegeForSetZoneConfig(

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
@@ -52,8 +52,11 @@ type zoneConfigAuthorizer interface {
 }
 
 type zoneConfigObjBuilder interface {
-	// getZoneConfigElem retrieves the scpb.Element for the zone config object.
-	getZoneConfigElem(b BuildCtx) scpb.Element
+	// getZoneConfigElem retrieves []scpb.Elements needed for modification for the
+	// zone config object. Having multiple elements needing to be modified becomes
+	// more relevant for subzone configs -- as configuring the zone on indexes
+	// and partitions can shift the subzone spans for other elements around.
+	getZoneConfigElem(b BuildCtx) []scpb.Element
 
 	// getTargetID returns the target ID of the zone config object. This is either
 	// a database or a table ID.
@@ -1211,4 +1214,21 @@ func isCorrespondingTemporaryIndex(
 			return idx == e.TemporaryIndexID && e.TemporaryIndexID == otherIdx+1
 		}).MustGetZeroOrOneElement()
 	return maybeCorresponding != nil
+}
+
+// getSubzoneSpansWithIdx groups each subzone span by their subzoneIndexs
+// for a lookup of which subzone spans a particular subzone is referred to by.
+func getSubzoneSpansWithIdx(
+	numSubzones int, newSubzoneSpans []zonepb.SubzoneSpan,
+) map[int32][]zonepb.SubzoneSpan {
+	// We initialize our map to the number of subzones to ensure it contains every
+	// subzoneIndex, even if there are no associated subzoneSpans.
+	idxToSpans := make(map[int32][]zonepb.SubzoneSpan, numSubzones)
+	for i := range numSubzones {
+		idxToSpans[int32(i)] = []zonepb.SubzoneSpan{}
+	}
+	for _, s := range newSubzoneSpans {
+		idxToSpans[s.SubzoneIndex] = append(idxToSpans[s.SubzoneIndex], s)
+	}
+	return idxToSpans
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
@@ -52,11 +52,19 @@ type zoneConfigAuthorizer interface {
 }
 
 type zoneConfigObjBuilder interface {
-	// getZoneConfigElem retrieves []scpb.Elements needed for modification for the
-	// zone config object. Having multiple elements needing to be modified becomes
-	// more relevant for subzone configs -- as configuring the zone on indexes
-	// and partitions can shift the subzone spans for other elements around.
-	getZoneConfigElem(b BuildCtx) []scpb.Element
+	// getZoneConfigElemForAdd retrieves (scpb.Element, []scpb.Element) needed for
+	// adding the zone config object. The slice of multiple elements to be
+	// modified becomes more relevant for subzone configs -- as configuring the
+	// zone on indexes and partitions can shift the subzone spans for other
+	// elements around.
+	getZoneConfigElemForAdd(b BuildCtx) (scpb.Element, []scpb.Element)
+
+	// getZoneConfigElemForDrop retrieves (scpb.Element, []scpb.Element) needed
+	// for dropping the zone config object. The slice of multiple elements
+	// to be modified becomes more relevant for subzone configs -- as configuring
+	// the zone on indexes and partitions can shift the subzone spans for other
+	// elements around.
+	getZoneConfigElemForDrop(b BuildCtx) (scpb.Element, []scpb.Element)
 
 	// getTargetID returns the target ID of the zone config object. This is either
 	// a database or a table ID.
@@ -74,9 +82,6 @@ type zoneConfigObjBuilder interface {
 	// setZoneConfigToWrite fills our object with the zone config/subzone config
 	// we will be writing to KV.
 	setZoneConfigToWrite(zone *zonepb.ZoneConfig)
-
-	// incrementSeqNum increments the seqNum by 1.
-	incrementSeqNum()
 
 	// isNoOp returns true if the zone config object is a no-op. This is defined
 	// by our object having no zone config yet.

--- a/pkg/sql/schemachanger/scdeps/exec_deps.go
+++ b/pkg/sql/schemachanger/scdeps/exec_deps.go
@@ -219,6 +219,26 @@ func (d *txnDeps) DeleteDescriptor(ctx context.Context, id descpb.ID) error {
 	return d.descsCollection.DeleteDescToBatch(ctx, d.kvTrace, id, d.getOrCreateBatch())
 }
 
+// GetZoneConfig implements the scexec.Catalog interface.
+func (d *txnDeps) GetZoneConfig(ctx context.Context, id descpb.ID) (catalog.ZoneConfig, error) {
+	zc, err := d.descsCollection.GetZoneConfig(ctx, d.txn.KV(), id)
+	if err != nil {
+		return nil, err
+	}
+	return zc, nil
+}
+
+// WriteZoneConfigToBatch implements the scexec.Catalog interface.
+func (d *txnDeps) WriteZoneConfigToBatch(
+	ctx context.Context, id descpb.ID, zc catalog.ZoneConfig,
+) error {
+	err := d.descsCollection.WriteZoneConfigToBatch(ctx, d.kvTrace, d.getOrCreateBatch(), id, zc)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // UpdateZoneConfig implements the scexec.Catalog interface.
 func (d *txnDeps) UpdateZoneConfig(ctx context.Context, id descpb.ID, zc *zonepb.ZoneConfig) error {
 	var newZc catalog.ZoneConfig

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -833,34 +833,42 @@ func (s *TestState) UpdateZoneConfig(
 // UpdateSubzoneConfig implements the scexec.Catalog interface.
 func (s *TestState) UpdateSubzoneConfig(
 	ctx context.Context,
-	tableID descpb.ID,
-	subzones []zonepb.Subzone,
+	parentZone catalog.ZoneConfig,
+	subzone zonepb.Subzone,
 	subzoneSpans []zonepb.SubzoneSpan,
-) error {
-	oldZc := s.uncommittedInMemory.LookupZoneConfig(tableID)
-
+) (catalog.ZoneConfig, error) {
 	var rawBytes []byte
 	var zc *zonepb.ZoneConfig
 	// If the zone config already exists, we need to preserve the raw bytes as the
 	// expected value that we will be updating. Otherwise, this will be a clean
 	// insert with no expected raw bytes.
-	if oldZc != nil {
-		rawBytes = oldZc.GetRawBytesInStorage()
-		zc = oldZc.ZoneConfigProto()
+	if parentZone != nil {
+		rawBytes = parentZone.GetRawBytesInStorage()
+		zc = parentZone.ZoneConfigProto()
 	} else {
 		// If no zone config exists, create a new one that is a subzone placeholder.
 		zc = zonepb.NewZoneConfig()
 		zc.DeleteTableConfig()
 	}
 
-	// Update the subzones in the zone config.
-	for _, s := range subzones {
-		zc.SetSubzone(s)
+	// Update the subzone in the zone config.
+	zc.SetSubzone(subzone)
+	subzoneIdx := zc.GetSubzoneIndex(subzone.IndexID, subzone.PartitionName)
+
+	// Update the subzone spans.
+	subzoneSpansToWrite := subzoneSpans
+	// If there are subzone spans that currently exist, merge those with the new
+	// spans we are updating. Otherwise, the zone config's set of subzone spans
+	// will be our input subzoneSpans.
+	if len(zc.SubzoneSpans) != 0 {
+		zc.DeleteSubzoneSpansForSubzoneIndex(subzoneIdx)
+		zc.MergeSubzoneSpans(subzoneSpansToWrite)
+		subzoneSpansToWrite = zc.SubzoneSpans
 	}
-	zc.SubzoneSpans = subzoneSpans
+	zc.SubzoneSpans = subzoneSpansToWrite
 
 	newZc := zone.NewZoneConfigWithRawBytes(zc, rawBytes)
-	return s.WriteZoneConfigToBatch(ctx, tableID, newZc)
+	return newZc, nil
 }
 
 // DeleteZoneConfig implements the scexec.Catalog interface.

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -67,7 +67,14 @@ type Catalog interface {
 	// DeleteDescriptor deletes a descriptor entry.
 	DeleteDescriptor(ctx context.Context, id descpb.ID) error
 
-	// UpdateZoneConfig upserts a zone config for a descriptor.
+	// WriteZoneConfigToBatch adds the new zoneconfig to uncommitted layer and
+	// writes to the kv batch.
+	WriteZoneConfigToBatch(ctx context.Context, id descpb.ID, zc catalog.ZoneConfig) error
+
+	// GetZoneConfig gets the zone config for a descriptor ID.
+	GetZoneConfig(ctx context.Context, id descpb.ID) (catalog.ZoneConfig, error)
+
+	// UpdateZoneConfig upserts a zone config for a descriptor ID.
 	UpdateZoneConfig(ctx context.Context, id descpb.ID, zc *zonepb.ZoneConfig) error
 
 	// UpdateSubzoneConfig upserts a subzone config into the zone config for a

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -77,14 +77,14 @@ type Catalog interface {
 	// UpdateZoneConfig upserts a zone config for a descriptor ID.
 	UpdateZoneConfig(ctx context.Context, id descpb.ID, zc *zonepb.ZoneConfig) error
 
-	// UpdateSubzoneConfig upserts a subzone config into the zone config for a
-	// descriptor.
+	// UpdateSubzoneConfig upserts a subzone config into the given zone config
+	// for a descriptor ID.
 	UpdateSubzoneConfig(
 		ctx context.Context,
-		tableID descpb.ID,
-		subzones []zonepb.Subzone,
+		parentZone catalog.ZoneConfig,
+		subzone zonepb.Subzone,
 		subzoneSpans []zonepb.SubzoneSpan,
-	) error
+	) (catalog.ZoneConfig, error)
 
 	// DeleteZoneConfig deletes the zone config for a descriptor.
 	DeleteZoneConfig(ctx context.Context, id descpb.ID) error

--- a/pkg/sql/schemachanger/scexec/mocks_generated_test.go
+++ b/pkg/sql/schemachanger/scexec/mocks_generated_test.go
@@ -260,11 +260,12 @@ func (mr *MockCatalogMockRecorder) UpdateComment(arg0, arg1, arg2 interface{}) *
 }
 
 // UpdateSubzoneConfig mocks base method.
-func (m *MockCatalog) UpdateSubzoneConfig(arg0 context.Context, arg1 catid.DescID, arg2 []zonepb.Subzone, arg3 []zonepb.SubzoneSpan) error {
+func (m *MockCatalog) UpdateSubzoneConfig(arg0 context.Context, arg1 catalog.ZoneConfig, arg2 zonepb.Subzone, arg3 []zonepb.SubzoneSpan) (catalog.ZoneConfig, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSubzoneConfig", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(catalog.ZoneConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // UpdateSubzoneConfig indicates an expected call of UpdateSubzoneConfig.

--- a/pkg/sql/schemachanger/scexec/mocks_generated_test.go
+++ b/pkg/sql/schemachanger/scexec/mocks_generated_test.go
@@ -143,6 +143,21 @@ func (mr *MockCatalogMockRecorder) GetFullyQualifiedName(arg0, arg1 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFullyQualifiedName", reflect.TypeOf((*MockCatalog)(nil).GetFullyQualifiedName), arg0, arg1)
 }
 
+// GetZoneConfig mocks base method.
+func (m *MockCatalog) GetZoneConfig(arg0 context.Context, arg1 catid.DescID) (catalog.ZoneConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetZoneConfig", arg0, arg1)
+	ret0, _ := ret[0].(catalog.ZoneConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetZoneConfig indicates an expected call of GetZoneConfig.
+func (mr *MockCatalogMockRecorder) GetZoneConfig(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetZoneConfig", reflect.TypeOf((*MockCatalog)(nil).GetZoneConfig), arg0, arg1)
+}
+
 // InitializeSequence mocks base method.
 func (m *MockCatalog) InitializeSequence(arg0 catid.DescID, arg1 int64) {
 	m.ctrl.T.Helper()
@@ -284,6 +299,20 @@ func (m *MockCatalog) Validate(arg0 context.Context) error {
 func (mr *MockCatalogMockRecorder) Validate(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockCatalog)(nil).Validate), arg0)
+}
+
+// WriteZoneConfigToBatch mocks base method.
+func (m *MockCatalog) WriteZoneConfigToBatch(arg0 context.Context, arg1 catid.DescID, arg2 catalog.ZoneConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteZoneConfigToBatch", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WriteZoneConfigToBatch indicates an expected call of WriteZoneConfigToBatch.
+func (mr *MockCatalogMockRecorder) WriteZoneConfigToBatch(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteZoneConfigToBatch", reflect.TypeOf((*MockCatalog)(nil).WriteZoneConfigToBatch), arg0, arg1, arg2)
 }
 
 // MockDependencies is a mock of Dependencies interface.

--- a/pkg/sql/schemachanger/scexec/scmutationexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/dependencies.go
@@ -83,7 +83,9 @@ type ImmediateMutationStateUpdater interface {
 
 	// UpdateSubzoneConfig upserts a subzone config.
 	UpdateSubzoneConfig(
-		tableid descpb.ID, subzone zonepb.Subzone, subzoneSpans []zonepb.SubzoneSpan,
+		tableid descpb.ID,
+		subzone zonepb.Subzone,
+		subzoneSpans []zonepb.SubzoneSpan,
 	)
 
 	// DeleteZoneConfig deletes the zone config for the given ID.

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -789,8 +789,6 @@ message IndexZoneConfig {
   uint32 table_id = 1 [(gogoproto.customname) = "TableID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
   uint32 index_id = 2 [(gogoproto.customname) = "IndexID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.IndexID"];
   cockroach.config.zonepb.Subzone subzone = 3 [(gogoproto.nullable) = false];
-  // `subzone_spans` is used solely for zone config writes. These spans are
-  // recreated for the table zone config during each configuration change.
   repeated cockroach.config.zonepb.SubzoneSpan subzone_spans = 4 [(gogoproto.nullable) = false];
   // `seq_num` is used to differentiate different subzone config elements tied
   // to the same index. E.g. If we attempt to update an index subzone config,
@@ -804,8 +802,6 @@ message PartitionZoneConfig {
   uint32 index_id = 2 [(gogoproto.customname) = "IndexID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.IndexID"];
   string partition_name = 3;
   cockroach.config.zonepb.Subzone subzone = 4 [(gogoproto.nullable) = false];
-  // `subzone_spans` is used solely for zone config writes. These spans are
-  // recreated for the table zone config during each configuration change.
   repeated cockroach.config.zonepb.SubzoneSpan subzone_spans = 5 [(gogoproto.nullable) = false];
   // `seq_num` is used to differentiate different subzone config elements tied
   // to the same partition. E.g. If we attempt to update a partition's subzone

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_index_zone_config.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_index_zone_config.go
@@ -16,7 +16,6 @@ func init() {
 			scpb.Status_ABSENT,
 			to(scpb.Status_PUBLIC,
 				emit(func(this *scpb.IndexZoneConfig) *scop.AddIndexZoneConfig {
-
 					return &scop.AddIndexZoneConfig{
 						TableID:      this.TableID,
 						Subzone:      this.Subzone,


### PR DESCRIPTION
### config/zonepb: add subzoneSpan-related methods
This patch adds subzoneSpan-related methods that aid in configuring
subzone zcs in the declarative schemachanger.

Epic: none

Release note: None

---

### schemachanger: extend Catalog interface to support subzone writes
This patch extends the `Catalog` interface to support getting and
writing a zone config. This is necessary for us to be able to get
the parent zone config, apply all subzone changes, and then write
to kv in `immediateState`.

Epic: none

Release note: None

---

### schemachanger: refactor subzone config elements
This patch refactors how subzoneSpans are handled in the declarative schema changer. We now filter out subzoneSpans that do not relate to the index/partition zone config element it is nested within. This makes discarding these subzone elements feasible.

In order to support zone config changes where the target's subzone spans -- along with other targets' subzone spans -- are modified, we make those changes a side-effect. That is:

```
...
ALTER PARTITION default OF TABLE db.person CONFIGURE ZONE USING gc.ttlseconds = 1;
-> PartitionZoneConfig{default}

ALTER PARTITION australia OF TABLE db.person CONFIGURE ZONE USING gc.ttlseconds = 2;
-> PartitionZoneConfig{default}
and
-> PartitionZoneConfig{australia}
```

Informs: #133158 
Epic: none

Release note: None

---

### schemachanger: refactor add/drop zc elements
This patch separates marking zc elements as dropped from
the add direction in the builder as subzone configs will have
a mixed state of drop subzone + add side effects.

Epic: none

Release note: None