### PR TITLE
kvserver: add leader lease type to TestLeaseRenewer

### DIFF
--- a/pkg/kv/kvserver/leases/build.go
+++ b/pkg/kv/kvserver/leases/build.go
@@ -773,3 +773,16 @@ func validateNonZero[T comparable](field T, name string) error {
 	}
 	return nil
 }
+
+// RunEachLeaseType calls f in a subtest for each lease type.
+func RunEachLeaseType[T testingTB[T]](t T, f func(T, roachpb.LeaseType)) {
+	for _, l := range roachpb.LeaseTypes() {
+		t.Run(l.String(), func(t T) { f(t, l) })
+	}
+}
+
+// testingTB is an interface that matches *testing.T and *testing.B, without
+// incurring the package dependency.
+type testingTB[T any] interface {
+	Run(name string, f func(t T)) bool
+}

--- a/pkg/kv/kvserver/replica_lease_renewal_test.go
+++ b/pkg/kv/kvserver/replica_lease_renewal_test.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/leases"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -36,11 +36,21 @@ func TestLeaseRenewer(t *testing.T) {
 
 	// We test with kv.expiration_leases_only.enabled both enabled and disabled,
 	// to ensure meta/liveness ranges are still eagerly extended, while regular
-	// ranges are upgraded to epoch leases.
-	testutils.RunTrueAndFalse(t, "kv.expiration_leases_only.enabled", func(t *testing.T, expOnly bool) {
+	// ranges are upgraded to epoch or leader leases.
+	leases.RunEachLeaseType(t, func(t *testing.T, leaseType roachpb.LeaseType) {
 		ctx := context.Background()
 		st := cluster.MakeTestingClusterSettings()
-		ExpirationLeasesOnly.Override(ctx, &st.SV, expOnly)
+		if leaseType == roachpb.LeaseExpiration {
+			ExpirationLeasesOnly.Override(ctx, &st.SV, true)
+		} else {
+			ExpirationLeasesOnly.Override(ctx, &st.SV, false)
+		}
+		if leaseType == roachpb.LeaseLeader {
+			RaftLeaderFortificationFractionEnabled.Override(ctx, &st.SV, 1.0)
+			LeaderLeasesEnabled.Override(ctx, &st.SV, true)
+		} else {
+			LeaderLeasesEnabled.Override(ctx, &st.SV, false)
+		}
 		tc := serverutils.StartCluster(t, 3, base.TestClusterArgs{
 			ServerArgs: base.TestServerArgs{
 				Settings: st,
@@ -102,12 +112,12 @@ func TestLeaseRenewer(t *testing.T) {
 		}
 
 		// assertLeaseUpgrade asserts that the range is eventually upgraded
-		// to an epoch lease.
-		assertLeaseUpgrade := func(rangeID roachpb.RangeID) {
+		// to an epoch or leader lease.
+		assertLeaseUpgrade := func(rangeID roachpb.RangeID, leaseType roachpb.LeaseType) {
 			repl := getNodeReplica(1, rangeID)
 			require.Eventually(t, func() bool {
 				lease, _ := repl.GetLease()
-				return lease.Type() == roachpb.LeaseEpoch
+				return lease.Type() == leaseType
 			}, 20*time.Second, 100*time.Millisecond)
 		}
 
@@ -132,10 +142,10 @@ func TestLeaseRenewer(t *testing.T) {
 		// Split off a regular non-system range. This should only be eagerly
 		// extended if kv.expiration_leases_only.enabled is true.
 		desc = tc.LookupRangeOrFatal(t, tc.ScratchRange(t))
-		if expOnly {
+		if leaseType == roachpb.LeaseExpiration {
 			assertLeaseExtension(desc.RangeID)
 		} else {
-			assertLeaseUpgrade(desc.RangeID)
+			assertLeaseUpgrade(desc.RangeID, leaseType)
 		}
 	})
 }


### PR DESCRIPTION
`TestLeaseRenewer` assumed either expiration leases or epoch leases and asserted that the correct lease is renewed. This was an issue when `RaftLeaderFortificationFractionEnabled` was metamorphically enabled because a leader lease would get acquired.

This commit extends the test to include leader leases.

Part of: #133763

Release note: None