### PR TITLE
release-24.2: server, ui: tweak language for throttling, remove obsolete alerts, add test probe

### DIFF
--- a/pkg/server/license/enforcer.go
+++ b/pkg/server/license/enforcer.go
@@ -340,6 +340,11 @@ func (e *Enforcer) GetTelemetryDeadline() (deadline, lastPing time.Time, ok bool
 
 	ptr := e.telemetryStatusReporter.Load()
 	lastTelemetryDataReceived := (*ptr).GetLastSuccessfulTelemetryPing()
+	pingOverrideForTesting := envutil.EnvOrDefaultInt64("COCKROACH_LAST_SUCCESSFUL_TELEMETRY_PING", lastTelemetryDataReceived.Unix())
+	if pingOverrideForTesting < lastTelemetryDataReceived.Unix() {
+		lastTelemetryDataReceived = timeutil.Unix(pingOverrideForTesting, 0)
+	}
+
 	throttleTS := lastTelemetryDataReceived.Add(e.getMaxTelemetryInterval())
 	return throttleTS, lastTelemetryDataReceived, true
 }

--- a/pkg/ui/workspaces/db-console/src/redux/alerts.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/alerts.spec.ts
@@ -11,7 +11,6 @@ import Long from "long";
 import * as protos from "src/js/protos";
 import { cockroach } from "src/js/protos";
 import { API_PREFIX } from "src/util/api";
-import { setDataFromServer } from "src/util/dataFromServer";
 import fetchMock from "src/util/fetch-mock";
 import { versionsSelector } from "src/redux/nodes";
 
@@ -29,12 +28,10 @@ import {
   emailSubscriptionAlertSelector,
   clusterPreserveDowngradeOptionDismissedSetting,
   clusterPreserveDowngradeOptionOvertimeSelector,
-  licenseUpdateNotificationSelector,
 } from "./alerts";
 import {
   VERSION_DISMISSED_KEY,
   INSTRUCTIONS_BOX_COLLAPSED_KEY,
-  LICENSE_UPDATE_DISMISSED_KEY,
   setUIDataKey,
   isInFlight,
 } from "./uiData";
@@ -253,31 +250,6 @@ describe("alerts", function () {
         const numAlert = staggeredVersionWarningSelector(state());
         numAlert.dismiss(dispatch, state);
         expect(staggeredVersionDismissedSetting.selector(state())).toBe(true);
-      });
-    });
-
-    describe("licence update notification", function () {
-      it("displays the alert when nothing is done", function () {
-        dispatch(setUIDataKey(LICENSE_UPDATE_DISMISSED_KEY, null));
-        const alert = licenseUpdateNotificationSelector(state());
-        expect(typeof alert).toBe("object");
-        expect(alert.level).toEqual(AlertLevel.INFORMATION);
-        expect(alert.text).toEqual(
-          "Important changes to CockroachDB’s licensing model.",
-        );
-      });
-
-      it("hides the alert when dismissed timestamp is present", function () {
-        dispatch(setUIDataKey(LICENSE_UPDATE_DISMISSED_KEY, moment()));
-        expect(licenseUpdateNotificationSelector(state())).toBeUndefined();
-      });
-
-      it("hides the alert when license is enterprise", function () {
-        dispatch(setUIDataKey(LICENSE_UPDATE_DISMISSED_KEY, null));
-        setDataFromServer({
-          LicenseType: "Enterprise",
-        } as any);
-        expect(licenseUpdateNotificationSelector(state())).toBeUndefined();
       });
     });
 
@@ -653,7 +625,6 @@ describe("alerts", function () {
       );
       dispatch(setUIDataKey(VERSION_DISMISSED_KEY, "blank"));
       dispatch(setUIDataKey(INSTRUCTIONS_BOX_COLLAPSED_KEY, false));
-      dispatch(setUIDataKey(LICENSE_UPDATE_DISMISSED_KEY, moment()));
       dispatch(
         versionReducerObj.receiveData({
           details: [],

--- a/pkg/ui/workspaces/db-console/src/redux/alerts.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/alerts.ts
@@ -30,7 +30,6 @@ import { getDataFromServer } from "../util/dataFromServer";
 
 import { LocalSetting } from "./localsettings";
 import {
-  LICENSE_UPDATE_DISMISSED_KEY,
   VERSION_DISMISSED_KEY,
   INSTRUCTIONS_BOX_COLLAPSED_KEY,
   saveUIData,
@@ -703,85 +702,6 @@ export const licenseUpdateDismissedLocalSetting = new LocalSetting(
   moment(0),
 );
 
-const licenseUpdateDismissedPersistentLoadedSelector = createSelector(
-  (state: AdminUIState) => state.uiData,
-  uiData =>
-    uiData &&
-    Object.prototype.hasOwnProperty.call(uiData, LICENSE_UPDATE_DISMISSED_KEY),
-);
-
-const licenseUpdateDismissedPersistentSelector = createSelector(
-  (state: AdminUIState) => state.uiData,
-  uiData => moment(uiData?.[LICENSE_UPDATE_DISMISSED_KEY]?.data ?? 0),
-);
-
-export const licenseUpdateNotificationSelector = createSelector(
-  licenseTypeSelector,
-  licenseUpdateDismissedLocalSetting.selector,
-  licenseUpdateDismissedPersistentSelector,
-  licenseUpdateDismissedPersistentLoadedSelector,
-  (
-    licenseType,
-    licenseUpdateDismissed,
-    licenseUpdateDismissedPersistent,
-    licenseUpdateDismissedPersistentLoaded,
-  ): Alert => {
-    // If customer has Enterprise license they don't need to worry about this.
-    if (licenseType === "Enterprise") {
-      return undefined;
-    }
-
-    // If the notification has been dismissed based on the session storage
-    // timestamp, don't show it.'
-    //
-    // Note: `licenseUpdateDismissed` is wrapped in `moment()` because
-    // the local storage selector won't convert it back from a string.
-    // We omit fixing that here since this change is being backported
-    // to many versions.
-    if (moment(licenseUpdateDismissed).isAfter(moment(0))) {
-      return undefined;
-    }
-
-    // If the notification has been dismissed based on the uiData
-    // storage in the cluster, don't show it. Note that this is
-    // different from how version upgrade notifications work, this one
-    // is dismissed forever and won't return even if you upgrade
-    // further or time passes.
-    if (
-      licenseUpdateDismissedPersistentLoaded &&
-      licenseUpdateDismissedPersistent &&
-      licenseUpdateDismissedPersistent.isAfter(moment(0))
-    ) {
-      return undefined;
-    }
-
-    return {
-      level: AlertLevel.INFORMATION,
-      title: "Coming November 18, 2024",
-      text: "Important changes to CockroachDB’s licensing model.",
-      link: docsURL.enterpriseLicenseUpdate,
-      dismiss: (dispatch: any) => {
-        const dismissedAt = moment();
-        // Note(davidh): I haven't been able to find historical context
-        // for why some alerts have both a "local" and a "persistent"
-        // dismissal. My thinking is that just the persistent dismissal
-        // should be adequate, but I'm preserving that behavior here to
-        // match the version upgrade notification.
-
-        // Dismiss locally.
-        dispatch(licenseUpdateDismissedLocalSetting.set(dismissedAt));
-        // Dismiss persistently.
-        return dispatch(
-          saveUIData({
-            key: LICENSE_UPDATE_DISMISSED_KEY,
-            value: dismissedAt.valueOf(),
-          }),
-        );
-      },
-    };
-  },
-);
-
 /**
  * Selector which returns an array of all active alerts which should be
  * displayed in the overview list page, these should be non-critical alerts.
@@ -791,7 +711,6 @@ export const overviewListAlertsSelector = createSelector(
   staggeredVersionWarningSelector,
   clusterPreserveDowngradeOptionOvertimeSelector,
   upgradeNotFinalizedWarningSelector,
-  licenseUpdateNotificationSelector,
   (...alerts: Alert[]): Alert[] => {
     return without(alerts, null, undefined);
   },
@@ -870,7 +789,6 @@ export function alertDataSync(store: Store<AdminUIState>) {
       const keysToMaybeLoad = [
         VERSION_DISMISSED_KEY,
         INSTRUCTIONS_BOX_COLLAPSED_KEY,
-        LICENSE_UPDATE_DISMISSED_KEY,
       ];
       const keysToLoad = filter(keysToMaybeLoad, key => {
         return !(has(uiData, key) || isInFlight(state, key));

--- a/pkg/ui/workspaces/db-console/src/redux/uiData.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/uiData.ts
@@ -57,11 +57,6 @@ export class OptInAttributes {
 // was last dismissed.
 export const VERSION_DISMISSED_KEY = "version_dismissed";
 
-// LICENSE_UPDATE_DISMISSED_KEY is the uiData key on the server that tracks when the licence
-// update banner was last dismissed. This banner notifies the user that we've changed our
-// licensing if they're deployed without an active license.
-export const LICENSE_UPDATE_DISMISSED_KEY = "license_update_dismissed";
-
 // INSTRUCTIONS_BOX_COLLAPSED_KEY is the uiData key on the server that tracks whether the
 // instructions box on the cluster viz has been collapsed or not.
 export const INSTRUCTIONS_BOX_COLLAPSED_KEY =

--- a/pkg/ui/workspaces/db-console/src/util/docs.ts
+++ b/pkg/ui/workspaces/db-console/src/util/docs.ts
@@ -59,8 +59,6 @@ export let licensingFaqs: string;
 export let throttlingFaqs: string;
 // Note that these explicitly don't use the current version, since we want to
 // link to the most up-to-date documentation available.
-export const enterpriseLicenseUpdate =
-  "https://www.cockroachlabs.com/enterprise-license-update/";
 export const upgradeCockroachVersion =
   "https://www.cockroachlabs.com/docs/stable/upgrade-cockroach-version.html";
 export const enterpriseLicensing =

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.spec.tsx
@@ -75,7 +75,7 @@ describe("AlertBar", () => {
 
     expect(wrapper.text()).toContain(
       "Your license key expired on September 15th, 2024. " +
-        `The cluster will be throttled on ${gracePeriodEnd.format("MMMM Do, YYYY")} unless the license is renewed. Learn more`,
+        `The cluster will be throttled on ${gracePeriodEnd.format("MMMM Do, YYYY")} unless a new license key is added. Learn more`,
     );
   });
 

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/alertBar/alertBar.tsx
@@ -131,8 +131,8 @@ export const AlertBar = ({
         <div className={cx("alert-bar", "alert--warning")}>
           Your license key expired on{" "}
           {licenseExpiryDate.format("MMMM Do, YYYY")}. The cluster will be
-          throttled on {gracePeriodEnd.format("MMMM Do, YYYY")} unless the
-          license is renewed. <a href={throttlingFaqs}>Learn more</a>
+          throttled on {gracePeriodEnd.format("MMMM Do, YYYY")} unless a new
+          license key is added. <a href={throttlingFaqs}>Learn more</a>
         </div>
       );
     }


### PR DESCRIPTION
Backport 3/3 commits from #133863.

/cc @cockroachdb/release

---

_Note: these 3 small changes are grouped for easy review + backporting_

----

[server: allow env var override for telemetry ping](https://github.com/cockroachdb/cockroach/commit/6f44b589f9c3978ce092cc0e94a008a8f2a3ffca) 

When testing the license throttling behavior, it's helpful to easily
override the telemetry ping timestamp. This timestamp will only be
accepted if it's smaller than the current recorded timestamp, which
reduces the chance that this ability can be used to extend the grace
period.

Epic: [CRDB-40209](https://cockroachlabs.atlassian.net/browse/CRDB-40209)
Release note: None
@[dhartunian](https://github.com/cockroachdb/cockroach/commits?author=dhartunian)
dhartunian committed 2 minutes ago

----
[ui: tweak license expiration text for throttle bar](https://github.com/cockroachdb/cockroach/commit/be48767a6108b8a98dbc01615e47e387ac62b783) 

Instead of asking a user to "renew" we tell them to "add" a new
license, which matches other language we've used.

Epic: [CRDB-40853](https://cockroachlabs.atlassian.net/browse/CRDB-40853)
Release note: None
@[dhartunian](https://github.com/cockroachdb/cockroach/commits?author=dhartunian)
dhartunian committed 1 minute ago

----
[ui: remove core deprecation notification](https://github.com/cockroachdb/cockroach/commit/3190cf8d2bf4c292c4afcddfade03c84612498c3) 

Prior to 24.3 release, we added a notification in the DB Console to
alert customers to the licensing changes and give them time to
prepare. Now that they'll be rolling out, the notice is removed since
it's no longer in the future.

Epic: [CRDB-40853](https://cockroachlabs.atlassian.net/browse/CRDB-40853)
Release note: None

----
Release justification: part of core deprecation work