### PR TITLE
quantize: add rabitq quantization

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -2301,6 +2301,7 @@ GO_TARGETS = [
     "//pkg/sql/vecindex/internal:internal_test",
     "//pkg/sql/vecindex/quantize:quantize",
     "//pkg/sql/vecindex/quantize:quantize_test",
+    "//pkg/sql/vecindex/testutils:testutils",
     "//pkg/sql/vtable:vtable",
     "//pkg/sql:sql",
     "//pkg/sql:sql_test",

--- a/pkg/sql/vecindex/BUILD.bazel
+++ b/pkg/sql/vecindex/BUILD.bazel
@@ -1,0 +1,5 @@
+filegroup(
+    name = "testdata",
+    srcs = glob(["testdata/**"]),
+    visibility = ["//pkg/sql/vecindex:__subpackages__"],
+)

--- a/pkg/sql/vecindex/quantize/BUILD.bazel
+++ b/pkg/sql/vecindex/quantize/BUILD.bazel
@@ -29,6 +29,8 @@ go_library(
     name = "quantize",
     srcs = [
         "quantizer.go",
+        "rabitq.go",
+        "rabitqpb.go",
         "unquantizedpb.go",
         "unquantizer.go",
     ],
@@ -36,6 +38,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/vecindex/quantize",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/sql/vecindex/internal",
         "//pkg/util/num32",
         "//pkg/util/vector",
         "@com_github_cockroachdb_errors//:errors",
@@ -45,11 +48,16 @@ go_library(
 go_test(
     name = "quantize_test",
     srcs = [
+        "rabitq_test.go",
+        "rabitqpb_test.go",
         "unquantizedpb_test.go",
         "unquantizer_test.go",
     ],
+    data = ["//pkg/sql/vecindex:testdata"],
     embed = [":quantize"],
     deps = [
+        "//pkg/sql/vecindex/internal",
+        "//pkg/sql/vecindex/testutils",
         "//pkg/util/num32",
         "//pkg/util/vector",
         "@com_github_stretchr_testify//require",

--- a/pkg/sql/vecindex/quantize/quantize.proto
+++ b/pkg/sql/vecindex/quantize/quantize.proto
@@ -12,6 +12,39 @@ import "gogoproto/gogo.proto";
 
 option (gogoproto.goproto_getters_all) = false;
 
+// RaBitQCodeSet is a set of RaBitQ quantization codes. Each code represents a
+// quantized vector.
+message RaBitQCodeSet {
+  // Count is the number of codes in the set.
+  int64 count = 1 [(gogoproto.casttype) = "int"];
+  // Width is the number of uint64 values that store a single code.
+  int64 width = 2 [(gogoproto.casttype) = "int"];
+  // Data is a uint64 slice that stores all the codes in the set. Codes are
+  // stored contiguously in row-wise order.
+  repeated uint64 data = 3;
+}
+
+// RaBitQuantizedVectorSet encodes a set of RaBitQ quantized vectors. This
+// includes enough information to estimate the distance from the original
+// full-size vectors to a user-provided query vector.
+message RaBitQuantizedVectorSet {
+  // Centroid is the average of vectors in the set, representing its "center of
+  // mass". Note that the centroid is computed when a vector set is created and
+  // is not updated when vectors are added or removed.
+  repeated float centroid = 1;
+  // Codes is a set of RaBitQ quantization codes, with one code per quantized
+  // vector in the set.
+  RaBitQCodeSet codes = 2 [(gogoproto.nullable) = false];
+  // CodeCounts records the count of "1" bits in each of the quantization codes.
+  repeated uint32 code_counts = 3;
+  // CentroidDistances is a slice of the exact distances of the original
+  // full-size vectors from the centroid.
+  repeated float centroidDistances = 4;
+  // DotProducts is a slice of the exact inner products between the original
+  // full-size vectors and their corresponding quantized vectors.
+  repeated float dotProducts = 5;
+}
+
 // UnQuantizedVectorSet trivially implements the QuantizedVectorSet interface,
 // storing the original full-size vectors without quantization. This is used in
 // testing and for the root partition, which is never quantized.

--- a/pkg/sql/vecindex/quantize/rabitq.go
+++ b/pkg/sql/vecindex/quantize/rabitq.go
@@ -1,0 +1,444 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package quantize
+
+import (
+	"context"
+	"math"
+	"math/bits"
+	"math/rand"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/internal"
+	"github.com/cockroachdb/cockroach/pkg/util/num32"
+	"github.com/cockroachdb/cockroach/pkg/util/vector"
+	"github.com/cockroachdb/errors"
+)
+
+// raBitQuantizer quantizes vectors according to the algorithm described in this
+// paper:
+//
+//	"RaBitQ: Quantizing High-Dimensional Vectors with a Theoretical Error Bound
+//	for Approximate Nearest Neighbor Search" by Jianyang Gao & Cheng Long.
+//	URL: https://arxiv.org/pdf/2405.12497
+//
+// The RaBitQ quantization method provides good accuracy, produces compact
+// codes, provides practical error bounds, is easy to implement, and can be
+// accelerated with fast SIMD instructions. RaBitQ quantization codes use only
+// 1 bit per dimension in the original vector.
+//
+// All methods in raBitQuantizer are thread-safe. It is intended to be cached
+// on a per-process basis and reused across all threads that query the same
+// vector index. This is important, because the ROT matrix is expensive to
+// generate and can use quite a bit of memory.
+type raBitQuantizer struct {
+	// dims is the dimensionality of vectors that can be quantized.
+	dims int
+	// sqrtDims is the precomputed square root of the "dims" field.
+	sqrtDims float32
+	// sqrtDimsInv precomputes "1 / sqrtDims".
+	sqrtDimsInv float32
+	// rot is a square dims x dims matrix that performs random orthogonal
+	// transformations on input vectors, in order to distribute skew more evenly.
+	rot num32.Matrix
+	// unbias is a precomputed slice of "dims" random values in the [0, 1)
+	// interval that's used to remove bias when quantizing query vectors.
+	unbias []float32
+}
+
+var _ Quantizer = (*raBitQuantizer)(nil)
+
+// NewRaBitQuantizer returns a new RaBitQ quantizer that quantizes vectors with
+// the given number of dimensions. The provided seed is used to generate the
+// pseudo-random values used by the algorithm. It's important that the quantizer
+// is created with the same seed that was previously used to create any
+// quantized sets that need to be searched or updated.
+func NewRaBitQuantizer(dims int, seed int64) Quantizer {
+	if dims <= 0 {
+		panic(errors.AssertionFailedf("dimensions are not positive: %d", dims))
+	}
+
+	rng := rand.New(rand.NewSource(seed))
+
+	// Generate dims x dims random orthogonal matrix to mitigate the impact of
+	// skewed input data distributions:
+	//
+	//   1. Set skew: some dimensions can have higher variance than others. For
+	//      example, perhaps all vectors in a set have similar values for one
+	//      dimension but widely differing values in another dimension.
+	//   2. Vector skew: Individual vectors can have internal skew, such that
+	//      values higher than the mean are more spread out than values lower
+	//      than the mean.
+	//
+	// Multiplying vectors by this matrix helps with both forms of skew. While
+	// total skew does not change, the skew is more evenly distributed across
+	// the dimensions. Now quantizing the vector will have more uniform
+	// information loss across dimensions. Critically, none of this impacts
+	// distance calculations, as orthogonal transformations do not change
+	// distances or angles between vectors.
+	//
+	// Ultimately, performing a random orthogonal transformation (ROT) means that
+	// the index will work more consistently across a diversity of input data
+	// sets, even those with skewed data distributions. In addition, the RaBitQ
+	// algorithm depends on the statistical properties that are granted by the
+	// ROT.
+	rot := num32.MakeRandomOrthoMatrix(rng, dims)
+
+	// Create random offsets in range [0, 1) to remove bias when quantizing
+	// query vectors.
+	unbias := make([]float32, dims)
+	for i := 0; i < len(unbias); i++ {
+		unbias[i] = rng.Float32()
+	}
+
+	sqrtDims := num32.Sqrt(float32(dims))
+	return &raBitQuantizer{
+		dims:        dims,
+		sqrtDims:    sqrtDims,
+		sqrtDimsInv: 1.0 / sqrtDims,
+		rot:         rot,
+		unbias:      unbias,
+	}
+}
+
+// GetOriginalDims implements the Quantizer interface.
+func (q *raBitQuantizer) GetOriginalDims() int {
+	return q.dims
+}
+
+// GetRandomDims implements the Quantizer interface.
+func (q *raBitQuantizer) GetRandomDims() int {
+	return q.dims
+}
+
+// RandomizeVector implements the Quantizer interface.
+func (q *raBitQuantizer) RandomizeVector(
+	ctx context.Context, original vector.T, randomized vector.T, invert bool,
+) {
+	if !invert {
+		num32.MulMatrixByVector(&q.rot, original, randomized, num32.NoTranspose)
+	} else {
+		num32.MulMatrixByVector(&q.rot, randomized, original, num32.Transpose)
+	}
+}
+
+// Quantize implements the Quantizer interface.
+func (q *raBitQuantizer) Quantize(ctx context.Context, vectors *vector.Set) QuantizedVectorSet {
+	// Allocate slice for the centroid.
+	quantizedSet := &RaBitQuantizedVectorSet{
+		Centroid: vectors.Centroid(make(vector.T, vectors.Dims)),
+		Codes:    MakeRaBitQCodeSet(vectors.Dims),
+	}
+	q.quantizeHelper(ctx, quantizedSet, vectors)
+	return quantizedSet
+}
+
+// QuantizeInSet implements the Quantizer interface.
+func (q *raBitQuantizer) QuantizeInSet(
+	ctx context.Context, quantizedSet QuantizedVectorSet, vectors *vector.Set,
+) {
+	q.quantizeHelper(ctx, quantizedSet.(*RaBitQuantizedVectorSet), vectors)
+}
+
+// EstimateSquaredDistances implements the Quantizer interface.
+func (q *raBitQuantizer) EstimateSquaredDistances(
+	ctx context.Context,
+	quantizedSet QuantizedVectorSet,
+	queryVector vector.T,
+	squaredDistances []float32,
+	errorBounds []float32,
+) {
+	raBitSet := quantizedSet.(*RaBitQuantizedVectorSet)
+
+	// Allocate temp space for calculations.
+	workspace := internal.WorkspaceFromContext(ctx)
+	tempCodes := allocCodes(workspace, 4, raBitSet.Codes.Width)
+	defer freeCodes(workspace, tempCodes)
+	tempVectors := workspace.AllocVectorSet(1, q.dims)
+	defer workspace.FreeVectorSet(tempVectors)
+
+	// Normalize the query vector to a unit vector.
+	// Paper: q = (q_raw - c) / ||q_raw - c||
+	tempQueryDiff := tempVectors.At(0)
+	num32.SubTo(tempQueryDiff, queryVector, quantizedSet.GetCentroid())
+	queryCentroidDistance := num32.Norm(tempQueryDiff)
+
+	if queryCentroidDistance == 0 {
+		// The query vector is the centroid. This means the squared distances from
+		// the query to the quantized vectors are just the centroid distances that
+		// have already been calculated, but just need to be squared.
+		centroidDistances := quantizedSet.GetCentroidDistances()
+		num32.MulTo(squaredDistances, centroidDistances, centroidDistances)
+		num32.Zero(errorBounds)
+		return
+	}
+
+	tempQueryUnitVector := tempQueryDiff
+	num32.Scale(1.0/queryCentroidDistance, tempQueryUnitVector)
+
+	// Find min and max values within the vector.
+	// Paper: v_left and v_right
+	minVal := num32.Min(tempQueryUnitVector)
+	maxVal := num32.Max(tempQueryUnitVector)
+
+	// Quantize query vector using small unsigned ints in the range [0,15].
+	// Paper: Δ = (v_right - v_left) / (2^B_q - 1)
+	//        q¯u[i] = floor((q'[i] - v_left) / Δ + u[i])
+	const quantizedRange = 15
+	delta := (maxVal - minVal) / quantizedRange
+
+	// The full quantized query code is separated into 4 sub-codes. The first
+	// sub-code includes bit 1 of the full code, the second sub-code includes
+	// bit 2, the third bit 3, and the fourth bit 4. This separation enables more
+	// efficient computation of the dot product between the quantized query vector
+	// and the quantized data vectors.
+	var quantized1, quantized2, quantized3, quantized4 uint64
+	var quantizedSum uint64
+	tempQueryQuantized1 := tempCodes.At(0)
+	tempQueryQuantized2 := tempCodes.At(1)
+	tempQueryQuantized3 := tempCodes.At(2)
+	tempQueryQuantized4 := tempCodes.At(3)
+	for i := 0; i < len(tempQueryUnitVector); {
+		// If delta == 0, then quantized sub-codes will be set to zero. This
+		// only happens when every dimension in the query has the same value.
+		if delta != 0 {
+			quantized := uint64(math.Floor(float64((tempQueryUnitVector[i]-minVal)/delta + q.unbias[i])))
+			quantizedSum += quantized
+			quantized1 = (quantized1 << 1) | (quantized & 1)
+			quantized2 = (quantized2 << 1) | ((quantized & 2) >> 1)
+			quantized3 = (quantized3 << 1) | ((quantized & 4) >> 2)
+			quantized4 = (quantized4 << 1) | ((quantized & 8) >> 3)
+		}
+
+		i++
+		if (i % 64) == 0 {
+			offset := (i - 1) / 64
+			tempQueryQuantized1[offset] = quantized1
+			tempQueryQuantized2[offset] = quantized2
+			tempQueryQuantized3[offset] = quantized3
+			tempQueryQuantized4[offset] = quantized4
+		}
+	}
+
+	// Set any leftover bits.
+	if (len(tempQueryUnitVector) % 64) != 0 {
+		offset := len(tempQueryUnitVector) / 64
+		shift := 64 - (len(tempQueryUnitVector) % 64)
+		tempQueryQuantized1[offset] = quantized1 << shift
+		tempQueryQuantized2[offset] = quantized2 << shift
+		tempQueryQuantized3[offset] = quantized3 << shift
+		tempQueryQuantized4[offset] = quantized4 << shift
+	}
+
+	count := raBitSet.GetCount()
+	for i := 0; i < count; i++ {
+		code := raBitSet.Codes.At(i)
+
+		var bitProduct int
+		for j := 0; j < len(code); j++ {
+			// Paper: <x¯bits,q¯u> = ∑ j in [0,B_q-1] (2^j * <x¯bits,q¯u¯j>)
+			bitProduct += 1 * bits.OnesCount64(code[j]&tempQueryQuantized1[j])
+			bitProduct += 2 * bits.OnesCount64(code[j]&tempQueryQuantized2[j])
+			bitProduct += 4 * bits.OnesCount64(code[j]&tempQueryQuantized3[j])
+			bitProduct += 8 * bits.OnesCount64(code[j]&tempQueryQuantized4[j])
+		}
+
+		// Compute the estimator efficiently.
+		// Paper: term1 = 2Δ / √D * <x¯bits,q¯u>
+		//        term2 = 2 * v_left / √D * count_bits(x¯bits)
+		//        term3 = Δ / √D * sum(q¯u)
+		//        term4 = √D * v_left
+		//        <x¯,q¯> = term1 + term2 - term3 - term4
+		//        <o¯,q> = <x¯,q'> ~ <x¯,q¯>
+		//        <o,q> ~ <o¯,q> / <o¯,o>
+		//
+		// Note one tweak to the paper, where <o¯,o> (i.e. vector_products) is
+		// stored as an inverted value so that it can be multiplied rather than
+		// divided, in order to avoid divide-by-zero.
+		term1 := 2 * delta * q.sqrtDimsInv * float32(bitProduct)
+		term2 := 2 * minVal * q.sqrtDimsInv * float32(raBitSet.CodeCounts[i])
+		term3 := delta * q.sqrtDimsInv * float32(quantizedSum)
+		term4 := q.sqrtDims * minVal
+		estimator := (term1 + term2 - term3 - term4) * raBitSet.DotProducts[i]
+
+		// Compute estimated distances between the query and the quantized data
+		// vectors.
+		// Paper: ||o_raw - q_raw||^2 = ||o_raw - c||^2 +
+		//        ||q_raw - c||^2 - 2 * ||o_raw - c|| * ||q_raw - c|| * <q,o>
+		dataCentroidDistance := raBitSet.CentroidDistances[i]
+		squaredDistance := dataCentroidDistance * dataCentroidDistance
+		squaredDistance += queryCentroidDistance * queryCentroidDistance
+		multiplier := 2 * dataCentroidDistance * queryCentroidDistance
+		squaredDistance -= multiplier * estimator
+		if squaredDistance < 0 {
+			squaredDistance = 0
+		}
+		squaredDistances[i] = squaredDistance
+
+		// Error bounds for the estimator are +- 1/√dims. For the entire distance,
+		// that must be scaled by the distance terms.
+		errorBounds[i] = multiplier / q.sqrtDims
+	}
+}
+
+// quantizeHelper quantizes the given set of vectors and adds the quantization
+// information to the provided quantized vector set.
+func (q *raBitQuantizer) quantizeHelper(
+	ctx context.Context, qs *RaBitQuantizedVectorSet, vectors *vector.Set,
+) {
+	// Extend any existing slices in the vector set.
+	count := vectors.Count
+	oldCount := qs.GetCount()
+	qs.AddUndefined(count)
+
+	// Allocate temp space for vector calculations.
+	workspace := internal.WorkspaceFromContext(ctx)
+	tempVectors := workspace.AllocVectorSet(qs.GetCount(), q.dims)
+	defer workspace.FreeVectorSet(tempVectors)
+
+	// Calculate the difference between input vector(s) and the centroid.
+	// Paper: o_raw - c
+	tempDiffs := tempVectors
+	for i := 0; i < count; i++ {
+		num32.SubTo(tempDiffs.At(i), vectors.At(i), qs.Centroid)
+	}
+
+	// Calculate distance from each input vector to the centroid.
+	// Paper: ||o_raw - c||
+	centroidDistances := qs.CentroidDistances[oldCount:]
+	for i := 0; i < len(centroidDistances); i++ {
+		centroidDistances[i] = num32.Norm(tempDiffs.At(i))
+	}
+
+	// Normalize the input vectors into unit vectors relative to the centroid.
+	// Paper (equation 1): o = (o_raw - c) / ||o_raw - c||
+	tempUnitVectors := tempDiffs
+	for i := 0; i < len(centroidDistances); i++ {
+		// If distance to the centroid is zero, then the diff is zero. The unit
+		// vector should be zero as well, so no need to do anything in that case.
+		centroidDistance := centroidDistances[i]
+		if centroidDistance != 0 {
+			num32.ScaleTo(tempUnitVectors.At(i), 1.0/centroidDistance, tempUnitVectors.At(i))
+		}
+	}
+
+	// Calculate:
+	//   1. Dot products between the quantized vectors and unit vectors.
+	//   2. Quantization code for each vector.
+	//   3. Count of "1" bits in the quantization code.
+	//
+	// Note a difference from the paper: we assume that the caller applies the
+	// random orthogonal transformation, so no need to do it here. This
+	// simplifies any formulas from the paper which include P.
+	dotProducts := qs.DotProducts[oldCount:]
+	codeCounts := qs.CodeCounts[oldCount:]
+	alignedDims := q.dims / 8 * 8
+	for i := 0; i < count; i++ {
+		// Define two functions that will be used to unroll the loop over the
+		// dimensions of the unit vector. Doing this gives ~20% boost on Intel
+		// and ARM.
+
+		// getSignBit returns the floating point value's sign bit, which will be 1
+		// if the value is negative (including -0), or 0 otherwise (including +0).
+		getSignBit := func(value float32) uint64 {
+			return uint64(math.Float32bits(value) >> 31)
+		}
+
+		// computeProduct multiplies a unit vector element by the quantized form
+		// of that element. The quantized form is equal to 1/√D if the element
+		// is positive and -1/√D otherwise.
+		computeProduct := func(element, sqrtDimsInv float32) float32 {
+			sign := float32(1 - 2*int32(getSignBit(element)))
+			return element * sign * sqrtDimsInv
+		}
+
+		var dotProduct float32
+		var codeBits, codeCount uint64
+		tempUnitVector := tempUnitVectors.At(i)
+		code := qs.Codes.At(oldCount + i)
+		for dim := 0; dim < alignedDims; dim += 8 {
+			// Unroll the loop 8x.
+
+			// Compute the dot product of the unit vector and the quantized vector.
+			// Paper: x¯bits ∈ {0, 1}^D | 0 if o[i] <= 0, 1 if o[i] > 0
+			//        x¯ = (2 * x¯bits − 1_bits)/√D
+			//        o¯ = Px¯
+			//        <o¯,o>
+			elements := tempUnitVector[dim : dim+8]
+			dotProduct += computeProduct(elements[0], q.sqrtDimsInv)
+			dotProduct += computeProduct(elements[1], q.sqrtDimsInv)
+			dotProduct += computeProduct(elements[2], q.sqrtDimsInv)
+			dotProduct += computeProduct(elements[3], q.sqrtDimsInv)
+			dotProduct += computeProduct(elements[4], q.sqrtDimsInv)
+			dotProduct += computeProduct(elements[5], q.sqrtDimsInv)
+			dotProduct += computeProduct(elements[6], q.sqrtDimsInv)
+			dotProduct += computeProduct(elements[7], q.sqrtDimsInv)
+
+			// Compute the quantization code as a packed bit string.
+			// Paper: x¯bits ∈ {0, 1}^D | 0 if o[i] <= 0, 1 if o[i] > 0
+			codeBits <<= 8
+			codeBits |= getSignBit(elements[0]) << 7
+			codeBits |= getSignBit(elements[1]) << 6
+			codeBits |= getSignBit(elements[2]) << 5
+			codeBits |= getSignBit(elements[3]) << 4
+			codeBits |= getSignBit(elements[4]) << 3
+			codeBits |= getSignBit(elements[5]) << 2
+			codeBits |= getSignBit(elements[6]) << 1
+			codeBits |= getSignBit(elements[7])
+
+			if (dim+8)%64 == 0 {
+				// Invert the sign bits, since a "1" sign bit indicates a
+				// negative float.
+				codeBits = ^codeBits
+				code[0] = codeBits
+				code = code[1:]
+
+				// Count the number of "1" bits in the code.
+				codeCount += uint64(bits.OnesCount64(codeBits))
+			}
+		}
+
+		// Handle any remaining unaligned elements in the unit vector.
+		if q.dims%64 != 0 {
+			for dim := alignedDims; dim < q.dims; dim++ {
+				dotProduct += computeProduct(tempUnitVector[dim], q.sqrtDimsInv)
+				codeBits <<= 1
+				if getSignBit(tempUnitVector[dim]) == 1 {
+					codeBits |= 1
+				}
+			}
+
+			// Invert the sign bits and shift remaining code bits to most
+			// significant bit positions.
+			codeBits = ^codeBits << (64 - q.dims%64)
+			code[0] = codeBits
+
+			// Count the number of "1" bits in the code.
+			codeCount += uint64(bits.OnesCount64(codeBits))
+		}
+
+		// Store the total number of "1" bits in the quantization code.
+		codeCounts[i] = uint32(codeCount)
+
+		// Store the inverted dot product, which will be used to make distance
+		// estimates. If the dot product is zero, then the vector must be equal
+		// to the centroid. By mapping the inverted dot product to zero here, the
+		// <o,q> estimator will also map to zero, and the distance estimate will
+		// collapse to the squared distance between the query vector and the
+		// centroid, which is what we want.
+		if dotProduct != 0 {
+			dotProducts[i] = 1.0 / dotProduct
+		}
+	}
+}
+
+func allocCodes(w *internal.Workspace, count, width int) RaBitQCodeSet {
+	tempUints := w.AllocUint64s(count * width)
+	return MakeRaBitQCodeSetFromRawData(tempUints, width)
+}
+
+func freeCodes(w *internal.Workspace, codeSet RaBitQCodeSet) {
+	w.FreeUint64s(codeSet.Data)
+}

--- a/pkg/sql/vecindex/quantize/rabitq_test.go
+++ b/pkg/sql/vecindex/quantize/rabitq_test.go
@@ -1,0 +1,270 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package quantize
+
+import (
+	"context"
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/internal"
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/num32"
+	"github.com/cockroachdb/cockroach/pkg/util/vector"
+	"github.com/stretchr/testify/require"
+)
+
+// Basic tests.
+func TestRaBitQuantizerSimple(t *testing.T) {
+	workspace := &internal.Workspace{}
+	ctx := internal.WithWorkspace(context.Background(), workspace)
+	defer require.True(t, workspace.IsClear())
+
+	t.Run("add and remove vectors", func(t *testing.T) {
+		quantizer := NewRaBitQuantizer(2, 42)
+		require.Equal(t, 2, quantizer.GetOriginalDims())
+		require.Equal(t, 2, quantizer.GetRandomDims())
+
+		// Add 3 vectors and verify centroid and centroid distances.
+		vectors := vector.MakeSetFromRawData([]float32{5, 2, 1, 2, 6, 5}, 2)
+		quantizedSet := quantizer.Quantize(ctx, &vectors)
+		require.Equal(t, vector.T{4, 3}, quantizedSet.GetCentroid())
+		require.Equal(t, []float32{1.41, 3.16, 2.83}, roundFloats(quantizedSet.GetCentroidDistances(), 2))
+
+		// Add 2 more vectors to existing set.
+		vectors = vector.MakeSetFromRawData([]float32{4, 3, 6, 5}, 2)
+		quantizer.QuantizeInSet(ctx, quantizedSet, &vectors)
+		require.Equal(t, 5, quantizedSet.GetCount())
+
+		// Ensure distances and error bounds are correct.
+		distances := make([]float32, quantizedSet.GetCount())
+		errorBounds := make([]float32, quantizedSet.GetCount())
+		quantizer.EstimateSquaredDistances(ctx, quantizedSet, vector.T{1, 1}, distances, errorBounds)
+		require.Equal(t, []float32{17, 0, 41, 13, 41}, roundFloats(distances, 2))
+		require.Equal(t, []float32{7.21, 16.12, 14.42, 0, 14.42}, roundFloats(errorBounds, 2))
+		require.Equal(t, vector.T{4, 3}, quantizedSet.GetCentroid())
+
+		// Remove quantized vectors from the set.
+		quantizedSet.ReplaceWithLast(1)
+		quantizedSet.ReplaceWithLast(3)
+		quantizedSet.ReplaceWithLast(1)
+		require.Equal(t, 2, quantizedSet.GetCount())
+		distances = distances[:2]
+		errorBounds = errorBounds[:2]
+		quantizer.EstimateSquaredDistances(ctx, quantizedSet, vector.T{1, 1}, distances, errorBounds)
+		require.Equal(t, []float32{17, 41}, roundFloats(distances, 2))
+		require.Equal(t, []float32{7.21, 14.42}, roundFloats(errorBounds, 2))
+
+		// Remove remaining quantized vectors.
+		quantizedSet.ReplaceWithLast(0)
+		quantizedSet.ReplaceWithLast(0)
+		require.Equal(t, 0, quantizedSet.GetCount())
+		require.Equal(t, vector.T{4, 3}, quantizedSet.GetCentroid())
+		distances = distances[:0]
+		errorBounds = errorBounds[:0]
+		quantizer.EstimateSquaredDistances(ctx, quantizedSet, vector.T{1, 1}, distances, errorBounds)
+	})
+
+	t.Run("empty quantized set", func(t *testing.T) {
+		quantizer := NewRaBitQuantizer(2, 42)
+		vectors := vector.MakeSet(2)
+		quantizedSet := quantizer.Quantize(ctx, &vectors)
+		require.Equal(t, vector.T{0, 0}, quantizedSet.GetCentroid())
+		require.Nil(t, quantizedSet.GetCentroidDistances())
+	})
+}
+
+// Edge cases.
+func TestRaBitQuantizerEdge(t *testing.T) {
+	workspace := &internal.Workspace{}
+	ctx := internal.WithWorkspace(context.Background(), workspace)
+	defer require.True(t, workspace.IsClear())
+
+	// Search for query vector with two equal dimensions, which makes Δ = 0.
+	t.Run("two dimensions equal", func(t *testing.T) {
+		quantizer := NewRaBitQuantizer(2, 42)
+		vectors := vector.MakeSetFromRawData([]float32{4, 4, -3, -3}, 2)
+		quantizedSet := quantizer.Quantize(ctx, &vectors).(*RaBitQuantizedVectorSet)
+		require.Equal(t, 2, quantizedSet.GetCount())
+		require.Equal(t, []uint64{0xc000000000000000, 0x0}, quantizedSet.Codes.Data)
+		require.Equal(t, []uint32{2, 0}, quantizedSet.CodeCounts)
+
+		distances := make([]float32, 2)
+		errorBounds := make([]float32, 2)
+		quantizer.EstimateSquaredDistances(ctx, quantizedSet, vector.T{1, 1}, distances, errorBounds)
+		require.Equal(t, []float32{18, 32}, roundFloats(distances, 2))
+		require.Equal(t, []float32{4.95, 4.95}, roundFloats(errorBounds, 2))
+	})
+
+	t.Run("many dimensions, not multiple of 64", func(t *testing.T) {
+		// Number dimensions is > 64 and not a multiple of 64.
+		quantizer := NewRaBitQuantizer(141, 42)
+
+		vectors := vector.MakeSet(141)
+		vectors.AddUndefined(2)
+		ones := vectors.At(1)
+		for i := 0; i < len(ones); i++ {
+			ones[i] = 1
+		}
+		quantizedSet := quantizer.Quantize(ctx, &vectors).(*RaBitQuantizedVectorSet)
+		require.Equal(t, []float32{5.94, 5.94}, roundFloats(quantizedSet.CentroidDistances, 2))
+		code := quantizedSet.Codes.At(0)
+		require.Equal(t, RaBitQCode{0, 0, 0}, code)
+		require.Equal(t, uint32(0), quantizedSet.CodeCounts[0])
+		code = quantizedSet.Codes.At(1)
+		require.Equal(t, RaBitQCode{0xffffffffffffffff, 0xffffffffffffffff, 0xfff8000000000000}, code)
+		require.Equal(t, uint32(141), quantizedSet.CodeCounts[1])
+
+		distances := make([]float32, quantizedSet.GetCount())
+		errorBounds := make([]float32, quantizedSet.GetCount())
+		quantizer.EstimateSquaredDistances(ctx, quantizedSet, ones, distances, errorBounds)
+		require.Equal(t, []float32{141, 0}, roundFloats(distances, 2))
+		require.Equal(t, []float32{5.94, 5.94}, roundFloats(errorBounds, 2))
+	})
+
+	t.Run("add centroid to set", func(t *testing.T) {
+		quantizer := NewRaBitQuantizer(2, 42)
+		vectors := vector.MakeSetFromRawData([]float32{1, 5, 5, 13}, 2)
+		quantizedSet := quantizer.Quantize(ctx, &vectors).(*RaBitQuantizedVectorSet)
+		require.Equal(t, []float32{3, 9}, quantizedSet.Centroid)
+
+		// Add centroid to the set along with another vector.
+		vectors = vector.MakeSetFromRawData([]float32{1, 5, 3, 9}, 2)
+		quantizer.QuantizeInSet(ctx, quantizedSet, &vectors)
+		distances := make([]float32, 4)
+		errorBounds := make([]float32, 4)
+		quantizer.EstimateSquaredDistances(ctx, quantizedSet, vector.T{3, 2}, distances, errorBounds)
+		require.Equal(t, []float32{22.33, 115.67, 22.33, 49}, roundFloats(distances, 2))
+		require.Equal(t, []float32{44.27, 44.27, 44.27, 0}, roundFloats(errorBounds, 2))
+	})
+
+	t.Run("query vector is centroid", func(t *testing.T) {
+		quantizer := NewRaBitQuantizer(2, 42)
+		vectors := vector.MakeSetFromRawData([]float32{1, 5, -3, -9}, 2)
+		quantizedSet := quantizer.Quantize(ctx, &vectors).(*RaBitQuantizedVectorSet)
+		require.Equal(t, []float32{-1, -2}, quantizedSet.Centroid)
+		distances := make([]float32, 2)
+		errorBounds := make([]float32, 2)
+		quantizer.EstimateSquaredDistances(ctx, quantizedSet, vector.T{-1, -2}, distances, errorBounds)
+		require.Equal(t, []float32{53, 53}, roundFloats(distances, 2))
+		require.Equal(t, []float32{0, 0}, roundFloats(errorBounds, 2))
+	})
+}
+
+func TestRaBitRandomizeVector(t *testing.T) {
+	workspace := &internal.Workspace{}
+	ctx := internal.WithWorkspace(context.Background(), workspace)
+	defer require.True(t, workspace.IsClear())
+
+	const dims = 97
+	const count = 5
+	quantizer := NewRaBitQuantizer(dims, 46)
+
+	// Generate random vectors with exponentially increasing norms, in order
+	// make distances more distinct.
+	rng := rand.New(rand.NewSource(42))
+	data := make([]float32, dims*count)
+	for i := range data {
+		vecIdx := float64(i / dims)
+		data[i] = float32(rng.NormFloat64() * math.Pow(1.5, vecIdx))
+	}
+
+	original := vector.MakeSetFromRawData(data, dims)
+	randomized := vector.MakeSet(dims)
+	randomized.AddUndefined(count)
+	for i := range original.Count {
+		quantizer.RandomizeVector(ctx, original.At(i), randomized.At(i), false /* invert */)
+
+		// Ensure that inverting RandomizeVector recovers original vector.
+		randomizedInv := make([]float32, dims)
+		quantizer.RandomizeVector(ctx, randomizedInv, randomized.At(i), true /* invert */)
+		for j, val := range original.At(i) {
+			require.InDelta(t, val, randomizedInv[j], 0.00001)
+		}
+	}
+
+	// Ensure that distances are similar, whether using the original vectors or
+	// the randomized vectors.
+	originalSet := quantizer.Quantize(ctx, &original).(*RaBitQuantizedVectorSet)
+	randomizedSet := quantizer.Quantize(ctx, &randomized).(*RaBitQuantizedVectorSet)
+
+	distances := make([]float32, count)
+	errorBounds := make([]float32, count)
+	quantizer.EstimateSquaredDistances(ctx, originalSet, original.At(0), distances, errorBounds)
+	require.Equal(t, []float32{3.25, 272.75, 555.63, 945.07, 2393.15}, roundFloats(distances, 2))
+	require.Equal(t, []float32{37.58, 46.08, 57.55, 69.46, 110.57}, roundFloats(errorBounds, 2))
+
+	quantizer.EstimateSquaredDistances(ctx, randomizedSet, randomized.At(0), distances, errorBounds)
+	require.Equal(t, []float32{0, 259.83, 504.97, 907.4, 2314.59}, roundFloats(distances, 2))
+	require.Equal(t, []float32{37.58, 46.08, 57.55, 69.46, 110.57}, roundFloats(errorBounds, 2))
+}
+
+// Load some real OpenAI embeddings and spot check calculations.
+func TestRaBitQuantizeEmbeddings(t *testing.T) {
+	workspace := &internal.Workspace{}
+	ctx := internal.WithWorkspace(context.Background(), workspace)
+	defer require.True(t, workspace.IsClear())
+
+	features := testutils.LoadFeatures(t, 100)
+	quantizer := NewRaBitQuantizer(features.Dims, 42)
+	require.Equal(t, 512, quantizer.GetOriginalDims())
+
+	quantizedSet := quantizer.Quantize(ctx, &features)
+	require.Equal(t, 100, quantizedSet.GetCount())
+
+	centroid := quantizedSet.GetCentroid()
+	require.Len(t, centroid, 512)
+	require.InDelta(t, -0.00452728, centroid[0], 0.0000001)
+	require.InDelta(t, -0.00299389, centroid[511], 0.0000001)
+
+	centroidDistances := quantizedSet.GetCentroidDistances()
+	require.Len(t, centroidDistances, 100)
+	require.InDelta(t, 0.7345806, centroidDistances[0], 0.0000001)
+	require.InDelta(t, 0.7328457, centroidDistances[99], 0.0000001)
+
+	queryVector := features.At(0)
+	squaredDistances := make([]float32, quantizedSet.GetCount())
+	errorBounds := make([]float32, quantizedSet.GetCount())
+	quantizer.EstimateSquaredDistances(ctx, quantizedSet, queryVector, squaredDistances, errorBounds)
+	num32.Round(squaredDistances, 4)
+	num32.Round(errorBounds, 4)
+	require.Equal(t, float32(0.0182), squaredDistances[0])
+	require.Equal(t, float32(1.0965), squaredDistances[99])
+	require.Equal(t, float32(0.0477), errorBounds[0])
+	require.Equal(t, float32(0.0476), errorBounds[99])
+}
+
+// Benchmark quantization of 100 vectors.
+func BenchmarkQuantize(b *testing.B) {
+	ctx := internal.WithWorkspace(context.Background(), &internal.Workspace{})
+	features := testutils.LoadFeatures(b, 100)
+	quantizer := NewRaBitQuantizer(features.Dims, 42)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		quantizer.Quantize(ctx, &features)
+	}
+}
+
+// Benchmark distance estimation of 100 vectors.
+func BenchmarkEstimateSquaredDistances(b *testing.B) {
+	ctx := internal.WithWorkspace(context.Background(), &internal.Workspace{})
+	features := testutils.LoadFeatures(b, 100)
+	quantizer := NewRaBitQuantizer(features.Dims, 42)
+	quantizedSet := quantizer.Quantize(ctx, &features)
+
+	queryVector := features.At(0)
+	squaredDistances := make([]float32, quantizedSet.GetCount())
+	errorBounds := make([]float32, quantizedSet.GetCount())
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		quantizer.EstimateSquaredDistances(ctx, quantizedSet, queryVector, squaredDistances, errorBounds)
+	}
+}

--- a/pkg/sql/vecindex/quantize/rabitqpb.go
+++ b/pkg/sql/vecindex/quantize/rabitqpb.go
@@ -1,0 +1,121 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package quantize
+
+import (
+	"slices"
+
+	"github.com/cockroachdb/cockroach/pkg/util/vector"
+	"github.com/cockroachdb/errors"
+)
+
+// RaBitQCode is a quantization code that partially encodes a quantized vector.
+// It has 1 bit per dimension of the quantized vector it represents. For
+// example, if the quantized vector has 512 dimensions, then its code will have
+// 512 bits that are packed into uint64 values using big-endian ordering (i.e.
+// a width of 64 bytes). If the dimensions are not evenly divisible by 64, the
+// trailing bits of the code are set to zero.
+type RaBitQCode []uint64
+
+// MakeRaBitQCodeSet returns an empty set of quantization codes, where each code
+// in the set represents a quantized vector with the given number of dimensions.
+func MakeRaBitQCodeSet(dims int) RaBitQCodeSet {
+	return RaBitQCodeSet{
+		Count: 0,
+		// Calculate the number of uint64 values needed to store 1 bit per
+		// dimension.
+		Width: (dims + 63) / 64,
+	}
+}
+
+// MakeRaBitQCodeSetFromRawData constructs a set of quantization codes from a
+// raw slice of codes. The raw codes are packed contiguously in memory and
+// represent quantized vectors having the given number of dimensions.
+// NB: The data slice is directly used rather than copied; do not use it outside
+// the context of this code set after this point.
+func MakeRaBitQCodeSetFromRawData(data []uint64, width int) RaBitQCodeSet {
+	if len(data)%width != 0 {
+		panic(errors.AssertionFailedf(
+			"data length %d is not a multiple of the width %d", len(data), width))
+	}
+	return RaBitQCodeSet{Count: len(data) / width, Width: width, Data: data}
+}
+
+// At returns the code at the given position in the set as a slice of uint64
+// values that can be read or written by the caller.
+func (cs *RaBitQCodeSet) At(offset int) RaBitQCode {
+	start := offset * cs.Width
+	return cs.Data[start : start+cs.Width]
+}
+
+// Add appends the given code to this set.
+func (cs *RaBitQCodeSet) Add(code RaBitQCode) {
+	if len(code) != cs.Width {
+		panic(errors.AssertionFailedf(
+			"cannot add code with %d width to set with width %d", len(code), cs.Width))
+	}
+	cs.Data = append(cs.Data, code...)
+	cs.Count++
+}
+
+// AddUndefined adds the given number of codes to this set. The codes should be
+// set to defined values before use.
+func (cs *RaBitQCodeSet) AddUndefined(count int) {
+	cs.Data = slices.Grow(cs.Data, count*cs.Width)
+	cs.Count += count
+	cs.Data = cs.Data[:cs.Count*cs.Width]
+}
+
+// ReplaceWithLast removes the code at the given offset from the set, replacing
+// it with the last code in the set. The modified set has one less element and
+// the last code's position changes.
+func (cs *RaBitQCodeSet) ReplaceWithLast(offset int) {
+	targetStart := offset * cs.Width
+	sourceEnd := len(cs.Data)
+	copy(cs.Data[targetStart:targetStart+cs.Width], cs.Data[sourceEnd-cs.Width:sourceEnd])
+	cs.Data = cs.Data[:sourceEnd-cs.Width]
+	cs.Count--
+}
+
+// GetCount implements the QuantizedVectorSet interface.
+func (vs *RaBitQuantizedVectorSet) GetCount() int {
+	return len(vs.CodeCounts)
+}
+
+// GetCentroid implements the QuantizedVectorSet interface.
+func (vs *RaBitQuantizedVectorSet) GetCentroid() vector.T {
+	return vs.Centroid
+}
+
+// GetCentroidDistances implements the QuantizedVectorSet interface.
+func (vs *RaBitQuantizedVectorSet) GetCentroidDistances() []float32 {
+	return vs.CentroidDistances
+}
+
+// ReplaceWithLast implements the QuantizedVectorSet interface.
+func (vs *RaBitQuantizedVectorSet) ReplaceWithLast(offset int) {
+	lastOffset := len(vs.CodeCounts) - 1
+	vs.Codes.ReplaceWithLast(offset)
+	vs.CodeCounts[offset] = vs.CodeCounts[lastOffset]
+	vs.CodeCounts = vs.CodeCounts[:lastOffset]
+	vs.CentroidDistances[offset] = vs.CentroidDistances[lastOffset]
+	vs.CentroidDistances = vs.CentroidDistances[:lastOffset]
+	vs.DotProducts[offset] = vs.DotProducts[lastOffset]
+	vs.DotProducts = vs.DotProducts[:lastOffset]
+}
+
+// AddUndefined adds the given number of quantized vectors to this set. The new
+// quantized vector information should be set to defined values before use.
+func (vs *RaBitQuantizedVectorSet) AddUndefined(count int) {
+	newCount := len(vs.CodeCounts) + count
+	vs.Codes.AddUndefined(count)
+	vs.CodeCounts = slices.Grow(vs.CodeCounts, count)
+	vs.CodeCounts = vs.CodeCounts[:newCount]
+	vs.CentroidDistances = slices.Grow(vs.CentroidDistances, count)
+	vs.CentroidDistances = vs.CentroidDistances[:newCount]
+	vs.DotProducts = slices.Grow(vs.DotProducts, count)
+	vs.DotProducts = vs.DotProducts[:newCount]
+}

--- a/pkg/sql/vecindex/quantize/rabitqpb_test.go
+++ b/pkg/sql/vecindex/quantize/rabitqpb_test.go
@@ -1,0 +1,73 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package quantize
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRaBitCodeSet(t *testing.T) {
+	cs := MakeRaBitQCodeSet(65)
+	require.Equal(t, 0, cs.Count)
+	require.Equal(t, 2, cs.Width)
+
+	// Add code.
+	cs.Add(RaBitQCode{1, 2})
+	require.Equal(t, 1, cs.Count)
+
+	// Add additional codes.
+	cs.AddUndefined(2)
+	copy(cs.At(1), []uint64{3, 4})
+	copy(cs.At(2), []uint64{5, 6})
+	require.Equal(t, 3, cs.Count)
+	require.Equal(t, RaBitQCode{5, 6}, cs.At(2))
+
+	// Remove codes.
+	cs.ReplaceWithLast(1)
+	require.Equal(t, 2, cs.Count)
+	require.Equal(t, RaBitQCode{5, 6}, cs.At(1))
+
+	cs.ReplaceWithLast(0)
+	require.Equal(t, 1, cs.Count)
+	require.Equal(t, RaBitQCode{5, 6}, cs.At(0))
+
+	cs.ReplaceWithLast(0)
+	require.Equal(t, 0, cs.Count)
+
+	data := []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+	cs = MakeRaBitQCodeSetFromRawData(data, 3)
+	require.Equal(t, 4, cs.Count)
+	require.Equal(t, 3, cs.Width)
+	require.Equal(t, data, cs.Data)
+}
+
+func TestRaBitQuantizedVectorSet(t *testing.T) {
+	var quantizedSet RaBitQuantizedVectorSet
+	quantizedSet.Centroid = []float32{1, 2, 3}
+	quantizedSet.Codes.Width = 3
+
+	quantizedSet.AddUndefined(5)
+	copy(quantizedSet.Codes.At(4), []uint64{1, 2, 3})
+	quantizedSet.CodeCounts[4] = 15
+	quantizedSet.CentroidDistances[4] = 1.23
+	quantizedSet.DotProducts[4] = 4.56
+	require.Equal(t, 5, quantizedSet.Codes.Count)
+	require.Len(t, quantizedSet.CodeCounts, 5)
+	require.Len(t, quantizedSet.CentroidDistances, 5)
+	require.Len(t, quantizedSet.DotProducts, 5)
+
+	quantizedSet.ReplaceWithLast(2)
+	require.Equal(t, 4, quantizedSet.Codes.Count)
+	require.Equal(t, RaBitQCode{1, 2, 3}, quantizedSet.Codes.At(2))
+	require.Len(t, quantizedSet.CodeCounts, 4)
+	require.Equal(t, uint32(15), quantizedSet.CodeCounts[2])
+	require.Len(t, quantizedSet.CentroidDistances, 4)
+	require.Equal(t, float32(1.23), quantizedSet.CentroidDistances[2])
+	require.Len(t, quantizedSet.DotProducts, 4)
+	require.Equal(t, float32(4.56), quantizedSet.DotProducts[2])
+}

--- a/pkg/sql/vecindex/testutils/BUILD.bazel
+++ b/pkg/sql/vecindex/testutils/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "testutils",
+    srcs = ["testutils.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/vecindex/testutils",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/build/bazel",
+        "//pkg/util/vector",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/sql/vecindex/testutils/testutils.go
+++ b/pkg/sql/vecindex/testutils/testutils.go
@@ -1,0 +1,49 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package testutils
+
+import (
+	"encoding/gob"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/build/bazel"
+	"github.com/cockroachdb/cockroach/pkg/util/vector"
+	"github.com/stretchr/testify/require"
+)
+
+// LoadFeatures loads up to 10K 512 dimension float32 unit vectors that are laid
+// out contiguously in row-wise order. These vectors are OpenAI embeddings of
+// images. If count < 10K, then a subset of the features are returned.
+func LoadFeatures(t testing.TB, count int) vector.Set {
+	var filePath string
+	if bazel.BuiltWithBazel() {
+		runfile, err := bazel.Runfile("pkg/sql/vecindex/testdata/features_10000.gob")
+		require.NoError(t, err)
+		filePath = runfile
+	} else {
+		// Get the absolute path of this test file.
+		_, testFile, _, ok := runtime.Caller(0)
+		require.True(t, ok)
+
+		// Point to the features file.
+		parentDir := filepath.Dir(testFile)
+		filePath = filepath.Join(parentDir, "..", "testdata", "features_10000.gob")
+	}
+
+	f, err := os.Open(filePath)
+	require.NoError(t, err)
+	defer f.Close()
+
+	decoder := gob.NewDecoder(f)
+	var data []float32
+	err = decoder.Decode(&data)
+	require.NoError(t, err)
+
+	return vector.MakeSetFromRawData(data[:count*512], 512)
+}


### PR DESCRIPTION
This commit implements RaBitQ quantization according to the algorithm described in this paper:

    "RaBitQ: Quantizing High-Dimensional Vectors with a Theoretical Error Bound
    for Approximate Nearest Neighbor Search" by Jianyang Gao & Cheng Long.

The RaBitQ quantization method provides good accuracy, produces compact codes, provides practical error bounds, is easy to implement, and can be accelerated with fast SIMD instructions. RaBitQ quantization codes use only 1 bit per dimension in the original vector.

Epic: CRDB-42943

Release note: None