### PR TITLE
release-24.1: pgwire,authccl: use pgx for TestAuthenticationAndHBARules

### DIFF
--- a/pkg/ccl/testccl/authccl/BUILD.bazel
+++ b/pkg/ccl/testccl/authccl/BUILD.bazel
@@ -33,7 +33,8 @@ go_test(
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//stdstrings",
-        "@com_github_lib_pq//:pq",
+        "@com_github_jackc_pgconn//:pgconn",
+        "@com_github_jackc_pgx_v4//:pgx",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/ccl/testccl/authccl/auth_test.go
+++ b/pkg/ccl/testccl/authccl/auth_test.go
@@ -42,7 +42,8 @@ import (
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/stdstrings"
-	"github.com/lib/pq"
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
 	"github.com/stretchr/testify/require"
 )
 
@@ -146,7 +147,7 @@ func makeSocketFile(t *testing.T) (socketDir, socketFile string, cleanupFn func(
 }
 
 func jwtRunTest(t *testing.T, insecure bool) {
-
+	ctx := context.Background()
 	datadriven.Walk(t, datapathutils.TestDataPath(t), func(t *testing.T, path string) {
 		defer leaktest.AfterTest(t)()
 
@@ -180,7 +181,7 @@ func jwtRunTest(t *testing.T, insecure bool) {
 		}
 		defer cleanup()
 
-		srv, conn, _ := serverutils.StartServer(t,
+		srv := serverutils.StartServerOnly(t,
 			base.TestServerArgs{
 				DefaultTestTenant: base.TestDoesNotWorkWithSharedProcessModeButWeDontKnowWhyYet(
 					base.TestTenantProbabilistic, 112949,
@@ -188,12 +189,21 @@ func jwtRunTest(t *testing.T, insecure bool) {
 				Insecure:   insecure,
 				SocketFile: maybeSocketFile,
 			})
-		defer srv.Stopper().Stop(context.Background())
+		defer srv.Stopper().Stop(ctx)
+
+		pgURL, cleanup := srv.PGUrl(t, serverutils.User(username.RootUser), serverutils.ClientCerts(!insecure))
+		defer cleanup()
+		rootConn, err := pgx.Connect(ctx, pgURL.String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = rootConn.Close(ctx) }()
+
 		s := srv.ApplicationLayer()
 
 		sv := &s.ClusterSettings().SV
 
-		if _, err := conn.ExecContext(context.Background(), fmt.Sprintf(`CREATE USER %s`, username.TestUser)); err != nil {
+		if _, err := rootConn.Exec(ctx, fmt.Sprintf(`CREATE USER %s`, username.TestUser)); err != nil {
 			t.Fatal(err)
 		}
 
@@ -211,27 +221,27 @@ func jwtRunTest(t *testing.T, insecure bool) {
 							if err != nil {
 								t.Fatalf("unknown value for jwt_cluster_setting enabled: %s", a.Vals[0])
 							}
-							jwtauthccl.JWTAuthEnabled.Override(context.Background(), sv, v)
+							jwtauthccl.JWTAuthEnabled.Override(ctx, sv, v)
 						case "audience":
 							if len(a.Vals) != 1 {
 								t.Fatalf("wrong number of argumenets to jwt_cluster_setting audience: %d", len(a.Vals))
 							}
-							jwtauthccl.JWTAuthAudience.Override(context.Background(), sv, a.Vals[0])
+							jwtauthccl.JWTAuthAudience.Override(ctx, sv, a.Vals[0])
 						case "issuers":
 							if len(a.Vals) != 1 {
 								t.Fatalf("wrong number of argumenets to jwt_cluster_setting issuers: %d", len(a.Vals))
 							}
-							jwtauthccl.JWTAuthIssuers.Override(context.Background(), sv, a.Vals[0])
+							jwtauthccl.JWTAuthIssuers.Override(ctx, sv, a.Vals[0])
 						case "jwks":
 							if len(a.Vals) != 1 {
 								t.Fatalf("wrong number of argumenets to jwt_cluster_setting jwks: %d", len(a.Vals))
 							}
-							jwtauthccl.JWTAuthJWKS.Override(context.Background(), sv, a.Vals[0])
+							jwtauthccl.JWTAuthJWKS.Override(ctx, sv, a.Vals[0])
 						case "claim":
 							if len(a.Vals) != 1 {
 								t.Fatalf("wrong number of argumenets to jwt_cluster_setting claim: %d", len(a.Vals))
 							}
-							jwtauthccl.JWTAuthClaim.Override(context.Background(), sv, a.Vals[0])
+							jwtauthccl.JWTAuthClaim.Override(ctx, sv, a.Vals[0])
 						case "ident_map":
 							if len(a.Vals) != 1 {
 								t.Fatalf("wrong number of argumenets to jwt_cluster_setting ident_map: %d", len(a.Vals))
@@ -240,7 +250,7 @@ func jwtRunTest(t *testing.T, insecure bool) {
 							if len(args) != 3 {
 								t.Fatalf("wrong number of comma separated argumenets to jwt_cluster_setting ident_map: %d", len(a.Vals))
 							}
-							pgwire.ConnIdentityMapConf.Override(context.Background(), sv, strings.Join(args, "    "))
+							pgwire.ConnIdentityMapConf.Override(ctx, sv, strings.Join(args, "    "))
 						case "jwks_auto_fetch.enabled":
 							if len(a.Vals) != 1 {
 								t.Fatalf("wrong number of argumenets to jwt_cluster_setting jwks_auto.fetch_enabled: %d", len(a.Vals))
@@ -249,7 +259,7 @@ func jwtRunTest(t *testing.T, insecure bool) {
 							if err != nil {
 								t.Fatalf("unknown value for jwt_cluster_setting jwks_auto_fetch.enabled: %s", a.Vals[0])
 							}
-							jwtauthccl.JWKSAutoFetchEnabled.Override(context.Background(), sv, v)
+							jwtauthccl.JWKSAutoFetchEnabled.Override(ctx, sv, v)
 						default:
 							t.Fatalf("unknown jwt_cluster_setting: %s", a.Key)
 						}
@@ -271,7 +281,7 @@ func jwtRunTest(t *testing.T, insecure bool) {
 					}
 
 				case "sql":
-					_, err := conn.ExecContext(context.Background(), td.Input)
+					_, err := rootConn.Exec(ctx, td.Input)
 					return "ok", err
 
 				case "connect", "connect_unix":
@@ -354,24 +364,29 @@ func jwtRunTest(t *testing.T, insecure bool) {
 						if len(a.Vals) > 0 {
 							val = a.Vals[0]
 						}
+						if len(val) == 0 {
+							// pgx.Connect requires empty values to be passed as a
+							// single-quoted empty string.
+							val = "''"
+						}
 						fmt.Fprintf(&dsnBuf, "%s%s=%s", sp, a.Key, val)
 						sp = " "
 					}
 					dsn := dsnBuf.String()
 
 					// Finally, connect and test the connection.
-					dbSQL, err := gosql.Open("postgres", dsn)
+					dbSQL, err := pgx.Connect(ctx, dsn)
 					if dbSQL != nil {
 						// Note: gosql.Open may return a valid db (with an open
 						// TCP connection) even if there is an error. We want to
 						// ensure this gets closed so that we catch the conn close
 						// message in the log.
-						defer dbSQL.Close()
+						defer func() { _ = dbSQL.Close(ctx) }()
 					}
 					if err != nil {
 						return "", err
 					}
-					row := dbSQL.QueryRow("SELECT current_catalog")
+					row := dbSQL.QueryRow(ctx, "SELECT current_catalog")
 					var dbName string
 					if err := row.Scan(&dbName); err != nil {
 						return "", err
@@ -439,20 +454,34 @@ var authLogFileRe = regexp.MustCompile(`"EventType":"client_`)
 func fmtErr(err error) string {
 	if err != nil {
 		errStr := ""
-		if pqErr := (*pq.Error)(nil); errors.As(err, &pqErr) {
-			errStr = pqErr.Message
-			if pgcode.MakeCode(string(pqErr.Code)) != pgcode.Uncategorized {
-				errStr += fmt.Sprintf(" (SQLSTATE %s)", pqErr.Code)
+		if pgxErr := (*pgconn.PgError)(nil); errors.As(err, &pgxErr) {
+			errStr = pgxErr.Message
+			if pgcode.MakeCode(pgxErr.Code) != pgcode.Uncategorized {
+				errStr += fmt.Sprintf(" (SQLSTATE %s)", pgxErr.Code)
 			}
-			if pqErr.Hint != "" {
-				hint := strings.Replace(pqErr.Hint, stdstrings.IssueReferral, "<STANDARD REFERRAL>", 1)
+			if pgxErr.Hint != "" {
+				hint := strings.Replace(pgxErr.Hint, stdstrings.IssueReferral, "<STANDARD REFERRAL>", 1)
+				if strings.Contains(hint, "Supported methods:") {
+					// Depending on whether the test is running on linux or not
+					// (or, more specifically, whether gss build tag is set),
+					// "gss" method might not be included, so we remove it here
+					// and not include into the expected output.
+					hint = strings.Replace(hint, "gss, ", "", 1)
+				}
 				errStr += "\nHINT: " + hint
 			}
-			if pqErr.Detail != "" {
-				errStr += "\nDETAIL: " + pqErr.Detail
+			if pgxErr.Detail != "" {
+				errStr += "\nDETAIL: " + pgxErr.Detail
 			}
 		} else {
 			errStr = err.Error()
+			// pgx uses an internal type (pgconn.connectError) for "TLS not enabled"
+			// errors here. We need to munge the error here to avoid including
+			// non-stable information like IP addresses in the output.
+			const tlsErr = "tls error (server refused TLS connection)"
+			if strings.HasSuffix(errStr, tlsErr) {
+				errStr = tlsErr
+			}
 		}
 		return "ERROR: " + errStr
 	}

--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -58,7 +58,6 @@ go_library(
         "//pkg/sql/sqltelemetry",
         "//pkg/sql/types",
         "//pkg/util",
-        "//pkg/util/buildutil",
         "//pkg/util/ctxlog",
         "//pkg/util/duration",
         "//pkg/util/envutil",

--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -42,8 +42,8 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/stdstrings"
 	"github.com/cockroachdb/redact"
+	"github.com/jackc/pgconn"
 	pgx "github.com/jackc/pgx/v4"
-	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 )
 
@@ -171,6 +171,7 @@ func hbaRunTest(t *testing.T, insecure bool) {
 	if !insecure {
 		httpScheme = "https://"
 	}
+	ctx := context.Background()
 
 	datadriven.Walk(t, datapathutils.TestDataPath(t, "auth"), func(t *testing.T, path string) {
 		defer leaktest.AfterTest(t)()
@@ -212,13 +213,21 @@ func hbaRunTest(t *testing.T, insecure bool) {
 		}
 		defer cleanup()
 
-		s, conn, _ := serverutils.StartServer(t,
+		s := serverutils.StartServerOnly(t,
 			base.TestServerArgs{
 				DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(107310),
 				Insecure:          insecure,
 				SocketFile:        maybeSocketFile,
 			})
-		defer s.Stopper().Stop(context.Background())
+		defer s.Stopper().Stop(ctx)
+
+		pgURL, cleanup := s.PGUrl(t, serverutils.User(username.RootUser), serverutils.ClientCerts(!insecure))
+		defer cleanup()
+		rootConn, err := pgx.Connect(ctx, pgURL.String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = rootConn.Close(ctx) }()
 
 		// Enable conn/auth logging.
 		// We can't use the cluster settings to do this, because
@@ -235,7 +244,7 @@ func hbaRunTest(t *testing.T, insecure bool) {
 		}
 		httpHBAUrl := httpScheme + s.HTTPAddr() + "/debug/hba_conf"
 
-		if _, err := conn.ExecContext(context.Background(), fmt.Sprintf(`CREATE USER %s`, username.TestUser)); err != nil {
+		if _, err := rootConn.Exec(ctx, fmt.Sprintf(`CREATE USER %s`, username.TestUser)); err != nil {
 			t.Fatal(err)
 		}
 
@@ -272,7 +281,7 @@ func hbaRunTest(t *testing.T, insecure bool) {
 					testServer.SetAcceptSQLWithoutTLS(false)
 
 				case "set_hba":
-					_, err := conn.ExecContext(context.Background(),
+					_, err := rootConn.Exec(ctx,
 						`SET CLUSTER SETTING server.host_based_authentication.configuration = $1`, td.Input)
 					if err != nil {
 						return "", err
@@ -313,7 +322,7 @@ func hbaRunTest(t *testing.T, insecure bool) {
 					return string(body), nil
 
 				case "set_identity_map":
-					_, err := conn.ExecContext(context.Background(),
+					_, err := rootConn.Exec(ctx,
 						`SET CLUSTER SETTING server.identity_map.configuration = $1`, td.Input)
 					if err != nil {
 						return "", err
@@ -354,7 +363,7 @@ func hbaRunTest(t *testing.T, insecure bool) {
 					return string(body), nil
 
 				case "sql":
-					_, err := conn.ExecContext(context.Background(), td.Input)
+					_, err := rootConn.Exec(ctx, td.Input)
 					return "ok", err
 
 				case "authlog":
@@ -550,30 +559,35 @@ func hbaRunTest(t *testing.T, insecure bool) {
 						if len(a.Vals) > 0 {
 							val = a.Vals[0]
 						}
+						if len(val) == 0 {
+							// pgx.Connect requires empty values to be passed as a
+							// single-quoted empty string.
+							val = "''"
+						}
 						fmt.Fprintf(&dsnBuf, "%s%s=%s", sp, a.Key, val)
 						sp = " "
 					}
 					dsn := dsnBuf.String()
 
 					// Finally, connect and test the connection.
-					dbSQL, err := gosql.Open("postgres", dsn)
+					dbSQL, err := pgx.Connect(ctx, dsn)
 					if dbSQL != nil {
-						// Note: gosql.Open may return a valid db (with an open
+						// Note: pgx.Connect may return a valid db (with an open
 						// TCP connection) even if there is an error. We want to
 						// ensure this gets closed so that we catch the conn close
 						// message in the log.
-						defer dbSQL.Close()
+						defer func() { _ = dbSQL.Close(ctx) }()
 					}
 					if err != nil {
 						return "", err
 					}
-					row := dbSQL.QueryRow("SELECT current_catalog")
+					row := dbSQL.QueryRow(ctx, "SELECT current_catalog")
 					var result string
 					if err := row.Scan(&result); err != nil {
 						return "", err
 					}
 					if showSystemIdentity {
-						row := dbSQL.QueryRow(`SHOW system_identity`)
+						row := dbSQL.QueryRow(ctx, `SHOW system_identity`)
 						var name string
 						if err := row.Scan(&name); err != nil {
 							t.Fatal(err)
@@ -602,13 +616,13 @@ var authLogFileRe = regexp.MustCompile(`"EventType":"client_`)
 func fmtErr(err error) string {
 	if err != nil {
 		errStr := ""
-		if pqErr := (*pq.Error)(nil); errors.As(err, &pqErr) {
-			errStr = pqErr.Message
-			if pgcode.MakeCode(string(pqErr.Code)) != pgcode.Uncategorized {
-				errStr += fmt.Sprintf(" (SQLSTATE %s)", pqErr.Code)
+		if pgxErr := (*pgconn.PgError)(nil); errors.As(err, &pgxErr) {
+			errStr = pgxErr.Message
+			if pgcode.MakeCode(pgxErr.Code) != pgcode.Uncategorized {
+				errStr += fmt.Sprintf(" (SQLSTATE %s)", pgxErr.Code)
 			}
-			if pqErr.Hint != "" {
-				hint := strings.Replace(pqErr.Hint, stdstrings.IssueReferral, "<STANDARD REFERRAL>", 1)
+			if pgxErr.Hint != "" {
+				hint := strings.Replace(pgxErr.Hint, stdstrings.IssueReferral, "<STANDARD REFERRAL>", 1)
 				if strings.Contains(hint, "Supported methods:") {
 					// Depending on whether the test is running on linux or not
 					// (or, more specifically, whether gss build tag is set),
@@ -618,11 +632,18 @@ func fmtErr(err error) string {
 				}
 				errStr += "\nHINT: " + hint
 			}
-			if pqErr.Detail != "" {
-				errStr += "\nDETAIL: " + pqErr.Detail
+			if pgxErr.Detail != "" {
+				errStr += "\nDETAIL: " + pgxErr.Detail
 			}
 		} else {
 			errStr = err.Error()
+			// pgx uses an internal type (pgconn.connectError) for "TLS not enabled"
+			// errors here. We need to munge the error here to avoid including
+			// non-stable information like IP addresses in the output.
+			const tlsErr = "tls error (server refused TLS connection)"
+			if strings.HasSuffix(errStr, tlsErr) {
+				errStr = tlsErr
+			}
 		}
 		return "ERROR: " + errStr
 	}

--- a/pkg/sql/pgwire/pre_serve.go
+++ b/pkg/sql/pgwire/pre_serve.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirecancel"
-	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -440,9 +439,6 @@ func (s *PreServeConnHandler) maybeUpgradeToSecureConn(
 		// TODO(knz): Remove this condition - see
 		// https://github.com/cockroachdb/cockroach/issues/53404
 		if s.cfg.Insecure {
-			if buildutil.CrdbTestBuild {
-				log.Infof(ctx, "using insecure mode since version=%d and cfg.Insecure=true", version)
-			}
 			return
 		}
 
@@ -450,13 +446,6 @@ func (s *PreServeConnHandler) maybeUpgradeToSecureConn(
 		// non-TLS SQL conns.
 		if !s.cfg.AcceptSQLWithoutTLS && connType != hba.ConnLocal && connType != hba.ConnInternalLoopback {
 			clientErr = pgerror.New(pgcode.ProtocolViolation, ErrSSLRequired)
-			// Extra logs under test to debug TestAuthenticationAndHBARules.
-			if buildutil.CrdbTestBuild {
-				log.Warningf(ctx, "client cannot connect since version=%d AcceptSQLWithoutTLS=false and connType=%s", version, connType)
-			}
-		}
-		if buildutil.CrdbTestBuild {
-			log.Infof(ctx, "client did not request SSL version=%d AcceptSQLWithoutTLS=false and connType=%s", version, connType)
 		}
 		return
 	}
@@ -468,19 +457,12 @@ func (s *PreServeConnHandler) maybeUpgradeToSecureConn(
 		// we don't want it.
 		clientErr = pgerror.New(pgcode.ProtocolViolation,
 			"cannot use SSL/TLS over local connections")
-		// Extra logs under test to debug TestAuthenticationAndHBARules.
-		if buildutil.CrdbTestBuild {
-			log.Warningf(ctx, "client cannot connect since version=%d and connType=%s", version, connType)
-		}
 		return
 	}
 
 	// Protocol sanity check.
 	if len(buf.Msg) > 0 {
 		serverErr = errors.Errorf("unexpected data after SSLRequest: %q", buf.Msg)
-		if buildutil.CrdbTestBuild {
-			log.Warningf(ctx, "protocol error err=%v", serverErr)
-		}
 		return
 	}
 
@@ -490,36 +472,20 @@ func (s *PreServeConnHandler) maybeUpgradeToSecureConn(
 	// Do we have a TLS configuration?
 	tlsConfig, serverErr := s.getTLSConfig()
 	if serverErr != nil {
-		if buildutil.CrdbTestBuild {
-			log.Warningf(ctx, "could not get TLS config err=%v", serverErr)
-		}
 		return
 	}
 
 	if tlsConfig == nil {
 		// We don't have a TLS configuration available, so we can't honor
 		// the client's request.
-		// Extra logs under test to debug TestAuthenticationAndHBARules.
-		if buildutil.CrdbTestBuild {
-			log.Infof(ctx, "sending sslUnsupported message to client")
-		}
 		n, serverErr = conn.Write(sslUnsupported)
 		if serverErr != nil {
-			if buildutil.CrdbTestBuild {
-				log.Warningf(ctx, "error while sending sslUnsupported message to client err=%v", serverErr)
-			}
 			return
 		}
 	} else {
-		if buildutil.CrdbTestBuild {
-			log.Infof(ctx, "sending sslSupported message to client")
-		}
 		// We have a TLS configuration. Upgrade the connection.
 		n, serverErr = conn.Write(sslSupported)
 		if serverErr != nil {
-			if buildutil.CrdbTestBuild {
-				log.Warningf(ctx, "error while sending sslSupported message to client err=%v", serverErr)
-			}
 			return
 		}
 		newConn = tls.Server(conn, tlsConfig)
@@ -529,9 +495,6 @@ func (s *PreServeConnHandler) maybeUpgradeToSecureConn(
 
 	// Finally, re-read the version/command from the client.
 	newVersion, *buf, serverErr = s.readVersion(newConn)
-	if buildutil.CrdbTestBuild && serverErr != nil {
-		log.Warningf(ctx, "error when reading version err=%v", serverErr)
-	}
 	return
 }
 

--- a/pkg/sql/pgwire/testdata/auth/conn_log
+++ b/pkg/sql/pgwire/testdata/auth/conn_log
@@ -58,13 +58,13 @@ ok defaultdb
 authlog 7
 .*client_connection_end
 ----
-6 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-7 {"EventType":"client_authentication_info","Info":"HBA rule: host  all root all cert-password # CockroachDB mandatory rule","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl"}
-8 {"EventType":"client_authentication_info","Info":"client presented certificate, proceeding with certificate validation","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl"}
-9 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl","User":"root"}
-10 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=defaultdb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl","User":"root"}
-11 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-12 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+2 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+3 {"EventType":"client_authentication_info","Info":"HBA rule: host  all root all cert-password # CockroachDB mandatory rule","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl"}
+4 {"EventType":"client_authentication_info","Info":"client presented certificate, proceeding with certificate validation","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl"}
+5 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl","User":"root"}
+6 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=defaultdb] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl","User":"root"}
+7 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+8 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 connect user=root password=secureabc sslmode=require sslcert= sslkey=
 ----
@@ -73,14 +73,14 @@ ok defaultdb
 authlog 8
 .*client_connection_end
 ----
-13 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-14 {"EventType":"client_authentication_info","Info":"HBA rule: host  all root all cert-password # CockroachDB mandatory rule","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl"}
-15 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl"}
-16 {"EventType":"client_authentication_info","Info":"no crdb-bcrypt credentials found; proceeding with SCRAM-SHA-256","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl","User":"root"}
-17 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl","User":"root"}
-18 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=defaultdb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl","User":"root"}
-19 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-20 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+9 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+10 {"EventType":"client_authentication_info","Info":"HBA rule: host  all root all cert-password # CockroachDB mandatory rule","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl"}
+11 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl"}
+12 {"EventType":"client_authentication_info","Info":"no crdb-bcrypt credentials found; proceeding with SCRAM-SHA-256","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl","User":"root"}
+13 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl","User":"root"}
+14 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=defaultdb] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl","User":"root"}
+15 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+16 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 connect user=root password=badpass sslmode=require sslcert= sslkey=
 ----
@@ -89,13 +89,13 @@ ERROR: password authentication failed for user root (SQLSTATE 28P01)
 authlog 7
 .*client_connection_end
 ----
-21 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-22 {"EventType":"client_authentication_info","Info":"HBA rule: host  all root all cert-password # CockroachDB mandatory rule","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl"}
-23 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl"}
-24 {"EventType":"client_authentication_info","Info":"no crdb-bcrypt credentials found; proceeding with SCRAM-SHA-256","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl","User":"root"}
-25 {"Detail":"scram handshake error: challenge proof invalid","EventType":"client_authentication_failed","InstanceID":1,"Method":"cert-password","Network":"tcp","Reason":"PRE_HOOK_ERROR","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl","User":"root"}
-26 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-27 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+17 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+18 {"EventType":"client_authentication_info","Info":"HBA rule: host  all root all cert-password # CockroachDB mandatory rule","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl"}
+19 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl"}
+20 {"EventType":"client_authentication_info","Info":"no crdb-bcrypt credentials found; proceeding with SCRAM-SHA-256","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl","User":"root"}
+21 {"Detail":"scram handshake error: challenge proof invalid","EventType":"client_authentication_failed","InstanceID":1,"Method":"cert-password","Network":"tcp","Reason":"PRE_HOOK_ERROR","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"hostssl","User":"root"}
+22 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+23 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 
 subtest end
@@ -109,12 +109,12 @@ ok defaultdb
 authlog 6
 .*client_connection_end
 ----
-28 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-29 {"EventType":"client_authentication_info","Info":"HBA rule: host  all trusted all trust         # custom","InstanceID":1,"Method":"trust","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"trusted","Timestamp":"XXX","Transport":"hostssl"}
-30 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"trust","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"trusted","Timestamp":"XXX","Transport":"hostssl","User":"trusted"}
-31 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=defaultdb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"trust","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"trusted","Timestamp":"XXX","Transport":"hostssl","User":"trusted"}
-32 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-33 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+24 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+25 {"EventType":"client_authentication_info","Info":"HBA rule: host  all trusted all trust         # custom","InstanceID":1,"Method":"trust","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"trusted","Timestamp":"XXX","Transport":"hostssl"}
+26 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"trust","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"trusted","Timestamp":"XXX","Transport":"hostssl","User":"trusted"}
+27 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=defaultdb] and CustomOptions=[]","InstanceID":1,"Method":"trust","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"trusted","Timestamp":"XXX","Transport":"hostssl","User":"trusted"}
+28 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+29 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 subtest end
 
@@ -127,14 +127,14 @@ ok defaultdb
 authlog 8
 .*client_connection_end
 ----
-34 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-35 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all     all cert-password # built-in CockroachDB default","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"hostssl"}
-36 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"hostssl"}
-37 {"EventType":"client_authentication_info","Info":"no crdb-bcrypt credentials found; proceeding with SCRAM-SHA-256","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"hostssl","User":"userpw"}
-38 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"hostssl","User":"userpw"}
-39 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=defaultdb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"hostssl","User":"userpw"}
-40 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-41 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+30 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+31 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all     all cert-password # built-in CockroachDB default","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"hostssl"}
+32 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"hostssl"}
+33 {"EventType":"client_authentication_info","Info":"no crdb-bcrypt credentials found; proceeding with SCRAM-SHA-256","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"hostssl","User":"userpw"}
+34 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"hostssl","User":"userpw"}
+35 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=defaultdb] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"hostssl","User":"userpw"}
+36 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+37 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 connect user=userpw password=badpass
 ----
@@ -143,13 +143,13 @@ ERROR: password authentication failed for user userpw (SQLSTATE 28P01)
 authlog 7
 .*client_connection_end
 ----
-42 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-43 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all     all cert-password # built-in CockroachDB default","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"hostssl"}
-44 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"hostssl"}
-45 {"EventType":"client_authentication_info","Info":"no crdb-bcrypt credentials found; proceeding with SCRAM-SHA-256","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"hostssl","User":"userpw"}
-46 {"Detail":"scram handshake error: challenge proof invalid","EventType":"client_authentication_failed","InstanceID":1,"Method":"cert-password","Network":"tcp","Reason":"PRE_HOOK_ERROR","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"hostssl","User":"userpw"}
-47 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-48 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+38 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+39 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all     all cert-password # built-in CockroachDB default","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"hostssl"}
+40 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"hostssl"}
+41 {"EventType":"client_authentication_info","Info":"no crdb-bcrypt credentials found; proceeding with SCRAM-SHA-256","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"hostssl","User":"userpw"}
+42 {"Detail":"scram handshake error: challenge proof invalid","EventType":"client_authentication_failed","InstanceID":1,"Method":"cert-password","Network":"tcp","Reason":"PRE_HOOK_ERROR","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"hostssl","User":"userpw"}
+43 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+44 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 subtest end
 
@@ -162,13 +162,13 @@ ERROR: password authentication failed for user usernopw (SQLSTATE 28P01)
 authlog 7
 .*client_connection_end
 ----
-49 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-50 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all     all cert-password # built-in CockroachDB default","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"usernopw","Timestamp":"XXX","Transport":"hostssl"}
-51 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"usernopw","Timestamp":"XXX","Transport":"hostssl"}
-52 {"EventType":"client_authentication_info","Info":"no crdb-bcrypt credentials found; proceeding with SCRAM-SHA-256","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"usernopw","Timestamp":"XXX","Transport":"hostssl","User":"usernopw"}
-53 {"Detail":"user password hash not in SCRAM format","EventType":"client_authentication_failed","InstanceID":1,"Method":"cert-password","Network":"tcp","Reason":"PRE_HOOK_ERROR","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"usernopw","Timestamp":"XXX","Transport":"hostssl","User":"usernopw"}
-54 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-55 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+45 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+46 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all     all cert-password # built-in CockroachDB default","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"usernopw","Timestamp":"XXX","Transport":"hostssl"}
+47 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"usernopw","Timestamp":"XXX","Transport":"hostssl"}
+48 {"EventType":"client_authentication_info","Info":"no crdb-bcrypt credentials found; proceeding with SCRAM-SHA-256","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"usernopw","Timestamp":"XXX","Transport":"hostssl","User":"usernopw"}
+49 {"Detail":"user password hash not in SCRAM format","EventType":"client_authentication_failed","InstanceID":1,"Method":"cert-password","Network":"tcp","Reason":"PRE_HOOK_ERROR","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"usernopw","Timestamp":"XXX","Transport":"hostssl","User":"usernopw"}
+50 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+51 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 
 subtest end
@@ -187,12 +187,12 @@ ok defaultdb
 authlog 6
 .*client_connection_end
 ----
-56 {"EventType":"client_connection_start","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-57 {"EventType":"client_authentication_info","Info":"HBA rule: local all all         password      # built-in CockroachDB default","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"local"}
-58 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"local","User":"root"}
-59 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=defaultdb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"local","User":"root"}
-60 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-61 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+52 {"EventType":"client_connection_start","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+53 {"EventType":"client_authentication_info","Info":"HBA rule: local all all         password      # built-in CockroachDB default","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"local"}
+54 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"local","User":"root"}
+55 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=defaultdb] and CustomOptions=[]","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"local","User":"root"}
+56 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+57 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 connect_unix user=root password=badpass
 ----
@@ -201,11 +201,11 @@ ERROR: password authentication failed for user root (SQLSTATE 28P01)
 authlog 5
 .*client_connection_end
 ----
-62 {"EventType":"client_connection_start","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-63 {"EventType":"client_authentication_info","Info":"HBA rule: local all all         password      # built-in CockroachDB default","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"local"}
-64 {"Detail":"password authentication failed for user root","EventType":"client_authentication_failed","InstanceID":1,"Method":"password","Network":"unix","Reason":"CREDENTIALS_INVALID","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"local","User":"root"}
-65 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-66 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+58 {"EventType":"client_connection_start","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+59 {"EventType":"client_authentication_info","Info":"HBA rule: local all all         password      # built-in CockroachDB default","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"local"}
+60 {"Detail":"password authentication failed for user root","EventType":"client_authentication_failed","InstanceID":1,"Method":"password","Network":"unix","Reason":"CREDENTIALS_INVALID","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"root","Timestamp":"XXX","Transport":"local","User":"root"}
+61 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+62 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 
 subtest end
@@ -219,11 +219,11 @@ ERROR: authentication rejected by configuration (SQLSTATE 28000)
 authlog 5
 .*client_connection_end
 ----
-67 {"EventType":"client_connection_start","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-68 {"EventType":"client_authentication_info","Info":"HBA rule: local all trusted     reject        # custom","InstanceID":1,"Method":"reject","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"trusted","Timestamp":"XXX","Transport":"local"}
-69 {"Detail":"authentication rejected by configuration","EventType":"client_authentication_failed","InstanceID":1,"Method":"reject","Network":"unix","Reason":"LOGIN_DISABLED","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"trusted","Timestamp":"XXX","Transport":"local","User":"trusted"}
-70 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-71 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+63 {"EventType":"client_connection_start","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+64 {"EventType":"client_authentication_info","Info":"HBA rule: local all trusted     reject        # custom","InstanceID":1,"Method":"reject","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"trusted","Timestamp":"XXX","Transport":"local"}
+65 {"Detail":"authentication rejected by configuration","EventType":"client_authentication_failed","InstanceID":1,"Method":"reject","Network":"unix","Reason":"LOGIN_DISABLED","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"trusted","Timestamp":"XXX","Transport":"local","User":"trusted"}
+66 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+67 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 subtest end
 
@@ -236,12 +236,12 @@ ok defaultdb
 authlog 6
 .*client_connection_end
 ----
-72 {"EventType":"client_connection_start","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-73 {"EventType":"client_authentication_info","Info":"HBA rule: local all all         password      # built-in CockroachDB default","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"local"}
-74 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"local","User":"userpw"}
-75 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=defaultdb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"local","User":"userpw"}
-76 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-77 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+68 {"EventType":"client_connection_start","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+69 {"EventType":"client_authentication_info","Info":"HBA rule: local all all         password      # built-in CockroachDB default","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"local"}
+70 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"local","User":"userpw"}
+71 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=defaultdb] and CustomOptions=[]","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"local","User":"userpw"}
+72 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+73 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 connect_unix user=userpw password=badpass
 ----
@@ -250,11 +250,11 @@ ERROR: password authentication failed for user userpw (SQLSTATE 28P01)
 authlog 5
 .*client_connection_end
 ----
-78 {"EventType":"client_connection_start","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-79 {"EventType":"client_authentication_info","Info":"HBA rule: local all all         password      # built-in CockroachDB default","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"local"}
-80 {"Detail":"password authentication failed for user userpw","EventType":"client_authentication_failed","InstanceID":1,"Method":"password","Network":"unix","Reason":"CREDENTIALS_INVALID","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"local","User":"userpw"}
-81 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-82 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+74 {"EventType":"client_connection_start","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+75 {"EventType":"client_authentication_info","Info":"HBA rule: local all all         password      # built-in CockroachDB default","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"local"}
+76 {"Detail":"password authentication failed for user userpw","EventType":"client_authentication_failed","InstanceID":1,"Method":"password","Network":"unix","Reason":"CREDENTIALS_INVALID","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userpw","Timestamp":"XXX","Transport":"local","User":"userpw"}
+77 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+78 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 subtest end
 
@@ -267,11 +267,11 @@ ERROR: usernologin does not have login privilege (SQLSTATE 28000)
 authlog 5
 .*client_connection_end
 ----
-83 {"EventType":"client_connection_start","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-84 {"EventType":"client_authentication_info","Info":"HBA rule: local all all         password      # built-in CockroachDB default","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"usernologin","Timestamp":"XXX","Transport":"local"}
-85 {"EventType":"client_authentication_failed","InstanceID":1,"Method":"password","Network":"unix","Reason":"LOGIN_DISABLED","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"usernologin","Timestamp":"XXX","Transport":"local","User":"usernologin"}
-86 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-87 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+79 {"EventType":"client_connection_start","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+80 {"EventType":"client_authentication_info","Info":"HBA rule: local all all         password      # built-in CockroachDB default","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"usernologin","Timestamp":"XXX","Transport":"local"}
+81 {"EventType":"client_authentication_failed","InstanceID":1,"Method":"password","Network":"unix","Reason":"LOGIN_DISABLED","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"usernologin","Timestamp":"XXX","Transport":"local","User":"usernologin"}
+82 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+83 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 
 connect_unix user=usernosqllogin password=123
@@ -281,11 +281,11 @@ ERROR: usernosqllogin does not have login privilege (SQLSTATE 28000)
 authlog 5
 .*client_connection_end
 ----
-88 {"EventType":"client_connection_start","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-89 {"EventType":"client_authentication_info","Info":"HBA rule: local all all         password      # built-in CockroachDB default","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"usernosqllogin","Timestamp":"XXX","Transport":"local"}
-90 {"EventType":"client_authentication_failed","InstanceID":1,"Method":"password","Network":"unix","Reason":"LOGIN_DISABLED","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"usernosqllogin","Timestamp":"XXX","Transport":"local","User":"usernosqllogin"}
-91 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-92 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+84 {"EventType":"client_connection_start","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+85 {"EventType":"client_authentication_info","Info":"HBA rule: local all all         password      # built-in CockroachDB default","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"usernosqllogin","Timestamp":"XXX","Transport":"local"}
+86 {"EventType":"client_authentication_failed","InstanceID":1,"Method":"password","Network":"unix","Reason":"LOGIN_DISABLED","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"usernosqllogin","Timestamp":"XXX","Transport":"local","User":"usernosqllogin"}
+87 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+88 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 connect_unix user=userglobalnosqllogin password=123
 ----
@@ -294,11 +294,11 @@ ERROR: userglobalnosqllogin does not have login privilege (SQLSTATE 28000)
 authlog 5
 .*client_connection_end
 ----
-93 {"EventType":"client_connection_start","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-94 {"EventType":"client_authentication_info","Info":"HBA rule: local all all         password      # built-in CockroachDB default","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userglobalnosqllogin","Timestamp":"XXX","Transport":"local"}
-95 {"EventType":"client_authentication_failed","InstanceID":1,"Method":"password","Network":"unix","Reason":"LOGIN_DISABLED","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userglobalnosqllogin","Timestamp":"XXX","Transport":"local","User":"userglobalnosqllogin"}
-96 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-97 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+89 {"EventType":"client_connection_start","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+90 {"EventType":"client_authentication_info","Info":"HBA rule: local all all         password      # built-in CockroachDB default","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userglobalnosqllogin","Timestamp":"XXX","Transport":"local"}
+91 {"EventType":"client_authentication_failed","InstanceID":1,"Method":"password","Network":"unix","Reason":"LOGIN_DISABLED","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userglobalnosqllogin","Timestamp":"XXX","Transport":"local","User":"userglobalnosqllogin"}
+92 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+93 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 connect_unix user=userinheritsnosqllogin password=123
 ----
@@ -307,11 +307,11 @@ ERROR: userinheritsnosqllogin does not have login privilege (SQLSTATE 28000)
 authlog 5
 .*client_connection_end
 ----
-98 {"EventType":"client_connection_start","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-99 {"EventType":"client_authentication_info","Info":"HBA rule: local all all         password      # built-in CockroachDB default","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userinheritsnosqllogin","Timestamp":"XXX","Transport":"local"}
-100 {"EventType":"client_authentication_failed","InstanceID":1,"Method":"password","Network":"unix","Reason":"LOGIN_DISABLED","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userinheritsnosqllogin","Timestamp":"XXX","Transport":"local","User":"userinheritsnosqllogin"}
-101 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-102 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+94 {"EventType":"client_connection_start","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+95 {"EventType":"client_authentication_info","Info":"HBA rule: local all all         password      # built-in CockroachDB default","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userinheritsnosqllogin","Timestamp":"XXX","Transport":"local"}
+96 {"EventType":"client_authentication_failed","InstanceID":1,"Method":"password","Network":"unix","Reason":"LOGIN_DISABLED","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userinheritsnosqllogin","Timestamp":"XXX","Transport":"local","User":"userinheritsnosqllogin"}
+97 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+98 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 connect_unix user=userexpired password=123
 ----
@@ -320,11 +320,11 @@ ERROR: password is expired (SQLSTATE 28000)
 authlog 5
 .*client_connection_end
 ----
-103 {"EventType":"client_connection_start","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-104 {"EventType":"client_authentication_info","Info":"HBA rule: local all all         password      # built-in CockroachDB default","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userexpired","Timestamp":"XXX","Transport":"local"}
-105 {"EventType":"client_authentication_failed","InstanceID":1,"Method":"password","Network":"unix","Reason":"CREDENTIALS_EXPIRED","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userexpired","Timestamp":"XXX","Transport":"local","User":"userexpired"}
-106 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-107 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+99 {"EventType":"client_connection_start","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+100 {"EventType":"client_authentication_info","Info":"HBA rule: local all all         password      # built-in CockroachDB default","InstanceID":1,"Method":"password","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userexpired","Timestamp":"XXX","Transport":"local"}
+101 {"EventType":"client_authentication_failed","InstanceID":1,"Method":"password","Network":"unix","Reason":"CREDENTIALS_EXPIRED","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"userexpired","Timestamp":"XXX","Transport":"local","User":"userexpired"}
+102 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+103 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 subtest end
 

--- a/pkg/sql/pgwire/testdata/auth/empty_hba
+++ b/pkg/sql/pgwire/testdata/auth/empty_hba
@@ -48,7 +48,7 @@ ERROR: password authentication failed for user root (SQLSTATE 28P01)
 
 # When no client cert is presented, the server would otherwise require
 # password auth. However, root does not have a password.
-connect user=root password=foo sslmode=verify-ca sslcert=
+connect user=root password=foo sslmode=verify-ca sslcert= sslkey=
 ----
 ERROR: password authentication failed for user root (SQLSTATE 28P01)
 
@@ -92,11 +92,11 @@ connect user=testuser database=defaultdb cert_name=testuser_cn_only force_certs 
 ok defaultdb testuser
 
 # If we don't present the client certificate, the password is required.
-connect user=testuser password=invalid sslmode=verify-ca sslcert=
+connect user=testuser password=invalid sslmode=verify-ca sslcert= sslkey=
 ----
 ERROR: password authentication failed for user testuser (SQLSTATE 28P01)
 
-connect user=testuser password=pass sslmode=verify-ca sslcert=
+connect user=testuser password=pass sslmode=verify-ca sslcert= sslkey=
 ----
 ok defaultdb
 

--- a/pkg/sql/pgwire/testdata/auth/hba_default_equivalence
+++ b/pkg/sql/pgwire/testdata/auth/hba_default_equivalence
@@ -43,7 +43,7 @@ ERROR: password authentication failed for user root (SQLSTATE 28P01)
 
 # When no client cert is presented, the server would otherwise require
 # password auth. However, root does not have a password.
-connect user=root password=foo sslmode=verify-ca sslcert=
+connect user=root password=foo sslmode=verify-ca sslcert= sslkey=
 ----
 ERROR: password authentication failed for user root (SQLSTATE 28P01)
 
@@ -78,11 +78,11 @@ connect_unix user=testuser password=pass
 ok defaultdb
 
 # If we don't present the client certificate, the password is required.
-connect user=testuser password=invalid sslmode=verify-ca sslcert=
+connect user=testuser password=invalid sslmode=verify-ca sslcert= sslkey=
 ----
 ERROR: password authentication failed for user testuser (SQLSTATE 28P01)
 
-connect user=testuser password=pass sslmode=verify-ca sslcert=
+connect user=testuser password=pass sslmode=verify-ca sslcert= sslkey=
 ----
 ok defaultdb
 

--- a/pkg/sql/pgwire/testdata/auth/identity_map
+++ b/pkg/sql/pgwire/testdata/auth/identity_map
@@ -73,14 +73,14 @@ ok mydb
 authlog 8
 .*client_connection_end
 ----
-6 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-7 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all  all cert-password map=testing","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl"}
-8 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl"}
-10 {"EventType":"client_authentication_info","Info":"no crdb-bcrypt credentials found; proceeding with SCRAM-SHA-256","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
-11 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
-12 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=mydb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
-13 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-14 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+2 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+3 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all  all cert-password map=testing","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl"}
+4 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl"}
+6 {"EventType":"client_authentication_info","Info":"no crdb-bcrypt credentials found; proceeding with SCRAM-SHA-256","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
+7 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
+8 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=mydb] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
+9 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+10 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 subtest end
 
@@ -99,12 +99,12 @@ ERROR: password authentication failed for user carl@cockroachlabs.com (SQLSTATE 
 authlog 6
 .*client_connection_end
 ----
-15 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-16 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all  all cert-password map=testing","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl@cockroachlabs.com","Timestamp":"XXX","Transport":"hostssl"}
-17 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl@cockroachlabs.com","Timestamp":"XXX","Transport":"hostssl"}
-18 {"EventType":"client_authentication_failed","InstanceID":1,"Method":"cert-password","Network":"tcp","Reason":"USER_NOT_FOUND","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl@cockroachlabs.com","Timestamp":"XXX","Transport":"hostssl","User":"carl@cockroachlabs.com"}
-19 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-20 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+11 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+12 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all  all cert-password map=testing","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl@cockroachlabs.com","Timestamp":"XXX","Transport":"hostssl"}
+13 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl@cockroachlabs.com","Timestamp":"XXX","Transport":"hostssl"}
+14 {"EventType":"client_authentication_failed","InstanceID":1,"Method":"cert-password","Network":"tcp","Reason":"USER_NOT_FOUND","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl@cockroachlabs.com","Timestamp":"XXX","Transport":"hostssl","User":"carl@cockroachlabs.com"}
+15 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+16 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 subtest end
 
@@ -119,14 +119,14 @@ ok mydb will_be_carl
 authlog 8
 .*client_connection_end
 ----
-21 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-22 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all  all cert-password map=testing","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"will_be_carl","Timestamp":"XXX","Transport":"hostssl"}
-23 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"will_be_carl","Timestamp":"XXX","Transport":"hostssl"}
-25 {"EventType":"client_authentication_info","Info":"no crdb-bcrypt credentials found; proceeding with SCRAM-SHA-256","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"will_be_carl","Timestamp":"XXX","Transport":"hostssl","User":"will_be_carl"}
-26 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"will_be_carl","Timestamp":"XXX","Transport":"hostssl","User":"will_be_carl"}
-27 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=mydb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"will_be_carl","Timestamp":"XXX","Transport":"hostssl","User":"will_be_carl"}
-28 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-29 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+17 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+18 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all  all cert-password map=testing","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"will_be_carl","Timestamp":"XXX","Transport":"hostssl"}
+19 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"will_be_carl","Timestamp":"XXX","Transport":"hostssl"}
+21 {"EventType":"client_authentication_info","Info":"no crdb-bcrypt credentials found; proceeding with SCRAM-SHA-256","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"will_be_carl","Timestamp":"XXX","Transport":"hostssl","User":"will_be_carl"}
+22 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"will_be_carl","Timestamp":"XXX","Transport":"hostssl","User":"will_be_carl"}
+23 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=mydb] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"will_be_carl","Timestamp":"XXX","Transport":"hostssl","User":"will_be_carl"}
+24 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+25 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 subtest end
 
@@ -140,13 +140,13 @@ ok mydb testuser
 authlog 7
 .*client_connection_end
 ----
-30 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-31 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all  all cert-password map=testing","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl"}
-32 {"EventType":"client_authentication_info","Info":"client presented certificate, proceeding with certificate validation","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl"}
-34 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
-35 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=mydb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
-36 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-37 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+26 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+27 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all  all cert-password map=testing","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl"}
+28 {"EventType":"client_authentication_info","Info":"client presented certificate, proceeding with certificate validation","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl"}
+30 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
+31 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=mydb] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
+32 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+33 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 subtest end
 
@@ -163,13 +163,13 @@ ok mydb testuser2
 authlog 7
 .*client_connection_end
 ----
-38 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-39 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all  all cert-password map=testing","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser2","Timestamp":"XXX","Transport":"hostssl"}
-40 {"EventType":"client_authentication_info","Info":"client presented certificate, proceeding with certificate validation","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser2","Timestamp":"XXX","Transport":"hostssl"}
-42 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser2","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
-43 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=mydb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser2","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
-44 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-45 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+34 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+35 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all  all cert-password map=testing","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser2","Timestamp":"XXX","Transport":"hostssl"}
+36 {"EventType":"client_authentication_info","Info":"client presented certificate, proceeding with certificate validation","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser2","Timestamp":"XXX","Transport":"hostssl"}
+38 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser2","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
+39 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=mydb] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser2","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
+40 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+41 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 subtest end
 
@@ -184,13 +184,13 @@ ok mydb testuser
 authlog 7
 .*client_connection_end
 ----
-46 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-47 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all  all cert-password map=testing","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl"}
-48 {"EventType":"client_authentication_info","Info":"client presented certificate, proceeding with certificate validation","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl"}
-50 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
-51 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=mydb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
-52 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-53 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+42 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+43 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all  all cert-password map=testing","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl"}
+44 {"EventType":"client_authentication_info","Info":"client presented certificate, proceeding with certificate validation","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl"}
+46 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
+47 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=mydb] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
+48 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+49 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 subtest end
 
@@ -205,13 +205,13 @@ ok mydb testuser
 authlog 7
 .*client_connection_end
 ----
-54 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-55 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all  all cert-password map=testing","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl"}
-56 {"EventType":"client_authentication_info","Info":"client presented certificate, proceeding with certificate validation","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl"}
-58 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
-59 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=mydb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
-60 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-61 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+50 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+51 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all  all cert-password map=testing","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl"}
+52 {"EventType":"client_authentication_info","Info":"client presented certificate, proceeding with certificate validation","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl"}
+54 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
+55 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=mydb] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl","User":"carl"}
+56 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+57 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 subtest end
 
@@ -226,12 +226,12 @@ ERROR: system identity "" did not map to a database role (SQLSTATE 28000)
 authlog 6
 .*client_connection_end
 ----
-62 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-63 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all  all cert-password map=testing","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl"}
-64 {"EventType":"client_authentication_info","Info":"client presented certificate, proceeding with certificate validation","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl"}
-65 {"Detail":"system identity \"\" did not map to a database role","EventType":"client_authentication_failed","InstanceID":1,"Method":"cert-password","Network":"tcp","Reason":"USER_NOT_FOUND","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX","Transport":"hostssl"}
-66 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-67 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+58 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+59 {"EventType":"client_authentication_info","Info":"HBA rule: host  all all  all cert-password map=testing","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl"}
+60 {"EventType":"client_authentication_info","Info":"client presented certificate, proceeding with certificate validation","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"carl","Timestamp":"XXX","Transport":"hostssl"}
+61 {"Detail":"system identity \"\" did not map to a database role","EventType":"client_authentication_failed","InstanceID":1,"Method":"cert-password","Network":"tcp","Reason":"USER_NOT_FOUND","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX","Transport":"hostssl"}
+62 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+63 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 subtest end
 

--- a/pkg/sql/pgwire/testdata/auth/insecure
+++ b/pkg/sql/pgwire/testdata/auth/insecure
@@ -6,7 +6,7 @@ subtest check_ssl_disabled_error
 # Check that an attempt to use SSL fails with "SSL not enabled".
 connect user=root sslmode=require
 ----
-ERROR: pq: SSL is not enabled on the server
+ERROR: tls error (server refused TLS connection)
 
 subtest end
 

--- a/pkg/sql/pgwire/testdata/auth/scram
+++ b/pkg/sql/pgwire/testdata/auth/scram
@@ -77,11 +77,11 @@ ERROR: password authentication failed for user abc (SQLSTATE 28P01)
 authlog 5
 .*client_connection_end
 ----
-6 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-7 {"EventType":"client_authentication_info","Info":"HBA rule: host all abc all password","InstanceID":1,"Method":"password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl"}
-8 {"Detail":"password authentication failed for user abc","EventType":"client_authentication_failed","InstanceID":1,"Method":"password","Network":"tcp","Reason":"CREDENTIALS_INVALID","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
-9 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-10 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+2 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+3 {"EventType":"client_authentication_info","Info":"HBA rule: host all abc all password","InstanceID":1,"Method":"password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl"}
+4 {"Detail":"password authentication failed for user abc","EventType":"client_authentication_failed","InstanceID":1,"Method":"password","Network":"tcp","Reason":"CREDENTIALS_INVALID","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
+5 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+6 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 connect user=abc password=abc
 ----
@@ -90,12 +90,12 @@ ok defaultdb
 authlog 6
 .*client_connection_end
 ----
-11 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-12 {"EventType":"client_authentication_info","Info":"HBA rule: host all abc all password","InstanceID":1,"Method":"password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl"}
-13 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
-14 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=defaultdb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
-15 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-16 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+7 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+8 {"EventType":"client_authentication_info","Info":"HBA rule: host all abc all password","InstanceID":1,"Method":"password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl"}
+9 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
+10 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=defaultdb] and CustomOptions=[]","InstanceID":1,"Method":"password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
+11 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+12 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 connect user=abc2 password=abc
 ----
@@ -104,12 +104,12 @@ ok defaultdb
 authlog 6
 .*client_connection_end
 ----
-17 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-18 {"EventType":"client_authentication_info","Info":"HBA rule: host all abc2 all password","InstanceID":1,"Method":"password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc2","Timestamp":"XXX","Transport":"hostssl"}
-19 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc2","Timestamp":"XXX","Transport":"hostssl","User":"abc2"}
-20 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=defaultdb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc2","Timestamp":"XXX","Transport":"hostssl","User":"abc2"}
-21 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-22 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+13 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+14 {"EventType":"client_authentication_info","Info":"HBA rule: host all abc2 all password","InstanceID":1,"Method":"password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc2","Timestamp":"XXX","Transport":"hostssl"}
+15 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc2","Timestamp":"XXX","Transport":"hostssl","User":"abc2"}
+16 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=defaultdb] and CustomOptions=[]","InstanceID":1,"Method":"password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc2","Timestamp":"XXX","Transport":"hostssl","User":"abc2"}
+17 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+18 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 subtest end
 
@@ -146,11 +146,11 @@ ERROR: password authentication failed for user foo (SQLSTATE 28P01)
 authlog 5
 .*client_connection_end
 ----
-23 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-24 {"EventType":"client_authentication_info","Info":"HBA rule: host all foo all scram-sha-256","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
-25 {"Detail":"user password hash not in SCRAM format","EventType":"client_authentication_failed","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","Reason":"PRE_HOOK_ERROR","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-26 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-27 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+19 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+20 {"EventType":"client_authentication_info","Info":"HBA rule: host all foo all scram-sha-256","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+21 {"Detail":"user password hash not in SCRAM format","EventType":"client_authentication_failed","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","Reason":"PRE_HOOK_ERROR","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+22 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+23 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 # User abc has SCRAM credentials, but 'mistake' is not its password.
 # Expect authn error.
@@ -161,11 +161,11 @@ ERROR: password authentication failed for user abc (SQLSTATE 28P01)
 authlog 5
 .*client_connection_end
 ----
-28 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-29 {"EventType":"client_authentication_info","Info":"HBA rule: host all abc all scram-sha-256","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl"}
-30 {"Detail":"scram handshake error: challenge proof invalid","EventType":"client_authentication_failed","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","Reason":"PRE_HOOK_ERROR","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
-31 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-32 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+24 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+25 {"EventType":"client_authentication_info","Info":"HBA rule: host all abc all scram-sha-256","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl"}
+26 {"Detail":"scram handshake error: challenge proof invalid","EventType":"client_authentication_failed","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","Reason":"PRE_HOOK_ERROR","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
+27 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+28 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 connect user=abc password=abc
 ----
@@ -174,12 +174,12 @@ ok defaultdb
 authlog 6
 .*client_connection_end
 ----
-33 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-34 {"EventType":"client_authentication_info","Info":"HBA rule: host all abc all scram-sha-256","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl"}
-35 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
-36 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=defaultdb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
-37 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-38 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+29 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+30 {"EventType":"client_authentication_info","Info":"HBA rule: host all abc all scram-sha-256","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl"}
+31 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
+32 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=defaultdb] and CustomOptions=[]","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
+33 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+34 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 connect user=abc2 password=abc
 ----
@@ -188,12 +188,12 @@ ok defaultdb
 authlog 6
 .*client_connection_end
 ----
-39 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-40 {"EventType":"client_authentication_info","Info":"HBA rule: host all abc2 all scram-sha-256","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc2","Timestamp":"XXX","Transport":"hostssl"}
-41 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc2","Timestamp":"XXX","Transport":"hostssl","User":"abc2"}
-42 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=defaultdb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc2","Timestamp":"XXX","Transport":"hostssl","User":"abc2"}
-43 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-44 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+35 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+36 {"EventType":"client_authentication_info","Info":"HBA rule: host all abc2 all scram-sha-256","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc2","Timestamp":"XXX","Transport":"hostssl"}
+37 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc2","Timestamp":"XXX","Transport":"hostssl","User":"abc2"}
+38 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=defaultdb] and CustomOptions=[]","InstanceID":1,"Method":"scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc2","Timestamp":"XXX","Transport":"hostssl","User":"abc2"}
+39 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+40 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 subtest end
 
@@ -227,13 +227,13 @@ ok defaultdb
 authlog 7
 .*client_connection_end
 ----
-45 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-46 {"EventType":"client_authentication_info","Info":"HBA rule: host all all all cert-scram-sha-256","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl"}
-47 {"EventType":"client_authentication_info","Info":"client presented certificate, proceeding with certificate validation","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl"}
-48 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl","User":"testuser"}
-49 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=defaultdb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl","User":"testuser"}
-50 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-51 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+41 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+42 {"EventType":"client_authentication_info","Info":"HBA rule: host all all all cert-scram-sha-256","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl"}
+43 {"EventType":"client_authentication_info","Info":"client presented certificate, proceeding with certificate validation","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl"}
+44 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl","User":"testuser"}
+45 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=defaultdb] and CustomOptions=[]","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testuser","Timestamp":"XXX","Transport":"hostssl","User":"testuser"}
+46 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+47 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 subtest end
 
@@ -246,12 +246,12 @@ ERROR: password authentication failed for user foo (SQLSTATE 28P01)
 authlog 6
 .*client_connection_end
 ----
-52 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-53 {"EventType":"client_authentication_info","Info":"HBA rule: host all all all cert-scram-sha-256","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
-54 {"EventType":"client_authentication_info","Info":"no client certificate, proceeding with SCRAM authentication","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
-55 {"Detail":"user password hash not in SCRAM format","EventType":"client_authentication_failed","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","Reason":"PRE_HOOK_ERROR","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-56 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-57 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+48 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+49 {"EventType":"client_authentication_info","Info":"HBA rule: host all all all cert-scram-sha-256","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+50 {"EventType":"client_authentication_info","Info":"no client certificate, proceeding with SCRAM authentication","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+51 {"Detail":"user password hash not in SCRAM format","EventType":"client_authentication_failed","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","Reason":"PRE_HOOK_ERROR","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+52 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+53 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 connect user=abc password=abc
 ----
@@ -260,13 +260,13 @@ ok defaultdb
 authlog 7
 .*client_connection_end
 ----
-58 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-59 {"EventType":"client_authentication_info","Info":"HBA rule: host all all all cert-scram-sha-256","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl"}
-60 {"EventType":"client_authentication_info","Info":"no client certificate, proceeding with SCRAM authentication","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl"}
-61 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
-62 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=defaultdb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
-63 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-64 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+54 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+55 {"EventType":"client_authentication_info","Info":"HBA rule: host all all all cert-scram-sha-256","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl"}
+56 {"EventType":"client_authentication_info","Info":"no client certificate, proceeding with SCRAM authentication","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl"}
+57 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
+58 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=defaultdb] and CustomOptions=[]","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
+59 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+60 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 connect user=abc2 password=abc
 ----
@@ -275,13 +275,13 @@ ok defaultdb
 authlog 7
 .*client_connection_end
 ----
-65 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-66 {"EventType":"client_authentication_info","Info":"HBA rule: host all all all cert-scram-sha-256","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc2","Timestamp":"XXX","Transport":"hostssl"}
-67 {"EventType":"client_authentication_info","Info":"no client certificate, proceeding with SCRAM authentication","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc2","Timestamp":"XXX","Transport":"hostssl"}
-68 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc2","Timestamp":"XXX","Transport":"hostssl","User":"abc2"}
-69 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=defaultdb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc2","Timestamp":"XXX","Transport":"hostssl","User":"abc2"}
-70 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-71 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+61 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+62 {"EventType":"client_authentication_info","Info":"HBA rule: host all all all cert-scram-sha-256","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc2","Timestamp":"XXX","Transport":"hostssl"}
+63 {"EventType":"client_authentication_info","Info":"no client certificate, proceeding with SCRAM authentication","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc2","Timestamp":"XXX","Transport":"hostssl"}
+64 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc2","Timestamp":"XXX","Transport":"hostssl","User":"abc2"}
+65 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=defaultdb] and CustomOptions=[]","InstanceID":1,"Method":"cert-scram-sha-256","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc2","Timestamp":"XXX","Transport":"hostssl","User":"abc2"}
+66 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+67 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 subtest end
 
@@ -316,14 +316,14 @@ ok defaultdb
 authlog 8
 .*client_connection_end
 ----
-72 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-73 {"EventType":"client_authentication_info","Info":"HBA rule: host all foo all cert-password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
-74 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
-75 {"EventType":"client_authentication_info","Info":"found stored crdb-bcrypt credentials; requesting cleartext password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-76 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-77 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=defaultdb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-78 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-79 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+68 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+69 {"EventType":"client_authentication_info","Info":"HBA rule: host all foo all cert-password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+70 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+71 {"EventType":"client_authentication_info","Info":"found stored crdb-bcrypt credentials; requesting cleartext password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+72 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+73 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=defaultdb] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+74 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+75 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 connect user=abc password=abc
 ----
@@ -333,12 +333,12 @@ ok defaultdb
 authlog 6
 .*client_connection_end
 ----
-82 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl"}
-83 {"EventType":"client_authentication_info","Info":"no crdb-bcrypt credentials found; proceeding with SCRAM-SHA-256","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
-84 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
-85 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=defaultdb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
-86 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-87 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+78 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl"}
+79 {"EventType":"client_authentication_info","Info":"no crdb-bcrypt credentials found; proceeding with SCRAM-SHA-256","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
+80 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
+81 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=defaultdb] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"abc","Timestamp":"XXX","Transport":"hostssl","User":"abc"}
+82 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+83 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 subtest end
 
@@ -370,14 +370,14 @@ ok defaultdb
 authlog 8
 .*client_connection_end
 ----
-88 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-89 {"EventType":"client_authentication_info","Info":"HBA rule: host all foo all cert-password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
-90 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
-91 {"EventType":"client_authentication_info","Info":"found stored crdb-bcrypt credentials; requesting cleartext password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-92 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-93 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=defaultdb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-94 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-95 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+84 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+85 {"EventType":"client_authentication_info","Info":"HBA rule: host all foo all cert-password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+86 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+87 {"EventType":"client_authentication_info","Info":"found stored crdb-bcrypt credentials; requesting cleartext password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+88 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+89 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=defaultdb] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+90 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+91 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 # Verify the stored hash has been converted now.
 sql
@@ -394,14 +394,14 @@ ok defaultdb
 authlog 8
 .*client_connection_end
 ----
-96 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-97 {"EventType":"client_authentication_info","Info":"HBA rule: host all foo all cert-password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
-98 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
-99 {"EventType":"client_authentication_info","Info":"no crdb-bcrypt credentials found; proceeding with SCRAM-SHA-256","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-100 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-101 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=defaultdb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-102 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-103 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+92 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+93 {"EventType":"client_authentication_info","Info":"HBA rule: host all foo all cert-password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+94 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+95 {"EventType":"client_authentication_info","Info":"no crdb-bcrypt credentials found; proceeding with SCRAM-SHA-256","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+96 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+97 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=defaultdb] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+98 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+99 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 sql
 -- change back to bcrypt.
@@ -418,14 +418,14 @@ ok defaultdb
 authlog 8
 .*client_connection_end
 ----
-104 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-105 {"EventType":"client_authentication_info","Info":"HBA rule: host all foo all cert-password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
-106 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
-107 {"EventType":"client_authentication_info","Info":"found stored SCRAM-SHA-256 credentials but cluster is configured to downgrade to bcrypt; requesting cleartext password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-108 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-109 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=defaultdb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-110 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-111 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+100 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+101 {"EventType":"client_authentication_info","Info":"HBA rule: host all foo all cert-password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+102 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+103 {"EventType":"client_authentication_info","Info":"found stored SCRAM-SHA-256 credentials but cluster is configured to downgrade to bcrypt; requesting cleartext password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+104 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+105 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=defaultdb] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+106 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+107 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 # Verify the stored hash has been converted to bcrypt now.
 sql
@@ -442,14 +442,14 @@ ok defaultdb
 authlog 8
 .*client_connection_end
 ----
-112 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-113 {"EventType":"client_authentication_info","Info":"HBA rule: host all foo all cert-password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
-114 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
-115 {"EventType":"client_authentication_info","Info":"found stored crdb-bcrypt credentials; requesting cleartext password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-116 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-117 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=defaultdb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-118 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-119 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+108 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+109 {"EventType":"client_authentication_info","Info":"HBA rule: host all foo all cert-password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+110 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+111 {"EventType":"client_authentication_info","Info":"found stored crdb-bcrypt credentials; requesting cleartext password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+112 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+113 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=defaultdb] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+114 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+115 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 sql
 -- change back to SCRAM for future tests, and connect again to cause the upgrade.
@@ -465,14 +465,14 @@ ok defaultdb
 authlog 8
 .*client_connection_end
 ----
-120 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-121 {"EventType":"client_authentication_info","Info":"HBA rule: host all foo all cert-password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
-122 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
-123 {"EventType":"client_authentication_info","Info":"found stored crdb-bcrypt credentials; requesting cleartext password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-124 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-125 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=defaultdb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-126 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-127 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+116 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+117 {"EventType":"client_authentication_info","Info":"HBA rule: host all foo all cert-password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+118 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+119 {"EventType":"client_authentication_info","Info":"found stored crdb-bcrypt credentials; requesting cleartext password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+120 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+121 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=defaultdb] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+122 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+123 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 subtest end
 
@@ -497,13 +497,13 @@ ok defaultdb
 authlog 8
 .*client_connection_end
 ----
-128 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-129 {"EventType":"client_authentication_info","Info":"HBA rule: host all foo all cert-password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
-130 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
-131 {"EventType":"client_authentication_info","Info":"found stored SCRAM-SHA-256 credentials but cluster is configured to re-hash after SCRAM cost change; requesting cleartext password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-132 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-133 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[client_encoding=UTF8; database=defaultdb; datestyle=ISO, MDY; extra_float_digits=2] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
-134 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
-135 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+124 {"EventType":"client_connection_start","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+125 {"EventType":"client_authentication_info","Info":"HBA rule: host all foo all cert-password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+126 {"EventType":"client_authentication_info","Info":"client did not present TLS certificate","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl"}
+127 {"EventType":"client_authentication_info","Info":"found stored SCRAM-SHA-256 credentials but cluster is configured to re-hash after SCRAM cost change; requesting cleartext password","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+128 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+129 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=defaultdb] and CustomOptions=[]","InstanceID":1,"Method":"cert-password","Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"foo","Timestamp":"XXX","Transport":"hostssl","User":"foo"}
+130 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+131 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"tcp","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
 
 subtest end

--- a/pkg/sql/pgwire/testdata/auth/special_cases
+++ b/pkg/sql/pgwire/testdata/auth/special_cases
@@ -29,7 +29,7 @@ loopback all      all  all       trust
 host     all      root all       cert-password
 host     all      root 0.0.0.0/0 password
 
-connect user=root password=abc sslmode=verify-ca sslcert=
+connect user=root password=abc sslmode=verify-ca sslcert= sslkey=
 ----
 ERROR: password authentication failed for user root (SQLSTATE 28P01)
 
@@ -63,7 +63,7 @@ loopback all      all      all       trust
 host     all      root     all       cert-password
 host     all      testuser 0.0.0.0/0 cert
 
-connect user=testuser password=pass sslmode=verify-ca sslcert=
+connect user=testuser password=pass sslmode=verify-ca sslcert= sslkey=
 ----
 ERROR: no TLS peer certificates, but required for auth (SQLSTATE 28000)
 


### PR DESCRIPTION
Backport 2/2 commits from #135086.

/cc @cockroachdb/release

Release justification: test only change

---

The lib/pq driver is not maintained. Since we started to see flakes related to how that driver does error handling for secure connections, we switch to pgx instead.

fixes https://github.com/cockroachdb/cockroach/issues/127745
fixes https://github.com/cockroachdb/cockroach/issues/131532
fixes https://github.com/cockroachdb/cockroach/issues/131110
fixes https://github.com/cockroachdb/cockroach/issues/133360

Release note: None
