### PR TITLE
roachtest: fix task manager race

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/task/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/task/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//pkg/roachprod/logger",
         "//pkg/util/ctxgroup",
+        "//pkg/util/syncutil",
     ],
 )
 

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -316,6 +316,7 @@ func TestRunnerTestTimeout(t *testing.T) {
 		debugMode: NoDebug,
 	}
 	numTasks := 3
+	startedAllTasks := make(chan struct{})
 	var tasksDone atomic.Uint32
 	test := registry.TestSpec{
 		Name:             `timeout`,
@@ -335,6 +336,7 @@ func TestRunnerTestTimeout(t *testing.T) {
 					return nil
 				})
 			}
+			close(startedAllTasks)
 			<-ctx.Done()
 		},
 	}
@@ -351,6 +353,7 @@ func TestRunnerTestTimeout(t *testing.T) {
 	}
 
 	// Ensure tasks are also canceled.
+	<-startedAllTasks
 	require.Equal(t, uint32(numTasks), tasksDone.Load())
 }
 


### PR DESCRIPTION
Previously, the cancel function slice was not wrapped in a mutex, leading to possible concurrent access. This change adds a mutex.

Fixes: #134302
Informs: #133263

Epic: None
Release note: None