### PR TITLE
sql/catalog: avoid multiple interface boxing allocs from `descpb.NameInfo`

### DIFF
--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -553,12 +553,12 @@ func (tc *Collection) getNonVirtualDescriptorID(
 		return continueLookups, descpb.InvalidID, nil
 	}
 	lookupStoreCacheID := func() (continueOrHalt, descpb.ID, error) {
-		ni := descpb.NameInfo{ParentID: parentID, ParentSchemaID: parentSchemaID, Name: name}
+		ni := &descpb.NameInfo{ParentID: parentID, ParentSchemaID: parentSchemaID, Name: name}
 		if tc.isShadowedName(ni) {
 			return continueLookups, descpb.InvalidID, nil
 		}
-		if tc.cr.IsNameInCache(&ni) {
-			if e := tc.cr.Cache().LookupNamespaceEntry(&ni); e != nil {
+		if tc.cr.IsNameInCache(ni) {
+			if e := tc.cr.Cache().LookupNamespaceEntry(ni); e != nil {
 				return haltLookups, e.GetID(), nil
 			}
 			return haltLookups, descpb.InvalidID, nil
@@ -587,15 +587,15 @@ func (tc *Collection) getNonVirtualDescriptorID(
 		if flags.layerFilters.withoutStorage {
 			return haltLookups, descpb.InvalidID, nil
 		}
-		ni := descpb.NameInfo{ParentID: parentID, ParentSchemaID: parentSchemaID, Name: name}
+		ni := &descpb.NameInfo{ParentID: parentID, ParentSchemaID: parentSchemaID, Name: name}
 		if tc.isShadowedName(ni) {
 			return haltLookups, descpb.InvalidID, nil
 		}
-		read, err := tc.cr.GetByNames(ctx, txn, []descpb.NameInfo{ni})
+		read, err := tc.cr.GetByNames(ctx, txn, []descpb.NameInfo{*ni})
 		if err != nil {
 			return haltLookups, descpb.InvalidID, err
 		}
-		if e := read.LookupNamespaceEntry(&ni); e != nil {
+		if e := read.LookupNamespaceEntry(ni); e != nil {
 			return haltLookups, e.GetID(), nil
 		}
 		return haltLookups, descpb.InvalidID, nil

--- a/pkg/sql/catalog/descs/system_table.go
+++ b/pkg/sql/catalog/descs/system_table.go
@@ -40,18 +40,18 @@ func (r *systemTableIDResolver) LookupSystemTableID(
 	if err := r.db.DescsTxn(ctx, func(
 		ctx context.Context, txn Txn,
 	) (err error) {
-		ni := descpb.NameInfo{
+		ni := &descpb.NameInfo{
 			ParentID:       keys.SystemDatabaseID,
 			ParentSchemaID: keys.SystemPublicSchemaID,
 			Name:           tableName,
 		}
 		read, err := txn.Descriptors().cr.GetByNames(
-			ctx, txn.KV(), []descpb.NameInfo{ni},
+			ctx, txn.KV(), []descpb.NameInfo{*ni},
 		)
 		if err != nil {
 			return err
 		}
-		if e := read.LookupNamespaceEntry(&ni); e != nil {
+		if e := read.LookupNamespaceEntry(ni); e != nil {
 			id = e.GetID()
 		}
 		return nil

--- a/pkg/sql/catalog/internal/catkv/catalog_reader.go
+++ b/pkg/sql/catalog/internal/catkv/catalog_reader.go
@@ -326,9 +326,10 @@ func (cr catalogReader) GetByNames(
 	var mc nstree.MutableCatalog
 	cq := catalogQuery{codec: cr.codec}
 	err := cq.query(ctx, txn, &mc, func(codec keys.SQLCodec, b *kv.Batch) {
-		for _, nameInfo := range nameInfos {
-			if nameInfo.Name != "" {
-				get(ctx, b, catalogkeys.EncodeNameKey(codec, nameInfo))
+		for i := range nameInfos {
+			ni := &nameInfos[i]
+			if ni.Name != "" {
+				get(ctx, b, catalogkeys.EncodeNameKey(codec, ni))
 			}
 		}
 	})

--- a/pkg/sql/catalog/internal/catkv/catalog_reader_cached.go
+++ b/pkg/sql/catalog/internal/catkv/catalog_reader_cached.go
@@ -374,18 +374,19 @@ func (c *cachedCatalogReader) GetByNames(
 ) (nstree.Catalog, error) {
 	numUncached := 0
 	// Move any uncached name keys to the front of the slice.
-	for i, ni := range nameInfos {
-		if c.byNameState[ni].hasGetNamespaceEntries || c.hasScanAll {
+	for i := range nameInfos {
+		ni := &nameInfos[i]
+		if c.byNameState[*ni].hasGetNamespaceEntries || c.hasScanAll {
 			continue
 		}
-		if id, ts := c.systemDatabaseCache.lookupDescriptorID(c.version, &ni); id != descpb.InvalidID {
-			c.cache.UpsertNamespaceEntry(&ni, id, ts)
-			s := c.byNameState[ni]
+		if id, ts := c.systemDatabaseCache.lookupDescriptorID(c.version, ni); id != descpb.InvalidID {
+			c.cache.UpsertNamespaceEntry(ni, id, ts)
+			s := c.byNameState[*ni]
 			s.hasGetNamespaceEntries = true
-			c.setByNameState(ni, s)
+			c.setByNameState(*ni, s)
 			continue
 		}
-		nameInfos[i], nameInfos[numUncached] = nameInfos[numUncached], ni
+		nameInfos[i], nameInfos[numUncached] = nameInfos[numUncached], *ni
 		numUncached++
 	}
 	if numUncached > 0 && !c.hasScanAll {

--- a/pkg/sql/catalog/internal/catkv/catalog_reader_test.go
+++ b/pkg/sql/catalog/internal/catkv/catalog_reader_test.go
@@ -107,12 +107,12 @@ func TestDataDriven(t *testing.T) {
 					var name string
 					var dbID, scID int
 					d.ScanArgs(t, "name_key", &dbID, &scID, &name)
-					ni := descpb.NameInfo{
+					ni := &descpb.NameInfo{
 						ParentID:       descpb.ID(dbID),
 						ParentSchemaID: descpb.ID(scID),
 						Name:           name,
 					}
-					return fmt.Sprintf("%v", ccr.IsNameInCache(&ni))
+					return fmt.Sprintf("%v", ccr.IsNameInCache(ni))
 
 				case "is_desc_id_known_to_not_exist":
 					var id, maybeParentID int

--- a/pkg/sql/catalog/nstree/catalog.go
+++ b/pkg/sql/catalog/nstree/catalog.go
@@ -360,12 +360,13 @@ func (c Catalog) FilterByNames(nameInfos []descpb.NameInfo) Catalog {
 		return Catalog{}
 	}
 	var ret MutableCatalog
-	for _, ni := range nameInfos {
+	for i := range nameInfos {
+		ni := &nameInfos[i]
 		found := c.byName.getByName(ni.ParentID, ni.ParentSchemaID, ni.Name)
 		if found == nil {
 			continue
 		}
-		e := ret.ensureForName(&ni)
+		e := ret.ensureForName(ni)
 		*e = *found.(*byNameEntry)
 		if foundByID := c.byID.get(e.id); foundByID != nil {
 			e := ret.ensureForID(e.id)


### PR DESCRIPTION
When we cast a `descpb.NameInfo` to a `catalog.NameKey`, we incur at least one heap allocation to box the struct in an interface. This commit ensures that it's only one, and not multiple.

The change was motivated by observing two heap allocations in `lookupStoreCacheID`. Ideally, we would have no heap allocations here, but this is a step in the right direction.

While here, we also clean up a few similar cases.

```
name                            old time/op    new time/op    delta
Sysbench/SQL/oltp_read_only       36.3ms ± 4%    36.0ms ± 3%    ~     (p=0.730 n=9+9)
Sysbench/SQL/oltp_write_only      19.3ms ± 6%    18.8ms ± 4%  -2.36%  (p=0.043 n=9+10)
Sysbench/SQL/oltp_read_write      58.7ms ± 3%    57.2ms ± 2%  -2.49%  (p=0.000 n=10+10)
Sysbench/SQL/oltp_point_select    1.61ms ± 1%    1.56ms ± 2%  -2.59%  (p=0.000 n=9+10)
Sysbench/SQL/oltp_begin_commit     594µs ± 4%     608µs ± 7%    ~     (p=0.089 n=10+10)

name                            old alloc/op   new alloc/op   delta
Sysbench/SQL/oltp_read_only       1.05MB ± 1%    1.04MB ± 0%  -0.64%  (p=0.004 n=9+10)
Sysbench/SQL/oltp_write_only       405kB ± 1%     404kB ± 1%    ~     (p=0.720 n=9+10)
Sysbench/SQL/oltp_read_write      1.50MB ± 1%    1.51MB ± 1%    ~     (p=0.447 n=9+10)
Sysbench/SQL/oltp_point_select    35.3kB ± 2%    35.1kB ± 2%    ~     (p=0.278 n=9+10)
Sysbench/SQL/oltp_begin_commit    18.9kB ± 0%    18.9kB ± 1%    ~     (p=0.055 n=10+10)

name                            old allocs/op  new allocs/op  delta
Sysbench/SQL/oltp_read_only        6.96k ± 1%     6.86k ± 1%  -1.37%  (p=0.000 n=9+10)
Sysbench/SQL/oltp_write_only       3.62k ± 1%     3.58k ± 0%  -0.96%  (p=0.000 n=9+10)
Sysbench/SQL/oltp_read_write       11.0k ± 1%     10.9k ± 1%  -0.56%  (p=0.030 n=9+10)
Sysbench/SQL/oltp_point_select       317 ± 1%       312 ± 0%  -1.74%  (p=0.000 n=9+10)
Sysbench/SQL/oltp_begin_commit       140 ± 0%       140 ± 0%    ~     (p=1.000 n=10+10)
```

Epic: None
Release note: None