### PR TITLE
admission: per-store work queue metrics

### DIFF
--- a/pkg/kv/kvserver/stores.go
+++ b/pkg/kv/kvserver/stores.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/limit"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
@@ -325,4 +326,12 @@ func (ls *Stores) CloseDiskMonitors() {
 		}
 		return nil
 	})
+}
+
+// GetStoreMetricRegistry returns the metric registry of the provided store ID.
+func (ls *Stores) GetStoreMetricRegistry(storeID roachpb.StoreID) *metric.Registry {
+	if s, ok := ls.storeMap.Load(storeID); ok {
+		return s.Registry()
+	}
+	return nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1954,6 +1954,10 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 		return errors.Wrapf(err, "failed to register engines for the disk stats map")
 	}
 
+	// Set up a store metrics registry provider to register AC store-level
+	// metrics.
+	mrp := s.node.makeStoreRegistryProvider()
+
 	// Stores have been initialized, so Node can now provide Pebble metrics.
 	//
 	// Note that all existing stores will be operational before Pebble-level
@@ -1962,7 +1966,7 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 	// existing stores shouldn’t be able to acquire leases yet. Although, below
 	// Raft commands like log application and snapshot application may be able
 	// to bypass admission control.
-	s.storeGrantCoords.SetPebbleMetricsProvider(ctx, pmp, s.node)
+	s.storeGrantCoords.SetPebbleMetricsProvider(ctx, pmp, mrp, s.node)
 
 	// Once all stores are initialized, check if offline storage recovery
 	// was done prior to start and record any actions appropriately.

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
@@ -9,11 +9,8 @@ import React from "react";
 import LineGraph from "src/views/cluster/components/linegraph";
 import { Metric, Axis } from "src/views/shared/components/metricQuery";
 
-import {
-  GraphDashboardProps,
-  nodeDisplayName,
-  storeIDsForNode,
-} from "./dashboardUtils";
+import { GraphDashboardProps, nodeDisplayName } from "./dashboardUtils";
+import { storeMetrics } from "./storeUtils";
 
 export default function (props: GraphDashboardProps) {
   const {
@@ -66,36 +63,32 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Admission IO Tokens Exhausted Duration Per Second"
-      sources={nodeSources}
+      sources={storeSources}
       tenantSource={tenantSource}
       showMetricsInTooltip={true}
       tooltip={`Relative time the node had exhausted IO tokens for all IO-bound work per second of wall time, measured in microseconds/second. Increased IO token exhausted duration indicates IO resource exhaustion.`}
     >
       <Axis label="Duration (micros/sec)">
-        {nodeIDs.map(nid => (
-          <>
-            <Metric
-              key={nid}
-              name="cr.node.admission.granter.io_tokens_exhausted_duration.kv"
-              title={
-                "Regular (Foreground) " +
-                nodeDisplayName(nodeDisplayNameByID, nid)
-              }
-              sources={[nid]}
-              nonNegativeRate
-            />
-            <Metric
-              key={nid}
-              name="cr.node.admission.granter.elastic_io_tokens_exhausted_duration.kv"
-              title={
-                "Elastic (Background) " +
-                nodeDisplayName(nodeDisplayNameByID, nid)
-              }
-              sources={[nid]}
-              nonNegativeRate
-            />
-          </>
-        ))}
+        {storeMetrics(
+          {
+            name: "cr.store.admission.granter.io_tokens_exhausted_duration.kv",
+            nonNegativeRate: true,
+            aggregateMax: true,
+          },
+          nodeIDs,
+          storeIDsByNodeID,
+          "regular (foreground)",
+        )}
+        {storeMetrics(
+          {
+            name: "cr.store.admission.granter.elastic_io_tokens_exhausted_duration.kv",
+            nonNegativeRate: true,
+            aggregateMax: true,
+          },
+          nodeIDs,
+          storeIDsByNodeID,
+          "elastic (background)",
+        )}
       </Axis>
     </LineGraph>,
 
@@ -107,16 +100,14 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
     >
       <Axis label="Score">
-        {nodeIDs.map(nid => (
-          <>
-            <Metric
-              key={nid}
-              name="cr.store.admission.io.overload"
-              title={nodeDisplayName(nodeDisplayNameByID, nid)}
-              sources={storeIDsForNode(storeIDsByNodeID, nid)}
-            />
-          </>
-        ))}
+        {storeMetrics(
+          {
+            name: "cr.store.admission.io.overload",
+            aggregateMax: true,
+          },
+          nodeIDs,
+          storeIDsByNodeID,
+        )}
       </Axis>
     </LineGraph>,
 
@@ -178,30 +169,30 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph
       title="Admission Queueing Delay p99 – Store"
-      sources={nodeSources}
+      sources={storeSources}
       tenantSource={tenantSource}
       showMetricsInTooltip={true}
       tooltip={`The 99th percentile latency of requests waiting in the Admission Control store queue.`}
     >
       <Axis units={AxisUnits.Duration} label="Write Delay Duration">
-        {nodeIDs.map(nid => (
-          <>
-            <Metric
-              key={nid}
-              name="cr.node.admission.wait_durations.kv-stores-p99"
-              title={"KV " + nodeDisplayName(nodeDisplayNameByID, nid)}
-              sources={[nid]}
-              downsampleMax
-            />
-            <Metric
-              key={nid}
-              name="cr.node.admission.wait_durations.elastic-stores-p99"
-              title={"Elastic " + nodeDisplayName(nodeDisplayNameByID, nid)}
-              sources={[nid]}
-              downsampleMax
-            />
-          </>
-        ))}
+        {storeMetrics(
+          {
+            name: "cr.store.admission.wait_durations.kv-stores-p99",
+            aggregateMax: true,
+          },
+          nodeIDs,
+          storeIDsByNodeID,
+          "KV",
+        )}
+        {storeMetrics(
+          {
+            name: "cr.store.admission.wait_durations.elastic-stores-p99",
+            aggregateMax: true,
+          },
+          nodeIDs,
+          storeIDsByNodeID,
+          "elastic",
+        )}
       </Axis>
     </LineGraph>,
 
@@ -420,16 +411,14 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
     >
       <Axis label="Count">
-        {nodeIDs.map(nid => (
-          <>
-            <Metric
-              key={nid}
-              name="cr.store.storage.l0-sublevels"
-              title={nodeDisplayName(nodeDisplayNameByID, nid)}
-              sources={storeIDsForNode(storeIDsByNodeID, nid)}
-            />
-          </>
-        ))}
+        {storeMetrics(
+          {
+            name: "cr.store.storage.l0-sublevels",
+            aggregateMax: true,
+          },
+          nodeIDs,
+          storeIDsByNodeID,
+        )}
       </Axis>
     </LineGraph>,
   ];

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -12,17 +12,14 @@ import {
   CapacityGraphTooltip,
   LiveBytesGraphTooltip,
 } from "src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips";
-import {
-  Metric,
-  Axis,
-  MetricProps,
-} from "src/views/shared/components/metricQuery";
+import { Metric, Axis } from "src/views/shared/components/metricQuery";
 
 import {
   GraphDashboardProps,
   nodeDisplayName,
   storeIDsForNode,
 } from "./dashboardUtils";
+import { storeMetrics } from "./storeUtils";
 
 export default function (props: GraphDashboardProps) {
   const {
@@ -37,51 +34,6 @@ export default function (props: GraphDashboardProps) {
 
   const getNodeNameById = (id: string) =>
     nodeDisplayName(nodeDisplayNameByID, id);
-
-  /**
-   * Dynamically shows either the aggregated node-level metric when viewing the
-   * cluster-level dashboard, or store-level metrics when viewing a single node.
-   */
-  const storeMetrics = (props: MetricProps) =>
-    nodeIDs.flatMap(nid => {
-      const storeIDs = storeIDsForNode(storeIDsByNodeID, nid);
-
-      let aggregateType = "total";
-      if (props.aggregateAvg) {
-        aggregateType = "average";
-      } else if (props.aggregateMax) {
-        aggregateType = "max";
-      } else if (props.aggregateMin) {
-        aggregateType = "min";
-      }
-
-      const nodeMetric = (
-        <Metric
-          key={nid}
-          title={`n${nid},${aggregateType}`}
-          sources={storeIDs}
-          {...props}
-        />
-      );
-
-      // show only the aggregated node-level metric when viewing multiple nodes
-      if (nodeIDs.length > 1) {
-        return nodeMetric;
-      }
-
-      // otherwise, show the aggregated metric and a per-store breakdown
-      return [
-        nodeMetric,
-        ...storeIDs.map(sid => (
-          <Metric
-            key={`${nid}-${sid}`}
-            title={`n${nid},s${sid}`}
-            sources={[sid]}
-            {...props}
-          />
-        )),
-      ];
-    });
 
   return [
     <LineGraph
@@ -160,10 +112,14 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
-        {storeMetrics({
-          name: "cr.store.raft.process.logcommit.latency-p99",
-          aggregateMax: true,
-        })}
+        {storeMetrics(
+          {
+            name: "cr.store.raft.process.logcommit.latency-p99",
+            aggregateMax: true,
+          },
+          nodeIDs,
+          storeIDsByNodeID,
+        )}
       </Axis>
     </LineGraph>,
 
@@ -177,10 +133,14 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
-        {storeMetrics({
-          name: "cr.store.raft.process.logcommit.latency-p50",
-          aggregateMax: true,
-        })}
+        {storeMetrics(
+          {
+            name: "cr.store.raft.process.logcommit.latency-p50",
+            aggregateMax: true,
+          },
+          nodeIDs,
+          storeIDsByNodeID,
+        )}
       </Axis>
     </LineGraph>,
 
@@ -195,10 +155,14 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
-        {storeMetrics({
-          name: "cr.store.raft.process.commandcommit.latency-p99",
-          aggregateMax: true,
-        })}
+        {storeMetrics(
+          {
+            name: "cr.store.raft.process.commandcommit.latency-p99",
+            aggregateMax: true,
+          },
+          nodeIDs,
+          storeIDsByNodeID,
+        )}
       </Axis>
     </LineGraph>,
 
@@ -213,10 +177,14 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Duration} label="latency">
-        {storeMetrics({
-          name: "cr.store.raft.process.commandcommit.latency-p50",
-          aggregateMax: true,
-        })}
+        {storeMetrics(
+          {
+            name: "cr.store.raft.process.commandcommit.latency-p50",
+            aggregateMax: true,
+          },
+          nodeIDs,
+          storeIDsByNodeID,
+        )}
       </Axis>
     </LineGraph>,
 
@@ -230,10 +198,14 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
     >
       <Axis label="factor">
-        {storeMetrics({
-          name: "cr.store.rocksdb.read-amplification",
-          aggregateAvg: true,
-        })}
+        {storeMetrics(
+          {
+            name: "cr.store.rocksdb.read-amplification",
+            aggregateAvg: true,
+          },
+          nodeIDs,
+          storeIDsByNodeID,
+        )}
       </Axis>
     </LineGraph>,
 
@@ -246,7 +218,11 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
     >
       <Axis label="sstables">
-        {storeMetrics({ name: "cr.store.rocksdb.num-sstables" })}
+        {storeMetrics(
+          { name: "cr.store.rocksdb.num-sstables" },
+          nodeIDs,
+          storeIDsByNodeID,
+        )}
       </Axis>
     </LineGraph>,
 
@@ -259,7 +235,11 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
     >
       <Axis label="sstables">
-        {storeMetrics({ name: "cr.store.storage.l0-num-files" })}
+        {storeMetrics(
+          { name: "cr.store.storage.l0-num-files" },
+          nodeIDs,
+          storeIDsByNodeID,
+        )}
       </Axis>
     </LineGraph>,
 
@@ -272,7 +252,11 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
     >
       <Axis label="Size" units={AxisUnits.Bytes}>
-        {storeMetrics({ name: "cr.store.storage.l0-level-size" })}
+        {storeMetrics(
+          { name: "cr.store.storage.l0-level-size" },
+          nodeIDs,
+          storeIDsByNodeID,
+        )}
       </Axis>
     </LineGraph>,
 
@@ -300,10 +284,14 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Bytes} label="written bytes">
-        {storeMetrics({
-          name: "cr.store.rocksdb.flushed-bytes",
-          nonNegativeRate: true,
-        })}
+        {storeMetrics(
+          {
+            name: "cr.store.rocksdb.flushed-bytes",
+            nonNegativeRate: true,
+          },
+          nodeIDs,
+          storeIDsByNodeID,
+        )}
       </Axis>
     </LineGraph>,
 
@@ -316,10 +304,14 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Bytes} label="written bytes">
-        {storeMetrics({
-          name: "cr.store.storage.wal.bytes_written",
-          nonNegativeRate: true,
-        })}
+        {storeMetrics(
+          {
+            name: "cr.store.storage.wal.bytes_written",
+            nonNegativeRate: true,
+          },
+          nodeIDs,
+          storeIDsByNodeID,
+        )}
       </Axis>
     </LineGraph>,
 
@@ -332,10 +324,14 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Bytes} label="written bytes">
-        {storeMetrics({
-          name: "cr.store.rocksdb.compacted-bytes-written",
-          nonNegativeRate: true,
-        })}
+        {storeMetrics(
+          {
+            name: "cr.store.rocksdb.compacted-bytes-written",
+            nonNegativeRate: true,
+          },
+          nodeIDs,
+          storeIDsByNodeID,
+        )}
       </Axis>
     </LineGraph>,
 
@@ -348,10 +344,14 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
     >
       <Axis units={AxisUnits.Bytes} label="written bytes">
-        {storeMetrics({
-          name: "cr.store.rocksdb.ingested-bytes",
-          nonNegativeRate: true,
-        })}
+        {storeMetrics(
+          {
+            name: "cr.store.rocksdb.ingested-bytes",
+            nonNegativeRate: true,
+          },
+          nodeIDs,
+          storeIDsByNodeID,
+        )}
       </Axis>
     </LineGraph>,
 

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storeUtils.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storeUtils.tsx
@@ -1,0 +1,64 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import React from "react";
+
+import { storeIDsForNode } from "src/views/cluster/containers/nodeGraphs/dashboards/dashboardUtils";
+import { Metric, MetricProps } from "src/views/shared/components/metricQuery";
+
+/**
+ * Dynamically shows either the aggregated node-level metric when viewing the
+ * cluster-level dashboard, or store-level metrics when viewing a single node.
+ */
+export const storeMetrics = (
+  props: MetricProps,
+  nodeIDs: string[],
+  storeIDsByNodeID: { [key: string]: string[] },
+  prefix?: string,
+) =>
+  nodeIDs.flatMap(nid => {
+    const storeIDs = storeIDsForNode(storeIDsByNodeID, nid);
+
+    let aggregateType = "total";
+    if (props.aggregateAvg) {
+      aggregateType = "average";
+    } else if (props.aggregateMax) {
+      aggregateType = "max";
+    } else if (props.aggregateMin) {
+      aggregateType = "min";
+    }
+
+    if (!prefix) {
+      // if prefix is not set, set it to empty string
+      prefix = "";
+    }
+
+    const nodeMetric = (
+      <Metric
+        key={nid}
+        title={`${prefix} (n${nid},${aggregateType})`}
+        sources={storeIDs}
+        {...props}
+      />
+    );
+
+    // show only the aggregated node-level metric when viewing multiple nodes
+    if (nodeIDs.length > 1) {
+      return nodeMetric;
+    }
+
+    // otherwise, show the aggregated metric and a per-store breakdown
+    return [
+      nodeMetric,
+      ...storeIDs.map(sid => (
+        <Metric
+          key={`${nid}-${sid}`}
+          title={`${prefix} (n${nid},s${sid})`}
+          sources={[sid]}
+          {...props}
+        />
+      )),
+    ];
+  });

--- a/pkg/util/admission/granter.go
+++ b/pkg/util/admission/granter.go
@@ -789,6 +789,11 @@ type PebbleMetricsProvider interface {
 	Close()
 }
 
+// MetricsRegistryProvider provides the store metric.Registry for a given store.
+type MetricsRegistryProvider interface {
+	GetMetricsRegistry(roachpb.StoreID) *metric.Registry
+}
+
 // IOThresholdConsumer is informed about updated IOThresholds.
 type IOThresholdConsumer interface {
 	UpdateIOThreshold(roachpb.StoreID, *admissionpb.IOThreshold)


### PR DESCRIPTION
This patch splits store work queue metrics to be per-store. It also does some general clean up around the `storeGrantCoordinators` code to centralize initialization of requesters and metrics.

Fixes #131562

Release note: None