### PR TITLE
backupccl: remove ldr job id references on restoring tables

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1161,6 +1161,10 @@ func createImportingDescriptors(
 	// Set the new descriptors' states to offline.
 	for _, desc := range mutableTables {
 		desc.SetOffline("restoring")
+
+		// Remove any LDR Jobs from the table descriptor, ensuring schema changes
+		// can be run on the table descriptor.
+		desc.LDRJobIDs = nil
 	}
 	for _, desc := range typesToWrite {
 		desc.SetOffline("restoring")


### PR DESCRIPTION
This patch ensures that the user can run schema changes on a restored a table that was previously apart of an LDR stream.

Fixes #134424

Release note(bug fix): this patch allows a user to run schema changes on a restored table that was previously apart of an LDR stream.