### PR TITLE
roachprod, roachtest: move log fatal to test framework

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/build",
+        "//pkg/cli/exit",
         "//pkg/cmd/bazci/githubpost/issues",
         "//pkg/cmd/roachprod/grafana",
         "//pkg/cmd/roachtest/cluster",

--- a/pkg/cmd/roachtest/work_pool.go
+++ b/pkg/cmd/roachtest/work_pool.go
@@ -211,7 +211,7 @@ func scoreTestAgainstCluster(
 	t := tc.spec
 	testPolicy := t.Cluster.ReusePolicy
 	if tag != "" && testPolicy != (spec.ReusePolicyTagged{Tag: tag}) {
-		l.Fatalf(
+		logFatalfCtx(context.Background(), l,
 			"incompatible test and cluster. Cluster tag: %s. Test policy: %+v",
 			tag, t.Cluster.ReusePolicy,
 		)
@@ -263,7 +263,7 @@ func (p *workPool) decTestLocked(ctx context.Context, l *logger.Logger, name str
 		}
 	}
 	if idx == -1 {
-		l.FatalfCtx(ctx, "failed to find test: %s", name)
+		logFatalfCtx(ctx, l, "failed to find test: %s", name)
 	}
 	tc := &p.mu.tests[idx]
 	tc.count--

--- a/pkg/roachprod/logger/BUILD.bazel
+++ b/pkg/roachprod/logger/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/roachprod/logger",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/cli/exit",
         "//pkg/util/log",
         "//pkg/util/log/logconfig",
         "//pkg/util/log/logpb",

--- a/pkg/roachprod/logger/log.go
+++ b/pkg/roachprod/logger/log.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	crdblog "github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
@@ -284,25 +283,6 @@ func (l *Logger) PrintfCtx(ctx context.Context, f string, args ...interface{}) {
 // can be passed.
 func (l *Logger) Printf(f string, args ...interface{}) {
 	l.PrintfCtxDepth(context.Background(), 2 /* depth */, f, args...)
-}
-
-// FatalfCtxDepth is like ErrorfCtxDepth, except that it closes the logger after
-// logging the message and then exits the process with status 1.
-func (l *Logger) FatalfCtxDepth(ctx context.Context, depth int, f string, args ...interface{}) {
-	l.ErrorfCtxDepth(ctx, depth, f, args...)
-	l.Close()
-	exit.WithCode(exit.UnspecifiedError())
-}
-
-// FatalfCtx is like FatalfCtxDepth, except without having to pass depth explicitly.
-func (l *Logger) FatalfCtx(ctx context.Context, f string, args ...interface{}) {
-	l.FatalfCtxDepth(ctx, 2 /* depth */, f, args...)
-}
-
-// Fatalf is like FatalfCtx, except it doesn't take a ctx and thus no log tags
-// can be passed.
-func (l *Logger) Fatalf(f string, args ...interface{}) {
-	l.FatalfCtx(context.Background(), f, args...)
 }
 
 // PrintfCtxDepth is like PrintfCtx, except that it allows the caller to control


### PR DESCRIPTION
Previously, `Fatalf`* was added to the roachprod logger to handle cases where the test framework encountered an error requiring termination of the process. In hindsight adding `Fatalf` to the roachprod logger is risky as it could end up being called from a roachtest, which would be incorrect usage.

To prevent possible programmer errors, this PR rather opts to move the fatal call to a private method within the framework.

Epic: None
Release note: None