### PR TITLE
release-23.2: sql: avoid role existence check in DROP ROLE when it's not necessary

### DIFF
--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -106,13 +106,17 @@ func (n *DropRoleNode) startExec(params runParams) error {
 
 		// Non-admin users cannot drop admins.
 		if !hasAdmin {
-			roleExists, err := RoleExists(params.ctx, params.p.InternalSQLTxn(), name)
-			if err != nil {
-				return err
-			}
-			if !roleExists {
-				// If the role does not exist, we can skip the check for targetIsAdmin.
-				continue
+			if n.ifExists {
+				// If `IF EXISTS` was specified, then a non-existing role should be
+				// skipped without causing any error.
+				roleExists, err := RoleExists(params.ctx, params.p.InternalSQLTxn(), name)
+				if err != nil {
+					return err
+				}
+				if !roleExists {
+					// If the role does not exist, we can skip the check for targetIsAdmin.
+					continue
+				}
 			}
 
 			targetIsAdmin, err := params.p.UserHasAdminRole(params.ctx, name)


### PR DESCRIPTION
Backport 1/1 commits from #134979.

/cc @cockroachdb/release

Release justification: low risk fix

---

We only need to make the RoleExists call when the `IF EXISTS` clause is used.

This check was recently added in 696869afeb369f3999384e2637610f5fee147362.

informs: https://github.com/cockroachdb/cockroach/issues/134538
Release note: None
