### PR TITLE
roachtest: add tpcc ldr roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -216,6 +216,7 @@ type replicateTPCC struct {
 	warehouses     int
 	duration       time.Duration
 	repairOrderIDs bool
+	tolerateErrors bool
 }
 
 func (tpcc replicateTPCC) sourceInitCmd(tenantName string, nodes option.NodeListOption) string {
@@ -227,11 +228,10 @@ func (tpcc replicateTPCC) sourceInitCmd(tenantName string, nodes option.NodeList
 }
 
 func (tpcc replicateTPCC) sourceRunCmd(tenantName string, nodes option.NodeListOption) string {
-	// added --tolerate-errors flags to prevent test from flaking due to a transaction retry error
 	cmd := roachtestutil.NewCommand(`./cockroach workload run tpcc`).
 		Flag("warehouses", tpcc.warehouses).
 		MaybeFlag(tpcc.duration > 0, "duration", tpcc.duration).
-		Option("tolerate-errors").
+		MaybeOption(tpcc.tolerateErrors, "tolerate-errors").
 		MaybeOption(tpcc.repairOrderIDs, "repair-order-ids").
 		Arg("{pgurl%s:%s}", nodes, tenantName).
 		WithEqualsSyntax()
@@ -1122,11 +1122,8 @@ func registerClusterToCluster(r registry.Registry) {
 			dstNodes:  4,
 			cpus:      8,
 			pdSize:    1000,
-			// 500 warehouses adds 30 GB to source
-			//
-			// TODO(msbutler): increase default test to 1000 warehouses once fingerprinting
-			// job speeds up.
-			workload:           replicateTPCC{warehouses: 1000},
+
+			workload:           replicateTPCC{warehouses: 1000, tolerateErrors: true},
 			timeout:            3 * time.Hour,
 			additionalDuration: 60 * time.Minute,
 			cutover:            30 * time.Minute,

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -213,8 +213,9 @@ func defaultWorkloadDriver(
 }
 
 type replicateTPCC struct {
-	warehouses int
-	duration   time.Duration
+	warehouses     int
+	duration       time.Duration
+	repairOrderIDs bool
 }
 
 func (tpcc replicateTPCC) sourceInitCmd(tenantName string, nodes option.NodeListOption) string {
@@ -231,7 +232,9 @@ func (tpcc replicateTPCC) sourceRunCmd(tenantName string, nodes option.NodeListO
 		Flag("warehouses", tpcc.warehouses).
 		MaybeFlag(tpcc.duration > 0, "duration", tpcc.duration).
 		Option("tolerate-errors").
-		Arg("{pgurl%s:%s}", nodes, tenantName)
+		MaybeOption(tpcc.repairOrderIDs, "repair-order-ids").
+		Arg("{pgurl%s:%s}", nodes, tenantName).
+		WithEqualsSyntax()
 	return cmd.String()
 }
 


### PR DESCRIPTION
This new roachtest runs a bidirectional replication stream on the tpcc
workload.  At stream start time, the left database has 10 warehouses, which
translates to a 1 GB initial scan, and the right has 1 warehouse. A 500
warehouse workload is run on the databases in steady state for a 10 minutes.

Epic: none

Release note: none