### PR TITLE
roachtest: use unsafe incompatible restore in OR tests

### DIFF
--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -559,9 +559,9 @@ func runRestore(
 			}
 
 		}
-		opts := ""
+		opts := "WITH UNSAFE_RESTORE_INCOMPATIBLE_VERSION"
 		if runOnline {
-			opts = "WITH EXPERIMENTAL DEFERRED COPY"
+			opts = "WITH EXPERIMENTAL DEFERRED COPY, UNSAFE_RESTORE_INCOMPATIBLE_VERSION"
 		}
 		if err := maybeAddSomeEmptyTables(ctx, rd); err != nil {
 			return errors.Wrapf(err, "failed to add some empty tables")


### PR DESCRIPTION
We need to create new fixtures, but that currently takes time. This quiets the test failures.

Fixes #134663
Fixes #134659

Release note: none