### PR TITLE
sql/schemachanger: make create sequence revertible

### DIFF
--- a/pkg/sql/schemachanger/scplan/internal/opgen/op_funcs.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/op_funcs.go
@@ -185,6 +185,9 @@ func checkIfDescriptorIsWithoutData(id descpb.ID, md *opGenContext) bool {
 				doesDescriptorHaveData = true
 			}
 		}
+		if doesDescriptorHaveData {
+			break
+		}
 	}
 	return !doesDescriptorHaveData
 }

--- a/pkg/sql/schemachanger/scplan/internal/opgen/op_gen.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/op_gen.go
@@ -128,8 +128,14 @@ func (r *registry) buildGraph(
 			if e.ops != nil {
 				ops = e.ops(e.n.Element(), &md)
 			}
+			// Operations are revertible unless stated otherwise.
+			revertible := true
+			if e.revertible != nil {
+				// If a callback function exists invoke it to find out.
+				revertible = e.revertible(e.n.Element(), &md)
+			}
 			if err := g.AddOpEdges(
-				e.n.Target, e.from, e.to, e.revertible, e.canFail, ops...,
+				e.n.Target, e.from, e.to, revertible, e.canFail, ops...,
 			); err != nil {
 				return nil, err
 			}

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_column.go
@@ -8,6 +8,7 @@ package opgen
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/screl"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
 
@@ -31,7 +32,9 @@ func init() {
 				}),
 			),
 			to(scpb.Status_PUBLIC,
-				revertible(false),
+				revertibleFunc(func(e scpb.Element, state *opGenContext) bool {
+					return checkIfDescriptorIsWithoutData(screl.GetDescID(e), state)
+				}),
 				emit(func(this *scpb.Column, md *opGenContext) *scop.MakeWriteOnlyColumnPublic {
 					return &scop.MakeWriteOnlyColumnPublic{
 						TableID:  this.TableID,

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_sequence.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_sequence.go
@@ -25,7 +25,6 @@ func init() {
 				}),
 			),
 			to(scpb.Status_PUBLIC,
-				revertible(false),
 				emit(func(this *scpb.Sequence) *scop.InitSequence {
 					return &scop.InitSequence{
 						SequenceID:     this.SequenceID,

--- a/pkg/sql/schemachanger/scplan/internal/opgen/register.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/register.go
@@ -16,7 +16,7 @@ import (
 
 // equiv defines the from status as being equivalent to the current status.
 func equiv(from scpb.Status) transitionSpec {
-	return transitionSpec{from: from, revertible: true}
+	return transitionSpec{from: from, revertible: nil}
 }
 
 func notImplemented(e scpb.Element) *scop.NotImplemented {

--- a/pkg/sql/schemachanger/scplan/internal/opgen/target.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/target.go
@@ -25,7 +25,7 @@ type target struct {
 // Target.
 type transition struct {
 	from, to   scpb.Status
-	revertible bool
+	revertible RevertibleFn
 	canFail    bool
 	ops        opsFunc
 	opType     scop.Type
@@ -153,7 +153,7 @@ func makeTransitions(e scpb.Element, spec targetSpec) (ret []transition, err err
 
 type transitionBuildState struct {
 	from         scpb.Status
-	isRevertible bool
+	isRevertible RevertibleFn
 
 	isEquivMapped map[scpb.Status]bool
 	isTo          map[scpb.Status]bool
@@ -163,7 +163,7 @@ type transitionBuildState struct {
 func makeTransitionBuildState(from scpb.Status) transitionBuildState {
 	return transitionBuildState{
 		from:          from,
-		isRevertible:  true,
+		isRevertible:  nil,
 		isEquivMapped: map[scpb.Status]bool{from: true},
 		isTo:          map[scpb.Status]bool{},
 		isFrom:        map[scpb.Status]bool{},
@@ -181,7 +181,14 @@ func (tbs *transitionBuildState) withTransition(s transitionSpec, isFirst bool) 
 		return errors.Errorf("%s was featured as 'from' in a previous equivalence mapping", s.to)
 	}
 
-	tbs.isRevertible = tbs.isRevertible && s.revertible
+	if tbs.isRevertible != nil && s.revertible != nil {
+		oldRevertibleFn := tbs.isRevertible
+		tbs.isRevertible = func(e scpb.Element, state *opGenContext) bool {
+			return oldRevertibleFn(e, state) && s.revertible(e, state)
+		}
+	} else if tbs.isRevertible == nil {
+		tbs.isRevertible = s.revertible
+	}
 	tbs.isEquivMapped[tbs.from] = true
 	tbs.isTo[s.to] = true
 	tbs.isFrom[tbs.from] = true
@@ -202,8 +209,9 @@ func (tbs *transitionBuildState) withEquivTransition(s transitionSpec) error {
 		return errors.Errorf("%s was featured as 'from' in a previous equivalence mapping", s.from)
 	}
 
-	// Check for absence of phase and revertibility constraints
-	if !s.revertible {
+	// The transition above is equivalent, so it cannot override the revertibility
+	// in any way.
+	if s.revertible != nil {
 		return errors.Errorf("must be revertible")
 	}
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column.side_effects
@@ -209,12 +209,20 @@ upsert descriptor #105
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 37 MutationType ops
+## PreCommitPhase stage 2 of 2 with 40 MutationType ops
+initializing sequence 105 with starting value of 31
 add object namespace entry {100 101 sq1} -> 105
 upsert descriptor #105
   -
   +table:
   +  checks: []
+  +  columns:
+  +  - id: 1
+  +    name: value
+  +    type:
+  +      family: IntFamily
+  +      oid: 20
+  +      width: 64
   +  createAsOfTime: {}
   +  declarativeSchemaChangerState:
   +    authorization:
@@ -244,16 +252,7 @@ upsert descriptor #105
   +  formatVersion: 3
   +  id: 105
   +  modificationTime: {}
-  +  mutations:
-  +  - column:
-  +      id: 1
-  +      name: value
-  +      type:
-  +        family: IntFamily
-  +        oid: 20
-  +        width: 64
-  +    direction: ADD
-  +    state: WRITE_ONLY
+  +  mutations: []
   +  name: sq1
   +  nextColumnId: 2
   +  nextConstraintId: 1
@@ -297,7 +296,6 @@ upsert descriptor #105
   +    minValue: "1"
   +    sequenceOwner: {}
   +    start: "32"
-  +  state: ADD
   +  unexposedParentSchemaId: 101
   +  version: "1"
 upsert descriptor #104
@@ -464,7 +462,7 @@ upsert descriptor #104
   +  version: "3"
 upsert descriptor #105
   ...
-     state: ADD
+       start: "32"
      unexposedParentSchemaId: 101
   -  version: "1"
   +  version: "2"
@@ -492,7 +490,7 @@ upsert descriptor #104
   +  version: "4"
 upsert descriptor #105
   ...
-     state: ADD
+       start: "32"
      unexposedParentSchemaId: 101
   -  version: "2"
   +  version: "3"
@@ -516,7 +514,7 @@ upsert descriptor #104
   +  version: "5"
 upsert descriptor #105
   ...
-     state: ADD
+       start: "32"
      unexposedParentSchemaId: 101
   -  version: "3"
   +  version: "4"
@@ -553,7 +551,7 @@ upsert descriptor #104
   +  version: "6"
 upsert descriptor #105
   ...
-     state: ADD
+       start: "32"
      unexposedParentSchemaId: 101
   -  version: "4"
   +  version: "5"
@@ -565,8 +563,7 @@ begin transaction #9
 validate forward indexes [2] in table #104
 commit transaction #9
 begin transaction #10
-## PostCommitNonRevertiblePhase stage 1 of 3 with 15 MutationType ops
-initializing sequence 105 with starting value of 31
+## PostCommitNonRevertiblePhase stage 1 of 3 with 12 MutationType ops
 upsert descriptor #104
   ...
          oid: 20
@@ -693,17 +690,6 @@ upsert descriptor #104
   -  version: "6"
   +  version: "7"
 upsert descriptor #105
-   table:
-     checks: []
-  +  columns:
-  +  - id: 1
-  +    name: value
-  +    type:
-  +      family: IntFamily
-  +      oid: 20
-  +      width: 64
-     createAsOfTime: {}
-     declarativeSchemaChangerState:
   ...
            statement: CREATE SEQUENCE sq1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32
            statementTag: CREATE SEQUENCE
@@ -711,25 +697,7 @@ upsert descriptor #105
        targetRanks: <redacted>
        targets: <redacted>
   ...
-     id: 105
-     modificationTime: {}
-  -  mutations:
-  -  - column:
-  -      id: 1
-  -      name: value
-  -      type:
-  -        family: IntFamily
-  -        oid: 20
-  -        width: 64
-  -    direction: ADD
-  -    state: WRITE_ONLY
-  +  mutations: []
-     name: sq1
-     nextColumnId: 2
-  ...
-       sequenceOwner: {}
        start: "32"
-  -  state: ADD
      unexposedParentSchemaId: 101
   -  version: "5"
   +  version: "6"

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_1_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_1_of_7.explain
@@ -10,33 +10,32 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 25 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC           → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100)}
-      │    │    ├── PUBLIC           → ABSENT  Owner:{DescID: 105 (sq1-)}
-      │    │    ├── PUBLIC           → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "admin"}
-      │    │    ├── PUBLIC           → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "root"}
-      │    │    ├── DESCRIPTOR_ADDED → DROPPED Sequence:{DescID: 105 (sq1-)}
-      │    │    ├── PUBLIC           → ABSENT  SequenceOption:{DescID: 105 (sq1-), Name: "START"}
-      │    │    ├── PUBLIC           → ABSENT  SchemaChild:{DescID: 105 (sq1-), ReferencedDescID: 101 (#101)}
-      │    │    ├── WRITE_ONLY       → ABSENT  Column:{DescID: 105 (sq1-), ColumnID: 1 (value-)}
-      │    │    ├── PUBLIC           → ABSENT  ColumnType:{DescID: 105 (sq1-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}
-      │    │    ├── PUBLIC           → ABSENT  ColumnNotNull:{DescID: 105 (sq1-), ColumnID: 1 (value-), IndexID: 0}
-      │    │    ├── PUBLIC           → ABSENT  ColumnName:{DescID: 105 (sq1-), Name: "value", ColumnID: 1 (value-)}
-      │    │    ├── PUBLIC           → ABSENT  PrimaryIndex:{DescID: 105 (sq1-), IndexID: 1 (primary-)}
-      │    │    ├── PUBLIC           → ABSENT  IndexName:{DescID: 105 (sq1-), Name: "primary", IndexID: 1 (primary-)}
-      │    │    ├── PUBLIC           → ABSENT  IndexColumn:{DescID: 105 (sq1-), ColumnID: 1 (value-), IndexID: 1 (primary-)}
-      │    │    ├── DELETE_ONLY      → ABSENT  Column:{DescID: 104 (t), ColumnID: 2 (j-)}
-      │    │    ├── PUBLIC           → ABSENT  ColumnName:{DescID: 104 (t), Name: "j", ColumnID: 2 (j-)}
-      │    │    ├── PUBLIC           → ABSENT  ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-), TypeName: "INT8"}
-      │    │    ├── PUBLIC           → ABSENT  ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 2 (j-), ReferencedSequenceIDs: [105 (sq1-)], Expr: nextval(105:::REGCLASS)}
-      │    │    ├── BACKFILL_ONLY    → ABSENT  PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC           → ABSENT  IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey-)}
-      │    │    ├── PUBLIC           → ABSENT  IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey-)}
-      │    │    ├── DELETE_ONLY      → ABSENT  TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC           → ABSENT  IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
-      │    │    ├── PUBLIC           → ABSENT  IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 2 (t_pkey-)}
-      │    │    └── PUBLIC           → ABSENT  IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 3}
-      │    └── 31 Mutation operations
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
+      │    │    ├── PUBLIC        → ABSENT  Namespace:{DescID: 105 (sq1-), Name: "sq1", ReferencedDescID: 100 (#100)}
+      │    │    ├── PUBLIC        → ABSENT  Owner:{DescID: 105 (sq1-)}
+      │    │    ├── PUBLIC        → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "admin"}
+      │    │    ├── PUBLIC        → ABSENT  UserPrivileges:{DescID: 105 (sq1-), Name: "root"}
+      │    │    ├── PUBLIC        → DROPPED Sequence:{DescID: 105 (sq1-)}
+      │    │    ├── PUBLIC        → ABSENT  SequenceOption:{DescID: 105 (sq1-), Name: "START"}
+      │    │    ├── PUBLIC        → ABSENT  SchemaChild:{DescID: 105 (sq1-), ReferencedDescID: 101 (#101)}
+      │    │    ├── PUBLIC        → ABSENT  Column:{DescID: 105 (sq1-), ColumnID: 1 (value-)}
+      │    │    ├── PUBLIC        → ABSENT  ColumnType:{DescID: 105 (sq1-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}
+      │    │    ├── PUBLIC        → ABSENT  ColumnNotNull:{DescID: 105 (sq1-), ColumnID: 1 (value-), IndexID: 0}
+      │    │    ├── PUBLIC        → ABSENT  ColumnName:{DescID: 105 (sq1-), Name: "value", ColumnID: 1 (value-)}
+      │    │    ├── PUBLIC        → ABSENT  PrimaryIndex:{DescID: 105 (sq1-), IndexID: 1 (primary-)}
+      │    │    ├── PUBLIC        → ABSENT  IndexName:{DescID: 105 (sq1-), Name: "primary", IndexID: 1 (primary-)}
+      │    │    ├── PUBLIC        → ABSENT  IndexColumn:{DescID: 105 (sq1-), ColumnID: 1 (value-), IndexID: 1 (primary-)}
+      │    │    ├── DELETE_ONLY   → ABSENT  Column:{DescID: 104 (t), ColumnID: 2 (j-)}
+      │    │    ├── PUBLIC        → ABSENT  ColumnName:{DescID: 104 (t), Name: "j", ColumnID: 2 (j-)}
+      │    │    ├── PUBLIC        → ABSENT  ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-), TypeName: "INT8"}
+      │    │    ├── PUBLIC        → ABSENT  ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 2 (j-), ReferencedSequenceIDs: [105 (sq1-)], Expr: nextval(105:::REGCLASS)}
+      │    │    ├── BACKFILL_ONLY → ABSENT  PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT  IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT  IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey-)}
+      │    │    ├── DELETE_ONLY   → ABSENT  TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT  IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT  IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 2 (t_pkey-)}
+      │    │    └── PUBLIC        → ABSENT  IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 3}
+      │    └── 32 Mutation operations
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":105}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":105}
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":104}
@@ -48,7 +47,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.SequenceOpt..."}
       │         ├── RemoveObjectParent {"ObjectID":105,"ParentSchemaID":101}
       │         ├── RemoveColumnNotNull {"ColumnID":1,"TableID":105}
-      │         ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":105}
       │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":105}
       │         ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":104}
       │         ├── UpdateTableBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":104}
@@ -59,18 +57,23 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.Owner"}
       │         ├── RemoveUserPrivileges {"DescriptorID":105,"User":"admin"}
       │         ├── RemoveUserPrivileges {"DescriptorID":105,"User":"root"}
+      │         ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":105}
+      │         ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":105}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":105}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":105}
-      │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":105}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
       │         ├── MakeIndexAbsent {"IndexID":1,"TableID":105}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":104}
+      │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":105}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
-           ├── 1 element transitioning toward ABSENT
-           │    └── DROPPED → ABSENT Sequence:{DescID: 105 (sq1-)}
-           └── 3 Mutation operations
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── DROPPED → ABSENT Sequence:{DescID: 105 (sq1-)}
+           │    └── PUBLIC  → ABSENT TableData:{DescID: 105 (sq1-), ReferencedDescID: 100 (#100)}
+           └── 4 Mutation operations
+                ├── CreateGCJobForTable {"DatabaseID":100,"TableID":105}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_2_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_2_of_7.explain
@@ -9,21 +9,18 @@ EXPLAIN (DDL) rollback at post-commit stage 2 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD COLUMN ‹j› INT8 DEFAULT nextval(‹'sq1'›); following CREATE SEQUENCE ‹defaultdb›.public.‹sq1› MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 12 elements transitioning toward ABSENT
-      │    │    ├── DESCRIPTOR_ADDED → PUBLIC      Sequence:{DescID: 105 (sq1-)}
-      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 105 (sq1-), ColumnID: 1 (value-)}
-      │    │    ├── PUBLIC           → ABSENT      ColumnNotNull:{DescID: 105 (sq1-), ColumnID: 1 (value-), IndexID: 0}
-      │    │    ├── PUBLIC           → DELETE_ONLY PrimaryIndex:{DescID: 105 (sq1-), IndexID: 1 (primary-)}
-      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 2 (j-)}
-      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 104 (t), Name: "j", ColumnID: 2 (j-)}
-      │    │    ├── BACKFILL_ONLY    → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey-)}
-      │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 2 (t_pkey-)}
-      │    │    └── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 3}
-      │    └── 16 Mutation operations
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
+      │    ├── 10 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC        → ABSENT      ColumnNotNull:{DescID: 105 (sq1-), ColumnID: 1 (value-), IndexID: 0}
+      │    │    ├── PUBLIC        → DELETE_ONLY PrimaryIndex:{DescID: 105 (sq1-), IndexID: 1 (primary-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 2 (j-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 104 (t), Name: "j", ColumnID: 2 (j-)}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 2 (t_pkey-)}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 3}
+      │    └── 15 Mutation operations
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":105}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":105}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":104}
@@ -48,7 +45,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 105 (sq1-)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 105 (sq1-), Name: "START"}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 105 (sq1-), ReferencedDescID: 101 (#101)}
-      │    │    ├── DELETE_ONLY → ABSENT  Column:{DescID: 105 (sq1-), ColumnID: 1 (value-)}
+      │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 105 (sq1-), ColumnID: 1 (value-)}
       │    │    ├── PUBLIC      → ABSENT  ColumnType:{DescID: 105 (sq1-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT  ColumnName:{DescID: 105 (sq1-), Name: "value", ColumnID: 1 (value-)}
       │    │    ├── DELETE_ONLY → ABSENT  PrimaryIndex:{DescID: 105 (sq1-), IndexID: 1 (primary-)}
@@ -60,10 +57,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC      → ABSENT  IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT  TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    └── PUBLIC      → ABSENT  IndexData:{DescID: 104 (t), IndexID: 3}
-      │    └── 21 Mutation operations
+      │    └── 23 Mutation operations
       │         ├── MarkDescriptorAsDropped {"DescriptorID":105}
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.SequenceOpt..."}
       │         ├── RemoveObjectParent {"ObjectID":105,"ParentSchemaID":101}
+      │         ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":105}
       │         ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":105}
       │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":105}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":105}
@@ -76,16 +74,19 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.Owner"}
       │         ├── RemoveUserPrivileges {"DescriptorID":105,"User":"admin"}
       │         ├── RemoveUserPrivileges {"DescriptorID":105,"User":"root"}
-      │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":105}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
       │         ├── MakeIndexAbsent {"IndexID":1,"TableID":105}
+      │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":105}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 1 element transitioning toward ABSENT
-           │    └── DROPPED → ABSENT Sequence:{DescID: 105 (sq1-)}
-           └── 3 Mutation operations
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── DROPPED → ABSENT Sequence:{DescID: 105 (sq1-)}
+           │    └── PUBLIC  → ABSENT TableData:{DescID: 105 (sq1-), ReferencedDescID: 100 (#100)}
+           └── 4 Mutation operations
+                ├── CreateGCJobForTable {"DatabaseID":100,"TableID":105}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_3_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_3_of_7.explain
@@ -9,21 +9,18 @@ EXPLAIN (DDL) rollback at post-commit stage 3 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD COLUMN ‹j› INT8 DEFAULT nextval(‹'sq1'›); following CREATE SEQUENCE ‹defaultdb›.public.‹sq1› MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 12 elements transitioning toward ABSENT
-      │    │    ├── DESCRIPTOR_ADDED → PUBLIC      Sequence:{DescID: 105 (sq1-)}
-      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 105 (sq1-), ColumnID: 1 (value-)}
-      │    │    ├── PUBLIC           → ABSENT      ColumnNotNull:{DescID: 105 (sq1-), ColumnID: 1 (value-), IndexID: 0}
-      │    │    ├── PUBLIC           → DELETE_ONLY PrimaryIndex:{DescID: 105 (sq1-), IndexID: 1 (primary-)}
-      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 2 (j-)}
-      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 104 (t), Name: "j", ColumnID: 2 (j-)}
-      │    │    ├── BACKFILL_ONLY    → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey-)}
-      │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 2 (t_pkey-)}
-      │    │    └── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 3}
-      │    └── 16 Mutation operations
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
+      │    ├── 10 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC        → ABSENT      ColumnNotNull:{DescID: 105 (sq1-), ColumnID: 1 (value-), IndexID: 0}
+      │    │    ├── PUBLIC        → DELETE_ONLY PrimaryIndex:{DescID: 105 (sq1-), IndexID: 1 (primary-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 2 (j-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 104 (t), Name: "j", ColumnID: 2 (j-)}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 2 (t_pkey-)}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 3}
+      │    └── 15 Mutation operations
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":105}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":105}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":104}
@@ -48,7 +45,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 105 (sq1-)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 105 (sq1-), Name: "START"}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 105 (sq1-), ReferencedDescID: 101 (#101)}
-      │    │    ├── DELETE_ONLY → ABSENT  Column:{DescID: 105 (sq1-), ColumnID: 1 (value-)}
+      │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 105 (sq1-), ColumnID: 1 (value-)}
       │    │    ├── PUBLIC      → ABSENT  ColumnType:{DescID: 105 (sq1-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT  ColumnName:{DescID: 105 (sq1-), Name: "value", ColumnID: 1 (value-)}
       │    │    ├── DELETE_ONLY → ABSENT  PrimaryIndex:{DescID: 105 (sq1-), IndexID: 1 (primary-)}
@@ -60,10 +57,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC      → ABSENT  IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT  TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    └── PUBLIC      → ABSENT  IndexData:{DescID: 104 (t), IndexID: 3}
-      │    └── 21 Mutation operations
+      │    └── 23 Mutation operations
       │         ├── MarkDescriptorAsDropped {"DescriptorID":105}
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.SequenceOpt..."}
       │         ├── RemoveObjectParent {"ObjectID":105,"ParentSchemaID":101}
+      │         ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":105}
       │         ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":105}
       │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":105}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":105}
@@ -76,16 +74,19 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.Owner"}
       │         ├── RemoveUserPrivileges {"DescriptorID":105,"User":"admin"}
       │         ├── RemoveUserPrivileges {"DescriptorID":105,"User":"root"}
-      │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":105}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
       │         ├── MakeIndexAbsent {"IndexID":1,"TableID":105}
+      │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":105}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 1 element transitioning toward ABSENT
-           │    └── DROPPED → ABSENT Sequence:{DescID: 105 (sq1-)}
-           └── 3 Mutation operations
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── DROPPED → ABSENT Sequence:{DescID: 105 (sq1-)}
+           │    └── PUBLIC  → ABSENT TableData:{DescID: 105 (sq1-), ReferencedDescID: 100 (#100)}
+           └── 4 Mutation operations
+                ├── CreateGCJobForTable {"DatabaseID":100,"TableID":105}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_4_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_4_of_7.explain
@@ -9,21 +9,18 @@ EXPLAIN (DDL) rollback at post-commit stage 4 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD COLUMN ‹j› INT8 DEFAULT nextval(‹'sq1'›); following CREATE SEQUENCE ‹defaultdb›.public.‹sq1› MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 12 elements transitioning toward ABSENT
-      │    │    ├── DESCRIPTOR_ADDED → PUBLIC      Sequence:{DescID: 105 (sq1-)}
-      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 105 (sq1-), ColumnID: 1 (value-)}
-      │    │    ├── PUBLIC           → ABSENT      ColumnNotNull:{DescID: 105 (sq1-), ColumnID: 1 (value-), IndexID: 0}
-      │    │    ├── PUBLIC           → DELETE_ONLY PrimaryIndex:{DescID: 105 (sq1-), IndexID: 1 (primary-)}
-      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 2 (j-)}
-      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 104 (t), Name: "j", ColumnID: 2 (j-)}
-      │    │    ├── DELETE_ONLY      → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey-)}
-      │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 2 (t_pkey-)}
-      │    │    └── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 3}
-      │    └── 16 Mutation operations
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
+      │    ├── 10 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC      → ABSENT      ColumnNotNull:{DescID: 105 (sq1-), ColumnID: 1 (value-), IndexID: 0}
+      │    │    ├── PUBLIC      → DELETE_ONLY PrimaryIndex:{DescID: 105 (sq1-), IndexID: 1 (primary-)}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 2 (j-)}
+      │    │    ├── PUBLIC      → ABSENT      ColumnName:{DescID: 104 (t), Name: "j", ColumnID: 2 (j-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey-)}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 2 (t_pkey-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 3}
+      │    └── 15 Mutation operations
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":105}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":105}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":104}
@@ -48,7 +45,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 105 (sq1-)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 105 (sq1-), Name: "START"}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 105 (sq1-), ReferencedDescID: 101 (#101)}
-      │    │    ├── DELETE_ONLY → ABSENT  Column:{DescID: 105 (sq1-), ColumnID: 1 (value-)}
+      │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 105 (sq1-), ColumnID: 1 (value-)}
       │    │    ├── PUBLIC      → ABSENT  ColumnType:{DescID: 105 (sq1-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT  ColumnName:{DescID: 105 (sq1-), Name: "value", ColumnID: 1 (value-)}
       │    │    ├── DELETE_ONLY → ABSENT  PrimaryIndex:{DescID: 105 (sq1-), IndexID: 1 (primary-)}
@@ -60,10 +57,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC      → ABSENT  IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT  TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    └── PUBLIC      → ABSENT  IndexData:{DescID: 104 (t), IndexID: 3}
-      │    └── 21 Mutation operations
+      │    └── 23 Mutation operations
       │         ├── MarkDescriptorAsDropped {"DescriptorID":105}
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.SequenceOpt..."}
       │         ├── RemoveObjectParent {"ObjectID":105,"ParentSchemaID":101}
+      │         ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":105}
       │         ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":105}
       │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":105}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":105}
@@ -76,16 +74,19 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.Owner"}
       │         ├── RemoveUserPrivileges {"DescriptorID":105,"User":"admin"}
       │         ├── RemoveUserPrivileges {"DescriptorID":105,"User":"root"}
-      │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":105}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
       │         ├── MakeIndexAbsent {"IndexID":1,"TableID":105}
+      │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":105}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 1 element transitioning toward ABSENT
-           │    └── DROPPED → ABSENT Sequence:{DescID: 105 (sq1-)}
-           └── 3 Mutation operations
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── DROPPED → ABSENT Sequence:{DescID: 105 (sq1-)}
+           │    └── PUBLIC  → ABSENT TableData:{DescID: 105 (sq1-), ReferencedDescID: 100 (#100)}
+           └── 4 Mutation operations
+                ├── CreateGCJobForTable {"DatabaseID":100,"TableID":105}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_5_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_5_of_7.explain
@@ -9,21 +9,18 @@ EXPLAIN (DDL) rollback at post-commit stage 5 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD COLUMN ‹j› INT8 DEFAULT nextval(‹'sq1'›); following CREATE SEQUENCE ‹defaultdb›.public.‹sq1› MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 12 elements transitioning toward ABSENT
-      │    │    ├── DESCRIPTOR_ADDED → PUBLIC      Sequence:{DescID: 105 (sq1-)}
-      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 105 (sq1-), ColumnID: 1 (value-)}
-      │    │    ├── PUBLIC           → ABSENT      ColumnNotNull:{DescID: 105 (sq1-), ColumnID: 1 (value-), IndexID: 0}
-      │    │    ├── PUBLIC           → DELETE_ONLY PrimaryIndex:{DescID: 105 (sq1-), IndexID: 1 (primary-)}
-      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 2 (j-)}
-      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 104 (t), Name: "j", ColumnID: 2 (j-)}
-      │    │    ├── MERGE_ONLY       → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey-)}
-      │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 2 (t_pkey-)}
-      │    │    └── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 3}
-      │    └── 16 Mutation operations
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
+      │    ├── 10 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT      ColumnNotNull:{DescID: 105 (sq1-), ColumnID: 1 (value-), IndexID: 0}
+      │    │    ├── PUBLIC     → DELETE_ONLY PrimaryIndex:{DescID: 105 (sq1-), IndexID: 1 (primary-)}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 2 (j-)}
+      │    │    ├── PUBLIC     → ABSENT      ColumnName:{DescID: 104 (t), Name: "j", ColumnID: 2 (j-)}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey-)}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 2 (t_pkey-)}
+      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 3}
+      │    └── 15 Mutation operations
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":105}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":105}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":104}
@@ -48,7 +45,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 105 (sq1-)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 105 (sq1-), Name: "START"}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 105 (sq1-), ReferencedDescID: 101 (#101)}
-      │    │    ├── DELETE_ONLY → ABSENT  Column:{DescID: 105 (sq1-), ColumnID: 1 (value-)}
+      │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 105 (sq1-), ColumnID: 1 (value-)}
       │    │    ├── PUBLIC      → ABSENT  ColumnType:{DescID: 105 (sq1-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT  ColumnName:{DescID: 105 (sq1-), Name: "value", ColumnID: 1 (value-)}
       │    │    ├── DELETE_ONLY → ABSENT  PrimaryIndex:{DescID: 105 (sq1-), IndexID: 1 (primary-)}
@@ -61,10 +58,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC      → ABSENT  IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT  TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    └── PUBLIC      → ABSENT  IndexData:{DescID: 104 (t), IndexID: 3}
-      │    └── 22 Mutation operations
+      │    └── 24 Mutation operations
       │         ├── MarkDescriptorAsDropped {"DescriptorID":105}
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.SequenceOpt..."}
       │         ├── RemoveObjectParent {"ObjectID":105,"ParentSchemaID":101}
+      │         ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":105}
       │         ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":105}
       │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":105}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":105}
@@ -78,16 +76,19 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.Owner"}
       │         ├── RemoveUserPrivileges {"DescriptorID":105,"User":"admin"}
       │         ├── RemoveUserPrivileges {"DescriptorID":105,"User":"root"}
-      │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":105}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
       │         ├── MakeIndexAbsent {"IndexID":1,"TableID":105}
+      │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":105}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 1 element transitioning toward ABSENT
-           │    └── DROPPED → ABSENT Sequence:{DescID: 105 (sq1-)}
-           └── 3 Mutation operations
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── DROPPED → ABSENT Sequence:{DescID: 105 (sq1-)}
+           │    └── PUBLIC  → ABSENT TableData:{DescID: 105 (sq1-), ReferencedDescID: 100 (#100)}
+           └── 4 Mutation operations
+                ├── CreateGCJobForTable {"DatabaseID":100,"TableID":105}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_6_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_6_of_7.explain
@@ -9,21 +9,18 @@ EXPLAIN (DDL) rollback at post-commit stage 6 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD COLUMN ‹j› INT8 DEFAULT nextval(‹'sq1'›); following CREATE SEQUENCE ‹defaultdb›.public.‹sq1› MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 12 elements transitioning toward ABSENT
-      │    │    ├── DESCRIPTOR_ADDED → PUBLIC      Sequence:{DescID: 105 (sq1-)}
-      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 105 (sq1-), ColumnID: 1 (value-)}
-      │    │    ├── PUBLIC           → ABSENT      ColumnNotNull:{DescID: 105 (sq1-), ColumnID: 1 (value-), IndexID: 0}
-      │    │    ├── PUBLIC           → DELETE_ONLY PrimaryIndex:{DescID: 105 (sq1-), IndexID: 1 (primary-)}
-      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 2 (j-)}
-      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 104 (t), Name: "j", ColumnID: 2 (j-)}
-      │    │    ├── MERGE_ONLY       → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey-)}
-      │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
-      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 2 (t_pkey-)}
-      │    │    └── PUBLIC           → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 3}
-      │    └── 16 Mutation operations
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
+      │    ├── 10 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT      ColumnNotNull:{DescID: 105 (sq1-), ColumnID: 1 (value-), IndexID: 0}
+      │    │    ├── PUBLIC     → DELETE_ONLY PrimaryIndex:{DescID: 105 (sq1-), IndexID: 1 (primary-)}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 2 (j-)}
+      │    │    ├── PUBLIC     → ABSENT      ColumnName:{DescID: 104 (t), Name: "j", ColumnID: 2 (j-)}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey-)}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 2 (t_pkey-)}
+      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 3}
+      │    └── 15 Mutation operations
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":105}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":105}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":104}
@@ -48,7 +45,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 105 (sq1-)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 105 (sq1-), Name: "START"}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 105 (sq1-), ReferencedDescID: 101 (#101)}
-      │    │    ├── DELETE_ONLY → ABSENT  Column:{DescID: 105 (sq1-), ColumnID: 1 (value-)}
+      │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 105 (sq1-), ColumnID: 1 (value-)}
       │    │    ├── PUBLIC      → ABSENT  ColumnType:{DescID: 105 (sq1-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT  ColumnName:{DescID: 105 (sq1-), Name: "value", ColumnID: 1 (value-)}
       │    │    ├── DELETE_ONLY → ABSENT  PrimaryIndex:{DescID: 105 (sq1-), IndexID: 1 (primary-)}
@@ -61,10 +58,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC      → ABSENT  IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey-)}
       │    │    ├── DELETE_ONLY → ABSENT  TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    └── PUBLIC      → ABSENT  IndexData:{DescID: 104 (t), IndexID: 3}
-      │    └── 22 Mutation operations
+      │    └── 24 Mutation operations
       │         ├── MarkDescriptorAsDropped {"DescriptorID":105}
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.SequenceOpt..."}
       │         ├── RemoveObjectParent {"ObjectID":105,"ParentSchemaID":101}
+      │         ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":105}
       │         ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":105}
       │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":105}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":105}
@@ -78,16 +76,19 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.Owner"}
       │         ├── RemoveUserPrivileges {"DescriptorID":105,"User":"admin"}
       │         ├── RemoveUserPrivileges {"DescriptorID":105,"User":"root"}
-      │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":105}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
       │         ├── MakeIndexAbsent {"IndexID":1,"TableID":105}
+      │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":105}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 1 element transitioning toward ABSENT
-           │    └── DROPPED → ABSENT Sequence:{DescID: 105 (sq1-)}
-           └── 3 Mutation operations
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── DROPPED → ABSENT Sequence:{DescID: 105 (sq1-)}
+           │    └── PUBLIC  → ABSENT TableData:{DescID: 105 (sq1-), ReferencedDescID: 100 (#100)}
+           └── 4 Mutation operations
+                ├── CreateGCJobForTable {"DatabaseID":100,"TableID":105}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_7_of_7.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__rollback_7_of_7.explain
@@ -9,9 +9,7 @@ EXPLAIN (DDL) rollback at post-commit stage 7 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD COLUMN ‹j› INT8 DEFAULT nextval(‹'sq1'›); following CREATE SEQUENCE ‹defaultdb›.public.‹sq1› MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32;
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 12 elements transitioning toward ABSENT
-      │    │    ├── DESCRIPTOR_ADDED      → PUBLIC      Sequence:{DescID: 105 (sq1-)}
-      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 105 (sq1-), ColumnID: 1 (value-)}
+      │    ├── 10 elements transitioning toward ABSENT
       │    │    ├── PUBLIC                → ABSENT      ColumnNotNull:{DescID: 105 (sq1-), ColumnID: 1 (value-), IndexID: 0}
       │    │    ├── PUBLIC                → DELETE_ONLY PrimaryIndex:{DescID: 105 (sq1-), IndexID: 1 (primary-)}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 2 (j-)}
@@ -22,8 +20,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 3}
-      │    └── 16 Mutation operations
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
+      │    └── 15 Mutation operations
       │         ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":105}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":105}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":104}
@@ -48,7 +45,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC      → DROPPED Sequence:{DescID: 105 (sq1-)}
       │    │    ├── PUBLIC      → ABSENT  SequenceOption:{DescID: 105 (sq1-), Name: "START"}
       │    │    ├── PUBLIC      → ABSENT  SchemaChild:{DescID: 105 (sq1-), ReferencedDescID: 101 (#101)}
-      │    │    ├── DELETE_ONLY → ABSENT  Column:{DescID: 105 (sq1-), ColumnID: 1 (value-)}
+      │    │    ├── PUBLIC      → ABSENT  Column:{DescID: 105 (sq1-), ColumnID: 1 (value-)}
       │    │    ├── PUBLIC      → ABSENT  ColumnType:{DescID: 105 (sq1-), ColumnFamilyID: 0, ColumnID: 1 (value-), TypeName: "INT8"}
       │    │    ├── PUBLIC      → ABSENT  ColumnName:{DescID: 105 (sq1-), Name: "value", ColumnID: 1 (value-)}
       │    │    ├── DELETE_ONLY → ABSENT  PrimaryIndex:{DescID: 105 (sq1-), IndexID: 1 (primary-)}
@@ -60,10 +57,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── DELETE_ONLY → ABSENT  PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC      → ABSENT  IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey-)}
       │    │    └── PUBLIC      → ABSENT  IndexData:{DescID: 104 (t), IndexID: 3}
-      │    └── 21 Mutation operations
+      │    └── 23 Mutation operations
       │         ├── MarkDescriptorAsDropped {"DescriptorID":105}
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.SequenceOpt..."}
       │         ├── RemoveObjectParent {"ObjectID":105,"ParentSchemaID":101}
+      │         ├── MakePublicColumnWriteOnly {"ColumnID":1,"TableID":105}
       │         ├── SetColumnName {"ColumnID":1,"Name":"crdb_internal_co...","TableID":105}
       │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":105}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":105}
@@ -76,16 +74,19 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── NotImplementedForPublicObjects {"DescID":105,"ElementType":"scpb.Owner"}
       │         ├── RemoveUserPrivileges {"DescriptorID":105,"User":"admin"}
       │         ├── RemoveUserPrivileges {"DescriptorID":105,"User":"root"}
-      │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":105}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":1,"TableID":105}
       │         ├── MakeIndexAbsent {"IndexID":1,"TableID":105}
+      │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":1,"TableID":105}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":105}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 1 element transitioning toward ABSENT
-           │    └── DROPPED → ABSENT Sequence:{DescID: 105 (sq1-)}
-           └── 3 Mutation operations
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── DROPPED → ABSENT Sequence:{DescID: 105 (sq1-)}
+           │    └── PUBLIC  → ABSENT TableData:{DescID: 105 (sq1-), ReferencedDescID: 100 (#100)}
+           └── 4 Mutation operations
+                ├── CreateGCJobForTable {"DatabaseID":100,"TableID":105}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__statement_2_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column__statement_2_of_2.explain
@@ -66,34 +66,35 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLU
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
- │         ├── 22 elements transitioning toward PUBLIC
- │         │    ├── ABSENT → PUBLIC           Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb)}
- │         │    ├── ABSENT → PUBLIC           Owner:{DescID: 105 (sq1+)}
- │         │    ├── ABSENT → PUBLIC           UserPrivileges:{DescID: 105 (sq1+), Name: "admin"}
- │         │    ├── ABSENT → PUBLIC           UserPrivileges:{DescID: 105 (sq1+), Name: "root"}
- │         │    ├── ABSENT → DESCRIPTOR_ADDED Sequence:{DescID: 105 (sq1+)}
- │         │    ├── ABSENT → PUBLIC           SequenceOption:{DescID: 105 (sq1+), Name: "START"}
- │         │    ├── ABSENT → PUBLIC           SchemaChild:{DescID: 105 (sq1+), ReferencedDescID: 101 (public)}
- │         │    ├── ABSENT → WRITE_ONLY       Column:{DescID: 105 (sq1+), ColumnID: 1 (value+)}
- │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 105 (sq1+), ColumnFamilyID: 0, ColumnID: 1 (value+), TypeName: "INT8"}
- │         │    ├── ABSENT → PUBLIC           ColumnNotNull:{DescID: 105 (sq1+), ColumnID: 1 (value+), IndexID: 0}
- │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 105 (sq1+), Name: "value", ColumnID: 1 (value+)}
- │         │    ├── ABSENT → PUBLIC           PrimaryIndex:{DescID: 105 (sq1+), IndexID: 1 (primary+)}
- │         │    ├── ABSENT → PUBLIC           IndexName:{DescID: 105 (sq1+), Name: "primary", IndexID: 1 (primary+)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 105 (sq1+), ColumnID: 1 (value+), IndexID: 1 (primary+)}
- │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 104 (t), ColumnID: 2 (j+)}
- │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 104 (t), Name: "j", ColumnID: 2 (j+)}
- │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 2 (j+), TypeName: "INT8"}
- │         │    ├── ABSENT → PUBLIC           ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 2 (j+), ReferencedSequenceIDs: [105 (sq1+)], Expr: nextval(105:::REGCLASS)}
- │         │    ├── ABSENT → BACKFILL_ONLY    PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey+)}
- │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey+)}
- │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 104 (t), ColumnID: 2 (j+), IndexID: 2 (t_pkey+)}
+ │         ├── 23 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → PUBLIC        Namespace:{DescID: 105 (sq1+), Name: "sq1", ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── ABSENT → PUBLIC        Owner:{DescID: 105 (sq1+)}
+ │         │    ├── ABSENT → PUBLIC        UserPrivileges:{DescID: 105 (sq1+), Name: "admin"}
+ │         │    ├── ABSENT → PUBLIC        UserPrivileges:{DescID: 105 (sq1+), Name: "root"}
+ │         │    ├── ABSENT → PUBLIC        Sequence:{DescID: 105 (sq1+)}
+ │         │    ├── ABSENT → PUBLIC        SequenceOption:{DescID: 105 (sq1+), Name: "START"}
+ │         │    ├── ABSENT → PUBLIC        SchemaChild:{DescID: 105 (sq1+), ReferencedDescID: 101 (public)}
+ │         │    ├── ABSENT → PUBLIC        TableData:{DescID: 105 (sq1+), ReferencedDescID: 100 (defaultdb)}
+ │         │    ├── ABSENT → PUBLIC        Column:{DescID: 105 (sq1+), ColumnID: 1 (value+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 105 (sq1+), ColumnFamilyID: 0, ColumnID: 1 (value+), TypeName: "INT8"}
+ │         │    ├── ABSENT → PUBLIC        ColumnNotNull:{DescID: 105 (sq1+), ColumnID: 1 (value+), IndexID: 0}
+ │         │    ├── ABSENT → PUBLIC        ColumnName:{DescID: 105 (sq1+), Name: "value", ColumnID: 1 (value+)}
+ │         │    ├── ABSENT → PUBLIC        PrimaryIndex:{DescID: 105 (sq1+), IndexID: 1 (primary+)}
+ │         │    ├── ABSENT → PUBLIC        IndexName:{DescID: 105 (sq1+), Name: "primary", IndexID: 1 (primary+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 105 (sq1+), ColumnID: 1 (value+), IndexID: 1 (primary+)}
+ │         │    ├── ABSENT → DELETE_ONLY   Column:{DescID: 104 (t), ColumnID: 2 (j+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnName:{DescID: 104 (t), Name: "j", ColumnID: 2 (j+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 2 (j+), TypeName: "INT8"}
+ │         │    ├── ABSENT → PUBLIC        ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 2 (j+), ReferencedSequenceIDs: [105 (sq1+)], Expr: nextval(105:::REGCLASS)}
+ │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey+)}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey+)}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j+), IndexID: 2 (t_pkey+)}
  │         ├── 3 elements transitioning toward TRANSIENT_ABSENT
- │         │    ├── ABSENT → DELETE_ONLY      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
- │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 104 (t), ColumnID: 2 (j+), IndexID: 3}
- │         └── 37 Mutation operations
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j+), IndexID: 3}
+ │         └── 40 Mutation operations
  │              ├── CreateSequenceDescriptor {"SequenceID":105}
  │              ├── SetSequenceOptions {"Key":"START","SequenceID":105,"Value":"32"}
  │              ├── SetObjectParentID {"ObjParent":{"ChildObjectID":105,"SchemaID":101}}
@@ -125,9 +126,12 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLU
  │              ├── MakeBackfillingIndexDeleteOnly {"IndexID":1,"TableID":105}
  │              ├── MakeValidatedColumnNotNullPublic {"ColumnID":1,"TableID":105}
  │              ├── MakeBackfilledIndexMerging {"IndexID":1,"TableID":105}
+ │              ├── MakeWriteOnlyColumnPublic {"ColumnID":1,"TableID":105}
  │              ├── MakeMergedIndexWriteOnly {"IndexID":1,"TableID":105}
  │              ├── SetIndexName {"IndexID":1,"Name":"primary","TableID":105}
  │              ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":105}
+ │              ├── InitSequence {"SequenceID":105}
+ │              ├── MarkDescriptorAsPublic {"DescriptorID":105}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":105,"Initialize":true}
  │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
@@ -188,10 +192,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLU
  │              └── ValidateIndex {"IndexID":2,"TableID":104}
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward PUBLIC
-      │    │    ├── DESCRIPTOR_ADDED      → PUBLIC           Sequence:{DescID: 105 (sq1+)}
-      │    │    ├── ABSENT                → PUBLIC           TableData:{DescID: 105 (sq1+), ReferencedDescID: 100 (defaultdb)}
-      │    │    ├── WRITE_ONLY            → PUBLIC           Column:{DescID: 105 (sq1+), ColumnID: 1 (value+)}
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY            → PUBLIC           Column:{DescID: 104 (t), ColumnID: 2 (j+)}
       │    │    ├── VALIDATED             → PUBLIC           PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
       │    │    └── ABSENT                → PUBLIC           IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 2 (t_pkey+)}
@@ -202,15 +203,12 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLU
       │    ├── 2 elements transitioning toward ABSENT
       │    │    ├── PUBLIC                → VALIDATED        PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
       │    │    └── PUBLIC                → ABSENT           IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey-)}
-      │    └── 15 Mutation operations
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":1,"TableID":105}
+      │    └── 12 Mutation operations
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"t_pkey","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
-      │         ├── InitSequence {"SequenceID":105}
-      │         ├── MarkDescriptorAsPublic {"DescriptorID":105}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}


### PR DESCRIPTION
Previously, the concept of reversibility was constant and decided inside the declarative schema changer opgen. While this works fine for simple single statement transactions more complex schema changes involving multiple objects may have different parameters. For example ADD COLUMN SERIAL needs to be able to revert plans after a sequence is created, since that sequence will not be accessible. To help support this patch does the following

1) Revertibility can now be either static or determined by the elements
   within a given plan.
2) Adding Column elements is now considered revertible if the object is
   newly created.
3) Sequence creation is now always considered revertible, since the
   object cannot be for other schema changes until the full transaction
   is complete.

Informs: #126900

Release note: None