### PR TITLE
sql: properly print redacted error when reverting

### DIFF
--- a/pkg/sql/revert.go
+++ b/pkg/sql/revert.go
@@ -121,7 +121,7 @@ func DeleteTableWithPredicate(
 							delRangeRequest)
 
 						if err != nil {
-							log.Errorf(ctx, "delete range %s - %s failed: %s", span.Key, span.EndKey, err.String())
+							log.Errorf(ctx, "delete range %s - %s failed: %v", span.Key, span.EndKey, err)
 							return errors.Wrapf(err.GoError(), "delete range %s - %s", span.Key, span.EndKey)
 						}
 						span = nil


### PR DESCRIPTION
Previously, we called `kvpb.Error.String()` method directly which strips the redaction markers from the error, and as a result we would get nothing in the redacted logs. This is now fixed by using `%v` directive instead. I manually confirmed that the problem is fixed.

Fixes: #133849.

Release note: None