### PR TITLE
sql/logictest: fix NPE in logic tests after error in testcluster setup

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1425,7 +1425,9 @@ func (t *logicTest) handleWaitForInitErr(ts testserver.TestServer, err error) {
 		if walkErr != nil {
 			t.t().Logf("error while walking logs directory: %v", walkErr)
 		} else if foundSnappyErr {
-			ts.Stop()
+			if ts != nil {
+				ts.Stop()
+			}
 			t.t().Skip("ignoring init did not finish for node error due to snappy error")
 		}
 	}


### PR DESCRIPTION
This commit adds a nil-check for the `testserver.TestServer` in `handleWaitForInitErr` before attempting to close the test server.

Fixes #133614

Release note: None