### PR TITLE
roachtest: refactor and code cleanup in openmetrics emission in roachtests

### DIFF
--- a/pkg/cmd/roachtest/clusterstats/exporter.go
+++ b/pkg/cmd/roachtest/clusterstats/exporter.go
@@ -135,7 +135,7 @@ func (r *ClusterStatRun) serializeOpenmetricsOutRun(
 	if err != nil {
 		return errors.Wrap(err, "failed to serialize perf artifacts")
 	}
-	dest := filepath.Join(t.PerfArtifactsDir(), "openmetrics.om")
+	dest := filepath.Join(t.PerfArtifactsDir(), "stats.om")
 	return statsWriter(ctx, t, c, report, dest)
 }
 
@@ -143,9 +143,9 @@ func serializeOpenmetricsReport(r ClusterStatRun, labelString *string) (*bytes.B
 	var buffer bytes.Buffer
 
 	// Emit summary metrics from Total
-	for key, value := range r.Total {
-		buffer.WriteString(fmt.Sprintf("# TYPE %s gauge\n", util.SanitizeMetricName(key)))
-		buffer.WriteString(fmt.Sprintf("%s{%s} %f %d\n", util.SanitizeKey(key), *labelString, value, timeutil.Now().UTC().Unix()))
+	for metricName, value := range r.Total {
+		buffer.WriteString(fmt.Sprintf("# TYPE %s gauge\n", util.SanitizeMetricName(metricName)))
+		buffer.WriteString(fmt.Sprintf("%s{%s} %f %d\n", util.SanitizeMetricName(metricName), *labelString, value, timeutil.Now().UTC().Unix()))
 	}
 
 	// Emit histogram metrics from Stats

--- a/pkg/cmd/roachtest/clusterstats/exporter_test.go
+++ b/pkg/cmd/roachtest/clusterstats/exporter_test.go
@@ -331,7 +331,7 @@ func TestExport(t *testing.T) {
 		statsWriter = func(ctx context.Context, tt test.Test, c cluster.Cluster, buffer *bytes.Buffer, dest string) error {
 			require.Equal(t, mockTest, tt)
 			require.Equal(t, mockCluster, c)
-			require.Equal(t, "/location/of/file/openmetrics.om", dest)
+			require.Equal(t, "/location/of/file/stats.om", dest)
 
 			require.Equal(t, parseData(expectedOutput), parseData(buffer.String()))
 			return nil

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -337,6 +337,7 @@ func registerBackup(r registry.Registry) {
 			dest := importBankData(ctx, rows, t, c)
 			exporter := roachtestutil.CreateWorkloadHistogramExporter(t, c)
 			tick, perfBuf := initBulkJobPerfArtifacts(2*time.Hour, t, exporter)
+			defer roachtestutil.UploadPerfArtifacts(ctx, t, c, perfBuf, exporter, c.Node(1))
 
 			m := c.NewMonitor(ctx)
 			m.Go(func(ctx context.Context) error {
@@ -356,10 +357,6 @@ func registerBackup(r registry.Registry) {
 					return err
 				}
 				tick()
-
-				if _, err := roachtestutil.CreateStatsFileInClusterFromExporter(ctx, t, c, perfBuf, exporter, c.Node(1)); err != nil {
-					return err
-				}
 				return nil
 			})
 			m.Wait()

--- a/pkg/cmd/roachtest/tests/cdc_bench.go
+++ b/pkg/cmd/roachtest/tests/cdc_bench.go
@@ -654,6 +654,8 @@ func writeCDCBenchStats(
 	writer := io.Writer(bytesBuf)
 
 	exporter.Init(&writer)
+	defer roachtestutil.UploadPerfArtifacts(ctx, t, c, bytesBuf, exporter, node)
+
 	var err error
 	reg.GetHandle().Get(metric).Record(valueS)
 	reg.Tick(func(tick histogram.Tick) {
@@ -663,8 +665,5 @@ func writeCDCBenchStats(
 		return err
 	}
 
-	if _, err = roachtestutil.CreateStatsFileInClusterFromExporter(ctx, t, c, bytesBuf, exporter, node); err != nil {
-		return err
-	}
 	return nil
 }

--- a/pkg/cmd/roachtest/tests/decommissionbench.go
+++ b/pkg/cmd/roachtest/tests/decommissionbench.go
@@ -499,16 +499,16 @@ func uploadPerfArtifacts(
 	benchSpec decommissionBenchSpec,
 	pinnedNode, workloadNode int,
 	perfBuf *bytes.Buffer,
-	exporter exporter.Exporter,
 ) {
 	// Store the perf artifacts on the pinned node so that the test
 	// runner copies it into an appropriate directory path.
 
-	destFileName, err := roachtestutil.CreateStatsFileInClusterFromExporter(ctx, t, c, perfBuf, exporter, c.Node(pinnedNode))
+	err := roachtestutil.CreateStatsFileInNode(ctx, t, c, perfBuf, c.Node(pinnedNode))
 	if err != nil {
 		t.L().Errorf("error creating perf stats file: %s", err)
 		return
 	}
+	destFileName := roachtestutil.GetBenchmarkMetricsFileName(t)
 	dest := filepath.Join(t.PerfArtifactsDir(), destFileName)
 
 	// Get the workload perf artifacts and move them to the pinned node, so that
@@ -675,6 +675,15 @@ func runDecommissionBench(
 		bytesUsedMetric,
 	)
 
+	defer func() {
+		if err := exporter.Close(func() error {
+			uploadPerfArtifacts(ctx, t, c, benchSpec, pinnedNode, workloadNode, perfBuf)
+			return nil
+		}); err != nil {
+			t.Errorf("error closing perf exporter: %s", err)
+		}
+	}()
+
 	// The logical node id of the current decommissioning node.
 	var targetNodeAtomic uint32
 
@@ -734,8 +743,6 @@ func runDecommissionBench(
 	if err := m.WaitE(); err != nil {
 		t.Fatal(err)
 	}
-
-	uploadPerfArtifacts(ctx, t, c, benchSpec, pinnedNode, workloadNode, perfBuf, exporter)
 }
 
 // runDecommissionBenchLong initializes a cluster with TPCC and attempts to
@@ -807,6 +814,15 @@ func runDecommissionBenchLong(
 		decommissionMetric, upreplicateMetric, bytesUsedMetric,
 	)
 
+	defer func() {
+		if err := exporter.Close(func() error {
+			uploadPerfArtifacts(ctx, t, c, benchSpec, pinnedNode, workloadNode, perfBuf)
+			return nil
+		}); err != nil {
+			t.Errorf("error closing perf exporter: %s", err)
+		}
+	}()
+
 	// The logical node id of the current decommissioning node.
 	var targetNodeAtomic uint32
 
@@ -861,7 +877,6 @@ func runDecommissionBenchLong(
 		t.Fatal(err)
 	}
 
-	uploadPerfArtifacts(ctx, t, c, benchSpec, pinnedNode, workloadNode, perfBuf, exporter)
 }
 
 // runSingleDecommission picks a random node and attempts to decommission that

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -138,6 +138,8 @@ func registerImportTPCC(r registry.Registry) {
 
 		exporter := roachtestutil.CreateWorkloadHistogramExporter(t, c)
 		tick, perfBuf := initBulkJobPerfArtifacts(timeout, t, exporter)
+		defer roachtestutil.UploadPerfArtifacts(ctx, t, c, perfBuf, exporter, c.Node(1))
+
 		workloadStr := `./cockroach workload fixtures import tpcc --warehouses=%d --csv-server='http://localhost:8081' {pgurl:1}`
 		m.Go(func(ctx context.Context) error {
 			defer dul.Done()
@@ -155,10 +157,6 @@ func registerImportTPCC(r registry.Registry) {
 			tick()
 			c.Run(ctx, option.WithNodes(c.Node(1)), cmd)
 			tick()
-
-			if _, err := roachtestutil.CreateStatsFileInClusterFromExporter(ctx, t, c, perfBuf, exporter, c.Node(1)); err != nil {
-				return err
-			}
 			return nil
 		})
 		m.Wait()
@@ -233,8 +231,8 @@ func registerImportTPCH(r registry.Registry) {
 			Leases:            registry.MetamorphicLeases,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				exporter := roachtestutil.CreateWorkloadHistogramExporter(t, c)
-
 				tick, perfBuf := initBulkJobPerfArtifacts(item.timeout, t, exporter)
+				defer roachtestutil.UploadPerfArtifacts(ctx, t, c, perfBuf, exporter, c.Node(1))
 
 				c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
 				conn := c.Conn(ctx, t.L(), 1)
@@ -318,10 +316,6 @@ func registerImportTPCH(r registry.Registry) {
 						return errors.Wrap(err, "import failed")
 					}
 					tick()
-
-					if _, err = roachtestutil.CreateStatsFileInClusterFromExporter(ctx, t, c, perfBuf, exporter, c.Node(1)); err != nil {
-						return err
-					}
 					return nil
 				})
 

--- a/pkg/cmd/roachtest/tests/perturbation/framework.go
+++ b/pkg/cmd/roachtest/tests/perturbation/framework.go
@@ -857,6 +857,7 @@ func (v variations) writePerfArtifacts(
 	bytesBuf := bytes.NewBuffer([]byte{})
 	writer := io.Writer(bytesBuf)
 	exporter.Init(&writer)
+	defer roachtestutil.UploadPerfArtifacts(ctx, t, c, bytesBuf, exporter, v.Node(1))
 
 	reg.GetHandle().Get("baseline").Record(baseline["write"].score)
 	reg.GetHandle().Get("perturbation").Record(perturbation["write"].score)
@@ -867,11 +868,6 @@ func (v variations) writePerfArtifacts(
 		err = tick.Exporter.SnapshotAndWrite(tick.Hist, tick.Now, tick.Elapsed, &tick.Name)
 	})
 	if err != nil {
-		return err
-	}
-
-	node := v.Node(1)
-	if _, err := roachtestutil.CreateStatsFileInClusterFromExporter(ctx, t, c, bytesBuf, exporter, node); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -1133,6 +1133,7 @@ func exportToRoachperf(
 	writer := io.Writer(bytesBuf)
 
 	exporter.Init(&writer)
+	defer roachtestutil.UploadPerfArtifacts(ctx, t, c, bytesBuf, exporter, c.Node(1))
 	var err error
 	// Ensure the histogram contains the name of the roachtest
 	reg.GetHandle().Get(testName)
@@ -1143,10 +1144,6 @@ func exportToRoachperf(
 	})
 
 	if err != nil {
-		return
-	}
-	if _, err = roachtestutil.CreateStatsFileInClusterFromExporter(ctx, t, c, bytesBuf, exporter, c.Node(1)); err != nil {
-		t.L().Errorf("error creating stats file: %s", err)
 		return
 	}
 }


### PR DESCRIPTION
1. This change aims to refactor `exporter.Close()` from
`CreateStatsFileFromExporter` to a each roachtest and use defer to make
the code more clean and easy to understand.
2. There were some code smell and nit errors in `statsexporter` package.
This change also fixes those.

Epic: none

Release note: None