### PR TITLE
sql/schemachanger: handle empty schemas gracefully

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -1481,3 +1481,24 @@ SELECT qux();
 NULL
 
 subtest end
+
+subtest empty_schema_name
+
+user root
+
+statement ok
+set role root;
+use defaultdb;
+
+skipif config local-legacy-schema-changer
+statement error pgcode 42601 pq: empty schema name
+CREATE SCHEMA ""."";
+
+onlyif config local-legacy-schema-changer
+statement error pgcode 42601 pq: empty database name
+CREATE SCHEMA ""."";
+
+statement error pgcode 42601 pq: .*empty schema name
+CREATE SCHEMA "";
+
+subtest end

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -1936,8 +1936,7 @@ func (b *builderState) serializeUserDefinedTypes(
 
 func (b *builderState) ResolveDatabasePrefix(schemaPrefix *tree.ObjectNamePrefix) {
 	if schemaPrefix.SchemaName == "" || !schemaPrefix.ExplicitSchema {
-		panic(errors.AssertionFailedf("schema name empty when resolving database prefix for a " +
-			"schema name"))
+		panic(pgerror.Newf(pgcode.Syntax, "empty schema name"))
 	}
 	if schemaPrefix.CatalogName == "" {
 		schemaPrefix.CatalogName = tree.Name(b.cr.CurrentDatabase())


### PR DESCRIPTION
Previously, when running CREATE SCHEMA in the declartive schema changer empty schema names with end up with an assertion failure error. This was because the declarative schema change code did not handle these cases properly. When an empty schema is specified ideally a syntax error should be generated. To address this, this patch will generate the correct errors and adds logic tests.

Fixes: #129676

Release note (bug fix): CREATE SCHEMA now returns the correct error if a the schema name is missing.