### PR TITLE
vecindex: implement C-SPANN insert and split

### DIFF
--- a/pkg/sql/vecindex/BUILD.bazel
+++ b/pkg/sql/vecindex/BUILD.bazel
@@ -9,7 +9,9 @@ filegroup(
 go_library(
     name = "vecindex",
     srcs = [
+        "fixup_processor.go",
         "kmeans.go",
+        "split_data.go",
         "vector_index.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/vecindex",
@@ -18,15 +20,19 @@ go_library(
         "//pkg/sql/vecindex/internal",
         "//pkg/sql/vecindex/quantize",
         "//pkg/sql/vecindex/vecstore",
+        "//pkg/util/log",
         "//pkg/util/num32",
+        "//pkg/util/syncutil",
         "//pkg/util/vector",
         "@com_github_cockroachdb_errors//:errors",
+        "@org_golang_x_exp//slices",
     ],
 )
 
 go_test(
     name = "vecindex_test",
     srcs = [
+        "fixup_processor_test.go",
         "kmeans_test.go",
         "vector_index_test.go",
     ],
@@ -40,7 +46,6 @@ go_test(
         "//pkg/util/num32",
         "//pkg/util/vector",
         "@com_github_cockroachdb_datadriven//:datadriven",
-        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
         "@org_gonum_v1_gonum//floats/scalar",
         "@org_gonum_v1_gonum//stat",

--- a/pkg/sql/vecindex/fixup_processor.go
+++ b/pkg/sql/vecindex/fixup_processor.go
@@ -1,0 +1,508 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package vecindex
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/internal"
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecstore"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/vector"
+	"github.com/cockroachdb/errors"
+	"golang.org/x/exp/slices"
+)
+
+// fixupType enumerates the different kinds of fixups.
+type fixupType int
+
+const (
+	// splitFixup is a fixup that includes the key of a partition to split as
+	// well as the key of its parent partition.
+	splitFixup fixupType = iota + 1
+)
+
+// maxFixups specifies the maximum number of pending index fixups that can be
+// enqueued by foreground threads, waiting for processing. Hitting this limit
+// indicates the background goroutine has fallen far behind.
+const maxFixups = 100
+
+// fixup describes an index fixup so that it can be enqueued for processing.
+// Each fixup type needs to have some subset of the fields defined.
+type fixup struct {
+	// Type is the kind of fixup.
+	Type fixupType
+	// PartitionKey is the key of the fixup's target partition, if the fixup
+	// operates on a partition.
+	PartitionKey vecstore.PartitionKey
+	// ParentPartitionKey is the key of the parent of the fixup's target
+	// partition, if the fixup operates on a partition
+	ParentPartitionKey vecstore.PartitionKey
+}
+
+// partitionFixupKey is used as a key in a uniqueness map for partition fixups.
+type partitionFixupKey struct {
+	// Type is the kind of fixup.
+	Type fixupType
+	// PartitionKey is the key of the fixup's target partition.
+	PartitionKey vecstore.PartitionKey
+}
+
+// fixupProcessor applies index fixups in a background goroutine. Fixups repair
+// issues like dangling vectors and maintain the index by splitting and merging
+// partitions. Rather than interrupt a search or insert by performing a fixup in
+// a foreground goroutine, the fixup is enqueued and run later in a background
+// goroutine. This scheme avoids adding unpredictable latency to foreground
+// operations.
+//
+// In addition, it’s important that each fixup is performed in its own
+// transaction, with no re-entrancy allowed. If a fixup itself triggers another
+// fixup, then that will likewise be enqueued and performed in a separate
+// transaction, in order to avoid contention and re-entrancy, both of which can
+// cause problems.
+type fixupProcessor struct {
+	// --------------------------------------------------
+	// These fields can be accessed on any goroutine once the lock is acquired.
+	// --------------------------------------------------
+	mu struct {
+		syncutil.Mutex
+
+		// pendingPartitions tracks pending fixups that operate on a partition.
+		pendingPartitions map[partitionFixupKey]bool
+	}
+
+	// --------------------------------------------------
+	// These fields can be accessed on any goroutine.
+	// --------------------------------------------------
+
+	// fixups is an ordered list of fixups to process.
+	fixups chan fixup
+	// fixupsLimitHit prevents flooding the log with warning messages when the
+	// maxFixups limit has been reached.
+	fixupsLimitHit log.EveryN
+
+	// --------------------------------------------------
+	// The following fields should only be accessed on a single background
+	// goroutine (or a single foreground goroutine in deterministic tests).
+	// --------------------------------------------------
+
+	// index points back to the vector index to which fixups are applied.
+	index *VectorIndex
+	// rng is a random number generator. If nil, then the global random number
+	// generator will be used.
+	rng *rand.Rand
+	// workspace is used to stack-allocate temporary memory.
+	workspace internal.Workspace
+	// searchCtx is reused to perform index searches and inserts.
+	searchCtx searchContext
+
+	// tempVectorsWithKeys is temporary memory for vectors and their keys.
+	tempVectorsWithKeys []vecstore.VectorWithKey
+}
+
+// Init initializes the fixup processor. If "seed" is non-zero, then the fixup
+// processor will use a deterministic random number generator. Otherwise, it
+// will use the global random number generator.
+func (fp *fixupProcessor) Init(index *VectorIndex, seed int64) {
+	fp.index = index
+	if seed != 0 {
+		// Create a random number generator for the background goroutine.
+		fp.rng = rand.New(rand.NewSource(seed))
+	}
+	fp.mu.pendingPartitions = make(map[partitionFixupKey]bool, maxFixups)
+	fp.fixups = make(chan fixup, maxFixups)
+	fp.fixupsLimitHit = log.Every(time.Second)
+}
+
+// AddSplit enqueues a split fixup for later processing.
+func (fp *fixupProcessor) AddSplit(
+	ctx context.Context, parentPartitionKey vecstore.PartitionKey, partitionKey vecstore.PartitionKey,
+) {
+	fp.addFixup(ctx, fixup{
+		Type:               splitFixup,
+		ParentPartitionKey: parentPartitionKey,
+		PartitionKey:       partitionKey,
+	})
+}
+
+// runAll processes all fixups in the queue. This should only be called by
+// tests on one foreground goroutine.
+func (fp *fixupProcessor) runAll(ctx context.Context) error {
+	for {
+		ok, err := fp.run(ctx, false /* wait */)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			// No more fixups to process.
+			return nil
+		}
+	}
+}
+
+// run processes the next fixup in the queue and returns true. If "wait" is
+// false, then run returns false if there are no fixups in the queue. If "wait"
+// is true, then run blocks until it has processed a fixup or until the context
+// is canceled, in which case it returns false.
+func (fp *fixupProcessor) run(ctx context.Context, wait bool) (ok bool, err error) {
+	// Get next fixup from the queue.
+	var next fixup
+	if wait {
+		// Wait until a fixup is enqueued or the context is canceled.
+		select {
+		case next = <-fp.fixups:
+			break
+
+		case <-ctx.Done():
+			// Context was canceled, abort.
+			return false, nil
+		}
+	} else {
+		// If no fixup is available, immediately return.
+		select {
+		case next = <-fp.fixups:
+			break
+
+		default:
+			return false, nil
+		}
+	}
+
+	// Invoke the fixup function. Note that we do not hold the lock while
+	// processing the fixup.
+	switch next.Type {
+	case splitFixup:
+		if err = fp.splitPartition(ctx, next.ParentPartitionKey, next.PartitionKey); err != nil {
+			err = errors.Wrapf(err, "splitting partition %d", next.PartitionKey)
+		}
+	}
+
+	// Delete already-processed fixup from its pending map, even if the fixup
+	// failed, in order to avoid looping over the same fixup.
+	fp.mu.Lock()
+	defer fp.mu.Unlock()
+
+	switch next.Type {
+	case splitFixup:
+		key := partitionFixupKey{Type: next.Type, PartitionKey: next.PartitionKey}
+		delete(fp.mu.pendingPartitions, key)
+	}
+
+	return true, err
+}
+
+// addFixup enqueues the given fixup for later processing, assuming there is not
+// already a duplicate fixup that's pending.
+func (fp *fixupProcessor) addFixup(ctx context.Context, fixup fixup) {
+	fp.mu.Lock()
+	defer fp.mu.Unlock()
+
+	// Check whether fixup limit has been reached.
+	if len(fp.mu.pendingPartitions) >= maxFixups {
+		// Don't enqueue the fixup.
+		if fp.fixupsLimitHit.ShouldLog() {
+			log.Warning(ctx, "reached limit of unprocessed fixups")
+		}
+		return
+	}
+
+	// Don't enqueue fixup if it's already pending.
+	switch fixup.Type {
+	case splitFixup:
+		key := partitionFixupKey{Type: fixup.Type, PartitionKey: fixup.PartitionKey}
+		if _, ok := fp.mu.pendingPartitions[key]; ok {
+			return
+		}
+		fp.mu.pendingPartitions[key] = true
+	}
+
+	// Note that the channel send operation should never block, since it has
+	// maxFixups capacity.
+	fp.fixups <- fixup
+}
+
+// splitPartition splits the partition with the given key and parent key. This
+// runs in its own transaction. For a given index, there is at most one split
+// happening per SQL process. However, there can be multiple SQL processes, each
+// running a split.
+func (fp *fixupProcessor) splitPartition(
+	ctx context.Context, parentPartitionKey vecstore.PartitionKey, partitionKey vecstore.PartitionKey,
+) (err error) {
+	// Run the split within a transaction.
+	txn, err := fp.index.store.BeginTransaction(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err == nil {
+			err = fp.index.store.CommitTransaction(ctx, txn)
+		} else {
+			err = errors.CombineErrors(err, fp.index.store.AbortTransaction(ctx, txn))
+		}
+	}()
+
+	// Get the partition to be split from the store.
+	partition, err := fp.index.store.GetPartition(ctx, txn, partitionKey)
+	if errors.Is(err, vecstore.ErrPartitionNotFound) {
+		log.VEventf(ctx, 2, "partition %d no longer exists, do not split", partitionKey)
+		return nil
+	} else if err != nil {
+		return errors.Wrapf(err, "getting partition %d to split", partitionKey)
+	}
+
+	// Load the parent of the partition to split.
+	var parentPartition *vecstore.Partition
+	if partitionKey != vecstore.RootKey {
+		parentPartition, err = fp.index.store.GetPartition(ctx, txn, parentPartitionKey)
+		if errors.Is(err, vecstore.ErrPartitionNotFound) {
+			log.VEventf(ctx, 2, "parent partition %d of partition %d no longer exists, do not split",
+				parentPartitionKey, partitionKey)
+			return nil
+		} else if err != nil {
+			return errors.Wrapf(err, "getting parent %d of partition %d to split",
+				parentPartitionKey, partitionKey)
+		}
+
+		if parentPartition.Find(vecstore.ChildKey{PartitionKey: partitionKey}) == -1 {
+			log.VEventf(ctx, 2, "partition %d is no longer child of partition %d, do not split",
+				partitionKey, parentPartitionKey)
+			return nil
+		}
+	}
+
+	// Get the full vectors for the partition's children.
+	vectors, err := fp.getFullVectorsForPartition(ctx, txn, partitionKey, partition)
+	if err != nil {
+		return errors.Wrapf(err, "getting full vectors for split of partition %d", partitionKey)
+	}
+	if vectors.Count < fp.index.options.MaxPartitionSize*3/4 {
+		// This could happen if the partition had tons of dangling references that
+		// need to be cleaned up.
+		log.VEventf(ctx, 2, "partition %d has only %d live vectors, do not split",
+			partitionKey, vectors.Count)
+		return nil
+	}
+
+	// Determine which partition children should go into the left split partition
+	// and which should go into the right split partition.
+	tempOffsets := fp.workspace.AllocUint64s(vectors.Count)
+	defer fp.workspace.FreeUint64s(tempOffsets)
+	kmeans := BalancedKmeans{Workspace: &fp.workspace, Rand: fp.rng}
+	tempLeftOffsets, tempRightOffsets := kmeans.Compute(&vectors, tempOffsets)
+
+	leftSplit, rightSplit := fp.splitPartitionData(
+		ctx, partition, &vectors, tempLeftOffsets, tempRightOffsets)
+
+	if parentPartition != nil {
+		// De-link the splitting partition from its parent partition.
+		childKey := vecstore.ChildKey{PartitionKey: partitionKey}
+		_, err = fp.index.removeFromPartition(ctx, txn, parentPartitionKey, childKey)
+		if err != nil {
+			return errors.Wrapf(err, "removing splitting partition %d from its parent %d",
+				partitionKey, parentPartitionKey)
+		}
+
+		// TODO(andyk): Move vectors to/from split partition.
+	}
+
+	// Insert the two new partitions into the index. This only adds their data
+	// (and metadata) for the partition - they're not yet linked into the K-means
+	// tree.
+	leftPartitionKey, err := fp.index.store.InsertPartition(ctx, txn, leftSplit.Partition)
+	if err != nil {
+		return errors.Wrapf(err, "creating left partition for split of partition %d", partitionKey)
+	}
+	rightPartitionKey, err := fp.index.store.InsertPartition(ctx, txn, rightSplit.Partition)
+	if err != nil {
+		return errors.Wrapf(err, "creating right partition for split of partition %d", partitionKey)
+	}
+
+	log.VEventf(ctx, 2,
+		"splitting partition %d (%d vectors) into left partition %d "+
+			"(%d vectors) and right partition %d (%d vectors)",
+		partitionKey, len(partition.ChildKeys()),
+		leftPartitionKey, len(leftSplit.Partition.ChildKeys()),
+		rightPartitionKey, len(rightSplit.Partition.ChildKeys()))
+
+	// Now link the new partitions into the K-means tree.
+	if partitionKey == vecstore.RootKey {
+		// Add a new level to the tree by setting a new root partition that points
+		// to the two new partitions.
+		centroids := vector.MakeSet(fp.index.rootQuantizer.GetRandomDims())
+		centroids.EnsureCapacity(2)
+		centroids.Add(leftSplit.Partition.Centroid())
+		centroids.Add(rightSplit.Partition.Centroid())
+		quantizedSet := fp.index.rootQuantizer.Quantize(ctx, &centroids)
+		childKeys := []vecstore.ChildKey{
+			{PartitionKey: leftPartitionKey},
+			{PartitionKey: rightPartitionKey},
+		}
+		rootPartition := vecstore.NewPartition(
+			fp.index.rootQuantizer, quantizedSet, childKeys, partition.Level()+1)
+		if err = fp.index.store.SetRootPartition(ctx, txn, rootPartition); err != nil {
+			return errors.Wrapf(err, "setting new root for split of partition %d", partitionKey)
+		}
+
+		log.VEventf(ctx, 2, "created new root level with child partitions %d and %d",
+			leftPartitionKey, rightPartitionKey)
+	} else {
+		// Link the two new partitions into the K-means tree by inserting them
+		// into the parent level. This can trigger a further split, this time of
+		// the parent level.
+		fp.searchCtx = searchContext{
+			Ctx:       ctx,
+			Workspace: fp.workspace,
+			Txn:       txn,
+			Level:     parentPartition.Level() + 1,
+		}
+
+		fp.searchCtx.Randomized = leftSplit.Partition.Centroid()
+		childKey := vecstore.ChildKey{PartitionKey: leftPartitionKey}
+		err = fp.index.insertHelper(&fp.searchCtx, childKey, true /* allowRetry */)
+		if err != nil {
+			return errors.Wrapf(err, "inserting left partition for split of partition %d", partitionKey)
+		}
+
+		fp.searchCtx.Randomized = rightSplit.Partition.Centroid()
+		childKey = vecstore.ChildKey{PartitionKey: rightPartitionKey}
+		err = fp.index.insertHelper(&fp.searchCtx, childKey, true /* allowRetry */)
+		if err != nil {
+			return errors.Wrapf(err, "inserting right partition for split of partition %d", partitionKey)
+		}
+
+		// Delete the old partition.
+		if err = fp.index.store.DeletePartition(ctx, txn, partitionKey); err != nil {
+			return errors.Wrapf(err, "deleting partition %d for split", partitionKey)
+		}
+	}
+
+	return nil
+}
+
+// Split the given partition into left and right partitions, according to the
+// provided left and right offsets. The offsets are expected to be in sorted
+// order and refer to the corresponding vectors and child keys in the splitting
+// partition.
+// NOTE: The vectors set will be updated in-place, via a partial sort that moves
+// vectors in the left partition to the left side of the set. However, the split
+// partition is not modified.
+func (fp *fixupProcessor) splitPartitionData(
+	ctx context.Context,
+	splitPartition *vecstore.Partition,
+	vectors *vector.Set,
+	leftOffsets, rightOffsets []uint64,
+) (leftSplit, rightSplit splitData) {
+	// Copy centroid distances and child keys so they can be split.
+	centroidDistances := slices.Clone(splitPartition.QuantizedSet().GetCentroidDistances())
+	childKeys := slices.Clone(splitPartition.ChildKeys())
+
+	tempVector := fp.workspace.AllocFloats(fp.index.quantizer.GetRandomDims())
+	defer fp.workspace.FreeFloats(tempVector)
+
+	// Any left offsets that point beyond the end of the left list indicate that
+	// a vector needs to be moved from the right partition to the left partition.
+	// The reverse is true for right offsets. Because the left and right offsets
+	// are in sorted order, out-of-bounds offsets must be at the end of the left
+	// list and the beginning of the right list. Therefore, the algorithm just
+	// needs to iterate over those offsets and swap the positions of the
+	// referenced vectors.
+	li := len(leftOffsets) - 1
+	ri := 0
+
+	var rightToLeft, leftToRight vector.T
+	for li >= 0 {
+		left := int(leftOffsets[li])
+		if left < len(leftOffsets) {
+			break
+		}
+
+		right := int(rightOffsets[ri])
+		if right >= len(leftOffsets) {
+			panic("expected equal number of left and right offsets that need to be swapped")
+		}
+
+		// Swap vectors.
+		rightToLeft = vectors.At(left)
+		leftToRight = vectors.At(right)
+		copy(tempVector, rightToLeft)
+		copy(rightToLeft, leftToRight)
+		copy(leftToRight, tempVector)
+
+		// Swap centroid distances and child keys.
+		centroidDistances[left], centroidDistances[right] =
+			centroidDistances[right], centroidDistances[left]
+		childKeys[left], childKeys[right] = childKeys[right], childKeys[left]
+
+		li--
+		ri++
+	}
+
+	leftVectorSet := *vectors
+	rightVectorSet := leftVectorSet.SplitAt(len(leftOffsets))
+
+	leftCentroidDistances := centroidDistances[:len(leftOffsets):len(leftOffsets)]
+	leftChildKeys := childKeys[:len(leftOffsets):len(leftOffsets)]
+	leftSplit.Init(ctx, fp.index.quantizer, &leftVectorSet,
+		leftCentroidDistances, leftChildKeys, splitPartition.Level())
+
+	rightCentroidDistances := centroidDistances[len(leftOffsets):]
+	rightChildKeys := childKeys[len(leftOffsets):]
+	rightSplit.Init(ctx, fp.index.quantizer, &rightVectorSet,
+		rightCentroidDistances, rightChildKeys, splitPartition.Level())
+
+	return leftSplit, rightSplit
+}
+
+// getFullVectorsForPartition fetches the full-size vectors (potentially
+// randomized by the quantizer) that are quantized by the given partition.
+func (fp *fixupProcessor) getFullVectorsForPartition(
+	ctx context.Context,
+	txn vecstore.Txn,
+	partitionKey vecstore.PartitionKey,
+	partition *vecstore.Partition,
+) (vector.Set, error) {
+	childKeys := partition.ChildKeys()
+	fp.tempVectorsWithKeys = ensureSliceLen(fp.tempVectorsWithKeys, len(childKeys))
+	for i := range childKeys {
+		fp.tempVectorsWithKeys[i].Key = childKeys[i]
+	}
+	err := fp.index.store.GetFullVectors(ctx, txn, fp.tempVectorsWithKeys)
+	if err != nil {
+		err = errors.Wrapf(err, "getting full vectors of partition %d to split", partitionKey)
+		return vector.Set{}, err
+	}
+
+	// Remove dangling vector references.
+	for i := range fp.tempVectorsWithKeys {
+		if fp.tempVectorsWithKeys[i].Vector != nil {
+			continue
+		}
+
+		// Move last reference to current location and reduce size of slice.
+		// TODO(andyk): Enqueue fixup to delete dangling vector from index.
+		count := len(fp.tempVectorsWithKeys) - 1
+		fp.tempVectorsWithKeys[i] = fp.tempVectorsWithKeys[count]
+		fp.tempVectorsWithKeys = fp.tempVectorsWithKeys[:count]
+		i--
+	}
+
+	vectors := vector.MakeSet(fp.index.quantizer.GetRandomDims())
+	vectors.AddUndefined(len(fp.tempVectorsWithKeys))
+	for i := range fp.tempVectorsWithKeys {
+		// Leaf vectors from the primary index need to be randomized.
+		if partition.Level() == vecstore.LeafLevel {
+			fp.index.quantizer.RandomizeVector(
+				ctx, fp.tempVectorsWithKeys[i].Vector, vectors.At(i), false /* invert */)
+		} else {
+			copy(vectors.At(i), fp.tempVectorsWithKeys[i].Vector)
+		}
+	}
+
+	return vectors, nil
+}

--- a/pkg/sql/vecindex/fixup_processor_test.go
+++ b/pkg/sql/vecindex/fixup_processor_test.go
@@ -1,0 +1,139 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package vecindex
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/internal"
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/quantize"
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecstore"
+	"github.com/cockroachdb/cockroach/pkg/util/num32"
+	"github.com/cockroachdb/cockroach/pkg/util/vector"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitPartitionData(t *testing.T) {
+	ctx := internal.WithWorkspace(context.Background(), &internal.Workspace{})
+	quantizer := quantize.NewRaBitQuantizer(2, 42)
+	store := vecstore.NewInMemoryStore(2, 42)
+	options := VectorIndexOptions{Seed: 42}
+	index, err := NewVectorIndex(ctx, store, quantizer, &options)
+	require.NoError(t, err)
+
+	vectors := vector.MakeSetFromRawData([]float32{
+		0, 0,
+		1, 1,
+		2, 3,
+		3, 3,
+		4, 4,
+		5, 5,
+		6, 6,
+	}, 2)
+	quantizedSet := quantizer.Quantize(ctx, &vectors)
+
+	splitPartition := vecstore.NewPartition(
+		quantizer,
+		quantizedSet,
+		[]vecstore.ChildKey{
+			{PrimaryKey: vecstore.PrimaryKey("vec1")},
+			{PrimaryKey: vecstore.PrimaryKey("vec2")},
+			{PrimaryKey: vecstore.PrimaryKey("vec3")},
+			{PrimaryKey: vecstore.PrimaryKey("vec4")},
+			{PrimaryKey: vecstore.PrimaryKey("vec5")},
+			{PrimaryKey: vecstore.PrimaryKey("vec6")},
+			{PrimaryKey: vecstore.PrimaryKey("vec7")},
+		},
+		1)
+
+	validate := func(split *splitData, offsets []uint64) {
+		require.Equal(t, splitPartition.Level(), split.Partition.Level())
+		require.Equal(t, len(offsets), split.Partition.Count())
+
+		// Validate centroid.
+		centroid := vector.T{0, 0}
+		split.Vectors.Centroid(centroid)
+		require.Equal(t, centroid, split.Partition.Centroid())
+
+		oldCentroidDistances := splitPartition.QuantizedSet().GetCentroidDistances()
+		centroidDistances := split.Partition.QuantizedSet().GetCentroidDistances()
+		for i, offset := range offsets {
+			cmp, err := vectors.At(int(offset)).Compare(split.Vectors.At(i))
+			require.NoError(t, err)
+			require.Equal(t, 0, cmp)
+			require.Equal(t, oldCentroidDistances[offset], split.OldCentroidDistances[i])
+			require.Equal(t, splitPartition.ChildKeys()[offset], split.Partition.ChildKeys()[i])
+
+			// Validate centroid distances.
+			expectedDistance := num32.L2Distance(centroid, split.Vectors.At(i))
+			require.Equal(t, expectedDistance, centroidDistances[i])
+		}
+	}
+
+	testCases := []struct {
+		desc          string
+		leftOffsets   []uint64
+		rightOffsets  []uint64
+		expectedLeft  []uint64
+		expectedRight []uint64
+	}{
+		{
+			desc:          "no reordering",
+			leftOffsets:   []uint64{0, 1, 2, 3},
+			rightOffsets:  []uint64{4, 5, 6},
+			expectedLeft:  []uint64{0, 1, 2, 3},
+			expectedRight: []uint64{4, 5, 6},
+		},
+		{
+			desc:          "only one on left",
+			leftOffsets:   []uint64{1},
+			rightOffsets:  []uint64{0, 2, 3, 4, 5, 6},
+			expectedLeft:  []uint64{1},
+			expectedRight: []uint64{0, 2, 3, 4, 5, 6},
+		},
+		{
+			desc:          "only one on right",
+			leftOffsets:   []uint64{0, 1, 2, 4, 5, 6},
+			rightOffsets:  []uint64{3},
+			expectedLeft:  []uint64{0, 1, 2, 6, 4, 5},
+			expectedRight: []uint64{3},
+		},
+		{
+			desc:          "interleaved",
+			leftOffsets:   []uint64{0, 2, 4, 6},
+			rightOffsets:  []uint64{1, 3, 5},
+			expectedLeft:  []uint64{0, 6, 2, 4},
+			expectedRight: []uint64{3, 5, 1},
+		},
+		{
+			desc:          "another interleaved",
+			leftOffsets:   []uint64{1, 4, 5},
+			rightOffsets:  []uint64{0, 2, 3, 6},
+			expectedLeft:  []uint64{5, 1, 4},
+			expectedRight: []uint64{3, 2, 0, 6},
+		},
+		{
+			desc:          "reversed",
+			leftOffsets:   []uint64{4, 5, 6},
+			rightOffsets:  []uint64{0, 1, 2, 3},
+			expectedLeft:  []uint64{6, 5, 4},
+			expectedRight: []uint64{3, 2, 1, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			tempVectors := vector.MakeSet(2)
+			tempVectors.AddSet(&vectors)
+			leftSplit, rightSplit := index.fixups.splitPartitionData(
+				ctx, splitPartition, &tempVectors, tc.leftOffsets, tc.rightOffsets)
+
+			validate(&leftSplit, tc.expectedLeft)
+			validate(&rightSplit, tc.expectedRight)
+		})
+	}
+}

--- a/pkg/sql/vecindex/kmeans.go
+++ b/pkg/sql/vecindex/kmeans.go
@@ -216,8 +216,9 @@ func (km *BalancedKmeans) assignPartitions() (leftOffsets, rightOffsets []uint64
 	}
 
 	// Arg sort by the distance differences in order of increasing distance to
-	// the left centroid, relative to the right centroid.
-	slices.SortFunc(km.offsets, func(i, j uint64) int {
+	// the left centroid, relative to the right centroid. Use a stable sort to
+	// ensure that tests are deterministic.
+	slices.SortStableFunc(km.offsets, func(i, j uint64) int {
 		return cmp.Compare(tempDistances[i], tempDistances[j])
 	})
 

--- a/pkg/sql/vecindex/split_data.go
+++ b/pkg/sql/vecindex/split_data.go
@@ -1,0 +1,54 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package vecindex
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/quantize"
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecstore"
+	"github.com/cockroachdb/cockroach/pkg/util/vector"
+)
+
+// splitData contains information about a smaller partition that is splitting
+// from an over-sized partition.
+type splitData struct {
+	// Partition contains a subset of the quantized vectors and child keys from
+	// the splitting partition.
+	Partition *vecstore.Partition
+	// Vectors is the subset of full-size vectors from the splitting partition.
+	// The vectors are in randomized format.
+	Vectors vector.Set
+	// OldCentroidDistances are the exact distances from each vector to the
+	// centroid of the splitting partition.
+	OldCentroidDistances []float32
+}
+
+// Init initializes the split information by creating a new partition from the
+// given subset of vectors from the splitting partition.
+func (s *splitData) Init(
+	ctx context.Context,
+	quantizer quantize.Quantizer,
+	vectors *vector.Set,
+	oldCentroidDistances []float32,
+	childKeys []vecstore.ChildKey,
+	level vecstore.Level,
+) {
+	s.Vectors = *vectors
+	s.OldCentroidDistances = oldCentroidDistances
+	quantizedSet := quantizer.Quantize(ctx, vectors)
+	s.Partition = vecstore.NewPartition(quantizer, quantizedSet, childKeys, level)
+}
+
+// ReplaceWithLast removes the vector at the given offset in the set, replacing
+// it with the last vector in the set. The modified set has one less element and
+// the last vector's position changes.
+func (s *splitData) ReplaceWithLast(offset int) {
+	s.Vectors.ReplaceWithLast(offset)
+	s.OldCentroidDistances[offset] = s.OldCentroidDistances[len(s.OldCentroidDistances)-1]
+	s.OldCentroidDistances = s.OldCentroidDistances[:len(s.OldCentroidDistances)-1]
+	s.Partition.ReplaceWithLast(offset)
+}

--- a/pkg/sql/vecindex/testdata/delete.ddt
+++ b/pkg/sql/vecindex/testdata/delete.ddt
@@ -7,32 +7,32 @@ vec2: (7, 4)
 vec3: (4, 3)
 vec4: (5, 5)
 ----
-• 1 (3.1667, 3)
+• 1 (4.25, 3.5)
 │
-├───• 2 (5.3333, 4)
+├───• 2 (6, 4.5)
 │   │
-│   ├───• vec2 (7, 4)
-│   ├───• vec3 (4, 3)
-│   └───• vec4 (5, 5)
+│   ├───• vec4 (5, 5)
+│   └───• vec2 (7, 4)
 │
-└───• 3 (1, 2)
+└───• 3 (2.5, 2.5)
     │
+    ├───• vec3 (4, 3)
     └───• vec1 (1, 2)
 
 # Delete vector from primary index, but not from secondary index.
 delete not-found
 vec3
 ----
-• 1 (3.1667, 3)
+• 1 (4.25, 3.5)
 │
-├───• 2 (5.3333, 4)
+├───• 2 (6, 4.5)
 │   │
-│   ├───• vec2 (7, 4)
-│   ├───• vec3 (MISSING)
-│   └───• vec4 (5, 5)
+│   ├───• vec4 (5, 5)
+│   └───• vec2 (7, 4)
 │
-└───• 3 (1, 2)
+└───• 3 (2.5, 2.5)
     │
+    ├───• vec3 (MISSING)
     └───• vec1 (1, 2)
 
 # Ensure deleted vector is not returned by search. This should enqueue a fixup
@@ -40,51 +40,71 @@ vec3
 search max-results=1
 (4, 3)
 ----
-vec4: 5 (centroid=1.0541)
-4 leaf vectors, 6 vectors, 2 full vectors, 3 partitions
+vec4: 5 (centroid=1.118)
+4 leaf vectors, 6 vectors, 4 full vectors, 3 partitions
 
 # Again, with higher max results.
 search max-results=2
 (4, 3)
 ----
-vec4: 5 (centroid=1.0541)
-vec2: 10 (centroid=1.6667)
+vec4: 5 (centroid=1.118)
+vec1: 10 (centroid=1.5811)
 4 leaf vectors, 6 vectors, 4 full vectors, 3 partitions
 
 # Vector should now be gone from the index.
 # TODO(andyk): This will be true once fixups are added.
 format-tree
 ----
-• 1 (3.1667, 3)
+• 1 (4.25, 3.5)
 │
-├───• 2 (5.3333, 4)
+├───• 2 (6, 4.5)
 │   │
-│   ├───• vec2 (7, 4)
-│   ├───• vec3 (MISSING)
-│   └───• vec4 (5, 5)
+│   ├───• vec4 (5, 5)
+│   └───• vec2 (7, 4)
 │
-└───• 3 (1, 2)
+└───• 3 (2.5, 2.5)
     │
+    ├───• vec3 (MISSING)
     └───• vec1 (1, 2)
 
 # Delete all vectors from one branch of the tree.
 delete not-found
 vec1
 ----
-• 1 (3.1667, 3)
+• 1 (4.25, 3.5)
 │
-├───• 2 (5.3333, 4)
+├───• 2 (6, 4.5)
 │   │
-│   ├───• vec2 (7, 4)
-│   ├───• vec3 (MISSING)
-│   └───• vec4 (5, 5)
+│   ├───• vec4 (5, 5)
+│   └───• vec2 (7, 4)
 │
-└───• 3 (1, 2)
+└───• 3 (2.5, 2.5)
     │
+    ├───• vec3 (MISSING)
     └───• vec1 (MISSING)
 
 # Search the empty branch.
 search max-results=1 beam-size=1
 (1, 2)
 ----
-1 leaf vectors, 3 vectors, 1 full vectors, 2 partitions
+2 leaf vectors, 4 vectors, 2 full vectors, 2 partitions
+
+# Search root partition with only missing vectors.
+new-index min-partition-size=1 max-partition-size=3 beam-size=2
+vec1: (1, 2)
+----
+• 1 (0, 0)
+│
+└───• vec1 (1, 2)
+
+delete not-found
+vec1
+----
+• 1 (0, 0)
+│
+└───• vec1 (MISSING)
+
+search max-results=1 beam-size=1
+(1, 2)
+----
+1 leaf vectors, 1 vectors, 1 full vectors, 1 partitions

--- a/pkg/sql/vecindex/testdata/insert.ddt
+++ b/pkg/sql/vecindex/testdata/insert.ddt
@@ -1,0 +1,106 @@
+new-index min-partition-size=1 max-partition-size=4 beam-size=2
+----
+• 1 (0, 0)
+
+# Insert vectors.
+insert
+vec1: (1, 2)
+vec2: (7, 4)
+vec3: (4, 3)
+----
+• 1 (0, 0)
+│
+├───• vec1 (1, 2)
+├───• vec2 (7, 4)
+└───• vec3 (4, 3)
+
+# Insert a duplicate vector.
+insert
+vec4: (4, 3)
+----
+• 1 (0, 0)
+│
+├───• vec1 (1, 2)
+├───• vec2 (7, 4)
+├───• vec3 (4, 3)
+└───• vec4 (4, 3)
+
+# Insert a duplicate child key and expect existing vector to be overwritten.
+insert
+vec2: (5, 6)
+----
+• 1 (0, 0)
+│
+├───• vec1 (1, 2)
+├───• vec2 (5, 6)
+├───• vec3 (4, 3)
+└───• vec4 (4, 3)
+
+# Insert more vectors.
+insert
+vec5: (8, 11)
+vec6: (14, 1)
+vec7: (0, 0)
+vec8: (0, 4)
+vec9: (-2, 8)
+----
+• 1 (3.6667, 3.4)
+│
+├───• 2 (7, 4.8)
+│   │
+│   ├───• vec6 (14, 1)
+│   ├───• vec2 (5, 6)
+│   ├───• vec3 (4, 3)
+│   ├───• vec4 (4, 3)
+│   └───• vec5 (8, 11)
+│
+└───• 3 (0.3333, 2)
+    │
+    ├───• vec1 (1, 2)
+    ├───• vec7 (0, 0)
+    ├───• vec8 (0, 4)
+    └───• vec9 (-2, 8)
+
+# Overwrite vector with a new value that won't be found in the index, causing
+# duplicate child keys that point to the same vector (but with different
+# quantized values). This simulates the situation where updating a vector fails
+# to locate the existing entry in the index and now there are multiple
+# references to the same vector. The duplicates should be detected before being
+# returned to the caller.
+insert
+vec2: (-5, -5)
+----
+• 1 (3.6667, 3.4)
+│
+├───• 2 (7, 4.8)
+│   │
+│   ├───• vec6 (14, 1)
+│   ├───• vec2 (-5, -5)
+│   ├───• vec3 (4, 3)
+│   ├───• vec4 (4, 3)
+│   └───• vec5 (8, 11)
+│
+├───• 4 (-1, 6)
+│   │
+│   ├───• vec9 (-2, 8)
+│   └───• vec8 (0, 4)
+│
+└───• 5 (-1.3333, -1)
+    │
+    ├───• vec7 (0, 0)
+    ├───• vec1 (1, 2)
+    └───• vec2 (-5, -5)
+
+search max-results=10 beam-size=8
+(-5, -5)
+----
+vec2: 0 (centroid=2.3324)
+vec7: 50 (centroid=1.6667)
+vec1: 85 (centroid=3.8006)
+vec8: 106 (centroid=2.2361)
+vec3: 145 (centroid=3.4986)
+vec4: 145 (centroid=3.4986)
+vec9: 178 (centroid=2.2361)
+vec6: 397 (centroid=7.9649)
+vec5: 425 (centroid=6.2801)
+10 leaf vectors, 13 vectors, 9 full vectors, 4 partitions

--- a/pkg/sql/vecindex/testdata/search-features.ddt
+++ b/pkg/sql/vecindex/testdata/search-features.ddt
@@ -1,72 +1,75 @@
-# Load 500 512-dimension features and search them. Use small partition size to
+# Load 1000 512-dimension features and search them. Use small partition size to
 # ensure a deeper tree.
 
-new-index dims=512 min-partition-size=2 max-partition-size=8 quality-samples=4 beam-size=2 load-features=500 hide-tree
+new-index dims=512 min-partition-size=2 max-partition-size=8 quality-samples=4 beam-size=2 load-features=1000 hide-tree
 ----
-Created index with 500 vectors with 512 dimensions.
+Created index with 1000 vectors with 512 dimensions.
 
 # Start with 1 result and default beam size of 2.
-search max-results=1 use-feature=9999
+search max-results=1 use-feature=5000
 ----
-vec441: 0.4646 (centroid=0.382)
-9 leaf vectors, 39 vectors, 2 full vectors, 5 partitions
+vec302: 0.6601 (centroid=0.4138)
+14 leaf vectors, 33 vectors, 4 full vectors, 5 partitions
 
 # Search for additional results.
-search max-results=3 use-feature=9999
+search max-results=6 use-feature=5000
 ----
-vec441: 0.4646 (centroid=0.382)
-vec99: 0.6356 (centroid=0.382)
-vec296: 0.7638 (centroid=0.5962)
-9 leaf vectors, 39 vectors, 6 full vectors, 5 partitions
+vec302: 0.6601 (centroid=0.4138)
+vec329: 0.6871 (centroid=0.5033)
+vec386: 0.7301 (centroid=0.5117)
+vec240: 0.7723 (centroid=0.4702)
+vec347: 0.7745 (centroid=0.6267)
+vec11: 0.777 (centroid=0.5067)
+14 leaf vectors, 33 vectors, 10 full vectors, 5 partitions
 
 # Use a larger beam size.
-search max-results=6 use-feature=9999 beam-size=8
+search max-results=6 use-feature=5000 beam-size=8
 ----
-vec74: 0.4155 (centroid=0.5092)
-vec195: 0.4359 (centroid=0.5127)
-vec441: 0.4646 (centroid=0.382)
-vec77: 0.4894 (centroid=0.4286)
-vec355: 0.5821 (centroid=0.4617)
-vec328: 0.6032 (centroid=0.5276)
-58 leaf vectors, 123 vectors, 14 full vectors, 15 partitions
+vec771: 0.5624 (centroid=0.4676)
+vec302: 0.6601 (centroid=0.4138)
+vec329: 0.6871 (centroid=0.5033)
+vec386: 0.7301 (centroid=0.5117)
+vec240: 0.7723 (centroid=0.4702)
+vec347: 0.7745 (centroid=0.6267)
+50 leaf vectors, 91 vectors, 12 full vectors, 15 partitions
 
 # Turn off re-ranking, which results in increased inaccuracy.
-search max-results=6 use-feature=9999 beam-size=8 skip-rerank
+search max-results=6 use-feature=5000 beam-size=8 skip-rerank
 ----
-vec195: 0.4179 ±0.0264 (centroid=0.5127)
-vec74: 0.4322 ±0.0263 (centroid=0.5092)
-vec441: 0.4657 ±0.0215 (centroid=0.382)
-vec77: 0.4881 ±0.0221 (centroid=0.4286)
-vec355: 0.5658 ±0.0238 (centroid=0.4617)
-vec415: 0.6142 ±0.0302 (centroid=0.5306)
-58 leaf vectors, 123 vectors, 0 full vectors, 15 partitions
+vec771: 0.5499 ±0.0291 (centroid=0.4676)
+vec302: 0.6246 ±0.0274 (centroid=0.4138)
+vec329: 0.6609 ±0.0333 (centroid=0.5033)
+vec386: 0.7245 ±0.0338 (centroid=0.5117)
+vec347: 0.7279 ±0.0415 (centroid=0.6267)
+vec11: 0.7509 ±0.0336 (centroid=0.5067)
+50 leaf vectors, 91 vectors, 0 full vectors, 15 partitions
 
-# Return top 25 results.
-search max-results=25 use-feature=9999 beam-size=8
+# Return top 25 results with large beam size.
+search max-results=25 use-feature=5000 beam-size=64
 ----
-vec74: 0.4155 (centroid=0.5092)
-vec195: 0.4359 (centroid=0.5127)
-vec441: 0.4646 (centroid=0.382)
-vec77: 0.4894 (centroid=0.4286)
-vec355: 0.5821 (centroid=0.4617)
-vec328: 0.6032 (centroid=0.5276)
-vec389: 0.6183 (centroid=0.5267)
-vec415: 0.6298 (centroid=0.5306)
-vec99: 0.6356 (centroid=0.382)
-vec267: 0.6742 (centroid=0.526)
-vec6: 0.685 (centroid=0.6015)
-vec485: 0.6867 (centroid=0.362)
-vec236: 0.687 (centroid=0.5071)
-vec198: 0.6885 (centroid=0.5094)
-vec65: 0.6898 (centroid=0.4403)
-vec146: 0.6901 (centroid=0.5601)
-vec282: 0.7197 (centroid=0.4023)
-vec410: 0.728 (centroid=0.4261)
-vec356: 0.7341 (centroid=0.4352)
-vec439: 0.7428 (centroid=0.6023)
-vec116: 0.7462 (centroid=0.4643)
-vec273: 0.7555 (centroid=0.5226)
-vec453: 0.7735 (centroid=0.3571)
-vec233: 0.7737 (centroid=0.5502)
-vec331: 0.7793 (centroid=0.4871)
-58 leaf vectors, 123 vectors, 44 full vectors, 15 partitions
+vec771: 0.5624 (centroid=0.4676)
+vec356: 0.5976 (centroid=0.5117)
+vec640: 0.6525 (centroid=0.6139)
+vec302: 0.6601 (centroid=0.4138)
+vec329: 0.6871 (centroid=0.5033)
+vec95: 0.7008 (centroid=0.5542)
+vec249: 0.7268 (centroid=0.3715)
+vec386: 0.7301 (centroid=0.5117)
+vec309: 0.7311 (centroid=0.4912)
+vec633: 0.7513 (centroid=0.4095)
+vec117: 0.7576 (centroid=0.4538)
+vec556: 0.7595 (centroid=0.5531)
+vec25: 0.761 (centroid=0.4576)
+vec872: 0.7707 (centroid=0.6427)
+vec859: 0.7708 (centroid=0.6614)
+vec240: 0.7723 (centroid=0.4702)
+vec347: 0.7745 (centroid=0.6267)
+vec11: 0.777 (centroid=0.5067)
+vec340: 0.7858 (centroid=0.4752)
+vec239: 0.7878 (centroid=0.4584)
+vec704: 0.7916 (centroid=0.7117)
+vec423: 0.7956 (centroid=0.4608)
+vec220: 0.7957 (centroid=0.4226)
+vec387: 0.8038 (centroid=0.4652)
+vec637: 0.8039 (centroid=0.5211)
+356 leaf vectors, 567 vectors, 97 full vectors, 103 partitions

--- a/pkg/sql/vecindex/testdata/search.ddt
+++ b/pkg/sql/vecindex/testdata/search.ddt
@@ -6,7 +6,7 @@ vec1: (1, 2)
 vec2: (7, 4)
 vec3: (4, 3)
 ----
-• 1 (4, 3)
+• 1 (0, 0)
 │
 ├───• vec1 (1, 2)
 ├───• vec2 (7, 4)
@@ -16,15 +16,15 @@ vec3: (4, 3)
 search
 (7, 4)
 ----
-vec2: 0 (centroid=3.1623)
+vec2: 0 (centroid=8.0623)
 3 leaf vectors, 3 vectors, 3 full vectors, 1 partitions
 
 # Search for vector with no exact match.
 search max-results=2
 (3, 5)
 ----
-vec3: 5 (centroid=0)
-vec1: 13 (centroid=3.1623)
+vec3: 5 (centroid=5)
+vec1: 13 (centroid=2.2361)
 3 leaf vectors, 3 vectors, 3 full vectors, 1 partitions
 
 # ----------
@@ -45,142 +45,129 @@ vec11: (1, 1)
 vec12: (5, 4)
 vec13: (6, 2)
 ----
-• 1 (2.0556, 1.1389)
+• 1 (1.6, 4.3)
 │
-├───• 8 (1, -6)
+├───• 5 (1, -1)
 │   │
-│   └───• 4 (1, -6)
-│       │
-│       └───• vec6 (1, -6)
+│   ├───• vec6 (1, -6)
+│   ├───• vec1 (1, 2)
+│   └───• vec11 (1, 1)
 │
-├───• 9 (5.5, 3.25)
+├───• 4 (-1.5, 5)
 │   │
-│   ├───• 3 (6.5, 3)
-│   │   │
-│   │   ├───• vec2 (7, 4)
-│   │   └───• vec13 (6, 2)
-│   │
-│   └───• 5 (4.5, 3.5)
-│       │
-│       ├───• vec3 (4, 3)
-│       └───• vec12 (5, 4)
+│   ├───• vec4 (-4, 5)
+│   ├───• vec10 (0, 3)
+│   ├───• vec8 (-2, 8)
+│   └───• vec7 (0, 4)
 │
-└───• 10 (-0.3333, 6.1667)
+├───• 6 (1.5, 9.5)
+│   │
+│   ├───• vec5 (1, 11)
+│   └───• vec9 (2, 8)
+│
+└───• 7 (5.3333, 3.6667)
     │
-    ├───• 2 (-3, 6.5)
-    │   │
-    │   ├───• vec4 (-4, 5)
-    │   └───• vec8 (-2, 8)
-    │
-    ├───• 6 (0.5, 2.5)
-    │   │
-    │   ├───• vec1 (1, 2)
-    │   ├───• vec7 (0, 4)
-    │   ├───• vec10 (0, 3)
-    │   └───• vec11 (1, 1)
-    │
-    └───• 7 (1.5, 9.5)
-        │
-        ├───• vec5 (1, 11)
-        └───• vec9 (2, 8)
+    ├───• vec3 (4, 3)
+    ├───• vec2 (7, 4)
+    ├───• vec12 (5, 4)
+    └───• vec13 (6, 2)
 
 # Search for closest vectors with beam-size=1.
 search max-results=2 beam-size=1
 (1, 6)
 ----
-vec9: 5 (centroid=1.5811)
-vec5: 25 (centroid=1.5811)
-2 leaf vectors, 8 vectors, 2 full vectors, 3 partitions
+vec7: 5 (centroid=1.8028)
+vec10: 10 (centroid=2.5)
+4 leaf vectors, 8 vectors, 4 full vectors, 2 partitions
 
 # Search for closest vectors with beam-size=2.
 search max-results=2 beam-size=2
 (1, 6)
 ----
+vec7: 5 (centroid=1.8028)
 vec9: 5 (centroid=1.5811)
-vec7: 5 (centroid=1.5811)
-6 leaf vectors, 12 vectors, 3 full vectors, 4 partitions
+6 leaf vectors, 10 vectors, 6 full vectors, 3 partitions
 
 # ----------
-# Construct new index with duplicate vectors.
+# Construct new index with only duplicate vectors.
 # ----------
 new-index min-partition-size=1 max-partition-size=4 beam-size=2
-vec1: (-3, 5)
-vec2: (10, -10)
+vec1: (4, 9)
+vec2: (4, 9)
 vec3: (4, 9)
-vec4: (1, 1)
+vec4: (4, 9)
 vec5: (4, 9)
-vec6: (6, 2)
+vec6: (4, 9)
 ----
-• 1 (3.6667, 2.6667)
+• 1 (4, 9)
 │
-├───• 2 (8, -4)
+├───• 2 (4, 9)
 │   │
-│   ├───• vec2 (10, -10)
-│   └───• vec6 (6, 2)
+│   ├───• vec1 (4, 9)
+│   └───• vec2 (4, 9)
 │
-├───• 3 (-1, 3)
-│   │
-│   ├───• vec1 (-3, 5)
-│   └───• vec4 (1, 1)
-│
-└───• 4 (4, 9)
+└───• 3 (4, 9)
     │
     ├───• vec3 (4, 9)
-    └───• vec5 (4, 9)
+    ├───• vec4 (4, 9)
+    ├───• vec5 (4, 9)
+    └───• vec6 (4, 9)
 
 # Ensure that search result returns multiple keys.
 search max-results=3
 (5, 10)
 ----
+vec1: 2 (centroid=0)
+vec2: 2 (centroid=0)
 vec3: 2 (centroid=0)
-vec5: 2 (centroid=0)
-vec1: 89 (centroid=2.8284)
-4 leaf vectors, 7 vectors, 4 full vectors, 3 partitions
+6 leaf vectors, 8 vectors, 6 full vectors, 3 partitions
 
 # ----------
 # Construct new index with duplicate keys. This can happen when a vector is
 # updated in the primary index, but it cannot be found in the secondary index.
 # ----------
-new-index min-partition-size=1 max-partition-size=4 beam-size=2
+new-index min-partition-size=1 max-partition-size=3 beam-size=2
 vec1: (1, 2)
 vec2: (7, 4)
 vec3: (4, 3)
 vec4: (-4, 5)
+vec5: (6, 1)
 vec1: (10, 5)
-vec1: (12, 7)
+vec1: (-2, -2)
 ----
-• 1 (2.7222, 4.2778)
+• 1 (3.8333, 3.6667)
 │
-├───• 2 (9.6667, 5.3333)
+├───• 2 (7.6667, 3.3333)
 │   │
+│   ├───• vec1 (-2, -2)
 │   ├───• vec2 (7, 4)
-│   ├───• vec1 (12, 7)
-│   └───• vec1 (12, 7)
+│   └───• vec5 (6, 1)
 │
-├───• 3 (2.5, 2.5)
-│   │
-│   ├───• vec1 (12, 7)
-│   └───• vec3 (4, 3)
-│
-└───• 4 (-4, 5)
+└───• 3 (0, 4)
     │
-    └───• vec4 (-4, 5)
+    ├───• vec4 (-4, 5)
+    ├───• vec3 (4, 3)
+    └───• vec1 (-2, -2)
 
 # Ensure that search result doesn't contain duplicates.
-search max-results=5
-(8, 9)
+search max-results=6
+(1, 1)
 ----
-vec1: 20 (centroid=1.5811)
-vec2: 26 (centroid=2.9814)
-vec3: 52 (centroid=1.5811)
-5 leaf vectors, 8 vectors, 3 full vectors, 3 partitions
+vec3: 13 (centroid=4.1231)
+vec1: 18 (centroid=2.8674)
+vec5: 25 (centroid=2.8674)
+vec4: 41 (centroid=4.1231)
+vec2: 45 (centroid=0.9428)
+6 leaf vectors, 8 vectors, 5 full vectors, 3 partitions
 
 # Do not rerank results. This may cause a different vec1 duplicate to be
 # returned.
-search max-results=5 skip-rerank
+search max-results=6 skip-rerank
 (8, 9)
 ----
-vec2: 26.3282 ±16.9822 (centroid=2.9814)
-vec3: 49.8042 ±19.0394 (centroid=1.5811)
-vec1: 100.1958 ±19.0394 (centroid=1.5811)
-5 leaf vectors, 8 vectors, 0 full vectors, 3 partitions
+vec3: 2.6557 ±55.0091 (centroid=4.1231)
+vec2: 23.4544 ±7.5686 (centroid=0.9428)
+vec5: 59.1248 ±23.019 (centroid=2.8674)
+vec4: 209.3443 ±55.0091 (centroid=4.1231)
+vec1: 294.9492 ±84.3801 (centroid=6.3246)
+6 leaf vectors, 8 vectors, 0 full vectors, 3 partitions

--- a/pkg/sql/vecindex/testdata/split.ddt
+++ b/pkg/sql/vecindex/testdata/split.ddt
@@ -1,0 +1,106 @@
+# Simple partition split cases.
+
+new-index min-partition-size=1 max-partition-size=4 beam-size=2
+----
+• 1 (0, 0)
+
+# Insert enough vectors in the store to trigger a split of the root.
+insert
+vec1: (1, 2)
+vec2: (7, 4)
+vec3: (4, 3)
+vec4: (8, 11)
+vec5: (14, 1)
+----
+• 1 (6.0833, 3.9167)
+│
+├───• 2 (2.5, 2.5)
+│   │
+│   ├───• vec1 (1, 2)
+│   └───• vec3 (4, 3)
+│
+└───• 3 (9.6667, 5.3333)
+    │
+    ├───• vec2 (7, 4)
+    ├───• vec4 (8, 11)
+    └───• vec5 (14, 1)
+
+# Trigger another split, this time of a child.
+insert
+vec6: (8, 6)
+vec7: (5, 8)
+----
+• 1 (6.0833, 3.9167)
+│
+├───• 2 (2.5, 2.5)
+│   │
+│   ├───• vec1 (1, 2)
+│   └───• vec3 (4, 3)
+│
+├───• 4 (9.6667, 3.6667)
+│   │
+│   ├───• vec2 (7, 4)
+│   ├───• vec6 (8, 6)
+│   └───• vec5 (14, 1)
+│
+└───• 5 (6.5, 9.5)
+    │
+    ├───• vec4 (8, 11)
+    └───• vec7 (5, 8)
+
+# Trigger another split that adds a level to the tree.
+insert
+vec8: (-2, -3)
+vec9: (4, 2)
+vec10: (3, 5)
+vec11: (3, 2)
+vec12: (4, 4)
+----
+• 1 (4.0694, 3.4028)
+│
+├───• 10 (6.5556, 5.8889)
+│   │
+│   ├───• 5 (6.5, 9.5)
+│   │   │
+│   │   ├───• vec4 (8, 11)
+│   │   └───• vec7 (5, 8)
+│   │
+│   ├───• 4 (9.6667, 3.6667)
+│   │   │
+│   │   ├───• vec2 (7, 4)
+│   │   ├───• vec6 (8, 6)
+│   │   └───• vec5 (14, 1)
+│   │
+│   └───• 8 (3.5, 4.5)
+│       │
+│       ├───• vec12 (4, 4)
+│       └───• vec10 (3, 5)
+│
+└───• 11 (1.5833, 0.9167)
+    │
+    ├───• 7 (-0.5, -0.5)
+    │   │
+    │   ├───• vec8 (-2, -3)
+    │   └───• vec1 (1, 2)
+    │
+    └───• 9 (3.6667, 2.3333)
+        │
+        ├───• vec3 (4, 3)
+        ├───• vec9 (4, 2)
+        └───• vec11 (3, 2)
+
+# Search for closest vectors with beam-size=1.
+search max-results=2 beam-size=1
+(1, 3)
+----
+vec11: 5 (centroid=0.7454)
+vec3: 9 (centroid=0.7454)
+3 leaf vectors, 7 vectors, 3 full vectors, 3 partitions
+
+# Search for closest vectors with beam-size=2.
+search max-results=2 beam-size=2
+(1, 3)
+----
+vec1: 1 (centroid=2.9155)
+vec11: 5 (centroid=0.7454)
+5 leaf vectors, 9 vectors, 4 full vectors, 4 partitions

--- a/pkg/sql/vecindex/vecstore/in_memory_store.go
+++ b/pkg/sql/vecindex/vecstore/in_memory_store.go
@@ -90,6 +90,7 @@ func (s *InMemoryStore) CommitTransaction(ctx context.Context, txn Txn) error {
 	case partitionLock:
 		s.txnLock.Unlock()
 	}
+	inMemTxn.lock = noLock
 	return nil
 }
 

--- a/pkg/sql/vecindex/vecstore/in_memory_store_test.go
+++ b/pkg/sql/vecindex/vecstore/in_memory_store_test.go
@@ -215,8 +215,8 @@ func TestInMemoryStore(t *testing.T) {
 			ctx, txn, []PartitionKey{partitionKey1, partitionKey2}, vector.T{3, 1}, &searchSet, partitionCounts)
 		require.NoError(t, err)
 		require.Equal(t, Level(1), level)
-		result4 := SearchResult{QuerySquaredDistance: 5, ErrorBound: 0, CentroidDistance: 5, ParentPartitionKey: 2, ChildKey: childKey30}
-		result5 := SearchResult{QuerySquaredDistance: 5, ErrorBound: 0, CentroidDistance: 4.61, ParentPartitionKey: 3, ChildKey: childKey50}
+		result4 := SearchResult{QuerySquaredDistance: 5, ErrorBound: 0, CentroidDistance: 2.24, ParentPartitionKey: 2, ChildKey: childKey10}
+		result5 := SearchResult{QuerySquaredDistance: 5, ErrorBound: 0, CentroidDistance: 5, ParentPartitionKey: 2, ChildKey: childKey30}
 		require.Equal(t, SearchResults{result4, result5}, roundResults(searchSet.PopResults(), 2))
 		require.Equal(t, []int{3, 2}, partitionCounts)
 	})

--- a/pkg/sql/vecindex/vecstore/partition.go
+++ b/pkg/sql/vecindex/vecstore/partition.go
@@ -138,11 +138,8 @@ func (p *Partition) Search(
 // Add quantizes the given vector as part of this partition. It returns false if
 // the vector is already in the partition.
 func (p *Partition) Add(ctx context.Context, vector vector.T, childKey ChildKey) bool {
-	for i := range p.childKeys {
-		if p.childKeys[i].Equal(childKey) {
-			// Child key is already in partition.
-			return false
-		}
+	if p.Find(childKey) != -1 {
+		return false
 	}
 
 	vectorSet := vector.AsSet()

--- a/pkg/sql/vecindex/vecstore/vecstorepb.go
+++ b/pkg/sql/vecindex/vecstore/vecstorepb.go
@@ -32,3 +32,18 @@ func (s *IndexStats) String() string {
 func (k ChildKey) Equal(other ChildKey) bool {
 	return k.PartitionKey == other.PartitionKey && bytes.Equal(k.PrimaryKey, other.PrimaryKey)
 }
+
+// Compare returns an integer comparing two child keys. The result is zero if
+// the two are equal, -1 if this key is less than the other, and +1 if this key
+// is greater than the other.
+func (k ChildKey) Compare(other ChildKey) int {
+	if k.PrimaryKey != nil {
+		return bytes.Compare(k.PrimaryKey, other.PrimaryKey)
+	}
+	if k.PartitionKey < other.PartitionKey {
+		return -1
+	} else if k.PartitionKey > other.PartitionKey {
+		return 1
+	}
+	return 0
+}

--- a/pkg/sql/vecindex/vecstore/vecstorepb_test.go
+++ b/pkg/sql/vecindex/vecstore/vecstorepb_test.go
@@ -25,4 +25,13 @@ func TestChildKey(t *testing.T) {
 	require.False(t, childKey3.Equal(childKey4))
 	require.False(t, childKey1.Equal(childKey5))
 	require.False(t, childKey4.Equal(childKey5))
+
+	// Compare method.
+	require.Equal(t, 0, childKey1.Compare(childKey1))
+	require.Equal(t, -1, childKey1.Compare(childKey2))
+	require.Equal(t, 1, childKey2.Compare(childKey1))
+
+	require.Equal(t, 0, childKey3.Compare(childKey3))
+	require.Equal(t, -1, childKey3.Compare(childKey4))
+	require.Equal(t, 1, childKey4.Compare(childKey3))
 }

--- a/pkg/sql/vecindex/vector_index_test.go
+++ b/pkg/sql/vecindex/vector_index_test.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math/rand"
 	"strconv"
 	"strings"
 	"testing"
@@ -18,10 +17,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/quantize"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/testutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecstore"
-	"github.com/cockroachdb/cockroach/pkg/util/num32"
 	"github.com/cockroachdb/cockroach/pkg/util/vector"
 	"github.com/cockroachdb/datadriven"
-	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,6 +41,9 @@ func TestDataDriven(t *testing.T) {
 			case "search":
 				return state.Search(d)
 
+			case "insert":
+				return state.Insert(d)
+
 			case "delete":
 				return state.Delete(d)
 			}
@@ -60,35 +60,29 @@ type testState struct {
 	Quantizer  quantize.Quantizer
 	InMemStore *vecstore.InMemoryStore
 	Index      *VectorIndex
+	Options    VectorIndexOptions
 	Features   vector.Set
 }
 
 func (s *testState) NewIndex(d *datadriven.TestData) string {
 	var err error
 	dims := 2
-	hideTree := false
-	count := 0
-	options := VectorIndexOptions{}
+	s.Options = VectorIndexOptions{Seed: 42}
 	for _, arg := range d.CmdArgs {
 		switch arg.Key {
 		case "min-partition-size":
 			require.Len(s.T, arg.Vals, 1)
-			options.MinPartitionSize, err = strconv.Atoi(arg.Vals[0])
+			s.Options.MinPartitionSize, err = strconv.Atoi(arg.Vals[0])
 			require.NoError(s.T, err)
 
 		case "max-partition-size":
 			require.Len(s.T, arg.Vals, 1)
-			options.MaxPartitionSize, err = strconv.Atoi(arg.Vals[0])
+			s.Options.MaxPartitionSize, err = strconv.Atoi(arg.Vals[0])
 			require.NoError(s.T, err)
 
 		case "quality-samples":
 			require.Len(s.T, arg.Vals, 1)
-			options.QualitySamples, err = strconv.Atoi(arg.Vals[0])
-			require.NoError(s.T, err)
-
-		case "load-features":
-			require.Len(s.T, arg.Vals, 1)
-			count, err = strconv.Atoi(arg.Vals[0])
+			s.Options.QualitySamples, err = strconv.Atoi(arg.Vals[0])
 			require.NoError(s.T, err)
 
 		case "dims":
@@ -98,69 +92,23 @@ func (s *testState) NewIndex(d *datadriven.TestData) string {
 
 		case "beam-size":
 			require.Len(s.T, arg.Vals, 1)
-			options.BaseBeamSize, err = strconv.Atoi(arg.Vals[0])
+			s.Options.BaseBeamSize, err = strconv.Atoi(arg.Vals[0])
 			require.NoError(s.T, err)
-
-		case "hide-tree":
-			require.Len(s.T, arg.Vals, 0)
-			hideTree = true
 		}
 	}
 
 	s.Quantizer = quantize.NewRaBitQuantizer(dims, 42)
 	s.InMemStore = vecstore.NewInMemoryStore(dims, 42)
-	s.Index, err = NewVectorIndex(s.Ctx, s.InMemStore, s.Quantizer, &options)
+	s.Index, err = NewVectorIndex(s.Ctx, s.InMemStore, s.Quantizer, &s.Options)
 	require.NoError(s.T, err)
-
-	txn := beginTransaction(s.Ctx, s.T, s.InMemStore)
-	defer commitTransaction(s.Ctx, s.T, s.InMemStore, txn)
 
 	// Insert empty root partition.
+	txn := beginTransaction(s.Ctx, s.T, s.InMemStore)
 	require.NoError(s.T, s.Index.CreateRoot(s.Ctx, txn))
+	commitTransaction(s.Ctx, s.T, s.InMemStore, txn)
 
-	vectors := vector.MakeSet(dims)
-	childKeys := make([]vecstore.ChildKey, 0, count)
-	if count != 0 {
-		// Load features.
-		s.Features = testutils.LoadFeatures(s.T, 10000)
-		vectors = s.Features
-		vectors.SplitAt(count)
-		for i := 0; i < count; i++ {
-			key := vecstore.PrimaryKey(fmt.Sprintf("vec%d", i))
-			childKeys = append(childKeys, vecstore.ChildKey{PrimaryKey: key})
-		}
-	} else {
-		// Parse vectors.
-		for _, line := range strings.Split(d.Input, "\n") {
-			line = strings.TrimSpace(line)
-			if len(line) == 0 {
-				continue
-			}
-			parts := strings.Split(line, ":")
-			require.Len(s.T, parts, 2)
-
-			vectors.Add(s.parseVector(parts[1]))
-			key := vecstore.PrimaryKey(parts[0])
-			childKeys = append(childKeys, vecstore.ChildKey{PrimaryKey: key})
-		}
-	}
-
-	// Insert vectors into the store.
-	for i := 0; i < vectors.Count; i++ {
-		s.InMemStore.InsertVector(txn, childKeys[i].PrimaryKey, vectors.At(i))
-	}
-
-	// Build the tree, bottom-up.
-	s.buildTree(txn, vectors, childKeys, options.MaxPartitionSize)
-
-	if hideTree {
-		return fmt.Sprintf("Created index with %d vectors with %d dimensions.\n",
-			vectors.Count, vectors.Dims)
-	}
-
-	tree, err := s.Index.Format(s.Ctx, txn, FormatOptions{PrimaryKeyStrings: true})
-	require.NoError(s.T, err)
-	return tree
+	// Insert initial vectors.
+	return s.Insert(d)
 }
 
 func (s *testState) FormatTree(d *datadriven.TestData) string {
@@ -234,6 +182,76 @@ func (s *testState) Search(d *datadriven.TestData) string {
 	return buf.String()
 }
 
+func (s *testState) Insert(d *datadriven.TestData) string {
+	var err error
+	hideTree := false
+	count := 0
+	for _, arg := range d.CmdArgs {
+		switch arg.Key {
+		case "load-features":
+			require.Len(s.T, arg.Vals, 1)
+			count, err = strconv.Atoi(arg.Vals[0])
+			require.NoError(s.T, err)
+
+		case "hide-tree":
+			require.Len(s.T, arg.Vals, 0)
+			hideTree = true
+		}
+	}
+
+	vectors := vector.MakeSet(s.Quantizer.GetRandomDims())
+	childKeys := make([]vecstore.ChildKey, 0, count)
+	if count != 0 {
+		// Load features.
+		s.Features = testutils.LoadFeatures(s.T, 10000)
+		vectors = s.Features
+		vectors.SplitAt(count)
+		for i := 0; i < count; i++ {
+			key := vecstore.PrimaryKey(fmt.Sprintf("vec%d", i))
+			childKeys = append(childKeys, vecstore.ChildKey{PrimaryKey: key})
+		}
+	} else {
+		// Parse vectors.
+		for _, line := range strings.Split(d.Input, "\n") {
+			line = strings.TrimSpace(line)
+			if len(line) == 0 {
+				continue
+			}
+			parts := strings.Split(line, ":")
+			require.Len(s.T, parts, 2)
+
+			vectors.Add(s.parseVector(parts[1]))
+			key := vecstore.PrimaryKey(parts[0])
+			childKeys = append(childKeys, vecstore.ChildKey{PrimaryKey: key})
+		}
+	}
+
+	// Insert vectors into the store.
+	for i := 0; i < vectors.Count; i++ {
+		// Insert within the scope of a transaction.
+		txn := beginTransaction(s.Ctx, s.T, s.InMemStore)
+		s.InMemStore.InsertVector(txn, childKeys[i].PrimaryKey, vectors.At(i))
+		require.NoError(s.T, s.Index.Insert(s.Ctx, txn, vectors.At(i), childKeys[i].PrimaryKey))
+		commitTransaction(s.Ctx, s.T, s.InMemStore, txn)
+
+		if (i+1)%s.Options.MaxPartitionSize == 0 {
+			// Periodically, run synchronous fixups so that test results are
+			// deterministic.
+			require.NoError(s.T, s.Index.fixups.runAll(s.Ctx))
+		}
+	}
+
+	// Handle any remaining fixups.
+	require.NoError(s.T, s.Index.fixups.runAll(s.Ctx))
+
+	if hideTree {
+		return fmt.Sprintf("Created index with %d vectors with %d dimensions.\n",
+			vectors.Count, vectors.Dims)
+	}
+
+	return s.FormatTree(d)
+}
+
 func (s *testState) Delete(d *datadriven.TestData) string {
 	notFound := false
 	for _, arg := range d.CmdArgs {
@@ -271,86 +289,6 @@ func (s *testState) Delete(d *datadriven.TestData) string {
 	return tree
 }
 
-// buildTree uses the K-means++ algorithm to build a K-means tree. Unlike the
-// incremental algorithm, this builds the tree from the complete set of initial
-// vectors. To start, the leaf level is built from the input vectors, with the
-// number of partitions derived from "maxPartitionSize". Once the leaf level has
-// been partitioned, the next higher level is built from the centroids of the
-// leaf partitions. And so on, up to the root of the tree.
-//
-// TODO(andyk): Use the incremental algorithm instead, once it's ready. This
-// alternate implementation is useful for testing and benchmarking. How much
-// more accurate is it than the incremental version?
-func (s *testState) buildTree(
-	txn vecstore.Txn, vectors vector.Set, childKeys []vecstore.ChildKey, maxPartitionSize int,
-) {
-	rng := rand.New(rand.NewSource(42))
-	level := vecstore.LeafLevel
-
-	// Randomize vectors.
-	randomized := vector.MakeSet(vectors.Dims)
-	randomized.AddUndefined(vectors.Count)
-	for i := 0; i < vectors.Count; i++ {
-		s.Quantizer.RandomizeVector(s.Ctx, vectors.At(i), randomized.At(i), false /* invert */)
-	}
-
-	// Partition each level of the tree.
-	for randomized.Count > maxPartitionSize {
-		n := randomized.Count * 2 / maxPartitionSize
-		randomized, childKeys = s.partitionVectors(txn, level, randomized, childKeys, n, rng)
-		level++
-	}
-
-	unQuantizer := quantize.NewUnQuantizer(randomized.Dims)
-	quantizedSet := unQuantizer.Quantize(s.Ctx, &randomized)
-	root := vecstore.NewPartition(unQuantizer, quantizedSet, childKeys, level)
-	err := s.InMemStore.SetRootPartition(s.Ctx, txn, root)
-	require.NoError(s.T, err)
-}
-
-// partitionVectors partitions the given full-size vectors at one level of the
-// tree using the K-means++ algorithm.
-func (s *testState) partitionVectors(
-	txn vecstore.Txn,
-	level vecstore.Level,
-	vectors vector.Set,
-	childKeys []vecstore.ChildKey,
-	numPartitions int,
-	rng *rand.Rand,
-) (centroids vector.Set, partitionKeys []vecstore.ChildKey) {
-	centroids = vector.MakeSet(vectors.Dims)
-	centroids.AddUndefined(numPartitions)
-	partitionKeys = make([]vecstore.ChildKey, numPartitions)
-
-	// Run K-means on the input vectors.
-	km := kmeans{Rand: rng}
-	partitionOffsets := make([]uint64, vectors.Count)
-	km.Partition(s.Ctx, &vectors, &centroids, partitionOffsets)
-
-	// Construct the partitions and insert them into the store.
-	tempVectors := vector.MakeSet(vectors.Dims)
-	for partitionIdx := 0; partitionIdx < numPartitions; partitionIdx++ {
-		var partitionChildKeys []vecstore.ChildKey
-		for vectorIdx := 0; vectorIdx < vectors.Count; vectorIdx++ {
-			if partitionIdx == int(partitionOffsets[vectorIdx]) {
-				tempVectors.Add(vectors.At(vectorIdx))
-				partitionChildKeys = append(partitionChildKeys, childKeys[vectorIdx])
-			}
-		}
-
-		quantizedSet := s.Quantizer.Quantize(s.Ctx, &tempVectors)
-		partition := vecstore.NewPartition(s.Quantizer, quantizedSet, partitionChildKeys, level)
-
-		partitionKey, err := s.InMemStore.InsertPartition(s.Ctx, txn, partition)
-		require.NoError(s.T, err)
-		partitionKeys[partitionIdx] = vecstore.ChildKey{PartitionKey: partitionKey}
-
-		tempVectors.Clear()
-	}
-
-	return centroids, partitionKeys
-}
-
 // parseVector parses a vector string in this form: (1.5, 6, -4).
 func (s *testState) parseVector(str string) vector.T {
 	// Remove parentheses and split by commas.
@@ -378,176 +316,6 @@ func formatFloat(value float32) string {
 		s = strings.TrimRight(s, ".")
 	}
 	return s
-}
-
-// kmeans implements the K-means++ algorithm:
-// http://ilpubs.stanford.edu:8090/778/1/2006-13.pdf
-type kmeans struct {
-	MaxIterations int
-	Rand          *rand.Rand
-
-	workspace    *internal.Workspace
-	vectors      *vector.Set
-	oldCentroids *vector.Set
-	newCentroids *vector.Set
-	partitions   []uint64
-}
-
-// Partition divides the input vectors into partitions. The caller is expected
-// to allocate the "centroids" set with length equal to the desired number of
-// partitions. Partition will write the centroid of each calculated partition
-// into the set. In addition, the caller allocates the "partitions" slice with
-// length equal to the number of input vectors. For each input vector, Partition
-// will write the index of its partition into the corresponding entry in
-// "partitions".
-func (km *kmeans) Partition(
-	ctx context.Context, vectors *vector.Set, centroids *vector.Set, partitions []uint64,
-) {
-	if vectors.Count != len(partitions) {
-		panic(errors.AssertionFailedf("vector count %d cannot be different than partitions length %d",
-			vectors.Count, len(partitions)))
-	}
-
-	km.workspace = internal.WorkspaceFromContext(ctx)
-	km.vectors = vectors
-	km.newCentroids = centroids
-	km.partitions = partitions
-
-	tempOldCentroids := km.workspace.AllocVectorSet(centroids.Count, vectors.Dims)
-	defer km.workspace.FreeVectorSet(tempOldCentroids)
-	km.oldCentroids = &tempOldCentroids
-
-	km.selectInitialCentroids()
-
-	maxIterations := km.MaxIterations
-	if maxIterations == 0 {
-		maxIterations = 32
-	}
-
-	for i := 0; i < maxIterations; i++ {
-		km.computeNewCentroids()
-
-		// Check if algorithm has converged.
-		done := true
-		for centroidIdx := 0; centroidIdx < km.oldCentroids.Count; centroidIdx++ {
-			distance := num32.L2SquaredDistance(
-				km.oldCentroids.At(centroidIdx), km.newCentroids.At(centroidIdx))
-			if distance > 1e-4 {
-				done = false
-				break
-			}
-		}
-		if done {
-			break
-		}
-
-		// Swap old and new centroid slices.
-		km.oldCentroids, km.newCentroids = km.newCentroids, km.oldCentroids
-
-		// Re-assign vectors to one of the partitions.
-		km.assignPartitions()
-	}
-}
-
-// assignPartitions re-assigns each input vector to the partition with the
-// closest centroid in "km.oldCentroids".
-func (km *kmeans) assignPartitions() {
-	vectorCount := km.vectors.Count
-	centroidCount := km.oldCentroids.Count
-
-	// Add vectors in each partition.
-	for vecIdx := 0; vecIdx < vectorCount; vecIdx++ {
-		var shortest float32
-		shortestIdx := -1
-		for centroidIdx := 0; centroidIdx < centroidCount; centroidIdx++ {
-			distance := num32.L2SquaredDistance(km.vectors.At(vecIdx), km.oldCentroids.At(centroidIdx))
-			if shortestIdx == -1 || distance < shortest {
-				shortest = distance
-				shortestIdx = centroidIdx
-			}
-		}
-		km.partitions[vecIdx] = uint64(shortestIdx)
-	}
-}
-
-// computeNewCentroids calculates a new centroid for each partition from the
-// vectors that have been assigned to that partition, and stores the resulting
-// centroids in "km.newCentroids".
-func (km *kmeans) computeNewCentroids() {
-	centroidCount := km.newCentroids.Count
-	vectorCount := km.vectors.Count
-
-	tempPartitionCounts := km.workspace.AllocUint64s(centroidCount)
-	defer km.workspace.FreeUint64s(tempPartitionCounts)
-	for i := 0; i < centroidCount; i++ {
-		tempPartitionCounts[i] = 0
-	}
-
-	// Calculate new centroids.
-	num32.Zero(km.newCentroids.Data)
-	for vecIdx := 0; vecIdx < vectorCount; vecIdx++ {
-		centroidIdx := int(km.partitions[vecIdx])
-		num32.Add(km.newCentroids.At(centroidIdx), km.vectors.At(vecIdx))
-		tempPartitionCounts[centroidIdx]++
-	}
-
-	// Divide each centroid by the count of vectors in its partition.
-	for centroidIdx := 0; centroidIdx < centroidCount; centroidIdx++ {
-		num32.Scale(1.0/float32(tempPartitionCounts[centroidIdx]), km.newCentroids.At(centroidIdx))
-	}
-}
-
-// selectInitialCentroids sets "km.oldCentroids" to random input vectors chosen
-// using the K-means++ algorithm.
-func (km *kmeans) selectInitialCentroids() {
-	count := km.vectors.Count
-	tempVectorDistances := km.workspace.AllocFloats(count)
-	defer km.workspace.FreeFloats(tempVectorDistances)
-
-	// Randomly select the first centroid from the vector set.
-	var offset int
-	if km.Rand != nil {
-		offset = km.Rand.Intn(count)
-	} else {
-		offset = rand.Intn(count)
-	}
-	copy(km.oldCentroids.At(0), km.vectors.At(offset))
-
-	selected := 0
-	for selected < km.oldCentroids.Count {
-		// Calculate shortest distance from each vector to one of the already
-		// selected centroids.
-		var distanceSum float32
-		for vecIdx := 0; vecIdx < count; vecIdx++ {
-			distance := num32.L2SquaredDistance(km.vectors.At(vecIdx), km.oldCentroids.At(selected))
-			if selected == 0 || distance < tempVectorDistances[vecIdx] {
-				tempVectorDistances[vecIdx] = distance
-				km.partitions[vecIdx] = uint64(selected)
-			}
-			distanceSum += tempVectorDistances[vecIdx]
-		}
-
-		// Calculate probability of each vector becoming the next centroid, with
-		// the probability being proportional to the vector's shortest distance
-		// to one of the already selected centroids.
-		var cum, rnd float32
-		if km.Rand != nil {
-			rnd = km.Rand.Float32() * distanceSum
-		} else {
-			rnd = rand.Float32() * distanceSum
-		}
-		offset = 0
-		for offset < len(tempVectorDistances) {
-			cum += tempVectorDistances[offset]
-			if rnd < cum {
-				break
-			}
-			offset++
-		}
-
-		selected++
-		copy(km.oldCentroids.At(selected), km.vectors.At(offset))
-	}
 }
 
 func beginTransaction(ctx context.Context, t *testing.T, store vecstore.Store) vecstore.Txn {


### PR DESCRIPTION
Add support for inserting new vectors into the vector index, as well as the ability to split partitions. A new "fixup processor" enqueues split operations. In the future, it will run in the background and asynchronously process the queue of operations. For now, tests process the operations synchronously, so that they are deterministic.

Epic: CRDB-42943

Release note: None