### PR TITLE
cmd/roachprod: skip cost calculation in list

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -184,7 +184,7 @@ func initFlags() {
 		"lifetime", "l", 12*time.Hour, "Lifetime of the cluster")
 
 	listCmd.Flags().BoolVarP(&listCost,
-		"cost", "c", os.Getenv("ROACHPROD_NO_COST_ESTIMATES") != "true",
+		"cost", "c", os.Getenv("ROACHPROD_COST_ESTIMATES") == "true",
 		"Show cost estimates",
 	)
 	listCmd.Flags().BoolVarP(&listDetails,


### PR DESCRIPTION
When roachprod list is run with --cost=true, it currently takes 1 minute. When it is false, the cmd takes 10 seconds. I'm not sure how a dev using roachprod would act on this cost column anyway.

[Slack for context](https://cockroachlabs.slack.com/archives/C023S0V4YEB/p1731593507232939)

Epic: none

Release note: none