### PR TITLE
sql: skip external tables in cluster locks internal table

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -8020,6 +8020,9 @@ func genClusterLocksGenerator(
 				if filters.databaseName != nil && *filters.databaseName != dbNames[uint32(desc.GetParentID())] {
 					continue
 				}
+				if desc.ExternalRowData() != nil {
+					continue
+				}
 				spansToQuery = append(spansToQuery, desc.TableSpan(p.execCfg.Codec))
 			}
 		}


### PR DESCRIPTION
This patch prevents the panic documented in #135755. As a follow up to this patch, the virtualTableGenerator should gracefully recover from panics.

Informs #135755

Release note: none