### PR TITLE
release-24.3: sql/schemachanger: Correct version gate for ALTER COLUMN TYPE

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -912,6 +912,7 @@ ALTER TABLE t_bytes ALTER COLUMN c1 SET DATA TYPE STRING;
 # declarative schema changer. So we skip when running the legacy schema changer.
 skipif config local-legacy-schema-changer
 skipif config local-mixed-24.1
+skipif config local-mixed-24.2
 query T
 SELECT c1 FROM t_bytes ORDER BY c1;
 ----
@@ -923,6 +924,7 @@ hello
 # for dsc.
 skipif config local-legacy-schema-changer
 skipif config local-mixed-24.1
+skipif config local-mixed-24.2
 statement error pq: validation of CHECK ".*" failed on row.*
 ALTER TABLE t_bytes ALTER COLUMN c2 SET DATA TYPE CHAR(4);
 
@@ -955,6 +957,7 @@ ALTER TABLE t_bytes ALTER COLUMN c3 SET DATA TYPE UUID USING c3::UUID;
 # legacy.
 skipif config local-legacy-schema-changer
 skipif config local-mixed-24.1
+skipif config local-mixed-24.2
 query TT
 SELECT c2,c3 FROM t_bytes ORDER BY c1;
 ----
@@ -1006,6 +1009,7 @@ ALTER TABLE t_decimal ALTER COLUMN c1 SET DATA TYPE DECIMAL(7,2);
 # properly detect this case.
 skipif config local-legacy-schema-changer
 skipif config local-mixed-24.1
+skipif config local-mixed-24.2
 statement error pq: validation of CHECK ".*" failed on row.*
 ALTER TABLE t_decimal ALTER COLUMN c2 SET DATA TYPE DECIMAL(10,2);
 
@@ -1060,6 +1064,7 @@ NULL  NULL  NULL   NULL   NULL
 # Skip for the legacy schema changer as it doesn't allow multiple alters in one statement.
 skipif config local-legacy-schema-changer
 skipif config local-mixed-24.1
+skipif config local-mixed-24.2
 statement error pq: validation of CHECK ".*" failed on row.*
 ALTER TABLE t_bit_string ALTER COLUMN c1 SET DATA TYPE BIT(4), ALTER COLUMN c2 SET DATA TYPE VARBIT(4);
 
@@ -1068,6 +1073,7 @@ UPDATE t_bit_string SET C2=B'1010' WHERE pk = 1;
 
 skipif config local-legacy-schema-changer
 skipif config local-mixed-24.1
+skipif config local-mixed-24.2
 statement ok
 ALTER TABLE t_bit_string ALTER COLUMN c1 SET DATA TYPE VARBIT(8), ALTER COLUMN c2 SET DATA TYPE VARBIT(4);
 
@@ -1101,6 +1107,7 @@ ALTER TABLE t_bit_string ALTER COLUMN c3 SET DATA TYPE BYTES USING C3::BYTES;
 # shouldn't be allowed.
 skipif config local-legacy-schema-changer
 skipif config local-mixed-24.1
+skipif config local-mixed-24.2
 statement error pq: validation of CHECK ".*" failed on row.*
 ALTER TABLE t_bit_string ALTER COLUMN c4 SET DATA TYPE CHAR(4);
 
@@ -1126,6 +1133,7 @@ NULL  NULL  NULL   NULL   NULL
 # legacy schema changer so skipping in that mode.
 skipif config local-legacy-schema-changer
 skipif config local-mixed-24.1
+skipif config local-mixed-24.2
 statement error pq: validation of CHECK ".*" failed on row.*
 ALTER TABLE t_bit_string ALTER COLUMN c5 SET DATA TYPE CHAR(6);
 

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -4235,6 +4235,7 @@ NOTICE: type of foreign key column "t1_fk_col1" (CHAR(8)) is not identical to re
 # Test trivial data type change
 skipif config local-legacy-schema-changer
 skipif config local-mixed-24.1
+skipif config local-mixed-24.2
 skipif config weak-iso-level-configs
 query T noticetrace
 ALTER TABLE t2_fk ALTER COLUMN t1_fk_col2 SET DATA TYPE INT8
@@ -4251,6 +4252,7 @@ NOTICE: type of foreign key column "t1_fk_col2" (INT8) is not identical to refer
 # Test validation data type change
 skipif config local-legacy-schema-changer
 skipif config local-mixed-24.1
+skipif config local-mixed-24.2
 skipif config weak-iso-level-configs
 query T noticetrace
 ALTER TABLE t2_fk ALTER COLUMN t1_fk_col1 SET DATA TYPE CHAR(5)
@@ -4267,6 +4269,7 @@ NOTICE: type of foreign key column "t1_fk_col1" (CHAR(5)) is not identical to re
 
 skipif config local-legacy-schema-changer
 skipif config local-mixed-24.1
+skipif config local-mixed-24.2
 query TT
 SHOW CREATE TABLE t2_fk
 ----

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
@@ -38,7 +38,7 @@ var supportedAlterTableStatements = map[reflect.Type]supportedAlterTableCommand{
 	reflect.TypeOf((*tree.AlterTableDropConstraint)(nil)):     {fn: alterTableDropConstraint, on: true, checks: nil},
 	reflect.TypeOf((*tree.AlterTableValidateConstraint)(nil)): {fn: alterTableValidateConstraint, on: true, checks: nil},
 	reflect.TypeOf((*tree.AlterTableSetDefault)(nil)):         {fn: alterTableSetDefault, on: true, checks: nil},
-	reflect.TypeOf((*tree.AlterTableAlterColumnType)(nil)):    {fn: alterTableAlterColumnType, on: true, checks: isV242Active},
+	reflect.TypeOf((*tree.AlterTableAlterColumnType)(nil)):    {fn: alterTableAlterColumnType, on: true, checks: isV243Active},
 }
 
 func init() {


### PR DESCRIPTION
Backport 1/1 commits from #135731.

/cc @cockroachdb/release

---

Previously, a version gate of 24.2 was applied to certain ALTER COLUMN TYPE operations. For trivial or validation-only changes, support for ALTER COLUMN TYPE in the declarative schema changer was added in PRs
 #126143 and #127823. However, the wrong version gate was used; these
changes were first introduced in version 24.3.0. This update corrects the version gate to reflect that.

Epic: CRDB-25314
Closes #132523
Release note: none
Release justification: low risk bug fix for any one using alter column type in a mixed-mode environment