### PR TITLE
sql: avoid ResolveBlankPaddedChar in writeTextString (0% cpu)

### DIFF
--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -101,8 +101,32 @@ func writeTextUUID(b *writeBuffer, v uuid.UUID) {
 	b.write(s)
 }
 
-func writeTextString(b *writeBuffer, v string, t *types.T) {
-	b.writeLengthPrefixedString(tree.ResolveBlankPaddedChar(v, t))
+func writeTextString(b *writeBuffer, s string, t *types.T) {
+	blankPaddedCharType := t.Oid() == oid.T_bpchar
+
+	if !blankPaddedCharType {
+		b.writeLengthPrefixedString(s)
+		return
+	}
+
+	// Add t.Width() as length prefix.
+	b.writeLengthPrefixedString(s, t.Width())
+
+	remainingPadLength := int(t.Width()) - len(s)
+	applyPadding(b, remainingPadLength)
+}
+
+// applyPadding applies padding to the right of the values inside
+// the write buffer to fill all the remaining width from t.Width()
+func applyPadding(b *writeBuffer, remainingPadLength int) {
+	for remainingPadLength > 0 {
+		padChunkLength := min(remainingPadLength, len(spaces))
+
+		padChunk := spaces[:padChunkLength]
+		b.write(padChunk)
+
+		remainingPadLength -= padChunkLength
+	}
 }
 
 func writeTextTimestamp(b *writeBuffer, v time.Time) {
@@ -189,7 +213,7 @@ func writeTextDatumNotNull(
 		writeTextString(b, string(*v), t)
 
 	case *tree.DCollatedString:
-		b.writeLengthPrefixedString(tree.ResolveBlankPaddedChar(v.Contents, t))
+		writeTextString(b, v.Contents, t)
 
 	case *tree.DDate:
 		b.textFormatter.FormatNode(v)
@@ -526,29 +550,28 @@ func writeBinaryBytes(b *writeBuffer, v []byte, t *types.T) {
 		// an empty string for the "char" type in the binary format.
 		v = []byte{0}
 	}
-	pad := 0
-	if t.Oid() == oid.T_bpchar && len(v) < int(t.Width()) {
-		// Pad spaces on the right of the byte slice to make it of length
-		// specified in the type t.
-		pad = int(t.Width()) - len(v)
+
+	blankPaddedCharType := t.Oid() == oid.T_bpchar
+	if !blankPaddedCharType {
+		b.writeLengthPrefixedByteSlice(v)
+		return
 	}
-	b.putInt32(int32(len(v) + pad))
-	b.write(v)
-	for pad > 0 {
-		n := min(pad, len(spaces))
-		b.write(spaces[:n])
-		pad -= n
-	}
+
+	// Add t.Width() as length prefix.
+	b.writeLengthPrefixedByteSlice(v, t.Width())
+
+	remainingPadLength := int(t.Width()) - len(v)
+	applyPadding(b, remainingPadLength)
 }
 
 func writeBinaryString(b *writeBuffer, v string, t *types.T) {
-	s := tree.ResolveBlankPaddedChar(v, t)
-	if t.Oid() == oid.T_char && s == "" {
+	if t.Oid() == oid.T_char && v == "" {
 		// Match Postgres and always explicitly include a null byte if we have
 		// an empty string for the "char" type in the binary format.
-		s = string([]byte{0})
+		v = string([]byte{0})
 	}
-	b.writeLengthPrefixedString(s)
+
+	writeTextString(b, v, t)
 }
 
 func writeBinaryTimestamp(b *writeBuffer, v time.Time) {
@@ -701,7 +724,7 @@ func writeBinaryDatumNotNull(
 		writeBinaryString(b, string(*v), t)
 
 	case *tree.DCollatedString:
-		b.writeLengthPrefixedString(tree.ResolveBlankPaddedChar(v.Contents, t))
+		writeTextString(b, v.Contents, t)
 
 	case *tree.DTimestamp:
 		writeBinaryTimestamp(b, v.Time)

--- a/pkg/sql/pgwire/write_buffer.go
+++ b/pkg/sql/pgwire/write_buffer.go
@@ -97,9 +97,24 @@ func (b *writeBuffer) writeFromFmtCtx(fmtCtx *tree.FmtCtx) {
 
 // writeLengthPrefixedString writes a length-prefixed string. The
 // length is encoded as an int32.
-func (b *writeBuffer) writeLengthPrefixedString(s string) {
-	b.putInt32(int32(len(s)))
+func (b *writeBuffer) writeLengthPrefixedString(s string, specifiedLength ...int32) {
+	if len(specifiedLength) > 0 {
+		b.putInt32(specifiedLength[0])
+	} else {
+		b.putInt32(int32(len(s)))
+	}
+
 	b.writeString(s)
+}
+
+func (b *writeBuffer) writeLengthPrefixedByteSlice(v []byte, specifiedLength ...int32) {
+	if len(specifiedLength) > 0 {
+		b.putInt32(specifiedLength[0])
+	} else {
+		b.putInt32(int32(len(v)))
+	}
+
+	b.write(v)
 }
 
 // writeLengthPrefixedDatum writes a length-prefixed Datum in its


### PR DESCRIPTION
writeTextString no longer uses ResolveBlankPaddedChar which was causing an increase in heap allocations mainly due to it's use of `make([]byte, t.Width())`.  Additionally in this PR I removed the call to ResolveBlankPaddedChar from writeBinaryString and other occurences in types.go.

These are the results that we now see from benchmark tests:

Micro benchmark:
```
                      │  before.txt  │             after.txt              │
                      │    sec/op    │   sec/op     vs base               │
WriteTextColumnarChar   44.10µ ± 20%   22.23µ ± 1%  -49.58% (p=0.002 n=6)

                      │  before.txt  │              after.txt              │
                      │     B/op     │    B/op      vs base                │
WriteTextColumnarChar   16.00Ki ± 0%   0.00Ki ± 0%  -100.00% (p=0.002 n=6)

                      │ before.txt  │              after.txt              │
                      │  allocs/op  │  allocs/op   vs base                │
WriteTextColumnarChar   1.024k ± 0%   0.000k ± 0%  -100.00% (p=0.002 n=6)
```

Sysbench:
```
                               │ sys_before.txt │           sys_after.txt            │
                               │     sec/op     │    sec/op     vs base              │
Sysbench/SQL/oltp_read_only       2.433m ±  54%   2.328m ±  9%       ~ (p=0.093 n=6)
Sysbench/SQL/oltp_write_only      2.151m ± 130%   2.068m ±  2%  -3.84% (p=0.002 n=6)
Sysbench/SQL/oltp_read_write      5.240m ±   5%   5.291m ± 15%       ~ (p=1.000 n=6)
Sysbench/SQL/oltp_point_select    142.7µ ±   2%   152.9µ ± 21%       ~ (p=0.180 n=6)
Sysbench/SQL/oltp_begin_commit    116.9µ ±   5%   121.8µ ± 26%       ~ (p=0.240 n=6)
geomean                           855.2µ          861.4µ        +0.73%

                               │ sys_before.txt │           sys_after.txt            │
                               │      B/op      │     B/op      vs base              │
Sysbench/SQL/oltp_read_only        920.6Ki ± 3%   883.6Ki ± 0%  -4.02% (p=0.002 n=6)
Sysbench/SQL/oltp_write_only       454.6Ki ± 4%   447.1Ki ± 5%       ~ (p=0.093 n=6)
Sysbench/SQL/oltp_read_write       1.245Mi ± 0%   1.209Mi ± 0%  -2.86% (p=0.002 n=6)
Sysbench/SQL/oltp_point_select     29.46Ki ± 0%   29.37Ki ± 0%  -0.28% (p=0.002 n=6)
Sysbench/SQL/oltp_begin_commit     14.38Ki ± 0%   14.36Ki ± 0%       ~ (p=0.394 n=6)
geomean                            186.5Ki        183.2Ki       -1.79%

                               │ sys_before.txt │            sys_after.txt            │
                               │   allocs/op    │  allocs/op   vs base                │
Sysbench/SQL/oltp_read_only         5.665k ± 5%   5.359k ± 0%  -5.42% (p=0.002 n=6)
Sysbench/SQL/oltp_write_only        3.175k ± 6%   3.174k ± 1%       ~ (p=0.738 n=6)
Sysbench/SQL/oltp_read_write        8.824k ± 0%   8.521k ± 0%  -3.43% (p=0.002 n=6)
Sysbench/SQL/oltp_point_select       284.0 ± 0%    283.5 ± 0%       ~ (p=0.076 n=6)
Sysbench/SQL/oltp_begin_commit       130.0 ± 0%    130.0 ± 0%       ~ (p=1.000 n=6) ¹
geomean                             1.424k        1.398k       -1.84%
```

Epic: CRDB-42584
Fixes: #134336
Release note: None