### PR TITLE
kvserver: remove use of GetIsLiveMap in replicaGCQueue

### DIFF
--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
@@ -164,7 +165,6 @@ func replicaIsSuspect(repl *Replica) bool {
 		return ok && !liveness.Membership.Active()
 	}
 
-	livenessMap := repl.store.cfg.NodeLiveness.GetIsLiveMap()
 	switch raftStatus.SoftState.RaftState {
 	// If a replica is a candidate, then by definition it has lost contact with
 	// its leader and possibly the rest of the Raft group, so consider it suspect.
@@ -179,7 +179,7 @@ func replicaIsSuspect(repl *Replica) bool {
 	// conditions, but if it fails it will be GCed within 12 hours anyway.
 	case raftpb.StateFollower:
 		leadDesc, ok := repl.Desc().GetReplicaDescriptorByID(roachpb.ReplicaID(raftStatus.Lead))
-		if !ok || !livenessMap[leadDesc.NodeID].IsLive {
+		if !ok || !repl.store.cfg.NodeLiveness.GetNodeVitalityFromCache(leadDesc.NodeID).IsLive(livenesspb.ReplicaGCQueue) {
 			return true
 		}
 
@@ -188,7 +188,7 @@ func replicaIsSuspect(repl *Replica) bool {
 	// which must cause the stale leader to relinquish its lease and GC itself.
 	case raftpb.StateLeader:
 		if !repl.Desc().Replicas().CanMakeProgress(func(d roachpb.ReplicaDescriptor) bool {
-			return livenessMap[d.NodeID].IsLive
+			return repl.store.cfg.NodeLiveness.GetNodeVitalityFromCache(d.NodeID).IsLive(livenesspb.ReplicaGCQueue)
 		}) {
 			return true
 		}


### PR DESCRIPTION
The GetIsLiveMap loads the entire map of liveness instead of looking only at the meaningful nodes. This is inefficient. Additionally the GetIsLiveMap is intended to be deprecated. This commit replaces one of the two remaining calls to it.

Epic: none

Release note: None