### PR TITLE
reports: skip TestCriticalLocalitiesReportIntegration under stress/race

### DIFF
--- a/pkg/kv/kvserver/reports/reporter_test.go
+++ b/pkg/kv/kvserver/reports/reporter_test.go
@@ -119,6 +119,11 @@ func TestConstraintConformanceReportIntegration(t *testing.T) {
 func TestCriticalLocalitiesReportIntegration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderStressWithIssue(t, 134948)
+	skip.UnderRaceWithIssue(t, 134948)
+	skip.UnderShort(t)
+
 	ctx := context.Background()
 	// 2 regions, 3 dcs per region.
 	tc := serverutils.StartCluster(t, 6, base.TestClusterArgs{


### PR DESCRIPTION
See #134948.
Epic: None
Release note: None
