### PR TITLE
release-24.3.0-rc: upgrade: adding is_draining to system.sql_instance can fail

### DIFF
--- a/pkg/upgrade/upgrades/v24_3_sql_instances_add_draining.go
+++ b/pkg/upgrade/upgrades/v24_3_sql_instances_add_draining.go
@@ -9,35 +9,22 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/errors"
 )
 
 // sqlInstancesAddDrainingMigration adds a new column `is_draining` to the
 // system.sql_instances table.
 func sqlInstancesAddDrainingMigration(
-	ctx context.Context, cs clusterversion.ClusterVersion, deps upgrade.TenantDeps,
+	ctx context.Context, clusterVersion clusterversion.ClusterVersion, deps upgrade.TenantDeps,
 ) error {
-	finalDescriptor := systemschema.SQLInstancesTable()
-	// Replace the stored descriptor with the bootstrap descriptor.
-	err := deps.DB.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
-		expectedDesc := finalDescriptor.TableDesc()
-		mutableDesc, err := txn.Descriptors().MutableByID(txn.KV()).Table(ctx, expectedDesc.GetID())
-		if err != nil {
-			return err
-		}
-		version := mutableDesc.Version
-		mutableDesc.TableDescriptor = *protoutil.Clone(expectedDesc).(*descpb.TableDescriptor)
-		mutableDesc.Version = version
-		return txn.Descriptors().WriteDesc(ctx, false, mutableDesc, txn.KV())
-	})
-	if err != nil {
-		return errors.Wrapf(err, "unable to replace system descriptor for system.%s (%+v)",
-			finalDescriptor.GetName(), finalDescriptor)
-	}
-	return err
+	return migrateTable(ctx, clusterVersion, deps, operation{
+		name:           "add-draining-column",
+		schemaList:     []string{"is_draining"},
+		schemaExistsFn: columnExists,
+		query:          `ALTER TABLE system.sql_instances ADD COLUMN IF NOT EXISTS is_draining BOOL NULL FAMILY "primary"`,
+	},
+		keys.SQLInstancesTableID,
+		systemschema.SQLInstancesTable())
 }


### PR DESCRIPTION
Backport 1/1 commits from #135737.

/cc @cockroachdb/release

---

Previously, the logic to add the is_draining column to the system.sql_instance descriptor would copy the bootstrap descriptor directly. While this works fine for non-multiregion system databases, this approach breaks for multi-region system databases. This is because bootstrap descriptors do not have multi-region modifications applied on top. To address this, this change modifies the upgrade to use ALTER TABLE ADD COLUMN.

Fixes: #135736

Release note: None

Release justification: low risk fix for an issue that can prevent version finalization with MR system databases
