### PR TITLE
dev: suggest crosslinuxarm on arm64

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=103
+DEV_VERSION=104
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions


### PR DESCRIPTION
Update to `dev doctor` to suggest `crosslinuxarm` instead of
`crosslinux` if `GOARCH=arm64`.

Epic: none
Release note: None