### PR TITLE
roachtest: inc wait to 10m for token return in perturbation tests

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/validation_check.go
+++ b/pkg/cmd/roachtest/roachtestutil/validation_check.go
@@ -163,6 +163,10 @@ func ValidateTokensReturned(
 				}
 			}
 			return nil
-		}, 5*time.Second)
+			// We wait up to 10 minutes for the tokens to be returned. In tests which
+			// purposefully create a send queue towards a node, the queue may take a
+			// while to drain. The tokens will not be returned until the queue is
+			// empty and there are no inflight requests.
+		}, 10*time.Minute)
 	}
 }


### PR DESCRIPTION
We assert that tokens are returned at the end of the `perturbation/*`
roachtests. However, we only waited 5 seconds before failing the
assertion. As the comment in this patch suggests, draining a send queue
can take longer as the node paces its catchup. In such cases, it is
acceptable that tokens are not returned within the lesser duration.

Bump this duration to 10 minutes.

Fixes: #136297
Release note: None