### PR TITLE
sql/catalog/descs: reduce heap allocations in getNonVirtualDescriptorID

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -440,6 +440,13 @@ func (tc *Collection) isShadowedName(nameKey catalog.NameKey) bool {
 	return ok
 }
 
+// isShadowedNameInfo is similar to isShadowedName, but has a concrete parameter
+// type instead of an interface to avoid heap allocations.
+func (tc *Collection) isShadowedNameInfo(nameInfo descpb.NameInfo) bool {
+	_, ok := tc.shadowedNames[nameInfo]
+	return ok
+}
+
 // WriteCommentToBatch adds the comment changes to uncommitted layer and writes
 // to the kv batch.
 func (tc *Collection) WriteCommentToBatch(
@@ -652,7 +659,7 @@ func (tc *Collection) lookupDescriptorID(
 		return objInMemory.GetID(), nil
 	}
 	// Look up ID in storage if nothing was found in memory.
-	if tc.isShadowedName(key) {
+	if tc.isShadowedNameInfo(key) {
 		return descpb.InvalidID, nil
 	}
 	read, err := tc.cr.GetByNames(ctx, txn, []descpb.NameInfo{key})

--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -554,7 +554,7 @@ func (tc *Collection) getNonVirtualDescriptorID(
 	}
 	lookupStoreCacheID := func() (continueOrHalt, descpb.ID, error) {
 		ni := descpb.NameInfo{ParentID: parentID, ParentSchemaID: parentSchemaID, Name: name}
-		if tc.isShadowedName(ni) {
+		if tc.isShadowedNameInfo(ni) {
 			return continueLookups, descpb.InvalidID, nil
 		}
 		if tc.cr.IsNameInCache(&ni) {
@@ -588,7 +588,7 @@ func (tc *Collection) getNonVirtualDescriptorID(
 			return haltLookups, descpb.InvalidID, nil
 		}
 		ni := descpb.NameInfo{ParentID: parentID, ParentSchemaID: parentSchemaID, Name: name}
-		if tc.isShadowedName(ni) {
+		if tc.isShadowedNameInfo(ni) {
 			return haltLookups, descpb.InvalidID, nil
 		}
 		read, err := tc.cr.GetByNames(ctx, txn, []descpb.NameInfo{ni})


### PR DESCRIPTION
Some heap allocations in `getNonVirtualDescriptorID` have been
eliminated. In a recent sysbench heap profile, these allocations
accounted for 0.85% of all allocations.

Epic: None

Release note: None
