### PR TITLE
cli: add timestamp as tag in tsdump datadog upload

### DIFF
--- a/pkg/cli/testdata/tsdump/json
+++ b/pkg/cli/testdata/tsdump/json
@@ -31,7 +31,7 @@ cr.node.admission.admitted.elastic.cpu 2 1.000000 1711130560
 ----
 POST: https://example.com/data
 DD-API-KEY: api-key
-Body: {"series":[{"metric":"crdb.tsdump.admission.admitted.elastic.cpu","type":0,"points":[{"timestamp":1711130470,"value":0},{"timestamp":1711130480,"value":1},{"timestamp":1711130490,"value":1},{"timestamp":1711130500,"value":1}],"resources":null,"tags":["node_id:1","cluster_type:SELF_HOSTED","job:cockroachdb","region:local","cluster_label:test-cluster","upload_id:test-cluster-1234"]}]}
+Body: {"series":[{"metric":"crdb.tsdump.admission.admitted.elastic.cpu","type":0,"points":[{"timestamp":1711130470,"value":0},{"timestamp":1711130480,"value":1},{"timestamp":1711130490,"value":1},{"timestamp":1711130500,"value":1}],"resources":null,"tags":["node_id:1","cluster_type:SELF_HOSTED","cluster_label:test-cluster","upload_id:test-cluster-20241114000000","upload_year:2024","upload_month:11","upload_day:14"]}]}
 POST: https://example.com/data
 DD-API-KEY: api-key
-Body: {"series":[{"metric":"crdb.tsdump.admission.admitted.elastic.cpu","type":0,"points":[{"timestamp":1711130510,"value":1},{"timestamp":1711130520,"value":1},{"timestamp":1711130530,"value":1},{"timestamp":1711130540,"value":1},{"timestamp":1711130550,"value":1},{"timestamp":1711130560,"value":1}],"resources":null,"tags":["node_id:2","cluster_type:SELF_HOSTED","job:cockroachdb","region:local","cluster_label:test-cluster","upload_id:test-cluster-1234"]}]}
+Body: {"series":[{"metric":"crdb.tsdump.admission.admitted.elastic.cpu","type":0,"points":[{"timestamp":1711130510,"value":1},{"timestamp":1711130520,"value":1},{"timestamp":1711130530,"value":1},{"timestamp":1711130540,"value":1},{"timestamp":1711130550,"value":1},{"timestamp":1711130560,"value":1}],"resources":null,"tags":["node_id:2","cluster_type:SELF_HOSTED","cluster_label:test-cluster","upload_id:test-cluster-20241114000000","upload_year:2024","upload_month:11","upload_day:14"]}]}

--- a/pkg/cli/tsdump_test.go
+++ b/pkg/cli/tsdump_test.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
@@ -188,8 +189,8 @@ func parseDDInput(t *testing.T, input string, w *datadogWriter) {
 func TestTsDumpFormatsDataDriven(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer testutils.TestingHook(&newUploadID, func(cluster string) string {
-		return fmt.Sprintf("%s-1234", cluster)
+	defer testutils.TestingHook(&getCurrentTime, func() time.Time {
+		return time.Date(2024, 11, 14, 0, 0, 0, 0, time.UTC)
 	})()
 
 	datadriven.Walk(t, "testdata/tsdump", func(t *testing.T, path string) {

--- a/pkg/cli/zip_upload.go
+++ b/pkg/cli/zip_upload.go
@@ -135,7 +135,7 @@ func runDebugZipUpload(cmd *cobra.Command, args []string) error {
 	}
 
 	// a unique ID for this upload session. This should be used to tag all the artifacts uploaded in this session
-	uploadID := newUploadID(debugZipUploadOpts.clusterName)
+	uploadID := newUploadID(debugZipUploadOpts.clusterName, timeutil.Now())
 
 	// override the list of artifacts to upload if the user has provided any
 	artifactsToUpload := zipArtifactTypes
@@ -848,9 +848,8 @@ var doUploadReq = func(req *http.Request) ([]byte, error) {
 // Everything is converted to lowercase and spaces are replaced with hyphens. Because,
 // datadog will do this anyway and we want to make sure the UUIDs match when we generate the
 // explore/dashboard links.
-var newUploadID = func(cluster string) string {
-	currentTime := timeutil.Now()
-	formattedTime := currentTime.Format("20060102150405")
+var newUploadID = func(cluster string, uploadTime time.Time) string {
+	formattedTime := uploadTime.Format("20060102150405")
 	return strings.ToLower(
 		strings.ReplaceAll(
 			fmt.Sprintf("%s-%s", cluster, formattedTime), " ", "-",

--- a/pkg/cli/zip_upload_test.go
+++ b/pkg/cli/zip_upload_test.go
@@ -108,7 +108,7 @@ func setupZipDir(t *testing.T, inputs zipUploadTestContents) (string, func()) {
 func TestUploadZipEndToEnd(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer testutils.TestingHook(&newUploadID, func(string) string {
+	defer testutils.TestingHook(&newUploadID, func(string, time.Time) string {
 		return "123"
 	})()
 	defer testutils.TestingHook(&newRandStr, func(l int, n bool) string {


### PR DESCRIPTION
Previously, we updated `upload_id` identifier to include timestamp as part of based on uploadID. This change adds upload year, month & day tags as part of tsdump upload.

Epic: None
Part of: CRDB-44379
Release note: None