### PR TITLE
builtins: fix FLOAT4 handling in percentile_cont and percentile_disc

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -4020,3 +4020,13 @@ SELECT a, sum_int(c) AS s FROM t124101 GROUP BY a, c ORDER BY a, a, s, c LIMIT 2
 
 statement ok
 RESET testing_optimizer_disable_rule_probability;
+
+# Regression test for erroring out on FLOAT4 type and percentile_cont (#90519).
+statement ok
+CREATE TABLE t90519 (i int);
+INSERT INTO t90519 VALUES (1),(2),(3),(4);
+
+query R
+SELECT percentile_cont(ARRAY[.4::FLOAT]) WITHIN GROUP (ORDER BY i::FLOAT4) FROM t90519;
+----
+{2.2}

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -5076,14 +5076,14 @@ func validateInputFractions(datum tree.Datum) ([]float64, bool, error) {
 		return nil
 	}
 
-	if datum.ResolvedType().Identical(types.Float) {
+	if t := datum.ResolvedType(); t.Family() == types.FloatFamily {
 		fraction := float64(tree.MustBeDFloat(datum))
 		singleInput = true
 		if err := validate(fraction); err != nil {
 			return nil, false, err
 		}
 		fractions = append(fractions, fraction)
-	} else if datum.ResolvedType().Equivalent(types.FloatArray) {
+	} else if t.Family() == types.ArrayFamily && t.ArrayContents().Family() == types.FloatFamily {
 		fractionsDatum := tree.MustBeDArray(datum)
 		for _, f := range fractionsDatum.Array {
 			fraction := float64(tree.MustBeDFloat(f))
@@ -5266,7 +5266,7 @@ func (a *percentileContAggregate) Result() (tree.Datum, error) {
 			ceilRowNumber := int(math.Ceil(rowNumber))
 			floorRowNumber := int(math.Floor(rowNumber))
 
-			if a.arr.ParamTyp.Identical(types.Float) {
+			if t := a.arr.ParamTyp; t.Family() == types.FloatFamily {
 				var target float64
 				if rowNumber == float64(ceilRowNumber) && rowNumber == float64(floorRowNumber) {
 					target = float64(tree.MustBeDFloat(a.arr.Array[int(rowNumber)-1]))
@@ -5279,7 +5279,7 @@ func (a *percentileContAggregate) Result() (tree.Datum, error) {
 				if err := res.Append(tree.NewDFloat(tree.DFloat(target))); err != nil {
 					return nil, err
 				}
-			} else if a.arr.ParamTyp.Family() == types.IntervalFamily {
+			} else if t.Family() == types.IntervalFamily {
 				var target *tree.DInterval
 				if rowNumber == float64(ceilRowNumber) && rowNumber == float64(floorRowNumber) {
 					target = tree.MustBeDInterval(a.arr.Array[int(rowNumber)-1])


### PR DESCRIPTION
Previously, we used `types.Float.Identical` check when working with a couple of aggregate functions and would return an error if FLOAT4 is used. However, our internal implementation is exactly the same (`float64`), so we can safely use the float type family check instead.

Fixes: #90519.

Release note (bug fix): CockroachDB now correctly evaluates `percentile_cont` and `percentile_disc` aggregates over FLOAT4 values (previously we would return an error).