### PR TITLE
kvserver: add logscope to BenchmarkStoreRangeSplit

### DIFF
--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -2661,6 +2661,8 @@ func TestLeaderAfterSplit(t *testing.T) {
 }
 
 func BenchmarkStoreRangeSplit(b *testing.B) {
+	defer log.Scope(b).Close(b)
+
 	ctx := context.Background()
 	s := serverutils.StartServerOnly(b, base.TestServerArgs{})
 


### PR DESCRIPTION
Epic: none
Release note: None