### PR TITLE
crosscluster/producer: flush at lower threshold if consumer is ready

### DIFF
--- a/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_writer_processor.go
@@ -133,7 +133,7 @@ var batchSizeSetting = settings.RegisterByteSizeSetting(
 	settings.ApplicationLevel,
 	"logical_replication.stream_batch_size",
 	"target batch size for logical replication stream",
-	1<<20,
+	16<<20,
 )
 
 func newLogicalReplicationWriterProcessor(


### PR DESCRIPTION
This patch allows the event stream to flush at a lower buffer threshold if the consumer is ready for more work. If a consumer is waiting around for more work, the producer should give them more work to keep consumer busy.

If the consumer is not ready, the event stream will buffer to a higher threshold, preventing a flush from blocking rangefeeds, inducing catchup scans.

Epic: none

Release note: none