### PR TITLE
kvserver/rangefeed: add UpdateMetricsOnRangefeedDisconnectBy

### DIFF
--- a/pkg/kv/kvserver/rangefeed/sender_helper_test.go
+++ b/pkg/kv/kvserver/rangefeed/sender_helper_test.go
@@ -32,7 +32,11 @@ func (c *testRangefeedCounter) UpdateMetricsOnRangefeedConnect() {
 }
 
 func (c *testRangefeedCounter) UpdateMetricsOnRangefeedDisconnect() {
-	c.count.Add(-1)
+	c.UpdateMetricsOnRangefeedDisconnectBy(1)
+}
+
+func (c *testRangefeedCounter) UpdateMetricsOnRangefeedDisconnectBy(num int64) {
+	c.count.Add(int32(-num))
 }
 
 func (c *testRangefeedCounter) get() int {

--- a/pkg/kv/kvserver/rangefeed/unbuffered_sender.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_sender.go
@@ -19,6 +19,7 @@ import (
 type RangefeedMetricsRecorder interface {
 	UpdateMetricsOnRangefeedConnect()
 	UpdateMetricsOnRangefeedDisconnect()
+	UpdateMetricsOnRangefeedDisconnectBy(num int64)
 }
 
 // ServerStreamSender forwards MuxRangefeedEvents from UnbufferedSender to the

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -361,10 +361,16 @@ func (nm *nodeMetrics) UpdateMetricsOnRangefeedConnect() {
 	nm.ActiveMuxRangeFeed.Inc(1)
 }
 
-// UpdateOnRangefeedDisconnect decrements rangefeed metrics when a server
-// rangefeed is disconnected.
+// UpdateMetricsOnRangefeedDisconnect decrements rangefeed metrics when one
+// server rangefeed is disconnected.
 func (nm *nodeMetrics) UpdateMetricsOnRangefeedDisconnect() {
-	nm.ActiveMuxRangeFeed.Dec(1)
+	nm.UpdateMetricsOnRangefeedDisconnectBy(1)
+}
+
+// UpdateMetricsOnRangefeedDisconnectBy decrements rangefeed metrics by the
+// given num argument when there are multiple rangefeed disconnects.
+func (nm *nodeMetrics) UpdateMetricsOnRangefeedDisconnectBy(num int64) {
+	nm.ActiveMuxRangeFeed.Dec(num)
 }
 
 // A Node manages a map of stores (by store ID) for which it serves


### PR DESCRIPTION
This patch updates RangefeedMetricsRecorder to include
UpdateMetricsOnRangefeedDisconnectBy, which decrements rangefeed metrics by the
given argument.

Epic: none
Release note: none
