### PR TITLE
Revert "gcs: remove test that asserts buckets produce not found error"

### DIFF
--- a/pkg/cloud/external_storage.go
+++ b/pkg/cloud/external_storage.go
@@ -128,10 +128,6 @@ type SQLConnI interface {
 // ErrFileDoesNotExist is a sentinel error for indicating that a specified
 // bucket/object/key/file (depending on storage terminology) does not exist.
 // This error is raised by the ReadFile method.
-//
-// On GCS, a non-existent bucket returns a 403 forbidden, so a not found is
-// only returned if the bucket exists and the user has the permissions needed
-// to interact with the bucket.
 var ErrFileDoesNotExist = errors.New("external_storage: file doesn't exist")
 
 // ErrListingUnsupported is a marker for indicating listing is unsupported.


### PR DESCRIPTION
This reverts commit 83ece20c3428f0767a506a2b9dcd24d34f306e89.

Release Note: None
Part of: #135307
Part of: #135348
Part of: #135349
Part of: #135350
Part of: #135351
Part of: #135352