### PR TITLE
roachtest: export openmetrics from tpccbench

### DIFF
--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -337,6 +337,7 @@ func registerBackup(r registry.Registry) {
 			dest := importBankData(ctx, rows, t, c)
 			exporter := roachtestutil.CreateWorkloadHistogramExporter(t, c)
 			tick, perfBuf := initBulkJobPerfArtifacts(2*time.Hour, t, exporter)
+			defer roachtestutil.CloseExporter(ctx, exporter, t, c, perfBuf, c.Node(1), "")
 
 			m := c.NewMonitor(ctx)
 			m.Go(func(ctx context.Context) error {
@@ -356,10 +357,6 @@ func registerBackup(r registry.Registry) {
 					return err
 				}
 				tick()
-
-				if _, err := roachtestutil.CreateStatsFileInClusterFromExporter(ctx, t, c, perfBuf, exporter, c.Node(1)); err != nil {
-					return err
-				}
 				return nil
 			})
 			m.Wait()

--- a/pkg/cmd/roachtest/tests/cdc_bench.go
+++ b/pkg/cmd/roachtest/tests/cdc_bench.go
@@ -654,6 +654,8 @@ func writeCDCBenchStats(
 	writer := io.Writer(bytesBuf)
 
 	exporter.Init(&writer)
+	defer roachtestutil.CloseExporter(ctx, exporter, t, c, bytesBuf, node, "")
+
 	var err error
 	reg.GetHandle().Get(metric).Record(valueS)
 	reg.Tick(func(tick histogram.Tick) {
@@ -663,8 +665,5 @@ func writeCDCBenchStats(
 		return err
 	}
 
-	if _, err = roachtestutil.CreateStatsFileInClusterFromExporter(ctx, t, c, bytesBuf, exporter, node); err != nil {
-		return err
-	}
 	return nil
 }

--- a/pkg/cmd/roachtest/tests/perturbation/framework.go
+++ b/pkg/cmd/roachtest/tests/perturbation/framework.go
@@ -857,6 +857,7 @@ func (v variations) writePerfArtifacts(
 	bytesBuf := bytes.NewBuffer([]byte{})
 	writer := io.Writer(bytesBuf)
 	exporter.Init(&writer)
+	defer roachtestutil.CloseExporter(ctx, exporter, t, c, bytesBuf, v.Node(1), "")
 
 	reg.GetHandle().Get("baseline").Record(baseline["write"].score)
 	reg.GetHandle().Get("perturbation").Record(perturbation["write"].score)
@@ -867,11 +868,6 @@ func (v variations) writePerfArtifacts(
 		err = tick.Exporter.SnapshotAndWrite(tick.Hist, tick.Now, tick.Elapsed, &tick.Name)
 	})
 	if err != nil {
-		return err
-	}
-
-	node := v.Node(1)
-	if _, err := roachtestutil.CreateStatsFileInClusterFromExporter(ctx, t, c, bytesBuf, exporter, node); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -1133,6 +1133,7 @@ func exportToRoachperf(
 	writer := io.Writer(bytesBuf)
 
 	exporter.Init(&writer)
+	defer roachtestutil.CloseExporter(ctx, exporter, t, c, bytesBuf, c.Node(1), "")
 	var err error
 	// Ensure the histogram contains the name of the roachtest
 	reg.GetHandle().Get(testName)
@@ -1143,10 +1144,6 @@ func exportToRoachperf(
 	})
 
 	if err != nil {
-		return
-	}
-	if _, err = roachtestutil.CreateStatsFileInClusterFromExporter(ctx, t, c, bytesBuf, exporter, c.Node(1)); err != nil {
-		t.L().Errorf("error creating stats file: %s", err)
 		return
 	}
 }

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -6,9 +6,11 @@
 package tests
 
 import (
+	"bytes"
 	"context"
 	gosql "database/sql"
 	"fmt"
+	"io"
 	"maps"
 	"math"
 	"math/rand"
@@ -33,9 +35,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram/exporter"
 	"github.com/cockroachdb/cockroach/pkg/workload/tpcc"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/ttycolor"
+	"github.com/codahale/hdrhistogram"
 	"github.com/lib/pq"
 	promapi "github.com/prometheus/client_golang/api"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -1716,9 +1720,36 @@ func runTPCCBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpccBen
 					t.Fatal(err)
 				}
 				result := tpcc.NewResultWithSnapshots(warehouses, 0, snapshots)
+
+				// This roachtest uses the stats.json emitted from hdr histogram to compute Tpmc and show it in the run log
+				// Since directly emitting openmetrics and computing Tpmc from it is not supported, it is better to convert the
+				// stats.json emitted to openmetrics in the test itself and upload it to the cluster
+				if t.ExportOpenmetrics() {
+					// Creating a prefix
+					statsFilePrefix := fmt.Sprintf("warehouses=%d/", warehouses)
+
+					// Create buffer for performance metrics
+					perfBuf := bytes.NewBuffer([]byte{})
+					exporter := roachtestutil.CreateWorkloadHistogramExporterWithLabels(t, c, map[string]string{"warehouses": fmt.Sprintf("%d", warehouses)})
+					writer := io.Writer(perfBuf)
+					exporter.Init(&writer)
+					defer func() {
+						if err := exporter.Close(func() error {
+							if _, err = roachtestutil.CreateStatsFileInClusterFromExporterWithPrefix(ctx, t, c, perfBuf, exporter, group.LoadNodes, statsFilePrefix); err != nil {
+								return err
+							}
+							return nil
+						}); err != nil {
+							t.Errorf("failed to close exporter: %v", err)
+						}
+					}()
+
+					if err := exportOpenMetrics(exporter, snapshots); err != nil {
+						return errors.Wrapf(err, "error converting histogram to openmetrics")
+					}
+				}
 				resultChan <- result
 				return nil
-
 			})
 		}
 		failErr := m.WaitE()
@@ -1865,4 +1896,20 @@ func getTpccLabels(
 	}
 
 	return labels
+}
+
+// This function converts exporter.SnapshotTick to openmetrics into a buffer
+func exportOpenMetrics(
+	exporter exporter.Exporter, snapshots map[string][]exporter.SnapshotTick
+) error {
+	for _, snaps := range snapshots {
+		for _, s := range snaps {
+			h := hdrhistogram.Import(s.Hist)
+			if err := exporter.SnapshotAndWrite(h, s.Now, s.Elapsed, &s.Name); err != nil {
+				return errors.Wrapf(err, "failed to write snapshot for histogram %q", s.Name)
+			}
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
This change adds capability to emit openmetrics in `tpccbench`. The tests calculate tpmc in its result calculation using hdrhistogram json. Therefore, tpccbench will emit hdr json from workload binary and then themselves convert them into openmetrics in the test itself.

This change also aims to refactor `exporter.Close()` from
`CreateStatsFileFromExporter` to a each roachtest and use defer to make
the code more clean and easy to understand.


Epic: none

Release note: None