### PR TITLE
server: fix flaking TestTriggerMetadataUpdateJob test

### DIFF
--- a/pkg/sql/tablemetadatacache/update_table_metadata_cache_job_test.go
+++ b/pkg/sql/tablemetadatacache/update_table_metadata_cache_job_test.go
@@ -38,7 +38,7 @@ func TestUpdateTableMetadataCacheJobRunsOnRPCTrigger(t *testing.T) {
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				TableMetadata: &tablemetadatacacheutil.TestingKnobs{
-					TableMetadataUpdater: &noopUpdater{},
+					TableMetadataUpdater: &tablemetadatacacheutil.NoopUpdater{},
 					OnJobComplete: func() {
 						jobCompleteCh <- struct{}{}
 					},
@@ -199,11 +199,3 @@ func (m *mockUpdaterWithSignal) RunUpdater(ctx context.Context) error {
 }
 
 var _ tablemetadatacacheutil.ITableMetadataUpdater = &mockUpdaterWithSignal{}
-
-type noopUpdater struct{}
-
-func (nu *noopUpdater) RunUpdater(_ctx context.Context) error {
-	return nil
-}
-
-var _ tablemetadatacacheutil.ITableMetadataUpdater = &noopUpdater{}

--- a/pkg/sql/tablemetadatacache/util/util.go
+++ b/pkg/sql/tablemetadatacache/util/util.go
@@ -14,3 +14,13 @@ import "context"
 type ITableMetadataUpdater interface {
 	RunUpdater(ctx context.Context) error
 }
+
+// NoopUpdater is an implementation of ITableMetadataUpdater that performs a noop when RunUpdater is called.
+// This should only be used in tests when the updating of the table_metadata system table isn't necessary.
+type NoopUpdater struct{}
+
+func (nu *NoopUpdater) RunUpdater(_ctx context.Context) error {
+	return nil
+}
+
+var _ ITableMetadataUpdater = &NoopUpdater{}


### PR DESCRIPTION
This test is failing due to the asynchronous nature of the update table metadata job and the triggering of it via the http endpoint. The test makes assumptions about when the job is ready and able to be triggered successfully, but there is no deterministic way to determine so, making the test flake.

To fix, we wrap the API call in SucceedsSoon() to retry the request if the job isn't ready to be triggered.

Release note: None
Fixes #133415, #132910