### PR TITLE
licenses: point at the correct file in license refs

### DIFF
--- a/pkg/util/interval/bu23.go
+++ b/pkg/util/interval/bu23.go
@@ -5,7 +5,7 @@
 
 // Copyright ©2014 The bíogo Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
-// license that can be found in licenses/BSD-biogo.txt.
+// license that can be found in licenses/BSD3-biogo.store.llrb.txt.
 
 // This code originated in the github.com/biogo/store/interval package.
 

--- a/pkg/util/interval/interval.go
+++ b/pkg/util/interval/interval.go
@@ -1,6 +1,6 @@
 // Copyright ©2012 The bíogo Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
-// license that can be found in licenses/BSD-biogo.txt.
+// license that can be found in licenses/BSD3-biogo.store.llrb.txt.
 
 // Portions of this file are additionally subject to the following
 // license and copyright.

--- a/pkg/util/interval/llrb_based_interval.go
+++ b/pkg/util/interval/llrb_based_interval.go
@@ -1,6 +1,6 @@
 // Copyright ©2012 The bíogo Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
-// license that can be found in licenses/BSD-biogo.txt.
+// license that can be found in licenses/BSD3-biogo.store.llrb.txt.
 
 // Portions of this file are additionally subject to the following
 // license and copyright.

--- a/pkg/util/interval/td234.go
+++ b/pkg/util/interval/td234.go
@@ -5,7 +5,7 @@
 
 // Copyright ©2014 The bíogo Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
-// license that can be found in licenses/BSD-biogo.txt.
+// license that can be found in licenses/BSD3-biogo.store.llrb.txt.
 
 // This code originated in the github.com/biogo/store/interval package.
 


### PR DESCRIPTION
The licenses/BSD-biogo.txt file moved in a prior commit. This fixes the source files that reference that file to instead reference the current location of the file: licenses/BSD3-biogo.store.llrb.txt.

Part of CRDB-43871

Release note: None