### PR TITLE
sql/tests: add remote sysbench microbenchmark configs

### DIFF
--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -86,6 +86,7 @@ go_test(
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/concurrency",
         "//pkg/roachpb",
+        "//pkg/rpc/nodedialer",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/security/username",


### PR DESCRIPTION
This commit adds a set of new sysbench microbenchmark configurations to exercise different cluster configurations. Specifically, it adds a 1node config without the gRPC local bypass fast-path and a 3node config.

```
BenchmarkSysbench/SQL/1node_local/oltp_read_only         	    2808	   2172196 ns/op	  945425 B/op	    5690 allocs/op
BenchmarkSysbench/SQL/1node_local/oltp_write_only        	    2646	   2567223 ns/op	  513577 B/op	    3236 allocs/op
BenchmarkSysbench/SQL/1node_local/oltp_read_write        	    1090	   5431570 ns/op	 1354056 B/op	    8788 allocs/op
BenchmarkSysbench/SQL/1node_local/oltp_point_select      	   38445	    133851 ns/op	   30238 B/op	     286 allocs/op
BenchmarkSysbench/SQL/1node_local/oltp_begin_commit      	   64358	     88215 ns/op	   14797 B/op	     130 allocs/op
BenchmarkSysbench/SQL/1node_remote/oltp_read_only        	    1506	   4063421 ns/op	 1457756 B/op	    8944 allocs/op
BenchmarkSysbench/SQL/1node_remote/oltp_write_only       	     916	   7515857 ns/op	  749820 B/op	    7787 allocs/op
BenchmarkSysbench/SQL/1node_remote/oltp_read_write       	     505	  10459219 ns/op	 2261270 B/op	   16712 allocs/op
BenchmarkSysbench/SQL/1node_remote/oltp_point_select     	   27060	    273717 ns/op	   46622 B/op	     515 allocs/op
BenchmarkSysbench/SQL/1node_remote/oltp_begin_commit     	   64244	    138563 ns/op	   14969 B/op	     132 allocs/op
BenchmarkSysbench/SQL/3node/oltp_read_only               	    1231	   5353521 ns/op	 1462484 B/op	    8984 allocs/op
BenchmarkSysbench/SQL/3node/oltp_write_only              	     862	   6592617 ns/op	 1200365 B/op	    9572 allocs/op
BenchmarkSysbench/SQL/3node/oltp_read_write              	     532	  11148618 ns/op	 2818459 B/op	   18891 allocs/op
BenchmarkSysbench/SQL/3node/oltp_point_select            	   29367	    198101 ns/op	   47361 B/op	     521 allocs/op
BenchmarkSysbench/SQL/3node/oltp_begin_commit            	   58438	     91320 ns/op	   15395 B/op	     136 allocs/op
BenchmarkSysbench/KV/1node_local/oltp_read_only          	   14305	    431711 ns/op	  261452 B/op	     577 allocs/op
BenchmarkSysbench/KV/1node_local/oltp_write_only         	    9225	    658046 ns/op	  199227 B/op	    1017 allocs/op
BenchmarkSysbench/KV/1node_local/oltp_read_write         	    5095	   1167826 ns/op	  426983 B/op	    1586 allocs/op
BenchmarkSysbench/KV/1node_local/oltp_point_select       	  334492	     18928 ns/op	    4711 B/op	      32 allocs/op
BenchmarkSysbench/KV/1node_local/oltp_begin_commit       	 4755694	      1203 ns/op	    2506 B/op	       6 allocs/op
BenchmarkSysbench/KV/1node_remote/oltp_read_only         	    5709	   1094599 ns/op	  801458 B/op	    4126 allocs/op
BenchmarkSysbench/KV/1node_remote/oltp_write_only        	    6037	    961582 ns/op	  341778 B/op	    3233 allocs/op
BenchmarkSysbench/KV/1node_remote/oltp_read_write        	    2786	   2371607 ns/op	 1139736 B/op	    7385 allocs/op
BenchmarkSysbench/KV/1node_remote/oltp_point_select      	  112892	     46291 ns/op	   17091 B/op	     220 allocs/op
BenchmarkSysbench/KV/1node_remote/oltp_begin_commit      	 4650241	      1393 ns/op	    2506 B/op	       6 allocs/op
BenchmarkSysbench/KV/3node/oltp_read_only                	    5101	   1183637 ns/op	  808329 B/op	    4160 allocs/op
BenchmarkSysbench/KV/3node/oltp_write_only               	    3284	   1840930 ns/op	  535523 B/op	    3919 allocs/op
BenchmarkSysbench/KV/3node/oltp_read_write               	    2073	   3055986 ns/op	 1366557 B/op	    8179 allocs/op
BenchmarkSysbench/KV/3node/oltp_point_select             	  133884	     48424 ns/op	   17536 B/op	     222 allocs/op
BenchmarkSysbench/KV/3node/oltp_begin_commit             	 4325113	      1241 ns/op	    2508 B/op	       6 allocs/op
```

Epic: None
Release note: None