### PR TITLE
release-24.3: cluster-ui: bump npm pkg to v24.3.2

### DIFF
--- a/pkg/ui/pnpm-lock.yaml
+++ b/pkg/ui/pnpm-lock.yaml
@@ -55,9 +55,6 @@ importers:
       '@babel/runtime':
         specifier: ^7.12.13
         version: 7.12.13
-      '@cockroachlabs/crdb-protobuf-client':
-        specifier: workspace:../db-console/src/js
-        version: link:../db-console/src/js
       '@cockroachlabs/design-tokens':
         specifier: 0.4.5
         version: 0.4.5
@@ -227,6 +224,9 @@ importers:
       '@bazel/worker':
         specifier: 5.5.0
         version: 5.5.0
+      '@cockroachlabs/crdb-protobuf-client':
+        specifier: workspace:../db-console/src/js
+        version: link:../db-console/src/js
       '@cockroachlabs/eslint-config':
         specifier: 1.0.7
         version: 1.0.7(@typescript-eslint/eslint-plugin@5.62.0)(eslint-plugin-prettier@5.2.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.34.1)(eslint@8.57.0)(typescript@5.1.6)

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "24.3.1",
+  "version": "24.3.2",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",
@@ -33,7 +33,6 @@
   "dependencies": {
     "@ant-design/icons": "^5.3.6",
     "@babel/runtime": "^7.12.13",
-    "@cockroachlabs/crdb-protobuf-client": "workspace:../db-console/src/js",
     "@cockroachlabs/design-tokens": "0.4.5",
     "@cockroachlabs/icons": "0.5.2",
     "@cockroachlabs/ui-components": "0.4.3",
@@ -90,6 +89,7 @@
     "@babel/preset-typescript": "^7.8.0",
     "@bazel/typescript": "5.5.0",
     "@bazel/worker": "5.5.0",
+    "@cockroachlabs/crdb-protobuf-client": "workspace:../db-console/src/js",
     "@cockroachlabs/eslint-config": "1.0.7",
     "@cockroachlabs/eslint-plugin-crdb": "workspace:../eslint-plugin-crdb",
     "@storybook/addon-actions": "^6.5.16",


### PR DESCRIPTION
We also move the crdb protobuf client to dev dependencies.

Epic: none

Release note: None

---------------------

Release justification: non production code changes