### PR TITLE
kvserver: crash a node if we detect an inconsistent lease

### DIFF
--- a/pkg/kv/kvserver/kvserverbase/forced_error.go
+++ b/pkg/kv/kvserver/kvserverbase/forced_error.go
@@ -129,7 +129,20 @@ func CheckForcedErr(
 			// It is only possible for this to fail when expiration-based
 			// lease extensions are proposed concurrently.
 			expToEpochEquiv := raftCmd.ReplicatedEvalResult.IsLeaseRequestWithExpirationToEpochEquivalent
-			leaseMismatch = !replicaState.Lease.Equivalent(requestedLease, expToEpochEquiv)
+			if !replicaState.Lease.Equivalent(requestedLease, expToEpochEquiv) {
+				if !replicaState.Lease.Start.Equal(requestedLease.Start) {
+					// It should never be possible for two leases to have the same
+					// sequence numbers but different start times. This would mean that
+					// the replica that committed the lease has a different view of the
+					// previous lease than us, as otherwise it wouldn't have assigned it
+					// this sequence number.
+					log.Fatalf(ctx,
+						"current lease %s has the same sequence number as committed lease %s; but start times differ",
+						replicaState.Lease, requestedLease,
+					)
+				}
+				leaseMismatch = true
+			}
 		}
 
 		// This is a check to see if the lease we proposed this lease request


### PR DESCRIPTION
We can't make strong equivalency claims about leases with the same sequence numbers, as two leases that are equivalent to a third lease may not be equivalent to each other. We therefore discard leases in CheckForcedErr, to prevent lease regressions in cases where proposals are re-ordered.

However, one claim we can make is that we should never have two leases with the same sequence number but different start times. If we find this to be the case, we can conclude that the replica that proposed the lease must have an inconsistent view of the lease compared to ours. We should crash the node proactively in such cases.

Informs https://github.com/cockroachdb/cockroach/issues/134640

Release note: None