### PR TITLE
roachtest: fix name of flaky pgjdbc test

### DIFF
--- a/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
+++ b/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
@@ -808,7 +808,7 @@ var pgjdbcIgnoreList = blocklist{
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testTruncatedUTF8Decode":                                                                        "54477",
 	"org.postgresql.test.jdbc2.DatabaseEncodingTest.testUTF8Decode":                                                                                 "54477",
 	"org.postgresql.test.jdbc2.DatabaseMetaDataCacheTest.testGetTypeInfoUsesCache":                                                                  "https://github.com/cockroachdb/cockroach/issues/119332#issuecomment-1950242848",
-	"org.postgresql.test.jdbc2.StatementTest.shortQueryTimeout":                                                                                     "flaky",
+	"org.postgresql.test.jdbc2.StatementTest.shortQueryTimeout()":                                                                                   "flaky",
 	"org.postgresql.test.jdbc4.jdbc41.SchemaTest.testCurrentSchemaPropertyNotVisibilityTableInsideFunction":                                         "https://github.com/pgjdbc/pgjdbc/pull/2806",
 	"org.postgresql.test.jdbc4.jdbc41.SchemaTest.testCurrentSchemaPropertyVisibilityFunction":                                                       "https://github.com/pgjdbc/pgjdbc/pull/2806",
 	"org.postgresql.test.jdbc4.jdbc41.SchemaTest.testCurrentSchemaPropertyVisibilityTableDuringFunctionCreation":                                    "https://github.com/pgjdbc/pgjdbc/pull/2806",


### PR DESCRIPTION
It turns out the name needs to include parentheses in it.

fixes https://github.com/cockroachdb/cockroach/issues/135245
Release note: None