### PR TITLE
release-23.1: settings: redact all string settings for diagnostics

### DIFF
--- a/pkg/ccl/serverccl/diagnosticsccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/diagnosticsccl/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
     args = ["-test.timeout=295s"],
     deps = [
         "//pkg/base",
+        "//pkg/ccl",
         "//pkg/ccl/kvccl/kvtenantccl",
         "//pkg/clusterversion",
         "//pkg/config/zonepb",

--- a/pkg/ccl/serverccl/diagnosticsccl/main_test.go
+++ b/pkg/ccl/serverccl/diagnosticsccl/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
@@ -20,5 +21,6 @@ func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	kvtenantccl.InitConnectorFactory()
+	defer ccl.TestingEnableEnterprise()
 	os.Exit(m.Run())
 }

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -350,11 +350,15 @@ var ReadableTypes = map[string]string{
 }
 
 // RedactedValue returns:
-//   - a string representation of the value, if the setting is reportable (or it
-//     is a string setting with an empty value);
-//   - "<redacted>" if the setting is not reportable;
+//   - a string representation of the value, if the setting is reportable;
+//   - "<redacted>" if the setting is not reportable, or a string;
 //   - "<unknown>" if there is no setting with this name.
 func RedactedValue(name string, values *Values, forSystemTenant bool) string {
+	if k, ok := registry[name]; ok {
+		if k.Typ() == "s" || !k.isReportable() {
+			return "<redacted>"
+		}
+	}
 	if setting, ok := LookupForReporting(name, forSystemTenant); ok {
 		return setting.String(values)
 	}


### PR DESCRIPTION
Backport 1/1 commits from #133754.

/cc @cockroachdb/release

---

Previously, the redaction logic for `Sensitive` settings in the diagnotics payload was conditional on the value of the `"server.redact_sensitive_settings.enabled"` cluster setting.

This commit modifies the behavior of `RedactedValue` used to render modified cluster settings by the `diagnostics` package to always fully redact the values of string settings and any sensitive or non- reportable settings.

Because the `MaskedSetting` struct is now in use by code in the `SHOW CLUSTER SETTING` code path, we no longer rely on it for redaction behavior of string settings.

Resolves: CRDB-43457
Epic: None

Release note (security update): all cluster settings that accept strings are now fully redacted when transmitted as part of our diagnostics telemetry. This payload includes a record of modified cluster settings and their values when they are not strings. Customers who previously applied the mitigations in Technical Advisory 133479 can safely set the value of cluster setting `server.redact_sensitive_settings.enabled` to false and turn on diagnostic reporting via the `diagnostics.reporting.enabled` cluster setting without leaking sensitive cluster settings values.

---
# Note: "sensitive" settings were introduced in 23.2 so this backport will affect non-reportable and string settings for 23.1

Release justification: removing sensitive data from diagnostics output.