### PR TITLE
sql: correctly handle triggers with cyclical dependencies

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -2221,6 +2221,332 @@ statement ok
 DELETE FROM xy WHERE True;
 
 # ==============================================================================
+# Test cyclical triggers.
+# ==============================================================================
+
+statement ok
+CREATE TABLE t1 (a INT, b INT);
+CREATE TABLE t2 (a INT, b INT);
+
+# Test cyclical AFTER triggers.
+subtest cyclical_after_triggers
+
+statement ok
+SET recursion_depth_limit = 10;
+
+statement ok
+CREATE FUNCTION insert_t1() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RAISE NOTICE ' ';
+    RAISE NOTICE '% trigger % with NEW: %', TG_WHEN, TG_NAME, NEW;
+    RAISE NOTICE 'max t1.a: %, max t2.a: %', (SELECT max(a) FROM t1), (SELECT max(a) FROM t2);
+    RAISE NOTICE 'inserting into t1: %', ROW((NEW).a + 1, (NEW).b);
+    INSERT INTO t1 VALUES ((NEW).a + 1, (NEW).b);
+    RETURN NEW;
+  END
+$$;
+CREATE FUNCTION insert_t2() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RAISE NOTICE ' ';
+    RAISE NOTICE '% trigger % with NEW: %', TG_WHEN, TG_NAME, NEW;
+    RAISE NOTICE 'max t1.a: %, max t2.a: %', (SELECT max(a) FROM t1), (SELECT max(a) FROM t2);
+    RAISE NOTICE 'inserting into t2: %', ROW((NEW).a + 1, (NEW).b);
+    INSERT INTO t2 VALUES ((NEW).a + 1, (NEW).b);
+    RETURN NEW;
+  END
+$$;
+
+statement ok
+CREATE TRIGGER foo AFTER INSERT ON t1 FOR EACH ROW EXECUTE FUNCTION insert_t2();
+
+statement ok
+CREATE TRIGGER bar AFTER INSERT ON t2 FOR EACH ROW EXECUTE FUNCTION insert_t1();
+
+# The triggers should fire until the limit is reached.
+statement error pgcode 09000 pq: trigger reached recursion depth limit: 10
+INSERT INTO t1 VALUES (1, 1);
+
+statement ok
+DROP TRIGGER foo ON t1;
+
+# Add a WHEN clause to end the cycle after a few iterations.
+statement ok
+CREATE TRIGGER foo AFTER INSERT ON t1 FOR EACH ROW WHEN ((NEW).a < 5) EXECUTE FUNCTION insert_t2();
+
+query T noticetrace
+INSERT INTO t1 VALUES (1, 1);
+----
+NOTICE:
+NOTICE: AFTER trigger foo with NEW: (1,1)
+NOTICE: max t1.a: 1, max t2.a: <NULL>
+NOTICE: inserting into t2: (2,1)
+NOTICE:
+NOTICE: AFTER trigger bar with NEW: (2,1)
+NOTICE: max t1.a: 1, max t2.a: 2
+NOTICE: inserting into t1: (3,1)
+NOTICE:
+NOTICE: AFTER trigger foo with NEW: (3,1)
+NOTICE: max t1.a: 3, max t2.a: 2
+NOTICE: inserting into t2: (4,1)
+NOTICE:
+NOTICE: AFTER trigger bar with NEW: (4,1)
+NOTICE: max t1.a: 3, max t2.a: 4
+NOTICE: inserting into t1: (5,1)
+
+query II rowsort
+SELECT * FROM t1;
+----
+1  1
+3  1
+5  1
+
+query II rowsort
+SELECT * FROM t2;
+----
+2  1
+4  1
+
+statement ok
+DELETE FROM t1 WHERE True;
+DELETE FROM t2 WHERE True;
+
+statement ok
+DROP TRIGGER foo ON t1;
+
+statement ok
+DROP TRIGGER bar ON t2;
+
+# Test cyclical BEFORE triggers.
+subtest cyclical_before_triggers
+
+statement ok
+CREATE TRIGGER foo BEFORE INSERT ON t1 FOR EACH ROW EXECUTE FUNCTION insert_t2();
+
+statement ok
+CREATE TRIGGER bar BEFORE INSERT ON t2 FOR EACH ROW EXECUTE FUNCTION insert_t1();
+
+# The triggers should fire until the limit is reached.
+statement error pgcode 09000 pq: trigger reached recursion depth limit: 10
+INSERT INTO t1 VALUES (1, 1);
+
+statement ok
+DROP TRIGGER foo ON t1;
+
+# Add a WHEN clause to end the cycle after a few iterations.
+statement ok
+CREATE TRIGGER foo BEFORE INSERT ON t1 FOR EACH ROW WHEN ((NEW).a < 5) EXECUTE FUNCTION insert_t2();
+
+query T noticetrace
+INSERT INTO t1 VALUES (1, 1);
+----
+NOTICE:
+NOTICE: BEFORE trigger foo with NEW: (1,1)
+NOTICE: max t1.a: <NULL>, max t2.a: <NULL>
+NOTICE: inserting into t2: (2,1)
+NOTICE:
+NOTICE: BEFORE trigger bar with NEW: (2,1)
+NOTICE: max t1.a: <NULL>, max t2.a: <NULL>
+NOTICE: inserting into t1: (3,1)
+NOTICE:
+NOTICE: BEFORE trigger foo with NEW: (3,1)
+NOTICE: max t1.a: <NULL>, max t2.a: <NULL>
+NOTICE: inserting into t2: (4,1)
+NOTICE:
+NOTICE: BEFORE trigger bar with NEW: (4,1)
+NOTICE: max t1.a: <NULL>, max t2.a: <NULL>
+NOTICE: inserting into t1: (5,1)
+
+query II rowsort
+SELECT * FROM t1;
+----
+1  1
+3  1
+5  1
+
+query II rowsort
+SELECT * FROM t2;
+----
+2  1
+4  1
+
+statement ok
+DELETE FROM t1 WHERE True;
+DELETE FROM t2 WHERE True;
+
+# Test mutually cyclical BEFORE and AFTER triggers.
+subtest cyclical_before_after_triggers
+
+statement ok
+DROP TRIGGER foo ON t1;
+
+statement ok
+CREATE TRIGGER foo AFTER INSERT ON t1 FOR EACH ROW EXECUTE FUNCTION insert_t2();
+
+# The triggers should fire until the limit is reached.
+statement error pgcode 09000 pq: trigger reached recursion depth limit: 10
+INSERT INTO t1 VALUES (1, 1);
+
+statement ok
+DROP TRIGGER foo ON t1;
+
+# Add a WHEN clause to end the cycle after a few iterations.
+statement ok
+CREATE TRIGGER foo AFTER INSERT ON t1 FOR EACH ROW WHEN ((NEW).a < 5) EXECUTE FUNCTION insert_t2();
+
+query T noticetrace
+INSERT INTO t1 VALUES (1, 1);
+----
+NOTICE:
+NOTICE: AFTER trigger foo with NEW: (1,1)
+NOTICE: max t1.a: 1, max t2.a: <NULL>
+NOTICE: inserting into t2: (2,1)
+NOTICE:
+NOTICE: BEFORE trigger bar with NEW: (2,1)
+NOTICE: max t1.a: 1, max t2.a: <NULL>
+NOTICE: inserting into t1: (3,1)
+NOTICE:
+NOTICE: AFTER trigger foo with NEW: (3,1)
+NOTICE: max t1.a: 3, max t2.a: <NULL>
+NOTICE: inserting into t2: (4,1)
+NOTICE:
+NOTICE: BEFORE trigger bar with NEW: (4,1)
+NOTICE: max t1.a: 3, max t2.a: <NULL>
+NOTICE: inserting into t1: (5,1)
+
+query II rowsort
+SELECT * FROM t1;
+----
+1  1
+3  1
+5  1
+
+query II rowsort
+SELECT * FROM t2;
+----
+2  1
+4  1
+
+statement ok
+DELETE FROM t1 WHERE True;
+DELETE FROM t2 WHERE True;
+
+statement ok
+DROP TRIGGER foo ON t1;
+
+statement ok
+DROP TRIGGER bar ON t2;
+
+# Test a single cyclical trigger.
+subtest cyclical_trigger_singleton
+
+statement ok
+CREATE TRIGGER foo AFTER INSERT ON t1 FOR EACH ROW EXECUTE FUNCTION insert_t1();
+
+# The trigger should fire until the limit is reached.
+statement error pgcode 09000 pq: trigger reached recursion depth limit: 10
+INSERT INTO t1 VALUES (1, 1);
+
+statement ok
+DROP TRIGGER foo ON t1;
+
+# Add a WHEN clause to end the cycle after a few iterations.
+statement ok
+CREATE TRIGGER foo AFTER INSERT ON t1 FOR EACH ROW WHEN ((NEW).a < 5) EXECUTE FUNCTION insert_t1();
+
+query T noticetrace
+INSERT INTO t1 VALUES (1, 1);
+----
+NOTICE:
+NOTICE: AFTER trigger foo with NEW: (1,1)
+NOTICE: max t1.a: 1, max t2.a: <NULL>
+NOTICE: inserting into t1: (2,1)
+NOTICE:
+NOTICE: AFTER trigger foo with NEW: (2,1)
+NOTICE: max t1.a: 2, max t2.a: <NULL>
+NOTICE: inserting into t1: (3,1)
+NOTICE:
+NOTICE: AFTER trigger foo with NEW: (3,1)
+NOTICE: max t1.a: 3, max t2.a: <NULL>
+NOTICE: inserting into t1: (4,1)
+NOTICE:
+NOTICE: AFTER trigger foo with NEW: (4,1)
+NOTICE: max t1.a: 4, max t2.a: <NULL>
+NOTICE: inserting into t1: (5,1)
+
+query II rowsort
+SELECT * FROM t1;
+----
+1  1
+2  1
+3  1
+4  1
+5  1
+
+statement ok
+DELETE FROM t1 WHERE True;
+
+statement ok
+DROP TRIGGER foo ON t1;
+
+statement ok
+CREATE TRIGGER bar BEFORE INSERT ON t1 FOR EACH ROW EXECUTE FUNCTION insert_t1();
+
+# The trigger should fire until the limit is reached.
+statement error pgcode 09000 pq: trigger reached recursion depth limit: 10
+INSERT INTO t1 VALUES (1, 1);
+
+statement ok
+DROP TRIGGER bar ON t1;
+
+# Add a WHEN clause to end the cycle after a few iterations.
+statement ok
+CREATE TRIGGER bar BEFORE INSERT ON t1 FOR EACH ROW WHEN ((NEW).a < 5) EXECUTE FUNCTION insert_t1();
+
+query T noticetrace
+INSERT INTO t1 VALUES (1, 1);
+----
+NOTICE:
+NOTICE: BEFORE trigger bar with NEW: (1,1)
+NOTICE: max t1.a: <NULL>, max t2.a: <NULL>
+NOTICE: inserting into t1: (2,1)
+NOTICE:
+NOTICE: BEFORE trigger bar with NEW: (2,1)
+NOTICE: max t1.a: <NULL>, max t2.a: <NULL>
+NOTICE: inserting into t1: (3,1)
+NOTICE:
+NOTICE: BEFORE trigger bar with NEW: (3,1)
+NOTICE: max t1.a: <NULL>, max t2.a: <NULL>
+NOTICE: inserting into t1: (4,1)
+NOTICE:
+NOTICE: BEFORE trigger bar with NEW: (4,1)
+NOTICE: max t1.a: <NULL>, max t2.a: <NULL>
+NOTICE: inserting into t1: (5,1)
+
+query II rowsort
+SELECT * FROM t1;
+----
+1  1
+2  1
+3  1
+4  1
+5  1
+
+statement ok
+DELETE FROM t1 WHERE True;
+
+statement ok
+DROP TRIGGER bar ON t1;
+
+statement ok
+DROP FUNCTION insert_t1;
+DROP FUNCTION insert_t2;
+DROP TABLE t1;
+DROP TABLE t2;
+
+statement ok
+RESET recursion_depth_limit;
+
+# ==============================================================================
 # Test row-level trigger interaction with FK cascades and checks.
 # ==============================================================================
 

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -2373,7 +2373,6 @@ func addPostQueriesFromPlan(
 	// In cyclical reference situations, the number of cascading operations can
 	// be arbitrarily large. To avoid OOM, we enforce a limit. This is also a
 	// safeguard in case we have a bug that results in an infinite cascade loop.
-	// TODO(drewk): add something similar for triggers.
 	if limit := int(evalCtx.SessionData().OptimizerFKCascadesLimit); len(toPlan.cascades) > limit {
 		telemetry.Inc(sqltelemetry.CascadesLimitReached)
 		err := pgerror.Newf(pgcode.TriggeredActionException, "cascades limit (%d) reached", limit)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3900,6 +3900,10 @@ func (m *sessionDataMutator) SetUnsafeAllowTriggersModifyingCascades(val bool) {
 	m.data.UnsafeAllowTriggersModifyingCascades = val
 }
 
+func (m *sessionDataMutator) SetRecursionDepthLimit(val int) {
+	m.data.RecursionDepthLimit = int64(val)
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -6343,6 +6343,7 @@ plpgsql_use_strict_into                                    off
 prefer_lookup_joins_for_fks                                off
 prepared_statements_cache_size                             0 B
 propagate_input_ordering                                   off
+recursion_depth_limit                                      1000
 reorder_joins_limit                                        8
 require_explicit_primary_keys                              off
 results_buffer_size                                        524288

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2996,6 +2996,7 @@ plpgsql_use_strict_into                                    off                 N
 prefer_lookup_joins_for_fks                                off                 NULL      NULL        NULL        string
 prepared_statements_cache_size                             0 B                 NULL      NULL        NULL        string
 propagate_input_ordering                                   off                 NULL      NULL        NULL        string
+recursion_depth_limit                                      1000                NULL      NULL        NULL        string
 reorder_joins_limit                                        8                   NULL      NULL        NULL        string
 require_explicit_primary_keys                              off                 NULL      NULL        NULL        string
 results_buffer_size                                        524288              NULL      NULL        NULL        string
@@ -3192,6 +3193,7 @@ plpgsql_use_strict_into                                    off                 N
 prefer_lookup_joins_for_fks                                off                 NULL  user     NULL      off                 off
 prepared_statements_cache_size                             0 B                 NULL  user     NULL      0 B                 0 B
 propagate_input_ordering                                   off                 NULL  user     NULL      off                 off
+recursion_depth_limit                                      1000                NULL  user     NULL      1000                1000
 reorder_joins_limit                                        8                   NULL  user     NULL      8                   8
 require_explicit_primary_keys                              off                 NULL  user     NULL      off                 off
 results_buffer_size                                        524288              NULL  user     NULL      524288              524288
@@ -3387,6 +3389,7 @@ plpgsql_use_strict_into                                    NULL    NULL     NULL
 prefer_lookup_joins_for_fks                                NULL    NULL     NULL     NULL        NULL
 prepared_statements_cache_size                             NULL    NULL     NULL     NULL        NULL
 propagate_input_ordering                                   NULL    NULL     NULL     NULL        NULL
+recursion_depth_limit                                      NULL    NULL     NULL     NULL        NULL
 reorder_joins_limit                                        NULL    NULL     NULL     NULL        NULL
 require_explicit_primary_keys                              NULL    NULL     NULL     NULL        NULL
 results_buffer_size                                        NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -162,6 +162,7 @@ plpgsql_use_strict_into                                    off
 prefer_lookup_joins_for_fks                                off
 prepared_statements_cache_size                             0 B
 propagate_input_ordering                                   off
+recursion_depth_limit                                      1000
 reorder_joins_limit                                        8
 require_explicit_primary_keys                              off
 results_buffer_size                                        524288

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -3405,6 +3405,7 @@ func (b *Builder) buildCall(c *memo.CallExpr) (_ execPlan, outputCols colOrdMap,
 		udf.Def.SetReturning,
 		false, /* tailCall */
 		true,  /* procedure */
+		false, /* triggerFunc */
 		false, /* blockStart */
 		nil,   /* blockState */
 		nil,   /* cursorDeclaration */

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -707,6 +707,7 @@ func (b *Builder) buildExistsSubquery(
 				false, /* generator */
 				false, /* tailCall */
 				false, /* procedure */
+				false, /* triggerFunc */
 				false, /* blockStart */
 				nil,   /* blockState */
 				nil,   /* cursorDeclaration */
@@ -828,6 +829,7 @@ func (b *Builder) buildSubquery(
 			false, /* generator */
 			false, /* tailCall */
 			false, /* procedure */
+			false, /* triggerFunc */
 			false, /* blockStart */
 			nil,   /* blockState */
 			nil,   /* cursorDeclaration */
@@ -888,6 +890,7 @@ func (b *Builder) buildSubquery(
 			false, /* generator */
 			false, /* tailCall */
 			false, /* procedure */
+			false, /* triggerFunc */
 			false, /* blockStart */
 			nil,   /* blockState */
 			nil,   /* cursorDeclaration */
@@ -1000,6 +1003,7 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 		udf.Def.SetReturning,
 		tailCall,
 		false, /* procedure */
+		udf.Def.TriggerFunc,
 		udf.Def.BlockStart,
 		blockState,
 		udf.Def.CursorDeclaration,
@@ -1056,6 +1060,7 @@ func (b *Builder) initRoutineExceptionHandler(
 			action.SetReturning,
 			false, /* tailCall */
 			false, /* procedure */
+			false, /* triggerFunc */
 			false, /* blockStart */
 			nil,   /* blockState */
 			nil,   /* cursorDeclaration */

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -708,6 +708,11 @@ type UDFDefinition struct {
 	// applies to direct as well as indirect recursive calls (mutual recursion).
 	IsRecursive bool
 
+	// TriggerFunc indicates whether the routine is a trigger function. It is only
+	// set for the outermost routine, and not for any sub-routines that implement
+	// the PL/pgSQL body.
+	TriggerFunc bool
+
 	// BlockStart indicates whether the routine marks the start of a PL/pgSQL
 	// block with an exception handler. This is used to determine when to
 	// initialize the common state held between sub-routines within the same

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -190,6 +190,11 @@ type Builder struct {
 	// DEFINER, the owner of the routine is checked. Otherwise, the check is
 	// against the user of the current session.
 	checkPrivilegeUser username.SQLUsername
+
+	// builtTriggerFuncs caches already-built trigger functions for a table. It is
+	// necessary to cache these functions since triggers can recursively reference
+	// one another.
+	builtTriggerFuncs map[cat.StableID][]cachedTriggerFunc
 }
 
 // New creates a new Builder structure initialized with the given

--- a/pkg/sql/opt/optbuilder/testdata/trigger
+++ b/pkg/sql/opt/optbuilder/testdata/trigger
@@ -11,6 +11,10 @@ CREATE TABLE computed (k INT PRIMARY KEY, v INT AS (k + 1) STORED, w INT AS (k +
 ----
 
 exec-ddl
+CREATE TABLE ab (a INT, b INT);
+----
+
+exec-ddl
 CREATE FUNCTION f() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
   BEGIN
     RETURN COALESCE(NEW, OLD);
@@ -254,21 +258,21 @@ root
  │    │    ├── x_new:26 => x:1
  │    │    └── y_new:27 => y:2
  │    ├── update-mapping:
- │    │    ├── upsert_x:46 => x:1
- │    │    └── upsert_y:47 => y:2
+ │    │    ├── upsert_x:33 => x:1
+ │    │    └── upsert_y:34 => y:2
  │    ├── input binding: &1
  │    ├── cascades
  │    │    └── child_x_fkey
  │    └── project
- │         ├── columns: upsert_x:46 upsert_y:47 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28 new:29 f:43 x_new:44 y_new:45
+ │         ├── columns: upsert_x:33 upsert_y:34 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28 new:29 f:30 x_new:31 y_new:32
  │         ├── project
- │         │    ├── columns: x_new:44 y_new:45 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28 new:29 f:43
+ │         │    ├── columns: x_new:31 y_new:32 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28 new:29 f:30
  │         │    ├── barrier
- │         │    │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28 new:29 f:43
+ │         │    │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28 new:29 f:30
  │         │    │    └── select
- │         │    │         ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28 new:29 f:43
+ │         │    │         ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28 new:29 f:30
  │         │    │         ├── project
- │         │    │         │    ├── columns: f:43 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28 new:29
+ │         │    │         │    ├── columns: f:30 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28 new:29
  │         │    │         │    ├── barrier
  │         │    │         │    │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 old:28 new:29
  │         │    │         │    │    └── project
@@ -316,79 +320,79 @@ root
  │         │    │         │    │         └── projections
  │         │    │         │    │              └── ((x:7, y_new:27) AS x, y) [as=new:29]
  │         │    │         │    └── projections
- │         │    │         │         └── CASE WHEN x:7 IS NOT NULL THEN f(new:29, old:28, 'tr', 'BEFORE', 'ROW', 'UPDATE', 53, 'xy', 'xy', 'public', 0, ARRAY[]) ELSE new:29 END [as=f:43]
+ │         │    │         │         └── CASE WHEN x:7 IS NOT NULL THEN f(new:29, old:28, 'tr', 'BEFORE', 'ROW', 'UPDATE', 53, 'xy', 'xy', 'public', 0, ARRAY[]) ELSE new:29 END [as=f:30]
  │         │    │         └── filters
- │         │    │              └── f:43 IS DISTINCT FROM NULL
+ │         │    │              └── f:30 IS DISTINCT FROM NULL
  │         │    └── projections
- │         │         ├── (f:43).x [as=x_new:44]
- │         │         └── (f:43).y [as=y_new:45]
+ │         │         ├── (f:30).x [as=x_new:31]
+ │         │         └── (f:30).y [as=y_new:32]
  │         └── projections
- │              ├── CASE WHEN x:7 IS NULL THEN x_new:26 ELSE x_new:44 END [as=upsert_x:46]
- │              └── CASE WHEN x:7 IS NULL THEN y_new:27 ELSE y_new:45 END [as=upsert_y:47]
+ │              ├── CASE WHEN x:7 IS NULL THEN x_new:26 ELSE x_new:31 END [as=upsert_x:33]
+ │              └── CASE WHEN x:7 IS NULL THEN y_new:27 ELSE y_new:32 END [as=upsert_y:34]
  └── cascade
       └── update child
            ├── columns: <none>
-           ├── fetch columns: k:52 child.x:53
+           ├── fetch columns: k:39 child.x:40
            ├── update-mapping:
-           │    └── x_new:57 => child.x:49
+           │    └── x_new:44 => child.x:36
            ├── input binding: &2
            ├── barrier
-           │    ├── columns: k:52 child.x:53 x_old:56 x_new:57 old:58 new:59 f:73 "check-rows":74
+           │    ├── columns: k:39 child.x:40 x_old:43 x_new:44 old:45 new:46 f:60 "check-rows":61
            │    └── select
-           │         ├── columns: k:52 child.x:53 x_old:56 x_new:57 old:58 new:59 f:73 "check-rows":74
+           │         ├── columns: k:39 child.x:40 x_old:43 x_new:44 old:45 new:46 f:60 "check-rows":61
            │         ├── barrier
-           │         │    ├── columns: k:52 child.x:53 x_old:56 x_new:57 old:58 new:59 f:73 "check-rows":74
+           │         │    ├── columns: k:39 child.x:40 x_old:43 x_new:44 old:45 new:46 f:60 "check-rows":61
            │         │    └── project
-           │         │         ├── columns: "check-rows":74 k:52 child.x:53 x_old:56 x_new:57 old:58 new:59 f:73
+           │         │         ├── columns: "check-rows":61 k:39 child.x:40 x_old:43 x_new:44 old:45 new:46 f:60
            │         │         ├── project
-           │         │         │    ├── columns: f:73 k:52 child.x:53 x_old:56 x_new:57 old:58 new:59
+           │         │         │    ├── columns: f:60 k:39 child.x:40 x_old:43 x_new:44 old:45 new:46
            │         │         │    ├── barrier
-           │         │         │    │    ├── columns: k:52 child.x:53 x_old:56 x_new:57 old:58 new:59
+           │         │         │    │    ├── columns: k:39 child.x:40 x_old:43 x_new:44 old:45 new:46
            │         │         │    │    └── project
-           │         │         │    │         ├── columns: new:59 k:52 child.x:53 x_old:56 x_new:57 old:58
+           │         │         │    │         ├── columns: new:46 k:39 child.x:40 x_old:43 x_new:44 old:45
            │         │         │    │         ├── project
-           │         │         │    │         │    ├── columns: old:58 k:52 child.x:53 x_old:56 x_new:57
+           │         │         │    │         │    ├── columns: old:45 k:39 child.x:40 x_old:43 x_new:44
            │         │         │    │         │    ├── inner-join (hash)
-           │         │         │    │         │    │    ├── columns: k:52 child.x:53 x_old:56 x_new:57
+           │         │         │    │         │    │    ├── columns: k:39 child.x:40 x_old:43 x_new:44
            │         │         │    │         │    │    ├── scan child
-           │         │         │    │         │    │    │    └── columns: k:52 child.x:53
+           │         │         │    │         │    │    │    └── columns: k:39 child.x:40
            │         │         │    │         │    │    ├── select
-           │         │         │    │         │    │    │    ├── columns: x_old:56 x_new:57
+           │         │         │    │         │    │    │    ├── columns: x_old:43 x_new:44
            │         │         │    │         │    │    │    ├── with-scan &1
-           │         │         │    │         │    │    │    │    ├── columns: x_old:56 x_new:57
+           │         │         │    │         │    │    │    │    ├── columns: x_old:43 x_new:44
            │         │         │    │         │    │    │    │    └── mapping:
-           │         │         │    │         │    │    │    │         ├──  xy.x:7 => x_old:56
-           │         │         │    │         │    │    │    │         └──  upsert_x:46 => x_new:57
+           │         │         │    │         │    │    │    │         ├──  xy.x:7 => x_old:43
+           │         │         │    │         │    │    │    │         └──  upsert_x:33 => x_new:44
            │         │         │    │         │    │    │    └── filters
-           │         │         │    │         │    │    │         └── x_old:56 IS DISTINCT FROM x_new:57
+           │         │         │    │         │    │    │         └── x_old:43 IS DISTINCT FROM x_new:44
            │         │         │    │         │    │    └── filters
-           │         │         │    │         │    │         └── child.x:53 = x_old:56
+           │         │         │    │         │    │         └── child.x:40 = x_old:43
            │         │         │    │         │    └── projections
-           │         │         │    │         │         └── ((k:52, child.x:53) AS k, x) [as=old:58]
+           │         │         │    │         │         └── ((k:39, child.x:40) AS k, x) [as=old:45]
            │         │         │    │         └── projections
-           │         │         │    │              └── ((k:52, x_new:57) AS k, x) [as=new:59]
+           │         │         │    │              └── ((k:39, x_new:44) AS k, x) [as=new:46]
            │         │         │    └── projections
-           │         │         │         └── f(new:59, old:58, 'tr_child', 'BEFORE', 'ROW', 'UPDATE', 54, 'child', 'child', 'public', 0, ARRAY[]) [as=f:73]
+           │         │         │         └── f(new:46, old:45, 'tr_child', 'BEFORE', 'ROW', 'UPDATE', 54, 'child', 'child', 'public', 0, ARRAY[]) [as=f:60]
            │         │         └── projections
-           │         │              └── CASE WHEN f:73 IS DISTINCT FROM new:59 THEN crdb_internal.plpgsql_raise('ERROR', 'trigger tr_child attempted to modify or filter a row in a cascade operation: ' || new:59::STRING, e'changing the rows updated or deleted by a foreign-key cascade\n can cause constraint violations, and therefore is not allowed', e'to enable this behavior (with risk of constraint violation), set\nthe session variable \'unsafe_allow_triggers_modifying_cascades\' to true', '27000') ELSE CAST(NULL AS INT8) END [as="check-rows":74]
+           │         │              └── CASE WHEN f:60 IS DISTINCT FROM new:46 THEN crdb_internal.plpgsql_raise('ERROR', 'trigger tr_child attempted to modify or filter a row in a cascade operation: ' || new:46::STRING, e'changing the rows updated or deleted by a foreign-key cascade\n can cause constraint violations, and therefore is not allowed', e'to enable this behavior (with risk of constraint violation), set\nthe session variable \'unsafe_allow_triggers_modifying_cascades\' to true', '27000') ELSE CAST(NULL AS INT8) END [as="check-rows":61]
            │         └── filters
-           │              └── f:73 IS DISTINCT FROM NULL
+           │              └── f:60 IS DISTINCT FROM NULL
            └── f-k-checks
                 └── f-k-checks-item: child(x) -> xy(x)
                      └── anti-join (hash)
-                          ├── columns: x:75
+                          ├── columns: x:62
                           ├── select
-                          │    ├── columns: x:75
+                          │    ├── columns: x:62
                           │    ├── with-scan &2
-                          │    │    ├── columns: x:75
+                          │    │    ├── columns: x:62
                           │    │    └── mapping:
-                          │    │         └──  x_new:57 => x:75
+                          │    │         └──  x_new:44 => x:62
                           │    └── filters
-                          │         └── x:75 IS NOT NULL
+                          │         └── x:62 IS NOT NULL
                           ├── scan xy
-                          │    └── columns: xy.x:76
+                          │    └── columns: xy.x:63
                           └── filters
-                               └── x:75 = xy.x:76
+                               └── x:62 = xy.x:63
 
 build-post-queries format=(hide-all,show-columns)
 INSERT INTO xy VALUES (1, 2) ON CONFLICT (x) DO UPDATE SET y = 3;
@@ -403,21 +407,21 @@ root
  │    │    ├── x_new:26 => x:1
  │    │    └── y_new:27 => y:2
  │    ├── update-mapping:
- │    │    ├── upsert_x:47 => x:1
- │    │    └── upsert_y:48 => y:2
+ │    │    ├── upsert_x:34 => x:1
+ │    │    └── upsert_y:35 => y:2
  │    ├── input binding: &1
  │    ├── cascades
  │    │    └── child_x_fkey
  │    └── project
- │         ├── columns: upsert_x:47 upsert_y:48 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28 old:29 new:30 f:44 x_new:45 y_new:46
+ │         ├── columns: upsert_x:34 upsert_y:35 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28 old:29 new:30 f:31 x_new:32 y_new:33
  │         ├── project
- │         │    ├── columns: x_new:45 y_new:46 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28 old:29 new:30 f:44
+ │         │    ├── columns: x_new:32 y_new:33 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28 old:29 new:30 f:31
  │         │    ├── barrier
- │         │    │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28 old:29 new:30 f:44
+ │         │    │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28 old:29 new:30 f:31
  │         │    │    └── select
- │         │    │         ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28 old:29 new:30 f:44
+ │         │    │         ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28 old:29 new:30 f:31
  │         │    │         ├── project
- │         │    │         │    ├── columns: f:44 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28 old:29 new:30
+ │         │    │         │    ├── columns: f:31 column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28 old:29 new:30
  │         │    │         │    ├── barrier
  │         │    │         │    │    ├── columns: column1:5 column2:6 x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10 new:11 f:25 x_new:26 y_new:27 y_new:28 old:29 new:30
  │         │    │         │    │    └── project
@@ -469,79 +473,79 @@ root
  │         │    │         │    │         └── projections
  │         │    │         │    │              └── ((x:7, y_new:28) AS x, y) [as=new:30]
  │         │    │         │    └── projections
- │         │    │         │         └── CASE WHEN x:7 IS NOT NULL THEN f(new:30, old:29, 'tr', 'BEFORE', 'ROW', 'UPDATE', 53, 'xy', 'xy', 'public', 0, ARRAY[]) ELSE new:30 END [as=f:44]
+ │         │    │         │         └── CASE WHEN x:7 IS NOT NULL THEN f(new:30, old:29, 'tr', 'BEFORE', 'ROW', 'UPDATE', 53, 'xy', 'xy', 'public', 0, ARRAY[]) ELSE new:30 END [as=f:31]
  │         │    │         └── filters
- │         │    │              └── f:44 IS DISTINCT FROM NULL
+ │         │    │              └── f:31 IS DISTINCT FROM NULL
  │         │    └── projections
- │         │         ├── (f:44).x [as=x_new:45]
- │         │         └── (f:44).y [as=y_new:46]
+ │         │         ├── (f:31).x [as=x_new:32]
+ │         │         └── (f:31).y [as=y_new:33]
  │         └── projections
- │              ├── CASE WHEN x:7 IS NULL THEN x_new:26 ELSE x_new:45 END [as=upsert_x:47]
- │              └── CASE WHEN x:7 IS NULL THEN y_new:27 ELSE y_new:46 END [as=upsert_y:48]
+ │              ├── CASE WHEN x:7 IS NULL THEN x_new:26 ELSE x_new:32 END [as=upsert_x:34]
+ │              └── CASE WHEN x:7 IS NULL THEN y_new:27 ELSE y_new:33 END [as=upsert_y:35]
  └── cascade
       └── update child
            ├── columns: <none>
-           ├── fetch columns: k:53 child.x:54
+           ├── fetch columns: k:40 child.x:41
            ├── update-mapping:
-           │    └── x_new:58 => child.x:50
+           │    └── x_new:45 => child.x:37
            ├── input binding: &2
            ├── barrier
-           │    ├── columns: k:53 child.x:54 x_old:57 x_new:58 old:59 new:60 f:74 "check-rows":75
+           │    ├── columns: k:40 child.x:41 x_old:44 x_new:45 old:46 new:47 f:61 "check-rows":62
            │    └── select
-           │         ├── columns: k:53 child.x:54 x_old:57 x_new:58 old:59 new:60 f:74 "check-rows":75
+           │         ├── columns: k:40 child.x:41 x_old:44 x_new:45 old:46 new:47 f:61 "check-rows":62
            │         ├── barrier
-           │         │    ├── columns: k:53 child.x:54 x_old:57 x_new:58 old:59 new:60 f:74 "check-rows":75
+           │         │    ├── columns: k:40 child.x:41 x_old:44 x_new:45 old:46 new:47 f:61 "check-rows":62
            │         │    └── project
-           │         │         ├── columns: "check-rows":75 k:53 child.x:54 x_old:57 x_new:58 old:59 new:60 f:74
+           │         │         ├── columns: "check-rows":62 k:40 child.x:41 x_old:44 x_new:45 old:46 new:47 f:61
            │         │         ├── project
-           │         │         │    ├── columns: f:74 k:53 child.x:54 x_old:57 x_new:58 old:59 new:60
+           │         │         │    ├── columns: f:61 k:40 child.x:41 x_old:44 x_new:45 old:46 new:47
            │         │         │    ├── barrier
-           │         │         │    │    ├── columns: k:53 child.x:54 x_old:57 x_new:58 old:59 new:60
+           │         │         │    │    ├── columns: k:40 child.x:41 x_old:44 x_new:45 old:46 new:47
            │         │         │    │    └── project
-           │         │         │    │         ├── columns: new:60 k:53 child.x:54 x_old:57 x_new:58 old:59
+           │         │         │    │         ├── columns: new:47 k:40 child.x:41 x_old:44 x_new:45 old:46
            │         │         │    │         ├── project
-           │         │         │    │         │    ├── columns: old:59 k:53 child.x:54 x_old:57 x_new:58
+           │         │         │    │         │    ├── columns: old:46 k:40 child.x:41 x_old:44 x_new:45
            │         │         │    │         │    ├── inner-join (hash)
-           │         │         │    │         │    │    ├── columns: k:53 child.x:54 x_old:57 x_new:58
+           │         │         │    │         │    │    ├── columns: k:40 child.x:41 x_old:44 x_new:45
            │         │         │    │         │    │    ├── scan child
-           │         │         │    │         │    │    │    └── columns: k:53 child.x:54
+           │         │         │    │         │    │    │    └── columns: k:40 child.x:41
            │         │         │    │         │    │    ├── select
-           │         │         │    │         │    │    │    ├── columns: x_old:57 x_new:58
+           │         │         │    │         │    │    │    ├── columns: x_old:44 x_new:45
            │         │         │    │         │    │    │    ├── with-scan &1
-           │         │         │    │         │    │    │    │    ├── columns: x_old:57 x_new:58
+           │         │         │    │         │    │    │    │    ├── columns: x_old:44 x_new:45
            │         │         │    │         │    │    │    │    └── mapping:
-           │         │         │    │         │    │    │    │         ├──  xy.x:7 => x_old:57
-           │         │         │    │         │    │    │    │         └──  upsert_x:47 => x_new:58
+           │         │         │    │         │    │    │    │         ├──  xy.x:7 => x_old:44
+           │         │         │    │         │    │    │    │         └──  upsert_x:34 => x_new:45
            │         │         │    │         │    │    │    └── filters
-           │         │         │    │         │    │    │         └── x_old:57 IS DISTINCT FROM x_new:58
+           │         │         │    │         │    │    │         └── x_old:44 IS DISTINCT FROM x_new:45
            │         │         │    │         │    │    └── filters
-           │         │         │    │         │    │         └── child.x:54 = x_old:57
+           │         │         │    │         │    │         └── child.x:41 = x_old:44
            │         │         │    │         │    └── projections
-           │         │         │    │         │         └── ((k:53, child.x:54) AS k, x) [as=old:59]
+           │         │         │    │         │         └── ((k:40, child.x:41) AS k, x) [as=old:46]
            │         │         │    │         └── projections
-           │         │         │    │              └── ((k:53, x_new:58) AS k, x) [as=new:60]
+           │         │         │    │              └── ((k:40, x_new:45) AS k, x) [as=new:47]
            │         │         │    └── projections
-           │         │         │         └── f(new:60, old:59, 'tr_child', 'BEFORE', 'ROW', 'UPDATE', 54, 'child', 'child', 'public', 0, ARRAY[]) [as=f:74]
+           │         │         │         └── f(new:47, old:46, 'tr_child', 'BEFORE', 'ROW', 'UPDATE', 54, 'child', 'child', 'public', 0, ARRAY[]) [as=f:61]
            │         │         └── projections
-           │         │              └── CASE WHEN f:74 IS DISTINCT FROM new:60 THEN crdb_internal.plpgsql_raise('ERROR', 'trigger tr_child attempted to modify or filter a row in a cascade operation: ' || new:60::STRING, e'changing the rows updated or deleted by a foreign-key cascade\n can cause constraint violations, and therefore is not allowed', e'to enable this behavior (with risk of constraint violation), set\nthe session variable \'unsafe_allow_triggers_modifying_cascades\' to true', '27000') ELSE CAST(NULL AS INT8) END [as="check-rows":75]
+           │         │              └── CASE WHEN f:61 IS DISTINCT FROM new:47 THEN crdb_internal.plpgsql_raise('ERROR', 'trigger tr_child attempted to modify or filter a row in a cascade operation: ' || new:47::STRING, e'changing the rows updated or deleted by a foreign-key cascade\n can cause constraint violations, and therefore is not allowed', e'to enable this behavior (with risk of constraint violation), set\nthe session variable \'unsafe_allow_triggers_modifying_cascades\' to true', '27000') ELSE CAST(NULL AS INT8) END [as="check-rows":62]
            │         └── filters
-           │              └── f:74 IS DISTINCT FROM NULL
+           │              └── f:61 IS DISTINCT FROM NULL
            └── f-k-checks
                 └── f-k-checks-item: child(x) -> xy(x)
                      └── anti-join (hash)
-                          ├── columns: x:76
+                          ├── columns: x:63
                           ├── select
-                          │    ├── columns: x:76
+                          │    ├── columns: x:63
                           │    ├── with-scan &2
-                          │    │    ├── columns: x:76
+                          │    │    ├── columns: x:63
                           │    │    └── mapping:
-                          │    │         └──  x_new:58 => x:76
+                          │    │         └──  x_new:45 => x:63
                           │    └── filters
-                          │         └── x:76 IS NOT NULL
+                          │         └── x:63 IS NOT NULL
                           ├── scan xy
-                          │    └── columns: xy.x:77
+                          │    └── columns: xy.x:64
                           └── filters
-                               └── x:76 = xy.x:77
+                               └── x:63 = xy.x:64
 
 # Show interaction with computed columns.
 exec-ddl
@@ -634,6 +638,154 @@ update computed
       └── projections
            ├── k_new:30 + 1 [as=v_comp:31]
            └── k_new:30 + 2 [as=w_comp:32]
+
+# Test a trigger that fires itself recursively.
+exec-ddl
+CREATE FUNCTION insert_ab() RETURNS TRIGGER AS $$
+  BEGIN
+    INSERT INTO ab VALUES ((NEW).a, (NEW).b);
+    RETURN NEW;
+  END;
+$$ LANGUAGE PLpgSQL;
+----
+
+exec-ddl
+CREATE TRIGGER tr BEFORE INSERT OR UPDATE ON ab FOR EACH ROW EXECUTE FUNCTION insert_ab();
+----
+
+norm format=(hide-all,show-columns,show-scalars)
+INSERT INTO ab VALUES (1, 2);
+----
+insert ab
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── a_new:49 => a:1
+ │    ├── b_new:50 => b:2
+ │    └── rowid_default:8 => rowid:3
+ └── project
+      ├── columns: a_new:49 b_new:50 column1:6 column2:7 rowid_default:8 new:9 insert_ab:48
+      ├── barrier
+      │    ├── columns: column1:6 column2:7 rowid_default:8 new:9 insert_ab:48
+      │    └── select
+      │         ├── columns: column1:6 column2:7 rowid_default:8 new:9 insert_ab:48
+      │         ├── project
+      │         │    ├── columns: insert_ab:48 column1:6 column2:7 rowid_default:8 new:9
+      │         │    ├── barrier
+      │         │    │    ├── columns: column1:6 column2:7 rowid_default:8 new:9
+      │         │    │    └── values
+      │         │    │         ├── columns: column1:6 column2:7 rowid_default:8 new:9
+      │         │    │         └── tuple
+      │         │    │              ├── const: 1
+      │         │    │              ├── const: 2
+      │         │    │              ├── function: unique_rowid
+      │         │    │              └── tuple
+      │         │    │                   ├── const: 1
+      │         │    │                   └── const: 2
+      │         │    └── projections
+      │         │         └── udf: insert_ab [as=insert_ab:48]
+      │         │              ├── args
+      │         │              │    ├── variable: new:9
+      │         │              │    ├── null
+      │         │              │    ├── const: 'tr'
+      │         │              │    ├── const: 'BEFORE'
+      │         │              │    ├── const: 'ROW'
+      │         │              │    ├── const: 'INSERT'
+      │         │              │    ├── const: 56
+      │         │              │    ├── const: 'ab'
+      │         │              │    ├── const: 'ab'
+      │         │              │    ├── const: 'public'
+      │         │              │    ├── const: 0
+      │         │              │    └── const: ARRAY[]
+      │         │              ├── params: new:10 old:11 tg_name:12 tg_when:13 tg_level:14 tg_op:15 tg_relid:16 tg_relname:17 tg_table_name:18 tg_table_schema:19 tg_nargs:20 tg_argv:21
+      │         │              └── body
+      │         │                   └── values
+      │         │                        ├── columns: "_stmt_exec_1":47
+      │         │                        └── tuple
+      │         │                             └── udf: _stmt_exec_1
+      │         │                                  ├── tail-call
+      │         │                                  ├── args
+      │         │                                  │    ├── variable: new:10
+      │         │                                  │    ├── variable: old:11
+      │         │                                  │    ├── variable: tg_name:12
+      │         │                                  │    ├── variable: tg_when:13
+      │         │                                  │    ├── variable: tg_level:14
+      │         │                                  │    ├── variable: tg_op:15
+      │         │                                  │    ├── variable: tg_relid:16
+      │         │                                  │    ├── variable: tg_relname:17
+      │         │                                  │    ├── variable: tg_table_name:18
+      │         │                                  │    ├── variable: tg_table_schema:19
+      │         │                                  │    ├── variable: tg_nargs:20
+      │         │                                  │    └── variable: tg_argv:21
+      │         │                                  ├── params: new:22 old:23 tg_name:24 tg_when:25 tg_level:26 tg_op:27 tg_relid:28 tg_relname:29 tg_table_name:30 tg_table_schema:31 tg_nargs:32 tg_argv:33
+      │         │                                  └── body
+      │         │                                       ├── insert ab
+      │         │                                       │    ├── columns: <none>
+      │         │                                       │    ├── insert-mapping:
+      │         │                                       │    │    ├── a_new:44 => a:34
+      │         │                                       │    │    ├── b_new:45 => b:35
+      │         │                                       │    │    └── rowid_default:41 => rowid:36
+      │         │                                       │    └── project
+      │         │                                       │         ├── columns: a_new:44 b_new:45 column1:39 column2:40 rowid_default:41 new:42 insert_ab:43
+      │         │                                       │         ├── barrier
+      │         │                                       │         │    ├── columns: column1:39 column2:40 rowid_default:41 new:42 insert_ab:43
+      │         │                                       │         │    └── select
+      │         │                                       │         │         ├── columns: column1:39 column2:40 rowid_default:41 new:42 insert_ab:43
+      │         │                                       │         │         ├── project
+      │         │                                       │         │         │    ├── columns: insert_ab:43 column1:39 column2:40 rowid_default:41 new:42
+      │         │                                       │         │         │    ├── barrier
+      │         │                                       │         │         │    │    ├── columns: column1:39 column2:40 rowid_default:41 new:42
+      │         │                                       │         │         │    │    └── project
+      │         │                                       │         │         │    │         ├── columns: new:42 column1:39 column2:40 rowid_default:41
+      │         │                                       │         │         │    │         ├── values
+      │         │                                       │         │         │    │         │    ├── columns: column1:39 column2:40 rowid_default:41
+      │         │                                       │         │         │    │         │    └── tuple
+      │         │                                       │         │         │    │         │         ├── column-access: 0
+      │         │                                       │         │         │    │         │         │    └── variable: new:22
+      │         │                                       │         │         │    │         │         ├── column-access: 1
+      │         │                                       │         │         │    │         │         │    └── variable: new:22
+      │         │                                       │         │         │    │         │         └── function: unique_rowid
+      │         │                                       │         │         │    │         └── projections
+      │         │                                       │         │         │    │              └── tuple [as=new:42]
+      │         │                                       │         │         │    │                   ├── variable: column1:39
+      │         │                                       │         │         │    │                   └── variable: column2:40
+      │         │                                       │         │         │    └── projections
+      │         │                                       │         │         │         └── udf: insert_ab [as=insert_ab:43]
+      │         │                                       │         │         │              ├── args
+      │         │                                       │         │         │              │    ├── variable: new:42
+      │         │                                       │         │         │              │    ├── null
+      │         │                                       │         │         │              │    ├── const: 'tr'
+      │         │                                       │         │         │              │    ├── const: 'BEFORE'
+      │         │                                       │         │         │              │    ├── const: 'ROW'
+      │         │                                       │         │         │              │    ├── const: 'INSERT'
+      │         │                                       │         │         │              │    ├── const: 56
+      │         │                                       │         │         │              │    ├── const: 'ab'
+      │         │                                       │         │         │              │    ├── const: 'ab'
+      │         │                                       │         │         │              │    ├── const: 'public'
+      │         │                                       │         │         │              │    ├── const: 0
+      │         │                                       │         │         │              │    └── const: ARRAY[]
+      │         │                                       │         │         │              └── recursive-call
+      │         │                                       │         │         └── filters
+      │         │                                       │         │              └── is-not
+      │         │                                       │         │                   ├── variable: insert_ab:43
+      │         │                                       │         │                   └── null
+      │         │                                       │         └── projections
+      │         │                                       │              ├── column-access: 0 [as=a_new:44]
+      │         │                                       │              │    └── variable: insert_ab:43
+      │         │                                       │              └── column-access: 1 [as=b_new:45]
+      │         │                                       │                   └── variable: insert_ab:43
+      │         │                                       └── values
+      │         │                                            ├── columns: stmt_return_2:46
+      │         │                                            └── tuple
+      │         │                                                 └── variable: new:22
+      │         └── filters
+      │              └── is-not
+      │                   ├── variable: insert_ab:48
+      │                   └── null
+      └── projections
+           ├── column-access: 0 [as=a_new:49]
+           │    └── variable: insert_ab:48
+           └── column-access: 1 [as=b_new:50]
+                └── variable: insert_ab:48
 
 # ------------------------------------------------------------------------------
 # Row-level AFTER triggers.
@@ -1038,7 +1190,7 @@ insert t133329
  │    │         │    │         └── projections
  │    │         │    │              └── ((column1, column2) AS k, a)
  │    │         │    └── projections
- │    │         │         └── f(new, NULL, 'tr', 'BEFORE', 'ROW', 'INSERT', 57, 't133329', 't133329', 'public', 0, ARRAY[])
+ │    │         │         └── f(new, NULL, 'tr', 'BEFORE', 'ROW', 'INSERT', 59, 't133329', 't133329', 'public', 0, ARRAY[])
  │    │         └── filters
  │    │              └── f IS DISTINCT FROM NULL
  │    └── projections

--- a/pkg/sql/opt/optbuilder/trigger.go
+++ b/pkg/sql/opt/optbuilder/trigger.go
@@ -809,11 +809,13 @@ func (b *Builder) buildTriggerFunction(
 	//
 	// All triggers are called on NULL input.
 	const calledOnNullInput = true
+	const isTriggerFunc = true
 	udfDef := &memo.UDFDefinition{
 		Name:              resolvedDef.Name,
 		Typ:               tableTyp,
 		Volatility:        o.Volatility,
 		CalledOnNullInput: calledOnNullInput,
+		TriggerFunc:       isTriggerFunc,
 		RoutineType:       o.Type,
 		RoutineLang:       o.Language,
 		Params:            paramCols,

--- a/pkg/sql/opt/optbuilder/trigger.go
+++ b/pkg/sql/opt/optbuilder/trigger.go
@@ -85,7 +85,7 @@ func (mb *mutationBuilder) buildRowLevelBeforeTriggers(
 
 		// Resolve the trigger function and build the invocation.
 		args := mb.buildTriggerFunctionArgs(trigger, eventType, oldColID, newColID)
-		triggerFn, def := mb.b.buildTriggerFunction(triggers[i], tableTyp, args)
+		triggerFn, def := mb.b.buildTriggerFunction(triggers[i], mb.tab.ID(), tableTyp, args)
 
 		// If there is a WHEN condition, wrap the trigger function invocation in a
 		// CASE WHEN statement that checks the WHEN condition.
@@ -711,7 +711,7 @@ func (tb *rowLevelAfterTriggerBuilder) Build(
 			}
 
 			// Resolve the trigger function and build the invocation.
-			triggerFn, def := b.buildTriggerFunction(trigger, tableTyp, args)
+			triggerFn, def := b.buildTriggerFunction(trigger, tb.mutatedTable.ID(), tableTyp, args)
 
 			// If there is a WHEN condition, wrap the trigger function invocation in a
 			// CASE WHEN statement that checks the WHEN condition.
@@ -762,17 +762,31 @@ func (tb *rowLevelAfterTriggerBuilder) Build(
 // Shared logic
 // ============================================================================
 
+type cachedTriggerFunc struct {
+	triggerName tree.Name
+	funDef      *memo.UDFDefinition
+	resolved    *tree.ResolvedFunctionDefinition
+}
+
 // buildTriggerFunction resolves and builds a trigger function invocation for
 // the given trigger, using the given arguments.
 func (b *Builder) buildTriggerFunction(
-	trigger cat.Trigger, tableTyp *types.T, args memo.ScalarListExpr,
+	trigger cat.Trigger, tableID cat.StableID, tableTyp *types.T, args memo.ScalarListExpr,
 ) (opt.ScalarExpr, *tree.ResolvedFunctionDefinition) {
+	cached := b.builtTriggerFuncs[tableID]
+	for _, cachedFunc := range cached {
+		if cachedFunc.triggerName == trigger.Name() {
+			private := &memo.UDFCallPrivate{Def: cachedFunc.funDef}
+			return b.factory.ConstructUDFCall(args, private), cachedFunc.resolved
+		}
+	}
+
 	f := b.factory
 	triggerFuncScope := b.allocScope()
 	funcRef := &tree.FunctionOID{OID: catid.FuncIDToOID(catid.DescID(trigger.FuncID()))}
 	funcExpr := tree.FuncExpr{Func: tree.ResolvableFunctionReference{FunctionReference: funcRef}}
 	triggerFuncScope.resolveType(&funcExpr, types.Any)
-	def := funcExpr.Func.FunctionReference.(*tree.ResolvedFunctionDefinition)
+	resolvedDef := funcExpr.Func.FunctionReference.(*tree.ResolvedFunctionDefinition)
 	o := funcExpr.ResolvedOverload()
 
 	// Build the set of parameters for the trigger function. The parameters are
@@ -790,34 +804,45 @@ func (b *Builder) buildTriggerFunction(
 		paramCols[colOrd] = col.id
 	}
 
+	// Initialize and cache the UDF definition before building the function body.
+	// This is necessary to handle recursive triggers.
+	//
+	// All triggers are called on NULL input.
+	const calledOnNullInput = true
+	udfDef := &memo.UDFDefinition{
+		Name:              resolvedDef.Name,
+		Typ:               tableTyp,
+		Volatility:        o.Volatility,
+		CalledOnNullInput: calledOnNullInput,
+		RoutineType:       o.Type,
+		RoutineLang:       o.Language,
+		Params:            paramCols,
+	}
+	if b.builtTriggerFuncs == nil {
+		b.builtTriggerFuncs = make(map[cat.StableID][]cachedTriggerFunc)
+	}
+	b.builtTriggerFuncs[tableID] = append(b.builtTriggerFuncs[tableID],
+		cachedTriggerFunc{
+			triggerName: trigger.Name(),
+			funDef:      udfDef,
+			resolved:    resolvedDef,
+		},
+	)
+
 	// Parse and build the function body.
 	stmt, err := plpgsql.Parse(trigger.FuncBody())
 	if err != nil {
 		panic(err)
 	}
 	plBuilder := newPLpgSQLBuilder(
-		b, def.Name, stmt.AST.Label, nil /* colRefs */, params, tableTyp,
+		b, resolvedDef.Name, stmt.AST.Label, nil /* colRefs */, params, tableTyp,
 		false /* isProc */, true /* buildSQL */, nil, /* outScope */
 	)
 	stmtScope := plBuilder.buildRootBlock(stmt.AST, triggerFuncScope, params)
+	udfDef.Body = []memo.RelExpr{stmtScope.expr}
+	udfDef.BodyProps = []*physical.Required{stmtScope.makePhysicalProps()}
 
-	// All triggers are called on NULL input.
-	const calledOnNullInput = true
-	return f.ConstructUDFCall(args,
-		&memo.UDFCallPrivate{
-			Def: &memo.UDFDefinition{
-				Name:              def.Name,
-				Typ:               tableTyp,
-				Volatility:        o.Volatility,
-				CalledOnNullInput: calledOnNullInput,
-				RoutineType:       o.Type,
-				RoutineLang:       o.Language,
-				Body:              []memo.RelExpr{stmtScope.expr},
-				BodyProps:         []*physical.Required{stmtScope.makePhysicalProps()},
-				Params:            paramCols,
-			},
-		},
-	), def
+	return f.ConstructUDFCall(args, &memo.UDFCallPrivate{Def: udfDef}), resolvedDef
 }
 
 // buildTriggerWhen wraps the trigger function invocation in a CASE WHEN

--- a/pkg/sql/sem/tree/routine.go
+++ b/pkg/sql/sem/tree/routine.go
@@ -124,6 +124,11 @@ type RoutineExpr struct {
 	// Procedure is true if the routine is a procedure being invoked by CALL.
 	Procedure bool
 
+	// TriggerFunc is true if this routine is a trigger function. Note that it is
+	// only set for the outermost routine, and not any sub-routines used to
+	// implement the PL/pgSQL body.
+	TriggerFunc bool
+
 	// BlockStart is true if this routine marks the start of a PL/pgSQL block with
 	// an exception handler. It determines when to initialize the state shared
 	// between sub-routines for the block.
@@ -150,6 +155,7 @@ func NewTypedRoutineExpr(
 	generator bool,
 	tailCall bool,
 	procedure bool,
+	triggerFunc bool,
 	blockStart bool,
 	blockState *BlockState,
 	cursorDeclaration *RoutineOpenCursor,
@@ -165,6 +171,7 @@ func NewTypedRoutineExpr(
 		Generator:         generator,
 		TailCall:          tailCall,
 		Procedure:         procedure,
+		TriggerFunc:       triggerFunc,
 		BlockStart:        blockStart,
 		BlockState:        blockState,
 		CursorDeclaration: cursorDeclaration,

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -560,6 +560,9 @@ message LocalOnlySessionData {
   // performed by the vectorized engine when transitioning into the draining
   // state in some cases.
   bool disable_vec_union_eager_cancellation = 143;
+  // RecursionDepthLimit is the maximum depth that nested trigger-function calls
+  // can reach.
+  int64 recursion_depth_limit = 144;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/sqltelemetry/exec.go
+++ b/pkg/sql/sqltelemetry/exec.go
@@ -29,6 +29,10 @@ func VecModeCounter(mode string) telemetry.Counter {
 // cascade for a single query is exceeded.
 var CascadesLimitReached = telemetry.GetCounterOnce("sql.exec.cascade-limit-reached")
 
+// RecursionDepthLimitReached is to be incremented whenever the limit of nested
+// triggers and/or recursive UDFs for a single query is exceeded.
+var RecursionDepthLimitReached = telemetry.GetCounterOnce("sql.exec.recursion-depth-limit-reached")
+
 // HashAggregationDiskSpillingDisabled is to be incremented whenever the disk
 // spilling of the vectorized hash aggregator is disabled.
 var HashAggregationDiskSpillingDisabled = telemetry.GetCounterOnce("sql.exec.hash-agg-spilling-disabled")

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3541,6 +3541,29 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+
+	// CockroachDB extension.
+	`recursion_depth_limit`: {
+		GetStringVal: makeIntGetStringValFn(`recursion_depth_limit`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := strconv.ParseInt(s, 10, 64)
+			if err != nil {
+				return err
+			}
+			if b < 0 {
+				return pgerror.Newf(pgcode.InvalidParameterValue,
+					"cannot set recursion_depth_limit to a negative value: %d", b)
+			}
+			m.SetRecursionDepthLimit(int(b))
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return strconv.FormatInt(evalCtx.SessionData().RecursionDepthLimit, 10), nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return strconv.FormatInt(1000, 10)
+		},
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
#### sql: allow recursive BEFORE triggers

This commit refactors the trigger function building logic so that the
function definition is cached as a stub *before* the function body is
built. This allows the definition to be recursively referenced, as is
the case when triggers have cyclical dependencies. This will make it
possible to define cyclical row-level BEFORE triggers.

Informs #134496

Release note: None

#### sql: limit the depth of nested trigger actions

This commit adds a limit to the maximum depth of nested trigger executions.
This is necessary because the depth can grow arbitrarily large if there is
a cycle between triggers. The limit is controlled by `recursion_depth_limit`,
which is `1000` by default.

Fixes #134496

Release note (sql change): When triggers fire one another cyclically,
the new `recursion_depth_limit` setting now limits the depth of the recursion.
By default, the limit is `1000` nested trigger executions.