### PR TITLE
release-24.2.5-rc: opt: make `max-stack` opt tester option more reliable

### DIFF
--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"text/tabwriter"
 	"time"
@@ -606,8 +607,23 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 	if ot.Flags.MaxStackBytes > 0 {
 		originalMaxStack := debug.SetMaxStack(ot.Flags.MaxStackBytes)
 		defer debug.SetMaxStack(originalMaxStack)
+		// Spawn a separate goroutine. A fresh stack makes tests using this
+		// setting more reliable.
+		var wg sync.WaitGroup
+		wg.Add(1)
+		var res string
+		go func() {
+			defer wg.Done()
+			res = ot.runCommandInternal(tb, d)
+		}()
+		wg.Wait()
+		return res
+	} else {
+		return ot.runCommandInternal(tb, d)
 	}
+}
 
+func (ot *OptTester) runCommandInternal(tb testing.TB, d *datadriven.TestData) string {
 	switch d.Cmd {
 	case "exec-ddl":
 		testCatalog, ok := ot.catalog.(*testcat.Catalog)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -2820,7 +2820,7 @@ CREATE TABLE t132669 (
 # unnecessary recursion to trigger a stack overflow without having to make the
 # `IN` list below huge - triggering a stack overflow with Go's default max stack
 # size requires a list of ~1.6 million elements.
-opt max-stack=50KB format=hide-all
+opt max-stack=100kB skip-race format=hide-all
 SELECT * FROM t132669
 WHERE a IN (
     1,  2,  3,  4,  5,  6,  7, 8, 9, 10,


### PR DESCRIPTION
Backport 1/1 commits from #134313.

/cc @cockroachdb/release

---

The `max-stack` opt tester option now runs the test command in a
separate goroutine. A fresh stack makes tests using this setting more
reliable.

It also decreases the `max-stack` of the original test that motivated
the `max-stack` option (see https://github.com/cockroachdb/cockroach/pull/132701) to 100KB, between 65KB in which the
test fails after the fix in https://github.com/cockroachdb/cockroach/pull/132701 and 135KB in which the test fails
before the fix.

Finally, the test has been disabled under `race` builds which increase
the size of stack frames and would cause this test to fail.

Epic: None

Release note: None

---

Release justification: Test-only change.

