### PR TITLE
release-24.2: changefeedccl: add PTS to system.users

### DIFF
--- a/pkg/ccl/changefeedccl/protected_timestamps.go
+++ b/pkg/ccl/changefeedccl/protected_timestamps.go
@@ -48,7 +48,8 @@ var systemTablesToProtect = []descpb.ID{
 	keys.ZonesTableID,
 	// Required for CDC Queries.
 	keys.RoleMembersTableID,
-	// TODO(#128806): identify and add any more required tables (such as, possibly, `keys.UsersTableID`)
+	keys.UsersTableID,
+	// TODO(#128806, #133566): identify and add any more required tables
 }
 
 func makeTargetToProtect(targets changefeedbase.Targets) *ptpb.Target {

--- a/pkg/upgrade/upgrades/v24_1_migrate_pts_records_test.go
+++ b/pkg/upgrade/upgrades/v24_1_migrate_pts_records_test.go
@@ -85,6 +85,7 @@ func TestMigrateOldStlePTSRecords(t *testing.T) {
 		)
 		allTargets = append(allTargets, []catid.DescID{
 			keys.DescriptorTableID,
+			keys.UsersTableID,
 			keys.ZonesTableID,
 			keys.RoleMembersTableID,
 			keys.CommentsTableID,
@@ -96,6 +97,7 @@ func TestMigrateOldStlePTSRecords(t *testing.T) {
 	require.NoError(t, err)
 	descIDsArr = append(descIDsArr,
 		keys.DescriptorTableID,
+		keys.UsersTableID,
 		keys.ZonesTableID,
 		keys.RoleMembersTableID,
 		keys.CommentsTableID)
@@ -150,5 +152,5 @@ func TestMigrateOldStlePTSRecords(t *testing.T) {
 		return a[len(a)-1] < b[len(b)-1]
 	})
 
-	require.Equal(t, allTargets, seenTargets)
+	require.ElementsMatch(t, allTargets, seenTargets)
 }


### PR DESCRIPTION
Backport 1/1 commits from #133568.

/cc @cockroachdb/release

Release justification: bug fix

---

Add `system.users` to the list of system tables
that changefeeds protect with PTS. This table is
required for CDC Queries.

Part of: #128806

Release note (enterprise change): Add
`system.users` to the list of system tables that
changefeeds protect with PTS. This table is
required for CDC Queries.

