### PR TITLE
release-23.2: testccl: give more memory to random schema workload unit test

### DIFF
--- a/pkg/ccl/testccl/workload/schemachange/BUILD.bazel
+++ b/pkg/ccl/testccl/workload/schemachange/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
     data = [
         "//c-deps:libgeos",
     ],
+    exec_properties = {"test.Pool": "large"},
     tags = ["ccl_test"],
     deps = [
         "//pkg/base",


### PR DESCRIPTION
Backport 1/1 commits from #135636.

/cc @cockroachdb/release

---


fixes https://github.com/cockroachdb/cockroach/issues/135066
Release note: None


---

Release justification: test-only change
