### PR TITLE
sql/schemachanger: fix a misattributed metric and noisy log

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4619,7 +4619,7 @@ func (sc *StatementCounters) incrementCount(ex *connExecutor, stmt tree.Statemen
 			sc.CopyNonAtomicCount.Inc()
 		}
 	default:
-		if tree.CanModifySchema(stmt) {
+		if stmt.StatementReturnType() == tree.DDL || stmt.StatementType() == tree.TypeDDL {
 			sc.DdlCount.Inc()
 		} else {
 			sc.MiscCount.Inc()

--- a/pkg/sql/schemachanger/scbuild/build.go
+++ b/pkg/sql/schemachanger/scbuild/build.go
@@ -59,8 +59,12 @@ func Build(
 	n tree.Statement,
 	memAcc *mon.BoundAccount,
 ) (_ scpb.CurrentState, eventLogCallBack LogSchemaChangerEventsFn, err error) {
+	// This message is logged at level=1 since this is called during the planning
+	// phase to check if the statement is supported by the declarative schema
+	// changer, which makes this quite verbose.
 	defer scerrors.StartEventf(
 		ctx,
+		1, /* level */
 		"building declarative schema change targets for %s",
 		redact.Safe(n.StatementTag()),
 	).HandlePanicAndLogError(ctx, &err)

--- a/pkg/sql/schemachanger/scbuild/event_log.go
+++ b/pkg/sql/schemachanger/scbuild/event_log.go
@@ -60,6 +60,7 @@ func makeEventLogCallback(
 	var swallowedError error
 	defer scerrors.StartEventf(
 		b.Context,
+		0, /* level */
 		"event logging for declarative schema change targets built for %s",
 		redact.Safe(ts.Statements[loggedTargets[0].target.Metadata.StatementID].StatementTag),
 	).HandlePanicAndLogError(b.Context, &swallowedError)

--- a/pkg/sql/schemachanger/scerrors/errors.go
+++ b/pkg/sql/schemachanger/scerrors/errors.go
@@ -34,9 +34,15 @@ type EventLogger struct {
 //
 // Typical usage is along the lines of:
 // - defer StartEventf(...).HandlePanicAndLogError(...)
-func StartEventf(ctx context.Context, format string, args ...interface{}) EventLogger {
+func StartEventf(
+	ctx context.Context, level log.Level, format string, args ...interface{},
+) EventLogger {
 	msg := redact.Safe(fmt.Sprintf(format, args...))
-	log.InfofDepth(ctx, 1, "%s", msg)
+	// Use depth=1 since we want to log as the caller of StartEventf.
+	const depth = 1
+	if log.VDepth(level, depth) {
+		log.InfofDepth(ctx, depth, "%s", msg)
+	}
 	return EventLogger{
 		msg:   msg,
 		start: timeutil.Now(),

--- a/pkg/sql/schemachanger/scplan/plan.go
+++ b/pkg/sql/schemachanger/scplan/plan.go
@@ -96,6 +96,7 @@ func (p Plan) StagesForCurrentPhase() []scstage.Stage {
 func MakePlan(ctx context.Context, initial scpb.CurrentState, params Params) (p Plan, err error) {
 	defer scerrors.StartEventf(
 		ctx,
+		0, /* level */
 		"building declarative schema changer plan in %s (rollback=%v) for %s",
 		redact.Safe(params.ExecutionPhase),
 		redact.Safe(params.InRollback),

--- a/pkg/sql/schemachanger/scrun/scrun.go
+++ b/pkg/sql/schemachanger/scrun/scrun.go
@@ -178,6 +178,7 @@ func executeStage(
 ) (err error) {
 	defer scerrors.StartEventf(
 		ctx,
+		0, /* level */
 		"executing declarative schema change %s (rollback=%v) for %s",
 		redact.Safe(stage),
 		redact.Safe(p.InRollback),
@@ -304,6 +305,7 @@ func makeState(
 ) (state scpb.CurrentState, err error) {
 	defer scerrors.StartEventf(
 		ctx,
+		0, /* level */
 		"rebuilding declarative schema change state from descriptors %v",
 		redact.Safe(descriptorIDs),
 	).HandlePanicAndLogError(ctx, &err)

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -44,8 +44,8 @@ const (
 	//
 	// Note: this is the type indicated back to the client; it is not a
 	// sufficient test for schema mutation for planning purposes. There
-	// are schema-modifying statements (e.g. CREATE TABLE AS) which
-	// report RowsAffected to the client, not DDL.
+	// are schema-modifying statements (e.g. DISCARD ALL) which
+	// report Ack to the client, not DDL.
 	// Use CanModifySchema() below instead.
 	DDL
 	// RowsAffected indicates that the statement returns the count of


### PR DESCRIPTION
### sql: only increment sql.ddl.count for DDL operations

This was leasing to a highly inflated count of the metric due to TCL
statements such as DISCARD ALL. Those are not DDL statements, but they
can modify schema by dropping temporary sequences. Using the statement
return type is a more accurate way to check.

Release note (bug fix): Fixed a minor bug where DISCARD ALL statements
were counted under the sql.ddl.count metric. Now these will be counted
under the sql.misc.count metric.

### sql: move a spammy log to a higher verbosity level

This was getting logged too frequently, since the function is called during the
planning phase to check if a statement works in the declarative schema
changer. This would get logged even if the statement does not use the
declarative schema changer, which is a little misleading.

Epic: None
Release note: None