### PR TITLE
roachtest: use system only for ac mixed-version roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_elastic_mixed_version.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_mixed_version.go
@@ -52,10 +52,7 @@ func registerElasticWorkloadMixedVersion(r registry.Registry) {
 				mixedversion.ClusterSettingOption(
 					install.ClusterSettingsOption(settings.ClusterSettings),
 				),
-				mixedversion.EnabledDeploymentModes(
-					mixedversion.SystemOnlyDeployment,
-					mixedversion.SharedProcessDeployment,
-				),
+				mixedversion.EnabledDeploymentModes(mixedversion.SystemOnlyDeployment),
 				mixedversion.AlwaysUseLatestPredecessors,
 				// Don't go back too far. We are mostly interested in upgrading to v24.3
 				// where RACv2 was introduced.


### PR DESCRIPTION
`admission-control/elastic-workload/mixed-version` collects metrics to assert on for token return. In shared process multi-tenancy, not all metrics required will be available, depending on the tenant used.

Only run this mixed-version test in `SystemOnlyDeployment` for now.

Fixes: #134489
Release note: None