### PR TITLE
sql: skip TestIndexBackfillMergeRetry under duress

### DIFF
--- a/pkg/sql/mvcc_backfiller_test.go
+++ b/pkg/sql/mvcc_backfiller_test.go
@@ -57,7 +57,7 @@ func TestIndexBackfillMergeRetry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderRace(t, "TODO(ssd) test times out under race")
+	skip.UnderDuress(t, "this test fails under duress")
 
 	params, _ := createTestServerParams()
 


### PR DESCRIPTION
This test fails under duress so we are skipping it.

Fixes: #134033
Release note: None