### PR TITLE
randgen: fix bpchar datum generation

### DIFF
--- a/pkg/sql/randgen/datum.go
+++ b/pkg/sql/randgen/datum.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"math/bits"
 	"math/rand"
+	"strings"
 	"time"
 	"unicode"
 
@@ -261,6 +262,9 @@ func RandDatumWithNullChance(
 		}
 		if typ.Oid() == oid.T_name {
 			return tree.NewDName(string(p))
+		}
+		if typ.Oid() == oid.T_bpchar {
+			return tree.NewDString(strings.TrimRight(string(p), " "))
 		}
 		return tree.NewDString(string(p))
 	case types.BytesFamily:


### PR DESCRIPTION
This commit applies the same space trimming logic as we just added in 0c57d5cb422b0bcd36a753d69244203b5a7d7253.

Fixes: #134742.

Release note: None