### PR TITLE
opt/idxconstraint: optimize computed column constraint derivation

### DIFF
--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -626,9 +626,9 @@ func (c *indexConstraintCtx) makeSpansForExpr(
 
 	// Attempt to build a single tight constraint from a scalar expression and use
 	// it to derive predicates/constraints on computed columns.
-	if c.computedColSet.Intersects(c.keyCols) &&
+	if !c.skipComputedColPredDerivation &&
 		c.evalCtx.SessionData().OptimizerUseImprovedComputedColumnFiltersDerivation &&
-		!c.skipComputedColPredDerivation {
+		c.computedColSet.Intersects(c.keyCols) {
 		switch t := e.(type) {
 		case *memo.FiltersExpr, *memo.FiltersItem, *memo.AndExpr, *memo.OrExpr:
 		// Skip over scalar expressions that are not conditions, require special

--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -655,9 +655,10 @@ func (c *indexConstraintCtx) makeSpansForExpr(
 					// All disjunctions fully represent the original condition
 					// plus derived predicates, so we only have to make spans on
 					// the list of disjunctions.
+					origSkip := c.skipComputedColPredDerivation
 					c.skipComputedColPredDerivation = true
+					defer func() { c.skipComputedColPredDerivation = origSkip }()
 					localTight := c.binaryMergeSpansForOr(offset, disjunctions, out)
-					c.skipComputedColPredDerivation = false
 					return localTight
 				}
 			}

--- a/pkg/sql/opt/idxconstraint/testdata/computed
+++ b/pkg/sql/opt/idxconstraint/testdata/computed
@@ -92,6 +92,40 @@ index-constraints vars=(a int, b int, c int as (a+5) stored) index=(a, c)
 [/3/8 - /3/8]
 [/5/10 - /5/10]
 
+# A computed column not in the 1st index position can derive a predicate.
+index-constraints vars=(a int, b int, c int as (a+5) stored) index=(a, c, b)
+a = 3 OR (a = 5 AND b > 0)
+----
+[/3/8 - /3/8]
+[/5/10/1 - /5/10]
+
+index-constraints vars=(a int, b int, c int as (a+5) stored) index=(c, a, b)
+(a = 3 OR a = 5) AND b > 0
+----
+[/8/3/1 - /8/3]
+[/10/5/1 - /10/5]
+
+index-constraints vars=(a int, b int, c int as (a+5) stored) index=(a, c, b)
+(a = 3 OR a = 5) AND b > 0
+----
+[/3/8/1 - /3/8]
+[/5/10/1 - /5/10]
+
+# A computed column not in the 1st index position can derive a predicate.
+index-constraints vars=(a int, b int as (a+1) virtual, c int as (b+5) stored) index=(c)
+a = 3 OR a = 5
+----
+[/9 - /9]
+[/11 - /11]
+Remaining filter: (a = 3) OR (a = 5)
+
+index-constraints vars=(a int, b int, c int as (b+5) stored) index=(a, c)
+a = 1 AND (b = 10 OR b = 20)
+----
+[/1/15 - /1/15]
+[/1/25 - /1/25]
+Remaining filter: (b = 10) OR (b = 20)
+
 # We don't derive a predicate for non-single-key cases.
 index-constraints vars=(a int, b int, c int as (a+b) stored) index=(a, c)
 (a=3 AND b=4) OR (a >= 3 AND b=6)


### PR DESCRIPTION
#### opt/bench: add benchmark like "internal-upsert-txn-stats" statement

A new opt benchmark has been added that mimics the
"internal-upsert-txn-stats" query executed by the `persistedsqlstats`
package.

Release note: None

#### opt/idxconstraint: correctly reset skip flag

The `skipComputedColPredDerivation` flag is now correctly reset to its
previous value with `defer`. This caused no known correctness or
performance issues—fixing it guards against future unexpected behavior.

Release note: None

#### opt/idxconstraint: reorder computed column derivation conditions

Some `if` conditionals have been reordered from least expensive to most
expensive to benefit from short-circuiting.

Release note: None

#### opt/idxconstraint: optimize computed column constraint derivation

Building index constraints on computed columns is currently very
expensive. Prior to this commit, this derivation occurred roughly
`C * E` times for every index, where `C` is the number of key columns in
the index and `E` is the number of filter expressions. For each suffix
of key columns, a computed column constraint was attempted to be
derived.

This commit reduces this by only trying to derive computed column
constraints on key column suffixes that actually contain computed
columns. In many cases, such as hash-sharded indexes, this effectively
reduces computed column constraint derivation to be attempted `E` times
per index, because in a hash-sharded index the first column is commonly
the only computed column.

Informs #134587

Release note: None
