### PR TITLE
enginepb: clean up MVCCValueHeaderPure hack

### DIFF
--- a/pkg/kv/kvnemesis/kvnemesisutil/seq.go
+++ b/pkg/kv/kvnemesis/kvnemesisutil/seq.go
@@ -27,6 +27,12 @@ type SeqContainer uint32
 
 var _ protoutil.Message = (*SeqContainer)(nil)
 
+// IsEmpty is used by generated marshalling code (with gogoproto.omitempty
+// extension).
+func (m SeqContainer) IsEmpty() bool {
+	return m == 0
+}
+
 // Reset implements (a part of) protoutil.Message.
 func (m *SeqContainer) Reset() {
 	*m = 0
@@ -108,6 +114,8 @@ func (m SeqContainer) Get() Seq {
 // proto messages. It uses no space. When the crdb_test build tag is set, this
 // type is instead represented by a NoopContainer.
 type NoopContainer struct{}
+
+func (m *NoopContainer) IsEmpty() bool { return true }
 
 func (m *NoopContainer) Reset() {}
 

--- a/pkg/storage/enginepb/BUILD.bazel
+++ b/pkg/storage/enginepb/BUILD.bazel
@@ -49,7 +49,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/kv/kvnemesis/kvnemesisutil",
-        "//pkg/util/buildutil",
         "//pkg/util/hlc",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/storage/enginepb/mvcc3.proto
+++ b/pkg/storage/enginepb/mvcc3.proto
@@ -146,14 +146,8 @@ message IgnoredSeqNumRange {
 // NB: a shallow copy of this value has to equal a deep copy, i.e. there
 // must be (recursively) no pointers in this type. Should this need to
 // change, need to update mvccGet.
-//
-// NB: ensure that this struct stays in sync with MVCCValueHeader{Pure,CrdbTest}.
-// See kvpb.RequestHeader for details on how they help us keep the KVNemesisSeq
-// field out of production code.
 message MVCCValueHeader {
   option (gogoproto.equal) = true;
-  option (gogoproto.marshaler) = false;
-  option (gogoproto.sizer) = false;
 
   message Empty{};
   // Empty is zero-size in production. It's an int64 under the crdb_test build tag.
@@ -166,6 +160,7 @@ message MVCCValueHeader {
   Empty kvnemesis_seq = 2 [
     (gogoproto.customname) = "KVNemesisSeq",
     (gogoproto.nullable) = false,
+    (gogoproto.omitempty) = true,
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/kv/kvnemesis/kvnemesisutil.Container"];
 
   // The local clock timestamp records the value of the local HLC clock on the
@@ -191,7 +186,11 @@ message MVCCValueHeader {
   // this will simply lead to additional uncertainty restarts. However, it is
   // not safe for the local clock timestamp to be rounded up, as this could lead
   // to stale reads.
-  util.hlc.Timestamp local_timestamp = 1 [(gogoproto.nullable) = false,
+  //
+  // TODO(radu): use gogoproto.omitempty (after investigating if changing the
+  // encoding is a problem).
+  util.hlc.Timestamp local_timestamp = 1 [
+    (gogoproto.nullable) = false,
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/util/hlc.ClockTimestamp"];
 
   // When set to true, this value will be filtered out by rangefeeds and will
@@ -207,46 +206,18 @@ message MVCCValueHeader {
   // Data Replication (LDR). 0 identifies a local write and the default value
   // when LDR is not being run, 1 identifies a remote write, and 2+ are reserved
   // to identify remote clusters.
-  uint32 origin_id = 5  [(gogoproto.customname) = "OriginID"];
+  uint32 origin_id = 5 [(gogoproto.customname) = "OriginID"];
   
   // OriginTimestamp identifies the timestamp this kv was written on the
   // original source cluster during Logical Data Replication. A default empty
   // timestamp implies that this kv did not originate from a Logical Data
   // Replication stream. 
-  util.hlc.Timestamp origin_timestamp = 6  [(gogoproto.nullable) = false,(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/util/hlc.Timestamp"];
+  util.hlc.Timestamp origin_timestamp = 6 [
+    (gogoproto.nullable) = false,
+    (gogoproto.omitempty) = true,
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/util/hlc.Timestamp"];
 
    // NextID = 7.
-}
-
-// MVCCValueHeaderPure is not to be used directly. It's generated only for use of
-// its marshaling methods by MVCCValueHeader. See the comment there.
-message MVCCValueHeaderPure {
-  util.hlc.Timestamp local_timestamp = 1 [(gogoproto.nullable) = false,
-    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/util/hlc.ClockTimestamp"];
-
-  bool omit_in_rangefeeds = 3;
-  uint32 import_epoch = 4;
-  uint32 origin_id = 5  [(gogoproto.customname) = "OriginID"];
-
-  // OriginTimestamp is not-nullable in MVCCValueHeader but here it is nullable.
-  // This is because it leads to more efficient marshaling when the timestamp is
-  // not set. See the pure() conversion method.
-  util.hlc.Timestamp origin_timestamp = 6 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/util/hlc.Timestamp"];
-}
-// MVCCValueHeaderCrdbTest is not to be used directly. It's generated only for use of
-// its marshaling methods by MVCCValueHeader. See the comment there.
-message MVCCValueHeaderCrdbTest {
-  message Empty{};
-  Empty kvnemesis_seq = 2 [
-    (gogoproto.customname) = "KVNemesisSeq",
-    (gogoproto.nullable) = false,
-    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/kv/kvnemesis/kvnemesisutil.Container"];
-  util.hlc.Timestamp local_timestamp = 1 [(gogoproto.nullable) = false,
-    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/util/hlc.ClockTimestamp"];
-  bool omit_in_rangefeeds = 3;
-  uint32 import_epoch = 4;
-  uint32 origin_id = 5  [(gogoproto.customname) = "OriginID"];
-  util.hlc.Timestamp origin_timestamp = 6 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/util/hlc.Timestamp"];
 }
 
 // MVCCStatsDelta is convertible to MVCCStats, but uses signed variable width

--- a/pkg/storage/enginepb/mvcc3_valueheader.go
+++ b/pkg/storage/enginepb/mvcc3_valueheader.go
@@ -5,77 +5,8 @@
 
 package enginepb
 
-import "github.com/cockroachdb/cockroach/pkg/util/buildutil"
-
 // IsEmpty returns true if the header is empty.
 // gcassert:inline
 func (h MVCCValueHeader) IsEmpty() bool {
 	return h == MVCCValueHeader{}
-}
-
-func (h *MVCCValueHeader) pure() MVCCValueHeaderPure {
-	result := MVCCValueHeaderPure{
-		LocalTimestamp:   h.LocalTimestamp,
-		OmitInRangefeeds: h.OmitInRangefeeds,
-		ImportEpoch:      h.ImportEpoch,
-		OriginID:         h.OriginID,
-	}
-	if !h.OriginTimestamp.IsEmpty() {
-		result.OriginTimestamp = &h.OriginTimestamp
-	}
-	return result
-}
-
-func (h *MVCCValueHeader) crdbTest() MVCCValueHeaderCrdbTest {
-	result := MVCCValueHeaderCrdbTest{
-		KVNemesisSeq:     h.KVNemesisSeq,
-		LocalTimestamp:   h.LocalTimestamp,
-		OmitInRangefeeds: h.OmitInRangefeeds,
-		ImportEpoch:      h.ImportEpoch,
-		OriginID:         h.OriginID,
-	}
-	if !h.OriginTimestamp.IsEmpty() {
-		result.OriginTimestamp = &h.OriginTimestamp
-	}
-	return result
-}
-
-// Size implements protoutil.Message.
-func (h *MVCCValueHeader) Size() int {
-	if buildutil.CrdbTestBuild && h.KVNemesisSeq.Get() != 0 {
-		ht := h.crdbTest() //gcassert:noescape
-		return ht.Size()
-	}
-	p := h.pure() //gcassert:noescape
-	return p.Size()
-}
-
-// Marshal implements protoutil.Message.
-func (h *MVCCValueHeader) Marshal() ([]byte, error) {
-	if buildutil.CrdbTestBuild && h.KVNemesisSeq.Get() != 0 {
-		ht := h.crdbTest() //gcassert:noescape
-		return ht.Marshal()
-	}
-	p := h.pure() //gcassert:noescape
-	return p.Marshal()
-}
-
-// MarshalTo implements protoutil.Message.
-func (h *MVCCValueHeader) MarshalTo(buf []byte) (int, error) {
-	if buildutil.CrdbTestBuild && h.KVNemesisSeq.Get() != 0 {
-		ht := h.crdbTest() //gcassert:noescape
-		return ht.MarshalTo(buf)
-	}
-	p := h.pure() //gcassert:noescape
-	return p.MarshalTo(buf)
-}
-
-// MarshalToSizedBuffer implements protoutil.Message.
-func (h *MVCCValueHeader) MarshalToSizedBuffer(buf []byte) (int, error) {
-	if buildutil.CrdbTestBuild && h.KVNemesisSeq.Get() != 0 {
-		ht := h.crdbTest() //gcassert:noescape
-		return ht.MarshalToSizedBuffer(buf)
-	}
-	p := h.pure() //gcassert:noescape
-	return p.MarshalToSizedBuffer(buf)
 }

--- a/pkg/util/hlc/timestamp.go
+++ b/pkg/util/hlc/timestamp.go
@@ -187,6 +187,8 @@ func (t Timestamp) AsOfSystemTime() string {
 // IsEmpty returns true if t is an empty Timestamp.
 // gcassert:inline
 func (t Timestamp) IsEmpty() bool {
+	// TODO(radu): consider making timestamps with zero wall time and non-zero
+	// logical time illegal. Then we can check just the wall time.
 	return t == Timestamp{}
 }
 


### PR DESCRIPTION
This change updates `MVCCValueHeader` to use the new
`gogoproto.omitempty` option from our fork to avoid encoding empty
fields that are not nullable. Without this option, even an empty
non-scalar field will result in a couple of encoded bytes (the tag and
the length).

We remove `MVCCValueHeaderPure` and `MVCCValueHeaderCrdbTest` which
were variants used to generate different versions of the marshaling
code.

The encoding should be unchanged. Performance is improved because we
no longer have to make a copy into `MVCCValueHeaderPure`.

```
name                                                                   old time/op    new time/op    delta
EncodeMVCCValue/header=local_walltime+logical/value=short-8              44.4ns ± 0%    35.6ns ± 0%  -19.94%  (p=0.000 n=7+8)
EncodeMVCCValue/header=local_walltime+logical/value=long-8                651ns ± 6%     612ns ± 4%   -5.98%  (p=0.005 n=8+8)
EncodeMVCCValue/header=local_walltime+logical/value=tombstone-8          43.2ns ± 0%    34.2ns ± 0%  -20.95%  (p=0.000 n=7+8)
EncodeMVCCValue/header=omit_in_rangefeeds/value=short-8                  34.1ns ± 3%    29.2ns ± 2%  -14.56%  (p=0.001 n=7+7)
EncodeMVCCValue/header=omit_in_rangefeeds/value=long-8                    589ns ± 9%     605ns ± 3%     ~     (p=0.130 n=8+8)
EncodeMVCCValue/header=omit_in_rangefeeds/value=tombstone-8              29.9ns ± 4%    25.7ns ± 0%  -14.18%  (p=0.000 n=8+8)
EncodeMVCCValue/header=local_walltime+jobID/value=tombstone-8            42.3ns ± 1%    34.9ns ± 3%  -17.56%  (p=0.000 n=7+8)
EncodeMVCCValue/header=local_walltime+jobID/value=short-8                43.1ns ± 0%    37.0ns ± 6%  -14.08%  (p=0.000 n=8+8)
EncodeMVCCValue/header=local_walltime+jobID/value=long-8                  628ns ± 2%     640ns ± 7%     ~     (p=0.161 n=8+8)
EncodeMVCCValue/header=local_walltime+logical+jobID/value=tombstone-8    44.4ns ± 0%    36.4ns ± 4%  -18.11%  (p=0.000 n=8+8)
EncodeMVCCValue/header=local_walltime+logical+jobID/value=short-8        45.6ns ± 2%    36.6ns ± 1%  -19.70%  (p=0.001 n=7+7)
EncodeMVCCValue/header=local_walltime+logical+jobID/value=long-8          600ns ± 4%     634ns ±15%     ~     (p=0.072 n=7+8)
EncodeMVCCValue/header=empty/value=short-8                               8.15ns ± 1%    8.24ns ± 6%     ~     (p=0.488 n=8+8)
EncodeMVCCValue/header=empty/value=long-8                                8.02ns ± 2%    8.15ns ± 7%     ~     (p=0.721 n=8+8)
EncodeMVCCValue/header=empty/value=tombstone-8                           7.84ns ± 0%    8.10ns ± 1%   +3.30%  (p=0.001 n=7+7)
EncodeMVCCValue/header=jobID/value=tombstone-8                           30.8ns ± 0%    26.9ns ± 2%  -12.45%  (p=0.000 n=8+8)
EncodeMVCCValue/header=jobID/value=short-8                               36.3ns ± 0%    30.1ns ± 0%  -17.05%  (p=0.000 n=8+8)
EncodeMVCCValue/header=jobID/value=long-8                                 602ns ± 1%     577ns ± 3%   -4.12%  (p=0.001 n=6+8)
EncodeMVCCValue/header=local_walltime/value=tombstone-8                  41.7ns ± 1%    32.4ns ± 0%  -22.49%  (p=0.000 n=8+7)
EncodeMVCCValue/header=local_walltime/value=short-8                      42.2ns ± 0%    33.5ns ± 0%  -20.77%  (p=0.000 n=7+8)
EncodeMVCCValue/header=local_walltime/value=long-8                        640ns ± 7%     643ns ± 1%     ~     (p=0.718 n=8+7)
EncodeMVCCValueForExport/header=empty/value=tombstone-8                  6.61ns ± 3%    6.55ns ± 1%     ~     (p=0.646 n=7+7)
EncodeMVCCValueForExport/header=empty/value=short-8                      6.52ns ± 1%    6.51ns ± 1%     ~     (p=0.196 n=7+7)
```

Epic: none
Release note: None