### PR TITLE
crosscluster/physical: avoiding copying SSTWriter

### DIFF
--- a/pkg/ccl/crosscluster/physical/stream_ingestion_processor.go
+++ b/pkg/ccl/crosscluster/physical/stream_ingestion_processor.go
@@ -1118,7 +1118,7 @@ func splitRangeKeySSTAtKey(
 		// we'll swap in the RHS writer.
 		leftWriter  = storage.MakeIngestionSSTWriter(ctx, st, left)
 		rightWriter = storage.MakeIngestionSSTWriter(ctx, st, right)
-		writer      = leftWriter
+		writer      = &leftWriter
 	)
 	defer leftWriter.Close()
 	defer rightWriter.Close()
@@ -1132,7 +1132,7 @@ func splitRangeKeySSTAtKey(
 		}
 
 		leftRet = &rangeKeySST{start: first, end: last, data: left.Data()}
-		writer = rightWriter
+		writer = &rightWriter
 		last = nil
 		first = nil
 		reachedSplit = true


### PR DESCRIPTION
Previously splitRangeKeySSTAtKey would copy SSTWriter structs, calling Finish on the copied struct. This copying of structs prevents SSTWriter's protection against double-Closing the underlying Writer.

Epic: none
Release note: none