### PR TITLE
kvserver: use scratch range in BenchmarkStoreRangeSplit

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -5302,6 +5302,8 @@ func setupClusterWithSubsumedRange(
 }
 
 func BenchmarkStoreRangeMerge(b *testing.B) {
+	defer log.Scope(b).Close(b)
+
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(b, 1,
 		base.TestClusterArgs{

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -2670,20 +2670,23 @@ func BenchmarkStoreRangeSplit(b *testing.B) {
 	store, err := s.GetStores().(*kvserver.Stores).GetStore(s.GetFirstStoreID())
 	require.NoError(b, err)
 
+	_, err = s.ScratchRange()
+	require.NoError(b, err)
+
 	// Perform initial split of ranges.
-	sArgs := adminSplitArgs(roachpb.Key("b"))
+	sArgs := adminSplitArgs(scratchKey("b"))
 	if _, err := kv.SendWrapped(ctx, store.TestSender(), sArgs); err != nil {
 		b.Fatal(err)
 	}
 
 	// Write some values left and right of the split key.
-	aDesc := store.LookupReplica([]byte("a")).Desc()
-	bDesc := store.LookupReplica([]byte("c")).Desc()
-	kvserver.WriteRandomDataToRange(b, store, aDesc.RangeID, []byte("aaa"))
-	kvserver.WriteRandomDataToRange(b, store, bDesc.RangeID, []byte("ccc"))
+	aDesc := store.LookupReplica([]byte(scratchKey("a"))).Desc()
+	bDesc := store.LookupReplica([]byte(scratchKey("c"))).Desc()
+	kvserver.WriteRandomDataToRange(b, store, aDesc.RangeID, scratchKey("aaa"))
+	kvserver.WriteRandomDataToRange(b, store, bDesc.RangeID, scratchKey("ccc"))
 
 	// Merge the b range back into the a range.
-	mArgs := adminMergeArgs(roachpb.KeyMin)
+	mArgs := adminMergeArgs(keys.ScratchRangeMin)
 	if _, err := kv.SendWrapped(ctx, store.TestSender(), mArgs); err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -2661,6 +2661,8 @@ func TestLeaderAfterSplit(t *testing.T) {
 }
 
 func BenchmarkStoreRangeSplit(b *testing.B) {
+	defer log.Scope(b).Close(b)
+
 	ctx := context.Background()
 	s := serverutils.StartServerOnly(b, base.TestServerArgs{})
 


### PR DESCRIPTION
When investigating a potential regression in this microbench mark, we
observed that merging timeseries data during stats calculation
accounted for a good deal of the allocations and runtime.

While we should certainly optimize timeseries handling, it raises the
question: why was this benchmark encountering so many timeseries
values?

This benchmark is repeatedly splitting and merging a range. In the old
test, it was always splitting range 1 which includes all of the system
keys and the tsdb.

Now, we do this splitting and merging on a scratch range.

This is still pretty noisy, but I hope this change will make it easier
to hunt down regressions in split itself.

Epic: none
Release note: None