### PR TITLE
roachtest: disable 23.1 -> 23.2 testing for follower reads

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -988,6 +988,7 @@ func runFollowerReadsMixedVersionSingleRegionTest(
 			mixedversion.SystemOnlyDeployment,
 			mixedversion.SharedProcessDeployment,
 		),
+		mixedversion.MinimumSupportedVersion("v23.2.0"),
 	)
 }
 


### PR DESCRIPTION
In #133092 the min version was set at 23.2 for the test, however it was only applied to the "locality=global" variation. This also applies to the single-region variation.

Fixes: #133433

Release note: None