### PR TITLE
license: unredact logs written by license enforcer

### DIFF
--- a/pkg/server/license/BUILD.bazel
+++ b/pkg/server/license/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/server/license/cclbridge.go
+++ b/pkg/server/license/cclbridge.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/redact"
 )
 
 // This file serves as a bridge to the license code in the CCL packages.
@@ -23,6 +24,11 @@ var RegisterCallbackOnLicenseChange = func(context.Context, *cluster.Settings, *
 // LicType is the type to define the license type, as needed by the license
 // enforcer.
 type LicType int
+
+var _ redact.SafeValue = LicType(0)
+
+// SafeValue implements the redact.SafeValue interface.
+func (i LicType) SafeValue() {}
 
 //go:generate stringer -type=LicType -linecomment
 const (

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -168,6 +168,9 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 					"github.com/cockroachdb/cockroach/pkg/rpc/rpcpb": {
 						"ConnectionClass": {},
 					},
+					"github.com/cockroachdb/cockroach/pkg/server/license": {
+						"LicType": {},
+					},
 					"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb": {
 						"JobID":      {},
 						"ScheduleID": {},


### PR DESCRIPTION
This makes it so log messages are not redacted unnecessarily.

- Use redact.StringBuilder instead of strings.Builder.
- Avoid using `.String()` arguments for log.Infof, since strings are always redacted.
- Mark license type as a redact.SafeValue.

Epic: None
Release note: None