### PR TITLE
rac2: add term assertion in RangeController

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
@@ -1281,7 +1281,10 @@ func TestRangeController(t *testing.T) {
 					require.NoError(t, testRC.raftLog.Append(entries))
 
 					raftEvent := RaftEvent{
-						MsgAppMode:        mode,
+						MsgAppMode: mode,
+						// Term is set to 1, to be consistent with what we use when
+						// calling NewRangeController in this test.
+						Term:              1,
 						Entries:           entries,
 						MsgApps:           map[roachpb.ReplicaID][]raftpb.Message{},
 						LogSnapshot:       testRC.logSnapshot(),


### PR DESCRIPTION
The assertion ensures that an append (entries or snapshot) has a term that matches the rangeController's term.

Epic: CRDB-37515

Release note: None