### PR TITLE
drtprod: use v24.3.0-beta.2 for drt-scale

### DIFF
--- a/pkg/cmd/drtprod/configs/drt_scale.yaml
+++ b/pkg/cmd/drtprod/configs/drt_scale.yaml
@@ -10,6 +10,7 @@ environment:
   WORKLOAD_CLUSTER: workload-scale
   CLUSTER_NODES: 150
   WORKLOAD_NODES: 9
+  COCKROACH_VERSION: v24.3.0-beta.2
 
 targets:
   # crdb cluster specs
@@ -36,10 +37,26 @@ targets:
       - command: sync
         flags:
           clouds: gce
-      - command: stage
+      - command: run
         args:
           - $CLUSTER
-          - cockroach
+          - --
+          - wget https://binaries.cockroachdb.com/cockroach-${COCKROACH_VERSION}.linux-amd64.tgz
+      - command: run
+        args:
+          - $CLUSTER
+          - --
+          - tar -xvzf cockroach-${COCKROACH_VERSION}.linux-amd64.tgz
+      - command: run
+        args:
+          - $CLUSTER
+          - --
+          - mv cockroach-${COCKROACH_VERSION}.linux-amd64/* .
+      - command: run
+        args:
+          - $CLUSTER
+          - --
+          - rm -rf cockroach-${COCKROACH_VERSION}.linux-amd64*
       - script: "pkg/cmd/drtprod/scripts/setup_datadog_cluster"
       - command: start
         args:

--- a/pkg/cmd/drtprod/configs/drt_scale_pcr.yaml
+++ b/pkg/cmd/drtprod/configs/drt_scale_pcr.yaml
@@ -8,6 +8,7 @@ environment:
   ROACHPROD_GCE_DEFAULT_PROJECT: cockroach-drt
   CLUSTER: drt-scale-pcr
   CLUSTER_NODES: 150
+  COCKROACH_VERSION: v24.3.0-beta.2
 
 targets:
   # crdb cluster specs
@@ -34,10 +35,26 @@ targets:
       - command: sync
         flags:
           clouds: gce
-      - command: stage
+      - command: run
         args:
           - $CLUSTER
-          - cockroach
+          - --
+          - wget https://binaries.cockroachdb.com/cockroach-${COCKROACH_VERSION}.linux-amd64.tgz
+      - command: run
+        args:
+          - $CLUSTER
+          - --
+          - tar -xvzf cockroach-${COCKROACH_VERSION}.linux-amd64.tgz
+      - command: run
+        args:
+          - $CLUSTER
+          - --
+          - mv cockroach-${COCKROACH_VERSION}.linux-amd64/* .
+      - command: run
+        args:
+          - $CLUSTER
+          - --
+          - rm -rf cockroach-${COCKROACH_VERSION}.linux-amd64*
       - script: "pkg/cmd/drtprod/scripts/setup_datadog_cluster"
       - command: start
         args:

--- a/pkg/cmd/drtprod/configs/drt_scale_restore.yaml
+++ b/pkg/cmd/drtprod/configs/drt_scale_restore.yaml
@@ -10,6 +10,7 @@ environment:
   WORKLOAD_CLUSTER: workload-scale-restore
   CLUSTER_NODES: 60
   WORKLOAD_NODES: 1
+  COCKROACH_VERSION: v24.3.0-beta.2
 
 targets:
   # crdb cluster specs
@@ -36,10 +37,26 @@ targets:
       - command: sync
         flags:
           clouds: gce
-      - command: stage
+      - command: run
         args:
           - $CLUSTER
-          - cockroach
+          - --
+          - wget https://binaries.cockroachdb.com/cockroach-${COCKROACH_VERSION}.linux-amd64.tgz
+      - command: run
+        args:
+          - $CLUSTER
+          - --
+          - tar -xvzf cockroach-${COCKROACH_VERSION}.linux-amd64.tgz
+      - command: run
+        args:
+          - $CLUSTER
+          - --
+          - mv cockroach-${COCKROACH_VERSION}.linux-amd64/* .
+      - command: run
+        args:
+          - $CLUSTER
+          - --
+          - rm -rf cockroach-${COCKROACH_VERSION}.linux-amd64*
       - script: "pkg/cmd/drtprod/scripts/setup_datadog_cluster"
       - command: start
         args:


### PR DESCRIPTION
The YAMLs for drt-scale clusters are changed to use the "v24.3.0-beta.2" version of cockroach.

The workload still uses the latest version of cockroach as the purpose of the binary is different. It uses the binary to run workload.

Epic: None
Release note: None