### PR TITLE
logictest: rework default config sets

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -134,11 +134,11 @@ import (
 // The directive also supports blocklists, i.e. running all specified
 // configurations apart from a blocklisted configuration:
 //
-//   # LogicTest: default-configs !3node-tenant
+//   # LogicTest: enterprise-configs !3node-tenant
 //
 // If a blocklist is specified without an accompanying configuration, the
-// default config is assumed. i.e., the following directive is equivalent to the
-// one above:
+// default config is assumed. i.e., the following directive uses all default
+// configurations except 3node-tenant:
 //
 //   # LogicTest: !3node-tenant
 //

--- a/pkg/sql/logictest/logictestbase/logictestbase.go
+++ b/pkg/sql/logictest/logictestbase/logictestbase.go
@@ -524,11 +524,21 @@ var LogicTestConfigs = []TestClusterConfig{
 // ConfigIdx is an index in the above slice.
 type ConfigIdx int
 
+func (idx ConfigIdx) Name() string {
+	return LogicTestConfigs[idx].Name
+}
+
 // ConfigSet is a collection of configurations.
 type ConfigSet []ConfigIdx
 
-// ConfigIdxToName is a map of ConfigIdx to the corresponding configuration name.
-var ConfigIdxToName = make(map[ConfigIdx]string)
+// ConfigNames returns the configuration names in the set.
+func (cs ConfigSet) ConfigNames() []string {
+	res := make([]string, len(cs))
+	for i, idx := range cs {
+		res[i] = idx.Name()
+	}
+	return res
+}
 
 // LineScanner handles reading from input test files.
 type LineScanner struct {
@@ -575,11 +585,18 @@ func (l *LineScanner) Text() string {
 	return l.Scanner.Text()
 }
 
-var (
-	// DefaultConfigName is a special alias for the default configs.
-	DefaultConfigName = "default-configs"
-	// DefaultConfigNames is the list of default configs captured by the DefaultConfigName.
-	DefaultConfigNames = []string{
+// DefaultConfigSet is an alias for the set of default configs.
+const DefaultConfigSet = "default-configs"
+
+// DefaultConfigSets are sets of configs that have an alias which can be used
+// instead of specific config names.
+//
+// Config sets allow referring to multiple configs more conveniently, and allow
+// updating some of these lists without changing the test files.
+var DefaultConfigSets = map[string]ConfigSet{
+	// Default configs which are used when a logictest file doesn't specify any
+	// specific configs.
+	DefaultConfigSet: makeConfigSet(
 		"local",
 		"local-legacy-schema-changer",
 		"local-vec-off",
@@ -590,51 +607,35 @@ var (
 		"fakedist-disk",
 		"local-mixed-24.2",
 		"local-mixed-24.3",
-	}
-	// FiveNodeDefaultConfigName is a special alias for all 5 node configs.
-	FiveNodeDefaultConfigName = "5node-default-configs"
-	// FiveNodeDefaultConfigNames is the list of 5 node configs.
-	FiveNodeDefaultConfigNames = []string{
+	),
+
+	// Special alias for all 5 node configs.
+	"5node-default-configs": makeConfigSet(
 		"5node",
 		"5node-disk",
-	}
-	// ThreeNodeTenantDefaultConfigName is a special alias for all 3-node tenant
-	// configs.
-	ThreeNodeTenantDefaultConfigName = "3node-tenant-default-configs"
-	// ThreeNodeTenantDefaultConfigNames is the list of 3 node tenant configs.
-	ThreeNodeTenantDefaultConfigNames = []string{
+	),
+
+	// Special alias for all 3-node tenant configs.
+	"3node-tenant-default-configs": makeConfigSet(
 		"3node-tenant",
 		"3node-tenant-multiregion",
-	}
-	// EnterpriseConfigName is a special alias for all enterprise configs.
-	EnterpriseConfigName = "enterprise-configs"
-	// EnterpriseConfigNames is the list of all enterprise configs.
-	EnterpriseConfigNames = []string{
+	),
+
+	// Special alias for all enterprise configs.
+	"enterprise-configs": makeConfigSet(
 		"3node-tenant",
 		"3node-tenant-multiregion",
 		"local-read-committed",
 		"local-repeatable-read",
-	}
-	// WeakIsoLevelConfigName is a special alias for all configs which default to
-	// a weak transaction isolation level.
-	WeakIsoLevelConfigName = "weak-iso-level-configs"
-	// WeakIsoLevelConfigNames is the list of all weak transaction isolation level
-	// configs.
-	WeakIsoLevelConfigNames = []string{
+	),
+
+	// Special alias for all configs which default to a weak transaction isolation
+	// level.
+	"weak-iso-level-configs": makeConfigSet(
 		"local-read-committed",
 		"local-repeatable-read",
-	}
-	// DefaultConfig is the default test configuration.
-	DefaultConfig = parseTestConfig(DefaultConfigNames)
-	// FiveNodeDefaultConfig is the five-node default test configuration.
-	FiveNodeDefaultConfig = parseTestConfig(FiveNodeDefaultConfigNames)
-	// ThreeNodeTenantDefaultConfig is the three-node tenant default test configuration.
-	ThreeNodeTenantDefaultConfig = parseTestConfig(ThreeNodeTenantDefaultConfigNames)
-	// EnterpriseConfig is the enterprise test configuration.
-	EnterpriseConfig = parseTestConfig(EnterpriseConfigNames)
-	// WeakIsoLevelConfig is the weak transaction isolation level test configuration.
-	WeakIsoLevelConfig = parseTestConfig(WeakIsoLevelConfigNames)
-)
+	),
+}
 
 // logger is an interface implemented by testing.TB as well as stdlogger below.
 type logger interface {
@@ -814,20 +815,11 @@ func processConfigs(
 
 		idx, ok := findLogicTestConfig(configName)
 		if !ok {
-			switch configName {
-			case DefaultConfigName:
-				configs = append(configs, applyBlocklistToConfigs(defaults, blocklist)...)
-			case FiveNodeDefaultConfigName:
-				configs = append(configs, applyBlocklistToConfigs(FiveNodeDefaultConfig, blocklist)...)
-			case ThreeNodeTenantDefaultConfigName:
-				configs = append(configs, applyBlocklistToConfigs(ThreeNodeTenantDefaultConfig, blocklist)...)
-			case EnterpriseConfigName:
-				configs = append(configs, applyBlocklistToConfigs(EnterpriseConfig, blocklist)...)
-			case WeakIsoLevelConfigName:
-				configs = append(configs, applyBlocklistToConfigs(WeakIsoLevelConfig, blocklist)...)
-			default:
+			configSet, ok := DefaultConfigSets[configName]
+			if !ok {
 				t.Fatalf("%s: unknown config name %s", path, configName)
 			}
+			configs = append(configs, applyBlocklistToConfigs(configSet, blocklist)...)
 		} else {
 			configs = append(configs, idx)
 		}
@@ -844,7 +836,7 @@ func applyBlocklistToConfigs(configs ConfigSet, blocklist map[string]int) Config
 	}
 	var newConfigs ConfigSet
 	for _, idx := range configs {
-		if _, ok := blocklist[ConfigIdxToName[idx]]; ok {
+		if _, ok := blocklist[idx.Name()]; ok {
 			continue
 		}
 		newConfigs = append(newConfigs, idx)
@@ -852,7 +844,7 @@ func applyBlocklistToConfigs(configs ConfigSet, blocklist map[string]int) Config
 	return newConfigs
 }
 
-func parseTestConfig(names []string) ConfigSet {
+func makeConfigSet(names ...string) ConfigSet {
 	ret := make(ConfigSet, len(names))
 	for i, name := range names {
 		idx, ok := findLogicTestConfig(name)
@@ -873,12 +865,6 @@ func findLogicTestConfig(name string) (ConfigIdx, bool) {
 	return -1, false
 }
 
-func init() {
-	for i, cfg := range LogicTestConfigs {
-		ConfigIdxToName[ConfigIdx(i)] = cfg.Name
-	}
-}
-
 // ConfigIsInDefaultList returns true if defaultName is one of the default
 // config lists and configName is a config included in that list.
 func ConfigIsInDefaultList(configName, defaultName string) bool {
@@ -891,19 +877,7 @@ func ConfigIsInDefaultList(configName, defaultName string) bool {
 }
 
 func getDefaultConfigListNames(name string) []string {
-	switch name {
-	case DefaultConfigName:
-		return DefaultConfigNames
-	case FiveNodeDefaultConfigName:
-		return FiveNodeDefaultConfigNames
-	case ThreeNodeTenantDefaultConfigName:
-		return ThreeNodeTenantDefaultConfigNames
-	case EnterpriseConfigName:
-		return EnterpriseConfigNames
-	case WeakIsoLevelConfigName:
-		return WeakIsoLevelConfigNames
-	}
-	return []string{}
+	return DefaultConfigSets[name].ConfigNames()
 }
 
 // ConfigCalculator is used to enumerate a map of configuration -> file.
@@ -931,17 +905,16 @@ func (c ConfigCalculator) Enumerate(globs ...string) ([][]string, error) {
 	// of paths per config.
 	configPaths := make([][]string, len(LogicTestConfigs))
 	var configFilter map[string]struct{}
-	configDefaults := DefaultConfig
+	configDefaults := DefaultConfigSets[DefaultConfigSet]
 	if len(c.ConfigOverrides) > 0 {
 		// If a config override is provided, we use it to replace the default
 		// config set. This ensures that the overrides are used for files where:
-		// 1. no config directive is present
-		// 2. a config directive containing only a blocklist is present
-		// 3. a config directive containing "default-configs" is present
+		// 1. no config directive is present, or
+		// 2. a config directive containing only a blocklist is present.
 		//
 		// We also create a filter to restrict configs to only those in the
 		// override list.
-		configDefaults = parseTestConfig(c.ConfigOverrides)
+		configDefaults = makeConfigSet(c.ConfigOverrides...)
 		configFilter = make(map[string]struct{})
 		for _, name := range c.ConfigOverrides {
 			configFilter[name] = struct{}{}

--- a/pkg/sql/logictest/logictestbase/logictestbase_test.go
+++ b/pkg/sql/logictest/logictestbase/logictestbase_test.go
@@ -16,7 +16,7 @@ func TestLogicTestMixedVersionConfigs(t *testing.T) {
 	// default set.
 	for _, v := range clusterversion.SupportedPreviousReleases() {
 		t.Run(v.String(), func(t *testing.T) {
-			for _, cIdx := range DefaultConfig {
+			for _, cIdx := range DefaultConfigSets[DefaultConfigSet] {
 				c := LogicTestConfigs[cIdx]
 				if c.DisableUpgrade && c.BootstrapVersion == v {
 					return

--- a/pkg/sql/logictest/testdata/logic_test/composite_types
+++ b/pkg/sql/logictest/testdata/logic_test/composite_types
@@ -1,5 +1,3 @@
-# LogicTest: default-configs
-
 statement ok
 CREATE TYPE t AS (a INT, b INT)
 

--- a/pkg/sql/logictest/testdata/logic_test/drop_owned_by
+++ b/pkg/sql/logictest/testdata/logic_test/drop_owned_by
@@ -1,4 +1,4 @@
-# LogicTest: default-configs !local-legacy-schema-changer
+# LogicTest: !local-legacy-schema-changer
 # Skipped on legacy schema changer since it unsupported.
 
 # Test dropping nothing.

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -1,5 +1,3 @@
-# LogicTest: default-configs
-
 statement ok
 CREATE TABLE t (
   k INT PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/grant_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_schema
@@ -1,5 +1,3 @@
-# LogicTest: default-configs
-
 statement ok
 GRANT CREATE ON DATABASE test TO testuser;
 CREATE USER testuser2

--- a/pkg/sql/logictest/testdata/logic_test/json_index
+++ b/pkg/sql/logictest/testdata/logic_test/json_index
@@ -1,5 +1,3 @@
-# LogicTest: default-configs
-
 # Add JSON columns as primary index.
 statement ok
 CREATE TABLE t (x JSONB PRIMARY KEY)


### PR DESCRIPTION
This change reworks the default config sets into a map, which makes
them easier to read and allows adding new config sets without
refactoring various pieces of code.

The only functional difference is that if a test specifies
`default-configs` explicitly, that now refers to the global defaults,
and not the defaults that may have been overridden for that test
(which can be achieved by not specifying anything).

Epic: none
Release note: None