### PR TITLE
release-24.1: release-24.2: span: fix corruption bug in btree span frontier

### DIFF
--- a/pkg/util/span/BUILD.bazel
+++ b/pkg/util/span/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
     deps = [
         "//pkg/roachpb",
         "//pkg/testutils",
+        "//pkg/util/encoding",
         "//pkg/util/hlc",
         "//pkg/util/interval",
         "//pkg/util/leaktest",

--- a/pkg/util/span/frontier.go
+++ b/pkg/util/span/frontier.go
@@ -367,6 +367,12 @@ func (f *btreeFrontier) mergeEntries(e *btreeFrontierEntry) (*btreeFrontierEntry
 		f.mergeAlloc = append(f.mergeAlloc, rightIter.Cur())
 	}
 
+	// If there were no left or right merges, return without restructuring the
+	// tree.
+	if len(f.mergeAlloc) == 0 {
+		return leftMost, nil
+	}
+
 	// Delete entries first, before updating leftMost boundaries since doing so
 	// will mess up btree.
 	for i, toRemove := range f.mergeAlloc {
@@ -376,10 +382,8 @@ func (f *btreeFrontier) mergeEntries(e *btreeFrontierEntry) (*btreeFrontierEntry
 		}
 	}
 
-	leftMost.End = end
-	if expensiveChecksEnabled() {
-		leftMost.spanCopy.EndKey = append(roachpb.Key{}, end...)
-	}
+	f.setEndKey(leftMost, end)
+
 	return leftMost, nil
 }
 
@@ -427,17 +431,29 @@ func (f *btreeFrontier) splitEntryAt(
 
 	right = newFrontierEntry(&f.idAlloc, split, e.End, e.ts)
 
-	// Adjust e boundary before we add right (so that there is no overlap in the tree).
-	e.End = split
-	if expensiveChecksEnabled() {
-		e.spanCopy.EndKey = append(roachpb.Key{}, split...)
-	}
+	// Adjust e boundary before we add right (so that there is no overlap in the
+	// tree).
+	f.setEndKey(e, split)
 
 	if err := f.setEntry(right); err != nil {
 		putFrontierEntry(right)
 		return nil, nil, err
 	}
 	return e, right, nil
+}
+
+// setEndKey changes the end key assigned to the entry. setEndKey requires the
+// entry to be in the tree.
+func (f *btreeFrontier) setEndKey(e *btreeFrontierEntry, endKey roachpb.Key) {
+	// The tree implementation expects the Start and End keys of a span to be
+	// immutable. We remove the leftMost node before updating the End index in
+	// order to avoid corrupting the `maxKey` that is inlined in the `node`.
+	f.tree.Delete(e)
+	e.End = endKey
+	if expensiveChecksEnabled() {
+		e.spanCopy.EndKey = append(roachpb.Key{}, endKey...)
+	}
+	f.tree.Set(e)
 }
 
 // forward is the work horse of the btreeFrontier.  It forwards the timestamp


### PR DESCRIPTION
Backport 1/1 commits from #135611.

/cc @cockroachdb/release

---

Backport 1/1 commits from #131714 *but with the default flipped to false*.

/cc @cockroachdb/release

---

Previously, the btree span frontier implementation modified the EndKey of btree entries. The btree internally expects the EndKey to be immutable, so it caused queries for containing spans to return incorrect results.

Now, entries are removed from the btree before their end key is modified. This is expected to have minimal impact on performance because the fast/common path does not require merging or splitting entries.

Fixes: #120987

