### PR TITLE
crosscluster/logical: drop leases at each checkpoint

### DIFF
--- a/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
@@ -1452,6 +1452,7 @@ func (m mockBatchHandler) GetLastRow() cdcevent.Row            { return cdcevent
 func (m mockBatchHandler) SetSyntheticFailurePercent(_ uint32) {}
 func (m mockBatchHandler) Close(context.Context)               {}
 func (m mockBatchHandler) ReportMutations(_ *stats.Refresher)  {}
+func (m mockBatchHandler) ReleaseLeases(_ context.Context)     {}
 
 type mockDLQ int
 

--- a/pkg/ccl/crosscluster/logical/lww_row_processor.go
+++ b/pkg/ccl/crosscluster/logical/lww_row_processor.go
@@ -68,7 +68,6 @@ type RowProcessor interface {
 	ProcessRow(context.Context, isql.Txn, roachpb.KeyValue, roachpb.Value) (batchStats, error)
 	GetLastRow() cdcevent.Row
 	SetSyntheticFailurePercent(uint32)
-	ReportMutations(*stats.Refresher)
 	Close(context.Context)
 }
 
@@ -258,10 +257,14 @@ func makeSQLProcessorFromQuerier(
 	}, nil
 }
 
-// ReportMutations implements the RowProcessor interface, but is a no-op for
+// ReportMutations implements the BatchHandler interface, but is a no-op for
 // sqlRowProcessor because its mutations are already reported by the queries it
 // runs when they are run.
 func (sqlRowProcessor) ReportMutations(_ *stats.Refresher) {}
+
+// ReleaseLeases implements the BatchHandler interface but is a no-op since each
+// query does this itself.
+func (sqlRowProcessor) ReleaseLeases(_ context.Context) {}
 
 func (*sqlRowProcessor) Close(ctx context.Context) {}
 


### PR DESCRIPTION
Release note: none.
Epic: none.