### PR TITLE
sql,authorization: use proper method for escaping SQL identifiers

### DIFF
--- a/pkg/ccl/testccl/authccl/testdata/ldap
+++ b/pkg/ccl/testccl/authccl/testdata/ldap
@@ -311,4 +311,21 @@ SELECT pg_has_role('ldap_user', 'ldap.user.parent.2', 'MEMBER')
 ----
 true
 
+ldap_mock set_groups=(ldap_user,cn=ldap-user-parent-1)
+----
+
+connect user=ldap_user password="ldap_pwd"
+----
+ok defaultdb
+
+query_row
+SELECT pg_has_role('ldap_user', 'ldap-user-parent-1', 'MEMBER')
+----
+true
+
+query_row
+SELECT pg_has_role('ldap_user', 'ldap.user.parent.2', 'MEMBER')
+----
+false
+
 subtest end

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -743,10 +743,10 @@ func EnsureUserOnlyBelongsToRoles(
 				if i > 0 {
 					revokeStmt.WriteString(", ")
 				}
-				revokeStmt.WriteString(role.Normalized())
+				revokeStmt.WriteString(role.SQLIdentifier())
 			}
 			revokeStmt.WriteString(" FROM ")
-			revokeStmt.WriteString(user.Normalized())
+			revokeStmt.WriteString(user.SQLIdentifier())
 			if _, err := txn.Exec(
 				ctx, "EnsureUserOnlyBelongsToRoles-revoke", txn.KV(), revokeStmt.String(),
 			); err != nil {
@@ -761,10 +761,10 @@ func EnsureUserOnlyBelongsToRoles(
 				if i > 0 {
 					grantStmt.WriteString(", ")
 				}
-				grantStmt.WriteString(fmt.Sprintf("%q", role.Normalized()))
+				grantStmt.WriteString(role.SQLIdentifier())
 			}
 			grantStmt.WriteString(" TO ")
-			grantStmt.WriteString(user.Normalized())
+			grantStmt.WriteString(user.SQLIdentifier())
 			if _, err := txn.Exec(
 				ctx, "EnsureUserOnlyBelongsToRoles-grant", txn.KV(), grantStmt.String(),
 			); err != nil {


### PR DESCRIPTION
The escaping rules for SQL identifiers is slightly different than the rules used by the %q format verb, so we change to the appropriate function here.

Also, escaping was not being done for the REVOKE path, so that is fixed and tested here.

This modifies the recent PR #134927.

informs https://github.com/cockroachdb/cockroach/issues/134923
Release note: None