### PR TITLE
raft: add replicas.leaders.not_fortified metric

### DIFF
--- a/docs/generated/metrics/metrics.html
+++ b/docs/generated/metrics/metrics.html
@@ -606,6 +606,7 @@
 <tr><td>STORAGE</td><td>replicas</td><td>Number of replicas</td><td>Replicas</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>replicas.leaders</td><td>Number of raft leaders</td><td>Raft Leaders</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>replicas.leaders_invalid_lease</td><td>Number of replicas that are Raft leaders whose lease is invalid</td><td>Replicas</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
+<tr><td>STORAGE</td><td>replicas.leaders_not_fortified</td><td>Number of replicas that are not fortified Raft leaders</td><td>Replicas</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>replicas.leaders_not_leaseholders</td><td>Number of replicas that are Raft leaders whose range lease is held by another store</td><td>Replicas</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>replicas.leaseholders</td><td>Number of lease holders</td><td>Replicas</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>replicas.quiescent</td><td>Number of quiesced replicas</td><td>Replicas</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -65,6 +65,12 @@ var (
 		Measurement: "Replicas",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaRaftLeaderNotFortifiedCount = metric.Metadata{
+		Name:        "replicas.leaders_not_fortified",
+		Help:        "Number of replicas that are not fortified Raft leaders",
+		Measurement: "Replicas",
+		Unit:        metric.Unit_COUNT,
+	}
 	metaRaftLeaderInvalidLeaseCount = metric.Metadata{
 		Name:        "replicas.leaders_invalid_lease",
 		Help:        "Number of replicas that are Raft leaders whose lease is invalid",
@@ -2585,6 +2591,7 @@ type StoreMetrics struct {
 	ReservedReplicaCount          *metric.Gauge
 	RaftLeaderCount               *metric.Gauge
 	RaftLeaderNotLeaseHolderCount *metric.Gauge
+	RaftLeaderNotFortifiedCount   *metric.Gauge
 	RaftLeaderInvalidLeaseCount   *metric.Gauge
 	LeaseHolderCount              *metric.Gauge
 	QuiescentCount                *metric.Gauge
@@ -3286,6 +3293,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		ReservedReplicaCount:          metric.NewGauge(metaReservedReplicaCount),
 		RaftLeaderCount:               metric.NewGauge(metaRaftLeaderCount),
 		RaftLeaderNotLeaseHolderCount: metric.NewGauge(metaRaftLeaderNotLeaseHolderCount),
+		RaftLeaderNotFortifiedCount:   metric.NewGauge(metaRaftLeaderNotFortifiedCount),
 		RaftLeaderInvalidLeaseCount:   metric.NewGauge(metaRaftLeaderInvalidLeaseCount),
 		LeaseHolderCount:              metric.NewGauge(metaLeaseHolderCount),
 		QuiescentCount:                metric.NewGauge(metaQuiescentCount),

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3288,6 +3288,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		leaseViolatingPreferencesCount int64
 		leaseLessPreferredCount        int64
 		raftLeaderNotLeaseHolderCount  int64
+		raftLeaderNotFortifiedCount    int64
 		raftLeaderInvalidLeaseCount    int64
 		quiescentCount                 int64
 		uninitializedCount             int64
@@ -3352,6 +3353,9 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 			}
 			if !metrics.LeaseValid {
 				raftLeaderInvalidLeaseCount++
+			}
+			if metrics.LeaderNotFortified {
+				raftLeaderNotFortifiedCount++
 			}
 			kvflowSendStats.Clear()
 			rep.SendStreamStats(&kvflowSendStats)
@@ -3443,6 +3447,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	s.metrics.RaftLeaderCount.Update(raftLeaderCount)
 	s.metrics.RaftLeaderNotLeaseHolderCount.Update(raftLeaderNotLeaseHolderCount)
 	s.metrics.RaftLeaderInvalidLeaseCount.Update(raftLeaderInvalidLeaseCount)
+	s.metrics.RaftLeaderNotFortifiedCount.Update(raftLeaderNotFortifiedCount)
 	s.metrics.LeaseHolderCount.Update(leaseHolderCount)
 	s.metrics.LeaseExpirationCount.Update(leaseExpirationCount)
 	s.metrics.LeaseEpochCount.Update(leaseEpochCount)

--- a/pkg/roachprod/opentelemetry/cockroachdb_metrics.go
+++ b/pkg/roachprod/opentelemetry/cockroachdb_metrics.go
@@ -1374,6 +1374,7 @@ var cockroachdbMetrics = map[string]string{
 	"replicas_leaders":                                            "replicas.leaders",
 	"replicas_leaders_invalid_lease":                              "replicas.leaders_invalid_lease",
 	"replicas_leaders_not_leaseholders":                           "replicas.leaders.not_leaseholders",
+	"replicas_leaders_not_fortified":                              "replicas.leaders.not_fortified",
 	"replicas_leaseholders":                                       "replicas.leaseholders",
 	"replicas_quiescent":                                          "replicas.quiescent",
 	"replicas_reserved":                                           "replicas.reserved",


### PR DESCRIPTION
This commit adds the metric replicas.leaders.not_fortified which reports the number of leaders that think they are not fortified.

References: #132754

Release note: None