### PR TITLE
sql/schemachanger: Correct version gate for ALTER COLUMN TYPE

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -939,7 +939,7 @@ ALTER TABLE t_bytes ALTER COLUMN c1 SET DATA TYPE STRING;
 # When the above alter is done in the legacy schema changer, the column is
 # rewritten, but with different result. The correct one is from the
 # declarative schema changer. So we skip when running the legacy schema changer.
-skipif config local-legacy-schema-changer
+skipif config local-legacy-schema-changer local-mixed-24.2
 query T
 SELECT c1 FROM t_bytes ORDER BY c1;
 ----
@@ -949,7 +949,7 @@ hello
 # The legacy schema changer doesn't properly handle this case. It will actually
 # allow it, which is wrong. So we expect success for legacy, but correctly fail
 # for dsc.
-skipif config local-legacy-schema-changer
+skipif config local-legacy-schema-changer local-mixed-24.2
 statement error pq: validation of CHECK ".*" failed on row.*
 ALTER TABLE t_bytes ALTER COLUMN c2 SET DATA TYPE CHAR(4);
 
@@ -980,7 +980,7 @@ ALTER TABLE t_bytes ALTER COLUMN c3 SET DATA TYPE UUID USING c3::UUID;
 # The alter of C2 will produce different output depending on the schema changer.
 # The output for the the dsc is correct, but wrong for legacy. So, skipping if
 # legacy.
-skipif config local-legacy-schema-changer
+skipif config local-legacy-schema-changer local-mixed-24.2
 query TT
 SELECT c2,c3 FROM t_bytes ORDER BY c1;
 ----
@@ -1094,14 +1094,14 @@ SELECT c1,c2,c3,c4,c5 FROM t_bit_string ORDER BY pk;
 NULL  NULL  NULL   NULL   NULL
 
 # Skip for the legacy schema changer as it doesn't allow multiple alters in one statement.
-skipif config local-legacy-schema-changer
+skipif config local-legacy-schema-changer local-mixed-24.2
 statement error pq: validation of CHECK ".*" failed on row.*
 ALTER TABLE t_bit_string ALTER COLUMN c1 SET DATA TYPE BIT(4), ALTER COLUMN c2 SET DATA TYPE VARBIT(4);
 
 statement ok
 UPDATE t_bit_string SET C2=B'1010' WHERE pk = 1;
 
-skipif config local-legacy-schema-changer
+skipif config local-legacy-schema-changer local-mixed-24.2
 statement ok
 ALTER TABLE t_bit_string ALTER COLUMN c1 SET DATA TYPE VARBIT(8), ALTER COLUMN c2 SET DATA TYPE VARBIT(4);
 
@@ -1133,7 +1133,7 @@ ALTER TABLE t_bit_string ALTER COLUMN c3 SET DATA TYPE BYTES USING C3::BYTES;
 
 # Skipping this for legacy since it allows the data type conversion when it
 # shouldn't be allowed.
-skipif config local-legacy-schema-changer
+skipif config local-legacy-schema-changer local-mixed-24.2
 statement error pq: validation of CHECK ".*" failed on row.*
 ALTER TABLE t_bit_string ALTER COLUMN c4 SET DATA TYPE CHAR(4);
 
@@ -1157,7 +1157,7 @@ NULL  NULL  NULL   NULL   NULL
 
 # Change c5 from VARCHAR(30) to CHAR(6). This is erroneously allowed in the
 # legacy schema changer so skipping in that mode.
-skipif config local-legacy-schema-changer
+skipif config local-legacy-schema-changer local-mixed-24.2
 statement error pq: validation of CHECK ".*" failed on row.*
 ALTER TABLE t_bit_string ALTER COLUMN c5 SET DATA TYPE CHAR(6);
 
@@ -1389,7 +1389,7 @@ SELECT * FROM stored1 ORDER BY A;
 statement ok
 INSERT INTO stored1 VALUES (2147483648),(2147483647);
 
-skipif config local-legacy-schema-changer local-mixed-24.1
+skipif config local-legacy-schema-changer local-mixed-24.1 local-mixed-24.2
 statement error pq: validate check constraint: integer out of range for type int4
 ALTER TABLE stored1 ALTER COLUMN COMP1 SET DATA TYPE INT4;
 
@@ -1401,11 +1401,11 @@ ALTER TABLE stored1 ALTER COLUMN COMP1 SET DATA TYPE INT4;
 statement ok
 DELETE FROM stored1 WHERE a = 2147483648;
 
-skipif config local-legacy-schema-changer local-mixed-24.1
+skipif config local-legacy-schema-changer local-mixed-24.1 local-mixed-24.2
 statement ok
 ALTER TABLE stored1 ALTER COLUMN COMP1 SET DATA TYPE INT4;
 
-skipif config local-legacy-schema-changer local-mixed-24.1
+skipif config local-legacy-schema-changer local-mixed-24.1 local-mixed-24.2
 query TT
 SHOW CREATE TABLE stored1;
 ----

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1013,7 +1013,7 @@ CREATE TABLE enum_data_type (x STRING, y INT);
 INSERT INTO enum_data_type VALUES ('hello'), ('howdy');
 
 # The legacy schema changed doesn't hydrate the type name in the message.
-skipif config local-legacy-schema-changer
+skipif config local-legacy-schema-changer local-mixed-24.2
 statement error pq: column "y" cannot be cast automatically to type public.greeting\nHINT: You might need to specify "USING y::public.greeting".
 ALTER TABLE enum_data_type ALTER COLUMN y SET DATA TYPE greeting;
 
@@ -1021,7 +1021,7 @@ statement error pq: invalid cast: int -> greeting
 ALTER TABLE enum_data_type ALTER COLUMN y SET DATA TYPE greeting USING y::greeting;
 
 # The legacy schema changed doesn't hydrate the type name in the message.
-skipif config local-legacy-schema-changer
+skipif config local-legacy-schema-changer local-mixed-24.2
 statement error pq: column "x" cannot be cast automatically to type public.greeting\nHINT: You might need to specify "USING x::public.greeting".
 ALTER TABLE enum_data_type ALTER COLUMN x SET DATA TYPE greeting;
 

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -4233,7 +4233,7 @@ NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 NOTICE: type of foreign key column "t1_fk_col1" (CHAR(8)) is not identical to referenced column "t1_fk"."col1" (CHAR(7))
 
 # Test trivial data type change
-skipif config local-legacy-schema-changer
+skipif config local-legacy-schema-changer local-mixed-24.2
 skipif config weak-iso-level-configs
 query T noticetrace
 ALTER TABLE t2_fk ALTER COLUMN t1_fk_col2 SET DATA TYPE INT8
@@ -4248,7 +4248,7 @@ NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 NOTICE: type of foreign key column "t1_fk_col2" (INT8) is not identical to referenced column "t1_fk"."col2" (INT4)
 
 # Test validation data type change
-skipif config local-legacy-schema-changer weak-iso-level-configs
+skipif config local-legacy-schema-changer weak-iso-level-configs local-mixed-24.2
 query T noticetrace
 ALTER TABLE t2_fk ALTER COLUMN t1_fk_col1 SET DATA TYPE CHAR(5)
 ----
@@ -4262,7 +4262,7 @@ NOTICE: setting transaction isolation level to SERIALIZABLE due to schema change
 NOTICE: type of foreign key column "t1_fk_col1" (CHAR(5)) is not identical to referenced column "t1_fk"."col1" (CHAR(7))
 
 
-skipif config local-legacy-schema-changer
+skipif config local-legacy-schema-changer local-mixed-24.2
 query TT
 SHOW CREATE TABLE t2_fk
 ----

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
@@ -38,7 +38,7 @@ var supportedAlterTableStatements = map[reflect.Type]supportedAlterTableCommand{
 	reflect.TypeOf((*tree.AlterTableDropConstraint)(nil)):     {fn: alterTableDropConstraint, on: true, checks: nil},
 	reflect.TypeOf((*tree.AlterTableValidateConstraint)(nil)): {fn: alterTableValidateConstraint, on: true, checks: nil},
 	reflect.TypeOf((*tree.AlterTableSetDefault)(nil)):         {fn: alterTableSetDefault, on: true, checks: nil},
-	reflect.TypeOf((*tree.AlterTableAlterColumnType)(nil)):    {fn: alterTableAlterColumnType, on: true, checks: isV242Active},
+	reflect.TypeOf((*tree.AlterTableAlterColumnType)(nil)):    {fn: alterTableAlterColumnType, on: true, checks: isV243Active},
 }
 
 func init() {


### PR DESCRIPTION
Previously, a version gate of 24.2 was applied to certain ALTER COLUMN TYPE operations. For trivial or validation-only changes, support for ALTER COLUMN TYPE in the declarative schema changer was added in PRs
 #126143 and #127823. However, the wrong version gate was used; these
changes were first introduced in version 24.3.0. This update corrects the version gate to reflect that.

Epic: CRDB-25314
Closes #132523
Release note: none