### PR TITLE
kv: print traced query when failing the TestProxyTracing

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -4918,6 +4918,22 @@ func TestProxyTracing(t *testing.T) {
 			return nil
 		}
 
+		printTrace := func() {
+			t.Log("started printing a trace")
+			rows, err := conn.QueryContext(ctx, "SELECT message, tag, location FROM [SHOW TRACE FOR SESSION]")
+			require.NoError(t, err)
+			defer rows.Close()
+
+			// Iterate over the results and print them
+			for rows.Next() {
+				var msg, tag, loc string
+				err := rows.Scan(&msg, &tag, &loc)
+				require.NoError(t, err)
+				t.Logf("msg: %s, tag: %s, loc: %s", msg, tag, loc)
+			}
+			require.NoError(t, rows.Err())
+		}
+
 		// Wait until the leaseholder for the test table ranges are on n3.
 		testutils.SucceedsSoon(t, func() error {
 			return checkLeaseCount(3, numRanges)
@@ -4927,7 +4943,6 @@ func TestProxyTracing(t *testing.T) {
 
 		_, err = conn.Exec("SET TRACING = on; SELECT FROM t where i = 987654321; SET TRACING = off")
 		require.NoError(t, err)
-
 		// Expect the "proxy request complete" message to be in the trace and that it
 		// comes from the proxy node n2.
 		var msg, tag, loc string
@@ -4937,6 +4952,10 @@ func TestProxyTracing(t *testing.T) {
 			AND location LIKE '%server/node%'
 			AND tag LIKE '%n2%'`,
 		).Scan(&msg, &tag, &loc); err != nil {
+			// If we fail for any reason, print the trace to help debugging.
+			printTrace()
+			// Make sure that node 3 still holds the leases.
+			require.NoError(t, checkLeaseCount(3, numRanges))
 			if errors.Is(err, gosql.ErrNoRows) {
 				t.Fatalf("request succeeded without proxying")
 			}


### PR DESCRIPTION
This commit prints the traced query when TestProxyTracing test fails. This should help with debugging the failures.

References: #135493

Release note: None