### PR TITLE
kvserver: create node liveness in tests

### DIFF
--- a/pkg/kv/kvserver/consistency_queue.go
+++ b/pkg/kv/kvserver/consistency_queue.go
@@ -125,11 +125,7 @@ func (q *consistencyQueue) shouldQueue(
 				return repl.getQueueLastProcessed(ctx, q.name)
 			},
 			isNodeAvailable: func(nodeID roachpb.NodeID) bool {
-				if repl.store.cfg.NodeLiveness != nil {
-					return repl.store.cfg.NodeLiveness.GetNodeVitalityFromCache(nodeID).IsLive(livenesspb.ConsistencyQueue)
-				}
-				// Some tests run without a NodeLiveness configured.
-				return true
+				return repl.store.cfg.NodeLiveness.GetNodeVitalityFromCache(nodeID).IsLive(livenesspb.ConsistencyQueue)
 			},
 			disableLastProcessedCheck: repl.store.cfg.TestingKnobs.DisableLastProcessedCheck,
 			interval:                  q.interval(),

--- a/pkg/kv/kvserver/liveness/cache.go
+++ b/pkg/kv/kvserver/liveness/cache.go
@@ -49,6 +49,7 @@ type Cache struct {
 	clock      *hlc.Clock
 	nodeDialer *nodedialer.Dialer
 	st         *cluster.Settings
+	isTestMode bool
 	mu         struct {
 		syncutil.RWMutex
 		// lastNodeUpdate stores timestamps of StoreDescriptor updates in Gossip.
@@ -214,6 +215,18 @@ func (c *Cache) self() (_ Record, ok bool) {
 // includes the raw, encoded value that the database has for this liveness
 // record in addition to the decoded liveness proto.
 func (c *Cache) getLiveness(nodeID roachpb.NodeID) (_ Record, ok bool) {
+	// In test mode, create a node vitality that is always live.
+	if c.isTestMode {
+		now := c.clock.Now()
+		return Record{
+			Liveness: livenesspb.Liveness{
+				NodeID:     nodeID,
+				Epoch:      1,
+				Expiration: now.AddDuration(time.Minute).ToLegacyTimestamp(),
+				Draining:   false,
+				Membership: livenesspb.MembershipStatus_ACTIVE,
+			}}, true
+	}
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if l, ok := c.mu.nodes[nodeID]; ok {

--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -149,11 +149,6 @@ func replicaIsSuspect(repl *Replica) bool {
 		return true
 	}
 
-	// NodeLiveness can be nil in tests/benchmarks.
-	if repl.store.cfg.NodeLiveness == nil {
-		return false
-	}
-
 	// If a replica doesn't have an active raft group, we should check whether
 	// or not the node is active. If not, we should consider the replica suspect
 	// because it has probably already been removed from its raft group but

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -796,8 +796,7 @@ func (r *Replica) GetRangeLeaseDuration() time.Duration {
 // shouldUseExpirationLeaseRLocked. We can merge these once there are no more
 // callers: when expiration leases don't quiesce and are always eagerly renewed.
 func (r *Replica) requiresExpirationLeaseRLocked() bool {
-	return r.store.cfg.NodeLiveness == nil ||
-		r.shMu.state.Desc.StartKey.Less(roachpb.RKey(keys.NodeLivenessKeyMax))
+	return r.shMu.state.Desc.StartKey.Less(roachpb.RKey(keys.NodeLivenessKeyMax))
 }
 
 // shouldUseExpirationLeaseRLocked returns true if this range should be using an

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -602,11 +602,9 @@ func newReplicateQueue(store *Store, allocator allocatorimpl.Allocator) *replica
 			updateFn()
 		})
 	}
-	if nl := store.cfg.NodeLiveness; nl != nil { // node liveness is nil for some unittests
-		nl.RegisterCallback(func(_ livenesspb.Liveness) {
-			updateFn()
-		})
-	}
+	store.cfg.NodeLiveness.RegisterCallback(func(_ livenesspb.Liveness) {
+		updateFn()
+	})
 
 	return rq
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2329,9 +2329,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 
 	// Register a callback to unquiesce any ranges with replicas on a
 	// node transitioning from non-live to live.
-	if s.cfg.NodeLiveness != nil {
-		s.cfg.NodeLiveness.RegisterCallback(s.nodeIsLiveCallback)
-	}
+	s.cfg.NodeLiveness.RegisterCallback(s.nodeIsLiveCallback)
 
 	// SystemConfigProvider can be nil during some tests.
 	if scp := s.cfg.SystemConfigProvider; scp != nil {

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -805,9 +805,7 @@ func (s *Store) raftTickLoop(ctx context.Context) {
 		select {
 		case <-ticker.C:
 			// Update the liveness map.
-			if s.cfg.NodeLiveness != nil {
-				s.updateLivenessMap()
-			}
+			s.updateLivenessMap()
 			s.updateIOThresholdMap()
 
 			s.unquiescedReplicas.Lock()

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
@@ -273,6 +274,7 @@ func createTestStoreWithoutStart(
 	}, ds)
 	require.Nil(t, cfg.DB)
 	cfg.DB = kv.NewDB(cfg.AmbientCtx, txnCoordSenderFactory, cfg.Clock, stopper)
+	cfg.NodeLiveness = liveness.NewTestNodeLiveness(stopper, cfg.Clock, cfg.Settings)
 	store := NewStore(ctx, *cfg, eng, nodeDesc)
 	storeSender.Sender = store
 


### PR DESCRIPTION
Previously node liveness wasn't constructed in tests. This commit adds it to allow removing a number of nil checks.

Epic: none

Release note: None