### PR TITLE
roachtest: fix grant revoke ops for dbuser with numbers

### DIFF
--- a/pkg/cmd/roachtest/operations/grant_revoke_all.go
+++ b/pkg/cmd/roachtest/operations/grant_revoke_all.go
@@ -56,7 +56,8 @@ func runGrant(
 	rng, _ := randutil.NewTestRand()
 	dbName := pickRandomDB(ctx, o, conn, systemDBs)
 	tableName := pickRandomTable(ctx, o, conn, dbName)
-	dbUser := randutil.RandString(rng, 10, randutil.PrintableKeyAlphabet)
+	// the dbUser cannot have a number in the beginning. So, adding an "a" to ensure that the first letter will not be a number
+	dbUser := fmt.Sprintf("a%s", randutil.RandString(rng, 9, randutil.PrintableKeyAlphabet))
 
 	o.Status(fmt.Sprintf("Creating user %s", dbUser))
 	_, err := conn.ExecContext(ctx, fmt.Sprintf("CREATE USER %s WITH PASSWORD '%s'", dbUser, dbUser))


### PR DESCRIPTION
The DB username cannot start with a number. This PR has a simple fix to add a letter "a" in the randomly generated username to ensure that the first letter will not be a number.

Epic: None
Release note: None