### PR TITLE
workflows: make cockroach-microbench-ci as required

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -17,6 +17,7 @@ status = [
        "macos_arm64_build",
        "unit_tests",
        "windows_build",
+       "cockroach-microbench-ci",
 ]
 
 # List of commit statuses that must not be failing on the PR commit when it is

--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -376,6 +376,21 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: compute metadata
         run: echo GITHUB_ACTIONS_BRANCH=${{ github.event.pull_request.number || github.ref_name}} >> "$GITHUB_ENV"
+      - name: Check for 'performance-regression-expected' label
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const labelToCheck = 'performance-regression-expected';
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              owner,
+              repo,
+              issue_number
+            });
+            const labelNames = labels.data.map(label => label.name);
+            const hasLabel = labelNames.includes(labelToCheck);
+            core.exportVariable('PERF_REGRESSION', hasLabel ? 'true' : 'false');
       - run: ./build/github/get-engflow-keys.sh
       - run: ./build/github/prepare-summarize-build.sh
       - name: run scripts
@@ -384,9 +399,7 @@ jobs:
           COMPARE_THRESHOLD: "20.00"
           PUSH_STEP: ${{ github.event_name == 'push' && env.GITHUB_ACTIONS_BRANCH != 'staging' }}
           BASE_SHA: ${{ steps.get_latest_commit_target_branch.outputs.latest_commit }}
-
-          # TODO(sambhav-jain-16): add Performance note check and use this flag. Currently set to false (https://github.com/cockroachdb/cockroach/issues/106661)
-          SKIP_COMPARISON: ${{ env.GITHUB_ACTIONS_BRANCH == 'staging' }}
+          SKIP_COMPARISON: ${{ env.GITHUB_ACTIONS_BRANCH == 'staging' && env.PERF_REGRESSION }}
       - name: upload build results
         run: ./build/github/summarize-build.sh bes.bin
         if: always()

--- a/build/github/cockroach-microbench-ci.sh
+++ b/build/github/cockroach-microbench-ci.sh
@@ -48,7 +48,6 @@ bazel test //pkg/sql/tests:tests_test \
   --test_arg=-test.run=- \
   --test_arg='-test.bench=^BenchmarkKV$' \
   --test_sharding_strategy=disabled \
-  --test_arg=-test.cpu --test_arg=1 \
   --test_arg=-test.v \
   --test_arg=-test.count=10 \
   --test_arg=-test.benchmem \


### PR DESCRIPTION
This change aims to make `cockroach-microbench-ci` a required step.
There is an addition of a label `performance-regression-expected` that
can be used to skip the comparison in case a regression is expected

Epic: https://cockroachlabs.atlassian.net/browse/CRDB-40772
Fixes: https://github.com/cockroachdb/cockroach/issues/106661