### PR TITLE
release-24.1: schemachanger: add PartitionName to IndexZoneConfig attr

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -1864,3 +1864,27 @@ SELECT crdb_internal.reset_multi_region_zone_configs_for_table($tbl11_id)
 
 query error user testuser must be owner of test or have CREATE privilege on database test
 SELECT crdb_internal.validate_multi_region_zone_configs()
+
+subtest drop_all_backrefs
+
+user root
+
+statement ok
+CREATE DATABASE db1 PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1" SURVIVE REGION FAILURE
+
+statement ok
+CREATE TABLE db1.t1_with_index_zone(x INT, j INT REFERENCES db1.t1_with_index_zone(x), PRIMARY KEY(x)) LOCALITY REGIONAL BY ROW
+
+statement ok
+ALTER PARTITION "ap-southeast-2" OF INDEX db1.t1_with_index_zone@t1_with_index_zone_pkey CONFIGURE ZONE USING gc.ttlseconds = 32000;
+
+statement ok
+ALTER PARTITION "ca-central-1" OF INDEX db1.t1_with_index_zone@t1_with_index_zone_pkey CONFIGURE ZONE USING gc.ttlseconds = 34000;
+
+statement ok
+ALTER PARTITION "us-east-1" OF INDEX db1.t1_with_index_zone@t1_with_index_zone_pkey CONFIGURE ZONE USING gc.ttlseconds = 38000;
+
+statement ok
+DROP TABLE db1.t1_with_index_zone CASCADE;
+
+subtest end

--- a/pkg/sql/schemachanger/screl/attr.go
+++ b/pkg/sql/schemachanger/screl/attr.go
@@ -91,6 +91,9 @@ const (
 	// Expr corresponds to the string representation of a SQL expression for an element.
 	Expr
 
+	// PartitionName corresponds to the name of a partition.
+	PartitionName
+
 	// AttrMax is the largest possible Attr value.
 	// Note: add any new enum values before TargetStatus, leave these at the end.
 	AttrMax = iota - 1
@@ -367,6 +370,7 @@ var elementSchemaOptions = []rel.SchemaOption{
 	rel.EntityMapping(t((*scpb.IndexZoneConfig)(nil)),
 		rel.EntityAttr(DescID, "TableID"),
 		rel.EntityAttr(IndexID, "IndexID"),
+		rel.EntityAttr(PartitionName, "PartitionName"),
 	),
 	rel.EntityMapping(t((*scpb.DatabaseData)(nil)),
 		rel.EntityAttr(DescID, "DatabaseID"),

--- a/pkg/sql/schemachanger/screl/attr_string.go
+++ b/pkg/sql/schemachanger/screl/attr_string.go
@@ -33,7 +33,8 @@ func _() {
 	_ = x[ReferencedFunctionIDs-18]
 	_ = x[ReferencedColumnIDs-19]
 	_ = x[Expr-20]
-	_ = x[AttrMax-20]
+	_ = x[PartitionName-21]
+	_ = x[AttrMax-21]
 }
 
 func (i Attr) String() string {
@@ -78,6 +79,8 @@ func (i Attr) String() string {
 		return "ReferencedColumnIDs"
 	case Expr:
 		return "Expr"
+	case PartitionName:
+		return "PartitionName"
 	default:
 		return "Attr(" + strconv.FormatInt(int64(i), 10) + ")"
 	}


### PR DESCRIPTION
This patch adds a `PartitionName` attribute to the `IndexZoneConfig` element to uniquely identify partitions from one another. Prior to this, hitting a certain DROP path on a table with more than 1 partition on an index would panic with an undropped backref error due to our inability to distinguish these partitions from eachother.

Our code to drop these partition elements would always refer to the top-most partition element in the descsCache's `elementIndexMap` -- as the key to identify partition1 from partition2 was the same. So, partition1 would be marked `toAbsent` "twice"; while partition2 got ignored </3.

Another thing to note is that this bug is not just met for partitioned tables of the nature mentioned above -- as the `builderState`'s descriptor cache would need to be unchanged between each partition's drop.

Epic: none
Fixes: #131862

Release note (bug fix): Addressed a bug with DROP CASCADE that would occasionally panic with an undropped backref message on partitioned tables.

---

Release justification: low-risk bug fix