### PR TITLE
workload: avoid some string format/parse roundtrips

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -240,6 +240,13 @@ func hashTableInitialData(
 				for i := 0; i < b.Length(); i++ {
 					_, _ = h.Write(colBytes.Get(i))
 				}
+			case types.TimestampFamily, types.TimestampTZFamily:
+				colTime := col.Timestamp()
+
+				for i := 0; i < b.Length(); i++ {
+					binary.LittleEndian.PutUint64(scratch[:8], uint64(colTime[i].UnixNano()))
+					_, _ = h.Write(scratch[:8])
+				}
 			default:
 				return errors.Errorf(`unhandled type %s`, col.Type())
 			}
@@ -275,7 +282,7 @@ func TestDeterministicInitialData(t *testing.T) {
 		`roachmart`:  0xda5e73423dbdb2d9,
 		`sqlsmith`:   0xcbf29ce484222325,
 		`startrek`:   0xa0249fbdf612734c,
-		`tpcc`:       0xab32e4f5e899eb2f,
+		`tpcc`:       0xf25e71062ca28dca,
 		`tpch`:       0xe4fd28db230b9149,
 		`ycsb`:       0xcfd3f148a01a2c47,
 	}

--- a/pkg/sql/importer/read_import_workload.go
+++ b/pkg/sql/importer/read_import_workload.go
@@ -120,6 +120,18 @@ func makeDatumFromColOffset(
 			str := *(*string)(unsafe.Pointer(&data))
 			return rowenc.ParseDatumStringAs(ctx, hint, str, evalCtx, semaCtx)
 		}
+	case types.TimestampFamily, types.TimestampTZFamily:
+		switch hint.Family() {
+		case types.TimestampFamily:
+			// workloads are responsible for rounding their timestamp(s) so skip
+			// MakeDTimestamp here and just directly construct it.
+			return alloc.NewDTimestamp(tree.DTimestamp{Time: col.Timestamp()[rowIdx]}), nil
+
+		case types.TimestampTZFamily:
+			// workloads are responsible for rounding their timestamp(s) so skip
+			// MakeDTimestamp here and just directly construct it.
+			return alloc.NewDTimestampTZ(tree.DTimestampTZ{Time: col.Timestamp()[rowIdx]}), nil
+		}
 	}
 	return nil, errors.Errorf(
 		`don't know how to interpret %s column as %s`, col.Type(), hint)

--- a/pkg/workload/tpcc/generate.go
+++ b/pkg/workload/tpcc/generate.go
@@ -301,7 +301,7 @@ var customerTypes = []*types.T{
 	types.Bytes,
 	types.Bytes,
 	types.Bytes,
-	types.Bytes,
+	types.Timestamp,
 	types.Bytes,
 	types.Float,
 	types.Float,
@@ -355,7 +355,7 @@ func (w *tpcc) tpccCustomerInitialRowBatch(
 	cb.ColVec(9).Bytes().Set(0, randStateInitialDataOnly(&l.rng, &lo, a))
 	cb.ColVec(10).Bytes().Set(0, randZipInitialDataOnly(&l.rng, &no, a))
 	cb.ColVec(11).Bytes().Set(0, randNStringInitialDataOnly(&l.rng, &no, a, 16, 16)) // phone number
-	cb.ColVec(12).Bytes().Set(0, w.nowString)
+	cb.ColVec(12).Timestamp()[0] = w.nowTime
 	cb.ColVec(13).Bytes().Set(0, credit)
 	cb.ColVec(14).Float64()[0] = creditLimit
 	cb.ColVec(15).Float64()[0] = float64(randInt(l.rng.Rand, 0, 5000)) / float64(10000.0) // discount
@@ -407,7 +407,7 @@ var historyTypes = []*types.T{
 	types.Int,
 	types.Int,
 	types.Int,
-	types.Bytes,
+	types.Timestamp,
 	types.Float,
 	types.Bytes,
 }
@@ -441,7 +441,7 @@ func (w *tpcc) tpccHistoryInitialRowBatch(rowIdx int, cb coldata.Batch, a *bufal
 	cb.ColVec(3).Int64()[0] = int64(wID)
 	cb.ColVec(4).Int64()[0] = int64(dID)
 	cb.ColVec(5).Int64()[0] = int64(wID)
-	cb.ColVec(6).Bytes().Set(0, w.nowString)
+	cb.ColVec(6).Timestamp()[0] = w.nowTime
 	cb.ColVec(7).Float64()[0] = 10.00
 	cb.ColVec(8).Bytes().Set(0, randAStringInitialDataOnly(&l.rng, &ao, a, 12, 24))
 }
@@ -468,7 +468,7 @@ var orderTypes = []*types.T{
 	types.Int,
 	types.Int,
 	types.Int,
-	types.Bytes,
+	types.Timestamp,
 	types.Int,
 	types.Int,
 	types.Int,
@@ -520,7 +520,7 @@ func (w *tpcc) tpccOrderInitialRowBatch(rowIdx int, cb coldata.Batch, a *bufallo
 	cb.ColVec(1).Int64()[0] = int64(dID)
 	cb.ColVec(2).Int64()[0] = int64(wID)
 	cb.ColVec(3).Int64()[0] = int64(cID)
-	cb.ColVec(4).Bytes().Set(0, w.nowString)
+	cb.ColVec(4).Timestamp()[0] = w.nowTime
 	cb.ColVec(5).Nulls().UnsetNulls()
 	if carrierSet {
 		cb.ColVec(5).Int64()[0] = carrierID
@@ -587,7 +587,7 @@ var orderLineTypes = []*types.T{
 	types.Int,
 	types.Int,
 	types.Int,
-	types.Bytes,
+	types.Timestamp,
 	types.Int,
 	types.Float,
 	types.Bytes,
@@ -619,23 +619,20 @@ func (w *tpcc) tpccOrderLineInitialRowBatch(
 	olSupplyWIDCol := cb.ColVec(5).Int64()
 	olDeliveryD := cb.ColVec(6)
 	olDeliveryD.Nulls().UnsetNulls()
-	olDeliveryDCol := olDeliveryD.Bytes()
+	olDeliveryDCol := olDeliveryD.Timestamp()
 	olQuantityCol := cb.ColVec(7).Int64()
 	olAmountCol := cb.ColVec(8).Float64()
 	olDistInfoCol := cb.ColVec(9).Bytes()
 
-	olDeliveryDCol.Reset()
 	olDistInfoCol.Reset()
 	for rowIdx := 0; rowIdx < numOrderLines; rowIdx++ {
 		olNumber := rowIdx + 1
 
 		var amount float64
 		var deliveryDSet bool
-		var deliveryD []byte
 		if oID < 2101 {
 			amount = 0
 			deliveryDSet = true
-			deliveryD = w.nowString
 		} else {
 			amount = float64(randInt(l.rng.Rand, 1, 999999)) / 100.0
 		}
@@ -647,10 +644,9 @@ func (w *tpcc) tpccOrderLineInitialRowBatch(
 		olIIDCol[rowIdx] = randInt(l.rng.Rand, 1, 100000)
 		olSupplyWIDCol[rowIdx] = int64(wID)
 		if deliveryDSet {
-			olDeliveryDCol.Set(rowIdx, deliveryD)
+			olDeliveryDCol.Set(rowIdx, w.nowTime)
 		} else {
 			olDeliveryD.Nulls().SetNull(rowIdx)
-			olDeliveryDCol.Set(rowIdx, nil)
 		}
 		olQuantityCol[rowIdx] = 5
 		olAmountCol[rowIdx] = amount

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -54,7 +54,7 @@ type tpcc struct {
 
 	warehouses       int
 	activeWarehouses int
-	nowString        []byte
+	nowTime          time.Time
 	numConns         int
 	idleConns        int
 	txnRetries       bool
@@ -318,7 +318,11 @@ var tpccMeta = workload.Meta{
 		g.connFlags = workload.NewConnFlags(&g.flags)
 		// Hardcode this since it doesn't seem like anyone will want to change
 		// it and it's really noisy in the generated fixture paths.
-		g.nowString = []byte(`2006-01-02 15:04:05`)
+		var err error
+		g.nowTime, err = time.Parse(`2006-01-02 15:04:05`, `2006-01-02 15:04:05`)
+		if err != nil {
+			panic(err) // unreachable.
+		}
 		return g
 	},
 }

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -361,6 +361,12 @@ func ColBatchToRows(cb coldata.Batch) [][]interface{} {
 					datums[rowIdx*numCols+colIdx] = colBytes.Get(rowIdx)
 				}
 			}
+		case types.TimestampTZFamily:
+			for rowIdx, datum := range col.Timestamp()[:numRows] {
+				if !nulls.NullAt(rowIdx) {
+					datums[rowIdx*numCols+colIdx] = datum
+				}
+			}
 		default:
 			panic(fmt.Sprintf(`unhandled type %s`, col.Type()))
 		}


### PR DESCRIPTION
Previously we were formatting Timestamps into strings, and allocating those strings, to put them into the column vector only for import's workload reader to parse the strings back into native types as it read the vector, accounting for 5% or more of total CPU usage when IMPORT'ing from workload-generated TPCC data.

Taken from #121417.

Epic: None