### PR TITLE
kvserver: remove use of IsLiveMap

### DIFF
--- a/pkg/kv/kvserver/replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/replica_circuit_breaker_test.go
@@ -33,9 +33,7 @@ func TestReplicaUnavailableError(t *testing.T) {
 	repls.AddReplica(roachpb.ReplicaDescriptor{NodeID: 1, StoreID: 10, ReplicaID: 100})
 	repls.AddReplica(roachpb.ReplicaDescriptor{NodeID: 2, StoreID: 20, ReplicaID: 200})
 	desc := roachpb.NewRangeDescriptor(10, roachpb.RKey("a"), roachpb.RKey("z"), repls)
-	lm := livenesspb.IsLiveMap{
-		1: livenesspb.IsLiveMapEntry{IsLive: true},
-	}
+	lm := livenesspb.TestCreateNodeVitality(1)
 	ts := hlc.Timestamp{WallTime: time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC).UnixNano()}
 	wrappedErr := errors.New("probe failed")
 	rs := raft.Status{}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -8145,6 +8145,9 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 	cfg := TestStoreConfig(nil)
 	// Disable ticks which would interfere with the manual ticking in this test.
 	cfg.RaftTickInterval = time.Hour
+	// The replica timeout is computed based on a multiple of RaftTickInterval.
+	// Set this high enough to avoid tripping circuit breakers during the test.
+	replicaCircuitBreakerSlowReplicationThreshold.Override(ctx, &cfg.Settings.SV, 24*time.Hour)
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 	tc.StartWithStoreConfig(ctx, t, stopper, cfg)


### PR DESCRIPTION
As part of the effort to remove the IsLiveMap from the Store, all non-lease related uses can be switched to directly use NodeVitality directly.

Epic: none

Release note: None