### PR TITLE
release-24.3: sql: display triggers in EXPLAIN output

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/generic
+++ b/pkg/ccl/logictestccl/testdata/logic_test/generic
@@ -1,10 +1,5 @@
 # LogicTest: local
 
-# Disable stats collection to prevent automatic stats collection from
-# invalidating plans.
-statement ok
-SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;
-
 statement ok
 CREATE TABLE t (
   k INT PRIMARY KEY,

--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers_explain
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers_explain
@@ -204,3 +204,940 @@ quality of service: regular
                           estimated row count: 1,000 (missing stats)
                           table: xy@xy_pkey
                           spans: FULL SCAN
+
+statement ok
+DROP TRIGGER t ON xy;
+
+# ==============================================================================
+# Display AFTER triggers in the EXPLAIN output.
+# ==============================================================================
+
+subtest explain_after
+
+statement ok
+CREATE TRIGGER t AFTER INSERT OR UPDATE OR DELETE ON xy FOR EACH ROW EXECUTE FUNCTION f();
+
+query T
+EXPLAIN INSERT INTO xy VALUES (1, 2);
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • insert
+│   │ into: xy(x, y, rowid)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             size: 3 columns, 1 row
+│
+└── • after-triggers
+    │ trigger: t
+    │
+    └── • render
+        │
+        └── • render
+            │
+            └── • scan buffer
+                  estimated row count: 100
+                  label: buffer 1000000
+
+query T
+EXPLAIN (VERBOSE) UPDATE xy SET x = 3 WHERE y = 2;
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • update
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ table: xy
+│   │ set: x
+│   │
+│   └── • buffer
+│       │ columns: (x, y, rowid, x_new)
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │ columns: (x, y, rowid, x_new)
+│           │ render x_new: 3
+│           │ render x: x
+│           │ render y: y
+│           │ render rowid: rowid
+│           │
+│           └── • filter
+│               │ columns: (x, y, rowid)
+│               │ estimated row count: 10 (missing stats)
+│               │ filter: y = 2
+│               │
+│               └── • scan
+│                     columns: (x, y, rowid)
+│                     estimated row count: 1,000 (missing stats)
+│                     table: xy@xy_pkey
+│                     spans: FULL SCAN
+│
+└── • after-triggers
+    │ trigger: t
+    │
+    └── • render
+        │ columns: (f, x_old, y_old, x_new_new, y_new, old, new)
+        │ render f: f(new, old, 't', 'AFTER', 'ROW', 'UPDATE', 106, 'xy', 'xy', 'public', 0, ARRAY[])
+        │ render x_old: x_old
+        │ render y_old: y_old
+        │ render x_new_new: x_new_new
+        │ render y_new: y_new
+        │ render old: old
+        │ render new: new
+        │
+        └── • render
+            │ columns: (new, old, x_old, y_old, x_new_new, y_new)
+            │ render new: ((x_new, y) AS x, y)
+            │ render old: ((x, y) AS x, y)
+            │ render x_old: x
+            │ render y_old: y
+            │ render x_new_new: x_new
+            │ render y_new: y
+            │
+            └── • project
+                │ columns: (x, y, x_new, y)
+                │
+                └── • scan buffer
+                      columns: (x, y, rowid, x_new)
+                      estimated row count: 100
+                      label: buffer 1000000
+
+# Since the implicit transaction is auto-committed and the AFTER trigger was not
+# fired during execution, a truncated output is displayed.
+query T
+EXPLAIN ANALYZE (VERBOSE) DELETE FROM xy WHERE y = 2;
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• root
+│ columns: ()
+│
+├── • delete
+│   │ columns: ()
+│   │ sql nodes: <hidden>
+│   │ regions: <hidden>
+│   │ actual row count: 1
+│   │ vectorized batch count: 0
+│   │ estimated row count: 0 (missing stats)
+│   │ from: xy
+│   │
+│   └── • buffer
+│       │ columns: (rowid, x, y)
+│       │ sql nodes: <hidden>
+│       │ regions: <hidden>
+│       │ actual row count: 0
+│       │ vectorized batch count: 0
+│       │ label: buffer 1
+│       │
+│       └── • filter
+│           │ columns: (rowid, x, y)
+│           │ sql nodes: <hidden>
+│           │ regions: <hidden>
+│           │ actual row count: 0
+│           │ vectorized batch count: 0
+│           │ estimated row count: 10 (missing stats)
+│           │ filter: y = 2
+│           │
+│           └── • scan
+│                 columns: (x, y, rowid)
+│                 sql nodes: <hidden>
+│                 kv nodes: <hidden>
+│                 regions: <hidden>
+│                 actual row count: 0
+│                 vectorized batch count: 0
+│                 KV time: 0µs
+│                 KV contention time: 0µs
+│                 KV rows decoded: 0
+│                 KV pairs read: 0
+│                 KV bytes read: 0 B
+│                 KV gRPC calls: 0
+│                 estimated max memory allocated: 0 B
+│                 MVCC step count (ext/int): 0/0
+│                 MVCC seek count (ext/int): 0/0
+│                 estimated row count: 1,000 (missing stats)
+│                 table: xy@xy_pkey
+│                 spans: FULL SCAN
+│
+└── • after-triggers
+      trigger: t
+      input: buffer 1
+
+# Insert a row so that the trigger fires, and show the trigger plan.
+statement ok
+INSERT INTO xy VALUES (1, 2);
+
+query T
+EXPLAIN ANALYZE (VERBOSE) DELETE FROM xy WHERE y = 2;
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+rows decoded from KV: 1 (8 B, 2 KVs, 1 gRPC calls)
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• root
+│ columns: ()
+│
+├── • delete
+│   │ columns: ()
+│   │ sql nodes: <hidden>
+│   │ regions: <hidden>
+│   │ actual row count: 1
+│   │ vectorized batch count: 0
+│   │ estimated row count: 0 (missing stats)
+│   │ from: xy
+│   │
+│   └── • buffer
+│       │ columns: (rowid, x, y)
+│       │ sql nodes: <hidden>
+│       │ regions: <hidden>
+│       │ actual row count: 1
+│       │ vectorized batch count: 0
+│       │ label: buffer 1
+│       │
+│       └── • filter
+│           │ columns: (rowid, x, y)
+│           │ sql nodes: <hidden>
+│           │ regions: <hidden>
+│           │ actual row count: 1
+│           │ vectorized batch count: 0
+│           │ estimated row count: 10 (missing stats)
+│           │ filter: y = 2
+│           │
+│           └── • scan
+│                 columns: (x, y, rowid)
+│                 sql nodes: <hidden>
+│                 kv nodes: <hidden>
+│                 regions: <hidden>
+│                 actual row count: 1
+│                 vectorized batch count: 0
+│                 KV time: 0µs
+│                 KV contention time: 0µs
+│                 KV rows decoded: 1
+│                 KV pairs read: 2
+│                 KV bytes read: 8 B
+│                 KV gRPC calls: 1
+│                 estimated max memory allocated: 0 B
+│                 MVCC step count (ext/int): 0/0
+│                 MVCC seek count (ext/int): 0/0
+│                 estimated row count: 1,000 (missing stats)
+│                 table: xy@xy_pkey
+│                 spans: FULL SCAN
+│
+└── • after-triggers
+    │ trigger: t
+    │
+    └── • render
+        │ columns: (f, x_old, y_old, old, new)
+        │ render f: f(NULL, old, 't', 'AFTER', 'ROW', 'DELETE', 106, 'xy', 'xy', 'public', 0, ARRAY[])
+        │ render x_old: x_old
+        │ render y_old: y_old
+        │ render old: old
+        │ render new: new
+        │
+        └── • render
+            │ columns: (new, old, x_old, y_old)
+            │ render new: NULL
+            │ render old: ((x, y) AS x, y)
+            │ render x_old: x
+            │ render y_old: y
+            │
+            └── • project
+                │ columns: (x, y)
+                │
+                └── • scan buffer
+                      columns: (rowid, x, y)
+                      sql nodes: <hidden>
+                      regions: <hidden>
+                      actual row count: 1
+                      vectorized batch count: 0
+                      estimated row count: 1
+                      label: buffer 1000000
+
+# Multiple AFTER triggers are displayed in the EXPLAIN output.
+statement ok
+CREATE TRIGGER t2 AFTER INSERT OR UPDATE OR DELETE ON xy FOR EACH ROW EXECUTE FUNCTION f();
+
+query T
+EXPLAIN (VERBOSE) DELETE FROM xy WHERE y = 2;
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • delete
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ from: xy
+│   │
+│   └── • buffer
+│       │ columns: (rowid, x, y)
+│       │ label: buffer 1
+│       │
+│       └── • filter
+│           │ columns: (rowid, x, y)
+│           │ estimated row count: 10 (missing stats)
+│           │ filter: y = 2
+│           │
+│           └── • scan
+│                 columns: (x, y, rowid)
+│                 estimated row count: 1,000 (missing stats)
+│                 table: xy@xy_pkey
+│                 spans: FULL SCAN
+│
+└── • after-triggers
+    │ trigger: t
+    │ trigger: t2
+    │
+    └── • render
+        │ columns: (f, x_old, y_old, old, new, f)
+        │ render f: f(new, old, 't2', 'AFTER', 'ROW', 'DELETE', 106, 'xy', 'xy', 'public', 0, ARRAY[])
+        │ render x_old: x_old
+        │ render y_old: y_old
+        │ render old: old
+        │ render new: new
+        │ render f: f
+        │
+        └── • render
+            │ columns: (f, x_old, y_old, old, new)
+            │ render f: f(NULL, old, 't', 'AFTER', 'ROW', 'DELETE', 106, 'xy', 'xy', 'public', 0, ARRAY[])
+            │ render x_old: x_old
+            │ render y_old: y_old
+            │ render old: old
+            │ render new: new
+            │
+            └── • render
+                │ columns: (new, old, x_old, y_old)
+                │ render new: NULL
+                │ render old: ((x, y) AS x, y)
+                │ render x_old: x
+                │ render y_old: y
+                │
+                └── • project
+                    │ columns: (x, y)
+                    │
+                    └── • scan buffer
+                          columns: (rowid, x, y)
+                          estimated row count: 100
+                          label: buffer 1000000
+
+statement ok
+DROP TRIGGER t ON xy;
+
+statement ok
+DROP TRIGGER t2 ON xy;
+
+statement ok
+DROP FUNCTION f;
+
+# Test a cyclical trigger.
+statement ok
+CREATE FUNCTION f() RETURNS TRIGGER AS $$
+  BEGIN
+    INSERT INTO xy VALUES ((NEW).y, (NEW).x);
+    RETURN NULL;
+  END;
+$$ LANGUAGE PLpgSQL;
+
+statement ok
+CREATE TRIGGER t AFTER INSERT ON xy FOR EACH ROW EXECUTE FUNCTION f();
+
+query T
+EXPLAIN (VERBOSE, TYPES) INSERT INTO xy VALUES (1, 2);
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • insert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: xy(x, y, rowid)
+│   │
+│   └── • buffer
+│       │ columns: (column1 int, column2 int, rowid_default int)
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             columns: (column1 int, column2 int, rowid_default int)
+│             size: 3 columns, 1 row
+│             row 0, expr 0: (1)[int]
+│             row 0, expr 1: (2)[int]
+│             row 0, expr 2: (unique_rowid())[int]
+│
+└── • after-triggers
+    │ trigger: t
+    │
+    └── • render
+        │ columns: (f tuple{int AS x, int AS y}, column1_new int, column2_new int, old tuple{int AS x, int AS y}, new tuple{int AS x, int AS y})
+        │ render f: (f((new)[tuple{int AS x, int AS y}], (NULL)[unknown], (('t')[string])[name], ('AFTER')[string], ('ROW')[string], ('INSERT')[string], (106)[oid], ('xy')[string], ('xy')[string], ('public')[string], (0)[int], (ARRAY[])[string[]]))[tuple{int AS x, int AS y}]
+        │ render column1_new: (column1_new)[int]
+        │ render column2_new: (column2_new)[int]
+        │ render old: (old)[tuple{int AS x, int AS y}]
+        │ render new: (new)[tuple{int AS x, int AS y}]
+        │
+        └── • render
+            │ columns: (new tuple{int AS x, int AS y}, old unknown, column1_new int, column2_new int)
+            │ render new: ((((column1)[int], (column2)[int]) AS x, y))[tuple{int AS x, int AS y}]
+            │ render old: (NULL)[unknown]
+            │ render column1_new: (column1)[int]
+            │ render column2_new: (column2)[int]
+            │
+            └── • project
+                │ columns: (column1 int, column2 int)
+                │
+                └── • scan buffer
+                      columns: (column1 int, column2 int, rowid_default int)
+                      estimated row count: 100
+                      label: buffer 1000000
+
+statement ok
+DROP TRIGGER t ON xy;
+
+statement ok
+DROP FUNCTION f;
+
+# ==============================================================================
+# Display triggers fired on a cascaded mutation.
+# ==============================================================================
+
+subtest explain_cascade_trigger
+
+statement ok
+CREATE FUNCTION f() RETURNS TRIGGER AS $$
+  BEGIN
+    RAISE NOTICE '%: % -> %', TG_OP, OLD, NEW;
+    RETURN COALESCE(NEW, OLD);
+  END;
+$$ LANGUAGE PLpgSQL;
+
+statement ok
+CREATE TABLE parent (k INT PRIMARY KEY);
+
+# Put both columns in a family to avoid column-family randomization changing the
+# plans non-deterministically.
+statement ok
+CREATE TABLE child (k INT PRIMARY KEY, fk INT REFERENCES parent(k) ON DELETE CASCADE ON UPDATE CASCADE, FAMILY (k, fk));
+
+statement ok
+CREATE TRIGGER t BEFORE INSERT OR UPDATE OR DELETE ON child FOR EACH ROW EXECUTE FUNCTION f();
+
+statement ok
+CREATE TRIGGER t2 AFTER INSERT OR UPDATE OR DELETE ON child FOR EACH ROW EXECUTE FUNCTION f();
+
+# Since there are no rows, the FK cascade is not executed. The implicit
+# transaction auto-commits before the EXPLAIN output is generated, so the full
+# plan is not displayed.
+query T
+EXPLAIN ANALYZE (VERBOSE) UPDATE parent SET k = 2 WHERE k = 1;
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• root
+│ columns: ()
+│
+├── • update
+│   │ columns: ()
+│   │ sql nodes: <hidden>
+│   │ regions: <hidden>
+│   │ actual row count: 1
+│   │ vectorized batch count: 0
+│   │ estimated row count: 0 (missing stats)
+│   │ table: parent
+│   │ set: k
+│   │
+│   └── • buffer
+│       │ columns: (k, k_new)
+│       │ sql nodes: <hidden>
+│       │ regions: <hidden>
+│       │ actual row count: 0
+│       │ vectorized batch count: 0
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │ columns: (k, k_new)
+│           │ render k_new: 2
+│           │ render k: k
+│           │
+│           └── • scan
+│                 columns: (k)
+│                 sql nodes: <hidden>
+│                 kv nodes: <hidden>
+│                 regions: <hidden>
+│                 actual row count: 0
+│                 vectorized batch count: 0
+│                 KV time: 0µs
+│                 KV contention time: 0µs
+│                 KV rows decoded: 0
+│                 KV pairs read: 0
+│                 KV bytes read: 0 B
+│                 KV gRPC calls: 0
+│                 estimated max memory allocated: 0 B
+│                 MVCC step count (ext/int): 0/0
+│                 MVCC seek count (ext/int): 0/0
+│                 estimated row count: 1 (missing stats)
+│                 table: parent@parent_pkey
+│                 spans: /1/0
+│                 locking strength: for update
+│
+└── • fk-cascade
+      fk: child_fk_fkey
+      input: buffer 1
+
+# Insert rows so that the cascade fires and the plan is generated.
+statement ok
+INSERT INTO parent VALUES (1);
+INSERT INTO child VALUES (1, 1);
+
+query T
+EXPLAIN ANALYZE (VERBOSE) UPDATE parent SET k = 2 WHERE k = 1;
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: generic, reused
+rows decoded from KV: 3 (24 B, 6 KVs, 3 gRPC calls)
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• root
+│ columns: ()
+│
+├── • update
+│   │ columns: ()
+│   │ sql nodes: <hidden>
+│   │ regions: <hidden>
+│   │ actual row count: 1
+│   │ vectorized batch count: 0
+│   │ estimated row count: 0 (missing stats)
+│   │ table: parent
+│   │ set: k
+│   │
+│   └── • buffer
+│       │ columns: (k, k_new)
+│       │ sql nodes: <hidden>
+│       │ regions: <hidden>
+│       │ actual row count: 1
+│       │ vectorized batch count: 0
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │ columns: (k, k_new)
+│           │ render k_new: 2
+│           │ render k: k
+│           │
+│           └── • scan
+│                 columns: (k)
+│                 sql nodes: <hidden>
+│                 kv nodes: <hidden>
+│                 regions: <hidden>
+│                 actual row count: 1
+│                 vectorized batch count: 0
+│                 KV time: 0µs
+│                 KV contention time: 0µs
+│                 KV rows decoded: 1
+│                 KV pairs read: 2
+│                 KV bytes read: 8 B
+│                 KV gRPC calls: 1
+│                 estimated max memory allocated: 0 B
+│                 MVCC step count (ext/int): 0/0
+│                 MVCC seek count (ext/int): 0/0
+│                 estimated row count: 1 (missing stats)
+│                 table: parent@parent_pkey
+│                 spans: /1/0
+│                 locking strength: for update
+│
+└── • fk-cascade
+    │ fk: child_fk_fkey
+    │
+    └── • root
+        │ columns: ()
+        │
+        ├── • update
+        │   │ columns: ()
+        │   │ sql nodes: <hidden>
+        │   │ regions: <hidden>
+        │   │ actual row count: 0
+        │   │ vectorized batch count: 0
+        │   │ estimated row count: 0 (missing stats)
+        │   │ table: child
+        │   │ set: fk
+        │   │
+        │   ├── • before-triggers
+        │   │     trigger: t
+        │   │
+        │   └── • buffer
+        │       │ columns: (k, fk, fk_new, fk_old, old, new, f, "check-rows")
+        │       │ sql nodes: <hidden>
+        │       │ regions: <hidden>
+        │       │ actual row count: 1
+        │       │ vectorized batch count: 0
+        │       │ label: buffer 1
+        │       │
+        │       └── • filter
+        │           │ columns: (k, fk, fk_new, fk_old, old, new, f, "check-rows")
+        │           │ sql nodes: <hidden>
+        │           │ regions: <hidden>
+        │           │ actual row count: 1
+        │           │ vectorized batch count: 0
+        │           │ estimated row count: 3 (missing stats)
+        │           │ filter: f IS DISTINCT FROM NULL
+        │           │
+        │           └── • render
+        │               │ columns: ("check-rows", k, fk, fk_old, fk_new, old, new, f)
+        │               │ render check-rows: CASE WHEN f IS DISTINCT FROM new THEN crdb_internal.plpgsql_raise('ERROR', 'trigger t attempted to modify or filter a row in a cascade operation: ' || new::STRING, e'changing the rows updated or deleted by a foreign-key cascade\n can cause constraint violations, and therefore is not allowed', e'to enable this behavior (with risk of constraint violation), set\nthe session variable \'unsafe_allow_triggers_modifying_cascades\' to true', '27000') ELSE CAST(NULL AS INT8) END
+        │               │ render k: k
+        │               │ render fk: fk
+        │               │ render fk_old: fk_old
+        │               │ render fk_new: fk_new
+        │               │ render old: old
+        │               │ render new: new
+        │               │ render f: f
+        │               │
+        │               └── • render
+        │                   │ columns: (f, k, fk, fk_old, fk_new, old, new)
+        │                   │ render f: f(new, old, 't', 'BEFORE', 'ROW', 'UPDATE', 111, 'child', 'child', 'public', 0, ARRAY[])
+        │                   │ render k: k
+        │                   │ render fk: fk
+        │                   │ render fk_old: fk_old
+        │                   │ render fk_new: fk_new
+        │                   │ render old: old
+        │                   │ render new: new
+        │                   │
+        │                   └── • render
+        │                       │ columns: (new, old, k, fk, fk_old, fk_new)
+        │                       │ render new: ((k, k_new) AS k, fk)
+        │                       │ render old: ((k, fk) AS k, fk)
+        │                       │ render k: k
+        │                       │ render fk: fk
+        │                       │ render fk_old: k
+        │                       │ render fk_new: k_new
+        │                       │
+        │                       └── • hash join (inner)
+        │                           │ columns: (k, fk, k, k_new)
+        │                           │ sql nodes: <hidden>
+        │                           │ regions: <hidden>
+        │                           │ actual row count: 1
+        │                           │ vectorized batch count: 0
+        │                           │ estimated max memory allocated: 0 B
+        │                           │ estimated max sql temp disk usage: 0 B
+        │                           │ estimated row count: 3 (missing stats)
+        │                           │ equality: (fk) = (k)
+        │                           │
+        │                           ├── • scan
+        │                           │     columns: (k, fk)
+        │                           │     sql nodes: <hidden>
+        │                           │     kv nodes: <hidden>
+        │                           │     regions: <hidden>
+        │                           │     actual row count: 1
+        │                           │     vectorized batch count: 0
+        │                           │     KV time: 0µs
+        │                           │     KV contention time: 0µs
+        │                           │     KV rows decoded: 1
+        │                           │     KV pairs read: 2
+        │                           │     KV bytes read: 8 B
+        │                           │     KV gRPC calls: 1
+        │                           │     estimated max memory allocated: 0 B
+        │                           │     MVCC step count (ext/int): 0/0
+        │                           │     MVCC seek count (ext/int): 0/0
+        │                           │     estimated row count: 1,000 (missing stats)
+        │                           │     table: child@child_pkey
+        │                           │     spans: FULL SCAN
+        │                           │
+        │                           └── • filter
+        │                               │ columns: (k, k_new)
+        │                               │ sql nodes: <hidden>
+        │                               │ regions: <hidden>
+        │                               │ actual row count: 1
+        │                               │ vectorized batch count: 0
+        │                               │ estimated row count: 0
+        │                               │ filter: k IS DISTINCT FROM k_new
+        │                               │
+        │                               └── • scan buffer
+        │                                     columns: (k, k_new)
+        │                                     sql nodes: <hidden>
+        │                                     regions: <hidden>
+        │                                     actual row count: 1
+        │                                     vectorized batch count: 0
+        │                                     estimated row count: 1
+        │                                     label: buffer 1000000
+        │
+        ├── • constraint-check
+        │   │
+        │   └── • error if rows
+        │       │ columns: ()
+        │       │ sql nodes: <hidden>
+        │       │ regions: <hidden>
+        │       │ actual row count: 0
+        │       │ vectorized batch count: 0
+        │       │
+        │       └── • lookup join (anti)
+        │           │ columns: (fk_new)
+        │           │ sql nodes: <hidden>
+        │           │ kv nodes: <hidden>
+        │           │ regions: <hidden>
+        │           │ actual row count: 0
+        │           │ vectorized batch count: 0
+        │           │ KV time: 0µs
+        │           │ KV contention time: 0µs
+        │           │ KV rows decoded: 1
+        │           │ KV pairs read: 2
+        │           │ KV bytes read: 8 B
+        │           │ KV gRPC calls: 1
+        │           │ estimated max memory allocated: 0 B
+        │           │ MVCC step count (ext/int): 0/0
+        │           │ MVCC seek count (ext/int): 0/0
+        │           │ estimated row count: 0 (missing stats)
+        │           │ table: parent@parent_pkey
+        │           │ equality: (fk_new) = (k)
+        │           │ equality cols are key
+        │           │
+        │           └── • filter
+        │               │ columns: (fk_new)
+        │               │ sql nodes: <hidden>
+        │               │ regions: <hidden>
+        │               │ actual row count: 1
+        │               │ vectorized batch count: 0
+        │               │ estimated row count: 3 (missing stats)
+        │               │ filter: fk_new IS NOT NULL
+        │               │
+        │               └── • project
+        │                   │ columns: (fk_new)
+        │                   │
+        │                   └── • scan buffer
+        │                         columns: (k, fk, fk_new, fk_old, old, new, f, "check-rows")
+        │                         sql nodes: <hidden>
+        │                         regions: <hidden>
+        │                         actual row count: 1
+        │                         vectorized batch count: 0
+        │                         estimated row count: 3 (missing stats)
+        │                         label: buffer 1
+        │
+        └── • after-triggers
+            │ trigger: t2
+            │
+            └── • render
+                │ columns: (f, k_old, fk_old, k_new, fk_new_new, old, new)
+                │ render f: f(new, old, 't2', 'AFTER', 'ROW', 'UPDATE', 111, 'child', 'child', 'public', 0, ARRAY[])
+                │ render k_old: k_old
+                │ render fk_old: fk_old
+                │ render k_new: k_new
+                │ render fk_new_new: fk_new_new
+                │ render old: old
+                │ render new: new
+                │
+                └── • render
+                    │ columns: (new, old, k_old, fk_old, k_new, fk_new_new)
+                    │ render new: ((k, fk_new) AS k, fk)
+                    │ render old: ((k, fk) AS k, fk)
+                    │ render k_old: k
+                    │ render fk_old: fk
+                    │ render k_new: k
+                    │ render fk_new_new: fk_new
+                    │
+                    └── • project
+                        │ columns: (k, fk, k, fk_new)
+                        │
+                        └── • scan buffer
+                              columns: (k, fk, fk_new, fk_old, old, new, f, "check-rows")
+                              sql nodes: <hidden>
+                              regions: <hidden>
+                              actual row count: 1
+                              vectorized batch count: 0
+                              estimated row count: 1
+                              label: buffer 1000000
+
+query T
+EXPLAIN ANALYZE (VERBOSE) DELETE FROM parent WHERE k = 2;
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+rows decoded from KV: 1 (8 B, 2 KVs, 1 gRPC calls)
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• root
+│ columns: ()
+│
+├── • delete range
+│     columns: ()
+│     sql nodes: <hidden>
+│     regions: <hidden>
+│     actual row count: 1
+│     vectorized batch count: 0
+│     estimated row count: 0 (missing stats)
+│     from: parent
+│     spans: /2/0
+│
+└── • fk-cascade
+    │ fk: child_fk_fkey
+    │
+    └── • root
+        │ columns: ()
+        │
+        ├── • delete
+        │   │ columns: ()
+        │   │ sql nodes: <hidden>
+        │   │ regions: <hidden>
+        │   │ actual row count: 0
+        │   │ vectorized batch count: 0
+        │   │ estimated row count: 0 (missing stats)
+        │   │ from: child
+        │   │
+        │   ├── • before-triggers
+        │   │     trigger: t
+        │   │
+        │   └── • buffer
+        │       │ columns: (k, fk, old, f, "check-rows")
+        │       │ sql nodes: <hidden>
+        │       │ regions: <hidden>
+        │       │ actual row count: 1
+        │       │ vectorized batch count: 0
+        │       │ label: buffer 1
+        │       │
+        │       └── • filter
+        │           │ columns: (k, fk, old, f, "check-rows")
+        │           │ sql nodes: <hidden>
+        │           │ regions: <hidden>
+        │           │ actual row count: 1
+        │           │ vectorized batch count: 0
+        │           │ estimated row count: 10 (missing stats)
+        │           │ filter: f IS DISTINCT FROM NULL
+        │           │
+        │           └── • render
+        │               │ columns: ("check-rows", k, fk, old, f)
+        │               │ render check-rows: CASE WHEN f IS DISTINCT FROM old THEN crdb_internal.plpgsql_raise('ERROR', 'trigger t attempted to modify or filter a row in a cascade operation: ' || old::STRING, e'changing the rows updated or deleted by a foreign-key cascade\n can cause constraint violations, and therefore is not allowed', e'to enable this behavior (with risk of constraint violation), set\nthe session variable \'unsafe_allow_triggers_modifying_cascades\' to true', '27000') ELSE CAST(NULL AS INT8) END
+        │               │ render k: k
+        │               │ render fk: fk
+        │               │ render old: old
+        │               │ render f: f
+        │               │
+        │               └── • render
+        │                   │ columns: (f, k, fk, old)
+        │                   │ render f: f(NULL, old, 't', 'BEFORE', 'ROW', 'DELETE', 111, 'child', 'child', 'public', 0, ARRAY[])
+        │                   │ render k: k
+        │                   │ render fk: fk
+        │                   │ render old: old
+        │                   │
+        │                   └── • render
+        │                       │ columns: (old, k, fk)
+        │                       │ render old: ((k, fk) AS k, fk)
+        │                       │ render k: k
+        │                       │ render fk: fk
+        │                       │
+        │                       └── • filter
+        │                           │ columns: (k, fk)
+        │                           │ sql nodes: <hidden>
+        │                           │ regions: <hidden>
+        │                           │ actual row count: 1
+        │                           │ vectorized batch count: 0
+        │                           │ estimated row count: 10 (missing stats)
+        │                           │ filter: fk = 2
+        │                           │
+        │                           └── • scan
+        │                                 columns: (k, fk)
+        │                                 sql nodes: <hidden>
+        │                                 kv nodes: <hidden>
+        │                                 regions: <hidden>
+        │                                 actual row count: 1
+        │                                 vectorized batch count: 0
+        │                                 KV time: 0µs
+        │                                 KV contention time: 0µs
+        │                                 KV rows decoded: 1
+        │                                 KV pairs read: 2
+        │                                 KV bytes read: 8 B
+        │                                 KV gRPC calls: 1
+        │                                 estimated max memory allocated: 0 B
+        │                                 MVCC step count (ext/int): 0/0
+        │                                 MVCC seek count (ext/int): 0/0
+        │                                 estimated row count: 1,000 (missing stats)
+        │                                 table: child@child_pkey
+        │                                 spans: FULL SCAN
+        │
+        └── • after-triggers
+            │ trigger: t2
+            │
+            └── • render
+                │ columns: (f, k_old, fk_old, old, new)
+                │ render f: f(NULL, old, 't2', 'AFTER', 'ROW', 'DELETE', 111, 'child', 'child', 'public', 0, ARRAY[])
+                │ render k_old: k_old
+                │ render fk_old: fk_old
+                │ render old: old
+                │ render new: new
+                │
+                └── • render
+                    │ columns: (new, old, k_old, fk_old)
+                    │ render new: NULL
+                    │ render old: ((k, fk) AS k, fk)
+                    │ render k_old: k
+                    │ render fk_old: fk
+                    │
+                    └── • project
+                        │ columns: (k, fk)
+                        │
+                        └── • scan buffer
+                              columns: (k, fk, old, f, "check-rows")
+                              sql nodes: <hidden>
+                              regions: <hidden>
+                              actual row count: 1
+                              vectorized batch count: 0
+                              estimated row count: 1
+                              label: buffer 1000000
+
+statement ok
+DROP TABLE child;
+DROP TABLE parent;
+DROP FUNCTION f;

--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers_explain
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers_explain
@@ -1,0 +1,206 @@
+# LogicTest: local
+
+# Put both columns in a family to avoid column-family randomization changing the
+# plans non-deterministically.
+statement ok
+CREATE TABLE xy (x INT, y INT, FAMILY (x, y));
+
+statement ok
+CREATE FUNCTION f() RETURNS TRIGGER AS $$
+  BEGIN
+    RAISE NOTICE '%: % -> %', TG_OP, OLD, NEW;
+    RETURN COALESCE(NEW, OLD);
+  END;
+$$ LANGUAGE PLpgSQL;
+
+# ==============================================================================
+# Display BEFORE triggers in the EXPLAIN output.
+# ==============================================================================
+
+subtest explain_before
+
+statement ok
+CREATE TRIGGER t BEFORE INSERT OR UPDATE OR DELETE ON xy FOR EACH ROW EXECUTE FUNCTION f();
+
+query T
+EXPLAIN INSERT INTO xy VALUES (1, 2);
+----
+distribution: local
+vectorized: true
+·
+• insert
+│ into: xy(x, y, rowid)
+│ auto commit
+│
+├── • before-triggers
+│     trigger: t
+│
+└── • render
+    │
+    └── • filter
+        │ estimated row count: 1
+        │ filter: f IS DISTINCT FROM NULL
+        │
+        └── • render
+            │
+            └── • values
+                  size: 4 columns, 1 row
+
+query T
+EXPLAIN (VERBOSE) DELETE FROM xy WHERE y = 2;
+----
+distribution: local
+vectorized: true
+·
+• delete
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ from: xy
+│ auto commit
+│
+├── • before-triggers
+│     trigger: t
+│
+└── • project
+    │ columns: (rowid)
+    │
+    └── • filter
+        │ columns: (f, x, y, rowid, crdb_internal_mvcc_timestamp, tableoid, crdb_internal_origin_id, crdb_internal_origin_timestamp, old)
+        │ estimated row count: 10 (missing stats)
+        │ filter: f IS DISTINCT FROM NULL
+        │
+        └── • render
+            │ columns: (f, x, y, rowid, crdb_internal_mvcc_timestamp, tableoid, crdb_internal_origin_id, crdb_internal_origin_timestamp, old)
+            │ render f: f(NULL, old, 't', 'BEFORE', 'ROW', 'DELETE', 106, 'xy', 'xy', 'public', 0, ARRAY[])
+            │ render x: x
+            │ render y: y
+            │ render rowid: rowid
+            │ render crdb_internal_mvcc_timestamp: crdb_internal_mvcc_timestamp
+            │ render tableoid: tableoid
+            │ render crdb_internal_origin_id: crdb_internal_origin_id
+            │ render crdb_internal_origin_timestamp: crdb_internal_origin_timestamp
+            │ render old: old
+            │
+            └── • render
+                │ columns: (old, x, y, rowid, crdb_internal_mvcc_timestamp, tableoid, crdb_internal_origin_id, crdb_internal_origin_timestamp)
+                │ render old: ((x, y) AS x, y)
+                │ render x: x
+                │ render y: y
+                │ render rowid: rowid
+                │ render crdb_internal_mvcc_timestamp: crdb_internal_mvcc_timestamp
+                │ render tableoid: tableoid
+                │ render crdb_internal_origin_id: crdb_internal_origin_id
+                │ render crdb_internal_origin_timestamp: crdb_internal_origin_timestamp
+                │
+                └── • filter
+                    │ columns: (x, y, rowid, crdb_internal_mvcc_timestamp, tableoid, crdb_internal_origin_id, crdb_internal_origin_timestamp)
+                    │ estimated row count: 10 (missing stats)
+                    │ filter: y = 2
+                    │
+                    └── • scan
+                          columns: (x, y, rowid, crdb_internal_mvcc_timestamp, tableoid, crdb_internal_origin_id, crdb_internal_origin_timestamp)
+                          estimated row count: 1,000 (missing stats)
+                          table: xy@xy_pkey
+                          spans: FULL SCAN
+
+query T
+EXPLAIN ANALYZE (VERBOSE) UPDATE xy SET x = 3 WHERE y = 2;
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• update
+│ columns: ()
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 1
+│ vectorized batch count: 0
+│ estimated row count: 0 (missing stats)
+│ table: xy
+│ set: x, y
+│ auto commit
+│
+├── • before-triggers
+│     trigger: t
+│
+└── • render
+    │ columns: (x, y, rowid, x_new, y_new)
+    │ render x_new: (f).x
+    │ render y_new: (f).y
+    │ render x: x
+    │ render y: y
+    │ render rowid: rowid
+    │
+    └── • filter
+        │ columns: (f, x, y, rowid, crdb_internal_mvcc_timestamp, tableoid, crdb_internal_origin_id, crdb_internal_origin_timestamp, x_new, old, new)
+        │ sql nodes: <hidden>
+        │ regions: <hidden>
+        │ actual row count: 0
+        │ vectorized batch count: 0
+        │ estimated row count: 10 (missing stats)
+        │ filter: f IS DISTINCT FROM NULL
+        │
+        └── • render
+            │ columns: (f, x, y, rowid, crdb_internal_mvcc_timestamp, tableoid, crdb_internal_origin_id, crdb_internal_origin_timestamp, x_new, old, new)
+            │ render f: f(new, old, 't', 'BEFORE', 'ROW', 'UPDATE', 106, 'xy', 'xy', 'public', 0, ARRAY[])
+            │ render x: x
+            │ render y: y
+            │ render rowid: rowid
+            │ render crdb_internal_mvcc_timestamp: crdb_internal_mvcc_timestamp
+            │ render tableoid: tableoid
+            │ render crdb_internal_origin_id: crdb_internal_origin_id
+            │ render crdb_internal_origin_timestamp: crdb_internal_origin_timestamp
+            │ render x_new: x_new
+            │ render old: old
+            │ render new: new
+            │
+            └── • render
+                │ columns: (new, old, x_new, x, y, rowid, crdb_internal_mvcc_timestamp, tableoid, crdb_internal_origin_id, crdb_internal_origin_timestamp)
+                │ render new: ((3, y) AS x, y)
+                │ render old: ((x, y) AS x, y)
+                │ render x_new: 3
+                │ render x: x
+                │ render y: y
+                │ render rowid: rowid
+                │ render crdb_internal_mvcc_timestamp: crdb_internal_mvcc_timestamp
+                │ render tableoid: tableoid
+                │ render crdb_internal_origin_id: crdb_internal_origin_id
+                │ render crdb_internal_origin_timestamp: crdb_internal_origin_timestamp
+                │
+                └── • filter
+                    │ columns: (x, y, rowid, crdb_internal_mvcc_timestamp, tableoid, crdb_internal_origin_id, crdb_internal_origin_timestamp)
+                    │ sql nodes: <hidden>
+                    │ regions: <hidden>
+                    │ actual row count: 0
+                    │ vectorized batch count: 0
+                    │ estimated row count: 10 (missing stats)
+                    │ filter: y = 2
+                    │
+                    └── • scan
+                          columns: (x, y, rowid, crdb_internal_mvcc_timestamp, tableoid, crdb_internal_origin_id, crdb_internal_origin_timestamp)
+                          sql nodes: <hidden>
+                          kv nodes: <hidden>
+                          regions: <hidden>
+                          actual row count: 0
+                          vectorized batch count: 0
+                          KV time: 0µs
+                          KV contention time: 0µs
+                          KV rows decoded: 0
+                          KV pairs read: 0
+                          KV bytes read: 0 B
+                          KV gRPC calls: 0
+                          estimated max memory allocated: 0 B
+                          MVCC step count (ext/int): 0/0
+                          MVCC seek count (ext/int): 0/0
+                          estimated row count: 1,000 (missing stats)
+                          table: xy@xy_pkey
+                          spans: FULL SCAN

--- a/pkg/ccl/logictestccl/tests/local/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local/generated_test.go
@@ -376,6 +376,13 @@ func TestCCLLogic_triggers(
 	runCCLLogicTest(t, "triggers")
 }
 
+func TestCCLLogic_triggers_explain(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "triggers_explain")
+}
+
 func TestCCLLogic_udf_params(
 	t *testing.T,
 ) {

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -1103,6 +1103,15 @@ func (m execNodeTraceMetadata) annotateExplain(
 	for i := range plan.Checks {
 		walk(plan.Checks[i])
 	}
+	for _, trigger := range plan.Triggers {
+		// We don't want to create new plans if they haven't been cached - all
+		// necessary plans must have been created during the actual execution of
+		// the query.
+		const createPlanIfMissing = false
+		if tp, _ := trigger.GetExplainPlan(ctx, createPlanIfMissing); tp != nil {
+			m.annotateExplain(ctx, tp.(*explain.Plan), spans, makeDeterministic, p)
+		}
+	}
 }
 
 // SetIndexRecommendations checks if we should generate a new index recommendation.

--- a/pkg/sql/opt/cat/BUILD.bazel
+++ b/pkg/sql/opt/cat/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/types",
+        "//pkg/util/intsets",
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/sql/opt/exec/execbuilder/post_queries.go
+++ b/pkg/sql/opt/exec/execbuilder/post_queries.go
@@ -151,8 +151,9 @@ func makePostQueryBuilder(b *Builder, mutationWithID opt.WithID) (*postQueryBuil
 // setupCascade fills in an exec.PostQuery struct for the given cascade.
 func (cb *postQueryBuilder) setupCascade(cascade *memo.FKCascade) exec.PostQuery {
 	return exec.PostQuery{
-		FKConstraint: cascade.FKConstraint,
-		Buffer:       cb.mutationBuffer,
+		FKConstraint:             cascade.FKConstraint,
+		CascadeHasBeforeTriggers: cascade.HasBeforeTriggers,
+		Buffer:                   cb.mutationBuffer,
 		PlanFn: func(
 			ctx context.Context,
 			semaCtx *tree.SemaContext,

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -156,7 +157,7 @@ func (f *PlanGistFactory) PlanGist() PlanGist {
 
 // DecodePlanGistToRows converts a gist to a logical plan and returns the rows.
 func DecodePlanGistToRows(
-	ctx context.Context, gist string, catalog cat.Catalog,
+	ctx context.Context, evalCtx *eval.Context, gist string, catalog cat.Catalog,
 ) (_ []string, retErr error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -180,7 +181,7 @@ func DecodePlanGistToRows(
 	if err != nil {
 		return nil, err
 	}
-	err = Emit(ctx, explainPlan, ob, func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string { return "" })
+	err = Emit(ctx, evalCtx, explainPlan, ob, func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string { return "" })
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/opt/exec/explain/plan_gist_test.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_test.go
@@ -46,7 +46,7 @@ func explainGist(gist string, catalog cat.Catalog) string {
 	if err != nil {
 		panic(err)
 	}
-	err = explain.Emit(context.Background(), explainPlan, ob, func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string { return "" })
+	err = explain.Emit(context.Background(), &eval.Context{}, explainPlan, ob, func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string { return "" })
 	if err != nil {
 		panic(err)
 	}
@@ -75,7 +75,7 @@ func plan(ot *opttester.OptTester, t *testing.T) string {
 	}
 	flags := explain.Flags{HideValues: true, Deflake: explain.DeflakeAll, OnlyShape: true}
 	ob := explain.NewOutputBuilder(flags)
-	err = explain.Emit(context.Background(), explainPlan.(*explain.Plan), ob, func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string { return "" })
+	err = explain.Emit(context.Background(), &eval.Context{}, explainPlan.(*explain.Plan), ob, func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string { return "" })
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -279,6 +279,11 @@ type PostQuery struct {
 	// PostQuery describes a set of AFTER triggers.
 	FKConstraint cat.ForeignKeyConstraint
 
+	// CascadeHasBeforeTriggers is set only for cascades. It indicates whether the
+	// mutation planned for the cascade will fire BEFORE triggers. It is used
+	// during EXPLAIN.
+	CascadeHasBeforeTriggers bool
+
 	// Triggers is used for logging and EXPLAIN purposes. It is nil if this
 	// PostQuery describes a foreign-key cascade action.
 	Triggers []cat.Trigger
@@ -287,9 +292,9 @@ type PostQuery struct {
 	// the mutation. It is nil if the cascade does not require a buffer.
 	Buffer Node
 
-	// PlanFn builds the cascade query and creates the plan for it.
-	// Note that the generated Plan can in turn contain more cascades (as well as
-	// checks, which should run after all cascades are executed).
+	// PlanFn builds the cascade/trigger query and creates the plan for it.
+	// Note that the generated Plan can in turn contain more cascades, triggers,
+	// and checks.
 	//
 	// The bufferRef is a reference that can be used with ConstructWithBuffer to
 	// read the mutation input. It is conceptually the same as the Buffer field;
@@ -297,8 +302,8 @@ type PostQuery struct {
 	// implementation of the node (e.g. to facilitate early cleanup of the
 	// original plan).
 	//
-	// If the cascade does not require input buffering (Buffer is nil), then
-	// bufferRef should be nil and numBufferedRows should be 0.
+	// If the cascade/trigger does not require input buffering (Buffer is nil),
+	// then bufferRef should be nil and numBufferedRows should be 0.
 	//
 	// This method does not mutate any captured state; it is ok to call PlanFn
 	// methods concurrently (provided that they don't use a single non-thread-safe
@@ -313,10 +318,10 @@ type PostQuery struct {
 		allowAutoCommit bool,
 	) (Plan, error)
 
-	// GetExplainPlan returns the explain plan for the cascade query. It will
-	// always return a cached plan if there is one, and the boolean argument
-	// controls whether this function can create a new plan (which will be
-	// cached going forward). If createPlanIfMissing is false and there is no
+	// GetExplainPlan returns the explain plan for the cascade or trigger query.
+	// It will always return a cached plan if there is one, and the boolean
+	// argument controls whether this function can create a new plan (which will
+	// be cached going forward). If createPlanIfMissing is false and there is no
 	// cached plan, then nil, nil is returned.
 	GetExplainPlan func(_ context.Context, createPlanIfMissing bool) (Plan, error)
 }

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -1340,6 +1340,10 @@ type FKCascades []FKCascade
 type FKCascade struct {
 	FKConstraint cat.ForeignKeyConstraint
 
+	// HasBeforeTriggers is true if the mutation that is planned for the cascade
+	// will have BEFORE triggers.
+	HasBeforeTriggers bool
+
 	// Builder is an object that can be used as the "optbuilder" for the cascading
 	// query.
 	Builder PostQueryBuilder

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -1560,7 +1560,7 @@ func (mb *mutationBuilder) buildCheckInputScan(
 	// We also do not inline constants for checks that have row-level triggers
 	// because the triggers may modify the values that are being checked.
 	if !isFK && mb.insertExpr != nil &&
-		!mb.hasRowLevelTriggers(tree.TriggerActionTimeBefore, tree.TriggerEventInsert) {
+		!cat.HasRowLevelTriggers(mb.tab, tree.TriggerActionTimeBefore, tree.TriggerEventInsert) {
 		// Find the constant columns produced by the insert expression. All
 		// input columns must be constant in order to inline them.
 		constCols := memo.FindInlinableConstants(mb.insertExpr)

--- a/pkg/sql/opt/optbuilder/testdata/trigger
+++ b/pkg/sql/opt/optbuilder/testdata/trigger
@@ -42,6 +42,8 @@ insert xy
  ├── insert-mapping:
  │    ├── x_new:22 => x:1
  │    └── y_new:23 => y:2
+ ├── before-triggers
+ │    └── tr
  └── project
       ├── columns: x_new:22 y_new:23 column1:5 column2:6 new:7 f:21
       ├── barrier
@@ -73,6 +75,8 @@ root
  │    ├── update-mapping:
  │    │    ├── x_new:26 => x:1
  │    │    └── y_new:27 => y:2
+ │    ├── before-triggers
+ │    │    └── tr
  │    ├── input binding: &1
  │    ├── cascades
  │    │    └── child_x_fkey
@@ -117,6 +121,8 @@ root
            ├── fetch columns: k:32 child.x:33
            ├── update-mapping:
            │    └── x_new:37 => child.x:29
+           ├── before-triggers
+           │    └── tr_child
            ├── input binding: &2
            ├── barrier
            │    ├── columns: k:32 child.x:33 x_old:36 x_new:37 old:38 new:39 f:53 "check-rows":54
@@ -183,6 +189,8 @@ root
  ├── delete xy
  │    ├── columns: <none>
  │    ├── fetch columns: x:5 y:6
+ │    ├── before-triggers
+ │    │    └── tr
  │    ├── input binding: &1
  │    ├── cascades
  │    │    └── child_x_fkey
@@ -212,6 +220,8 @@ root
       └── delete child
            ├── columns: <none>
            ├── fetch columns: k:28 child.x:29
+           ├── before-triggers
+           │    └── tr_child
            └── barrier
                 ├── columns: k:28 child.x:29 old:33 f:47 "check-rows":48
                 └── select
@@ -260,6 +270,8 @@ root
  │    ├── update-mapping:
  │    │    ├── upsert_x:33 => x:1
  │    │    └── upsert_y:34 => y:2
+ │    ├── before-triggers
+ │    │    └── tr
  │    ├── input binding: &1
  │    ├── cascades
  │    │    └── child_x_fkey
@@ -335,6 +347,8 @@ root
            ├── fetch columns: k:39 child.x:40
            ├── update-mapping:
            │    └── x_new:44 => child.x:36
+           ├── before-triggers
+           │    └── tr_child
            ├── input binding: &2
            ├── barrier
            │    ├── columns: k:39 child.x:40 x_old:43 x_new:44 old:45 new:46 f:60 "check-rows":61
@@ -409,6 +423,8 @@ root
  │    ├── update-mapping:
  │    │    ├── upsert_x:34 => x:1
  │    │    └── upsert_y:35 => y:2
+ │    ├── before-triggers
+ │    │    └── tr
  │    ├── input binding: &1
  │    ├── cascades
  │    │    └── child_x_fkey
@@ -488,6 +504,8 @@ root
            ├── fetch columns: k:40 child.x:41
            ├── update-mapping:
            │    └── x_new:45 => child.x:37
+           ├── before-triggers
+           │    └── tr_child
            ├── input binding: &2
            ├── barrier
            │    ├── columns: k:40 child.x:41 x_old:44 x_new:45 old:46 new:47 f:61 "check-rows":62
@@ -562,6 +580,8 @@ insert computed
  │    ├── k_new:24 => k:1
  │    ├── v_comp:25 => v:2
  │    └── w_comp:26 => w:3
+ ├── before-triggers
+ │    └── tr
  └── project
       ├── columns: v_comp:25 w_comp:26 column1:6 v_comp:7 w_comp:8 new:9 f:23 k_new:24
       ├── project
@@ -597,6 +617,8 @@ update computed
  │    ├── k_new:30 => k:1
  │    ├── v_comp:31 => v:2
  │    └── w_comp:32 => w:3
+ ├── before-triggers
+ │    └── tr
  └── project
       ├── columns: v_comp:31 w_comp:32 k:6 v:7 w:8 k_new:30
       ├── project
@@ -662,6 +684,8 @@ insert ab
  │    ├── a_new:49 => a:1
  │    ├── b_new:50 => b:2
  │    └── rowid_default:8 => rowid:3
+ ├── before-triggers
+ │    └── tr
  └── project
       ├── columns: a_new:49 b_new:50 column1:6 column2:7 rowid_default:8 new:9 insert_ab:48
       ├── barrier
@@ -724,6 +748,8 @@ insert ab
       │         │                                       │    │    ├── a_new:44 => a:34
       │         │                                       │    │    ├── b_new:45 => b:35
       │         │                                       │    │    └── rowid_default:41 => rowid:36
+      │         │                                       │    ├── before-triggers
+      │         │                                       │    │    └── tr
       │         │                                       │    └── project
       │         │                                       │         ├── columns: a_new:44 b_new:45 column1:39 column2:40 rowid_default:41 new:42 insert_ab:43
       │         │                                       │         ├── barrier
@@ -902,6 +928,8 @@ root
  │    └── delete child
  │         ├── columns: <none>
  │         ├── fetch columns: k:13 child.x:14
+ │         ├── before-triggers
+ │         │    └── tr_child
  │         └── barrier
  │              ├── columns: k:13 child.x:14 old:17 f:31 "check-rows":32
  │              └── select

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -963,7 +963,7 @@ func (p *planner) DecodeGist(ctx context.Context, gist string, external bool) ([
 	if !external {
 		cat = p.optPlanningCtx.catalog
 	}
-	return explain.DecodePlanGistToRows(ctx, gist, cat)
+	return explain.DecodePlanGistToRows(ctx, p.EvalContext(), gist, cat)
 }
 
 // makeQueryIndexRecommendation builds a statement and walks through it to find

--- a/pkg/sql/sem/tree/create_trigger.go
+++ b/pkg/sql/sem/tree/create_trigger.go
@@ -154,6 +154,16 @@ type TriggerEventTypeSet uint8
 // Ensure that TriggerEventTypeSet can contain all TriggerEventTypes.
 const _ = TriggerEventTypeSet(1) << TriggerEventTypeMax
 
+// MakeTriggerEventTypeSet creates a TriggerEventTypeSet from a list of
+// TriggerEventType values.
+func MakeTriggerEventTypeSet(types ...TriggerEventType) TriggerEventTypeSet {
+	var s TriggerEventTypeSet
+	for _, t := range types {
+		s.Add(t)
+	}
+	return s
+}
+
 // Add adds a TriggerEventType value to the set.
 func (s *TriggerEventTypeSet) Add(t TriggerEventType) {
 	*s |= 1 << t


### PR DESCRIPTION
Backport 4/4 commits from #135556.

/cc @cockroachdb/release

---

#### sql: refactor functions for handling cat.Trigger

This commit performs some refactoring for the functions that check for
the presence of and collect the list of triggers that apply to a given
mutation. The functions are now exported to be used in following commits.

Informs #134747
Informs #135155

Release note: None

#### opt: display BEFORE-trigger names in opt-tester output

This commit adds a `before-triggers` field to the opt-tester output
for mutations. Similar to the `after-triggers` field, it displays the
names of the triggers that will fire for that mutation.

Informs #134747

Release note: None

#### sql: display BEFORE trigger names for EXPLAIN

This commit adds the names of fired BEFORE triggers to the EXPLAIN
output for a mutation. This is visible in both verbose and non-verbose
variants, as well as `EXPLAIN ANALYZE`. Note that the verbose EXPLAIN
already shows the trigger-function invocations; the benefit of this
change is that it makes clear even in non-verbose EXPLAIN which triggers
fired.

Fixes #134747

Release note (sql change): The names of BEFORE triggers fired by a
mutation now show up in the EXPLAIN output. The trigger-function
invocations are visible in the output of verbose EXPLAIN.

#### sql: display AFTER triggers for EXPLAIN

This commit adds AFTER triggers to the `EXPLAIN` and `EXPLAIN ANALYZE`
outputs. The output displays the names of the fired triggers, and then
the expressions used to implement them, including the buffer scan that
supplies the mutated rows.

There is a subtlety in displaying the plans for triggers for the `ANALYZE`
variants that actually execute the query. This is because the transaction
may have auto-committed by the time the plan is being explained, and so
attempts to resolve objects while building the trigger plan will fail.

To avoid this problem, we check if the transaction is still open before
attempting to build the plan for `AFTER` triggers, or a cascade with
`BEFORE` triggers. As a result, if the statement auto-commits, only the
trigger plans that were actually involved in the execution will be
displayed. Note that this will only affect the EXPLAIN output for
mutations that involve triggers.

Fixes #135155

Release note (sql change): AFTER triggers will now show up in the
output of vanilla `EXPLAIN`, as well as `EXPLAIN ANALYZE`.

---

Release justification: observability improvement for new functionality in 24.3