### PR TITLE
release-23.1: opt/exec/explain: gracefully handle decoding negative integers

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
@@ -196,3 +196,9 @@ query T nosort
 SELECT crdb_internal.decode_external_plan_gist('Ag8f')
 ----
 • union all
+
+# Regression test for #133015. Gracefully handle decoding negative integers.
+query T
+SELECT crdb_internal.decode_external_plan_gist('Aifvzn5p':::STRING)
+----
+• create view

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -329,6 +329,9 @@ func (f *PlanGistFactory) encodeNodeColumnOrdinals(vals []exec.NodeColumnOrdinal
 
 func (f *PlanGistFactory) decodeNodeColumnOrdinals() []exec.NodeColumnOrdinal {
 	l := f.decodeInt()
+	if l < 0 {
+		return nil
+	}
 	vals := make([]exec.NodeColumnOrdinal, l)
 	return vals
 }
@@ -339,6 +342,9 @@ func (f *PlanGistFactory) encodeResultColumns(vals colinfo.ResultColumns) {
 
 func (f *PlanGistFactory) decodeResultColumns() colinfo.ResultColumns {
 	numCols := f.decodeInt()
+	if numCols < 0 {
+		return nil
+	}
 	return make(colinfo.ResultColumns, numCols)
 }
 
@@ -461,6 +467,9 @@ func (f *PlanGistFactory) encodeRows(rows [][]tree.TypedExpr) {
 
 func (f *PlanGistFactory) decodeRows() [][]tree.TypedExpr {
 	numRows := f.decodeInt()
+	if numRows < 0 {
+		return nil
+	}
 	return make([][]tree.TypedExpr, numRows)
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #133245.

/cc @cockroachdb/release

---

Fixes #133015

Release note: None

---

Release justification: Low-risk bug fix.