### PR TITLE
kvserver/rangefeed: move drainAllocation call

### DIFF
--- a/pkg/kv/kvserver/rangefeed/buffered_registration.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_registration.go
@@ -254,6 +254,8 @@ func (br *bufferedRegistration) outputLoop(ctx context.Context) error {
 }
 
 func (br *bufferedRegistration) runOutputLoop(ctx context.Context, _forStacks roachpb.RangeID) {
+	defer br.drainAllocations(ctx)
+
 	br.mu.Lock()
 	if br.mu.disconnected {
 		// The registration has already been disconnected.

--- a/pkg/kv/kvserver/rangefeed/buffered_registration.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_registration.go
@@ -117,9 +117,10 @@ func (br *bufferedRegistration) publish(
 
 	br.mu.Lock()
 	defer br.mu.Unlock()
-	if br.mu.overflowed {
+	if br.mu.overflowed || br.mu.disconnected {
 		return
 	}
+
 	alloc.Use(ctx)
 	select {
 	case br.buf <- e:

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -340,15 +340,11 @@ func (reg *registry) PublishToOverlapping(
 // Unregister removes a registration from the registry. It is assumed that the
 // registration has already been disconnected, this is intended only to clean
 // up the registry.
-// We also drain all pending events for the sake of memory accounting. To do
-// that we rely on a fact that caller is not going to post any more events
-// concurrently or after this function is called.
 func (reg *registry) Unregister(ctx context.Context, r registration) {
 	reg.metrics.RangeFeedRegistrations.Dec(1)
 	if err := reg.tree.Delete(r, false /* fast */); err != nil {
 		log.Fatalf(ctx, "%v", err)
 	}
-	r.drainAllocations(ctx)
 }
 
 // DisconnectAllOnShutdown disconnectes all registrations on processor shutdown.

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -361,6 +361,7 @@ func (p *ScheduledProcessor) Register(
 			// could only happen on shutdown. Disconnect stream and just remove
 			// registration.
 			r.Disconnect(kvpb.NewError(err))
+			r.drainAllocations(ctx)
 			p.reg.Unregister(ctx, r)
 		}
 		return f


### PR DESCRIPTION
Previously, drainAllocations was called by registry.Unregister. While this was nice as it was a single call site, it seems a bit off to me because it ties to lifetime of the allocations in the registration's buffer to the registry rather than to the registration's output loop which is the reader of that buffer.

Epic: none
Release note: None