### PR TITLE
sql: match PG error when dropping non-existent trigger

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -737,7 +737,7 @@ statement ok
 DROP TRIGGER bar ON xy;
 
 # Dropping a nonexistent trigger is an error.
-statement error pgcode 42704 pq: trigger "foo" of relation "xy" does not exist
+statement error pgcode 42704 pq: trigger "foo" for table "xy" does not exist
 DROP TRIGGER foo ON xy;
 
 # The IF EXISTS syntax allows dropping a nonexistent trigger without error.

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -431,7 +431,7 @@ func NewUndefinedConstraintError(constraintName, tableName string) error {
 // NewUndefinedTriggerError returns a missing constraint error.
 func NewUndefinedTriggerError(triggerName, tableName string) error {
 	return pgerror.Newf(pgcode.UndefinedObject,
-		"trigger %q of relation %q does not exist", triggerName, tableName)
+		"trigger %q for table %q does not exist", triggerName, tableName)
 }
 
 // NewRangeUnavailableError creates an unavailable range error.


### PR DESCRIPTION
Found in pg_regress (which we'll update separately).

Informs: #132515
Epic: None

Release note: None