### PR TITLE
sql: fix statement generation when ensuring roles

### DIFF
--- a/pkg/ccl/testccl/authccl/testdata/ldap
+++ b/pkg/ccl/testccl/authccl/testdata/ldap
@@ -352,7 +352,7 @@ CREATE ROLE "ldap-parent-synced";
 ----
 ok
 
-ldap_mock set_groups=(ldap_user,cn=ldap-parent-synced,cn=ldap-parent-unsynced)
+ldap_mock set_groups=(ldap_user,cn=ldap-parent-unsynced,cn=ldap-parent-synced)
 ----
 
 connect user=ldap_user password="ldap_pwd"

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -739,11 +739,13 @@ func EnsureUserOnlyBelongsToRoles(
 		if len(rolesToRevoke) > 0 {
 			revokeStmt := strings.Builder{}
 			revokeStmt.WriteString("REVOKE ")
-			for i, role := range rolesToRevoke {
-				if i > 0 {
+			addComma := false
+			for _, role := range rolesToRevoke {
+				if addComma {
 					revokeStmt.WriteString(", ")
 				}
 				revokeStmt.WriteString(role.SQLIdentifier())
+				addComma = true
 			}
 			revokeStmt.WriteString(" FROM ")
 			revokeStmt.WriteString(user.SQLIdentifier())
@@ -757,12 +759,14 @@ func EnsureUserOnlyBelongsToRoles(
 		if len(rolesToGrant) > 0 {
 			grantStmt := strings.Builder{}
 			grantStmt.WriteString("GRANT ")
-			for i, role := range rolesToGrant {
+			addComma := false
+			for _, role := range rolesToGrant {
 				if roleExists, _ := RoleExists(ctx, txn, role); roleExists {
-					if i > 0 {
+					if addComma {
 						grantStmt.WriteString(", ")
 					}
 					grantStmt.WriteString(role.SQLIdentifier())
+					addComma = true
 				}
 			}
 			grantStmt.WriteString(" TO ")


### PR DESCRIPTION
Since we started skipping over non-existent roles in 35f723e3812a29f4b295c26885be706cc49ddd67, we need to make sure we only add commas at the appropriate point.

The test update demonstrates that there was a bug before this patch, as it would fail with:
```
expected:
ok defaultdb

found:
ERROR: LDAP authorization: error assigning roles to user ldap_user: EnsureUserOnlyBelongsToRoles-grant: at or near ",": syntax error (SQLSTATE 42601)
HINT: try \h GRANT
DETAIL: source SQL:
GRANT , "ldap-parent-synced" TO ldap_user
```

informs https://github.com/cockroachdb/cockroach/issues/133779
Release note: None