### PR TITLE
kv/kvnemesis: add leader lease config

### DIFF
--- a/pkg/kv/kvserver/client_raft_epoch_leases_test.go
+++ b/pkg/kv/kvserver/client_raft_epoch_leases_test.go
@@ -67,7 +67,7 @@ func TestRaftCheckQuorumEpochLeases(t *testing.T) {
 
 			// Only run the test with epoch based leases.
 			st := cluster.MakeTestingClusterSettings()
-			alwaysRunWithEpochLeases(ctx, st)
+			kvserver.OverrideDefaultLeaseType(ctx, &st.SV, roachpb.LeaseEpoch)
 
 			tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
 				ReplicationMode: base.ReplicationManual,
@@ -230,7 +230,7 @@ func TestRequestsOnLaggingReplicaEpochLeases(t *testing.T) {
 	ctx := context.Background()
 
 	st := cluster.MakeTestingClusterSettings()
-	alwaysRunWithEpochLeases(ctx, st)
+	kvserver.OverrideDefaultLeaseType(ctx, &st.SV, roachpb.LeaseEpoch)
 
 	clusterArgs := base.TestClusterArgs{
 		ReplicationMode: base.ReplicationManual,

--- a/pkg/kv/kvserver/client_raft_helpers_test.go
+++ b/pkg/kv/kvserver/client_raft_helpers_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness/storelivenesspb"
 	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -492,23 +491,4 @@ func getMapsDiff(beforeMap map[string]int64, afterMap map[string]int64) map[stri
 		}
 	}
 	return diffMap
-}
-
-// alwaysRunWithLeaderLeases configures settings to ensure the caller is always
-// using leader leases, regardless of any metamorphic constants.
-func alwaysRunWithLeaderLeases(ctx context.Context, st *cluster.Settings) {
-	kvserver.ExpirationLeasesOnly.Override(ctx, &st.SV, false)
-	kvserver.LeaderLeasesEnabled.Override(ctx, &st.SV, true)
-	kvserver.RaftLeaderFortificationFractionEnabled.Override(ctx, &st.SV, 1.0)
-	// TODO(arul): Once https://github.com/cockroachdb/cockroach/issues/118435 we
-	// can remove this. Leader leases require us to reject lease requests on
-	// replicas that are not the leader.
-	kvserver.RejectLeaseOnLeaderUnknown.Override(ctx, &st.SV, true)
-}
-
-func alwaysRunWithEpochLeases(ctx context.Context, st *cluster.Settings) {
-	// Only run the test with epoch based leases.
-	kvserver.TransferExpirationLeasesFirstEnabled.Override(ctx, &st.SV, false)
-	kvserver.ExpirationLeasesOnly.Override(ctx, &st.SV, false)
-	kvserver.RaftLeaderFortificationFractionEnabled.Override(ctx, &st.SV, 0.0)
 }

--- a/pkg/kv/kvserver/replica_lease_renewal_test.go
+++ b/pkg/kv/kvserver/replica_lease_renewal_test.go
@@ -40,17 +40,7 @@ func TestLeaseRenewer(t *testing.T) {
 	leases.RunEachLeaseType(t, func(t *testing.T, leaseType roachpb.LeaseType) {
 		ctx := context.Background()
 		st := cluster.MakeTestingClusterSettings()
-		if leaseType == roachpb.LeaseExpiration {
-			ExpirationLeasesOnly.Override(ctx, &st.SV, true)
-		} else {
-			ExpirationLeasesOnly.Override(ctx, &st.SV, false)
-		}
-		if leaseType == roachpb.LeaseLeader {
-			RaftLeaderFortificationFractionEnabled.Override(ctx, &st.SV, 1.0)
-			LeaderLeasesEnabled.Override(ctx, &st.SV, true)
-		} else {
-			LeaderLeasesEnabled.Override(ctx, &st.SV, false)
-		}
+		OverrideDefaultLeaseType(ctx, &st.SV, leaseType)
 		tc := serverutils.StartCluster(t, 3, base.TestClusterArgs{
 			ServerArgs: base.TestServerArgs{
 				Settings: st,

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -161,6 +161,23 @@ var RejectLeaseOnLeaderUnknown = settings.RegisterBoolSetting(
 	false,
 )
 
+// OverrideDefaultLeaseType overrides the default lease type for the cluster
+// settings, regardless of any metamorphic constants.
+func OverrideDefaultLeaseType(ctx context.Context, sv *settings.Values, typ roachpb.LeaseType) {
+	switch typ {
+	case roachpb.LeaseExpiration:
+		ExpirationLeasesOnly.Override(ctx, sv, true)
+	case roachpb.LeaseEpoch:
+		ExpirationLeasesOnly.Override(ctx, sv, false)
+		RaftLeaderFortificationFractionEnabled.Override(ctx, sv, 0.0)
+	case roachpb.LeaseLeader:
+		ExpirationLeasesOnly.Override(ctx, sv, false)
+		RaftLeaderFortificationFractionEnabled.Override(ctx, sv, 1.0)
+	default:
+		log.Fatalf(ctx, "unexpected lease type: %v", typ)
+	}
+}
+
 // leaseRequestHandle is a handle to an asynchronous lease request.
 type leaseRequestHandle struct {
 	p *pendingLeaseRequest


### PR DESCRIPTION
Informs #125260.

This commit adds a new `TestKVNemesisMultiNode_LeaderLeases` test, which uses leader leases.

While here, we clean up the utility to override the default lease type in unit tests.

Release note: None