### PR TITLE
kvserver: add leader leases to TestRangefeedCheckpointsRecoverFromLeaseExpiration

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -4758,13 +4758,7 @@ func TestPartialPartition(t *testing.T) {
 				require.NoError(t, tc.WaitForFullReplication())
 
 				desc := tc.LookupRangeOrFatal(t, scratchKey)
-				err := tc.TransferRangeLease(desc, tc.Target(1))
-				if leaseType != roachpb.LeaseLeader {
-					// In leader leases, the leader won't campaign if it's not supported
-					// by a majority. We will keep trying to transfer the lease until it
-					// succeeds below.
-					require.NoError(t, err)
-				}
+				tc.TransferRangeLeaseOrFatal(t, desc, tc.Target(1))
 
 				// TODO(baptist): This test should work without this block.
 				// After the lease is transferred, the lease might still be on
@@ -4778,16 +4772,6 @@ func TestPartialPartition(t *testing.T) {
 				// DistSender we will never succeed once we partition. Remove
 				// this block once #118943 is fixed.
 				testutils.SucceedsSoon(t, func() error {
-					if leaseType == roachpb.LeaseLeader {
-						// In leader leases, the leader won't campaign if it's not supported
-						// by a majority of voters. This causes a flake in this test
-						// where the new leader is not elected if it doesn't yet have
-						// support from a majority. We need to keep trying to transfer the
-						// lease until the new leader is elected.
-						if err := tc.TransferRangeLease(desc, tc.Target(1)); err != nil {
-							return err
-						}
-					}
 					sl := tc.StorageLayer(1)
 					store, err := sl.GetStores().(*kvserver.Stores).GetStore(sl.GetFirstStoreID())
 					require.NoError(t, err)
@@ -4805,7 +4789,7 @@ func TestPartialPartition(t *testing.T) {
 				// to fail faster.
 				cancelCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 				defer cancel()
-				err = txn.Put(cancelCtx, scratchKey, "abc")
+				err := txn.Put(cancelCtx, scratchKey, "abc")
 				if test.useProxy {
 					require.NoError(t, err)
 					require.NoError(t, txn.Commit(cancelCtx))

--- a/pkg/kv/kvserver/storeliveness/config.go
+++ b/pkg/kv/kvserver/storeliveness/config.go
@@ -5,7 +5,10 @@
 
 package storeliveness
 
-import "time"
+import (
+	"sync/atomic"
+	"time"
+)
 
 // Options includes all Store Liveness durations needed by the SupportManager.
 // TODO(mira): make sure these are initialized correctly as part of #125066.
@@ -50,10 +53,15 @@ type TransportKnobs struct {
 }
 
 // SupportManagerKnobs includes all knobs that facilitate testing the
-// SupportManager.
+// SupportManager. It is convenient to pass the same knobs to the entire node,
+// and distinguish which store they are intended for within the knobs. E.g.
+// TestEngine has a storeID field; DisableHeartbeats points to a store ID.
 type SupportManagerKnobs struct {
 	// TestEngine is a test engine to be used instead of a real one.
 	TestEngine *TestEngine
+	// DisableHeartbeats denotes the ID of a store whose heartbeats should be
+	// stopped. Setting DisableHeartbeats to nil will re-enable heartbeats.
+	DisableHeartbeats *atomic.Value // slpb.StoreIdent
 }
 
 // TestingKnobs is a wrapper around TransportKnobs and SupportManagerKnobs.

--- a/pkg/kv/kvserver/storeliveness/requester_state.go
+++ b/pkg/kv/kvserver/storeliveness/requester_state.go
@@ -447,10 +447,6 @@ func assert(condition bool, msg string) {
 	}
 }
 
-func supportChangeStr(
-	current slpb.SupportState, previous slpb.SupportState,
-) redact.RedactableString {
-	return redact.Sprintf(
-		"store %+v; current = %+v, previous = %+v", current.Target, current, previous,
-	)
+func supportChangeStr(ssOld slpb.SupportState, ssNew slpb.SupportState) redact.RedactableString {
+	return redact.Sprintf("store %+v; old = %+v, new = %+v", ssNew.Target, ssOld, ssNew)
 }

--- a/pkg/kv/kvserver/storeliveness/support_manager.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager.go
@@ -284,6 +284,9 @@ func (sm *SupportManager) sendHeartbeats(ctx context.Context) {
 	if !sm.SupportFromEnabled(ctx) {
 		return
 	}
+	if sm.knobs != nil && sm.knobs.DisableHeartbeats != nil && sm.knobs.DisableHeartbeats.Load() == sm.storeID {
+		return
+	}
 	rsfu := sm.requesterStateHandler.checkOutUpdate()
 	defer sm.requesterStateHandler.finishUpdate(rsfu)
 	livenessInterval := sm.options.LivenessInterval

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1376,8 +1376,10 @@ func (r *raft) hup(t CampaignType) {
 		return
 	}
 
-	// We shouldn't campaign if we don't have quorum support in store liveness.
-	if r.fortificationTracker.RequireQuorumSupportOnCampaign() &&
+	// We shouldn't campaign if we don't have quorum support in store liveness. We
+	// only make an exception if this is a leadership transfer, because otherwise
+	// the transfer might fail if the new leader doesn't already have support.
+	if t != campaignTransfer && r.fortificationTracker.RequireQuorumSupportOnCampaign() &&
 		!r.fortificationTracker.QuorumSupported() {
 		r.logger.Debugf("%x cannot campaign since it's not supported by a quorum in store liveness", r.id)
 		return

--- a/pkg/raft/testdata/transfer-leadership.txt
+++ b/pkg/raft/testdata/transfer-leadership.txt
@@ -1,0 +1,304 @@
+# Test that leadership transfers don't use PreVote and don't need store liveness
+# support to campaign.
+
+log-level none
+----
+ok
+
+add-nodes 3 voters=(1,2,3) index=10
+----
+ok
+
+# Elect 1 as leader.
+campaign 1
+----
+ok
+
+stabilize
+----
+ok
+
+log-level debug
+----
+ok
+
+raft-state
+----
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+
+# Transfer leadership to 2.
+transfer-leadership from=1 to=2
+----
+INFO 1 [term 1] starts to transfer leadership to 2
+INFO 1 sends MsgTimeoutNow to 2 immediately as 2 already has up-to-date log
+INFO 1 became follower at term 1
+
+stabilize
+----
+> 1 handling Ready
+  Ready MustSync=false:
+  State:StateFollower
+  Messages:
+  1->2 MsgTimeoutNow Term:1 Log:0/0
+> 2 receiving messages
+  1->2 MsgTimeoutNow Term:1 Log:0/0
+  INFO 2 [term 1] received MsgTimeoutNow from 1 and starts an election to get leadership
+  INFO 2 is starting a new election at term 1
+  INFO 2 became candidate at term 2
+  INFO 2 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
+  INFO 2 [logterm: 1, index: 11] sent MsgVote request to 3 at term 2
+> 2 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:2 Vote:2 Commit:11 Lead:0 LeadEpoch:0
+  Messages:
+  2->1 MsgVote Term:2 Log:1/11
+  2->3 MsgVote Term:2 Log:1/11
+  INFO 2 received MsgVoteResp from 2 at term 2
+  INFO 2 has received 1 MsgVoteResp votes and 0 vote rejections
+> 1 receiving messages
+  2->1 MsgVote Term:2 Log:1/11
+  DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
+  INFO 1 [term: 1] received a MsgVote message with higher term from 2 [term: 2], advancing term
+  INFO 1 became follower at term 2
+  INFO 1 [logterm: 1, index: 11, vote: 0] cast MsgVote for 2 [logterm: 1, index: 11] at term 2
+> 3 receiving messages
+  2->3 MsgVote Term:2 Log:1/11
+  DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
+  INFO 3 [term: 1] received a MsgVote message with higher term from 2 [term: 2], advancing term
+  INFO 3 became follower at term 2
+  INFO 3 [logterm: 1, index: 11, vote: 0] cast MsgVote for 2 [logterm: 1, index: 11] at term 2
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:2 Vote:2 Commit:11 Lead:0 LeadEpoch:0
+  Messages:
+  1->2 MsgVoteResp Term:2 Log:0/0
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:2 Vote:2 Commit:11 Lead:0 LeadEpoch:0
+  Messages:
+  3->2 MsgVoteResp Term:2 Log:0/0
+> 2 receiving messages
+  1->2 MsgVoteResp Term:2 Log:0/0
+  INFO 2 received MsgVoteResp from 1 at term 2
+  INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
+  INFO 2 became leader at term 2
+  3->2 MsgVoteResp Term:2 Log:0/0
+> 2 handling Ready
+  Ready MustSync=true:
+  State:StateLeader
+  HardState Term:2 Vote:2 Commit:11 Lead:2 LeadEpoch:1
+  Entries:
+  2/12 EntryNormal ""
+  Messages:
+  2->1 MsgFortifyLeader Term:2 Log:0/0
+  2->3 MsgFortifyLeader Term:2 Log:0/0
+  2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
+  2->3 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
+> 1 receiving messages
+  2->1 MsgFortifyLeader Term:2 Log:0/0
+  2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
+> 3 receiving messages
+  2->3 MsgFortifyLeader Term:2 Log:0/0
+  2->3 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:2 Vote:2 Commit:11 Lead:2 LeadEpoch:1
+  Entries:
+  2/12 EntryNormal ""
+  Messages:
+  1->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
+  1->2 MsgAppResp Term:2 Log:0/12 Commit:11
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:2 Vote:2 Commit:11 Lead:2 LeadEpoch:1
+  Entries:
+  2/12 EntryNormal ""
+  Messages:
+  3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
+  3->2 MsgAppResp Term:2 Log:0/12 Commit:11
+> 2 receiving messages
+  1->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
+  1->2 MsgAppResp Term:2 Log:0/12 Commit:11
+  3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
+  3->2 MsgAppResp Term:2 Log:0/12 Commit:11
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:2 Vote:2 Commit:12 Lead:2 LeadEpoch:1
+  CommittedEntries:
+  2/12 EntryNormal ""
+  Messages:
+  2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
+  2->1 MsgApp Term:2 Log:2/12 Commit:12
+  2->3 MsgApp Term:2 Log:1/11 Commit:12 Entries:[2/12 EntryNormal ""]
+  2->3 MsgApp Term:2 Log:2/12 Commit:12
+> 1 receiving messages
+  2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
+  2->1 MsgApp Term:2 Log:2/12 Commit:12
+> 3 receiving messages
+  2->3 MsgApp Term:2 Log:1/11 Commit:12 Entries:[2/12 EntryNormal ""]
+  2->3 MsgApp Term:2 Log:2/12 Commit:12
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:2 Vote:2 Commit:12 Lead:2 LeadEpoch:1
+  CommittedEntries:
+  2/12 EntryNormal ""
+  Messages:
+  1->2 MsgAppResp Term:2 Log:0/12 Commit:11
+  1->2 MsgAppResp Term:2 Log:0/12 Commit:12
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:2 Vote:2 Commit:12 Lead:2 LeadEpoch:1
+  CommittedEntries:
+  2/12 EntryNormal ""
+  Messages:
+  3->2 MsgAppResp Term:2 Log:0/12 Commit:12
+  3->2 MsgAppResp Term:2 Log:0/12 Commit:12
+> 2 receiving messages
+  1->2 MsgAppResp Term:2 Log:0/12 Commit:11
+  1->2 MsgAppResp Term:2 Log:0/12 Commit:12
+  3->2 MsgAppResp Term:2 Log:0/12 Commit:12
+  3->2 MsgAppResp Term:2 Log:0/12 Commit:12
+
+# Withdraw support for 3 and transfer leadership to it.
+withdraw-support 1 3
+----
+  1 2 3
+1 1 1 x
+2 1 1 1
+3 1 1 1
+
+withdraw-support 2 3
+----
+  1 2 3
+1 1 1 x
+2 1 1 x
+3 1 1 1
+
+# 3 should fail to campaign.
+campaign 3
+----
+DEBUG 3 ignoring MsgHup due to leader fortification
+
+stabilize
+----
+ok
+
+transfer-leadership from=2 to=3
+----
+INFO 2 [term 2] starts to transfer leadership to 3
+INFO 2 sends MsgTimeoutNow to 3 immediately as 3 already has up-to-date log
+INFO 2 became follower at term 2
+
+stabilize
+----
+> 2 handling Ready
+  Ready MustSync=false:
+  State:StateFollower
+  Messages:
+  2->3 MsgTimeoutNow Term:2 Log:0/0
+> 3 receiving messages
+  2->3 MsgTimeoutNow Term:2 Log:0/0
+  INFO 3 [term 2] received MsgTimeoutNow from 2 and starts an election to get leadership
+  INFO 3 is starting a new election at term 2
+  INFO 3 became candidate at term 3
+  INFO 3 [logterm: 2, index: 12] sent MsgVote request to 1 at term 3
+  INFO 3 [logterm: 2, index: 12] sent MsgVote request to 2 at term 3
+> 3 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:3 Vote:3 Commit:12 Lead:0 LeadEpoch:0
+  Messages:
+  3->1 MsgVote Term:3 Log:2/12
+  3->2 MsgVote Term:3 Log:2/12
+  INFO 3 received MsgVoteResp from 3 at term 3
+  INFO 3 has received 1 MsgVoteResp votes and 0 vote rejections
+> 1 receiving messages
+  3->1 MsgVote Term:3 Log:2/12
+  DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
+  INFO 1 [term: 2] received a MsgVote message with higher term from 3 [term: 3], advancing term
+  INFO 1 became follower at term 3
+  INFO 1 [logterm: 2, index: 12, vote: 0] cast MsgVote for 3 [logterm: 2, index: 12] at term 3
+> 2 receiving messages
+  3->2 MsgVote Term:3 Log:2/12
+  DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
+  INFO 2 [term: 2] received a MsgVote message with higher term from 3 [term: 3], advancing term
+  INFO 2 became follower at term 3
+  INFO 2 [logterm: 2, index: 12, vote: 0] cast MsgVote for 3 [logterm: 2, index: 12] at term 3
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:3 Vote:3 Commit:12 Lead:0 LeadEpoch:0
+  Messages:
+  1->3 MsgVoteResp Term:3 Log:0/0
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:3 Vote:3 Commit:12 Lead:0 LeadEpoch:0
+  Messages:
+  2->3 MsgVoteResp Term:3 Log:0/0
+> 3 receiving messages
+  1->3 MsgVoteResp Term:3 Log:0/0
+  INFO 3 received MsgVoteResp from 1 at term 3
+  INFO 3 has received 2 MsgVoteResp votes and 0 vote rejections
+  INFO 3 became leader at term 3
+  2->3 MsgVoteResp Term:3 Log:0/0
+> 3 handling Ready
+  Ready MustSync=true:
+  State:StateLeader
+  HardState Term:3 Vote:3 Commit:12 Lead:3 LeadEpoch:1
+  Entries:
+  3/13 EntryNormal ""
+  Messages:
+  3->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
+  3->2 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
+> 1 receiving messages
+  3->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
+> 2 receiving messages
+  3->2 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:3 Vote:3 Commit:12 Lead:3 LeadEpoch:0
+  Entries:
+  3/13 EntryNormal ""
+  Messages:
+  1->3 MsgAppResp Term:3 Log:0/13 Commit:12
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:3 Vote:3 Commit:12 Lead:3 LeadEpoch:0
+  Entries:
+  3/13 EntryNormal ""
+  Messages:
+  2->3 MsgAppResp Term:3 Log:0/13 Commit:12
+> 3 receiving messages
+  1->3 MsgAppResp Term:3 Log:0/13 Commit:12
+  2->3 MsgAppResp Term:3 Log:0/13 Commit:12
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:3 Vote:3 Commit:13 Lead:3 LeadEpoch:1
+  CommittedEntries:
+  3/13 EntryNormal ""
+  Messages:
+  3->1 MsgApp Term:3 Log:3/13 Commit:13
+  3->2 MsgApp Term:3 Log:3/13 Commit:13
+> 1 receiving messages
+  3->1 MsgApp Term:3 Log:3/13 Commit:13
+> 2 receiving messages
+  3->2 MsgApp Term:3 Log:3/13 Commit:13
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:3 Vote:3 Commit:13 Lead:3 LeadEpoch:0
+  CommittedEntries:
+  3/13 EntryNormal ""
+  Messages:
+  1->3 MsgAppResp Term:3 Log:0/13 Commit:13
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:3 Vote:3 Commit:13 Lead:3 LeadEpoch:0
+  CommittedEntries:
+  3/13 EntryNormal ""
+  Messages:
+  2->3 MsgAppResp Term:3 Log:0/13 Commit:13
+> 3 receiving messages
+  1->3 MsgAppResp Term:3 Log:0/13 Commit:13
+  2->3 MsgAppResp Term:3 Log:0/13 Commit:13


### PR DESCRIPTION
Previously, the test assumed epoch leases and had some special logic around manipulating node liveness to expire the lease.

This commit extends the test to leader leases. In order to expire the leader lease, the test manipulates the store liveness heartbeating.

Part of: [#133763](https://github.com/cockroachdb/cockroach/issues/133763)

Release note: None

----

The PR also includes changes to store liveness and Raft to power this test.