### PR TITLE
workload : fix tpcc multiple workload load generation

### DIFF
--- a/pkg/workload/tpcc/audit.go
+++ b/pkg/workload/tpcc/audit.go
@@ -23,6 +23,19 @@ type auditor struct {
 	syncutil.Mutex
 
 	warehouses int
+	// These are needed while checking for remote payments for order-line and
+	// payments table.
+	// partitionAffinity - partitionIds for which to do these checks
+	// partitioner - helps map which warehouseId belongs to those partitions
+	partitionAffinity []int
+	partitioner       *partitioner
+	// CountOfTotalPartitions / CountOfAffinityPartitions
+	// Used in audit checks, if load is generated only for
+	// some partition, the audit checks should also be reduced
+	// by that factor.
+	// Used specially in case there are multiple workload nodes
+	// generating load for different partitions.
+	partitionFactor int
 
 	// transaction counts
 	newOrderTransactions    atomic.Uint64
@@ -49,9 +62,19 @@ type auditor struct {
 	skippedDelivieries atomic.Uint64
 }
 
-func newAuditor(warehouses int) *auditor {
+func newAuditor(warehouses int, partitioner *partitioner, partitionAffinity []int) *auditor {
 	return &auditor{
-		warehouses:                   warehouses,
+		warehouses:        warehouses,
+		partitioner:       partitioner,
+		partitionAffinity: partitionAffinity,
+		partitionFactor: func() int {
+			countAffinity := len(partitionAffinity)
+			if countAffinity == 0 || partitioner.parts == 0 {
+				return 1
+			} else {
+				return partitioner.parts / countAffinity
+			}
+		}(),
 		orderLinesFreq:               make(map[int]uint64),
 		orderLineRemoteWarehouseFreq: make(map[int]uint64),
 		paymentRemoteWarehouseFreq:   make(map[int]uint64),
@@ -212,15 +235,31 @@ func check92253(a *auditor) auditResult {
 	// least once. We need the number of remote order-lines to be at least 15
 	// times the number of warehouses (experimentally determined) to have this
 	// expectation.
-	if remoteOrderLines < 15*uint64(a.warehouses) {
-		return newSkipResult("insufficient data for remote warehouse distribution check")
-	}
-	for i := 0; i < a.warehouses; i++ {
-		if _, ok := a.orderLineRemoteWarehouseFreq[i]; !ok {
-			return newFailResult("no remote order-lines for warehouses %d", i)
+	//
+	var warehouses []int
+	if len(a.partitionAffinity) == 0 {
+		warehouses = make([]int, a.warehouses)
+		for i := 0; i < a.warehouses; i++ {
+			warehouses[i] = i
+		}
+	} else {
+		for _, partition := range a.partitionAffinity {
+			warehouses = append(warehouses, a.partitioner.partElems[partition]...)
 		}
 	}
 
+	checkRemoteOrderLines := func(warehouses []int, orderLineRemoteWarehouseFreq map[int]uint64) error {
+		for _, warehouse := range warehouses {
+			if _, ok := orderLineRemoteWarehouseFreq[warehouse]; !ok {
+				return fmt.Errorf("no remote order-lines for warehouse %d", warehouse)
+			}
+		}
+		return nil
+	}
+
+	if err := checkRemoteOrderLines(warehouses, a.orderLineRemoteWarehouseFreq); err != nil {
+		return newFailResult("%s", err.Error())
+	}
 	return passResult
 }
 
@@ -250,13 +289,32 @@ func check92254(a *auditor) auditResult {
 			"remote payment percent %.1f is not between allowed bounds [14, 16]", remotePct)
 	}
 
-	if remotePayments < 15*uint64(a.warehouses) {
+	if remotePayments < 15*uint64(a.warehouses/a.partitionFactor) {
 		return newSkipResult("insufficient data for remote warehouse distribution check")
 	}
-	for i := 0; i < a.warehouses; i++ {
-		if _, ok := a.paymentRemoteWarehouseFreq[i]; !ok {
-			return newFailResult("no remote payments for warehouses %d", i)
+
+	var warehouses []int
+	if len(a.partitionAffinity) == 0 {
+		warehouses = make([]int, a.warehouses)
+		for i := 0; i < a.warehouses; i++ {
+			warehouses[i] = i
 		}
+	} else {
+		for _, partition := range a.partitionAffinity {
+			warehouses = append(warehouses, a.partitioner.partElems[partition]...)
+		}
+	}
+	checkRemotePayments := func(warehouses []int, paymentRemoteWarehouseFreq map[int]uint64) error {
+		for _, warehouse := range warehouses {
+			if _, ok := paymentRemoteWarehouseFreq[warehouse]; !ok {
+				return fmt.Errorf("no remote payments for warehouses %d", warehouse)
+			}
+		}
+		return nil
+	}
+
+	if err := checkRemotePayments(warehouses, a.paymentRemoteWarehouseFreq); err != nil {
+		return newFailResult("%s", err.Error())
 	}
 
 	return passResult


### PR DESCRIPTION
This change addresses three things for multiple workload load generation for tpcc workload for tpcc benchmarking
1. Partitions assignment to warehouses based on affinity partitions and active warehouses
    - Earlier partition assignment to workers didn't take into account affinity partition, this change takes care of that
    - Also, would skip assigning some partitions to some worker, as the isMyPart() checked happened after partition assignment, we fix this by taking into account affinity partitions early
2. Updating audit checks based on count of affinity partitions
   - Now that we are generating different load from multiple workload nodes, the audit checks needs to be adjusted to take this into account, as there is no aggregated audit checks for multiple workload nodes.
   - Introduced partitionFactor to take into account number of workload nodes, and decrease the overall numbers for audit checks by this factor.
3. Correcting partitions to connections urls mapping
     - URL mapping happens for each partition based on the urls passed in the workload command. This fix makes sure we do url to partition mapping correctly taking into account the affinity partitions. Earlier we just ignored affinity partitions in this part.

Epic: none
Release: none