### PR TITLE
util/log: avoid heap allocation on no-op VEvent call

### DIFF
--- a/pkg/util/log/gen/main.go
+++ b/pkg/util/log/gen/main.go
@@ -417,7 +417,7 @@ func (logger{{.Name}}) Shoutf(ctx context.Context, sev Severity, format string, 
 // verbosity level is active.
 {{.Comment -}}
 func (logger{{.Name}}) VEvent(ctx context.Context, level Level, msg string) {
-	vEventf(ctx, false /* isErr */, 1, level, channel.{{.NAME}}, "%s", msg)
+	vEvent(ctx, false /* isErr */, 1, level, channel.{{.NAME}}, msg)
 }
 
 // VEventf either logs a message to the channel (which also outputs to the

--- a/pkg/util/log/log_channels_generated.go
+++ b/pkg/util/log/log_channels_generated.go
@@ -972,7 +972,7 @@ func (loggerDev) Shoutf(ctx context.Context, sev Severity, format string, args .
 // sensitive operational data.
 // See [Configure logs](configure-logs.html#dev-channel).
 func (loggerDev) VEvent(ctx context.Context, level Level, msg string) {
-	vEventf(ctx, false /* isErr */, 1, level, channel.DEV, "%s", msg)
+	vEvent(ctx, false /* isErr */, 1, level, channel.DEV, msg)
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
@@ -1504,7 +1504,7 @@ func (loggerOps) Shoutf(ctx context.Context, sev Severity, format string, args .
 //   - [Cluster setting](cluster-settings.html) changes
 //   - [Zone configuration](configure-replication-zones.html) changes
 func (loggerOps) VEvent(ctx context.Context, level Level, msg string) {
-	vEventf(ctx, false /* isErr */, 1, level, channel.OPS, "%s", msg)
+	vEvent(ctx, false /* isErr */, 1, level, channel.OPS, msg)
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
@@ -1939,7 +1939,7 @@ func (loggerHealth) Shoutf(ctx context.Context, sev Severity, format string, arg
 //   - Range and table leasing events
 //   - Up- and down-replication, range unavailability
 func (loggerHealth) VEvent(ctx context.Context, level Level, msg string) {
-	vEventf(ctx, false /* isErr */, 1, level, channel.HEALTH, "%s", msg)
+	vEvent(ctx, false /* isErr */, 1, level, channel.HEALTH, msg)
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
@@ -2248,7 +2248,7 @@ func (loggerStorage) Shoutf(ctx context.Context, sev Severity, format string, ar
 // The `STORAGE` channel is used to report low-level storage
 // layer events (RocksDB/Pebble).
 func (loggerStorage) VEvent(ctx context.Context, level Level, msg string) {
-	vEventf(ctx, false /* isErr */, 1, level, channel.STORAGE, "%s", msg)
+	vEvent(ctx, false /* isErr */, 1, level, channel.STORAGE, msg)
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
@@ -2705,7 +2705,7 @@ func (loggerSessions) Shoutf(ctx context.Context, sev Severity, format string, a
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 func (loggerSessions) VEvent(ctx context.Context, level Level, msg string) {
-	vEventf(ctx, false /* isErr */, 1, level, channel.SESSIONS, "%s", msg)
+	vEvent(ctx, false /* isErr */, 1, level, channel.SESSIONS, msg)
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
@@ -3238,7 +3238,7 @@ func (loggerSqlSchema) Shoutf(ctx context.Context, sev Severity, format string, 
 // `SQL_SCHEMA` events generally comprise changes to the schema that affect the
 // functional behavior of client apps using stored objects.
 func (loggerSqlSchema) VEvent(ctx context.Context, level Level, msg string) {
-	vEventf(ctx, false /* isErr */, 1, level, channel.SQL_SCHEMA, "%s", msg)
+	vEvent(ctx, false /* isErr */, 1, level, channel.SQL_SCHEMA, msg)
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
@@ -3717,7 +3717,7 @@ func (loggerUserAdmin) Shoutf(ctx context.Context, sev Severity, format string, 
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 func (loggerUserAdmin) VEvent(ctx context.Context, level Level, msg string) {
-	vEventf(ctx, false /* isErr */, 1, level, channel.USER_ADMIN, "%s", msg)
+	vEvent(ctx, false /* isErr */, 1, level, channel.USER_ADMIN, msg)
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
@@ -4150,7 +4150,7 @@ func (loggerPrivileges) Shoutf(ctx context.Context, sev Severity, format string,
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 func (loggerPrivileges) VEvent(ctx context.Context, level Level, msg string) {
-	vEventf(ctx, false /* isErr */, 1, level, channel.PRIVILEGES, "%s", msg)
+	vEvent(ctx, false /* isErr */, 1, level, channel.PRIVILEGES, msg)
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
@@ -4659,7 +4659,7 @@ func (loggerSensitiveAccess) Shoutf(ctx context.Context, sev Severity, format st
 // This is typically configured in "audit" mode, with event
 // numbering and synchronous writes.
 func (loggerSensitiveAccess) VEvent(ctx context.Context, level Level, msg string) {
-	vEventf(ctx, false /* isErr */, 1, level, channel.SENSITIVE_ACCESS, "%s", msg)
+	vEvent(ctx, false /* isErr */, 1, level, channel.SENSITIVE_ACCESS, msg)
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
@@ -5056,7 +5056,7 @@ func (loggerSqlExec) Shoutf(ctx context.Context, sev Severity, format string, ar
 //     `sql.log.all_statements.enabled` [cluster setting](cluster-settings.html))
 //   - uncaught Go panic errors during the execution of a SQL statement.
 func (loggerSqlExec) VEvent(ctx context.Context, level Level, msg string) {
-	vEventf(ctx, false /* isErr */, 1, level, channel.SQL_EXEC, "%s", msg)
+	vEvent(ctx, false /* isErr */, 1, level, channel.SQL_EXEC, msg)
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
@@ -5501,7 +5501,7 @@ func (loggerSqlPerf) Shoutf(ctx context.Context, sev Severity, format string, ar
 // with versions prior to v21.1, where the corresponding events
 // were redirected to separate files.
 func (loggerSqlPerf) VEvent(ctx context.Context, level Level, msg string) {
-	vEventf(ctx, false /* isErr */, 1, level, channel.SQL_PERF, "%s", msg)
+	vEvent(ctx, false /* isErr */, 1, level, channel.SQL_PERF, msg)
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
@@ -5852,7 +5852,7 @@ func (loggerSqlInternalPerf) Shoutf(ctx context.Context, sev Severity, format st
 // channel so as to not pollute the `SQL_PERF` logging output with
 // internal troubleshooting details.
 func (loggerSqlInternalPerf) VEvent(ctx context.Context, level Level, msg string) {
-	vEventf(ctx, false /* isErr */, 1, level, channel.SQL_INTERNAL_PERF, "%s", msg)
+	vEvent(ctx, false /* isErr */, 1, level, channel.SQL_INTERNAL_PERF, msg)
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
@@ -6173,7 +6173,7 @@ func (loggerTelemetry) Shoutf(ctx context.Context, sev Severity, format string, 
 // feature usage within CockroachDB and anonymizes any application-
 // specific data.
 func (loggerTelemetry) VEvent(ctx context.Context, level Level, msg string) {
-	vEventf(ctx, false /* isErr */, 1, level, channel.TELEMETRY, "%s", msg)
+	vEvent(ctx, false /* isErr */, 1, level, channel.TELEMETRY, msg)
 }
 
 // VEventf either logs a message to the channel (which also outputs to the
@@ -6492,7 +6492,7 @@ func (loggerKvDistribution) Shoutf(ctx context.Context, sev Severity, format str
 // replicas between stores in the cluster, or adding (removing) replicas to
 // ranges.
 func (loggerKvDistribution) VEvent(ctx context.Context, level Level, msg string) {
-	vEventf(ctx, false /* isErr */, 1, level, channel.KV_DISTRIBUTION, "%s", msg)
+	vEvent(ctx, false /* isErr */, 1, level, channel.KV_DISTRIBUTION, msg)
 }
 
 // VEventf either logs a message to the channel (which also outputs to the

--- a/pkg/util/log/trace.go
+++ b/pkg/util/log/trace.go
@@ -98,6 +98,16 @@ func Eventf(ctx context.Context, format string, args ...interface{}) {
 	eventInternal(sp, false /* isErr */, &entry)
 }
 
+// NOTE: we maintain a vEvent function separate from vEventf, instead of having
+// all VEvent callers invoke vEventf directly, so that the heap allocation from
+// the `msg` parameter escaping when packed into a vararg slice is not incurred
+// on the no-op path.
+func vEvent(ctx context.Context, isErr bool, depth int, level Level, ch Channel, msg string) {
+	if VDepth(level, 1+depth) || getSpan(ctx) != nil {
+		vEventf(ctx, isErr, 1+depth, level, ch, "%s", msg)
+	}
+}
+
 func vEventf(
 	ctx context.Context,
 	isErr bool,
@@ -114,12 +124,7 @@ func vEventf(
 			sev = severity.ERROR
 		}
 		logfDepth(ctx, 1+depth, sev, ch, format, args...)
-	} else {
-		sp := getSpan(ctx)
-		if sp == nil {
-			// Nothing to log. Skip the work.
-			return
-		}
+	} else if sp := getSpan(ctx); sp != nil {
 		entry := makeUnstructuredEntry(ctx,
 			severity.INFO, /* unused for trace events */
 			channel.DEV,   /* unused for trace events */
@@ -134,7 +139,7 @@ func vEventf(
 // active trace) or to the trace alone, depending on whether the specified
 // verbosity level is active.
 func VEvent(ctx context.Context, level Level, msg string) {
-	vEventf(ctx, false /* isErr */, 1, level, channel.DEV, "%s", msg)
+	vEvent(ctx, false /* isErr */, 1, level, channel.DEV, msg)
 }
 
 // VEventf either logs a message to the DEV channel (which also outputs to the
@@ -154,7 +159,7 @@ func VEventfDepth(ctx context.Context, depth int, level Level, format string, ar
 // outputs to the active trace) or to the trace alone, depending on whether
 // the specified verbosity level is active.
 func VErrEvent(ctx context.Context, level Level, msg string) {
-	vEventf(ctx, true /* isErr */, 1, level, channel.DEV, "%s", msg)
+	vEvent(ctx, true /* isErr */, 1, level, channel.DEV, msg)
 }
 
 // VErrEventf either logs an error message to the DEV Channel (which also

--- a/pkg/util/log/trace_test.go
+++ b/pkg/util/log/trace_test.go
@@ -38,3 +38,21 @@ func TestTrace(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// BenchmarkVEventNoop measures the cost of a VEvent call when neither verbose
+// logging nor tracing is enabled.
+func BenchmarkVEventNoop(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		VEvent(context.Background(), 1, "should be free")
+	}
+}
+
+// BenchmarkVEventfNoop measures the cost of a VEventf call when neither verbose
+// logging nor tracing is enabled.
+func BenchmarkVEventfNoop(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		VEventf(context.Background(), 1, "%s", "should be free")
+	}
+}


### PR DESCRIPTION
This commit avoid a heap allocation from the `msg` parameter of VEvent escaping when packed into a vararg slice on the (common) no-op path. This allocation was new as of 15db309a.

```
name         old time/op    new time/op    delta
VEventNoop     30.1ns ±14%     5.4ns ± 1%   -81.90%  (p=0.000 n=9+9)
VEventfNoop    5.77ns ± 1%    5.76ns ± 0%    -0.23%  (p=0.004 n=10+8)

name         old alloc/op   new alloc/op   delta
VEventNoop      16.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
VEventfNoop     0.00B          0.00B           ~     (all equal)

name         old allocs/op  new allocs/op  delta
VEventNoop       1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
VEventfNoop      0.00           0.00           ~     (all equal)
```

The impact on sysbench is:
```
name                            old time/op    new time/op    delta
Sysbench/SQL/oltp_read_only       2.42ms ± 9%    2.36ms ±11%    ~     (p=0.268 n=9+19)
Sysbench/SQL/oltp_write_only      2.23ms ± 3%    2.19ms ± 4%    ~     (p=0.125 n=8+18)
Sysbench/SQL/oltp_read_write      5.36ms ± 3%    5.32ms ± 4%    ~     (p=0.391 n=10+20)
Sysbench/SQL/oltp_point_select     160µs ± 2%     159µs ± 3%    ~     (p=0.603 n=9+19)
Sysbench/SQL/oltp_begin_commit     120µs ± 7%     116µs ± 7%  -2.87%  (p=0.060 n=9+17)
Sysbench/KV/oltp_read_only         421µs ± 3%     418µs ± 2%    ~     (p=0.165 n=10+10)
Sysbench/KV/oltp_write_only        563µs ± 3%     570µs ± 3%    ~     (p=0.146 n=8+10)
Sysbench/KV/oltp_read_write       1.02ms ± 6%    1.07ms ± 7%  +4.09%  (p=0.043 n=10+10)
Sysbench/KV/oltp_point_select     18.4µs ± 4%    18.1µs ± 4%    ~     (p=0.367 n=10+9)
Sysbench/KV/oltp_begin_commit     1.32µs ± 5%    1.35µs ± 3%  +2.34%  (p=0.050 n=10+10)

name                            old alloc/op   new alloc/op   delta
Sysbench/SQL/oltp_read_only        961kB ± 0%     961kB ± 0%    ~     (p=0.837 n=10+20)
Sysbench/SQL/oltp_write_only       479kB ± 1%     477kB ± 1%    ~     (p=0.087 n=9+16)
Sysbench/SQL/oltp_read_write      1.34MB ± 0%    1.34MB ± 0%    ~     (p=0.243 n=10+20)
Sysbench/SQL/oltp_point_select    34.1kB ± 0%    34.0kB ± 0%    ~     (p=0.096 n=10+18)
Sysbench/SQL/oltp_begin_commit    18.7kB ± 0%    18.7kB ± 0%    ~     (p=0.435 n=10+19)
Sysbench/KV/oltp_read_only         264kB ± 0%     263kB ± 0%  -0.39%  (p=0.000 n=10+9)
Sysbench/KV/oltp_write_only        185kB ± 5%     184kB ± 7%    ~     (p=0.247 n=10+10)
Sysbench/KV/oltp_read_write        439kB ± 1%     438kB ± 1%    ~     (p=0.143 n=10+10)
Sysbench/KV/oltp_point_select     5.15kB ± 1%    5.09kB ± 0%  -1.03%  (p=0.000 n=9+9)
Sysbench/KV/oltp_begin_commit     2.50kB ± 0%    2.50kB ± 0%    ~     (all equal)

name                            old allocs/op  new allocs/op  delta
Sysbench/SQL/oltp_read_only        6.22k ± 0%     6.17k ± 1%  -0.79%  (p=0.026 n=10+20)
Sysbench/SQL/oltp_write_only       3.39k ± 0%     3.34k ± 3%  -1.21%  (p=0.055 n=9+20)
Sysbench/SQL/oltp_read_write       9.60k ± 0%     9.52k ± 1%  -0.88%  (p=0.041 n=8+20)
Sysbench/SQL/oltp_point_select       309 ± 0%       307 ± 3%    ~     (p=0.191 n=9+20)
Sysbench/SQL/oltp_begin_commit       139 ± 0%       139 ± 0%    ~     (all equal)
Sysbench/KV/oltp_read_only           650 ± 0%       608 ± 0%  -6.46%  (p=0.000 n=10+10)
Sysbench/KV/oltp_write_only        1.08k ± 1%     1.04k ± 1%  -3.92%  (p=0.000 n=10+10)
Sysbench/KV/oltp_read_write        1.73k ± 0%     1.64k ± 0%  -4.86%  (p=0.000 n=10+7)
Sysbench/KV/oltp_point_select       37.0 ± 0%      34.0 ± 0%  -8.11%  (p=0.000 n=10+10)
Sysbench/KV/oltp_begin_commit       6.00 ± 0%      6.00 ± 0%    ~     (all equal)
```

Epic: None
Release note: None