### PR TITLE
workload/schemachanger: allow additional errors for ALTER COLUMN TYPE

### DIFF
--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -31,7 +31,6 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/randgen",
-        "//pkg/sql/schemachange",
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",


### PR DESCRIPTION
This update enhances error handling for ALTER COLUMN TYPE operations, covering additional error cases that may arise:
- pgcode.CannotCoerce: Raised when a type conversion is not permissible (e.g., attempting an unsupported type change). We previously only did by inspecting the type change, but there are additional cases not covered in `schemachange.ClassifyConversion`. So, making it more general.
- pgcode.NumericValueOutOfRange: Raised when the new type cannot accommodate existing data values (e.g., converting from INT8 to INT2 where some values exceed the INT2 range).

I also moved existing potential errors up to the branch where we know we are moving to a known type. We don’t need to check for those if the type name doesn’t exist.

Epic: CRDB-25314
Release note: none