### PR TITLE
amazon: increase timeout of amazon cloud tests

### DIFF
--- a/pkg/cloud/amazon/BUILD.bazel
+++ b/pkg/cloud/amazon/BUILD.bazel
@@ -45,12 +45,11 @@ go_library(
 
 go_test(
     name = "amazon_test",
-    size = "small",
     srcs = [
         "aws_kms_test.go",
         "s3_storage_test.go",
     ],
-    args = ["-test.timeout=55s"],
+    args = ["-test.timeout=295s"],
     embed = [":amazon"],
     exec_properties = {
         "dockerNetwork": "standard",


### PR DESCRIPTION
The 295s timeout matches the timeout of all other cloud tests on 23.2. This change is only being applied to the 23.2 release branch because newer releases already have a longer timeout.

See for context:
https://github.com/cockroachdb/cockroach/pull/134512#issuecomment-2462523235

Release Justification: Test only change
Release Note: None
Fixes: #133901
Fixes: #134021
Fixes: #133900