### PR TITLE
sql: avoid ResolveBlankPaddedChar in writeTextString

### DIFF
--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -101,8 +101,19 @@ func writeTextUUID(b *writeBuffer, v uuid.UUID) {
 	b.write(s)
 }
 
-func writeTextString(b *writeBuffer, v string, t *types.T) {
-	b.writeLengthPrefixedString(tree.ResolveBlankPaddedChar(v, t))
+func writeTextString(b *writeBuffer, s string, t *types.T) {
+	if paddingNeeded([]byte(s), t) {
+		b.writePaddedData([]byte(s), t)
+	} else {
+		b.writeLengthPrefixedString(s)
+	}
+}
+
+func paddingNeeded(v []byte, t *types.T) bool {
+	blankPaddedCharType := t.Oid() == oid.T_bpchar
+	paddingNeeded := len(v) < int(t.Width())
+
+	return blankPaddedCharType && paddingNeeded
 }
 
 func writeTextTimestamp(b *writeBuffer, v time.Time) {
@@ -189,7 +200,7 @@ func writeTextDatumNotNull(
 		writeTextString(b, string(*v), t)
 
 	case *tree.DCollatedString:
-		b.writeLengthPrefixedString(tree.ResolveBlankPaddedChar(v.Contents, t))
+		writeTextString(b, v.Contents, t)
 
 	case *tree.DDate:
 		b.textFormatter.FormatNode(v)
@@ -526,29 +537,26 @@ func writeBinaryBytes(b *writeBuffer, v []byte, t *types.T) {
 		// an empty string for the "char" type in the binary format.
 		v = []byte{0}
 	}
-	pad := 0
-	if t.Oid() == oid.T_bpchar && len(v) < int(t.Width()) {
-		// Pad spaces on the right of the byte slice to make it of length
-		// specified in the type t.
-		pad = int(t.Width()) - len(v)
-	}
-	b.putInt32(int32(len(v) + pad))
-	b.write(v)
-	for pad > 0 {
-		n := min(pad, len(spaces))
-		b.write(spaces[:n])
-		pad -= n
+
+	if paddingNeeded(v, t) {
+		b.writePaddedData(v, t)
+	} else {
+		b.writeLengthPrefixedByteSlice(v, int32(len(v)))
 	}
 }
 
-func writeBinaryString(b *writeBuffer, v string, t *types.T) {
-	s := tree.ResolveBlankPaddedChar(v, t)
+func writeBinaryString(b *writeBuffer, s string, t *types.T) {
 	if t.Oid() == oid.T_char && s == "" {
 		// Match Postgres and always explicitly include a null byte if we have
 		// an empty string for the "char" type in the binary format.
 		s = string([]byte{0})
 	}
-	b.writeLengthPrefixedString(s)
+
+	if paddingNeeded([]byte(s), t) {
+		b.writePaddedData([]byte(s), t)
+	} else {
+		b.writeLengthPrefixedString(s)
+	}
 }
 
 func writeBinaryTimestamp(b *writeBuffer, v time.Time) {
@@ -701,7 +709,7 @@ func writeBinaryDatumNotNull(
 		writeBinaryString(b, string(*v), t)
 
 	case *tree.DCollatedString:
-		b.writeLengthPrefixedString(tree.ResolveBlankPaddedChar(v.Contents, t))
+		writeTextString(b, v.Contents, t)
 
 	case *tree.DTimestamp:
 		writeBinaryTimestamp(b, v.Time)


### PR DESCRIPTION
writeTextString no longer uses ResolveBlankPaddedChar which was causing an increase in heap allocations mainly due to it's use of `make([]byte, t.Width())`.  Additionally in this PR I removed the call to ResolveBlankPaddedChar from writeBinaryString and other occurences in types.go.

These are the results that we now see from benchmark tests:

Micro Benchmark:
```
                      │   sec/op    │   sec/op     vs base               │
WriteTextColumnarChar   41.49µ ± 2%   24.05µ ± 3%  -42.03% (p=0.001 n=7)

                      │  before.txt  │              after.txt              │
                      │     B/op     │    B/op      vs base                │
WriteTextColumnarChar   16.00Ki ± 0%   0.00Ki ± 0%  -100.00% (p=0.001 n=7)

                      │ before.txt  │              after.txt              │
                      │  allocs/op  │  allocs/op   vs base                │
WriteTextColumnarChar   1.024k ± 0%   0.000k ± 0%  -100.00% (p=0.001 n=7)
```

Sysbench:
```
                                        │ sys_gce_before.txt │         sys_gce_after.txt         │
                                        │       sec/op       │   sec/op     vs base              │
Sysbench/SQL/1node_local/oltp_read_only          7.313m ± 4%   7.071m ± 4%  -3.32% (p=0.009 n=6)

                                        │ sys_gce_before.txt │         sys_gce_after.txt          │
                                        │        B/op        │     B/op      vs base              │
Sysbench/SQL/1node_local/oltp_read_only         972.3Ki ± 2%   895.3Ki ± 1%  -7.92% (p=0.002 n=6)

                                        │ sys_gce_before.txt │         sys_gce_after.txt          │
                                        │     allocs/op      │  allocs/op   vs base               │
Sysbench/SQL/1node_local/oltp_read_only          6.179k ± 4%   5.250k ± 2%  -15.03% (p=0.002 n=6)
```

Epic: CRDB-42584
Fixes: #134336
Release note: None