### PR TITLE
upgrades: add missing SkipWhenMinSupportedVersionIsAtLeast

### DIFF
--- a/pkg/upgrade/upgrades/v24_2_delete_version_tenant_settings_test.go
+++ b/pkg/upgrade/upgrades/v24_2_delete_version_tenant_settings_test.go
@@ -24,6 +24,8 @@ func TestDeleteVersionTenantSettings(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	clusterversion.SkipWhenMinSupportedVersionIsAtLeast(t, 24, 2)
+
 	clusterArgs := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{

--- a/pkg/upgrade/upgrades/v24_2_tenant_rates_test.go
+++ b/pkg/upgrade/upgrades/v24_2_tenant_rates_test.go
@@ -24,6 +24,8 @@ func TestTenantRatesMigration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	clusterversion.SkipWhenMinSupportedVersionIsAtLeast(t, 24, 2)
+
 	clusterArgs := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{

--- a/pkg/upgrade/upgrades/v24_2_tenant_system_tables_test.go
+++ b/pkg/upgrade/upgrades/v24_2_tenant_system_tables_test.go
@@ -29,6 +29,8 @@ func TestCreateTenantSystemTables(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
+	clusterversion.SkipWhenMinSupportedVersionIsAtLeast(t, 24, 2)
+
 	// Set up the storage cluster at v1.
 	v1 := clusterversion.MinSupported.Version()
 	v2 := clusterversion.V24_2_TenantSystemTables.Version()

--- a/pkg/upgrade/upgrades/v24_3_add_table_metadata_cols_test.go
+++ b/pkg/upgrade/upgrades/v24_3_add_table_metadata_cols_test.go
@@ -24,6 +24,8 @@ func TestAddTableMetadataCols(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	clusterversion.SkipWhenMinSupportedVersionIsAtLeast(t, 24, 3)
+
 	clusterArgs := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{

--- a/pkg/upgrade/upgrades/v24_3_check_license_violation_test.go
+++ b/pkg/upgrade/upgrades/v24_3_check_license_violation_test.go
@@ -29,6 +29,8 @@ func TestCheckLicenseViolations(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	clusterversion.SkipWhenMinSupportedVersionIsAtLeast(t, 24, 3)
+
 	ctx := context.Background()
 
 	// Set up the storage cluster at v1.

--- a/pkg/upgrade/upgrades/v24_3_sql_instances_add_draining_test.go
+++ b/pkg/upgrade/upgrades/v24_3_sql_instances_add_draining_test.go
@@ -37,6 +37,8 @@ func TestSQLInstancesAddIsDraining(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	clusterversion.SkipWhenMinSupportedVersionIsAtLeast(t, 24, 3)
+
 	ctx := context.Background()
 	ts, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{

--- a/pkg/upgrade/upgrades/v24_3_table_metadata_system_table_test.go
+++ b/pkg/upgrade/upgrades/v24_3_table_metadata_system_table_test.go
@@ -23,6 +23,8 @@ func TestAddTableMetadataTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	clusterversion.SkipWhenMinSupportedVersionIsAtLeast(t, 24, 3)
+
 	clusterArgs := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{


### PR DESCRIPTION
This was supposed to be used so that we don't have to necessarily
remove these tests in the PR which bumps `MinVersion` (which is
typically very large as-is).

Epic: none
Release note: None

REL-1292