### PR TITLE
crosscluster/logical: eliminate RowProcessor indirection

### DIFF
--- a/pkg/ccl/crosscluster/logical/BUILD.bazel
+++ b/pkg/ccl/crosscluster/logical/BUILD.bazel
@@ -133,6 +133,7 @@ go_test(
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/execinfra",
+        "//pkg/sql/execinfrapb",
         "//pkg/sql/isql",
         "//pkg/sql/randgen",
         "//pkg/sql/rowenc",


### PR DESCRIPTION
The extra layer of wrapper/indirection between the batching logic and retrying in the LDR processor and the actual kv or sql batch handler was not really helping us and indeed was going to make extending the KV handler to support multi-row batches harder. Instead the KV and SQL processors now directly implement HandleBatch themselves.

Release note: none.
Epic: none.