### PR TITLE
opt: make `max-stack` opt tester option more reliable

### DIFF
--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -2820,7 +2820,7 @@ CREATE TABLE t132669 (
 # unnecessary recursion to trigger a stack overflow without having to make the
 # `IN` list below huge - triggering a stack overflow with Go's default max stack
 # size requires a list of ~1.6 million elements.
-opt max-stack=125KB format=hide-all
+opt max-stack=100kB skip-race format=hide-all
 SELECT * FROM t132669
 WHERE a IN (
     1,  2,  3,  4,  5,  6,  7, 8, 9, 10,


### PR DESCRIPTION
The `max-stack` opt tester option now runs the test command in a
separate goroutine. A fresh stack makes tests using this setting more
reliable.

It also decreases the `max-stack` of the original test that motivated
the `max-stack` option (see https://github.com/cockroachdb/cockroach/pull/132701) to 100KB, between 65KB in which the
test fails after the fix in https://github.com/cockroachdb/cockroach/pull/132701 and 135KB in which the test fails
before the fix.

Finally, the test has been disabled under `race` builds which increase
the size of stack frames and would cause this test to fail.

Epic: None

Release note: None
