### PR TITLE
sql: fix recently introduced data race

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -727,25 +727,6 @@ func NewColOperator(
 	result := opResult{NewColOperatorResult: colexecargs.GetNewColOperatorResult()}
 	r := result.NewColOperatorResult
 	spec := args.Spec
-	// Throughout this method we often use the type slice from the input spec to
-	// create the type schema of an operator. However, it is possible that the
-	// same type slice is shared by multiple stages of processors. If it just so
-	// happens that there is free capacity in the slice, and we append to it
-	// when planning operators for both stages, we might corrupt the type schema
-	// captured by the operators for the earlier stage. In order to prevent such
-	// type schema corruption we cap the slice to force creation of a fresh copy
-	// on the first append.
-	if flowCtx.Gateway {
-		// Sharing of the same type slice is only possible on the gateway node
-		// because we don't serialize the specs created during the physical
-		// planning. On the remote nodes each stage of processors gets their own
-		// allocation, so there is no aliasing that can lead to the type schema
-		// corruption.
-		for i := range spec.Input {
-			inputSpec := &spec.Input[i]
-			inputSpec.ColumnTypes = inputSpec.ColumnTypes[:len(inputSpec.ColumnTypes):len(inputSpec.ColumnTypes)]
-		}
-	}
 	inputs := args.Inputs
 	if args.Factory == nil {
 		// This code path is only used in tests.


### PR DESCRIPTION
Recently, in a5b8d06dfde18f40dabb1f3ec04f4a731641377a we introduced a possible data race. Namely, that change modifies a proto inside of the physical plan to cap the slice of types during the vectorized operator planning in order to prevent a type schema corruption due to slice aliasing. However, it's been assumed in a couple of places that the physical plan is immutable. This commit clarifies that the physical plan is immutable after its finalization and moves the capping into the finalization.

Fixes: #133934.

Release note: None