### PR TITLE
raft: enable store liveness in raft unit tests phase 2

### DIFF
--- a/pkg/raft/raftstoreliveness/mock_store_liveness.go
+++ b/pkg/raft/raftstoreliveness/mock_store_liveness.go
@@ -194,10 +194,22 @@ type LivenessFabric struct {
 
 // NewLivenessFabric initializes and returns a LivenessFabric.
 func NewLivenessFabric() *LivenessFabric {
+	return NewLivenessFabricWithPeers()
+}
+
+// NewLivenessFabricWithPeers initializes and returns a LivenessFabric with the
+// given peer IDs provided.
+func NewLivenessFabricWithPeers(peers ...pb.PeerID) *LivenessFabric {
 	state := make(map[pb.PeerID]*MockStoreLiveness)
-	return &LivenessFabric{
+	fabric := &LivenessFabric{
 		state: state,
 	}
+
+	for _, peer := range peers {
+		fabric.AddPeer(peer)
+	}
+
+	return fabric
 }
 
 // AddPeer adds a peer to the liveness fabric.


### PR DESCRIPTION
This commit modifies the following tests to allow them to run in both
store liveness enabled/disabled configurations:

1) TestPreVoteMigrationCanCompleteElection
2) TestPreVoteMigrationWithFreeStuckPreCandidate
3) TestAddNodeCheckQuorum
4) TestCandidateResetTermMsgHeartbeat
5) TestCandidateResetTermMsgApp

Note that these tests create their own Raft instances instead of relying
on the network te create ones.

References: https://github.com/cockroachdb/cockroach/issues/132241

Release note: None