### PR TITLE
kvserver: deflake TestLeaseQueueLeasePreferencePurgatoryError

### DIFF
--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -160,10 +160,14 @@ func (s *Store) SplitQueuePurgatoryLength() int {
 	return s.splitQueue.PurgatoryLength()
 }
 
-// LeaseQueuePurgatoryLength returns the number of replicas in lease queue
-// purgatory.
-func (s *Store) LeaseQueuePurgatoryLength() int {
-	return s.leaseQueue.PurgatoryLength()
+// LeaseQueuePurgatory returns a map of RangeIDs representing the purgatory.
+func (s *Store) LeaseQueuePurgatory() map[roachpb.RangeID]struct{} {
+	defer s.leaseQueue.baseQueue.lockProcessing()()
+	m := make(map[roachpb.RangeID]struct{}, len(s.leaseQueue.baseQueue.mu.purgatory))
+	for k := range s.leaseQueue.baseQueue.mu.purgatory {
+		m[k] = struct{}{}
+	}
+	return m
 }
 
 // SetRaftLogQueueActive enables or disables the raft log queue.


### PR DESCRIPTION
The test sets up an environment in which 40 replicas of interest are
supposed to enter the lease queue purgatory. The test was waiting for
this to happen before proceeding, but was doing so incorrectly: It
checked that the number of replicas in the purgatory matches 40 (as
opposed to checking directly that all ranges of interest had entered
it). Since other ranges could slip in, occasionally the test would
proceed too early, remove the condition that causes ranges to enter the
purgatory, and then find that a few ranges would not be processed (since
they never entered the purgatory in the first place).

This commit fixes this by waiting explicitly for the RangeIDs of
interest to be represented in the lease queue purgatory.

I was able to reproduce the flake in a few minutes on my gceworker via

```
./dev test --count 10000 --stress ./pkg/kv/kvserver \
	--filter TestLeaseQueueLeasePreferencePurgatoryError  -- \
	--jobs 100 --local_resources=cpu=100 --local_resources=memory=HOST_RAM 2>&1
```

This no longer reproduces as of this PR:

```
INFO: Elapsed time: 2091.413s, Critical Path: 166.06s
INFO: 3356 processes: 2 internal, 3354 linux-sandbox.
INFO: Build completed successfully, 3356 total actions
INFO:
//pkg/kv/kvserver:kvserver_test                                          PASSED in 50.3s
  Stats over 3000 runs: max = 50.3s, min = 12.3s, avg = 26.6s, dev = 6.6s
```

Fixes #134578.
Fixes https://github.com/cockroachdb/cockroach/issues/134768.

The backports will fix but this
Touches https://github.com/cockroachdb/cockroach/issues/134765.

Epic: none
Release note: None
