### PR TITLE
ccl/schemachangerccl: deflake TestBackupSuccess

### DIFF
--- a/pkg/sql/schemachanger/sctest/framework.go
+++ b/pkg/sql/schemachanger/sctest/framework.go
@@ -949,7 +949,7 @@ func waitForSchemaChangesToFinish(t *testing.T, tdb *sqlutils.SQLRunner) {
 
 func hasLatestSchemaChangeSucceeded(t *testing.T, tdb *sqlutils.SQLRunner) bool {
 	result := tdb.QueryStr(t, fmt.Sprintf(
-		`SELECT status FROM [SHOW JOBS] WHERE job_type IN ('%s') ORDER BY finished DESC LIMIT 1`,
+		`SELECT status FROM [SHOW JOBS] WHERE job_type IN ('%s') ORDER BY finished DESC, job_id DESC LIMIT 1`,
 		jobspb.TypeNewSchemaChange,
 	))
 	return result[0][0] == "succeeded"


### PR DESCRIPTION
Previously, the backup and restore tests for the declarative schema changer could flake because the latest completed schema job could not be sufficiently determined by the finish_time. This was because this time only has resolution of seconds at most, so multiple jobs could have the same finish time. To address this, this patch also sorts the jobs by job_id as well, which should be increasing for later jobs.

Fixes: #131583

Release note: None