### PR TITLE
internal/team: remove a couple of unused fields

### DIFF
--- a/pkg/internal/team/team.go
+++ b/pkg/internal/team/team.go
@@ -36,14 +36,6 @@ type Team struct {
 	TriageColumnID int `yaml:"triage_column_id"`
 	// SilenceMentions is true if @-mentions should be supressed for this team.
 	SilenceMentions bool `yaml:"silence_mentions"`
-	// Email is the email address for this team.
-	//
-	// Currently unused.
-	Email string `yaml:"email"`
-	// Slack is the slack channel for this team.
-	//
-	// Currently unused.
-	Slack string `yaml:"slack"`
 }
 
 // Name returns the main Alias of the team.

--- a/pkg/internal/team/team_test.go
+++ b/pkg/internal/team/team_test.go
@@ -18,13 +18,9 @@ sql:
   aliases:
     sql-alias: other
     sql-roachtest: roachtest
-  email: otan@cockroachlabs.com
-  slack: otan
   triage_column_id: 1
   silence_mentions: true
 test-infra-team:
-  email: jlinder@cockroachlabs.com
-  slack: jlinder
   triage_column_id: 2
 `)
 	ret, err := LoadTeams(bytes.NewReader(yamlFile))
@@ -35,8 +31,6 @@ test-infra-team:
 			"sql-alias":     PurposeOther,
 			"sql-roachtest": PurposeRoachtest,
 		},
-		Email:           "otan@cockroachlabs.com",
-		Slack:           "otan",
 		TriageColumnID:  1,
 		SilenceMentions: true,
 	}
@@ -70,8 +64,6 @@ test-infra-team:
 			"sql-roachtest": sqlTeam,
 			"test-infra-team": {
 				TeamName:       "test-infra-team",
-				Email:          "jlinder@cockroachlabs.com",
-				Slack:          "jlinder",
 				TriageColumnID: 2,
 			},
 		},


### PR DESCRIPTION
Email and Slack fields of `Team` struct haven't been used since their removal in ab074857515e556e8a5057535d168004758a1b95, and I doubt we'll ever start using them, so let's remove them altogether.

Epic: None

Release note: None