### PR TITLE
[WIP] kv: add TestGossipRecoversBeforeUnavailableRanges

### DIFF
--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -1026,7 +1026,7 @@ func (bq *baseQueue) replicaCanBeProcessed(
 		var err error
 		confReader, err = bq.store.GetConfReader(ctx)
 		if err != nil {
-			if log.V(1) || !errors.Is(err, errSpanConfigsUnavailable) {
+			if log.V(1) || !errors.Is(err, ErrSpanConfigsUnavailable) {
 				log.Warningf(ctx, "unable to retrieve conf reader, skipping: %v", err)
 			}
 			return nil, err

--- a/pkg/kv/kvserver/queue_test.go
+++ b/pkg/kv/kvserver/queue_test.go
@@ -620,7 +620,7 @@ func TestNeedsSystemConfig(t *testing.T) {
 	{
 		confReader, err := tc.store.GetConfReader(ctx)
 		require.Nil(t, confReader)
-		require.True(t, errors.Is(err, errSpanConfigsUnavailable))
+		require.True(t, errors.Is(err, ErrSpanConfigsUnavailable))
 	}
 
 	r, err := tc.store.GetReplica(1)

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -375,7 +375,7 @@ func (r *Replica) updateRangeInfo(ctx context.Context, desc *roachpb.RangeDescri
 	// to different zones.
 	// Load the system config.
 	confReader, err := r.store.GetConfReader(ctx)
-	if errors.Is(err, errSpanConfigsUnavailable) {
+	if errors.Is(err, ErrSpanConfigsUnavailable) {
 		// This could be before the span config subscription was ever
 		// established.
 		log.Warningf(ctx, "unable to retrieve conf reader, cannot determine range MaxBytes")

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2410,7 +2410,7 @@ func (s *Store) WaitForInit() {
 // GetConfReader exposes access to a configuration reader.
 func (s *Store) GetConfReader(ctx context.Context) (spanconfig.StoreReader, error) {
 	if s.cfg.TestingKnobs.MakeSystemConfigSpanUnavailableToQueues {
-		return nil, errSpanConfigsUnavailable
+		return nil, ErrSpanConfigsUnavailable
 	}
 	if s.cfg.TestingKnobs.ConfReaderInterceptor != nil {
 		return s.cfg.TestingKnobs.ConfReaderInterceptor(), nil
@@ -2419,7 +2419,7 @@ func (s *Store) GetConfReader(ctx context.Context) (spanconfig.StoreReader, erro
 	if s.cfg.SpanConfigsDisabled || s.TestingKnobs().UseSystemConfigSpanForQueues {
 		sysCfg := s.cfg.SystemConfigProvider.GetSystemConfig()
 		if sysCfg == nil {
-			return nil, errSpanConfigsUnavailable
+			return nil, ErrSpanConfigsUnavailable
 		}
 		return sysCfg, nil
 	}
@@ -2442,7 +2442,7 @@ func (s *Store) GetConfReader(ctx context.Context) (spanconfig.StoreReader, erro
 		//   failing to find expected data.
 		// - enabling the replicate queue would mean replicating towards the
 		//   statically defined 3x replication in the fallback span config.
-		return nil, errSpanConfigsUnavailable
+		return nil, ErrSpanConfigsUnavailable
 	}
 	return s.cfg.SpanConfigSubscriber, nil
 }

--- a/pkg/kv/kvserver/store_gossip.go
+++ b/pkg/kv/kvserver/store_gossip.go
@@ -178,7 +178,9 @@ func (s *Store) startGossip() {
 	}
 }
 
-var errSpanConfigsUnavailable = errors.New("span configs not available")
+// ErrSpanConfigsUnavailable indicates that an operation failed because the span
+// configs are not available.
+var ErrSpanConfigsUnavailable = errors.New("span configs not available")
 
 // systemGossipUpdate is a callback for gossip updates to
 // the system config which affect range split boundaries.

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -3583,7 +3583,7 @@ func TestAllocatorCheckRangeUnconfigured(t *testing.T) {
 		} else {
 			// Expect error looking up spanConfig if we can't use the system config span,
 			// as the spanconfig.KVSubscriber infrastructure is not initialized.
-			require.ErrorIs(t, err, errSpanConfigsUnavailable)
+			require.ErrorIs(t, err, ErrSpanConfigsUnavailable)
 			require.Equal(t, allocatorimpl.AllocatorNoop, action)
 		}
 	})

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1185,6 +1185,11 @@ func (t *testTenant) DrainClients(ctx context.Context) error {
 	return t.drain.drainClients(ctx, nil /* reporter */)
 }
 
+// DrainNode exports the drainNode() method for use by tests.
+func (t *testTenant) DrainNode(ctx context.Context) error {
+	return t.drain.drainNode(ctx, nil /* reporter */, false /* verbose */)
+}
+
 // Readiness is part of the serverutils.ApplicationLayerInterface.
 func (t *testTenant) Readiness(ctx context.Context) error {
 	return t.t.admin.checkReadinessForHealthCheck(ctx)
@@ -1851,6 +1856,11 @@ func (ts *testServer) SQLAddr() string {
 // DrainClients exports the drainClients() method for use by tests.
 func (ts *testServer) DrainClients(ctx context.Context) error {
 	return ts.drain.drainClients(ctx, nil /* reporter */)
+}
+
+// DrainNode exports the drainNode() method for use by tests.
+func (ts *testServer) DrainNode(ctx context.Context) error {
+	return ts.drain.drainNode(ctx, nil /* reporter */, false /* verbose */)
 }
 
 // Readiness is part of the serverutils.ApplicationLayerInterface.

--- a/pkg/testutils/serverutils/api.go
+++ b/pkg/testutils/serverutils/api.go
@@ -366,6 +366,9 @@ type ApplicationLayerInterface interface {
 	// DrainClients shuts down client connections.
 	DrainClients(ctx context.Context) error
 
+	// DrainNode drains leases from the node.
+	DrainNode(ctx context.Context) error
+
 	// SystemConfigProvider provides access to the system config.
 	SystemConfigProvider() config.SystemConfigProvider
 

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -1439,7 +1439,11 @@ func (tc *TestCluster) WaitForFullReplication() error {
 				// Force upreplication. Otherwise, if we rely on the scanner to do it,
 				// it'll take a while.
 				if err := s.ForceReplicationScanAndProcess(); err != nil {
-					return err
+					// This can sometimes fail since ComputeMetrics calls
+					// updateReplicationGauges which needs the system config gossiped.
+					log.Infof(context.TODO(), "%v", err)
+					notReplicated = true
+					return nil
 				}
 				if err := s.ComputeMetrics(context.TODO()); err != nil {
 					// This can sometimes fail since ComputeMetrics calls


### PR DESCRIPTION
The test is timing based, so it is difficult to make not flaky. Reducing the SentinelGossipTTL from 6s to 3s drops the failure rate from 47% to 3%.

Epic: None
Release note: None