### PR TITLE
sql: deflake TestStatementTimeoutForSchemaChangeCommit

### DIFF
--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -1016,6 +1016,10 @@ func TestStatementTimeoutForSchemaChangeCommit(t *testing.T) {
 				require.NoError(t, err)
 				// Test implicit transactions first.
 				blockSchemaChange.Swap(true)
+				defer func() {
+					close(waitForTimeout)
+					blockSchemaChange.Swap(false)
+				}()
 				if implicitTxn {
 					_, err := conn.DB.ExecContext(ctx, "ALTER TABLE t1 ADD COLUMN j INT DEFAULT 32")
 					require.ErrorContains(t, err, sqlerrors.QueryTimeoutError.Error())
@@ -1030,8 +1034,6 @@ func TestStatementTimeoutForSchemaChangeCommit(t *testing.T) {
 					err = txn.Commit()
 					require.NoError(t, err)
 				}
-				close(waitForTimeout)
-				blockSchemaChange.Swap(false)
 			})
 	}
 }


### PR DESCRIPTION
Now we release the lock in a defer so that the test can't hang during shutdown.

fixes https://github.com/cockroachdb/cockroach/issues/133397
Release note: None