### PR TITLE
cli: skip TestTenantZip under deadlock

### DIFF
--- a/pkg/cli/zip_tenant_test.go
+++ b/pkg/cli/zip_tenant_test.go
@@ -26,6 +26,7 @@ func TestTenantZip(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderRace(t, "test too slow under race")
+	skip.UnderDeadlock(t, "this test takes cpu profiles")
 
 	tenants := []struct {
 		testName      string


### PR DESCRIPTION
We had some CPU profile failures under deadlock, skipping under that scenario since that's not relevant for this test.

Resolves: #134187

Release note: None