### PR TITLE
roachtest: fix perturbation/metamorphic/backfill

### DIFF
--- a/pkg/cmd/roachtest/tests/perturbation/index_backfill.go
+++ b/pkg/cmd/roachtest/tests/perturbation/index_backfill.go
@@ -35,10 +35,11 @@ func (b backfill) setupMetamorphic(rng *rand.Rand) variations {
 	v := b.setup()
 	// TODO(#133114): The backfill test can cause OOM with low memory
 	// configurations.
+	v = v.randomize(rng)
 	if v.mem == spec.Low {
 		v.mem = spec.Standard
 	}
-	return v.randomize(rng)
+	return v
 }
 
 // startTargetNode starts the target node and creates the backfill table.


### PR DESCRIPTION
Previously this test was setting the memory spec before it called randomize. This could set it back to low memory. We already know that low memory configuration doesn't work for backfill as part of #133114.

This change calls randomize and then sets the memory configuration.

Epic: none
Fixes: #135799

Release note: None