### PR TITLE
release-24.3: storage: backport columnar KeySchema updates

### DIFF
--- a/pkg/storage/engine_key_test.go
+++ b/pkg/storage/engine_key_test.go
@@ -489,3 +489,26 @@ func engineKey(key string, ts int) EngineKey {
 		Version: encodeMVCCTimestamp(wallTS(ts)),
 	}
 }
+
+var possibleVersionLens = []int{
+	engineKeyNoVersion,
+	engineKeyVersionWallTimeLen,
+	engineKeyVersionWallAndLogicalTimeLen,
+	engineKeyVersionWallLogicalAndSyntheticTimeLen,
+	engineKeyVersionLockTableLen,
+}
+
+func randomSerializedEngineKey(r *rand.Rand, maxUserKeyLen int) []byte {
+	userKeyLen := randutil.RandIntInRange(r, 1, maxUserKeyLen)
+	versionLen := possibleVersionLens[r.Intn(len(possibleVersionLens))]
+	serializedLen := userKeyLen + versionLen + 1
+	if versionLen > 0 {
+		serializedLen++ // sentinel
+	}
+	k := randutil.RandBytes(r, serializedLen)
+	k[userKeyLen] = 0x00
+	if versionLen > 0 {
+		k[len(k)-1] = byte(versionLen + 1)
+	}
+	return k
+}

--- a/pkg/storage/pebble_key_schema_test.go
+++ b/pkg/storage/pebble_key_schema_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/rand"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -20,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/crlib/crbytes"
 	"github.com/cockroachdb/crlib/crstrings"
@@ -29,6 +31,7 @@ import (
 	"github.com/cockroachdb/pebble/sstable/block"
 	"github.com/cockroachdb/pebble/sstable/colblk"
 	"github.com/olekukonko/tablewriter"
+	"github.com/stretchr/testify/require"
 )
 
 func TestKeySchema_KeyWriter(t *testing.T) {
@@ -306,4 +309,49 @@ func parseTestKey(s string) ([]byte, error) {
 			Timestamp: ts,
 		}), nil
 	}
+}
+
+func TestKeySchema_RandomKeys(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	rng, _ := randutil.NewTestRand()
+	maxUserKeyLen := randutil.RandIntInRange(rng, 2, 10)
+	keys := make([][]byte, randutil.RandIntInRange(rng, 1, 1000))
+	for i := range keys {
+		keys[i] = randomSerializedEngineKey(rng, maxUserKeyLen)
+	}
+	slices.SortFunc(keys, EngineKeyCompare)
+
+	var enc colblk.DataBlockEncoder
+	enc.Init(&keySchema)
+	for i := range keys {
+		ikey := pebble.InternalKey{
+			UserKey: keys[i],
+			Trailer: pebble.MakeInternalKeyTrailer(0, pebble.InternalKeyKindSet),
+		}
+		enc.Add(ikey, keys[i], block.InPlaceValuePrefix(false), enc.KeyWriter.ComparePrev(keys[i]), false /* isObsolete */)
+	}
+	blk, _ := enc.Finish(len(keys), enc.Size())
+	blk = crbytes.CopyAligned(blk)
+
+	var dec colblk.DataBlockDecoder
+	dec.Init(&keySchema, blk)
+	var it colblk.DataBlockIter
+	it.InitOnce(&keySchema, EngineKeyCompare, EngineKeySplit, nil)
+	require.NoError(t, it.Init(&dec, block.NoTransforms))
+	for k, kv := 0, it.First(); kv != nil; k, kv = k+1, it.Next() {
+		require.True(t, EngineKeyEqual(keys[k], kv.K.UserKey))
+		require.Zero(t, EngineKeyCompare(keys[k], kv.K.UserKey))
+		// Note we allow the key read from the block to be physically different,
+		// because the above randomization generates point keys with the
+		// synthetic bit encoding. However the materialized key should not be
+		// longer than the original key, because we depend on the max key length
+		// during writing bounding the key length during reading.
+		if n := len(kv.K.UserKey); n > len(keys[k]) {
+			t.Fatalf("key %q is longer than original key %q", kv.K.UserKey, keys[k])
+		}
+		checkEngineKey(kv.K.UserKey)
+	}
+	require.NoError(t, it.Close())
 }

--- a/pkg/storage/testdata/key_schema_key_seeker
+++ b/pkg/storage/testdata/key_schema_key_seeker
@@ -147,3 +147,25 @@ MaterializeUserKey(-1, 3) = hex:6d6f6f0000000000b2d05e00000000010d
 MaterializeUserKey(3, 2) = hex:666f6f0000000000b2d05e00000000010d
 MaterializeUserKey(2, 0) = hex:6261720000000000b2d05e00000000010d
 MaterializeUserKey(0, 1) = hex:6261780000000000b2d05e00000000010d
+
+define-block
+moo@3.000000001,0
+moo@3.000000000,2
+moo@3.000000000,1
+moo@3.000000000,0
+----
+Parse("moo@3.000000001,0") = hex:6d6f6f0000000000b2d05e0109
+Parse("moo@3.000000000,2") = hex:6d6f6f0000000000b2d05e00000000020d
+Parse("moo@3.000000000,1") = hex:6d6f6f0000000000b2d05e00000000010d
+Parse("moo@3.000000000,0") = hex:6d6f6f0000000000b2d05e0009
+
+materialize-user-key
+0
+1
+2
+3
+----
+MaterializeUserKey(-1, 0) = hex:6d6f6f0000000000b2d05e0109
+MaterializeUserKey(0, 1) = hex:6d6f6f0000000000b2d05e00000000020d
+MaterializeUserKey(1, 2) = hex:6d6f6f0000000000b2d05e00000000010d
+MaterializeUserKey(2, 3) = hex:6d6f6f0000000000b2d05e0009

--- a/pkg/storage/testdata/key_schema_key_writer
+++ b/pkg/storage/testdata/key_schema_key_writer
@@ -98,10 +98,42 @@ Parse("/MVCC/poi@1.000000000,3") = hex:2f4d5643432f706f6900000000003b9aca0000000
 
 finish
 ----
-+------------------------+------------+---------+--------------------------------------+
-|          KEY           |    WALL    | LOGICAL |               UNTYPED                |
-+------------------------+------------+---------+--------------------------------------+
-| hex:017a6b12706f690001 |          0 |       0 | 022a84b329b76b4616ac151047f0a3fe9c12 |
-| hex:017a6b12706f690001 |          0 |       0 | 02073a83c45688420eaf97824255790f1e12 |
-| /MVCC/poi              | 1000000000 |       3 |                                      |
-+------------------------+------------+---------+--------------------------------------+
++------------------------+------------+---------+------------------------------------+
+|          KEY           |    WALL    | LOGICAL |              UNTYPED               |
++------------------------+------------+---------+------------------------------------+
+| hex:017a6b12706f690001 |          0 |       0 | 022a84b329b76b4616ac151047f0a3fe9c |
+| hex:017a6b12706f690001 |          0 |       0 | 02073a83c45688420eaf97824255790f1e |
+| /MVCC/poi              | 1000000000 |       3 |                                    |
++------------------------+------------+---------+------------------------------------+
+
+# Regression test for #134053.
+#
+# Write consecutive keys where the engine key prefix of the 1st key (including
+# the sentinel byte) is a byte prefix of the 2nd key, but the two keys have
+# different MVCC prefixes. Previously, ComparePrev would return the wrong value
+# for CommonPrefixLen, omitting the sentinel byte of the previous prefix.
+
+init
+----
+
+write
+hex:fa00180512db93969eee09
+hex:fa0000180512db93c71f7409
+----
+Parse("hex:fa00180512db93969eee09") = hex:fa00180512db93969eee09
+00: ComparePrev("hex:fa00180512db93969eee09"): PrefixLen=2; CommonPrefixLen=0; UserKeyComparison=1
+00: WriteKey(0, "hex:fa00180512db93969eee09", PrefixLen=2, CommonPrefixLen=0)
+00: MaterializeKey(_, 0) = hex:fa00180512db93969eee09
+Parse("hex:fa0000180512db93c71f7409") = hex:fa0000180512db93c71f7409
+01: ComparePrev("hex:fa0000180512db93c71f7409"): PrefixLen=3; CommonPrefixLen=2; UserKeyComparison=1
+01: WriteKey(1, "hex:fa0000180512db93c71f7409", PrefixLen=3, CommonPrefixLen=2)
+01: MaterializeKey(_, 1) = hex:fa0000180512db93c71f7409
+
+finish
+----
++----------+---------------------+---------+---------+
+|   KEY    |        WALL         | LOGICAL | UNTYPED |
++----------+---------------------+---------+---------+
+| hex:fa   | 1730810366077083374 |       0 |         |
+| hex:fa00 | 1730810366080262004 |       0 |         |
++----------+---------------------+---------+---------+


### PR DESCRIPTION
Backports edits from #133164, #133409 and #134349. They're not individually cherry-picked because they don't apply cleanly and depend on differing intermediary Pebble SHAs.

Epic: none
Release note: None
Release justification: Fixes serious correctness issues with columnar blocks.