### PR TITLE
kvserver/rangefeed: rename Disconnect to SendError for stream interface

### DIFF
--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -1645,9 +1645,9 @@ func (c *channelSink) Error() error {
 	}
 }
 
-// Disconnect implements the Stream interface. It mocks the disconnect behavior
+// SendError implements the Stream interface. It mocks the disconnect behavior
 // by sending the error to the done channel.
-func (c *channelSink) Disconnect(err *kvpb.Error) {
+func (c *channelSink) SendError(err *kvpb.Error) {
 	c.done <- err
 }
 

--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -472,9 +472,9 @@ func (s *dummyStream) SendUnbuffered(ev *kvpb.RangeFeedEvent) error {
 	}
 }
 
-// Disconnect implements the Stream interface. It mocks the disconnect behavior
+// SendError implements the Stream interface. It mocks the disconnect behavior
 // by sending the error to the done channel.
-func (s *dummyStream) Disconnect(err *kvpb.Error) {
+func (s *dummyStream) SendError(err *kvpb.Error) {
 	s.done <- err
 }
 

--- a/pkg/kv/kvserver/rangefeed/bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/bench_test.go
@@ -202,9 +202,9 @@ func (s *noopStream) SendUnbuffered(*kvpb.RangeFeedEvent) error {
 // thread-safety.
 func (s *noopStream) SendUnbufferedIsThreadSafe() {}
 
-// Disconnect implements the Stream interface. It mocks the disconnect behavior
+// SendError implements the Stream interface. It mocks the disconnect behavior
 // by sending the error to the done channel.
-func (s *noopStream) Disconnect(error *kvpb.Error) {
+func (s *noopStream) SendError(error *kvpb.Error) {
 	s.done <- error
 }
 

--- a/pkg/kv/kvserver/rangefeed/buffered_registration.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_registration.go
@@ -163,7 +163,7 @@ func (br *bufferedRegistration) disconnect(pErr *kvpb.Error) {
 			br.mu.outputLoopCancelFn()
 		}
 		br.mu.disconnected = true
-		br.stream.Disconnect(pErr)
+		br.stream.SendError(pErr)
 	}
 }
 

--- a/pkg/kv/kvserver/rangefeed/buffered_stream.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_stream.go
@@ -80,12 +80,12 @@ func (s *BufferedPerRangeEventSink) SendUnbuffered(event *kvpb.RangeFeedEvent) e
 	return s.wrapped.SendUnbuffered(response, nil)
 }
 
-// Disconnect implements the Stream interface. BufferedSender is then
+// SendError implements the Stream interface. BufferedSender is then
 // responsible for canceling the context of the stream. The actual rangefeed
 // disconnection from processor happens late when the error event popped from
 // the queue and about to be sent to the grpc stream. So caller should not rely
 // on immediate disconnection as cleanup takes place async.
-func (s *BufferedPerRangeEventSink) Disconnect(err *kvpb.Error) {
+func (s *BufferedPerRangeEventSink) SendError(err *kvpb.Error) {
 	ev := &kvpb.MuxRangeFeedEvent{
 		StreamID: s.streamID,
 		RangeID:  s.rangeID,

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -303,7 +303,7 @@ func TestProcessorBasic(t *testing.T) {
 		r1Stream.Cancel()
 		require.NotNil(t, r1Stream.WaitForError(t))
 
-		// Disconnect the registration via Disconnect should work.
+		// Disconnect the registration via SendError should work.
 		r3Stream := newTestStream()
 		r30K, _ := p.Register(
 			r3Stream.ctx,
@@ -317,7 +317,7 @@ func TestProcessorBasic(t *testing.T) {
 			func() {},
 		)
 		require.True(t, r30K)
-		r3Stream.Disconnect(kvpb.NewError(fmt.Errorf("disconnection error")))
+		r3Stream.SendError(kvpb.NewError(fmt.Errorf("disconnection error")))
 		require.NotNil(t, r3Stream.WaitForError(t))
 
 		// Stop the processor with an error.
@@ -1393,9 +1393,9 @@ func (c *consumer) WaitBlock() {
 	<-c.blocked
 }
 
-// Disconnect implements the Stream interface. It mocks the disconnect behavior
+// SendError implements the Stream interface. It mocks the disconnect behavior
 // by sending the error to the done channel.
-func (c *consumer) Disconnect(error *kvpb.Error) {
+func (c *consumer) SendError(error *kvpb.Error) {
 	c.done <- error
 }
 

--- a/pkg/kv/kvserver/rangefeed/registry_helper_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_helper_test.go
@@ -198,9 +198,9 @@ func (s *testStream) BlockSend() func() {
 	}
 }
 
-// Disconnect implements the Stream interface. It mocks the disconnect behavior
+// SendError implements the Stream interface. It mocks the disconnect behavior
 // by sending the error to the done channel.
-func (s *testStream) Disconnect(err *kvpb.Error) {
+func (s *testStream) SendError(err *kvpb.Error) {
 	s.done <- err
 }
 

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -508,7 +508,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 
 		scanner, err := rangefeed.NewSeparatedIntentScanner(streamCtx, r.store.TODOEngine(), desc.RSpan())
 		if err != nil {
-			stream.Disconnect(kvpb.NewError(err))
+			stream.SendError(kvpb.NewError(err))
 			return nil
 		}
 		return scanner

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -82,9 +82,9 @@ func (s *testStream) Events() []*kvpb.RangeFeedEvent {
 	return s.mu.events
 }
 
-// Disconnect implements the Stream interface. It mocks the disconnect behavior
+// SendError implements the Stream interface. It mocks the disconnect behavior
 // by sending the error to the done channel.
-func (s *testStream) Disconnect(error *kvpb.Error) {
+func (s *testStream) SendError(error *kvpb.Error) {
 	s.done <- error
 }
 

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -2143,7 +2143,7 @@ func (n *Node) MuxRangeFeed(muxStream kvpb.Internal_MuxRangeFeedServer) error {
 			// span. If registration fails, it returns an error. Otherwise, it returns
 			// nil without blocking on rangefeed completion. Events are then sent to
 			// the provided streamSink. If the rangefeed disconnects after being
-			// successfully registered, it calls streamSink.Disconnect with the error.
+			// successfully registered, it calls streamSink.SendError with the error.
 			if err := n.stores.RangeFeed(streamCtx, req, streamSink); err != nil {
 				sm.SendBufferedError(
 					makeMuxRangefeedErrorEvent(req.StreamID, req.RangeID, kvpb.NewError(err)))


### PR DESCRIPTION
This patch renames `Disconnect` to `SendError` in the
`rangefeed.Stream` interface to clarify its role for sending
errors, distinguishing it from other similarly named
functions like `registration.disconnect`.

Part of: https://github.com/cockroachdb/cockroach/issues/110432
Release note: none

Co-authored-by: Steven Danna danna@cockroachlabs.com