### PR TITLE
opt: reduce allocations in JSON value hashing

### DIFF
--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -117,7 +117,7 @@ func valueEncodePartitionTuple(
 		if err := colinfo.CheckDatumTypeFitsColumnType(cols[i], datum.ResolvedType()); err != nil {
 			return nil, err
 		}
-		value, err = valueside.Encode(value, valueside.NoColumnID, datum, scratch)
+		value, err = valueside.EncodeWithScratch(value, valueside.NoColumnID, datum, scratch)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -117,7 +117,7 @@ func valueEncodePartitionTuple(
 		if err := colinfo.CheckDatumTypeFitsColumnType(cols[i], datum.ResolvedType()); err != nil {
 			return nil, err
 		}
-		value, err = valueside.EncodeWithScratch(value, valueside.NoColumnID, datum, scratch)
+		value, scratch, err = valueside.EncodeWithScratch(value, valueside.NoColumnID, datum, scratch[:0])
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/col/coldataext/datum_vec.go
+++ b/pkg/col/coldataext/datum_vec.go
@@ -142,9 +142,12 @@ func (dv *datumVec) Cap() int {
 }
 
 // MarshalAt implements coldata.DatumVec interface.
-func (dv *datumVec) MarshalAt(appendTo []byte, i int) ([]byte, error) {
+func (dv *datumVec) MarshalAt(appendTo []byte, i int) (_ []byte, err error) {
 	dv.maybeSetDNull(i)
-	return valueside.EncodeWithScratch(appendTo, valueside.NoColumnID, dv.data[i], dv.scratch)
+	appendTo, dv.scratch, err = valueside.EncodeWithScratch(
+		appendTo, valueside.NoColumnID, dv.data[i], dv.scratch[:0],
+	)
+	return appendTo, err
 }
 
 // UnmarshalTo implements coldata.DatumVec interface.

--- a/pkg/col/coldataext/datum_vec.go
+++ b/pkg/col/coldataext/datum_vec.go
@@ -144,9 +144,7 @@ func (dv *datumVec) Cap() int {
 // MarshalAt implements coldata.DatumVec interface.
 func (dv *datumVec) MarshalAt(appendTo []byte, i int) ([]byte, error) {
 	dv.maybeSetDNull(i)
-	return valueside.Encode(
-		appendTo, valueside.NoColumnID, dv.data[i], dv.scratch,
-	)
+	return valueside.EncodeWithScratch(appendTo, valueside.NoColumnID, dv.data[i], dv.scratch)
 }
 
 // UnmarshalTo implements coldata.DatumVec interface.

--- a/pkg/col/colserde/record_batch_test.go
+++ b/pkg/col/colserde/record_batch_test.go
@@ -227,7 +227,9 @@ func randomDataFromType(rng *rand.Rand, t *types.T, n int, nullProbability float
 		)
 		for i := range data {
 			d := randgen.RandDatum(rng, t, false /* nullOk */)
-			data[i], err = valueside.EncodeWithScratch(data[i], valueside.NoColumnID, d, scratch)
+			data[i], scratch, err = valueside.EncodeWithScratch(
+				data[i], valueside.NoColumnID, d, scratch[:0],
+			)
 			if err != nil {
 				panic(err)
 			}

--- a/pkg/col/colserde/record_batch_test.go
+++ b/pkg/col/colserde/record_batch_test.go
@@ -227,7 +227,7 @@ func randomDataFromType(rng *rand.Rand, t *types.T, n int, nullProbability float
 		)
 		for i := range data {
 			d := randgen.RandDatum(rng, t, false /* nullOk */)
-			data[i], err = valueside.Encode(data[i], valueside.NoColumnID, d, scratch)
+			data[i], err = valueside.EncodeWithScratch(data[i], valueside.NoColumnID, d, scratch)
 			if err != nil {
 				panic(err)
 			}

--- a/pkg/server/settingswatcher/setting_encoder.go
+++ b/pkg/server/settingswatcher/setting_encoder.go
@@ -33,22 +33,19 @@ func EncodeSettingValue(rawValue []byte, valueType string) ([]byte, error) {
 	if tuple, err = valueside.Encode(tuple,
 		valueside.MakeColumnIDDelta(descpb.ColumnID(encoding.NoColumnID),
 			systemschema.SettingsTable.PublicColumns()[1].GetID()),
-		tree.NewDString(string(rawValue)),
-		nil); err != nil {
+		tree.NewDString(string(rawValue))); err != nil {
 		return nil, err
 	}
 	if tuple, err = valueside.Encode(tuple,
 		valueside.MakeColumnIDDelta(systemschema.SettingsTable.PublicColumns()[1].GetID(),
 			systemschema.SettingsTable.PublicColumns()[2].GetID()),
-		tree.MustMakeDTimestamp(timeutil.Now(), time.Microsecond),
-		nil); err != nil {
+		tree.MustMakeDTimestamp(timeutil.Now(), time.Microsecond)); err != nil {
 		return nil, err
 	}
 	if tuple, err = valueside.Encode(tuple,
 		valueside.MakeColumnIDDelta(systemschema.SettingsTable.PublicColumns()[2].GetID(),
 			systemschema.SettingsTable.PublicColumns()[3].GetID()),
-		tree.NewDString(valueType),
-		nil); err != nil {
+		tree.NewDString(valueType)); err != nil {
 		return nil, err
 	}
 	return tuple, nil

--- a/pkg/sql/colenc/value.go
+++ b/pkg/sql/colenc/value.go
@@ -70,6 +70,6 @@ func valuesideEncodeCol(
 		}
 		return encoding.EncodeUUIDValue(appendTo, uint32(colID), u), nil
 	default:
-		return valueside.Encode(appendTo, colID, vec.Datum().Get(row).(tree.Datum), nil)
+		return valueside.Encode(appendTo, colID, vec.Datum().Get(row).(tree.Datum))
 	}
 }

--- a/pkg/sql/colencoding/value_encoding_test.go
+++ b/pkg/sql/colencoding/value_encoding_test.go
@@ -33,7 +33,7 @@ func TestDecodeTableValueToCol(t *testing.T) {
 		typs[i] = ct
 		datums[i] = datum
 		var err error
-		buf, err = valueside.Encode(buf, valueside.NoColumnID, datum, scratch)
+		buf, err = valueside.EncodeWithScratch(buf, valueside.NoColumnID, datum, scratch)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/colencoding/value_encoding_test.go
+++ b/pkg/sql/colencoding/value_encoding_test.go
@@ -33,7 +33,7 @@ func TestDecodeTableValueToCol(t *testing.T) {
 		typs[i] = ct
 		datums[i] = datum
 		var err error
-		buf, err = valueside.EncodeWithScratch(buf, valueside.NoColumnID, datum, scratch)
+		buf, scratch, err = valueside.EncodeWithScratch(buf, valueside.NoColumnID, datum, scratch[:0])
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/colexec/colexectestutils/utils.go
+++ b/pkg/sql/colexec/colexectestutils/utils.go
@@ -1791,9 +1791,8 @@ func MakeRandWindowFrameRangeOffset(t *testing.T, rng *rand.Rand, typ *types.T) 
 // EncodeWindowFrameOffset returns the given datum offset encoded as bytes, for
 // use in testing window functions in RANGE mode with offsets.
 func EncodeWindowFrameOffset(t *testing.T, offset tree.Datum) []byte {
-	var encoded, scratch []byte
-	encoded, err := valueside.Encode(
-		encoded, valueside.NoColumnID, offset, scratch)
+	var encoded []byte
+	encoded, err := valueside.Encode(encoded, valueside.NoColumnID, offset)
 	require.NoError(t, err)
 	return encoded
 }

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -240,6 +240,19 @@ var schemas = []string{
 	)
 	`,
 	`
+	CREATE TABLE json_comp
+	(
+		k INT PRIMARY KEY,
+		i INT,
+		j1 JSON,
+		j2 JSON,
+		j3 JSON,
+		j4 INT AS ((j1->'foo'->'bar'->'int')::INT) STORED,
+		j5 INT AS ((j1->'foo'->'bar'->'int2')::INT) STORED,
+		j6 STRING AS ((j2->'str')::STRING) STORED
+	)
+	`,
+	`
 		CREATE TABLE single_col_histogram (k TEXT PRIMARY KEY);
 	`,
 	`
@@ -507,6 +520,12 @@ var queries = [...]benchQuery{
 		name:    "json-insert",
 		query:   `INSERT INTO json_table(k, i, j) VALUES (1, 10, '{"a": "foo", "b": "bar", "c": [2, 3, "baz", true, false, null]}')`,
 		args:    []interface{}{},
+		cleanup: "TRUNCATE TABLE json_table",
+	},
+	{
+		name:    "json-comp-insert",
+		query:   `INSERT INTO json_comp(k, i, j1, j2, j3) VALUES ($1, $2, $3, $4, $5)`,
+		args:    []interface{}{1, 10, `'{"foo": {"bar": {"int": 12345, "int2": 1}}, "baz": false}'`, `'{"str": "hello world"}'`, `'{"c": [2, 3, "baz", true, false, null]}'`},
 		cleanup: "TRUNCATE TABLE json_table",
 	},
 	{

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -250,13 +250,9 @@ func (c *internCache) Add(item interface{}) {
 // interner. To use, first call the init method, then a series of hash methods.
 // The final value is stored in the hash field.
 type hasher struct {
-	// bytes is a scratch byte array used to serialize certain types of values
-	// during hashing and equality testing.
-	bytes []byte
-
-	// bytes2 is a scratch byte array used to serialize certain types of values
-	// during equality testing.
-	bytes2 []byte
+	// bytes, bytes2, and bytes3 are scratch byte arrays used to serialize
+	// certain types of values during hashing and equality testing.
+	bytes, bytes2, bytes3 []byte
 
 	// hash stores the hash value as it is incrementally computed.
 	hash internHash
@@ -268,6 +264,7 @@ func (h *hasher) Init() {
 	*h = hasher{
 		bytes:  h.bytes,
 		bytes2: h.bytes2,
+		bytes3: h.bytes3,
 		hash:   offset64,
 	}
 }
@@ -361,8 +358,6 @@ func (h *hasher) HashDatum(val tree.Datum) {
 		h.HashUint64(uint64(t.PGEpochDays()))
 	case *tree.DTime:
 		h.HashUint64(uint64(*t))
-	case *tree.DJSON:
-		h.HashString(t.String())
 	case *tree.DTuple:
 		// If labels are present, then hash of tuple's static type is needed to
 		// disambiguate when everything is the same except labels.
@@ -377,7 +372,7 @@ func (h *hasher) HashDatum(val tree.Datum) {
 		h.HashString(t.Locale)
 		h.HashString(t.Contents)
 	default:
-		h.bytes = encodeDatum(h.bytes[:0], val)
+		h.bytes, h.bytes3 = encodeDatum(h.bytes[:0], val, h.bytes3[:0])
 		h.HashBytes(h.bytes)
 	}
 }
@@ -891,9 +886,6 @@ func (h *hasher) IsDatumEqual(l, r tree.Datum) bool {
 	case *tree.DTime:
 		rt := r.(*tree.DTime)
 		return uint64(*lt) == uint64(*rt)
-	case *tree.DJSON:
-		rt := r.(*tree.DJSON)
-		return h.IsStringEqual(lt.String(), rt.String())
 	case *tree.DTuple:
 		rt := r.(*tree.DTuple)
 		// Compare datums and then compare static types if nulls or labels
@@ -915,8 +907,8 @@ func (h *hasher) IsDatumEqual(l, r tree.Datum) bool {
 		}
 		return len(lt.Array) != 0 || h.IsTypeEqual(ltyp, rtyp)
 	default:
-		h.bytes = encodeDatum(h.bytes[:0], l)
-		h.bytes2 = encodeDatum(h.bytes2[:0], r)
+		h.bytes, h.bytes3 = encodeDatum(h.bytes[:0], l, h.bytes3[:0])
+		h.bytes2, h.bytes3 = encodeDatum(h.bytes2[:0], r, h.bytes3[:0])
 		return bytes.Equal(h.bytes, h.bytes2)
 	}
 }
@@ -1374,7 +1366,7 @@ func (h *hasher) IsTransactionModesEqual(l, r tree.TransactionModes) bool {
 // Conversely, if two datums are not equivalent, then their encoded bytes will
 // differ. This will panic if the datum cannot be encoded.
 // Notice: DCollatedString does not encode its collation and won't work here.
-func encodeDatum(b []byte, val tree.Datum) []byte {
+func encodeDatum(b []byte, val tree.Datum, scratch []byte) (res []byte, newScratch []byte) {
 	var err error
 
 	// Fast path: encode the datum using table key encoding. This does not always
@@ -1384,13 +1376,13 @@ func encodeDatum(b []byte, val tree.Datum) []byte {
 	if !colinfo.CanHaveCompositeKeyEncoding(val.ResolvedType()) {
 		b, err = keyside.Encode(b, val, encoding.Ascending)
 		if err == nil {
-			return b
+			return b, newScratch
 		}
 	}
 
-	b, err = valueside.Encode(b, valueside.NoColumnID, val)
+	b, scratch, err = valueside.EncodeWithScratch(b, valueside.NoColumnID, val, scratch)
 	if err != nil {
 		panic(err)
 	}
-	return b
+	return b, scratch
 }

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -1388,7 +1388,7 @@ func encodeDatum(b []byte, val tree.Datum) []byte {
 		}
 	}
 
-	b, err = valueside.Encode(b, valueside.NoColumnID, val, nil /* scratch */)
+	b, err = valueside.Encode(b, valueside.NoColumnID, val)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/sql/opt/memo/interner_test.go
+++ b/pkg/sql/opt/memo/interner_test.go
@@ -1061,7 +1061,7 @@ func BenchmarkEncodeDatum(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, d := range datums {
-			encodeDatum(nil, d)
+			encodeDatum(nil, d, nil /* scratch */)
 		}
 	}
 }

--- a/pkg/sql/row/helper.go
+++ b/pkg/sql/row/helper.go
@@ -356,7 +356,7 @@ func (rh *RowHelper) encodePrimaryIndexValuesToBuf(
 		colIDDelta := valueside.MakeColumnIDDelta(lastColID, col.GetID())
 		lastColID = col.GetID()
 		var err error
-		buf, err = valueside.Encode(buf, colIDDelta, vals[idx], nil)
+		buf, err = valueside.Encode(buf, colIDDelta, vals[idx])
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/rowenc/encoded_datum.go
+++ b/pkg/sql/rowenc/encoded_datum.go
@@ -307,7 +307,7 @@ func (ed *EncDatum) Encode(
 	case catenumpb.DatumEncoding_DESCENDING_KEY:
 		return keyside.Encode(appendTo, ed.Datum, encoding.Descending)
 	case catenumpb.DatumEncoding_VALUE:
-		return valueside.Encode(appendTo, valueside.NoColumnID, ed.Datum, nil /* scratch */)
+		return valueside.Encode(appendTo, valueside.NoColumnID, ed.Datum)
 	default:
 		panic(errors.AssertionFailedf("unknown encoding requested %s", enc))
 	}
@@ -366,7 +366,7 @@ func (ed *EncDatum) Fingerprint(
 		}
 		// We must use value encodings without a column ID even if the EncDatum already
 		// is encoded with the value encoding so that the hashes are indeed unique.
-		fingerprint, err = valueside.Encode(appendTo, valueside.NoColumnID, ed.Datum, nil /* scratch */)
+		fingerprint, err = valueside.Encode(appendTo, valueside.NoColumnID, ed.Datum)
 	} else {
 		// For values that are key encodable, using the ascending key.
 		// Note that using a value encoding will not easily work in case when

--- a/pkg/sql/rowenc/encoded_datum_test.go
+++ b/pkg/sql/rowenc/encoded_datum_test.go
@@ -543,7 +543,7 @@ func TestValueEncodeDecodeTuple(t *testing.T) {
 		switch typedTest := test.(type) {
 		case *tree.DTuple:
 
-			buf, err := valueside.Encode(nil, valueside.NoColumnID, typedTest, nil)
+			buf, err := valueside.Encode(nil, valueside.NoColumnID, typedTest)
 			if err != nil {
 				t.Fatalf("seed %d: encoding tuple %v with types %v failed with error: %v",
 					seed, test, colTypes[i], err)

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -1583,7 +1583,7 @@ func writeColumnValues(
 		colIDDelta := valueside.MakeColumnIDDelta(lastColID, col.ColID)
 		lastColID = col.ColID
 		var err error
-		value, err = valueside.Encode(value, colIDDelta, val, nil)
+		value, err = valueside.Encode(value, colIDDelta, val)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/rowenc/valueside/array.go
+++ b/pkg/sql/rowenc/valueside/array.go
@@ -317,7 +317,8 @@ func encodeArrayElement(b []byte, d tree.Datum) ([]byte, error) {
 		}
 		return encoding.EncodeUntaggedBytesValue(b, encoded), nil
 	case *tree.DTuple:
-		return encodeUntaggedTuple(t, b, nil)
+		res, _, err := encodeUntaggedTuple(t, b, nil)
+		return res, err
 	case *tree.DTSQuery:
 		encoded := tsearch.EncodeTSQueryPGBinary(nil, t.TSQuery)
 		return encoding.EncodeUntaggedBytesValue(b, encoded), nil

--- a/pkg/sql/rowenc/valueside/array.go
+++ b/pkg/sql/rowenc/valueside/array.go
@@ -317,7 +317,7 @@ func encodeArrayElement(b []byte, d tree.Datum) ([]byte, error) {
 		}
 		return encoding.EncodeUntaggedBytesValue(b, encoded), nil
 	case *tree.DTuple:
-		return encodeUntaggedTuple(t, b, encoding.NoColumnID, nil)
+		return encodeUntaggedTuple(t, b, nil)
 	case *tree.DTSQuery:
 		encoded := tsearch.EncodeTSQueryPGBinary(nil, t.TSQuery)
 		return encoding.EncodeUntaggedBytesValue(b, encoded), nil

--- a/pkg/sql/rowenc/valueside/encode.go
+++ b/pkg/sql/rowenc/valueside/encode.go
@@ -29,7 +29,15 @@ import (
 // datum types (JSON, arrays, tuples).
 //
 // See also: docs/tech-notes/encoding.md, keyside.Encode().
-func Encode(appendTo []byte, colID ColumnIDDelta, val tree.Datum, scratch []byte) ([]byte, error) {
+func Encode(appendTo []byte, colID ColumnIDDelta, val tree.Datum) ([]byte, error) {
+	return EncodeWithScratch(appendTo, colID, val, nil /* scratch */)
+}
+
+// EncodeWithScratch is similar to Encode, but requires a scratch buffer that is
+// used as a temporary buffer for certain datum types (JSON, arrays, tuples).
+func EncodeWithScratch(
+	appendTo []byte, colID ColumnIDDelta, val tree.Datum, scratch []byte,
+) ([]byte, error) {
 	if val == tree.DNull {
 		return encoding.EncodeNullValue(appendTo, uint32(colID)), nil
 	}

--- a/pkg/sql/rowenc/valueside/encode.go
+++ b/pkg/sql/rowenc/valueside/encode.go
@@ -30,103 +30,110 @@ import (
 //
 // See also: docs/tech-notes/encoding.md, keyside.Encode().
 func Encode(appendTo []byte, colID ColumnIDDelta, val tree.Datum) ([]byte, error) {
-	return EncodeWithScratch(appendTo, colID, val, nil /* scratch */)
+	res, _, err := EncodeWithScratch(appendTo, colID, val, nil /* scratch */)
+	return res, err
 }
 
 // EncodeWithScratch is similar to Encode, but requires a scratch buffer that is
-// used as a temporary buffer for certain datum types (JSON, arrays, tuples).
+// used as a temporary buffer for certain datum types (JSON, arrays, tuples). It
+// may overwrite any existing values in the scratch buffer. If successful it
+// returns the encoded bytes and the scratch buffer, which allows reusing a
+// scratch buffer that has grown during encoding.
 func EncodeWithScratch(
 	appendTo []byte, colID ColumnIDDelta, val tree.Datum, scratch []byte,
-) ([]byte, error) {
+) (res []byte, newScratch []byte, err error) {
 	if val == tree.DNull {
-		return encoding.EncodeNullValue(appendTo, uint32(colID)), nil
+		return encoding.EncodeNullValue(appendTo, uint32(colID)), scratch, nil
 	}
 	switch t := tree.UnwrapDOidWrapper(val).(type) {
 	case *tree.DBitArray:
-		return encoding.EncodeBitArrayValue(appendTo, uint32(colID), t.BitArray), nil
+		return encoding.EncodeBitArrayValue(appendTo, uint32(colID), t.BitArray), scratch, nil
 	case *tree.DBool:
-		return encoding.EncodeBoolValue(appendTo, uint32(colID), bool(*t)), nil
+		return encoding.EncodeBoolValue(appendTo, uint32(colID), bool(*t)), scratch, nil
 	case *tree.DInt:
-		return encoding.EncodeIntValue(appendTo, uint32(colID), int64(*t)), nil
+		return encoding.EncodeIntValue(appendTo, uint32(colID), int64(*t)), scratch, nil
 	case *tree.DFloat:
-		return encoding.EncodeFloatValue(appendTo, uint32(colID), float64(*t)), nil
+		return encoding.EncodeFloatValue(appendTo, uint32(colID), float64(*t)), scratch, nil
 	case *tree.DDecimal:
-		return encoding.EncodeDecimalValue(appendTo, uint32(colID), &t.Decimal), nil
+		return encoding.EncodeDecimalValue(appendTo, uint32(colID), &t.Decimal), scratch, nil
 	case *tree.DString:
-		return encoding.EncodeBytesValue(appendTo, uint32(colID), t.UnsafeBytes()), nil
+		return encoding.EncodeBytesValue(appendTo, uint32(colID), t.UnsafeBytes()), scratch, nil
 	case *tree.DBytes:
-		return encoding.EncodeBytesValue(appendTo, uint32(colID), t.UnsafeBytes()), nil
+		return encoding.EncodeBytesValue(appendTo, uint32(colID), t.UnsafeBytes()), scratch, nil
 	case *tree.DEncodedKey:
-		return encoding.EncodeBytesValue(appendTo, uint32(colID), t.UnsafeBytes()), nil
+		return encoding.EncodeBytesValue(appendTo, uint32(colID), t.UnsafeBytes()), scratch, nil
 	case *tree.DDate:
-		return encoding.EncodeIntValue(appendTo, uint32(colID), t.UnixEpochDaysWithOrig()), nil
+		return encoding.EncodeIntValue(appendTo, uint32(colID), t.UnixEpochDaysWithOrig()), scratch, nil
 	case *tree.DPGLSN:
-		return encoding.EncodeIntValue(appendTo, uint32(colID), int64(t.LSN)), nil
+		return encoding.EncodeIntValue(appendTo, uint32(colID), int64(t.LSN)), scratch, nil
 	case *tree.DBox2D:
-		return encoding.EncodeBox2DValue(appendTo, uint32(colID), t.CartesianBoundingBox.BoundingBox)
+		res, err = encoding.EncodeBox2DValue(appendTo, uint32(colID), t.CartesianBoundingBox.BoundingBox)
+		return res, scratch, err
 	case *tree.DGeography:
-		return encoding.EncodeGeoValue(appendTo, uint32(colID), t.SpatialObjectRef())
+		res, err = encoding.EncodeGeoValue(appendTo, uint32(colID), t.SpatialObjectRef())
+		return res, scratch, err
 	case *tree.DGeometry:
-		return encoding.EncodeGeoValue(appendTo, uint32(colID), t.SpatialObjectRef())
+		res, err = encoding.EncodeGeoValue(appendTo, uint32(colID), t.SpatialObjectRef())
+		return res, scratch, err
 	case *tree.DTime:
-		return encoding.EncodeIntValue(appendTo, uint32(colID), int64(*t)), nil
+		return encoding.EncodeIntValue(appendTo, uint32(colID), int64(*t)), scratch, nil
 	case *tree.DTimeTZ:
-		return encoding.EncodeTimeTZValue(appendTo, uint32(colID), t.TimeTZ), nil
+		return encoding.EncodeTimeTZValue(appendTo, uint32(colID), t.TimeTZ), scratch, nil
 	case *tree.DTimestamp:
-		return encoding.EncodeTimeValue(appendTo, uint32(colID), t.Time), nil
+		return encoding.EncodeTimeValue(appendTo, uint32(colID), t.Time), scratch, nil
 	case *tree.DTimestampTZ:
-		return encoding.EncodeTimeValue(appendTo, uint32(colID), t.Time), nil
+		return encoding.EncodeTimeValue(appendTo, uint32(colID), t.Time), scratch, nil
 	case *tree.DInterval:
-		return encoding.EncodeDurationValue(appendTo, uint32(colID), t.Duration), nil
+		return encoding.EncodeDurationValue(appendTo, uint32(colID), t.Duration), scratch, nil
 	case *tree.DUuid:
-		return encoding.EncodeUUIDValue(appendTo, uint32(colID), t.UUID), nil
+		return encoding.EncodeUUIDValue(appendTo, uint32(colID), t.UUID), scratch, nil
 	case *tree.DIPAddr:
-		return encoding.EncodeIPAddrValue(appendTo, uint32(colID), t.IPAddr), nil
+		return encoding.EncodeIPAddrValue(appendTo, uint32(colID), t.IPAddr), scratch, nil
 	case *tree.DJSON:
-		encoded, err := json.EncodeJSON(scratch, t.JSON)
+		scratch, err = json.EncodeJSON(scratch[:0], t.JSON)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return encoding.EncodeJSONValue(appendTo, uint32(colID), encoded), nil
+		return encoding.EncodeJSONValue(appendTo, uint32(colID), scratch), scratch, nil
 	case *tree.DTSQuery:
-		encoded, err := tsearch.EncodeTSQuery(scratch, t.TSQuery)
+		scratch, err = tsearch.EncodeTSQuery(scratch[:0], t.TSQuery)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return encoding.EncodeTSQueryValue(appendTo, uint32(colID), encoded), nil
+		return encoding.EncodeTSQueryValue(appendTo, uint32(colID), scratch), scratch, nil
 	case *tree.DTSVector:
-		encoded, err := tsearch.EncodeTSVector(scratch, t.TSVector)
+		scratch, err = tsearch.EncodeTSVector(scratch[:0], t.TSVector)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return encoding.EncodeTSVectorValue(appendTo, uint32(colID), encoded), nil
+		return encoding.EncodeTSVectorValue(appendTo, uint32(colID), scratch), scratch, nil
 	case *tree.DPGVector:
-		encoded, err := vector.Encode(scratch, t.T)
+		scratch, err = vector.Encode(scratch[:0], t.T)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return encoding.EncodePGVectorValue(appendTo, uint32(colID), encoded), nil
+		return encoding.EncodePGVectorValue(appendTo, uint32(colID), scratch), scratch, nil
 	case *tree.DArray:
-		a, err := encodeArray(t, scratch)
+		scratch, err = encodeArray(t, scratch[:0])
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return encoding.EncodeArrayValue(appendTo, uint32(colID), a), nil
+		return encoding.EncodeArrayValue(appendTo, uint32(colID), scratch), scratch, nil
 	case *tree.DTuple:
-		return encodeTuple(t, appendTo, uint32(colID), scratch)
+		return encodeTuple(t, appendTo, uint32(colID), scratch[:0])
 	case *tree.DCollatedString:
-		return encoding.EncodeBytesValue(appendTo, uint32(colID), t.UnsafeContentBytes()), nil
+		return encoding.EncodeBytesValue(appendTo, uint32(colID), t.UnsafeContentBytes()), scratch, nil
 	case *tree.DOid:
-		return encoding.EncodeIntValue(appendTo, uint32(colID), int64(t.Oid)), nil
+		return encoding.EncodeIntValue(appendTo, uint32(colID), int64(t.Oid)), scratch, nil
 	case *tree.DEnum:
-		return encoding.EncodeBytesValue(appendTo, uint32(colID), t.PhysicalRep), nil
+		return encoding.EncodeBytesValue(appendTo, uint32(colID), t.PhysicalRep), scratch, nil
 	case *tree.DVoid:
-		return encoding.EncodeVoidValue(appendTo, uint32(colID)), nil
+		return encoding.EncodeVoidValue(appendTo, uint32(colID)), scratch, nil
 	default:
 		if buildutil.CrdbTestBuild {
-			return nil, errors.AssertionFailedf("unable to encode table value: %T", t)
+			return nil, nil, errors.AssertionFailedf("unable to encode table value: %T", t)
 		}
-		return nil, errors.Errorf("unable to encode table value: %T", t)
+		return nil, nil, errors.Errorf("unable to encode table value: %T", t)
 	}
 }
 

--- a/pkg/sql/rowenc/valueside/legacy.go
+++ b/pkg/sql/rowenc/valueside/legacy.go
@@ -187,7 +187,7 @@ func MarshalLegacy(colType *types.T, val tree.Datum) (roachpb.Value, error) {
 		}
 	case types.TupleFamily:
 		if v, ok := val.(*tree.DTuple); ok {
-			b, err := encodeUntaggedTuple(v, nil /* appendTo */, 0 /* colID */, nil /* scratch */)
+			b, err := encodeUntaggedTuple(v, nil /* appendTo */, nil /* scratch */)
 			if err != nil {
 				return r, err
 			}

--- a/pkg/sql/rowenc/valueside/legacy.go
+++ b/pkg/sql/rowenc/valueside/legacy.go
@@ -187,7 +187,7 @@ func MarshalLegacy(colType *types.T, val tree.Datum) (roachpb.Value, error) {
 		}
 	case types.TupleFamily:
 		if v, ok := val.(*tree.DTuple); ok {
-			b, err := encodeUntaggedTuple(v, nil /* appendTo */, nil /* scratch */)
+			b, _, err := encodeUntaggedTuple(v, nil /* appendTo */, nil /* scratch */)
 			if err != nil {
 				return r, err
 			}

--- a/pkg/sql/rowenc/valueside/tuple.go
+++ b/pkg/sql/rowenc/valueside/tuple.go
@@ -14,13 +14,11 @@ import (
 // encodeTuple produces the value encoding for a tuple.
 func encodeTuple(t *tree.DTuple, appendTo []byte, colID uint32, scratch []byte) ([]byte, error) {
 	appendTo = encoding.EncodeValueTag(appendTo, colID, encoding.Tuple)
-	return encodeUntaggedTuple(t, appendTo, colID, scratch)
+	return encodeUntaggedTuple(t, appendTo, scratch)
 }
 
 // encodeUntaggedTuple produces the value encoding for a tuple without a value tag.
-func encodeUntaggedTuple(
-	t *tree.DTuple, appendTo []byte, colID uint32, scratch []byte,
-) ([]byte, error) {
+func encodeUntaggedTuple(t *tree.DTuple, appendTo []byte, scratch []byte) ([]byte, error) {
 	appendTo = encoding.EncodeNonsortingUvarint(appendTo, uint64(len(t.D)))
 
 	var err error

--- a/pkg/sql/rowenc/valueside/tuple.go
+++ b/pkg/sql/rowenc/valueside/tuple.go
@@ -12,23 +12,25 @@ import (
 )
 
 // encodeTuple produces the value encoding for a tuple.
-func encodeTuple(t *tree.DTuple, appendTo []byte, colID uint32, scratch []byte) ([]byte, error) {
+func encodeTuple(
+	t *tree.DTuple, appendTo []byte, colID uint32, scratch []byte,
+) (_, newScratch []byte, err error) {
 	appendTo = encoding.EncodeValueTag(appendTo, colID, encoding.Tuple)
 	return encodeUntaggedTuple(t, appendTo, scratch)
 }
 
 // encodeUntaggedTuple produces the value encoding for a tuple without a value tag.
-func encodeUntaggedTuple(t *tree.DTuple, appendTo []byte, scratch []byte) ([]byte, error) {
+func encodeUntaggedTuple(
+	t *tree.DTuple, appendTo []byte, scratch []byte,
+) (_, newScratch []byte, err error) {
 	appendTo = encoding.EncodeNonsortingUvarint(appendTo, uint64(len(t.D)))
-
-	var err error
 	for _, dd := range t.D {
-		appendTo, err = EncodeWithScratch(appendTo, NoColumnID, dd, scratch)
+		appendTo, scratch, err = EncodeWithScratch(appendTo, NoColumnID, dd, scratch[:0])
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
-	return appendTo, nil
+	return appendTo, scratch, nil
 }
 
 // decodeTuple decodes a tuple from its value encoding. It is the

--- a/pkg/sql/rowenc/valueside/tuple.go
+++ b/pkg/sql/rowenc/valueside/tuple.go
@@ -23,7 +23,7 @@ func encodeUntaggedTuple(t *tree.DTuple, appendTo []byte, scratch []byte) ([]byt
 
 	var err error
 	for _, dd := range t.D {
-		appendTo, err = Encode(appendTo, NoColumnID, dd, scratch)
+		appendTo, err = EncodeWithScratch(appendTo, NoColumnID, dd, scratch)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/rowenc/valueside/valueside_test.go
+++ b/pkg/sql/rowenc/valueside/valueside_test.go
@@ -38,7 +38,7 @@ func TestEncodeDecode(t *testing.T) {
 	var scratch []byte
 	properties.Property("roundtrip", prop.ForAll(
 		func(d tree.Datum) string {
-			b, err := valueside.Encode(nil, 0, d, scratch)
+			b, err := valueside.EncodeWithScratch(nil, 0, d, scratch)
 			if err != nil {
 				return "error: " + err.Error()
 			}
@@ -78,8 +78,8 @@ func TestDecode(t *testing.T) {
 		{tree.DBoolTrue, types.Int, "decoding failed"},
 	} {
 		t.Run("", func(t *testing.T) {
-			var prefix, scratch []byte
-			buf, err := valueside.Encode(prefix, 0 /* colID */, tc.in, scratch)
+			var prefix []byte
+			buf, err := valueside.Encode(prefix, 0 /* colID */, tc.in)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -108,7 +108,7 @@ func TestDecodeTableValueOutOfRangeTimestamp(t *testing.T) {
 	} {
 		t.Run(d.String(), func(t *testing.T) {
 			var b []byte
-			encoded, err := valueside.Encode(b, 1 /* colID */, d, []byte{})
+			encoded, err := valueside.Encode(b, 1 /* colID */, d)
 			require.NoError(t, err)
 			a := &tree.DatumAlloc{}
 			decoded, _, err := valueside.Decode(a, d.ResolvedType(), encoded)
@@ -123,7 +123,7 @@ func TestDecodeTableValueOutOfRangeTimestamp(t *testing.T) {
 func TestDecodeTupleValueWithType(t *testing.T) {
 	tupleType := types.MakeLabeledTuple([]*types.T{types.Int, types.String}, []string{"a", "b"})
 	datum := tree.NewDTuple(tupleType, tree.NewDInt(tree.DInt(1)), tree.NewDString("foo"))
-	buf, err := valueside.Encode(nil, valueside.NoColumnID, datum, nil)
+	buf, err := valueside.Encode(nil, valueside.NoColumnID, datum)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/rowenc/valueside/valueside_test.go
+++ b/pkg/sql/rowenc/valueside/valueside_test.go
@@ -38,7 +38,11 @@ func TestEncodeDecode(t *testing.T) {
 	var scratch []byte
 	properties.Property("roundtrip", prop.ForAll(
 		func(d tree.Datum) string {
-			b, err := valueside.EncodeWithScratch(nil, 0, d, scratch)
+			var (
+				b   []byte
+				err error
+			)
+			b, scratch, err = valueside.EncodeWithScratch(nil, 0, d, scratch[:0])
 			if err != nil {
 				return "error: " + err.Error()
 			}

--- a/pkg/sql/scrub_test.go
+++ b/pkg/sql/scrub_test.go
@@ -487,7 +487,7 @@ INSERT INTO t.test VALUES (10, 2);
 	values = []tree.Datum{tree.NewDInt(10), tree.NewDInt(0)}
 	// Encode the column value.
 	valueBuf, err := valueside.Encode(
-		[]byte(nil), valueside.MakeColumnIDDelta(0, tableDesc.PublicColumns()[1].GetID()), values[1], []byte(nil))
+		[]byte(nil), valueside.MakeColumnIDDelta(0, tableDesc.PublicColumns()[1].GetID()), values[1])
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -2043,7 +2043,7 @@ var pgBuiltins = map[string]builtinDefinition{
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				var totalSize int
 				for _, arg := range args {
-					encodeTableValue, err := valueside.Encode(nil, valueside.NoColumnID, arg, nil)
+					encodeTableValue, err := valueside.Encode(nil, valueside.NoColumnID, arg)
 					if err != nil {
 						return tree.DNull, err
 					}

--- a/pkg/sql/sqlinstance/instancestorage/row_codec.go
+++ b/pkg/sql/sqlinstance/instancestorage/row_codec.go
@@ -261,7 +261,7 @@ func (d *rowCodec) encodeValue(
 			prev = d.valueColumnIDs[i-1]
 		}
 		delta := valueside.MakeColumnIDDelta(prev, d.valueColumnIDs[i])
-		if valueBuf, err = valueside.Encode(valueBuf, delta, f(), nil); err != nil {
+		if valueBuf, err = valueside.Encode(valueBuf, delta, f()); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/sql/stats/histogram.go
+++ b/pkg/sql/stats/histogram.go
@@ -117,7 +117,7 @@ const upperBoundsKeyEncodedVersion = HistogramVersion(2)
 func EncodeUpperBound(version HistogramVersion, upperBound tree.Datum) ([]byte, error) {
 	if version >= upperBoundsValueEncodedVersion || upperBound.ResolvedType().Family() == types.TSQueryFamily {
 		// TSQuery doesn't have key-encoding, so we must use value-encoding.
-		return valueside.Encode(nil /* appendTo */, valueside.NoColumnID, upperBound, nil /* scratch */)
+		return valueside.Encode(nil /* appendTo */, valueside.NoColumnID, upperBound)
 	}
 	return keyside.Encode(nil /* b */, upperBound, encoding.Ascending)
 }


### PR DESCRIPTION
#### opt/bench: add case for INSERT with columns computed from JSON

Release note: None

#### sql/rowenc/valueside: remove unused `colID` param in `encodeUntaggedTuple`

Release note: None

#### sql/rowenc/valueside: introduce `EncodeWithScratch`

The `Encode` function has been split into two functions: `Encode` and
`EncodeWithScratch`. They are the same except that the latter accepts a
scratch buffer that is used to encode certain data types. This was
previously allowed in `Encode`. Splitting up the two functions allows
for easier and safer refactoring in future commits.

Release note: None

#### sql/rowenc/valueside: correctly reuse scratch buffer in `EncodeWithScratch`

`EncodeWithScratch` now returns a new scratch buffer, which may have
grown during encoding. Previously, it was impossible to reuse
allocations that grew the scratch slice. `EncodeWithScratch` call sites
have been refactored to correctly reuse the returned scratch slice.

Release note: None

#### opt/memo/interner: use valueside encoding to hash JSON values

Value-side encoding is now used to hash `tree.DJSON` datums in the
interner, which reduces allocations. A third scratch slice has been
added to the interner that is used for this encoding, which helps reduce
allocations further.

Epic: None

Release note: None
