### PR TITLE
publish-provisional-artifacts: add licenses to THIRD-PARTY-NOTICES.txt

### DIFF
--- a/build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh
@@ -54,7 +54,27 @@ export google_credentials="$gcs_credentials"
 source "build/teamcity-support.sh"  # For log_into_gcloud
 log_into_gcloud
 export GOOGLE_APPLICATION_CREDENTIALS="$PWD/.google-credentials.json"
-$BAZEL_BIN/pkg/cmd/publish-provisional-artifacts/publish-provisional-artifacts_/publish-provisional-artifacts -provisional -release --gcs-bucket="$gcs_bucket" --output-directory=artifacts --platform=$platform
+
+cat licenses/THIRD-PARTY-NOTICES.txt > /tmp/THIRD-PARTY-NOTICES.txt.tmp
+echo "================================================================================" >> /tmp/THIRD-PARTY-NOTICES.txt.tmp 
+echo "Additional licenses" >> /tmp/THIRD-PARTY-NOTICES.txt.tmp 
+echo >> /tmp/THIRD-PARTY-NOTICES.txt.tmp
+echo "================================================================================" >> /tmp/THIRD-PARTY-NOTICES.txt.tmp 
+for f in $(cd licenses && ls -1 * | grep -v THIRD-PARTY-NOTICES.txt | sort ); do
+  echo >> /tmp/THIRD-PARTY-NOTICES.txt.tmp
+  echo >> /tmp/THIRD-PARTY-NOTICES.txt.tmp
+  echo >> /tmp/THIRD-PARTY-NOTICES.txt.tmp
+  echo "------------------------------------------------------------------------" >> /tmp/THIRD-PARTY-NOTICES.txt.tmp
+  echo "Notices from $f" >> /tmp/THIRD-PARTY-NOTICES.txt.tmp
+  echo "------------------------------------------------------------------------" >> /tmp/THIRD-PARTY-NOTICES.txt.tmp
+  echo >> /tmp/THIRD-PARTY-NOTICES.txt.tmp
+  echo >> /tmp/THIRD-PARTY-NOTICES.txt.tmp
+  cat "licenses/$f" >> /tmp/THIRD-PARTY-NOTICES.txt.tmp
+done
+
+tr -d '\r' < /tmp/THIRD-PARTY-NOTICES.txt.tmp > /tmp/THIRD-PARTY-NOTICES.txt
+
+$BAZEL_BIN/pkg/cmd/publish-provisional-artifacts/publish-provisional-artifacts_/publish-provisional-artifacts -provisional -release --gcs-bucket="$gcs_bucket" --output-directory=artifacts --platform=$platform --third-party-notices-file=/tmp/THIRD-PARTY-NOTICES.txt
 EOF
 tc_end_block "Make and publish release artifacts"
 

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh
@@ -77,7 +77,27 @@ export google_credentials="$gcs_credentials"
 source "build/teamcity-support.sh"  # For log_into_gcloud
 log_into_gcloud
 export GOOGLE_APPLICATION_CREDENTIALS="$PWD/.google-credentials.json"
-$BAZEL_BIN/pkg/cmd/publish-provisional-artifacts/publish-provisional-artifacts_/publish-provisional-artifacts -provisional -release --gcs-bucket="$gcs_bucket" --output-directory=artifacts --build-tag-override="$build_name" --platform $platform
+
+cat licenses/THIRD-PARTY-NOTICES.txt > /tmp/THIRD-PARTY-NOTICES.txt.tmp
+echo "================================================================================" >> /tmp/THIRD-PARTY-NOTICES.txt.tmp 
+echo "Additional licenses" >> /tmp/THIRD-PARTY-NOTICES.txt.tmp 
+echo >> /tmp/THIRD-PARTY-NOTICES.txt.tmp
+echo "================================================================================" >> /tmp/THIRD-PARTY-NOTICES.txt.tmp 
+for f in $(cd licenses && ls -1 * | grep -v THIRD-PARTY-NOTICES.txt | sort ); do
+  echo >> /tmp/THIRD-PARTY-NOTICES.txt.tmp
+  echo >> /tmp/THIRD-PARTY-NOTICES.txt.tmp
+  echo >> /tmp/THIRD-PARTY-NOTICES.txt.tmp
+  echo "------------------------------------------------------------------------" >> /tmp/THIRD-PARTY-NOTICES.txt.tmp
+  echo "Notices from $f" >> /tmp/THIRD-PARTY-NOTICES.txt.tmp
+  echo "------------------------------------------------------------------------" >> /tmp/THIRD-PARTY-NOTICES.txt.tmp
+  echo >> /tmp/THIRD-PARTY-NOTICES.txt.tmp
+  echo >> /tmp/THIRD-PARTY-NOTICES.txt.tmp
+  cat "licenses/$f" >> /tmp/THIRD-PARTY-NOTICES.txt.tmp
+done
+
+tr -d '\r' < /tmp/THIRD-PARTY-NOTICES.txt.tmp > /tmp/THIRD-PARTY-NOTICES.txt
+
+$BAZEL_BIN/pkg/cmd/publish-provisional-artifacts/publish-provisional-artifacts_/publish-provisional-artifacts -provisional -release --gcs-bucket="$gcs_bucket" --output-directory=artifacts --build-tag-override="$build_name" --platform $platform --third-party-notices-file=/tmp/THIRD-PARTY-NOTICES.txt
 
 EOF
 tc_end_block "Compile and publish artifacts"

--- a/pkg/cmd/publish-provisional-artifacts/main.go
+++ b/pkg/cmd/publish-provisional-artifacts/main.go
@@ -30,6 +30,7 @@ func main() {
 	var gcsBucket string
 	var outputDirectory string
 	var buildTagOverride string
+	var thirdPartyNoticesFileOverride string
 	var doProvisional bool
 	var isRelease bool
 	var doBless bool
@@ -39,6 +40,7 @@ func main() {
 	flag.StringVar(&outputDirectory, "output-directory", "",
 		"Save local copies of uploaded release archives in this directory")
 	flag.StringVar(&buildTagOverride, "build-tag-override", "", "override the version from version.txt")
+	flag.StringVar(&thirdPartyNoticesFileOverride, "third-party-notices-file", "", "override the file with third party notices")
 	flag.BoolVar(&doProvisional, "provisional", false, "publish provisional binaries")
 	flag.BoolVar(&doBless, "bless", false, "bless provisional binaries")
 
@@ -84,26 +86,28 @@ func main() {
 	}
 
 	run(providers, platforms, runFlags{
-		doProvisional:    doProvisional,
-		doBless:          doBless,
-		isRelease:        isRelease,
-		buildTagOverride: buildTagOverride,
-		branch:           branch,
-		pkgDir:           pkg,
-		sha:              string(bytes.TrimSpace(shaOut)),
-		outputDirectory:  outputDirectory,
+		doProvisional:                 doProvisional,
+		doBless:                       doBless,
+		isRelease:                     isRelease,
+		buildTagOverride:              buildTagOverride,
+		branch:                        branch,
+		pkgDir:                        pkg,
+		sha:                           string(bytes.TrimSpace(shaOut)),
+		outputDirectory:               outputDirectory,
+		thirdPartyNoticesFileOverride: thirdPartyNoticesFileOverride,
 	}, release.ExecFn{})
 }
 
 type runFlags struct {
-	doProvisional    bool
-	doBless          bool
-	isRelease        bool
-	buildTagOverride string
-	branch           string
-	sha              string
-	pkgDir           string
-	outputDirectory  string
+	doProvisional                 bool
+	doBless                       bool
+	isRelease                     bool
+	buildTagOverride              string
+	branch                        string
+	sha                           string
+	pkgDir                        string
+	outputDirectory               string
+	thirdPartyNoticesFileOverride string
 }
 
 func run(
@@ -182,13 +186,17 @@ func run(
 					)
 				}
 			} else {
+				thirdPartyNoticesFile := filepath.Join(o.PkgDir, "licenses", "THIRD-PARTY-NOTICES.txt")
+				if flags.thirdPartyNoticesFileOverride != "" {
+					thirdPartyNoticesFile = flags.thirdPartyNoticesFileOverride
+				}
 				licenseFiles := []release.ArchiveFile{
 					{
 						LocalAbsolutePath: filepath.Join(o.PkgDir, "LICENSE"),
 						ArchiveFilePath:   "LICENSE",
 					},
 					{
-						LocalAbsolutePath: filepath.Join(o.PkgDir, "licenses", "THIRD-PARTY-NOTICES.txt"),
+						LocalAbsolutePath: thirdPartyNoticesFile,
 						ArchiveFilePath:   "THIRD-PARTY-NOTICES.txt",
 					},
 				}


### PR DESCRIPTION
This PR appends all third party licenses to the THIRD-PARTY-NOTICES.txt file.

Fixes: CRDB-43872
Release note: None