### PR TITLE
logictest: allow multiple configs for skipif, onlyif

### DIFF
--- a/pkg/sql/logictest/BUILD.bazel
+++ b/pkg/sql/logictest/BUILD.bazel
@@ -47,7 +47,10 @@ filegroup(
 go_library(
     name = "logictest",
     testonly = 1,
-    srcs = ["logic.go"],
+    srcs = [
+        "logic.go",
+        "parsing.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/logictest",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/sql/logictest/parsing.go
+++ b/pkg/sql/logictest/parsing.go
@@ -1,0 +1,38 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package logictest
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// extractGithubIssue parses directive fields of the form:
+//
+//	[#ISSUE] [args...]
+//
+// If the first field is a number prefixed with #, it will be interpreted as
+// a github issue and the rest of the fiels are returned. Otherwise, returns -1
+// and the given fields.
+func extractGithubIssue(fields []string) (githubIssueID int, args []string) {
+	if len(fields) < 1 {
+		return -1, nil
+	}
+	if numStr, ok := strings.CutPrefix(fields[0], "#"); ok {
+		if num, err := strconv.ParseUint(numStr, 10, 32); err == nil {
+			return int(num), fields[1:]
+		}
+	}
+	return -1, fields
+}
+
+func githubIssueStr(githubIssueID int) string {
+	if githubIssueID <= 0 {
+		return "no issue given"
+	}
+	return fmt.Sprintf("#%d", githubIssueID)
+}

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -1389,8 +1389,7 @@ SELECT * FROM stored1 ORDER BY A;
 statement ok
 INSERT INTO stored1 VALUES (2147483648),(2147483647);
 
-skipif config local-legacy-schema-changer
-skipif config local-mixed-24.1
+skipif config local-legacy-schema-changer local-mixed-24.1
 statement error pq: validate check constraint: integer out of range for type int4
 ALTER TABLE stored1 ALTER COLUMN COMP1 SET DATA TYPE INT4;
 
@@ -1402,13 +1401,11 @@ ALTER TABLE stored1 ALTER COLUMN COMP1 SET DATA TYPE INT4;
 statement ok
 DELETE FROM stored1 WHERE a = 2147483648;
 
-skipif config local-legacy-schema-changer
-skipif config local-mixed-24.1
+skipif config local-legacy-schema-changer local-mixed-24.1
 statement ok
 ALTER TABLE stored1 ALTER COLUMN COMP1 SET DATA TYPE INT4;
 
-skipif config local-legacy-schema-changer
-skipif config local-mixed-24.1
+skipif config local-legacy-schema-changer local-mixed-24.1
 query TT
 SHOW CREATE TABLE stored1;
 ----
@@ -1419,8 +1416,7 @@ stored1  CREATE TABLE public.stored1 (
            FAMILY f1 (a, comp1)
          )
 
-skipif config local-legacy-schema-changer
-skipif config local-mixed-24.1
+skipif config local-legacy-schema-changer local-mixed-24.1
 query II
 SELECT * FROM stored1 ORDER BY A;
 ----
@@ -1430,33 +1426,25 @@ SELECT * FROM stored1 ORDER BY A;
 2000 2000
 2147483647  2147483647
 
-skipif config local-legacy-schema-changer
-skipif config local-mixed-24.1
-skipif config local-mixed-24.2
+skipif config local-legacy-schema-changer local-mixed-24.1 local-mixed-24.2
 # Attempt to convert to a type that is incompatible with the computed expression
 statement error pq: expected STORED COMPUTED COLUMN expression to have type bool, but 'a' has type int
 ALTER TABLE stored1 ALTER COLUMN comp1 SET DATA TYPE BOOL;
 
-skipif config local-legacy-schema-changer
-skipif config local-mixed-24.1
-skipif config local-mixed-24.2
+skipif config local-legacy-schema-changer local-mixed-24.1 local-mixed-24.2
 statement error pq: expected STORED COMPUTED COLUMN expression to have type string, but 'a' has type int
 ALTER TABLE stored1 ALTER COLUMN comp1 SET DATA TYPE TEXT;
 
 # Convert the type to something compatible, but specify a custom value for the
 # column with the USING expression. This will force a type conversion with a backfill.
-skipif config local-legacy-schema-changer
-skipif config local-mixed-24.1
-skipif config local-mixed-24.2
+skipif config local-legacy-schema-changer local-mixed-24.1 local-mixed-24.2
 statement ok
 ALTER TABLE stored1 ALTER COLUMN comp1 SET DATA TYPE INT2 USING -1;
 
 statement ok
 INSERT INTO stored1 VALUES (-1000);
 
-skipif config local-legacy-schema-changer
-skipif config local-mixed-24.1
-skipif config local-mixed-24.2
+skipif config local-legacy-schema-changer local-mixed-24.1 local-mixed-24.2
 query TT
 SHOW CREATE TABLE stored1;
 ----
@@ -1467,9 +1455,7 @@ stored1  CREATE TABLE public.stored1 (
            FAMILY f1 (a, comp1)
          )
 
-skipif config local-legacy-schema-changer
-skipif config local-mixed-24.1
-skipif config local-mixed-24.2
+skipif config local-legacy-schema-changer local-mixed-24.1 local-mixed-24.2
 query II
 SELECT * FROM stored1 ORDER BY A;
 ----
@@ -1481,9 +1467,7 @@ SELECT * FROM stored1 ORDER BY A;
 2147483647  -1
 
 # Attempt to drop stored along with changing the column type
-skipif config local-legacy-schema-changer
-skipif config local-mixed-24.1
-skipif config local-mixed-24.2
+skipif config local-legacy-schema-changer local-mixed-24.1 local-mixed-24.2
 statement error pq: unimplemented: ALTER COLUMN TYPE cannot be used in combination with other ALTER TABLE commands
 ALTER TABLE stored1 ALTER COLUMN comp1 SET DATA TYPE INT4 USING -1, ALTER COLUMN comp1 drop stored;
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1584,19 +1584,19 @@ statement error column "g" does not exist
 ALTER TABLE unique_without_index ADD CONSTRAINT bad_partial_unique UNIQUE WITHOUT INDEX (f) WHERE g > 0
 
 # The unique constraint prevents new duplicate values.
-skipif config weak-iso-level-configs 110873
+skipif config #110873 weak-iso-level-configs
 statement error pgcode 23505 pq: duplicate key value violates unique constraint "my_unique_f"\nDETAIL: Key \(f\)=\(1\) already exists\.
 INSERT INTO unique_without_index (f) VALUES (1), (1)
 
 # There is no unique constraint on e, yet, so this insert succeeds.
-skipif config weak-iso-level-configs 110873
+skipif config #110873 weak-iso-level-configs
 statement ok
 INSERT INTO unique_without_index (e, f) VALUES (1, 1), (1, 2)
 
 # But trying to add a unique constraint now fails.
 # Note that we omit the constraint name in the expected error message because if the declarative schema changer is used,
 # the constraint name, at the time of validation failure, is still a place-holder name.
-skipif config weak-iso-level-configs 110873
+skipif config #110873 weak-iso-level-configs
 statement error pgcode 23505 pq: could not create unique constraint ".*"\nDETAIL: Key \(e\)=\(1\) is duplicated\.
 ALTER TABLE unique_without_index ADD CONSTRAINT my_unique_e UNIQUE WITHOUT INDEX (e)
 
@@ -1606,7 +1606,7 @@ ALTER TABLE unique_without_index ADD CONSTRAINT my_unique_e UNIQUE WITHOUT INDEX
 ALTER TABLE unique_without_index ADD CONSTRAINT my_unique_e2 UNIQUE WITHOUT INDEX (e) NOT VALID
 
 # Trying to validate one of the constraints will fail.
-skipif config weak-iso-level-configs 110873
+skipif config #110873 weak-iso-level-configs
 statement error pgcode 23505 pq: could not create unique constraint ".*"\nDETAIL: Key \(e\)=\(1\) is duplicated\.
 ALTER TABLE unique_without_index VALIDATE CONSTRAINT my_unique_e
 
@@ -1618,7 +1618,7 @@ statement ok
 ALTER TABLE unique_without_index VALIDATE CONSTRAINT my_unique_e
 
 # All these constraints are already valid, so validation should succeed.
-skipif config weak-iso-level-configs 110873
+skipif config #110873 weak-iso-level-configs
 statement ok
 ALTER TABLE unique_without_index VALIDATE CONSTRAINT unique_b;
 ALTER TABLE unique_without_index VALIDATE CONSTRAINT unique_a_b;

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -120,13 +120,13 @@ SELECT ARRAY(VALUES (1),(2),(1))
 
 # This query works in local config but fails in distributed config since the
 # support for nested arrays is incomplete.
-onlyif config local 32552
+onlyif config #32252 local
 query T
 SELECT ARRAY(VALUES (ARRAY[1]))
 ----
 {"{1}"}
 
-onlyif config fakedist 32552
+onlyif config #32252 fakedist
 query error unimplemented: nested arrays are not fully supported.*\nHINT.*\n.*32552
 SELECT ARRAY(VALUES (ARRAY[1]))
 
@@ -452,13 +452,13 @@ CREATE TABLE badtable (b INT[][])
 
 # This query works in local config but fails in distributed config since the
 # support for nested arrays is incomplete.
-onlyif config local 32552
+onlyif config #32252 local
 query T
 SELECT ARRAY[ARRAY[1,2,3]]
 ----
 {"{1,2,3}"}
 
-onlyif config fakedist 32552
+onlyif config #32552 fakedist
 query error unimplemented: nested arrays are not fully supported.*\nHINT.*\n.*32552
 SELECT ARRAY[ARRAY[1,2,3]]
 

--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -1990,11 +1990,11 @@ INSERT INTO b VALUES (1, 1), (2, 2), (3, 4);
 INSERT INTO c VALUES (2, 1), (1, 2);
 
 # Perform a standard cascading update.
-skipif config weak-iso-level-configs 112488
+skipif config #112488 weak-iso-level-configs
 statement ok
 UPDATE a SET id = id*10;
 
-skipif config weak-iso-level-configs 112488
+skipif config #112488 weak-iso-level-configs
 query TII rowsort
 SELECT name, id1, id2 FROM (
   SELECT 'a' AS name, id AS id1, 0 AS id2 FROM a
@@ -2017,26 +2017,26 @@ c  10  20
 c  20  10
 
 # Try to update one value to fail c.less_than_100
-skipif config weak-iso-level-configs 112488
+skipif config #112488 weak-iso-level-configs
 statement error pq: failed to satisfy CHECK constraint \(\(id1 \+ id2\) < 100:::INT8\)
 UPDATE a SET id = id*10;
 
 # Try to update one value to fail c.less_than_100 or c.less_than_1000
-skipif config weak-iso-level-configs 112488
+skipif config #112488 weak-iso-level-configs
 statement error pq: failed to satisfy CHECK constraint \(\(id1 \+ id2\) < 100:::INT8\)
 UPDATE a SET id = id*10;
 
 # Try to update one value to fail c.less_than_100
-skipif config weak-iso-level-configs 112488
+skipif config #112488 weak-iso-level-configs
 statement error pq: failed to satisfy CHECK constraint \(\(id1 \+ id2\) < 1000:::INT8\)
 UPDATE a SET id = 1000 WHERE id = 30;
 
-skipif config weak-iso-level-configs 112488
+skipif config #112488 weak-iso-level-configs
 statement error pq: failed to satisfy CHECK constraint \(\(id1 \+ id2\) < 1000:::INT8\)
 UPDATE a SET id = 1000 WHERE id = 40;
 
 # Update a value that would fail the check if it was cascaded, but wasn't.
-skipif config weak-iso-level-configs 112488
+skipif config #112488 weak-iso-level-configs
 statement ok
 UPDATE a SET id = 100000 WHERE id = 50;
 

--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -133,15 +133,15 @@ SELECT * from t3
 ----
 3 2
 
-skipif config weak-iso-level-configs 112488
+skipif config #112488 weak-iso-level-configs
 statement error pgcode 23514 failed to satisfy CHECK constraint
 UPDATE t3 SET b = 3 WHERE a = 3
 
-onlyif config weak-iso-level-configs 112488
+onlyif config #112488 weak-iso-level-configs
 statement error multi-column-family check constraints are not yet supported under read committed isolation
 UPDATE t3 SET b = 3 WHERE a = 3
 
-skipif config weak-iso-level-configs 112488
+skipif config #112488 weak-iso-level-configs
 statement ok
 UPDATE t3 SET b = 1 WHERE a = 3
 
@@ -328,23 +328,23 @@ INSERT INTO t9 VALUES (5, 3)
 statement error pgcode 23514 failed to satisfy CHECK constraint \(a > b\)
 INSERT INTO t9 VALUES (6, 7)
 
-skipif config weak-iso-level-configs 112488
+skipif config #112488 weak-iso-level-configs
 statement ok
 UPDATE t9 SET b = 4 WHERE a = 5
 
-skipif config weak-iso-level-configs 112488
+skipif config #112488 weak-iso-level-configs
 statement error pgcode 23514 failed to satisfy CHECK constraint \(a > b\)
 UPDATE t9 SET b = 6 WHERE a = 5
 
-skipif config weak-iso-level-configs 112488
+skipif config #112488 weak-iso-level-configs
 statement ok
 UPDATE t9 SET a = 7 WHERE a = 4
 
-skipif config weak-iso-level-configs 112488
+skipif config #112488 weak-iso-level-configs
 statement error pgcode 23514 failed to satisfy CHECK constraint \(a > b\)
 UPDATE t9 SET a = 2 WHERE a = 5
 
-onlyif config weak-iso-level-configs 112488
+onlyif config #112488 weak-iso-level-configs
 statement error multi-column-family check constraints are not yet supported under read committed isolation
 UPDATE t9 SET b = 4 WHERE a = 5
 

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_catalog
@@ -100,8 +100,7 @@ SELECT
 	)
 $$;
 
-skipif config local-mixed-24.2
-skipif config local-mixed-24.3
+skipif config local-mixed-24.2 local-mixed-24.3
 query IT
 SELECT id, strip_volatile(descriptor) FROM crdb_internal.kv_catalog_descriptor ORDER BY id
 ----

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -360,7 +360,7 @@ DROP INDEX t_secondary CASCADE;
 ALTER TABLE t DROP COLUMN b;
 INSERT INTO t SELECT a + 1 FROM t;
 
-skipif config weak-iso-level-configs 112488
+skipif config #112488 weak-iso-level-configs
 statement error pgcode 23505 duplicate key value violates unique constraint "t_secondary"\nDETAIL: Key \(b\)=\(0\.0\) already exists
 UPSERT INTO t SELECT a + 1 FROM t;
 

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1012,14 +1012,16 @@ statement ok
 CREATE TABLE enum_data_type (x STRING, y INT);
 INSERT INTO enum_data_type VALUES ('hello'), ('howdy');
 
-skipif config local-legacy-schema-changer "legacy doesn't hydrate the type name in the message"
+# The legacy schema changed doesn't hydrate the type name in the message.
+skipif config local-legacy-schema-changer
 statement error pq: column "y" cannot be cast automatically to type public.greeting\nHINT: You might need to specify "USING y::public.greeting".
 ALTER TABLE enum_data_type ALTER COLUMN y SET DATA TYPE greeting;
 
 statement error pq: invalid cast: int -> greeting
 ALTER TABLE enum_data_type ALTER COLUMN y SET DATA TYPE greeting USING y::greeting;
 
-skipif config local-legacy-schema-changer "legacy doesn't hydrate the type name in the message"
+# The legacy schema changed doesn't hydrate the type name in the message.
+skipif config local-legacy-schema-changer
 statement error pq: column "x" cannot be cast automatically to type public.greeting\nHINT: You might need to specify "USING x::public.greeting".
 ALTER TABLE enum_data_type ALTER COLUMN x SET DATA TYPE greeting;
 

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -4248,8 +4248,7 @@ NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 NOTICE: type of foreign key column "t1_fk_col2" (INT8) is not identical to referenced column "t1_fk"."col2" (INT4)
 
 # Test validation data type change
-skipif config local-legacy-schema-changer
-skipif config weak-iso-level-configs
+skipif config local-legacy-schema-changer weak-iso-level-configs
 query T noticetrace
 ALTER TABLE t2_fk ALTER COLUMN t1_fk_col1 SET DATA TYPE CHAR(5)
 ----

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -1810,7 +1810,7 @@ CREATE TABLE t61414_c (
   FAMILY (k, a, c)
 )
 
-skipif config weak-iso-level-configs 110873
+skipif config #110873 weak-iso-level-configs
 statement ok
 UPSERT INTO t61414_c (k, a, b, d) VALUES (1, 2, 3, 4)
 

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -8,8 +8,7 @@ test       root  NULL  NULL  {}  NULL
 
 # The test expectations are different on tenants because of
 # descriptor_id_sq, tenant, tenant_usage, and span_configurations.
-skipif config 3node-tenant-default-configs
-skipif config local-mixed-24.2
+skipif config 3node-tenant-default-configs local-mixed-24.2
 query TTTTT
 SELECT schema_name, table_name, type, owner, locality FROM [SHOW TABLES FROM system] ORDER BY 2
 ----

--- a/pkg/sql/logictest/testdata/logic_test/system_namespace
+++ b/pkg/sql/logictest/testdata/logic_test/system_namespace
@@ -1,5 +1,4 @@
-skipif config 3node-tenant-default-configs
-skipif config local-mixed-24.2
+skipif config 3node-tenant-default-configs local-mixed-24.2
 query IITI rowsort
 SELECT * FROM system.namespace
 ----

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -706,27 +706,27 @@ CREATE TABLE uniq_no_index (
   UNIQUE WITHOUT INDEX (v)
 )
 
-skipif config weak-iso-level-configs 110873
+skipif config #110873 weak-iso-level-configs
 statement ok
 INSERT INTO uniq_no_index VALUES (1, 10), (2, 20)
 
-skipif config weak-iso-level-configs 110873
+skipif config #110873 weak-iso-level-configs
 statement error duplicate key value violates unique constraint
 INSERT INTO uniq_no_index VALUES (3, 8)
 
-skipif config weak-iso-level-configs 110873
+skipif config #110873 weak-iso-level-configs
 statement error duplicate key value violates unique constraint
 UPDATE uniq_no_index SET b=b+11 WHERE a < 2
 
-skipif config weak-iso-level-configs 110873
+skipif config #110873 weak-iso-level-configs
 statement error duplicate key value violates unique constraint
 UPSERT INTO uniq_no_index VALUES (2, 30), (5, 6)
 
-skipif config weak-iso-level-configs 110873
+skipif config #110873 weak-iso-level-configs
 statement ok
 INSERT INTO uniq_no_index VALUES (5, 6) ON CONFLICT (v) DO UPDATE SET b=15
 
-skipif config weak-iso-level-configs 110873
+skipif config #110873 weak-iso-level-configs
 query III colnames,rowsort
 SELECT * FROM uniq_no_index
 ----
@@ -743,23 +743,23 @@ CREATE TABLE uniq_no_index_multi (
   UNIQUE WITHOUT INDEX (v, c)
 )
 
-skipif config weak-iso-level-configs 110873
+skipif config #110873 weak-iso-level-configs
 statement ok
 INSERT INTO uniq_no_index_multi VALUES (1, 1, 1), (2, 4, 2), (3, 3, 3)
 
-skipif config weak-iso-level-configs 110873
+skipif config #110873 weak-iso-level-configs
 statement error duplicate key value violates unique constraint
 INSERT INTO uniq_no_index_multi VALUES (4, 2, 2)
 
-skipif config weak-iso-level-configs 110873
+skipif config #110873 weak-iso-level-configs
 statement error duplicate key value violates unique constraint
 UPDATE uniq_no_index_multi SET c=2 WHERE a=3
 
-skipif config weak-iso-level-configs 110873
+skipif config #110873 weak-iso-level-configs
 statement ok
 UPSERT INTO uniq_no_index_multi VALUES (3, 3, 10)
 
-skipif config weak-iso-level-configs 110873
+skipif config #110873 weak-iso-level-configs
 statement error duplicate key value violates unique constraint
 UPSERT INTO uniq_no_index_multi VALUES (3, 3, 2)
 

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -303,13 +303,11 @@ onlyif config local-legacy-schema-changer
 statement error pq: user root does not have CREATE or ZONECONFIG privilege on relation columns
 ALTER TABLE information_schema.columns CONFIGURE ZONE USING gc.ttlseconds = 100000
 
-skipif config local-mixed-24.2
-skipif config local-legacy-schema-changer
+skipif config local-legacy-schema-changer local-mixed-24.2
 statement error pq: pg_type is a system catalog
 ALTER TABLE pg_catalog.pg_type CONFIGURE ZONE USING gc.ttlseconds = 100000
 
-skipif config local-mixed-24.2
-skipif config local-legacy-schema-changer
+skipif config local-legacy-schema-changer local-mixed-24.2
 statement error pq: columns is a virtual object and cannot be modified
 ALTER TABLE information_schema.columns CONFIGURE ZONE USING gc.ttlseconds = 100000
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant_locality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant_locality
@@ -1,5 +1,5 @@
 # LogicTest: 3node-tenant-multiregion
-skip under duress 118627
+skip under duress #118627
 
 user host-cluster-root
 


### PR DESCRIPTION
This is mostly a convenience for `skipif` but it is a necessity for
`onlyif`, which we can't use twice.

Epic: none
Release note: None