### PR TITLE
roachtest: disk bandwidth limiter test should only asssert on writes

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -181,8 +181,10 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 						continue
 					}
 					totalBW := writeVal + readVal
-					if totalBW > bandwidthThreshold {
-						t.Fatalf("write + read bandwidth %f (%f + %f) exceeded threshold of %f", totalBW, writeVal, readVal, bandwidthThreshold)
+					// TODO(aaditya): We should be asserting on total bandwidth once reads
+					// are being paced.
+					if writeVal > bandwidthThreshold {
+						t.Fatalf("write bandwidth %f exceeded threshold of %f, read bandwidth: %f, total bandwidth: %f", writeVal, bandwidthThreshold, readVal, totalBW)
 					}
 					numSuccesses++
 				}


### PR DESCRIPTION
Since we do not pace reads yet, the test will remain flaky in this assertion, as the system can see unbounded read bandwidth usage and fail the assertion even if writes are paced.

Fixes #131484

Release note: None