### PR TITLE
sqlsmith: disable stats forecasting in sqlsmith-based tests

### DIFF
--- a/pkg/internal/sqlsmith/setup.go
+++ b/pkg/internal/sqlsmith/setup.go
@@ -123,6 +123,10 @@ func randTablesN(r *rand.Rand, n int, prefix string, isMultiRegion bool) []strin
 	// Since we use the stats mutator, disable auto stats generation.
 	stmts = append(stmts, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;`)
 	stmts = append(stmts, `SET CLUSTER SETTING sql.stats.histogram_collection.enabled = false;`)
+	// We randomly run CREATE STATISTICS and ANALYZE statements. The
+	// nondeterministic createAt times of these statements make any forecasts
+	// based on them nondeterministic, so disable stats forecasting.
+	stmts = append(stmts, `SET CLUSTER SETTING sql.stats.forecasts.enabled = false;`)
 
 	// Create the random tables.
 	opt := randgen.TableOptCrazyNames


### PR DESCRIPTION
In #125267 we added CREATE STATISTICS and ANALYZE statements to all of the sqlsmith-based randomized tests. But because CREATE STATISTICS and ANALYZE produce table statistics with nondeterministic `createdAt` times, this makes the forecasts based on these stats nondeterministic as well. I think the proper fix here would be to add an option to CREATE STATISTICS to set the `createdAt` time, but for now simply disable stats forecasting.

Epic: None

Release note: None