### PR TITLE
kvclient/rangefeed: fix rangefeed restart metrics

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -548,8 +548,6 @@ type rangefeedErrorInfo struct {
 func handleRangefeedError(
 	ctx context.Context, metrics *DistSenderRangeFeedMetrics, err error, spawnedFromManualSplit bool,
 ) (rangefeedErrorInfo, error) {
-	metrics.Errors.RangefeedRestartRanges.Inc(1)
-
 	if err == nil {
 		return rangefeedErrorInfo{}, nil
 	}


### PR DESCRIPTION
Previously, we bump the metrics in restartActiveRangefeed
and again in handleRangefeedError. This patch addresses
the issue of double counting metrics during rangefeed
restarts.

Informs: https://github.com/cockroachdb/cockroach/issues/129486
Release note: fixed a metrics bug in rangefeed restarts
introduced since v23.2