### PR TITLE
release-24.1: ttljob: log progress in TTL job

### DIFF
--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1188,8 +1188,8 @@ message RowLevelTTLDetails {
 
 message RowLevelTTLProgress {
 
-  // JobRowCount is the number of deleted rows for the entire TTL job.
-  int64 job_row_count = 1;
+  // JobDeletedRowCount is the number of rows deleted by TTL job so far.
+  int64 job_deleted_row_count = 1;
 
   // ProcessorProgresses is the progress per DistSQL processor.
   repeated RowLevelTTLProcessorProgress processor_progresses = 2 [(gogoproto.nullable)=false];

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1197,8 +1197,12 @@ message RowLevelTTLProgress {
   // UseDistSQL is no longer used in v23.1+ as all TTL jobs are using DistSQL.
   reserved 3;
 
-  // JobSpanCount is the number of spans for the entire TTL job.
-  int64 job_span_count = 4;
+  // JobTotalSpanCount is the number of spans for the entire TTL job.
+  int64 job_total_span_count = 4;
+
+  // JobProcessedSpanCount is the number of spans that have been processed by
+  // the TTL job so far.
+  int64 job_processed_span_count = 5;
 }
 
 message RowLevelTTLProcessorProgress {

--- a/pkg/sql/ttl/ttljob/ttljob.go
+++ b/pkg/sql/ttl/ttljob/ttljob.go
@@ -214,7 +214,7 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) (re
 			func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
 				progress := md.Progress
 				rowLevelTTL := progress.Details.(*jobspb.Progress_RowLevelTTL).RowLevelTTL
-				rowLevelTTL.JobSpanCount = int64(jobSpanCount)
+				rowLevelTTL.JobTotalSpanCount = int64(jobSpanCount)
 				ju.UpdateProgress(progress)
 				return nil
 			},

--- a/pkg/sql/ttl/ttljob/ttljob_processor.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor.go
@@ -281,7 +281,7 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 			progress.Progress = &jobspb.Progress_FractionCompleted{
 				FractionCompleted: fractionCompleted,
 			}
-			rowLevelTTL.JobRowCount += rowsDeletedSoFar.Load()
+			rowLevelTTL.JobDeletedRowCount += rowsDeletedSoFar.Load()
 			rowLevelTTL.JobProcessedSpanCount += spansProccessedSoFar.Load()
 			rowLevelTTL.ProcessorProgresses = append(rowLevelTTL.ProcessorProgresses, jobspb.RowLevelTTLProcessorProgress{
 				ProcessorID:          processorID,
@@ -295,7 +295,7 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 				ctx,
 				2, /* level */
 				"TTL processorRowCount updated processorID=%d sqlInstanceID=%d tableID=%d jobRowCount=%d processorRowCount=%d fractionCompleted=%.3f",
-				processorID, sqlInstanceID, tableID, rowLevelTTL.JobRowCount, rowsDeletedSoFar.Load(), fractionCompleted,
+				processorID, sqlInstanceID, tableID, rowLevelTTL.JobDeletedRowCount, rowsDeletedSoFar.Load(), fractionCompleted,
 			)
 			return nil
 		},

--- a/pkg/sql/ttl/ttljob/ttljob_processor.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor.go
@@ -155,7 +155,21 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 	if processorSpanCount < processorConcurrency {
 		processorConcurrency = processorSpanCount
 	}
-	var processorRowCount atomic.Int64
+	var rowsDeletedSoFar atomic.Int64
+	var spansProccessedSoFar atomic.Int64
+
+	// Log progress approximately every 1% of spans processed.
+	updateEvery := max(1, processorSpanCount/100)
+	logProgress := func() error {
+		processorID := t.ProcessorID
+		log.Infof(
+			ctx,
+			"TTL progress processorID=%d tableID=%d deletedRowCount=%d processedSpanCountForProcessor=%d totalSpanCountForProcessor=%d",
+			processorID, tableID, rowsDeletedSoFar.Load(), spansProccessedSoFar.Load(), processorSpanCount,
+		)
+		return nil
+	}
+
 	err := func() error {
 		boundsChan := make(chan QueryBounds, processorConcurrency)
 		defer close(boundsChan)
@@ -195,7 +209,8 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 						deleteBuilder,
 					)
 					// add before returning err in case of partial success
-					processorRowCount.Add(spanRowCount)
+					rowsDeletedSoFar.Add(spanRowCount)
+					spansProccessedSoFar.Add(1)
 					if err != nil {
 						// Continue until channel is fully read.
 						// Otherwise, the keys input will be blocked.
@@ -228,6 +243,15 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 			} else if hasRows {
 				// Only process bounds from spans with rows inside them.
 				boundsChan <- bounds
+			} else {
+				// If the span has no rows, we still need to increment the processed
+				// count.
+				spansProccessedSoFar.Add(1)
+			}
+			if spansProccessedSoFar.Load() >= updateEvery {
+				if err := logProgress(); err != nil {
+					return err
+				}
 			}
 		}
 		return nil
@@ -237,6 +261,9 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 	}
 
 	if err := group.Wait(); err != nil {
+		return err
+	}
+	if err := logProgress(); err != nil {
 		return err
 	}
 
@@ -249,12 +276,17 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 		func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
 			progress := md.Progress
 			rowLevelTTL := progress.Details.(*jobspb.Progress_RowLevelTTL).RowLevelTTL
-			rowLevelTTL.JobRowCount += processorRowCount.Load()
 			processorID := t.ProcessorID
+			fractionCompleted := float32(processorSpanCount) / float32(rowLevelTTL.JobTotalSpanCount)
+			progress.Progress = &jobspb.Progress_FractionCompleted{
+				FractionCompleted: fractionCompleted,
+			}
+			rowLevelTTL.JobRowCount += rowsDeletedSoFar.Load()
+			rowLevelTTL.JobProcessedSpanCount += spansProccessedSoFar.Load()
 			rowLevelTTL.ProcessorProgresses = append(rowLevelTTL.ProcessorProgresses, jobspb.RowLevelTTLProcessorProgress{
 				ProcessorID:          processorID,
 				SQLInstanceID:        sqlInstanceID,
-				ProcessorRowCount:    processorRowCount.Load(),
+				ProcessorRowCount:    rowsDeletedSoFar.Load(),
 				ProcessorSpanCount:   processorSpanCount,
 				ProcessorConcurrency: processorConcurrency,
 			})
@@ -262,8 +294,8 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 			log.VInfof(
 				ctx,
 				2, /* level */
-				"TTL processorRowCount updated jobID=%d processorID=%d sqlInstanceID=%d tableID=%d jobRowCount=%d processorRowCount=%d",
-				jobID, processorID, sqlInstanceID, tableID, rowLevelTTL.JobRowCount, processorRowCount,
+				"TTL processorRowCount updated processorID=%d sqlInstanceID=%d tableID=%d jobRowCount=%d processorRowCount=%d fractionCompleted=%.3f",
+				processorID, sqlInstanceID, tableID, rowLevelTTL.JobRowCount, rowsDeletedSoFar.Load(), fractionCompleted,
 			)
 			return nil
 		},

--- a/pkg/sql/ttl/ttljob/ttljob_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_test.go
@@ -270,7 +270,8 @@ func (h *rowLevelTTLTestJobTestHelper) verifyExpiredRows(
 			require.Equal(t, expectedProcessorRowCount, processorProgress.ProcessorRowCount)
 			expectedJobRowCount += expectedProcessorRowCount
 		}
-		require.Equal(t, expectedJobSpanCount, rowLevelTTLProgress.JobSpanCount)
+		require.Equal(t, expectedJobSpanCount, rowLevelTTLProgress.JobProcessedSpanCount)
+		require.Equal(t, expectedJobSpanCount, rowLevelTTLProgress.JobTotalSpanCount)
 		require.Equal(t, expectedJobRowCount, rowLevelTTLProgress.JobRowCount)
 		jobCount++
 	}

--- a/pkg/sql/ttl/ttljob/ttljob_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_test.go
@@ -214,7 +214,7 @@ func (h *rowLevelTTLTestJobTestHelper) verifyExpiredRowsJobOnly(
 		var progress jobspb.Progress
 		require.NoError(t, protoutil.Unmarshal(progressBytes, &progress))
 
-		actualNumExpiredRows := progress.UnwrapDetails().(jobspb.RowLevelTTLProgress).JobRowCount
+		actualNumExpiredRows := progress.UnwrapDetails().(jobspb.RowLevelTTLProgress).JobDeletedRowCount
 		require.Equal(t, int64(expectedNumExpiredRows), actualNumExpiredRows)
 		jobCount++
 	}
@@ -272,7 +272,7 @@ func (h *rowLevelTTLTestJobTestHelper) verifyExpiredRows(
 		}
 		require.Equal(t, expectedJobSpanCount, rowLevelTTLProgress.JobProcessedSpanCount)
 		require.Equal(t, expectedJobSpanCount, rowLevelTTLProgress.JobTotalSpanCount)
-		require.Equal(t, expectedJobRowCount, rowLevelTTLProgress.JobRowCount)
+		require.Equal(t, expectedJobRowCount, rowLevelTTLProgress.JobDeletedRowCount)
 		jobCount++
 	}
 	require.Equal(t, 1, jobCount)


### PR DESCRIPTION
Backport 4/4 commits from #135142.

/cc @cockroachdb/release

Release justification: low risk high reward o11y change

---

This patch adds better o11y for tracking the progress of the TTL job.
Previously, the progress struct would be updated, but we would never
update the FractionCompleted measurement.

Now, the main loop of the TTL processor will periodically log the
number of spans that have been processed so far.

fixes https://github.com/cockroachdb/cockroach/issues/86884
Release note (ops change): The row-level TTL job now will periodically
log progress by showing the number of table spans that have been
processed so far.

---

Other commits are small refactors.

