### PR TITLE
roachprod: Remove outdated license warning message

### DIFF
--- a/pkg/roachprod/install/BUILD.bazel
+++ b/pkg/roachprod/install/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/roachprod/install",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/ccl/utilccl/licenseccl",
         "//pkg/roachprod/cloud",
         "//pkg/roachprod/config",
         "//pkg/roachprod/errors",


### PR DESCRIPTION
Previously, starting a cluster with `roachprod` may display the following warning:
```
COCKROACH_DEV_LICENSE unset: enterprise features will be unavailable
```

With the deprecation of the core license, enterprise features are no longer disabled. Instead, clusters without a license are subject to throttling only after the 7-day grace period expires.

To address this, roachprod now automatically installs a license valid for one month. This prevents unnecessary warnings in the DB console and client notices about potential throttling.

Epic: None
Release note: None