### PR TITLE
release-24.3: cluster-ui: publish 24.3.0 cluster-ui pkg

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "24.3.0-prerelease.3",
+  "version": "24.3.0",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Publish 24.3.0 cluster-ui pkg to npm.

Epic: none
Fixes: #134096

Release justification: non production code changes