### PR TITLE
raft: disarm inHeartbeatLease when appropriate for leader leases

### DIFF
--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -1984,7 +1984,7 @@ func testLeaderStepdownWhenQuorumLost(t *testing.T, storeLivenessEnabled bool) {
 	sm.becomeLeader()
 	assert.Equal(t, pb.StateLeader, sm.state)
 
-	for i := int64(0); i < sm.electionTimeout+1; i++ {
+	for i := int64(0); i < sm.electionTimeout; i++ {
 		sm.tick()
 	}
 

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -1999,39 +1999,39 @@ func TestLeaderSupersedingWithCheckQuorum(t *testing.T) {
 }
 func testLeaderSupersedingWithCheckQuorum(t *testing.T, storeLivenessEnabled bool) {
 	var fabric *raftstoreliveness.LivenessFabric
-	var a, b, c *raft
+	var n1, n2, n3 *raft
 
 	if storeLivenessEnabled {
 		fabric = raftstoreliveness.NewLivenessFabricWithPeers(1, 2, 3)
-		a = newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)),
+		n1 = newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)),
 			withStoreLiveness(fabric.GetStoreLiveness(1)))
-		b = newTestRaft(2, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)),
+		n2 = newTestRaft(2, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)),
 			withStoreLiveness(fabric.GetStoreLiveness(2)))
-		c = newTestRaft(3, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)),
+		n3 = newTestRaft(3, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)),
 			withStoreLiveness(fabric.GetStoreLiveness(3)))
 	} else {
-		a = newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)),
+		n1 = newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)),
 			withStoreLiveness(raftstoreliveness.Disabled{}))
-		b = newTestRaft(2, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)),
+		n2 = newTestRaft(2, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)),
 			withStoreLiveness(raftstoreliveness.Disabled{}))
-		c = newTestRaft(3, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)),
+		n3 = newTestRaft(3, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)),
 			withStoreLiveness(raftstoreliveness.Disabled{}))
 	}
 
-	a.checkQuorum = true
-	b.checkQuorum = true
-	c.checkQuorum = true
+	n1.checkQuorum = true
+	n2.checkQuorum = true
+	n3.checkQuorum = true
 
-	nt := newNetworkWithConfigAndLivenessFabric(nil, fabric, a, b, c)
-	setRandomizedElectionTimeout(b, b.electionTimeout+1)
+	nt := newNetworkWithConfigAndLivenessFabric(nil, fabric, n1, n2, n3)
+	setRandomizedElectionTimeout(n2, n2.electionTimeout+1)
 
-	for i := int64(0); i < b.electionTimeout; i++ {
-		b.tick()
+	for i := int64(0); i < n2.electionTimeout; i++ {
+		n2.tick()
 	}
 	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgHup})
 
-	assert.Equal(t, pb.StateLeader, a.state)
-	assert.Equal(t, pb.StateFollower, c.state)
+	assert.Equal(t, pb.StateLeader, n1.state)
+	assert.Equal(t, pb.StateFollower, n3.state)
 
 	if storeLivenessEnabled {
 		// We need to withdraw support from 1 so 3 can campaign and not get rejected
@@ -2041,16 +2041,22 @@ func testLeaderSupersedingWithCheckQuorum(t *testing.T, storeLivenessEnabled boo
 
 	nt.send(pb.Message{From: 3, To: 3, Type: pb.MsgHup})
 
-	// Peer b rejected c's vote since its electionElapsed had not reached to electionTimeout
-	assert.Equal(t, pb.StateCandidate, c.state)
+	if storeLivenessEnabled {
+		// 2 voted for 3 since its support for 1 was withdrawn.
+		assert.Equal(t, pb.StateLeader, n3.state)
+	} else {
+		// 2 rejected 3's vote request since its electionElapsed had not reached to
+		// electionTimeout.
+		assert.Equal(t, pb.StateCandidate, n3.state)
+	}
 
 	// Letting b's electionElapsed reach to electionTimeout
-	for i := int64(0); i < b.electionTimeout; i++ {
-		b.tick()
+	for i := int64(0); i < n2.electionTimeout; i++ {
+		n2.tick()
 	}
 	nt.send(pb.Message{From: 3, To: 3, Type: pb.MsgHup})
 
-	assert.Equal(t, pb.StateLeader, c.state)
+	assert.Equal(t, pb.StateLeader, n3.state)
 }
 
 func TestLeaderElectionWithCheckQuorum(t *testing.T) {
@@ -2165,7 +2171,6 @@ func testFreeStuckCandidateWithCheckQuorum(t *testing.T, storeLivenessEnabled bo
 	c.checkQuorum = true
 
 	nt := newNetworkWithConfigAndLivenessFabric(nil, fabric, a, b, c)
-	setRandomizedElectionTimeout(b, b.electionTimeout+1)
 
 	for i := int64(0); i < b.electionTimeout; i++ {
 		b.tick()
@@ -2174,8 +2179,12 @@ func testFreeStuckCandidateWithCheckQuorum(t *testing.T, storeLivenessEnabled bo
 
 	nt.isolate(1)
 	if storeLivenessEnabled {
-		// Isolate node 1 in the store liveness layer as well.
-		nt.livenessFabric.WithdrawSupportForPeerFromAllPeers(1)
+		// For the purposes of this test, we want 3 to campaign and get rejected.
+		// However, if we withdraw the support between 2 and 1, 2 will vote for 3
+		// when it campaigns. Therefore, we only withdraw the support between
+		// 1 and 3.
+		nt.livenessFabric.WithdrawSupport(1, 3)
+		nt.livenessFabric.WithdrawSupport(3, 1)
 	}
 
 	nt.send(pb.Message{From: 3, To: 3, Type: pb.MsgHup})
@@ -2336,12 +2345,21 @@ func testDisruptiveFollower(t *testing.T, storeLivenessEnabled bool) {
 	// check state
 	require.Equal(t, pb.StateFollower, n1.state)
 	require.Equal(t, pb.StateFollower, n2.state)
-	require.Equal(t, pb.StateCandidate, n3.state)
-
-	// check term
-	require.Equal(t, uint64(3), n1.Term)
-	require.Equal(t, uint64(2), n2.Term)
-	require.Equal(t, uint64(3), n3.Term)
+	if storeLivenessEnabled {
+		// Since the support for 1 was withdrawn, the inFortifyLease is no longer
+		// valid, and n3 will receive votes and become a leader.
+		require.Equal(t, pb.StateLeader, n3.state)
+		require.Equal(t, uint64(3), n1.Term)
+		require.Equal(t, uint64(3), n2.Term)
+		require.Equal(t, uint64(3), n3.Term)
+	} else {
+		// Since other peers still hold a valid inHeartbeatLease, n3 will not
+		// receive enough votes to become a leader.
+		require.Equal(t, pb.StateCandidate, n3.state)
+		require.Equal(t, uint64(3), n1.Term)
+		require.Equal(t, uint64(2), n2.Term)
+		require.Equal(t, uint64(3), n3.Term)
+	}
 }
 
 // TestDisruptiveFollowerPreVote tests isolated follower,
@@ -2414,7 +2432,15 @@ func testDisruptiveFollowerPreVote(t *testing.T, storeLivenessEnabled bool) {
 	// check state
 	require.Equal(t, pb.StateLeader, n1.state)
 	require.Equal(t, pb.StateFollower, n2.state)
-	require.Equal(t, pb.StatePreCandidate, n3.state)
+	if storeLivenessEnabled {
+		// Since the peers no longer hold a valid inFortifyLease, 3 will receive
+		// rejection votes and become a follower again.
+		require.Equal(t, pb.StateFollower, n3.state)
+	} else {
+		// Peers will just ignore the MsgVoteRequest due to the inHeartbeatLease and
+		// 3 will remain a preCandidate.
+		require.Equal(t, pb.StatePreCandidate, n3.state)
+	}
 
 	// check term
 	require.Equal(t, uint64(2), n1.Term)

--- a/pkg/raft/testdata/campaign_learner_must_vote.txt
+++ b/pkg/raft/testdata/campaign_learner_must_vote.txt
@@ -81,6 +81,7 @@ stabilize 3
 ----
 > 3 receiving messages
   2->3 MsgVote Term:2 Log:1/4
+  DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 3 [term: 1] received a MsgVote message with higher term from 2 [term: 2]
   INFO 3 became follower at term 2
   INFO 3 [logterm: 1, index: 3, vote: 0] cast MsgVote for 2 [logterm: 1, index: 4] at term 2

--- a/pkg/raft/testdata/confchange_v2_replace_leader.txt
+++ b/pkg/raft/testdata/confchange_v2_replace_leader.txt
@@ -176,6 +176,11 @@ support-expired 1
 ----
 ok
 
+# Make sure that 1 doesn't attempt to campaign on the next tick-heartbeat.
+set-randomized-election-timeout 1 timeout=5
+----
+ok
+
 tick-heartbeat 1
 ----
 ok
@@ -191,10 +196,13 @@ stabilize log-level=debug
   1->4 MsgDeFortifyLeader Term:1 Log:0/0
 > 2 receiving messages
   1->2 MsgDeFortifyLeader Term:1 Log:0/0
+  DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
 > 3 receiving messages
   1->3 MsgDeFortifyLeader Term:1 Log:0/0
+  DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
 > 4 receiving messages
   1->4 MsgDeFortifyLeader Term:1 Log:0/0
+  DEBUG 4 setting election elapsed to start from 3 ticks after store liveness support expired
 > 2 handling Ready
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:0

--- a/pkg/raft/testdata/de_fortification_basic.txt
+++ b/pkg/raft/testdata/de_fortification_basic.txt
@@ -316,6 +316,7 @@ stabilize
   1->2 MsgDeFortifyLeader Term:1 Log:0/0
 > 2 receiving messages
   1->2 MsgDeFortifyLeader Term:1 Log:0/0
+  DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
 > 3 receiving messages
   1->3 MsgDeFortifyLeader Term:1 Log:0/0
   DEBUG 3 is not fortifying 1; de-fortification is a no-op
@@ -351,7 +352,7 @@ ok
 # De-fortifying ourselves should also work as expected.
 send-de-fortify 1 1
 ----
-ok
+DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
 
 stabilize
 ----
@@ -649,6 +650,7 @@ stabilize
   2->3 MsgDeFortifyLeader Term:2 Log:0/0
 > 3 receiving messages
   2->3 MsgDeFortifyLeader Term:2 Log:0/0
+  DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
 > 3 handling Ready
   Ready MustSync=true:
   HardState Term:2 Vote:2 Commit:4 Lead:2 LeadEpoch:0
@@ -715,6 +717,7 @@ stabilize
   2->1 MsgDeFortifyLeader Term:2 Log:0/0
 > 1 receiving messages
   2->1 MsgDeFortifyLeader Term:2 Log:0/0
+  DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
 > 1 handling Ready
   Ready MustSync=true:
   HardState Term:2 Vote:2 Commit:4 Lead:2 LeadEpoch:0
@@ -805,6 +808,7 @@ stabilize
 > 2 receiving messages
   3->2 MsgFortifyLeader Term:4 Log:0/0
   INFO 2 [term: 2] received a MsgFortifyLeader message with higher term from 3 [term: 4]
+  DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 2 became follower at term 4
   3->2 MsgApp Term:4 Log:2/4 Commit:4 Entries:[4/5 EntryNormal ""]
 > 3 processing append thread
@@ -1021,6 +1025,7 @@ stabilize
   ]
 > 1 receiving messages
   2->1 MsgVote Term:5 Log:4/5
+  DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 1 [term: 4] received a MsgVote message with higher term from 2 [term: 5]
   INFO 1 became follower at term 5
   INFO 1 [logterm: 4, index: 5, vote: 0] cast MsgVote for 2 [logterm: 4, index: 5] at term 5
@@ -1273,6 +1278,7 @@ stabilize
   2->1 MsgDeFortifyLeader Term:5 Log:0/0
 > 1 receiving messages
   2->1 MsgDeFortifyLeader Term:5 Log:0/0
+  DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
 > 1 handling Ready
   Ready MustSync=true:
   HardState Term:5 Vote:2 Commit:6 Lead:2 LeadEpoch:0
@@ -1310,6 +1316,7 @@ stabilize
   ]
 > 2 receiving messages
   1->2 MsgVote Term:6 Log:5/6
+  DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 2 [term: 5] received a MsgVote message with higher term from 1 [term: 6]
   INFO 2 became follower at term 6
   INFO 2 [logterm: 5, index: 6, vote: 0] cast MsgVote for 1 [logterm: 5, index: 6] at term 6
@@ -1363,6 +1370,7 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:6 Log:5/6 Commit:6 Entries:[6/7 EntryNormal ""]
   INFO 3 [term: 5] received a MsgApp message with higher term from 1 [term: 6]
+  DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 3 became follower at term 6
 > 1 processing append thread
   Processing:

--- a/pkg/raft/testdata/de_fortification_checkquorum.txt
+++ b/pkg/raft/testdata/de_fortification_checkquorum.txt
@@ -81,6 +81,7 @@ ok
 # which is what we're interested in for this test.
 tick-election 1
 ----
+DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
 DEBUG 1 cannot campaign since it's not supported by a quorum in store liveness
 
 raft-state 1
@@ -105,12 +106,14 @@ stabilize
   1->3 MsgDeFortifyLeader Term:1 Log:0/0
 > 2 receiving messages
   1->2 MsgDeFortifyLeader Term:1 Log:0/0
+  DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
   1->2 MsgDeFortifyLeader Term:1 Log:0/0
   DEBUG 2 is not fortifying 1; de-fortification is a no-op
   1->2 MsgDeFortifyLeader Term:1 Log:0/0
   DEBUG 2 is not fortifying 1; de-fortification is a no-op
 > 3 receiving messages
   1->3 MsgDeFortifyLeader Term:1 Log:0/0
+  DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
   1->3 MsgDeFortifyLeader Term:1 Log:0/0
   DEBUG 3 is not fortifying 1; de-fortification is a no-op
   1->3 MsgDeFortifyLeader Term:1 Log:0/0
@@ -246,7 +249,7 @@ stabilize 3
 > 3 handling Ready
   Ready MustSync=true:
   State:StatePreCandidate
-  HardState Term:2 Commit:12 Lead:0 LeadEpoch:0
+  HardState Term:2 Vote:2 Commit:12 Lead:0 LeadEpoch:0
   Messages:
   3->1 MsgPreVote Term:3 Log:2/12
   3->2 MsgPreVote Term:3 Log:2/12
@@ -372,10 +375,15 @@ raft-log 2
 1/11 EntryNormal ""
 2/12 EntryNormal ""
 
+# Make sure 2 doesn't attempt to campaign on the next tick-heartbeat.
+set-randomized-election-timeout 2 timeout=5
+----
+ok
+
 # And as a result, it continues to send out de-fortification requests.
 tick-heartbeat 2
 ----
-ok
+DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
 
 stabilize
 ----

--- a/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
+++ b/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
@@ -53,9 +53,9 @@ stabilize 3
 deliver-msgs 1 2
 ----
 3->1 MsgPreVote Term:2 Log:1/11
-INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3) and supporting fortified leader 1 at epoch 1
+INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
 3->2 MsgPreVote Term:2 Log:1/11
-INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3) and supporting fortified leader 1 at epoch 1
+INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
 
 grant-support 3 1
 ----

--- a/pkg/raft/testdata/fortification_followers_dont_prevote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_prevote.txt
@@ -237,6 +237,7 @@ stabilize
   INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 2 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
 > 3 receiving messages
   2->3 MsgPreVote Term:2 Log:1/11
+  DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 3 [logterm: 1, index: 11, vote: 1] cast MsgPreVote for 2 [logterm: 1, index: 11] at term 1
 > 3 handling Ready
   Ready MustSync=true:
@@ -449,8 +450,10 @@ stabilize
   2->3 MsgDeFortifyLeader Term:2 Log:0/0
 > 1 receiving messages
   2->1 MsgDeFortifyLeader Term:2 Log:0/0
+  DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
 > 3 receiving messages
   2->3 MsgDeFortifyLeader Term:2 Log:0/0
+  DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
 > 1 handling Ready
   Ready MustSync=true:
   HardState Term:2 Commit:12 Lead:2 LeadEpoch:0

--- a/pkg/raft/testdata/fortification_followers_dont_vote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_vote.txt
@@ -210,6 +210,7 @@ stabilize
   INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 2 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
 > 3 receiving messages
   2->3 MsgVote Term:3 Log:1/11
+  DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 3 [term: 1] received a MsgVote message with higher term from 2 [term: 3]
   INFO 3 became follower at term 3
   INFO 3 [logterm: 1, index: 11, vote: 0] cast MsgVote for 2 [logterm: 1, index: 11] at term 3
@@ -386,8 +387,10 @@ stabilize
   2->3 MsgDeFortifyLeader Term:3 Log:0/0
 > 1 receiving messages
   2->1 MsgDeFortifyLeader Term:3 Log:0/0
+  DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
 > 3 receiving messages
   2->3 MsgDeFortifyLeader Term:3 Log:0/0
+  DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
 > 1 handling Ready
   Ready MustSync=true:
   HardState Term:3 Commit:12 Lead:2 LeadEpoch:0

--- a/pkg/raft/testdata/fortification_support_tracking.txt
+++ b/pkg/raft/testdata/fortification_support_tracking.txt
@@ -191,6 +191,7 @@ stabilize
   INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 2 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
 > 3 receiving messages
   2->3 MsgVote Term:2 Log:1/11
+  DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 3 [term: 1] received a MsgVote message with higher term from 2 [term: 2]
   INFO 3 became follower at term 2
   INFO 3 [logterm: 1, index: 11, vote: 0] cast MsgVote for 2 [logterm: 1, index: 11] at term 2

--- a/pkg/raft/testdata/prevote.txt
+++ b/pkg/raft/testdata/prevote.txt
@@ -105,6 +105,7 @@ deliver-msgs 1 2
 3->1 MsgPreVote Term:2 Log:1/11
 INFO 1 [logterm: 1, index: 12, vote: 1] rejected MsgPreVote from 3 [logterm: 1, index: 11] at term 1
 3->2 MsgPreVote Term:2 Log:1/11
+DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 2 [logterm: 1, index: 12, vote: 1] rejected MsgPreVote from 3 [logterm: 1, index: 11] at term 1
 
 # 3 failed to campaign. Let the network stabilize.

--- a/pkg/raft/testdata/prevote_checkquorum.txt
+++ b/pkg/raft/testdata/prevote_checkquorum.txt
@@ -51,10 +51,10 @@ stabilize
   INFO 2 has received 1 MsgPreVoteResp votes and 0 vote rejections
 > 1 receiving messages
   2->1 MsgPreVote Term:2 Log:1/11
-  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 2 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3) and supporting fortified leader 1 at epoch 1
+  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 2 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
 > 3 receiving messages
   2->3 MsgPreVote Term:2 Log:1/11
-  INFO 3 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 2 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3) and supporting fortified leader 1 at epoch 1
+  INFO 3 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 2 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
 
 # If 2 hasn't heard from the leader in the past election timeout, it should
 # grant prevotes, allowing 3 to hold an election.
@@ -106,7 +106,7 @@ stabilize
 ----
 > 1 receiving messages
   3->1 MsgPreVote Term:2 Log:1/11
-  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3) and supporting fortified leader 1 at epoch 1
+  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 3 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
 > 3 receiving messages
   2->3 MsgPreVoteResp Term:2 Log:0/0
   INFO 3 received MsgPreVoteResp from 2 at term 1
@@ -125,7 +125,7 @@ stabilize
   INFO 3 has received 1 MsgVoteResp votes and 0 vote rejections
 > 1 receiving messages
   3->1 MsgVote Term:2 Log:1/11
-  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 3 [logterm: 1, index: 11] at term 1: recently received communication from leader (remaining ticks: 3) and supporting fortified leader 1 at epoch 1
+  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 3 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
 > 2 receiving messages
   3->2 MsgVote Term:2 Log:1/11
   INFO 2 [term: 1] received a MsgVote message with higher term from 3 [term: 2]
@@ -268,10 +268,10 @@ stabilize
   INFO 1 has received 1 MsgPreVoteResp votes and 0 vote rejections
 > 2 receiving messages
   1->2 MsgPreVote Term:3 Log:2/12
-  INFO 2 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 1 [logterm: 2, index: 12] at term 2: recently received communication from leader (remaining ticks: 3) and supporting fortified leader 3 at epoch 1
+  INFO 2 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 1 [logterm: 2, index: 12] at term 2: supporting fortified leader 3 at epoch 1
 > 3 receiving messages
   1->3 MsgPreVote Term:3 Log:2/12
-  INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 1 [logterm: 2, index: 12] at term 2: recently received communication from leader (remaining ticks: 3) and supporting fortified leader 3 at epoch 1
+  INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 1 [logterm: 2, index: 12] at term 2: supporting fortified leader 3 at epoch 1
 
 withdraw-support 2 3
 ----
@@ -303,7 +303,7 @@ stabilize
   INFO 1 [logterm: 2, index: 12, vote: 0] cast MsgPreVote for 2 [logterm: 2, index: 12] at term 2
 > 3 receiving messages
   2->3 MsgPreVote Term:3 Log:2/12
-  INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 2 [logterm: 2, index: 12] at term 2: recently received communication from leader (remaining ticks: 3) and supporting fortified leader 3 at epoch 1
+  INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 2 [logterm: 2, index: 12] at term 2: supporting fortified leader 3 at epoch 1
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
@@ -331,7 +331,7 @@ stabilize
   INFO 1 [logterm: 2, index: 12, vote: 0] cast MsgVote for 2 [logterm: 2, index: 12] at term 3
 > 3 receiving messages
   2->3 MsgVote Term:3 Log:2/12
-  INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgVote from 2 [logterm: 2, index: 12] at term 2: recently received communication from leader (remaining ticks: 3) and supporting fortified leader 3 at epoch 1
+  INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgVote from 2 [logterm: 2, index: 12] at term 2: supporting fortified leader 3 at epoch 1
 > 1 handling Ready
   Ready MustSync=true:
   State:StateFollower

--- a/pkg/raft/testdata/snapshot_new_term.txt
+++ b/pkg/raft/testdata/snapshot_new_term.txt
@@ -60,6 +60,7 @@ stabilize 1 2
   INFO 2 has received 1 MsgVoteResp votes and 0 vote rejections
 > 1 receiving messages
   2->1 MsgVote Term:2 Log:1/11
+  DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 1 [term: 1] received a MsgVote message with higher term from 2 [term: 2]
   INFO 1 became follower at term 2
   INFO 1 [logterm: 1, index: 11, vote: 0] cast MsgVote for 2 [logterm: 1, index: 11] at term 2
@@ -140,6 +141,7 @@ stabilize
   2->3 MsgSnap Term:2 Log:0/0
     Snapshot: Index:12 Term:2 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   INFO 3 [term: 1] received a MsgSnap message with higher term from 2 [term: 2]
+  DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 3 became follower at term 2
   INFO log [committed=11, applied=11, applying=11, unstable.offset=12, unstable.offsetInProgress=12, len(unstable.Entries)=0] starts to restore snapshot [index: 12, term: 2]
   INFO 3 switched to configuration voters=(1 2 3)


### PR DESCRIPTION
We need to disarm the inHeartbeatLease where appropriate when using leader leases.

This PR does the following:

1) Whenever a peer is de-fortifying a leader, it advances its electionElapsed to electionTimeout. This means that (A) The peer can immediately vote in elections, and (B) The peer can attempt to call elections `electionTimeout` faster.

2) If a follower fortified a leader, its inHeartbeatLease is basically disabled and we just rely on the store liveness signal using `inFortifyLease()`

Epic: None

Release note: None