### PR TITLE
builtins: populate cast builtin overloads deterministically

### DIFF
--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -8,6 +8,7 @@ package builtins
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -176,8 +177,16 @@ func init() {
 			},
 		)
 	})
-	// Add casts between the same type.
-	for typOID, def := range castBuiltins {
+	// Add casts between the same type in deterministic order.
+	typOIDs := make([]oid.Oid, 0, len(castBuiltins))
+	for typOID := range castBuiltins {
+		typOIDs = append(typOIDs, typOID)
+	}
+	sort.Slice(typOIDs, func(i, j int) bool {
+		return typOIDs[i] < typOIDs[j]
+	})
+	for _, typOID := range typOIDs {
+		def := castBuiltins[typOID]
 		typ := types.OidToType[typOID]
 		if !shouldMakeFromCastBuiltin(typ) {
 			continue

--- a/pkg/sql/sem/cast/cast.go
+++ b/pkg/sql/sem/cast/cast.go
@@ -10,6 +10,8 @@
 package cast
 
 import (
+	"sort"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/lib/pq/oid"
@@ -128,14 +130,31 @@ type Cast struct {
 }
 
 // ForEachCast calls fn for every valid cast from a source type to a target
-// type.
+// type. Iteration order is deterministic.
 func ForEachCast(
 	fn func(
 		src oid.Oid, tgt oid.Oid, castCtx Context, ctxOrigin ContextOrigin, v volatility.V,
 	),
 ) {
-	for src, tgts := range castMap {
-		for tgt, cast := range tgts {
+	srcOids := make([]oid.Oid, 0, len(castMap))
+	for src := range castMap {
+		srcOids = append(srcOids, src)
+	}
+	sort.Slice(srcOids, func(i, j int) bool {
+		return srcOids[i] < srcOids[j]
+	})
+	var tgtOids []oid.Oid
+	for _, src := range srcOids {
+		tgts := castMap[src]
+		tgtOids = tgtOids[:0]
+		for tgt := range tgts {
+			tgtOids = append(tgtOids, tgt)
+		}
+		sort.Slice(tgtOids, func(i, j int) bool {
+			return tgtOids[i] < tgtOids[j]
+		})
+		for _, tgt := range tgtOids {
+			cast := tgts[tgt]
 			fn(src, tgt, cast.MaxContext, cast.origin, cast.Volatility)
 		}
 	}


### PR DESCRIPTION
This commit adjusts a couple of places where we populate the overloads of the cast builtin function to be in determinstic order. This will allow for easier reproduction of some tests that use sqlsmith. Note that there were other sources of non-determinism with `TestExplainGist` that I couldn't track down.

Fixes: #133430.

Release note: None