### PR TITLE
roachtest: remove direct go calls

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/task/tasker.go
+++ b/pkg/cmd/roachtest/roachtestutil/task/tasker.go
@@ -16,9 +16,12 @@ type Func func(context.Context, *logger.Logger) error
 // Tasker is an interface for executing tasks (goroutines). It is intended for
 // use in tests, enabling the test framework to manage panics and errors.
 type Tasker interface {
-	// Go runs the given function in a goroutine.
+	// Go runs the given function in a goroutine. If an error is returned, it will
+	// fail the test. Panics are recovered and treated as errors.
 	Go(fn Func, opts ...Option)
 	// GoWithCancel runs the given function in a goroutine and returns a
-	// CancelFunc that can be used to cancel the function.
+	// CancelFunc that can be used to cancel the function. If an error is
+	// returned, it will fail the test. Panics are recovered and treated as
+	// errors.
 	GoWithCancel(fn Func, opts ...Option) context.CancelFunc
 }

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -349,6 +349,7 @@ go_test(
     deps = [
         "//pkg/cmd/roachtest/option",
         "//pkg/cmd/roachtest/registry",
+        "//pkg/cmd/roachtest/roachtestutil/task",
         "//pkg/cmd/roachtest/spec",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/prometheus",

--- a/pkg/cmd/roachtest/tests/decommissionbench.go
+++ b/pkg/cmd/roachtest/tests/decommissionbench.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
@@ -313,20 +314,22 @@ func registerDecommissionBenchSpec(r registry.Registry, benchSpec decommissionBe
 	})
 }
 
-// fireAfter executes fn after the duration elapses. If the context expires
-// first, it will not be executed.
-func fireAfter(ctx context.Context, duration time.Duration, fn func()) {
-	go func() {
+// fireAfter executes fn after the duration elapses. If the passed context, or
+// tasker context, expires first, it will not be executed.
+func fireAfter(ctx context.Context, t task.Tasker, duration time.Duration, fn func()) {
+	t.Go(func(taskCtx context.Context, _ *logger.Logger) error {
 		var fireTimer timeutil.Timer
 		defer fireTimer.Stop()
 		fireTimer.Reset(duration)
 		select {
 		case <-ctx.Done():
+		case <-taskCtx.Done():
 		case <-fireTimer.C:
 			fireTimer.Read = true
 			fn()
 		}
-	}()
+		return nil
+	})
 }
 
 // createDecommissionBenchPerfArtifacts initializes a histogram registry for
@@ -977,7 +980,7 @@ func runSingleDecommission(
 
 	if estimateDuration {
 		estimateDecommissionDuration(
-			ctx, h.t.L(), tickByName, snapshotRateMb, bytesUsed, candidateStores,
+			ctx, h.t, h.t.L(), tickByName, snapshotRateMb, bytesUsed, candidateStores,
 			rangeCount, avgBytesPerReplica,
 		)
 	}
@@ -1133,6 +1136,7 @@ func logLSMHealth(ctx context.Context, l *logger.Logger, c cluster.Cluster, targ
 // recorded perf artifacts as ticks.
 func estimateDecommissionDuration(
 	ctx context.Context,
+	t task.Tasker,
 	log *logger.Logger,
 	tickByName func(name string),
 	snapshotRateMb int,
@@ -1170,7 +1174,7 @@ func estimateDecommissionDuration(
 		rangeCount, humanizeutil.IBytes(avgBytesPerReplica), minDuration, estDuration,
 	)
 
-	fireAfter(ctx, estDuration, func() {
+	fireAfter(ctx, t, estDuration, func() {
 		tickByName(estimatedMetric)
 	})
 }

--- a/pkg/cmd/roachtest/tests/drt.go
+++ b/pkg/cmd/roachtest/tests/drt.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/prometheus"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -233,8 +234,8 @@ func (ep *tpccChaosEventProcessor) err() error {
 	return err
 }
 
-func (ep *tpccChaosEventProcessor) listen(ctx context.Context, l *logger.Logger) {
-	go func() {
+func (ep *tpccChaosEventProcessor) listen(ctx context.Context, t task.Tasker, l *logger.Logger) {
+	t.Go(func(context.Context, *logger.Logger) error {
 		var prevTime time.Time
 		started := false
 		for ev := range ep.ch {
@@ -294,5 +295,6 @@ func (ep *tpccChaosEventProcessor) listen(ctx context.Context, l *logger.Logger)
 			}
 			prevTime = ev.Time
 		}
-	}()
+		return nil
+	})
 }

--- a/pkg/cmd/roachtest/tests/drt_test.go
+++ b/pkg/cmd/roachtest/tests/drt_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/prometheus"
 	gomock "github.com/golang/mock/gomock"
@@ -530,7 +531,8 @@ func TestTPCCChaosEventProcessor(t *testing.T) {
 			l, err := (&logger.Config{}).NewLogger("")
 			require.NoError(t, err)
 
-			ep.listen(ctx, l)
+			tasker := task.NewManager(ctx, l)
+			ep.listen(ctx, tasker, l)
 			for _, chaosEvent := range tc.chaosEvents {
 				ch <- chaosEvent
 			}

--- a/pkg/cmd/roachtest/tests/jepsen.go
+++ b/pkg/cmd/roachtest/tests/jepsen.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 )
 
@@ -279,17 +280,19 @@ func (j jepsenConfig) startTest(
 			}
 			t.Fatalf("error installing Jepsen deps: %+v", err)
 		}
-		go func() {
+		t.Go(func(context.Context, *logger.Logger) error {
 			errCh <- run("bash", "-e", "-c", fmt.Sprintf(
 				`"cd /mnt/data1/jepsen/cockroachdb && set -eo pipefail && ~/lein run %s > invoke.log 2>&1"`,
 				testArgs))
-		}()
+			return nil
+		})
 	} else {
-		go func() {
+		t.Go(func(context.Context, *logger.Logger) error {
 			errCh <- run("bash", "-e", "-c", fmt.Sprintf(
 				`"cd /mnt/data1/jepsen/cockroachdb && set -eo pipefail && java -jar %s %s > invoke.log 2>&1"`,
 				j.binaryName(), testArgs))
-		}()
+			return nil
+		})
 	}
 	return errCh
 }

--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -164,10 +164,11 @@ func runMultitenantUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) 
 		}
 
 		returnCh := make(chan struct{})
-		go func() {
+		h.Go(func(context.Context, *logger.Logger) error {
 			wg.Wait()
 			close(returnCh)
-		}()
+			return nil
+		})
 
 		return returnCh
 	}
@@ -280,16 +281,18 @@ func runMultitenantUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) 
 			var wg sync.WaitGroup
 			wg.Add(2) // tpcc worklaod and upgrade finalization
 
-			go func() {
+			h.Go(func(_ context.Context, l *logger.Logger) error {
 				defer wg.Done()
 				<-tpccFinished
 				l.Printf("tpcc workload finished running on tenants")
-			}()
-			go func() {
+				return nil
+			})
+			h.Go(func(_ context.Context, l *logger.Logger) error {
 				defer wg.Done()
 				<-upgradeFinished
 				l.Printf("tenant upgrades finished")
-			}()
+				return nil
+			})
 
 			wg.Wait()
 			return nil

--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -411,7 +411,7 @@ func runOneRoundQueryComparison(
 			// state of the database.
 			if i < numInitialMutations || i%25 == 0 {
 				mConn, mConnInfo := h.chooseConn()
-				runMutationStatement(mConn, mConnInfo, mutatingSmither, logStmt)
+				runMutationStatement(t, mConn, mConnInfo, mutatingSmither, logStmt)
 				continue
 			}
 

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -263,7 +263,7 @@ func runTPCC(
 		if err != nil {
 			t.Fatal(err)
 		}
-		cep.listen(ctx, l)
+		cep.listen(ctx, t, l)
 		ep = &cep
 	}
 


### PR DESCRIPTION
Previously, tests had to use  bare goroutine calls to start a goroutine. This change removes all bare goroutine calls and replaces it with the new task APIs.

The use of `errgroup.Group` and `Monitor` still remains and will be addressed in a different PR.

Informs: #118214

Epic: None
Release note: None