### PR TITLE
release-23.2: changefeedccl: don't log error on context cancel

### DIFF
--- a/pkg/ccl/changefeedccl/batching_sink.go
+++ b/pkg/ccl/changefeedccl/batching_sink.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 )
 
 // SinkClient is an interface to an external sink, where messages are written
@@ -429,7 +430,7 @@ func (s *batchingSink) runBatchingWorker(ctx context.Context) {
 		select {
 		case req := <-s.eventCh:
 			if err := s.pacer.Pace(ctx); err != nil {
-				if pacerLogEvery.ShouldLog() {
+				if !errors.Is(err, context.Canceled) && pacerLogEvery.ShouldLog() {
 					log.Errorf(ctx, "automatic sink batcher pacing: %v", err)
 				}
 			}


### PR DESCRIPTION
Logging an error on context cancel on shutdown can cause a use-after-closed tracing span error. Fix
an instance of this.

Fixes: #128868

Release note: None

Release justification: fix test failure.