### PR TITLE
kvserver: disable leader leases for TestRaftUnquiesceLeaderNoProposal

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -6719,6 +6719,9 @@ func TestRaftUnquiesceLeaderNoProposal(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	kvserver.TransferExpirationLeasesFirstEnabled.Override(ctx, &st.SV, false)
 	kvserver.ExpirationLeasesOnly.Override(ctx, &st.SV, false)
+	// Quiescence is disabled for leader leases
+	// (see shouldReplicaQuiesceRaftMuLockedReplicaMuLocked).
+	kvserver.LeaderLeasesEnabled.Override(ctx, &st.SV, false)
 
 	// Block writes to the range, to prevent spurious proposals (typically due to
 	// txn record GC).


### PR DESCRIPTION
`TestRaftUnquiesceLeaderNoProposal` forces replicas to quiesce by blocking all requests to a given range. However, with leader leases, leaders never initiate quiescence
(see `shouldReplicaQuiesceRaftMuLockedReplicaMuLocked`).

This commit disables leader leases for this test.

Part of: #133763

Release note: None