### PR TITLE
kvserver/rangefeed: use StreamManager for unbuffered sender

### DIFF
--- a/pkg/kv/kvserver/rangefeed/stream_manager.go
+++ b/pkg/kv/kvserver/rangefeed/stream_manager.go
@@ -90,8 +90,13 @@ func NewStreamManager(sender sender, metrics RangefeedMetricsRecorder) *StreamMa
 }
 
 func (sm *StreamManager) NewStream(streamID int64, rangeID roachpb.RangeID) (sink Stream) {
-	log.Fatalf(context.Background(), "unexpected sender type %T", sm)
-	return nil
+	switch sender := sm.sender.(type) {
+	case *UnbufferedSender:
+		return NewPerRangeEventSink(rangeID, streamID, sender)
+	default:
+		log.Fatalf(context.Background(), "unexpected sender type %T", sm)
+		return nil
+	}
 }
 
 // OnError is a callback that is called when a sender sends a rangefeed


### PR DESCRIPTION
Previously, UnbufferedSender was responsible for  forwarding events to the gRPC
stream and managing the stream itself. This patch refactors UnbufferedSender to
separate these responsibilities by adopting the `rangefeed.sender` and
`rangefeed.StreamManager` interfaces. Now, `rangefeed.UnbufferedSender` is dedicated
to sending messages, while rangefeed.StreamManager manages the stream.

Additionally, this patch changes rangefeed disconnection handling at the node
level. Instead of disconnecting individual streams by canceling their contexts,
`node.MuxRangefeed` now uses the `Disconnector` provided by `p.Register` to
manage rangefeed disconnections. Although the benefits may not be immediately
clear, future commits on unbuffered registration - which lack a long lived
goroutine - will rely on this disconnector. This commit allows us to draw more
parallels between the two types of registrations.

Part of: https://github.com/cockroachdb/cockroach/issues/110432
Release note: none