### PR TITLE
release-23.2: changefeedccl: fix changefeed description for core changefeeds

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -202,6 +202,7 @@ go_test(
         "avro_test.go",
         "changefeed_dist_test.go",
         "changefeed_processors_test.go",
+        "changefeed_stmt_test.go",
         "changefeed_test.go",
         "csv_test.go",
         "encoder_test.go",

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -385,7 +385,7 @@ func createChangefeedJobRecord(
 		p.BufferClientNotice(ctx, pgnotice.Newf("%s", warning))
 	}
 
-	jobDescription, err := changefeedJobDescription(ctx, changefeedStmt.CreateChangefeed, sinkURI, opts)
+	jobDescription, err := makeChangefeedJobDescription(ctx, changefeedStmt.CreateChangefeed, sinkURI, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -658,7 +658,7 @@ func createChangefeedJobRecord(
 		details.Opts = opts.AsMap()
 		// Jobs should not be created for sinkless changefeeds. However, note that
 		// we create and return a job record for sinkless changefeeds below. This is
-		// because we need the details field to create our sinkless changefeed.
+		// because we need the job description and details to create our sinkless changefeed.
 		// After this job record is returned, we create our forever running sinkless
 		// changefeed, thus ensuring that no job is created for this changefeed as
 		// desired.
@@ -987,37 +987,41 @@ func requiresTopicInValue(s Sink) bool {
 	return s.getConcreteType() == sinkTypeWebhook
 }
 
-func changefeedJobDescription(
+func makeChangefeedJobDescription(
 	ctx context.Context,
 	changefeed *tree.CreateChangefeed,
 	sinkURI string,
 	opts changefeedbase.StatementOptions,
 ) (string, error) {
-	// Redacts user sensitive information from job description.
-	cleanedSinkURI, err := cloud.SanitizeExternalStorageURI(sinkURI, []string{
-		changefeedbase.SinkParamSASLPassword,
-		changefeedbase.SinkParamCACert,
-		changefeedbase.SinkParamClientCert,
-		changefeedbase.SinkParamClientKey,
-		changefeedbase.SinkParamConfluentAPISecret,
-	})
-	if err != nil {
-		return "", err
-	}
-
-	cleanedSinkURI, err = changefeedbase.RedactUserFromURI(cleanedSinkURI)
-	if err != nil {
-		return "", err
-	}
-
-	logSanitizedChangefeedDestination(ctx, cleanedSinkURI)
-
 	c := &tree.CreateChangefeed{
 		Targets: changefeed.Targets,
-		SinkURI: tree.NewDString(cleanedSinkURI),
 		Select:  changefeed.Select,
 	}
-	if err = opts.ForEachWithRedaction(func(k string, v string) {
+
+	if sinkURI != "" {
+		// Redacts user sensitive information from job description.
+		cleanedSinkURI, err := cloud.SanitizeExternalStorageURI(sinkURI, []string{
+			changefeedbase.SinkParamSASLPassword,
+			changefeedbase.SinkParamCACert,
+			changefeedbase.SinkParamClientCert,
+			changefeedbase.SinkParamClientKey,
+			changefeedbase.SinkParamConfluentAPISecret,
+		})
+		if err != nil {
+			return "", err
+		}
+
+		cleanedSinkURI, err = changefeedbase.RedactUserFromURI(cleanedSinkURI)
+		if err != nil {
+			return "", err
+		}
+
+		logSanitizedChangefeedDestination(ctx, cleanedSinkURI)
+
+		c.SinkURI = tree.NewDString(cleanedSinkURI)
+	}
+
+	if err := opts.ForEachWithRedaction(func(k string, v string) {
 		opt := tree.KVOption{Key: tree.Name(k)}
 		if len(v) > 0 {
 			opt.Value = tree.NewDString(v)
@@ -1027,6 +1031,7 @@ func changefeedJobDescription(
 		return "", err
 	}
 	sort.Slice(c.Options, func(i, j int) bool { return c.Options[i].Key < c.Options[j].Key })
+
 	return tree.AsStringWithFlags(c, tree.FmtShowFullURIs), nil
 }
 

--- a/pkg/ccl/changefeedccl/changefeed_stmt_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt_test.go
@@ -1,0 +1,89 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package changefeedccl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeChangefeedJobDescription(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		createStmt string
+		sinkURI    string
+		opts       map[string]string
+		expected   string
+	}{
+		{
+			createStmt: `CREATE CHANGEFEED FOR t`,
+			expected:   `EXPERIMENTAL CHANGEFEED FOR TABLE t`,
+		},
+		{
+			createStmt: `CREATE CHANGEFEED FOR t WITH diff`,
+			opts:       map[string]string{"diff": ""},
+			expected:   `EXPERIMENTAL CHANGEFEED FOR TABLE t WITH OPTIONS (diff)`,
+		},
+		{
+			createStmt: `CREATE CHANGEFEED FOR t WITH diff, client_cert='a', client_key='b'`,
+			opts:       map[string]string{"diff": "", "client_cert": "a", "client_key": "b"},
+			expected:   `EXPERIMENTAL CHANGEFEED FOR TABLE t WITH OPTIONS (client_cert = 'a', client_key = 'redacted', diff)`,
+		},
+		{
+			createStmt: `CREATE CHANGEFEED FOR t INTO 'null://'`,
+			sinkURI:    `null://`,
+			expected:   `CREATE CHANGEFEED FOR TABLE t INTO 'null:'`,
+		},
+		{
+			createStmt: `CREATE CHANGEFEED FOR t INTO 'null://' WITH diff`,
+			sinkURI:    `null://`,
+			opts:       map[string]string{"diff": ""},
+			expected:   `CREATE CHANGEFEED FOR TABLE t INTO 'null:' WITH OPTIONS (diff)`,
+		},
+		{
+			createStmt: `CREATE CHANGEFEED FOR t INTO 'null://' WITH diff, client_cert='a', client_key='b'`,
+			sinkURI:    `null://`,
+			opts:       map[string]string{"diff": "", "client_cert": "a", "client_key": "b"},
+			expected:   `CREATE CHANGEFEED FOR TABLE t INTO 'null:' WITH OPTIONS (client_cert = 'a', client_key = 'redacted', diff)`,
+		},
+		{
+			createStmt: `CREATE CHANGEFEED FOR t INTO 'kafka://fake.kafka'`,
+			sinkURI:    `kafka://fake.kafka`,
+			expected:   `CREATE CHANGEFEED FOR TABLE t INTO 'kafka://fake.kafka'`,
+		},
+		{
+			createStmt: `CREATE CHANGEFEED FOR t INTO 'kafka://fake.kafka' WITH diff`,
+			sinkURI:    `kafka://fake.kafka`,
+			opts:       map[string]string{"diff": ""},
+			expected:   `CREATE CHANGEFEED FOR TABLE t INTO 'kafka://fake.kafka' WITH OPTIONS (diff)`,
+		},
+		{
+			createStmt: `CREATE CHANGEFEED FOR t INTO 'kafka://fake.kafka' WITH diff, client_cert='a', client_key='b'`,
+			sinkURI:    `kafka://fake.kafka`,
+			opts:       map[string]string{"diff": "", "client_cert": "a", "client_key": "b"},
+			expected:   `CREATE CHANGEFEED FOR TABLE t INTO 'kafka://fake.kafka' WITH OPTIONS (client_cert = 'a', client_key = 'redacted', diff)`,
+		},
+	} {
+		parsed, err := parser.ParseOne(tc.createStmt)
+		require.NoError(t, err)
+		create := parsed.AST.(*tree.CreateChangefeed)
+
+		opts := changefeedbase.MakeStatementOptions(tc.opts)
+
+		desc, err := makeChangefeedJobDescription(ctx, create, tc.sinkURI, opts)
+		require.NoError(t, err)
+		require.Equal(t, tc.expected, desc)
+	}
+}

--- a/pkg/ccl/changefeedccl/scheduled_changefeed.go
+++ b/pkg/ccl/changefeedccl/scheduled_changefeed.go
@@ -489,7 +489,7 @@ func emitSchedule(
 	resultsCh chan<- tree.Datums,
 ) error {
 	opts := changefeedbase.MakeStatementOptions(createChangefeedOpts)
-	redactedChangefeedNode, err := changefeedJobDescription(ctx, createChangefeedNode, sinkURI, opts)
+	redactedChangefeedNode, err := makeChangefeedJobDescription(ctx, createChangefeedNode, sinkURI, opts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Backport 1/1 commits from #135308.

/cc @cockroachdb/release

---

This patch fixes the changefeed description generation for core
changefeeds to not include an empty sink URI. It also adds a
unit test for the `makeChangefeedJobDescription` function.

Informs: #135309

Release note: None

---

Release justification: low-risk observability fix
