### PR TITLE
kvserver/rangefeed: return Disconnector to node.MuxRangefeed

### DIFF
--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -1451,7 +1451,8 @@ func TestRangeFeedIntentResolutionRace(t *testing.T) {
 	}
 	eventC := make(chan *kvpb.RangeFeedEvent)
 	sink := newChannelSink(ctx, eventC)
-	require.NoError(t, s3.RangeFeed(sink.ctx, &req, sink)) // check if we've errored yet
+	_, rErr := s3.RangeFeed(sink.ctx, &req, sink)
+	require.NoError(t, rErr) // check if we've errored yet
 	require.NoError(t, sink.Error())
 	t.Logf("started rangefeed on %s", repl3)
 

--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -489,7 +489,7 @@ func waitReplicaRangeFeed(
 		return stream.SendUnbuffered(&event)
 	}
 
-	err := r.RangeFeed(stream.ctx, req, stream, nil /* pacer */)
+	_, err := r.RangeFeed(stream.ctx, req, stream, nil /* pacer */)
 	if err != nil {
 		return sendErrToStream(kvpb.NewError(err))
 	}

--- a/pkg/kv/kvserver/rangefeed/bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/bench_test.go
@@ -103,7 +103,7 @@ func runBenchmarkRangefeed(b *testing.B, opts benchmarkRangefeedOpts) {
 		// extra data.
 		const withFiltering = false
 		streams[i] = &noopStream{ctx: ctx, done: make(chan *kvpb.Error, 1)}
-		ok, _ := p.Register(ctx, span, hlc.MinTimestamp, nil,
+		ok, _, _ := p.Register(ctx, span, hlc.MinTimestamp, nil,
 			withDiff, withFiltering, false, /* withOmitRemote */
 			streams[i], nil)
 		require.True(b, ok)

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -192,7 +192,8 @@ type Processor interface {
 		withOmitRemote bool,
 		stream Stream,
 		disconnectFn func(),
-	) (bool, *Filter)
+	) (bool, Disconnector, *Filter)
+
 	// DisconnectSpanWithErr disconnects all rangefeed registrations that overlap
 	// the given span with the given error.
 	DisconnectSpanWithErr(span roachpb.Span, pErr *kvpb.Error)

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -61,7 +61,7 @@ func TestProcessorBasic(t *testing.T) {
 
 		// Add a registration.
 		r1Stream := newTestStream()
-		r1OK, r1Filter := p.Register(
+		r1OK, _, r1Filter := p.Register(
 			r1Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
@@ -196,7 +196,7 @@ func TestProcessorBasic(t *testing.T) {
 
 		// Add another registration with withDiff = true and withFiltering = true.
 		r2Stream := newTestStream()
-		r2OK, r1And2Filter := p.Register(
+		r2OK, _, r1And2Filter := p.Register(
 			r2Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("c"), EndKey: roachpb.RKey("z")},
 			hlc.Timestamp{WallTime: 1},
@@ -305,7 +305,7 @@ func TestProcessorBasic(t *testing.T) {
 
 		// Disconnect the registration via SendError should work.
 		r3Stream := newTestStream()
-		r30K, _ := p.Register(
+		r30K, _, _ := p.Register(
 			r3Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("c"), EndKey: roachpb.RKey("z")},
 			hlc.Timestamp{WallTime: 1},
@@ -327,7 +327,7 @@ func TestProcessorBasic(t *testing.T) {
 
 		// Adding another registration should fail.
 		r4Stream := newTestStream()
-		r4OK, _ := p.Register(
+		r4OK, _, _ := p.Register(
 			r3Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("c"), EndKey: roachpb.RKey("z")},
 			hlc.Timestamp{WallTime: 1},
@@ -353,7 +353,7 @@ func TestProcessorOmitRemote(t *testing.T) {
 
 		// Add a registration.
 		r1Stream := newTestStream()
-		r1OK, _ := p.Register(
+		r1OK, _, _ := p.Register(
 			r1Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
@@ -379,7 +379,7 @@ func TestProcessorOmitRemote(t *testing.T) {
 
 		// Add another registration with withOmitRemote = true.
 		r2Stream := newTestStream()
-		r2OK, _ := p.Register(
+		r2OK, _, _ := p.Register(
 			r2Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
@@ -433,7 +433,7 @@ func TestProcessorSlowConsumer(t *testing.T) {
 
 		// Add a registration.
 		r1Stream := newTestStream()
-		_, _ = p.Register(
+		p.Register(
 			r1Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
@@ -542,7 +542,7 @@ func TestProcessorMemoryBudgetExceeded(t *testing.T) {
 
 		// Add a registration.
 		r1Stream := newTestStream()
-		_, _ = p.Register(
+		p.Register(
 			r1Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
@@ -1120,7 +1120,7 @@ func TestBudgetReleaseOnProcessorStop(t *testing.T) {
 		// Add a registration.
 		rStream := newConsumer(50)
 		defer func() { rStream.Resume() }()
-		_, _ = p.Register(
+		p.Register(
 			rStream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
@@ -1201,7 +1201,7 @@ func TestBudgetReleaseOnLastStreamError(t *testing.T) {
 		// Add a registration.
 		rStream := newConsumer(90)
 		defer func() { rStream.Resume() }()
-		_, _ = p.Register(
+		p.Register(
 			rStream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
@@ -1272,7 +1272,7 @@ func TestBudgetReleaseOnOneStreamError(t *testing.T) {
 		// Add a registration.
 		r1Stream := newConsumer(50)
 		defer func() { r1Stream.Resume() }()
-		_, _ = p.Register(
+		p.Register(
 			r1Stream.ctx,
 			roachpb.RSpan{Key: roachpb.RKey("a"), EndKey: roachpb.RKey("m")},
 			hlc.Timestamp{WallTime: 1},
@@ -1462,7 +1462,7 @@ func TestProcessorBackpressure(t *testing.T) {
 
 		// Add a registration.
 		stream := newTestStream()
-		ok, _ := p.Register(stream.ctx, span, hlc.MinTimestamp, nil, /* catchUpIter */
+		ok, _, _ := p.Register(stream.ctx, span, hlc.MinTimestamp, nil, /* catchUpIter */
 			false /* withDiff */, false /* withFiltering */, false /* withOmitRemote */, stream, nil)
 		require.True(t, ok)
 

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -305,7 +305,7 @@ func (p *ScheduledProcessor) Register(
 	withOmitRemote bool,
 	stream Stream,
 	disconnectFn func(),
-) (bool, *Filter) {
+) (bool, Disconnector, *Filter) {
 	// Synchronize the event channel so that this registration doesn't see any
 	// events that were consumed before this registration was called. Instead,
 	// it should see these events during its catch up scan.
@@ -318,8 +318,7 @@ func (p *ScheduledProcessor) Register(
 			"unimplemented: unbuffered registrations for rangefeed, see #126560")
 	} else {
 		r = newBufferedRegistration(
-			streamCtx,
-			span.AsRawSpanWithNoLocals(), startTS, catchUpIter, withDiff, withFiltering, withOmitRemote,
+			streamCtx, span.AsRawSpanWithNoLocals(), startTS, catchUpIter, withDiff, withFiltering, withOmitRemote,
 			p.Config.EventChanCap, blockWhenFull, p.Metrics, stream, disconnectFn,
 		)
 	}
@@ -367,9 +366,9 @@ func (p *ScheduledProcessor) Register(
 		return f
 	})
 	if filter != nil {
-		return true, filter
+		return true, r, filter
 	}
-	return false, nil
+	return false, nil, nil
 }
 
 func (p *ScheduledProcessor) unregisterClient(r registration) bool {

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -241,23 +241,23 @@ func (r *Replica) RangeFeed(
 	args *kvpb.RangeFeedRequest,
 	stream rangefeed.Stream,
 	pacer *admission.Pacer,
-) error {
+) (rangefeed.Disconnector, error) {
 	streamCtx = r.AnnotateCtx(streamCtx)
 
 	rSpan, err := keys.SpanAddr(args.Span)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := r.ensureClosedTimestampStarted(streamCtx); err != nil {
-		return err.GoError()
+		return nil, err.GoError()
 	}
 
 	var omitRemote bool
 	if len(args.WithMatchingOriginIDs) == 1 && args.WithMatchingOriginIDs[0] == 0 {
 		omitRemote = true
 	} else if len(args.WithMatchingOriginIDs) > 0 {
-		return errors.Errorf("multiple origin IDs and OriginID != 0 not supported yet")
+		return nil, errors.Errorf("multiple origin IDs and OriginID != 0 not supported yet")
 	}
 
 	// If the RangeFeed is performing a catch-up scan then it will observe all
@@ -283,7 +283,7 @@ func (r *Replica) RangeFeed(
 		usingCatchUpIter = true
 		alloc, err := r.store.limiters.ConcurrentRangefeedIters.Begin(streamCtx)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		// Finish the iterator limit if we exit before the iterator finishes.
@@ -308,7 +308,7 @@ func (r *Replica) RangeFeed(
 	if err := r.checkExecutionCanProceedForRangeFeed(streamCtx, rSpan, checkTS); err != nil {
 		r.raftMu.Unlock()
 		iterSemRelease()
-		return err
+		return nil, err
 	}
 
 	// Register the stream with a catch-up iterator.
@@ -322,14 +322,14 @@ func (r *Replica) RangeFeed(
 		if err != nil {
 			r.raftMu.Unlock()
 			iterSemRelease()
-			return err
+			return nil, err
 		}
 		if f := r.store.TestingKnobs().RangefeedValueHeaderFilter; f != nil {
 			catchUpIter.OnEmit = f
 		}
 	}
 
-	p, err := r.registerWithRangefeedRaftMuLocked(
+	p, disconnector, err := r.registerWithRangefeedRaftMuLocked(
 		streamCtx, rSpan, args.Timestamp, catchUpIter, args.WithDiff, args.WithFiltering, omitRemote, stream,
 	)
 	r.raftMu.Unlock()
@@ -338,7 +338,7 @@ func (r *Replica) RangeFeed(
 	// encountered an error after we created processor, disconnect if processor
 	// is empty.
 	defer r.maybeDisconnectEmptyRangefeed(p)
-	return err
+	return disconnector, err
 }
 
 func (r *Replica) getRangefeedProcessorAndFilter() (rangefeed.Processor, *rangefeed.Filter) {
@@ -428,7 +428,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 	withFiltering bool,
 	withOmitRemote bool,
 	stream rangefeed.Stream,
-) (rangefeed.Processor, error) {
+) (rangefeed.Processor, rangefeed.Disconnector, error) {
 	defer logSlowRangefeedRegistration(streamCtx)()
 
 	// Always defer closing iterator to cover old and new failure cases.
@@ -447,7 +447,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 	p := r.rangefeedMu.proc
 
 	if p != nil {
-		reg, filter := p.Register(streamCtx, span, startTS, catchUpIter, withDiff, withFiltering, withOmitRemote,
+		reg, disconnector, filter := p.Register(streamCtx, span, startTS, catchUpIter, withDiff, withFiltering, withOmitRemote,
 			stream, func() { r.maybeDisconnectEmptyRangefeed(p) })
 		if reg {
 			// Registered successfully with an existing processor.
@@ -456,7 +456,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 			r.setRangefeedFilterLocked(filter)
 			r.rangefeedMu.Unlock()
 			catchUpIter = nil
-			return p, nil
+			return p, disconnector, nil
 		}
 		// If the registration failed, the processor was already being shut
 		// down. Help unset it and then continue on with initializing a new
@@ -520,7 +520,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 	// due to stopping, but before it enters the quiescing state, then the select
 	// below will fall through to the panic.
 	if err := p.Start(r.store.Stopper(), rtsIter); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Register with the processor *before* we attach its reference to the
@@ -528,12 +528,12 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 	// any other goroutines are able to stop the processor. In other words,
 	// this ensures that the only time the registration fails is during
 	// server shutdown.
-	reg, filter := p.Register(streamCtx, span, startTS, catchUpIter, withDiff,
+	reg, disconnector, filter := p.Register(streamCtx, span, startTS, catchUpIter, withDiff,
 		withFiltering, withOmitRemote, stream, func() { r.maybeDisconnectEmptyRangefeed(p) })
 	if !reg {
 		select {
 		case <-r.store.Stopper().ShouldQuiesce():
-			return nil, &kvpb.NodeUnavailableError{}
+			return nil, nil, &kvpb.NodeUnavailableError{}
 		default:
 			panic("unexpected Stopped processor")
 		}
@@ -549,7 +549,7 @@ func (r *Replica) registerWithRangefeedRaftMuLocked(
 	// Check for an initial closed timestamp update immediately to help
 	// initialize the rangefeed's resolved timestamp as soon as possible.
 	r.handleClosedTimestampUpdateRaftMuLocked(streamCtx, r.GetCurrentClosedTimestamp(streamCtx))
-	return p, nil
+	return p, disconnector, nil
 }
 
 // maybeDisconnectEmptyRangefeed tears down the provided Processor if it is

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -104,7 +104,7 @@ func (s *testStream) WaitForError(t *testing.T) error {
 func waitRangeFeed(
 	t *testing.T, store *kvserver.Store, req *kvpb.RangeFeedRequest, stream *testStream,
 ) error {
-	if err := store.RangeFeed(stream.ctx, req, stream); err != nil {
+	if _, err := store.RangeFeed(stream.ctx, req, stream); err != nil {
 		return err
 	}
 	return stream.WaitForError(t)

--- a/pkg/kv/kvserver/stores.go
+++ b/pkg/kv/kvserver/stores.go
@@ -206,7 +206,7 @@ func (ls *Stores) SendWithWriteBytes(
 // when the rangefeed is complete.
 func (ls *Stores) RangeFeed(
 	streamCtx context.Context, args *kvpb.RangeFeedRequest, stream rangefeed.Stream,
-) error {
+) (rangefeed.Disconnector, error) {
 	if args.RangeID == 0 {
 		log.Fatal(streamCtx, "rangefeed request missing range ID")
 	} else if args.Replica.StoreID == 0 {
@@ -215,7 +215,7 @@ func (ls *Stores) RangeFeed(
 
 	store, err := ls.GetStore(args.Replica.StoreID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	return store.RangeFeed(streamCtx, args, stream)

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -2144,7 +2144,7 @@ func (n *Node) MuxRangeFeed(muxStream kvpb.Internal_MuxRangeFeedServer) error {
 			// nil without blocking on rangefeed completion. Events are then sent to
 			// the provided streamSink. If the rangefeed disconnects after being
 			// successfully registered, it calls streamSink.SendError with the error.
-			if err := n.stores.RangeFeed(streamCtx, req, streamSink); err != nil {
+			if _, err := n.stores.RangeFeed(streamCtx, req, streamSink); err != nil {
 				sm.SendBufferedError(
 					makeMuxRangefeedErrorEvent(req.StreamID, req.RangeID, kvpb.NewError(err)))
 			}


### PR DESCRIPTION
This patch updates p.Register to return each registration as a `Disconnector` up
the stack to `node.MuxRangefeed`. While it's currently unused, future commits
will use the `Disconnector` to disconnect rangefeeds at the node level,
replacing the current approach of canceling each stream’s context to disconnect
each rangefeed.

Part of: https://github.com/cockroachdb/cockroach/issues/110432
Release note: none

Co-authored-by: Steven Danna danna@cockroachlabs.com