### PR TITLE
logictest: separate out stmts in upsert test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upsert_non_metamorphic
+++ b/pkg/sql/logictest/testdata/logic_test/upsert_non_metamorphic
@@ -4,7 +4,11 @@
 # limiting (#102472).
 statement ok
 CREATE TABLE src (s STRING);
+
+statement ok
 CREATE TABLE dest (s STRING);
+
+statement ok
 INSERT INTO src SELECT repeat('a', 100000) FROM generate_series(1, 60)
 
 user host-cluster-root
@@ -36,6 +40,8 @@ user root
 
 statement ok
 DROP TABLE src;
+
+statement ok
 DROP TABLE dest
 
 # Regression test for UPSERT batching logic (#51391).
@@ -48,7 +54,11 @@ user root
 
 statement ok
 CREATE TABLE src (s STRING);
+
+statement ok
 CREATE TABLE dest (s STRING);
+
+statement ok
 INSERT INTO src
 SELECT
 	'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
@@ -69,11 +79,15 @@ user root
 
 statement ok
 DROP TABLE src;
+
+statement ok
 DROP TABLE dest
 
 # Regression test for finishing UPSERT too early (#54456).
 statement ok
 CREATE TABLE t54456 (c INT PRIMARY KEY);
+
+statement ok
 UPSERT INTO t54456 SELECT i FROM generate_series(1, 25000) AS i
 
 query I


### PR DESCRIPTION
This commit makes it so that we execute each query via a separate logic test directive in `upsert_non_metamorphic` test. My hope is that this will make the test consume a bit less resources so that we don't hit timeouts under race. I confirmed that disabling metamorphic randomization appears to work correctly in this case. If we still see timeouts on this file under race, I'd consider skipping this test in such config (which was recently reverted in 18bd696f3308d3d40aafcb0ab656c45e9c5c7028).

Fixes: #135166.

Release note: None