### PR TITLE
changefeedccl: make changefeed_emitted_bytes work for core changefeeds

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -262,17 +262,29 @@ func (ca *changeAggregator) MustBeStreaming() bool {
 	return true
 }
 
-// wrapMetricsController wraps the supplied metricsRecorder to emit metrics to telemetry.
-// This method modifies ca.cancel().
-func (ca *changeAggregator) wrapMetricsController(
+// wrapMetricsRecorderWithTelemetry wraps the supplied metricsRecorder
+// so it periodically emits metrics to telemetry.
+func (ca *changeAggregator) wrapMetricsRecorderWithTelemetry(
 	ctx context.Context, recorder metricsRecorder,
 ) (metricsRecorder, error) {
-	job, err := ca.FlowCtx.Cfg.JobRegistry.LoadJob(ctx, ca.spec.JobID)
-	if err != nil {
-		return ca.sliMetrics, err
+	details := ca.spec.Feed
+	jobID := ca.spec.JobID
+	var description string
+	if ca.isSinkless() {
+		// Don't emit telemetry messages for core changefeeds without a description.
+		if details.SinklessInfo == nil {
+			return recorder, nil
+		}
+		description = details.SinklessInfo.Description
+	} else {
+		job, err := ca.FlowCtx.Cfg.JobRegistry.LoadJob(ctx, jobID)
+		if err != nil {
+			return nil, err
+		}
+		description = job.Payload().Description
 	}
 
-	recorderWithTelemetry, err := wrapMetricsRecorderWithTelemetry(ctx, job, ca.FlowCtx.Cfg.Settings, recorder)
+	recorderWithTelemetry, err := wrapMetricsRecorderWithTelemetry(ctx, details, description, jobID, ca.FlowCtx.Cfg.Settings, recorder)
 	if err != nil {
 		return ca.sliMetrics, err
 	}
@@ -337,18 +349,15 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 	}
 	ca.sliMetricsID = ca.sliMetrics.claimId()
 
-	// TODO(jayant): add support for sinkless changefeeds using UUID
 	recorder := metricsRecorder(ca.sliMetrics)
-	if !ca.isSinkless() {
-		recorder, err = ca.wrapMetricsController(ctx, recorder)
-		if err != nil {
-			if log.V(2) {
-				log.Infof(ca.Ctx(), "change aggregator moving to draining due to error wrapping metrics controller: %v", err)
-			}
-			ca.MoveToDraining(err)
-			ca.cancel()
-			return
+	recorder, err = ca.wrapMetricsRecorderWithTelemetry(ctx, recorder)
+	if err != nil {
+		if log.V(2) {
+			log.Infof(ca.Ctx(), "change aggregator moving to draining due to error wrapping metrics controller: %v", err)
 		}
+		ca.MoveToDraining(err)
+		ca.cancel()
+		return
 	}
 
 	ca.sink, err = getEventSink(ctx, ca.FlowCtx.Cfg, ca.spec.Feed, timestampOracle,

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -657,6 +657,11 @@ func createChangefeedJobRecord(
 		}
 
 		details.Opts = opts.AsMap()
+
+		details.SinklessInfo = &jobspb.ChangefeedDetails_SinklessChangefeedInfo{
+			Description: description,
+		}
+
 		// Jobs should not be created for sinkless changefeeds. However, note that
 		// we create and return a job record for sinkless changefeeds below. This is
 		// because we need the job description and details to create our sinkless changefeed.

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1123,6 +1123,16 @@ message ChangefeedDetails {
   sessiondatapb.SessionData session_data = 11;
   reserved 1, 2, 5;
   reserved "targets";
+
+  // SinklessChangefeedInfo contains some metadata for sinkless changefeeds that
+  // is normally stored in the job payload for changefeeds with sinks.
+  message SinklessChangefeedInfo {
+    string description = 1;
+  }
+
+  // SinklessInfo will only be set for sinkless changefeeds and contains metadata
+  // that is normally stored in the job payload for changefeeds with sinks.
+  SinklessChangefeedInfo sinkless_info = 12;
 }
 
 message ResolvedSpan {


### PR DESCRIPTION
This patch makes `changefeed_emitted_bytes` structured log events (and
any future changefeed structured log events) work for core changefeeds
by including the changefeed description in the processor specs.

Informs: #135309

Release note: None