### PR TITLE
sql: disallow replacing a referenced trigger function

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -3091,4 +3091,17 @@ CREATE OR REPLACE TRIGGER foo AFTER INSERT ON xy FOR EACH ROW EXECUTE FUNCTION f
 statement error pgcode 0A000 pq: unimplemented: cascade dropping triggers
 DROP TRIGGER foo ON xy CASCADE;
 
+statement ok
+CREATE TRIGGER foo AFTER INSERT ON xy FOR EACH ROW EXECUTE FUNCTION f();
+
+statement error pgcode 0A000 pq: unimplemented: cannot replace a trigger function with an active trigger
+CREATE OR REPLACE FUNCTION f() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$ BEGIN RETURN NEW; END $$;
+
+statement ok
+DROP TRIGGER foo ON xy;
+
+# CREATE OR REPLACE still works if there are no referencing triggers.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$ BEGIN RETURN NEW; END $$;
+
 subtest end

--- a/pkg/sql/create_function.go
+++ b/pkg/sql/create_function.go
@@ -226,6 +226,15 @@ func (n *createFunctionNode) replaceFunction(
 		udfDesc.ReturnType.Type = retType
 	}
 
+	// Make sure that a trigger function is not replaced.
+	if retType.Identical(types.Trigger) && len(udfDesc.DependedOnBy) > 0 {
+		return errors.WithHint(
+			unimplemented.NewWithIssue(134555,
+				"cannot replace a trigger function with an active trigger"),
+			"consider dropping and recreating the trigger",
+		)
+	}
+
 	// Verify whether changes, if any, to the parameter names and classes are
 	// allowed. This needs to happen after the return type has already been
 	// checked.


### PR DESCRIPTION
This commit disallows replacing a trigger function that is actively used in a trigger. This is necessary because triggers keep an inlined version of the function body (specialized for the table the trigger is on) and the inlined version currently does not change when the function is replaced. Note that it is still possible to use CREATE OR REPLACE syntax if the function is not yet used in a trigger.

Fixes #134549

Release note: None