### PR TITLE
row: mark an error from streamer as StorageError

### DIFF
--- a/pkg/sql/row/BUILD.bazel
+++ b/pkg/sql/row/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//pkg/sql/catalog/fetchpb",
         "//pkg/sql/catalog/schemaexpr",
         "//pkg/sql/catalog/seqexpr",
+        "//pkg/sql/colexecerror",
         "//pkg/sql/colmem",
         "//pkg/sql/isql",
         "//pkg/sql/pgwire/pgcode",


### PR DESCRIPTION
Earlier this year we changed the vectorized panic-catcher, namely, we now check a few special error types (like `StorageError`, `notInternalError`, and `internalError` upfront - to avoid more expensive stack-based checks). If we find an `internalError` _and_ it doesn't have a PG code and doesn't have `StorageError` or `notInternalError` in the causes, we now always mark the error as assertion failure. This made it so that we started receiving more sentry reports than previously; in particular, whenever we're using the streamer API, we could now get `stop.ErrUnavailable` via the following sequence of calls `ColIndexJoin.Next` -> `cFetcher.StartScan` -> `txnKVStreamer.SetupNextFetch` -> `Streamer.Enqueue`, and this would trigger a sentry report. This commit fixes this by marking an error coming from `Streamer.Enqueue` as `StorageError` which will by-pass the logic in the panic-catcher.

Fixes: #128649.

Release note: None