### PR TITLE
release-23.2: catalog/lease: Improve reliability of TestLeaseRenewedAutomatically

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -1246,6 +1246,9 @@ func TestLeaseRenewedAutomatically(testingT *testing.T) {
 
 	var testAcquiredCount int32
 	var testAcquisitionBlockCount int32
+	// Descriptor IDs for the two tables under test
+	var test1ID atomic.Int32
+	var test2ID atomic.Int32
 	var params base.TestClusterArgs
 	params.ServerArgs.DefaultTestTenant = base.TestDoesNotWorkWithSharedProcessModeButWeDontKnowWhyYet(
 		base.TestTenantProbabilistic, 112957,
@@ -1267,7 +1270,15 @@ func TestLeaseRenewedAutomatically(testingT *testing.T) {
 					if uint32(id) < bootstrap.TestingMinUserDescID() || typ == lease.AcquireBackground {
 						return
 					}
+					if int32(id) != test1ID.Load() && int32(id) != test2ID.Load() {
+						return
+					}
 					atomic.AddInt32(&testAcquisitionBlockCount, 1)
+					// The test sets the IDs of the two tables only when we shouldn't  block. So if we
+					// see a block event dump a stack to aid in debugging.
+					log.Infof(ctx,
+						"Lease acquisition of ID %d resulted in a block event. Stack trace to follow:\n%s",
+						id, debug.Stack())
 				},
 			},
 		},
@@ -1331,8 +1342,10 @@ CREATE TABLE t.test2 ();
 	}
 	eo2 := ts2.Expiration()
 
-	// Reset testAcquisitionBlockCount as the first acqusition will always block.
-	atomic.StoreInt32(&testAcquisitionBlockCount, 0)
+	// Save off the IDs of the two tables so that we increment testAcquisitionBlockCount
+	// if we ever block waiting for those leases to expire.
+	test1ID.Store(int32(test1Desc.GetID()))
+	test2ID.Store(int32(test2Desc.GetID()))
 
 	testutils.SucceedsSoon(t, func() error {
 		// Acquire another lease by name on test1. At first this will be the


### PR DESCRIPTION
Backport 1/1 commits from #134665.

/cc @cockroachdb/release

---

The TestLeaseRenewedAutomatically test is designed to verify that an expired lease is reacquired automatically. However, background processes acquiring leases caused occasional test flakiness. Efforts to limit this interference, such as disabling autostats, were only partially effective, as other background activity still sometimes caused issues. Rather than attempting to track every background process, I modified the test to focus lease checks exclusively on the two tables under test. This improved reliability in my local runs since it was the database descriptor lease, not the leases for the two tables, that was being acquired. This adjustment preserves the test’s intent while enhancing its stability.

Epic: none
Closes #133030
Release note: none
Release justification: low risk test only change