### PR TITLE
sql: update trigger back-references for legacy schema changer drop table

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -783,6 +783,30 @@ CREATE TRIGGER foo AFTER INSERT ON xy FOR EACH ROW EXECUTE FUNCTION g();
 statement ok
 DROP FUNCTION g;
 
+subtest regression_134630
+
+statement ok
+CREATE TABLE t1 (a INT, b INT);
+CREATE TABLE t2 (a INT, b INT);
+
+statement ok
+CREATE FUNCTION g() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    INSERT INTO t2 VALUES ((NEW).a, (NEW).b);
+    RETURN NEW;
+  END
+$$;
+
+statement ok
+CREATE TRIGGER foo BEFORE INSERT OR UPDATE ON t1 FOR EACH ROW EXECUTE FUNCTION g();
+
+# Make sure the legacy schema-changer correctly removes the backreference from
+# t2 to t1.
+statement ok
+DROP TABLE t1;
+DROP TABLE t2;
+DROP FUNCTION g;
+
 # ==============================================================================
 # Test dependency tracking for a user-defined type reference.
 # ==============================================================================


### PR DESCRIPTION
This commit fixes `DROP TABLE` in the legacy schema changer when the table has triggers that reference another table. Previously, back-references were not removed in the legacy schema changer, which lead to validation errors.

Fixes #134630

Release note: None