### PR TITLE
roachtest: fix multi-store-remove roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/multi_store_remove.go
+++ b/pkg/cmd/roachtest/tests/multi_store_remove.go
@@ -56,7 +56,7 @@ func runMultiStoreRemove(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// tolerate the removal of a store. Today, the mapping of failover
 	// secondaries is fixed, making WAL failover incompatible with the removal
 	// of a store.
-	startOpts.RoachprodOpts.WALFailover = "disabled"
+	startOpts.RoachprodOpts.WALFailover = ""
 	startSettings := install.MakeClusterSettings()
 	// Speed up the replicate queue.
 	startSettings.Env = append(startSettings.Env, "COCKROACH_SCAN_INTERVAL=30s")


### PR DESCRIPTION
Fix the multi-store-remove roachtest. Setting --wal-failover=disabled on a multi-store node that has never had WAL failover enabled is not yet supported.

Fixes #133939.
Informs #131468.
Epic: none
Release note: none