### PR TITLE
sql: audit error creation during planning

### DIFF
--- a/pkg/sql/colcontainer/diskqueue.go
+++ b/pkg/sql/colcontainer/diskqueue.go
@@ -620,13 +620,13 @@ func (d *diskQueue) Enqueue(ctx context.Context, b coldata.Batch) error {
 	}
 	if d.state == diskQueueStateDequeueing {
 		if d.cfg.CacheMode != DiskQueueCacheModeIntertwinedCalls {
-			return errors.Errorf(
+			return errors.AssertionFailedf(
 				"attempted to Enqueue to DiskQueue after Dequeueing "+
 					"in mode that disallows it: %d", d.cfg.CacheMode,
 			)
 		}
 		if d.rewindable {
-			return errors.Errorf("attempted to Enqueue to RewindableDiskQueue after Dequeue has been called")
+			return errors.AssertionFailedf("attempted to Enqueue to RewindableDiskQueue after Dequeue has been called")
 		}
 	}
 	d.state = diskQueueStateEnqueueing
@@ -752,7 +752,7 @@ func (d *diskQueue) maybeInitDeserializer(ctx context.Context) (bool, error) {
 		d.cfg.SpilledBytesRead.Inc(int64(n))
 	}
 	if n != len(d.writer.scratch.compressedBuf) {
-		return false, errors.Errorf("expected to read %d bytes but read %d", len(d.writer.scratch.compressedBuf), n)
+		return false, errors.AssertionFailedf("expected to read %d bytes but read %d", len(d.writer.scratch.compressedBuf), n)
 	}
 
 	blockType := d.writer.scratch.compressedBuf[0]

--- a/pkg/sql/colcontainer/partitionedqueue.go
+++ b/pkg/sql/colcontainer/partitionedqueue.go
@@ -221,7 +221,7 @@ func (p *PartitionedDiskQueue) Enqueue(
 			idxToClose, found := p.partitionIdxToIndex[p.lastEnqueuedPartitionIdx]
 			if !found {
 				// This would be unexpected.
-				return errors.New("PartitionerStrategyCloseOnNewPartition unable to find last Enqueued partition")
+				return errors.AssertionFailedf("PartitionerStrategyCloseOnNewPartition unable to find last Enqueued partition")
 			}
 			if p.partitions[idxToClose].state == partitionStateWriting {
 				// Close the last enqueued partition. No need to release or acquire a new
@@ -255,9 +255,9 @@ func (p *PartitionedDiskQueue) Enqueue(
 	}
 	if state := p.partitions[idx].state; state != partitionStateWriting {
 		if state == partitionStatePermanentlyClosed {
-			return errors.Errorf("partition at index %d permanently closed, cannot Enqueue", partitionIdx)
+			return errors.AssertionFailedf("partition at index %d permanently closed, cannot Enqueue", partitionIdx)
 		}
-		return errors.New("Enqueue illegally called after Dequeue or CloseAllOpenWriteFileDescriptors")
+		return errors.AssertionFailedf("Enqueue illegally called after Dequeue or CloseAllOpenWriteFileDescriptors")
 	}
 	p.lastEnqueuedPartitionIdx = partitionIdx
 	return p.partitions[idx].Enqueue(ctx, batch)
@@ -290,7 +290,7 @@ func (p *PartitionedDiskQueue) Dequeue(
 	case partitionStateReading:
 	// Do nothing.
 	case partitionStatePermanentlyClosed:
-		return errors.Errorf("partition at index %d permanently closed, cannot Dequeue", partitionIdx)
+		return errors.AssertionFailedf("partition at index %d permanently closed, cannot Dequeue", partitionIdx)
 	default:
 		colexecerror.InternalError(errors.AssertionFailedf("unhandled state %d", state))
 	}

--- a/pkg/sql/colexec/colexecagg/any_not_null_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/any_not_null_agg_tmpl.go
@@ -84,7 +84,7 @@ func newAnyNotNull_AGGKINDAggAlloc(
 		}
 		// {{end}}
 	}
-	return nil, errors.Errorf("unsupported any not null agg type %s", t.Name())
+	return nil, errors.AssertionFailedf("unsupported any not null agg type %s", t.Name())
 }
 
 // {{range .}}

--- a/pkg/sql/colexec/colexecagg/avg_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/avg_agg_tmpl.go
@@ -93,7 +93,7 @@ func newAvg_AGGKINDAggAlloc(
 		}
 		// {{end}}
 	}
-	return nil, errors.Errorf("unsupported avg agg type %s", t.Name())
+	return nil, errors.AssertionFailedf("unsupported avg agg type %s", t.Name())
 }
 
 // {{range .}}

--- a/pkg/sql/colexec/colexecagg/hash_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_any_not_null_agg.eg.go
@@ -96,7 +96,7 @@ func newAnyNotNullHashAggAlloc(
 			return &anyNotNullDatumHashAggAlloc{aggAllocBase: allocBase}, nil
 		}
 	}
-	return nil, errors.Errorf("unsupported any not null agg type %s", t.Name())
+	return nil, errors.AssertionFailedf("unsupported any not null agg type %s", t.Name())
 }
 
 // anyNotNullBoolHashAgg implements the ANY_NOT_NULL aggregate, returning the

--- a/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
@@ -63,7 +63,7 @@ func newAvgHashAggAlloc(
 			return &avgIntervalHashAggAlloc{aggAllocBase: allocBase}, nil
 		}
 	}
-	return nil, errors.Errorf("unsupported avg agg type %s", t.Name())
+	return nil, errors.AssertionFailedf("unsupported avg agg type %s", t.Name())
 }
 
 type avgInt16HashAgg struct {

--- a/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_agg.eg.go
@@ -63,7 +63,7 @@ func newSumHashAggAlloc(
 			return &sumIntervalHashAggAlloc{aggAllocBase: allocBase}, nil
 		}
 	}
-	return nil, errors.Errorf("unsupported sum agg type %s", t.Name())
+	return nil, errors.AssertionFailedf("unsupported sum agg type %s", t.Name())
 }
 
 type sumInt16HashAgg struct {

--- a/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_sum_int_agg.eg.go
@@ -45,7 +45,7 @@ func newSumIntHashAggAlloc(
 			return &sumIntInt64HashAggAlloc{aggAllocBase: allocBase}, nil
 		}
 	}
-	return nil, errors.Errorf("unsupported sum agg type %s", t.Name())
+	return nil, errors.AssertionFailedf("unsupported sum agg type %s", t.Name())
 }
 
 type sumIntInt16HashAgg struct {

--- a/pkg/sql/colexec/colexecagg/ordered_any_not_null_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_any_not_null_agg.eg.go
@@ -172,7 +172,7 @@ func newAnyNotNullOrderedAggAlloc(
 			return &anyNotNullDatumOrderedAggAlloc{aggAllocBase: allocBase}, nil
 		}
 	}
-	return nil, errors.Errorf("unsupported any not null agg type %s", t.Name())
+	return nil, errors.AssertionFailedf("unsupported any not null agg type %s", t.Name())
 }
 
 // anyNotNullBoolOrderedAgg implements the ANY_NOT_NULL aggregate, returning the

--- a/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
@@ -114,7 +114,7 @@ func newAvgOrderedAggAlloc(
 			return &avgIntervalOrderedAggAlloc{aggAllocBase: allocBase}, nil
 		}
 	}
-	return nil, errors.Errorf("unsupported avg agg type %s", t.Name())
+	return nil, errors.AssertionFailedf("unsupported avg agg type %s", t.Name())
 }
 
 type avgInt16OrderedAgg struct {

--- a/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_agg.eg.go
@@ -114,7 +114,7 @@ func newSumOrderedAggAlloc(
 			return &sumIntervalOrderedAggAlloc{aggAllocBase: allocBase}, nil
 		}
 	}
-	return nil, errors.Errorf("unsupported sum agg type %s", t.Name())
+	return nil, errors.AssertionFailedf("unsupported sum agg type %s", t.Name())
 }
 
 type sumInt16OrderedAgg struct {

--- a/pkg/sql/colexec/colexecagg/ordered_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_sum_int_agg.eg.go
@@ -81,7 +81,7 @@ func newSumIntOrderedAggAlloc(
 			return &sumIntInt64OrderedAggAlloc{aggAllocBase: allocBase}, nil
 		}
 	}
-	return nil, errors.Errorf("unsupported sum agg type %s", t.Name())
+	return nil, errors.AssertionFailedf("unsupported sum agg type %s", t.Name())
 }
 
 type sumIntInt16OrderedAgg struct {

--- a/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/sum_agg_tmpl.go
@@ -94,7 +94,7 @@ func newSum_SUMKIND_AGGKINDAggAlloc(
 		}
 		// {{end}}
 	}
-	return nil, errors.Errorf("unsupported sum agg type %s", t.Name())
+	return nil, errors.AssertionFailedf("unsupported sum agg type %s", t.Name())
 }
 
 // {{range .Infos}}

--- a/pkg/sql/colexec/colexecagg/window_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_avg_agg.eg.go
@@ -63,7 +63,7 @@ func newAvgWindowAggAlloc(
 			return &avgIntervalWindowAggAlloc{aggAllocBase: allocBase}, nil
 		}
 	}
-	return nil, errors.Errorf("unsupported avg agg type %s", t.Name())
+	return nil, errors.AssertionFailedf("unsupported avg agg type %s", t.Name())
 }
 
 type avgInt16WindowAgg struct {

--- a/pkg/sql/colexec/colexecagg/window_sum_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_sum_agg.eg.go
@@ -63,7 +63,7 @@ func newSumWindowAggAlloc(
 			return &sumIntervalWindowAggAlloc{aggAllocBase: allocBase}, nil
 		}
 	}
-	return nil, errors.Errorf("unsupported sum agg type %s", t.Name())
+	return nil, errors.AssertionFailedf("unsupported sum agg type %s", t.Name())
 }
 
 type sumInt16WindowAgg struct {

--- a/pkg/sql/colexec/colexecagg/window_sum_int_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_sum_int_agg.eg.go
@@ -45,7 +45,7 @@ func newSumIntWindowAggAlloc(
 			return &sumIntInt64WindowAggAlloc{aggAllocBase: allocBase}, nil
 		}
 	}
-	return nil, errors.Errorf("unsupported sum agg type %s", t.Name())
+	return nil, errors.AssertionFailedf("unsupported sum agg type %s", t.Name())
 }
 
 type sumIntInt16WindowAgg struct {

--- a/pkg/sql/colexec/colexecbase/cast.eg.go
+++ b/pkg/sql/colexec/colexecbase/cast.eg.go
@@ -9,7 +9,6 @@ package colexecbase
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -33,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -71,7 +71,10 @@ func isIdentityCast(fromType, toType *types.T) bool {
 	return false
 }
 
+var errUnhandledCast = errors.New("unhandled cast")
+
 func GetCastOperator(
+	ctx context.Context,
 	allocator *colmem.Allocator,
 	input colexecop.Operator,
 	colIdx int,
@@ -627,11 +630,11 @@ func GetCastOperator(
 			}
 		}
 	}
-	return nil, errors.Errorf(
-		"unhandled cast %s -> %s",
-		fromType.SQLStringForError(),
-		toType.SQLStringForError(),
-	)
+	err := errUnhandledCast
+	if log.ExpensiveLogEnabled(ctx, 1) {
+		err = errors.Newf("unhandled cast %s -> %s", fromType.SQLStringForError(), toType.SQLStringForError())
+	}
+	return nil, err
 }
 
 func IsCastSupported(fromType, toType *types.T) bool {
@@ -1206,7 +1209,7 @@ func (c *castOpNullAny) Next() coldata.Batch {
 			if vecNulls.NullAt(i) {
 				projNulls.SetNull(i)
 			} else {
-				colexecerror.InternalError(errors.Errorf("unexpected non-null at index %d", i))
+				colexecerror.InternalError(errors.AssertionFailedf("unexpected non-null at index %d", i))
 			}
 		}
 	} else {
@@ -1214,7 +1217,7 @@ func (c *castOpNullAny) Next() coldata.Batch {
 			if vecNulls.NullAt(i) {
 				projNulls.SetNull(i)
 			} else {
-				colexecerror.InternalError(fmt.Errorf("unexpected non-null at index %d", i))
+				colexecerror.InternalError(errors.AssertionFailedf("unexpected non-null at index %d", i))
 			}
 		}
 	}

--- a/pkg/sql/colexec/colexecbase/cast_test.go
+++ b/pkg/sql/colexec/colexecbase/cast_test.go
@@ -77,7 +77,7 @@ func TestRandomizedCast(t *testing.T) {
 		colexectestutils.RunTestsWithoutAllNullsInjectionWithErrorHandler(t, testAllocator,
 			[]colexectestutils.Tuples{input}, [][]*types.T{{from}}, output, colexectestutils.OrderedVerifier,
 			func(input []colexecop.Operator) (colexecop.Operator, error) {
-				return colexecbase.GetCastOperator(testAllocator, input[0], 0, 1, from, to, &evalCtx)
+				return colexecbase.GetCastOperator(ctx, testAllocator, input[0], 0, 1, from, to, &evalCtx)
 			}, func(err error) {
 				if !errorExpected {
 					t.Fatal(err)
@@ -118,7 +118,7 @@ func BenchmarkCastOp(b *testing.B) {
 							coldata.BatchSize(), nullProbability, selectivity,
 						)
 						source := colexecop.NewRepeatableBatchSource(testAllocator, batch, typs)
-						op, err := colexecbase.GetCastOperator(testAllocator, source, 0, 1, typePair[0], typePair[1], &evalCtx)
+						op, err := colexecbase.GetCastOperator(ctx, testAllocator, source, 0, 1, typePair[0], typePair[1], &evalCtx)
 						require.NoError(b, err)
 						b.SetBytes(int64(8 * coldata.BatchSize()))
 						b.ResetTimer()

--- a/pkg/sql/colexec/colexecbase/const.eg.go
+++ b/pkg/sql/colexec/colexecbase/const.eg.go
@@ -154,7 +154,7 @@ func NewConstOp(
 			}, nil
 		}
 	}
-	return nil, errors.Errorf("unsupported const type %s", t.Name())
+	return nil, errors.AssertionFailedf("unsupported const type %s", t.Name())
 }
 
 type constBoolOp struct {

--- a/pkg/sql/colexec/colexecbase/const_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/const_tmpl.go
@@ -78,7 +78,7 @@ func NewConstOp(
 		}
 		// {{end}}
 	}
-	return nil, errors.Errorf("unsupported const type %s", t.Name())
+	return nil, errors.AssertionFailedf("unsupported const type %s", t.Name())
 }
 
 // {{range .}}

--- a/pkg/sql/colexec/colexecdisk/external_hash_joiner.go
+++ b/pkg/sql/colexec/colexecdisk/external_hash_joiner.go
@@ -6,6 +6,8 @@
 package colexecdisk
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecargs"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecjoin"
@@ -56,6 +58,7 @@ import (
 // components of the external hash joiner which is responsible for making sure
 // that the components stay within the memory limit.
 func NewExternalHashJoiner(
+	ctx context.Context,
 	unlimitedAllocator *colmem.Allocator,
 	flowCtx *execinfra.FlowCtx,
 	args *colexecargs.NewColOperatorArgs,
@@ -109,7 +112,7 @@ func NewExternalHashJoiner(
 			partitionedInputs[1], spec.Right.SourceTypes, rightOrdering, externalSorterMaxNumberPartitions,
 		)
 		return colexecjoin.NewMergeJoinOp(
-			unlimitedAllocator, memoryLimit, args.DiskQueueCfg, fdSemaphore, spec.JoinType,
+			ctx, unlimitedAllocator, memoryLimit, args.DiskQueueCfg, fdSemaphore, spec.JoinType,
 			leftPartitionSorter, rightPartitionSorter, spec.Left.SourceTypes,
 			spec.Right.SourceTypes, leftOrdering, rightOrdering, diskAcc, diskQueueMemAcc, flowCtx.EvalCtx,
 		)

--- a/pkg/sql/colexec/colexecjoin/mergejoiner.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner.go
@@ -300,6 +300,7 @@ type mergeJoinInput struct {
 //
 // evalCtx will not be mutated.
 func NewMergeJoinOp(
+	ctx context.Context,
 	unlimitedAllocator *colmem.Allocator,
 	memoryLimit int64,
 	diskQueueCfg colcontainer.DiskQueueCfg,
@@ -363,7 +364,7 @@ func NewMergeJoinOp(
 			}
 			if castLeftToRight {
 				castColumnIdx := len(actualLeftTypes)
-				left, err = colexecbase.GetCastOperator(unlimitedAllocator, left, int(leftColIdx), castColumnIdx, leftType, rightType, evalCtx)
+				left, err = colexecbase.GetCastOperator(ctx, unlimitedAllocator, left, int(leftColIdx), castColumnIdx, leftType, rightType, evalCtx)
 				if err != nil {
 					colexecerror.InternalError(err)
 				}
@@ -371,7 +372,7 @@ func NewMergeJoinOp(
 				actualLeftOrdering[i].ColIdx = uint32(castColumnIdx)
 			} else {
 				castColumnIdx := len(actualRightTypes)
-				right, err = colexecbase.GetCastOperator(unlimitedAllocator, right, int(rightColIdx), castColumnIdx, rightType, leftType, evalCtx)
+				right, err = colexecbase.GetCastOperator(ctx, unlimitedAllocator, right, int(rightColIdx), castColumnIdx, rightType, leftType, evalCtx)
 				if err != nil {
 					colexecerror.InternalError(err)
 				}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_test.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_test.go
@@ -93,7 +93,7 @@ func TestMergeJoinCrossProduct(t *testing.T) {
 	leftHJSource := colexectestutils.NewChunkingBatchSource(testAllocator, typs, colsLeft, nTuples)
 	rightHJSource := colexectestutils.NewChunkingBatchSource(testAllocator, typs, colsRight, nTuples)
 	mj := NewMergeJoinOp(
-		testAllocator, execinfra.DefaultMemoryLimit, queueCfg,
+		ctx, testAllocator, execinfra.DefaultMemoryLimit, queueCfg,
 		colexecop.NewTestingSemaphore(mjFDLimit), descpb.InnerJoin,
 		leftMJSource, rightMJSource, typs, typs,
 		[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},

--- a/pkg/sql/colexec/colexecprojconst/like_ops.go
+++ b/pkg/sql/colexec/colexecprojconst/like_ops.go
@@ -15,6 +15,8 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+var ilikeConstantPatternErr = errors.New("ILIKE and NOT ILIKE aren't supported with a constant pattern")
+
 // GetLikeProjectionOperator returns a projection operator which projects the
 // result of the specified LIKE pattern, or NOT LIKE if the negate argument is
 // true. The implementation varies depending on the complexity of the pattern.
@@ -55,7 +57,7 @@ func GetLikeProjectionOperator(
 			// We don't have an equivalent projection operator that would
 			// convert the argument to capital letters, so for now we fall back
 			// to the default comparison operator.
-			return nil, errors.New("ILIKE and NOT ILIKE aren't supported with a constant pattern")
+			return nil, ilikeConstantPatternErr
 		}
 		if negate {
 			return &projNEBytesBytesConstOp{

--- a/pkg/sql/colexec/colexecsel/like_ops.go
+++ b/pkg/sql/colexec/colexecsel/like_ops.go
@@ -12,6 +12,8 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+var ilikeConstantPatternErr = errors.New("ILIKE and NOT ILIKE aren't supported with a constant pattern")
+
 // GetLikeOperator returns a selection operator which applies the specified LIKE
 // pattern, or NOT LIKE if the negate argument is true. The implementation
 // varies depending on the complexity of the pattern.
@@ -47,7 +49,7 @@ func GetLikeOperator(
 			// We don't have an equivalent projection operator that would
 			// convert the argument to capital letters, so for now we fall back
 			// to the default comparison operator.
-			return nil, errors.New("ILIKE and NOT ILIKE aren't supported with a constant pattern")
+			return nil, ilikeConstantPatternErr
 		}
 		if negate {
 			return &selNEBytesBytesConstOp{

--- a/pkg/sql/colexec/colexecutils/bool_vec_to_sel.go
+++ b/pkg/sql/colexec/colexecutils/bool_vec_to_sel.go
@@ -28,7 +28,7 @@ func BoolOrUnknownToSelOp(
 		// can simply plan a zero operator.
 		return NewZeroOp(input), nil
 	default:
-		return nil, errors.Errorf("unexpectedly %s is neither bool nor unknown", typs[vecIdx])
+		return nil, errors.AssertionFailedf("unexpectedly %s is neither bool nor unknown", typs[vecIdx].SQLStringForError())
 	}
 }
 

--- a/pkg/sql/colexec/colexecutils/spilling_queue.go
+++ b/pkg/sql/colexec/colexecutils/spilling_queue.go
@@ -158,7 +158,7 @@ func NewRewindableSpillingQueue(args *NewSpillingQueueArgs) *SpillingQueue {
 // spilling queue will account for memory used by the in-memory copies).
 func (q *SpillingQueue) Enqueue(ctx context.Context, batch coldata.Batch) {
 	if q.rewindable && q.rewindableState.numItemsDequeued > 0 {
-		colexecerror.InternalError(errors.Errorf("attempted to Enqueue to rewindable SpillingQueue after Dequeue has been called"))
+		colexecerror.InternalError(errors.AssertionFailedf("attempted to Enqueue to rewindable SpillingQueue after Dequeue has been called"))
 	}
 
 	n := batch.Length()
@@ -556,7 +556,7 @@ func (q *SpillingQueue) Close(ctx context.Context) error {
 // Rewind rewinds the spilling queue.
 func (q *SpillingQueue) Rewind(ctx context.Context) error {
 	if !q.rewindable {
-		return errors.Newf("unexpectedly Rewind() called when spilling queue is not rewindable")
+		return errors.AssertionFailedf("unexpectedly Rewind() called when spilling queue is not rewindable")
 	}
 	if q.diskQueue != nil {
 		if err := q.diskQueue.(colcontainer.RewindableQueue).Rewind(ctx); err != nil {

--- a/pkg/sql/colexec/colexecwindow/first_last_nth_value_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/first_last_nth_value_tmpl.go
@@ -91,7 +91,7 @@ func New_UPPERCASE_NAMEOperator(
 		}
 		// {{end}}
 	}
-	return nil, errors.Errorf("unsupported _OP_NAME window operator type %s", argType.Name())
+	return nil, errors.AssertionFailedf("unsupported _OP_NAME window operator type %s", argType.Name())
 }
 
 type _OP_NAMEBase struct {

--- a/pkg/sql/colexec/colexecwindow/first_value.eg.go
+++ b/pkg/sql/colexec/colexecwindow/first_value.eg.go
@@ -122,7 +122,7 @@ func NewFirstValueOperator(
 			return newBufferedWindowOperator(args, windower, argType, mainMemLimit), nil
 		}
 	}
-	return nil, errors.Errorf("unsupported firstValue window operator type %s", argType.Name())
+	return nil, errors.AssertionFailedf("unsupported firstValue window operator type %s", argType.Name())
 }
 
 type firstValueBase struct {

--- a/pkg/sql/colexec/colexecwindow/lag.eg.go
+++ b/pkg/sql/colexec/colexecwindow/lag.eg.go
@@ -116,7 +116,7 @@ func NewLagOperator(
 				args, &lagDatumWindow{lagBase: base}, argType, mainMemLimit), nil
 		}
 	}
-	return nil, errors.Errorf("unsupported lag window operator type %s", argType.Name())
+	return nil, errors.AssertionFailedf("unsupported lag window operator type %s", argType.Name())
 }
 
 // lagBase extracts common fields and methods of the lag windower

--- a/pkg/sql/colexec/colexecwindow/last_value.eg.go
+++ b/pkg/sql/colexec/colexecwindow/last_value.eg.go
@@ -122,7 +122,7 @@ func NewLastValueOperator(
 			return newBufferedWindowOperator(args, windower, argType, mainMemLimit), nil
 		}
 	}
-	return nil, errors.Errorf("unsupported lastValue window operator type %s", argType.Name())
+	return nil, errors.AssertionFailedf("unsupported lastValue window operator type %s", argType.Name())
 }
 
 type lastValueBase struct {

--- a/pkg/sql/colexec/colexecwindow/lead.eg.go
+++ b/pkg/sql/colexec/colexecwindow/lead.eg.go
@@ -116,7 +116,7 @@ func NewLeadOperator(
 				args, &leadDatumWindow{leadBase: base}, argType, mainMemLimit), nil
 		}
 	}
-	return nil, errors.Errorf("unsupported lead window operator type %s", argType.Name())
+	return nil, errors.AssertionFailedf("unsupported lead window operator type %s", argType.Name())
 }
 
 // leadBase extracts common fields and methods of the lead windower

--- a/pkg/sql/colexec/colexecwindow/lead_lag_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/lead_lag_tmpl.go
@@ -79,7 +79,7 @@ func New_UPPERCASE_NAMEOperator(
 		}
 		// {{end}}
 	}
-	return nil, errors.Errorf("unsupported _OP_NAME window operator type %s", argType.Name())
+	return nil, errors.AssertionFailedf("unsupported _OP_NAME window operator type %s", argType.Name())
 }
 
 // _OP_NAMEBase extracts common fields and methods of the _OP_NAME windower

--- a/pkg/sql/colexec/colexecwindow/nth_value.eg.go
+++ b/pkg/sql/colexec/colexecwindow/nth_value.eg.go
@@ -135,7 +135,7 @@ func NewNthValueOperator(
 			return newBufferedWindowOperator(args, windower, argType, mainMemLimit), nil
 		}
 	}
-	return nil, errors.Errorf("unsupported nthValue window operator type %s", argType.Name())
+	return nil, errors.AssertionFailedf("unsupported nthValue window operator type %s", argType.Name())
 }
 
 type nthValueBase struct {

--- a/pkg/sql/colexec/colexecwindow/rank.eg.go
+++ b/pkg/sql/colexec/colexecwindow/rank.eg.go
@@ -60,7 +60,7 @@ func NewRankOperator(
 		}
 		return &denseRankNoPartitionOp{rankInitFields: initFields}, nil
 	default:
-		return nil, errors.Errorf("unsupported rank type %s", windowFn)
+		return nil, errors.AssertionFailedf("unsupported rank type %s", windowFn)
 	}
 }
 

--- a/pkg/sql/colexec/colexecwindow/rank_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/rank_tmpl.go
@@ -70,7 +70,7 @@ func NewRankOperator(
 		}
 		return &denseRankNoPartitionOp{rankInitFields: initFields}, nil
 	default:
-		return nil, errors.Errorf("unsupported rank type %s", windowFn)
+		return nil, errors.AssertionFailedf("unsupported rank type %s", windowFn)
 	}
 }
 

--- a/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
@@ -77,7 +77,7 @@ func NewRelativeRankOperator(
 			relativeRankInitFields: rrInitFields,
 		}, nil
 	default:
-		return nil, errors.Errorf("unsupported relative rank type %s", windowFn)
+		return nil, errors.AssertionFailedf("unsupported relative rank type %s", windowFn)
 	}
 }
 

--- a/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
@@ -87,7 +87,7 @@ func NewRelativeRankOperator(
 			relativeRankInitFields: rrInitFields,
 		}, nil
 	default:
-		return nil, errors.Errorf("unsupported relative rank type %s", windowFn)
+		return nil, errors.AssertionFailedf("unsupported relative rank type %s", windowFn)
 	}
 }
 

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1748,7 +1748,7 @@ func TestFullOuterMergeJoinWithMaximumNumberOfGroups(t *testing.T) {
 	leftSource := colexectestutils.NewChunkingBatchSource(testAllocator, typs, colsLeft, nTuples)
 	rightSource := colexectestutils.NewChunkingBatchSource(testAllocator, typs, colsRight, nTuples)
 	a := colexecjoin.NewMergeJoinOp(
-		testAllocator, execinfra.DefaultMemoryLimit, queueCfg,
+		ctx, testAllocator, execinfra.DefaultMemoryLimit, queueCfg,
 		colexecop.NewTestingSemaphore(mjFDLimit), descpb.FullOuterJoin,
 		leftSource, rightSource, typs, typs,
 		[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
@@ -1820,7 +1820,7 @@ func TestMergeJoinerMultiBatch(t *testing.T) {
 				leftSource := colexectestutils.NewChunkingBatchSource(testAllocator, typs, cols, nTuples)
 				rightSource := colexectestutils.NewChunkingBatchSource(testAllocator, typs, cols, nTuples)
 				a := colexecjoin.NewMergeJoinOp(
-					testAllocator, execinfra.DefaultMemoryLimit,
+					ctx, testAllocator, execinfra.DefaultMemoryLimit,
 					queueCfg, colexecop.NewTestingSemaphore(mjFDLimit), descpb.InnerJoin,
 					leftSource, rightSource, typs, typs,
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
@@ -1897,7 +1897,7 @@ func TestMergeJoinerMultiBatchRuns(t *testing.T) {
 					leftSource := colexectestutils.NewChunkingBatchSource(testAllocator, typs, cols, nTuples)
 					rightSource := colexectestutils.NewChunkingBatchSource(testAllocator, typs, cols, nTuples)
 					a := colexecjoin.NewMergeJoinOp(
-						testAllocator, execinfra.DefaultMemoryLimit,
+						ctx, testAllocator, execinfra.DefaultMemoryLimit,
 						queueCfg, colexecop.NewTestingSemaphore(mjFDLimit), descpb.InnerJoin,
 						leftSource, rightSource, typs, typs,
 						[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}, {ColIdx: 1, Direction: execinfrapb.Ordering_Column_ASC}},
@@ -2022,7 +2022,7 @@ func TestMergeJoinerRandomized(t *testing.T) {
 					rightSource := colexectestutils.NewChunkingBatchSource(testAllocator, typs, rCols, nTuples)
 
 					a := colexecjoin.NewMergeJoinOp(
-						testAllocator, execinfra.DefaultMemoryLimit,
+						ctx, testAllocator, execinfra.DefaultMemoryLimit,
 						queueCfg, colexecop.NewTestingSemaphore(mjFDLimit), descpb.InnerJoin,
 						leftSource, rightSource, typs, typs,
 						[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},

--- a/pkg/sql/colexec/select_in.eg.go
+++ b/pkg/sql/colexec/select_in.eg.go
@@ -212,7 +212,7 @@ func GetInProjectionOperator(
 			return obj, nil
 		}
 	}
-	return nil, errors.Errorf("unhandled type: %s", t.Name())
+	return nil, errors.AssertionFailedf("unhandled type: %s", t.Name())
 }
 
 func GetInOperator(
@@ -350,7 +350,7 @@ func GetInOperator(
 			return obj, nil
 		}
 	}
-	return nil, errors.Errorf("unhandled type: %s", t.Name())
+	return nil, errors.AssertionFailedf("unhandled type: %s", t.Name())
 }
 
 type selectInOpBool struct {

--- a/pkg/sql/colexec/select_in_tmpl.go
+++ b/pkg/sql/colexec/select_in_tmpl.go
@@ -109,7 +109,7 @@ func GetInProjectionOperator(
 		}
 		// {{end}}
 	}
-	return nil, errors.Errorf("unhandled type: %s", t.Name())
+	return nil, errors.AssertionFailedf("unhandled type: %s", t.Name())
 }
 
 func GetInOperator(
@@ -138,7 +138,7 @@ func GetInOperator(
 		}
 		// {{end}}
 	}
-	return nil, errors.Errorf("unhandled type: %s", t.Name())
+	return nil, errors.AssertionFailedf("unhandled type: %s", t.Name())
 }
 
 // {{range .}}

--- a/pkg/sql/colexec/substring.eg.go
+++ b/pkg/sql/colexec/substring.eg.go
@@ -71,7 +71,7 @@ func newSubstringOperator(
 			return &substringInt32Int64Operator{base}
 		}
 	}
-	colexecerror.InternalError(errors.Errorf("unsupported substring argument types: %s %s", startType, lengthType))
+	colexecerror.InternalError(errors.AssertionFailedf("unsupported substring argument types: %s %s", startType, lengthType))
 	// This code is unreachable, but the compiler cannot infer that.
 	return nil
 }

--- a/pkg/sql/colexec/substring_tmpl.go
+++ b/pkg/sql/colexec/substring_tmpl.go
@@ -69,7 +69,7 @@ func newSubstringOperator(
 		}
 		// {{end}}
 	}
-	colexecerror.InternalError(errors.Errorf("unsupported substring argument types: %s %s", startType, lengthType))
+	colexecerror.InternalError(errors.AssertionFailedf("unsupported substring argument types: %s %s", startType, lengthType))
 	// This code is unreachable, but the compiler cannot infer that.
 	return nil
 }

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -381,7 +381,7 @@ func (cf *cFetcher) Init(
 	allocator *colmem.Allocator, nextKVer storage.NextKVer, tableArgs *cFetcherTableArgs,
 ) error {
 	if tableArgs.spec.Version != fetchpb.IndexFetchSpecVersionInitial {
-		return errors.Newf("unsupported IndexFetchSpec version %d", tableArgs.spec.Version)
+		return errors.AssertionFailedf("unsupported IndexFetchSpec version %d", tableArgs.spec.Version)
 	}
 	table := newCTableInfo()
 	nCols := tableArgs.ColIdxMap.Len()
@@ -716,7 +716,7 @@ func (cf *cFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 		}
 		switch cf.machine.state[0] {
 		case stateInvalid:
-			return nil, errors.New("invalid fetcher state")
+			return nil, errors.AssertionFailedf("invalid fetcher state")
 		case stateInitFetch:
 			cf.machine.firstKeyOfRow = nil
 			cf.cpuStopWatch.Start()
@@ -1145,7 +1145,7 @@ func (cf *cFetcher) processValue(ctx context.Context, familyID descpb.FamilyID) 
 			if defaultColumnID == 0 {
 				return scrub.WrapError(
 					scrub.IndexKeyDecodingError,
-					errors.Errorf("single entry value with no default column id"),
+					errors.AssertionFailedf("single entry value with no default column id"),
 				)
 			}
 			prettyKey, prettyValue, err = cf.processValueSingle(ctx, table, defaultColumnID, prettyKey)
@@ -1365,7 +1365,7 @@ func (cf *cFetcher) fillNulls() error {
 			for i := range table.spec.KeyFullColumns() {
 				indexColNames = append(indexColNames, table.spec.KeyAndSuffixColumns[i].Name)
 			}
-			return scrub.WrapError(scrub.UnexpectedNullValueError, errors.Errorf(
+			return scrub.WrapError(scrub.UnexpectedNullValueError, errors.AssertionFailedf(
 				"non-nullable column \"%s:%s\" with no value! Index scanned was %q with the index key columns (%s) and the values (%s)",
 				table.spec.TableName, table.spec.FetchedColumns[i].Name, table.spec.IndexName,
 				strings.Join(indexColNames, ","), indexColValues.String()))

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -128,7 +128,7 @@ func newColBatchScanBase(
 ) (*colBatchScanBase, *kvpb.BoundedStalenessHeader, *cFetcherTableArgs, error) {
 	// NB: we hit this with a zero NodeID (but !ok) with multi-tenancy.
 	if nodeID, ok := flowCtx.NodeID.OptionalNodeID(); nodeID == 0 && ok {
-		return nil, nil, nil, errors.Errorf("attempting to create a ColBatchScan with uninitialized NodeID")
+		return nil, nil, nil, errors.AssertionFailedf("attempting to create a ColBatchScan with uninitialized NodeID")
 	}
 	var bsHeader *kvpb.BoundedStalenessHeader
 	if aost := flowCtx.EvalCtx.AsOfSystemTime; aost != nil && aost.BoundedStaleness {

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -495,7 +495,7 @@ func NewColIndexJoin(
 ) (*ColIndexJoin, error) {
 	// NB: we hit this with a zero NodeID (but !ok) with multi-tenancy.
 	if nodeID, ok := flowCtx.NodeID.OptionalNodeID(); nodeID == 0 && ok {
-		return nil, errors.Errorf("attempting to create a ColIndexJoin with uninitialized NodeID")
+		return nil, errors.AssertionFailedf("attempting to create a ColIndexJoin with uninitialized NodeID")
 	}
 	if !spec.LookupExpr.Empty() {
 		return nil, errors.AssertionFailedf("non-empty lookup expressions are not supported for index joins")

--- a/pkg/sql/colflow/stats.go
+++ b/pkg/sql/colflow/stats.go
@@ -383,7 +383,7 @@ func (i *statsInvariantChecker) GetStats() *execinfrapb.ComponentStats {
 
 func (i *statsInvariantChecker) DrainMeta() []execinfrapb.ProducerMetadata {
 	if !i.statsRetrieved {
-		return []execinfrapb.ProducerMetadata{{Err: errors.New("GetStats wasn't called before DrainMeta")}}
+		return []execinfrapb.ProducerMetadata{{Err: errors.AssertionFailedf("GetStats wasn't called before DrainMeta")}}
 	}
 	return nil
 }

--- a/pkg/sql/colflow/stats_test.go
+++ b/pkg/sql/colflow/stats_test.go
@@ -112,7 +112,7 @@ func TestVectorizedStatsCollector(t *testing.T) {
 			nil, /* inputStatsCollectors */
 		)
 		mergeJoiner := colexecjoin.NewMergeJoinOp(
-			tu.testAllocator, execinfra.DefaultMemoryLimit, queueCfg,
+			ctx, tu.testAllocator, execinfra.DefaultMemoryLimit, queueCfg,
 			colexecop.NewTestingSemaphore(4), descpb.InnerJoin, leftInput, rightInput,
 			[]*types.T{types.Int}, []*types.T{types.Int},
 			[]execinfrapb.Ordering_Column{{ColIdx: 0}},

--- a/pkg/sql/rowenc/encoded_datum.go
+++ b/pkg/sql/rowenc/encoded_datum.go
@@ -139,7 +139,7 @@ func EncDatumFromEncoded(enc catenumpb.DatumEncoding, encoded []byte) EncDatum {
 // slice for the rest of the buffer.
 func EncDatumFromBuffer(enc catenumpb.DatumEncoding, buf []byte) (EncDatum, []byte, error) {
 	if len(buf) == 0 {
-		return EncDatum{}, nil, errors.New("empty encoded value")
+		return EncDatum{}, nil, errors.AssertionFailedf("empty encoded value")
 	}
 	switch enc {
 	case catenumpb.DatumEncoding_ASCENDING_KEY, catenumpb.DatumEncoding_DESCENDING_KEY:

--- a/pkg/sql/rowenc/keyside/json.go
+++ b/pkg/sql/rowenc/keyside/json.go
@@ -59,7 +59,7 @@ func decodeJSONKey(buf []byte, dir encoding.Direction) (json.JSON, []byte, error
 			return nil, nil, errors.NewAssertionErrorWithWrappedErrf(err, "could not decode JSON Number")
 		}
 		if len(buf) == 0 || !encoding.IsJSONKeyDone(buf, dir) {
-			return nil, nil, errors.New("cannot find JSON terminator")
+			return nil, nil, errors.AssertionFailedf("cannot find JSON terminator")
 		}
 		buf = buf[1:] // removing the terminator
 		jsonVal = json.FromDecimal(dec)
@@ -70,7 +70,7 @@ func decodeJSONKey(buf []byte, dir encoding.Direction) (json.JSON, []byte, error
 			return nil, nil, errors.NewAssertionErrorWithWrappedErrf(err, "could not decode JSON Number")
 		}
 		if len(buf) == 0 || !encoding.IsJSONKeyDone(buf, dir) {
-			return nil, nil, errors.New("cannot find JSON terminator")
+			return nil, nil, errors.AssertionFailedf("cannot find JSON terminator")
 		}
 		buf = buf[1:] // removing the terminator
 		jsonVal = json.FromDecimal(dec)
@@ -104,7 +104,7 @@ func decodeJSONString(buf []byte, dir encoding.Direction) (json.JSON, []byte, er
 			"the JSON String")
 	}
 	if len(buf) == 0 || !encoding.IsJSONKeyDone(buf, dir) {
-		return nil, nil, errors.New("cannot find JSON terminator")
+		return nil, nil, errors.AssertionFailedf("cannot find JSON terminator")
 	}
 	buf = buf[1:] // removing the terminator
 	jsonVal, err := json.MakeJSON(str)

--- a/pkg/sql/rowenc/valueside/array.go
+++ b/pkg/sql/rowenc/valueside/array.go
@@ -187,6 +187,8 @@ func decodeArrayHeader(b []byte) (arrayHeader, []byte, error) {
 	}, b, nil
 }
 
+var errNestedArraysNotFullySupported = unimplemented.NewWithIssueDetail(32552, "", "nested arrays are not fully supported")
+
 // DatumTypeToArrayElementEncodingType decides an encoding type to
 // place in the array header given a datum type. The element encoding
 // type is then used to encode/decode array elements.
@@ -235,7 +237,7 @@ func DatumTypeToArrayElementEncodingType(t *types.T) (encoding.Type, error) {
 	case types.TupleFamily:
 		return encoding.Tuple, nil
 	case types.ArrayFamily:
-		return 0, unimplemented.NewWithIssueDetail(32552, "", "nested arrays are not fully supported")
+		return 0, errNestedArraysNotFullySupported
 	default:
 		return 0, errors.AssertionFailedf("no known encoding type for %s", t.Family().Name())
 	}

--- a/pkg/sql/rowexec/inverted_filterer.go
+++ b/pkg/sql/rowexec/inverted_filterer.go
@@ -225,11 +225,11 @@ func (ifr *invertedFilterer) readInput() (invertedFiltererState, *execinfrapb.Pr
 		// key as a DBytes. The Datum should never be DNull since nulls aren't
 		// stored in inverted indexes.
 		if row[ifr.invertedColIdx].Datum == nil {
-			ifr.MoveToDraining(errors.New("no datum found"))
+			ifr.MoveToDraining(errors.AssertionFailedf("no datum found"))
 			return ifrStateUnknown, ifr.DrainHelper()
 		}
 		if row[ifr.invertedColIdx].Datum.ResolvedType().Family() != types.EncodedKeyFamily {
-			ifr.MoveToDraining(errors.New("inverted column should have type encodedkey"))
+			ifr.MoveToDraining(errors.AssertionFailedf("inverted column should have type encodedkey"))
 			return ifrStateUnknown, ifr.DrainHelper()
 		}
 		enc = []byte(*row[ifr.invertedColIdx].Datum.(*tree.DEncodedKey))

--- a/pkg/sql/rowexec/joinerbase.go
+++ b/pkg/sql/rowexec/joinerbase.go
@@ -57,7 +57,7 @@ func (jb *joinerBase) init(
 
 	if jb.joinType.IsSetOpJoin() {
 		if !onExpr.Empty() {
-			return nil, errors.Errorf("expected empty onExpr, got %v", onExpr)
+			return nil, errors.AssertionFailedf("expected empty onExpr, got %v", onExpr)
 		}
 	}
 

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -320,7 +320,7 @@ func newJoinReader(
 	case lookupJoinReaderType:
 		lookupCols = spec.LookupColumns
 	default:
-		return nil, errors.Errorf("unsupported joinReaderType")
+		return nil, errors.AssertionFailedf("unsupported joinReaderType")
 	}
 	// The joiner has a choice to make between getting DistSender-level
 	// parallelism for its lookup batches and setting row and memory limits (due
@@ -394,7 +394,7 @@ func newJoinReader(
 	case lookupJoinReaderType:
 		leftTypes = input.OutputTypes()
 	default:
-		return nil, errors.Errorf("unsupported joinReaderType")
+		return nil, errors.AssertionFailedf("unsupported joinReaderType")
 	}
 	rightTypes := spec.FetchSpec.FetchedColumnTypes()
 

--- a/pkg/sql/rowexec/processors.go
+++ b/pkg/sql/rowexec/processors.go
@@ -88,7 +88,7 @@ func emitHelper(
 
 func checkNumIn(inputs []execinfra.RowSource, numIn int) error {
 	if len(inputs) != numIn {
-		return errors.Errorf("expected %d input(s), got %d", numIn, len(inputs))
+		return errors.AssertionFailedf("expected %d input(s), got %d", numIn, len(inputs))
 	}
 	return nil
 }
@@ -315,7 +315,7 @@ func NewProcessor(
 				return nil, err
 			}
 		} else if numInputs > 1 {
-			return nil, errors.Errorf("invalid localPlanNode core with multiple inputs %+v", core.LocalPlanNode)
+			return nil, errors.AssertionFailedf("invalid localPlanNode core with multiple inputs %+v", core.LocalPlanNode)
 		}
 		return processor, nil
 	}

--- a/pkg/sql/rowexec/stream_merger.go
+++ b/pkg/sql/rowexec/stream_merger.go
@@ -172,12 +172,12 @@ func makeStreamMerger(
 	memMonitor *mon.BytesMonitor,
 ) (streamMerger, error) {
 	if len(leftOrdering) != len(rightOrdering) {
-		return streamMerger{}, errors.Errorf(
+		return streamMerger{}, errors.AssertionFailedf(
 			"ordering lengths don't match: %d and %d", len(leftOrdering), len(rightOrdering))
 	}
 	for i, ord := range leftOrdering {
 		if ord.Direction != rightOrdering[i].Direction {
-			return streamMerger{}, errors.New("ordering mismatch")
+			return streamMerger{}, errors.AssertionFailedf("ordering mismatch")
 		}
 	}
 

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -80,7 +80,7 @@ func newTableReader(
 ) (*tableReader, error) {
 	// NB: we hit this with a zero NodeID (but !ok) with multi-tenancy.
 	if nodeID, ok := flowCtx.NodeID.OptionalNodeID(); ok && nodeID == 0 {
-		return nil, errors.Errorf("attempting to create a tableReader with uninitialized NodeID")
+		return nil, errors.AssertionFailedf("attempting to create a tableReader with uninitialized NodeID")
 	}
 
 	if spec.LimitHint > 0 || spec.BatchBytesLimit > 0 {


### PR DESCRIPTION
This commit audits error creation during the execution planning phase (mostly for vectorized engine) to avoid retrieving the stack trace when creating errors on the hot path. We do so by only wrapping or creating fresh errors when "expensive log is enabled" (so that the detailed errors still show up in trace) and otherwise using the provided or a global error. In many places I also substituted miscellaneous calls to `AssertionFailedf` where I thought we'd be getting into an invalid state, to make it more clear.

Fixes: #134586.

Release note: None