### PR TITLE
roachtest: move validateTokensReturned to roachtestutil

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/roachprod/config",
         "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
+        "//pkg/testutils",
         "//pkg/testutils/sqlutils",
         "//pkg/util",
         "//pkg/util/ctxgroup",

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_mixed_version.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_mixed_version.go
@@ -130,7 +130,7 @@ func registerElasticWorkloadMixedVersion(r registry.Registry) {
 			mvt.Run()
 			// TODO(pav-kv): also validate that the write throughput was kept under
 			// control, and the foreground traffic was not starved.
-			validateTokensReturned(ctx, t, c, c.CRDBNodes())
+			roachtestutil.ValidateTokensReturned(ctx, t, c, c.CRDBNodes())
 		},
 	})
 }

--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
-	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -948,49 +947,7 @@ func (v variations) runTest(ctx context.Context, t test.Test, c cluster.Cluster)
 	t.L().Printf("validating stats after the perturbation")
 	failures = append(failures, isAcceptableChange(t.L(), baselineStats, afterStats, v.acceptableChange)...)
 	require.True(t, len(failures) == 0, strings.Join(failures, "\n"))
-	validateTokensReturned(ctx, t, v, v.stableNodes())
-}
-
-// validateTokensReturned ensures that all RACv2 tokens are returned to the pool
-// at the end of the test.
-func validateTokensReturned(
-	ctx context.Context, t test.Test, c cluster.Cluster, nodes option.NodeListOption,
-) {
-	t.L().Printf("validating all tokens returned")
-	for _, node := range nodes {
-		// Wait for the tokens to be returned to the pool. Normally this will
-		// pass immediately however it is possible that there is still some
-		// recovery so loop a few times.
-		testutils.SucceedsWithin(t, func() error {
-			db := c.Conn(ctx, t.L(), node)
-			defer db.Close()
-			for _, sType := range []string{"send", "eval"} {
-				for _, tType := range []string{"elastic", "regular"} {
-					statPrefix := fmt.Sprintf("kvflowcontrol.tokens.%s.%s", sType, tType)
-					query := fmt.Sprintf(`
-		SELECT d.value::INT8 AS deducted, r.value::INT8 AS returned
-		FROM
-		  crdb_internal.node_metrics d,
-		  crdb_internal.node_metrics r
-		WHERE
-		  d.name='%s.deducted' AND
-		  r.name='%s.returned'`,
-						statPrefix, statPrefix)
-					rows, err := db.QueryContext(ctx, query)
-					require.NoError(t, err)
-					require.True(t, rows.Next())
-					var deducted, returned int64
-					if err := rows.Scan(&deducted, &returned); err != nil {
-						return err
-					}
-					if deducted != returned {
-						return errors.Newf("tokens not returned for %s: deducted %d returned %d", statPrefix, deducted, returned)
-					}
-				}
-			}
-			return nil
-		}, 5*time.Second)
-	}
+	roachtestutil.ValidateTokensReturned(ctx, t, v, v.stableNodes())
 }
 
 // trackedStat is a collection of the relevant values from the histogram. The


### PR DESCRIPTION
This function is now used in additional tests and needs to move to allow breaking the perturbation tests into their own package.

Epic: none

Release note: None