### PR TITLE
roachtest: fix health and consistency checks

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -52,7 +52,6 @@ go_library(
         "//pkg/testutils/skip",
         "//pkg/util/allstacks",
         "//pkg/util/ctxgroup",
-        "//pkg/util/httputil",
         "//pkg/util/leaktest",
         "//pkg/util/quotapool",
         "//pkg/util/randutil",

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -47,7 +47,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/prometheus"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce"
-	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -1547,9 +1546,10 @@ func (c *clusterImpl) HealthStatus(
 	if err != nil {
 		return nil, errors.WithDetail(err, "Unable to get admin UI address(es)")
 	}
+	client := roachtestutil.DefaultHTTPClient(c, l)
 	getStatus := func(ctx context.Context, node int) *HealthStatusResult {
 		url := fmt.Sprintf(`https://%s/health?ready=1`, adminAddrs[node-1])
-		resp, err := httputil.Get(ctx, url)
+		resp, err := client.Get(ctx, url)
 		if err != nil {
 			return newHealthStatusResult(node, 0, nil, err)
 		}


### PR DESCRIPTION
The post-assertions were always failing and skipped:

```
test-post-assertions: 2024/10/31 22:19:05 test_runner.go:1459: n1:/health?ready=1 error=Get "https://<IP>:26258/health?ready=1": tls: failed to verify certificate: x509: "node" certificate is not standards compliant
test-post-assertions: 2024/10/31 22:19:05 test_runner.go:1459: n2:/health?ready=1 error=Get "https://<IP>:26258/health?ready=1": tls: failed to verify certificate: x509: "node" certificate is not standards compliant
test-post-assertions: 2024/10/31 22:19:05 test_runner.go:1459: n3:/health?ready=1 error=Get "https://<IP>:26258/health?ready=1": tls: failed to verify certificate: x509: "node" certificate is not standards compliant
test-post-assertions: 2024/10/31 22:19:05 test_runner.go:1459: n4:/health?ready=1 error=Get "https://34.74.5.126:26258/health?ready=1": dial tcp <IP>: connect: connection refused
test-post-assertions: 2024/10/31 22:19:05 test_runner.go:1501: no live node found, skipping validation checks
```

Epic: none
Release note: none