### PR TITLE
raft: mark a step-down intent in case of a stranded follower

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1209,6 +1209,13 @@ func (r *raft) tickElection() {
 func (r *raft) tickHeartbeat() {
 	assertTrue(r.state == pb.StateLeader, "tickHeartbeat called by non-leader")
 
+	// Check if we intended to step down. If so, step down if it's safe to do so.
+	// Otherwise, continue doing leader things.
+	if r.fortificationTracker.SteppingDown() && r.fortificationTracker.CanDefortify() {
+		r.becomeFollower(r.fortificationTracker.SteppingDownTerm(), None)
+		return
+	}
+
 	r.heartbeatElapsed++
 	r.electionElapsed++
 
@@ -1573,18 +1580,37 @@ func (r *raft) Step(m pb.Message) error {
 					// larger term. Instead, we need to wait for the leader to learn about
 					// the stranded peer, step down, and defortify. The only thing to do
 					// here is check whether we are that leader, in which case we should
-					// step down to kick off this process of catching up to the term of the
-					// stranded peer.
+					// step down to kick off this process of catching up to the term of
+					// the stranded peer.
+					//
+					// However, the leader can't just blindly step down and defortify.
+					// Doing so could cause LeadSupportUntil to regress. Instead, the
+					// leader checks if it's safe to step down (it can defortify). If it
+					// is, it will step down. Otherwise, it will mark its intention to
+					// step down. This will freeze LeadSupportUntil[1], and eventually the
+					// leader will be able to safely step down.
+					//
+					// [1] When freezing the LeadSupportUntil, we'll also track the term
+					// of the stranded follower. This then allows us to become a follower
+					// at that term and campaign at a term higher to allow the stranded
+					// follower to rejoin. Had we not done this, we may have had to
+					// campaign at a lower term, and then know about the higher term, and
+					// then campaign again at the higher term.
 					if r.state == pb.StateLeader {
-						r.logMsgHigherTerm(m, "stepping down as leader to recover stranded peer")
-						r.becomeFollower(r.Term, r.id)
+						if r.fortificationTracker.CanDefortify() {
+							r.logMsgHigherTerm(m, "stepping down as leader to recover stranded peer")
+							r.deFortify(r.id, m.Term)
+							r.becomeFollower(m.Term, None)
+						} else {
+							r.logMsgHigherTerm(m, "intending to step down as leader to recover stranded peer")
+							r.fortificationTracker.BeginSteppingDown(m.Term)
+						}
 					} else {
 						r.logMsgHigherTerm(m, "ignoring and still supporting fortified leader")
 					}
 				}
 				return nil
 			}
-
 			// If we are willing process a message at a higher term, then make sure we
 			// record that we have withdrawn our support for the current leader, if we
 			// were still providing it with fortification support up to this point.

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -2226,31 +2226,36 @@ func testFreeStuckCandidateWithCheckQuorum(t *testing.T, storeLivenessEnabled bo
 		hbType = pb.MsgFortifyLeader
 	}
 	nt.send(pb.Message{From: 1, To: 3, Type: hbType, Term: a.Term})
-	assert.Equal(t, pb.StateFollower, a.state)
-	if storeLivenessEnabled {
-		// Node 1 still remembers that it was the leader.
-		assert.Equal(t, c.Term-2, a.Term)
-		assert.Equal(t, a.id, a.lead)
 
-		// The ex-leader still hasn't defortified, so the stranded peer still can't
-		// win an election.
+	if storeLivenessEnabled {
+		// Expect that we are still the leader since it's still not safe to step
+		// down, however, the step-down intent is recorded.
+		assert.Equal(t, pb.StateLeader, a.state)
+		assert.Equal(t, true, a.fortificationTracker.SteppingDown())
+		assert.Equal(t, c.Term, a.fortificationTracker.SteppingDownTerm())
+
+		// The leader hasn't defortified yet, so 3 can't win an election.
 		nt.send(pb.Message{From: 3, To: 3, Type: pb.MsgHup})
 		assert.Equal(t, pb.StateCandidate, c.state)
-		assert.Equal(t, pb.StateFollower, a.state)
+		assert.Equal(t, pb.StateLeader, a.state)
 		assert.Equal(t, c.Term-3, a.Term)
 		assert.Equal(t, a.id, a.lead)
 
-		// The ex-leader defortifies itself and its followers once its remaining
-		// support has expired.
-		require.False(t, a.shouldBcastDeFortify())
-		fabric.SetSupportExpired(1, true)
-		require.True(t, a.shouldBcastDeFortify())
-		for range a.heartbeatTimeout {
-			nt.tick(a)
-		}
+		// Expire the support, and tick it once. It should step down.
+		nt.livenessFabric.SetSupportExpired(1, true)
+		a.tick()
+	}
+	assert.Equal(t, pb.StateFollower, a.state)
+
+	// Node 1 doesn't remember that it was the leader.
+	assert.Equal(t, None, a.lead)
+
+	if storeLivenessEnabled {
+		// Since node 3 campaigned one extra time above, it will have a term that is
+		// higher than node 1 by one.
+		assert.Equal(t, c.Term-1, a.Term)
 	} else {
 		assert.Equal(t, c.Term, a.Term)
-		assert.Equal(t, None, a.lead)
 	}
 
 	// Vote again, should become leader this time.
@@ -4505,45 +4510,43 @@ func testPreVoteMigrationWithFreeStuckPreCandidate(t *testing.T, storeLivenessEn
 	}
 
 	// Disrupt the leader so that the stuck peer is freed. The leader steps down
-	// immediately, but only changes its term if it was not fortified. If it was,
-	// it waits for defortification.
+	// immediately if it's not fortified. However, if it was fortified, it will
+	// only step down when a quorum stops supporting it.
 	hbType := pb.MsgHeartbeat
 	if storeLivenessEnabled {
 		hbType = pb.MsgFortifyLeader
 	}
 	nt.send(pb.Message{From: 1, To: 3, Type: hbType, Term: n1.Term})
-	assert.Equal(t, pb.StateFollower, n1.state)
-	if storeLivenessEnabled {
-		// Node 1 still remembers that it was the leader.
-		assert.Equal(t, n3.Term-2, n1.Term)
-		assert.Equal(t, n1.id, n1.lead)
 
-		// The ex-leader still hasn't defortified, so the stranded peer still can't
+	if storeLivenessEnabled {
+		// Expect that we are still the leader since it's still not safe to step
+		// down, however, the step-down intent is recorded.
+		assert.Equal(t, pb.StateLeader, n1.state)
+		assert.Equal(t, true, n1.fortificationTracker.SteppingDown())
+
+		// The leader still hasn't defortified, so the stranded peer still can't
 		// win an election.
 		nt.send(pb.Message{From: 3, To: 3, Type: pb.MsgHup})
 		assert.Equal(t, pb.StatePreCandidate, n3.state)
-		assert.Equal(t, pb.StateFollower, n1.state)
+		assert.Equal(t, pb.StateLeader, n1.state)
 		assert.Equal(t, n3.Term-2, n1.Term)
 		assert.Equal(t, n1.id, n1.lead)
 
-		// The ex-leader defortifies itself and its followers once its remaining
-		// support has expired.
-		require.False(t, n1.shouldBcastDeFortify())
-		fabric.SetSupportExpired(1, true)
-		require.True(t, n1.shouldBcastDeFortify())
-		for range n1.heartbeatTimeout {
-			nt.tick(n1)
-		}
-
-		// The ex-leader calls an election, which it loses and through which it
-		// learns about the larger term.
-		fabric.SetSupportExpired(1, false)
-		nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgHup})
-		assert.Equal(t, pb.StateFollower, n1.state)
+		// Expire the support, and tick it once. It should step down.
+		nt.livenessFabric.SetSupportExpired(1, true)
+		n1.tick()
 	}
 
-	assert.Equal(t, n1.Term, n3.Term)
+	assert.Equal(t, pb.StateFollower, n1.state)
+
+	// Node 1 doesn't remember that it was the leader.
 	assert.Equal(t, None, n1.lead)
+	assert.Equal(t, n3.Term, n1.Term)
+
+	// Return the support back to node 1 so that it can call an election.
+	if storeLivenessEnabled {
+		fabric.SetSupportExpired(1, false)
+	}
 
 	// The ex-leader calls an election, which it wins.
 	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgHup})

--- a/pkg/raft/testdata/leader_step_down_stranded_peer.txt
+++ b/pkg/raft/testdata/leader_step_down_stranded_peer.txt
@@ -225,225 +225,178 @@ stabilize 1 3
 > 1 receiving messages
   3->1 MsgAppResp Term:3 Log:0/0
   INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgAppResp from 3 [logterm: 0, index: 0] at term 1: supporting fortified leader 1 at epoch 1
-  INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3], stepping down as leader to recover stranded peer
-  INFO 1 became follower at term 1
-  DEBUG 1 reset election elapsed to 0
+  INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3], intending to step down as leader to recover stranded peer
   3->1 MsgAppResp Term:3 Log:0/0
   INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgAppResp from 3 [logterm: 0, index: 0] at term 1: supporting fortified leader 1 at epoch 1
-  INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3], ignoring and still supporting fortified leader
-> 1 handling Ready
-  Ready MustSync=false:
-  State:StateFollower
+  INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3], intending to step down as leader to recover stranded peer
 
-# Wait until the ex-leader can be safely defortified.
-campaign 1
+# 1 is still the leader because it's unsafe to step down at this point.
+raft-state
 ----
-DEBUG 1 ignoring MsgHup due to leader fortification
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+3: StateCandidate (Voter) Term:3 Lead:0 LeadEpoch:0
 
-send-de-fortify 1 1
+# Now that we are intending to step down, we should step down after the support
+# expired on the next tick.
+support-expired 1
+----
+ok
+
+tick-heartbeat 1
 ----
 DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
+INFO 1 became follower at term 3
+DEBUG 1 reset election elapsed to 0
 
-# Without pre-vote, the process through which the ex-leader learns about the
-# higher term of the stranded peer is sub-optimal, but still works. Because
-# the stranded peer does not respond when rejecting the MsgVote, we must wait
-# for the stranded peer to campaign for the ex-leader (and next leader) to
-# learn about the higher term and campaign with it.
+support-expired 1 reset
+----
+ok
+
 campaign 1
 ----
-INFO 1 is starting a new election at term 1
-INFO 1 became candidate at term 2
-INFO 1 [logterm: 1, index: 11] sent MsgVote request to 2 at term 2
-INFO 1 [logterm: 1, index: 11] sent MsgVote request to 3 at term 2
+INFO 1 is starting a new election at term 3
+INFO 1 became candidate at term 4
+INFO 1 [logterm: 1, index: 11] sent MsgVote request to 2 at term 4
+INFO 1 [logterm: 1, index: 11] sent MsgVote request to 3 at term 4
 
 stabilize
 ----
 > 1 handling Ready
   Ready MustSync=true:
   State:StateCandidate
-  HardState Term:2 Vote:1 Commit:11 Lead:0 LeadEpoch:0
+  HardState Term:4 Vote:1 Commit:11 Lead:0 LeadEpoch:0
   Messages:
-  1->2 MsgVote Term:2 Log:1/11
-  1->3 MsgVote Term:2 Log:1/11
-  INFO 1 received MsgVoteResp from 1 at term 2
+  1->2 MsgDeFortifyLeader Term:1 Log:0/0
+  1->3 MsgDeFortifyLeader Term:1 Log:0/0
+  1->2 MsgVote Term:4 Log:1/11
+  1->3 MsgVote Term:4 Log:1/11
+  INFO 1 received MsgVoteResp from 1 at term 4
   INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
 > 2 receiving messages
-  1->2 MsgVote Term:2 Log:1/11
-  INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 1 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
+  1->2 MsgDeFortifyLeader Term:1 Log:0/0
+  DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
+  1->2 MsgVote Term:4 Log:1/11
+  INFO 2 [term: 1] received a MsgVote message with higher term from 1 [term: 4], advancing term
+  INFO 2 became follower at term 4
+  DEBUG 2 reset election elapsed to 0
+  INFO 2 [logterm: 1, index: 11, vote: 0] cast MsgVote for 1 [logterm: 1, index: 11] at term 4
 > 3 receiving messages
-  1->3 MsgVote Term:2 Log:1/11
-  INFO 3 [term: 3] ignored a MsgVote message with lower term from 1 [term: 2]
-
-campaign 3
-----
-INFO 3 is starting a new election at term 3
-INFO 3 became candidate at term 4
-INFO 3 [logterm: 1, index: 10] sent MsgVote request to 1 at term 4
-INFO 3 [logterm: 1, index: 10] sent MsgVote request to 2 at term 4
-
-stabilize
-----
-> 3 handling Ready
-  Ready MustSync=true:
-  HardState Term:4 Vote:3 Commit:10 Lead:0 LeadEpoch:0
-  Messages:
-  3->1 MsgVote Term:4 Log:1/10
-  3->2 MsgVote Term:4 Log:1/10
-  INFO 3 received MsgVoteResp from 3 at term 4
-  INFO 3 has received 1 MsgVoteResp votes and 0 vote rejections
-> 1 receiving messages
-  3->1 MsgVote Term:4 Log:1/10
-  INFO 1 [term: 2] received a MsgVote message with higher term from 3 [term: 4], advancing term
-  INFO 1 became follower at term 4
-  DEBUG 1 reset election elapsed to 0
-  INFO 1 [logterm: 1, index: 11, vote: 0] rejected MsgVote from 3 [logterm: 1, index: 10] at term 4
-> 2 receiving messages
-  3->2 MsgVote Term:4 Log:1/10
-  INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 3 [logterm: 1, index: 10] at term 1: supporting fortified leader 1 at epoch 1
-> 1 handling Ready
-  Ready MustSync=true:
-  State:StateFollower
-  HardState Term:4 Commit:11 Lead:0 LeadEpoch:0
-  Messages:
-  1->3 MsgVoteResp Term:4 Log:0/0 Rejected (Hint: 0)
-> 3 receiving messages
-  1->3 MsgVoteResp Term:4 Log:0/0 Rejected (Hint: 0)
-  INFO 3 received MsgVoteResp rejection from 1 at term 4
-  INFO 3 has received 1 MsgVoteResp votes and 1 vote rejections
-
-campaign 1
-----
-INFO 1 is starting a new election at term 4
-INFO 1 became candidate at term 5
-INFO 1 [logterm: 1, index: 11] sent MsgVote request to 2 at term 5
-INFO 1 [logterm: 1, index: 11] sent MsgVote request to 3 at term 5
-
-stabilize
-----
-> 1 handling Ready
-  Ready MustSync=true:
-  State:StateCandidate
-  HardState Term:5 Vote:1 Commit:11 Lead:0 LeadEpoch:0
-  Messages:
-  1->2 MsgVote Term:5 Log:1/11
-  1->3 MsgVote Term:5 Log:1/11
-  INFO 1 received MsgVoteResp from 1 at term 5
-  INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
-> 2 receiving messages
-  1->2 MsgVote Term:5 Log:1/11
-  INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 1 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
-> 3 receiving messages
-  1->3 MsgVote Term:5 Log:1/11
-  INFO 3 [term: 4] received a MsgVote message with higher term from 1 [term: 5], advancing term
-  INFO 3 became follower at term 5
+  1->3 MsgDeFortifyLeader Term:1 Log:0/0
+  INFO 3 [term: 3] ignored a MsgDeFortifyLeader message with lower term from 1 [term: 1]
+  1->3 MsgVote Term:4 Log:1/11
+  INFO 3 [term: 3] received a MsgVote message with higher term from 1 [term: 4], advancing term
+  INFO 3 became follower at term 4
   DEBUG 3 reset election elapsed to 0
-  INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 11] at term 5
+  INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 11] at term 4
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:4 Vote:1 Commit:11 Lead:0 LeadEpoch:0
+  Messages:
+  2->1 MsgVoteResp Term:4 Log:0/0
 > 3 handling Ready
   Ready MustSync=true:
   State:StateFollower
-  HardState Term:5 Vote:1 Commit:10 Lead:0 LeadEpoch:0
+  HardState Term:4 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   Messages:
-  3->1 MsgVoteResp Term:5 Log:0/0
+  3->1 MsgVoteResp Term:4 Log:0/0
 > 1 receiving messages
-  3->1 MsgVoteResp Term:5 Log:0/0
-  INFO 1 received MsgVoteResp from 3 at term 5
+  2->1 MsgVoteResp Term:4 Log:0/0
+  INFO 1 received MsgVoteResp from 2 at term 4
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
-  INFO 1 became leader at term 5
+  INFO 1 became leader at term 4
+  3->1 MsgVoteResp Term:4 Log:0/0
 > 1 handling Ready
   Ready MustSync=true:
   State:StateLeader
-  HardState Term:5 Vote:1 Commit:11 Lead:1 LeadEpoch:1
+  HardState Term:4 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   Entries:
-  5/12 EntryNormal ""
+  4/12 EntryNormal ""
   Messages:
-  1->2 MsgFortifyLeader Term:5 Log:0/0
-  1->3 MsgFortifyLeader Term:5 Log:0/0
-  1->2 MsgApp Term:5 Log:1/11 Commit:11 Entries:[5/12 EntryNormal ""]
-  1->3 MsgApp Term:5 Log:1/11 Commit:11 Entries:[5/12 EntryNormal ""]
+  1->2 MsgFortifyLeader Term:4 Log:0/0
+  1->3 MsgFortifyLeader Term:4 Log:0/0
+  1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
+  1->3 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
 > 2 receiving messages
-  1->2 MsgFortifyLeader Term:5 Log:0/0
-  INFO 2 [term: 1] received a MsgFortifyLeader message with higher term from 1 [term: 5], new leader indicated, advancing term
-  DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
-  INFO 2 became follower at term 5
-  DEBUG 2 reset election elapsed to 0
-  1->2 MsgApp Term:5 Log:1/11 Commit:11 Entries:[5/12 EntryNormal ""]
+  1->2 MsgFortifyLeader Term:4 Log:0/0
+  1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
 > 3 receiving messages
-  1->3 MsgFortifyLeader Term:5 Log:0/0
-  1->3 MsgApp Term:5 Log:1/11 Commit:11 Entries:[5/12 EntryNormal ""]
+  1->3 MsgFortifyLeader Term:4 Log:0/0
+  1->3 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
   DEBUG 3 [logterm: 0, index: 11] rejected MsgApp [logterm: 1, index: 11] from 1
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:5 Commit:11 Lead:1 LeadEpoch:1
+  HardState Term:4 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   Entries:
-  5/12 EntryNormal ""
+  4/12 EntryNormal ""
   Messages:
-  2->1 MsgFortifyLeaderResp Term:5 Log:0/0 LeadEpoch:1
-  2->1 MsgAppResp Term:5 Log:0/12 Commit:11
+  2->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
+  2->1 MsgAppResp Term:4 Log:0/12 Commit:11
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:5 Vote:1 Commit:10 Lead:1 LeadEpoch:1
+  HardState Term:4 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   Messages:
-  3->1 MsgFortifyLeaderResp Term:5 Log:0/0 LeadEpoch:1
-  3->1 MsgAppResp Term:5 Log:1/11 Rejected (Hint: 10) Commit:10
+  3->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
+  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
 > 1 receiving messages
-  2->1 MsgFortifyLeaderResp Term:5 Log:0/0 LeadEpoch:1
-  2->1 MsgAppResp Term:5 Log:0/12 Commit:11
-  3->1 MsgFortifyLeaderResp Term:5 Log:0/0 LeadEpoch:1
-  3->1 MsgAppResp Term:5 Log:1/11 Rejected (Hint: 10) Commit:10
+  2->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
+  2->1 MsgAppResp Term:4 Log:0/12 Commit:11
+  3->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
+  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
   DEBUG 1 received MsgAppResp(rejected, hint: (index 10, term 1)) from 3 for index 11
   DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=11 sentCommit=10 matchCommit=10]
 > 1 handling Ready
   Ready MustSync=true:
-  HardState Term:5 Vote:1 Commit:12 Lead:1 LeadEpoch:1
+  HardState Term:4 Vote:1 Commit:12 Lead:1 LeadEpoch:1
   CommittedEntries:
-  5/12 EntryNormal ""
+  4/12 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:5 Log:1/11 Commit:11 Entries:[5/12 EntryNormal ""]
-  1->2 MsgApp Term:5 Log:5/12 Commit:12
-  1->3 MsgApp Term:5 Log:1/11 Commit:12 Entries:[5/12 EntryNormal ""]
-  1->3 MsgApp Term:5 Log:1/10 Commit:12 Entries:[
+  1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
+  1->2 MsgApp Term:4 Log:4/12 Commit:12
+  1->3 MsgApp Term:4 Log:1/11 Commit:12 Entries:[4/12 EntryNormal ""]
+  1->3 MsgApp Term:4 Log:1/10 Commit:12 Entries:[
     1/11 EntryNormal ""
-    5/12 EntryNormal ""
+    4/12 EntryNormal ""
   ]
 > 2 receiving messages
-  1->2 MsgApp Term:5 Log:1/11 Commit:11 Entries:[5/12 EntryNormal ""]
-  1->2 MsgApp Term:5 Log:5/12 Commit:12
+  1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
+  1->2 MsgApp Term:4 Log:4/12 Commit:12
 > 3 receiving messages
-  1->3 MsgApp Term:5 Log:1/11 Commit:12 Entries:[5/12 EntryNormal ""]
+  1->3 MsgApp Term:4 Log:1/11 Commit:12 Entries:[4/12 EntryNormal ""]
   DEBUG 3 [logterm: 0, index: 11] rejected MsgApp [logterm: 1, index: 11] from 1
-  1->3 MsgApp Term:5 Log:1/10 Commit:12 Entries:[
+  1->3 MsgApp Term:4 Log:1/10 Commit:12 Entries:[
     1/11 EntryNormal ""
-    5/12 EntryNormal ""
+    4/12 EntryNormal ""
   ]
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:5 Commit:12 Lead:1 LeadEpoch:1
+  HardState Term:4 Vote:1 Commit:12 Lead:1 LeadEpoch:1
   CommittedEntries:
-  5/12 EntryNormal ""
+  4/12 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:5 Log:0/12 Commit:11
-  2->1 MsgAppResp Term:5 Log:0/12 Commit:12
+  2->1 MsgAppResp Term:4 Log:0/12 Commit:11
+  2->1 MsgAppResp Term:4 Log:0/12 Commit:12
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:5 Vote:1 Commit:12 Lead:1 LeadEpoch:1
+  HardState Term:4 Vote:1 Commit:12 Lead:1 LeadEpoch:1
   Entries:
   1/11 EntryNormal ""
-  5/12 EntryNormal ""
+  4/12 EntryNormal ""
   CommittedEntries:
   1/11 EntryNormal ""
-  5/12 EntryNormal ""
+  4/12 EntryNormal ""
   Messages:
-  3->1 MsgAppResp Term:5 Log:1/11 Rejected (Hint: 10) Commit:10
-  3->1 MsgAppResp Term:5 Log:0/12 Commit:12
+  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
+  3->1 MsgAppResp Term:4 Log:0/12 Commit:12
 > 1 receiving messages
-  2->1 MsgAppResp Term:5 Log:0/12 Commit:11
-  2->1 MsgAppResp Term:5 Log:0/12 Commit:12
-  3->1 MsgAppResp Term:5 Log:1/11 Rejected (Hint: 10) Commit:10
+  2->1 MsgAppResp Term:4 Log:0/12 Commit:11
+  2->1 MsgAppResp Term:4 Log:0/12 Commit:12
+  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
   DEBUG 1 received MsgAppResp(rejected, hint: (index 10, term 1)) from 3 for index 11
-  3->1 MsgAppResp Term:5 Log:0/12 Commit:12
+  3->1 MsgAppResp Term:4 Log:0/12 Commit:12
 
 raft-state
 ----
-1: StateLeader (Voter) Term:5 Lead:1 LeadEpoch:1
-2: StateFollower (Voter) Term:5 Lead:1 LeadEpoch:1
-3: StateFollower (Voter) Term:5 Lead:1 LeadEpoch:1
+1: StateLeader (Voter) Term:4 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:4 Lead:1 LeadEpoch:1
+3: StateFollower (Voter) Term:4 Lead:1 LeadEpoch:1

--- a/pkg/raft/testdata/leader_step_down_stranded_peer_prevote.txt
+++ b/pkg/raft/testdata/leader_step_down_stranded_peer_prevote.txt
@@ -344,65 +344,26 @@ stabilize 1 3
 > 1 receiving messages
   3->1 MsgAppResp Term:3 Log:0/0
   INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgAppResp from 3 [logterm: 0, index: 0] at term 1: supporting fortified leader 1 at epoch 1
-  INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3], stepping down as leader to recover stranded peer
-  INFO 1 became follower at term 1
-  DEBUG 1 reset election elapsed to 0
+  INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3], intending to step down as leader to recover stranded peer
   3->1 MsgAppResp Term:3 Log:0/0
   INFO 1 [logterm: 1, index: 11, vote: 1] ignored MsgAppResp from 3 [logterm: 0, index: 0] at term 1: supporting fortified leader 1 at epoch 1
-  INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3], ignoring and still supporting fortified leader
-> 1 handling Ready
-  Ready MustSync=false:
-  State:StateFollower
+  INFO 1 [term: 1] received a MsgAppResp message with higher term from 3 [term: 3], intending to step down as leader to recover stranded peer
 
-# Wait until the ex-leader can be safely defortified.
-campaign 1
+# Now that we are intending to step down, we should step down after the support
+# expired on the next tick.
+support-expired 1
 ----
-DEBUG 1 ignoring MsgHup due to leader fortification
+ok
 
-send-de-fortify 1 1
+tick-heartbeat 1
 ----
 DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
+INFO 1 became follower at term 3
+DEBUG 1 reset election elapsed to 0
 
-# With pre-vote, the ex-leader will learn about the higher term from the stranded
-# peer during the first time that it campaigns. When it campaigns again, it will
-# do so at the higher term and will be able to win the election.
-campaign 1
+support-expired 1 reset
 ----
-INFO 1 is starting a new election at term 1
-INFO 1 became pre-candidate at term 1
-INFO 1 [logterm: 1, index: 11] sent MsgPreVote request to 2 at term 1
-INFO 1 [logterm: 1, index: 11] sent MsgPreVote request to 3 at term 1
-
-stabilize
-----
-> 1 handling Ready
-  Ready MustSync=true:
-  State:StatePreCandidate
-  HardState Term:1 Vote:1 Commit:11 Lead:0 LeadEpoch:0
-  Messages:
-  1->2 MsgPreVote Term:2 Log:1/11
-  1->3 MsgPreVote Term:2 Log:1/11
-  INFO 1 received MsgPreVoteResp from 1 at term 1
-  INFO 1 has received 1 MsgPreVoteResp votes and 0 vote rejections
-> 2 receiving messages
-  1->2 MsgPreVote Term:2 Log:1/11
-  INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 1 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
-> 3 receiving messages
-  1->3 MsgPreVote Term:2 Log:1/11
-  INFO 3 [logterm: 1, index: 10, vote: 3] rejected MsgPreVote from 1 [logterm: 1, index: 11] at term 3
-> 3 handling Ready
-  Ready MustSync=false:
-  Messages:
-  3->1 MsgPreVoteResp Term:3 Log:0/0 Rejected (Hint: 0)
-> 1 receiving messages
-  3->1 MsgPreVoteResp Term:3 Log:0/0 Rejected (Hint: 0)
-  INFO 1 [term: 1] received a MsgPreVoteResp message with higher term from 3 [term: 3], advancing term
-  INFO 1 became follower at term 3
-  DEBUG 1 reset election elapsed to 0
-> 1 handling Ready
-  Ready MustSync=true:
-  State:StateFollower
-  HardState Term:3 Commit:11 Lead:0 LeadEpoch:0
+ok
 
 campaign 1
 ----
@@ -414,30 +375,43 @@ INFO 1 [logterm: 1, index: 11] sent MsgPreVote request to 3 at term 3
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready MustSync=true:
   State:StatePreCandidate
+  HardState Term:3 Commit:11 Lead:0 LeadEpoch:0
   Messages:
+  1->2 MsgDeFortifyLeader Term:1 Log:0/0
+  1->3 MsgDeFortifyLeader Term:1 Log:0/0
   1->2 MsgPreVote Term:4 Log:1/11
   1->3 MsgPreVote Term:4 Log:1/11
   INFO 1 received MsgPreVoteResp from 1 at term 3
   INFO 1 has received 1 MsgPreVoteResp votes and 0 vote rejections
 > 2 receiving messages
+  1->2 MsgDeFortifyLeader Term:1 Log:0/0
+  DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
   1->2 MsgPreVote Term:4 Log:1/11
-  INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 1 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
+  INFO 2 [logterm: 1, index: 11, vote: 1] cast MsgPreVote for 1 [logterm: 1, index: 11] at term 1
 > 3 receiving messages
+  1->3 MsgDeFortifyLeader Term:1 Log:0/0
+  INFO 3 [term: 3] ignored a MsgDeFortifyLeader message with lower term from 1 [term: 1]
   1->3 MsgPreVote Term:4 Log:1/11
   INFO 3 [logterm: 1, index: 10, vote: 3] cast MsgPreVote for 1 [logterm: 1, index: 11] at term 3
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:0
+  Messages:
+  2->1 MsgPreVoteResp Term:4 Log:0/0
 > 3 handling Ready
   Ready MustSync=false:
   Messages:
   3->1 MsgPreVoteResp Term:4 Log:0/0
 > 1 receiving messages
-  3->1 MsgPreVoteResp Term:4 Log:0/0
-  INFO 1 received MsgPreVoteResp from 3 at term 3
+  2->1 MsgPreVoteResp Term:4 Log:0/0
+  INFO 1 received MsgPreVoteResp from 2 at term 3
   INFO 1 has received 2 MsgPreVoteResp votes and 0 vote rejections
   INFO 1 became candidate at term 4
   INFO 1 [logterm: 1, index: 11] sent MsgVote request to 2 at term 4
   INFO 1 [logterm: 1, index: 11] sent MsgVote request to 3 at term 4
+  3->1 MsgPreVoteResp Term:4 Log:0/0
 > 1 handling Ready
   Ready MustSync=true:
   State:StateCandidate
@@ -449,13 +423,21 @@ stabilize
   INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
 > 2 receiving messages
   1->2 MsgVote Term:4 Log:1/11
-  INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgVote from 1 [logterm: 1, index: 11] at term 1: supporting fortified leader 1 at epoch 1
+  INFO 2 [term: 1] received a MsgVote message with higher term from 1 [term: 4], advancing term
+  INFO 2 became follower at term 4
+  DEBUG 2 reset election elapsed to 0
+  INFO 2 [logterm: 1, index: 11, vote: 0] cast MsgVote for 1 [logterm: 1, index: 11] at term 4
 > 3 receiving messages
   1->3 MsgVote Term:4 Log:1/11
   INFO 3 [term: 3] received a MsgVote message with higher term from 1 [term: 4], advancing term
   INFO 3 became follower at term 4
   DEBUG 3 reset election elapsed to 0
   INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 11] at term 4
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:4 Vote:1 Commit:11 Lead:0 LeadEpoch:0
+  Messages:
+  2->1 MsgVoteResp Term:4 Log:0/0
 > 3 handling Ready
   Ready MustSync=true:
   State:StateFollower
@@ -463,10 +445,11 @@ stabilize
   Messages:
   3->1 MsgVoteResp Term:4 Log:0/0
 > 1 receiving messages
-  3->1 MsgVoteResp Term:4 Log:0/0
-  INFO 1 received MsgVoteResp from 3 at term 4
+  2->1 MsgVoteResp Term:4 Log:0/0
+  INFO 1 received MsgVoteResp from 2 at term 4
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 1 became leader at term 4
+  3->1 MsgVoteResp Term:4 Log:0/0
 > 1 handling Ready
   Ready MustSync=true:
   State:StateLeader
@@ -480,10 +463,6 @@ stabilize
   1->3 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
 > 2 receiving messages
   1->2 MsgFortifyLeader Term:4 Log:0/0
-  INFO 2 [term: 1] received a MsgFortifyLeader message with higher term from 1 [term: 4], new leader indicated, advancing term
-  DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
-  INFO 2 became follower at term 4
-  DEBUG 2 reset election elapsed to 0
   1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
 > 3 receiving messages
   1->3 MsgFortifyLeader Term:4 Log:0/0
@@ -491,7 +470,7 @@ stabilize
   DEBUG 3 [logterm: 0, index: 11] rejected MsgApp [logterm: 1, index: 11] from 1
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:4 Commit:11 Lead:1 LeadEpoch:1
+  HardState Term:4 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   Entries:
   4/12 EntryNormal ""
   Messages:
@@ -535,7 +514,7 @@ stabilize
   ]
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:4 Commit:12 Lead:1 LeadEpoch:1
+  HardState Term:4 Vote:1 Commit:12 Lead:1 LeadEpoch:1
   CommittedEntries:
   4/12 EntryNormal ""
   Messages:

--- a/pkg/raft/tracker/fortificationtracker_test.go
+++ b/pkg/raft/tracker/fortificationtracker_test.go
@@ -70,7 +70,7 @@ func TestLeadSupportUntil(t *testing.T) {
 		{
 			ids:           []pb.PeerID{1, 2, 3},
 			storeLiveness: mockLiveness3Peers,
-			setup: func(supportTracker *FortificationTracker) {
+			setup: func(fortificationTracker *FortificationTracker) {
 				// No fortification recorded.
 			},
 			expTS: hlc.Timestamp{},
@@ -78,75 +78,75 @@ func TestLeadSupportUntil(t *testing.T) {
 		{
 			ids:           []pb.PeerID{1, 2, 3},
 			storeLiveness: mockLiveness3Peers,
-			setup: func(supportTracker *FortificationTracker) {
-				supportTracker.RecordFortification(1, 10)
+			setup: func(fortificationTracker *FortificationTracker) {
+				fortificationTracker.RecordFortification(1, 10)
 			},
 			expTS: hlc.Timestamp{},
 		},
 		{
 			ids:           []pb.PeerID{1, 2, 3},
 			storeLiveness: mockLiveness3Peers,
-			setup: func(supportTracker *FortificationTracker) {
-				supportTracker.RecordFortification(1, 10)
-				supportTracker.RecordFortification(3, 30)
+			setup: func(fortificationTracker *FortificationTracker) {
+				fortificationTracker.RecordFortification(1, 10)
+				fortificationTracker.RecordFortification(3, 30)
 			},
 			expTS: ts(10),
 		},
 		{
 			ids:           []pb.PeerID{1, 2, 3},
 			storeLiveness: mockLiveness3Peers,
-			setup: func(supportTracker *FortificationTracker) {
-				supportTracker.RecordFortification(1, 10)
-				supportTracker.RecordFortification(3, 30)
-				supportTracker.RecordFortification(2, 20)
+			setup: func(fortificationTracker *FortificationTracker) {
+				fortificationTracker.RecordFortification(1, 10)
+				fortificationTracker.RecordFortification(3, 30)
+				fortificationTracker.RecordFortification(2, 20)
 			},
 			expTS: ts(15),
 		},
 		{
 			ids:           []pb.PeerID{1, 2, 3},
 			storeLiveness: mockLiveness3Peers,
-			setup: func(supportTracker *FortificationTracker) {
+			setup: func(fortificationTracker *FortificationTracker) {
 				// Record fortification at epochs at expired epochs.
-				supportTracker.RecordFortification(1, 9)
-				supportTracker.RecordFortification(3, 29)
-				supportTracker.RecordFortification(2, 19)
+				fortificationTracker.RecordFortification(1, 9)
+				fortificationTracker.RecordFortification(3, 29)
+				fortificationTracker.RecordFortification(2, 19)
 			},
 			expTS: hlc.Timestamp{},
 		},
 		{
 			ids:           []pb.PeerID{1, 2, 3},
 			storeLiveness: mockLiveness3Peers,
-			setup: func(supportTracker *FortificationTracker) {
+			setup: func(fortificationTracker *FortificationTracker) {
 				// Record fortification at newer epochs than what are present in
 				// StoreLiveness.
 				//
 				// NB: This is possible if there is a race between store liveness
 				// heartbeats updates and fortification responses.
-				supportTracker.RecordFortification(1, 11)
-				supportTracker.RecordFortification(3, 31)
-				supportTracker.RecordFortification(2, 21)
+				fortificationTracker.RecordFortification(1, 11)
+				fortificationTracker.RecordFortification(3, 31)
+				fortificationTracker.RecordFortification(2, 21)
 			},
 			expTS: hlc.Timestamp{},
 		},
 		{
 			ids:           []pb.PeerID{1, 2, 3},
 			storeLiveness: mockLiveness3Peers,
-			setup: func(supportTracker *FortificationTracker) {
+			setup: func(fortificationTracker *FortificationTracker) {
 				// One of the epochs being supported is expired.
-				supportTracker.RecordFortification(1, 10)
-				supportTracker.RecordFortification(3, 29) // expired
-				supportTracker.RecordFortification(2, 20)
+				fortificationTracker.RecordFortification(1, 10)
+				fortificationTracker.RecordFortification(3, 29) // expired
+				fortificationTracker.RecordFortification(2, 20)
 			},
 			expTS: ts(10),
 		},
 		{
 			ids:           []pb.PeerID{1, 2, 3},
 			storeLiveness: mockLiveness3Peers,
-			setup: func(supportTracker *FortificationTracker) {
+			setup: func(fortificationTracker *FortificationTracker) {
 				// Two of the epochs being supported is expired.
-				supportTracker.RecordFortification(1, 10)
-				supportTracker.RecordFortification(3, 29) // expired
-				supportTracker.RecordFortification(2, 19) // expired
+				fortificationTracker.RecordFortification(1, 10)
+				fortificationTracker.RecordFortification(3, 29) // expired
+				fortificationTracker.RecordFortification(2, 19) // expired
 			},
 			expTS: hlc.Timestamp{},
 		},
@@ -292,92 +292,92 @@ func TestQuorumActive(t *testing.T) {
 		expQuorumActive bool
 	}{
 		{
-			setup: func(supportTracker *FortificationTracker) {
+			setup: func(fortificationTracker *FortificationTracker) {
 				// No fortification recorded.
 			},
 			curTS:           ts(10),
 			expQuorumActive: false,
 		},
 		{
-			setup: func(supportTracker *FortificationTracker) {
-				supportTracker.RecordFortification(1, 10)
+			setup: func(fortificationTracker *FortificationTracker) {
+				fortificationTracker.RecordFortification(1, 10)
 			},
 			curTS:           ts(10),
 			expQuorumActive: false,
 		},
 		{
-			setup: func(supportTracker *FortificationTracker) {
-				supportTracker.RecordFortification(1, 10)
-				supportTracker.RecordFortification(3, 30)
+			setup: func(fortificationTracker *FortificationTracker) {
+				fortificationTracker.RecordFortification(1, 10)
+				fortificationTracker.RecordFortification(3, 30)
 			},
 			curTS:           ts(9),
 			expQuorumActive: true,
 		},
 		{
-			setup: func(supportTracker *FortificationTracker) {
-				supportTracker.RecordFortification(1, 10)
-				supportTracker.RecordFortification(3, 30)
+			setup: func(fortificationTracker *FortificationTracker) {
+				fortificationTracker.RecordFortification(1, 10)
+				fortificationTracker.RecordFortification(3, 30)
 			},
 			curTS:           ts(14),
 			expQuorumActive: false,
 		},
 		{
-			setup: func(supportTracker *FortificationTracker) {
-				supportTracker.RecordFortification(1, 10)
-				supportTracker.RecordFortification(3, 30)
-				supportTracker.RecordFortification(2, 20)
+			setup: func(fortificationTracker *FortificationTracker) {
+				fortificationTracker.RecordFortification(1, 10)
+				fortificationTracker.RecordFortification(3, 30)
+				fortificationTracker.RecordFortification(2, 20)
 			},
 			curTS:           ts(14),
 			expQuorumActive: true,
 		},
 		{
-			setup: func(supportTracker *FortificationTracker) {
-				supportTracker.RecordFortification(1, 10)
-				supportTracker.RecordFortification(3, 30)
-				supportTracker.RecordFortification(2, 20)
+			setup: func(fortificationTracker *FortificationTracker) {
+				fortificationTracker.RecordFortification(1, 10)
+				fortificationTracker.RecordFortification(3, 30)
+				fortificationTracker.RecordFortification(2, 20)
 			},
 			curTS:           ts(16),
 			expQuorumActive: false,
 		},
 		{
-			setup: func(supportTracker *FortificationTracker) {
+			setup: func(fortificationTracker *FortificationTracker) {
 				// Record fortification at epochs at expired epochs.
-				supportTracker.RecordFortification(1, 9)
-				supportTracker.RecordFortification(3, 29)
-				supportTracker.RecordFortification(2, 19)
+				fortificationTracker.RecordFortification(1, 9)
+				fortificationTracker.RecordFortification(3, 29)
+				fortificationTracker.RecordFortification(2, 19)
 			},
 			curTS:           ts(10),
 			expQuorumActive: false,
 		},
 		{
-			setup: func(supportTracker *FortificationTracker) {
+			setup: func(fortificationTracker *FortificationTracker) {
 				// Record fortification at newer epochs than what are present in
 				// StoreLiveness.
 				//
 				// NB: This is possible if there is a race between store liveness
 				// heartbeats updates and fortification responses.
-				supportTracker.RecordFortification(1, 11)
-				supportTracker.RecordFortification(3, 31)
-				supportTracker.RecordFortification(2, 21)
+				fortificationTracker.RecordFortification(1, 11)
+				fortificationTracker.RecordFortification(3, 31)
+				fortificationTracker.RecordFortification(2, 21)
 			},
 			expQuorumActive: false,
 		},
 		{
-			setup: func(supportTracker *FortificationTracker) {
+			setup: func(fortificationTracker *FortificationTracker) {
 				// One of the epochs being supported is expired.
-				supportTracker.RecordFortification(1, 10)
-				supportTracker.RecordFortification(3, 29) // expired
-				supportTracker.RecordFortification(2, 20)
+				fortificationTracker.RecordFortification(1, 10)
+				fortificationTracker.RecordFortification(3, 29) // expired
+				fortificationTracker.RecordFortification(2, 20)
 			},
 			curTS:           ts(5),
 			expQuorumActive: true,
 		},
 		{
-			setup: func(supportTracker *FortificationTracker) {
+			setup: func(fortificationTracker *FortificationTracker) {
 				// Two of the epochs being supported is expired.
-				supportTracker.RecordFortification(1, 10)
-				supportTracker.RecordFortification(3, 29) // expired
-				supportTracker.RecordFortification(2, 19) // expired
+				fortificationTracker.RecordFortification(1, 10)
+				fortificationTracker.RecordFortification(3, 29) // expired
+				fortificationTracker.RecordFortification(2, 19) // expired
 			},
 			curTS:           ts(10),
 			expQuorumActive: false,

--- a/pkg/raft/tracker/fortificationtracker_test.go
+++ b/pkg/raft/tracker/fortificationtracker_test.go
@@ -62,10 +62,12 @@ func TestLeadSupportUntil(t *testing.T) {
 	)
 
 	testCases := []struct {
-		ids           []pb.PeerID
-		storeLiveness raftstoreliveness.StoreLiveness
-		setup         func(tracker *FortificationTracker)
-		expTS         hlc.Timestamp
+		ids                    []pb.PeerID
+		storeLiveness          raftstoreliveness.StoreLiveness
+		setup                  func(tracker *FortificationTracker)
+		state                  pb.StateType
+		initLeadSupportedUntil hlc.Timestamp
+		expTS                  hlc.Timestamp
 	}{
 		{
 			ids:           []pb.PeerID{1, 2, 3},
@@ -73,7 +75,9 @@ func TestLeadSupportUntil(t *testing.T) {
 			setup: func(fortificationTracker *FortificationTracker) {
 				// No fortification recorded.
 			},
-			expTS: hlc.Timestamp{},
+			state:                  pb.StateLeader,
+			initLeadSupportedUntil: hlc.Timestamp{},
+			expTS:                  hlc.Timestamp{},
 		},
 		{
 			ids:           []pb.PeerID{1, 2, 3},
@@ -81,7 +85,9 @@ func TestLeadSupportUntil(t *testing.T) {
 			setup: func(fortificationTracker *FortificationTracker) {
 				fortificationTracker.RecordFortification(1, 10)
 			},
-			expTS: hlc.Timestamp{},
+			state:                  pb.StateLeader,
+			initLeadSupportedUntil: hlc.Timestamp{},
+			expTS:                  hlc.Timestamp{},
 		},
 		{
 			ids:           []pb.PeerID{1, 2, 3},
@@ -90,7 +96,9 @@ func TestLeadSupportUntil(t *testing.T) {
 				fortificationTracker.RecordFortification(1, 10)
 				fortificationTracker.RecordFortification(3, 30)
 			},
-			expTS: ts(10),
+			state:                  pb.StateLeader,
+			initLeadSupportedUntil: hlc.Timestamp{},
+			expTS:                  ts(10),
 		},
 		{
 			ids:           []pb.PeerID{1, 2, 3},
@@ -100,7 +108,9 @@ func TestLeadSupportUntil(t *testing.T) {
 				fortificationTracker.RecordFortification(3, 30)
 				fortificationTracker.RecordFortification(2, 20)
 			},
-			expTS: ts(15),
+			state:                  pb.StateLeader,
+			initLeadSupportedUntil: hlc.Timestamp{},
+			expTS:                  ts(15),
 		},
 		{
 			ids:           []pb.PeerID{1, 2, 3},
@@ -111,7 +121,9 @@ func TestLeadSupportUntil(t *testing.T) {
 				fortificationTracker.RecordFortification(3, 29)
 				fortificationTracker.RecordFortification(2, 19)
 			},
-			expTS: hlc.Timestamp{},
+			state:                  pb.StateLeader,
+			initLeadSupportedUntil: hlc.Timestamp{},
+			expTS:                  hlc.Timestamp{},
 		},
 		{
 			ids:           []pb.PeerID{1, 2, 3},
@@ -126,7 +138,9 @@ func TestLeadSupportUntil(t *testing.T) {
 				fortificationTracker.RecordFortification(3, 31)
 				fortificationTracker.RecordFortification(2, 21)
 			},
-			expTS: hlc.Timestamp{},
+			state:                  pb.StateLeader,
+			initLeadSupportedUntil: hlc.Timestamp{},
+			expTS:                  hlc.Timestamp{},
 		},
 		{
 			ids:           []pb.PeerID{1, 2, 3},
@@ -137,7 +151,9 @@ func TestLeadSupportUntil(t *testing.T) {
 				fortificationTracker.RecordFortification(3, 29) // expired
 				fortificationTracker.RecordFortification(2, 20)
 			},
-			expTS: ts(10),
+			state:                  pb.StateLeader,
+			initLeadSupportedUntil: hlc.Timestamp{},
+			expTS:                  ts(10),
 		},
 		{
 			ids:           []pb.PeerID{1, 2, 3},
@@ -148,7 +164,52 @@ func TestLeadSupportUntil(t *testing.T) {
 				fortificationTracker.RecordFortification(3, 29) // expired
 				fortificationTracker.RecordFortification(2, 19) // expired
 			},
-			expTS: hlc.Timestamp{},
+			state:                  pb.StateLeader,
+			initLeadSupportedUntil: hlc.Timestamp{},
+			expTS:                  hlc.Timestamp{},
+		},
+		{
+			ids:           []pb.PeerID{1, 2, 3},
+			storeLiveness: mockLiveness3Peers,
+			setup: func(fortificationTracker *FortificationTracker) {
+				fortificationTracker.RecordFortification(1, 10)
+				fortificationTracker.RecordFortification(3, 30)
+				fortificationTracker.RecordFortification(2, 20)
+			},
+			// If the state isn't StateLeader, we expect the LeadSupportUntil won't
+			// be computed, and the previous value will be returned.
+			state:                  pb.StateFollower,
+			initLeadSupportedUntil: ts(1),
+			expTS:                  ts(1),
+		},
+		{
+			ids:           []pb.PeerID{1, 2, 3},
+			storeLiveness: mockLiveness3Peers,
+			setup: func(fortificationTracker *FortificationTracker) {
+				fortificationTracker.RecordFortification(1, 10)
+				fortificationTracker.RecordFortification(3, 30)
+				fortificationTracker.RecordFortification(2, 20)
+			},
+			// If the state isn't StateLeader, we expect that LeadSupportUntil won't
+			// be computed, and the previous value will be returned.
+			state:                  pb.StateCandidate,
+			initLeadSupportedUntil: ts(1),
+			expTS:                  ts(1),
+		},
+		{
+			ids:           []pb.PeerID{1, 2, 3},
+			storeLiveness: mockLiveness3Peers,
+			setup: func(fortificationTracker *FortificationTracker) {
+				// If we are stepping down, expect that LeadSupportUntil won't be
+				// computed, and the previous value will be returned.
+				fortificationTracker.BeginSteppingDown(1)
+				fortificationTracker.RecordFortification(1, 10)
+				fortificationTracker.RecordFortification(3, 30)
+				fortificationTracker.RecordFortification(2, 20)
+			},
+			state:                  pb.StateLeader,
+			initLeadSupportedUntil: ts(1),
+			expTS:                  ts(1),
 		},
 	}
 
@@ -160,7 +221,64 @@ func TestLeadSupportUntil(t *testing.T) {
 		fortificationTracker := NewFortificationTracker(&cfg, tc.storeLiveness, raftlogger.DiscardLogger)
 
 		tc.setup(fortificationTracker)
-		require.Equal(t, tc.expTS, fortificationTracker.LeadSupportUntil(pb.StateLeader))
+		fortificationTracker.leaderMaxSupported.Forward(tc.initLeadSupportedUntil)
+		require.Equal(t, tc.expTS, fortificationTracker.LeadSupportUntil(tc.state))
+	}
+}
+
+// TestBeginSteppingDownUsesMaxTerm ensures that the max term is used when
+// stepping down. This helps to simulate the situation where the leader receives
+// multiple messages with different terms that indicate that it should step
+// down.
+func TestBeginSteppingDownUsesMaxTerm(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testCases := []struct {
+		setup               func(tracker *FortificationTracker)
+		expSteppingDown     bool
+		expSteppingDownTerm uint64
+	}{
+		{
+			setup: func(fortificationTracker *FortificationTracker) {
+				// Not stepping down.
+			},
+			expSteppingDown:     false,
+			expSteppingDownTerm: 0,
+		},
+		{
+			setup: func(fortificationTracker *FortificationTracker) {
+				fortificationTracker.BeginSteppingDown(1)
+			},
+			expSteppingDown:     true,
+			expSteppingDownTerm: 1,
+		},
+		{
+			setup: func(fortificationTracker *FortificationTracker) {
+				fortificationTracker.BeginSteppingDown(5)
+			},
+			expSteppingDown:     true,
+			expSteppingDownTerm: 5,
+		},
+		{
+			setup: func(fortificationTracker *FortificationTracker) {
+				fortificationTracker.BeginSteppingDown(5)
+				// The max steppingDown term should be used.
+				fortificationTracker.BeginSteppingDown(7)
+				fortificationTracker.BeginSteppingDown(4)
+			},
+			expSteppingDown:     true,
+			expSteppingDownTerm: 7,
+		},
+	}
+
+	for _, tc := range testCases {
+		cfg := quorum.MakeEmptyConfig()
+		fortificationTracker := NewFortificationTracker(&cfg, raftstoreliveness.AlwaysLive{},
+			raftlogger.DiscardLogger)
+		tc.setup(fortificationTracker)
+		require.Equal(t, tc.expSteppingDown, fortificationTracker.SteppingDown())
+		require.Equal(t, tc.expSteppingDownTerm, fortificationTracker.SteppingDownTerm())
 	}
 }
 


### PR DESCRIPTION
This commit addresses the case where in order for a stranded follower to join the quorum, a leader needs to step down. Before this commit, we used to step down and keep remembering that we were the leader for this term. This commit delays stepping down until it's safe to do so, but when we do, we can safely forget that we were the leader.

Fixes: #135078

Release notes: None