### PR TITLE
raft: fix TODOs in TestLeaderTransfer{StaleFollower,StepsDownImmediately}

### DIFF
--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -3488,10 +3488,6 @@ func TestLeaderTransferLeaderStepsDownImmediately(t *testing.T) {
 	require.Equal(t, uint64(1), lead.Term)
 	checkLeaderTransferState(t, lead, pb.StateFollower, 1)
 
-	// TODO(arul): a leader that steps down will currently never campaign due to
-	// the fortification promise that it made to itself. We'll need to fix this.
-	lead.deFortify(lead.lead, lead.Term)
-
 	// Eventually, the previous leader gives up on waiting and calls an election
 	// to reestablish leadership at the next term.
 	for i := int64(0); i < lead.randomizedElectionTimeout; i++ {
@@ -3956,10 +3952,6 @@ func TestLeaderTransferStaleFollower(t *testing.T) {
 		require.Equal(t, pb.StateFollower, n.state)
 		require.Equal(t, uint64(1), n.Term)
 	}
-
-	// TODO(arul): a leader that steps down will currently never campaign due to
-	// the fortification promise that it made to itself. We'll need to fix this.
-	n1.deFortify(n1.lead, n1.Term)
 
 	// Eventually, the previous leader gives up on waiting and calls an election
 	// to reestablish leadership at the next term. Node 3 does not hear about this


### PR DESCRIPTION
These TODOs were written because we hadn't implemented the de-fortification protocl back then. Now that we have, we can address them.

Epic: none
Release note: None