### PR TITLE
metric: truncate help text in prom output

### DIFF
--- a/pkg/util/metric/prometheus_exporter.go
+++ b/pkg/util/metric/prometheus_exporter.go
@@ -8,6 +8,7 @@ package metric
 import (
 	"context"
 	"io"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -60,9 +61,15 @@ func (pm *PrometheusExporter) findOrCreateFamily(
 		return family
 	}
 
+	// The Help field for metric metadata is written as a string literal
+	// which is formatted for reading in a code editor. When outputting
+	// to Prometheus and other systems, we want to remove all the
+	// newlines an only capture the first sentence for brevity.
+	left, _, _ := strings.Cut(strings.Join(strings.Fields(prom.GetHelp()), " "), ".")
+
 	family := &prometheusgo.MetricFamily{
 		Name: proto.String(familyName),
-		Help: proto.String(prom.GetHelp()),
+		Help: proto.String(left),
 		Type: prom.GetType(),
 	}
 

--- a/pkg/util/metric/prometheus_exporter_test.go
+++ b/pkg/util/metric/prometheus_exporter_test.go
@@ -37,6 +37,14 @@ func TestPrometheusExporter(t *testing.T) {
 	c2Dup := NewCounter(c2MetaDup)
 	r2.AddMetric(c2Dup)
 
+	multilineHelp := `This is a multiline
+      help message. With a second 
+      sentence.`
+	r1.AddMetric(NewGauge(Metadata{
+		Name: "help.multiline",
+		Help: multilineHelp,
+	}))
+
 	pe := MakePrometheusExporter()
 	const includeChildMetrics = false
 	pe.ScrapeRegistry(r1, includeChildMetrics)
@@ -66,6 +74,9 @@ func TestPrometheusExporter(t *testing.T) {
 		}},
 		"shared_counter_dup": {[]metricLabels{
 			{"counter": "two", "registry": "two"},
+		}},
+		"help_multiline": {[]metricLabels{
+			{},
 		}},
 	}
 
@@ -153,7 +164,11 @@ func TestPrometheusExporter(t *testing.T) {
 	require.Regexp(t, "one_gauge 0", output)
 	require.Regexp(t, "one_gauge_dup 0", output)
 	require.Regexp(t, "shared_counter{counter=\"one\"}", output)
-	require.Len(t, strings.Split(output, "\n"), 10)
+
+	require.Regexp(t, "This is a multiline help message", output)
+	require.NotRegexp(t, multilineHelp, output)
+
+	require.Len(t, strings.Split(output, "\n"), 13)
 
 	buf.Reset()
 	r1.RemoveMetric(g1Dup)
@@ -164,7 +179,7 @@ func TestPrometheusExporter(t *testing.T) {
 	output = buf.String()
 	require.Regexp(t, "one_gauge 0", output)
 	require.NotRegexp(t, "one_gauge_dup 0", output)
-	require.Len(t, strings.Split(output, "\n"), 7)
+	require.Len(t, strings.Split(output, "\n"), 10)
 }
 
 func TestPrometheusExporterNativeHistogram(t *testing.T) {


### PR DESCRIPTION
We have some long multiline help text defined for metrics that makes the prometheus output quite large. This change automatically truncates help text at the first newline during prometheus output. We can still access the full text in our docs and code.

Resolves: CRDB-43497
Epic: None

Release note (ops change): the metrics scrape HTTP endpoint at `/ _status/vars` will now truncate HELP text at the first newline, reducing the metadata for metrics with large descriptions. Customers can still access these descriptions via our docs.