### PR TITLE
amazon: fix s3 client caching

### DIFF
--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -518,12 +518,13 @@ func (s *s3Storage) newClient(ctx context.Context) (s3Client, string, error) {
 		opts.Config.HTTPClient = httpClient
 	}
 
+	region := s.opts.region
 	if s.opts.endpoint != "" {
 		opts.Config.Endpoint = aws.String(s.opts.endpoint)
 		opts.Config.S3ForcePathStyle = aws.Bool(true)
 
-		if s.opts.region == "" {
-			s.opts.region = "default-region"
+		if region == "" {
+			region = "default-region"
 		}
 
 		client, err := cloud.MakeHTTPClient(s.settings, s.metrics, "aws", s.opts.bucket, s.storageOptions.ClientName)
@@ -587,7 +588,6 @@ func (s *s3Storage) newClient(ctx context.Context) (s3Client, string, error) {
 		}
 	}
 
-	region := s.opts.region
 	if region == "" {
 		if err := cloud.DelayedRetry(ctx, "s3manager.GetBucketRegion", s3ErrDelay, func() error {
 			region, err = s3manager.GetBucketRegion(ctx, sess, s.opts.bucket, "us-east-1")


### PR DESCRIPTION
This fixes an issue introduced by #132953. The issue only impacts the 23.2 back port. If the S3 client config specifies an explicit endpoint and it does not specify an explicit region, the client cache is thrashed. This cache thrashing was detected by the cloud unit tests when a worker pool change moved the tests farther away from the S3 bucket.

Fixes: #134021
Fixes: #133901

Release Note: None. Issue caught before release cut.