### PR TITLE
sql/schemachanger: Ensure column alterations check for dropped status

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -1665,4 +1665,50 @@ virt3      CREATE TABLE public.virt3 (
 statement ok
 DROP TABLE virt3;
 
+subtest alter_dropped_col
+
+# Force DSC always so that we use it within a transaction
+let $schema_changer_state
+SELECT value FROM information_schema.session_variables where variable='use_declarative_schema_changer'
+
+skipif config local-legacy-schema-changer
+statement ok
+set use_declarative_schema_changer = 'unsafe_always';
+
+statement ok
+create table t_droppedcol (dropme int);
+
+statement ok
+begin;
+
+statement ok
+alter table t_droppedcol drop column dropme;
+
+skipif config local-legacy-schema-changer local-mixed-24.2
+statement error pq: column "dropme" does not exist
+alter table t_droppedcol alter column dropme set data type text;
+
+onlyif config local-legacy-schema-changer
+statement error pq: column "dropme" in the middle of being dropped
+alter table t_droppedcol alter column dropme set data type text;
+
+statement ok
+rollback;
+
+query TT
+SHOW CREATE TABLE t_droppedcol;
+----
+t_droppedcol CREATE TABLE public.t_droppedcol (
+               dropme INT8 NULL,
+               rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+               CONSTRAINT t_droppedcol_pkey PRIMARY KEY (rowid ASC)
+             )
+
+statement ok
+DROP TABLE t_droppedcol;
+
+# Restore the schema changer state back.
+statement ok
+SET use_declarative_schema_changer = $schema_changer_state
+
 subtest end

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -4083,4 +4083,67 @@ SELECT * FROM tbl_with_dft_column_family ORDER BY 1
 2  2.0  {"lion": "gazelle"}  def
 3  3.0  {"wolf": "sheep"}    ghi
 
+subtest alter_dropped_col
+
+# Force DSC always so that we use it within a transaction
+let $schema_changer_state
+SELECT value FROM information_schema.session_variables where variable='use_declarative_schema_changer'
+
+skipif config local-legacy-schema-changer
+statement ok
+set use_declarative_schema_changer = 'unsafe_always';
+
+statement ok
+create table t_droppedcol (dropme int);
+
+statement ok
+begin;
+
+statement ok
+alter table t_droppedcol drop column dropme;
+
+skipif config local-legacy-schema-changer
+statement error pq: column "dropme" does not exist
+alter table t_droppedcol alter column dropme set not null;
+
+onlyif config local-legacy-schema-changer
+statement error pq: column "dropme" in the middle of being dropped
+alter table t_droppedcol alter column dropme set not null;
+
+statement ok
+rollback;
+
+statement ok
+begin;
+
+statement ok
+alter table t_droppedcol drop column dropme;
+
+skipif config local-legacy-schema-changer
+statement error pq: column "dropme" does not exist
+alter table t_droppedcol alter column dropme set default 99;
+
+onlyif config local-legacy-schema-changer
+statement error pq: column "dropme" in the middle of being dropped
+alter table t_droppedcol alter column dropme set default 99;
+
+statement ok
+rollback;
+
+query TT
+SHOW CREATE TABLE t_droppedcol;
+----
+t_droppedcol CREATE TABLE public.t_droppedcol (
+               dropme INT8 NULL,
+               rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+               CONSTRAINT t_droppedcol_pkey PRIMARY KEY (rowid ASC)
+             )
+
+statement ok
+DROP TABLE t_droppedcol;
+
+# Restore the schema changer state back.
+statement ok
+SET use_declarative_schema_changer = $schema_changer_state
+
 subtest end

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
@@ -368,9 +369,12 @@ func getColumnIDFromColumnName(
 		return 0
 	}
 
-	_, _, colElem := scpb.FindColumn(colElems)
+	_, targetStatus, colElem := scpb.FindColumn(colElems)
 	if colElem == nil {
 		panic(errors.AssertionFailedf("programming error: cannot find a Column element for column %v", columnName))
+	}
+	if targetStatus == scpb.ToAbsent && required {
+		panic(colinfo.NewUndefinedColumnError(string(columnName)))
 	}
 	return colElem.ColumnID
 }


### PR DESCRIPTION
In the Declarative Schema Changer (DSC), three operations—ALTER COLUMN TYPE, SET NULLABILITY, and SET DEFAULT—did not verify whether a column had already been marked for drop. This could lead to issues if a DROP COLUMN and one of these operations were executed within the same transaction.

This update ensures that when these operations look up a column element, they also check its target status to confirm it has not been dropped.

Epic: CRDB-25314
Closes: #134008
Release note: None