### PR TITLE
kvserver/rangefeed: introduce Disconnector interface 

### DIFF
--- a/pkg/kv/kvserver/rangefeed/buffered_registration.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_registration.go
@@ -148,6 +148,13 @@ func (br *bufferedRegistration) publish(
 	}
 }
 
+// IsDisconnected returns true if the registration has been disconnected.
+func (br *bufferedRegistration) IsDisconnected() bool {
+	br.mu.Lock()
+	defer br.mu.Unlock()
+	return br.mu.disconnected
+}
+
 // Disconnect cancels the output loop context for the registration and passes an
 // error to the output error stream for the registration.
 // Safe to run multiple times, but subsequent errors would be discarded.

--- a/pkg/kv/kvserver/rangefeed/registry.go
+++ b/pkg/kv/kvserver/rangefeed/registry.go
@@ -17,16 +17,28 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
+// Disconnector defines an interface for disconnecting a registration. It is
+// returned to node.MuxRangefeed to allow node level stream manager to
+// disconnect a registration.
+type Disconnector interface {
+	// Disconnect disconnects the registration with the provided error. Safe to
+	// run multiple times, but subsequent errors would be discarded.
+	Disconnect(pErr *kvpb.Error)
+	// IsDisconnected returns whether the registration has been disconnected.
+	// Disconnected is a permanent state; once IsDisconnected returns true, it
+	// always returns true
+	IsDisconnected() bool
+}
+
 // registration defines an interface for registration that can be added to a
 // processor registry. Implemented by bufferedRegistration.
 type registration interface {
+	Disconnector
+
 	// publish sends the provided event to the registration. It is up to the
 	// registration implementation to decide how to handle the event and how to
 	// prevent missing events.
 	publish(ctx context.Context, event *kvpb.RangeFeedEvent, alloc *SharedBudgetAllocation)
-	// Disconnect disconnects the registration with the provided error. Safe to
-	// run multiple times, but subsequent errors would be discarded.
-	Disconnect(pErr *kvpb.Error)
 	// runOutputLoop runs the output loop for the registration. The output loop is
 	// meant to be run in a separate goroutine.
 	runOutputLoop(ctx context.Context, forStacks roachpb.RangeID)


### PR DESCRIPTION
This patch introduces the `Disconnector` interface, implemented by the
`registration` interface. Although currently unused, future commits will pass this
interface to `node.MuxRangefeed`, allowing disconnection of individual
registrations at the node level.

Part of: https://github.com/cockroachdb/cockroach/issues/110432
Release note: none

Co-authored-by: Steven Danna danna@cockroachlabs.com