### PR TITLE
release-23.2: jobs: don't redact job ID in log tags

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
 	"github.com/cockroachdb/logtags"
+	"github.com/cockroachdb/redact"
 )
 
 // adoptedJobs represents the epoch and cancellation of a job id being run by
@@ -1697,8 +1698,7 @@ func (r *Registry) stepThroughStateMachine(
 			return errors.NewAssertionErrorWithWrappedErrf(jobErr,
 				"job %d: resuming with non-nil error", job.ID())
 		}
-		resumeCtx := logtags.AddTag(ctx, "job",
-			fmt.Sprintf("%s id=%d", jobType, job.ID()))
+		resumeCtx := logtags.AddTag(ctx, "job", redact.Sprintf("%s id=%d", jobType, job.ID()))
 		// Adding all tags as pprof labels (including the one we just added for job
 		// type and id).
 		resumeCtx, undo := pprofutil.SetProfilerLabelsFromCtxTags(resumeCtx)


### PR DESCRIPTION
Backport 1/2 commits from #134347.

/cc @cockroachdb/release

Release justification: low risk logging change

---

This will assist with debugging.

fixes https://github.com/cockroachdb/cockroach/issues/132113
Release note: None
