### PR TITLE
raft: Proxy r.leadEpoch access through supportingFortifiedLeader

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1505,8 +1505,8 @@ func (r *raft) Step(m pb.Message) error {
 	case m.Term > r.Term:
 		if m.Type == pb.MsgVote || m.Type == pb.MsgPreVote {
 			force := bytes.Equal(m.Context, []byte(campaignTransfer))
-			inHeartbeatLease := r.checkQuorum && r.lead != None && r.leadEpoch == 0 &&
-				r.electionElapsed < r.electionTimeout
+			inHeartbeatLease := !r.supportingFortifiedLeader(true /* maybeDefortify */) &&
+				r.checkQuorum && r.lead != None && r.electionElapsed < r.electionTimeout
 			inFortifyLease := r.supportingFortifiedLeader(true /* maybeDefortify */) &&
 				// NB: If the peer that's campaigning has an entry in its log with a
 				// higher term than what we're aware of, then this conclusively proves

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1231,7 +1231,7 @@ func (r *raft) tickHeartbeat() {
 // function instead; in there, we can add safety checks to ensure we're not
 // overwriting the leader.
 func (r *raft) becomeFollower(term uint64, lead pb.PeerID) {
-	if r.leadEpoch == 0 && lead == r.id {
+	if !r.supportingFortifiedLeader(true /* maybeDefortify */) && lead == r.id {
 		// A non-zero lead epoch indicates that the leader fortified its term.
 		// Fortification promises should hold true even if the leader steps down, so
 		// as the leader, we remember that we were the leader even after we step

--- a/pkg/raft/testdata/campaign_learner_must_vote.txt
+++ b/pkg/raft/testdata/campaign_learner_must_vote.txt
@@ -56,6 +56,7 @@ ok
 
 campaign 2
 ----
+DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 2 is starting a new election at term 1
 INFO 2 became candidate at term 2
 INFO 2 [logterm: 1, index: 4] sent MsgVote request to 1 at term 2

--- a/pkg/raft/testdata/de_fortification_basic.txt
+++ b/pkg/raft/testdata/de_fortification_basic.txt
@@ -1006,6 +1006,7 @@ bump-epoch 3
 
 campaign 2
 ----
+DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 2 is starting a new election at term 4
 INFO 2 became candidate at term 5
 INFO 2 [logterm: 4, index: 5] sent MsgVote request to 1 at term 5

--- a/pkg/raft/testdata/de_fortification_checkquorum.txt
+++ b/pkg/raft/testdata/de_fortification_checkquorum.txt
@@ -239,6 +239,7 @@ DEBUG 1 setting election elapsed to start from 3 ticks after store liveness supp
 
 campaign 3
 ----
+DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 3 is starting a new election at term 2
 INFO 3 became pre-candidate at term 2
 INFO 3 [logterm: 2, index: 12] sent MsgPreVote request to 1 at term 2

--- a/pkg/raft/testdata/forget_leader.txt
+++ b/pkg/raft/testdata/forget_leader.txt
@@ -48,6 +48,7 @@ withdraw-support 2 1
 # term. It's a noop if it's called again.
 forget-leader 2
 ----
+DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 2 forgetting leader 1 at term 1
 
 raft-state
@@ -84,6 +85,7 @@ withdraw-support 4 1
 
 forget-leader 4
 ----
+DEBUG 4 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 4 forgetting leader 1 at term 1
 
 raft-state
@@ -181,6 +183,7 @@ withdraw-support 4 1
 # ForgetLeader is a noop on candidates.
 campaign 3
 ----
+DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 3 is starting a new election at term 1
 INFO 3 became candidate at term 2
 INFO 3 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2

--- a/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
+++ b/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
@@ -33,6 +33,7 @@ withdraw-support 3 1
 # If 3 attempts to campaign, 2 rejects it because it has a leader.
 campaign 3
 ----
+DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 3 is starting a new election at term 1
 INFO 3 became pre-candidate at term 1
 INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 1 at term 1
@@ -118,6 +119,7 @@ withdraw-support 2 1
 # despite 2 having heard from the leader recently.
 forget-leader 2
 ----
+DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 2 forgetting leader 1 at term 1
 
 raft-state
@@ -128,6 +130,7 @@ raft-state
 
 campaign 3
 ----
+DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 3 is starting a new election at term 1
 INFO 3 became pre-candidate at term 1
 INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 1 at term 1
@@ -223,6 +226,7 @@ withdraw-support 2 3
 
 forget-leader 2
 ----
+DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 2 forgetting leader 3 at term 2
 
 # 1 is now behind on its log. It tries to campaign, but fails.
@@ -241,6 +245,7 @@ withdraw-support 1 3
 # At this point we can't campaign because we are not supported by a quorum.
 campaign 1
 ----
+DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
 DEBUG 1 cannot campaign since it's not supported by a quorum in store liveness
 
 grant-support 3 1

--- a/pkg/raft/testdata/fortification_followers_dont_prevote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_prevote.txt
@@ -178,6 +178,7 @@ withdraw-support 2 1
 # supporting the fortified leader (1).
 campaign 2
 ----
+DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 2 is starting a new election at term 1
 INFO 2 became pre-candidate at term 1
 INFO 2 [logterm: 1, index: 11] sent MsgPreVote request to 1 at term 1
@@ -389,6 +390,7 @@ withdraw-support 2 2
 
 campaign 2
 ----
+DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 2 is starting a new election at term 2
 INFO 2 became pre-candidate at term 2
 INFO 2 [logterm: 2, index: 12] sent MsgPreVote request to 1 at term 2
@@ -421,6 +423,11 @@ raft-state
 2: StatePreCandidate (Voter) Term:2 Lead:0 LeadEpoch:0
 3: StateFollower (Voter) Term:2 Lead:2 LeadEpoch:1
 
+# Make sure that 2 doesn't attempt to campaign on the next two tick-heartbeat
+# calls.
+set-randomized-election-timeout 2 timeout=6
+----
+ok
 
 # Let's de-fortify {1,3}. First, sanity check that simply ticking doesn't send
 # out a de-fortification request, as leaderMaxSupported isn't in the past yet.

--- a/pkg/raft/testdata/fortification_followers_dont_vote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_vote.txt
@@ -150,6 +150,7 @@ withdraw-support 2 1
 # supporting the fortified leader (1).
 campaign 2
 ----
+DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 2 is starting a new election at term 1
 INFO 2 became candidate at term 2
 INFO 2 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
@@ -335,6 +336,7 @@ withdraw-support 2 2
 
 campaign 2
 ----
+DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 2 is starting a new election at term 3
 INFO 2 became candidate at term 4
 INFO 2 [logterm: 3, index: 12] sent MsgVote request to 1 at term 4

--- a/pkg/raft/testdata/prevote.txt
+++ b/pkg/raft/testdata/prevote.txt
@@ -82,6 +82,7 @@ withdraw-support 1 1
 
 campaign 3
 ----
+DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 3 is starting a new election at term 1
 INFO 3 became pre-candidate at term 1
 INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 1 at term 1

--- a/pkg/raft/testdata/prevote_checkquorum.txt
+++ b/pkg/raft/testdata/prevote_checkquorum.txt
@@ -33,6 +33,7 @@ withdraw-support 2 1
 # 2 should fail to campaign, leaving 1's leadership alone.
 campaign 2
 ----
+DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 2 is starting a new election at term 1
 INFO 2 became pre-candidate at term 1
 INFO 2 [logterm: 1, index: 11] sent MsgPreVote request to 1 at term 1
@@ -56,16 +57,6 @@ stabilize
   2->3 MsgPreVote Term:2 Log:1/11
   INFO 3 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 2 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
 
-# If 2 hasn't heard from the leader in the past election timeout, it should
-# grant prevotes, allowing 3 to hold an election.
-set-randomized-election-timeout 2 timeout=5
-----
-ok
-
-tick-election 2
-----
-ok
-
 withdraw-support 3 1
 ----
   1 2 3
@@ -75,6 +66,7 @@ withdraw-support 3 1
 
 campaign 3
 ----
+DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 3 is starting a new election at term 1
 INFO 3 became pre-candidate at term 1
 INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 1 at term 1
@@ -231,6 +223,7 @@ withdraw-support 1 3
 # At this point we can't campaign because we are not supported by a quorum.
 campaign 1
 ----
+DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
 DEBUG 1 cannot campaign since it's not supported by a quorum in store liveness
 
 grant-support 3 1
@@ -282,6 +275,7 @@ withdraw-support 2 3
 
 campaign 2
 ----
+DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 2 is starting a new election at term 2
 INFO 2 became pre-candidate at term 2
 INFO 2 [logterm: 2, index: 12] sent MsgPreVote request to 1 at term 2


### PR DESCRIPTION
Limit all direct `r.leadEpoch` accesses that are meant to determine if the follower is fortifying a leader. This PR achieves that by replacing those checks with supportingFortifiedLeader(). Moreover, it makes supportingFortifiedLeader() call deFortify() if the support is expired.

Epic: None

Release note: None