### PR TITLE
roachtest: add wait for replication to obs tests

### DIFF
--- a/pkg/cmd/roachtest/tests/db_console.go
+++ b/pkg/cmd/roachtest/tests/db_console.go
@@ -244,7 +244,7 @@ func runDbConsoleCypressMixedVersions(ctx context.Context, t test.Test, c cluste
 	if c.IsLocal() {
 		t.Fatal("cannot be run in local mode")
 	}
-	mvt := mixedversion.NewTest(ctx, t, t.L(), c, c.CRDBNodes())
+	mvt := mixedversion.NewTest(ctx, t, t.L(), c, c.CRDBNodes(), mixedversion.EnableWaitForReplication)
 	cypressTest := newDbConsoleCypressTest(t, c, "cypress/e2e/health-check/*.ts", seedQueries)
 	init := func(ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper) error {
 		_, db := h.RandomDB(r)

--- a/pkg/cmd/roachtest/tests/mixed_version_sql_stats.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_sql_stats.go
@@ -55,6 +55,7 @@ func runSQLStatsMixedVersion(ctx context.Context, t test.Test, c cluster.Cluster
 		// the `workload fixtures import` command, which is only supported
 		// reliably multi-tenant mode starting from that version.
 		mixedversion.MinimumSupportedVersion("v23.2.0"),
+		mixedversion.EnableWaitForReplication,
 	)
 	flushInterval := 2 * time.Minute
 


### PR DESCRIPTION
We had flakes recently that could be related to the original one that motivated the inclusion of this option.

Resolves: #134814
Part of: #134808

Release note: None