### PR TITLE
release-24.3: upgrade: corrupt descriptor repair does not handle GC timestamp errors

### DIFF
--- a/pkg/upgrade/upgrades/BUILD.bazel
+++ b/pkg/upgrade/upgrades/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//pkg/keys",
         "//pkg/keyvisualizer/keyvisjob",
         "//pkg/kv",
+        "//pkg/kv/kvpb",
         "//pkg/roachpb",
         "//pkg/security/username",
         "//pkg/settings",


### PR DESCRIPTION
Backport 1/1 commits from #134654.

/cc @cockroachdb/release

---

When detecting corrupt descriptors during an upgrade, we use an AOST query. While this works effectively in the production environment, in test environments, the batch timestamp can be too far in the past. This problem occurs because certain tests
(declarative_schema_changer/job-compatibility-mixed-version-V242-V243) intentionally use short garbage collection TTL's, which can cause this logic to fail. To address this, this patch disables the AOST when a BatchTimestampBeforeGCError occurs.

Fixes: #134024

Release note: None
Relese justification: low risk change that can help with test flakes
