### PR TITLE
kvclient: prevent MuxRangeFeed call from hanging

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
@@ -390,6 +390,9 @@ func (m *rangefeedMuxer) startNodeMuxRangeFeed(
 
 	mux, err := client.MuxRangeFeed(ctx)
 	if err != nil {
+		// Remove the mux client from the cache if it hit an
+		// error.
+		m.muxClients.Delete(nodeID)
 		return future.MustSet(stream, muxStreamOrError{err: err})
 	}
 


### PR DESCRIPTION
The rangefeedMuxer holds a cache of `muxStreamOrError`. If the initial MuxRangeFeed call fails, the error is cached rather than a working client. That failure would be cached forever, and future attempts to initiate a rangefeed on that particular node would then return the cached error.

If all replicas for a particular range failed in this way, the rangefeed would hang forever, continuously "retrying" but only ever encountering the cached error.

Here, we remove items from the cache on error.

Epic: none
Release note: None