### PR TITLE
settings: retire kvadmission.low_pri_read_elastic_control.enabled

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -242,8 +242,9 @@ var retiredSettings = map[InternalKey]struct{}{
 	"kv.rangefeed.range_stuck_threshold": {},
 
 	// removed as of 24.3
-	"bulkio.backup.split_keys_on_timestamps": {},
-	"sql.create_tenant.default_template":     {},
+	"bulkio.backup.split_keys_on_timestamps":           {},
+	"sql.create_tenant.default_template":               {},
+	"kvadmission.low_pri_read_elastic_control.enabled": {},
 }
 
 // sqlDefaultSettings is the list of "grandfathered" existing sql.defaults


### PR DESCRIPTION
Release note (ops change): The kvadmission.low_pri_read_elastic_control.enabled has been removed as all bulk requests are now subject to eleastic admission by default.
Epic: https://cockroachlabs.atlassian.net/browse/CRDB-39798.