### PR TITLE
raft: don't step down to newer term while fortifying

### DIFF
--- a/pkg/raft/BUILD.bazel
+++ b/pkg/raft/BUILD.bazel
@@ -61,6 +61,7 @@ go_test(
         "//pkg/raft/tracker",
         "//pkg/settings/cluster",
         "//pkg/testutils",
+        "//pkg/util/hlc",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1500,60 +1500,11 @@ func (r *raft) Step(m pb.Message) error {
 	case m.Term == 0:
 		// local message
 	case m.Term > r.Term:
-		if m.Type == pb.MsgVote || m.Type == pb.MsgPreVote {
-			force := bytes.Equal(m.Context, []byte(campaignTransfer))
-			inHeartbeatLease := r.checkQuorum && r.lead != None && r.leadEpoch == 0 &&
-				r.electionElapsed < r.electionTimeout
-			inFortifyLease := r.supportingFortifiedLeader() &&
-				// NB: If the peer that's campaigning has an entry in its log with a
-				// higher term than what we're aware of, then this conclusively proves
-				// that a new leader was elected at a higher term. We never heard from
-				// this new leader (otherwise we'd have bumped r.Term in response).
-				// However, any fortification we're providing to a leader that has been
-				// since dethroned is pointless.
-				m.LogTerm <= r.Term
-
-			if !force && (inHeartbeatLease || inFortifyLease) {
-				// If a server receives a Request{,Pre}Vote message but is still
-				// supporting a fortified leader, it does not update its term or grant
-				// its vote. Similarly, if a server receives a Request{,Pre}Vote message
-				// within the minimum election timeout of hearing from the current
-				// leader it does not update its term or grant its vote.
-				//
-				// Log why we're ignoring the Request{,Pre}Vote.
-				var leaseMsg redact.RedactableString
-				if inHeartbeatLease {
-					leaseMsg = redact.Sprintf("recently received communication from leader (remaining ticks: %d)", r.electionTimeout-r.electionElapsed)
-				} else {
-					leaseMsg = redact.Sprintf("supporting fortified leader %d at epoch %d", r.lead, r.leadEpoch)
-				}
-
-				last := r.raftLog.lastEntryID()
-				// TODO(pav-kv): it should be ok to simply print the %+v of the lastEntryID.
-				r.logger.Infof("%x [logterm: %d, index: %d, vote: %x] ignored %s from %x [logterm: %d, index: %d] at term %d: %s",
-					r.id, last.term, last.index, r.Vote, m.Type, m.From, m.LogTerm, m.Index, r.Term, leaseMsg)
-				return nil // don't update term/grant vote; early return
-			}
-			// If we're willing to vote in this election at a higher term, then make
-			// sure we have withdrawn our support for the current leader, if we're
-			// still providing it support.
-			r.deFortify(m.From, m.Term)
-		}
-
-		switch {
-		case m.Type == pb.MsgPreVote:
-			// Never change our term in response to a PreVote.
-		case m.Type == pb.MsgPreVoteResp && !m.Reject:
-			// We send pre-vote requests with a term in our future. If the
-			// pre-vote is granted, we will increment our term when we get a
-			// quorum. If it is not, the term comes from the node that
-			// rejected our vote so we should become a follower at the new
-			// term.
-		case IsMsgIndicatingLeader(m.Type):
-			// We've just received a message that indicates that a new leader
-			// was elected at a higher term, but the message may not be from the
-			// leader itself. Either way, the old leader is no longer fortified,
-			// so it's safe to de-fortify at this point.
+		if IsMsgIndicatingLeader(m.Type) {
+			// We've just received a message that indicates that a new leader was
+			// elected at a higher term, but the message may not be from the leader
+			// itself. Either way, the old leader is no longer fortified, so it's safe
+			// to de-fortify at this point.
 			r.logMsgHigherTerm(m, "new leader indicated, advancing term")
 			r.deFortify(m.From, m.Term)
 			var lead pb.PeerID
@@ -1561,30 +1512,56 @@ func (r *raft) Step(m pb.Message) error {
 				lead = m.From
 			}
 			r.becomeFollower(m.Term, lead)
-		default:
-			// We've just received a message that does not indicate that a new
-			// leader was elected at a higher term. All it means is that some
-			// other peer has this term.
-			if r.supportingFortifiedLeader() {
-				// If we are supporting a fortified leader, we can't just jump to the
-				// larger term. Instead, we need to wait for the leader to learn about
-				// the stranded peer, step down, and defortify. The only thing to do
-				// here is check whether we are that leader, in which case we should
-				// step down to kick off this process of catching up to the term of the
-				// stranded peer.
-				if r.state == pb.StateLeader {
-					r.logMsgHigherTerm(m, "stepping down as leader to recover stranded peer")
-					r.becomeFollower(r.Term, r.id)
-				} else {
-					r.logMsgHigherTerm(m, "ignoring and still supporting fortified leader")
+		} else {
+			// We've just received a message that does not indicate that a new leader
+			// was elected at a higher term. All it means is that some other peer may
+			// be operating at this term.
+
+			// If a server receives a message (with any type) but is still supporting
+			// a fortified leader ("in a leader lease"), it does not update its term,
+			// grant a vote, or process the message in any other way.
+			if r.inLeaderLease(m) {
+				// However, since we're in a leader lease and have received a message at
+				// a higher term, we may need to take action to recover a stranded peer
+				// by catching the quorum's term up to the peer's.
+				//
+				// For legacy reasons, we don't consider a MsgVote at a higher term to
+				// be a reason to advance the term to recover a stranded peer. Instead,
+				// we wait for the leader's heartbeat message to be rejected by the
+				// stranded peer, which will cause the leader to step down.
+				//
+				// TODO(nvanbenschoten): remove this special case. If we see a MsgVote
+				// from a peer at a higher term while we are in a leader lease, we should
+				// still step down.
+				strandedPeer := senderHasMsgTerm(m) && m.Type != pb.MsgVote
+				if strandedPeer {
+					// If we are supporting a fortified leader, we can't just jump to the
+					// larger term. Instead, we need to wait for the leader to learn about
+					// the stranded peer, step down, and defortify. The only thing to do
+					// here is check whether we are that leader, in which case we should
+					// step down to kick off this process of catching up to the term of the
+					// stranded peer.
+					if r.state == pb.StateLeader {
+						r.logMsgHigherTerm(m, "stepping down as leader to recover stranded peer")
+						r.becomeFollower(r.Term, r.id)
+					} else {
+						r.logMsgHigherTerm(m, "ignoring and still supporting fortified leader")
+					}
 				}
 				return nil
 			}
 
-			// If we're not supporting a fortified leader, we can just jump to the
-			// term communicated by the peer.
-			r.logMsgHigherTerm(m, "advancing term")
-			r.becomeFollower(m.Term, None)
+			// If we are willing process a message at a higher term, then make sure we
+			// record that we have withdrawn our support for the current leader, if we
+			// were still providing it with fortification support up to this point.
+			r.deFortify(m.From, m.Term)
+
+			// If the message indicates a higher term, we should update our term and
+			// step down to a follower.
+			if senderHasMsgTerm(m) {
+				r.logMsgHigherTerm(m, "advancing term")
+				r.becomeFollower(m.Term, None)
+			}
 		}
 
 	case m.Term < r.Term:
@@ -1740,6 +1717,55 @@ func (r *raft) Step(m pb.Message) error {
 		}
 	}
 	return nil
+}
+
+// inLeaderLease returns whether the message should be ignored because the
+// recipient is supporting a leader lease.
+func (r *raft) inLeaderLease(m pb.Message) bool {
+	force := bytes.Equal(m.Context, []byte(campaignTransfer))
+	if force {
+		// If the message is a transfer request, we ignore the leader lease.
+		return false
+	}
+
+	inHeartbeatLease := r.checkQuorum &&
+		// We know who the leader is...
+		r.lead != None &&
+		// And we're not fortifying the leader (else we'd be in a fortify lease, see
+		// below)...
+		r.leadEpoch == 0 &&
+		// And we've heard from the leader recently...
+		r.electionElapsed < r.electionTimeout &&
+		// And the message is a pre-vote or vote request. Unlike a fortify lease,
+		// a heartbeat lease only applies to these two message types.
+		(m.Type == pb.MsgPreVote || m.Type == pb.MsgVote)
+
+	inFortifyLease := r.supportingFortifiedLeader() &&
+		// NB: If the peer that's campaigning has an entry in its log with a
+		// higher term than what we're aware of, then this conclusively proves
+		// that a new leader was elected at a higher term. We never heard from
+		// this new leader (otherwise we'd have bumped r.Term in response).
+		// However, any fortification we're providing to a leader that has been
+		// since dethroned is pointless.
+		m.LogTerm <= r.Term
+
+	if !inHeartbeatLease && !inFortifyLease {
+		// We're not in either form of lease. We can safely process the message.
+		return false
+	}
+
+	// Log why we're ignoring the message.
+	var leaseMsg redact.RedactableString
+	if inHeartbeatLease {
+		leaseMsg = redact.Sprintf("recently received communication from leader (remaining ticks: %d)", r.electionTimeout-r.electionElapsed)
+	} else {
+		leaseMsg = redact.Sprintf("supporting fortified leader %d at epoch %d", r.lead, r.leadEpoch)
+	}
+	last := r.raftLog.lastEntryID()
+	// TODO(pav-kv): it should be ok to simply print the %+v of the lastEntryID.
+	r.logger.Infof("%x [logterm: %d, index: %d, vote: %x] ignored %s from %x [logterm: %d, index: %d] at term %d: %s",
+		r.id, last.term, last.index, r.Vote, m.Type, m.From, m.LogTerm, m.Index, r.Term, leaseMsg)
+	return true
 }
 
 func (r *raft) logMsgHigherTerm(m pb.Message, suffix redact.SafeString) {

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1550,7 +1550,7 @@ func (r *raft) Step(m pb.Message) error {
 			// rejected our vote so we should become a follower at the new
 			// term.
 		default:
-			r.logger.Infof("%x [term: %d] received a %s message with higher term from %x [term: %d]",
+			r.logger.Infof("%x [term: %d] received a %s message with higher term from %x [term: %d], advancing term",
 				r.id, r.Term, m.Type, m.From, m.Term)
 			if IsMsgIndicatingLeader(m.Type) {
 				// We've just received a message that indicates that a new leader

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1029,8 +1029,8 @@ func (r *raft) reset(term uint64) {
 		//
 		// [*] this case, and other cases where a state transition implies
 		// de-fortification.
-		assertTrue(!r.supportingFortifiedLeader() || r.lead == r.id,
-			"should not be changing terms when supporting a fortified leader; leader exempted")
+		assertTrue(!r.supportingFortifiedLeader(),
+			"should not be changing terms when supporting a fortified leader")
 		r.setTerm(term)
 	}
 
@@ -1542,33 +1542,49 @@ func (r *raft) Step(m pb.Message) error {
 
 		switch {
 		case m.Type == pb.MsgPreVote:
-			// Never change our term in response to a PreVote
+			// Never change our term in response to a PreVote.
 		case m.Type == pb.MsgPreVoteResp && !m.Reject:
 			// We send pre-vote requests with a term in our future. If the
 			// pre-vote is granted, we will increment our term when we get a
 			// quorum. If it is not, the term comes from the node that
 			// rejected our vote so we should become a follower at the new
 			// term.
-		default:
-			r.logger.Infof("%x [term: %d] received a %s message with higher term from %x [term: %d], advancing term",
-				r.id, r.Term, m.Type, m.From, m.Term)
-			if IsMsgIndicatingLeader(m.Type) {
-				// We've just received a message that indicates that a new leader
-				// was elected at a higher term, but the message may not be from the
-				// leader itself. Either way, the old leader is no longer fortified,
-				// so it's safe to de-fortify at this point.
-				r.deFortify(m.From, m.Term)
-				var lead pb.PeerID
-				if IsMsgFromLeader(m.Type) {
-					lead = m.From
-				}
-				r.becomeFollower(m.Term, lead)
-			} else {
-				// We've just received a message that does not indicate that a new
-				// leader was elected at a higher term. All it means is that some
-				// other peer has this term.
-				r.becomeFollower(m.Term, None)
+		case IsMsgIndicatingLeader(m.Type):
+			// We've just received a message that indicates that a new leader
+			// was elected at a higher term, but the message may not be from the
+			// leader itself. Either way, the old leader is no longer fortified,
+			// so it's safe to de-fortify at this point.
+			r.logMsgHigherTerm(m, "new leader indicated, advancing term")
+			r.deFortify(m.From, m.Term)
+			var lead pb.PeerID
+			if IsMsgFromLeader(m.Type) {
+				lead = m.From
 			}
+			r.becomeFollower(m.Term, lead)
+		default:
+			// We've just received a message that does not indicate that a new
+			// leader was elected at a higher term. All it means is that some
+			// other peer has this term.
+			if r.supportingFortifiedLeader() {
+				// If we are supporting a fortified leader, we can't just jump to the
+				// larger term. Instead, we need to wait for the leader to learn about
+				// the stranded peer, step down, and defortify. The only thing to do
+				// here is check whether we are that leader, in which case we should
+				// step down to kick off this process of catching up to the term of the
+				// stranded peer.
+				if r.state == pb.StateLeader {
+					r.logMsgHigherTerm(m, "stepping down as leader to recover stranded peer")
+					r.becomeFollower(r.Term, r.id)
+				} else {
+					r.logMsgHigherTerm(m, "ignoring and still supporting fortified leader")
+				}
+				return nil
+			}
+
+			// If we're not supporting a fortified leader, we can just jump to the
+			// term communicated by the peer.
+			r.logMsgHigherTerm(m, "advancing term")
+			r.becomeFollower(m.Term, None)
 		}
 
 	case m.Term < r.Term:
@@ -1724,6 +1740,11 @@ func (r *raft) Step(m pb.Message) error {
 		}
 	}
 	return nil
+}
+
+func (r *raft) logMsgHigherTerm(m pb.Message, suffix redact.SafeString) {
+	r.logger.Infof("%x [term: %d] received a %s message with higher term from %x [term: %d], %s",
+		r.id, r.Term, m.Type, m.From, m.Term, suffix)
 }
 
 type stepFunc func(r *raft, m pb.Message) error

--- a/pkg/raft/raftstoreliveness/mock_store_liveness.go
+++ b/pkg/raft/raftstoreliveness/mock_store_liveness.go
@@ -272,7 +272,7 @@ func (l *LivenessFabric) WithdrawSupportFor(fromID pb.PeerID, forID pb.PeerID) {
 	fromEntry.withdrawSupportFor(forID)
 }
 
-// WithdrawSupportFor causes the store liveness SupportFrom() to return not
+// WithdrawSupportFrom causes the store liveness SupportFrom() to return not
 // supported when fromID calls it for forID.
 func (l *LivenessFabric) WithdrawSupportFrom(fromID pb.PeerID, forID pb.PeerID) {
 	fromEntry, exists := l.state[fromID]
@@ -289,22 +289,22 @@ func (l *LivenessFabric) WithdrawSupport(fromID pb.PeerID, forID pb.PeerID) {
 	l.WithdrawSupportFrom(forID, fromID)
 }
 
-// GrantSupport causes the store liveness SupportFor() to return supported when
-// fromID calls it for forID.
+// GrantSupportFor causes the store liveness SupportFor() to return supported
+// when fromID calls it for forID.
 func (l *LivenessFabric) GrantSupportFor(fromID pb.PeerID, forID pb.PeerID) {
 	fromEntry, exists := l.state[fromID]
 	if !exists {
-		panic("attempting to call GrantSupport() for a non-existing fromID entry")
+		panic("attempting to call GrantSupportFor() for a non-existing fromID entry")
 	}
 	fromEntry.grantSupportFor(forID)
 }
 
-// GrantSupport causes the store liveness SupportFrom() to return supported when
-// fromID calls it for forID.
+// GrantSupportFrom causes the store liveness SupportFrom() to return supported
+// when fromID calls it for forID.
 func (l *LivenessFabric) GrantSupportFrom(fromID pb.PeerID, forID pb.PeerID) {
 	fromEntry, exists := l.state[fromID]
 	if !exists {
-		panic("attempting to call GrantSupport() for a non-existing fromID entry")
+		panic("attempting to call GrantSupportFrom() for a non-existing fromID entry")
 	}
 	fromEntry.grantSupportFrom(forID)
 }

--- a/pkg/raft/testdata/async_storage_writes.txt
+++ b/pkg/raft/testdata/async_storage_writes.txt
@@ -34,12 +34,12 @@ stabilize
   ]
 > 2 receiving messages
   1->2 MsgVote Term:1 Log:1/10
-  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 2 became follower at term 1
   INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
 > 3 receiving messages
   1->3 MsgVote Term:1 Log:1/10
-  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 3 became follower at term 1
   INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
 > 1 processing append thread

--- a/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
+++ b/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
@@ -112,15 +112,15 @@ Messages:
 deliver-msgs 4 5 6
 ----
 3->4 MsgVote Term:2 Log:1/11
-INFO 4 [term: 1] received a MsgVote message with higher term from 3 [term: 2]
+INFO 4 [term: 1] received a MsgVote message with higher term from 3 [term: 2], advancing term
 INFO 4 became follower at term 2
 INFO 4 [logterm: 1, index: 11, vote: 0] cast MsgVote for 3 [logterm: 1, index: 11] at term 2
 3->5 MsgVote Term:2 Log:1/11
-INFO 5 [term: 1] received a MsgVote message with higher term from 3 [term: 2]
+INFO 5 [term: 1] received a MsgVote message with higher term from 3 [term: 2], advancing term
 INFO 5 became follower at term 2
 INFO 5 [logterm: 1, index: 11, vote: 0] cast MsgVote for 3 [logterm: 1, index: 11] at term 2
 3->6 MsgVote Term:2 Log:1/11
-INFO 6 [term: 1] received a MsgVote message with higher term from 3 [term: 2]
+INFO 6 [term: 1] received a MsgVote message with higher term from 3 [term: 2], advancing term
 INFO 6 became follower at term 2
 INFO 6 [logterm: 1, index: 11, vote: 0] cast MsgVote for 3 [logterm: 1, index: 11] at term 2
 
@@ -221,7 +221,7 @@ Messages:
 deliver-msgs 1 drop=(2,4,5,6,7)
 ----
 3->1 MsgVote Term:2 Log:1/11
-INFO 1 [term: 1] received a MsgVote message with higher term from 3 [term: 2]
+INFO 1 [term: 1] received a MsgVote message with higher term from 3 [term: 2], advancing term
 INFO 1 became follower at term 2
 INFO 1 [logterm: 1, index: 12, vote: 0] rejected MsgVote from 3 [logterm: 1, index: 11] at term 2
 3->1 MsgFortifyLeader Term:2 Log:0/0
@@ -287,15 +287,15 @@ Messages:
 deliver-msgs 5 6 7
 ----
 4->5 MsgVote Term:3 Log:1/11
-INFO 5 [term: 2] received a MsgVote message with higher term from 4 [term: 3]
+INFO 5 [term: 2] received a MsgVote message with higher term from 4 [term: 3], advancing term
 INFO 5 became follower at term 3
 INFO 5 [logterm: 1, index: 11, vote: 0] cast MsgVote for 4 [logterm: 1, index: 11] at term 3
 4->6 MsgVote Term:3 Log:1/11
-INFO 6 [term: 2] received a MsgVote message with higher term from 4 [term: 3]
+INFO 6 [term: 2] received a MsgVote message with higher term from 4 [term: 3], advancing term
 INFO 6 became follower at term 3
 INFO 6 [logterm: 1, index: 11, vote: 0] cast MsgVote for 4 [logterm: 1, index: 11] at term 3
 4->7 MsgVote Term:3 Log:1/11
-INFO 7 [term: 1] received a MsgVote message with higher term from 4 [term: 3]
+INFO 7 [term: 1] received a MsgVote message with higher term from 4 [term: 3], advancing term
 INFO 7 became follower at term 3
 INFO 7 [logterm: 1, index: 11, vote: 0] cast MsgVote for 4 [logterm: 1, index: 11] at term 3
 
@@ -427,7 +427,7 @@ Messages:
 deliver-msgs 1
 ----
 4->1 MsgFortifyLeader Term:3 Log:0/0
-INFO 1 [term: 2] received a MsgFortifyLeader message with higher term from 4 [term: 3]
+INFO 1 [term: 2] received a MsgFortifyLeader message with higher term from 4 [term: 3], advancing term
 INFO 1 became follower at term 3
 4->1 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
 INFO found conflict at index 12 [existing term: 2, conflicting term: 3]

--- a/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
+++ b/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
@@ -427,7 +427,7 @@ Messages:
 deliver-msgs 1
 ----
 4->1 MsgFortifyLeader Term:3 Log:0/0
-INFO 1 [term: 2] received a MsgFortifyLeader message with higher term from 4 [term: 3], advancing term
+INFO 1 [term: 2] received a MsgFortifyLeader message with higher term from 4 [term: 3], new leader indicated, advancing term
 INFO 1 became follower at term 3
 4->1 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
 INFO found conflict at index 12 [existing term: 2, conflicting term: 3]

--- a/pkg/raft/testdata/campaign.txt
+++ b/pkg/raft/testdata/campaign.txt
@@ -34,12 +34,12 @@ stabilize
   INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
 > 2 receiving messages
   1->2 MsgVote Term:1 Log:1/2
-  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 2 became follower at term 1
   INFO 2 [logterm: 1, index: 2, vote: 0] cast MsgVote for 1 [logterm: 1, index: 2] at term 1
 > 3 receiving messages
   1->3 MsgVote Term:1 Log:1/2
-  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 3 became follower at term 1
   INFO 3 [logterm: 1, index: 2, vote: 0] cast MsgVote for 1 [logterm: 1, index: 2] at term 1
 > 2 handling Ready

--- a/pkg/raft/testdata/campaign_learner_must_vote.txt
+++ b/pkg/raft/testdata/campaign_learner_must_vote.txt
@@ -82,7 +82,7 @@ stabilize 3
 > 3 receiving messages
   2->3 MsgVote Term:2 Log:1/4
   DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
-  INFO 3 [term: 1] received a MsgVote message with higher term from 2 [term: 2]
+  INFO 3 [term: 1] received a MsgVote message with higher term from 2 [term: 2], advancing term
   INFO 3 became follower at term 2
   INFO 3 [logterm: 1, index: 3, vote: 0] cast MsgVote for 2 [logterm: 1, index: 4] at term 2
 > 3 handling Ready

--- a/pkg/raft/testdata/confchange_fortification_safety.txt
+++ b/pkg/raft/testdata/confchange_fortification_safety.txt
@@ -143,7 +143,7 @@ stabilize 1 4
   1->3 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
 > 4 receiving messages
   1->4 MsgFortifyLeader Term:1 Log:0/0
-  INFO 4 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1]
+  INFO 4 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], advancing term
   INFO 4 became follower at term 1
   1->4 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v4]
   DEBUG 4 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1

--- a/pkg/raft/testdata/confchange_fortification_safety.txt
+++ b/pkg/raft/testdata/confchange_fortification_safety.txt
@@ -143,7 +143,7 @@ stabilize 1 4
   1->3 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
 > 4 receiving messages
   1->4 MsgFortifyLeader Term:1 Log:0/0
-  INFO 4 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], advancing term
+  INFO 4 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], new leader indicated, advancing term
   INFO 4 became follower at term 1
   1->4 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v4]
   DEBUG 4 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1

--- a/pkg/raft/testdata/confchange_v1_add_single.txt
+++ b/pkg/raft/testdata/confchange_v1_add_single.txt
@@ -60,7 +60,7 @@ stabilize
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChange v2]
 > 2 receiving messages
   1->2 MsgFortifyLeader Term:1 Log:0/0
-  INFO 2 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], advancing term
+  INFO 2 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], new leader indicated, advancing term
   INFO 2 became follower at term 1
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChange v2]
   DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1

--- a/pkg/raft/testdata/confchange_v1_add_single.txt
+++ b/pkg/raft/testdata/confchange_v1_add_single.txt
@@ -60,7 +60,7 @@ stabilize
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChange v2]
 > 2 receiving messages
   1->2 MsgFortifyLeader Term:1 Log:0/0
-  INFO 2 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1]
+  INFO 2 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], advancing term
   INFO 2 became follower at term 1
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChange v2]
   DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1

--- a/pkg/raft/testdata/confchange_v2_add_double_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_auto.txt
@@ -84,7 +84,7 @@ stabilize 1 2
 ----
 > 2 receiving messages
   1->2 MsgFortifyLeader Term:1 Log:0/0
-  INFO 2 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], advancing term
+  INFO 2 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], new leader indicated, advancing term
   INFO 2 became follower at term 1
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2 v3]
   DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
@@ -178,7 +178,7 @@ stabilize 1 3
 ----
 > 3 receiving messages
   1->3 MsgFortifyLeader Term:1 Log:0/0
-  INFO 3 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], advancing term
+  INFO 3 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], new leader indicated, advancing term
   INFO 3 became follower at term 1
   1->3 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2 v3]
   DEBUG 3 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1

--- a/pkg/raft/testdata/confchange_v2_add_double_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_auto.txt
@@ -84,7 +84,7 @@ stabilize 1 2
 ----
 > 2 receiving messages
   1->2 MsgFortifyLeader Term:1 Log:0/0
-  INFO 2 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1]
+  INFO 2 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], advancing term
   INFO 2 became follower at term 1
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2 v3]
   DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
@@ -178,7 +178,7 @@ stabilize 1 3
 ----
 > 3 receiving messages
   1->3 MsgFortifyLeader Term:1 Log:0/0
-  INFO 3 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1]
+  INFO 3 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], advancing term
   INFO 3 became follower at term 1
   1->3 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2 v3]
   DEBUG 3 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1

--- a/pkg/raft/testdata/confchange_v2_add_single_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_auto.txt
@@ -61,7 +61,7 @@ stabilize
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
 > 2 receiving messages
   1->2 MsgFortifyLeader Term:1 Log:0/0
-  INFO 2 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1]
+  INFO 2 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], advancing term
   INFO 2 became follower at term 1
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
   DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1

--- a/pkg/raft/testdata/confchange_v2_add_single_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_auto.txt
@@ -61,7 +61,7 @@ stabilize
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
 > 2 receiving messages
   1->2 MsgFortifyLeader Term:1 Log:0/0
-  INFO 2 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], advancing term
+  INFO 2 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], new leader indicated, advancing term
   INFO 2 became follower at term 1
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
   DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1

--- a/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
@@ -61,7 +61,7 @@ stabilize 1 2
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
 > 2 receiving messages
   1->2 MsgFortifyLeader Term:1 Log:0/0
-  INFO 2 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], advancing term
+  INFO 2 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], new leader indicated, advancing term
   INFO 2 became follower at term 1
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
   DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1

--- a/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
@@ -61,7 +61,7 @@ stabilize 1 2
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
 > 2 receiving messages
   1->2 MsgFortifyLeader Term:1 Log:0/0
-  INFO 2 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1]
+  INFO 2 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], advancing term
   INFO 2 became follower at term 1
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
   DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1

--- a/pkg/raft/testdata/confchange_v2_add_single_implicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_implicit.txt
@@ -93,7 +93,7 @@ stabilize
   1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
 > 3 receiving messages
   1->3 MsgFortifyLeader Term:1 Log:0/0
-  INFO 3 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], advancing term
+  INFO 3 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], new leader indicated, advancing term
   INFO 3 became follower at term 1
   1->3 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v3]
   DEBUG 3 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1

--- a/pkg/raft/testdata/confchange_v2_add_single_implicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_implicit.txt
@@ -93,7 +93,7 @@ stabilize
   1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
 > 3 receiving messages
   1->3 MsgFortifyLeader Term:1 Log:0/0
-  INFO 3 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1]
+  INFO 3 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], advancing term
   INFO 3 became follower at term 1
   1->3 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v3]
   DEBUG 3 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1

--- a/pkg/raft/testdata/de_fortification_basic.txt
+++ b/pkg/raft/testdata/de_fortification_basic.txt
@@ -807,7 +807,7 @@ stabilize
   3->1 MsgApp Term:4 Log:2/4 Commit:4 Entries:[4/5 EntryNormal ""]
 > 2 receiving messages
   3->2 MsgFortifyLeader Term:4 Log:0/0
-  INFO 2 [term: 2] received a MsgFortifyLeader message with higher term from 3 [term: 4], advancing term
+  INFO 2 [term: 2] received a MsgFortifyLeader message with higher term from 3 [term: 4], new leader indicated, advancing term
   DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 2 became follower at term 4
   3->2 MsgApp Term:4 Log:2/4 Commit:4 Entries:[4/5 EntryNormal ""]
@@ -1369,7 +1369,7 @@ stabilize
   1->2 MsgApp Term:6 Log:5/6 Commit:6 Entries:[6/7 EntryNormal ""]
 > 3 receiving messages
   1->3 MsgApp Term:6 Log:5/6 Commit:6 Entries:[6/7 EntryNormal ""]
-  INFO 3 [term: 5] received a MsgApp message with higher term from 1 [term: 6], advancing term
+  INFO 3 [term: 5] received a MsgApp message with higher term from 1 [term: 6], new leader indicated, advancing term
   DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 3 became follower at term 6
 > 1 processing append thread

--- a/pkg/raft/testdata/de_fortification_basic.txt
+++ b/pkg/raft/testdata/de_fortification_basic.txt
@@ -79,12 +79,12 @@ stabilize
   ]
 > 2 receiving messages
   1->2 MsgVote Term:1 Log:1/2
-  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 2 became follower at term 1
   INFO 2 [logterm: 1, index: 2, vote: 0] cast MsgVote for 1 [logterm: 1, index: 2] at term 1
 > 3 receiving messages
   1->3 MsgVote Term:1 Log:1/2
-  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 3 became follower at term 1
   INFO 3 [logterm: 1, index: 2, vote: 0] cast MsgVote for 1 [logterm: 1, index: 2] at term 1
 > 1 processing append thread
@@ -405,12 +405,12 @@ stabilize
   ]
 > 1 receiving messages
   2->1 MsgVote Term:2 Log:1/3
-  INFO 1 [term: 1] received a MsgVote message with higher term from 2 [term: 2]
+  INFO 1 [term: 1] received a MsgVote message with higher term from 2 [term: 2], advancing term
   INFO 1 became follower at term 2
   INFO 1 [logterm: 1, index: 3, vote: 0] cast MsgVote for 2 [logterm: 1, index: 3] at term 2
 > 3 receiving messages
   2->3 MsgVote Term:2 Log:1/3
-  INFO 3 [term: 1] received a MsgVote message with higher term from 2 [term: 2]
+  INFO 3 [term: 1] received a MsgVote message with higher term from 2 [term: 2], advancing term
   INFO 3 became follower at term 2
   INFO 3 [logterm: 1, index: 3, vote: 0] cast MsgVote for 2 [logterm: 1, index: 3] at term 2
 > 2 processing append thread
@@ -754,7 +754,7 @@ stabilize
   ]
 > 1 receiving messages
   3->1 MsgVote Term:4 Log:2/4
-  INFO 1 [term: 2] received a MsgVote message with higher term from 3 [term: 4]
+  INFO 1 [term: 2] received a MsgVote message with higher term from 3 [term: 4], advancing term
   INFO 1 became follower at term 4
   INFO 1 [logterm: 2, index: 4, vote: 0] cast MsgVote for 3 [logterm: 2, index: 4] at term 4
 > 2 receiving messages
@@ -807,7 +807,7 @@ stabilize
   3->1 MsgApp Term:4 Log:2/4 Commit:4 Entries:[4/5 EntryNormal ""]
 > 2 receiving messages
   3->2 MsgFortifyLeader Term:4 Log:0/0
-  INFO 2 [term: 2] received a MsgFortifyLeader message with higher term from 3 [term: 4]
+  INFO 2 [term: 2] received a MsgFortifyLeader message with higher term from 3 [term: 4], advancing term
   DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 2 became follower at term 4
   3->2 MsgApp Term:4 Log:2/4 Commit:4 Entries:[4/5 EntryNormal ""]
@@ -1026,12 +1026,12 @@ stabilize
 > 1 receiving messages
   2->1 MsgVote Term:5 Log:4/5
   DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
-  INFO 1 [term: 4] received a MsgVote message with higher term from 2 [term: 5]
+  INFO 1 [term: 4] received a MsgVote message with higher term from 2 [term: 5], advancing term
   INFO 1 became follower at term 5
   INFO 1 [logterm: 4, index: 5, vote: 0] cast MsgVote for 2 [logterm: 4, index: 5] at term 5
 > 3 receiving messages
   2->3 MsgVote Term:5 Log:4/5
-  INFO 3 [term: 4] received a MsgVote message with higher term from 2 [term: 5]
+  INFO 3 [term: 4] received a MsgVote message with higher term from 2 [term: 5], advancing term
   INFO 3 became follower at term 5
   INFO 3 [logterm: 4, index: 5, vote: 0] cast MsgVote for 2 [logterm: 4, index: 5] at term 5
 > 2 processing append thread
@@ -1317,7 +1317,7 @@ stabilize
 > 2 receiving messages
   1->2 MsgVote Term:6 Log:5/6
   DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
-  INFO 2 [term: 5] received a MsgVote message with higher term from 1 [term: 6]
+  INFO 2 [term: 5] received a MsgVote message with higher term from 1 [term: 6], advancing term
   INFO 2 became follower at term 6
   INFO 2 [logterm: 5, index: 6, vote: 0] cast MsgVote for 1 [logterm: 5, index: 6] at term 6
 > 3 receiving messages
@@ -1369,7 +1369,7 @@ stabilize
   1->2 MsgApp Term:6 Log:5/6 Commit:6 Entries:[6/7 EntryNormal ""]
 > 3 receiving messages
   1->3 MsgApp Term:6 Log:5/6 Commit:6 Entries:[6/7 EntryNormal ""]
-  INFO 3 [term: 5] received a MsgApp message with higher term from 1 [term: 6]
+  INFO 3 [term: 5] received a MsgApp message with higher term from 1 [term: 6], advancing term
   DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 3 became follower at term 6
 > 1 processing append thread

--- a/pkg/raft/testdata/de_fortification_checkquorum.txt
+++ b/pkg/raft/testdata/de_fortification_checkquorum.txt
@@ -415,7 +415,7 @@ stabilize
   3->2 MsgApp Term:3 Log:2/12 Commit:13 Entries:[3/13 EntryNormal ""]
 > 2 receiving messages
   3->2 MsgFortifyLeader Term:3 Log:0/0
-  INFO 2 [term: 2] received a MsgFortifyLeader message with higher term from 3 [term: 3], advancing term
+  INFO 2 [term: 2] received a MsgFortifyLeader message with higher term from 3 [term: 3], new leader indicated, advancing term
   INFO 2 became follower at term 3
   3->2 MsgApp Term:3 Log:2/12 Commit:13 Entries:[3/13 EntryNormal ""]
 > 2 handling Ready

--- a/pkg/raft/testdata/de_fortification_checkquorum.txt
+++ b/pkg/raft/testdata/de_fortification_checkquorum.txt
@@ -24,7 +24,7 @@ raft-state
 2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
 3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
 
-# Set the randomized election timeout to be worth 1 tick-electon. This makes the
+# Set the randomized election timeout to be worth 1 tick-election. This makes the
 # test deterministic. We then have to tick-election twice as the leader heard
 # from followers when it stabilized above. This should then trip the heartbeat
 # lease check quorum condition.

--- a/pkg/raft/testdata/de_fortification_checkquorum.txt
+++ b/pkg/raft/testdata/de_fortification_checkquorum.txt
@@ -290,7 +290,7 @@ stabilize 1 3
   INFO 3 has received 1 MsgVoteResp votes and 0 vote rejections
 > 1 receiving messages
   3->1 MsgVote Term:3 Log:2/12
-  INFO 1 [term: 2] received a MsgVote message with higher term from 3 [term: 3]
+  INFO 1 [term: 2] received a MsgVote message with higher term from 3 [term: 3], advancing term
   INFO 1 became follower at term 3
   INFO 1 [logterm: 2, index: 12, vote: 0] cast MsgVote for 3 [logterm: 2, index: 12] at term 3
 > 1 handling Ready
@@ -415,7 +415,7 @@ stabilize
   3->2 MsgApp Term:3 Log:2/12 Commit:13 Entries:[3/13 EntryNormal ""]
 > 2 receiving messages
   3->2 MsgFortifyLeader Term:3 Log:0/0
-  INFO 2 [term: 2] received a MsgFortifyLeader message with higher term from 3 [term: 3]
+  INFO 2 [term: 2] received a MsgFortifyLeader message with higher term from 3 [term: 3], advancing term
   INFO 2 became follower at term 3
   3->2 MsgApp Term:3 Log:2/12 Commit:13 Entries:[3/13 EntryNormal ""]
 > 2 handling Ready

--- a/pkg/raft/testdata/fortification_basic.txt
+++ b/pkg/raft/testdata/fortification_basic.txt
@@ -79,17 +79,17 @@ stabilize 2 3 4
 ----
 > 2 receiving messages
   1->2 MsgVote Term:1 Log:1/2
-  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 2 became follower at term 1
   INFO 2 [logterm: 1, index: 2, vote: 0] cast MsgVote for 1 [logterm: 1, index: 2] at term 1
 > 3 receiving messages
   1->3 MsgVote Term:1 Log:1/2
-  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 3 became follower at term 1
   INFO 3 [logterm: 1, index: 2, vote: 0] cast MsgVote for 1 [logterm: 1, index: 2] at term 1
 > 4 receiving messages
   1->4 MsgVote Term:1 Log:1/2
-  INFO 4 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 4 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 4 became follower at term 1
   INFO 4 [logterm: 1, index: 2, vote: 0] cast MsgVote for 1 [logterm: 1, index: 2] at term 1
 > 2 handling Ready

--- a/pkg/raft/testdata/fortification_followers_dont_call_election.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_call_election.txt
@@ -37,12 +37,12 @@ stabilize
   INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
 > 2 receiving messages
   1->2 MsgVote Term:1 Log:1/10
-  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 2 became follower at term 1
   INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
 > 3 receiving messages
   1->3 MsgVote Term:1 Log:1/10
-  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 3 became follower at term 1
   INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
 > 2 handling Ready

--- a/pkg/raft/testdata/fortification_followers_dont_call_election_prevote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_call_election_prevote.txt
@@ -67,12 +67,12 @@ stabilize
   INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
 > 2 receiving messages
   1->2 MsgVote Term:1 Log:1/10
-  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 2 became follower at term 1
   INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
 > 3 receiving messages
   1->3 MsgVote Term:1 Log:1/10
-  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 3 became follower at term 1
   INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
 > 2 handling Ready

--- a/pkg/raft/testdata/fortification_followers_dont_prevote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_prevote.txt
@@ -67,12 +67,12 @@ stabilize
   INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
 > 2 receiving messages
   1->2 MsgVote Term:1 Log:1/10
-  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 2 became follower at term 1
   INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
 > 3 receiving messages
   1->3 MsgVote Term:1 Log:1/10
-  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 3 became follower at term 1
   INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
 > 2 handling Ready
@@ -265,7 +265,7 @@ stabilize
   INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 2 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
 > 3 receiving messages
   2->3 MsgVote Term:2 Log:1/11
-  INFO 3 [term: 1] received a MsgVote message with higher term from 2 [term: 2]
+  INFO 3 [term: 1] received a MsgVote message with higher term from 2 [term: 2], advancing term
   INFO 3 became follower at term 2
   INFO 3 [logterm: 1, index: 11, vote: 0] cast MsgVote for 2 [logterm: 1, index: 11] at term 2
 > 3 handling Ready
@@ -291,7 +291,7 @@ stabilize
   2->3 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 1 receiving messages
   2->1 MsgFortifyLeader Term:2 Log:0/0
-  INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 2 [term: 2]
+  INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 2 [term: 2], advancing term
   INFO 1 became follower at term 2
   2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 3 receiving messages
@@ -530,12 +530,12 @@ stabilize
   INFO 2 has received 1 MsgVoteResp votes and 0 vote rejections
 > 1 receiving messages
   2->1 MsgVote Term:3 Log:2/12
-  INFO 1 [term: 2] received a MsgVote message with higher term from 2 [term: 3]
+  INFO 1 [term: 2] received a MsgVote message with higher term from 2 [term: 3], advancing term
   INFO 1 became follower at term 3
   INFO 1 [logterm: 2, index: 12, vote: 0] cast MsgVote for 2 [logterm: 2, index: 12] at term 3
 > 3 receiving messages
   2->3 MsgVote Term:3 Log:2/12
-  INFO 3 [term: 2] received a MsgVote message with higher term from 2 [term: 3]
+  INFO 3 [term: 2] received a MsgVote message with higher term from 2 [term: 3], advancing term
   INFO 3 became follower at term 3
   INFO 3 [logterm: 2, index: 12, vote: 0] cast MsgVote for 2 [logterm: 2, index: 12] at term 3
 > 1 handling Ready

--- a/pkg/raft/testdata/fortification_followers_dont_prevote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_prevote.txt
@@ -291,7 +291,7 @@ stabilize
   2->3 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 1 receiving messages
   2->1 MsgFortifyLeader Term:2 Log:0/0
-  INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 2 [term: 2], advancing term
+  INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 2 [term: 2], new leader indicated, advancing term
   INFO 1 became follower at term 2
   2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 3 receiving messages

--- a/pkg/raft/testdata/fortification_followers_dont_vote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_vote.txt
@@ -39,12 +39,12 @@ stabilize
   INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
 > 2 receiving messages
   1->2 MsgVote Term:1 Log:1/10
-  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 2 became follower at term 1
   INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
 > 3 receiving messages
   1->3 MsgVote Term:1 Log:1/10
-  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 3 became follower at term 1
   INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
 > 2 handling Ready
@@ -211,7 +211,7 @@ stabilize
 > 3 receiving messages
   2->3 MsgVote Term:3 Log:1/11
   DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
-  INFO 3 [term: 1] received a MsgVote message with higher term from 2 [term: 3]
+  INFO 3 [term: 1] received a MsgVote message with higher term from 2 [term: 3], advancing term
   INFO 3 became follower at term 3
   INFO 3 [logterm: 1, index: 11, vote: 0] cast MsgVote for 2 [logterm: 1, index: 11] at term 3
 > 3 handling Ready
@@ -237,7 +237,7 @@ stabilize
   2->3 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
 > 1 receiving messages
   2->1 MsgFortifyLeader Term:3 Log:0/0
-  INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 2 [term: 3]
+  INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 2 [term: 3], advancing term
   INFO 1 became follower at term 3
   2->1 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
 > 3 receiving messages
@@ -438,12 +438,12 @@ stabilize
   INFO 2 has received 1 MsgVoteResp votes and 0 vote rejections
 > 1 receiving messages
   2->1 MsgVote Term:5 Log:3/12
-  INFO 1 [term: 3] received a MsgVote message with higher term from 2 [term: 5]
+  INFO 1 [term: 3] received a MsgVote message with higher term from 2 [term: 5], advancing term
   INFO 1 became follower at term 5
   INFO 1 [logterm: 3, index: 12, vote: 0] cast MsgVote for 2 [logterm: 3, index: 12] at term 5
 > 3 receiving messages
   2->3 MsgVote Term:5 Log:3/12
-  INFO 3 [term: 3] received a MsgVote message with higher term from 2 [term: 5]
+  INFO 3 [term: 3] received a MsgVote message with higher term from 2 [term: 5], advancing term
   INFO 3 became follower at term 5
   INFO 3 [logterm: 3, index: 12, vote: 0] cast MsgVote for 2 [logterm: 3, index: 12] at term 5
 > 1 handling Ready

--- a/pkg/raft/testdata/fortification_followers_dont_vote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_vote.txt
@@ -237,7 +237,7 @@ stabilize
   2->3 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
 > 1 receiving messages
   2->1 MsgFortifyLeader Term:3 Log:0/0
-  INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 2 [term: 3], advancing term
+  INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 2 [term: 3], new leader indicated, advancing term
   INFO 1 became follower at term 3
   2->1 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
 > 3 receiving messages

--- a/pkg/raft/testdata/fortification_leader_does_not_support_itself.txt
+++ b/pkg/raft/testdata/fortification_leader_does_not_support_itself.txt
@@ -66,12 +66,12 @@ stabilize
   INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
 > 2 receiving messages
   1->2 MsgVote Term:1 Log:1/2
-  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 2 became follower at term 1
   INFO 2 [logterm: 1, index: 2, vote: 0] cast MsgVote for 1 [logterm: 1, index: 2] at term 1
 > 3 receiving messages
   1->3 MsgVote Term:1 Log:1/2
-  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 3 became follower at term 1
   INFO 3 [logterm: 1, index: 2, vote: 0] cast MsgVote for 1 [logterm: 1, index: 2] at term 1
 > 2 handling Ready

--- a/pkg/raft/testdata/fortification_support_tracking.txt
+++ b/pkg/raft/testdata/fortification_support_tracking.txt
@@ -218,7 +218,7 @@ stabilize
   2->3 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 1 receiving messages
   2->1 MsgFortifyLeader Term:2 Log:0/0
-  INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 2 [term: 2], advancing term
+  INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 2 [term: 2], new leader indicated, advancing term
   INFO 1 became follower at term 2
   2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 3 receiving messages

--- a/pkg/raft/testdata/fortification_support_tracking.txt
+++ b/pkg/raft/testdata/fortification_support_tracking.txt
@@ -43,12 +43,12 @@ stabilize
   INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
 > 2 receiving messages
   1->2 MsgVote Term:1 Log:1/10
-  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 2 became follower at term 1
   INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
 > 3 receiving messages
   1->3 MsgVote Term:1 Log:1/10
-  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 3 became follower at term 1
   INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
 > 2 handling Ready
@@ -192,7 +192,7 @@ stabilize
 > 3 receiving messages
   2->3 MsgVote Term:2 Log:1/11
   DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
-  INFO 3 [term: 1] received a MsgVote message with higher term from 2 [term: 2]
+  INFO 3 [term: 1] received a MsgVote message with higher term from 2 [term: 2], advancing term
   INFO 3 became follower at term 2
   INFO 3 [logterm: 1, index: 11, vote: 0] cast MsgVote for 2 [logterm: 1, index: 11] at term 2
 > 3 handling Ready
@@ -218,7 +218,7 @@ stabilize
   2->3 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 1 receiving messages
   2->1 MsgFortifyLeader Term:2 Log:0/0
-  INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 2 [term: 2]
+  INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 2 [term: 2], advancing term
   INFO 1 became follower at term 2
   2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 3 receiving messages

--- a/pkg/raft/testdata/leader_step_down_stranded_peer.txt
+++ b/pkg/raft/testdata/leader_step_down_stranded_peer.txt
@@ -220,9 +220,11 @@ stabilize 1 3
   3->1 MsgAppResp Term:3 Log:0/0
 > 1 receiving messages
   3->1 MsgAppResp Term:3 Log:0/0
+  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgAppResp from 3 [logterm: 0, index: 0] at term 1: supporting fortified leader 1 at epoch 1
   INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3], stepping down as leader to recover stranded peer
   INFO 1 became follower at term 1
   3->1 MsgAppResp Term:3 Log:0/0
+  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgAppResp from 3 [logterm: 0, index: 0] at term 1: supporting fortified leader 1 at epoch 1
   INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3], ignoring and still supporting fortified leader
 > 1 handling Ready
   Ready MustSync=false:

--- a/pkg/raft/testdata/leader_step_down_stranded_peer.txt
+++ b/pkg/raft/testdata/leader_step_down_stranded_peer.txt
@@ -1,0 +1,364 @@
+# Test which demonstrates how a leader steps down when a peer is stranded at a
+# higher term, after a series of hung elections.
+
+add-nodes 3 voters=(1,2,3) index=10 checkquorum=true
+----
+INFO 1 switched to configuration voters=(1 2 3)
+INFO 1 became follower at term 0
+INFO newRaft 1 [peers: [1,2,3], term: 0, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
+INFO 2 switched to configuration voters=(1 2 3)
+INFO 2 became follower at term 0
+INFO newRaft 2 [peers: [1,2,3], term: 0, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
+INFO 3 switched to configuration voters=(1 2 3)
+INFO 3 became follower at term 0
+INFO newRaft 3 [peers: [1,2,3], term: 0, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
+
+###############################################################################
+# Strand node 3 at a higher term.
+###############################################################################
+
+campaign 3
+----
+INFO 3 is starting a new election at term 0
+INFO 3 became candidate at term 1
+INFO 3 [logterm: 1, index: 10] sent MsgVote request to 1 at term 1
+INFO 3 [logterm: 1, index: 10] sent MsgVote request to 2 at term 1
+
+stabilize 3
+----
+> 3 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:1 Vote:3 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  3->1 MsgVote Term:1 Log:1/10
+  3->2 MsgVote Term:1 Log:1/10
+  INFO 3 received MsgVoteResp from 3 at term 1
+  INFO 3 has received 1 MsgVoteResp votes and 0 vote rejections
+
+# Set the randomized election timeout to be worth 1 tick-election. This makes the
+# test deterministic.
+set-randomized-election-timeout 3 timeout=3
+----
+ok
+
+tick-election 3
+----
+INFO 3 is starting a new election at term 1
+INFO 3 became candidate at term 2
+INFO 3 [logterm: 1, index: 10] sent MsgVote request to 1 at term 2
+INFO 3 [logterm: 1, index: 10] sent MsgVote request to 2 at term 2
+
+stabilize 3
+----
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:2 Vote:3 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  3->1 MsgVote Term:2 Log:1/10
+  3->2 MsgVote Term:2 Log:1/10
+  INFO 3 received MsgVoteResp from 3 at term 2
+  INFO 3 has received 1 MsgVoteResp votes and 0 vote rejections
+
+set-randomized-election-timeout 3 timeout=3
+----
+ok
+
+tick-election 3
+----
+INFO 3 is starting a new election at term 2
+INFO 3 became candidate at term 3
+INFO 3 [logterm: 1, index: 10] sent MsgVote request to 1 at term 3
+INFO 3 [logterm: 1, index: 10] sent MsgVote request to 2 at term 3
+
+stabilize 3
+----
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:3 Vote:3 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  3->1 MsgVote Term:3 Log:1/10
+  3->2 MsgVote Term:3 Log:1/10
+  INFO 3 received MsgVoteResp from 3 at term 3
+  INFO 3 has received 1 MsgVoteResp votes and 0 vote rejections
+
+deliver-msgs drop=(1, 2)
+----
+dropped: 3->1 MsgVote Term:1 Log:1/10
+dropped: 3->1 MsgVote Term:2 Log:1/10
+dropped: 3->1 MsgVote Term:3 Log:1/10
+dropped: 3->2 MsgVote Term:1 Log:1/10
+dropped: 3->2 MsgVote Term:2 Log:1/10
+dropped: 3->2 MsgVote Term:3 Log:1/10
+
+raft-state
+----
+1: StateFollower (Voter) Term:0 Lead:0 LeadEpoch:0
+2: StateFollower (Voter) Term:0 Lead:0 LeadEpoch:0
+3: StateCandidate (Voter) Term:3 Lead:0 LeadEpoch:0
+
+###############################################################################
+# Now that node 3 is stranded, establish node 1 as leader of term 1.
+###############################################################################
+
+campaign 1
+----
+INFO 1 is starting a new election at term 0
+INFO 1 became candidate at term 1
+INFO 1 [logterm: 1, index: 10] sent MsgVote request to 2 at term 1
+INFO 1 [logterm: 1, index: 10] sent MsgVote request to 3 at term 1
+
+stabilize 1 2
+----
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  1->2 MsgVote Term:1 Log:1/10
+  1->3 MsgVote Term:1 Log:1/10
+  INFO 1 received MsgVoteResp from 1 at term 1
+  INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
+> 2 receiving messages
+  1->2 MsgVote Term:1 Log:1/10
+  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 2 became follower at term 1
+  INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  2->1 MsgVoteResp Term:1 Log:0/0
+> 1 receiving messages
+  2->1 MsgVoteResp Term:1 Log:0/0
+  INFO 1 received MsgVoteResp from 2 at term 1
+  INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
+  INFO 1 became leader at term 1
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateLeader
+  HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
+  Entries:
+  1/11 EntryNormal ""
+  Messages:
+  1->2 MsgFortifyLeader Term:1 Log:0/0
+  1->3 MsgFortifyLeader Term:1 Log:0/0
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+  1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+> 2 receiving messages
+  1->2 MsgFortifyLeader Term:1 Log:0/0
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
+  Entries:
+  1/11 EntryNormal ""
+  Messages:
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
+> 1 receiving messages
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/11 EntryNormal ""
+  Messages:
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+  1->2 MsgApp Term:1 Log:1/11 Commit:11
+> 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+  1->2 MsgApp Term:1 Log:1/11 Commit:11
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/11 EntryNormal ""
+  Messages:
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:11
+> 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:11
+
+deliver-msgs drop=(3)
+----
+dropped: 1->3 MsgVote Term:1 Log:1/10
+dropped: 1->3 MsgFortifyLeader Term:1 Log:0/0
+dropped: 1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+
+raft-state
+----
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+3: StateCandidate (Voter) Term:3 Lead:0 LeadEpoch:0
+
+###############################################################################
+# Reconnect node 1 and 3 and demonstrate that node 1 steps down as leader to
+# catch up to node 3's term.
+###############################################################################
+
+tick-heartbeat 1
+----
+ok
+
+stabilize 1 3
+----
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->3 MsgFortifyLeader Term:1 Log:0/0
+  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
+> 3 receiving messages
+  1->3 MsgFortifyLeader Term:1 Log:0/0
+  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
+> 3 handling Ready
+  Ready MustSync=false:
+  Messages:
+  3->1 MsgAppResp Term:3 Log:0/0
+  3->1 MsgAppResp Term:3 Log:0/0
+> 1 receiving messages
+  3->1 MsgAppResp Term:3 Log:0/0
+  INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3]
+  INFO 1 became follower at term 3
+  3->1 MsgAppResp Term:3 Log:0/0
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateFollower
+  HardState Term:3 Commit:11 Lead:0 LeadEpoch:0
+
+campaign 1
+----
+INFO 1 is starting a new election at term 3
+INFO 1 became candidate at term 4
+INFO 1 [logterm: 1, index: 11] sent MsgVote request to 2 at term 4
+INFO 1 [logterm: 1, index: 11] sent MsgVote request to 3 at term 4
+
+stabilize
+----
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:4 Vote:1 Commit:11 Lead:0 LeadEpoch:0
+  Messages:
+  1->2 MsgVote Term:4 Log:1/11
+  1->3 MsgVote Term:4 Log:1/11
+  INFO 1 received MsgVoteResp from 1 at term 4
+  INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
+> 2 receiving messages
+  1->2 MsgVote Term:4 Log:1/11
+  INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 1 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
+> 3 receiving messages
+  1->3 MsgVote Term:4 Log:1/11
+  INFO 3 [term: 3] received a MsgVote message with higher term from 1 [term: 4]
+  INFO 3 became follower at term 4
+  INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 11] at term 4
+> 3 handling Ready
+  Ready MustSync=true:
+  State:StateFollower
+  HardState Term:4 Vote:1 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  3->1 MsgVoteResp Term:4 Log:0/0
+> 1 receiving messages
+  3->1 MsgVoteResp Term:4 Log:0/0
+  INFO 1 received MsgVoteResp from 3 at term 4
+  INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
+  INFO 1 became leader at term 4
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateLeader
+  HardState Term:4 Vote:1 Commit:11 Lead:1 LeadEpoch:1
+  Entries:
+  4/12 EntryNormal ""
+  Messages:
+  1->2 MsgFortifyLeader Term:4 Log:0/0
+  1->3 MsgFortifyLeader Term:4 Log:0/0
+  1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
+  1->3 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
+> 2 receiving messages
+  1->2 MsgFortifyLeader Term:4 Log:0/0
+  INFO 2 [term: 1] received a MsgFortifyLeader message with higher term from 1 [term: 4]
+  DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
+  INFO 2 became follower at term 4
+  1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
+> 3 receiving messages
+  1->3 MsgFortifyLeader Term:4 Log:0/0
+  1->3 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
+  DEBUG 3 [logterm: 0, index: 11] rejected MsgApp [logterm: 1, index: 11] from 1
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:4 Commit:11 Lead:1 LeadEpoch:1
+  Entries:
+  4/12 EntryNormal ""
+  Messages:
+  2->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
+  2->1 MsgAppResp Term:4 Log:0/12 Commit:11
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:4 Vote:1 Commit:10 Lead:1 LeadEpoch:1
+  Messages:
+  3->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
+  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
+> 1 receiving messages
+  2->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
+  2->1 MsgAppResp Term:4 Log:0/12 Commit:11
+  3->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
+  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 10, term 1)) from 3 for index 11
+  DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=11 sentCommit=10 matchCommit=10]
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:4 Vote:1 Commit:12 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  4/12 EntryNormal ""
+  Messages:
+  1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
+  1->2 MsgApp Term:4 Log:4/12 Commit:12
+  1->3 MsgApp Term:4 Log:1/11 Commit:12 Entries:[4/12 EntryNormal ""]
+  1->3 MsgApp Term:4 Log:1/10 Commit:12 Entries:[
+    1/11 EntryNormal ""
+    4/12 EntryNormal ""
+  ]
+> 2 receiving messages
+  1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
+  1->2 MsgApp Term:4 Log:4/12 Commit:12
+> 3 receiving messages
+  1->3 MsgApp Term:4 Log:1/11 Commit:12 Entries:[4/12 EntryNormal ""]
+  DEBUG 3 [logterm: 0, index: 11] rejected MsgApp [logterm: 1, index: 11] from 1
+  1->3 MsgApp Term:4 Log:1/10 Commit:12 Entries:[
+    1/11 EntryNormal ""
+    4/12 EntryNormal ""
+  ]
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:4 Commit:12 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  4/12 EntryNormal ""
+  Messages:
+  2->1 MsgAppResp Term:4 Log:0/12 Commit:11
+  2->1 MsgAppResp Term:4 Log:0/12 Commit:12
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:4 Vote:1 Commit:12 Lead:1 LeadEpoch:1
+  Entries:
+  1/11 EntryNormal ""
+  4/12 EntryNormal ""
+  CommittedEntries:
+  1/11 EntryNormal ""
+  4/12 EntryNormal ""
+  Messages:
+  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
+  3->1 MsgAppResp Term:4 Log:0/12 Commit:12
+> 1 receiving messages
+  2->1 MsgAppResp Term:4 Log:0/12 Commit:11
+  2->1 MsgAppResp Term:4 Log:0/12 Commit:12
+  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 10, term 1)) from 3 for index 11
+  3->1 MsgAppResp Term:4 Log:0/12 Commit:12
+
+raft-state
+----
+1: StateLeader (Voter) Term:4 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:4 Lead:1 LeadEpoch:1
+3: StateFollower (Voter) Term:4 Lead:1 LeadEpoch:1

--- a/pkg/raft/testdata/leader_step_down_stranded_peer.txt
+++ b/pkg/raft/testdata/leader_step_down_stranded_peer.txt
@@ -121,7 +121,7 @@ stabilize 1 2
   INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
 > 2 receiving messages
   1->2 MsgVote Term:1 Log:1/10
-  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 2 became follower at term 1
   INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
 > 2 handling Ready
@@ -220,7 +220,7 @@ stabilize 1 3
   3->1 MsgAppResp Term:3 Log:0/0
 > 1 receiving messages
   3->1 MsgAppResp Term:3 Log:0/0
-  INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3]
+  INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3], advancing term
   INFO 1 became follower at term 3
   3->1 MsgAppResp Term:3 Log:0/0
 > 1 handling Ready
@@ -251,7 +251,7 @@ stabilize
   INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 1 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
 > 3 receiving messages
   1->3 MsgVote Term:4 Log:1/11
-  INFO 3 [term: 3] received a MsgVote message with higher term from 1 [term: 4]
+  INFO 3 [term: 3] received a MsgVote message with higher term from 1 [term: 4], advancing term
   INFO 3 became follower at term 4
   INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 11] at term 4
 > 3 handling Ready
@@ -278,7 +278,7 @@ stabilize
   1->3 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
 > 2 receiving messages
   1->2 MsgFortifyLeader Term:4 Log:0/0
-  INFO 2 [term: 1] received a MsgFortifyLeader message with higher term from 1 [term: 4]
+  INFO 2 [term: 1] received a MsgFortifyLeader message with higher term from 1 [term: 4], advancing term
   DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 2 became follower at term 4
   1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]

--- a/pkg/raft/testdata/leader_step_down_stranded_peer.txt
+++ b/pkg/raft/testdata/leader_step_down_stranded_peer.txt
@@ -220,145 +220,220 @@ stabilize 1 3
   3->1 MsgAppResp Term:3 Log:0/0
 > 1 receiving messages
   3->1 MsgAppResp Term:3 Log:0/0
-  INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3], advancing term
-  INFO 1 became follower at term 3
+  INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3], stepping down as leader to recover stranded peer
+  INFO 1 became follower at term 1
   3->1 MsgAppResp Term:3 Log:0/0
+  INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3], ignoring and still supporting fortified leader
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready MustSync=false:
   State:StateFollower
-  HardState Term:3 Commit:11 Lead:0 LeadEpoch:0
 
+# Wait until the ex-leader can be safely defortified.
 campaign 1
 ----
-INFO 1 is starting a new election at term 3
-INFO 1 became candidate at term 4
-INFO 1 [logterm: 1, index: 11] sent MsgVote request to 2 at term 4
-INFO 1 [logterm: 1, index: 11] sent MsgVote request to 3 at term 4
+DEBUG 1 ignoring MsgHup due to leader fortification
+
+send-de-fortify 1 1
+----
+DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
+
+# Without pre-vote, the process through which the ex-leader learns about the
+# higher term of the stranded peer is sub-optimal, but still works. Because
+# the stranded peer does not respond when rejecting the MsgVote, we must wait
+# for the stranded peer to campaign for the ex-leader (and next leader) to
+# learn about the higher term and campaign with it.
+campaign 1
+----
+INFO 1 is starting a new election at term 1
+INFO 1 became candidate at term 2
+INFO 1 [logterm: 1, index: 11] sent MsgVote request to 2 at term 2
+INFO 1 [logterm: 1, index: 11] sent MsgVote request to 3 at term 2
 
 stabilize
 ----
 > 1 handling Ready
   Ready MustSync=true:
   State:StateCandidate
-  HardState Term:4 Vote:1 Commit:11 Lead:0 LeadEpoch:0
+  HardState Term:2 Vote:1 Commit:11 Lead:0 LeadEpoch:0
   Messages:
-  1->2 MsgVote Term:4 Log:1/11
-  1->3 MsgVote Term:4 Log:1/11
-  INFO 1 received MsgVoteResp from 1 at term 4
+  1->2 MsgVote Term:2 Log:1/11
+  1->3 MsgVote Term:2 Log:1/11
+  INFO 1 received MsgVoteResp from 1 at term 2
   INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
 > 2 receiving messages
-  1->2 MsgVote Term:4 Log:1/11
+  1->2 MsgVote Term:2 Log:1/11
   INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 1 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
 > 3 receiving messages
-  1->3 MsgVote Term:4 Log:1/11
-  INFO 3 [term: 3] received a MsgVote message with higher term from 1 [term: 4], advancing term
-  INFO 3 became follower at term 4
-  INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 11] at term 4
+  1->3 MsgVote Term:2 Log:1/11
+  INFO 3 [term: 3] ignored a MsgVote message with lower term from 1 [term: 2]
+
+campaign 3
+----
+INFO 3 is starting a new election at term 3
+INFO 3 became candidate at term 4
+INFO 3 [logterm: 1, index: 10] sent MsgVote request to 1 at term 4
+INFO 3 [logterm: 1, index: 10] sent MsgVote request to 2 at term 4
+
+stabilize
+----
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:4 Vote:3 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  3->1 MsgVote Term:4 Log:1/10
+  3->2 MsgVote Term:4 Log:1/10
+  INFO 3 received MsgVoteResp from 3 at term 4
+  INFO 3 has received 1 MsgVoteResp votes and 0 vote rejections
+> 1 receiving messages
+  3->1 MsgVote Term:4 Log:1/10
+  INFO 1 [term: 2] received a MsgVote message with higher term from 3 [term: 4], advancing term
+  INFO 1 became follower at term 4
+  INFO 1 [logterm: 1, index: 11, vote: 0] rejected MsgVote from 3 [logterm: 1, index: 10] at term 4
+> 2 receiving messages
+  3->2 MsgVote Term:4 Log:1/10
+  INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 3 [logterm: 1, index: 10] at term 1: supporting fortified leader 1 at epoch 1
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateFollower
+  HardState Term:4 Commit:11 Lead:0 LeadEpoch:0
+  Messages:
+  1->3 MsgVoteResp Term:4 Log:0/0 Rejected (Hint: 0)
+> 3 receiving messages
+  1->3 MsgVoteResp Term:4 Log:0/0 Rejected (Hint: 0)
+  INFO 3 received MsgVoteResp rejection from 1 at term 4
+  INFO 3 has received 1 MsgVoteResp votes and 1 vote rejections
+
+campaign 1
+----
+INFO 1 is starting a new election at term 4
+INFO 1 became candidate at term 5
+INFO 1 [logterm: 1, index: 11] sent MsgVote request to 2 at term 5
+INFO 1 [logterm: 1, index: 11] sent MsgVote request to 3 at term 5
+
+stabilize
+----
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:5 Vote:1 Commit:11 Lead:0 LeadEpoch:0
+  Messages:
+  1->2 MsgVote Term:5 Log:1/11
+  1->3 MsgVote Term:5 Log:1/11
+  INFO 1 received MsgVoteResp from 1 at term 5
+  INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
+> 2 receiving messages
+  1->2 MsgVote Term:5 Log:1/11
+  INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 1 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
+> 3 receiving messages
+  1->3 MsgVote Term:5 Log:1/11
+  INFO 3 [term: 4] received a MsgVote message with higher term from 1 [term: 5], advancing term
+  INFO 3 became follower at term 5
+  INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 11] at term 5
 > 3 handling Ready
   Ready MustSync=true:
   State:StateFollower
-  HardState Term:4 Vote:1 Commit:10 Lead:0 LeadEpoch:0
+  HardState Term:5 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   Messages:
-  3->1 MsgVoteResp Term:4 Log:0/0
+  3->1 MsgVoteResp Term:5 Log:0/0
 > 1 receiving messages
-  3->1 MsgVoteResp Term:4 Log:0/0
-  INFO 1 received MsgVoteResp from 3 at term 4
+  3->1 MsgVoteResp Term:5 Log:0/0
+  INFO 1 received MsgVoteResp from 3 at term 5
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
-  INFO 1 became leader at term 4
+  INFO 1 became leader at term 5
 > 1 handling Ready
   Ready MustSync=true:
   State:StateLeader
-  HardState Term:4 Vote:1 Commit:11 Lead:1 LeadEpoch:1
+  HardState Term:5 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   Entries:
-  4/12 EntryNormal ""
+  5/12 EntryNormal ""
   Messages:
-  1->2 MsgFortifyLeader Term:4 Log:0/0
-  1->3 MsgFortifyLeader Term:4 Log:0/0
-  1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
-  1->3 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
+  1->2 MsgFortifyLeader Term:5 Log:0/0
+  1->3 MsgFortifyLeader Term:5 Log:0/0
+  1->2 MsgApp Term:5 Log:1/11 Commit:11 Entries:[5/12 EntryNormal ""]
+  1->3 MsgApp Term:5 Log:1/11 Commit:11 Entries:[5/12 EntryNormal ""]
 > 2 receiving messages
-  1->2 MsgFortifyLeader Term:4 Log:0/0
-  INFO 2 [term: 1] received a MsgFortifyLeader message with higher term from 1 [term: 4], advancing term
+  1->2 MsgFortifyLeader Term:5 Log:0/0
+  INFO 2 [term: 1] received a MsgFortifyLeader message with higher term from 1 [term: 5], new leader indicated, advancing term
   DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
-  INFO 2 became follower at term 4
-  1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
+  INFO 2 became follower at term 5
+  1->2 MsgApp Term:5 Log:1/11 Commit:11 Entries:[5/12 EntryNormal ""]
 > 3 receiving messages
-  1->3 MsgFortifyLeader Term:4 Log:0/0
-  1->3 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
+  1->3 MsgFortifyLeader Term:5 Log:0/0
+  1->3 MsgApp Term:5 Log:1/11 Commit:11 Entries:[5/12 EntryNormal ""]
   DEBUG 3 [logterm: 0, index: 11] rejected MsgApp [logterm: 1, index: 11] from 1
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:4 Commit:11 Lead:1 LeadEpoch:1
+  HardState Term:5 Commit:11 Lead:1 LeadEpoch:1
   Entries:
-  4/12 EntryNormal ""
+  5/12 EntryNormal ""
   Messages:
-  2->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
-  2->1 MsgAppResp Term:4 Log:0/12 Commit:11
+  2->1 MsgFortifyLeaderResp Term:5 Log:0/0 LeadEpoch:1
+  2->1 MsgAppResp Term:5 Log:0/12 Commit:11
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:4 Vote:1 Commit:10 Lead:1 LeadEpoch:1
+  HardState Term:5 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   Messages:
-  3->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
-  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
+  3->1 MsgFortifyLeaderResp Term:5 Log:0/0 LeadEpoch:1
+  3->1 MsgAppResp Term:5 Log:1/11 Rejected (Hint: 10) Commit:10
 > 1 receiving messages
-  2->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
-  2->1 MsgAppResp Term:4 Log:0/12 Commit:11
-  3->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
-  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
+  2->1 MsgFortifyLeaderResp Term:5 Log:0/0 LeadEpoch:1
+  2->1 MsgAppResp Term:5 Log:0/12 Commit:11
+  3->1 MsgFortifyLeaderResp Term:5 Log:0/0 LeadEpoch:1
+  3->1 MsgAppResp Term:5 Log:1/11 Rejected (Hint: 10) Commit:10
   DEBUG 1 received MsgAppResp(rejected, hint: (index 10, term 1)) from 3 for index 11
   DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=11 sentCommit=10 matchCommit=10]
 > 1 handling Ready
   Ready MustSync=true:
-  HardState Term:4 Vote:1 Commit:12 Lead:1 LeadEpoch:1
+  HardState Term:5 Vote:1 Commit:12 Lead:1 LeadEpoch:1
   CommittedEntries:
-  4/12 EntryNormal ""
+  5/12 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
-  1->2 MsgApp Term:4 Log:4/12 Commit:12
-  1->3 MsgApp Term:4 Log:1/11 Commit:12 Entries:[4/12 EntryNormal ""]
-  1->3 MsgApp Term:4 Log:1/10 Commit:12 Entries:[
+  1->2 MsgApp Term:5 Log:1/11 Commit:11 Entries:[5/12 EntryNormal ""]
+  1->2 MsgApp Term:5 Log:5/12 Commit:12
+  1->3 MsgApp Term:5 Log:1/11 Commit:12 Entries:[5/12 EntryNormal ""]
+  1->3 MsgApp Term:5 Log:1/10 Commit:12 Entries:[
     1/11 EntryNormal ""
-    4/12 EntryNormal ""
+    5/12 EntryNormal ""
   ]
 > 2 receiving messages
-  1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
-  1->2 MsgApp Term:4 Log:4/12 Commit:12
+  1->2 MsgApp Term:5 Log:1/11 Commit:11 Entries:[5/12 EntryNormal ""]
+  1->2 MsgApp Term:5 Log:5/12 Commit:12
 > 3 receiving messages
-  1->3 MsgApp Term:4 Log:1/11 Commit:12 Entries:[4/12 EntryNormal ""]
+  1->3 MsgApp Term:5 Log:1/11 Commit:12 Entries:[5/12 EntryNormal ""]
   DEBUG 3 [logterm: 0, index: 11] rejected MsgApp [logterm: 1, index: 11] from 1
-  1->3 MsgApp Term:4 Log:1/10 Commit:12 Entries:[
+  1->3 MsgApp Term:5 Log:1/10 Commit:12 Entries:[
     1/11 EntryNormal ""
-    4/12 EntryNormal ""
+    5/12 EntryNormal ""
   ]
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:4 Commit:12 Lead:1 LeadEpoch:1
+  HardState Term:5 Commit:12 Lead:1 LeadEpoch:1
   CommittedEntries:
-  4/12 EntryNormal ""
+  5/12 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:4 Log:0/12 Commit:11
-  2->1 MsgAppResp Term:4 Log:0/12 Commit:12
+  2->1 MsgAppResp Term:5 Log:0/12 Commit:11
+  2->1 MsgAppResp Term:5 Log:0/12 Commit:12
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:4 Vote:1 Commit:12 Lead:1 LeadEpoch:1
+  HardState Term:5 Vote:1 Commit:12 Lead:1 LeadEpoch:1
   Entries:
   1/11 EntryNormal ""
-  4/12 EntryNormal ""
+  5/12 EntryNormal ""
   CommittedEntries:
   1/11 EntryNormal ""
-  4/12 EntryNormal ""
+  5/12 EntryNormal ""
   Messages:
-  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
-  3->1 MsgAppResp Term:4 Log:0/12 Commit:12
+  3->1 MsgAppResp Term:5 Log:1/11 Rejected (Hint: 10) Commit:10
+  3->1 MsgAppResp Term:5 Log:0/12 Commit:12
 > 1 receiving messages
-  2->1 MsgAppResp Term:4 Log:0/12 Commit:11
-  2->1 MsgAppResp Term:4 Log:0/12 Commit:12
-  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
+  2->1 MsgAppResp Term:5 Log:0/12 Commit:11
+  2->1 MsgAppResp Term:5 Log:0/12 Commit:12
+  3->1 MsgAppResp Term:5 Log:1/11 Rejected (Hint: 10) Commit:10
   DEBUG 1 received MsgAppResp(rejected, hint: (index 10, term 1)) from 3 for index 11
-  3->1 MsgAppResp Term:4 Log:0/12 Commit:12
+  3->1 MsgAppResp Term:5 Log:0/12 Commit:12
 
 raft-state
 ----
-1: StateLeader (Voter) Term:4 Lead:1 LeadEpoch:1
-2: StateFollower (Voter) Term:4 Lead:1 LeadEpoch:1
-3: StateFollower (Voter) Term:4 Lead:1 LeadEpoch:1
+1: StateLeader (Voter) Term:5 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:5 Lead:1 LeadEpoch:1
+3: StateFollower (Voter) Term:5 Lead:1 LeadEpoch:1

--- a/pkg/raft/testdata/leader_step_down_stranded_peer_prevote.txt
+++ b/pkg/raft/testdata/leader_step_down_stranded_peer_prevote.txt
@@ -339,9 +339,58 @@ stabilize 1 3
   3->1 MsgAppResp Term:3 Log:0/0
 > 1 receiving messages
   3->1 MsgAppResp Term:3 Log:0/0
-  INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3], advancing term
-  INFO 1 became follower at term 3
+  INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3], stepping down as leader to recover stranded peer
+  INFO 1 became follower at term 1
   3->1 MsgAppResp Term:3 Log:0/0
+  INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3], ignoring and still supporting fortified leader
+> 1 handling Ready
+  Ready MustSync=false:
+  State:StateFollower
+
+# Wait until the ex-leader can be safely defortified.
+campaign 1
+----
+DEBUG 1 ignoring MsgHup due to leader fortification
+
+send-de-fortify 1 1
+----
+DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
+
+# With pre-vote, the ex-leader will learn about the higher term from the stranded
+# peer during the first time that it campaigns. When it campaigns again, it will
+# do so at the higher term and will be able to win the election.
+campaign 1
+----
+INFO 1 is starting a new election at term 1
+INFO 1 became pre-candidate at term 1
+INFO 1 [logterm: 1, index: 11] sent MsgPreVote request to 2 at term 1
+INFO 1 [logterm: 1, index: 11] sent MsgPreVote request to 3 at term 1
+
+stabilize
+----
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StatePreCandidate
+  HardState Term:1 Vote:1 Commit:11 Lead:0 LeadEpoch:0
+  Messages:
+  1->2 MsgPreVote Term:2 Log:1/11
+  1->3 MsgPreVote Term:2 Log:1/11
+  INFO 1 received MsgPreVoteResp from 1 at term 1
+  INFO 1 has received 1 MsgPreVoteResp votes and 0 vote rejections
+> 2 receiving messages
+  1->2 MsgPreVote Term:2 Log:1/11
+  INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 1 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
+> 3 receiving messages
+  1->3 MsgPreVote Term:2 Log:1/11
+  INFO 3 [logterm: 1, index: 10, vote: 3] rejected MsgPreVote from 1 [logterm: 1, index: 11] at term 3
+> 3 handling Ready
+  Ready MustSync=false:
+  Messages:
+  3->1 MsgPreVoteResp Term:3 Log:0/0 Rejected (Hint: 0)
+> 1 receiving messages
+  3->1 MsgPreVoteResp Term:3 Log:0/0 Rejected (Hint: 0)
+  INFO 1 [term: 1] received a MsgPreVoteResp message with higher term from 3 [term: 3], advancing term
+  INFO 1 became follower at term 3
 > 1 handling Ready
   Ready MustSync=true:
   State:StateFollower
@@ -422,7 +471,7 @@ stabilize
   1->3 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
 > 2 receiving messages
   1->2 MsgFortifyLeader Term:4 Log:0/0
-  INFO 2 [term: 1] received a MsgFortifyLeader message with higher term from 1 [term: 4], advancing term
+  INFO 2 [term: 1] received a MsgFortifyLeader message with higher term from 1 [term: 4], new leader indicated, advancing term
   DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 2 became follower at term 4
   1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]

--- a/pkg/raft/testdata/leader_step_down_stranded_peer_prevote.txt
+++ b/pkg/raft/testdata/leader_step_down_stranded_peer_prevote.txt
@@ -339,9 +339,11 @@ stabilize 1 3
   3->1 MsgAppResp Term:3 Log:0/0
 > 1 receiving messages
   3->1 MsgAppResp Term:3 Log:0/0
+  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgAppResp from 3 [logterm: 0, index: 0] at term 1: supporting fortified leader 1 at epoch 1
   INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3], stepping down as leader to recover stranded peer
   INFO 1 became follower at term 1
   3->1 MsgAppResp Term:3 Log:0/0
+  INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgAppResp from 3 [logterm: 0, index: 0] at term 1: supporting fortified leader 1 at epoch 1
   INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3], ignoring and still supporting fortified leader
 > 1 handling Ready
   Ready MustSync=false:

--- a/pkg/raft/testdata/leader_step_down_stranded_peer_prevote.txt
+++ b/pkg/raft/testdata/leader_step_down_stranded_peer_prevote.txt
@@ -1,0 +1,508 @@
+# Test which demonstrates how a leader steps down when a peer is stranded at a
+# higher term, after a series of hung elections, using pre-vote.
+
+add-nodes 3 voters=(1,2,3) index=10 prevote=true checkquorum=true
+----
+INFO 1 switched to configuration voters=(1 2 3)
+INFO 1 became follower at term 0
+INFO newRaft 1 [peers: [1,2,3], term: 0, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
+INFO 2 switched to configuration voters=(1 2 3)
+INFO 2 became follower at term 0
+INFO newRaft 2 [peers: [1,2,3], term: 0, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
+INFO 3 switched to configuration voters=(1 2 3)
+INFO 3 became follower at term 0
+INFO newRaft 3 [peers: [1,2,3], term: 0, commit: 10, applied: 10, lastindex: 10, lastterm: 1]
+
+###############################################################################
+# Strand node 3 at a higher term. This is a little more complicated with
+# prevote, but it is possible.
+###############################################################################
+
+campaign 3
+----
+INFO 3 is starting a new election at term 0
+INFO 3 became pre-candidate at term 0
+INFO 3 [logterm: 1, index: 10] sent MsgPreVote request to 1 at term 0
+INFO 3 [logterm: 1, index: 10] sent MsgPreVote request to 2 at term 0
+
+stabilize 3
+----
+> 3 handling Ready
+  Ready MustSync=false:
+  State:StatePreCandidate
+  Messages:
+  3->1 MsgPreVote Term:1 Log:1/10
+  3->2 MsgPreVote Term:1 Log:1/10
+  INFO 3 received MsgPreVoteResp from 3 at term 0
+  INFO 3 has received 1 MsgPreVoteResp votes and 0 vote rejections
+
+stabilize 2
+----
+> 2 receiving messages
+  3->2 MsgPreVote Term:1 Log:1/10
+  INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgPreVote for 3 [logterm: 1, index: 10] at term 0
+> 2 handling Ready
+  Ready MustSync=false:
+  Messages:
+  2->3 MsgPreVoteResp Term:1 Log:0/0
+
+stabilize 3
+----
+> 3 receiving messages
+  2->3 MsgPreVoteResp Term:1 Log:0/0
+  INFO 3 received MsgPreVoteResp from 2 at term 0
+  INFO 3 has received 2 MsgPreVoteResp votes and 0 vote rejections
+  INFO 3 became candidate at term 1
+  INFO 3 [logterm: 1, index: 10] sent MsgVote request to 1 at term 1
+  INFO 3 [logterm: 1, index: 10] sent MsgVote request to 2 at term 1
+> 3 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:1 Vote:3 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  3->1 MsgVote Term:1 Log:1/10
+  3->2 MsgVote Term:1 Log:1/10
+  INFO 3 received MsgVoteResp from 3 at term 1
+  INFO 3 has received 1 MsgVoteResp votes and 0 vote rejections
+
+deliver-msgs drop=(2)
+----
+dropped: 3->2 MsgVote Term:1 Log:1/10
+
+# Set the randomized election timeout to be worth 1 tick-election. This makes the
+# test deterministic.
+set-randomized-election-timeout 3 timeout=3
+----
+ok
+
+tick-election 3
+----
+INFO 3 is starting a new election at term 1
+INFO 3 became pre-candidate at term 1
+INFO 3 [logterm: 1, index: 10] sent MsgPreVote request to 1 at term 1
+INFO 3 [logterm: 1, index: 10] sent MsgPreVote request to 2 at term 1
+
+stabilize 3
+----
+> 3 handling Ready
+  Ready MustSync=false:
+  State:StatePreCandidate
+  Messages:
+  3->1 MsgPreVote Term:2 Log:1/10
+  3->2 MsgPreVote Term:2 Log:1/10
+  INFO 3 received MsgPreVoteResp from 3 at term 1
+  INFO 3 has received 1 MsgPreVoteResp votes and 0 vote rejections
+
+stabilize 2
+----
+> 2 receiving messages
+  3->2 MsgPreVote Term:2 Log:1/10
+  INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgPreVote for 3 [logterm: 1, index: 10] at term 0
+> 2 handling Ready
+  Ready MustSync=false:
+  Messages:
+  2->3 MsgPreVoteResp Term:2 Log:0/0
+
+stabilize 3
+----
+> 3 receiving messages
+  2->3 MsgPreVoteResp Term:2 Log:0/0
+  INFO 3 received MsgPreVoteResp from 2 at term 1
+  INFO 3 has received 2 MsgPreVoteResp votes and 0 vote rejections
+  INFO 3 became candidate at term 2
+  INFO 3 [logterm: 1, index: 10] sent MsgVote request to 1 at term 2
+  INFO 3 [logterm: 1, index: 10] sent MsgVote request to 2 at term 2
+> 3 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:2 Vote:3 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  3->1 MsgVote Term:2 Log:1/10
+  3->2 MsgVote Term:2 Log:1/10
+  INFO 3 received MsgVoteResp from 3 at term 2
+  INFO 3 has received 1 MsgVoteResp votes and 0 vote rejections
+
+deliver-msgs drop=(2)
+----
+dropped: 3->2 MsgVote Term:2 Log:1/10
+
+set-randomized-election-timeout 3 timeout=3
+----
+ok
+
+tick-election 3
+----
+INFO 3 is starting a new election at term 2
+INFO 3 became pre-candidate at term 2
+INFO 3 [logterm: 1, index: 10] sent MsgPreVote request to 1 at term 2
+INFO 3 [logterm: 1, index: 10] sent MsgPreVote request to 2 at term 2
+
+stabilize 3
+----
+> 3 handling Ready
+  Ready MustSync=false:
+  State:StatePreCandidate
+  Messages:
+  3->1 MsgPreVote Term:3 Log:1/10
+  3->2 MsgPreVote Term:3 Log:1/10
+  INFO 3 received MsgPreVoteResp from 3 at term 2
+  INFO 3 has received 1 MsgPreVoteResp votes and 0 vote rejections
+
+stabilize 2
+----
+> 2 receiving messages
+  3->2 MsgPreVote Term:3 Log:1/10
+  INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgPreVote for 3 [logterm: 1, index: 10] at term 0
+> 2 handling Ready
+  Ready MustSync=false:
+  Messages:
+  2->3 MsgPreVoteResp Term:3 Log:0/0
+
+stabilize 3
+----
+> 3 receiving messages
+  2->3 MsgPreVoteResp Term:3 Log:0/0
+  INFO 3 received MsgPreVoteResp from 2 at term 2
+  INFO 3 has received 2 MsgPreVoteResp votes and 0 vote rejections
+  INFO 3 became candidate at term 3
+  INFO 3 [logterm: 1, index: 10] sent MsgVote request to 1 at term 3
+  INFO 3 [logterm: 1, index: 10] sent MsgVote request to 2 at term 3
+> 3 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:3 Vote:3 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  3->1 MsgVote Term:3 Log:1/10
+  3->2 MsgVote Term:3 Log:1/10
+  INFO 3 received MsgVoteResp from 3 at term 3
+  INFO 3 has received 1 MsgVoteResp votes and 0 vote rejections
+
+deliver-msgs drop=(1, 2)
+----
+dropped: 3->1 MsgPreVote Term:1 Log:1/10
+dropped: 3->1 MsgVote Term:1 Log:1/10
+dropped: 3->1 MsgPreVote Term:2 Log:1/10
+dropped: 3->1 MsgVote Term:2 Log:1/10
+dropped: 3->1 MsgPreVote Term:3 Log:1/10
+dropped: 3->1 MsgVote Term:3 Log:1/10
+dropped: 3->2 MsgVote Term:3 Log:1/10
+
+raft-state
+----
+1: StateFollower (Voter) Term:0 Lead:0 LeadEpoch:0
+2: StateFollower (Voter) Term:0 Lead:0 LeadEpoch:0
+3: StateCandidate (Voter) Term:3 Lead:0 LeadEpoch:0
+
+###############################################################################
+# Now that node 3 is stranded, establish node 1 as leader of term 1.
+###############################################################################
+
+campaign 1
+----
+INFO 1 is starting a new election at term 0
+INFO 1 became pre-candidate at term 0
+INFO 1 [logterm: 1, index: 10] sent MsgPreVote request to 2 at term 0
+INFO 1 [logterm: 1, index: 10] sent MsgPreVote request to 3 at term 0
+
+stabilize 1 2
+----
+> 1 handling Ready
+  Ready MustSync=false:
+  State:StatePreCandidate
+  Messages:
+  1->2 MsgPreVote Term:1 Log:1/10
+  1->3 MsgPreVote Term:1 Log:1/10
+  INFO 1 received MsgPreVoteResp from 1 at term 0
+  INFO 1 has received 1 MsgPreVoteResp votes and 0 vote rejections
+> 2 receiving messages
+  1->2 MsgPreVote Term:1 Log:1/10
+  INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgPreVote for 1 [logterm: 1, index: 10] at term 0
+> 2 handling Ready
+  Ready MustSync=false:
+  Messages:
+  2->1 MsgPreVoteResp Term:1 Log:0/0
+> 1 receiving messages
+  2->1 MsgPreVoteResp Term:1 Log:0/0
+  INFO 1 received MsgPreVoteResp from 2 at term 0
+  INFO 1 has received 2 MsgPreVoteResp votes and 0 vote rejections
+  INFO 1 became candidate at term 1
+  INFO 1 [logterm: 1, index: 10] sent MsgVote request to 2 at term 1
+  INFO 1 [logterm: 1, index: 10] sent MsgVote request to 3 at term 1
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  1->2 MsgVote Term:1 Log:1/10
+  1->3 MsgVote Term:1 Log:1/10
+  INFO 1 received MsgVoteResp from 1 at term 1
+  INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
+> 2 receiving messages
+  1->2 MsgVote Term:1 Log:1/10
+  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 2 became follower at term 1
+  INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  2->1 MsgVoteResp Term:1 Log:0/0
+> 1 receiving messages
+  2->1 MsgVoteResp Term:1 Log:0/0
+  INFO 1 received MsgVoteResp from 2 at term 1
+  INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
+  INFO 1 became leader at term 1
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateLeader
+  HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
+  Entries:
+  1/11 EntryNormal ""
+  Messages:
+  1->2 MsgFortifyLeader Term:1 Log:0/0
+  1->3 MsgFortifyLeader Term:1 Log:0/0
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+  1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+> 2 receiving messages
+  1->2 MsgFortifyLeader Term:1 Log:0/0
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
+  Entries:
+  1/11 EntryNormal ""
+  Messages:
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
+> 1 receiving messages
+  2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/11 EntryNormal ""
+  Messages:
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+  1->2 MsgApp Term:1 Log:1/11 Commit:11
+> 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+  1->2 MsgApp Term:1 Log:1/11 Commit:11
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/11 EntryNormal ""
+  Messages:
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:11
+> 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
+  2->1 MsgAppResp Term:1 Log:0/11 Commit:11
+
+deliver-msgs drop=(3)
+----
+dropped: 1->3 MsgPreVote Term:1 Log:1/10
+dropped: 1->3 MsgVote Term:1 Log:1/10
+dropped: 1->3 MsgFortifyLeader Term:1 Log:0/0
+dropped: 1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+
+raft-state
+----
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+3: StateCandidate (Voter) Term:3 Lead:0 LeadEpoch:0
+
+###############################################################################
+# Reconnect node 1 and 3 and demonstrate that node 1 steps down as leader to
+# catch up to node 3's term.
+###############################################################################
+
+tick-heartbeat 1
+----
+ok
+
+stabilize 1 3
+----
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->3 MsgFortifyLeader Term:1 Log:0/0
+  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
+> 3 receiving messages
+  1->3 MsgFortifyLeader Term:1 Log:0/0
+  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
+> 3 handling Ready
+  Ready MustSync=false:
+  Messages:
+  3->1 MsgAppResp Term:3 Log:0/0
+  3->1 MsgAppResp Term:3 Log:0/0
+> 1 receiving messages
+  3->1 MsgAppResp Term:3 Log:0/0
+  INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3]
+  INFO 1 became follower at term 3
+  3->1 MsgAppResp Term:3 Log:0/0
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateFollower
+  HardState Term:3 Commit:11 Lead:0 LeadEpoch:0
+
+campaign 1
+----
+INFO 1 is starting a new election at term 3
+INFO 1 became pre-candidate at term 3
+INFO 1 [logterm: 1, index: 11] sent MsgPreVote request to 2 at term 3
+INFO 1 [logterm: 1, index: 11] sent MsgPreVote request to 3 at term 3
+
+stabilize
+----
+> 1 handling Ready
+  Ready MustSync=false:
+  State:StatePreCandidate
+  Messages:
+  1->2 MsgPreVote Term:4 Log:1/11
+  1->3 MsgPreVote Term:4 Log:1/11
+  INFO 1 received MsgPreVoteResp from 1 at term 3
+  INFO 1 has received 1 MsgPreVoteResp votes and 0 vote rejections
+> 2 receiving messages
+  1->2 MsgPreVote Term:4 Log:1/11
+  INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 1 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
+> 3 receiving messages
+  1->3 MsgPreVote Term:4 Log:1/11
+  INFO 3 [logterm: 1, index: 10, vote: 3] cast MsgPreVote for 1 [logterm: 1, index: 11] at term 3
+> 3 handling Ready
+  Ready MustSync=false:
+  Messages:
+  3->1 MsgPreVoteResp Term:4 Log:0/0
+> 1 receiving messages
+  3->1 MsgPreVoteResp Term:4 Log:0/0
+  INFO 1 received MsgPreVoteResp from 3 at term 3
+  INFO 1 has received 2 MsgPreVoteResp votes and 0 vote rejections
+  INFO 1 became candidate at term 4
+  INFO 1 [logterm: 1, index: 11] sent MsgVote request to 2 at term 4
+  INFO 1 [logterm: 1, index: 11] sent MsgVote request to 3 at term 4
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:4 Vote:1 Commit:11 Lead:0 LeadEpoch:0
+  Messages:
+  1->2 MsgVote Term:4 Log:1/11
+  1->3 MsgVote Term:4 Log:1/11
+  INFO 1 received MsgVoteResp from 1 at term 4
+  INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
+> 2 receiving messages
+  1->2 MsgVote Term:4 Log:1/11
+  INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 1 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
+> 3 receiving messages
+  1->3 MsgVote Term:4 Log:1/11
+  INFO 3 [term: 3] received a MsgVote message with higher term from 1 [term: 4]
+  INFO 3 became follower at term 4
+  INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 11] at term 4
+> 3 handling Ready
+  Ready MustSync=true:
+  State:StateFollower
+  HardState Term:4 Vote:1 Commit:10 Lead:0 LeadEpoch:0
+  Messages:
+  3->1 MsgVoteResp Term:4 Log:0/0
+> 1 receiving messages
+  3->1 MsgVoteResp Term:4 Log:0/0
+  INFO 1 received MsgVoteResp from 3 at term 4
+  INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
+  INFO 1 became leader at term 4
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateLeader
+  HardState Term:4 Vote:1 Commit:11 Lead:1 LeadEpoch:1
+  Entries:
+  4/12 EntryNormal ""
+  Messages:
+  1->2 MsgFortifyLeader Term:4 Log:0/0
+  1->3 MsgFortifyLeader Term:4 Log:0/0
+  1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
+  1->3 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
+> 2 receiving messages
+  1->2 MsgFortifyLeader Term:4 Log:0/0
+  INFO 2 [term: 1] received a MsgFortifyLeader message with higher term from 1 [term: 4]
+  DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
+  INFO 2 became follower at term 4
+  1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
+> 3 receiving messages
+  1->3 MsgFortifyLeader Term:4 Log:0/0
+  1->3 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
+  DEBUG 3 [logterm: 0, index: 11] rejected MsgApp [logterm: 1, index: 11] from 1
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:4 Commit:11 Lead:1 LeadEpoch:1
+  Entries:
+  4/12 EntryNormal ""
+  Messages:
+  2->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
+  2->1 MsgAppResp Term:4 Log:0/12 Commit:11
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:4 Vote:1 Commit:10 Lead:1 LeadEpoch:1
+  Messages:
+  3->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
+  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
+> 1 receiving messages
+  2->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
+  2->1 MsgAppResp Term:4 Log:0/12 Commit:11
+  3->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
+  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 10, term 1)) from 3 for index 11
+  DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=11 sentCommit=10 matchCommit=10]
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:4 Vote:1 Commit:12 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  4/12 EntryNormal ""
+  Messages:
+  1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
+  1->2 MsgApp Term:4 Log:4/12 Commit:12
+  1->3 MsgApp Term:4 Log:1/11 Commit:12 Entries:[4/12 EntryNormal ""]
+  1->3 MsgApp Term:4 Log:1/10 Commit:12 Entries:[
+    1/11 EntryNormal ""
+    4/12 EntryNormal ""
+  ]
+> 2 receiving messages
+  1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
+  1->2 MsgApp Term:4 Log:4/12 Commit:12
+> 3 receiving messages
+  1->3 MsgApp Term:4 Log:1/11 Commit:12 Entries:[4/12 EntryNormal ""]
+  DEBUG 3 [logterm: 0, index: 11] rejected MsgApp [logterm: 1, index: 11] from 1
+  1->3 MsgApp Term:4 Log:1/10 Commit:12 Entries:[
+    1/11 EntryNormal ""
+    4/12 EntryNormal ""
+  ]
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:4 Commit:12 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  4/12 EntryNormal ""
+  Messages:
+  2->1 MsgAppResp Term:4 Log:0/12 Commit:11
+  2->1 MsgAppResp Term:4 Log:0/12 Commit:12
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:4 Vote:1 Commit:12 Lead:1 LeadEpoch:1
+  Entries:
+  1/11 EntryNormal ""
+  4/12 EntryNormal ""
+  CommittedEntries:
+  1/11 EntryNormal ""
+  4/12 EntryNormal ""
+  Messages:
+  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
+  3->1 MsgAppResp Term:4 Log:0/12 Commit:12
+> 1 receiving messages
+  2->1 MsgAppResp Term:4 Log:0/12 Commit:11
+  2->1 MsgAppResp Term:4 Log:0/12 Commit:12
+  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 10, term 1)) from 3 for index 11
+  3->1 MsgAppResp Term:4 Log:0/12 Commit:12
+
+raft-state
+----
+1: StateLeader (Voter) Term:4 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:4 Lead:1 LeadEpoch:1
+3: StateFollower (Voter) Term:4 Lead:1 LeadEpoch:1

--- a/pkg/raft/testdata/leader_step_down_stranded_peer_prevote.txt
+++ b/pkg/raft/testdata/leader_step_down_stranded_peer_prevote.txt
@@ -239,7 +239,7 @@ stabilize 1 2
   INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
 > 2 receiving messages
   1->2 MsgVote Term:1 Log:1/10
-  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 2 became follower at term 1
   INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
 > 2 handling Ready
@@ -339,7 +339,7 @@ stabilize 1 3
   3->1 MsgAppResp Term:3 Log:0/0
 > 1 receiving messages
   3->1 MsgAppResp Term:3 Log:0/0
-  INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3]
+  INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3], advancing term
   INFO 1 became follower at term 3
   3->1 MsgAppResp Term:3 Log:0/0
 > 1 handling Ready
@@ -395,7 +395,7 @@ stabilize
   INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 1 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
 > 3 receiving messages
   1->3 MsgVote Term:4 Log:1/11
-  INFO 3 [term: 3] received a MsgVote message with higher term from 1 [term: 4]
+  INFO 3 [term: 3] received a MsgVote message with higher term from 1 [term: 4], advancing term
   INFO 3 became follower at term 4
   INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 11] at term 4
 > 3 handling Ready
@@ -422,7 +422,7 @@ stabilize
   1->3 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
 > 2 receiving messages
   1->2 MsgFortifyLeader Term:4 Log:0/0
-  INFO 2 [term: 1] received a MsgFortifyLeader message with higher term from 1 [term: 4]
+  INFO 2 [term: 1] received a MsgFortifyLeader message with higher term from 1 [term: 4], advancing term
   DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 2 became follower at term 4
   1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]

--- a/pkg/raft/testdata/mixedversions/checkquorum.txt
+++ b/pkg/raft/testdata/mixedversions/checkquorum.txt
@@ -202,7 +202,7 @@ stabilize
   2->1 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
 > 3 receiving messages
   2->3 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
-  INFO 3 [term: 1] received a MsgApp message with higher term from 2 [term: 3], advancing term
+  INFO 3 [term: 1] received a MsgApp message with higher term from 2 [term: 3], new leader indicated, advancing term
   INFO 3 became follower at term 3
 > 1 handling Ready
   Ready MustSync=true:

--- a/pkg/raft/testdata/mixedversions/checkquorum.txt
+++ b/pkg/raft/testdata/mixedversions/checkquorum.txt
@@ -126,7 +126,7 @@ stabilize
   3->1 MsgHeartbeatResp Term:1 Log:0/0
 > 1 receiving messages
   2->1 MsgAppResp Term:2 Log:0/0
-  INFO 1 [term: 1] received a MsgAppResp message with higher term from 2 [term: 2]
+  INFO 1 [term: 1] received a MsgAppResp message with higher term from 2 [term: 2], advancing term
   INFO 1 became follower at term 2
   2->1 MsgAppResp Term:2 Log:0/0
   2->1 MsgAppResp Term:2 Log:0/0
@@ -168,7 +168,7 @@ INFO 2 has received 1 MsgVoteResp votes and 0 vote rejections
 deliver-msgs 1
 ----
 2->1 MsgVote Term:3 Log:1/11
-INFO 1 [term: 2] received a MsgVote message with higher term from 2 [term: 3]
+INFO 1 [term: 2] received a MsgVote message with higher term from 2 [term: 3], advancing term
 INFO 1 became follower at term 3
 INFO 1 [logterm: 1, index: 11, vote: 0] cast MsgVote for 2 [logterm: 1, index: 11] at term 3
 
@@ -202,7 +202,7 @@ stabilize
   2->1 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
 > 3 receiving messages
   2->3 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
-  INFO 3 [term: 1] received a MsgApp message with higher term from 2 [term: 3]
+  INFO 3 [term: 1] received a MsgApp message with higher term from 2 [term: 3], advancing term
   INFO 3 became follower at term 3
 > 1 handling Ready
   Ready MustSync=true:

--- a/pkg/raft/testdata/mixedversions/snapshot_succeed_via_app_resp.txt
+++ b/pkg/raft/testdata/mixedversions/snapshot_succeed_via_app_resp.txt
@@ -76,7 +76,7 @@ stabilize 3
 ----
 > 3 receiving messages
   1->3 MsgHeartbeat Term:1 Log:0/0
-  INFO 3 [term: 0] received a MsgHeartbeat message with higher term from 1 [term: 1]
+  INFO 3 [term: 0] received a MsgHeartbeat message with higher term from 1 [term: 1], advancing term
   INFO 3 became follower at term 1
 > 3 handling Ready
   Ready MustSync=true:

--- a/pkg/raft/testdata/mixedversions/snapshot_succeed_via_app_resp.txt
+++ b/pkg/raft/testdata/mixedversions/snapshot_succeed_via_app_resp.txt
@@ -76,7 +76,7 @@ stabilize 3
 ----
 > 3 receiving messages
   1->3 MsgHeartbeat Term:1 Log:0/0
-  INFO 3 [term: 0] received a MsgHeartbeat message with higher term from 1 [term: 1], advancing term
+  INFO 3 [term: 0] received a MsgHeartbeat message with higher term from 1 [term: 1], new leader indicated, advancing term
   INFO 3 became follower at term 1
 > 3 handling Ready
   Ready MustSync=true:

--- a/pkg/raft/testdata/prevote.txt
+++ b/pkg/raft/testdata/prevote.txt
@@ -209,12 +209,12 @@ stabilize
   INFO 2 has received 1 MsgVoteResp votes and 0 vote rejections
 > 1 receiving messages
   2->1 MsgVote Term:2 Log:1/12
-  INFO 1 [term: 1] received a MsgVote message with higher term from 2 [term: 2]
+  INFO 1 [term: 1] received a MsgVote message with higher term from 2 [term: 2], advancing term
   INFO 1 became follower at term 2
   INFO 1 [logterm: 1, index: 12, vote: 0] cast MsgVote for 2 [logterm: 1, index: 12] at term 2
 > 3 receiving messages
   2->3 MsgVote Term:2 Log:1/12
-  INFO 3 [term: 1] received a MsgVote message with higher term from 2 [term: 2]
+  INFO 3 [term: 1] received a MsgVote message with higher term from 2 [term: 2], advancing term
   INFO 3 became follower at term 2
   INFO 3 [logterm: 1, index: 12, vote: 0] cast MsgVote for 2 [logterm: 1, index: 12] at term 2
 > 1 handling Ready

--- a/pkg/raft/testdata/prevote_checkquorum.txt
+++ b/pkg/raft/testdata/prevote_checkquorum.txt
@@ -128,7 +128,7 @@ stabilize
   INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 3 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
 > 2 receiving messages
   3->2 MsgVote Term:2 Log:1/11
-  INFO 2 [term: 1] received a MsgVote message with higher term from 3 [term: 2]
+  INFO 2 [term: 1] received a MsgVote message with higher term from 3 [term: 2], advancing term
   INFO 2 became follower at term 2
   INFO 2 [logterm: 1, index: 11, vote: 0] cast MsgVote for 3 [logterm: 1, index: 11] at term 2
 > 2 handling Ready
@@ -155,7 +155,7 @@ stabilize
   3->2 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 1 receiving messages
   3->1 MsgFortifyLeader Term:2 Log:0/0
-  INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 3 [term: 2]
+  INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 3 [term: 2], advancing term
   INFO 1 became follower at term 2
   3->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 2 receiving messages
@@ -326,7 +326,7 @@ stabilize
   INFO 2 has received 1 MsgVoteResp votes and 0 vote rejections
 > 1 receiving messages
   2->1 MsgVote Term:3 Log:2/12
-  INFO 1 [term: 2] received a MsgVote message with higher term from 2 [term: 3]
+  INFO 1 [term: 2] received a MsgVote message with higher term from 2 [term: 3], advancing term
   INFO 1 became follower at term 3
   INFO 1 [logterm: 2, index: 12, vote: 0] cast MsgVote for 2 [logterm: 2, index: 12] at term 3
 > 3 receiving messages
@@ -359,7 +359,7 @@ stabilize
   2->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
 > 3 receiving messages
   2->3 MsgFortifyLeader Term:3 Log:0/0
-  INFO 3 [term: 2] received a MsgFortifyLeader message with higher term from 2 [term: 3]
+  INFO 3 [term: 2] received a MsgFortifyLeader message with higher term from 2 [term: 3], advancing term
   INFO 3 became follower at term 3
   2->3 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
 > 1 handling Ready

--- a/pkg/raft/testdata/prevote_checkquorum.txt
+++ b/pkg/raft/testdata/prevote_checkquorum.txt
@@ -155,7 +155,7 @@ stabilize
   3->2 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 1 receiving messages
   3->1 MsgFortifyLeader Term:2 Log:0/0
-  INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 3 [term: 2], advancing term
+  INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 3 [term: 2], new leader indicated, advancing term
   INFO 1 became follower at term 2
   3->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 2 receiving messages
@@ -359,7 +359,7 @@ stabilize
   2->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
 > 3 receiving messages
   2->3 MsgFortifyLeader Term:3 Log:0/0
-  INFO 3 [term: 2] received a MsgFortifyLeader message with higher term from 2 [term: 3], advancing term
+  INFO 3 [term: 2] received a MsgFortifyLeader message with higher term from 2 [term: 3], new leader indicated, advancing term
   INFO 3 became follower at term 3
   2->3 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
 > 1 handling Ready

--- a/pkg/raft/testdata/probe_and_replicate.txt
+++ b/pkg/raft/testdata/probe_and_replicate.txt
@@ -419,32 +419,32 @@ stabilize 2 3 4 5 6 7
 ----
 > 2 receiving messages
   1->2 MsgVote Term:8 Log:6/20
-  INFO 2 [term: 6] received a MsgVote message with higher term from 1 [term: 8]
+  INFO 2 [term: 6] received a MsgVote message with higher term from 1 [term: 8], advancing term
   INFO 2 became follower at term 8
   INFO 2 [logterm: 6, index: 19, vote: 0] cast MsgVote for 1 [logterm: 6, index: 20] at term 8
 > 3 receiving messages
   1->3 MsgVote Term:8 Log:6/20
-  INFO 3 [term: 7] received a MsgVote message with higher term from 1 [term: 8]
+  INFO 3 [term: 7] received a MsgVote message with higher term from 1 [term: 8], advancing term
   INFO 3 became follower at term 8
   INFO 3 [logterm: 4, index: 14, vote: 0] cast MsgVote for 1 [logterm: 6, index: 20] at term 8
 > 4 receiving messages
   1->4 MsgVote Term:8 Log:6/20
-  INFO 4 [term: 6] received a MsgVote message with higher term from 1 [term: 8]
+  INFO 4 [term: 6] received a MsgVote message with higher term from 1 [term: 8], advancing term
   INFO 4 became follower at term 8
   INFO 4 [logterm: 6, index: 21, vote: 0] rejected MsgVote from 1 [logterm: 6, index: 20] at term 8
 > 5 receiving messages
   1->5 MsgVote Term:8 Log:6/20
-  INFO 5 [term: 7] received a MsgVote message with higher term from 1 [term: 8]
+  INFO 5 [term: 7] received a MsgVote message with higher term from 1 [term: 8], advancing term
   INFO 5 became follower at term 8
   INFO 5 [logterm: 7, index: 22, vote: 0] rejected MsgVote from 1 [logterm: 6, index: 20] at term 8
 > 6 receiving messages
   1->6 MsgVote Term:8 Log:6/20
-  INFO 6 [term: 7] received a MsgVote message with higher term from 1 [term: 8]
+  INFO 6 [term: 7] received a MsgVote message with higher term from 1 [term: 8], advancing term
   INFO 6 became follower at term 8
   INFO 6 [logterm: 4, index: 17, vote: 0] cast MsgVote for 1 [logterm: 6, index: 20] at term 8
 > 7 receiving messages
   1->7 MsgVote Term:8 Log:6/20
-  INFO 7 [term: 7] received a MsgVote message with higher term from 1 [term: 8]
+  INFO 7 [term: 7] received a MsgVote message with higher term from 1 [term: 8], advancing term
   INFO 7 became follower at term 8
   INFO 7 [logterm: 3, index: 21, vote: 0] cast MsgVote for 1 [logterm: 6, index: 20] at term 8
 > 2 handling Ready

--- a/pkg/raft/testdata/refortification_basic.txt
+++ b/pkg/raft/testdata/refortification_basic.txt
@@ -61,12 +61,12 @@ stabilize
   INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
 > 2 receiving messages
   1->2 MsgVote Term:1 Log:1/2
-  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 2 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 2 became follower at term 1
   INFO 2 [logterm: 1, index: 2, vote: 0] cast MsgVote for 1 [logterm: 1, index: 2] at term 1
 > 3 receiving messages
   1->3 MsgVote Term:1 Log:1/2
-  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1]
+  INFO 3 [term: 0] received a MsgVote message with higher term from 1 [term: 1], advancing term
   INFO 3 became follower at term 1
   INFO 3 [logterm: 1, index: 2, vote: 0] cast MsgVote for 1 [logterm: 1, index: 2] at term 1
 > 2 handling Ready

--- a/pkg/raft/testdata/snapshot_new_term.txt
+++ b/pkg/raft/testdata/snapshot_new_term.txt
@@ -61,7 +61,7 @@ stabilize 1 2
 > 1 receiving messages
   2->1 MsgVote Term:2 Log:1/11
   DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
-  INFO 1 [term: 1] received a MsgVote message with higher term from 2 [term: 2]
+  INFO 1 [term: 1] received a MsgVote message with higher term from 2 [term: 2], advancing term
   INFO 1 became follower at term 2
   INFO 1 [logterm: 1, index: 11, vote: 0] cast MsgVote for 2 [logterm: 1, index: 11] at term 2
 > 1 handling Ready
@@ -140,7 +140,7 @@ stabilize
 > 3 receiving messages
   2->3 MsgSnap Term:2 Log:0/0
     Snapshot: Index:12 Term:2 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
-  INFO 3 [term: 1] received a MsgSnap message with higher term from 2 [term: 2]
+  INFO 3 [term: 1] received a MsgSnap message with higher term from 2 [term: 2], advancing term
   DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 3 became follower at term 2
   INFO log [committed=11, applied=11, applying=11, unstable.offset=12, unstable.offsetInProgress=12, len(unstable.Entries)=0] starts to restore snapshot [index: 12, term: 2]

--- a/pkg/raft/testdata/snapshot_new_term.txt
+++ b/pkg/raft/testdata/snapshot_new_term.txt
@@ -140,7 +140,7 @@ stabilize
 > 3 receiving messages
   2->3 MsgSnap Term:2 Log:0/0
     Snapshot: Index:12 Term:2 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
-  INFO 3 [term: 1] received a MsgSnap message with higher term from 2 [term: 2], advancing term
+  INFO 3 [term: 1] received a MsgSnap message with higher term from 2 [term: 2], new leader indicated, advancing term
   DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 3 became follower at term 2
   INFO log [committed=11, applied=11, applying=11, unstable.offset=12, unstable.offsetInProgress=12, len(unstable.Entries)=0] starts to restore snapshot [index: 12, term: 2]

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
@@ -72,7 +72,7 @@ stabilize 3
 ----
 > 3 receiving messages
   1->3 MsgFortifyLeader Term:1 Log:0/0
-  INFO 3 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], advancing term
+  INFO 3 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], new leader indicated, advancing term
   INFO 3 became follower at term 1
 > 3 handling Ready
   Ready MustSync=true:

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
@@ -72,7 +72,7 @@ stabilize 3
 ----
 > 3 receiving messages
   1->3 MsgFortifyLeader Term:1 Log:0/0
-  INFO 3 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1]
+  INFO 3 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], advancing term
   INFO 3 became follower at term 1
 > 3 handling Ready
   Ready MustSync=true:


### PR DESCRIPTION
Informs #132762.

This commit fixes a bug where a peer would step down to a newer term while fortifying a leader. This would break the leader fortification promise, which is critical for the leader lease disjointness property.

Instead, we now ignore the message as a follower and let the leader handle the process of stepping down, safely defortifying, and eventually stepping back up leader in the new term.

A subsequent commit will combine this logic with the other leader lease check for votes and pre-votes.

Release note: None