### PR TITLE
sql: fix FETCH ABSOLUTE 0 cursor handling

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cursor
+++ b/pkg/sql/logictest/testdata/logic_test/cursor
@@ -217,6 +217,10 @@ FETCH 0 foo
 ----
 
 query II
+FETCH ABSOLUTE 0 foo
+----
+
+query II
 FETCH FIRST foo
 ----
 1  2

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -225,6 +225,10 @@ func (f *fetchNode) nextInternal(ctx context.Context) (bool, error) {
 			if f.cursor.curRow > f.offset {
 				return false, errBackwardScan
 			}
+			if f.offset == 0 {
+				// ABSOLUTE 0 is positioned before the first row.
+				return false, nil
+			}
 			for f.cursor.curRow < f.offset {
 				more, err := f.cursor.Next(ctx)
 				if !more || err != nil {


### PR DESCRIPTION
`FETCH ABSOLUTE 0` positions the cursor before the first row, so nothing should be fetched. Previously, this would result in an internal error because we'd be working on unset datums.

Fixes: #131115.

Release note (bug fix): Previously, CockroachDB would encounter an internal error when evaluating `FETCH ABSOLUTE 0` statements, and this is now fixed. The bug has been present since 22.1 version.