### PR TITLE
ui, server: modify hot ranges api and table to use new contents approx.

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3653,9 +3653,9 @@ HotRange message describes a single hot range, ie its QPS, node ID it belongs to
 | range_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | range_id indicates Range ID that's identified as hot range. | [reserved](#support-status) |
 | node_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | node_id indicates the node that contains the current hot range. | [reserved](#support-status) |
 | qps | [double](#cockroach.server.serverpb.HotRangesResponseV2-double) |  | qps (queries per second) shows the amount of queries that interact with current range. | [reserved](#support-status) |
-| table_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | table_name indicates the SQL table that the range belongs to. | [reserved](#support-status) |
-| database_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | database_name indicates on database that has current hot range. | [reserved](#support-status) |
-| index_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | index_name indicates the index name for current range. | [reserved](#support-status) |
+| table_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | table_name has been deprecated in favor of tables = 16; | [reserved](#support-status) |
+| database_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | database_name has been deprecated in favor of databases = 17; | [reserved](#support-status) |
+| index_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | index_name has been deprecated in favor of indexes = 17; | [reserved](#support-status) |
 | replica_node_ids | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) | repeated | replica_node_ids specifies the list of node ids that contain replicas with current hot range. | [reserved](#support-status) |
 | leaseholder_node_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | leaseholder_node_id indicates the Node ID that is the current leaseholder for the given range. | [reserved](#support-status) |
 | schema_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | schema_name provides the name of schema (if exists) for table in current range. | [reserved](#support-status) |
@@ -3665,6 +3665,9 @@ HotRange message describes a single hot range, ie its QPS, node ID it belongs to
 | write_bytes_per_second | [double](#cockroach.server.serverpb.HotRangesResponseV2-double) |  | write_bytes_per_second is the recent number of bytes written per second on this range. | [reserved](#support-status) |
 | read_bytes_per_second | [double](#cockroach.server.serverpb.HotRangesResponseV2-double) |  | read_bytes_per_second is the recent number of bytes read per second on this range. | [reserved](#support-status) |
 | cpu_time_per_second | [double](#cockroach.server.serverpb.HotRangesResponseV2-double) |  | CPU time (ns) per second is the recent cpu usage per second on this range. | [reserved](#support-status) |
+| databases | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) | repeated | Databases for the range. | [reserved](#support-status) |
+| tables | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) | repeated | Tables for the range | [reserved](#support-status) |
+| indexes | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) | repeated | Indexes for the range | [reserved](#support-status) |
 
 
 

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -84,6 +84,7 @@ go_test(
         "//pkg/raft/raftpb",
         "//pkg/raft/tracker",
         "//pkg/storage/enginepb",
+        "//pkg/testutils",
         "//pkg/testutils/zerofields",
         "//pkg/util",
         "//pkg/util/bitarray",

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -1006,3 +1006,18 @@ func (h *GCHint) advanceGCTimestamp(gcThreshold hlc.Timestamp) bool {
 	h.GCTimestamp, h.GCTimestampNext = hlc.Timestamp{}, hlc.Timestamp{}
 	return true
 }
+
+type RangeDescriptorsByStartKey []RangeDescriptor
+
+func (r RangeDescriptorsByStartKey) Len() int {
+	return len(r)
+}
+func (r RangeDescriptorsByStartKey) Less(i, j int) bool {
+	return r[i].StartKey.AsRawKey().Less(r[j].StartKey.AsRawKey())
+}
+
+func (r RangeDescriptorsByStartKey) Swap(i, j int) {
+	tmp := r[i]
+	r[i] = r[j]
+	r[j] = tmp
+}

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -209,7 +209,6 @@ go_library(
         "//pkg/sql",
         "//pkg/sql/appstatspb",
         "//pkg/sql/auditlogging",
-        "//pkg/sql/catalog",
         "//pkg/sql/catalog/bootstrap",
         "//pkg/sql/catalog/catalogkeys",
         "//pkg/sql/catalog/catsessiondata",

--- a/pkg/server/apiutil/BUILD.bazel
+++ b/pkg/server/apiutil/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "apiutil",
     srcs = [
         "apiutil.go",
+        "index_names.go",
         "rangeutil.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/server/apiutil",
@@ -21,7 +22,10 @@ go_library(
 
 go_test(
     name = "apiutil_test",
-    srcs = ["rangeutil_test.go"],
+    srcs = [
+        "index_names_test.go",
+        "rangeutil_test.go",
+    ],
     deps = [
         ":apiutil",
         "//pkg/keys",

--- a/pkg/server/apiutil/index_names.go
+++ b/pkg/server/apiutil/index_names.go
@@ -1,0 +1,91 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package apiutil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
+// IndexNames and IndexNamesList are utilities for representing an
+// index span by its corresponding identifiers.
+// They include the underlying span for comparison against other spans
+// and omit the server and schema parts of their four part name.
+type IndexNames struct {
+	Database string
+	Table    string
+	Index    string
+	Span     roachpb.Span
+}
+
+func (idx IndexNames) String() string {
+	return fmt.Sprintf("%s.%s.%s", idx.Database, idx.Table, idx.Index)
+}
+
+type IndexNamesList []IndexNames
+
+// quoteIfContainsDot adds quotes to an identifier if it contains
+// the four part delimiter '.'.
+func quoteIfContainsDot(identifier string) string {
+	if strings.Contains(identifier, ".") {
+		return `"` + identifier + `"`
+	}
+	return identifier
+}
+
+// ToOutput is a simple function which returns a set of
+// de-duplicated, fully referenced database, table, and index names
+// depending on the number of databases and tables which appear.
+func (idxl IndexNamesList) ToOutput() ([]string, []string, []string) {
+	fpi := quoteIfContainsDot
+	seenDatabases := map[string]bool{}
+	databases := []string{}
+	for _, idx := range idxl {
+		database := fpi(idx.Database)
+		if !seenDatabases[database] {
+			seenDatabases[database] = true
+			databases = append(databases, database)
+		}
+	}
+
+	multipleDatabases := len(databases) > 1
+	seenTables := map[string]bool{}
+	tables := []string{}
+	for _, idx := range idxl {
+		table := fpi(idx.Table)
+		if multipleDatabases {
+			table = fpi(idx.Database) + "." + table
+		}
+		if !seenTables[table] {
+			seenTables[table] = true
+			tables = append(tables, table)
+		}
+	}
+
+	multipleTables := len(tables) > 1
+	indexes := []string{}
+	for _, idx := range idxl {
+		index := fpi(idx.Index)
+		if multipleTables {
+			index = fpi(idx.Table) + "." + index
+			if multipleDatabases {
+				index = fpi(idx.Database) + "." + index
+			}
+		}
+		indexes = append(indexes, index)
+	}
+
+	return databases, tables, indexes
+}
+
+// Equal only compares the names, not the spans
+func (idx IndexNames) Equal(other IndexNames) bool {
+	return idx.Database == other.Database &&
+		idx.Table == other.Table &&
+		idx.Index == other.Index
+}

--- a/pkg/server/apiutil/index_names_test.go
+++ b/pkg/server/apiutil/index_names_test.go
@@ -1,0 +1,119 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package apiutil_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/server/apiutil"
+)
+
+func TestToOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    apiutil.IndexNamesList
+		expected struct {
+			databases []string
+			tables    []string
+			indexes   []string
+		}
+	}{
+		{
+			name: "Single database, single table",
+			input: apiutil.IndexNamesList{
+				{Database: "db1", Table: "table1", Index: "index1"},
+			},
+			expected: struct {
+				databases []string
+				tables    []string
+				indexes   []string
+			}{
+				databases: []string{"db1"},
+				tables:    []string{"table1"},
+				indexes:   []string{"index1"},
+			},
+		},
+		{
+			name: "Single database, multiple tables",
+			input: apiutil.IndexNamesList{
+				{Database: "db1", Table: "table1", Index: "index1"},
+				{Database: "db1", Table: "table2", Index: "index2"},
+			},
+			expected: struct {
+				databases []string
+				tables    []string
+				indexes   []string
+			}{
+				databases: []string{"db1"},
+				tables:    []string{"table1", "table2"},
+				indexes:   []string{"table1.index1", "table2.index2"},
+			},
+		},
+		{
+			name: "Multiple databases, multiple tables",
+			input: apiutil.IndexNamesList{
+				{Database: "db1", Table: "table1", Index: "index1"},
+				{Database: "db2", Table: "table2", Index: "index2"},
+			},
+			expected: struct {
+				databases []string
+				tables    []string
+				indexes   []string
+			}{
+				databases: []string{"db1", "db2"},
+				tables:    []string{"db1.table1", "db2.table2"},
+				indexes:   []string{"db1.table1.index1", "db2.table2.index2"},
+			},
+		},
+		{
+			name: "Duplicate entries",
+			input: apiutil.IndexNamesList{
+				{Database: "db1", Table: "table1", Index: "index1"},
+				{Database: "db1", Table: "table1", Index: "index1"},
+			},
+			expected: struct {
+				databases []string
+				tables    []string
+				indexes   []string
+			}{
+				databases: []string{"db1"},
+				tables:    []string{"table1"},
+				indexes:   []string{"index1", "index1"},
+			},
+		},
+		{
+			name: "Identifiers with dot in the name",
+			input: apiutil.IndexNamesList{
+				{Database: "db.1", Table: "table.1", Index: "index1"},
+			},
+			expected: struct {
+				databases []string
+				tables    []string
+				indexes   []string
+			}{
+				databases: []string{"\"db.1\""},
+				tables:    []string{"\"table.1\""},
+				indexes:   []string{"index1"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			databases, tables, indexes := tt.input.ToOutput()
+			if !reflect.DeepEqual(databases, tt.expected.databases) {
+				t.Errorf("expected databases %v, got %v", tt.expected.databases, databases)
+			}
+			if !reflect.DeepEqual(tables, tt.expected.tables) {
+				t.Errorf("expected tables %v, got %v", tt.expected.tables, tables)
+			}
+			if !reflect.DeepEqual(indexes, tt.expected.indexes) {
+				t.Errorf("expected indexes %v, got %v", tt.expected.indexes, indexes)
+			}
+		})
+	}
+}

--- a/pkg/server/apiutil/rangeutil_test.go
+++ b/pkg/server/apiutil/rangeutil_test.go
@@ -117,8 +117,9 @@ func TestRangesToTableSpans(t *testing.T) {
 		},
 	}
 
-	result := apiutil.RangesToTableSpans(codec, ranges)
+	result, err := apiutil.RangesToTableSpans(codec, ranges)
 
+	require.NoError(t, err)
 	require.Equal(t, len(result), len(expected))
 
 	for i, span := range expected {

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1484,11 +1484,11 @@ message HotRangesResponseV2 {
     double qps = 3 [
       (gogoproto.customname) = "QPS"
     ];
-    // table_name indicates the SQL table that the range belongs to.
-    string table_name = 4;
-    // database_name indicates on database that has current hot range.
+    // table_name has been deprecated in favor of tables = 16;
+    string table_name = 4 [deprecated = true];
+    // database_name has been deprecated in favor of databases = 17;
     string database_name = 5;
-    // index_name indicates the index name for current range.
+    // index_name has been deprecated in favor of indexes = 17;
     string index_name = 6;
     // replica_node_ids specifies the list of node ids that contain replicas with current hot range.
     repeated int32 replica_node_ids = 7 [
@@ -1524,6 +1524,12 @@ message HotRangesResponseV2 {
     // CPU time (ns) per second is the recent cpu usage per second on this
     // range.
     double cpu_time_per_second = 15 [(gogoproto.customname) = "CPUTimePerSecond"];
+    // Databases for the range.
+    repeated string databases = 16;
+    // Tables for the range
+    repeated string tables = 17;
+    // Indexes for the range
+    repeated string indexes = 18;
   }
   // Ranges contain list of hot ranges info that has highest number of QPS.
   repeated HotRange ranges = 1;

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/apiconstants"
+	"github.com/cockroachdb/cockroach/pkg/server/apiutil"
 	"github.com/cockroachdb/cockroach/pkg/server/authserver"
 	"github.com/cockroachdb/cockroach/pkg/server/debug"
 	"github.com/cockroachdb/cockroach/pkg/server/diagnostics/diagnosticspb"
@@ -57,8 +58,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
 	"github.com/cockroachdb/cockroach/pkg/sql/contention"
@@ -2825,13 +2824,6 @@ func (s *systemStatusServer) HotRanges(
 	return response, nil
 }
 
-type tableMeta struct {
-	dbName     string
-	tableName  string
-	schemaName string
-	indexName  string
-}
-
 func (t *statusServer) HotRangesV2(
 	ctx context.Context, req *serverpb.HotRangesRequest,
 ) (*serverpb.HotRangesResponseV2, error) {
@@ -2874,8 +2866,6 @@ func (s *systemStatusServer) HotRangesV2(
 		}
 	}
 
-	var tableMetaCache syncutil.Map[roachpb.RangeID, tableMeta]
-
 	response := &serverpb.HotRangesResponseV2{
 		ErrorsByNodeID: make(map[roachpb.NodeID]string),
 	}
@@ -2889,70 +2879,30 @@ func (s *systemStatusServer) HotRangesV2(
 		if local {
 			resp := s.localHotRanges(ctx, tenantID)
 			var ranges []*serverpb.HotRangesResponseV2_HotRange
+			var rangeIndexMappings map[roachpb.RangeID]apiutil.IndexNamesList
 			for _, store := range resp.Stores {
+				rangeDescriptors := []roachpb.RangeDescriptor{}
 				for _, r := range store.HotRanges {
-					var (
-						dbName, tableName, indexName, schemaName string
-						replicaNodeIDs                           []roachpb.NodeID
-					)
-					rangeID := r.Desc.RangeID
+					rangeDescriptors = append(rangeDescriptors, r.Desc)
+				}
+				if err = s.sqlServer.distSQLServer.DB.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
+					databases, err := txn.Descriptors().GetAllDatabaseDescriptorsMap(ctx, txn.KV())
+					if err != nil {
+						return err
+					}
+					rangeIndexMappings, err = apiutil.GetRangeIndexMapping(ctx, txn, s.sqlServer.execCfg.Codec, databases, rangeDescriptors)
+					return err
+				}); err != nil {
+					return nil, err
+				}
+				for _, r := range store.HotRanges {
+					var replicaNodeIDs []roachpb.NodeID
+
 					for _, repl := range r.Desc.Replicas().Descriptors() {
 						replicaNodeIDs = append(replicaNodeIDs, repl.NodeID)
 					}
-					if maybeIndexPrefix, tableID, ok := decodeTableID(s.sqlServer.execCfg.Codec, r.Desc.StartKey.AsRawKey()); !ok {
-						dbName = "system"
-						tableName = r.Desc.StartKey.String()
-					} else if meta, ok := tableMetaCache.Load(rangeID); ok {
-						dbName = meta.dbName
-						tableName = meta.tableName
-						schemaName = meta.schemaName
-						indexName = meta.indexName
-					} else {
-						if err = s.sqlServer.distSQLServer.DB.DescsTxn(
-							ctx, func(ctx context.Context, txn descs.Txn) error {
-								col := txn.Descriptors()
-								desc, err := col.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Table(ctx, descpb.ID(tableID))
-								if err != nil {
-									return errors.Wrapf(err, "cannot get table descriptor with tableID: %d, %s", tableID, r.Desc)
-								}
-								tableName = desc.GetName()
 
-								if !maybeIndexPrefix.Equal(roachpb.KeyMin) {
-									if _, _, idxID, err := s.sqlServer.execCfg.Codec.DecodeIndexPrefix(r.Desc.StartKey.AsRawKey()); err != nil {
-										log.Warningf(ctx, "cannot decode index prefix for range descriptor: %s: %v", r.Desc, err)
-									} else {
-										if index := catalog.FindIndexByID(desc, descpb.IndexID(idxID)); index == nil {
-											log.Warningf(ctx, "cannot get index name for range descriptor: %s: index with ID %d not found", r.Desc, idxID)
-										} else {
-											indexName = index.GetName()
-										}
-									}
-								}
-
-								if dbDesc, err := col.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Database(ctx, desc.GetParentID()); err != nil {
-									log.Warningf(ctx, "cannot get database by descriptor ID: %s: %v", r.Desc, err)
-								} else {
-									dbName = dbDesc.GetName()
-								}
-
-								if schemaDesc, err := col.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Schema(ctx, desc.GetParentSchemaID()); err != nil {
-									log.Warningf(ctx, "cannot get schema name for range descriptor: %s: %v", r.Desc, err)
-								} else {
-									schemaName = schemaDesc.GetName()
-								}
-								return nil
-							}); err != nil {
-							log.Warningf(ctx, "failed to get table info for %s: %v", r.Desc, err)
-							continue
-						}
-
-						tableMetaCache.Store(rangeID, &tableMeta{
-							dbName:     dbName,
-							tableName:  tableName,
-							schemaName: schemaName,
-							indexName:  indexName,
-						})
-					}
+					databases, tables, indexes := rangeIndexMappings[r.Desc.RangeID].ToOutput()
 
 					ranges = append(ranges, &serverpb.HotRangesResponseV2_HotRange{
 						RangeID:             r.Desc.RangeID,
@@ -2963,13 +2913,12 @@ func (s *systemStatusServer) HotRangesV2(
 						WriteBytesPerSecond: r.WriteBytesPerSecond,
 						ReadBytesPerSecond:  r.ReadBytesPerSecond,
 						CPUTimePerSecond:    r.CPUTimePerSecond,
-						TableName:           tableName,
-						SchemaName:          schemaName,
-						DatabaseName:        dbName,
-						IndexName:           indexName,
 						ReplicaNodeIds:      replicaNodeIDs,
 						LeaseholderNodeID:   r.LeaseholderNodeID,
 						StoreID:             store.StoreID,
+						Databases:           databases,
+						Tables:              tables,
+						Indexes:             indexes,
 					})
 				}
 			}
@@ -3012,23 +2961,6 @@ func (s *systemStatusServer) HotRangesV2(
 	}
 	response.NextPageToken = string(nextBytes)
 	return response, nil
-}
-
-func decodeTableID(codec keys.SQLCodec, key roachpb.Key) (roachpb.Key, uint32, bool) {
-	remaining, tableID, err := codec.DecodeTablePrefix(key)
-	if err != nil {
-		return nil, 0, false
-	}
-	// Validate that tableID doesn't belong to system or pseudo table.
-	if key.Equal(roachpb.KeyMin) ||
-		tableID <= keys.SystemDatabaseID ||
-		keys.IsPseudoTableID(tableID) ||
-		bytes.HasPrefix(key, keys.Meta1Prefix) ||
-		bytes.HasPrefix(key, keys.Meta2Prefix) ||
-		bytes.HasPrefix(key, keys.SystemPrefix) {
-		return nil, 0, false
-	}
-	return remaining, tableID, true
 }
 
 func (s *systemStatusServer) localHotRanges(

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -1132,10 +1132,12 @@ func (tc *Collection) GetAllDatabaseDescriptors(
 	return ret, nil
 }
 
-// GetAllDatabaseDescriptorsMap returns the results of GetAllDatabaseDescriptors
+// GetAllDatabaseDescriptorsMap returns the results of
+// GetAllDatabaseDescriptors but as a map with the database ID as the
+// key.
 func (tc *Collection) GetAllDatabaseDescriptorsMap(
 	ctx context.Context, txn *kv.Txn,
-) (ret map[descpb.ID]catalog.DatabaseDescriptor, _ error) {
+) (map[descpb.ID]catalog.DatabaseDescriptor, error) {
 	descriptors, err := tc.GetAllDatabaseDescriptors(ctx, txn)
 	result := map[descpb.ID]catalog.DatabaseDescriptor{}
 	if err != nil {
@@ -1149,7 +1151,9 @@ func (tc *Collection) GetAllDatabaseDescriptorsMap(
 	return result, nil
 }
 
-// but as a map with the database ID as the key.
+// GetSchemasForDatabase returns the schemas for a given database
+// visible by the transaction.
+// Deprecated: prefer GetAllSchemasInDatabase.
 func (tc *Collection) GetSchemasForDatabase(
 	ctx context.Context, txn *kv.Txn, db catalog.DatabaseDescriptor,
 ) (map[descpb.ID]string, error) {

--- a/pkg/sql/catalog/internal/catkv/catalog_reader.go
+++ b/pkg/sql/catalog/internal/catkv/catalog_reader.go
@@ -209,13 +209,16 @@ func (cr catalogReader) ScanDescriptorsInSpans(
 ) (nstree.Catalog, error) {
 	var mc nstree.MutableCatalog
 
-	descSpans := make([]roachpb.Span, len(spans))
-	for i, span := range spans {
+	descSpans := []roachpb.Span{}
+	for _, span := range spans {
 		descSpan, err := getDescriptorSpanFromSpan(cr.Codec(), span)
 		if err != nil {
 			return mc.Catalog, err
 		}
-		descSpans[i] = descSpan
+		if descSpan.ZeroLength() {
+			continue
+		}
+		descSpans = append(descSpans, descSpan)
 	}
 
 	cq := catalogQuery{codec: cr.codec}

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
@@ -231,8 +231,8 @@ const HotRangesTable = ({
             Database
           </Tooltip>
         ),
-        cell: val => <>{val.database_name}</>,
-        sort: val => val.database_name,
+        cell: val => <>{val.databases.join(", ")}</>,
+        sort: val => val.databases.join(", "),
       },
       {
         name: "table",
@@ -244,22 +244,7 @@ const HotRangesTable = ({
             Table
           </Tooltip>
         ),
-        cell: val =>
-          // A hot range may not necessarily back a SQL table. If we see a
-          // "table name" that starts with a slash, it is not a table name but
-          // instead the start key of the range, and we should not link it.
-          val.table_name.startsWith("/") ? (
-            val.table_name
-          ) : (
-            <Link
-              to={util.EncodeDatabaseTableUri(
-                val.database_name,
-                val.table_name,
-              )}
-            >
-              {val.table_name}
-            </Link>
-          ),
+        cell: val => val.tables.join(", "),
         sort: val => val.table_name,
       },
       {
@@ -272,8 +257,8 @@ const HotRangesTable = ({
             Index
           </Tooltip>
         ),
-        cell: val => <>{val.index_name}</>,
-        sort: val => val.index_name,
+        cell: val => <>{val.indexes.join(", ")}</>,
+        sort: val => val.indexes.join(", "),
       },
       {
         name: "locality",


### PR DESCRIPTION
ui, server: modify hot ranges api and table to use new contents approx.

This change is the last in a set of commits to change the hot ranges
page from only showing one table, index per range to many. It builds on
top of the changes in the catalog reader
(10b9ee03fba37f314771d8624b2619f10b5bbb59) and the range utilities
(109219d5fca6d347663127bf21b8dd162ef51d4a) to surface a set of tables,
indexes for each range.

The primary changes in this commit specifically are the modification of
the status server to use the new `rangeutil` utilities, and changing the
wire, presentation format of the information.

![image](https://github.com/user-attachments/assets/c5e0a175-7940-4051-b4de-c9ba9c492951)

Epic: CRDB-43151
Fixes: #130997

Release note: changes the table, index contents of the hot ranges page in DB console.
