### PR TITLE
sql/tablemetadatacache: speed up tests

### DIFF
--- a/pkg/sql/tablemetadatacache/update_table_metadata_cache_job_test.go
+++ b/pkg/sql/tablemetadatacache/update_table_metadata_cache_job_test.go
@@ -41,6 +41,7 @@ func TestUpdateTableMetadataCacheAutomaticUpdates(t *testing.T) {
 	// Server setup.
 	s := serverutils.StartServerOnly(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 			TableMetadata: &tablemetadatacacheutil.TestingKnobs{
 				TableMetadataUpdater: &updater,
 			},


### PR DESCRIPTION
This test was taking 35s or more before while sleeping for adoption intervals but can run in ~5s with fast adoptions.

Release note: none.
Epic: none.