### PR TITLE
roachtest: increase passing criteria for elasticWorkload test

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -209,7 +209,7 @@ func registerLatencyTests(r registry.Registry) {
 	addMetamorphic(r, decommission{}, 5.0)
 	addMetamorphic(r, backfill{}, 40.0)
 	addMetamorphic(r, &slowDisk{}, math.Inf(1))
-	addMetamorphic(r, elasticWorkload{}, 5.0)
+	addMetamorphic(r, elasticWorkload{}, 20.0)
 
 	// NB: If these tests fail, it likely signals a regression. Investigate the
 	// history of the test on roachperf to see what changed.
@@ -219,7 +219,7 @@ func registerLatencyTests(r registry.Registry) {
 	addFull(r, decommission{drain: true}, 5.0)
 	addFull(r, backfill{}, 40.0)
 	addFull(r, &slowDisk{slowLiveness: true, walFailover: true}, math.Inf(1))
-	addFull(r, elasticWorkload{}, 5.0)
+	addFull(r, elasticWorkload{}, 20.0)
 
 	// NB: These tests will never fail and are not enabled, but they are useful
 	// for development.


### PR DESCRIPTION
Change the passing criteria for the perturbation/*/elasticWorkload tests from 5.0 to 20.0. We have seen a number of failures where the value is in the 6-12 range and by increasing this we will prevent many of the flakes. Ideally we will drop this number in the future.

Fixes: https://github.com/cockroachdb/cockroach/issues/133557
Fixes: https://github.com/cockroachdb/cockroach/issues/134104

Release note: None