### PR TITLE
kvserver/rangefeed: use StreamManager for buffered sender

### DIFF
--- a/pkg/kv/kvserver/rangefeed/buffered_sender.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_sender.go
@@ -51,55 +51,31 @@ type BufferedSender struct {
 	// Note that lockedMuxStream wraps the underlying grpc server stream, ensuring
 	// thread safety.
 	sender ServerStreamSender
-
-	// metrics is used to record rangefeed metrics for the node.
-	metrics RangefeedMetricsRecorder
 }
 
-func NewBufferedSender(
-	sender ServerStreamSender, metrics RangefeedMetricsRecorder,
-) *BufferedSender {
-	return &BufferedSender{
-		sender:  sender,
-		metrics: metrics,
+func NewBufferedSender(sender ServerStreamSender) *BufferedSender {
+	bs := &BufferedSender{
+		sender: sender,
 	}
+	return bs
 }
 
-// SendBuffered buffers the event before sending them to the underlying
-// ServerStreamSender.
-func (bs *BufferedSender) SendBuffered(
-	event *kvpb.MuxRangeFeedEvent, alloc *SharedBudgetAllocation,
+func (bs *BufferedSender) sendBuffered(
+	ev *kvpb.MuxRangeFeedEvent, alloc *SharedBudgetAllocation,
 ) error {
 	panic("unimplemented: buffered sender for rangefeed #126560")
 }
 
-// SendUnbuffered bypasses the buffer and sends the event to the underlying
-// ServerStreamSender directly. Note that this can cause event re-ordering.
-// Caller is responsible for ensuring that events are sent in order.
-func (bs *BufferedSender) SendUnbuffered(
-	event *kvpb.MuxRangeFeedEvent, alloc *SharedBudgetAllocation,
+func (bs *BufferedSender) sendUnbuffered(ev *kvpb.MuxRangeFeedEvent) error {
+	panic("unimplemented: buffered sender for rangefeed #126560")
+}
+
+func (bs *BufferedSender) run(
+	ctx context.Context, stopper *stop.Stopper, onError func(streamID int64),
 ) error {
 	panic("unimplemented: buffered sender for rangefeed #126560")
 }
 
-func (bs *BufferedSender) SendBufferedError(ev *kvpb.MuxRangeFeedEvent) {
-	// Disconnect stream and cancel context. Then call SendBuffered with the error
-	// event.
-	panic("unimplemented: buffered sender for rangefeed #126560")
-}
-
-func (bs *BufferedSender) AddStream(streamID int64, cancel context.CancelFunc) {
-	panic("unimplemented: buffered sender for rangefeed #126560")
-}
-
-func (bs *BufferedSender) Start(ctx context.Context, stopper *stop.Stopper) error {
-	panic("unimplemented: buffered sender for rangefeed #126560")
-}
-
-func (bs *BufferedSender) Stop() {
-	panic("unimplemented: buffered sender for rangefeed #126560")
-}
-
-func (bs *BufferedSender) Error() chan error {
+func (bs *BufferedSender) cleanup(ctx context.Context) {
 	panic("unimplemented: buffered sender for rangefeed #126560")
 }

--- a/pkg/kv/kvserver/rangefeed/stream.go
+++ b/pkg/kv/kvserver/rangefeed/stream.go
@@ -133,5 +133,10 @@ var _ BufferedStream = (*BufferedPerRangeEventSink)(nil)
 func (s *BufferedPerRangeEventSink) SendBuffered(
 	event *kvpb.RangeFeedEvent, alloc *SharedBudgetAllocation,
 ) error {
-	panic("unimplemented: buffered sender for rangefeed #126560")
+	response := &kvpb.MuxRangeFeedEvent{
+		RangeFeedEvent: *event,
+		RangeID:        s.rangeID,
+		StreamID:       s.streamID,
+	}
+	return s.wrapped.sendBuffered(response, alloc)
 }

--- a/pkg/kv/kvserver/rangefeed/stream_manager.go
+++ b/pkg/kv/kvserver/rangefeed/stream_manager.go
@@ -91,6 +91,10 @@ func NewStreamManager(sender sender, metrics RangefeedMetricsRecorder) *StreamMa
 
 func (sm *StreamManager) NewStream(streamID int64, rangeID roachpb.RangeID) (sink Stream) {
 	switch sender := sm.sender.(type) {
+	case *BufferedSender:
+		return &BufferedPerRangeEventSink{
+			PerRangeEventSink: NewPerRangeEventSink(rangeID, streamID, sender),
+		}
 	case *UnbufferedSender:
 		return NewPerRangeEventSink(rangeID, streamID, sender)
 	default:

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -2130,7 +2130,7 @@ func (n *Node) MuxRangeFeed(muxStream kvpb.Internal_MuxRangeFeedServer) error {
 
 	sm := &rangefeed.StreamManager{}
 	if kvserver.RangefeedUseBufferedSender.Get(&n.storeCfg.Settings.SV) {
-		return kvserver.ErrBufferedSenderNotSupported
+		sm = rangefeed.NewStreamManager(rangefeed.NewBufferedSender(lockedMuxStream), n.metrics)
 	} else {
 		sm = rangefeed.NewStreamManager(rangefeed.NewUnbufferedSender(lockedMuxStream), n.metrics)
 	}


### PR DESCRIPTION
Previously, we introduced the sender interface and updated the UnbufferedSender
to implement it. This patch updates the BufferedSender to implement the
interface as well. Note that the actual implementation is incomplete and using it
will panic. Future commits will address it.

Part of: https://github.com/cockroachdb/cockroach/issues/110432
Release note: none

Co-authored-by: Steven Danna danna@cockroachlabs.com