### PR TITLE
release-24.3.0-rc: tablemetadatacache,ui: change error messaging for failed tmj update

### DIFF
--- a/pkg/sql/tablemetadatacache/table_metadata_batch_iterator.go
+++ b/pkg/sql/tablemetadatacache/table_metadata_batch_iterator.go
@@ -8,13 +8,13 @@ package tablemetadatacache
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
@@ -204,9 +204,10 @@ func (batchIter *tableMetadataBatchIterator) fetchNextBatch(ctx context.Context)
 	}
 
 	if len(res.Errors) > 0 {
-		errMsg := strings.Join(res.Errors, " ; ")
-		// For now we won't write partial results to the cache.
-		return true, errors.Newf("%s", errMsg)
+		log.Errorf(ctx, "SpanStats request completed with %d errors. errors=%q",
+			len(res.Errors), res.Errors)
+		// For now, we won't write partial results to the cache.
+		return true, errors.New("An error has occurred while fetching span stats.")
 	}
 
 	if res.SpanToStats != nil {

--- a/pkg/sql/tablemetadatacache/table_metadata_updater.go
+++ b/pkg/sql/tablemetadatacache/table_metadata_updater.go
@@ -112,7 +112,7 @@ func (u *tableMetadataUpdater) updateCache(ctx context.Context) (updated int, er
 			u.metrics.Errors.Inc(1)
 			if !more {
 				// If we were able to fetch some rows, we can proceed and move on to the next batch.
-				// Otherwise a non-recoverable error was encountered and we can't proceed.
+				// Otherwise, a non-recoverable error was encountered and we can't proceed.
 				return updated, batchErr
 			}
 		}

--- a/pkg/sql/tablemetadatacache/testdata/update_table_metadata_errors
+++ b/pkg/sql/tablemetadatacache/testdata/update_table_metadata_errors
@@ -11,63 +11,63 @@ query
 SELECT * FROM system.table_metadata
 ORDER BY (db_name, table_name)
 ----
-1 24 system public comments 4 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 44 system public database_role_settings 4 2 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 3 system public descriptor 2 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 7 system public descriptor_id_seq 1 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC SEQUENCE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 12 system public eventlog 6 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 53 system public external_connections 7 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 54 system public job_info 4 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 15 system public jobs 12 5 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 41 system public join_tokens 3 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 11 system public lease 5 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 21 system public locations 4 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 40 system public migrations 5 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 64 system public mvcc_statistics 6 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 30 system public namespace 4 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 52 system public privileges 5 3 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 31 system public protected_ts_meta 5 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 32 system public protected_ts_records 8 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 13 system public rangelog 7 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 9 system public region_liveness 2 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 25 system public replication_constraint_stats 7 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 26 system public replication_critical_localities 5 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 27 system public replication_stats 7 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 28 system public reports_meta 2 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 48 system public role_id_seq 1 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC SEQUENCE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 23 system public role_members 5 6 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 33 system public role_options 4 2 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 37 system public scheduled_jobs 10 2 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 6 system public settings 4 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 47 system public span_configurations 3 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 51 system public span_count 2 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 56 system public span_stats_buckets 5 2 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 57 system public span_stats_samples 2 2 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 58 system public span_stats_tenant_boundaries 2 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 55 system public span_stats_unique_keys 2 2 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 46 system public sql_instances 8 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 39 system public sqlliveness 3 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 61 system public statement_activity 17 8 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 34 system public statement_bundle_chunks 3 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 36 system public statement_diagnostics 7 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 35 system public statement_diagnostics_requests 11 2 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 66 system public statement_execution_insights 29 5 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 42 system public statement_statistics 19 9 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 67 system public table_metadata 18 11 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 20 system public table_statistics 12 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 59 system public task_payloads 8 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 63 system public tenant_id_seq 1 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC SEQUENCE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 50 system public tenant_settings 6 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 60 system public tenant_tasks 7 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 45 system public tenant_usage 14 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 8 system public tenants 6 3 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 62 system public transaction_activity 14 8 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 65 system public transaction_execution_insights 23 3 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 43 system public transaction_statistics 14 8 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 14 system public ui 3 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 4 system public users 4 2 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 19 system public web_sessions 9 5 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
-1 5 system public zones 2 1 {} 0 0 0 0 0 error1 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 24 system public comments 4 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 44 system public database_role_settings 4 2 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 3 system public descriptor 2 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 7 system public descriptor_id_seq 1 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC SEQUENCE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 12 system public eventlog 6 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 53 system public external_connections 7 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 54 system public job_info 4 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 15 system public jobs 12 5 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 41 system public join_tokens 3 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 11 system public lease 5 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 21 system public locations 4 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 40 system public migrations 5 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 64 system public mvcc_statistics 6 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 30 system public namespace 4 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 52 system public privileges 5 3 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 31 system public protected_ts_meta 5 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 32 system public protected_ts_records 8 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 13 system public rangelog 7 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 9 system public region_liveness 2 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 25 system public replication_constraint_stats 7 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 26 system public replication_critical_localities 5 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 27 system public replication_stats 7 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 28 system public reports_meta 2 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 48 system public role_id_seq 1 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC SEQUENCE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 23 system public role_members 5 6 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 33 system public role_options 4 2 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 37 system public scheduled_jobs 10 2 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 6 system public settings 4 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 47 system public span_configurations 3 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 51 system public span_count 2 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 56 system public span_stats_buckets 5 2 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 57 system public span_stats_samples 2 2 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 58 system public span_stats_tenant_boundaries 2 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 55 system public span_stats_unique_keys 2 2 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 46 system public sql_instances 8 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 39 system public sqlliveness 3 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 61 system public statement_activity 17 8 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 34 system public statement_bundle_chunks 3 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 36 system public statement_diagnostics 7 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 35 system public statement_diagnostics_requests 11 2 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 66 system public statement_execution_insights 29 5 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 42 system public statement_statistics 19 9 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 67 system public table_metadata 18 11 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 20 system public table_statistics 12 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 59 system public task_payloads 8 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 63 system public tenant_id_seq 1 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC SEQUENCE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 50 system public tenant_settings 6 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 60 system public tenant_tasks 7 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 45 system public tenant_usage 14 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 8 system public tenants 6 3 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 62 system public transaction_activity 14 8 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 65 system public transaction_execution_insights 23 3 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 43 system public transaction_statistics 14 8 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 14 system public ui 3 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 4 system public users 4 2 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 19 system public web_sessions 9 5 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
+1 5 system public zones 2 1 {} 0 0 0 0 0 An error has occurred while fetching span stats. 2021-01-07 06:13:20 +0000 UTC TABLE {"auto_stats_enabled": null, "replica_count": 0, "stats_last_updated": null}
 
 
 set-time unixSecs=1710000000
@@ -178,63 +178,63 @@ SELECT
   last_update_error
 FROM system.table_metadata
 ----
-1 3 descriptor 2 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 4 users 4 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 5 zones 2 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 6 settings 4 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 7 descriptor_id_seq 1 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 8 tenants 6 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 9 region_liveness 2 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 11 lease 5 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 12 eventlog 6 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 13 rangelog 7 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 14 ui 3 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 15 jobs 12 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 19 web_sessions 9 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 20 table_statistics 12 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 21 locations 4 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 23 role_members 5 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 24 comments 4 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 25 replication_constraint_stats 7 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 26 replication_critical_localities 5 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 27 replication_stats 7 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 28 reports_meta 2 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 30 namespace 4 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 31 protected_ts_meta 5 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 32 protected_ts_records 8 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 33 role_options 4 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 34 statement_bundle_chunks 3 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 35 statement_diagnostics_requests 11 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 36 statement_diagnostics 7 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 37 scheduled_jobs 10 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 39 sqlliveness 3 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 40 migrations 5 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 41 join_tokens 3 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 42 statement_statistics 19 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 43 transaction_statistics 14 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 44 database_role_settings 4 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 45 tenant_usage 14 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 46 sql_instances 8 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 47 span_configurations 3 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 48 role_id_seq 1 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 50 tenant_settings 6 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 51 span_count 2 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 52 privileges 5 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 53 external_connections 7 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 54 job_info 4 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 55 span_stats_unique_keys 2 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 56 span_stats_buckets 5 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 57 span_stats_samples 2 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 58 span_stats_tenant_boundaries 2 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 59 task_payloads 8 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 60 tenant_tasks 7 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 61 statement_activity 17 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 62 transaction_activity 14 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 63 tenant_id_seq 1 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 64 mvcc_statistics 6 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 65 transaction_execution_insights 23 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 66 statement_execution_insights 29 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
-1 67 table_metadata 18 {1} 1 2024-03-09 16:00:00 +0000 UTC error2 ; error3
+1 3 descriptor 2 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 4 users 4 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 5 zones 2 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 6 settings 4 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 7 descriptor_id_seq 1 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 8 tenants 6 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 9 region_liveness 2 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 11 lease 5 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 12 eventlog 6 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 13 rangelog 7 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 14 ui 3 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 15 jobs 12 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 19 web_sessions 9 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 20 table_statistics 12 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 21 locations 4 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 23 role_members 5 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 24 comments 4 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 25 replication_constraint_stats 7 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 26 replication_critical_localities 5 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 27 replication_stats 7 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 28 reports_meta 2 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 30 namespace 4 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 31 protected_ts_meta 5 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 32 protected_ts_records 8 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 33 role_options 4 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 34 statement_bundle_chunks 3 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 35 statement_diagnostics_requests 11 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 36 statement_diagnostics 7 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 37 scheduled_jobs 10 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 39 sqlliveness 3 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 40 migrations 5 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 41 join_tokens 3 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 42 statement_statistics 19 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 43 transaction_statistics 14 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 44 database_role_settings 4 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 45 tenant_usage 14 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 46 sql_instances 8 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 47 span_configurations 3 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 48 role_id_seq 1 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 50 tenant_settings 6 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 51 span_count 2 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 52 privileges 5 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 53 external_connections 7 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 54 job_info 4 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 55 span_stats_unique_keys 2 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 56 span_stats_buckets 5 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 57 span_stats_samples 2 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 58 span_stats_tenant_boundaries 2 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 59 task_payloads 8 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 60 tenant_tasks 7 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 61 statement_activity 17 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 62 transaction_activity 14 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 63 tenant_id_seq 1 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 64 mvcc_statistics 6 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 65 transaction_execution_insights 23 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 66 statement_execution_insights 29 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
+1 67 table_metadata 18 {1} 1 2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats.
 
 
 set-time unixSecs=1810010000
@@ -258,26 +258,26 @@ SELECT
 FROM system.table_metadata
 ORDER BY last_updated
 ----
-2024-03-09 16:00:00 +0000 UTC error4 1 30 namespace
-2024-03-09 16:00:00 +0000 UTC error4 1 64 mvcc_statistics
-2024-03-09 16:00:00 +0000 UTC error4 1 54 job_info
-2024-03-09 16:00:00 +0000 UTC error4 1 53 external_connections
-2024-03-09 16:00:00 +0000 UTC error4 1 7 descriptor_id_seq
-2024-03-09 16:00:00 +0000 UTC error4 1 52 privileges
-2024-03-09 16:00:00 +0000 UTC error4 1 9 region_liveness
-2024-03-09 16:00:00 +0000 UTC error4 1 11 lease
-2024-03-09 16:00:00 +0000 UTC error4 1 12 eventlog
-2024-03-09 16:00:00 +0000 UTC error4 1 13 rangelog
-2024-03-09 16:00:00 +0000 UTC error4 1 44 database_role_settings
-2024-03-09 16:00:00 +0000 UTC error4 1 15 jobs
-2024-03-09 16:00:00 +0000 UTC error4 1 41 join_tokens
-2024-03-09 16:00:00 +0000 UTC error4 1 3 descriptor
-2024-03-09 16:00:00 +0000 UTC error4 1 21 locations
-2024-03-09 16:00:00 +0000 UTC error4 1 40 migrations
-2024-03-09 16:00:00 +0000 UTC error4 1 24 comments
-2024-03-09 16:00:00 +0000 UTC error4 1 25 replication_constraint_stats
-2024-03-09 16:00:00 +0000 UTC error4 1 32 protected_ts_records
-2024-03-09 16:00:00 +0000 UTC error4 1 31 protected_ts_meta
+2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats. 1 30 namespace
+2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats. 1 64 mvcc_statistics
+2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats. 1 54 job_info
+2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats. 1 53 external_connections
+2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats. 1 7 descriptor_id_seq
+2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats. 1 52 privileges
+2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats. 1 9 region_liveness
+2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats. 1 11 lease
+2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats. 1 12 eventlog
+2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats. 1 13 rangelog
+2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats. 1 44 database_role_settings
+2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats. 1 15 jobs
+2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats. 1 41 join_tokens
+2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats. 1 3 descriptor
+2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats. 1 21 locations
+2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats. 1 40 migrations
+2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats. 1 24 comments
+2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats. 1 25 replication_constraint_stats
+2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats. 1 32 protected_ts_records
+2024-03-09 16:00:00 +0000 UTC An error has occurred while fetching span stats. 1 31 protected_ts_meta
 2027-05-11 04:33:20 +0000 UTC <nil> 1 20 table_statistics
 2027-05-11 04:33:20 +0000 UTC <nil> 1 50 tenant_settings
 2027-05-11 04:33:20 +0000 UTC <nil> 1 27 replication_stats

--- a/pkg/ui/workspaces/cluster-ui/src/components/tooltipMessages/tableMetadataLastUpdatedTooltip.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/components/tooltipMessages/tableMetadataLastUpdatedTooltip.tsx
@@ -16,14 +16,7 @@ import styles from "./tableMetadataLastUpdatedTooltip.module.scss";
 const TABLE_METADATA_LAST_UPDATED_HELP =
   "Data was last refreshed automatically (per cluster setting) or manually.";
 
-const formatErrorMessage = (
-  errorMessage: string | null,
-  lastUpdatedTime: moment.Moment | null,
-) => {
-  if (!errorMessage) {
-    return null;
-  }
-
+const formatErrorMessage = (lastUpdatedTime: moment.Moment | null) => {
   return (
     <>
       Last refresh failed to retrieve data about this table. The data shown is
@@ -34,8 +27,6 @@ const formatErrorMessage = (
         fallback={"Never"}
       />
       .
-      <br />
-      Last refresh error: {errorMessage}
     </>
   );
 };
@@ -46,13 +37,13 @@ type Props = {
     formattedRelativeTime: React.ReactNode,
     icon?: JSX.Element,
   ) => React.ReactNode;
-  errorMessage?: string;
+  hasError?: boolean;
   loading?: boolean;
 };
 
 export const TableMetadataLastUpdatedTooltip = ({
   timestamp,
-  errorMessage,
+  hasError,
   children,
   loading,
 }: Props) => {
@@ -69,18 +60,19 @@ export const TableMetadataLastUpdatedTooltip = ({
     </span>
   );
 
-  const icon = errorMessage ? (
+  const icon = hasError ? (
     <Icon fill={"warning"} iconName={"Caution"} />
   ) : (
     <Icon fill="info" iconName={"InfoCircle"} />
   );
 
-  const formattedErr = formatErrorMessage(errorMessage, timestamp);
   return (
     <Tooltip
       title={
         <div>
-          {formattedErr ?? (
+          {hasError ? (
+            formatErrorMessage(timestamp)
+          ) : (
             <>
               {timestamp && (
                 <Timestamp

--- a/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/tableOverview.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableDetailsV2/tableOverview.tsx
@@ -51,7 +51,7 @@ export const TableOverview: React.FC<TableOverviewProps> = ({
         <Row justify={"end"}>
           <Col>
             <TableMetadataLastUpdatedTooltip
-              errorMessage={metadata.lastUpdateError}
+              hasError={!!metadata.lastUpdateError}
               timestamp={metadata.lastUpdated}
             >
               {(durationText, icon) => (


### PR DESCRIPTION
Backport 1/1 commits from #134902.

/cc @cockroachdb/release

---

Previously, error messages from the table metaddata update job were surfaced in the UI on the table overview page. These errors are usually overly verbose and don't provide any actionable info to the end user.

In addition to this, error messages can be very big if the error is a result of a span stats fanout failure, which can contain errors for each fanned out request.

Now, db-console will simply report that an error occured in the job and that the data is stale. The error returned from failed SpanStats requests will now have a generic "An error has occurred while fetching span stats."

Epic: None
Release note: None

Old error messaging:
<img width="338" alt="image" src="https://github.com/user-attachments/assets/382ce140-3778-48f4-a300-fe5fcaed5faa">

New error messaging:
<img width="434" alt="image" src="https://github.com/user-attachments/assets/21df4f80-dd0e-4d95-87a1-a64752b0d867">

