### PR TITLE
roachtest: deflake perturbation/*/elasticWorkload tests

### DIFF
--- a/pkg/cmd/roachtest/tests/perturbation/elastic_workload.go
+++ b/pkg/cmd/roachtest/tests/perturbation/elastic_workload.go
@@ -37,7 +37,12 @@ func (e elasticWorkload) setupMetamorphic(rng *rand.Rand) variations {
 	// almost all regular requests. To prevent this, we set the min latency to
 	// 100ms instead of the default.
 	v.profileOptions = append(v.profileOptions, roachtestutil.ProfMinimumLatency(100*time.Millisecond))
-	return v.randomize(rng)
+	v = v.randomize(rng)
+	// TODO(#134668): Remove this once this test passes with a longer perturbation duration.
+	if v.perturbationDuration > 10*time.Minute {
+		v.perturbationDuration = 10 * time.Minute
+	}
+	return v
 }
 
 func (e elasticWorkload) startTargetNode(ctx context.Context, t test.Test, v variations) {

--- a/pkg/cmd/roachtest/tests/perturbation/elastic_workload.go
+++ b/pkg/cmd/roachtest/tests/perturbation/elastic_workload.go
@@ -28,7 +28,7 @@ type elasticWorkload struct{}
 var _ perturbation = elasticWorkload{}
 
 func (e elasticWorkload) setup() variations {
-	return setup(e, 5.0)
+	return setup(e, 20.0)
 }
 
 func (e elasticWorkload) setupMetamorphic(rng *rand.Rand) variations {


### PR DESCRIPTION
Previously the elastic workload tests ran close to the 5x increase of score. This change increases the limit to 20 which should be more stable.

This change prevent the metamorphic variation of the elastic workload test from running longer than 10 minutes. We have seen that long runs can cause foreground traffic to stall.

Epic: none
Informs: #134668
Fixes: #135109
Fixes: #134945

Release note: None