### PR TITLE
backupccl: Fix MR enum in non-MR temp sys DB

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1179,6 +1179,7 @@ func createImportingDescriptors(
 		for _, desc := range mutableTables {
 			if desc.GetParentID() == tempSystemDBID {
 				desc.SetPublic()
+				desc.LocalityConfig = nil
 			}
 		}
 	}
@@ -1246,6 +1247,13 @@ func createImportingDescriptors(
 
 				if db, ok := dbsByID[regionTypeDesc.GetParentID()]; ok {
 					desc := db.DatabaseDesc()
+					if db.GetName() == restoreTempSystemDB {
+						t.TypeDesc().Kind = descpb.TypeDescriptor_ENUM
+						t.TypeDesc().RegionConfig = nil
+						// TODO(foundations): should these be rewritten instead of blank? Does it matter since we drop the whole DB before the job exits?
+						t.TypeDesc().ReferencingDescriptorIDs = nil
+						continue
+					}
 					if desc.RegionConfig == nil {
 						return errors.AssertionFailedf(
 							"found MULTIREGION_ENUM on non-multi-region database %s", desc.Name)

--- a/pkg/ccl/backupccl/testdata/backup-restore/multiregion
+++ b/pkg/ccl/backupccl/testdata/backup-restore/multiregion
@@ -6,7 +6,11 @@ skip-under-duress
 new-cluster name=s1 allow-implicit-access disable-tenant localities=us-east-1,us-west-1,eu-central-1
 ----
 
+set-cluster-setting setting=sql.multiregion.system_database_multiregion.enabled value=true
+----
+
 exec-sql
+ALTER DATABASE system SET PRIMARY REGION "us-east-1";
 CREATE DATABASE d PRIMARY REGION "us-east-1" REGIONS "us-west-1", "eu-central-1" SURVIVE REGION FAILURE;
 CREATE TABLE d.t (x INT);
 INSERT INTO d.t VALUES (1), (2), (3);


### PR DESCRIPTION
The temp db doesn't need to be MR just for us to copy stuff out of it into the real one.

Release note (bug fix): Fix a bug that prevented restoring cluster backup taken in an MR cluster that had configured a the system database with a region configuration into a non-multi-region cluster.
Epic: CRDB-42475.