### PR TITLE
crosscluster: switch debug status from atomics to mu

### DIFF
--- a/pkg/ccl/crosscluster/producer/replication_manager.go
+++ b/pkg/ccl/crosscluster/producer/replication_manager.go
@@ -296,7 +296,7 @@ func (r *replicationStreamManagerImpl) SetupSpanConfigsStream(
 
 func (r *replicationStreamManagerImpl) DebugGetProducerStatuses(
 	ctx context.Context,
-) []*streampb.DebugProducerStatus {
+) []streampb.DebugProducerStatus {
 	// NB: we don't check license here since if a stream started but the license
 	// expired or was removed, we still want visibility into it during debugging.
 

--- a/pkg/repstream/streampb/BUILD.bazel
+++ b/pkg/repstream/streampb/BUILD.bazel
@@ -47,6 +47,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/repstream/streampb",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/jobs/jobspb",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
     ],

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -915,7 +915,7 @@ type ReplicationStreamManager interface {
 		successfulIngestion bool,
 	) error
 
-	DebugGetProducerStatuses(ctx context.Context) []*streampb.DebugProducerStatus
+	DebugGetProducerStatuses(ctx context.Context) []streampb.DebugProducerStatus
 	DebugGetLogicalConsumerStatuses(ctx context.Context) []*streampb.DebugLogicalConsumerStatus
 
 	PlanLogicalReplication(


### PR DESCRIPTION
Storing or getting several atomics in a row is worse than just one mutex.

Release note: none.
Epic: none.