### PR TITLE
ttljob: update fraction completed in TTL job

### DIFF
--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1276,8 +1276,8 @@ message RowLevelTTLDetails {
 
 message RowLevelTTLProgress {
 
-  // JobRowCount is the number of deleted rows for the entire TTL job.
-  int64 job_row_count = 1;
+  // JobDeletedRowCount is the number of rows deleted by TTL job so far.
+  int64 job_deleted_row_count = 1;
 
   // ProcessorProgresses is the progress per DistSQL processor.
   repeated RowLevelTTLProcessorProgress processor_progresses = 2 [(gogoproto.nullable)=false];

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1285,8 +1285,12 @@ message RowLevelTTLProgress {
   // UseDistSQL is no longer used in v23.1+ as all TTL jobs are using DistSQL.
   reserved 3;
 
-  // JobSpanCount is the number of spans for the entire TTL job.
-  int64 job_span_count = 4;
+  // JobTotalSpanCount is the number of spans for the entire TTL job.
+  int64 job_total_span_count = 4;
+
+  // JobProcessedSpanCount is the number of spans that have been processed by
+  // the TTL job so far.
+  int64 job_processed_span_count = 5;
 }
 
 message RowLevelTTLProcessorProgress {

--- a/pkg/sql/ttl/ttljob/ttljob.go
+++ b/pkg/sql/ttl/ttljob/ttljob.go
@@ -214,7 +214,7 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) (re
 			func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
 				progress := md.Progress
 				rowLevelTTL := progress.Details.(*jobspb.Progress_RowLevelTTL).RowLevelTTL
-				rowLevelTTL.JobSpanCount = int64(jobSpanCount)
+				rowLevelTTL.JobTotalSpanCount = int64(jobSpanCount)
 				ju.UpdateProgress(progress)
 				return nil
 			},

--- a/pkg/sql/ttl/ttljob/ttljob_processor.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor.go
@@ -187,8 +187,8 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 				progress := md.Progress
 				rowLevelTTL := progress.Details.(*jobspb.Progress_RowLevelTTL).RowLevelTTL
 				rowLevelTTL.JobProcessedSpanCount += spansToAdd
-				rowLevelTTL.JobRowCount += rowsToAdd
-				jobRowCount = rowLevelTTL.JobRowCount
+				rowLevelTTL.JobDeletedRowCount += rowsToAdd
+				jobRowCount = rowLevelTTL.JobDeletedRowCount
 				jobSpanCount = rowLevelTTL.JobTotalSpanCount
 
 				fractionCompleted = float32(rowLevelTTL.JobProcessedSpanCount) / float32(rowLevelTTL.JobTotalSpanCount)
@@ -336,7 +336,7 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 				ctx,
 				2, /* level */
 				"TTL processorRowCount updated processorID=%d sqlInstanceID=%d tableID=%d jobRowCount=%d processorRowCount=%d fractionCompleted=%.3f",
-				processorID, sqlInstanceID, tableID, rowLevelTTL.JobRowCount, processorRowCount.Load(), fractionCompleted,
+				processorID, sqlInstanceID, tableID, rowLevelTTL.JobDeletedRowCount, processorRowCount.Load(), fractionCompleted,
 			)
 			return nil
 		},

--- a/pkg/sql/ttl/ttljob/ttljob_processor.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor.go
@@ -166,6 +166,52 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 		processorConcurrency = processorSpanCount
 	}
 	var processorRowCount atomic.Int64
+	var spansProccessedSinceLastUpdate atomic.Int64
+	var rowsProccessedSinceLastUpdate atomic.Int64
+
+	// Update progress for approximately every 1% of spans processed.
+	updateEvery := max(1, processorSpanCount/100)
+	updateFractionCompleted := func() error {
+		jobID := ttlSpec.JobID
+		spansToAdd := spansProccessedSinceLastUpdate.Swap(0)
+		rowsToAdd := rowsProccessedSinceLastUpdate.Swap(0)
+
+		var jobRowCount, jobSpanCount int64
+		var fractionCompleted float32
+
+		err := jobRegistry.UpdateJobWithTxn(
+			ctx,
+			jobID,
+			nil, /* txn */
+			func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+				progress := md.Progress
+				rowLevelTTL := progress.Details.(*jobspb.Progress_RowLevelTTL).RowLevelTTL
+				rowLevelTTL.JobProcessedSpanCount += spansToAdd
+				rowLevelTTL.JobRowCount += rowsToAdd
+				jobRowCount = rowLevelTTL.JobRowCount
+				jobSpanCount = rowLevelTTL.JobTotalSpanCount
+
+				fractionCompleted = float32(rowLevelTTL.JobProcessedSpanCount) / float32(rowLevelTTL.JobTotalSpanCount)
+				progress.Progress = &jobspb.Progress_FractionCompleted{
+					FractionCompleted: fractionCompleted,
+				}
+
+				ju.UpdateProgress(progress)
+				return nil
+			},
+		)
+		if err != nil {
+			return err
+		}
+		processorID := t.ProcessorID
+		log.Infof(
+			ctx,
+			"TTL fractionCompleted updated processorID=%d tableID=%d jobRowCount=%d jobSpanCount=%d fractionCompleted=%.3f",
+			processorID, tableID, jobRowCount, jobSpanCount, fractionCompleted,
+		)
+		return nil
+	}
+
 	err = func() error {
 		boundsChan := make(chan QueryBounds, processorConcurrency)
 		defer close(boundsChan)
@@ -206,6 +252,8 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 					)
 					// add before returning err in case of partial success
 					processorRowCount.Add(spanRowCount)
+					rowsProccessedSinceLastUpdate.Add(spanRowCount)
+					spansProccessedSinceLastUpdate.Add(1)
 					if err != nil {
 						// Continue until channel is fully read.
 						// Otherwise, the keys input will be blocked.
@@ -238,6 +286,15 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 			} else if hasRows {
 				// Only process bounds from spans with rows inside them.
 				boundsChan <- bounds
+			} else {
+				// If the span has no rows, we still need to increment the processed
+				// count.
+				spansProccessedSinceLastUpdate.Add(1)
+			}
+			if spansProccessedSinceLastUpdate.Load() >= updateEvery {
+				if err := updateFractionCompleted(); err != nil {
+					return err
+				}
 			}
 		}
 		return nil
@@ -247,6 +304,9 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 	}
 
 	if err := group.Wait(); err != nil {
+		return err
+	}
+	if err := updateFractionCompleted(); err != nil {
 		return err
 	}
 
@@ -259,7 +319,6 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 		func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
 			progress := md.Progress
 			rowLevelTTL := progress.Details.(*jobspb.Progress_RowLevelTTL).RowLevelTTL
-			rowLevelTTL.JobRowCount += processorRowCount.Load()
 			processorID := t.ProcessorID
 			rowLevelTTL.ProcessorProgresses = append(rowLevelTTL.ProcessorProgresses, jobspb.RowLevelTTLProcessorProgress{
 				ProcessorID:          processorID,
@@ -268,12 +327,16 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 				ProcessorSpanCount:   processorSpanCount,
 				ProcessorConcurrency: processorConcurrency,
 			})
+			var fractionCompleted float32
+			if f, ok := progress.Progress.(*jobspb.Progress_FractionCompleted); ok {
+				fractionCompleted = f.FractionCompleted
+			}
 			ju.UpdateProgress(progress)
 			log.VInfof(
 				ctx,
 				2, /* level */
-				"TTL processorRowCount updated jobID=%d processorID=%d sqlInstanceID=%d tableID=%d jobRowCount=%d processorRowCount=%d",
-				jobID, processorID, sqlInstanceID, tableID, rowLevelTTL.JobRowCount, processorRowCount,
+				"TTL processorRowCount updated processorID=%d sqlInstanceID=%d tableID=%d jobRowCount=%d processorRowCount=%d fractionCompleted=%.3f",
+				processorID, sqlInstanceID, tableID, rowLevelTTL.JobRowCount, processorRowCount.Load(), fractionCompleted,
 			)
 			return nil
 		},

--- a/pkg/sql/ttl/ttljob/ttljob_processor.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor.go
@@ -165,7 +165,7 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 	if processorSpanCount < processorConcurrency {
 		processorConcurrency = processorSpanCount
 	}
-	var processorRowCount int64
+	var processorRowCount atomic.Int64
 	err = func() error {
 		boundsChan := make(chan QueryBounds, processorConcurrency)
 		defer close(boundsChan)
@@ -205,7 +205,7 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 						deleteBuilder,
 					)
 					// add before returning err in case of partial success
-					atomic.AddInt64(&processorRowCount, spanRowCount)
+					processorRowCount.Add(spanRowCount)
 					if err != nil {
 						// Continue until channel is fully read.
 						// Otherwise, the keys input will be blocked.
@@ -259,12 +259,12 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 		func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
 			progress := md.Progress
 			rowLevelTTL := progress.Details.(*jobspb.Progress_RowLevelTTL).RowLevelTTL
-			rowLevelTTL.JobRowCount += processorRowCount
+			rowLevelTTL.JobRowCount += processorRowCount.Load()
 			processorID := t.ProcessorID
 			rowLevelTTL.ProcessorProgresses = append(rowLevelTTL.ProcessorProgresses, jobspb.RowLevelTTLProcessorProgress{
 				ProcessorID:          processorID,
 				SQLInstanceID:        sqlInstanceID,
-				ProcessorRowCount:    processorRowCount,
+				ProcessorRowCount:    processorRowCount.Load(),
 				ProcessorSpanCount:   processorSpanCount,
 				ProcessorConcurrency: processorConcurrency,
 			})

--- a/pkg/sql/ttl/ttljob/ttljob_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_test.go
@@ -270,7 +270,8 @@ func (h *rowLevelTTLTestJobTestHelper) verifyExpiredRows(
 			require.Equal(t, expectedProcessorRowCount, processorProgress.ProcessorRowCount)
 			expectedJobRowCount += expectedProcessorRowCount
 		}
-		require.Equal(t, expectedJobSpanCount, rowLevelTTLProgress.JobSpanCount)
+		require.Equal(t, expectedJobSpanCount, rowLevelTTLProgress.JobProcessedSpanCount)
+		require.Equal(t, expectedJobSpanCount, rowLevelTTLProgress.JobTotalSpanCount)
 		require.Equal(t, expectedJobRowCount, rowLevelTTLProgress.JobRowCount)
 		jobCount++
 	}

--- a/pkg/sql/ttl/ttljob/ttljob_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_test.go
@@ -214,7 +214,7 @@ func (h *rowLevelTTLTestJobTestHelper) verifyExpiredRowsJobOnly(
 		var progress jobspb.Progress
 		require.NoError(t, protoutil.Unmarshal(progressBytes, &progress))
 
-		actualNumExpiredRows := progress.UnwrapDetails().(jobspb.RowLevelTTLProgress).JobRowCount
+		actualNumExpiredRows := progress.UnwrapDetails().(jobspb.RowLevelTTLProgress).JobDeletedRowCount
 		require.Equal(t, int64(expectedNumExpiredRows), actualNumExpiredRows)
 		jobCount++
 	}
@@ -272,7 +272,7 @@ func (h *rowLevelTTLTestJobTestHelper) verifyExpiredRows(
 		}
 		require.Equal(t, expectedJobSpanCount, rowLevelTTLProgress.JobProcessedSpanCount)
 		require.Equal(t, expectedJobSpanCount, rowLevelTTLProgress.JobTotalSpanCount)
-		require.Equal(t, expectedJobRowCount, rowLevelTTLProgress.JobRowCount)
+		require.Equal(t, expectedJobRowCount, rowLevelTTLProgress.JobDeletedRowCount)
 		jobCount++
 	}
 	require.Equal(t, 1, jobCount)


### PR DESCRIPTION
This patch adds better o11y for tracking the progress of the TTL job.
Previously, the progress struct would be updated, but we would never
update the FractionCompleted measurement.

Now, the main loop of the TTL processor will periodically update the
fraction completed based on the proportion of spans that have been
processed so far divided by the total span count.

fixes https://github.com/cockroachdb/cockroach/issues/86884
Release note (ops change): The row-level TTL job now will periodically
update the progress meter in the jobs introspection interfaces,
including SHOW JOBS and the Jobs page in the DB console.

---

Other commits are small refactors.
