### PR TITLE
roachtest: add cs op to toggle automatic table metadata job

### DIFF
--- a/pkg/cmd/roachtest/operations/cluster_settings.go
+++ b/pkg/cmd/roachtest/operations/cluster_settings.go
@@ -92,6 +92,12 @@ func registerClusterSettings(r registry.Registry) {
 			}),
 			Owner: registry.OwnerStorage,
 		},
+		{
+			// Observe if there is any unexpected impact with running the job periodically.
+			Name:      "obs.tablemetadata.automatic_updates.enabled",
+			Generator: timeBasedValues(timeutil.Now, []string{"true", "false"}, 12*time.Hour),
+			Owner:     registry.OwnerObservability,
+		},
 	}
 	sanitizeOpName := func(name string) string {
 		return strings.ReplaceAll(name, ".", "_")


### PR DESCRIPTION
This commit adds a roachtest operation that toggles automatic runs of the update table metadata job, which collects and writes information about storage statistics for all tables in the cluster.

Epic: none

Release note: None