### PR TITLE
sql/importer: avoid pointless rand read for imported uuids

### DIFF
--- a/pkg/sql/row/expr_walker.go
+++ b/pkg/sql/row/expr_walker.go
@@ -274,7 +274,7 @@ func importGenUUID(
 		c.randSource = makeImportRand(c)
 	}
 	gen := c.randSource.Int63(c)
-	id := uuid.MakeV4()
+	id := uuid.UUID{}
 	id.DeterministicV4(uint64(gen), uint64(1<<63))
 	return tree.NewDUuid(tree.DUuid{UUID: id}), nil
 }


### PR DESCRIPTION
Imported UUIDs are replaced with deterministic UUIDs to enable resuming imports. Previously however, the in-memory UUID with this deterministic UUID was made by making a random UUID -- reading random numbers from system entropy -- and then replacing what it read with the deterministic numbers.

This skips the epensive and pointless init and just makes an empty struct for the deterministic numbers to be set in.

Release note: none.
Epic: none.