### PR TITLE
vecindex: implement C-SPANN merge

### DIFF
--- a/pkg/sql/vecindex/fixup_processor.go
+++ b/pkg/sql/vecindex/fixup_processor.go
@@ -28,6 +28,9 @@ const (
 	// splitFixup is a fixup that includes the key of a partition to split as
 	// well as the key of its parent partition.
 	splitFixup fixupType = iota + 1
+	// mergeFixup is a fixup that includes the key of a partition to merge as
+	// well as the key of its parent partition.
+	mergeFixup
 )
 
 // maxFixups specifies the maximum number of pending index fixups that can be
@@ -137,6 +140,17 @@ func (fp *fixupProcessor) AddSplit(
 	})
 }
 
+// AddMerge enqueues a merge fixup for later processing.
+func (fp *fixupProcessor) AddMerge(
+	ctx context.Context, parentPartitionKey vecstore.PartitionKey, partitionKey vecstore.PartitionKey,
+) {
+	fp.addFixup(ctx, fixup{
+		Type:               mergeFixup,
+		ParentPartitionKey: parentPartitionKey,
+		PartitionKey:       partitionKey,
+	})
+}
+
 // Start is meant to be called on a background goroutine. It runs until the
 // provided context is canceled, processing fixups as they are added to the
 // fixup processor.
@@ -215,6 +229,14 @@ func (fp *fixupProcessor) run(ctx context.Context, wait bool) (ok bool, err erro
 		if err = fp.splitPartition(ctx, next.ParentPartitionKey, next.PartitionKey); err != nil {
 			err = errors.Wrapf(err, "splitting partition %d", next.PartitionKey)
 		}
+
+	case mergeFixup:
+		if err = fp.mergePartition(ctx, next.ParentPartitionKey, next.PartitionKey); err != nil {
+			err = errors.Wrapf(err, "merging partition %d", next.PartitionKey)
+		}
+
+	default:
+		return false, errors.AssertionFailedf("unknown fixup %d", next.Type)
 	}
 
 	// Delete already-processed fixup from its pending map, even if the fixup
@@ -226,7 +248,7 @@ func (fp *fixupProcessor) run(ctx context.Context, wait bool) (ok bool, err erro
 	fp.pendingCount.Done()
 
 	switch next.Type {
-	case splitFixup:
+	case splitFixup, mergeFixup:
 		key := partitionFixupKey{Type: next.Type, PartitionKey: next.PartitionKey}
 		delete(fp.mu.pendingPartitions, key)
 	}
@@ -251,7 +273,7 @@ func (fp *fixupProcessor) addFixup(ctx context.Context, fixup fixup) {
 
 	// Don't enqueue fixup if it's already pending.
 	switch fixup.Type {
-	case splitFixup:
+	case splitFixup, mergeFixup:
 		key := partitionFixupKey{Type: fixup.Type, PartitionKey: fixup.PartitionKey}
 		if _, ok := fp.mu.pendingPartitions[key]; ok {
 			return
@@ -309,21 +331,24 @@ func (fp *fixupProcessor) splitPartition(
 				parentPartitionKey, partitionKey)
 		}
 
-		if parentPartition.Find(vecstore.ChildKey{PartitionKey: partitionKey}) == -1 {
+		// Remove the splitting partition from the parent partition.
+		if !parentPartition.ReplaceWithLastByKey(vecstore.ChildKey{PartitionKey: partitionKey}) {
 			log.VEventf(ctx, 2, "partition %d is no longer child of partition %d, do not split",
 				partitionKey, parentPartitionKey)
 			return nil
 		}
 	}
 
-	// Get the full vectors for the partition's children.
+	// Get the full vectors for the splitting partition's children.
 	vectors, err := fp.getFullVectorsForPartition(ctx, txn, partitionKey, partition)
 	if err != nil {
 		return errors.Wrapf(err, "getting full vectors for split of partition %d", partitionKey)
 	}
-	if vectors.Count < fp.index.options.MaxPartitionSize*3/4 {
+	if vectors.Count < 2 {
 		// This could happen if the partition had tons of dangling references that
 		// need to be cleaned up.
+		// TODO(andyk): We might consider cleaning up references and/or rewriting
+		// the partition.
 		log.VEventf(ctx, 2, "partition %d has only %d live vectors, do not split",
 			partitionKey, vectors.Count)
 		return nil
@@ -679,8 +704,127 @@ func (fp *fixupProcessor) linkNearbyVectors(
 	return nil
 }
 
+// mergePartition merges the partition with the given key and parent key. This
+// runs in its own transaction. For a given index, there is at most one merge
+// happening per SQL process. However, there can be multiple SQL processes, each
+// running a merge.
+func (fp *fixupProcessor) mergePartition(
+	ctx context.Context, parentPartitionKey vecstore.PartitionKey, partitionKey vecstore.PartitionKey,
+) (err error) {
+	if partitionKey == vecstore.RootKey {
+		return errors.AssertionFailedf("cannot merge the root partition")
+	}
+
+	// Run the merge within a transaction.
+	txn, err := fp.index.store.BeginTransaction(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err == nil {
+			err = fp.index.store.CommitTransaction(ctx, txn)
+		} else {
+			err = errors.CombineErrors(err, fp.index.store.AbortTransaction(ctx, txn))
+		}
+	}()
+
+	// Get the partition to be merged from the store.
+	partition, err := fp.index.store.GetPartition(ctx, txn, partitionKey)
+	if errors.Is(err, vecstore.ErrPartitionNotFound) {
+		log.VEventf(ctx, 2, "partition %d no longer exists, do not merge", partitionKey)
+		return nil
+	} else if err != nil {
+		return errors.Wrapf(err, "getting partition %d to merge", partitionKey)
+	}
+
+	// Load the parent of the partition to merge.
+	parentPartition, err := fp.index.store.GetPartition(ctx, txn, parentPartitionKey)
+	if errors.Is(err, vecstore.ErrPartitionNotFound) {
+		log.VEventf(ctx, 2, "parent partition %d of partition %d no longer exists, do not merge",
+			parentPartitionKey, partitionKey)
+		return nil
+	} else if err != nil {
+		return errors.Wrapf(err, "getting parent %d of partition %d to merge",
+			parentPartitionKey, partitionKey)
+	}
+
+	// This check ensures that the tree always stays fully balanced; removing a
+	// level always happens at the root.
+	if parentPartition.Count() == 1 && parentPartitionKey != vecstore.RootKey {
+		log.VEventf(ctx, 2, "partition %d has no sibling partitions, do not merge", partitionKey)
+		return nil
+	}
+
+	// Get the full vectors for the merging partition's children.
+	vectors, err := fp.getFullVectorsForPartition(ctx, txn, partitionKey, partition)
+	if err != nil {
+		return errors.Wrapf(err, "getting full vectors for merge of partition %d", partitionKey)
+	}
+
+	log.VEventf(ctx, 2, "merging partition %d (%d vectors)",
+		partitionKey, len(partition.ChildKeys()))
+
+	// De-link the merging partition from its parent partition. This does not
+	// delete data or metadata in the partition.
+	childKey := vecstore.ChildKey{PartitionKey: partitionKey}
+	if !parentPartition.ReplaceWithLastByKey(childKey) {
+		log.VEventf(ctx, 2, "partition %d is no longer child of partition %d, do not merge",
+			partitionKey, parentPartitionKey)
+		return nil
+	}
+	if _, err = fp.index.removeFromPartition(ctx, txn, parentPartitionKey, childKey); err != nil {
+		return errors.Wrapf(err, "remove partition %d from parent partition %d",
+			partitionKey, parentPartitionKey)
+	}
+
+	// Delete the merging partition from the store. This actually deletes the
+	// partition's data and metadata.
+	if err = fp.index.store.DeletePartition(ctx, txn, partitionKey); err != nil {
+		return errors.Wrapf(err, "deleting partition %d", partitionKey)
+	}
+
+	// Move vectors from the deleted partition to other partitions.
+	if parentPartition.Count() == 0 {
+		// The parent is now empty, which means the deleted partition was the last
+		// partition in the parent. That means that the entire level needs to be
+		// removed from the tree. This is only allowed if the parent partition is
+		// the root partition (the sibling partition check made above ensure that
+		// this is the case). Reduce the number of levels in the tree by one by
+		// merging vectors in the merging partition into the root partition.
+		if parentPartitionKey != vecstore.RootKey {
+			return errors.AssertionFailedf("only root partition can have zero vectors")
+		}
+		quantizedSet := fp.index.rootQuantizer.Quantize(ctx, &vectors)
+		rootPartition := vecstore.NewPartition(
+			fp.index.rootQuantizer, quantizedSet, partition.ChildKeys(), partition.Level())
+		if err = fp.index.store.SetRootPartition(ctx, txn, rootPartition); err != nil {
+			return errors.Wrapf(err, "setting new root for merge of partition %d", partitionKey)
+		}
+	} else {
+		// Re-insert vectors into remaining partitions at the same level.
+		fp.searchCtx = searchContext{
+			Ctx:       ctx,
+			Workspace: fp.workspace,
+			Txn:       txn,
+			Level:     parentPartition.Level(),
+		}
+
+		childKeys := partition.ChildKeys()
+		for i := range childKeys {
+			fp.searchCtx.Randomized = vectors.At(i)
+			err = fp.index.insertHelper(&fp.searchCtx, childKeys[i], true /* allowRetry */)
+			if err != nil {
+				return errors.Wrapf(err, "inserting vector from merged partition %d", partitionKey)
+			}
+		}
+	}
+
+	return nil
+}
+
 // getFullVectorsForPartition fetches the full-size vectors (potentially
 // randomized by the quantizer) that are quantized by the given partition.
+// Discard any dangling vectors in the partition.
 func (fp *fixupProcessor) getFullVectorsForPartition(
 	ctx context.Context,
 	txn vecstore.Txn,
@@ -699,16 +843,16 @@ func (fp *fixupProcessor) getFullVectorsForPartition(
 	}
 
 	// Remove dangling vector references.
-	for i := range fp.tempVectorsWithKeys {
+	for i := 0; i < len(fp.tempVectorsWithKeys); i++ {
 		if fp.tempVectorsWithKeys[i].Vector != nil {
 			continue
 		}
 
 		// Move last reference to current location and reduce size of slice.
-		// TODO(andyk): Enqueue fixup to delete dangling vector from index.
 		count := len(fp.tempVectorsWithKeys) - 1
 		fp.tempVectorsWithKeys[i] = fp.tempVectorsWithKeys[count]
 		fp.tempVectorsWithKeys = fp.tempVectorsWithKeys[:count]
+		partition.ReplaceWithLast(i)
 		i--
 	}
 

--- a/pkg/sql/vecindex/quantize/quantizer.go
+++ b/pkg/sql/vecindex/quantize/quantizer.go
@@ -105,4 +105,8 @@ type QuantizedVectorSet interface {
 	// set, replacing it with the last quantized vector in the set. The modified
 	// set has one less element and the last quantized vector's position changes.
 	ReplaceWithLast(offset int)
+
+	// Clone makes a deep copy of this quantized vector set. Changes to either
+	// the original or clone will not affect the other.
+	Clone() QuantizedVectorSet
 }

--- a/pkg/sql/vecindex/quantize/rabitqpb.go
+++ b/pkg/sql/vecindex/quantize/rabitqpb.go
@@ -44,6 +44,16 @@ func MakeRaBitQCodeSetFromRawData(data []uint64, width int) RaBitQCodeSet {
 	return RaBitQCodeSet{Count: len(data) / width, Width: width, Data: data}
 }
 
+// Clone makes a deep copy of the code set. Changes to either the original or
+// clone will not affect the other.
+func (cs *RaBitQCodeSet) Clone() RaBitQCodeSet {
+	return RaBitQCodeSet{
+		Count: cs.Count,
+		Width: cs.Width,
+		Data:  slices.Clone(cs.Data),
+	}
+}
+
 // At returns the code at the given position in the set as a slice of uint64
 // values that can be read or written by the caller.
 func (cs *RaBitQCodeSet) At(offset int) RaBitQCode {
@@ -105,6 +115,17 @@ func (vs *RaBitQuantizedVectorSet) ReplaceWithLast(offset int) {
 	vs.CentroidDistances = vs.CentroidDistances[:lastOffset]
 	vs.DotProducts[offset] = vs.DotProducts[lastOffset]
 	vs.DotProducts = vs.DotProducts[:lastOffset]
+}
+
+// Clone implements the QuantizedVectorSet interface.
+func (vs *RaBitQuantizedVectorSet) Clone() QuantizedVectorSet {
+	return &RaBitQuantizedVectorSet{
+		Centroid:          slices.Clone(vs.Centroid),
+		Codes:             vs.Codes.Clone(),
+		CodeCounts:        slices.Clone(vs.CodeCounts),
+		CentroidDistances: slices.Clone(vs.CentroidDistances),
+		DotProducts:       slices.Clone(vs.DotProducts),
+	}
 }
 
 // AddUndefined adds the given number of quantized vectors to this set. The new

--- a/pkg/sql/vecindex/quantize/rabitqpb_test.go
+++ b/pkg/sql/vecindex/quantize/rabitqpb_test.go
@@ -44,6 +44,19 @@ func TestRaBitCodeSet(t *testing.T) {
 	require.Equal(t, 4, cs.Count)
 	require.Equal(t, 3, cs.Width)
 	require.Equal(t, data, cs.Data)
+
+	// Clone.
+	data = []uint64{1, 2, 3, 4, 5, 6}
+	cs = MakeRaBitQCodeSetFromRawData(data, 2)
+	cs2 := cs.Clone()
+	cs.ReplaceWithLast(0)
+	cs2.Add(RaBitQCode{10, 20})
+	require.Equal(t, 2, cs.Count)
+	require.Equal(t, 2, cs.Width)
+	require.Equal(t, []uint64{5, 6, 3, 4}, cs.Data)
+	require.Equal(t, 4, cs2.Count)
+	require.Equal(t, 2, cs2.Width)
+	require.Equal(t, []uint64{1, 2, 3, 4, 5, 6, 10, 20}, cs2.Data)
 }
 
 func TestRaBitQuantizedVectorSet(t *testing.T) {
@@ -61,6 +74,18 @@ func TestRaBitQuantizedVectorSet(t *testing.T) {
 	require.Len(t, quantizedSet.CentroidDistances, 5)
 	require.Len(t, quantizedSet.DotProducts, 5)
 
+	// Ensure that cloning does not disturb anything.
+	cloned := quantizedSet.Clone().(*RaBitQuantizedVectorSet)
+	copy(cloned.Codes.At(0), []uint64{10, 20, 30})
+	cloned.Centroid[0] = 10
+	cloned.CodeCounts[0] = 10
+	cloned.CentroidDistances[0] = 10
+	cloned.DotProducts[0] = 10
+	cloned.ReplaceWithLast(1)
+	cloned.ReplaceWithLast(1)
+	cloned.ReplaceWithLast(1)
+	cloned.ReplaceWithLast(1)
+
 	quantizedSet.ReplaceWithLast(2)
 	require.Equal(t, 4, quantizedSet.Codes.Count)
 	require.Equal(t, RaBitQCode{1, 2, 3}, quantizedSet.Codes.At(2))
@@ -70,4 +95,11 @@ func TestRaBitQuantizedVectorSet(t *testing.T) {
 	require.Equal(t, float32(1.23), quantizedSet.CentroidDistances[2])
 	require.Len(t, quantizedSet.DotProducts, 4)
 	require.Equal(t, float32(4.56), quantizedSet.DotProducts[2])
+
+	// Check that clone is unaffected.
+	require.Equal(t, []float32{10, 2, 3}, cloned.Centroid)
+	require.Equal(t, RaBitQCodeSet{Count: 1, Width: 3, Data: []uint64{10, 20, 30}}, cloned.Codes)
+	require.Equal(t, []uint32{10}, cloned.CodeCounts)
+	require.Equal(t, []float32{10}, cloned.CentroidDistances)
+	require.Equal(t, []float32{10}, cloned.DotProducts)
 }

--- a/pkg/sql/vecindex/quantize/unquantizedpb.go
+++ b/pkg/sql/vecindex/quantize/unquantizedpb.go
@@ -27,6 +27,15 @@ func (vs *UnQuantizedVectorSet) GetCentroidDistances() []float32 {
 	return vs.CentroidDistances
 }
 
+// Clone implements the QuantizedVectorSet interface.
+func (vs *UnQuantizedVectorSet) Clone() QuantizedVectorSet {
+	return &UnQuantizedVectorSet{
+		Centroid:          slices.Clone(vs.Centroid),
+		CentroidDistances: slices.Clone(vs.CentroidDistances),
+		Vectors:           vs.Vectors.Clone(),
+	}
+}
+
 // ComputeSquaredDistances computes the exact squared distances between the
 // given query vector and the vectors in the set, and writes the distances to
 // the "squaredDistances" slice.

--- a/pkg/sql/vecindex/quantize/unquantizedpb_test.go
+++ b/pkg/sql/vecindex/quantize/unquantizedpb_test.go
@@ -30,6 +30,13 @@ func TestUnQuantizedVectorSet(t *testing.T) {
 	distances := roundFloats(quantizedSet.GetCentroidDistances(), 4)
 	require.Equal(t, []float32{3, 2.2361, 4.1231, 6.7082, 9.434}, distances)
 
+	// Ensure that cloning does not disturb anything.
+	cloned := quantizedSet.Clone().(*UnQuantizedVectorSet)
+	cloned.Centroid[0] = 10
+	cloned.CentroidDistances[0] = 10
+	copy(cloned.Vectors.At(0), vector.T{0, 0})
+	cloned.ReplaceWithLast(1)
+
 	// Remove vector.
 	quantizedSet.ReplaceWithLast(2)
 	require.Equal(t, 4, quantizedSet.GetCount())
@@ -39,4 +46,9 @@ func TestUnQuantizedVectorSet(t *testing.T) {
 	// ComputeSquaredDistances on vectors.
 	quantizedSet.ComputeSquaredDistances(vector.T{-1, 1}, distances)
 	require.Equal(t, []float32{5, 25, 181, 113}, roundFloats(distances, 4))
+
+	// Check that clone is unaffected.
+	require.Equal(t, []float32{10, 2}, cloned.Centroid)
+	require.Equal(t, []float32{10, 9.43, 4.12, 6.71}, roundFloats(cloned.CentroidDistances, 2))
+	require.Equal(t, vector.Set{Dims: 2, Count: 4, Data: []float32{0, 0, 9, 10, 5, 6, 7, 8}}, cloned.Vectors)
 }

--- a/pkg/sql/vecindex/testdata/delete.ddt
+++ b/pkg/sql/vecindex/testdata/delete.ddt
@@ -16,7 +16,7 @@ vec1
 # ----------
 # Delete vectors with duplicate values.
 # ----------
-new-index min-partition-size=1 max-partition-size=3 beam-size=2
+new-index min-partition-size=1 max-partition-size=4 beam-size=2
 vec1: (1, 2)
 vec2: (1, 2)
 vec3: (1, 2)
@@ -65,53 +65,47 @@ vec3: (4, 3)
 vec4: (-4, 5)
 vec5: (1, 11)
 vec6: (1, -6)
-vec7: (0, 4)
-vec8: (-2, 8)
-vec9: (2, 8)
+vec7: (2, 8)
 ----
-• 1 (1.5, 1.875)
+• 1 (2, 3.5)
 │
-├───• 2 (1, -2)
+├───• 2 (5.5, 3.5)
+│   │
+│   ├───• vec3 (4, 3)
+│   └───• vec2 (7, 4)
+│
+├───• 4 (1, -2)
 │   │
 │   ├───• vec1 (1, 2)
 │   └───• vec6 (1, -6)
 │
-├───• 4 (1.75, 4)
-│   │
-│   ├───• vec3 (4, 3)
-│   ├───• vec4 (-4, 5)
-│   ├───• vec7 (0, 4)
-│   └───• vec2 (7, 4)
-│
-└───• 5 (0.3333, 9)
+└───• 5 (-1.5, 8)
     │
     ├───• vec5 (1, 11)
-    ├───• vec8 (-2, 8)
-    └───• vec9 (2, 8)
+    ├───• vec4 (-4, 5)
+    └───• vec7 (2, 8)
 
 # Test case where initial search fails to find vector to delete and it must be
 # retried.
 delete
-vec1: (0, 8)
+vec1: (4, 8)
 ----
-• 1 (1.5, 1.875)
+• 1 (2, 3.5)
 │
-├───• 2 (1, -2)
+├───• 2 (5.5, 3.5)
+│   │
+│   ├───• vec3 (4, 3)
+│   └───• vec2 (7, 4)
+│
+├───• 4 (1, -2)
 │   │
 │   └───• vec6 (1, -6)
 │
-├───• 4 (1.75, 4)
-│   │
-│   ├───• vec3 (4, 3)
-│   ├───• vec4 (-4, 5)
-│   ├───• vec7 (0, 4)
-│   └───• vec2 (7, 4)
-│
-└───• 5 (0.3333, 9)
+└───• 5 (-1.5, 8)
     │
     ├───• vec5 (1, 11)
-    ├───• vec8 (-2, 8)
-    └───• vec9 (2, 8)
+    ├───• vec4 (-4, 5)
+    └───• vec7 (2, 8)
 
 # Delete multiple vectors.
 delete
@@ -119,19 +113,23 @@ vec4
 vec5
 vec6
 ----
-• 1 (1.5, 1.875)
+• 1 (2, 3.5)
 │
-├───• 2 (1, -2)
-├───• 4 (1.75, 4)
+├───• 2 (5.5, 3.5)
 │   │
 │   ├───• vec3 (4, 3)
-│   ├───• vec2 (7, 4)
-│   └───• vec7 (0, 4)
+│   └───• vec2 (7, 4)
 │
-└───• 5 (0.3333, 9)
+├───• 4 (1, -2)
+└───• 5 (-1.5, 8)
     │
-    ├───• vec9 (2, 8)
-    └───• vec8 (-2, 8)
+    └───• vec7 (2, 8)
+
+# Search for vector in empty leaf partition.
+search max-results=1 beam-size=1
+(1, -6)
+----
+0 leaf vectors, 3 vectors, 0 full vectors, 2 partitions
 
 # ----------
 # Delete vectors from primary index, but not from secondary index.
@@ -224,7 +222,9 @@ search max-results=1 beam-size=1
 ----
 2 leaf vectors, 4 vectors, 2 full vectors, 2 partitions
 
+# ----------
 # Search root partition with only missing vectors.
+# ----------
 new-index min-partition-size=1 max-partition-size=3 beam-size=2
 vec1: (1, 2)
 ----

--- a/pkg/sql/vecindex/testdata/insert.ddt
+++ b/pkg/sql/vecindex/testdata/insert.ddt
@@ -54,17 +54,17 @@ vec9: (-2, 8)
 │   ├───• vec6 (14, 1)
 │   └───• vec5 (8, 11)
 │
-├───• 4 (0.3333, 2)
+├───• 4 (4.3333, 4)
 │   │
-│   ├───• vec8 (0, 4)
-│   ├───• vec7 (0, 0)
-│   └───• vec1 (1, 2)
+│   ├───• vec3 (4, 3)
+│   ├───• vec4 (4, 3)
+│   └───• vec2 (5, 6)
 │
-└───• 5 (2.75, 5)
+└───• 5 (0.3333, 2)
     │
-    ├───• vec2 (5, 6)
-    ├───• vec4 (4, 3)
-    ├───• vec3 (4, 3)
+    ├───• vec1 (1, 2)
+    ├───• vec7 (0, 0)
+    ├───• vec8 (0, 4)
     └───• vec9 (-2, 8)
 
 # Overwrite vector with a new value that won't be found in the index, causing
@@ -83,30 +83,33 @@ vec2: (-5, -5)
 │   ├───• vec6 (14, 1)
 │   └───• vec5 (8, 11)
 │
-├───• 4 (0.3333, 2)
+├───• 4 (4.3333, 4)
 │   │
-│   ├───• vec8 (0, 4)
-│   ├───• vec7 (0, 0)
-│   ├───• vec1 (1, 2)
+│   ├───• vec3 (4, 3)
+│   ├───• vec4 (4, 3)
 │   └───• vec2 (-5, -5)
 │
-└───• 5 (2.75, 5)
+├───• 6 (-1, 6)
+│   │
+│   ├───• vec9 (-2, 8)
+│   └───• vec8 (0, 4)
+│
+└───• 7 (-1.3333, -1)
     │
-    ├───• vec2 (-5, -5)
-    ├───• vec4 (4, 3)
-    ├───• vec3 (4, 3)
-    └───• vec9 (-2, 8)
+    ├───• vec7 (0, 0)
+    ├───• vec1 (1, 2)
+    └───• vec2 (-5, -5)
 
 search max-results=10 beam-size=8
 (-5, -5)
 ----
-vec2: 0 (centroid=2.4622)
-vec7: 50 (centroid=2.0276)
-vec1: 85 (centroid=0.6667)
-vec8: 106 (centroid=2.0276)
-vec3: 145 (centroid=2.3585)
-vec4: 145 (centroid=2.3585)
-vec9: 178 (centroid=5.6181)
+vec2: 0 (centroid=2.1082)
+vec7: 50 (centroid=1.6667)
+vec1: 85 (centroid=3.8006)
+vec8: 106 (centroid=2.2361)
+vec3: 145 (centroid=1.0541)
+vec4: 145 (centroid=1.0541)
+vec9: 178 (centroid=2.2361)
 vec6: 397 (centroid=5.831)
 vec5: 425 (centroid=5.831)
-10 leaf vectors, 13 vectors, 9 full vectors, 4 partitions
+10 leaf vectors, 14 vectors, 9 full vectors, 5 partitions

--- a/pkg/sql/vecindex/testdata/merge.ddt
+++ b/pkg/sql/vecindex/testdata/merge.ddt
@@ -1,0 +1,379 @@
+# ----------
+# Basic merge cases.
+# ----------
+new-index min-partition-size=2 max-partition-size=4 beam-size=2
+vec1: (0, -1)
+vec2: (3, 10)
+vec3: (-2, 8)
+vec4: (2, 7)
+vec5: (3, 6)
+vec6: (14, 1)
+vec7: (0, 0)
+vec8: (1, 4)
+vec9: (5, 2)
+----
+• 1 (4.625, 5.25)
+│
+├───• 2 (8.5, 5.5)
+│   │
+│   ├───• vec6 (14, 1)
+│   ├───• vec2 (3, 10)
+│   └───• vec9 (5, 2)
+│
+├───• 4 (0, -0.5)
+│   │
+│   ├───• vec7 (0, 0)
+│   └───• vec1 (0, -1)
+│
+└───• 5 (1, 6.25)
+    │
+    ├───• vec5 (3, 6)
+    ├───• vec4 (2, 7)
+    ├───• vec3 (-2, 8)
+    └───• vec8 (1, 4)
+
+# Delete vectors from a partition, causing it to drop below min-partition-size.
+delete
+vec5
+vec3
+vec8
+----
+• 1 (4.625, 5.25)
+│
+├───• 2 (8.5, 5.5)
+│   │
+│   ├───• vec6 (14, 1)
+│   ├───• vec2 (3, 10)
+│   └───• vec9 (5, 2)
+│
+├───• 4 (0, -0.5)
+│   │
+│   ├───• vec7 (0, 0)
+│   └───• vec1 (0, -1)
+│
+└───• 5 (1, 6.25)
+    │
+    └───• vec4 (2, 7)
+
+# Search will trigger a merge operation of the under-sized partition.
+search
+(3, 6)
+----
+vec4: 2 (centroid=1.25)
+4 leaf vectors, 7 vectors, 3 full vectors, 3 partitions
+
+format-tree
+----
+• 1 (4.625, 5.25)
+│
+├───• 2 (8.5, 5.5)
+│   │
+│   ├───• vec6 (14, 1)
+│   ├───• vec2 (3, 10)
+│   ├───• vec9 (5, 2)
+│   └───• vec4 (2, 7)
+│
+└───• 4 (0, -0.5)
+    │
+    ├───• vec7 (0, 0)
+    └───• vec1 (0, -1)
+
+# Delete all but one vector in a partition and expect it to be merged.
+delete
+vec7
+----
+• 1 (4.625, 5.25)
+│
+├───• 2 (8.5, 5.5)
+│   │
+│   ├───• vec6 (14, 1)
+│   ├───• vec2 (3, 10)
+│   ├───• vec9 (5, 2)
+│   └───• vec4 (2, 7)
+│
+└───• 4 (0, -0.5)
+    │
+    └───• vec1 (0, -1)
+
+# Partition was merged (and then split).
+search
+(0, -1)
+----
+vec1: 0 (centroid=0.5)
+5 leaf vectors, 7 vectors, 5 full vectors, 3 partitions
+
+format-tree
+----
+• 1 (4.625, 5.25)
+│
+├───• 6 (1.6667, 5.3333)
+│   │
+│   ├───• vec1 (0, -1)
+│   ├───• vec2 (3, 10)
+│   └───• vec4 (2, 7)
+│
+└───• 7 (9.5, 1.5)
+    │
+    ├───• vec9 (5, 2)
+    └───• vec6 (14, 1)
+
+# Delete all but one vector and ensure that remaining partition is merged into
+# the root.
+delete
+vec1
+vec4
+vec6
+vec9
+----
+• 1 (3, 10)
+│
+└───• vec2 (3, 10)
+
+search
+(0, 0)
+----
+vec2: 109 (centroid=0)
+1 leaf vectors, 1 vectors, 1 full vectors, 1 partitions
+
+format-tree
+----
+• 1 (3, 10)
+│
+└───• vec2 (3, 10)
+
+# ----------
+# Test merge with dangling vectors.
+# ----------
+new-index min-partition-size=3 max-partition-size=6 beam-size=2
+vec1: (0, -1)
+vec2: (3, 9)
+vec3: (-2, 8)
+vec4: (2, 7)
+vec5: (3, 6)
+vec6: (5, 2)
+vec7: (1, 3)
+----
+• 1 (1.4583, 4.6667)
+│
+├───• 2 (3.25, 6)
+│   │
+│   ├───• vec6 (5, 2)
+│   ├───• vec2 (3, 9)
+│   ├───• vec5 (3, 6)
+│   └───• vec4 (2, 7)
+│
+└───• 3 (-0.3333, 3.3333)
+    │
+    ├───• vec3 (-2, 8)
+    ├───• vec1 (0, -1)
+    └───• vec7 (1, 3)
+
+# Trigger merge when a partition contains only dangling vectors.
+delete not-found
+vec6
+vec5
+----
+• 1 (1.4583, 4.6667)
+│
+├───• 2 (3.25, 6)
+│   │
+│   ├───• vec6 (MISSING)
+│   ├───• vec2 (3, 9)
+│   ├───• vec5 (MISSING)
+│   └───• vec4 (2, 7)
+│
+└───• 3 (-0.3333, 3.3333)
+    │
+    ├───• vec3 (-2, 8)
+    ├───• vec1 (0, -1)
+    └───• vec7 (1, 3)
+
+delete
+vec2
+vec4
+----
+• 1 (1.4583, 4.6667)
+│
+├───• 2 (3.25, 6)
+│   │
+│   ├───• vec6 (MISSING)
+│   └───• vec5 (MISSING)
+│
+└───• 3 (-0.3333, 3.3333)
+    │
+    ├───• vec3 (-2, 8)
+    ├───• vec1 (0, -1)
+    └───• vec7 (1, 3)
+
+# Search will trigger merge of the partition containing only missing vectors.
+search
+(5, 2)
+----
+vec7: 17 (centroid=1.3744)
+5 leaf vectors, 7 vectors, 4 full vectors, 3 partitions
+
+format-tree
+----
+• 1 (1.4583, 4.6667)
+│
+└───• 3 (-0.3333, 3.3333)
+    │
+    ├───• vec3 (-2, 8)
+    ├───• vec1 (0, -1)
+    └───• vec7 (1, 3)
+
+# Repeat, but this time merge with both a missing and a present vector.
+delete not-found
+vec7
+----
+• 1 (1.4583, 4.6667)
+│
+└───• 3 (-0.3333, 3.3333)
+    │
+    ├───• vec3 (-2, 8)
+    ├───• vec1 (0, -1)
+    └───• vec7 (MISSING)
+
+delete
+vec1
+----
+• 1 (1.4583, 4.6667)
+│
+└───• 3 (-0.3333, 3.3333)
+    │
+    ├───• vec3 (-2, 8)
+    └───• vec7 (MISSING)
+
+search
+(1, 3)
+----
+vec3: 34 (centroid=4.9554)
+2 leaf vectors, 3 vectors, 2 full vectors, 2 partitions
+
+format-tree
+----
+• 1 (-2, 8)
+│
+└───• vec3 (-2, 8)
+
+# ----------
+# Delete all vectors and expect tree to be merged back to empty root.
+# ----------
+new-index min-partition-size=2 max-partition-size=4 beam-size=2
+vec1: (0, -1)
+vec2: (3, 9)
+vec3: (-2, 8)
+vec4: (2, 7)
+vec5: (3, 6)
+vec6: (14, 1)
+vec7: (0, 0)
+vec8: (1, 4)
+vec9: (5, 2)
+----
+• 1 (4.625, 5)
+│
+├───• 2 (8.5, 5)
+│   │
+│   ├───• vec6 (14, 1)
+│   ├───• vec2 (3, 9)
+│   └───• vec9 (5, 2)
+│
+├───• 4 (0, -0.5)
+│   │
+│   ├───• vec7 (0, 0)
+│   └───• vec1 (0, -1)
+│
+└───• 5 (1, 6.25)
+    │
+    ├───• vec5 (3, 6)
+    ├───• vec4 (2, 7)
+    ├───• vec3 (-2, 8)
+    └───• vec8 (1, 4)
+
+insert
+vec10: (3, 6)
+vec11: (2, 10)
+vec12: (6, 8)
+vec13: (4, 6)
+vec14: (2, 7)
+vec15: (3, 7)
+vec16: (3, 8)
+vec17: (3, 5)
+vec18: (6, 6)
+----
+• 1 (2.4583, 4.6667)
+│
+├───• 10 (3.75, 6.9167)
+│   │
+│   ├───• 2 (8.5, 5)
+│   │   │
+│   │   ├───• vec6 (14, 1)
+│   │   └───• vec9 (5, 2)
+│   │
+│   ├───• 7 (0, 9)
+│   │   │
+│   │   ├───• vec3 (-2, 8)
+│   │   ├───• vec11 (2, 10)
+│   │   └───• vec2 (3, 9)
+│   │
+│   ├───• 12 (2.5, 7.25)
+│   │   │
+│   │   ├───• vec15 (3, 7)
+│   │   ├───• vec4 (2, 7)
+│   │   ├───• vec14 (2, 7)
+│   │   └───• vec16 (3, 8)
+│   │
+│   └───• 13 (3.5, 5.5)
+│       │
+│       ├───• vec13 (4, 6)
+│       ├───• vec17 (3, 5)
+│       ├───• vec12 (6, 8)
+│       └───• vec18 (6, 6)
+│
+└───• 11 (1.1667, 2.4167)
+    │
+    ├───• 4 (0, -0.5)
+    │   │
+    │   ├───• vec7 (0, 0)
+    │   └───• vec1 (0, -1)
+    │
+    └───• 9 (2.3333, 5.3333)
+        │
+        ├───• vec8 (1, 4)
+        ├───• vec10 (3, 6)
+        └───• vec5 (3, 6)
+
+# Delete all vectors.
+delete
+vec1
+vec2
+vec3
+vec4
+vec5
+vec6
+vec7
+vec8
+vec9
+vec10
+vec11
+vec12
+vec13
+vec14
+vec15
+vec16
+vec17
+vec18
+----
+• 1 (3.5, 5.5)
+│
+└───• 13 (3.5, 5.5)
+
+# Search to trigger merge to root.
+search max-results=1 beam-size=1
+(3, 6)
+----
+0 leaf vectors, 1 vectors, 0 full vectors, 2 partitions
+
+format-tree
+----
+• 1 (0, 0)

--- a/pkg/sql/vecindex/testdata/search-features.ddt
+++ b/pkg/sql/vecindex/testdata/search-features.ddt
@@ -8,89 +8,89 @@ Created index with 1000 vectors with 512 dimensions.
 # Start with 1 result and default beam size of 4.
 search max-results=1 use-feature=5000
 ----
-vec356: 0.5976 (centroid=0.5024)
-43 leaf vectors, 74 vectors, 3 full vectors, 7 partitions
+vec640: 0.6525 (centroid=0.5514)
+44 leaf vectors, 72 vectors, 9 full vectors, 7 partitions
 
 # Search for additional results.
 search max-results=6 use-feature=5000
 ----
-vec356: 0.5976 (centroid=0.5024)
-vec302: 0.6601 (centroid=0.4991)
-vec329: 0.6871 (centroid=0.5033)
-vec386: 0.7301 (centroid=0.5117)
-vec240: 0.7723 (centroid=0.4702)
-vec347: 0.7745 (centroid=0.5095)
-43 leaf vectors, 74 vectors, 16 full vectors, 7 partitions
+vec640: 0.6525 (centroid=0.5514)
+vec309: 0.7311 (centroid=0.552)
+vec704: 0.7916 (centroid=0.5851)
+vec637: 0.8039 (centroid=0.5594)
+vec979: 0.8066 (centroid=0.4849)
+vec246: 0.8141 (centroid=0.5458)
+44 leaf vectors, 72 vectors, 14 full vectors, 7 partitions
 
 # Use a larger beam size.
 search max-results=6 use-feature=5000 beam-size=8
 ----
-vec771: 0.5624 (centroid=0.6671)
-vec356: 0.5976 (centroid=0.5024)
-vec302: 0.6601 (centroid=0.4991)
-vec329: 0.6871 (centroid=0.5033)
-vec95: 0.7008 (centroid=0.5941)
-vec386: 0.7301 (centroid=0.5117)
-96 leaf vectors, 143 vectors, 23 full vectors, 13 partitions
+vec356: 0.5976 (centroid=0.4578)
+vec640: 0.6525 (centroid=0.5514)
+vec329: 0.6871 (centroid=0.6602)
+vec309: 0.7311 (centroid=0.552)
+vec117: 0.7576 (centroid=0.5359)
+vec25: 0.761 (centroid=0.4909)
+78 leaf vectors, 130 vectors, 22 full vectors, 13 partitions
 
 # Turn off re-ranking, which results in increased inaccuracy.
 search max-results=6 use-feature=5000 beam-size=8 skip-rerank
 ----
-vec771: 0.6053 ±0.0461 (centroid=0.6671)
-vec356: 0.6163 ±0.0323 (centroid=0.5024)
-vec302: 0.6365 ±0.0321 (centroid=0.4991)
-vec329: 0.6609 ±0.0333 (centroid=0.5033)
-vec11: 0.7085 ±0.0389 (centroid=0.5695)
-vec95: 0.7165 ±0.0394 (centroid=0.5941)
-96 leaf vectors, 143 vectors, 0 full vectors, 13 partitions
+vec640: 0.6316 ±0.0382 (centroid=0.5514)
+vec356: 0.6319 ±0.0288 (centroid=0.4578)
+vec329: 0.707 ±0.0415 (centroid=0.6602)
+vec309: 0.7518 ±0.0355 (centroid=0.552)
+vec704: 0.7535 ±0.0376 (centroid=0.5851)
+vec117: 0.7669 ±0.0337 (centroid=0.5359)
+78 leaf vectors, 130 vectors, 0 full vectors, 13 partitions
 
 # Return top 25 results with large beam size.
 search max-results=25 use-feature=5000 beam-size=32
 ----
-vec771: 0.5624 (centroid=0.6671)
-vec356: 0.5976 (centroid=0.5024)
-vec640: 0.6525 (centroid=0.5124)
-vec302: 0.6601 (centroid=0.4991)
-vec329: 0.6871 (centroid=0.5033)
-vec95: 0.7008 (centroid=0.5941)
-vec386: 0.7301 (centroid=0.5117)
-vec309: 0.7311 (centroid=0.601)
-vec633: 0.7513 (centroid=0.4651)
-vec117: 0.7576 (centroid=0.5399)
-vec556: 0.7595 (centroid=0.5536)
-vec25: 0.761 (centroid=0.4783)
-vec872: 0.7707 (centroid=0.5177)
-vec240: 0.7723 (centroid=0.4702)
-vec347: 0.7745 (centroid=0.5095)
-vec11: 0.777 (centroid=0.5695)
-vec340: 0.7858 (centroid=0.4752)
-vec704: 0.7916 (centroid=0.6659)
-vec423: 0.7956 (centroid=0.4682)
-vec848: 0.7958 (centroid=0.5798)
-vec720: 0.8012 (centroid=0.4557)
-vec387: 0.8038 (centroid=0.5598)
-vec637: 0.8039 (centroid=0.5473)
-vec410: 0.8062 (centroid=0.5447)
-vec979: 0.8066 (centroid=0.621)
-342 leaf vectors, 441 vectors, 84 full vectors, 42 partitions
+vec771: 0.5624 (centroid=0.6715)
+vec356: 0.5976 (centroid=0.4578)
+vec640: 0.6525 (centroid=0.5514)
+vec302: 0.6601 (centroid=0.5498)
+vec329: 0.6871 (centroid=0.6602)
+vec95: 0.7008 (centroid=0.5807)
+vec386: 0.7301 (centroid=0.5575)
+vec309: 0.7311 (centroid=0.552)
+vec117: 0.7576 (centroid=0.5359)
+vec556: 0.7595 (centroid=0.5041)
+vec25: 0.761 (centroid=0.4909)
+vec776: 0.7633 (centroid=0.4385)
+vec872: 0.7707 (centroid=0.5722)
+vec859: 0.7708 (centroid=0.6085)
+vec240: 0.7723 (centroid=0.6017)
+vec347: 0.7745 (centroid=0.5306)
+vec11: 0.777 (centroid=0.6096)
+vec340: 0.7858 (centroid=0.5223)
+vec239: 0.7878 (centroid=0.4991)
+vec704: 0.7916 (centroid=0.5851)
+vec423: 0.7956 (centroid=0.5476)
+vec220: 0.7957 (centroid=0.4112)
+vec387: 0.8038 (centroid=0.4619)
+vec637: 0.8039 (centroid=0.5594)
+vec410: 0.8062 (centroid=0.5024)
+311 leaf vectors, 415 vectors, 88 full vectors, 42 partitions
 
 # Test recall at different beam sizes.
 recall topk=10 beam-size=4 samples=50
 ----
-55.60% recall@10
-47.44 leaf vectors, 76.34 vectors, 20.88 full vectors, 7.00 partitions
+48.40% recall@10
+43.64 leaf vectors, 74.00 vectors, 19.76 full vectors, 7.00 partitions
 
 recall topk=10 beam-size=8 samples=50
 ----
-75.60% recall@10
-93.90 leaf vectors, 142.62 vectors, 24.54 full vectors, 13.00 partitions
+73.00% recall@10
+88.06 leaf vectors, 140.62 vectors, 24.82 full vectors, 13.00 partitions
 
 recall topk=10 beam-size=16 samples=50
 ----
-91.20% recall@10
-186.54 leaf vectors, 275.74 vectors, 27.58 full vectors, 25.00 partitions
+87.80% recall@10
+173.74 leaf vectors, 268.50 vectors, 28.26 full vectors, 25.00 partitions
 
 recall topk=10 beam-size=32 samples=50
 ----
-98.60% recall@10
-371.72 leaf vectors, 470.72 vectors, 32.00 full vectors, 42.00 partitions
+97.00% recall@10
+344.68 leaf vectors, 448.68 vectors, 32.10 full vectors, 42.00 partitions

--- a/pkg/sql/vecindex/testdata/search.ddt
+++ b/pkg/sql/vecindex/testdata/search.ddt
@@ -49,44 +49,44 @@ vec13: (6, 2)
 │
 ├───• 2 (1, -2)
 │   │
-│   ├───• vec11 (1, 1)
 │   └───• vec6 (1, -6)
 │
-├───• 5 (0.3333, 9)
+├───• 4 (-1.6667, 8)
 │   │
 │   ├───• vec8 (-2, 8)
-│   ├───• vec9 (2, 8)
-│   └───• vec5 (1, 11)
+│   ├───• vec4 (-4, 5)
+│   ├───• vec5 (1, 11)
+│   └───• vec9 (2, 8)
 │
-├───• 6 (5.5, 3.25)
+├───• 6 (0.3333, 3)
 │   │
-│   ├───• vec3 (4, 3)
-│   ├───• vec13 (6, 2)
-│   ├───• vec12 (5, 4)
-│   └───• vec2 (7, 4)
+│   ├───• vec10 (0, 3)
+│   ├───• vec7 (0, 4)
+│   ├───• vec1 (1, 2)
+│   └───• vec11 (1, 1)
 │
-└───• 7 (-1.3333, 4)
+└───• 7 (5.5, 3.5)
     │
-    ├───• vec7 (0, 4)
-    ├───• vec10 (0, 3)
-    ├───• vec4 (-4, 5)
-    └───• vec1 (1, 2)
+    ├───• vec3 (4, 3)
+    ├───• vec2 (7, 4)
+    ├───• vec12 (5, 4)
+    └───• vec13 (6, 2)
 
 # Search for closest vectors with beam-size=1.
 search max-results=2 beam-size=1
 (1, 6)
 ----
-vec7: 5 (centroid=1.3333)
-vec10: 10 (centroid=1.6667)
+vec7: 5 (centroid=1.0541)
+vec10: 10 (centroid=0.3333)
 4 leaf vectors, 8 vectors, 4 full vectors, 2 partitions
 
 # Search for closest vectors with beam-size=2.
 search max-results=2 beam-size=2
 (1, 6)
 ----
-vec7: 5 (centroid=1.3333)
-vec9: 5 (centroid=1.9437)
-7 leaf vectors, 11 vectors, 7 full vectors, 3 partitions
+vec7: 5 (centroid=1.0541)
+vec9: 5 (centroid=3.6667)
+8 leaf vectors, 12 vectors, 6 full vectors, 3 partitions
 
 # ----------
 # Search tree with only duplicate vectors.
@@ -135,39 +135,40 @@ vec5: (6, 1)
 vec1: (10, 5)
 vec1: (-2, -2)
 ----
-• 1 (3.8333, 3.6667)
+• 1 (2, 3.5)
 │
-├───• 2 (7.6667, 3.3333)
+├───• 3 (-1.5, 3.5)
 │   │
-│   ├───• vec1 (-2, -2)
-│   ├───• vec2 (7, 4)
+│   ├───• vec4 (-4, 5)
+│   └───• vec1 (-2, -2)
+│
+├───• 4 (5, 2)
+│   │
+│   ├───• vec3 (4, 3)
 │   └───• vec5 (6, 1)
 │
-└───• 3 (0, 4)
+└───• 5 (8.5, 4.5)
     │
-    ├───• vec4 (-4, 5)
-    ├───• vec3 (4, 3)
+    ├───• vec2 (7, 4)
     └───• vec1 (-2, -2)
 
 # Ensure that search result doesn't contain duplicates.
 search max-results=6
 (1, 1)
 ----
-vec3: 13 (centroid=4.1231)
-vec1: 18 (centroid=2.8674)
-vec5: 25 (centroid=2.8674)
-vec4: 41 (centroid=4.1231)
-vec2: 45 (centroid=0.9428)
-6 leaf vectors, 8 vectors, 5 full vectors, 3 partitions
+vec3: 13 (centroid=1.4142)
+vec1: 18 (centroid=5.5227)
+vec5: 25 (centroid=1.4142)
+vec4: 41 (centroid=2.9155)
+4 leaf vectors, 7 vectors, 4 full vectors, 3 partitions
 
 # Do not rerank results. This may cause a different vec1 duplicate to be
 # returned.
 search max-results=6 skip-rerank
 (8, 9)
 ----
-vec3: 2.6557 ±55.0091 (centroid=4.1231)
-vec2: 23.4544 ±7.5686 (centroid=0.9428)
-vec5: 59.1248 ±23.019 (centroid=2.8674)
-vec4: 209.3443 ±55.0091 (centroid=4.1231)
-vec1: 294.9492 ±84.3801 (centroid=6.3246)
-6 leaf vectors, 8 vectors, 0 full vectors, 3 partitions
+vec1: 17.8042 ±10.1242 (centroid=1.5811)
+vec2: 28.1958 ±10.1242 (centroid=1.5811)
+vec3: 45.6359 ±15.2315 (centroid=1.4142)
+vec5: 74.3641 ±15.2315 (centroid=1.4142)
+4 leaf vectors, 7 vectors, 0 full vectors, 3 partitions

--- a/pkg/sql/vecindex/testdata/split.ddt
+++ b/pkg/sql/vecindex/testdata/split.ddt
@@ -59,27 +59,30 @@ vec12: (4, 4)
 vec13: (3, 4)
 vec14: (3, 3)
 ----
-• 1 (5.2917, 4.375)
+• 1 (5.125, 4.2639)
 │
-├───• 10 (2.5, 2.1667)
+├───• 10 (2.1667, 1.9444)
 │   │
-│   ├───• 9 (3.5, 4)
+│   ├───• 9 (3.3333, 4.3333)
 │   │   │
-│   │   ├───• vec12 (4, 4)
-│   │   ├───• vec3 (4, 3)
 │   │   ├───• vec10 (3, 5)
+│   │   ├───• vec12 (4, 4)
 │   │   └───• vec13 (3, 4)
 │   │
-│   ├───• 8 (3, 2.5)
+│   ├───• 7 (-0.5, -0.5)
+│   │   │
+│   │   └───• vec8 (-2, -3)
+│   │
+│   ├───• 12 (2.6667, 2.6667)
 │   │   │
 │   │   ├───• vec14 (3, 3)
-│   │   ├───• vec11 (3, 2)
-│   │   └───• vec9 (4, 1)
+│   │   ├───• vec3 (4, 3)
+│   │   └───• vec1 (1, 2)
 │   │
-│   └───• 7 (1, 0)
+│   └───• 13 (3.5, 1.5)
 │       │
-│       ├───• vec1 (1, 2)
-│       └───• vec8 (-2, -3)
+│       ├───• vec9 (4, 1)
+│       └───• vec11 (3, 2)
 │
 └───• 11 (8.0833, 6.5833)
     │
@@ -107,9 +110,9 @@ search max-results=3 beam-size=3
 (4, 7)
 ----
 vec7: 2 (centroid=2.1213)
-vec10: 5 (centroid=1.118)
-vec12: 9 (centroid=0.5)
-9 leaf vectors, 16 vectors, 5 full vectors, 6 partitions
+vec10: 5 (centroid=0.7454)
+vec12: 9 (centroid=0.7454)
+8 leaf vectors, 16 vectors, 6 full vectors, 6 partitions
 
 # ----------
 # Test linking nearby vectors from other partitions.
@@ -216,58 +219,132 @@ vec8: (4, 4)
     └───• vec3 (1, 1)
 
 # ----------
-# Test edge cases that occur with tiny max partition sizes.
+# Test splits in the presence of dangling vectors.
 # ----------
-new-index min-partition-size=0 max-partition-size=1 beam-size=2
-vec1: (-5, -5)
-vec2: (5, 5)
-vec3: (5, -4)
+new-index min-partition-size=1 max-partition-size=4 beam-size=2
+vec1: (0, -1)
+vec2: (3, 9)
+vec3: (-2, 8)
+vec4: (-2, 8)
 ----
-• 1 (0, -2.25)
+• 1 (0, 0)
 │
-├───• 6 (5, 0.5)
-│   │
-│   ├───• 5 (5, -4)
-│   │   │
-│   │   └───• vec3 (5, -4)
-│   │
-│   └───• 4 (5, 5)
-│       │
-│       └───• vec2 (5, 5)
+├───• vec1 (0, -1)
+├───• vec2 (3, 9)
+├───• vec3 (-2, 8)
+└───• vec4 (-2, 8)
+
+# Trigger split of root with dangling vectors.
+delete not-found
+vec1
+vec4
+----
+• 1 (0, 0)
 │
-└───• 7 (-5, -5)
-    │
-    └───• 3 (-5, -5)
-        │
-        └───• vec1 (-5, -5)
+├───• vec1 (MISSING)
+├───• vec2 (3, 9)
+├───• vec3 (-2, 8)
+└───• vec4 (MISSING)
 
 insert
-vec4: (4, 4)
+vec5: (4, 3)
+vec6: (1, 2)
+vec7: (5, 0)
+vec8: (2, 2)
 ----
-• 1 (-0.125, -2.375)
+• 1 (1.5, 5.5)
 │
-├───• 12 (4.75, 0.25)
+├───• 2 (0.5, 8.5)
 │   │
-│   ├───• 11 (5, -4)
-│   │   │
-│   │   └───• 5 (5, -4)
-│   │       │
-│   │       └───• vec3 (5, -4)
-│   │
-│   └───• 10 (4.5, 4.5)
-│       │
-│       ├───• 9 (5, 5)
-│       │   │
-│       │   └───• vec2 (5, 5)
-│       │
-│       └───• 8 (4, 4)
-│           │
-│           └───• vec4 (4, 4)
+│   ├───• vec3 (-2, 8)
+│   └───• vec2 (3, 9)
 │
-└───• 13 (-5, -5)
+└───• 3 (2.5, 2.5)
     │
-    └───• 7 (-5, -5)
-        │
-        └───• 3 (-5, -5)
-            │
-            └───• vec1 (-5, -5)
+    ├───• vec6 (1, 2)
+    ├───• vec5 (4, 3)
+    ├───• vec7 (5, 0)
+    └───• vec8 (2, 2)
+
+# Again, this time at a lower level, with more dangling vectors.
+delete not-found
+vec5
+vec6
+vec7
+----
+• 1 (1.5, 5.5)
+│
+├───• 2 (0.5, 8.5)
+│   │
+│   ├───• vec3 (-2, 8)
+│   └───• vec2 (3, 9)
+│
+└───• 3 (2.5, 2.5)
+    │
+    ├───• vec6 (MISSING)
+    ├───• vec5 (MISSING)
+    ├───• vec7 (MISSING)
+    └───• vec8 (2, 2)
+
+insert
+vec9: (6, 1)
+----
+• 1 (1.5, 5.5)
+│
+├───• 2 (0.5, 8.5)
+│   │
+│   ├───• vec3 (-2, 8)
+│   └───• vec2 (3, 9)
+│
+├───• 4 (6, 1)
+│   │
+│   └───• vec9 (6, 1)
+│
+└───• 5 (2, 2)
+    │
+    └───• vec8 (2, 2)
+
+# ----------
+# Test split of root partition with every vector dangling.
+# ----------
+new-index min-partition-size=1 max-partition-size=4 beam-size=2
+vec1: (0, -1)
+vec2: (3, 9)
+vec3: (-2, 8)
+vec4: (-2, 8)
+----
+• 1 (0, 0)
+│
+├───• vec1 (0, -1)
+├───• vec2 (3, 9)
+├───• vec3 (-2, 8)
+└───• vec4 (-2, 8)
+
+# Delete all vectors in the primary index, but leave them "dangling" in the
+# secondary index.
+delete not-found
+vec1
+vec2
+vec3
+vec4
+----
+• 1 (0, 0)
+│
+├───• vec1 (MISSING)
+├───• vec2 (MISSING)
+├───• vec3 (MISSING)
+└───• vec4 (MISSING)
+
+# Trigger a split.
+# TODO(andyk): Consider cleaning up the dangling vectors while attempting to
+# split rather than waiting for a search to clean them up.
+insert
+vec5: (4, 3)
+----
+• 1 (0, 0)
+│
+├───• vec1 (MISSING)
+├───• vec2 (MISSING)
+├───• vec3 (MISSING)
+├───• vec4 (MISSING)
+└───• vec5 (4, 3)

--- a/pkg/sql/vecindex/vecstore/partition.go
+++ b/pkg/sql/vecindex/vecstore/partition.go
@@ -7,6 +7,7 @@ package vecstore
 
 import (
 	"context"
+	"slices"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/internal"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/quantize"
@@ -63,6 +64,17 @@ func NewPartition(
 		quantizedSet: quantizedSet,
 		childKeys:    childKeys,
 		level:        level,
+	}
+}
+
+// Clone makes a deep copy of this partition. Changes to the original or clone
+// do not affect the other.
+func (p *Partition) Clone() *Partition {
+	return &Partition{
+		quantizer:    p.quantizer,
+		quantizedSet: p.quantizedSet.Clone(),
+		childKeys:    slices.Clone(p.childKeys),
+		level:        p.level,
 	}
 }
 

--- a/pkg/sql/vecindex/vector_index.go
+++ b/pkg/sql/vecindex/vector_index.go
@@ -101,6 +101,7 @@ type searchContext struct {
 	// Original and different values in those dimensions.
 	Randomized vector.T
 
+	tempResults         [1]vecstore.SearchResult
 	tempKeys            []vecstore.PartitionKey
 	tempCounts          []int
 	tempVectorsWithKeys []vecstore.VectorWithKey
@@ -162,6 +163,9 @@ func NewVectorIndex(
 	}
 	if vi.options.QualitySamples == 0 {
 		vi.options.QualitySamples = 16
+	}
+	if vi.options.MaxPartitionSize < 2 {
+		return nil, errors.AssertionFailedf("MaxPartitionSize cannot be less than 2")
 	}
 
 	vi.fixups.Init(vi, options.Seed)
@@ -415,9 +419,9 @@ func (vi *VectorIndex) searchHelper(
 	maxResults := max(
 		searchSet.MaxResults, vi.options.QualitySamples, searchCtx.Options.BaseBeamSize*4)
 	subSearchSet := vecstore.SearchSet{MaxResults: maxResults}
-	searchCtx.tempKeys = ensureSliceLen(searchCtx.tempKeys, 1)
-	searchCtx.tempKeys[0] = vecstore.RootKey
-	searchLevel, err := vi.searchChildPartitions(searchCtx, &subSearchSet, searchCtx.tempKeys)
+	searchCtx.tempResults[0] = vecstore.SearchResult{
+		ChildKey: vecstore.ChildKey{PartitionKey: vecstore.RootKey}}
+	searchLevel, err := vi.searchChildPartitions(searchCtx, &subSearchSet, searchCtx.tempResults[:])
 	if err != nil {
 		return err
 	}
@@ -519,13 +523,8 @@ func (vi *VectorIndex) searchHelper(
 
 		// Search up to beamSize child partitions.
 		results.Sort()
-		keyCount := min(beamSize, len(results))
-		searchCtx.tempKeys = ensureSliceLen(searchCtx.tempKeys, keyCount)
-		for i := 0; i < keyCount; i++ {
-			searchCtx.tempKeys[i] = results[i].ChildKey.PartitionKey
-		}
-
-		_, err = vi.searchChildPartitions(searchCtx, &subSearchSet, searchCtx.tempKeys)
+		results = results[:min(beamSize, len(results))]
+		_, err = vi.searchChildPartitions(searchCtx, &subSearchSet, results)
 		if errors.Is(err, vecstore.ErrPartitionNotFound) {
 			// The cached root partition must be stale, so retry the search.
 			if !allowRetry {
@@ -544,23 +543,37 @@ func (vi *VectorIndex) searchHelper(
 	return nil
 }
 
-// searchChildPartitions searches the set of requested partitions for the query
-// vector and adds the closest matches to the given search set.
+// searchChildPartitions searches for nearest neighbors to the query vector in
+// the set of partitions referenced by the given search results. It adds the
+// closest matches to the given search set.
 func (vi *VectorIndex) searchChildPartitions(
-	searchCtx *searchContext, searchSet *vecstore.SearchSet, partitionKeys []vecstore.PartitionKey,
+	searchCtx *searchContext, searchSet *vecstore.SearchSet, parentResults vecstore.SearchResults,
 ) (level vecstore.Level, err error) {
-	searchCtx.tempCounts = ensureSliceLen(searchCtx.tempCounts, len(partitionKeys))
+	searchCtx.tempKeys = ensureSliceLen(searchCtx.tempKeys, len(parentResults))
+	for i := range parentResults {
+		searchCtx.tempKeys[i] = parentResults[i].ChildKey.PartitionKey
+	}
+
+	searchCtx.tempCounts = ensureSliceLen(searchCtx.tempCounts, len(parentResults))
 	level, err = vi.store.SearchPartitions(
-		searchCtx.Ctx, searchCtx.Txn, partitionKeys, searchCtx.Randomized,
+		searchCtx.Ctx, searchCtx.Txn, searchCtx.tempKeys, searchCtx.Randomized,
 		searchSet, searchCtx.tempCounts)
 	if err != nil {
 		return 0, err
 	}
 
-	for i := 0; i < len(searchCtx.tempCounts); i++ {
+	for i := range parentResults {
 		count := searchCtx.tempCounts[i]
 		searchSet.Stats.SearchedPartition(level, count)
-		// TODO(andyk): Enqueue a split/merge fixup for the partition.
+
+		partitionKey := parentResults[i].ChildKey.PartitionKey
+		if count < vi.options.MinPartitionSize && partitionKey != vecstore.RootKey {
+			vi.fixups.AddMerge(
+				searchCtx.Ctx, parentResults[i].ParentPartitionKey, partitionKey)
+		} else if count > vi.options.MaxPartitionSize {
+			vi.fixups.AddSplit(
+				searchCtx.Ctx, parentResults[i].ParentPartitionKey, partitionKey)
+		}
 	}
 
 	return level, nil

--- a/pkg/util/vector/vector_set.go
+++ b/pkg/util/vector/vector_set.go
@@ -36,6 +36,16 @@ func MakeSetFromRawData(data []float32, dims int) Set {
 	}
 }
 
+// Clone performs a deep copy of the vector set. Changes to the original or
+// clone will not affect the other.
+func (vs *Set) Clone() Set {
+	return Set{
+		Dims:  vs.Dims,
+		Count: vs.Count,
+		Data:  slices.Clone(vs.Data),
+	}
+}
+
 // AsMatrix returns this set as a matrix, to be used with the num32 package.
 // NB: The underlying float32 slice is shared by the resulting matrix, so any
 // changes will affect both the vector set and matrix.

--- a/pkg/util/vector/vector_set_test.go
+++ b/pkg/util/vector/vector_set_test.go
@@ -13,114 +13,145 @@ import (
 )
 
 func TestVectorSet(t *testing.T) {
-	vs := MakeSet(2)
-	require.Equal(t, 2, vs.Dims)
-	require.Equal(t, 0, vs.Count)
-	require.Equal(t, T{0, 0}, vs.Centroid(T{-1, -1}))
+	t.Run("Add methods", func(t *testing.T) {
+		vs := MakeSet(2)
+		require.Equal(t, 2, vs.Dims)
+		require.Equal(t, 0, vs.Count)
+		require.Equal(t, T{0, 0}, vs.Centroid(T{-1, -1}))
 
-	// Add methods.
-	v1 := T{1, 2}
-	v2 := T{5, 3}
-	v3 := T{6, 6}
-	vs.Add(v1)
-	vs.Add(v2)
-	vs.Add(v3)
-	require.Equal(t, 3, vs.Count)
-	require.Equal(t, []float32{1, 2, 5, 3, 6, 6}, vs.Data)
+		// Add methods.
+		v1 := T{1, 2}
+		v2 := T{5, 3}
+		v3 := T{6, 6}
+		vs.Add(v1)
+		vs.Add(v2)
+		vs.Add(v3)
+		require.Equal(t, 3, vs.Count)
+		require.Equal(t, []float32{1, 2, 5, 3, 6, 6}, vs.Data)
 
-	vs.AddSet(&vs)
-	require.Equal(t, 6, vs.Count)
-	require.Equal(t, []float32{1, 2, 5, 3, 6, 6, 1, 2, 5, 3, 6, 6}, vs.Data)
+		vs.AddSet(&vs)
+		require.Equal(t, 6, vs.Count)
+		require.Equal(t, []float32{1, 2, 5, 3, 6, 6, 1, 2, 5, 3, 6, 6}, vs.Data)
 
-	vs.AddUndefined(2)
-	copy(vs.At(6), []float32{3, 1})
-	copy(vs.At(7), []float32{4, 4})
-	vs.AddUndefined(0)
-	require.Equal(t, 8, vs.Count)
-	require.Equal(t, []float32{1, 2, 5, 3, 6, 6, 1, 2, 5, 3, 6, 6, 3, 1, 4, 4}, vs.Data)
+		vs.AddUndefined(2)
+		copy(vs.At(6), []float32{3, 1})
+		copy(vs.At(7), []float32{4, 4})
+		vs.AddUndefined(0)
+		require.Equal(t, 8, vs.Count)
+		require.Equal(t, []float32{1, 2, 5, 3, 6, 6, 1, 2, 5, 3, 6, 6, 3, 1, 4, 4}, vs.Data)
 
-	// Centroid method.
-	vs2 := T{-10.5}.AsSet()
-	require.Equal(t, T{3.875, 3.375}, vs.Centroid(T{-1, -1}))
-	require.Equal(t, T{-10.5}, vs2.Centroid(T{-1}))
+		vs2 := MakeSetFromRawData([]float32{0, 1, -1, 3}, 2)
+		vs2.AddSet(&vs)
+		require.Equal(t, 10, vs2.Count)
+		require.Equal(t, []float32{0, 1, -1, 3, 1, 2, 5, 3, 6, 6, 1, 2, 5, 3, 6, 6, 3, 1, 4, 4}, vs2.Data)
+	})
 
-	// ReplaceWithLast.
-	vs.ReplaceWithLast(1)
-	vs.ReplaceWithLast(4)
-	vs.ReplaceWithLast(5)
-	require.Equal(t, 5, vs.Count)
-	require.Equal(t, []float32{1, 2, 4, 4, 6, 6, 1, 2, 3, 1}, vs.Data)
+	t.Run("Centroid method", func(t *testing.T) {
+		vs := MakeSetFromRawData([]float32{1, 4, 5, 3, 6, 2, 0, 0}, 2)
+		require.Equal(t, T{3, 2.25}, vs.Centroid(T{-1, -1}))
 
-	// Clear.
-	vs.Clear()
-	require.Equal(t, 2, vs.Dims)
-	require.Equal(t, 0, vs.Count)
+		vs2 := T{-10.5}.AsSet()
+		require.Equal(t, T{-10.5}, vs2.Centroid(T{-1}))
+	})
 
-	vs3 := MakeSetFromRawData(vs.Data, 2)
-	require.Equal(t, vs, vs3)
+	t.Run("ReplaceWithLast and Clear methods", func(t *testing.T) {
+		vs := MakeSetFromRawData([]float32{1, 2, 5, 3, 6, 6, 1, 2, 5, 3, 6, 6, 3, 1, 4, 4}, 2)
 
-	// Ensure capacity.
-	vs4 := MakeSet(3)
-	vs4.EnsureCapacity(5)
-	require.Equal(t, 0, len(vs4.Data))
-	require.GreaterOrEqual(t, cap(vs4.Data), 15)
-	vs4.AddUndefined(2)
-	copy(vs4.At(0), []float32{3, 1, 2})
-	copy(vs4.At(1), []float32{4, 4, 4})
-	require.Equal(t, 2, vs4.Count)
-	require.Equal(t, 6, len(vs4.Data))
+		// ReplaceWithLast.
+		vs.ReplaceWithLast(1)
+		vs.ReplaceWithLast(4)
+		vs.ReplaceWithLast(5)
+		require.Equal(t, 5, vs.Count)
+		require.Equal(t, []float32{1, 2, 4, 4, 6, 6, 1, 2, 3, 1}, vs.Data)
 
-	// AsSet.
-	vs5 := T{1, 2, 3}.AsSet()
-	require.Equal(t, 3, cap(vs5.Data))
-	vs4.AddSet(&vs5)
-	require.Equal(t, 3, vs4.Count)
-	require.Equal(t, []float32{3, 1, 2, 4, 4, 4, 1, 2, 3}, vs4.Data)
+		// Clear.
+		vs.Clear()
+		require.Equal(t, 2, vs.Dims)
+		require.Equal(t, 0, vs.Count)
+	})
 
-	// SplitAt.
-	vs6 := MakeSetFromRawData([]float32{1, 2, 3, 4, 5, 6}, 2)
-	vs7 := vs6.SplitAt(0)
-	require.Equal(t, 0, vs6.Count)
-	require.Equal(t, []float32{}, vs6.Data)
-	require.Equal(t, 3, vs7.Count)
-	require.Equal(t, []float32{1, 2, 3, 4, 5, 6}, vs7.Data)
+	t.Run("EnsureCapacity method", func(t *testing.T) {
+		vs := MakeSet(3)
+		vs.EnsureCapacity(5)
+		require.Equal(t, 0, len(vs.Data))
+		require.GreaterOrEqual(t, cap(vs.Data), 15)
+		vs.AddUndefined(2)
+		copy(vs.At(0), []float32{3, 1, 2})
+		copy(vs.At(1), []float32{4, 4, 4})
+		require.Equal(t, 2, vs.Count)
+		require.Equal(t, 6, len(vs.Data))
+	})
 
-	// Append to vs6 and ensure that it does not affect vs7.
-	vs6.Add([]float32{7, 8})
-	require.Equal(t, []float32{1, 2, 3, 4, 5, 6}, vs7.Data)
+	t.Run("AsSet method", func(t *testing.T) {
+		vs5 := T{1, 2, 3}.AsSet()
+		require.Equal(t, 3, cap(vs5.Data))
+	})
 
-	vs8 := vs7.SplitAt(2)
-	require.Equal(t, 2, vs7.Count)
-	require.Equal(t, []float32{1, 2, 3, 4}, vs7.Data)
-	require.Equal(t, 1, vs8.Count)
-	require.Equal(t, []float32{5, 6}, vs8.Data)
+	t.Run("SplitAt method", func(t *testing.T) {
+		vs := MakeSetFromRawData([]float32{1, 2, 3, 4, 5, 6}, 2)
+		vs2 := vs.SplitAt(0)
+		require.Equal(t, 0, vs.Count)
+		require.Equal(t, []float32{}, vs.Data)
+		require.Equal(t, 3, vs2.Count)
+		require.Equal(t, []float32{1, 2, 3, 4, 5, 6}, vs2.Data)
 
-	vs9 := vs7.SplitAt(2)
-	require.Equal(t, 2, vs7.Count)
-	require.Equal(t, []float32{1, 2, 3, 4}, vs7.Data)
-	require.Equal(t, 0, vs9.Count)
-	require.Equal(t, []float32{}, vs9.Data)
+		// Append to vs and ensure that it does not affect vs2.
+		vs.Add([]float32{7, 8})
+		require.Equal(t, []float32{1, 2, 3, 4, 5, 6}, vs2.Data)
 
-	// AsMatrix.
-	vs10 := MakeSetFromRawData([]float32{1, 2, 3, 4, 5, 6}, 2)
-	mat := vs10.AsMatrix()
-	require.Equal(t, num32.Matrix{Rows: 3, Cols: 2, Stride: 2, Data: vs10.Data}, mat)
+		vs3 := vs2.SplitAt(2)
+		require.Equal(t, 2, vs2.Count)
+		require.Equal(t, []float32{1, 2, 3, 4}, vs2.Data)
+		require.Equal(t, 1, vs3.Count)
+		require.Equal(t, []float32{5, 6}, vs3.Data)
 
-	// Check that invalid operations will panic.
-	vs11 := MakeSetFromRawData([]float32{1, 2, 3, 4, 5, 6}, 2)
-	require.Panics(t, func() { vs11.At(-1) })
-	require.Panics(t, func() { vs11.SplitAt(-1) })
-	require.Panics(t, func() { vs11.AddUndefined(-1) })
-	require.Panics(t, func() { vs11.AddSet(nil) })
-	require.Panics(t, func() { vs11.ReplaceWithLast(-1) })
-	require.Panics(t, func() { vs11.Centroid([]float32{0, 0, 0}) })
+		vs4 := vs2.SplitAt(2)
+		require.Equal(t, 2, vs2.Count)
+		require.Equal(t, []float32{1, 2, 3, 4}, vs2.Data)
+		require.Equal(t, 0, vs4.Count)
+		require.Equal(t, []float32{}, vs4.Data)
+	})
 
-	vs12 := MakeSet(2)
-	require.Panics(t, func() { vs12.At(0) })
-	require.Panics(t, func() { vs12.SplitAt(1) })
-	require.Panics(t, func() { vs12.ReplaceWithLast(0) })
+	t.Run("AsMatrix method", func(t *testing.T) {
+		vs := MakeSetFromRawData([]float32{1, 2, 3, 4, 5, 6}, 2)
+		mat := vs.AsMatrix()
+		require.Equal(t, num32.Matrix{Rows: 3, Cols: 2, Stride: 2, Data: vs.Data}, mat)
+	})
 
-	vs13 := MakeSet(-1)
-	require.Panics(t, func() { vs13.Add(v1) })
-	require.Panics(t, func() { vs13.AddUndefined(1) })
+	t.Run("Clone method", func(t *testing.T) {
+		vs := MakeSetFromRawData([]float32{1, 2, 3, 4, 5, 6}, 2)
+		vs2 := vs.Clone()
+
+		vs.Add(T{0, 1})
+		vs.ReplaceWithLast(1)
+		add := MakeSetFromRawData([]float32{7, 8, 9, 10}, 2)
+		vs2.AddSet(&add)
+		vs2.ReplaceWithLast(0)
+
+		// Ensure that changes to each did not impact the other.
+		require.Equal(t, 3, vs.Count)
+		require.Equal(t, []float32{1, 2, 0, 1, 5, 6}, vs.Data)
+
+		require.Equal(t, 4, vs2.Count)
+		require.Equal(t, []float32{9, 10, 3, 4, 5, 6, 7, 8}, vs2.Data)
+	})
+
+	t.Run("check that invalid operations will panic", func(t *testing.T) {
+		vs := MakeSetFromRawData([]float32{1, 2, 3, 4, 5, 6}, 2)
+		require.Panics(t, func() { vs.At(-1) })
+		require.Panics(t, func() { vs.SplitAt(-1) })
+		require.Panics(t, func() { vs.AddUndefined(-1) })
+		require.Panics(t, func() { vs.AddSet(nil) })
+		require.Panics(t, func() { vs.ReplaceWithLast(-1) })
+		require.Panics(t, func() { vs.Centroid([]float32{0, 0, 0}) })
+
+		vs2 := MakeSet(2)
+		require.Panics(t, func() { vs2.At(0) })
+		require.Panics(t, func() { vs2.SplitAt(1) })
+		require.Panics(t, func() { vs2.ReplaceWithLast(0) })
+
+		vs3 := MakeSet(-1)
+		require.Panics(t, func() { vs3.Add(vs.At(0)) })
+		require.Panics(t, func() { vs3.AddUndefined(1) })
+	})
 }


### PR DESCRIPTION
Add support for merging under-sized partitions in the vector index. This happens in a background goroutine managed by the fixup processor. Handle the case where merging or splitting partitions contain dangling vectors. Enqueue split/merge fixups during search.

Epic: CRDB-42943

Release note: None