### PR TITLE
backupccl: clean up old backup syntax code

### DIFF
--- a/pkg/ccl/backupccl/alter_backup_schedule.go
+++ b/pkg/ccl/backupccl/alter_backup_schedule.go
@@ -240,8 +240,7 @@ func emitAlteredSchedule(
 	for i, incDest := range stmt.Options.IncrementalStorage {
 		incDests[i] = tree.AsStringWithFlags(incDest, tree.FmtBareStrings|tree.FmtShowFullURIs)
 	}
-	if err := emitSchedule(job, stmt, to, nil, /* incrementalFrom */
-		kmsURIs, incDests, resultsCh); err != nil {
+	if err := emitSchedule(job, stmt, to, kmsURIs, incDests, resultsCh); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -614,12 +614,12 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	defaultURI := details.URI
 	var backupDest backupdest.ResolvedDestination
 	if details.URI == "" {
-		// Choose which scheduled backup pts we will update at the the end of the
+		// Choose which scheduled backup pts we will update at the end of the
 		// backup _before_ we resolve the destination of the backup. This avoids a
 		// race with inc backups where backup destination resolution leads this backup
 		// to extend a chain that is about to be superseded by a new full backup
 		// chain, which could cause this inc to accidentally push the pts for the
-		// _new_ chain instead of the old chain it is apart of. By choosing the pts to
+		// _new_ chain instead of the old chain it is a part of. By choosing the pts to
 		// move before we resolve the destination, we guarantee that we push the old
 		// chain.
 		insqlDB := p.ExecCfg().InternalDB
@@ -630,8 +630,7 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		}
 
 		var err error
-		backupDest, err = backupdest.ResolveDest(ctx, p.User(), details.Destination, details.EndTime,
-			details.IncrementalFrom, p.ExecCfg())
+		backupDest, err = backupdest.ResolveDest(ctx, p.User(), details.Destination, details.EndTime, p.ExecCfg())
 		if err != nil {
 			return err
 		}
@@ -1069,9 +1068,7 @@ func collectTelemetry(
 		countSource("backup.span.incremental")
 		telemetry.CountBucketed("backup.incremental-span-sec",
 			int64(backupDetails.EndTime.GoTime().Sub(backupDetails.StartTime.GoTime()).Seconds()))
-		if len(initialDetails.IncrementalFrom) == 0 {
-			countSource("backup.auto-incremental")
-		}
+		countSource("backup.auto-incremental")
 	}
 	if len(backupDetails.URIsByLocalityKV) > 1 {
 		countSource("backup.partitioned")

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -723,7 +723,7 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 		"BACKUP INTO LATEST IN $4 WITH incremental_location=($1, $2, $3)",
 		append(incrementals, collections[0])...)
 
-	sqlDB.ExpectErr(t, "A full backup cannot be written to \"/subdir\", a user defined subdirectory. To take a full backup, remove the subdirectory from the backup command",
+	sqlDB.ExpectErr(t, "No full backup exists in \"/subdir\" to append an incremental backup to. To take a full backup, remove the subdirectory from the backup command",
 		"BACKUP INTO $4 IN ($1, $2, $3)", append(collections, "subdir")...)
 
 	time.Sleep(time.Second + 2)

--- a/pkg/ccl/backupccl/backupdest/BUILD.bazel
+++ b/pkg/ccl/backupccl/backupdest/BUILD.bazel
@@ -64,7 +64,6 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/randutil",
-        "//pkg/util/timeutil",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/ccl/backupccl/backuppb/backup.go
+++ b/pkg/ccl/backupccl/backuppb/backup.go
@@ -117,20 +117,6 @@ func (m ScheduledBackupExecutionArgs) MarshalJSONPB(marshaller *jsonpb.Marshaler
 		backup.To[i] = tree.NewDString(clean)
 	}
 
-	// NB: this will never be non-nil with current schedule syntax but is here for
-	// completeness.
-	for i := range backup.IncrementalFrom {
-		raw, ok := backup.IncrementalFrom[i].(*tree.StrVal)
-		if !ok {
-			return nil, errors.Errorf("unexpected %T arg in backup schedule: %v", raw, raw)
-		}
-		clean, err := cloud.SanitizeExternalStorageURI(raw.RawString(), nil /* extraParams */)
-		if err != nil {
-			return nil, err
-		}
-		backup.IncrementalFrom[i] = tree.NewDString(clean)
-	}
-
 	for i := range backup.Options.IncrementalStorage {
 		raw, ok := backup.Options.IncrementalStorage[i].(*tree.StrVal)
 		if !ok {

--- a/pkg/ccl/backupccl/schedule_exec.go
+++ b/pkg/ccl/backupccl/schedule_exec.go
@@ -321,7 +321,6 @@ func (e *scheduledBackupExecutor) GetCreateScheduleStatement(
 	redactedBackupNode, err := GetRedactedBackupNode(
 		backupNode.Backup,
 		destinations,
-		nil, /* incrementalFrom */
 		kmsURIs,
 		"",
 		nil,

--- a/pkg/internal/sqlsmith/bulkio.go
+++ b/pkg/internal/sqlsmith/bulkio.go
@@ -111,7 +111,6 @@ func makeBackup(s *Smither) (tree.Statement, bool) {
 	}
 
 	return &tree.Backup{
-		Nested:  true,
 		Targets: &targets,
 		To:      tree.StringOrPlaceholderOptList{tree.NewStrVal(name)},
 		AsOf:    makeAsOf(s),

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -398,7 +398,7 @@ message BackupDetails {
   SchedulePTSChainingRecord schedule_pts_chaining_record = 10 [(gogoproto.customname) = "SchedulePTSChainingRecord"];
 
   bool revision_history = 13;
-  repeated string incremental_from = 14;
+  reserved 14;
   bool full_cluster = 15;
 
   reserved 16;

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3359,7 +3359,6 @@ backup_stmt:
     $$.val = &tree.Backup{
       Targets: $2.backupTargetListPtr(),
       To: $6.stringOrPlaceholderOptList(),
-      Nested: true,
       AppendToLatest: false,
       Subdir: $4.expr(),
       AsOf: $7.asOfClause(),
@@ -3371,7 +3370,6 @@ backup_stmt:
     $$.val = &tree.Backup{
       Targets: $2.backupTargetListPtr(),
       To: $4.stringOrPlaceholderOptList(),
-      Nested: true,
       AsOf: $5.asOfClause(),
       Options: *$6.backupOptions(),
     }
@@ -3381,7 +3379,6 @@ backup_stmt:
     $$.val = &tree.Backup{
       Targets: $2.backupTargetListPtr(),
       To: $6.stringOrPlaceholderOptList(),
-      Nested: true,
       AppendToLatest: true,
       AsOf: $7.asOfClause(),
       Options: *$8.backupOptions(),

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -55,24 +55,17 @@ type Backup struct {
 	// the docs).
 	To StringOrPlaceholderOptList
 
-	// IncrementalFrom is only set for the old 'BACKUP .... TO ...' syntax.
-	IncrementalFrom Exprs
-
 	AsOf    AsOfClause
 	Options BackupOptions
-
-	// Nested is set to true when the user creates a backup with
-	//`BACKUP ... INTO... ` syntax.
-	Nested bool
 
 	// AppendToLatest is set to true if the user creates a backup with
 	//`BACKUP...INTO LATEST...`
 	AppendToLatest bool
 
 	// Subdir may be set by the parser when the SQL query is of the form `BACKUP
-	// INTO 'subdir' IN...`. Alternatively, if Nested is true but a subdir was not
-	// explicitly specified by the user, then this will be set during BACKUP
-	// planning once the destination has been resolved.
+	// INTO 'subdir' IN...`. Alternatively, if a subdir was not explicitly specified
+	// by the user, then this will be set during BACKUP planning once the destination
+	// has been resolved.
 	Subdir Expr
 }
 
@@ -85,30 +78,17 @@ func (node *Backup) Format(ctx *FmtCtx) {
 		ctx.FormatNode(node.Targets)
 		ctx.WriteString(" ")
 	}
-	if node.Nested {
-		ctx.WriteString("INTO ")
-		if node.Subdir != nil {
-			ctx.FormatNode(node.Subdir)
-			ctx.WriteString(" IN ")
-		} else if node.AppendToLatest {
-			ctx.WriteString("LATEST IN ")
-		}
-	} else {
-		ctx.WriteString("TO ")
+	ctx.WriteString("INTO ")
+	if node.Subdir != nil {
+		ctx.FormatNode(node.Subdir)
+		ctx.WriteString(" IN ")
+	} else if node.AppendToLatest {
+		ctx.WriteString("LATEST IN ")
 	}
 	ctx.FormatURIs(node.To)
 	if node.AsOf.Expr != nil {
 		ctx.WriteString(" ")
 		ctx.FormatNode(&node.AsOf)
-	}
-	if node.IncrementalFrom != nil {
-		ctx.WriteString(" INCREMENTAL FROM ")
-		for i, from := range node.IncrementalFrom {
-			if i > 0 {
-				ctx.WriteString(", ")
-			}
-			ctx.FormatURI(from)
-		}
 	}
 
 	if !node.Options.IsDefault() {

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -2155,24 +2155,17 @@ func (node *Backup) doc(p *PrettyCfg) pretty.Doc {
 	if node.Targets != nil {
 		items = append(items, node.Targets.docRow(p))
 	}
-	if node.Nested {
-		if node.Subdir != nil {
-			items = append(items, p.row("INTO ", p.Doc(node.Subdir)))
-			items = append(items, p.row(" IN ", p.Doc(&node.To)))
-		} else if node.AppendToLatest {
-			items = append(items, p.row("INTO LATEST IN", p.Doc(&node.To)))
-		} else {
-			items = append(items, p.row("INTO", p.Doc(&node.To)))
-		}
+	if node.Subdir != nil {
+		items = append(items, p.row("INTO ", p.Doc(node.Subdir)))
+		items = append(items, p.row(" IN ", p.Doc(&node.To)))
+	} else if node.AppendToLatest {
+		items = append(items, p.row("INTO LATEST IN", p.Doc(&node.To)))
 	} else {
-		items = append(items, p.row("TO", p.Doc(&node.To)))
+		items = append(items, p.row("INTO", p.Doc(&node.To)))
 	}
 
 	if node.AsOf.Expr != nil {
 		items = append(items, node.AsOf.docRow(p))
-	}
-	if node.IncrementalFrom != nil {
-		items = append(items, p.row("INCREMENTAL FROM", p.Doc(&node.IncrementalFrom)))
 	}
 	if !node.Options.IsDefault() {
 		items = append(items, p.row("WITH", p.Doc(&node.Options)))

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -1265,7 +1265,6 @@ func (n *DropTenant) walkStmt(v Visitor) Statement {
 // copyNode makes a copy of this Statement without recursing in any child Statements.
 func (stmt *Backup) copyNode() *Backup {
 	stmtCopy := *stmt
-	stmtCopy.IncrementalFrom = append(Exprs(nil), stmt.IncrementalFrom...)
 	return &stmtCopy
 }
 
@@ -1290,15 +1289,7 @@ func (stmt *Backup) walkStmt(v Visitor) Statement {
 			ret.To[i] = e
 		}
 	}
-	for i, expr := range stmt.IncrementalFrom {
-		e, changed := WalkExpr(v, expr)
-		if changed {
-			if ret == stmt {
-				ret = stmt.copyNode()
-			}
-			ret.IncrementalFrom[i] = e
-		}
-	}
+
 	if stmt.Options.EncryptionPassphrase != nil {
 		pw, changed := WalkExpr(v, stmt.Options.EncryptionPassphrase)
 		if changed {


### PR DESCRIPTION
The old backup syntax was fully removed in #133610. This commit removes all the old code that ran for the old syntax.

Epic: none

Release note: none