### PR TITLE
roachtest: increase pause poll frequency

### DIFF
--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -167,7 +167,7 @@ func registerRestore(r registry.Registry) {
 				done := ctx.Done()
 				jobID := <-jobIDCh
 
-				jobProgressTick := time.NewTicker(time.Minute * 1)
+				jobProgressTick := time.NewTicker(time.Second * 5)
 				defer jobProgressTick.Stop()
 				for {
 					if pauseIndex == len(pauseAtProgress) {


### PR DESCRIPTION
Now, the test checks to see if it should pause every five seconds instead of every minute. It was previously possible for a restore to finish before the test was able to pause the job.

Release Note: none
Release Justification: test only change
Fixes: #134137
Fixes: #133793
Fixes: #134184