### PR TITLE
roachtest: add debugging to gossip/chaos

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -269,6 +269,7 @@ go_library(
         "//pkg/testutils/sqlutils",
         "//pkg/ts/tspb",
         "//pkg/util",
+        "//pkg/util/allstacks",
         "//pkg/util/cancelchecker",
         "//pkg/util/ctxgroup",
         "//pkg/util/hlc",


### PR DESCRIPTION
This test has had a string of weird failures where
either a `t.L().Printf` call or `time.Sleep(1s)`
take dozens of seconds.

This PR adds a goroutine that gets spawned right
before and, unless signaled within 2s by both
the Printf and the Sleep having completed, dumps
stacks to stderr.

See the main issue https://github.com/cockroachdb/cockroach/issues/130737.
Closes the duplicates across various branches:

Closes https://github.com/cockroachdb/cockroach/issues/132651.
Closes https://github.com/cockroachdb/cockroach/issues/134495.

Epic: none
Release note: None
