### PR TITLE
scripts: update check-pebble-dep.sh

### DIFF
--- a/scripts/check-pebble-dep.sh
+++ b/scripts/check-pebble-dep.sh
@@ -9,8 +9,7 @@
 set -euo pipefail
 #set -x
 
-RELEASES="23.1 23.2 24.1 master"
-
+RELEASES="23.1 23.2 24.1 24.2 24.3 master"
 
 for REL in $RELEASES; do
   if [ "$REL" == "master" ]; then


### PR DESCRIPTION
Update script to check 24.2 and 24.3 branches as well.

Epic: none
Release note: None