### PR TITLE
roachtest: ignore flaky pgjdbc and activerecord tests

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord_blocklist.go
+++ b/pkg/cmd/roachtest/tests/activerecord_blocklist.go
@@ -43,4 +43,6 @@ var activeRecordBlocklist = blocklist{
 	`PostGISTest#test_point_to_json`:                                                                                                    "unknown",
 }
 
-var activeRecordIgnoreList = blocklist{}
+var activeRecordIgnoreList = blocklist{
+	`ActiveRecord::ConnectionAdapters::PostgreSQLAdapterTest#test_translate_no_connection_exception_to_not_established`: "pg_terminate_backend not implemented",
+}

--- a/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
+++ b/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
@@ -808,7 +808,7 @@ var pgjdbcIgnoreList = blocklist{
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testTruncatedUTF8Decode":                                                                        "54477",
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testUTF8Decode":                                                                                 "54477",
 	"org.postgresql.test.jdbc2.DatabaseMetaDataCacheTest.testGetTypeInfoUsesCache":                                                                  "https://github.com/cockroachdb/cockroach/issues/119332#issuecomment-1950242848",
-	"org.postgresql.test.jdbc2.StatementTest.testShortQueryTimeout":                                                                                 "flaky",
+	"org.postgresql.test.jdbc2.StatementTest.shortQueryTimeout":                                                                                     "flaky",
 	"org.postgresql.test.jdbc4.jdbc41.SchemaTest.testCurrentSchemaPropertyNotVisibilityTableInsideFunction":                                         "https://github.com/pgjdbc/pgjdbc/pull/2806",
 	"org.postgresql.test.jdbc4.jdbc41.SchemaTest.testCurrentSchemaPropertyVisibilityFunction":                                                       "https://github.com/pgjdbc/pgjdbc/pull/2806",
 	"org.postgresql.test.jdbc4.jdbc41.SchemaTest.testCurrentSchemaPropertyVisibilityTableDuringFunctionCreation":                                    "https://github.com/pgjdbc/pgjdbc/pull/2806",


### PR DESCRIPTION
- The name of a flaky pgjdbc test was changed in pgjdbc/pgjdbc#2979, so we update it here.
- An activerecord test relies on the pg_terminate_backend function, which we do not implement, so we ignore the test.

fixes https://github.com/cockroachdb/cockroach/issues/133929
fixes https://github.com/cockroachdb/cockroach/issues/133810
fixes https://github.com/cockroachdb/cockroach/issues/133928
fixes https://github.com/cockroachdb/cockroach/issues/134135
Release note: None