### PR TITLE
kvserver: detect lease divergence in CheckForcedErr

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -4409,7 +4409,7 @@ func TestProposalOverhead(t *testing.T) {
 	// users ranges do not have rangefeeds on by default whereas system ranges
 	// do.
 	const (
-		expectedUserOverhead uint32 = 42
+		expectedUserOverhead uint32 = 61
 	)
 	t.Run("user-key overhead", func(t *testing.T) {
 		userKey := tc.ScratchRange(t)

--- a/pkg/kv/kvserver/kvserverbase/BUILD.bazel
+++ b/pkg/kv/kvserver/kvserverbase/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/util/envutil",
         "//pkg/util/errorutil",
         "//pkg/util/hlc",
         "//pkg/util/log",

--- a/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
+++ b/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
@@ -303,6 +303,18 @@ message RaftCommand {
   // - the command applies on replica 2
   uint64 proposer_lease_sequence = 6 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.LeaseSequence"];
 
+  // ProposerLease is the lease is only set for lease acquisition/transfer
+  // requests. It corresponds tot he full lease under which the command was
+  // proposed (unlike proposer_lease_sequence which is only the sequence
+  // number). It allows us to make stronger assertions below raft when applying
+  // the command.
+  //
+  // TODO(arul): improve this comment.
+  //
+  // Note that this field was introduced in 24.3, so nodes running versions <
+  // 24.3 do not populate it.
+    roachpb.Lease proposer_lease = 22 [(gogoproto.nullable) = false];
+
   // When the command is applied, its result is an error if the lease log
   // counter has already reached (or exceeded) max_lease_index.
   //
@@ -399,6 +411,9 @@ message RaftCommand {
   // to inform said node of this raft command's (virtual) admission in order for
   // it to release flow tokens for subsequent commands.
   int32 admission_origin_node = 20 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"];
+
+  // Next ID: 22
+
 
   reserved 1, 2, 10001 to 10014;
 }

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -299,6 +299,7 @@ func (r *Replica) makeReproposal(origP *ProposalData) (reproposal *ProposalData,
 
 	newCommand := kvserverpb.RaftCommand{
 		ProposerLeaseSequence: origP.command.ProposerLeaseSequence,
+		ProposerLease:         origP.command.ProposerLease,
 		ReplicatedEvalResult:  origP.command.ReplicatedEvalResult,
 		WriteBatch:            origP.command.WriteBatch,
 		LogicalOpLog:          origP.command.LogicalOpLog,

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -250,8 +250,14 @@ func (r *Replica) evalAndPropose(
 		switch t := ba.Requests[0].GetInner().(type) {
 		case *kvpb.RequestLeaseRequest:
 			seq = t.PrevLease.Sequence
+			if kvserverbase.BelowRaftPreviousLeaseAssertions {
+				proposal.command.ProposerLease = t.PrevLease
+			}
 		case *kvpb.TransferLeaseRequest:
 			seq = t.PrevLease.Sequence
+			if kvserverbase.BelowRaftPreviousLeaseAssertions {
+				proposal.command.ProposerLease = t.PrevLease
+			}
 		default:
 		}
 		proposal.command.ProposerLeaseSequence = seq


### PR DESCRIPTION
This patch adds an eager form of consistency checking for lease request
and lease transfer commands in CheckForcedErr. While we can't make
strong assertions on lease requests/transfers that are proposed, we can
make strong assertions on the lease which was used by the proposer. This
is because that lease must have been applied by the proposer, and we
know that an applied lease must be consistent for a range.

This patch adds two assertions:

- It ensures that if two replicas have applied a lease with the same
sequence number, then they're both held by the same guy.
- It ensures that as a replica is going through its raft log, applying
leases, leases never jump by more than 1.

Both these cases, previously, would've resulted in the lease being
rejected in CheckForcedErr because we didn't have enough information
to distinguish bugs from legitimately proposed leases that should be
discarded. By threading through the previous lease, which was applied,
we're able to make stronger assertions.

Epic: none
Release note: None