### PR TITLE
githubpost: plumb Side-Eye snapshot URL

### DIFF
--- a/pkg/cmd/bazci/githubpost/issues/issues.go
+++ b/pkg/cmd/bazci/githubpost/issues/issues.go
@@ -273,16 +273,18 @@ func (p *poster) templateData(
 		artifactsURL = p.teamcityArtifactsURL(req.Artifacts).String()
 	}
 	return TemplateData{
-		PostRequest:      req,
-		Parameters:       p.parameters(req.ExtraParams),
-		CondensedMessage: CondensedMessage(req.Message),
-		Branch:           p.Branch,
-		Commit:           p.SHA,
-		ArtifactsURL:     artifactsURL,
-		URL:              p.buildURL().String(),
-		RelatedIssues:    relatedIssues,
-		PackageNameShort: strings.TrimPrefix(req.PackageName, CockroachPkgPrefix),
-		CommitURL:        fmt.Sprintf("https://github.com/%s/%s/commits/%s", p.Org, p.Repo, p.SHA),
+		PostRequest:        req,
+		PackageNameShort:   strings.TrimPrefix(req.PackageName, CockroachPkgPrefix),
+		Parameters:         p.parameters(req.ExtraParams),
+		CondensedMessage:   CondensedMessage(req.Message),
+		Commit:             p.SHA,
+		CommitURL:          fmt.Sprintf("https://github.com/%s/%s/commits/%s", p.Org, p.Repo, p.SHA),
+		Branch:             p.Branch,
+		ArtifactsURL:       artifactsURL,
+		URL:                p.buildURL().String(),
+		SideEyeSnapshotURL: req.SideEyeSnapshotURL,
+		SideEyeSnapshotMsg: req.SideEyeSnapshotMsg,
+		RelatedIssues:      relatedIssues,
 	}
 }
 


### PR DESCRIPTION
The URL to the Side-Eye snapshot was not properly plumbed to the GitHub issue poster, resulting in the issues created for timing out roachtests not including the link to Side-Eye. Now, with the plumbing fixed, the respective issues should look like can be seen in the templates used by the roachtest unit tests -- e.g. https://github.com/cockroachdb/cockroach/blob/496c129415425d8b787e2d186508b68b03c782bc/pkg/cmd/roachtest/testdata/github/basic_test_create_post_request#L10

Epic: none
Release note: None