### PR TITLE
authserver: fix "use of Span after Finish." in v2 auth

### DIFF
--- a/pkg/server/authserver/api_v2.go
+++ b/pkg/server/authserver/api_v2.go
@@ -36,7 +36,6 @@ func NewV2Server(
 		sqlServer:  s,
 		authServer: innerServer,
 		mux:        simpleMux,
-		ctx:        ctx,
 		basePath:   basePath,
 	}
 


### PR DESCRIPTION
fixes a bug where GET api/v2/login results in the error: `use of Span after Finish`. This was happening due to the endpoint re-using the context that is stored in `authenticationV2Server`.

This has been updated to use the request context instead and the context field of `authenticationV2Server` has been removed,

Fixes: #133493
Epic: none
Release note: None