### PR TITLE
release-23.2: changefeedccl: fix race in test

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -7778,10 +7778,10 @@ func TestChangefeedPredicates(t *testing.T) {
 			sqlDB.Exec(t, `CREATE TYPE status AS ENUM ('open', 'closed', 'inactive')`)
 			sqlDB.Exec(t, `
 CREATE TABLE foo (
-  a INT, 
-  b STRING, 
+  a INT,
+  b STRING,
   c STRING,
-  d STRING AS (concat(b, c)) VIRTUAL, 
+  d STRING AS (concat(b, c)) VIRTUAL,
   e status DEFAULT 'inactive',
   PRIMARY KEY (a, b)
 )`)
@@ -7796,9 +7796,9 @@ INSERT INTO foo (a, b, e) VALUES (2, 'two', 'closed');
 				topic, fromClause = "foo", "foo AS "+alias
 			}
 			feed := feed(t, f, `
-CREATE CHANGEFEED 
+CREATE CHANGEFEED
 WITH schema_change_policy='stop'
-AS SELECT * FROM `+fromClause+` 
+AS SELECT * FROM `+fromClause+`
 WHERE e IN ('open', 'closed') AND event_op() != 'delete'`)
 			defer closeFeed(t, feed)
 
@@ -7844,10 +7844,10 @@ func TestChangefeedInvalidPredicate(t *testing.T) {
 	sqlDB.Exec(t, `CREATE TYPE status AS ENUM ('open', 'closed', 'inactive')`)
 	sqlDB.Exec(t, `
 CREATE TABLE foo (
-  a INT, 
-  b STRING, 
+  a INT,
+  b STRING,
   c STRING,
-  d STRING AS (concat(b, c)) VIRTUAL, 
+  d STRING AS (concat(b, c)) VIRTUAL,
   e status DEFAULT 'inactive',
   PRIMARY KEY (a, b)
 )`)
@@ -7905,8 +7905,8 @@ func TestChangefeedPredicateWithSchemaChange(t *testing.T) {
 		`CREATE SCHEMA alt`,
 		`CREATE TYPE alt.status AS ENUM ('alt_open', 'alt_closed')`,
 		`CREATE TABLE foo (
-  a INT, 
-  b STRING, 
+  a INT,
+  b STRING,
   c STRING,
   e status DEFAULT 'inactive',
   PRIMARY KEY (a, b)
@@ -9516,13 +9516,13 @@ func TestParallelIOMetrics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// Add delay so queuing occurs, which results in the below metrics being
+	// nonzero.
+	defer testingEnableQueuingDelay()()
+
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		registry := s.Server.JobRegistry().(*jobs.Registry)
 		metrics := registry.MetricsStruct().Changefeed.(*Metrics).AggMetrics
-
-		// Add delay so queuing occurs, which results in the below metrics being
-		// nonzero.
-		defer testingEnableQueuingDelay()()
 
 		db := sqlutils.MakeSQLRunner(s.DB)
 		db.Exec(t, `SET CLUSTER SETTING changefeed.new_pubsub_sink_enabled = true`)


### PR DESCRIPTION
Backport 1/1 commits from #134229.

/cc @cockroachdb/release

Release justification: test fix

---

Fix a data race in duration overrides in tests.

Fixes: #133817

Release note: None

