### PR TITLE
server,ui: fix custom chart metrics dropdown

### DIFF
--- a/pkg/server/nodes_response.go
+++ b/pkg/server/nodes_response.go
@@ -55,7 +55,9 @@ var uiStoreMetrics = []string{
 	"syscount",
 }
 
-func nodeStatusToResp(n *statuspb.NodeStatus, hasViewClusterMetadata bool) serverpb.NodeResponse {
+func nodeStatusToResp(
+	n *statuspb.NodeStatus, hasViewClusterMetadata bool, includeAllMetrics bool,
+) serverpb.NodeResponse {
 	tiers := make([]serverpb.Tier, len(n.Desc.Locality.Tiers))
 	for j, t := range n.Desc.Locality.Tiers {
 		tiers[j] = serverpb.Tier{
@@ -93,10 +95,15 @@ func nodeStatusToResp(n *statuspb.NodeStatus, hasViewClusterMetadata bool) serve
 
 	statuses := make([]serverpb.StoreStatus, len(n.StoreStatuses))
 	for i, ss := range n.StoreStatuses {
-		storeMetrics := make(map[string]float64, len(uiStoreMetrics))
-		for _, m := range uiStoreMetrics {
-			if d, ok := ss.Metrics[m]; ok {
-				storeMetrics[m] = d
+		var storeMetrics map[string]float64
+		if includeAllMetrics {
+			storeMetrics = ss.Metrics
+		} else {
+			storeMetrics = make(map[string]float64, len(uiStoreMetrics))
+			for _, m := range uiStoreMetrics {
+				if d, ok := ss.Metrics[m]; ok {
+					storeMetrics[m] = d
+				}
 			}
 		}
 		statuses[i] = serverpb.StoreStatus{
@@ -127,10 +134,15 @@ func nodeStatusToResp(n *statuspb.NodeStatus, hasViewClusterMetadata bool) serve
 		}
 	}
 
-	metrics := make(map[string]float64, len(uiNodeMetrics))
-	for _, m := range uiNodeMetrics {
-		if d, ok := n.Metrics[m]; ok {
-			metrics[m] = d
+	var metrics map[string]float64
+	if includeAllMetrics {
+		metrics = n.Metrics
+	} else {
+		metrics = make(map[string]float64, len(uiNodeMetrics))
+		for _, m := range uiNodeMetrics {
+			if d, ok := n.Metrics[m]; ok {
+				metrics[m] = d
+			}
 		}
 	}
 

--- a/pkg/server/nodes_response_test.go
+++ b/pkg/server/nodes_response_test.go
@@ -53,7 +53,7 @@ func TestNodeStatusToResp(t *testing.T) {
 		Args: []string{"args"},
 		Env:  []string{"env"},
 	}
-	resp := nodeStatusToResp(nodeStatus, false)
+	resp := nodeStatusToResp(nodeStatus, false, false)
 	require.Empty(t, resp.Args)
 	require.Empty(t, resp.Env)
 	require.Empty(t, resp.Desc.Address)
@@ -65,7 +65,7 @@ func TestNodeStatusToResp(t *testing.T) {
 	require.Empty(t, resp.StoreStatuses[0].Desc.Properties.FileStoreProperties.Path)
 
 	// Now fetch all the node statuses as admin.
-	resp = nodeStatusToResp(nodeStatus, true)
+	resp = nodeStatusToResp(nodeStatus, true, false)
 	require.NotEmpty(t, resp.Args)
 	require.NotEmpty(t, resp.Env)
 	require.NotEmpty(t, resp.Desc.Address)

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1933,7 +1933,7 @@ func (s *statusServer) NodesUI(
 		LivenessByNodeID: internalResp.LivenessByNodeID,
 	}
 	for i, nodeStatus := range internalResp.Nodes {
-		resp.Nodes[i] = nodeStatusToResp(&nodeStatus, hasViewClusterMetadata)
+		resp.Nodes[i] = nodeStatusToResp(&nodeStatus, hasViewClusterMetadata, false)
 	}
 
 	return resp, nil
@@ -1964,7 +1964,7 @@ func (s *systemStatusServer) NodesUI(
 		LivenessByNodeID: internalResp.LivenessByNodeID,
 	}
 	for i, nodeStatus := range internalResp.Nodes {
-		resp.Nodes[i] = nodeStatusToResp(&nodeStatus, hasViewClusterMetadata)
+		resp.Nodes[i] = nodeStatusToResp(&nodeStatus, hasViewClusterMetadata, false)
 	}
 
 	return resp, nil
@@ -2115,7 +2115,7 @@ func (s *statusServer) NodeUI(
 		// already returns a proper gRPC error status.
 		return nil, err
 	}
-	resp := nodeStatusToResp(nodeStatus, isAdmin)
+	resp := nodeStatusToResp(nodeStatus, isAdmin, true)
 	return &resp, nil
 }
 

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -23,6 +23,7 @@ import { createSelector, ParametricSelector } from "reselect";
 import { VersionList } from "src/interfaces/cockroachlabs";
 import * as protos from "src/js/protos";
 import * as api from "src/util/api";
+import { NodeResponse } from "src/util/api";
 import { versionCheck } from "src/util/cockroachlabsAPI";
 import { INodeStatus, RollupStoreMetrics } from "src/util/proto";
 
@@ -91,6 +92,17 @@ export const nodesReducerObj = new CachedDataReducer(
   moment.duration(10, "s"),
 );
 export const refreshNodes = nodesReducerObj.refresh;
+
+export const nodeReducerObj = new CachedDataReducer(
+  (req: api.NodesRequestMessage, timeout?: moment.Duration) =>
+    api.getNodeUI(req, timeout).then(nr => {
+      RollupStoreMetrics(nr);
+      return nr;
+    }),
+  "node",
+);
+
+export const refreshNode = nodeReducerObj.refresh;
 
 const raftReducerObj = new CachedDataReducer(
   api.raftDebug,
@@ -546,6 +558,7 @@ export interface APIReducersState {
   >;
   health: HealthState;
   nodes: CachedDataReducerState<INodeStatus[]>;
+  node: CachedDataReducerState<NodeResponse>;
   raft: CachedDataReducerState<api.RaftDebugResponseMessage>;
   version: CachedDataReducerState<VersionList>;
   locations: CachedDataReducerState<api.LocationsResponseMessage>;
@@ -606,6 +619,7 @@ export const apiReducersReducer = combineReducers<APIReducersState>({
   [eventsReducerObj.actionNamespace]: eventsReducerObj.reducer,
   [healthReducerObj.actionNamespace]: healthReducerObj.reducer,
   [nodesReducerObj.actionNamespace]: nodesReducerObj.reducer,
+  [nodeReducerObj.actionNamespace]: nodeReducerObj.reducer,
   [raftReducerObj.actionNamespace]: raftReducerObj.reducer,
   [versionReducerObj.actionNamespace]: versionReducerObj.reducer,
   [locationsReducerObj.actionNamespace]: locationsReducerObj.reducer,

--- a/pkg/ui/workspaces/db-console/src/redux/metricMetadata.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/metricMetadata.ts
@@ -3,12 +3,18 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
+import isEmpty from "lodash/isEmpty";
 import { createSelector } from "reselect";
 
+import { nodeStatusSelector } from "src/redux/nodes";
 import { AdminUIState } from "src/redux/state";
 import { MetricMetadataResponseMessage } from "src/util/api";
 
-export type MetricsMetadata = MetricMetadataResponseMessage["metadata"];
+export type MetricsMetadata = {
+  metadata?: MetricMetadataResponseMessage["metadata"];
+  allMetrics?: Set<string>;
+  storeMetrics?: Set<string>;
+};
 
 // State selectors
 const metricsMetadataStateSelector = (state: AdminUIState) =>
@@ -16,6 +22,17 @@ const metricsMetadataStateSelector = (state: AdminUIState) =>
 
 export const metricsMetadataSelector = createSelector(
   metricsMetadataStateSelector,
-  (metricsMetadata): MetricsMetadata =>
-    metricsMetadata ? metricsMetadata.metadata : undefined,
+  nodeStatusSelector,
+  (metricsMetadata, nodeStatus): MetricsMetadata => {
+    if (isEmpty(metricsMetadata) || isEmpty(nodeStatus)) {
+      return {};
+    }
+    return {
+      metadata: metricsMetadata?.metadata,
+      allMetrics: new Set(Object.keys(nodeStatus?.metrics ?? {})),
+      storeMetrics: new Set(
+        Object.keys(nodeStatus?.store_statuses[0].metrics ?? {}),
+      ),
+    };
+  },
 );

--- a/pkg/ui/workspaces/db-console/src/redux/nodes.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/nodes.ts
@@ -73,9 +73,16 @@ const livenessesSelector = (state: AdminUIState) =>
 /*
  * nodeStatusesSelector returns the current status for each node in the cluster.
  */
-type NodeStatusState = Pick<AdminUIState, "cachedData", "nodes">;
-export const nodeStatusesSelector = (state: NodeStatusState) =>
+type NodeStatusesState = Pick<AdminUIState, "cachedData", "nodes">;
+export const nodeStatusesSelector = (state: NodeStatusesState) =>
   state.cachedData.nodes.data;
+
+/*
+ * nodeStatusesSelector returns the current status for each node in the cluster.
+ */
+type NodeStatusState = Pick<AdminUIState, "cachedData", "node">;
+export const nodeStatusSelector = (state: NodeStatusState) =>
+  state.cachedData.node.data;
 
 // partialNodeStatusesSelector returns NodeStatus items without fields that constantly change
 // and causes selectors to recompute.

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -13,6 +13,7 @@ import map from "lodash/map";
 import moment from "moment-timezone";
 
 import * as protos from "src/js/protos";
+import { getDataFromServer } from "src/util/dataFromServer";
 import { FixLong } from "src/util/fixLong";
 import { propsToQueryString } from "src/util/query";
 
@@ -24,6 +25,8 @@ export type LocationsResponseMessage =
 export type NodesRequestMessage = protos.cockroach.server.serverpb.NodesRequest;
 export type NodesResponseExternalMessage =
   protos.cockroach.server.serverpb.NodesResponseExternal;
+
+export type NodeResponse = protos.cockroach.server.serverpb.NodeResponse;
 
 export type GetUIDataRequestMessage =
   protos.cockroach.server.serverpb.GetUIDataRequest;
@@ -167,7 +170,10 @@ export type MetricMetadataRequestMessage =
   protos.cockroach.server.serverpb.MetricMetadataRequest;
 export type MetricMetadataResponseMessage =
   protos.cockroach.server.serverpb.MetricMetadataResponse;
-
+export type MetricMetadata = {
+  metadata: protos.cockroach.util.metric.IMetadata;
+  tsDbName: string;
+};
 export type StatementDetailsRequestMessage =
   protos.cockroach.server.serverpb.StatementDetailsRequest;
 
@@ -396,6 +402,20 @@ export function getNodesUI(
   return timeoutFetch(
     serverpb.NodesResponseExternal,
     `${STATUS_PREFIX}/nodes_ui`,
+    null,
+    timeout,
+  );
+}
+
+// getNodeUI gets node data for a specific node
+export function getNodeUI(
+  _req: NodesRequestMessage,
+  timeout?: moment.Duration,
+): Promise<NodeResponse> {
+  const nodeId = getDataFromServer().NodeID;
+  return timeoutFetch(
+    serverpb.NodeResponse,
+    `${STATUS_PREFIX}/nodes_ui/${nodeId}`,
     null,
     timeout,
   );

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/index.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/index.spec.ts
@@ -4,26 +4,36 @@
 // included in the /LICENSE file.
 
 import * as protos from "src/js/protos";
+import { MetricsMetadata } from "src/redux/metricMetadata";
 import { NodesSummary } from "src/redux/nodes";
 import { INodeStatus } from "src/util/proto";
 import { CustomMetricState } from "src/views/reports/containers/customChart/customMetric";
-import { GetSources } from "src/views/reports/containers/customChart/index";
+import { getSources } from "src/views/reports/containers/customChart/index";
 
 import TimeSeriesQueryAggregator = protos.cockroach.ts.tspb.TimeSeriesQueryAggregator;
 import TimeSeriesQueryDerivative = protos.cockroach.ts.tspb.TimeSeriesQueryDerivative;
 
+const emptyMetricsMetadata: MetricsMetadata = {
+  metadata: {},
+  allMetrics: new Set(),
+  storeMetrics: new Set(),
+};
 describe("Custom charts page", function () {
   describe("Getting metric sources", function () {
     it("returns empty when nodesSummary is undefined", function () {
       const metricState = new testCustomMetricStateBuilder().build();
-      expect(GetSources(undefined, metricState)).toStrictEqual([]);
+      expect(
+        getSources(undefined, metricState, emptyMetricsMetadata),
+      ).toStrictEqual([]);
     });
 
     it("returns empty when the nodeStatuses collection is empty", function () {
       const nodesSummary = new testNodesSummaryBuilder().build();
       nodesSummary.nodeStatuses = [];
       const metricState = new testCustomMetricStateBuilder().build();
-      expect(GetSources(nodesSummary, metricState)).toStrictEqual([]);
+      expect(
+        getSources(nodesSummary, metricState, emptyMetricsMetadata),
+      ).toStrictEqual([]);
     });
 
     it("returns empty when no specific node source is requested, nor per-source metrics", function () {
@@ -32,7 +42,9 @@ describe("Custom charts page", function () {
         .setNodeSource("")
         .setIsPerSource(false)
         .build();
-      expect(GetSources(nodesSummary, metricState)).toStrictEqual([]);
+      expect(
+        getSources(nodesSummary, metricState, emptyMetricsMetadata),
+      ).toStrictEqual([]);
     });
 
     describe("The metric is at the store-level", function () {
@@ -49,9 +61,9 @@ describe("Custom charts page", function () {
             "1": expectedSources,
           })
           .build();
-        expect(GetSources(nodesSummary, metricState)).toStrictEqual(
-          expectedSources,
-        );
+        expect(
+          getSources(nodesSummary, metricState, emptyMetricsMetadata),
+        ).toStrictEqual(expectedSources);
       });
 
       it("returns all known store IDs for the cluster when no node source is set", function () {
@@ -66,7 +78,11 @@ describe("Custom charts page", function () {
             "3": ["7", "8", "9"],
           })
           .build();
-        const actualSources = GetSources(nodesSummary, metricState).sort();
+        const actualSources = getSources(
+          nodesSummary,
+          metricState,
+          emptyMetricsMetadata,
+        ).sort();
         expect(actualSources).toStrictEqual(expectedSources);
       });
     });
@@ -81,9 +97,9 @@ describe("Custom charts page", function () {
           .setNodeSource("1")
           .build();
         const nodesSummary = new testNodesSummaryBuilder().build();
-        expect(GetSources(nodesSummary, metricState)).toStrictEqual(
-          expectedSources,
-        );
+        expect(
+          getSources(nodesSummary, metricState, emptyMetricsMetadata),
+        ).toStrictEqual(expectedSources);
       });
 
       it("returns all known node IDs when no node source is set", function () {
@@ -94,9 +110,9 @@ describe("Custom charts page", function () {
         const nodesSummary = new testNodesSummaryBuilder()
           .setNodeIDs(["1", "2", "3"])
           .build();
-        expect(GetSources(nodesSummary, metricState)).toStrictEqual(
-          expectedSources,
-        );
+        expect(
+          getSources(nodesSummary, metricState, emptyMetricsMetadata),
+        ).toStrictEqual(expectedSources);
       });
     });
   });


### PR DESCRIPTION
fixes a bug recently introduced, which resulted in the selectable metrics in the dropdown to be a small subset of the total metrics that used to appear

Epic: none
Release note: None