### PR TITLE
storage: disable multilevel compactions

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -891,6 +891,10 @@ func DefaultPebbleOptions() *pebble.Options {
 		Lower: EncodeMVCCKey(MVCCKey{Key: keys.LocalRangeLockTablePrefix}),
 		Upper: EncodeMVCCKey(MVCCKey{Key: keys.LocalRangeLockTablePrefix.PrefixEnd()}),
 	}
+	// Disable multi-level compaction heuristic for now. See #134423
+	// for why this was disabled, and what needs to be changed to reenable it.
+	// This issue tracks re-enablement: https://github.com/cockroachdb/pebble/issues/4139
+	opts.Experimental.MultiLevelCompactionHeuristic = pebble.NoMultiLevel{}
 
 	for i := 0; i < len(opts.Levels); i++ {
 		l := &opts.Levels[i]


### PR DESCRIPTION
In their current state, multilevel compactions can cause momentary spikes in L0 sublevels, resulting in undesirable side-effects elsewhere.

Fixes #134423.

Epic: none

Release note: None