### PR TITLE
ccl/sqlproxyccl: improve connection logging behavior

### DIFF
--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -174,13 +174,10 @@ type proxyHandler struct {
 	cancelInfoMap *cancelInfoMap
 }
 
-const throttledErrorHint string = `Connection throttling is triggered by repeated authentication failure. Make
-sure the username and password are correct.
-`
+const throttledErrorHint string = `Connection throttling is triggered by repeated authentication failure. Make sure the username and password are correct.`
 
 var authThrottledError = errors.WithHint(
-	withCode(errors.New(
-		"too many failed authentication attempts"), codeProxyRefusedConnection),
+	withCode(errors.New("too many failed authentication attempts"), codeProxyRefusedConnection),
 	throttledErrorHint)
 
 // newProxyHandler will create a new proxy handler with configuration based on
@@ -372,25 +369,15 @@ func (handler *proxyHandler) handle(
 
 	// NOTE: Errors returned from this function are user-facing errors so we
 	// should be careful with the details that we want to expose.
+	//
+	// TODO(jaylim-crl): Update this such that we return both the internal and
+	// user-facing errors from clusterNameAndTenantFromParams. Only the internal
+	// error should be returned to the caller.
 	backendStartupMsg, clusterName, tenID, err := clusterNameAndTenantFromParams(ctx, fe, handler.metrics)
 	if err != nil {
 		clientErr := withCode(err, codeParamsRoutingFailed)
-		log.Errorf(ctx, "unable to extract cluster name and tenant id: %s", err.Error())
 		updateMetricsAndSendErrToClient(clientErr, fe.Conn, handler.metrics)
-		return clientErr
-	}
-
-	ctx = logtags.AddTag(ctx, "cluster", clusterName)
-	ctx = logtags.AddTag(ctx, "tenant", tenID)
-
-	// Use an empty string as the default port as we only care about the
-	// correctly parsing the IP address here.
-	ipAddr, _, err := addr.SplitHostPort(fe.Conn.RemoteAddr().String(), "")
-	if err != nil {
-		clientErr := withCode(errors.New("unexpected connection address"), codeParamsRoutingFailed)
-		log.Errorf(ctx, "could not parse address: %v", err.Error())
-		updateMetricsAndSendErrToClient(clientErr, fe.Conn, handler.metrics)
-		return clientErr
+		return errors.Wrap(err, "extracting cluster identifier")
 	}
 
 	// Validate the incoming connection and ensure that the cluster name
@@ -400,6 +387,26 @@ func (handler *proxyHandler) handle(
 		// We do not need to log here as validateConnection already logs.
 		updateMetricsAndSendErrToClient(err, fe.Conn, handler.metrics)
 		return err
+	}
+
+	// Only add logtags after validating the connection. If the connection isn't
+	// validated, clusterName may not match the tenant ID, and this could cause
+	// confusion when analyzing logs.
+	ctx = logtags.AddTag(ctx, "cluster", clusterName)
+	ctx = logtags.AddTag(ctx, "tenant", tenID)
+
+	// Add request tags so that callers can provide a better context for errors.
+	reqTags := requestTagsFromContext(ctx)
+	reqTags["cluster"] = clusterName
+	reqTags["tenant"] = tenID
+
+	// Use an empty string as the default port as we only care about the
+	// correctly parsing the IP address here.
+	ipAddr, _, err := addr.SplitHostPort(fe.Conn.RemoteAddr().String(), "")
+	if err != nil {
+		clientErr := withCode(errors.New("unexpected connection address"), codeParamsRoutingFailed)
+		updateMetricsAndSendErrToClient(clientErr, fe.Conn, handler.metrics)
+		return errors.Wrap(err, "parsing remote address")
 	}
 
 	errConnection := make(chan error, 1)
@@ -426,20 +433,21 @@ func (handler *proxyHandler) handle(
 		// with a deleting tenant. This case is rare, and we'll just return a
 		// "connection refused" error. The next time they connect, they will
 		// get a "not found" error.
-		log.Errorf(ctx, "connection blocked by access control list: %v", err)
-		err = withCode(errors.New("connection refused"), codeProxyRefusedConnection)
-		updateMetricsAndSendErrToClient(err, fe.Conn, handler.metrics)
-		return err
+		//
+		// TODO(jaylim-crl): We can enrich this error with the proper reason on
+		// why they were refused (e.g. IP allowlist, or private endpoints).
+		clientErr := withCode(errors.New("connection refused"), codeProxyRefusedConnection)
+		updateMetricsAndSendErrToClient(clientErr, fe.Conn, handler.metrics)
+		return errors.Wrap(err, "connection blocked by access control list")
 	}
 	defer removeListener()
 
 	throttleTags := throttler.ConnectionTags{IP: ipAddr, TenantID: tenID.String()}
 	throttleTime, err := handler.throttleService.LoginCheck(throttleTags)
 	if err != nil {
-		log.Errorf(ctx, "throttler refused connection: %v", err.Error())
-		err = authThrottledError
-		updateMetricsAndSendErrToClient(err, fe.Conn, handler.metrics)
-		return err
+		clientErr := authThrottledError
+		updateMetricsAndSendErrToClient(clientErr, fe.Conn, handler.metrics)
+		return errors.Wrap(err, "throttler refused connection")
 	}
 
 	connector := &connector{
@@ -471,6 +479,8 @@ func (handler *proxyHandler) handle(
 			if err := handler.throttleService.ReportAttempt(
 				ctx, throttleTags, throttleTime, status,
 			); err != nil {
+				// We have to log here because errors returned by this closure
+				// will be sent to the client.
 				log.Errorf(ctx, "throttler refused connection after authentication: %v", err.Error())
 				return authThrottledError
 			}
@@ -478,7 +488,6 @@ func (handler *proxyHandler) handle(
 		},
 	)
 	if err != nil {
-		log.Errorf(ctx, "could not connect to cluster: %v", err.Error())
 		if sentToClient {
 			handler.metrics.updateForError(err)
 		} else {
@@ -490,16 +499,20 @@ func (handler *proxyHandler) handle(
 
 	// Update the cancel info.
 	handler.cancelInfoMap.addCancelInfo(connector.CancelInfo.proxySecretID(), connector.CancelInfo)
+	defer func() {
+		handler.cancelInfoMap.deleteCancelInfo(connector.CancelInfo.proxySecretID())
+	}()
 
 	// Record the connection success and how long it took.
 	handler.metrics.ConnectionLatency.RecordValue(timeutil.Since(connReceivedTime).Nanoseconds())
 	handler.metrics.SuccessfulConnCount.Inc(1)
 
-	log.Infof(ctx, "new connection")
+	// TOOD(jaylim-crl): Consider replacing this with a metric that measures
+	// connection lifetime. We might also be able to fetch these by analyzing
+	// the session logs.
 	connBegin := timeutil.Now()
 	defer func() {
 		log.Infof(ctx, "closing after %.2fs", timeutil.Since(connBegin).Seconds())
-		handler.cancelInfoMap.deleteCancelInfo(connector.CancelInfo.proxySecretID())
 	}()
 
 	// Wrap the client connection with an error annotater. WARNING: The TLS

--- a/pkg/ccl/sqlproxyccl/throttler/service.go
+++ b/pkg/ccl/sqlproxyccl/throttler/service.go
@@ -37,7 +37,7 @@ const (
 type Service interface {
 	// LoginCheck determines whether a login request should be allowed to
 	// proceed. It rate limits login attempts from IP addresses.
-	LoginCheck(connection ConnectionTags) (time.Time, error)
+	LoginCheck(ctx context.Context, connection ConnectionTags) (time.Time, error)
 
 	// Report an authentication attempt. The throttleTime is used to
 	// retroactively throttle the request if a racing request triggered the
@@ -46,5 +46,5 @@ type Service interface {
 	// error instead of authentication success/failure. This limits the
 	// information a malicious user gets from using racing requests to guess
 	// multiple passwords in one throttle window.
-	ReportAttempt(context context.Context, connection ConnectionTags, throttleTime time.Time, status AttemptStatus) error
+	ReportAttempt(ctx context.Context, connection ConnectionTags, throttleTime time.Time, status AttemptStatus) error
 }

--- a/pkg/ccl/sqlproxyccl/throttler/throttle.go
+++ b/pkg/ccl/sqlproxyccl/throttler/throttle.go
@@ -5,11 +5,18 @@
 
 package throttler
 
-import "time"
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
 
 const (
-	// throttleDisabled is a sentinal value used to disable the throttle.
+	// throttleDisabled is a sentinel value used to disable the throttle.
 	throttleDisabled = time.Duration(0)
+	// throttleLogErrorDuration indicates how frequent the throttle error should
+	// be logged for a given throttle instance.
+	throttleLogErrorDuration = 5 * time.Minute
 )
 
 type throttle struct {
@@ -18,12 +25,15 @@ type throttle struct {
 	// The amount of backoff to introduce the next time the throttle
 	// is triggered. Setting nextBackoff to zero disables the throttle.
 	nextBackoff time.Duration
+	// everyLog controls how frequent the throttle error should be logged.
+	everyLog log.EveryN
 }
 
 func newThrottle(initialBackoff time.Duration) *throttle {
 	return &throttle{
 		nextTime:    time.Time{},
 		nextBackoff: initialBackoff,
+		everyLog:    log.Every(throttleLogErrorDuration),
 	}
 }
 


### PR DESCRIPTION
### ccl/sqlproxyccl: improve connection logging behavior

Previously, the connection logging behavior in the proxy had several issues that led to unnecessary log spam:

1. **Excessive "registerAssignment" and "unregisterAssignment" logs**: These logs were emitted for every connection attempt (including migration) and were not useful under normal operation.
2. **Redundant error logging**: Most errors were logged twice -- once in the `handle` method, and again when it returns.
3. **Unfiltered error hints**: User-facing errors containing hints were logged line by line, cluttering the logs.
4. **Lack of context in error logs**: Errors logged from the proxy lacked tenant and cluster context, which made troubleshooting more difficult.

This commit addresses these issues as follows:

1. **Reduced logging**: "registerAssignment" and "unregisterAssignment" logs are now only shown with vmodule logging enabled.
2. **Error logging improvements**: `handle` no longer logs errors (with the exception of some cases); the caller is now responsible for logging. Additionally, errors with hints are no longer logged, only the main error is recorded. When those errors are logged, they will now include the tenant and cluster information where possible.

No release note as this is an internal change.

Epic: none

Release note: None

### ccl/sqlproxyccl: rate limit throttler errors from being logged

Previously, each request refused by the throttler would result in a "throttler refused connection" message being logged, generating a log entry for every rejected request.

The throttler service is responsible for rate limiting invalid login attempts from IP addresses, and in practice, it can generate a high volume of such traffic. To address this, errors are now rate limited in the logs to occur once every 5 minutes per (IP, tenant) pair, ensuring that only one log entry is generated within that time frame.

This change is internal, so no release note is required.

Epic: none

Release note: None
