### PR TITLE
importer: reduce retry duration for virtual clusters

### DIFF
--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -1358,15 +1358,6 @@ func ingestWithRetry(
 		}
 
 		maxRetryDuration := retryDuration.Get(&execCtx.ExecCfg().Settings.SV)
-		if !execCtx.ExecCfg().Codec.ForSystemTenant() && flowinfra.IsFlowRetryableError(err) {
-			// If we encountered "could not register flow because the registry
-			// is draining" error in the application virtual cluster, we
-			// calibrate the retry duration. This is the case since DistSQL
-			// physical planning in virtual clusters uses 'sql_instances' table
-			// which currently doesn't have draining information
-			// TODO(#100578): remove this when this problem is addressed.
-			maxRetryDuration *= 30
-		}
 		if timeutil.Since(lastProgressChange) > maxRetryDuration {
 			log.Warningf(ctx, "encountered retryable error but exceeded retry duration, stopping: %+v", err)
 			break


### PR DESCRIPTION
This commit reverts 0ac60589fefd29322cc5fe4e4eb3e7c8135222fc and effectively reduces retry duration for virtual clusters. That commit was introduced as a temporary measure until we properly handled the draining process in multi-tenant environments, and that has been addressed a few months ago.

Related: #100578.
Informs: #119592.
Epic: None

Release note: None