### PR TITLE
changefeedccl: fix changefeed description for core changefeeds

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -211,6 +211,7 @@ go_test(
         "avro_test.go",
         "changefeed_dist_test.go",
         "changefeed_processors_test.go",
+        "changefeed_stmt_test.go",
         "changefeed_test.go",
         "csv_test.go",
         "encoder_json_test.go",

--- a/pkg/ccl/changefeedccl/changefeed_stmt_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt_test.go
@@ -1,0 +1,89 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package changefeedccl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeChangefeedJobDescription(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		createStmt string
+		sinkURI    string
+		opts       map[string]string
+		expected   string
+	}{
+		{
+			createStmt: `CREATE CHANGEFEED FOR t`,
+			expected:   `EXPERIMENTAL CHANGEFEED FOR TABLE t`,
+		},
+		{
+			createStmt: `CREATE CHANGEFEED FOR t WITH diff`,
+			opts:       map[string]string{"diff": ""},
+			expected:   `EXPERIMENTAL CHANGEFEED FOR TABLE t WITH OPTIONS (diff)`,
+		},
+		{
+			createStmt: `CREATE CHANGEFEED FOR t WITH diff, client_cert='a', client_key='b'`,
+			opts:       map[string]string{"diff": "", "client_cert": "a", "client_key": "b"},
+			expected:   `EXPERIMENTAL CHANGEFEED FOR TABLE t WITH OPTIONS (client_cert = 'a', client_key = 'redacted', diff)`,
+		},
+		{
+			createStmt: `CREATE CHANGEFEED FOR t INTO 'null://'`,
+			sinkURI:    `null://`,
+			expected:   `CREATE CHANGEFEED FOR TABLE t INTO 'null:'`,
+		},
+		{
+			createStmt: `CREATE CHANGEFEED FOR t INTO 'null://' WITH diff`,
+			sinkURI:    `null://`,
+			opts:       map[string]string{"diff": ""},
+			expected:   `CREATE CHANGEFEED FOR TABLE t INTO 'null:' WITH OPTIONS (diff)`,
+		},
+		{
+			createStmt: `CREATE CHANGEFEED FOR t INTO 'null://' WITH diff, client_cert='a', client_key='b'`,
+			sinkURI:    `null://`,
+			opts:       map[string]string{"diff": "", "client_cert": "a", "client_key": "b"},
+			expected:   `CREATE CHANGEFEED FOR TABLE t INTO 'null:' WITH OPTIONS (client_cert = 'a', client_key = 'redacted', diff)`,
+		},
+		{
+			createStmt: `CREATE CHANGEFEED FOR t INTO 'kafka://fake.kafka'`,
+			sinkURI:    `kafka://fake.kafka`,
+			expected:   `CREATE CHANGEFEED FOR TABLE t INTO 'kafka://fake.kafka'`,
+		},
+		{
+			createStmt: `CREATE CHANGEFEED FOR t INTO 'kafka://fake.kafka' WITH diff`,
+			sinkURI:    `kafka://fake.kafka`,
+			opts:       map[string]string{"diff": ""},
+			expected:   `CREATE CHANGEFEED FOR TABLE t INTO 'kafka://fake.kafka' WITH OPTIONS (diff)`,
+		},
+		{
+			createStmt: `CREATE CHANGEFEED FOR t INTO 'kafka://fake.kafka' WITH diff, client_cert='a', client_key='b'`,
+			sinkURI:    `kafka://fake.kafka`,
+			opts:       map[string]string{"diff": "", "client_cert": "a", "client_key": "b"},
+			expected:   `CREATE CHANGEFEED FOR TABLE t INTO 'kafka://fake.kafka' WITH OPTIONS (client_cert = 'a', client_key = 'redacted', diff)`,
+		},
+	} {
+		parsed, err := parser.ParseOne(tc.createStmt)
+		require.NoError(t, err)
+		create := parsed.AST.(*tree.CreateChangefeed)
+
+		opts := changefeedbase.MakeStatementOptions(tc.opts)
+
+		desc, err := makeChangefeedJobDescription(ctx, create, tc.sinkURI, opts)
+		require.NoError(t, err)
+		require.Equal(t, tc.expected, desc)
+	}
+}

--- a/pkg/ccl/changefeedccl/scheduled_changefeed.go
+++ b/pkg/ccl/changefeedccl/scheduled_changefeed.go
@@ -506,7 +506,7 @@ func emitSchedule(
 	resultsCh chan<- tree.Datums,
 ) error {
 	opts := changefeedbase.MakeStatementOptions(createChangefeedOpts)
-	redactedChangefeedNode, err := changefeedJobDescription(ctx, createChangefeedNode, sinkURI, opts)
+	redactedChangefeedNode, err := makeChangefeedJobDescription(ctx, createChangefeedNode, sinkURI, opts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This patch fixes the changefeed description generation for core
changefeeds to not include an empty sink URI. It also adds a
unit test for the `makeChangefeedJobDescription` function.

Informs: #135309

Release note: None