### PR TITLE
cli: skip excluded node in debug zip

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -450,6 +450,7 @@ go_test(
         "//pkg/workload/examples",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_errors//oserror",
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_google_pprof//profile",
         "@com_github_pmezard_go_difflib//difflib",

--- a/pkg/cli/testdata/zip/partial1_excluded
+++ b/pkg/cli/testdata/zip/partial1_excluded
@@ -132,7 +132,7 @@ debug zip /dev/null --concurrency=1 --exclude-nodes=2 --cpu-profile-duration=0
 [node ?] ? log files found
 [node 1] requesting ranges... received response... done
 [node 1] writing ranges... writing JSON output: debug/nodes/1/ranges.json... done
-[node 2] skipping node... writing binary output: debug/nodes/2.skipped... done
+[node 2] skipping excluded node
 [node 3] node status... writing JSON output: debug/nodes/3/status.json... done
 [node 3] using SQL connection URL: postgresql://...
 [node 3] retrieving SQL data for crdb_internal.active_range_feeds... writing output: debug/nodes/3/crdb_internal.active_range_feeds.txt... done

--- a/pkg/cli/zip_per_node.go
+++ b/pkg/cli/zip_per_node.go
@@ -91,6 +91,10 @@ func (zc *debugZipContext) collectCPUProfiles(
 		if livenessByNodeID[nodeID] == livenesspb.NodeLivenessStatus_DECOMMISSIONED {
 			continue
 		}
+		if !zipCtx.nodes.isIncluded(nodeID) {
+			zc.clusterPrinter.info(fmt.Sprintf("skipping excluded node %d", nodeID))
+			continue
+		}
 		wg.Add(1)
 		go func(ctx context.Context, i int) {
 			defer wg.Done()
@@ -261,10 +265,7 @@ func (zc *debugZipContext) collectPerNodeData(
 	prefix := fmt.Sprintf("%s%s/%s", zc.prefix, nodesPrefix, id)
 
 	if !zipCtx.nodes.isIncluded(nodeID) {
-		if err := zc.z.createRaw(nodePrinter.start("skipping node"), prefix+".skipped",
-			[]byte(fmt.Sprintf("skipping excluded node %d\n", nodeID))); err != nil {
-			return err
-		}
+		nodePrinter.info("skipping excluded node")
 		return nil
 	}
 	if nodeStatus != nil {


### PR DESCRIPTION
Previously, debug zip cli command generates node directory with format `nodeID.skipped` for excluded nodes. It was causing confusion in analysing debug zip artifacts. To address this, this patch skips CPU profiles and directory generation for excluded nodes.

Epic: CRDB-32134
Fixes: #128590
Release note: None