### PR TITLE
scjob: treat descriptor not found as permanent job error

### DIFF
--- a/pkg/sql/schemachanger/scjob/job.go
+++ b/pkg/sql/schemachanger/scjob/job.go
@@ -144,15 +144,15 @@ func (n *newSchemaChangeResumer) run(ctx context.Context, execCtxI interface{}) 
 	)
 	// Return permanent errors back, otherwise we will try to retry
 	if sql.IsPermanentSchemaChangeError(err) {
+		return err
+	}
+	if err != nil {
 		// If a descriptor can't be found, we additionally mark the error as a
 		// permanent job error, so that non-cancelable jobs don't get retried. If a
 		// descriptor has gone missing, it isn't likely to come back.
 		if errors.IsAny(err, catalog.ErrDescriptorNotFound, catalog.ErrDescriptorDropped, catalog.ErrReferencedDescriptorNotFound) {
 			err = jobs.MarkAsPermanentJobError(err)
 		}
-		return err
-	}
-	if err != nil {
 		return jobs.MarkAsRetryJobError(err)
 	}
 	return nil


### PR DESCRIPTION
Previously, we tried to mark descriptor errors as terminal for the schema change jobs inside #129332. Unfortunately, the logic was placed in the wrong code path, so it never kicked in. This happened because descriptor errors are not processed by sql.IsPermanentSchemaChangeError. To address this, the logic moved a bit further down to when other errors are handled.

Fixes: #131405

Release note: None