### PR TITLE
sql: avoid expensive errors with empty database name lookups (2% cpu)

### DIFF
--- a/pkg/sql/catalog/descs/BUILD.bazel
+++ b/pkg/sql/catalog/descs/BUILD.bazel
@@ -118,6 +118,7 @@ go_test(
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
+        "//pkg/sql/sqlerrors",
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqlliveness/sqllivenesstestutils",
         "//pkg/sql/types",

--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -252,6 +253,10 @@ func TestAddUncommittedDescriptorAndMutableResolution(t *testing.T) {
 			immByIDAfter, err := descriptors.ByIDWithLeased(txn.KV()).WithoutNonPublic().Get().Database(ctx, dbID)
 			require.NoError(t, err)
 			require.Same(t, immByNameAfter, immByIDAfter)
+
+			// The name must be non-empty.
+			_, err = descriptors.ByNameWithLeased(txn.KV()).Get().Database(ctx, "")
+			require.Equal(t, sqlerrors.ErrEmptyDatabaseName, err)
 
 			return nil
 		}))

--- a/pkg/sql/catalog/descs/getters.go
+++ b/pkg/sql/catalog/descs/getters.go
@@ -241,6 +241,12 @@ type ByNameGetter getterBase
 func (g ByNameGetter) Database(
 	ctx context.Context, name string,
 ) (catalog.DatabaseDescriptor, error) {
+	if name == "" {
+		if g.flags.isOptional {
+			return nil, nil
+		}
+		return nil, sqlerrors.ErrEmptyDatabaseName
+	}
 	desc, err := getDescriptorByName(
 		ctx, g.KV(), g.Descriptors(), nil /* db */, nil /* sc */, name, g.flags, catalog.Database,
 	)

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -562,8 +562,15 @@ func maybeLookupRoutine(
 		return nil, nil
 	}
 
+	db := sr.CurrentDatabase()
+	if db == "" {
+		// The database is empty for queries run in the internal executor. None
+		// of the lookups below will succeed, so we can return early.
+		return nil, nil
+	}
+
 	if fn.ExplicitSchema && fn.Schema() != catconstants.CRDBInternalSchemaName {
-		found, prefix, err := sr.LookupSchema(ctx, sr.CurrentDatabase(), fn.Schema())
+		found, prefix, err := sr.LookupSchema(ctx, db, fn.Schema())
 		if err != nil {
 			return nil, err
 		}
@@ -579,7 +586,7 @@ func maybeLookupRoutine(
 	var udfDef *tree.ResolvedFunctionDefinition
 	for i, n := 0, path.NumElements(); i < n; i++ {
 		schema := path.GetSchema(i)
-		found, prefix, err := sr.LookupSchema(ctx, sr.CurrentDatabase(), schema)
+		found, prefix, err := sr.LookupSchema(ctx, db, schema)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Previously, the memo staleness check attempted to lookup a database
descriptor with an empty name when resolving functions. No such database
exists so the lookup would always fail. This was particularly costly
because the failed lookup would generate a new error with `errors.Wrapf`
which relies on the expensive `runtime.Callers` functions to generate a
stacktrace for the error. The unnecessary lookup has been eliminated in
this particular code path. In addition, `descs.ByNameGetter.Database`
now returns early when given an empty database name to prevent other
callers from incurring expensive overhead.

Informs #105867

Release note: None
