### PR TITLE
kvserver/rangefeed: make r.disconnect a public method

### DIFF
--- a/pkg/kv/kvserver/rangefeed/buffered_registration.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_registration.go
@@ -148,10 +148,10 @@ func (br *bufferedRegistration) publish(
 	}
 }
 
-// disconnect cancels the output loop context for the registration and passes an
+// Disconnect cancels the output loop context for the registration and passes an
 // error to the output error stream for the registration.
 // Safe to run multiple times, but subsequent errors would be discarded.
-func (br *bufferedRegistration) disconnect(pErr *kvpb.Error) {
+func (br *bufferedRegistration) Disconnect(pErr *kvpb.Error) {
 	br.mu.Lock()
 	defer br.mu.Unlock()
 	if !br.mu.disconnected {
@@ -230,7 +230,7 @@ func (br *bufferedRegistration) runOutputLoop(ctx context.Context, _forStacks ro
 	ctx, br.mu.outputLoopCancelFn = context.WithCancel(ctx)
 	br.mu.Unlock()
 	err := br.outputLoop(ctx)
-	br.disconnect(kvpb.NewError(err))
+	br.Disconnect(kvpb.NewError(err))
 }
 
 // drainAllocations should be done after registration is disconnected from

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -24,9 +24,9 @@ type registration interface {
 	// registration implementation to decide how to handle the event and how to
 	// prevent missing events.
 	publish(ctx context.Context, event *kvpb.RangeFeedEvent, alloc *SharedBudgetAllocation)
-	// disconnect disconnects the registration with the provided error. Safe to
+	// Disconnect disconnects the registration with the provided error. Safe to
 	// run multiple times, but subsequent errors would be discarded.
-	disconnect(pErr *kvpb.Error)
+	Disconnect(pErr *kvpb.Error)
 	// runOutputLoop runs the output loop for the registration. The output loop is
 	// meant to be run in a separate goroutine.
 	runOutputLoop(ctx context.Context, forStacks roachpb.RangeID)
@@ -380,7 +380,7 @@ func (reg *registry) forOverlappingRegs(
 		r := i.(registration)
 		dis, pErr := fn(r)
 		if dis {
-			r.disconnect(pErr)
+			r.Disconnect(pErr)
 			toDelete = append(toDelete, i)
 		}
 		return false

--- a/pkg/kv/kvserver/rangefeed/registry_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_test.go
@@ -38,7 +38,7 @@ func TestRegistrationBasic(t *testing.T) {
 	go noCatchupReg.runOutputLoop(ctx, 0)
 	require.NoError(t, noCatchupReg.waitForCaughtUp(ctx))
 	require.Equal(t, []*kvpb.RangeFeedEvent{ev1, ev2}, noCatchupReg.GetAndClearEvents())
-	noCatchupReg.disconnect(nil)
+	noCatchupReg.Disconnect(nil)
 
 	// Registration with catchup scan.
 	catchupReg := newTestRegistration(spBC, hlc.Timestamp{WallTime: 1},
@@ -56,7 +56,7 @@ func TestRegistrationBasic(t *testing.T) {
 	events := catchupReg.GetAndClearEvents()
 	require.Equal(t, 5, len(events))
 	require.Equal(t, []*kvpb.RangeFeedEvent{ev1, ev2}, events[3:])
-	catchupReg.disconnect(nil)
+	catchupReg.Disconnect(nil)
 
 	// EXIT CONDITIONS
 	// External Disconnect.
@@ -67,7 +67,7 @@ func TestRegistrationBasic(t *testing.T) {
 	go disconnectReg.runOutputLoop(ctx, 0)
 	require.NoError(t, disconnectReg.waitForCaughtUp(ctx))
 	discErr := kvpb.NewError(fmt.Errorf("disconnection error"))
-	disconnectReg.disconnect(discErr)
+	disconnectReg.Disconnect(discErr)
 	require.Equal(t, discErr.GoError(), disconnectReg.WaitForError(t))
 	require.Equal(t, 2, len(disconnectReg.GetAndClearEvents()))
 
@@ -76,7 +76,7 @@ func TestRegistrationBasic(t *testing.T) {
 		false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */)
 	disconnectEarlyReg.publish(ctx, ev1, nil /* alloc */)
 	disconnectEarlyReg.publish(ctx, ev2, nil /* alloc */)
-	disconnectEarlyReg.disconnect(discErr)
+	disconnectEarlyReg.Disconnect(discErr)
 	go disconnectEarlyReg.runOutputLoop(ctx, 0)
 	require.Equal(t, discErr.GoError(), disconnectEarlyReg.WaitForError(t))
 	require.Equal(t, 0, len(disconnectEarlyReg.GetAndClearEvents()))
@@ -156,8 +156,8 @@ func TestRegistryWithOmitOrigin(t *testing.T) {
 	go rAC.runOutputLoop(ctx, 0)
 	go originFiltering.runOutputLoop(ctx, 0)
 
-	defer rAC.disconnect(nil)
-	defer originFiltering.disconnect(nil)
+	defer rAC.Disconnect(nil)
+	defer originFiltering.Disconnect(nil)
 
 	reg.Register(ctx, rAC.bufferedRegistration)
 	reg.Register(ctx, originFiltering.bufferedRegistration)
@@ -208,11 +208,11 @@ func TestRegistryBasic(t *testing.T) {
 	go rCD.runOutputLoop(ctx, 0)
 	go rAC.runOutputLoop(ctx, 0)
 	go rACFiltering.runOutputLoop(ctx, 0)
-	defer rAB.disconnect(nil)
-	defer rBC.disconnect(nil)
-	defer rCD.disconnect(nil)
-	defer rAC.disconnect(nil)
-	defer rACFiltering.disconnect(nil)
+	defer rAB.Disconnect(nil)
+	defer rBC.Disconnect(nil)
+	defer rCD.Disconnect(nil)
+	defer rAC.Disconnect(nil)
+	defer rACFiltering.Disconnect(nil)
 
 	// Register 6 registrations.
 	reg.Register(ctx, rAB.bufferedRegistration)
@@ -355,7 +355,7 @@ func TestRegistryPublishBeneathStartTimestamp(t *testing.T) {
 	require.NoError(t, reg.waitForCaughtUp(ctx, all))
 	require.Equal(t, []*kvpb.RangeFeedEvent{ev}, r.GetAndClearEvents())
 
-	r.disconnect(nil)
+	r.Disconnect(nil)
 }
 
 func TestRegistrationString(t *testing.T) {

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -361,7 +361,7 @@ func (p *ScheduledProcessor) Register(
 			// If we can't schedule internally, processor is already stopped which
 			// could only happen on shutdown. Disconnect stream and just remove
 			// registration.
-			r.disconnect(kvpb.NewError(err))
+			r.Disconnect(kvpb.NewError(err))
 			p.reg.Unregister(ctx, r)
 		}
 		return f


### PR DESCRIPTION
This patch renames `r.disconnect` to `r.Disconnect`, making it a public method. This
change allows other packages to call `r.Disconnect` at the node-level `MuxRangefeed`
in future commits.

Part of: https://github.com/cockroachdb/cockroach/issues/110432
Release note: none

Co-authored-by: Steven Danna danna@cockroachlabs.com