### PR TITLE
sql/schemachanger: don't allow ALTER PK in multi-stmt txn

### DIFF
--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -53,6 +53,11 @@ func (p *planner) AlterPrimaryKey(
 	alterPKNode tree.AlterTableAlterPrimaryKey,
 	alterPrimaryKeyLocalitySwap *alterPrimaryKeyLocalitySwap,
 ) error {
+	if !p.EvalContext().TxnIsSingleStmt {
+		return pgerror.Newf(pgcode.InvalidTransactionState,
+			"ALTER PRIMARY KEY cannot be used inside a multi-statement transaction")
+	}
+
 	if err := paramparse.ValidateUniqueConstraintParams(
 		alterPKNode.StorageParams,
 		paramparse.UniqueConstraintParamContext{

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -2046,3 +2046,22 @@ CREATE TABLE public.table_w0_66 (
 )
 
 subtest end
+
+subtest multiple_operations
+
+statement ok
+CREATE TABLE public.table_w1_14 (i int not null);
+
+# statement error ALTER PRIMARY KEY cannot be combined with other ALTER TABLE commands
+# ALTER TABLE public.table_w1_14 ADD COLUMN col_w1_14_w1_122 BOX2D NULL UNIQUE, ALTER PRIMARY KEY USING COLUMNS (i) USING HASH;
+
+statement ok
+BEGIN
+
+statement error ALTER PRIMARY KEY cannot be used inside a multi-statement transaction
+ALTER TABLE public.table_w1_14 ALTER PRIMARY KEY USING COLUMNS (i) USING HASH;
+
+statement ok
+ROLLBACK
+
+subtest end

--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -124,6 +124,7 @@ func (p *planner) newSchemaChangeBuilderDependencies(statements []string) scbuil
 		p, /* nodesStatusInfo */
 		p, /* regionProvider */
 		p.SemaCtx(),
+		p.EvalContext(),
 	)
 }
 

--- a/pkg/sql/schemachanger/scbuild/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/BUILD.bazel
@@ -31,7 +31,6 @@ go_library(
         "//pkg/sql/catalog/seqexpr",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/catalog/typedesc",
-        "//pkg/sql/faketreeeval",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",

--- a/pkg/sql/schemachanger/scbuild/build.go
+++ b/pkg/sql/schemachanger/scbuild/build.go
@@ -278,10 +278,11 @@ type cachedDesc struct {
 func newBuilderState(
 	ctx context.Context, d Dependencies, incumbent scpb.CurrentState, localMemAcc *mon.BoundAccount,
 ) *builderState {
+
 	bs := builderState{
 		ctx:                      ctx,
 		clusterSettings:          d.ClusterSettings(),
-		evalCtx:                  newEvalCtx(d),
+		evalCtx:                  d.EvalCtx(),
 		semaCtx:                  d.SemaCtx(),
 		cr:                       d.CatalogReader(),
 		tr:                       d.TableReader(),

--- a/pkg/sql/schemachanger/scbuild/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/dependencies.go
@@ -56,6 +56,9 @@ type Dependencies interface {
 	// Statements returns the statements behind this schema change.
 	Statements() []string
 
+	// EvalCtx returns the eval.Context for the schema change statement.
+	EvalCtx() *eval.Context
+
 	// SemaCtx returns the tree.SemaContext for the schema change statement.
 	SemaCtx() *tree.SemaContext
 

--- a/pkg/sql/schemachanger/scbuild/tree_context_builder.go
+++ b/pkg/sql/schemachanger/scbuild/tree_context_builder.go
@@ -6,11 +6,9 @@
 package scbuild
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/sql/faketreeeval"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild/internal/scbuildstmt"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 )
 
 var _ scbuildstmt.TreeContextBuilder = buildCtx{}
@@ -22,24 +20,5 @@ func (b buildCtx) SemaCtx() *tree.SemaContext {
 
 // EvalCtx implements the scbuildstmt.TreeContextBuilder interface.
 func (b buildCtx) EvalCtx() *eval.Context {
-	return newEvalCtx(b.Dependencies)
-}
-
-func newEvalCtx(d Dependencies) *eval.Context {
-	return &eval.Context{
-		ClusterID:            d.ClusterID(),
-		SessionDataStack:     sessiondata.NewStack(d.SessionData()),
-		Planner:              &faketreeeval.DummyEvalPlanner{},
-		StreamManagerFactory: &faketreeeval.DummyStreamManagerFactory{},
-		PrivilegedAccessor:   &faketreeeval.DummyPrivilegedAccessor{},
-		SessionAccessor:      &faketreeeval.DummySessionAccessor{},
-		ClientNoticeSender:   d.ClientNoticeSender(),
-		Sequence:             &faketreeeval.DummySequenceOperators{},
-		Tenant:               &faketreeeval.DummyTenantOperator{},
-		Regions:              &faketreeeval.DummyRegionOperator{},
-		Settings:             d.ClusterSettings(),
-		Codec:                d.Codec(),
-		DescIDGenerator:      d.DescIDGenerator(),
-		Placeholders:         &d.SemaCtx().Placeholders,
-	}
+	return b.Dependencies.EvalCtx()
 }

--- a/pkg/sql/schemachanger/scdeps/build_deps.go
+++ b/pkg/sql/schemachanger/scdeps/build_deps.go
@@ -55,6 +55,7 @@ func NewBuilderDependencies(
 	nodesStatusInfo scbuild.NodesStatusInfo,
 	regionProvider scbuild.RegionProvider,
 	semaCtx *tree.SemaContext,
+	evalCtx *eval.Context,
 ) scbuild.Dependencies {
 	return &buildDeps{
 		clusterID:       clusterID,
@@ -78,6 +79,7 @@ func NewBuilderDependencies(
 		nodesStatusInfo:          nodesStatusInfo,
 		regionProvider:           regionProvider,
 		semaCtx:                  semaCtx,
+		evalCtx:                  evalCtx,
 	}
 }
 
@@ -101,6 +103,7 @@ type buildDeps struct {
 	nodesStatusInfo          scbuild.NodesStatusInfo
 	regionProvider           scbuild.RegionProvider
 	semaCtx                  *tree.SemaContext
+	evalCtx                  *eval.Context
 }
 
 var _ scbuild.CatalogReader = (*buildDeps)(nil)
@@ -368,6 +371,11 @@ func (d *buildDeps) ClusterSettings() *cluster.Settings {
 // Statements implements the scbuild.Dependencies interface.
 func (d *buildDeps) Statements() []string {
 	return d.statements
+}
+
+// EvalCtx implements the scbuild.Dependencies interface.
+func (d *buildDeps) EvalCtx() *eval.Context {
+	return d.evalCtx
 }
 
 // SemaCtx implements the scbuild.Dependencies interface.

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/config.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -187,5 +188,10 @@ var defaultOptions = []Option{
 		semaCtx := tree.MakeSemaContext(state)
 		semaCtx.SearchPath = &state.SessionData().SearchPath
 		state.semaCtx = &semaCtx
+
+		evalCtx := &eval.Context{
+			SessionDataStack: sessiondata.NewStack(state.SessionData()),
+		}
+		state.evalCtx = evalCtx
 	}),
 }

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -94,6 +94,11 @@ func (s *TestState) Statements() []string {
 	return s.statements
 }
 
+// EvalCtx implements the scbuild.Dependencies interface.
+func (s *TestState) EvalCtx() *eval.Context {
+	return s.evalCtx
+}
+
 // SemaCtx implements the scbuild.Dependencies interface.
 func (s *TestState) SemaCtx() *tree.SemaContext {
 	return s.semaCtx

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_state.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_state.go
@@ -57,6 +57,7 @@ type TestState struct {
 	sessionData             sessiondata.SessionData
 	statements              []string
 	semaCtx                 *tree.SemaContext
+	evalCtx                 *eval.Context
 	testingKnobs            *scexec.TestingKnobs
 	jobs                    []jobs.Record
 	createdJobsInCurrentTxn []jobspb.JobID

--- a/pkg/sql/schemachanger/scdeps/sctestutils/BUILD.bazel
+++ b/pkg/sql/schemachanger/scdeps/sctestutils/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/schemachanger/scplan",
         "//pkg/sql/schemachanger/scplan/scviz",
+        "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",

--- a/pkg/sql/schemachanger/scdeps/sctestutils/sctestutils.go
+++ b/pkg/sql/schemachanger/scdeps/sctestutils/sctestutils.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/scviz"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
@@ -64,6 +65,7 @@ func WithBuilderDependenciesFromTestServer(
 		Descriptors() *descs.Collection
 		SessionData() *sessiondata.SessionData
 		SemaCtx() *tree.SemaContext
+		EvalCtx() *eval.Context
 		resolver.SchemaResolver
 		scbuild.AuthorizationAccessor
 		scbuild.AstFormatter
@@ -104,6 +106,7 @@ func WithBuilderDependenciesFromTestServer(
 		planner, /* nodesStatusInfo */
 		planner, /* regionProvider */
 		planner.SemaCtx(),
+		planner.EvalCtx(),
 	))
 }
 


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/128420
Release note (sql change): The ALTER PRIMARY KEY command can no longer be executed along with other ALTER commands in the same transaction.