### PR TITLE
ui: fix db console bugs

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -12,6 +12,7 @@ import {
 import isEmpty from "lodash/isEmpty";
 import isNil from "lodash/isNil";
 import map from "lodash/map";
+import sortby from "lodash/sortBy";
 import Long from "long";
 import moment from "moment-timezone";
 import { RouteComponentProps } from "react-router";
@@ -77,7 +78,15 @@ function rollupStoreMetrics(
 
 export const nodesReducerObj = new CachedDataReducer(
   (req: api.NodesRequestMessage, timeout?: moment.Duration) =>
-    api.getNodesUI(req, timeout).then(rollupStoreMetrics),
+    api
+      .getNodesUI(req, timeout)
+      .then(rollupStoreMetrics)
+      .then(nodeStatuses => {
+        nodeStatuses.forEach(ns => {
+          ns.store_statuses = sortby(ns.store_statuses, ss => ss.desc.store_id);
+        });
+        return nodeStatuses;
+      }),
   "nodes",
   moment.duration(10, "s"),
 );

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodesOverview/index.tsx
@@ -253,6 +253,11 @@ export class NodeList extends React.Component<LiveNodeListProps> {
       },
       sorter: (a: NodeStatusRow, b: NodeStatusRow) => {
         if (!isUndefined(a.nodeId) && !isUndefined(b.nodeId)) {
+          // If nodeId is defined but regionId is not, this means that there is only
+          // a single region. In this case, sort the by nodeId.
+          if (isUndefined(a.region) && isUndefined(b.region)) {
+            return a.nodeId - b.nodeId;
+          }
           return 0;
         }
         if (a.region < b.region) {
@@ -273,13 +278,7 @@ export class NodeList extends React.Component<LiveNodeListProps> {
         if (isUndefined(a.nodesCount) || isUndefined(b.nodesCount)) {
           return 0;
         }
-        if (a.nodesCount < b.nodesCount) {
-          return -1;
-        }
-        if (a.nodesCount > b.nodesCount) {
-          return 1;
-        }
-        return 0;
+        return a.nodesCount - b.nodesCount;
       },
       render: (_text: string, record: NodeStatusRow) => record.nodesCount,
       sortDirections: ["ascend", "descend"],
@@ -291,7 +290,7 @@ export class NodeList extends React.Component<LiveNodeListProps> {
       dataIndex: "uptime",
       render: formatWithPossibleStaleIndicator,
       title: <UptimeTooltip>Uptime</UptimeTooltip>,
-      sorter: true,
+      sorter: false,
       className: "column--align-right",
       width: "10%",
       ellipsis: true,
@@ -301,7 +300,7 @@ export class NodeList extends React.Component<LiveNodeListProps> {
       dataIndex: "replicas",
       render: formatWithPossibleStaleIndicator,
       title: <ReplicasTooltip>Replicas</ReplicasTooltip>,
-      sorter: true,
+      sorter: (a: NodeStatusRow, b: NodeStatusRow) => a.replicas - b.replicas,
       className: "column--align-right",
       width: "10%",
     },
@@ -340,7 +339,7 @@ export class NodeList extends React.Component<LiveNodeListProps> {
       key: "numCpus",
       title: <CPUsTooltip>vCPUs</CPUsTooltip>,
       dataIndex: "numCpus",
-      sorter: true,
+      sorter: (a: NodeStatusRow, b: NodeStatusRow) => a.numCpus - b.numCpus,
       className: "column--align-right",
       width: "8%",
     },
@@ -348,7 +347,7 @@ export class NodeList extends React.Component<LiveNodeListProps> {
       key: "version",
       dataIndex: "version",
       title: <VersionTooltip>Version</VersionTooltip>,
-      sorter: true,
+      sorter: false,
       width: "8%",
       ellipsis: true,
     },


### PR DESCRIPTION
Fixes the following bugs

Overview page:
  - Sorting the nodes column for single region clustesr now sorts by node id. Previously, it didn't sort at all.
  - Sorting by replica count now works as expected.
  - Sorting by vCPUs now works as expected.
  - Removed sorting icons from the following columns:
    - Uptime
    - Version

Node Overview Page:
  - Fixed a bug where the store columns rendered in random order and would re-render in random order periodically.

Resolves: #135290, #134197
Epic: none
Release note (ui change): fixes UI bugs in db-console. See commit message for full list of bug fixes.