### PR TITLE
sql: blank pad character datums more efficiently

### DIFF
--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -80,6 +80,7 @@ go_library(
         "//pkg/util/ring",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
+        "//pkg/util/system",
         "//pkg/util/timeofday",
         "//pkg/util/timeutil",
         "//pkg/util/timeutil/pgdate",

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -6,6 +6,7 @@
 package pgwire
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"math"
@@ -29,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ipaddr"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/system"
 	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/cockroach/pkg/util/tsearch"
@@ -516,9 +518,7 @@ func writeBinaryDecimal(b *writeBuffer, v *apd.Decimal) {
 }
 
 // spaces is used for padding CHAR(N) datums.
-var spaces = [16]byte{
-	' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
-}
+var spaces = bytes.Repeat([]byte{' '}, system.CacheLineSize)
 
 func writeBinaryBytes(b *writeBuffer, v []byte, t *types.T) {
 	if t.Oid() == oid.T_char && len(v) == 0 {

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -163,6 +163,7 @@ go_library(
         "//pkg/util/pretty",
         "//pkg/util/stringencoding",
         "//pkg/util/syncutil",
+        "//pkg/util/system",
         "//pkg/util/timeofday",
         "//pkg/util/timetz",
         "//pkg/util/timeutil",

--- a/pkg/sql/sem/tree/pgwire_encode.go
+++ b/pkg/sql/sem/tree/pgwire_encode.go
@@ -7,7 +7,6 @@ package tree
 
 import (
 	"bytes"
-	"fmt"
 	"math"
 	"strconv"
 	"time"
@@ -15,11 +14,16 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/system"
 	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
 	"github.com/cockroachdb/cockroach/pkg/util/timetz"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/lib/pq/oid"
 )
+
+// spaces is a static slice of spaces used for efficient padding.
+var spaces = bytes.Repeat([]byte{' '}, system.CacheLineSize)
 
 // ResolveBlankPaddedChar pads the given string with spaces if blank padding is
 // required or returns the string unmodified otherwise.
@@ -27,7 +31,15 @@ func ResolveBlankPaddedChar(s string, t *types.T) string {
 	if t.Oid() == oid.T_bpchar && len(s) < int(t.Width()) {
 		// Pad spaces on the right of the string to make it of length specified
 		// in the type t.
-		return fmt.Sprintf("%-*v", t.Width(), s)
+		res := make([]byte, t.Width())
+		copy(res, s)
+		pad := res[len(s):]
+		for len(pad) > len(spaces) {
+			copy(pad, spaces)
+			pad = pad[len(spaces):]
+		}
+		copy(pad, spaces)
+		return encoding.UnsafeConvertBytesToString(res)
 	}
 	return s
 }

--- a/pkg/util/system/BUILD.bazel
+++ b/pkg/util/system/BUILD.bazel
@@ -2,7 +2,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "system",
-    srcs = ["num_cpu.go"],
+    srcs = [
+        "cache_line.go",
+        "num_cpu.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/system",
     visibility = ["//visibility:public"],
+    deps = ["@org_golang_x_sys//cpu"],
 )

--- a/pkg/util/system/cache_line.go
+++ b/pkg/util/system/cache_line.go
@@ -1,0 +1,27 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package system
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/cpu"
+)
+
+// CacheLineSize is the size of a CPU cache line in bytes, or a non-zero
+// estimate if the size is unknown.
+const CacheLineSize = max(
+	int(unsafe.Sizeof(cpu.CacheLinePad{})),
+	// The size of the CacheLinePad struct is 0 on some software-abstracted
+	// platforms, like Wasm, where the cache line size of the underlying CPU is
+	// not known. In such cases, use a reasonable default value of 64 bytes.
+	//
+	// NOTE: we use max instead of an init-time comparison so that CacheLineSize
+	// can be used in const expressions. The subtraction here drives this term
+	// below 0 to be ignored by max in all cases except when the size of the
+	// CacheLinePad struct is 0.
+	64-65*int(unsafe.Sizeof(cpu.CacheLinePad{})),
+)


### PR DESCRIPTION
This commit updates `ResolveBlankPaddedChar` to more efficiently pad bpchar datums. Instead of passing through `fmt.Sprintf`, we can just allocate a new byte slice, copy the character slice into the front, and quickly pad the back with spaces.

Microbenchmarks:
```
name                     old time/op    new time/op    delta
WriteTextColumnarChar       154µs ± 2%      43µs ± 1%  -72.28%  (p=0.000 n=10+9)

name                     old alloc/op   new alloc/op   delta
WriteTextColumnarChar      34.6kB ± 1%    16.4kB ± 0%  -52.61%  (p=0.000 n=10+10)

name                     old allocs/op  new allocs/op  delta
WriteTextColumnarChar       2.05k ± 0%     1.02k ± 0%  -50.00%  (p=0.000 n=10+10)
```

This is important for sysbench, which uses two fixed-length, blank padded character columns (`c` and `pad`).

Sysbench:
```
name                            old time/op    new time/op    delta
Sysbench/SQL/oltp_read_write      5.32ms ± 2%    5.29ms ± 3%    ~     (p=0.315 n=10+10)
Sysbench/SQL/oltp_read_only       2.37ms ± 3%    2.27ms ± 5%  -3.92%  (p=0.003 n=10+10)
Sysbench/SQL/oltp_write_only      2.15ms ± 4%    2.16ms ± 3%    ~     (p=0.549 n=10+9)
Sysbench/SQL/oltp_point_select     131µs ± 4%     133µs ± 1%    ~     (p=0.182 n=10+9)

name                            old alloc/op   new alloc/op   delta
Sysbench/SQL/oltp_read_write      1.32MB ± 0%    1.31MB ± 1%  -0.51%  (p=0.002 n=10+10)
Sysbench/SQL/oltp_read_only        949kB ± 0%     945kB ± 0%  -0.41%  (p=0.000 n=10+10)
Sysbench/SQL/oltp_write_only       461kB ± 1%     462kB ± 0%    ~     (p=0.258 n=9+9)
Sysbench/SQL/oltp_point_select    30.2kB ± 0%    30.2kB ± 0%    ~     (p=0.297 n=9+9)

name                            old allocs/op  new allocs/op  delta
Sysbench/SQL/oltp_read_write       9.22k ± 0%     8.89k ± 1%  -3.48%  (p=0.000 n=10+10)
Sysbench/SQL/oltp_read_only        5.99k ± 0%     5.68k ± 0%  -5.21%  (p=0.000 n=10+10)
Sysbench/SQL/oltp_write_only       3.21k ± 0%     3.20k ± 0%    ~     (p=0.613 n=9+7)
Sysbench/SQL/oltp_point_select       286 ± 1%       286 ± 0%  -0.28%  (p=0.019 n=10+10)
```

Epic: None
Release note: None