### PR TITLE
testutils: use race duration in a few places

### DIFF
--- a/pkg/testutils/sqlutils/sql_runner.go
+++ b/pkg/testutils/sqlutils/sql_runner.go
@@ -26,7 +26,7 @@ import (
 // convenience functions to run SQL statements and fail the test on any errors.
 type SQLRunner struct {
 	DB                   DBHandle
-	SucceedsSoonDuration time.Duration // defaults to testutils.DefaultSucceedsSoonDuration
+	SucceedsSoonDuration time.Duration // defaults to testutils.DefaultSucceedsSoonDuration or testutils.RaceSucceedsSoonDuration
 	MaxTxnRetries        int           // defaults to 0 for unlimited retries
 }
 
@@ -124,7 +124,7 @@ func (sr *SQLRunner) succeedsWithin(t Fataler, f func() error) {
 	helperOrNoop(t)()
 	d := sr.SucceedsSoonDuration
 	if d == 0 {
-		d = testutils.DefaultSucceedsSoonDuration
+		d = testutils.SucceedsSoonDuration()
 	}
 	require.NoError(requireT{t}, testutils.SucceedsWithinError(f, d))
 }
@@ -230,7 +230,7 @@ func (sr *SQLRunner) ExpectErrWithTimeout(
 	helperOrNoop(t)()
 	d := sr.SucceedsSoonDuration
 	if d == 0 {
-		d = testutils.DefaultSucceedsSoonDuration
+		d = testutils.SucceedsSoonDuration()
 	}
 	err := timeutil.RunWithTimeout(context.Background(), "expect-err", d, func(ctx context.Context) error {
 		_, err := sr.DB.ExecContext(ctx, query, args...)


### PR DESCRIPTION
**sql: skip TestShowRangesMultipleStores under race**

This test starts multiple servers so that it overloads the machine under stress-race. We no longer have a skip for this, so we skip the test under a race (which is more general). Also this commit fixes a few comments.

Fixes: #130490.

Release note: None

**testutils: use race duration in a few places**

Previously, in a few test helper methods (like `CheckQueryResultsRetry` and `ExecSucceedsSoon`) we unconditionally used the "default" SucceedsSoon duration of 45s. This was an oversight and could lead to flakes in race / stress builds, so this commit properly changes those callsites to use the race duration whenever applicable (which is 225s).

Release note: None