### PR TITLE
drtprod: modify tpcc run script.

### DIFF
--- a/pkg/cmd/drtprod/configs/drt_scale.yaml
+++ b/pkg/cmd/drtprod/configs/drt_scale.yaml
@@ -162,8 +162,8 @@ targets:
         flags:
           db: cct_tpcc
           warehouses: 400000
-          max-rate: 10000
-          workers: 5000
+          max-rate: 1000
+          workers: 400000
           conns: 5000
           duration: 12h
           ramp: 10m


### PR DESCRIPTION
Modifying generate_tpcc_run.sh script to equally distribute pgurls of cluster nodes among workload nodes.

Epic: none

Release note: None