### PR TITLE
raft: don't remember leader after stepping down if not fortified

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1249,6 +1249,25 @@ func (r *raft) tickHeartbeat() {
 // function instead; in there, we can add safety checks to ensure we're not
 // overwriting the leader.
 func (r *raft) becomeFollower(term uint64, lead pb.PeerID) {
+	if r.leadEpoch == 0 && lead == r.id {
+		// A non-zero lead epoch indicates that the leader fortified its term.
+		// Fortification promises should hold true even if the leader steps down, so
+		// as the leader, we remember that we were the leader even after we step
+		// down.
+		//
+		// In cases where the leader wasn't fortified prior to stepping down, we
+		// eschew remembering that we were the leader. This maintains parity with
+		// the behavior of leaders stepping down before the fortification protocol
+		// was introduced. This gives us time to stabilize the following state as
+		// the v24.3 release is rolled out:
+		//
+		//   r.state = StateFollower && r.lead = r.id
+		//
+		// Once this state is stabilized (within and above pkg/raft), we can remove
+		// this special case.
+		r.lead = None
+		lead = None
+	}
 	r.step = stepFollower
 	r.reset(term)
 	r.tick = r.tickElection

--- a/pkg/raft/testdata/mixedversions/checkquorum.txt
+++ b/pkg/raft/testdata/mixedversions/checkquorum.txt
@@ -82,8 +82,9 @@ INFO 1 became follower at term 1
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   State:StateFollower
+  HardState Term:1 Vote:1 Commit:11 Lead:0 LeadEpoch:0
   Messages:
   1->2 MsgHeartbeat Term:1 Log:0/0 Commit:11
   1->3 MsgHeartbeat Term:1 Log:0/0 Commit:11


### PR DESCRIPTION
This commit extends the change in bee163a4 to not remember that a replica was the leader if it is not fortified when stepping down. This gives us time to stabilize the following state as the v24.3 release is rolled out:

```
r.state = StateFollower && r.lead = r.id
```

Once this state is stabilized (within and above `pkg/raft`), we can remove this special case.

Epic: None
Release note: None