### PR TITLE
sql: added a NOTICE that a table created using CREATE TABLE AS does not inherit the primary key

### DIFF
--- a/pkg/cli/clisqlshell/sql_test.go
+++ b/pkg/cli/clisqlshell/sql_test.go
@@ -102,6 +102,7 @@ func Example_sql() {
 	// sql -e create table t.g1 (x int)
 	// CREATE TABLE
 	// sql -e create table t.g2 as select * from generate_series(1,10)
+	// NOTICE: CREATE TABLE ... AS does not copy over indexes, default expressions, or constraints; the new table has a hidden rowid primary key column
 	// CREATE TABLE AS
 	// sql -d nonexistent -e select count(*) from "".information_schema.tables limit 0
 	// count

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -373,6 +373,13 @@ func (n *createTableNode) startExec(params runParams) error {
 		return err
 	}
 	if n.n.As() {
+		params.p.BufferClientNotice(
+			params.ctx,
+			pgnotice.Newf("CREATE TABLE ... AS does not copy over "+
+				"indexes, default expressions, or constraints; the new table "+
+				"has a hidden rowid primary key column"),
+		)
+
 		asCols := planColumns(n.sourcePlan)
 		if !n.n.AsHasUserSpecifiedPrimaryKey() {
 			// rowID column is already present in the input as the last column

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -1110,3 +1110,23 @@ statement error pgcode 42804 could not find matching function overload for given
 CREATE TABLE t_133399 AS (SELECT * FROM v_133399 WINDOW window_name AS (ROWS c01 BETWEEN nextval ('abc', 'abc', 'abc') AND c01 PRECEDING));
 
 subtest end
+
+subtest create_table_as_notice
+
+statement ok
+CREATE TABLE IF NOT EXISTS t1 (
+  id1 UUID NOT NULL DEFAULT gen_random_uuid(),
+  id2 UUID NOT NULL DEFAULT gen_random_uuid(),
+  ts TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp(),
+  val JSONB,
+  PRIMARY KEY(id1, id2)
+);
+
+# Ignore weaker isolation levels, since that will cause additional NOTICEs that we don't want to check in this test.
+skipif config weak-iso-level-configs
+query T noticetrace
+CREATE TABLE t2 AS SELECT * FROM t1;
+----
+NOTICE: CREATE TABLE ... AS does not copy over indexes, default expressions, or constraints; the new table has a hidden rowid primary key column
+
+subtest end

--- a/pkg/sql/pgwire/testdata/pgtest/multiple_active_portals
+++ b/pkg/sql/pgwire/testdata/pgtest/multiple_active_portals
@@ -1324,7 +1324,7 @@ Query {"String": "CREATE TABLE t110486_1 (k1 PRIMARY KEY) AS VALUES (1), (2), (3
 Query {"String": "CREATE TABLE t110486_2 (k2 PRIMARY KEY) AS VALUES (1), (2), (3);"}
 ----
 
-until
+until ignore=NoticeResponse
 ReadyForQuery
 ReadyForQuery
 ----


### PR DESCRIPTION
Previously we had no notice when the user runs CREATE TABLE ... AS statement. Now we have a notice making the user aware of it's limitations.

Fixes: #131675
Release note (sql change): Added an informational notice to the result of `CREATE TABLE ... AS` statements that describes that indexes and constraints are not copied to the new table.