### PR TITLE
release-24.2: roachtest: small mvt test fixes

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2657,8 +2657,6 @@ func registerBackupMixedVersion(r registry.Registry) {
 			)
 			testRNG := mvt.RNG()
 
-			uploadCockroach(ctx, t, c, c.WorkloadNode(), clusterupgrade.CurrentVersion())
-
 			dbs := []string{"bank", "tpcc"}
 			backupTest, err := newMixedVersionBackup(t, c, c.CRDBNodes(), dbs)
 			if err != nil {

--- a/pkg/cmd/roachtest/tests/tpcc_test.go
+++ b/pkg/cmd/roachtest/tests/tpcc_test.go
@@ -21,6 +21,8 @@ func TestTPCCSupportedWarehouses(t *testing.T) {
 		buildVersion *version.Version
 		expected     int
 	}{
+		{spec.Local, spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v2.1.0`), 15},
+
 		{"gce", spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v2.1.0`), 1300},
 		{"gce", spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v19.1.0-rc.1`), 1250},
 		{"gce", spec.MakeClusterSpec(4, spec.CPU(16)), version.MustParse(`v19.1.0`), 1250},


### PR DESCRIPTION
Backport 1/1 commits from #133862.

/cc @cockroachdb/release

---

This change removes the unnecessary upload of the current cockroach binary in some tests, as the framework already uploads it to all nodes.

It also makes a small change to the tpcc/mixed-headroom test so it can be run locally.

Fixes: none
Epic: none
Release note: none

Release Justification: test-only change