### PR TITLE
vecindex: support deleting vectors from C-SPANN index

### DIFF
--- a/pkg/sql/vecindex/testdata/delete.ddt
+++ b/pkg/sql/vecindex/testdata/delete.ddt
@@ -1,5 +1,141 @@
 # ----------
-# Test deleting vectors from primary index, but not from secondary index.
+# Construct new index with one vector in the root.
+# ----------
+new-index min-partition-size=1 max-partition-size=3 beam-size=2
+vec1: (1, 2)
+----
+• 1 (0, 0)
+│
+└───• vec1 (1, 2)
+
+# Delete remaining vector in the root.
+delete
+vec1
+----
+• 1 (0, 0)
+
+# ----------
+# Construct new index with only duplicate vectors.
+# ----------
+new-index min-partition-size=1 max-partition-size=3 beam-size=2
+vec1: (1, 2)
+vec2: (1, 2)
+vec3: (1, 2)
+vec4: (1, 2)
+vec5: (1, 2)
+vec6: (1, 2)
+----
+• 1 (1, 2)
+│
+├───• 2 (1, 2)
+│   │
+│   ├───• vec1 (1, 2)
+│   └───• vec2 (1, 2)
+│
+└───• 3 (1, 2)
+    │
+    ├───• vec3 (1, 2)
+    ├───• vec4 (1, 2)
+    ├───• vec5 (1, 2)
+    └───• vec6 (1, 2)
+
+# Ensure the correct duplicates are deleted (i.e. with matching keys).
+delete
+vec1
+vec5
+----
+• 1 (1, 2)
+│
+├───• 2 (1, 2)
+│   │
+│   └───• vec2 (1, 2)
+│
+└───• 3 (1, 2)
+    │
+    ├───• vec3 (1, 2)
+    ├───• vec4 (1, 2)
+    └───• vec6 (1, 2)
+
+# ----------
+# Construct new index with multiple levels.
+# ----------
+new-index min-partition-size=1 max-partition-size=3 beam-size=1
+vec1: (1, 2)
+vec2: (7, 4)
+vec3: (4, 3)
+vec4: (-4, 5)
+vec5: (1, 11)
+vec6: (1, -6)
+vec7: (0, 4)
+vec8: (-2, 8)
+vec9: (2, 8)
+----
+• 1 (1.5, 1.875)
+│
+├───• 2 (1, -2)
+│   │
+│   ├───• vec1 (1, 2)
+│   └───• vec6 (1, -6)
+│
+├───• 4 (1.75, 4)
+│   │
+│   ├───• vec3 (4, 3)
+│   ├───• vec4 (-4, 5)
+│   ├───• vec7 (0, 4)
+│   └───• vec2 (7, 4)
+│
+└───• 5 (0.3333, 9)
+    │
+    ├───• vec5 (1, 11)
+    ├───• vec8 (-2, 8)
+    └───• vec9 (2, 8)
+
+# Test case where initial search fails to find vector to delete and it must be
+# retried.
+delete
+vec1: (0, 8)
+----
+• 1 (1.5, 1.875)
+│
+├───• 2 (1, -2)
+│   │
+│   └───• vec6 (1, -6)
+│
+├───• 4 (1.75, 4)
+│   │
+│   ├───• vec3 (4, 3)
+│   ├───• vec4 (-4, 5)
+│   ├───• vec7 (0, 4)
+│   └───• vec2 (7, 4)
+│
+└───• 5 (0.3333, 9)
+    │
+    ├───• vec5 (1, 11)
+    ├───• vec8 (-2, 8)
+    └───• vec9 (2, 8)
+
+# Delete multiple vectors.
+delete
+vec4
+vec5
+vec6
+----
+• 1 (1.5, 1.875)
+│
+├───• 2 (1, -2)
+├───• 4 (1.75, 4)
+│   │
+│   ├───• vec3 (4, 3)
+│   ├───• vec2 (7, 4)
+│   └───• vec7 (0, 4)
+│
+└───• 5 (0.3333, 9)
+    │
+    ├───• vec9 (2, 8)
+    └───• vec8 (-2, 8)
+
+# ----------
+# Construct new index with multiple levels.
 # ----------
 new-index min-partition-size=1 max-partition-size=3 beam-size=2
 vec1: (1, 2)

--- a/pkg/sql/vecindex/testdata/insert.ddt
+++ b/pkg/sql/vecindex/testdata/insert.ddt
@@ -1,3 +1,6 @@
+# ----------
+# Construct empty index.
+# ----------
 new-index min-partition-size=1 max-partition-size=4 beam-size=2
 ----
 • 1 (0, 0)

--- a/pkg/sql/vecindex/vecstore/in_memory_store.go
+++ b/pkg/sql/vecindex/vecstore/in_memory_store.go
@@ -352,6 +352,15 @@ func (s *InMemoryStore) DeleteVector(txn Txn, key PrimaryKey) {
 	delete(s.mu.vectors, string(key))
 }
 
+// GetVector returns a single vector from the store, by its primary key. This
+// is used for testing.
+func (s *InMemoryStore) GetVector(key PrimaryKey) vector.T {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.mu.vectors[string(key)]
+}
+
 // GetAllVectors returns all vectors that have been added to the store as key
 // and vector pairs. This is used for testing.
 func (s *InMemoryStore) GetAllVectors() []VectorWithKey {

--- a/pkg/sql/vecindex/vecstore/search_set_test.go
+++ b/pkg/sql/vecindex/vecstore/search_set_test.go
@@ -132,4 +132,9 @@ func TestSearchSet(t *testing.T) {
 	otherSet.MaxExtraResults = 1
 	otherSet.AddAll(SearchResults{result1, result2, result3, result4, result5, result6, result7})
 	require.Equal(t, SearchResults{result3, result1, result4, result7}, otherSet.PopResults())
+
+	// Ignore results without a matching primary key.
+	otherSet = SearchSet{MaxResults: 2, MatchKey: []byte{60}}
+	otherSet.AddAll(SearchResults{result1, result2, result3, result4, result5, result6, result7})
+	require.Equal(t, SearchResults{result6}, otherSet.PopResults())
 }


### PR DESCRIPTION
Add Delete method to the vector index, which attempts to remove a vector from the index, given its value and primary key. Delete may not be able to locate the vector in the index, leaving a "dangling vector" reference which other methods need to take care not to ignore.

Epic: CRDB-42943

Release note: None