### PR TITLE
release-24.1: sql/sem/tree: type unknown literals as `BPCHAR` if overload exists

### DIFF
--- a/docs/generated/sql/operators.md
+++ b/docs/generated/sql/operators.md
@@ -163,6 +163,7 @@
 <tr><td><a href="bool.html">bool</a> <code><</code> <a href="bool.html">bool</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bool.html">bool[]</a> <code><</code> <a href="bool.html">bool[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>box2d <code><</code> box2d</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>bpchar <code><</code> bpchar</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes</a> <code><</code> <a href="bytes.html">bytes</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes[]</a> <code><</code> <a href="bytes.html">bytes[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="collate.html">collatedstring</a> <code><</code> <a href="collate.html">collatedstring</a></td><td><a href="bool.html">bool</a></td></tr>
@@ -228,6 +229,7 @@
 <tr><td><a href="bool.html">bool</a> <code><=</code> <a href="bool.html">bool</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bool.html">bool[]</a> <code><=</code> <a href="bool.html">bool[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>box2d <code><=</code> box2d</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>bpchar <code><=</code> bpchar</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes</a> <code><=</code> <a href="bytes.html">bytes</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes[]</a> <code><=</code> <a href="bytes.html">bytes[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="collate.html">collatedstring</a> <code><=</code> <a href="collate.html">collatedstring</a></td><td><a href="bool.html">bool</a></td></tr>
@@ -292,6 +294,7 @@
 <tr><td><a href="bool.html">bool</a> <code>=</code> <a href="bool.html">bool</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bool.html">bool[]</a> <code>=</code> <a href="bool.html">bool[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>box2d <code>=</code> box2d</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>bpchar <code>=</code> bpchar</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes</a> <code>=</code> <a href="bytes.html">bytes</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes[]</a> <code>=</code> <a href="bytes.html">bytes[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="collate.html">collatedstring</a> <code>=</code> <a href="collate.html">collatedstring</a></td><td><a href="bool.html">bool</a></td></tr>
@@ -390,6 +393,7 @@
 <tr><td>anyenum <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bool.html">bool</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>box2d <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>bpchar <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="collate.html">collatedstring</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
@@ -421,6 +425,7 @@
 <tr><td><a href="bool.html">bool</a> <code>IS NOT DISTINCT FROM</code> <a href="bool.html">bool</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bool.html">bool[]</a> <code>IS NOT DISTINCT FROM</code> <a href="bool.html">bool[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>box2d <code>IS NOT DISTINCT FROM</code> box2d</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>bpchar <code>IS NOT DISTINCT FROM</code> bpchar</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes</a> <code>IS NOT DISTINCT FROM</code> <a href="bytes.html">bytes</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes[]</a> <code>IS NOT DISTINCT FROM</code> <a href="bytes.html">bytes[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="collate.html">collatedstring</a> <code>IS NOT DISTINCT FROM</code> <a href="collate.html">collatedstring</a></td><td><a href="bool.html">bool</a></td></tr>

--- a/pkg/ccl/changefeedccl/cdceval/functions.go
+++ b/pkg/ccl/changefeedccl/cdceval/functions.go
@@ -152,6 +152,12 @@ func cdcTimestampBuiltin(
 	preferredOverloadReturnType *types.T,
 	tsFn func(rowEvalCtx *rowEvalContext) hlc.Timestamp,
 ) *tree.ResolvedFunctionDefinition {
+	pref := func(t *types.T) tree.OverloadPreference {
+		if preferredOverloadReturnType.Identical(t) {
+			return tree.OverloadPreferencePreferred
+		}
+		return tree.OverloadPreferenceNone
+	}
 	def := tree.NewFunctionDefinition(
 		fnName,
 		cdcFnProps,
@@ -163,9 +169,9 @@ func cdcTimestampBuiltin(
 					rowEvalCtx := rowEvalContextFromEvalContext(evalCtx)
 					return eval.TimestampToDecimalDatum(tsFn(rowEvalCtx)), nil
 				},
-				Info:              doc + " as HLC timestamp",
-				Volatility:        v,
-				PreferredOverload: preferredOverloadReturnType.Identical(types.Decimal),
+				Info:               doc + " as HLC timestamp",
+				Volatility:         v,
+				OverloadPreference: pref(types.Decimal),
 			},
 			{
 				Types:      tree.ParamTypes{},
@@ -174,9 +180,9 @@ func cdcTimestampBuiltin(
 					rowEvalCtx := rowEvalContextFromEvalContext(evalCtx)
 					return tree.MakeDTimestampTZ(tsFn(rowEvalCtx).GoTime(), time.Microsecond)
 				},
-				Info:              doc + " as TIMESTAMPTZ",
-				Volatility:        v,
-				PreferredOverload: preferredOverloadReturnType.Identical(types.TimestampTZ),
+				Info:               doc + " as TIMESTAMPTZ",
+				Volatility:         v,
+				OverloadPreference: pref(types.TimestampTZ),
 			},
 			{
 				Types:      tree.ParamTypes{},
@@ -185,9 +191,9 @@ func cdcTimestampBuiltin(
 					rowEvalCtx := rowEvalContextFromEvalContext(evalCtx)
 					return tree.MakeDTimestamp(tsFn(rowEvalCtx).GoTime(), time.Microsecond)
 				},
-				Info:              doc + " as TIMESTAMP",
-				Volatility:        v,
-				PreferredOverload: preferredOverloadReturnType.Identical(types.Timestamp),
+				Info:               doc + " as TIMESTAMP",
+				Volatility:         v,
+				OverloadPreference: pref(types.Timestamp),
 			},
 		},
 	)

--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -122,6 +122,28 @@ SELECT ts FROM untyped WHERE ts != '2015-09-18 00:00:00'
 ----
 2010-09-28 12:00:00.1 +0000 +0000
 
+# Test qualified type references.
+query IITR
+SELECT 1::pg_catalog.int4, 1::pg_catalog.int8, 'aa'::pg_catalog.text, 4.2::pg_catalog.float4
+----
+1 1 aa 4.2
+
+# Test fixed-length types.
+
+query TTT
+SELECT VARCHAR(4) 'foo', CHAR(2) 'bar', STRING(1) 'cat'
+----
+foo  ba  c
+
+# Test that we error out referencing unknown types in pg_catalog.
+query error pq: type "pg_catalog.special_int" does not exist
+SELECT 1::pg_catalog.special_int
+
+# Test that we error out trying to reference types in schemas that
+# don't have types.
+query error pq: type "crdb_internal.mytype" does not exist
+SELECT 1::crdb_internal.mytype
+
 # Regression tests for #15050
 
 statement error pq: parsing as type timestamp: could not parse "Not Timestamp"
@@ -220,28 +242,6 @@ query T
 SELECT max(NULL) FROM (VALUES (NULL), (NULL)) t0(c0)
 ----
 NULL
-
-# Test qualified type references.
-query IITR
-SELECT 1::pg_catalog.int4, 1::pg_catalog.int8, 'aa'::pg_catalog.text, 4.2::pg_catalog.float4
-----
-1 1 aa 4.2
-
-# Test fixed-length types.
-
-query TTT
-SELECT VARCHAR(4) 'foo', CHAR(2) 'bar', STRING(1) 'cat'
-----
-foo  ba  c
-
-# Test that we error out referencing unknown types in pg_catalog.
-query error pq: type "pg_catalog.special_int" does not exist
-SELECT 1::pg_catalog.special_int
-
-# Test that we error out trying to reference types in schemas that
-# don't have types.
-query error pq: type "crdb_internal.mytype" does not exist
-SELECT 1::crdb_internal.mytype
 
 # Regression test for #50978.
 query T

--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -144,6 +144,147 @@ SELECT 1::pg_catalog.special_int
 query error pq: type "crdb_internal.mytype" does not exist
 SELECT 1::crdb_internal.mytype
 
+# Untyped string literals in binary operators assume the type of the other
+# argument, if an overload exists with exactly matching parameter types. The
+# values are adjusted as necessary, e.g., trailing spaces are trimmed from
+# string literals when they assume the BPCHAR type.
+query B
+SELECT 'foo'::BPCHAR = 'foo   '
+----
+true
+
+query B
+SELECT 'foo'::BPCHAR != 'foo   '
+----
+false
+
+query B
+SELECT 'foo'::BPCHAR >= 'foo   '
+----
+true
+
+query B
+SELECT 'foo'::BPCHAR <= 'foo   '
+----
+true
+
+query B
+SELECT 'foo'::BPCHAR > 'foo   '
+----
+false
+
+query B
+SELECT 'foo'::BPCHAR < 'foo   '
+----
+false
+
+query B
+SELECT 'foo'::BPCHAR IN ('foo   ')
+----
+true
+
+query B
+SELECT 'foo'::BPCHAR IN ('foo   ', 'bar')
+----
+true
+
+# There is no LIKE overload for BPCHAR, so the string literal does not assume
+# the other argument's type.
+query B
+SELECT 'foo'::BPCHAR LIKE 'foo   '
+----
+false
+
+# There is no ~ overload for BPCHAR, so the string literal does not assume
+# that type.
+query B
+SELECT 'foo'::BPCHAR ~ 'foo   '
+----
+false
+
+statement ok
+PREPARE p AS SELECT 'foo'::BPCHAR = $1
+
+query B
+EXECUTE p('foo   ')
+----
+true
+
+statement ok
+DEALLOCATE p;
+PREPARE p AS SELECT 'foo'::BPCHAR = $1
+
+query B
+EXECUTE p('foo   ')
+----
+true
+
+query B
+SELECT 'foo'::CHAR = 'f  '
+----
+true
+
+# The LHS is typed as CHAR(1) and truncated and the RHS is typed as BPCHAR and
+# not truncated, so they do not match.
+query B
+SELECT 'foo'::CHAR = 'foo'
+----
+false
+
+query B
+SELECT 'foo'::CHAR = 'foo  '
+----
+false
+
+statement ok
+CREATE TABLE chars (
+  bp BPCHAR,
+  c CHAR(20)
+)
+
+statement ok
+INSERT INTO chars VALUES ('foo   ', 'bar    ');
+
+query TI
+SELECT bp, length(bp) FROM chars WHERE bp = 'foo   '
+----
+foo  3
+
+statement ok
+DEALLOCATE p;
+PREPARE p AS SELECT bp, length(bp) FROM chars WHERE bp = $1
+
+query TI
+EXECUTE p('foo   ')
+----
+foo  3
+
+query TI
+SELECT c, length(c) FROM chars WHERE c = 'bar   '
+----
+bar                   3
+
+statement ok
+DEALLOCATE p;
+PREPARE p AS SELECT c, length(c) FROM chars WHERE c = $1
+
+query TI
+EXECUTE p('bar   ')
+----
+bar                   3
+
+query B
+SELECT ROW('foo'::BPCHAR) = ROW('foo   ')
+----
+true
+
+query B
+SELECT bp = c FROM
+  (VALUES ('foo'::BPCHAR)) v1(bp),
+  (VALUES ('foo  ')) v2(c)
+----
+false
+
 # Regression tests for #15050
 
 statement error pq: parsing as type timestamp: could not parse "Not Timestamp"

--- a/pkg/sql/opt/memo/typing_test.go
+++ b/pkg/sql/opt/memo/typing_test.go
@@ -104,6 +104,9 @@ func TestTypingComparisonAssumptions(t *testing.T) {
 				if op == op2 {
 					return nil
 				}
+				if op.OverloadPreference != op2.OverloadPreference {
+					return nil
+				}
 				if op.LeftType.Equivalent(op2.LeftType) && op.RightType.Equivalent(op2.RightType) {
 					format := "found equivalent operand type ambiguity for %s:\n%+v\n%+v"
 					t.Errorf(format, name, op, op2)

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -208,6 +208,7 @@ build
 SELECT array_agg(NULL)
 ----
 error (42725): ambiguous call: array_agg(unknown), candidates are:
+array_agg(bool) -> bool[]
 array_agg(bool[]) -> bool[][]
 array_agg(box2d) -> box2d[]
 array_agg(box2d[]) -> box2d[][]
@@ -255,7 +256,6 @@ array_agg(anyenum) -> anyenum[]
 array_agg(anyenum[]) -> anyenum[][]
 array_agg(tuple) -> tuple[]
 array_agg(tuple[]) -> tuple[][]
-array_agg(bool) -> bool[]
 
 # With an explicit cast, this works as expected.
 build
@@ -2747,9 +2747,9 @@ build
 SELECT corr(k, NULL) FROM kv
 ----
 error (42725): ambiguous call: corr(int, unknown), candidates are:
+corr(int, decimal) -> float
 corr(int, int) -> float
 corr(int, float) -> float
-corr(int, decimal) -> float
 
 build
 SELECT corr('foo', v) FROM kv
@@ -2819,9 +2819,9 @@ build
 SELECT covar_pop(k, NULL) FROM kv
 ----
 error (42725): ambiguous call: covar_pop(int, unknown), candidates are:
+covar_pop(int, decimal) -> float
 covar_pop(int, int) -> float
 covar_pop(int, float) -> float
-covar_pop(int, decimal) -> float
 
 build
 SELECT covar_pop('foo', v) FROM kv
@@ -2891,9 +2891,9 @@ build
 SELECT regr_intercept(k, NULL) FROM kv
 ----
 error (42725): ambiguous call: regr_intercept(int, unknown), candidates are:
+regr_intercept(int, decimal) -> float
 regr_intercept(int, int) -> float
 regr_intercept(int, float) -> float
-regr_intercept(int, decimal) -> float
 
 build
 SELECT regr_intercept('foo', v) FROM kv
@@ -2963,9 +2963,9 @@ build
 SELECT regr_r2(k, NULL) FROM kv
 ----
 error (42725): ambiguous call: regr_r2(int, unknown), candidates are:
+regr_r2(int, decimal) -> float
 regr_r2(int, int) -> float
 regr_r2(int, float) -> float
-regr_r2(int, decimal) -> float
 
 build
 SELECT regr_r2('foo', v) FROM kv
@@ -3035,9 +3035,9 @@ build
 SELECT regr_slope(k, NULL) FROM kv
 ----
 error (42725): ambiguous call: regr_slope(int, unknown), candidates are:
+regr_slope(int, decimal) -> float
 regr_slope(int, int) -> float
 regr_slope(int, float) -> float
-regr_slope(int, decimal) -> float
 
 build
 SELECT regr_slope('foo', v) FROM kv
@@ -3108,9 +3108,9 @@ build
 SELECT regr_sxx(k, NULL) FROM kv
 ----
 error (42725): ambiguous call: regr_sxx(int, unknown), candidates are:
+regr_sxx(int, decimal) -> float
 regr_sxx(int, int) -> float
 regr_sxx(int, float) -> float
-regr_sxx(int, decimal) -> float
 
 build
 SELECT regr_sxx('foo', v) FROM kv
@@ -3180,9 +3180,9 @@ build
 SELECT regr_sxy(k, NULL) FROM kv
 ----
 error (42725): ambiguous call: regr_sxy(int, unknown), candidates are:
+regr_sxy(int, decimal) -> float
 regr_sxy(int, int) -> float
 regr_sxy(int, float) -> float
-regr_sxy(int, decimal) -> float
 
 build
 SELECT regr_sxy('foo', v) FROM kv
@@ -3252,9 +3252,9 @@ build
 SELECT regr_syy(k, NULL) FROM kv
 ----
 error (42725): ambiguous call: regr_syy(int, unknown), candidates are:
+regr_syy(int, decimal) -> float
 regr_syy(int, int) -> float
 regr_syy(int, float) -> float
-regr_syy(int, decimal) -> float
 
 build
 SELECT regr_syy('foo', v) FROM kv
@@ -3324,9 +3324,9 @@ build
 SELECT regr_count(k, NULL) FROM kv
 ----
 error (42725): ambiguous call: regr_count(int, unknown), candidates are:
+regr_count(int, decimal) -> int
 regr_count(int, int) -> int
 regr_count(int, float) -> int
-regr_count(int, decimal) -> int
 
 build
 SELECT regr_count('foo', v) FROM kv
@@ -3396,9 +3396,9 @@ build
 SELECT regr_avgx(k, NULL) FROM kv
 ----
 error (42725): ambiguous call: regr_avgx(int, unknown), candidates are:
+regr_avgx(int, decimal) -> float
 regr_avgx(int, int) -> float
 regr_avgx(int, float) -> float
-regr_avgx(int, decimal) -> float
 
 build
 SELECT regr_avgx('foo', v) FROM kv
@@ -3468,9 +3468,9 @@ build
 SELECT regr_avgy(k, NULL) FROM kv
 ----
 error (42725): ambiguous call: regr_avgy(int, unknown), candidates are:
+regr_avgy(int, decimal) -> float
 regr_avgy(int, int) -> float
 regr_avgy(int, float) -> float
-regr_avgy(int, decimal) -> float
 
 build
 SELECT regr_avgy('foo', v) FROM kv

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -1357,7 +1357,7 @@ insert assn_cast
       │    ├── columns: c_cast:12!null qc_cast:13!null s_cast:14!null column3:10!null
       │    ├── values
       │    │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null
-      │    │    └── (' ', 'foo', 1, 2)
+      │    │    └── ('', 'foo', 1, 2)
       │    └── projections
       │         ├── assignment-cast: CHAR [as=c_cast:12]
       │         │    └── column1:8
@@ -1385,7 +1385,7 @@ insert assn_cast
       │    ├── columns: c_cast:11!null qc_cast:12!null column3:10!null
       │    ├── values
       │    │    ├── columns: column1:8!null column2:9!null column3:10!null
-      │    │    └── (' ', 'foo', 1)
+      │    │    └── ('', 'foo', 1)
       │    └── projections
       │         ├── assignment-cast: CHAR [as=c_cast:11]
       │         │    └── column1:8

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -2002,7 +2002,7 @@ update assn_cast
       │    │    │         └── d_comp:15
       │    │    │              └── (d:14 + 10.0)::DECIMAL(10)
       │    │    └── projections
-      │    │         ├── ' ' [as=c_new:19]
+      │    │         ├── '' [as=c_new:19]
       │    │         ├── 'foo' [as=qc_new:20]
       │    │         ├── 1 [as=i_new:21]
       │    │         └── 2 [as=s_new:22]
@@ -2039,7 +2039,7 @@ update assn_cast
       │    │    │         └── d_comp:15
       │    │    │              └── (d:14 + 10.0)::DECIMAL(10)
       │    │    └── projections
-      │    │         ├── ' ' [as=c_new:19]
+      │    │         ├── '' [as=c_new:19]
       │    │         ├── 'foo' [as=qc_new:20]
       │    │         └── 1 [as=i_new:21]
       │    └── projections
@@ -2258,7 +2258,7 @@ update assn_cast
       │    │    │         └── d_comp:15
       │    │    │              └── (d:14 + 10.0)::DECIMAL(10)
       │    │    └── projections
-      │    │         ├── ' ' [as=c_new:19]
+      │    │         ├── '' [as=c_new:19]
       │    │         └── 10::INT2 [as=i_new:20]
       │    └── projections
       │         ├── assignment-cast: CHAR [as=c_cast:21]
@@ -2290,7 +2290,7 @@ update assn_cast
       │    │    │         └── d_comp:15
       │    │    │              └── (d:14 + 10.0)::DECIMAL(10)
       │    │    └── projections
-      │    │         ├── ' ' [as=c_new:19]
+      │    │         ├── '' [as=c_new:19]
       │    │         └── 10::INT2 [as=i_new:20]
       │    └── projections
       │         ├── assignment-cast: CHAR [as=c_cast:21]
@@ -2436,7 +2436,7 @@ update assn_cast
       │    │    │    │              └── 1 [as="?column?":25]
       │    │    │    └── filters (true)
       │    │    └── projections
-      │    │         └── ' ' [as=c_new:26]
+      │    │         └── '' [as=c_new:26]
       │    └── projections
       │         ├── assignment-cast: CHAR [as=c_cast:27]
       │         │    └── c_new:26

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -3369,7 +3369,7 @@ upsert assn_cast
       │    │    │    │    │    │    │    ├── columns: k_cast:15!null c_cast:16!null qc_cast:17!null s_cast:18!null column4:13!null
       │    │    │    │    │    │    │    ├── values
       │    │    │    │    │    │    │    │    ├── columns: column1:10!null column2:11!null column3:12!null column4:13!null column5:14!null
-      │    │    │    │    │    │    │    │    └── (1.0, ' ', 'foo', 1, 2)
+      │    │    │    │    │    │    │    │    └── (1.0, '', 'foo', 1, 2)
       │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │         ├── assignment-cast: INT8 [as=k_cast:15]
       │    │    │    │    │    │    │         │    └── column1:10
@@ -3454,7 +3454,7 @@ upsert assn_cast
       │    │    │    │    │    │    │    ├── columns: k_cast:14 c_cast:15!null qc_cast:16!null column4:13!null
       │    │    │    │    │    │    │    ├── values
       │    │    │    │    │    │    │    │    ├── columns: column1:10 column2:11!null column3:12!null column4:13!null
-      │    │    │    │    │    │    │    │    └── (1.0::DECIMAL, ' ', 'foo', 1)
+      │    │    │    │    │    │    │    │    └── (1.0::DECIMAL, '', 'foo', 1)
       │    │    │    │    │    │    │    └── projections
       │    │    │    │    │    │    │         ├── assignment-cast: INT8 [as=k_cast:14]
       │    │    │    │    │    │    │         │    └── column1:10
@@ -3529,7 +3529,7 @@ insert assn_cast
       │    │    │    │    │    ├── columns: k_cast:15!null c_cast:16!null qc_cast:17!null s_cast:18!null column4:13!null
       │    │    │    │    │    ├── values
       │    │    │    │    │    │    ├── columns: column1:10!null column2:11!null column3:12!null column4:13!null column5:14!null
-      │    │    │    │    │    │    └── (1.0, ' ', 'foo', 1, 2)
+      │    │    │    │    │    │    └── (1.0, '', 'foo', 1, 2)
       │    │    │    │    │    └── projections
       │    │    │    │    │         ├── assignment-cast: INT8 [as=k_cast:15]
       │    │    │    │    │         │    └── column1:10
@@ -3651,7 +3651,7 @@ upsert assn_cast
       │    │    │    │    └── filters
       │    │    │    │         └── k_cast:15 = k:21
       │    │    │    └── projections
-      │    │    │         ├── ' ' [as=c_new:30]
+      │    │    │         ├── '' [as=c_new:30]
       │    │    │         ├── 'foo' [as=qc_new:31]
       │    │    │         ├── 1 [as=i_new:32]
       │    │    │         └── 2 [as=s_new:33]

--- a/pkg/sql/randgen/datum.go
+++ b/pkg/sql/randgen/datum.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"math/bits"
 	"math/rand"
+	"strings"
 	"time"
 	"unicode"
 
@@ -260,6 +261,9 @@ func RandDatumWithNullChance(
 		}
 		if typ.Oid() == oid.T_name {
 			return tree.NewDName(string(p))
+		}
+		if typ.Oid() == oid.T_bpchar {
+			return tree.NewDString(strings.TrimRight(string(p), " "))
 		}
 		return tree.NewDString(string(p))
 	case types.BytesFamily:

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1930,9 +1930,9 @@ var regularBuiltins = map[string]builtinDefinition{
 
 	"quote_literal": makeBuiltin(defProps(),
 		tree.Overload{
-			Types:             tree.ParamTypes{{Name: "val", Typ: types.String}},
-			ReturnType:        tree.FixedReturnType(types.String),
-			PreferredOverload: true,
+			Types:              tree.ParamTypes{{Name: "val", Typ: types.String}},
+			ReturnType:         tree.FixedReturnType(types.String),
+			OverloadPreference: tree.OverloadPreferencePreferred,
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := tree.MustBeDString(args[0])
 				return tree.NewDString(lexbase.EscapeSQLString(string(s))), nil
@@ -1964,9 +1964,9 @@ var regularBuiltins = map[string]builtinDefinition{
 			Category: builtinconstants.CategoryString,
 		},
 		tree.Overload{
-			Types:             tree.ParamTypes{{Name: "val", Typ: types.String}},
-			ReturnType:        tree.FixedReturnType(types.String),
-			PreferredOverload: true,
+			Types:              tree.ParamTypes{{Name: "val", Typ: types.String}},
+			ReturnType:         tree.FixedReturnType(types.String),
+			OverloadPreference: tree.OverloadPreferencePreferred,
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull {
 					return tree.NewDString("NULL"), nil
@@ -2718,9 +2718,9 @@ months and years, use the timestamptz subtraction operator.`,
 	"statement_timestamp": makeBuiltin(
 		defProps(),
 		tree.Overload{
-			Types:             tree.ParamTypes{},
-			ReturnType:        tree.FixedReturnType(types.TimestampTZ),
-			PreferredOverload: true,
+			Types:              tree.ParamTypes{},
+			ReturnType:         tree.FixedReturnType(types.TimestampTZ),
+			OverloadPreference: tree.OverloadPreferencePreferred,
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.MakeDTimestampTZ(evalCtx.GetStmtTimestamp(), time.Microsecond)
 			},
@@ -2883,9 +2883,9 @@ value if you rely on the HLC for accuracy.`,
 	"clock_timestamp": makeBuiltin(
 		defProps(),
 		tree.Overload{
-			Types:             tree.ParamTypes{},
-			ReturnType:        tree.FixedReturnType(types.TimestampTZ),
-			PreferredOverload: true,
+			Types:              tree.ParamTypes{},
+			ReturnType:         tree.FixedReturnType(types.TimestampTZ),
+			OverloadPreference: tree.OverloadPreferencePreferred,
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.MakeDTimestampTZ(timeutil.Now(), time.Microsecond)
 			},
@@ -9190,12 +9190,17 @@ func getTimeAdditionalDesc(preferTZOverload bool) (string, string) {
 }
 
 func txnTSOverloads(preferTZOverload bool) []tree.Overload {
+	pref := tree.OverloadPreferencePreferred
+	tzPref := tree.OverloadPreferenceNone
+	if preferTZOverload {
+		pref, tzPref = tzPref, pref
+	}
 	tzAdditionalDesc, noTZAdditionalDesc := getTimeAdditionalDesc(preferTZOverload)
 	return []tree.Overload{
 		{
-			Types:             tree.ParamTypes{},
-			ReturnType:        tree.FixedReturnType(types.TimestampTZ),
-			PreferredOverload: preferTZOverload,
+			Types:              tree.ParamTypes{},
+			ReturnType:         tree.FixedReturnType(types.TimestampTZ),
+			OverloadPreference: tzPref,
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return evalCtx.GetTxnTimestamp(time.Microsecond), nil
 			},
@@ -9203,9 +9208,9 @@ func txnTSOverloads(preferTZOverload bool) []tree.Overload {
 			Volatility: volatility.Stable,
 		},
 		{
-			Types:             tree.ParamTypes{},
-			ReturnType:        tree.FixedReturnType(types.Timestamp),
-			PreferredOverload: !preferTZOverload,
+			Types:              tree.ParamTypes{},
+			ReturnType:         tree.FixedReturnType(types.Timestamp),
+			OverloadPreference: pref,
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return evalCtx.GetTxnTimestampNoZone(time.Microsecond), nil
 			},
@@ -9223,13 +9228,18 @@ func txnTSOverloads(preferTZOverload bool) []tree.Overload {
 }
 
 func txnTSWithPrecisionOverloads(preferTZOverload bool) []tree.Overload {
+	pref := tree.OverloadPreferencePreferred
+	tzPref := tree.OverloadPreferenceNone
+	if preferTZOverload {
+		pref, tzPref = tzPref, pref
+	}
 	tzAdditionalDesc, noTZAdditionalDesc := getTimeAdditionalDesc(preferTZOverload)
 	return append(
 		[]tree.Overload{
 			{
-				Types:             tree.ParamTypes{{Name: "precision", Typ: types.Int}},
-				ReturnType:        tree.FixedReturnType(types.TimestampTZ),
-				PreferredOverload: preferTZOverload,
+				Types:              tree.ParamTypes{{Name: "precision", Typ: types.Int}},
+				ReturnType:         tree.FixedReturnType(types.TimestampTZ),
+				OverloadPreference: tzPref,
 				Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 					prec := int32(tree.MustBeDInt(args[0]))
 					if prec < 0 || prec > 6 {
@@ -9241,9 +9251,9 @@ func txnTSWithPrecisionOverloads(preferTZOverload bool) []tree.Overload {
 				Volatility: volatility.Stable,
 			},
 			{
-				Types:             tree.ParamTypes{{Name: "precision", Typ: types.Int}},
-				ReturnType:        tree.FixedReturnType(types.Timestamp),
-				PreferredOverload: !preferTZOverload,
+				Types:              tree.ParamTypes{{Name: "precision", Typ: types.Int}},
+				ReturnType:         tree.FixedReturnType(types.Timestamp),
+				OverloadPreference: pref,
 				Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 					prec := int32(tree.MustBeDInt(args[0]))
 					if prec < 0 || prec > 6 {
@@ -9291,13 +9301,18 @@ func txnTSWithPrecisionImplBuiltin(preferTZOverload bool) builtinDefinition {
 }
 
 func txnTimeWithPrecisionBuiltin(preferTZOverload bool) builtinDefinition {
+	pref := tree.OverloadPreferencePreferred
+	tzPref := tree.OverloadPreferenceNone
+	if preferTZOverload {
+		pref, tzPref = tzPref, pref
+	}
 	tzAdditionalDesc, noTZAdditionalDesc := getTimeAdditionalDesc(preferTZOverload)
 	return makeBuiltin(
 		defProps(),
 		tree.Overload{
-			Types:             tree.ParamTypes{},
-			ReturnType:        tree.FixedReturnType(types.TimeTZ),
-			PreferredOverload: preferTZOverload,
+			Types:              tree.ParamTypes{},
+			ReturnType:         tree.FixedReturnType(types.TimeTZ),
+			OverloadPreference: tzPref,
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return evalCtx.GetTxnTime(time.Microsecond), nil
 			},
@@ -9305,9 +9320,9 @@ func txnTimeWithPrecisionBuiltin(preferTZOverload bool) builtinDefinition {
 			Volatility: volatility.Stable,
 		},
 		tree.Overload{
-			Types:             tree.ParamTypes{},
-			ReturnType:        tree.FixedReturnType(types.Time),
-			PreferredOverload: !preferTZOverload,
+			Types:              tree.ParamTypes{},
+			ReturnType:         tree.FixedReturnType(types.Time),
+			OverloadPreference: pref,
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return evalCtx.GetTxnTimeNoZone(time.Microsecond), nil
 			},
@@ -9315,9 +9330,9 @@ func txnTimeWithPrecisionBuiltin(preferTZOverload bool) builtinDefinition {
 			Volatility: volatility.Stable,
 		},
 		tree.Overload{
-			Types:             tree.ParamTypes{{Name: "precision", Typ: types.Int}},
-			ReturnType:        tree.FixedReturnType(types.TimeTZ),
-			PreferredOverload: preferTZOverload,
+			Types:              tree.ParamTypes{{Name: "precision", Typ: types.Int}},
+			ReturnType:         tree.FixedReturnType(types.TimeTZ),
+			OverloadPreference: tzPref,
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				prec := int32(tree.MustBeDInt(args[0]))
 				if prec < 0 || prec > 6 {
@@ -9329,9 +9344,9 @@ func txnTimeWithPrecisionBuiltin(preferTZOverload bool) builtinDefinition {
 			Volatility: volatility.Stable,
 		},
 		tree.Overload{
-			Types:             tree.ParamTypes{{Name: "precision", Typ: types.Int}},
-			ReturnType:        tree.FixedReturnType(types.Time),
-			PreferredOverload: !preferTZOverload,
+			Types:              tree.ParamTypes{{Name: "precision", Typ: types.Int}},
+			ReturnType:         tree.FixedReturnType(types.Time),
+			OverloadPreference: pref,
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				prec := int32(tree.MustBeDInt(args[0]))
 				if prec < 0 || prec > 6 {

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -771,9 +771,9 @@ var geoBuiltins = map[string]builtinDefinition{
 			},
 			// Simulate PostgreSQL's ambiguity type resolving check that prefers
 			// strings over JSON.
-			PreferredOverload: true,
-			Info:              infoBuilder{info: "Returns the Geometry from an GeoJSON representation."}.String(),
-			Volatility:        volatility.Immutable,
+			OverloadPreference: tree.OverloadPreferencePreferred,
+			Info:               infoBuilder{info: "Returns the Geometry from an GeoJSON representation."}.String(),
+			Volatility:         volatility.Immutable,
 		},
 		jsonOverload1(
 			func(_ context.Context, _ *eval.Context, s json.JSON) (tree.Datum, error) {

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -456,9 +456,6 @@ func commonConstantType(vals []Expr, idxs intsets.Fast) (*types.T, bool) {
 
 // StrVal represents a constant string value.
 type StrVal struct {
-	// We could embed a constant.Value here (like NumVal) and use the stringVal implementation,
-	// but that would have extra overhead without much of a benefit. However, it would make
-	// constant folding (below) a little more straightforward.
 	s string
 
 	// scannedAsBytes is true iff the input syntax was using b'...' or
@@ -507,6 +504,7 @@ var (
 		// default type that raw strings get parsed into, without any casts or type
 		// assertions.
 		types.String,
+		types.BPChar,
 		types.AnyCollatedString,
 		types.Bytes,
 		types.Bool,
@@ -626,12 +624,22 @@ func (expr *StrVal) ResolveAsType(
 	// Typing a string literal constant into some value type.
 	switch typ.Family() {
 	case types.StringFamily:
-		if typ.Oid() == oid.T_name {
+		switch typ.Oid() {
+		case oid.T_name:
 			expr.resString = DString(expr.s)
 			return NewDNameFromDString(&expr.resString), nil
+		case oid.T_bpchar:
+			// TODO(mgartner): This should probably use the same logic in
+			// tree.AdjustValueToType and/or
+			// eval.performCastWithoutPrecisionTruncation. casts use (see the
+			// cast package). We might be able to replace this entire function
+			// with logic in those functions.
+			expr.resString = DString(strings.TrimRight(expr.s, " "))
+			return &expr.resString, nil
+		default:
+			expr.resString = DString(expr.s)
+			return &expr.resString, nil
 		}
-		expr.resString = DString(expr.s)
-		return &expr.resString, nil
 
 	case types.BytesFamily:
 		return ParseDByte(expr.s)

--- a/pkg/sql/sem/tree/constant_test.go
+++ b/pkg/sql/sem/tree/constant_test.go
@@ -399,6 +399,7 @@ func mustParseDArrayOfType(typ *types.T) func(t *testing.T, s string) tree.Datum
 
 var parseFuncs = map[*types.T]func(*testing.T, string) tree.Datum{
 	types.String:           func(t *testing.T, s string) tree.Datum { return tree.NewDString(s) },
+	types.BPChar:           func(t *testing.T, s string) tree.Datum { return tree.NewDString(strings.TrimRight(s, " ")) },
 	types.Bytes:            func(t *testing.T, s string) tree.Datum { return tree.NewDBytes(tree.DBytes(s)) },
 	types.Int:              mustParseDInt,
 	types.Float:            mustParseDFloat,
@@ -461,33 +462,39 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 		parseOptions map[*types.T]struct{}
 	}{
 		{
-			c:            tree.NewStrVal("abc 世界"),
-			parseOptions: typeSet(types.String, types.Bytes, types.TSVector, types.RefCursor),
+			c: tree.NewStrVal("abc 世界"),
+			parseOptions: typeSet(types.String, types.BPChar, types.Bytes, types.TSVector,
+				types.RefCursor),
+		},
+		{
+			c: tree.NewStrVal("abc 世界   "),
+			parseOptions: typeSet(types.String, types.BPChar, types.Bytes, types.TSVector,
+				types.RefCursor),
 		},
 		{
 			c: tree.NewStrVal("true"),
-			parseOptions: typeSet(types.String, types.Bytes, types.Bool, types.Jsonb, types.TSVector,
-				types.TSQuery, types.RefCursor),
+			parseOptions: typeSet(types.String, types.BPChar, types.Bytes, types.Bool, types.Jsonb,
+				types.TSVector, types.TSQuery, types.RefCursor),
 		},
 		{
 			c: tree.NewStrVal("2010-09-28"),
-			parseOptions: typeSet(types.String, types.Bytes, types.Date, types.Timestamp,
-				types.TimestampTZ, types.TSVector, types.TSQuery, types.RefCursor),
+			parseOptions: typeSet(types.String, types.BPChar, types.Bytes, types.Date,
+				types.Timestamp, types.TimestampTZ, types.TSVector, types.TSQuery, types.RefCursor),
 		},
 		{
 			c: tree.NewStrVal("2010-09-28 12:00:00.1"),
-			parseOptions: typeSet(types.String, types.Bytes, types.Time, types.TimeTZ, types.Timestamp,
-				types.TimestampTZ, types.Date, types.RefCursor),
+			parseOptions: typeSet(types.String, types.BPChar, types.Bytes, types.Time, types.TimeTZ,
+				types.Timestamp, types.TimestampTZ, types.Date, types.RefCursor),
 		},
 		{
 			c: tree.NewStrVal("2006-07-08T00:00:00.000000123Z"),
-			parseOptions: typeSet(types.String, types.Bytes, types.Time, types.TimeTZ, types.Timestamp,
-				types.TimestampTZ, types.Date, types.RefCursor),
+			parseOptions: typeSet(types.String, types.BPChar, types.Bytes, types.Time, types.TimeTZ,
+				types.Timestamp, types.TimestampTZ, types.Date, types.RefCursor),
 		},
 		{
 			c: tree.NewStrVal("PT12H2M"),
-			parseOptions: typeSet(types.String, types.Bytes, types.Interval, types.TSVector,
-				types.TSQuery, types.RefCursor),
+			parseOptions: typeSet(types.String, types.BPChar, types.Bytes, types.Interval,
+				types.TSVector, types.TSQuery, types.RefCursor),
 		},
 		{
 			c:            tree.NewBytesStrVal("abc 世界"),
@@ -511,23 +518,24 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 		},
 		{
 			c: tree.NewStrVal("box(0 0, 1 1)"),
-			parseOptions: typeSet(types.String, types.Bytes, types.Box2D, types.TSVector,
-				types.RefCursor),
-		},
-		{
-			c: tree.NewStrVal("POINT(-100.59 42.94)"),
-			parseOptions: typeSet(types.String, types.Bytes, types.Geography, types.Geometry,
+			parseOptions: typeSet(types.String, types.BPChar, types.Bytes, types.Box2D,
 				types.TSVector, types.RefCursor),
 		},
 		{
+			c: tree.NewStrVal("POINT(-100.59 42.94)"),
+			parseOptions: typeSet(types.String, types.BPChar, types.Bytes, types.Geography,
+				types.Geometry, types.TSVector, types.RefCursor),
+		},
+		{
 			c: tree.NewStrVal("192.168.100.128/25"),
-			parseOptions: typeSet(types.String, types.Bytes, types.INet, types.TSVector, types.TSQuery,
-				types.RefCursor),
+			parseOptions: typeSet(types.String, types.BPChar, types.Bytes, types.INet,
+				types.TSVector, types.TSQuery, types.RefCursor),
 		},
 		{
 			c: tree.NewStrVal("111000110101"),
 			parseOptions: typeSet(
 				types.String,
+				types.BPChar,
 				types.Bytes,
 				types.VarBit,
 				types.Int,
@@ -542,17 +550,19 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 		},
 		{
 			c: tree.NewStrVal("A/1"),
-			parseOptions: typeSet(types.String, types.PGLSN, types.Bytes, types.TSQuery, types.TSVector,
-				types.RefCursor),
+			parseOptions: typeSet(types.String, types.BPChar, types.PGLSN, types.Bytes,
+				types.TSQuery, types.TSVector, types.RefCursor),
 		},
 		{
-			c:            tree.NewStrVal(`{"a": 1}`),
-			parseOptions: typeSet(types.String, types.Bytes, types.Jsonb, types.RefCursor),
+			c: tree.NewStrVal(`{"a": 1}`),
+			parseOptions: typeSet(types.String, types.BPChar, types.Bytes, types.Jsonb,
+				types.RefCursor),
 		},
 		{
 			c: tree.NewStrVal(`{1,2}`),
 			parseOptions: typeSet(
 				types.String,
+				types.BPChar,
 				types.Bytes,
 				types.BytesArray,
 				types.StringArray,
@@ -570,6 +580,7 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 			c: tree.NewStrVal(`{1.5,2.0}`),
 			parseOptions: typeSet(
 				types.String,
+				types.BPChar,
 				types.Bytes,
 				types.BytesArray,
 				types.StringArray,
@@ -584,8 +595,17 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 		},
 		{
 			c: tree.NewStrVal(`{a,b}`),
-			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray,
-				types.TSVector, types.TSQuery, types.RefCursor, types.RefCursorArray),
+			parseOptions: typeSet(
+				types.String,
+				types.BPChar,
+				types.Bytes,
+				types.BytesArray,
+				types.StringArray,
+				types.TSVector,
+				types.TSQuery,
+				types.RefCursor,
+				types.RefCursorArray,
+			),
 		},
 		{
 			c:            tree.NewBytesStrVal(string([]byte{0xff, 0xfe, 0xfd})),
@@ -593,34 +613,38 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 		},
 		{
 			c: tree.NewStrVal(`18e7b17e-4ead-4e27-bfd5-bb6d11261bb6`),
-			parseOptions: typeSet(types.String, types.Bytes, types.Uuid, types.TSVector, types.TSQuery,
-				types.RefCursor),
+			parseOptions: typeSet(types.String, types.BPChar, types.Bytes, types.Uuid,
+				types.TSVector, types.TSQuery, types.RefCursor),
 		},
 		{
 			c: tree.NewStrVal(`{18e7b17e-4ead-4e27-bfd5-bb6d11261bb6, 18e7b17e-4ead-4e27-bfd5-bb6d11261bb7}`),
-			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray,
-				types.UUIDArray, types.TSVector, types.RefCursor, types.RefCursorArray),
+			parseOptions: typeSet(types.String, types.BPChar, types.Bytes, types.BytesArray,
+				types.StringArray, types.UUIDArray, types.TSVector, types.RefCursor,
+				types.RefCursorArray),
 		},
 		{
 			c: tree.NewStrVal("{true, false}"),
-			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray,
-				types.BoolArray, types.TSVector, types.RefCursor, types.RefCursorArray),
+			parseOptions: typeSet(types.String, types.BPChar, types.Bytes, types.BytesArray,
+				types.StringArray, types.BoolArray, types.TSVector, types.RefCursor,
+				types.RefCursorArray),
 		},
 		{
 			c: tree.NewStrVal("{2010-09-28, 2010-09-29}"),
-			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray,
-				types.DateArray, types.TimestampArray, types.TimestampTZArray, types.TSVector,
-				types.RefCursor, types.RefCursorArray),
+			parseOptions: typeSet(types.String, types.BPChar, types.Bytes, types.BytesArray,
+				types.StringArray, types.DateArray, types.TimestampArray, types.TimestampTZArray,
+				types.TSVector, types.RefCursor, types.RefCursorArray),
 		},
 		{
 			c: tree.NewStrVal("{1A/1,2/2A}"),
-			parseOptions: typeSet(types.String, types.PGLSNArray, types.Bytes, types.BytesArray,
-				types.StringArray, types.TSQuery, types.TSVector, types.RefCursor, types.RefCursorArray),
+			parseOptions: typeSet(types.String, types.BPChar, types.PGLSNArray, types.Bytes,
+				types.BytesArray, types.StringArray, types.TSQuery, types.TSVector, types.RefCursor,
+				types.RefCursorArray),
 		},
 		{
 			c: tree.NewStrVal("{2010-09-28 12:00:00.1, 2010-09-29 12:00:00.1}"),
 			parseOptions: typeSet(
 				types.String,
+				types.BPChar,
 				types.Bytes,
 				types.BytesArray,
 				types.StringArray,
@@ -636,6 +660,7 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 			c: tree.NewStrVal("{2006-07-08T00:00:00.000000123Z, 2006-07-10T00:00:00.000000123Z}"),
 			parseOptions: typeSet(
 				types.String,
+				types.BPChar,
 				types.Bytes,
 				types.BytesArray,
 				types.StringArray,
@@ -649,18 +674,19 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 		},
 		{
 			c: tree.NewStrVal("{PT12H2M, -23:00:00}"),
-			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray,
-				types.IntervalArray, types.RefCursor, types.RefCursorArray),
+			parseOptions: typeSet(types.String, types.BPChar, types.Bytes, types.BytesArray,
+				types.StringArray, types.IntervalArray, types.RefCursor, types.RefCursorArray),
 		},
 		{
 			c: tree.NewStrVal("{192.168.100.128, ::ffff:10.4.3.2}"),
-			parseOptions: typeSet(types.String, types.Bytes, types.BytesArray, types.StringArray,
-				types.INetArray, types.RefCursor, types.RefCursorArray),
+			parseOptions: typeSet(types.String, types.BPChar, types.Bytes, types.BytesArray,
+				types.StringArray, types.INetArray, types.RefCursor, types.RefCursorArray),
 		},
 		{
 			c: tree.NewStrVal("{0101, 11}"),
 			parseOptions: typeSet(
 				types.String,
+				types.BPChar,
 				types.Bytes,
 				types.BytesArray,
 				types.StringArray,

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -1541,6 +1541,10 @@ func makeLeFn(a, b *types.T, v volatility.V) *CmpOp {
 func makeIsFn(a, b *types.T, v volatility.V) *CmpOp {
 	return makeCmpOpOverload(treecmp.IsNotDistinctFrom, a, b, true, v)
 }
+func unpreferred(cmp *CmpOp) *CmpOp {
+	cmp.OverloadPreference = OverloadPreferenceUnpreferred
+	return cmp
+}
 
 // CmpOps contains the comparison operations indexed by operation type.
 var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]*CmpOpOverloads{
@@ -1567,6 +1571,10 @@ var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]*CmpOpOverloads{
 		makeEqFn(types.PGLSN, types.PGLSN, volatility.Leakproof),
 		makeEqFn(types.RefCursor, types.RefCursor, volatility.Leakproof),
 		makeEqFn(types.String, types.String, volatility.Leakproof),
+		// NOTE: Using unpreferred here is a hack that avoids some "ambiguous
+		// comparison operator" errors. It is necessary because we do not follow
+		// all of Postgres's type conversion rules. See #75101.
+		unpreferred(makeEqFn(types.BPChar, types.BPChar, volatility.Leakproof)),
 		makeEqFn(types.Time, types.Time, volatility.Leakproof),
 		makeEqFn(types.TimeTZ, types.TimeTZ, volatility.Leakproof),
 		makeEqFn(types.Timestamp, types.Timestamp, volatility.Leakproof),
@@ -1627,6 +1635,10 @@ var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]*CmpOpOverloads{
 		makeLtFn(types.PGLSN, types.PGLSN, volatility.Leakproof),
 		makeLtFn(types.RefCursor, types.RefCursor, volatility.Leakproof),
 		makeLtFn(types.String, types.String, volatility.Leakproof),
+		// NOTE: Using unpreferred here is a hack that avoids some "ambiguous
+		// comparison operator" errors. It is necessary because we do not follow
+		// all of Postgres's type conversion rules. See #75101.
+		unpreferred(makeLtFn(types.BPChar, types.BPChar, volatility.Leakproof)),
 		makeLtFn(types.Time, types.Time, volatility.Leakproof),
 		makeLtFn(types.TimeTZ, types.TimeTZ, volatility.Leakproof),
 		makeLtFn(types.Timestamp, types.Timestamp, volatility.Leakproof),
@@ -1686,6 +1698,10 @@ var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]*CmpOpOverloads{
 		makeLeFn(types.PGLSN, types.PGLSN, volatility.Leakproof),
 		makeLeFn(types.RefCursor, types.RefCursor, volatility.Leakproof),
 		makeLeFn(types.String, types.String, volatility.Leakproof),
+		// NOTE: Using unpreferred here is a hack that avoids some "ambiguous
+		// comparison operator" errors. It is necessary because we do not follow
+		// all of Postgres's type conversion rules. See #75101.
+		unpreferred(makeLeFn(types.BPChar, types.BPChar, volatility.Leakproof)),
 		makeLeFn(types.Time, types.Time, volatility.Leakproof),
 		makeLeFn(types.TimeTZ, types.TimeTZ, volatility.Leakproof),
 		makeLeFn(types.Timestamp, types.Timestamp, volatility.Leakproof),
@@ -1766,6 +1782,10 @@ var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]*CmpOpOverloads{
 		makeIsFn(types.PGLSN, types.PGLSN, volatility.Leakproof),
 		makeIsFn(types.RefCursor, types.RefCursor, volatility.Leakproof),
 		makeIsFn(types.String, types.String, volatility.Leakproof),
+		// NOTE: Using unpreferred here is a hack that avoids some "ambiguous
+		// comparison operator" errors. It is necessary because we do not follow
+		// all of Postgres's type conversion rules. See #75101.
+		unpreferred(makeIsFn(types.BPChar, types.BPChar, volatility.Leakproof)),
 		makeIsFn(types.Time, types.Time, volatility.Leakproof),
 		makeIsFn(types.TimeTZ, types.TimeTZ, volatility.Leakproof),
 		makeIsFn(types.Timestamp, types.Timestamp, volatility.Leakproof),
@@ -1834,6 +1854,10 @@ var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]*CmpOpOverloads{
 		makeEvalTupleIn(types.PGLSN, volatility.Leakproof),
 		makeEvalTupleIn(types.RefCursor, volatility.Leakproof),
 		makeEvalTupleIn(types.String, volatility.Leakproof),
+		// NOTE: Using unpreferred here is a hack that avoids some "ambiguous
+		// comparison operator" errors. It is necessary because we do not follow
+		// all of Postgres's type conversion rules. See #75101.
+		unpreferred(makeEvalTupleIn(types.BPChar, volatility.Leakproof)),
 		makeEvalTupleIn(types.Time, volatility.Leakproof),
 		makeEvalTupleIn(types.TimeTZ, volatility.Leakproof),
 		makeEvalTupleIn(types.Timestamp, volatility.Leakproof),

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -77,8 +77,8 @@ func (op *UnaryOp) returnType() ReturnTyper {
 	return op.retType
 }
 
-func (*UnaryOp) preferred() bool {
-	return false
+func (*UnaryOp) preference() OverloadPreference {
+	return OverloadPreferenceNone
 }
 
 func (*UnaryOp) outParamInfo() (RoutineType, []int32, TypeList) {
@@ -239,7 +239,7 @@ type BinOp struct {
 	CalledOnNullInput bool
 	EvalOp            BinaryEvalOp
 	Volatility        volatility.V
-	PreferredOverload bool
+	OverloadPreference
 
 	types   TypeList
 	retType ReturnTyper
@@ -259,8 +259,8 @@ func (op *BinOp) returnType() ReturnTyper {
 	return op.retType
 }
 
-func (op *BinOp) preferred() bool {
-	return op.PreferredOverload
+func (op *BinOp) preference() OverloadPreference {
+	return op.OverloadPreference
 }
 
 func (op *BinOp) outParamInfo() (RoutineType, []int32, TypeList) {
@@ -1319,12 +1319,12 @@ var BinOps = map[treebin.BinaryOperatorSymbol]*BinOpOverloads{
 
 	treebin.JSONFetchVal: {overloads: []*BinOp{
 		{
-			LeftType:          types.Jsonb,
-			RightType:         types.String,
-			ReturnType:        types.Jsonb,
-			EvalOp:            &JSONFetchValStringOp{},
-			PreferredOverload: true,
-			Volatility:        volatility.Immutable,
+			LeftType:           types.Jsonb,
+			RightType:          types.String,
+			ReturnType:         types.Jsonb,
+			EvalOp:             &JSONFetchValStringOp{},
+			OverloadPreference: OverloadPreferencePreferred,
+			Volatility:         volatility.Immutable,
 		},
 		{
 			LeftType:   types.Jsonb,
@@ -1347,12 +1347,12 @@ var BinOps = map[treebin.BinaryOperatorSymbol]*BinOpOverloads{
 
 	treebin.JSONFetchText: {overloads: []*BinOp{
 		{
-			LeftType:          types.Jsonb,
-			RightType:         types.String,
-			ReturnType:        types.String,
-			PreferredOverload: true,
-			EvalOp:            &JSONFetchTextStringOp{},
-			Volatility:        volatility.Immutable,
+			LeftType:           types.Jsonb,
+			RightType:          types.String,
+			ReturnType:         types.String,
+			OverloadPreference: OverloadPreferencePreferred,
+			EvalOp:             &JSONFetchTextStringOp{},
+			Volatility:         volatility.Immutable,
 		},
 		{
 			LeftType:   types.Jsonb,
@@ -1392,7 +1392,7 @@ type CmpOp struct {
 
 	Volatility volatility.V
 
-	PreferredOverload bool
+	OverloadPreference
 }
 
 func (op *CmpOp) params() TypeList {
@@ -1409,8 +1409,8 @@ func (op *CmpOp) returnType() ReturnTyper {
 	return cmpOpReturnType
 }
 
-func (op *CmpOp) preferred() bool {
-	return op.PreferredOverload
+func (op *CmpOp) preference() OverloadPreference {
+	return op.OverloadPreference
 }
 
 func (op *CmpOp) outParamInfo() (RoutineType, []int32, TypeList) {
@@ -1732,8 +1732,8 @@ var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]*CmpOpOverloads{
 			},
 			CalledOnNullInput: true,
 			// Avoids ambiguous comparison error for NULL IS NOT DISTINCT FROM NULL.
-			PreferredOverload: true,
-			Volatility:        volatility.Leakproof,
+			OverloadPreference: OverloadPreferencePreferred,
+			Volatility:         volatility.Leakproof,
 		},
 		{
 			LeftType:  types.AnyArray,

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -160,7 +160,7 @@ func NewFunctionDefinition(
 	overloads := make([]*Overload, len(def))
 
 	for i := range def {
-		if def[i].PreferredOverload {
+		if def[i].OverloadPreference == OverloadPreferencePreferred {
 			// Builtins with a preferred overload are always ambiguous.
 			props.AmbiguousReturnType = true
 			break
@@ -486,7 +486,7 @@ func combineOverloads(a, b []QualifiedOverload, path SearchPath) []QualifiedOver
 	if foundUDFOverload {
 		for i, overload := range result {
 			copiedOverload := *overload.Overload
-			copiedOverload.PreferredOverload = false
+			copiedOverload.OverloadPreference = OverloadPreferenceNone
 			result[i] = QualifiedOverload{
 				Schema:   overload.Schema,
 				Overload: &copiedOverload,

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -1122,6 +1122,43 @@ func (s *overloadTypeChecker) typeCheckOverloadedExprs(
 		}
 	}
 
+	// If this is a binary operator with one untyped literal or placeholder,
+	// check for a binary operator with parameter types matching the type of the
+	// opposite argument.
+	if inBinOp && len(s.exprs) == 2 {
+		var typ *types.T
+		numConsts := s.constIdxs.Len()
+		numPlaceholders := s.placeholderIdxs.Len()
+		if (numConsts == 1 && numPlaceholders == 0) ||
+			(numConsts == 0 && numPlaceholders == 1) {
+			// If one argument is a constant then it assumes the same type
+			// as the other argument. This matches Postgres's behavior. See
+			// the documentation about "unknown" types (this is how Postgres
+			// initially types constant values):
+			// https://www.postgresql.org/docs/17/typeconv-oper.html.
+			if s.typedExprs[0] != nil {
+				typ = s.typedExprs[0].ResolvedType()
+			} else if s.typedExprs[1] != nil {
+				typ = s.typedExprs[1].ResolvedType()
+			}
+		}
+		if typ != nil {
+			exactOverloads := filterOverloads(s.overloadIdxs, s.overloads,
+				func(ov overloadImpl) bool {
+					typs := ov.params().Types()
+					return typ.Oid() == typs[0].Oid() && typ.Oid() == typs[1].Oid()
+				})
+			if len(exactOverloads) == 1 {
+				prevOverloadIdxs := s.overloadIdxs
+				s.overloadIdxs = exactOverloads
+				if ok, err := checkReturn(ctx, semaCtx, s); ok {
+					return err
+				}
+				s.overloadIdxs = prevOverloadIdxs
+			}
+		}
+	}
+
 	if !s.constIdxs.Empty() {
 		allConstantsAreHomogenous := false
 		if ok, err := filterAttempt(ctx, semaCtx, s, func() {
@@ -1381,6 +1418,9 @@ func (s *overloadTypeChecker) typeCheckOverloadedExprs(
 	// we prefer overloads where we infer the type of the NULL to be the same as the
 	// other argument. This is used to differentiate the behavior of
 	// STRING[] || NULL and STRING || NULL.
+	// TODO(mgartner): I think we can remove this heuristic in favor of the rule
+	// applied above that types untyped literals and placeholders based on the
+	// input types of overloads.
 	if inBinOp && len(s.exprs) == 2 {
 		if ok, err := filterAttempt(ctx, semaCtx, s, func() {
 			var err error

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -151,22 +151,30 @@ func (t RoutineType) String() string {
 	}
 }
 
+// OverloadPreference is used to disambiguate between eligible overload
+// candidates during type-checking. When multiple overloads are eligible based
+// on types even after applying all the other disambiguation heuristics, the
+// overload with the highest preference will be chosen, if no other overloads
+// have the same preference.
+//
+// NOTE: This is a hack that is necessary because we do not follow all of
+// Postgres's type conversion rules. It should be used sparingly.
+// See #75101.
+type OverloadPreference int
+
+const (
+	OverloadPreferenceUnpreferred = OverloadPreference(-1)
+	OverloadPreferenceNone        = OverloadPreference(0)
+	OverloadPreferencePreferred   = OverloadPreference(1)
+)
+
 // Overload is one of the overloads of a built-in function.
 // Each FunctionDefinition may contain one or more overloads.
 type Overload struct {
 	Types      TypeList
 	ReturnType ReturnTyper
 	Volatility volatility.V
-
-	// PreferredOverload determines overload resolution as follows.
-	// When multiple overloads are eligible based on types even after all of of
-	// the heuristics to pick one have been used, if one of the overloads is a
-	// Overload with the `PreferredOverload` flag set to true it can be selected
-	// rather than returning a no-such-method error.
-	// This should generally be avoided -- avoiding introducing ambiguous
-	// overloads in the first place is a much better solution -- and only done
-	// after consultation with @knz @nvanbenschoten.
-	PreferredOverload bool
+	OverloadPreference
 
 	// Info is a description of the function, which is surfaced on the CockroachDB
 	// docs site on the "Functions and Operators" page. Descriptions typically use
@@ -299,7 +307,7 @@ func (b Overload) params() TypeList { return b.Types }
 func (b Overload) returnType() ReturnTyper { return b.ReturnType }
 
 // preferred implements the overloadImpl interface.
-func (b Overload) preferred() bool { return b.PreferredOverload }
+func (b Overload) preference() OverloadPreference { return b.OverloadPreference }
 
 func (b Overload) outParamInfo() (RoutineType, []int32, TypeList) {
 	return b.Type, b.OutParamOrdinals, b.OutParamTypes
@@ -386,8 +394,7 @@ func (b Overload) SignatureWithDefaults(simplify bool, includeDefaults bool) str
 type overloadImpl interface {
 	params() TypeList
 	returnType() ReturnTyper
-	// allows manually resolving preference between multiple compatible overloads.
-	preferred() bool
+	preference() OverloadPreference
 	// outParamInfo is only used for routines. See comment on
 	// Overload.OutParamOrdinals and Overload.OutParamTypes for more details.
 	outParamInfo() (_ RoutineType, outParamOrdinals []int32, outParamTypes TypeList)
@@ -1254,11 +1261,19 @@ func (s *overloadTypeChecker) typeCheckOverloadedExprs(
 		}
 	}
 
-	// The fifth heuristic is to defer to preferred candidates, if one has been
-	// specified in the overload list.
+	// The fifth heuristic is to defer to candidates with the highest
+	// preference.
+	maxPreference := OverloadPreferenceUnpreferred
+	for _, idx := range s.overloadIdxs {
+		if p := s.overloads[idx].preference(); p > maxPreference {
+			maxPreference = p
+		}
+	}
 	if ok, err := filterAttempt(ctx, semaCtx, s, func() {
 		s.overloadIdxs = filterOverloads(
-			s.overloadIdxs, s.overloads, overloadImpl.preferred,
+			s.overloadIdxs, s.overloads, func(o overloadImpl) bool {
+				return o.preference() == maxPreference
+			},
 		)
 	}); ok {
 		return err
@@ -1633,8 +1648,11 @@ func formatCandidates(prefix string, candidates []overloadImpl, filter []uint8) 
 		}
 		buf.WriteString(") -> ")
 		buf.WriteString(returnTypeToFixedType(candidate.returnType(), inputTyps).String())
-		if candidate.preferred() {
+		switch candidate.preference() {
+		case OverloadPreferencePreferred:
 			buf.WriteString(" [preferred]")
+		case OverloadPreferenceUnpreferred:
+			buf.WriteString(" [unpreferred]")
 		}
 		buf.WriteByte('\n')
 	}

--- a/pkg/sql/sem/tree/overload_test.go
+++ b/pkg/sql/sem/tree/overload_test.go
@@ -93,7 +93,7 @@ func TestVariadicFunctions(t *testing.T) {
 type testOverload struct {
 	paramTypes ParamTypes
 	retType    *types.T
-	pref       bool
+	OverloadPreference
 }
 
 func (to *testOverload) params() TypeList {
@@ -104,8 +104,8 @@ func (to *testOverload) returnType() ReturnTyper {
 	return FixedReturnType(to.retType)
 }
 
-func (to testOverload) preferred() bool {
-	return to.pref
+func (to testOverload) preference() OverloadPreference {
+	return to.OverloadPreference
 }
 
 func (to *testOverload) outParamInfo() (RoutineType, []int32, TypeList) {
@@ -116,8 +116,8 @@ func (to *testOverload) defaultExprs() Exprs {
 	return nil
 }
 
-func (to testOverload) withPreferred(pref bool) *testOverload {
-	to.pref = pref
+func (to testOverload) preferred() *testOverload {
+	to.OverloadPreference = OverloadPreferencePreferred
 	return &to
 }
 
@@ -166,14 +166,14 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 	}
 
 	unaryIntFn := makeTestOverload(types.Int, types.Int)
-	unaryIntFnPref := makeTestOverload(types.Int, types.Int).withPreferred(true)
+	unaryIntFnPref := makeTestOverload(types.Int, types.Int).preferred()
 	unaryFloatFn := makeTestOverload(types.Float, types.Float)
 	unaryDecimalFn := makeTestOverload(types.Decimal, types.Decimal)
 	unaryStringFn := makeTestOverload(types.String, types.String)
 	unaryIntervalFn := makeTestOverload(types.Interval, types.Interval)
 	unaryTimestampFn := makeTestOverload(types.Timestamp, types.Timestamp)
 	binaryIntFn := makeTestOverload(types.Int, types.Int, types.Int)
-	binaryIntFnPref := makeTestOverload(types.Int, types.Int, types.Int).withPreferred(true)
+	binaryIntFnPref := makeTestOverload(types.Int, types.Int, types.Int).preferred()
 	binaryFloatFn := makeTestOverload(types.Float, types.Float, types.Float)
 	binaryDecimalFn := makeTestOverload(types.Decimal, types.Decimal, types.Decimal)
 	binaryStringFn := makeTestOverload(types.String, types.String, types.String)

--- a/pkg/sql/types/oid.go
+++ b/pkg/sql/types/oid.go
@@ -57,7 +57,7 @@ var OidToType = map[oid.Oid]*T{
 	oid.T_anyelement: Any,
 	oid.T_bit:        typeBit,
 	oid.T_bool:       Bool,
-	oid.T_bpchar:     typeBpChar,
+	oid.T_bpchar:     BPChar,
 	oid.T_bytea:      Bytes,
 	oid.T_char:       QChar,
 	oid.T_date:       Date,

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -322,6 +322,14 @@ var (
 	String = &T{InternalType: InternalType{
 		Family: StringFamily, Oid: oid.T_text, Locale: &emptyLocale}}
 
+	// BPChar is a CHAR type with an unspecified width. "BP" stands for
+	// "blank padded".
+	//
+	// It is reported as BPCHAR in SHOW CREATE and "character" in introspection
+	// for compatibility with PostgreSQL.
+	BPChar = &T{InternalType: InternalType{
+		Family: StringFamily, Oid: oid.T_bpchar, Locale: &emptyLocale}}
+
 	// VarChar is equivalent to String, but has a differing OID (T_varchar),
 	// which makes it show up differently when displayed. It is reported as
 	// VARCHAR in SHOW CREATE and "character varying" in introspection for
@@ -706,15 +714,6 @@ var (
 	typeBit = &T{InternalType: InternalType{
 		Family: BitFamily, Oid: oid.T_bit, Locale: &emptyLocale}}
 
-	// typeBpChar is a CHAR type with an unspecified width. "bp" stands for
-	// "blank padded". It is not exported to avoid confusion with QChar, as well
-	// as confusion over CHAR's default width of 1.
-	//
-	// It is reported as CHAR in SHOW CREATE and "character" in introspection for
-	// compatibility with PostgreSQL.
-	typeBpChar = &T{InternalType: InternalType{
-		Family: StringFamily, Oid: oid.T_bpchar, Locale: &emptyLocale}}
-
 	// typeQChar is a "char" type with an unspecified width. It is not exported
 	// to avoid confusion with QChar. The "char" type should always have a width
 	// of one. A "char" type with an unspecified width is only used when the
@@ -922,7 +921,7 @@ func MakeVarChar(width int32) *T {
 // the given max # characters (0 = unspecified number).
 func MakeChar(width int32) *T {
 	if width == 0 {
-		return typeBpChar
+		return BPChar
 	}
 	if width < 0 {
 		panic(errors.AssertionFailedf("width %d cannot be negative", width))

--- a/pkg/sql/types/types_test.go
+++ b/pkg/sql/types/types_test.go
@@ -107,7 +107,7 @@ func TestTypes(t *testing.T) {
 		{MakeCollatedString(MakeVarChar(20), enCollate),
 			MakeScalar(CollatedStringFamily, oid.T_varchar, 0, 20, enCollate)},
 
-		{MakeCollatedString(typeBpChar, enCollate), &T{InternalType: InternalType{
+		{MakeCollatedString(BPChar, enCollate), &T{InternalType: InternalType{
 			Family: CollatedStringFamily, Oid: oid.T_bpchar, Locale: &enCollate}}},
 		{MakeCollatedString(MakeChar(20), enCollate), &T{InternalType: InternalType{
 			Family: CollatedStringFamily, Oid: oid.T_bpchar, Width: 20, Locale: &enCollate}}},
@@ -841,7 +841,7 @@ func TestUnmarshalCompat(t *testing.T) {
 		{InternalType{Family: StringFamily}, String},
 		{InternalType{Family: StringFamily, VisibleType: visibleVARCHAR}, VarChar},
 		{InternalType{Family: StringFamily, VisibleType: visibleVARCHAR, Width: 20}, MakeVarChar(20)},
-		{InternalType{Family: StringFamily, VisibleType: visibleCHAR}, typeBpChar},
+		{InternalType{Family: StringFamily, VisibleType: visibleCHAR}, BPChar},
 		{InternalType{Family: StringFamily, VisibleType: visibleQCHAR, Width: 1}, QChar},
 	}
 
@@ -1083,11 +1083,11 @@ func TestWithoutTypeModifiers(t *testing.T) {
 		{MakeVarBit(2), VarBit},
 		{MakeString(2), String},
 		{MakeVarChar(2), VarChar},
-		{MakeChar(2), typeBpChar},
+		{MakeChar(2), BPChar},
 		{QChar, typeQChar},
 		{MakeCollatedString(MakeString(2), "en"), MakeCollatedString(String, "en")},
 		{MakeCollatedString(MakeVarChar(2), "en"), MakeCollatedString(VarChar, "en")},
-		{MakeCollatedString(MakeChar(2), "en"), MakeCollatedString(typeBpChar, "en")},
+		{MakeCollatedString(MakeChar(2), "en"), MakeCollatedString(BPChar, "en")},
 		{MakeCollatedString(QChar, "en"), MakeCollatedString(typeQChar, "en")},
 		{MakeDecimal(5, 1), Decimal},
 		{MakeTime(2), Time},


### PR DESCRIPTION
Backport 4/4 commits from #133037.
Backport 1/1 commits from #135041.

/cc @cockroachdb/release

----

#### sql/types: export BPCHAR type

The `typeBpChar` type, which is a `CHAR` type with unspecific length, is
now exported as `BPChar` for future use outside of the types package.

Release note: None

#### sql/logictest: move non-regression test above regression tests

Release note: None

#### sql/sem/tree: add third level of overload preference

Overload preference can now be one of three values—preferred, none, and
unpreferred—instead of two—preferred, and not preferred. The unpreferred
value is necessary in order to allow defining additional operator
overloads with input types that are equivalent (see
`(*types.T).Equivalent`) to input types of existing overloads without
causing statements to result in "ambiguous overload" errors.

An integer is used for overload preference, which allows for defining
addition levels of preference in the future, should those be necessary.

Release note: None

#### sql/sem/tree: type unknown literals as `BPCHAR` if overload exists

String literals in binary expressions can now be typed as a `BPCHAR` if
the other input to the binary expression has type `BPCHAR` and an
overload exists specifically with the `BPCHAR` type. When the literal is
typed as a `BPCHAR`, any trailing whitespace in the literal becomes
semantically insignificant.

Fixes #132268
Informs #75101

Release note (bug fix): A bug has been fixed that caused incorrect
evaluation of some binary expressions involving `CHAR(N)` values and
untyped string literals with trailing whitespace characters. For
example, the expression `'f'::CHAR = 'f '` now correctly evaluates to
`true`.

#### randgen: fix bpchar datum generation

This commit applies the same space trimming logic as we just added in
0c57d5cb422b0bcd36a753d69244203b5a7d7253.

Release note: None

----

Release justification: Minor bug fix.