### PR TITLE
cloud: use uuid as bucket name

### DIFF
--- a/pkg/cloud/amazon/BUILD.bazel
+++ b/pkg/cloud/amazon/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
         "//pkg/testutils",
         "//pkg/testutils/skip",
         "//pkg/util/leaktest",
+        "//pkg/util/uuid",
         "@com_github_aws_aws_sdk_go//aws/awserr",
         "@com_github_aws_aws_sdk_go//aws/request",
         "@com_github_aws_aws_sdk_go_v2_config//:config",

--- a/pkg/cloud/gcp/BUILD.bazel
+++ b/pkg/cloud/gcp/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
         "//pkg/testutils/skip",
         "//pkg/util/ioctx",
         "//pkg/util/leaktest",
+        "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_googleapis_gax_go_v2//apierror",
         "@com_github_stretchr_testify//assert",

--- a/pkg/cloud/gcp/gcs_storage_test.go
+++ b/pkg/cloud/gcp/gcs_storage_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2/google"
 )
@@ -355,13 +355,13 @@ func TestFileDoesNotExist(t *testing.T) {
 		)
 		require.NoError(t, err)
 		_, _, err = s.ReadFile(context.Background(), "", cloud.ReadOptions{NoFileSize: true})
-		require.Error(t, err, "")
-		require.True(t, errors.Is(err, cloud.ErrFileDoesNotExist))
+		require.ErrorIs(t, err, cloud.ErrFileDoesNotExist)
 	}
 
 	{
-		// Invalid gsBucket.
-		gsFile := "gs://cockroach-fixtures-us-east1-invalid/tpch-csv/sf-1/region.tbl?AUTH=implicit"
+		// Use a random UUID as the name of the bucket that does not exist in order
+		// to avoid name squating.
+		gsFile := fmt.Sprintf("gs://%s/tpch-csv/sf-1/region.tbl?AUTH=implicit", uuid.NewV4())
 		conf, err := cloud.ExternalStorageConfFromURI(gsFile, user)
 		require.NoError(t, err)
 
@@ -373,8 +373,7 @@ func TestFileDoesNotExist(t *testing.T) {
 		)
 		require.NoError(t, err)
 		_, _, err = s.ReadFile(context.Background(), "", cloud.ReadOptions{NoFileSize: true})
-		require.Error(t, err, "")
-		require.True(t, errors.Is(err, cloud.ErrFileDoesNotExist))
+		require.ErrorIs(t, err, cloud.ErrFileDoesNotExist)
 	}
 }
 


### PR DESCRIPTION
Previously, the GCS and S3 tests used hard coded bucket names to test
the behavior of buckets that do not exist. Now, the tests use a random
UUID. This change is necessary because someone appears to have created
the GCP bucket which causes the test to fail.

Release Justification: Test Only Change
Release Note: None
Fixes: https://github.com/cockroachdb/cockroach/issues/135307
Fixes: https://github.com/cockroachdb/cockroach/issues/135348
Fixes: https://github.com/cockroachdb/cockroach/issues/135349
Fixes: https://github.com/cockroachdb/cockroach/issues/135350
Fixes: https://github.com/cockroachdb/cockroach/issues/135351
Fixes: https://github.com/cockroachdb/cockroach/issues/135352