### PR TITLE
crosscluster: fix vtable

### DIFF
--- a/pkg/repstream/streampb/empty.go
+++ b/pkg/repstream/streampb/empty.go
@@ -57,6 +57,7 @@ func (h *DebugProducerStatusHolder) Flushed(size int64, reason FlushReason, seqN
 	defer h.mu.Unlock()
 	h.s.Flushes.Batches++
 	h.s.Flushes.Bytes += size
+	h.s.Flushes.LastSize = size
 	h.s.SeqNum = seqNum
 
 	switch reason {
@@ -65,7 +66,7 @@ func (h *DebugProducerStatusHolder) Flushed(size int64, reason FlushReason, seqN
 	case FlushReady:
 		h.s.Flushes.Ready++
 	case FlushCheckpoint:
-		h.s.Flushes.Checkpoints++
+		h.s.Flushes.Forced++
 	}
 }
 

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -9337,7 +9337,7 @@ CREATE TABLE crdb_internal.cluster_replication_node_streams (
 				}
 				return 0
 			}
-			flushFull, flushReady, flushCheckpoint := s.Flushes.Full, s.Flushes.Ready, s.Flushes.Checkpoints
+			flushFull, flushReady, flushCheckpoint := s.Flushes.Full, s.Flushes.Ready, s.Flushes.Forced
 
 			if err := addRow(
 				tree.NewDInt(tree.DInt(s.StreamID)),                                              // stream_id


### PR DESCRIPTION
Flushes forced by a checkpoint should inc forced flush count, not checkpoint count.

Release note: none.
Epic: none.