### PR TITLE
roachtest: monitor use correct dir for ignore empty

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -855,7 +855,6 @@ func (c *SyncedCluster) Monitor(
 				OneShot     bool
 				Node        Node
 				IgnoreEmpty bool
-				Store       string
 				Local       bool
 				Separator   string
 				SkippedMsg  string
@@ -866,7 +865,6 @@ func (c *SyncedCluster) Monitor(
 				OneShot:     opts.OneShot,
 				Node:        node,
 				IgnoreEmpty: opts.IgnoreEmptyNodes,
-				Store:       c.NodeDir(node, 1 /* storeIndex */),
 				Local:       c.IsLocal(),
 				Separator:   separator,
 				SkippedMsg:  skippedMsg,
@@ -876,6 +874,9 @@ func (c *SyncedCluster) Monitor(
 			}
 
 			storeFor := func(name string, instance int) string {
+				if name == SystemInterfaceName {
+					return c.NodeDir(node, 1 /* storeIndex */)
+				}
 				return c.InstanceStoreDir(node, name, instance)
 			}
 
@@ -894,7 +895,7 @@ dead_parent() {
 {{ range .Processes }}
 monitor_process_{{$.Node}}_{{.Name}}_{{.Instance}}() {
   {{ if $.IgnoreEmpty }}
-  if ! ls {{storeFor .Name .Instance}}/marker.* 1> /dev/null 2>&1; then
+  if ! find {{storeFor .Name .Instance}} -name 'marker.*' 2> /dev/null | grep . > /dev/null; then
     echo "{{.Name}}{{$.Separator}}{{.Instance}}{{$.Separator}}{{$.SkippedMsg}}"
     return 0
   fi

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -520,8 +520,9 @@ func (c *SyncedCluster) LogDir(node Node, virtualClusterName string, instance in
 	return dirName
 }
 
-// InstanceStoreDir returns the data directory for the given instance of
-// the given virtual cluster.
+// InstanceStoreDir returns the data directory for the given instance of the
+// given virtual cluster. This should only be used for external processes. For
+// shared processes to get the data directory, use NodeDir.
 func (c *SyncedCluster) InstanceStoreDir(
 	node Node, virtualClusterName string, instance int,
 ) string {


### PR DESCRIPTION
Previously, roachprod Monitor used the incorrect function to determine the store dir of a cockroach process. The `cluster.InstanceStoreDir` only returns the correct store for an instance of an external process virtual cluster. For the system interface `cluster.NodeDir` should be used to determine the store dir.

This change updates the `storeFor` function to choose the correct method based on if it is a System interface, or an external process virtual cluster. A comment has been added to `cluster.InstanceStoreDir` to explain that it is only intended for external process virtual clusters.

Epic: None
Release note: None