### PR TITLE
cloud/azure: fix cloud unit test

### DIFF
--- a/pkg/cloud/azure/azure_file_credentials_test.go
+++ b/pkg/cloud/azure/azure_file_credentials_test.go
@@ -124,7 +124,7 @@ func TestAzureFileCredential(t *testing.T) {
 		defaultCreds, err := azidentity.NewDefaultAzureCredential(nil)
 		require.NoError(t, err)
 
-		require.ErrorContains(t, verifyCredentialsAccess(defaultCreds), "DefaultAzureCredential: failed to acquire a token")
+		require.ErrorContains(t, verifyCredentialsAccess(defaultCreds), "DefaultAzureCredential authentication failed. failed to acquire a token")
 
 		require.NoError(t, writeAzureCredentialsFile(credFile, cfg.tenantID, cfg.clientID, cfg.clientSecret))
 


### PR DESCRIPTION
Language is different after SDK upgrade.

[Teamcity run](https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Nightlies_CloudUnitTests/17841345?hideProblemsFromDependencies=false&hideTestsFromDependencies=false)

Fixes: #135661
Release note: None