### PR TITLE
roachtest: fix perturbation/restart/* return from setup

### DIFF
--- a/pkg/cmd/roachtest/tests/perturbation/restart_node.go
+++ b/pkg/cmd/roachtest/tests/perturbation/restart_node.go
@@ -39,7 +39,7 @@ func (r restart) setup() variations {
 	// duration once RACv2 pull mode (send queue) is enabled.
 	// v.clusterSettings["server.time_after_store_suspect"] = (10 * time.Second).String()
 
-	return setup(r, math.Inf(1))
+	return v
 }
 
 func (r restart) setupMetamorphic(rng *rand.Rand) variations {


### PR DESCRIPTION
Previously the setup code for the restart tests was constructing the variation but not returning the newly constructed value. This change correctly returns the update value with the right settings. This bug was introduced due to a merge skew from previous refactorings.

Epic: none

Release note: None