### PR TITLE
sql: hack to avoid tracing all BEGIN/COMMIT

### DIFF
--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -458,6 +458,9 @@ func (ih *instrumentationHelper) Setup(
 
 	var previouslySampled bool
 	previouslySampled, ih.savePlanForStats = statsCollector.ShouldSample(fingerprint, implicitTxn, p.SessionData().Database)
+	if !previouslySampled && (fingerprint == "BEGIN TRANSACTION" || fingerprint == "COMMIT TRANSACTION") {
+		previouslySampled = true
+	}
 
 	defer func() { ih.finalizeSetup(newCtx, cfg) }()
 


### PR DESCRIPTION
Touches https://github.com/cockroachdb/cockroach/issues/133307.

```
=== RUN   TestSampledStatsCollectionOnNewFingerprint/do-sampling-when-container-not-full
    instrumentation_test.go:256: 
        	Error Trace:	pkg/sql/instrumentation_test.go:256
        	Error:      	Should be true
        	Test:       	TestSampledStatsCollectionOnNewFingerprint/do-sampling-when-container-not-full
    --- FAIL: TestSampledStatsCollectionOnNewFingerprint/do-sampling-when-container-not-full (0.01s)
```

TODO: check if this moves the needle on tracing allocs when placed on top of https://github.com/cockroachdb/cockroach/pull/135146.

I ran this on top of #135146 and https://github.com/cockroachdb/cockroach/pull/135682 and it looks like we're not getting a big boost out of this:

```
benchdiff --old=6cfb42e375f46d6df1087a73cb75c4c001fd05c7 ./pkg/sql/tests -b -r 'Sysbench/SQL/3node/oltp_read_write' --memprofile -d 1000x -c 5

name                                   old time/op    new time/op    delta
Sysbench/SQL/3node/oltp_read_write-24    14.5ms ± 1%    14.2ms ± 1%  -2.14%  (p=0.008 n=5+5)

name                                   old alloc/op   new alloc/op   delta
Sysbench/SQL/3node/oltp_read_write-24    2.64MB ± 4%    2.64MB ± 3%    ~     (p=1.000 n=5+5)

name                                   old allocs/op  new allocs/op  delta
Sysbench/SQL/3node/oltp_read_write-24     18.0k ± 1%     17.8k ± 1%    ~     (p=0.056 n=5+5)
```
