### PR TITLE
ldapccl: fix ldap connection timeout due to idleness

### DIFF
--- a/pkg/ccl/ldapccl/ldap_util.go
+++ b/pkg/ccl/ldapccl/ldap_util.go
@@ -45,8 +45,10 @@ func (lu *ldapUtil) MaybeInitLDAPsConn(ctx context.Context, conf ldapConfig) (er
 	// connections crdb nodes can take up(either in total or on a per node basis)
 	//
 	// ldapAddress := "ldap://ldap.example.com:636"
-	//
-	if lu.conn != nil {
+	// If the connection is idle for sometime, we get a ERRCONNRESET error from
+	// server, the ldap client sets the connection to closing. We need to dial for
+	// a new connection to continue using the client.
+	if lu.conn != nil && !lu.conn.IsClosing() {
 		return nil
 	}
 	ldapAddress := conf.ldapServer + ":" + conf.ldapPort


### PR DESCRIPTION
fixes #133777
Epic CRDB-33829

If LDAP connection is idle for some period of time, we receive a `ERRCONNRESET` signal from server, and the ldap client marks the connection to closing. We need to dial for a new connection to continue using the client. The fix checks for the connection state and performs redial before any other ldap operation is performed.

Release note(security): Previously if ldap connection was closed by server and we tried to perform bind or any other operation over reset connection, we got an error log saying:
```
"LDAP authentication: unable to find LDAP user distinguished name\nerror when
searching for user in LDAP server: LDAP search failed: LDAP bind failed: ‹LDAP
Result Code 200 \"Network Error\"›: ‹ldap: connection closed›"
```
This fix automatically handles closed connections and performs redial on behalf of the client if it finds connection was reset.