### PR TITLE
roachtest: use full cockroach binary for cockroach-ea

### DIFF
--- a/build/teamcity/cockroach/nightlies/roachtest_compile_component.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_compile_component.sh
@@ -70,9 +70,9 @@ case "$component" in
     artifacts=("pkg/cmd/cockroach/cockroach_/cockroach:bin/cockroach.$os-$arch")
     ;;
   cockroach-ea)
-    # Cockroach-short with enabled assertions (EA).
-    bazel_args=(--config force_build_cdeps //pkg/cmd/cockroach-short --crdb_test $crdb_extra_flags)
-    artifacts=("pkg/cmd/cockroach-short/cockroach-short_/cockroach-short:bin/cockroach-ea.$os-$arch")
+    # Cockroach binary with enabled assertions (EA).
+    bazel_args=(--config force_build_cdeps //pkg/cmd/cockroach --crdb_test $crdb_extra_flags)
+    artifacts=("pkg/cmd/cockroach/cockroach_/cockroach:bin/cockroach-ea.$os-$arch")
     ;;
   workload)
     # Workload binary.

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -94,7 +94,7 @@ func (t testWrapper) StandardCockroach() string {
 }
 
 func (t testWrapper) RuntimeAssertionsCockroach() string {
-	return "./dummy-path/to/cockroach-short"
+	return "./dummy-path/to/cockroach-ea"
 }
 
 func (t testWrapper) DeprecatedWorkload() string {

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -143,7 +143,7 @@ func TestCreatePostRequest(t *testing.T) {
 			start:       time.Date(2023, time.July, 21, 16, 34, 3, 817, time.UTC),
 			end:         time.Date(2023, time.July, 21, 16, 42, 13, 137, time.UTC),
 			cockroach:   "cockroach",
-			cockroachEA: "cockroach-short",
+			cockroachEA: "cockroach-ea",
 		}
 
 		testClusterImpl := &clusterImpl{spec: clusterSpec, arch: vm.ArchAMD64, name: "foo"}

--- a/pkg/cmd/roachtest/test/test_interface.go
+++ b/pkg/cmd/roachtest/test/test_interface.go
@@ -29,7 +29,7 @@ type Test interface {
 	// StandardCockroach returns path to main cockroach binary, compiled
 	// without runtime assertions.
 	StandardCockroach() string
-	// RuntimeAssertionsCockroach returns the path to cockroach-short
+	// RuntimeAssertionsCockroach returns the path to cockroach
 	// binary compiled with --crdb_test build tag, or an empty string if
 	// no such binary was given.
 	RuntimeAssertionsCockroach() string

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -60,10 +60,10 @@ type testImpl struct {
 	spec *registry.TestSpec
 
 	cockroach   string // path to main cockroach binary
-	cockroachEA string // path to cockroach-short binary compiled with --crdb_test build tag
+	cockroachEA string // path to cockroach binary compiled with --crdb_test build tag
 
 	randomCockroachOnce sync.Once
-	randomizedCockroach string // either `cockroach` or `cockroach-short`, picked randomly
+	randomizedCockroach string // either `cockroach` or `cockroach-ea`, picked randomly
 
 	deprecatedWorkload string // path to workload binary
 	debug              bool   // whether the test is in debug mode.

--- a/pkg/cmd/roachtest/tests/db_console.go
+++ b/pkg/cmd/roachtest/tests/db_console.go
@@ -195,16 +195,11 @@ func (d *dbConsoleCypressTest) writeCypressFilesToWorkloadNode(ctx context.Conte
 }
 
 func registerDbConsole(r registry.Registry) {
-	// Explicitly set CockroachBinary to registry.StandardCockroach to ensure that a binary
-	// containing db console is used. Currently, registry.RuntimeAssertionsCockroach
-	// is built using cockroach-short and the default of registry.RandomizedCockroach
-	// causes the tests to be flaky
 	r.Add(registry.TestSpec{
 		Name:             "db-console/mixed-version-cypress",
 		Owner:            registry.OwnerObservability,
 		Cluster:          r.MakeClusterSpec(5, spec.WorkloadNode()),
 		CompatibleClouds: registry.AllClouds,
-		CockroachBinary:  registry.StandardCockroach,
 		Suites:           registry.Suites(registry.Nightly),
 		Randomized:       false,
 		Run:              runDbConsoleCypressMixedVersions,
@@ -215,7 +210,6 @@ func registerDbConsole(r registry.Registry) {
 		Owner:            registry.OwnerObservability,
 		Cluster:          r.MakeClusterSpec(4, spec.WorkloadNode()),
 		CompatibleClouds: registry.AllClouds,
-		CockroachBinary:  registry.StandardCockroach,
 		Suites:           registry.Suites(registry.Nightly),
 		Randomized:       false,
 		Run:              runDbConsoleCypress,


### PR DESCRIPTION
Previously we compiled cockroach-ea for nightlies using cockroach-short mainly due to historical reasons. There was no good way to specify a cockroach-ea binary so we used cockroach-short as a placeholder to mean assertions on.

However, we have since reworked the framework and this is now no longer an issue. This change switches cockroach-ea to be compiled with the full cockroach binary instead, as we now have roachtests that require the ui.

Release note: none
Epic: none
Fixes: none