### PR TITLE
release-24.1: scbuild: fix unhandled case during DROP SCHEMA

### DIFF
--- a/pkg/sql/drop_schema.go
+++ b/pkg/sql/drop_schema.go
@@ -70,6 +70,14 @@ func (p *planner) DropSchema(ctx context.Context, n *tree.DropSchema) (planNode,
 			}
 			return nil, pgerror.Newf(pgcode.InvalidSchemaName, "unknown schema %q", scName)
 		}
+		hasOwnership, err := p.HasOwnership(ctx, sc)
+		if err != nil {
+			return nil, err
+		}
+		if !hasOwnership {
+			return nil, pgerror.Newf(pgcode.InsufficientPrivilege,
+				"must be owner of schema %s", tree.Name(sc.GetName()))
+		}
 
 		if scName == catconstants.PublicSchemaName {
 			return nil, pgerror.Newf(pgcode.InvalidSchemaName, "cannot drop schema %q", scName)
@@ -79,14 +87,6 @@ func (p *planner) DropSchema(ctx context.Context, n *tree.DropSchema) (planNode,
 		case catalog.SchemaPublic, catalog.SchemaVirtual, catalog.SchemaTemporary:
 			return nil, pgerror.Newf(pgcode.InvalidSchemaName, "cannot drop schema %q", scName)
 		case catalog.SchemaUserDefined:
-			hasOwnership, err := p.HasOwnership(ctx, sc)
-			if err != nil {
-				return nil, err
-			}
-			if !hasOwnership {
-				return nil, pgerror.Newf(pgcode.InsufficientPrivilege,
-					"must be owner of schema %s", tree.Name(sc.GetName()))
-			}
 			namesBefore := len(d.objectNamesToDelete)
 			fnsBefore := len(d.functionsToDelete)
 			if err := d.collectObjectsInSchema(ctx, p, db, sc); err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/drop_schema
+++ b/pkg/sql/logictest/testdata/logic_test/drop_schema
@@ -21,3 +21,22 @@ BEGIN;
 ALTER TYPE schema_123539.enum_123539 DROP VALUE 's';
 DROP SCHEMA schema_123539 CASCADE;
 COMMIT;
+
+# Check that we block dropping the public schema of the system database, as
+# well as virtual schemas.
+
+statement error must be owner of schema public
+DROP SCHEMA system.public
+
+statement error must be owner of schema pg_catalog
+DROP SCHEMA pg_catalog
+
+user testuser
+
+statement error must be owner of schema public
+DROP SCHEMA system.public
+
+statement error must be owner of schema crdb_internal
+DROP SCHEMA crdb_internal
+
+user root


### PR DESCRIPTION
Backport 1/1 commits from #135149.

/cc @cockroachdb/release

Release justification: bug fix

---

fixes https://github.com/cockroachdb/cockroach/issues/135141
fixes https://github.com/cockroachdb/cockroach/issues/133913
fixes https://github.com/cockroachdb/cockroach/issues/134752
fixes https://github.com/cockroachdb/cockroach/issues/134280
fixes https://github.com/cockroachdb/cockroach/issues/133510

Release note (bug fix): Fixed an unhandled error that would occur if DROP SCHEMA was executed on the `public` schema of the `system` database, or on an internal schema like `pg_catalog` or `information_schema`.
