### PR TITLE
roachtest: increase timeout for cdc/bank roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -2296,7 +2296,7 @@ func registerCDC(r registry.Registry) {
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		RequiresLicense:  true,
-		Timeout:          30 * time.Minute,
+		Timeout:          60 * time.Minute,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runCDCBank(ctx, t, c)
 		},


### PR DESCRIPTION
Validation sometimes takes longer than the current timeout to complete. Increasing the test timeout until we can improve the performance of the test validation.

Epic: none
Fixes: #134025
Fixes: #133936
Fixes: #133921
Fixes: #133799

Release note: None