### PR TITLE
kvcoord: disable deadlock/race for expiration leases TestProxyTracing

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -4818,7 +4818,10 @@ func TestProxyTracing(t *testing.T) {
 	ctx := context.Background()
 
 	testutils.RunValues(t, "lease-type", roachpb.LeaseTypes(), func(t *testing.T, leaseType roachpb.LeaseType) {
-		if leaseType == roachpb.LeaseEpoch {
+		if leaseType == roachpb.LeaseExpiration {
+			skip.UnderRace(t, "too slow")
+			skip.UnderDeadlock(t, "too slow")
+		} else if leaseType == roachpb.LeaseEpoch {
 			// With epoch leases this test doesn't work reliably. It passes
 			// in cases where it should fail and fails in cases where it
 			// should pass.


### PR DESCRIPTION
This commit disables deadlock/race runs for TestProxyTracing when running with expiration leases. The main reason is that it consumes resources unnecessarily.

References: #135493

Release note: None