### PR TITLE
catalog/replication: deflake TestReaderCatalogTSAdvance

### DIFF
--- a/pkg/sql/catalog/replication/BUILD.bazel
+++ b/pkg/sql/catalog/replication/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/sql",
+        "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/lease",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",


### PR DESCRIPTION
Previously, we added a new test to TestReaderCatalogTSAdvance to disable AOST timestamps for reader catalogs and confirm errors were surfaced by the leasing subsystem when timestamps are mixed. This test relied on a fixed number of iterations to reproduce this error, which wasn't reliable. To address this, this patch will use a lease manager hook to cause descriptor updates to be partially be picked up when the AOST is disabled. This ensures the scenario is encountered without extra iterations.

Fixes: #133897
Fixes: #133902

Release note: None