### PR TITLE
sql: fire DELETE triggers for cascading deletes

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -2717,6 +2717,42 @@ DROP FUNCTION g;
 DROP FUNCTION h;
 DROP FUNCTION filter;
 
+# Regression test for #134745: fire DELETE triggers for cascading deletes.
+subtest delete_cascade_triggers
+
+statement ok
+CREATE TABLE parent (k INT PRIMARY KEY);
+CREATE TABLE child (v INT NOT NULL REFERENCES parent(k) ON DELETE CASCADE);
+
+statement ok
+CREATE FUNCTION g() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RAISE NOTICE '%', TG_OP;
+    RETURN COALESCE(NEW, OLD);
+  END
+$$;
+
+statement ok
+INSERT INTO parent VALUES (1), (2), (3);
+INSERT INTO child VALUES (1), (2), (2);
+
+statement ok
+CREATE TRIGGER foo BEFORE INSERT OR DELETE ON child FOR EACH ROW EXECUTE FUNCTION g();
+
+query T noticetrace
+DELETE FROM parent WHERE k = 2;
+----
+NOTICE: DELETE
+NOTICE: DELETE
+
+statement ok
+DROP TRIGGER foo ON child;
+
+statement ok
+DROP FUNCTION g;
+DROP TABLE child;
+DROP TABLE parent;
+
 # ==============================================================================
 # Test order of execution.
 # ==============================================================================

--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -360,7 +360,7 @@ func (cb *onDeleteFastCascadeBuilder) Build(
 		mb.setFetchColIDs(mb.outScope.cols)
 
 		// Cascades can fire triggers on the child table.
-		mb.buildRowLevelBeforeTriggers(tree.TriggerEventInsert, true /* cascade */)
+		mb.buildRowLevelBeforeTriggers(tree.TriggerEventDelete, true /* cascade */)
 
 		mb.buildDelete(nil /* returning */)
 		return mb.outScope.expr

--- a/pkg/sql/opt/optbuilder/testdata/trigger
+++ b/pkg/sql/opt/optbuilder/testdata/trigger
@@ -751,19 +751,19 @@ root
  │         ├── columns: <none>
  │         ├── fetch columns: k:13 child.x:14
  │         └── barrier
- │              ├── columns: k:13 child.x:14 new:17 f:31 "check-rows":32
+ │              ├── columns: k:13 child.x:14 old:17 f:31 "check-rows":32
  │              └── select
- │                   ├── columns: k:13 child.x:14 new:17 f:31 "check-rows":32
+ │                   ├── columns: k:13 child.x:14 old:17 f:31 "check-rows":32
  │                   ├── barrier
- │                   │    ├── columns: k:13 child.x:14 new:17 f:31 "check-rows":32
+ │                   │    ├── columns: k:13 child.x:14 old:17 f:31 "check-rows":32
  │                   │    └── project
- │                   │         ├── columns: "check-rows":32 k:13 child.x:14 new:17 f:31
+ │                   │         ├── columns: "check-rows":32 k:13 child.x:14 old:17 f:31
  │                   │         ├── project
- │                   │         │    ├── columns: f:31 k:13 child.x:14 new:17
+ │                   │         │    ├── columns: f:31 k:13 child.x:14 old:17
  │                   │         │    ├── barrier
- │                   │         │    │    ├── columns: k:13 child.x:14 new:17
+ │                   │         │    │    ├── columns: k:13 child.x:14 old:17
  │                   │         │    │    └── project
- │                   │         │    │         ├── columns: new:17 k:13 child.x:14
+ │                   │         │    │         ├── columns: old:17 k:13 child.x:14
  │                   │         │    │         ├── select
  │                   │         │    │         │    ├── columns: k:13 child.x:14
  │                   │         │    │         │    ├── scan child
@@ -772,11 +772,11 @@ root
  │                   │         │    │         │         ├── child.x:14 = 1
  │                   │         │    │         │         └── child.x:14 IS DISTINCT FROM CAST(NULL AS INT8)
  │                   │         │    │         └── projections
- │                   │         │    │              └── ((k:13, child.x:14) AS k, x) [as=new:17]
+ │                   │         │    │              └── ((k:13, child.x:14) AS k, x) [as=old:17]
  │                   │         │    └── projections
- │                   │         │         └── f(new:17, NULL, 'tr_child', 'BEFORE', 'ROW', 'INSERT', 54, 'child', 'child', 'public', 0, ARRAY[]) [as=f:31]
+ │                   │         │         └── f(NULL, old:17, 'tr_child', 'BEFORE', 'ROW', 'DELETE', 54, 'child', 'child', 'public', 0, ARRAY[]) [as=f:31]
  │                   │         └── projections
- │                   │              └── CASE WHEN f:31 IS DISTINCT FROM new:17 THEN crdb_internal.plpgsql_raise('ERROR', 'trigger tr_child attempted to modify or filter a row in a cascade operation: ' || new:17::STRING, e'changing the rows updated or deleted by a foreign-key cascade\n can cause constraint violations, and therefore is not allowed', e'to enable this behavior (with risk of constraint violation), set\nthe session variable \'unsafe_allow_triggers_modifying_cascades\' to true', '27000') ELSE CAST(NULL AS INT8) END [as="check-rows":32]
+ │                   │              └── CASE WHEN f:31 IS DISTINCT FROM old:17 THEN crdb_internal.plpgsql_raise('ERROR', 'trigger tr_child attempted to modify or filter a row in a cascade operation: ' || old:17::STRING, e'changing the rows updated or deleted by a foreign-key cascade\n can cause constraint violations, and therefore is not allowed', e'to enable this behavior (with risk of constraint violation), set\nthe session variable \'unsafe_allow_triggers_modifying_cascades\' to true', '27000') ELSE CAST(NULL AS INT8) END [as="check-rows":32]
  │                   └── filters
  │                        └── f:31 IS DISTINCT FROM NULL
  └── after-triggers


### PR DESCRIPTION
This commit fixes a bug in `onDeleteFastCascadeBuilder` which caused the incorrect type of trigger to fire. This issue is that `TriggerEventInsert` was supplied to `buildRowLevelBeforeTriggers` rather than `TriggerEventDelete`.

Fixes #134741
Fixes #134745

Release note (bug fix): Fixed a bug that could cause DELETE triggers not to fire on cascading delete, and which could cause INSERT triggers to match incorrectly in the same scenario.