### PR TITLE
roachtest: properly set error in Get/Put

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2252,7 +2252,7 @@ func (c *SyncedCluster) Put(
 
 	var finalErr error
 	setErr := func(e error) {
-		if finalErr != nil {
+		if finalErr == nil {
 			finalErr = e
 		}
 	}
@@ -2596,7 +2596,7 @@ func (c *SyncedCluster) Get(
 
 	var finalErr error
 	setErr := func(e error) {
-		if finalErr != nil {
+		if finalErr == nil {
 			finalErr = e
 		}
 	}


### PR DESCRIPTION
In #132478, Get and Put were changed to remove an unnecessary mutex used to check if an error had already been set. We want to only return one error so we only set the returning error if it is not already set.

However, a regression was introduced as we accidentally checked if an error was not nil instead of nil before setting. This change fixes that.

Fixes: #134289
Release note: none
Epic: none