### PR TITLE
release-24.2: sqlccl: improve TestExplainGist a bit

### DIFF
--- a/pkg/ccl/testccl/sqlccl/BUILD.bazel
+++ b/pkg/ccl/testccl/sqlccl/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/spanconfig",
         "//pkg/sql",
+        "//pkg/sql/colexecerror",
         "//pkg/sql/gcjob",
         "//pkg/sql/isql",
         "//pkg/sql/lexbase",

--- a/pkg/ccl/testccl/sqlccl/explain_test.go
+++ b/pkg/ccl/testccl/sqlccl/explain_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
@@ -136,6 +137,11 @@ func TestExplainGist(t *testing.T) {
 
 	skip.UnderDeadlock(t, "the test is too slow")
 	skip.UnderRace(t, "the test is too slow")
+
+	// Use the release-build panic-catching behavior instead of the
+	// crdb_test-build behavior. This is needed so that some known bugs like
+	// #117101 don't result in a test failure.
+	defer colexecerror.ProductionBehaviorForTests()()
 
 	ctx := context.Background()
 	rng, _ := randutil.NewTestRand()


### PR DESCRIPTION
Backport 1/1 commits from #135133.

/cc @cockroachdb/release

---

This commit adjusts `TestExplainGist` so that it uses the production behavior of the panic catcher in the vectorized engine. This will allow us to not crash in case we hit one of the known bugs (we have an allow-list of internal errors that are silently swallowed, and all others will result in a test failure anyway).

Fixes: #134766.

Release note: None

Release justification: test-only change.