### PR TITLE
pebbleiter: implement ValueAndErr

### DIFF
--- a/pkg/storage/pebbleiter/crdb_test_on.go
+++ b/pkg/storage/pebbleiter/crdb_test_on.go
@@ -118,12 +118,24 @@ func (i *assertionIter) Key() []byte {
 }
 
 func (i *assertionIter) Value() []byte {
+	panic(errors.AssertionFailedf("Value() is deprecated; use ValueAndErr()"))
+}
+
+func (i *assertionIter) ValueAndErr() ([]byte, error) {
 	if !i.Valid() {
-		panic(errors.AssertionFailedf("Value() called on !Valid() pebble.Iterator"))
+		panic(errors.AssertionFailedf("ValueAndErr() called on !Valid() pebble.Iterator"))
 	}
+	val, err := i.Iterator.ValueAndErr()
 	idx := i.unsafeBufs.idx
-	i.unsafeBufs.val[idx] = append(i.unsafeBufs.val[idx][:0], i.Iterator.Value()...)
-	return i.unsafeBufs.val[idx]
+	i.unsafeBufs.val[idx] = append(i.unsafeBufs.val[idx][:0], val...)
+	// Preserve nil-ness to ensure we test exactly the behavior of Pebble.
+	if val == nil {
+		return val, err
+	}
+	if i.unsafeBufs.val[idx] == nil {
+		i.unsafeBufs.val[idx] = []byte{}
+	}
+	return i.unsafeBufs.val[idx], err
 }
 
 func (i *assertionIter) LazyValue() pebble.LazyValue {


### PR DESCRIPTION
Implement ValueAndErr on the storage/pebbleiter package's assertionIter to ensure correct use of value slices. Additionally, assert that no callers make use of the deprecated Value method.

Epic: none
Release note: none