### PR TITLE
ldapccl: support LDAP over non TLS connection

### DIFF
--- a/pkg/ccl/ldapccl/ldap_util.go
+++ b/pkg/ccl/ldapccl/ldap_util.go
@@ -52,7 +52,15 @@ func (lu *ldapUtil) MaybeInitLDAPsConn(ctx context.Context, conf ldapConfig) (er
 		return nil
 	}
 	ldapAddress := conf.ldapServer + ":" + conf.ldapPort
-	if lu.conn, err = ldap.DialTLS("tcp", ldapAddress, lu.tlsConfig); err != nil {
+	var opts []ldap.DialOpt
+	if conf.ldapPort == "636" {
+		opts = append(opts, ldap.DialWithTLSConfig(lu.tlsConfig))
+		ldapAddress = "ldaps://" + ldapAddress
+	} else {
+		ldapAddress = "ldap://" + ldapAddress
+	}
+
+	if lu.conn, err = ldap.DialURL(ldapAddress, opts...); err != nil {
 		return errors.Wrap(err, ldapsFailureMessage)
 	}
 	return nil


### PR DESCRIPTION
fixes #136095
Epic CRDB-33829

This PR adds support for LDAP for non TLS connections ands the required URI
scheme to the configured LDAP address.

Release note: None