### PR TITLE
opt: correctly type lookup join constant projections

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -1627,3 +1627,86 @@ INNER HASH JOIN t_124732 ON v.i = t_124732.i;
 1  1.000  1.000
 
 subtest end
+
+# Regression test for #134697. Constant projections for lookup joins should be
+# correctly typed.
+statement ok
+CREATE TABLE t134697 (
+  a INT,
+  b BIT(2),
+  vb VARBIT(2),
+  c CHAR(2),
+  vc VARCHAR(2),
+  d DECIMAL(6, 2),
+  INDEX (b, a),
+  INDEX (vb, a),
+  INDEX (c, a),
+  INDEX (vc, a),
+  INDEX (d, a)
+)
+
+statement ok
+CREATE TABLE t134697_x (
+  x INT PRIMARY KEY
+)
+
+statement ok
+INSERT INTO t134697 VALUES (1, '11', '11', 'ab', 'ab', 1234.12)
+
+statement ok
+INSERT INTO t134697_x VALUES (1);
+
+query IT
+SELECT a, b FROM t134697_x
+JOIN t134697 ON a = x AND b = '111';
+----
+
+# This should return zero rows, like the non-hinted query above.
+query IT
+SELECT a, b FROM t134697_x
+INNER LOOKUP JOIN t134697 ON a = x AND b = '111';
+----
+
+query IT
+SELECT a, vb FROM t134697_x
+JOIN t134697 ON a = x AND vb = '111';
+----
+
+# This should return zero rows, like the non-hinted query above.
+query IT
+SELECT a, vb FROM t134697_x
+INNER LOOKUP JOIN t134697 ON a = x AND vb = '111';
+----
+
+query IT
+SELECT a, c FROM t134697_x
+JOIN t134697 ON a = x AND c = 'abc';
+----
+
+# This should return zero rows, like the non-hinted query above.
+query IT
+SELECT a, c FROM t134697_x
+INNER LOOKUP JOIN t134697 ON a = x AND c = 'abc';
+----
+
+query IT
+SELECT a, vc FROM t134697_x
+JOIN t134697 ON a = x AND vc = 'abc';
+----
+
+# This should return zero rows, like the non-hinted query above.
+query IT
+SELECT a, vc FROM t134697_x
+INNER LOOKUP JOIN t134697 ON a = x AND vc = 'abc';
+----
+
+query IT
+SELECT a, d FROM t134697_x
+JOIN t134697 ON a = x AND d = 1234.123412::DECIMAL(8, 4);
+----
+
+# This should return zero rows, like the non-hinted query above.
+query IT
+SELECT a, d FROM t134697_x
+INNER LOOKUP JOIN t134697 ON a = x AND d = 1234.1234::DECIMAL(8, 4);
+----

--- a/pkg/sql/opt/lookupjoin/constraint_builder.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder.go
@@ -313,13 +313,10 @@ func (b *ConstraintBuilder) Build(
 		// If a single constant value was found, project it in the input
 		// and use it as an equality column.
 		if ok && len(foundVals) == 1 {
-			idxColType := b.md.ColumnMeta(idxCol).Type
-			constColID := b.md.AddColumn(
-				fmt.Sprintf("lookup_join_const_col_@%d", idxCol),
-				idxColType,
-			)
+			typ := foundVals[0].ResolvedType()
+			constColID := b.md.AddColumn(fmt.Sprintf("lookup_join_const_col_@%d", idxCol), typ)
 			inputProjections = append(inputProjections, b.f.ConstructProjectionsItem(
-				b.f.ConstructConstVal(foundVals[0], idxColType),
+				b.f.ConstructConstVal(foundVals[0], typ),
 				constColID,
 			))
 			allLookupFilters = append(allLookupFilters, b.allFilters[allIdx])

--- a/pkg/sql/opt/lookupjoin/constraint_builder_test.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder_test.go
@@ -162,11 +162,14 @@ func TestLookupConstraints(t *testing.T) {
 					b.WriteString("input projections:\n")
 					for i := range lookupConstraint.InputProjections {
 						col := lookupConstraint.InputProjections[i].Col
+						colMeta := md.ColumnMeta(col)
 						b.WriteString("  ")
-						b.WriteString(md.ColumnMeta(col).Alias)
+						b.WriteString(colMeta.Alias)
 						b.WriteString(" = ")
 						b.WriteString(formatScalar(lookupConstraint.InputProjections[i].Element, &f, &semaCtx, &evalCtx))
-						b.WriteString("\n")
+						b.WriteString(" [type=")
+						b.WriteString(colMeta.Type.SQLString())
+						b.WriteString("]\n")
 					}
 				}
 				if len(lookupConstraint.LookupExpr) > 0 {

--- a/pkg/sql/opt/lookupjoin/testdata/computed
+++ b/pkg/sql/opt/lookupjoin/testdata/computed
@@ -7,7 +7,7 @@ key cols:
   v = v_eq
   x = a
 input projections:
-  v_eq = a + 10
+  v_eq = a + 10 [type=INT8]
 
 lookup-constraints left=(a int, b int) right=(x int, v int not null as (x + 10) virtual) index=(v, x)
 x = a
@@ -16,7 +16,7 @@ key cols:
   v = v_eq
   x = a
 input projections:
-  v_eq = a + 10
+  v_eq = a + 10 [type=INT8]
 
 # TODO(mgartner): The x=a remaining filter is not necessary.
 lookup-constraints left=(a int, b int) right=(x int, y INT, v int not null as (x + 10) virtual) index=(v, y)
@@ -26,8 +26,8 @@ key cols:
   v = v_eq
   y = lookup_join_const_col_@7
 input projections:
-  v_eq = a + 10
-  lookup_join_const_col_@7 = 10
+  v_eq = a + 10 [type=INT8]
+  lookup_join_const_col_@7 = 10 [type=INT8]
 remaining filters:
   x = a
 
@@ -40,8 +40,8 @@ key cols:
   v = v_eq
   y = lookup_join_const_col_@7
 input projections:
-  v_eq = a + 10
-  lookup_join_const_col_@7 = 10
+  v_eq = a + 10 [type=INT8]
+  lookup_join_const_col_@7 = 10 [type=INT8]
 remaining filters:
   x = a
 
@@ -59,8 +59,8 @@ key cols:
   x = a
   y = lookup_join_const_col_@8
 input projections:
-  v_eq = a + 10
-  lookup_join_const_col_@8 = 0
+  v_eq = a + 10 [type=INT8]
+  lookup_join_const_col_@8 = 0 [type=INT8]
 remaining filters:
   z = 3
 
@@ -73,15 +73,15 @@ key cols:
   x = a
   y = lookup_join_const_col_@7
 input projections:
-  v_eq = a + 10
-  lookup_join_const_col_@7 = 0
+  v_eq = a + 10 [type=INT8]
+  lookup_join_const_col_@7 = 0 [type=INT8]
 
 lookup-constraints left=(a int, b int) right=(x int, v int not null as (x + 10) virtual, y INT) index=(v, y, x)
 x = a
 optional: y IN (10, 20)
 ----
 input projections:
-  v_eq = a + 10
+  v_eq = a + 10 [type=INT8]
 lookup expression:
   ((y IN (10, 20)) AND (v_eq = v)) AND (a = x)
 
@@ -90,7 +90,7 @@ x = a AND z > 0
 optional: y IN (10, 20)
 ----
 input projections:
-  v_eq = a + 10
+  v_eq = a + 10 [type=INT8]
 lookup expression:
   (((y IN (10, 20)) AND (z > 0)) AND (v_eq = v)) AND (a = x)
 
@@ -99,7 +99,7 @@ x = a AND w > 0
 optional: y IN (10, 20)
 ----
 input projections:
-  v_eq = a + 10
+  v_eq = a + 10 [type=INT8]
 lookup expression:
   ((y IN (10, 20)) AND (v_eq = v)) AND (a = x)
 remaining filters:
@@ -113,7 +113,7 @@ key cols:
   v = v_eq
   x = a
 input projections:
-  v_eq = a + 10
+  v_eq = a + 10 [type=INT8]
 
 lookup-constraints left=(a int, b int) right=(x int, v int not null as (x + 10) virtual, z INT) index=(v, x, z)
 x = a
@@ -123,7 +123,7 @@ key cols:
   v = v_eq
   x = a
 input projections:
-  v_eq = a + 10
+  v_eq = a + 10 [type=INT8]
 
 # TODO(mgartner): We should be able to generate a lookup join by determining
 # that v is not null because the filter demands that x is not null, and v is
@@ -141,7 +141,7 @@ key cols:
   x = a
   y = b
 input projections:
-  v_eq = a + 10
+  v_eq = a + 10 [type=INT8]
 
 lookup-constraints left=(a int, b int) right=(x int, y int, v int not null as (x + 10) virtual) index=(v, x, y)
 x = a AND y = 1
@@ -151,14 +151,14 @@ key cols:
   x = a
   y = lookup_join_const_col_@7
 input projections:
-  v_eq = a + 10
-  lookup_join_const_col_@7 = 1
+  v_eq = a + 10 [type=INT8]
+  lookup_join_const_col_@7 = 1 [type=INT8]
 
 lookup-constraints left=(a int, b int) right=(x int, y int, v int not null as (x + 10) virtual) index=(v, x, y)
 x = a AND y IN (1, 2)
 ----
 input projections:
-  v_eq = a + 10
+  v_eq = a + 10 [type=INT8]
 lookup expression:
   ((y IN (1, 2)) AND (v_eq = v)) AND (a = x)
 
@@ -166,7 +166,7 @@ lookup-constraints left=(a int, b int) right=(x int, y int, v int not null as (x
 x = a AND y > 0
 ----
 input projections:
-  v_eq = a + 10
+  v_eq = a + 10 [type=INT8]
 lookup expression:
   ((y > 0) AND (v_eq = v)) AND (a = x)
 
@@ -191,4 +191,4 @@ key cols:
   v = v_eq
   x = a
 input projections:
-  v_eq = a + 2.5
+  v_eq = a + 2.5 [type=DECIMAL]

--- a/pkg/sql/opt/lookupjoin/testdata/key_cols
+++ b/pkg/sql/opt/lookupjoin/testdata/key_cols
@@ -218,3 +218,49 @@ key cols:
   y = b
 input projections:
   lookup_join_const_col_@6 = 1 [type=INT8]
+
+# The projected constant should not have type modifiers of the indexed column.
+lookup-constraints left=(a int) right=(x int, y CHAR(2)) index=(x, y)
+x = a AND y = 'foo'
+----
+key cols:
+  x = a
+  y = lookup_join_const_col_@6
+input projections:
+  lookup_join_const_col_@6 = 'foo' [type=STRING]
+
+lookup-constraints left=(a int) right=(x int, y VARCHAR(2)) index=(x, y)
+x = a AND y = 'foo'
+----
+key cols:
+  x = a
+  y = lookup_join_const_col_@6
+input projections:
+  lookup_join_const_col_@6 = 'foo' [type=STRING]
+
+lookup-constraints left=(a int) right=(x int, y BIT(2)) index=(x, y)
+x = a AND y = '111'
+----
+key cols:
+  x = a
+  y = lookup_join_const_col_@6
+input projections:
+  lookup_join_const_col_@6 = B'111' [type=VARBIT]
+
+lookup-constraints left=(a int) right=(x int, y VARBIT(2)) index=(x, y)
+x = a AND y = '111'
+----
+key cols:
+  x = a
+  y = lookup_join_const_col_@6
+input projections:
+  lookup_join_const_col_@6 = B'111' [type=VARBIT]
+
+lookup-constraints left=(a int) right=(x int, y DECIMAL(6,2)) index=(x, y)
+x = a AND y = 1234.1234::DECIMAL(8, 4)
+----
+key cols:
+  x = a
+  y = lookup_join_const_col_@6
+input projections:
+  lookup_join_const_col_@6 = 1234.1234 [type=DECIMAL]

--- a/pkg/sql/opt/lookupjoin/testdata/key_cols
+++ b/pkg/sql/opt/lookupjoin/testdata/key_cols
@@ -85,7 +85,7 @@ key cols:
   x = a
   y = lookup_join_const_col_@8
 input projections:
-  lookup_join_const_col_@8 = 1
+  lookup_join_const_col_@8 = 1 [type=INT8]
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
 y = b AND z = c
@@ -99,7 +99,7 @@ key cols:
   x = lookup_join_const_col_@7
   y = b
 input projections:
-  lookup_join_const_col_@7 = 1
+  lookup_join_const_col_@7 = 1 [type=INT8]
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
 x = 1 AND y = 2 AND z = c
@@ -109,8 +109,8 @@ key cols:
   y = lookup_join_const_col_@8
   z = c
 input projections:
-  lookup_join_const_col_@7 = 1
-  lookup_join_const_col_@8 = 2
+  lookup_join_const_col_@7 = 1 [type=INT8]
+  lookup_join_const_col_@8 = 2 [type=INT8]
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
 x = 1 AND y = b AND z = 3
@@ -120,8 +120,8 @@ key cols:
   y = b
   z = lookup_join_const_col_@9
 input projections:
-  lookup_join_const_col_@7 = 1
-  lookup_join_const_col_@9 = 3
+  lookup_join_const_col_@7 = 1 [type=INT8]
+  lookup_join_const_col_@9 = 3 [type=INT8]
 
 lookup-constraints left=(a int, b int, c int, d int) right=(x int, y int, z int) index=(x, y, z)
 d > 4 AND x = 1 AND y = b AND z = 3
@@ -131,8 +131,8 @@ key cols:
   y = b
   z = lookup_join_const_col_@10
 input projections:
-  lookup_join_const_col_@8 = 1
-  lookup_join_const_col_@10 = 3
+  lookup_join_const_col_@8 = 1 [type=INT8]
+  lookup_join_const_col_@10 = 3 [type=INT8]
 remaining filters:
   d > 4
 
@@ -143,7 +143,7 @@ key cols:
   x = lookup_join_const_col_@7
   y = b
 input projections:
-  lookup_join_const_col_@7 = 1
+  lookup_join_const_col_@7 = 1 [type=INT8]
 remaining filters:
   z = 3
 
@@ -155,7 +155,7 @@ key cols:
   x = lookup_join_const_col_@7
   y = b
 input projections:
-  lookup_join_const_col_@7 = 1
+  lookup_join_const_col_@7 = 1 [type=INT8]
 
 lookup-constraints left=(a int) right=(x int, y int, z int) index=(x, z)
 a = z AND (x = 0 OR y IN (0) AND y > 0)
@@ -164,7 +164,7 @@ key cols:
   x = lookup_join_const_col_@5
   z = a
 input projections:
-  lookup_join_const_col_@5 = 0
+  lookup_join_const_col_@5 = 0 [type=INT8]
 
 lookup-constraints left=(a int, b int) right=(x int, y int, z int) index=(x, y, z)
 x = a AND y = b
@@ -182,7 +182,7 @@ key cols:
   x = lookup_join_const_col_@6
   y = b
 input projections:
-  lookup_join_const_col_@6 = 1
+  lookup_join_const_col_@6 = 1 [type=INT8]
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y, z)
 x = a
@@ -207,7 +207,7 @@ key cols:
   x = lookup_join_const_col_@6
   y = b
 input projections:
-  lookup_join_const_col_@6 = 1
+  lookup_join_const_col_@6 = 1 [type=INT8]
 
 lookup-constraints left=(a int, b int) right=(x int, y int, z int, zz int) index=(x, y, z, zz)
 x = 1 AND y = b
@@ -217,4 +217,4 @@ key cols:
   x = lookup_join_const_col_@6
   y = b
 input projections:
-  lookup_join_const_col_@6 = 1
+  lookup_join_const_col_@6 = 1 [type=INT8]

--- a/pkg/sql/opt/lookupjoin/testdata/lookup_expr
+++ b/pkg/sql/opt/lookupjoin/testdata/lookup_expr
@@ -43,7 +43,7 @@ lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=
 x IN (1, 2, 3) AND y = 4 AND z = c
 ----
 input projections:
-  lookup_join_const_col_@8 = 4
+  lookup_join_const_col_@8 = 4 [type=INT8]
 lookup expression:
   ((x IN (1, 2, 3)) AND (lookup_join_const_col_@8 = y)) AND (c = z)
 
@@ -51,7 +51,7 @@ lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=
 x IN (1, 2, 3) AND y = b AND z = 1
 ----
 input projections:
-  lookup_join_const_col_@9 = 1
+  lookup_join_const_col_@9 = 1 [type=INT8]
 lookup expression:
   ((x IN (1, 2, 3)) AND (b = y)) AND (lookup_join_const_col_@9 = z)
 
@@ -102,7 +102,7 @@ x = a
 optional: y IN (1, 2, 3) AND z = 1
 ----
 input projections:
-  lookup_join_const_col_@8 = 1
+  lookup_join_const_col_@8 = 1 [type=INT8]
 lookup expression:
   ((y IN (1, 2, 3)) AND (a = x)) AND (lookup_join_const_col_@8 = z)
 
@@ -111,7 +111,7 @@ x = 1 AND z = c
 optional: y IN (3, 4)
 ----
 input projections:
-  lookup_join_const_col_@7 = 1
+  lookup_join_const_col_@7 = 1 [type=INT8]
 lookup expression:
   ((y IN (3, 4)) AND (lookup_join_const_col_@7 = x)) AND (c = z)
 
@@ -151,7 +151,7 @@ lookup-constraints left=(a int) right=(x int, y bool, z int) index=(x, y, z)
 x = a AND y = false AND z > 0
 ----
 input projections:
-  lookup_join_const_col_@6 = false
+  lookup_join_const_col_@6 = false [type=BOOL]
 lookup expression:
   ((z > 0) AND (a = x)) AND (lookup_join_const_col_@6 = y)
 
@@ -197,7 +197,7 @@ lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=
 x = 1 AND y = b AND z > 0
 ----
 input projections:
-  lookup_join_const_col_@7 = 1
+  lookup_join_const_col_@7 = 1 [type=INT8]
 lookup expression:
   ((z > 0) AND (lookup_join_const_col_@7 = x)) AND (b = y)
 
@@ -205,7 +205,7 @@ lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=
 x = a AND y = 1 AND z > 0
 ----
 input projections:
-  lookup_join_const_col_@8 = 1
+  lookup_join_const_col_@8 = 1 [type=INT8]
 lookup expression:
   ((z > 0) AND (a = x)) AND (lookup_join_const_col_@8 = y)
 
@@ -217,7 +217,7 @@ key cols:
   x = lookup_join_const_col_@7
   y = b
 input projections:
-  lookup_join_const_col_@7 = 1
+  lookup_join_const_col_@7 = 1 [type=INT8]
 
 lookup-constraints left=(a int, b int, c int) right=(x int, y int, z int) index=(x, y)
 x = a AND z = 1

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -87,6 +87,14 @@ CREATE TABLE shard (
 ----
 
 exec-ddl
+CREATE TABLE tchar (
+    a INT,
+    c VARCHAR(2),
+    PRIMARY KEY (a, c)
+)
+----
+
+exec-ddl
 CREATE TABLE large (m INT, n INT)
 ----
 
@@ -3649,6 +3657,31 @@ inner-join (lookup abcde)
  │    │    └── columns: m:1 n:2
  │    └── filters
  │         └── c:8 = 10 [outer=(8), constraints=(/8: [/10 - /10]; tight), fd=()-->(8)]
+ └── filters (true)
+
+# Constant value projections should have the type of the constant, not the
+# indexed column.
+opt expect=GenerateLookupJoinsWithFilter format=show-types
+SELECT * FROM (VALUES (1), (3)) v(i) INNER LOOKUP JOIN tchar ON a = i AND c = 'foo'
+----
+inner-join (lookup tchar)
+ ├── columns: i:1(int!null) a:2(int!null) c:3(varchar!null)
+ ├── flags: force lookup join (into right side)
+ ├── key columns: [1 6] = [2 3]
+ ├── lookup columns are key
+ ├── cardinality: [0 - 2]
+ ├── fd: ()-->(3), (1)==(2), (2)==(1)
+ ├── project
+ │    ├── columns: "lookup_join_const_col_@3":6(string!null) column1:1(int!null)
+ │    ├── cardinality: [2 - 2]
+ │    ├── fd: ()-->(6)
+ │    ├── values
+ │    │    ├── columns: column1:1(int!null)
+ │    │    ├── cardinality: [2 - 2]
+ │    │    ├── (1,) [type=tuple{int}]
+ │    │    └── (3,) [type=tuple{int}]
+ │    └── projections
+ │         └── 'foo' [as="lookup_join_const_col_@3":6, type=string]
  └── filters (true)
 
 # Multiple constant columns projected and used by lookup joiner.


### PR DESCRIPTION
#### opt/lookupjoin: show type of projected constants in tests

Release note: None

#### opt: correctly type lookup join constant projections

Fixes #134697

Release note (bug fix): A bug has been fixed that could cause incorrect
query results when the optimizer planned a lookup join on an index
containing a column of type `CHAR(N)`, `VARCHAR(N)`, `BIT(N)`,
`VARBIT(N)`, or `DECIMAL(M, N)`, and the query held that column constant
to a single value (e.g., with an equality filter).
