### PR TITLE
props: handle 1-to-many mapping in FuncDepSet.RemapFrom

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/set
+++ b/pkg/sql/opt/memo/testdata/logprops/set
@@ -669,3 +669,74 @@ intersect-all
       ├── fd: (5)-->(6)
       ├── prune: (5,6)
       └── interesting orderings: (+5)
+
+# Regression test for #133221: if a column with an equivalency is remapped more
+# than once, create a new equivalency for each remapping.
+norm
+SELECT * FROM (SELECT x, x, COALESCE(NULL, x) FROM xy) INTERSECT VALUES (1, 2, 3);
+----
+intersect-all
+ ├── columns: x:9(int!null) x:10(int!null) coalesce:11(int!null)
+ ├── left columns: xy.x:1(int) xy.x:1(int) coalesce:5(int)
+ ├── right columns: column1:6(int) column2:7(int) column3:8(int)
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(9-11), (11)==(9,10), (9)==(10,11), (10)==(9,11)
+ ├── interesting orderings: (+(9|10|11))
+ ├── project
+ │    ├── columns: coalesce:5(int!null) xy.x:1(int!null)
+ │    ├── key: (1)
+ │    ├── fd: (1)==(5), (5)==(1)
+ │    ├── prune: (1,5)
+ │    ├── interesting orderings: (+(1|5))
+ │    ├── scan xy
+ │    │    ├── columns: xy.x:1(int!null)
+ │    │    ├── key: (1)
+ │    │    ├── prune: (1)
+ │    │    └── interesting orderings: (+1)
+ │    └── projections
+ │         └── variable: xy.x:1 [as=coalesce:5, type=int, outer=(1)]
+ └── values
+      ├── columns: column1:6(int!null) column2:7(int!null) column3:8(int!null)
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(6-8)
+      ├── prune: (6-8)
+      └── tuple [type=tuple{int, int, int}]
+           ├── const: 1 [type=int]
+           ├── const: 2 [type=int]
+           └── const: 3 [type=int]
+
+norm
+SELECT * FROM (SELECT x, x, COALESCE(NULL, x) FROM xy) EXCEPT VALUES (1, 2, 3);
+----
+except-all
+ ├── columns: x:9(int!null) x:10(int!null) coalesce:11(int!null)
+ ├── left columns: xy.x:1(int) xy.x:1(int) coalesce:5(int)
+ ├── right columns: column1:6(int) column2:7(int) column3:8(int)
+ ├── key: (10)
+ ├── fd: (11)==(9,10), (9)==(10,11), (10)==(9,11)
+ ├── interesting orderings: (+(9|10|11))
+ ├── project
+ │    ├── columns: coalesce:5(int!null) xy.x:1(int!null)
+ │    ├── key: (1)
+ │    ├── fd: (1)==(5), (5)==(1)
+ │    ├── prune: (1,5)
+ │    ├── interesting orderings: (+(1|5))
+ │    ├── scan xy
+ │    │    ├── columns: xy.x:1(int!null)
+ │    │    ├── key: (1)
+ │    │    ├── prune: (1)
+ │    │    └── interesting orderings: (+1)
+ │    └── projections
+ │         └── variable: xy.x:1 [as=coalesce:5, type=int, outer=(1)]
+ └── values
+      ├── columns: column1:6(int!null) column2:7(int!null) column3:8(int!null)
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(6-8)
+      ├── prune: (6-8)
+      └── tuple [type=tuple{int, int, int}]
+           ├── const: 1 [type=int]
+           ├── const: 2 [type=int]
+           └── const: 3 [type=int]

--- a/pkg/sql/opt/memo/testdata/logprops/with
+++ b/pkg/sql/opt/memo/testdata/logprops/with
@@ -287,3 +287,16 @@ with &2 (cte)
       ├── prune: (10-12)
       └── cte-uses
            └── &2: count=1 used-columns=(3-5)
+
+# Regression test for #133221: if a column with an equivalency is remapped more
+# than once, create a new equivalency for each remapping.
+norm
+WITH foo AS (SELECT x, x, COALESCE(NULL, x) FROM xy) SELECT 1 FROM foo;
+----
+project
+ ├── columns: "?column?":9(int!null)
+ ├── fd: ()-->(9)
+ ├── prune: (9)
+ ├── scan xy
+ └── projections
+      └── const: 1 [as="?column?":9, type=int]

--- a/pkg/sql/opt/props/func_dep_test.go
+++ b/pkg/sql/opt/props/func_dep_test.go
@@ -1276,6 +1276,16 @@ func TestFuncDeps_RemapFrom(t *testing.T) {
 	to = opt.ColList{10, 30, 40, 50}
 	res.RemapFrom(abcde, from, to)
 	verifyFD(t, &res, "key(10); (10)-->(30,40,50)")
+
+	// Test a one-to-many relationship between remapped columns. An equality
+	// should be split into two, and the remapped key should be reduced.
+	eqFD := &props.FuncDepSet{}
+	eqFD.AddStrictKey(c(1, 2, 3), c(1, 2, 3))
+	eqFD.AddEquivalency(2, 3)
+	from = opt.ColList{1, 2, 2, 3}
+	to = opt.ColList{10, 30, 20, 50}
+	res.RemapFrom(eqFD, from, to)
+	verifyFD(t, &res, "key(10,50); (50)==(20,30), (20)==(30,50), (30)==(20,50)")
 }
 
 // Construct base table FD from figure 3.3, page 114:


### PR DESCRIPTION
Previously, `FuncDepSet.RemapFrom` could produce an invalid FD set if the remapping mapped a "from" column to more than one "to" column. This is possible in some cases for `WithScan`, `Intersect`, and `Except` operators. This commit fixes the bug by creating a new equivalence for each remapped column when there are multiple "to" columns.

This assertion is only checked in test builds, and the bug has not caused any known problems, so there is not release note.

Fixes #133221

Release note: None