### PR TITLE
sql: add readable_high_water_timestamp column to SHOW CHANGEFEED JOBS

### DIFF
--- a/pkg/sql/delegate/show_changefeed_jobs.go
+++ b/pkg/sql/delegate/show_changefeed_jobs.go
@@ -41,6 +41,7 @@ SELECT
   finished,
   modified,
   high_water_timestamp,
+  hlc_to_timestamp(high_water_timestamp) as readable_high_water_timestamptz,
   error,
   replace(
     changefeed_details->>'sink_uri',


### PR DESCRIPTION
Epic: CRDB-39390

Fixes: #132278

Release note (sql change): Adds column "readable_high_water_timestamp"
to the output of SHOW CHANGEFEED JOBS. "high_water_timestamp" still
exists and is in epoch nanoseconds. This human readable form will be
easier to consume.