### PR TITLE
ldapccl: handle non-standard sql groups in ldap authZ

### DIFF
--- a/pkg/ccl/testccl/authccl/testdata/ldap
+++ b/pkg/ccl/testccl/authccl/testdata/ldap
@@ -270,3 +270,45 @@ SELECT pg_has_role('ldap_user', 'ldap_user_parent_1', 'MEMBER')
 true
 
 subtest end
+
+subtest non_standard_sql_group_names
+
+set_hba
+host  all ldap_user 127.0.0.1/32 ldap ldapserver=localhost ldapport=636 ldapbasedn="O=security org,DC=localhost" ldapbinddn="CN=service_account,O=security org,DC=localhost" ldapbindpasswd=ldap_pwd ldapsearchattribute=sAMAccountName ldapsearchfilter="(memberOf=*)" "ldapgrouplistfilter=(cn=*)"
+----
+# Active authentication configuration on this node:
+# Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
+# host  all root all cert-password # CockroachDB mandatory rule
+# host  all ldap_user 127.0.0.1/32 ldap ldapserver=localhost ldapport=636 ldapbasedn="O=security org,DC=localhost" ldapbinddn="CN=service_account,O=security org,DC=localhost" ldapbindpasswd=ldap_pwd ldapsearchattribute=sAMAccountName ldapsearchfilter="(memberOf=*)" "ldapgrouplistfilter=(cn=*)"
+#
+# Interpreted configuration:
+# TYPE   DATABASE USER      ADDRESS      METHOD        OPTIONS
+loopback all      all       all          trust
+host     all      root      all          cert-password
+host     all      ldap_user 127.0.0.1/32 ldap          ldapserver=localhost ldapport=636 "ldapbasedn=O=security org,DC=localhost" "ldapbinddn=CN=service_account,O=security org,DC=localhost" ldapbindpasswd=ldap_pwd ldapsearchattribute=sAMAccountName "ldapsearchfilter=(memberOf=*)" "ldapgrouplistfilter=(cn=*)"
+
+sql
+CREATE ROLE "ldap-user-parent-1";
+CREATE ROLE "ldap.user.parent.2";
+----
+ok
+
+ldap_mock set_groups=(ldap_user,cn=ldap-user-parent-1,cn=ldap.user.parent.2)
+----
+
+connect user=ldap_user password="ldap_pwd"
+----
+ok defaultdb
+
+query_row
+SELECT pg_has_role('ldap_user', 'ldap-user-parent-1', 'MEMBER')
+----
+true
+
+query_row
+SELECT pg_has_role('ldap_user', 'ldap.user.parent.2', 'MEMBER')
+----
+true
+
+subtest end

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -761,7 +761,7 @@ func EnsureUserOnlyBelongsToRoles(
 				if i > 0 {
 					grantStmt.WriteString(", ")
 				}
-				grantStmt.WriteString(role.Normalized())
+				grantStmt.WriteString(fmt.Sprintf("%q", role.Normalized()))
 			}
 			grantStmt.WriteString(" TO ")
 			grantStmt.WriteString(user.Normalized())


### PR DESCRIPTION
fixes #134923
Epic CRDB-33829

LDAP authZ currently fails where we process grant roles for ldap groups with `.` or `-` in their CN fail as they need a quoted string to process the stmt.

Release note(security):  This fix handles non-standard sql roles created for managing ldap groups cn and modifies the grant statement to handle using quoted sql roles.