### PR TITLE
release-23.2: changefeedccl: increase buffer size for mixed versions roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -42,7 +42,7 @@ const (
 
 	// kafkaBufferMessageSize is the number of messages from kafka
 	// we allow to be buffered in memory before validating them.
-	kafkaBufferMessageSize = 8192
+	kafkaBufferMessageSize = 1 << 16 // 64 KiB
 
 	v222CV = "22.2"
 )


### PR DESCRIPTION
Backport 1/1 commits from #133998.

/cc @cockroachdb/release

Release justification: test fix

---

The mixed-versions roachtest has been failing
recently due to running out of buffer space. This
is an attempt to fix the issue by just adding more.


Fixes: #133806
Fixes: #133809
Fixes: #133811
Fixes: #133816
Fixes: #133932

Release note: None

