### PR TITLE
tablemetadatacache: update bucket config for job duration metric

### DIFF
--- a/pkg/sql/tablemetadatacache/update_table_metadata_cache_job.go
+++ b/pkg/sql/tablemetadatacache/update_table_metadata_cache_job.go
@@ -242,7 +242,7 @@ func newTableMetadataUpdateJobMetrics() metric.Struct {
 				Measurement: "Duration",
 				Unit:        metric.Unit_NANOSECONDS},
 			Duration:     base.DefaultHistogramWindowInterval(),
-			BucketConfig: metric.IOLatencyBuckets,
+			BucketConfig: metric.LongRunning60mLatencyBuckets,
 			Mode:         metric.HistogramModePrometheus,
 		}),
 	}


### PR DESCRIPTION
Previously the job was using IOLatencyBuckets for the duration histogram metric, which has a min of 10µs and max of 10s. This job will likely take a lot longer than 10s for larger clusters, which would make this metric useless.

Now, this metric uses LongRunning60mLatencyBuckets, which has a max bucket size of 60m.

Epic: none
Release note: None