### PR TITLE
logictest: revert some incorrect recent rewrites

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
@@ -205,8 +205,8 @@ ORDER BY start_key
 /Table/106  14400
 /Table/107  14400
 /Table/110  90001
-/Table/111  90001
-/Table/112  14400
+/Table/111  1
+/Table/112  1
 
 subtest transactional_schemachanges
 


### PR DESCRIPTION
These were included in 533e5479f024dd4b07693f892176f6db7c66b31e.

Fixes: #134299
Fixes: #134300
Fixes: #134404
Fixes: #134406

Release note: None