### PR TITLE
release-24.1: schemachange/mixed-versions: handle possible syntax error for BIT(0) column usage

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1358,6 +1358,18 @@ func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opSt
 	if err != nil {
 		return nil, err
 	}
+	mixedVersion, err := isMixedVersionState(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	hasUnsupportedBit0Type := func() bool {
+		for _, def := range stmt.Defs {
+			if col, ok := def.(*tree.ColumnTableDef); ok && isUnsupportedBit0Type(col.Type.SQLString(), mixedVersion) {
+				return true
+			}
+		}
+		return false
+	}()
 
 	tableExists, err := og.tableExists(ctx, tx, tableName)
 	if err != nil {
@@ -1385,6 +1397,7 @@ func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opSt
 		{code: pgcode.UndefinedObject, condition: refCursorNotSupported},
 		{code: pgcode.FeatureNotSupported, condition: hasUnsupportedIdxQueries},
 		{code: pgcode.InvalidTableDefinition, condition: hasUnsupportedIdxQueries},
+		{code: pgcode.InvalidParameterValue, condition: hasUnsupportedBit0Type},
 	})
 	opStmt.sql = tree.Serialize(stmt)
 	return opStmt, nil
@@ -3861,7 +3874,16 @@ func (og *operationGenerator) randType(
 		}
 		return typName, typ, nil
 	}
+	mixedVersion, err := isMixedVersionState(ctx, tx)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	typ := randgen.RandSortingType(og.params.rng)
+	for isUnsupportedBit0Type(typ.SQLString(), mixedVersion) {
+		typ = randgen.RandSortingType(og.params.rng)
+	}
+
 	typeName := tree.MakeUnqualifiedTypeName(typ.SQLString())
 	return &typeName, typ, nil
 }
@@ -4611,6 +4633,22 @@ func isClusterVersionLessThan(
 		return false, err
 	}
 	return clusterVersion.Less(targetVersion), nil
+}
+
+// isMixedVersionState works similarly to isClusterVersionLessThan, but without
+// specifying a version. It returns true if the cluster version is not the
+// latest, indicating a mixed-version test.
+func isMixedVersionState(ctx context.Context, tx pgx.Tx) (bool, error) {
+	return isClusterVersionLessThan(ctx, tx, clusterversion.Latest.Version())
+}
+
+func isUnsupportedBit0Type(typName string, mixedVersion bool) bool {
+	// TODO(spilchen): In mixed-version testing, declaring a BIT(0) column can cause a
+	// syntax error. Support for this type was recently added and backported, but the
+	// backport release is still pending. We need to regenerate the type until
+	// something other than BIT(0) is generated. This can be removed once 23.2.15 is
+	// publicly released.
+	return mixedVersion && strings.HasPrefix(typName, "BIT(0)")
 }
 
 func (og *operationGenerator) setSeedInDB(ctx context.Context, tx pgx.Tx) error {


### PR DESCRIPTION
Backport 1/1 commits from #134407.

/cc @cockroachdb/release

---

A recent fix enabled support for BIT(0) columns (see issue #132944), which has since been backported. However, since this backport hasn’t been released yet, running against an older down-level client may still trigger a syntax error. This change adds a temporary check to handle such errors until the backports for #132944 are publicly released.

This adjustment will be backported to older branches, with slight variations per release:
- release-24.3: Reuse the same fix as in master.
- release-24.2: Use isClusterVersionLessThan with clusterversion.V24.2.
- release-24.1: Use isClusterVersionLessThan with clusterversion.V24.1.
- release-23.2: Use isClusterVersionLessThan with clusterversion.V23.2.

Epic: None
Release note: None
Closes #133339
Closes #133790
Closes #131162

Release justification: Test only change