### PR TITLE
release-24.3: cluster-ui: publish cluster-ui 24.3.1

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "24.3.0",
+  "version": "24.3.1",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump npm package version to 24.3.1.

Epic: none

Release note: None

Release justification: non production code changes