### PR TITLE
release-24.1: roachtest: use full cockroach binary for cockroach-ea

### DIFF
--- a/build/teamcity/cockroach/nightlies/roachtest_compile_component.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_compile_component.sh
@@ -70,9 +70,9 @@ case "$component" in
     artifacts=("pkg/cmd/cockroach/cockroach_/cockroach:bin/cockroach.$os-$arch")
     ;;
   cockroach-ea)
-    # Cockroach-short with enabled assertions (EA).
-    bazel_args=(--config force_build_cdeps //pkg/cmd/cockroach-short --crdb_test $crdb_extra_flags)
-    artifacts=("pkg/cmd/cockroach-short/cockroach-short_/cockroach-short:bin/cockroach-ea.$os-$arch")
+    # Cockroach binary with enabled assertions (EA).
+    bazel_args=(--config force_build_cdeps //pkg/cmd/cockroach --crdb_test $crdb_extra_flags)
+    artifacts=("pkg/cmd/cockroach/cockroach_/cockroach:bin/cockroach-ea.$os-$arch")
     ;;
   workload)
     # Workload binary.

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -79,7 +79,7 @@ func (t testWrapper) StandardCockroach() string {
 }
 
 func (t testWrapper) RuntimeAssertionsCockroach() string {
-	return "./dummy-path/to/cockroach-short"
+	return "./dummy-path/to/cockroach-ea"
 }
 
 func (t testWrapper) DeprecatedWorkload() string {

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -143,7 +143,7 @@ func TestCreatePostRequest(t *testing.T) {
 			start:       time.Date(2023, time.July, 21, 16, 34, 3, 817, time.UTC),
 			end:         time.Date(2023, time.July, 21, 16, 42, 13, 137, time.UTC),
 			cockroach:   "cockroach",
-			cockroachEA: "cockroach-short",
+			cockroachEA: "cockroach-ea",
 		}
 
 		testClusterImpl := &clusterImpl{spec: clusterSpec, arch: vm.ArchAMD64, name: "foo"}

--- a/pkg/cmd/roachtest/test/test_interface.go
+++ b/pkg/cmd/roachtest/test/test_interface.go
@@ -26,7 +26,7 @@ type Test interface {
 	// StandardCockroach returns path to main cockroach binary, compiled
 	// without runtime assertions.
 	StandardCockroach() string
-	// RuntimeAssertionsCockroach returns the path to cockroach-short
+	// RuntimeAssertionsCockroach returns the path to cockroach
 	// binary compiled with --crdb_test build tag, or an empty string if
 	// no such binary was given.
 	RuntimeAssertionsCockroach() string

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -59,10 +59,10 @@ type testImpl struct {
 	spec *registry.TestSpec
 
 	cockroach   string // path to main cockroach binary
-	cockroachEA string // path to cockroach-short binary compiled with --crdb_test build tag
+	cockroachEA string // path to cockroach binary compiled with --crdb_test build tag
 
 	randomCockroachOnce sync.Once
-	randomizedCockroach string // either `cockroach` or `cockroach-short`, picked randomly
+	randomizedCockroach string // either `cockroach` or `cockroach-ea`, picked randomly
 
 	deprecatedWorkload string // path to workload binary
 	debug              bool   // whether the test is in debug mode.


### PR DESCRIPTION
Backport 1/1 commits from #135579.

/cc @cockroachdb/release

---

Previously we compiled cockroach-ea for nightlies using cockroach-short mainly due to historical reasons. There was no good way to specify a cockroach-ea binary so we used cockroach-short as a placeholder to mean assertions on.

However, we have since reworked the framework and this is now no longer an issue. This change switches cockroach-ea to be compiled with the full cockroach binary instead, as we now have roachtests that require the ui.

Release note: none
Epic: none
Fixes: none

Release Justification: Test only change