### PR TITLE
roachtest: add leader lease support to perturbation tests

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -108,6 +108,7 @@ var cloudSets = []registry.CloudSet{registry.OnlyAWS, registry.OnlyGCE, registry
 
 var leases = []registry.LeaseType{
 	registry.EpochLeases,
+	registry.LeaderLeases,
 	registry.ExpirationLeases,
 }
 


### PR DESCRIPTION
This commit adds leader lease suuport to all the
perturbation/metamorphic/* tests.

Epic: none

Release note: None