### PR TITLE
crosscluster: require 24.3 for LDR

### DIFF
--- a/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/ccl/crosscluster/logical/create_logical_replication_stmt.go
@@ -73,7 +73,7 @@ func createLogicalReplicationStreamPlanHook(
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer span.Finish()
 
-		if !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.V24_2) {
+		if !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.V24_3) {
 			return pgerror.New(pgcode.FeatureNotSupported,
 				"replication job not supported before V24.2")
 		}


### PR DESCRIPTION
We now require a number of options that are only available on 24.3.

Epic: none
Release note: None