### PR TITLE
changefeedccl: eliminate race in test validation

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -471,13 +471,33 @@ func TestChangefeedIdleness(t *testing.T) {
 
 		registry := s.Server.JobRegistry().(*jobs.Registry)
 		currentlyIdle := registry.MetricsStruct().JobMetrics[jobspb.TypeChangefeed].CurrentlyIdle
+		// Use a wait group for cases when the number of idle changefeeds temporarily
+		// decreases, to avoid a race condition where the changefeed becomes idle
+		// before the idleness is checked.
+		var wg sync.WaitGroup
 		waitForIdleCount := func(numIdle int64) {
+			wg.Add(1)
 			testutils.SucceedsSoon(t, func() error {
 				if currentlyIdle.Value() != numIdle {
 					return fmt.Errorf("expected (%+v) idle changefeeds, found (%+v)", numIdle, currentlyIdle.Value())
 				}
 				return nil
 			})
+			wg.Done()
+		}
+		done := make(chan bool)
+		workload := func() {
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					sqlDB.Exec(t, `INSERT INTO foo VALUES (0)`)
+					sqlDB.Exec(t, `DELETE FROM foo WHERE a = 0`)
+					sqlDB.Exec(t, `INSERT INTO bar VALUES (0)`)
+					sqlDB.Exec(t, `DELETE FROM bar WHERE b = 0`)
+				}
+			}
 		}
 
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
@@ -486,9 +506,10 @@ func TestChangefeedIdleness(t *testing.T) {
 		cf2 := feed(t, f, "CREATE CHANGEFEED FOR TABLE bar WITH resolved='10ms'")
 		defer closeFeed(t, cf1)
 
-		sqlDB.Exec(t, `INSERT INTO foo VALUES (0)`)
-		sqlDB.Exec(t, `INSERT INTO bar VALUES (0)`)
-		waitForIdleCount(0)
+		go workload()
+		go waitForIdleCount(0)
+		wg.Wait()
+		done <- true
 		waitForIdleCount(2) // Both should eventually be considered idle
 
 		jobFeed := cf2.(cdctest.EnterpriseTestFeed)
@@ -501,14 +522,12 @@ func TestChangefeedIdleness(t *testing.T) {
 		closeFeed(t, cf2)
 		waitForIdleCount(1) // The cancelled changefeed isn't considered idle
 
-		sqlDB.Exec(t, `INSERT INTO foo VALUES (1)`)
-		waitForIdleCount(0)
+		go workload()
+		go waitForIdleCount(0)
+		wg.Wait()
+		done <- true
 		waitForIdleCount(1)
 
-		assertPayloads(t, cf1, []string{
-			`foo: [0]->{"after": {"a": 0}}`,
-			`foo: [1]->{"after": {"a": 1}}`,
-		})
 	}, feedTestEnterpriseSinks)
 }
 


### PR DESCRIPTION
TestChangefeedIdleness checks that the changefeed job state correctly moves in and out of the idle state. This change fixes a race condition when validating that jobs move out of idle state after an insert, since it's possible that the job becomes active and then idle again before the test is able to validate that the state was not idle.

Epic: none

Fixes: #134304
Fixes: #133660

Release note: None