### PR TITLE
sql/stats: silence noisy autostats log message

### DIFF
--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -984,7 +984,9 @@ func (r *Refresher) refreshStats(
 		usingExtremes,
 	)
 
-	log.Infof(ctx, "automatically executing %q", stmt)
+	if log.ExpensiveLogEnabled(ctx, 1) {
+		log.Infof(ctx, "automatically executing %q", stmt)
+	}
 	_ /* rows */, err := r.internalDB.Executor().Exec(
 		ctx,
 		"create-stats",


### PR DESCRIPTION
We currently only allow a single automatic stats collection at a time. If a stats collection is running for a long time, any queued automatic stats collections will log the following message once a minute:

```
automatically executing "CREATE STATISTICS __auto__ FROM [... "
```

This is expected, but we don't need to fill the logs with this message. Let's only log it if verbose logging is enabled.

Epic: None

Release note: None