### PR TITLE
ui: hit allocs endpoint instead of heap for delta profile

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
@@ -427,7 +427,7 @@ export default function Debug() {
           />
           <DebugTableLink
             name="Heap (recent allocs)"
-            url="debug/pprof/ui/heap/"
+            url="debug/pprof/ui/allocs/"
             params={{ node: nodeID, seconds: "5", si: "alloc_objects" }}
           />
           <DebugTableLink


### PR DESCRIPTION
The allocs endpoint defaults to alloc_space, the heap endpoint to inuse_space.
inuse_space does not make much sense for a delta profile.

Epic: none
Release note: None