### PR TITLE
ui: add leadSupportUntil to raft range pages

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/range/rangeTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/range/rangeTable.tsx
@@ -88,6 +88,11 @@ const rangeTableDisplayList: RangeTableRow[] = [
     compareToLeader: true,
   },
   {
+    variable: "leadSupportUntil",
+    display: "Lead Support Until",
+    compareToLeader: false,
+  },
+  {
     variable: "leaseAppliedIndex",
     display: "Lease Applied Index",
     compareToLeader: true,
@@ -735,6 +740,10 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
           ? this.createContent("") // `problems` above will report "Awaiting GC" in this case
           : this.createContent(contentReplicaType(localReplica.type)),
         raftState: raftState,
+        leadSupportUntil: this.contentTimestamp(
+          info.raft_state.lead_support_until,
+          now,
+        ),
         quiescent: info.quiescent
           ? rangeTableQuiescent
           : rangeTableEmptyContent,


### PR DESCRIPTION
This commit adds the field `leadSupportUntil` to the raft range pages.

Examples:

![Screenshot 2024-11-13 at 5 10 51 PM](https://github.com/user-attachments/assets/6db81d05-ec7e-4085-9f1c-d4022470986b)
![Screenshot 2024-11-13 at 6 41 33 PM](https://github.com/user-attachments/assets/7a67a458-4001-40cc-a944-f1cff6139e1e)


Fixes: #132756

Release notes: None