### PR TITLE
roachtest: increase kv.closed_timestamp.target_duration for copyfrom

### DIFF
--- a/pkg/cmd/roachtest/tests/copyfrom.go
+++ b/pkg/cmd/roachtest/tests/copyfrom.go
@@ -137,7 +137,9 @@ func runCopyFromCRDB(ctx context.Context, t test.Test, c cluster.Cluster, sf int
 	// Enable the verbose logging on relevant files to have better understanding
 	// in case the test fails.
 	startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, "--vmodule=copy_from=2,insert=2")
-	c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), c.All())
+	// roachtest frequently runs on overloaded instances and can timeout as a result
+	clusterSettings := install.MakeClusterSettings(install.ClusterSettingsOption{"kv.closed_timestamp.target_duration": "60s"})
+	c.Start(ctx, t.L(), startOpts, clusterSettings, c.All())
 	initTest(ctx, t, c, sf)
 	db, err := c.ConnE(ctx, t.L(), 1)
 	require.NoError(t, err)


### PR DESCRIPTION
Per PR #117091, the roachtest copyfrom test frequently runs in an overloaded environment, causing transactions to time out. That PR attempted to add a retry loop around the transaction, but the test is failed by a log watcher anyway.

Consulting the CRDB documentation on "Transaction Retry Error Reference" reveals a suggested course of action of increasing kv.closed_timestamp.target_duration, with some caveats regarding AS OF SYSTEM TIME and changefeeds that we don't care about for the purposes of this test. The most recent test failure indicates a 40s overage, so we set the target_duration to 60s (up from a default of 3s) and hope for the best.

Fixes: #133797
Release note: None