### PR TITLE
backupccl: remove index/bytes columns from backup/restore return stmt

### DIFF
--- a/pkg/backup/backup_job.go
+++ b/pkg/backup/backup_job.go
@@ -1023,8 +1023,6 @@ func (b *backupResumer) ReportResults(ctx context.Context, resultsCh chan<- tree
 		tree.NewDString(string(jobs.StatusSucceeded)),
 		tree.NewDFloat(tree.DFloat(1.0)),
 		tree.NewDInt(tree.DInt(b.backupStats.Rows)),
-		tree.NewDInt(tree.DInt(b.backupStats.IndexEntries)),
-		tree.NewDInt(tree.DInt(b.backupStats.DataSize)),
 	}:
 		return nil
 	}

--- a/pkg/backup/backup_planning.go
+++ b/pkg/backup/backup_planning.go
@@ -376,7 +376,7 @@ func backupTypeCheck(
 	if detached {
 		header = jobs.DetachedJobExecutionResultHeader
 	} else {
-		header = jobs.BulkJobExecutionResultHeader
+		header = jobs.BackupRestoreJobResultHeader
 	}
 	if err := exprutil.TypeCheck(
 		ctx, "BACKUP", p.SemaCtx(),
@@ -740,7 +740,7 @@ func backupPlanHook(
 	if detached {
 		return fn, jobs.DetachedJobExecutionResultHeader, nil, false, nil
 	}
-	return fn, jobs.BulkJobExecutionResultHeader, nil, false, nil
+	return fn, jobs.BackupRestoreJobResultHeader, nil, false, nil
 }
 
 func logAndSanitizeKmsURIs(ctx context.Context, kmsURIs ...string) error {

--- a/pkg/backup/backuptestutils/testutils.go
+++ b/pkg/backup/backuptestutils/testutils.go
@@ -225,7 +225,7 @@ func VerifyBackupRestoreStatementResult(
 		return err
 	}
 	if a, e := columns, []string{
-		"job_id", "status", "fraction_completed", "rows", "index_entries", "bytes",
+		"job_id", "status", "fraction_completed", "rows",
 	}; !reflect.DeepEqual(e, a) {
 		return errors.Errorf("unexpected columns:\n%s", strings.Join(pretty.Diff(e, a), "\n"))
 	}
@@ -247,7 +247,7 @@ func VerifyBackupRestoreStatementResult(
 		return errors.New("zero rows in result")
 	}
 	if err := rows.Scan(
-		&actualJob.id, &actualJob.status, &actualJob.fractionCompleted, &unused, &unused, &unused,
+		&actualJob.id, &actualJob.status, &actualJob.fractionCompleted, &unused,
 	); err != nil {
 		return err
 	}

--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -2195,8 +2195,6 @@ func (r *restoreResumer) ReportResults(ctx context.Context, resultsCh chan<- tre
 				tree.NewDString(string(jobs.StatusSucceeded)),
 				tree.NewDFloat(tree.DFloat(1.0)),
 				tree.NewDInt(tree.DInt(r.restoreStats.Rows)),
-				tree.NewDInt(tree.DInt(r.restoreStats.IndexEntries)),
-				tree.NewDInt(tree.DInt(r.restoreStats.DataSize)),
 			}
 		}
 	}():

--- a/pkg/backup/restore_old_sequences_test.go
+++ b/pkg/backup/restore_old_sequences_test.go
@@ -90,7 +90,7 @@ func restoreOldSequencesTest(exportDir string, isSchemaOnly bool) func(t *testin
 			restoreQuery = restoreQuery + ", schema_only"
 		}
 		sqlDB.QueryRow(t, restoreQuery, localFoo).Scan(
-			&unused, &unused, &unused, &importedRows, &unused, &unused,
+			&unused, &unused, &unused, &importedRows,
 		)
 		totalRows := 4
 		if isSchemaOnly {

--- a/pkg/backup/restore_planning.go
+++ b/pkg/backup/restore_planning.go
@@ -1189,7 +1189,7 @@ func restoreTypeCheck(
 	} else if restoreStmt.Options.ExperimentalOnline {
 		header = jobs.OnlineRestoreJobExecutionResultHeader
 	} else {
-		header = jobs.BulkJobExecutionResultHeader
+		header = jobs.BackupRestoreJobResultHeader
 	}
 	return true, header, nil
 }
@@ -1426,7 +1426,7 @@ func restorePlanHook(
 	} else if restoreStmt.Options.ExperimentalOnline {
 		header = jobs.OnlineRestoreJobExecutionResultHeader
 	} else {
-		header = jobs.BulkJobExecutionResultHeader
+		header = jobs.BackupRestoreJobResultHeader
 	}
 	return fn, header, nil, false, nil
 }

--- a/pkg/ccl/telemetryccl/telemetry_logging_test.go
+++ b/pkg/ccl/telemetryccl/telemetry_logging_test.go
@@ -358,8 +358,10 @@ func TestBulkJobTelemetryLogging(t *testing.T) {
 
 		if strings.Contains(tc.query, "WITH detached") {
 			err = db.DB.QueryRowContext(ctx, tc.query).Scan(&jobID)
-		} else {
+		} else if strings.HasPrefix(tc.query, "IMPORT") {
 			err = db.DB.QueryRowContext(ctx, tc.query).Scan(&jobID, &unused, &unused, &unused, &unused, &unused)
+		} else {
+			err = db.DB.QueryRowContext(ctx, tc.query).Scan(&jobID, &unused, &unused, &unused)
 		}
 		if err != nil {
 			t.Errorf("unexpected error executing query `%s`: %v", tc.query, err)

--- a/pkg/jobs/resultcols.go
+++ b/pkg/jobs/resultcols.go
@@ -21,6 +21,13 @@ var BulkJobExecutionResultHeader = colinfo.ResultColumns{
 	{Name: "bytes", Typ: types.Int},
 }
 
+var BackupRestoreJobResultHeader = colinfo.ResultColumns{
+	{Name: "job_id", Typ: types.Int},
+	{Name: "status", Typ: types.String},
+	{Name: "fraction_completed", Typ: types.Float},
+	{Name: "rows", Typ: types.Int},
+}
+
 // OnlineRestoreJobExecutionResultHeader is the header for an online restore
 // job, which provides a header different from the usual bulk job execution
 var OnlineRestoreJobExecutionResultHeader = colinfo.ResultColumns{
@@ -31,7 +38,7 @@ var OnlineRestoreJobExecutionResultHeader = colinfo.ResultColumns{
 	{Name: "background_download_job_id", Typ: types.Int},
 }
 
-// DetachedJobExecutionResultHeader is a the header for various job commands when
+// DetachedJobExecutionResultHeader is the header for various job commands when
 // job executes in detached mode (i.e. the caller doesn't wait for job completion).
 var DetachedJobExecutionResultHeader = colinfo.ResultColumns{
 	{Name: "job_id", Typ: types.Int},


### PR DESCRIPTION
This removes the index entries and bytes columns from the return result of a backup/restore/import. This columns do not inform the user of anything useful and only serve to mislead them.

Fixes: #133053

Epic: None

Release note (backward-incompatible change): Backup/restore/import statements no longer return index entries and bytes backed up/restored.