### PR TITLE
roachtest: change username in grant revoke

### DIFF
--- a/pkg/cmd/roachtest/operations/grant_revoke_all.go
+++ b/pkg/cmd/roachtest/operations/grant_revoke_all.go
@@ -57,7 +57,7 @@ func runGrant(
 	dbName := pickRandomDB(ctx, o, conn, systemDBs)
 	tableName := pickRandomTable(ctx, o, conn, dbName)
 	// the dbUser cannot have a number in the beginning. So, adding an "a" to ensure that the first letter will not be a number
-	dbUser := fmt.Sprintf("a%s", randutil.RandString(rng, 9, randutil.PrintableKeyAlphabet))
+	dbUser := fmt.Sprintf("roachprod_ops_add_role_%s", randutil.RandString(rng, 10, randutil.PrintableKeyAlphabet))
 
 	o.Status(fmt.Sprintf("Creating user %s", dbUser))
 	_, err := conn.ExecContext(ctx, fmt.Sprintf("CREATE USER %s WITH PASSWORD '%s'", dbUser, dbUser))


### PR DESCRIPTION
We are generating the user for roachtest grant-revoke operation. This user name is a randomly generated string of length 10 today. But, it becomes confusing as the name looks hacky. So, we are adding a prefix to the username.

Epic: none
Release note: None