### PR TITLE
kv: add stack trace to batch timestamp before gc error

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -2029,14 +2029,14 @@ func (r *Replica) checkTSAboveGCThresholdRLocked(
 		return nil
 	}
 	desc := r.descRLocked()
-	return &kvpb.BatchTimestampBeforeGCError{
+	return errors.WithStack(&kvpb.BatchTimestampBeforeGCError{
 		Timestamp:              ts,
 		Threshold:              threshold,
 		DataExcludedFromBackup: r.excludeReplicaFromBackupRLocked(ctx, rspan),
 		RangeID:                desc.RangeID,
 		StartKey:               desc.StartKey.AsRawKey(),
 		EndKey:                 desc.EndKey.AsRawKey(),
-	}
+	})
 }
 
 // shouldWaitForPendingMergeRLocked determines whether the given batch request


### PR DESCRIPTION
Add a stack trace to BatchTimestampBeforeGCError to help with debugging.

Fixes: #133569

Release note: None
