### PR TITLE
rpc: reduce certificate-related allocations during authentication

### DIFF
--- a/pkg/rpc/helpers_test.go
+++ b/pkg/rpc/helpers_test.go
@@ -34,21 +34,9 @@ func TestingNewWrappedServerStream(
 // TestingAuthenticateTenant performs authentication of a tenant from a context
 // for testing.
 func TestingAuthenticateTenant(
-	ctx context.Context,
-	serverTenantID roachpb.TenantID,
-	clusterSettings map[settings.InternalKey]settings.EncodedValue,
+	ctx context.Context, serverTenantID roachpb.TenantID, sv *settings.Values,
 ) (roachpb.TenantID, error) {
-	sv := &settings.Values{}
-	sv.Init(ctx, settings.TestOpaque)
-	u := settings.NewUpdater(sv)
-
 	kvAuthObject := kvAuth{sv: sv, tenant: tenantAuthorizer{tenantID: serverTenantID}}
-	for setting := range clusterSettings {
-		err := u.Set(ctx, setting, clusterSettings[setting])
-		if err != nil {
-			return roachpb.TenantID{}, err
-		}
-	}
 	_, authz, err := kvAuthObject.authenticateAndSelectAuthzRule(ctx)
 	if err != nil {
 		return roachpb.TenantID{}, err


### PR DESCRIPTION
#### rpc: add authenication benchmark

Release note: None

#### rpc: reduce certificate-related allocations during authentication

This commit avoids certificate-related allocations in the happy path of
authenticating network requests.

Release note: None

#### security: inline getCertificatePrincipals

The `getCertificatePrincipals` function has been inlined into its one
callsite to avoid allocating a slice of the results.

Fixes #133317

Release note: None