### PR TITLE
sql/schemachanger: Handle decimal column types in ALTER COLUMN TYPE

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -1011,20 +1011,21 @@ t_bytes     CREATE TABLE public.t_bytes (
 statement ok
 DROP TABLE t_bytes;
 
-subtest validation_only_decimal
+subtest rewrite_decimal
 
 statement ok
-CREATE TABLE t_decimal (c1 DECIMAL(20,5), c2 DECIMAL(10,5), FAMILY F1(c1,c2,rowid));
+CREATE TABLE t_decimal (c1 DECIMAL(20,5), c2 DECIMAL(10,5), c3 DECIMAL(10,0), FAMILY F1(c1,c2,c3,rowid));
 
 statement ok
-INSERT INTO t_decimal VALUES (12345.6, 1.23456),(NULL,NULL),(100012.34,4563.21);
+INSERT INTO t_decimal VALUES (12345.6, 1.23456, 44.1234),(NULL,NULL,NULL),(100012.34,4563.21,22.9871),(99.77777,99.77777,-5.51);
 
-query FF
+query FFF
 SELECT * FROM t_decimal ORDER BY c1;
 ----
-NULL  NULL
-12345.6  1.23456
-100012.34  4563.21
+NULL  NULL  NULL
+99.77777 99.77777 -6
+12345.6  1.23456 44
+100012.34  4563.21 23
 
 # Reduce the overall precision of the decimal
 statement error pq: .*value with precision 7, scale 2 must round to an absolute value less than 10\^5
@@ -1037,37 +1038,29 @@ UPDATE t_decimal SET c1 = 10012.34 WHERE c1 = 100012.34;
 statement ok
 ALTER TABLE t_decimal ALTER COLUMN c1 SET DATA TYPE DECIMAL(7,2);
 
-# Reduce just the scale of the decimal. The legacy schema changer doesn't
-# properly detect this case.
-skipif config local-legacy-schema-changer
-statement error pq: validation of CHECK ".*" failed on row.*
-ALTER TABLE t_decimal ALTER COLUMN c2 SET DATA TYPE DECIMAL(10,2);
-
-query FF
-SELECT * FROM t_decimal ORDER BY c1;
-----
-NULL         NULL
-10012.34000  4563.21000
-12345.60000  1.23456
-
-statement ok
-UPDATE t_decimal SET c2 = 1.23 WHERE c1 = 12345.6;
-
 statement ok
 ALTER TABLE t_decimal ALTER COLUMN c2 SET DATA TYPE DECIMAL(10,2);
 
-query FF
+statement ok
+ALTER TABLE t_decimal ALTER COLUMN c3 SET DATA TYPE DECIMAL(5,2);
+
+statement ok
+ALTER TABLE t_decimal ALTER COLUMN c3 SET DATA TYPE DECIMAL(6,1);
+
+query FFF
 SELECT * FROM t_decimal ORDER BY c1;
 ----
-NULL  NULL
-10012.34  4563.21
-12345.60  1.23
+NULL         NULL NULL
+99.78 99.78 -6.0
+10012.34  4563.21 23.0
+12345.60  1.23 44.0
 
 query TTBTTTB rowsort
 SHOW COLUMNS FROM t_decimal;
 ----
 c1     DECIMAL(7,2)  true   NULL            ·  {t_decimal_pkey}  false
 c2     DECIMAL(10,2) true   NULL            ·  {t_decimal_pkey}  false
+c3     DECIMAL(6,1)  true   NULL            ·  {t_decimal_pkey}  false
 rowid  INT8          false  unique_rowid()  ·  {t_decimal_pkey}  true
 
 query TT colnames
@@ -1077,9 +1070,10 @@ table_name  create_statement
 t_decimal   CREATE TABLE public.t_decimal (
               c1 DECIMAL(7,2) NULL,
               c2 DECIMAL(10,2) NULL,
+              c3 DECIMAL(6,1) NULL,
               rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
               CONSTRAINT t_decimal_pkey PRIMARY KEY (rowid ASC),
-              FAMILY f1 (c1, c2, rowid)
+              FAMILY f1 (c1, c2, c3, rowid)
             )
 
 statement ok

--- a/pkg/sql/schemachange/alter_column_type.go
+++ b/pkg/sql/schemachange/alter_column_type.go
@@ -76,7 +76,7 @@ var classifiers = map[types.Family]map[types.Family]classifier{
 	},
 	types.DecimalFamily: {
 		// Decimals are always encoded as an apd.Decimal
-		types.DecimalFamily: classifierHardestOf(classifierDecimalPrecision, classifierWidth),
+		types.DecimalFamily: classifierHardestOf(classifierDecimalPrecision, classifierDecimalScale),
 	},
 	types.FloatFamily: {
 		// Floats are always encoded as 64-bit values on disk and we don't
@@ -183,6 +183,23 @@ func classifierWidth(oldType *types.T, newType *types.T) ColumnConversionKind {
 		return ColumnConversionTrivial
 	default:
 		return ColumnConversionValidate
+	}
+}
+
+// classifierDecimalScale handles when the scale of the decimal changes.
+func classifierDecimalScale(oldType *types.T, newType *types.T) ColumnConversionKind {
+	// Changing the scale of decimals differs from other types because the SQL
+	// standard allows for some data loss. For example, if a column is defined as
+	// DECIMAL(5,3) with a value of 12.345, changing the column type to DECIMAL(5,2)
+	// would round the value to two decimal places, resulting in 12.35. To achieve
+	// this behavior, when decreasing the scale, we need to rewrite the entire column.
+	switch {
+	case oldType.Width() == newType.Width():
+		return ColumnConversionTrivial
+	case newType.Width() < oldType.Width():
+		return ColumnConversionGeneral
+	default:
+		return ColumnConversionTrivial
 	}
 }
 

--- a/pkg/sql/schemachange/alter_column_type_test.go
+++ b/pkg/sql/schemachange/alter_column_type_test.go
@@ -55,6 +55,11 @@ func TestColumnConversions(t *testing.T) {
 			"DECIMAL(8)": ColumnConversionTrivial,
 		},
 
+		"DECIMAL(10,2)": {
+			"DECIMAL(10,1)": ColumnConversionGeneral,
+			"DECIMAL(10,5)": ColumnConversionTrivial,
+		},
+
 		"FLOAT4": {
 			"FLOAT4": ColumnConversionTrivial,
 			"FLOAT8": ColumnConversionTrivial,
@@ -241,11 +246,19 @@ func TestColumnConversions(t *testing.T) {
 						}
 
 					case types.DecimalFamily:
-						insert = []interface{}{"-112358", "112358"}
+						// Decimal values will be truncated on insert to either 0 or 2 digits.
+						insert = []interface{}{"-112358.878", "112358.134"}
 						switch toTyp.Family() {
 						case types.DecimalFamily:
 							// We're going to see decimals returned as strings
-							expect = []interface{}{[]uint8("-112358"), []uint8("112358")}
+							switch toTyp.Width() {
+							case 0:
+								expect = []interface{}{[]uint8("-112359"), []uint8("112358")}
+							case 1:
+								expect = []interface{}{[]uint8("-112358.9"), []uint8("112358.1")}
+							case 5:
+								expect = []interface{}{[]uint8("-112358.88"), []uint8("112358.13")}
+							}
 						}
 
 					case types.FloatFamily:


### PR DESCRIPTION
DECIMAL columns require special handling when altering the column type because, unlike other types, they allow for a reduction in scale with rounding applied to digits after the decimal point. For example, a column defined as DECIMAL(5,3) with a value of 12.345 can be converted to DECIMAL(5,2), resulting in a value of 12.35. To achieve this behavior, when reducing the scale of a DECIMAL type, we rewrite the column data instead of performing a validation-only type change. This aligns with PostgreSQL's behavior.

Epic: CRDB-25314
Closes #134711
Release note: none