### PR TITLE
cloud: fix missing shared config profile error on kms backups

### DIFF
--- a/pkg/cloud/amazon/aws_kms.go
+++ b/pkg/cloud/amazon/aws_kms.go
@@ -185,7 +185,6 @@ func MakeAWSKMS(ctx context.Context, uri string, env cloud.KMSEnv) (cloud.KMS, e
 			return nil, errors.New(
 				"implicit credentials disallowed for s3 due to --external-io-disable-implicit-credentials flag")
 		}
-		addLoadOption(config.WithSharedConfigProfile(config.DefaultSharedConfigProfile))
 	default:
 		return nil, errors.Errorf("unsupported value %s for %s", kmsURIParams.auth, cloud.AuthParam)
 	}


### PR DESCRIPTION
Backups with KMS keys fail due to a missing shared config profile `default` after the upgrade to the AWS SDK V2. This is due to a bad port over to the V2 SDK where we enforce that the `default` shared config must be used for implicit auth on AWS KMS. As we now use `config.LoadDefaultConfig` to load the client configuration, it will automatically attempt to load the shared config but ignore the error if it does not exist. We should not explicitly specify that the shared config must be used or else it will error upon failing to find it.

Fixes: #134214

Epic: none

Release note (bug fix): Fixed AWS backup/restore with kms failing due to missing shared config.