### PR TITLE
leaktest: ignore leaked goroutines if test was skipped

### DIFF
--- a/pkg/util/leaktest/leaktest.go
+++ b/pkg/util/leaktest/leaktest.go
@@ -136,11 +136,17 @@ func AfterTest(t T) func() {
 		// to see if the leak detector should be disabled for future tests.
 		if f, ok := t.(interface {
 			Failed() bool
-		}); ok && f.Failed() {
-			if err := diffGoroutines(orig); err != nil {
-				atomic.StoreUint32(&leakDetectorDisabled, 1)
+			Skipped() bool
+		}); ok {
+			switch {
+			case f.Failed():
+				if err := diffGoroutines(orig); err != nil {
+					atomic.StoreUint32(&leakDetectorDisabled, 1)
+				}
+				fallthrough
+			case f.Skipped():
+				return
 			}
-			return
 		}
 
 		if tb, ok := t.(testing.TB); ok {


### PR DESCRIPTION
If a test is skipped in the middle of running, it might not have performed all the cleanup it needs to. Previously, this would cause the leak detector to report errors that we don't want to action on.

fixes https://github.com/cockroachdb/cockroach/issues/135572
Release note: None