### PR TITLE
changefeedccl: bump test timeout

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/testfeed.go
+++ b/pkg/ccl/changefeedccl/cdctest/testfeed.go
@@ -7,6 +7,7 @@ package cdctest
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -75,6 +76,8 @@ type EnterpriseTestFeed interface {
 	Resume() error
 	// WaitForStatus waits for the provided func to return true, or returns an error.
 	WaitForStatus(func(s jobs.Status) bool) error
+	// WaitDurationForStatus waits for a specified time for the provided func to return true, or returns an error.
+	WaitDurationForStatus(dur time.Duration, statusPred func(status jobs.Status) bool) error
 	// FetchTerminalJobErr retrieves the error message from changefeed job.
 	FetchTerminalJobErr() error
 	// FetchRunningStatus retrieves running status from changefeed job.

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -6472,6 +6472,9 @@ func TestChangefeedTimelyResolvedTimestampUpdatePostRollingRestart(t *testing.T)
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// Add verbose logging to help debug future failures.
+	require.NoError(t, log.SetVModule("changefeed_processors=1"))
+
 	// This test requires many range splits, which can be slow under certain test
 	// conditions. Skip potentially slow tests.
 	skip.UnderDeadlock(t)
@@ -6569,7 +6572,7 @@ func TestChangefeedTimelyResolvedTimestampUpdatePostRollingRestart(t *testing.T)
 	defer DiscardMessages(testFeed)()
 
 	// Ensure the changefeed is able to complete in a reasonable amount of time.
-	require.NoError(t, testFeed.(cdctest.EnterpriseTestFeed).WaitForStatus(func(s jobs.Status) bool {
+	require.NoError(t, testFeed.(cdctest.EnterpriseTestFeed).WaitDurationForStatus(5*time.Minute, func(s jobs.Status) bool {
 		return s == jobs.StatusSucceeded
 	}))
 }


### PR DESCRIPTION
The
TestChangefeedTimelyResolvedTimestampUpdatePostRollingRestart
test has been flaky, on kv's advice I am
increasing its timeout. I'm also enabling verbose
changefeed logging to help diagnose future issues
here.

Fixes: #134903
Fixed: #134916

Release note: None
