### PR TITLE
sqlsmith: adjust restore generation for deprecation

### DIFF
--- a/pkg/internal/sqlsmith/bulkio.go
+++ b/pkg/internal/sqlsmith/bulkio.go
@@ -149,6 +149,7 @@ func makeRestore(s *Smither) (tree.Statement, bool) {
 
 	return &tree.Restore{
 		Targets: targets,
+		Subdir:  tree.NewStrVal("LATEST"),
 		From:    []tree.StringOrPlaceholderOptList{{tree.NewStrVal(name)}},
 		AsOf:    makeAsOf(s),
 		Options: tree.RestoreOptions{


### PR DESCRIPTION
We recently completely removed the parser support for some of the RESTORE syntax. This commit teaches the sqlsmith to no longer generate the old syntax.

Fixes: #134263.

Release note: None