### PR TITLE
catalog: add error condition tests to ScanDescriptorsInSpan

### DIFF
--- a/pkg/sql/catalog/internal/catkv/testdata/testdata_app
+++ b/pkg/sql/catalog/internal/catkv/testdata/testdata_app
@@ -754,3 +754,17 @@ catalog:
 trace:
 - Scan Range /Table/3/1/110/2/1 /Table/3/1/111/2/1
 - Scan Range /Table/3/1/111/2/1 /Table/3/1/112/2/1
+
+# verify that passing a zero length span returns nothing
+scan_descriptors_in_span start=111/1 end=111/1
+----
+catalog: {}
+trace: []
+
+# verify that passing a negative length span throws an error
+scan_descriptors_in_span start=112/1 end=111/1
+----
+catalog: {}
+error: 'failed to verify keys for Scan: end key /Tenant/10/Table/3/1/111/2/1 must be greater than start /Tenant/10/Table/3/1/112/2/1'
+trace:
+- Scan Range /Table/3/1/112/2/1 /Table/3/1/111/2/1

--- a/pkg/sql/catalog/internal/catkv/testdata/testdata_system
+++ b/pkg/sql/catalog/internal/catkv/testdata/testdata_system
@@ -772,3 +772,17 @@ catalog:
 trace:
 - Scan Range /Table/3/1/110/2/1 /Table/3/1/111/2/1
 - Scan Range /Table/3/1/111/2/1 /Table/3/1/112/2/1
+
+# verify that passing a zero length span returns nothing
+scan_descriptors_in_span start=111/1 end=111/1
+----
+catalog: {}
+trace: []
+
+# verify that passing a negative length span throws an error
+scan_descriptors_in_span start=112/1 end=111/1
+----
+catalog: {}
+error: 'failed to verify keys for Scan: end key /Table/3/1/111/2/1 must be greater than start /Table/3/1/112/2/1'
+trace:
+- Scan Range /Table/3/1/112/2/1 /Table/3/1/111/2/1


### PR DESCRIPTION
catalog: add error condition tests to ScanDescriptorsInSpan

Earlier, in #133190, we had added the functionality to scan descriptors for a set of specified spans. This change included data driven tests in which a variety of spans could be passed in for checking. Because of how the test framework was prepared, tests to check error conditions weren't added at the time.

This PR addresses this gap by testing zero and negative-length spans for errors or empty responses in the `catalog_reader_test` data driven tests.

Fixes: CRDB-43984
Epic: CRDB-43151

Release note: None