### PR TITLE
roachtest: skip running backup schedule on c2c source

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -556,7 +556,7 @@ func (rd *replicationDriver) setupC2C(
 	srcTenantName := "src-tenant"
 	destTenantName := "destination-tenant"
 
-	startOpts := option.StartSharedVirtualClusterOpts(srcTenantName, option.StorageCluster(srcCluster))
+	startOpts := option.StartSharedVirtualClusterOpts(srcTenantName, option.StorageCluster(srcCluster), option.NoBackupSchedule)
 	c.StartServiceForVirtualCluster(ctx, t.L(), startOpts, srcClusterSetting)
 
 	pgURL, err := copyPGCertsAndMakeURL(ctx, t, c, srcNode, srcClusterSetting.PGUrlCertsDir, addr[0])


### PR DESCRIPTION
The c2c perf tests histoically have not run a backup schedule on the source. A recent refactor (#131940), lead to backups running on the source. During full backup execution, cpu utilization exceeded 90%, leading to overload and replication lag higher than 2 minutes. This patch removes the backup schedule.

At some point, we should run the c2c tests with a backup schedule, but that would require more hardware or more ac pacing work to stabilize the test. These are not priorities now.

Fixes #133233

Release note: none