### PR TITLE
server: databases apis privilege fixes

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -117,6 +117,10 @@ var (
 	redactedMarker = string(redact.RedactedMarker())
 )
 
+const (
+	updateTableMetadataCachePermissionErrMsg = "only admin users can trigger table metadata cache updates"
+)
+
 type metricMarshaler interface {
 	json.Marshaler
 	PrintAsText(io.Writer, expfmt.Format) error
@@ -4258,6 +4262,10 @@ func (s *statusServer) localUpdateTableMetadataCache() (
 func (s *statusServer) UpdateTableMetadataCache(
 	ctx context.Context, req *serverpb.UpdateTableMetadataCacheRequest,
 ) (*serverpb.UpdateTableMetadataCacheResponse, error) {
+	_, isAdmin, _ := s.privilegeChecker.GetUserAndRole(ctx)
+	if !isAdmin {
+		return nil, status.Error(codes.PermissionDenied, updateTableMetadataCachePermissionErrMsg)
+	}
 	if req.Local {
 		return s.localUpdateTableMetadataCache()
 	}

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -14,15 +14,21 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/server/authserver"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/insights"
+	tablemetadatacacheutil "github.com/cockroachdb/cockroach/pkg/sql/tablemetadatacache/util"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -458,4 +464,82 @@ func TestListExecutionInsightsWhileEvictingInsights(t *testing.T) {
 	}()
 
 	wg.Wait()
+}
+
+// TestStatusUpdateTableMetadataCache tests that signalling the update
+// table metadata cache job via the status server triggers the update
+// table metadata job to run.
+func TestStatusUpdateTableMetadataCache(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	var zeroDuration time.Duration
+	jobCompleteCh := make(chan struct{})
+	ctx := context.Background()
+	tc := serverutils.StartCluster(t, 3, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				JobsTestingKnobs: &jobs.TestingKnobs{
+					IntervalOverrides: jobs.TestingIntervalOverrides{
+						Adopt: &zeroDuration,
+					}},
+				TableMetadata: &tablemetadatacacheutil.TestingKnobs{
+					TableMetadataUpdater: &tablemetadatacacheutil.NoopUpdater{},
+					OnJobComplete: func() {
+						jobCompleteCh <- struct{}{}
+					},
+				},
+			},
+		},
+	})
+	defer tc.Stopper().Stop(context.Background())
+
+	conn := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+
+	t.Run("gated on admin privilege", func(t *testing.T) {
+		authCtx := authserver.ForwardHTTPAuthInfoToRPCCalls(authserver.ContextWithHTTPAuthInfo(ctx, username.TestUser, 1), nil)
+		_, err := tc.Server(0).GetStatusClient(t).UpdateTableMetadataCache(authCtx,
+			&serverpb.UpdateTableMetadataCacheRequest{Local: false})
+		require.Truef(t, testutils.IsError(err, updateTableMetadataCachePermissionErrMsg), "received error: %v", err)
+	})
+
+	t.Run("triggers update table metadata cache job", func(t *testing.T) {
+		// Get the node id that claimed the update job. We'll issue the
+		// RPC to a node that doesn't own the job to test that the RPC can
+		// propagate the request to the correct node.
+		var nodeID int
+		testutils.SucceedsSoon(t, func() error {
+			row := conn.Query(t, `
+SELECT claim_instance_id FROM system.jobs 
+WHERE id = $1 AND claim_instance_id IS NOT NULL`, jobs.UpdateTableMetadataCacheJobID)
+			if !row.Next() {
+				return errors.New("no node has claimed the job")
+			}
+			require.NoError(t, row.Scan(&nodeID))
+
+			rpcGatewayNode := (nodeID + 1) % 3
+			_, err := tc.Server(rpcGatewayNode).GetStatusClient(t).UpdateTableMetadataCache(ctx,
+				&serverpb.UpdateTableMetadataCacheRequest{Local: false})
+			if err != nil {
+				return err
+			}
+			// The job shouldn't be busy.
+			return nil
+		})
+
+		// Wait for the job to complete.
+		t.Log("waiting for job to complete")
+		<-jobCompleteCh
+		t.Log("job completed")
+
+		row := conn.Query(t,
+			`SELECT running_status FROM crdb_internal.jobs WHERE job_id = $1 AND running_status IS NOT NULL`,
+			jobs.UpdateTableMetadataCacheJobID)
+		if !row.Next() {
+			t.Fatal("last_run_time not updated")
+		}
+		var runningStatus string
+		require.NoError(t, row.Scan(&runningStatus))
+		require.Containsf(t, runningStatus, "Job completed at", "running_status not updated: %s", runningStatus)
+	})
 }

--- a/pkg/sql/tablemetadatacache/util/test_utils.go
+++ b/pkg/sql/tablemetadatacache/util/test_utils.go
@@ -5,6 +5,8 @@
 
 package tablemetadatacacheutil
 
+import "context"
+
 // TestingKnobs provides hooks into the table metadata cache job
 type TestingKnobs struct {
 	// onJobResume is called when the job is ready
@@ -56,3 +58,13 @@ func CreateTestingKnobs() *TestingKnobs {
 		aostClause: "AS OF SYSTEM TIME '-1us'",
 	}
 }
+
+// NoopUpdater is an implementation of ITableMetadataUpdater that performs a noop when RunUpdater is called.
+// This should only be used in tests when the updating of the table_metadata system table isn't necessary.
+type NoopUpdater struct{}
+
+func (nu *NoopUpdater) RunUpdater(_ctx context.Context) error {
+	return nil
+}
+
+var _ ITableMetadataUpdater = &NoopUpdater{}

--- a/pkg/sql/tablemetadatacache/util/util.go
+++ b/pkg/sql/tablemetadatacache/util/util.go
@@ -14,13 +14,3 @@ import "context"
 type ITableMetadataUpdater interface {
 	RunUpdater(ctx context.Context) error
 }
-
-// NoopUpdater is an implementation of ITableMetadataUpdater that performs a noop when RunUpdater is called.
-// This should only be used in tests when the updating of the table_metadata system table isn't necessary.
-type NoopUpdater struct{}
-
-func (nu *NoopUpdater) RunUpdater(_ctx context.Context) error {
-	return nil
-}
-
-var _ ITableMetadataUpdater = &NoopUpdater{}


### PR DESCRIPTION
- Gate status server grpc UpdateTableMetadataCache on ADMIN This should only be accessed via the api v2 http handler, which performs finer privilege checks on if the user has CONNECT privs on a database.
- When filtering dbs and tables to return in the apis, permit dbs and tables that have CONNECT on the public role.
- Move TestUpdateTableMetadataCacheJobRunsOnRPCTrigger test to status_test.go. This test is more well-suited to live here since it tests functionality in the status server.

Epic: CRDB-37558
Fixes: #134431
Fixes: #130245

Release note (ui change): Users may access DB Console's db pages (db overview, tables overview, table details) if they have CONNECT privilege on the database.