### PR TITLE
release-24.2: scjob: support handling permanent job errors

### DIFF
--- a/pkg/sql/schemachanger/schemachanger_test.go
+++ b/pkg/sql/schemachanger/schemachanger_test.go
@@ -1035,3 +1035,36 @@ func TestCompareLegacyAndDeclarative(t *testing.T) {
 
 	sctest.CompareLegacyAndDeclarative(t, ss)
 }
+
+func TestSchemaChangerFailsOnMissingDesc(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	var params base.TestServerArgs
+	params.Knobs = base.TestingKnobs{
+		SQLDeclarativeSchemaChanger: &scexec.TestingKnobs{
+			AfterStage: func(p scplan.Plan, stageIdx int) error {
+				if p.Params.ExecutionPhase != scop.PostCommitPhase || stageIdx > 1 {
+					return nil
+				}
+
+				return catalog.ErrDescriptorNotFound
+			},
+		},
+		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+	}
+
+	s, sqlDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(ctx)
+
+	tdb := sqlutils.MakeSQLRunner(sqlDB)
+	tdb.Exec(t, `SET use_declarative_schema_changer = 'off'`)
+	tdb.Exec(t, `CREATE DATABASE db`)
+	tdb.Exec(t, `CREATE TABLE db.t (a INT PRIMARY KEY)`)
+	tdb.Exec(t, `SET use_declarative_schema_changer = 'unsafe'`)
+	tdb.ExpectErr(t, "descriptor not found", `ALTER TABLE db.t ADD COLUMN b INT NOT NULL DEFAULT (123)`)
+	// Validate the job has hit a terminal state.
+	tdb.CheckQueryResults(t, "SELECT status FROM crdb_internal.jobs WHERE statement LIKE '%ADD COLUMN%'",
+		[][]string{{"failed"}})
+}


### PR DESCRIPTION
Backport 1/1 commits from #134746.

/cc @cockroachdb/release

---

Previously, when a descriptor was detect as a dropped the error was marked as permanent for schema change jobs. However, the declarative schema change job framework did not properly handle these errors. As a result, even if the erorr was tagged we would keep attempting rollbacks. To address this, this patch makes the OnFailOrCancel logic detect permanent errors and allows them to cause the schema change to hit the terminal state.

Fixes: #131405
Release note: None
Release justification: low risk fix for scenarios that can lead to infinitely retrying jobs when dropping objects
