### PR TITLE
sql/schemachanger: plumb EvalCtx into BuildCtx

### DIFF
--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -441,6 +441,7 @@ func newInternalPlanner(
 	p.extendedEvalCtx.NodeID = execCfg.NodeInfo.NodeID
 	p.extendedEvalCtx.Locality = execCfg.Locality
 	p.extendedEvalCtx.OriginalLocality = execCfg.Locality
+	p.extendedEvalCtx.DescIDGenerator = execCfg.DescIDGenerator
 
 	p.sessionDataMutatorIterator = smi
 

--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -124,6 +124,7 @@ func (p *planner) newSchemaChangeBuilderDependencies(statements []string) scbuil
 		p, /* nodesStatusInfo */
 		p, /* regionProvider */
 		p.SemaCtx(),
+		p.EvalContext(),
 		p.execCfg.DefaultZoneConfig,
 	)
 }

--- a/pkg/sql/schemachanger/scbuild/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "//pkg/sql/catalog/seqexpr",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/catalog/typedesc",
-        "//pkg/sql/faketreeeval",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",

--- a/pkg/sql/schemachanger/scbuild/build.go
+++ b/pkg/sql/schemachanger/scbuild/build.go
@@ -278,10 +278,11 @@ type cachedDesc struct {
 func newBuilderState(
 	ctx context.Context, d Dependencies, incumbent scpb.CurrentState, localMemAcc *mon.BoundAccount,
 ) *builderState {
+
 	bs := builderState{
 		ctx:                      ctx,
 		clusterSettings:          d.ClusterSettings(),
-		evalCtx:                  newEvalCtx(d),
+		evalCtx:                  d.EvalCtx(),
 		semaCtx:                  d.SemaCtx(),
 		cr:                       d.CatalogReader(),
 		tr:                       d.TableReader(),

--- a/pkg/sql/schemachanger/scbuild/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/dependencies.go
@@ -57,6 +57,9 @@ type Dependencies interface {
 	// Statements returns the statements behind this schema change.
 	Statements() []string
 
+	// EvalCtx returns the eval.Context for the schema change statement.
+	EvalCtx() *eval.Context
+
 	// SemaCtx returns the tree.SemaContext for the schema change statement.
 	SemaCtx() *tree.SemaContext
 

--- a/pkg/sql/schemachanger/scbuild/tree_context_builder.go
+++ b/pkg/sql/schemachanger/scbuild/tree_context_builder.go
@@ -6,11 +6,9 @@
 package scbuild
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/sql/faketreeeval"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild/internal/scbuildstmt"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 )
 
 var _ scbuildstmt.TreeContextBuilder = buildCtx{}
@@ -22,24 +20,5 @@ func (b buildCtx) SemaCtx() *tree.SemaContext {
 
 // EvalCtx implements the scbuildstmt.TreeContextBuilder interface.
 func (b buildCtx) EvalCtx() *eval.Context {
-	return newEvalCtx(b.Dependencies)
-}
-
-func newEvalCtx(d Dependencies) *eval.Context {
-	return &eval.Context{
-		ClusterID:            d.ClusterID(),
-		SessionDataStack:     sessiondata.NewStack(d.SessionData()),
-		Planner:              &faketreeeval.DummyEvalPlanner{},
-		StreamManagerFactory: &faketreeeval.DummyStreamManagerFactory{},
-		PrivilegedAccessor:   &faketreeeval.DummyPrivilegedAccessor{},
-		SessionAccessor:      &faketreeeval.DummySessionAccessor{},
-		ClientNoticeSender:   d.ClientNoticeSender(),
-		Sequence:             &faketreeeval.DummySequenceOperators{},
-		Tenant:               &faketreeeval.DummyTenantOperator{},
-		Regions:              &faketreeeval.DummyRegionOperator{},
-		Settings:             d.ClusterSettings(),
-		Codec:                d.Codec(),
-		DescIDGenerator:      d.DescIDGenerator(),
-		Placeholders:         &d.SemaCtx().Placeholders,
-	}
+	return b.Dependencies.EvalCtx()
 }

--- a/pkg/sql/schemachanger/scdeps/build_deps.go
+++ b/pkg/sql/schemachanger/scdeps/build_deps.go
@@ -56,6 +56,7 @@ func NewBuilderDependencies(
 	nodesStatusInfo scbuild.NodesStatusInfo,
 	regionProvider scbuild.RegionProvider,
 	semaCtx *tree.SemaContext,
+	evalCtx *eval.Context,
 	defaultZoneConfig *zonepb.ZoneConfig,
 ) scbuild.Dependencies {
 	return &buildDeps{
@@ -80,6 +81,7 @@ func NewBuilderDependencies(
 		nodesStatusInfo:          nodesStatusInfo,
 		regionProvider:           regionProvider,
 		semaCtx:                  semaCtx,
+		evalCtx:                  evalCtx,
 		defaultZoneConfig:        defaultZoneConfig,
 	}
 }
@@ -104,6 +106,7 @@ type buildDeps struct {
 	nodesStatusInfo          scbuild.NodesStatusInfo
 	regionProvider           scbuild.RegionProvider
 	semaCtx                  *tree.SemaContext
+	evalCtx                  *eval.Context
 	defaultZoneConfig        *zonepb.ZoneConfig
 }
 
@@ -372,6 +375,11 @@ func (d *buildDeps) ClusterSettings() *cluster.Settings {
 // Statements implements the scbuild.Dependencies interface.
 func (d *buildDeps) Statements() []string {
 	return d.statements
+}
+
+// EvalCtx implements the scbuild.Dependencies interface.
+func (d *buildDeps) EvalCtx() *eval.Context {
+	return d.evalCtx
 }
 
 // SemaCtx implements the scbuild.Dependencies interface.

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/config.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbuild"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -155,7 +156,7 @@ func WithMerger(merger scexec.Merger) Option {
 
 func WithIDGenerator(s serverutils.ApplicationLayerInterface) Option {
 	return optionFunc(func(state *TestState) {
-		state.idGenerator = descidgen.NewGenerator(s.ClusterSettings(), s.Codec(), s.DB())
+		state.evalCtx.DescIDGenerator = descidgen.NewGenerator(s.ClusterSettings(), s.Codec(), s.DB())
 	})
 }
 
@@ -187,5 +188,12 @@ var defaultOptions = []Option{
 		semaCtx := tree.MakeSemaContext(state)
 		semaCtx.SearchPath = &state.SessionData().SearchPath
 		state.semaCtx = &semaCtx
+
+		evalCtx := &eval.Context{
+			SessionDataStack:   sessiondata.NewStack(state.SessionData()),
+			Settings:           state.ClusterSettings(),
+			ClientNoticeSender: state.ClientNoticeSender(),
+		}
+		state.evalCtx = evalCtx
 	}),
 }

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -94,6 +94,11 @@ func (s *TestState) Statements() []string {
 	return s.statements
 }
 
+// EvalCtx implements the scbuild.Dependencies interface.
+func (s *TestState) EvalCtx() *eval.Context {
+	return s.evalCtx
+}
+
 // SemaCtx implements the scbuild.Dependencies interface.
 func (s *TestState) SemaCtx() *tree.SemaContext {
 	return s.semaCtx

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_state.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_state.go
@@ -57,6 +57,7 @@ type TestState struct {
 	sessionData             sessiondata.SessionData
 	statements              []string
 	semaCtx                 *tree.SemaContext
+	evalCtx                 *eval.Context
 	testingKnobs            *scexec.TestingKnobs
 	jobs                    []jobs.Record
 	createdJobsInCurrentTxn []jobspb.JobID
@@ -79,7 +80,6 @@ type TestState struct {
 	approximateTimestamp time.Time
 
 	catalogChanges     catalogChanges
-	idGenerator        eval.DescIDGenerator
 	refProviderFactory scbuild.ReferenceProviderFactory
 }
 
@@ -241,7 +241,7 @@ func (s *TestState) ClientNoticeSender() eval.ClientNoticeSender {
 
 // DescIDGenerator implements scbuild.Dependencies.
 func (s *TestState) DescIDGenerator() eval.DescIDGenerator {
-	return s.idGenerator
+	return s.evalCtx.DescIDGenerator
 }
 
 // ReferenceProviderFactory implements scbuild.Dependencies.

--- a/pkg/sql/schemachanger/scdeps/sctestutils/BUILD.bazel
+++ b/pkg/sql/schemachanger/scdeps/sctestutils/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/schemachanger/scplan",
         "//pkg/sql/schemachanger/scplan/scviz",
+        "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",

--- a/pkg/sql/schemachanger/scdeps/sctestutils/sctestutils.go
+++ b/pkg/sql/schemachanger/scdeps/sctestutils/sctestutils.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/scviz"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
@@ -64,6 +65,7 @@ func WithBuilderDependenciesFromTestServer(
 		Descriptors() *descs.Collection
 		SessionData() *sessiondata.SessionData
 		SemaCtx() *tree.SemaContext
+		EvalContext() *eval.Context
 		resolver.SchemaResolver
 		scbuild.AuthorizationAccessor
 		scbuild.AstFormatter
@@ -104,6 +106,7 @@ func WithBuilderDependenciesFromTestServer(
 		planner, /* nodesStatusInfo */
 		planner, /* regionProvider */
 		planner.SemaCtx(),
+		planner.EvalContext(),
 		execCfg.DefaultZoneConfig,
 	))
 }


### PR DESCRIPTION
This will allow us to access useful fields in the EvalCtx, such as the fields relating to transaction state.

Epic: None
Release note: None