### PR TITLE
pkg/cli: debug-zip log upload with datadog logs API

### DIFF
--- a/pkg/cli/testdata/upload/logs
+++ b/pkg/cli/testdata/upload/logs
@@ -16,12 +16,13 @@ upload-logs
   }
 }
 ----
-ABC/123/dt=20240716/hour=17/1/cockroach.hostname.username.2024-07-16T17_51_43Z.048498.log:
-Upload ID: 123
+Create DD Archive: https://api.us5.datadoghq.com/api/v2/logs/config/archives
+Create DD Archive: {"data":{"type":"archives","attributes":{"name":"abc-20241114000000","query":"-*","destination":{"type":"gcs","path":"ABC/abc-20241114000000","bucket":"debugzip-archives","integration":{"project_id":"arjun-sandbox-424904","client_email":"datadog-archive@arjun-sandbox-424904.iam.gserviceaccount.com"}}}}}
+GCS Upload: ABC/abc-20241114000000/dt=20240716/hour=17/1/cockroach.hostname.username.2024-07-16T17_51_43Z.048498.log:
+Upload ID: abc-20241114000000
 debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=logs
-{"data":{"type":"archives","attributes":{"name":"123","query":"-*","destination":{"type":"gcs","path":"ABC/123","bucket":"debugzip-archives","integration":{"project_id":"arjun-sandbox-424904","client_email":"datadog-archive@arjun-sandbox-424904.iam.gserviceaccount.com"}}}}}
-{"timestamp":1721152304,"date":"2024-07-16T17:51:44Z","message":"failed to start query profiler worker: failed to detect cgroup memory limit: failed to read memory cgroup from cgroups file: /proc/self/cgroup: open /proc/self/cgroup: no such file or directory","tags":["cluster:ABC","env:debug","node_id:1","service:CRDB-SH","source:cockroachdb","upload_id:123"],"_id":"a1b2c3","attributes":{"goroutine":100,"file":"server/env_sampler.go","line":125,"counter":33,"tenant_id":"1","date":"2024-07-16T17:51:44Z","timestamp":1721152304,"channel":"DEV","severity":"WARNING"}}
-{"timestamp":1721152304,"date":"2024-07-16T17:51:44Z","message":"initialized store s1","tags":["cluster:ABC","env:debug","node_id:1","service:CRDB-SH","source:cockroachdb","upload_id:123"],"_id":"a1b2c3","attributes":{"goroutine":100,"file":"server/node.go","line":533,"counter":24,"tenant_id":"1","date":"2024-07-16T17:51:44Z","timestamp":1721152304,"channel":"DEV","severity":"INFO"}}
+{"timestamp":1721152304,"date":"2024-07-16T17:51:44Z","message":"failed to start query profiler worker: failed to detect cgroup memory limit: failed to read memory cgroup from cgroups file: /proc/self/cgroup: open /proc/self/cgroup: no such file or directory","tags":["cluster:ABC","env:debug","node_id:1","service:CRDB-SH","source:cockroachdb","upload_id:abc-20241114000000"],"_id":"a1b2c3","attributes":{"goroutine":100,"file":"server/env_sampler.go","line":125,"counter":33,"tenant_id":"1","date":"2024-07-16T17:51:44Z","timestamp":1721152304,"channel":"DEV","severity":"WARNING"}}
+{"timestamp":1721152304,"date":"2024-07-16T17:51:44Z","message":"initialized store s1","tags":["cluster:ABC","env:debug","node_id:1","service:CRDB-SH","source:cockroachdb","upload_id:abc-20241114000000"],"_id":"a1b2c3","attributes":{"goroutine":100,"file":"server/node.go","line":533,"counter":24,"tenant_id":"1","date":"2024-07-16T17:51:44Z","timestamp":1721152304,"channel":"DEV","severity":"INFO"}}
 
 
 # single-node with wrong log format
@@ -43,7 +44,7 @@ upload-logs log-format=crdb-v2
 }
 ----
 Failed to upload logs: decoding on line 2: malformed log entry
-Upload ID: 123
+Upload ID: abc-20241114000000
 debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=logs --log-format=crdb-v2
 
 
@@ -76,12 +77,70 @@ upload-logs log-format=crdb-v1
   }
 }
 ----
-ABC/123/dt=20240716/hour=17/1/cockroach.node1.username.2024-07-16T17_51_43Z.048498.log:
-ABC/123/dt=20240716/hour=17/2/cockroach.node2.username.2024-07-16T17_51_43Z.048498.log:
-Upload ID: 123
+Create DD Archive: https://api.us5.datadoghq.com/api/v2/logs/config/archives
+Create DD Archive: {"data":{"type":"archives","attributes":{"name":"abc-20241114000000","query":"-*","destination":{"type":"gcs","path":"ABC/abc-20241114000000","bucket":"debugzip-archives","integration":{"project_id":"arjun-sandbox-424904","client_email":"datadog-archive@arjun-sandbox-424904.iam.gserviceaccount.com"}}}}}
+GCS Upload: ABC/abc-20241114000000/dt=20240716/hour=17/1/cockroach.node1.username.2024-07-16T17_51_43Z.048498.log:
+GCS Upload: ABC/abc-20241114000000/dt=20240716/hour=17/2/cockroach.node2.username.2024-07-16T17_51_43Z.048498.log:
+Upload ID: abc-20241114000000
 debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=logs --log-format=crdb-v1
-{"data":{"type":"archives","attributes":{"name":"123","query":"-*","destination":{"type":"gcs","path":"ABC/123","bucket":"debugzip-archives","integration":{"project_id":"arjun-sandbox-424904","client_email":"datadog-archive@arjun-sandbox-424904.iam.gserviceaccount.com"}}}}}
-{"timestamp":1721152304,"date":"2024-07-16T17:51:44Z","message":"created new SQL liveness session 01018071445fbd54a44ee88e906efb311d7193","tags":["cluster:ABC","env:debug","node_id:2","service:CRDB-SH","source:cockroachdb","upload_id:123"],"_id":"a1b2c3","attributes":{"goroutine":916,"file":"sql/sqlliveness/slinstance/slinstance.go","line":258,"counter":44,"tenant_id":"1","date":"2024-07-16T17:51:44Z","timestamp":1721152304,"channel":"DEV","severity":"INFO"}}
-{"timestamp":1721152304,"date":"2024-07-16T17:51:44Z","message":"failed to start query profiler worker: failed to detect cgroup memory limit: failed to read memory cgroup from cgroups file: /proc/self/cgroup: open /proc/self/cgroup: no such file or directory","tags":["cluster:ABC","env:debug","node_id:1","service:CRDB-SH","source:cockroachdb","upload_id:123"],"_id":"a1b2c3","attributes":{"goroutine":100,"file":"server/env_sampler.go","line":125,"counter":33,"tenant_id":"1","date":"2024-07-16T17:51:44Z","timestamp":1721152304,"channel":"DEV","severity":"WARNING"}}
-{"timestamp":1721152304,"date":"2024-07-16T17:51:44Z","message":"initialized store s1","tags":["cluster:ABC","env:debug","node_id:1","service:CRDB-SH","source:cockroachdb","upload_id:123"],"_id":"a1b2c3","attributes":{"goroutine":100,"file":"server/node.go","line":533,"counter":24,"tenant_id":"1","date":"2024-07-16T17:51:44Z","timestamp":1721152304,"channel":"DEV","severity":"INFO"}}
-{"timestamp":1721152304,"date":"2024-07-16T17:51:44Z","message":"inserted sqlliveness session 01018071445fbd54a44ee88e906efb311d7193","tags":["cluster:ABC","env:debug","node_id:2","service:CRDB-SH","source:cockroachdb","upload_id:123"],"_id":"a1b2c3","attributes":{"goroutine":916,"file":"sql/sqlliveness/slstorage/slstorage.go","line":540,"counter":43,"tenant_id":"1","date":"2024-07-16T17:51:44Z","timestamp":1721152304,"channel":"DEV","severity":"INFO"}}
+{"timestamp":1721152304,"date":"2024-07-16T17:51:44Z","message":"created new SQL liveness session 01018071445fbd54a44ee88e906efb311d7193","tags":["cluster:ABC","env:debug","node_id:2","service:CRDB-SH","source:cockroachdb","upload_id:abc-20241114000000"],"_id":"a1b2c3","attributes":{"goroutine":916,"file":"sql/sqlliveness/slinstance/slinstance.go","line":258,"counter":44,"tenant_id":"1","date":"2024-07-16T17:51:44Z","timestamp":1721152304,"channel":"DEV","severity":"INFO"}}
+{"timestamp":1721152304,"date":"2024-07-16T17:51:44Z","message":"failed to start query profiler worker: failed to detect cgroup memory limit: failed to read memory cgroup from cgroups file: /proc/self/cgroup: open /proc/self/cgroup: no such file or directory","tags":["cluster:ABC","env:debug","node_id:1","service:CRDB-SH","source:cockroachdb","upload_id:abc-20241114000000"],"_id":"a1b2c3","attributes":{"goroutine":100,"file":"server/env_sampler.go","line":125,"counter":33,"tenant_id":"1","date":"2024-07-16T17:51:44Z","timestamp":1721152304,"channel":"DEV","severity":"WARNING"}}
+{"timestamp":1721152304,"date":"2024-07-16T17:51:44Z","message":"initialized store s1","tags":["cluster:ABC","env:debug","node_id:1","service:CRDB-SH","source:cockroachdb","upload_id:abc-20241114000000"],"_id":"a1b2c3","attributes":{"goroutine":100,"file":"server/node.go","line":533,"counter":24,"tenant_id":"1","date":"2024-07-16T17:51:44Z","timestamp":1721152304,"channel":"DEV","severity":"INFO"}}
+{"timestamp":1721152304,"date":"2024-07-16T17:51:44Z","message":"inserted sqlliveness session 01018071445fbd54a44ee88e906efb311d7193","tags":["cluster:ABC","env:debug","node_id:2","service:CRDB-SH","source:cockroachdb","upload_id:abc-20241114000000"],"_id":"a1b2c3","attributes":{"goroutine":916,"file":"sql/sqlliveness/slstorage/slstorage.go","line":540,"counter":43,"tenant_id":"1","date":"2024-07-16T17:51:44Z","timestamp":1721152304,"channel":"DEV","severity":"INFO"}}
+
+
+# Single-node - with recent logs that are use logs API
+upload-logs
+{
+  "nodes": {
+    "1": {
+      "logs": [
+        {
+          "name": "cockroach.hostname.username.2024-07-16T17_51_43Z.048498.log",
+          "lines": [
+            "I{{now}} 100 server/node.go:533 ⋮ [T1,n1] 24 initialized store s1",
+            "W{{now}} 100 server/env_sampler.go:125 ⋮ [T1,n1] 33 failed to start query profiler worker: failed to detect cgroup memory limit: failed to read memory cgroup from cgroups file: ‹/proc/self/cgroup›: open ‹/proc/self/cgroup›: no such file or directory"
+          ]
+        }
+      ]
+    }
+  }
+}
+----
+Logs API Hook: https://http-intake.logs.us5.datadoghq.com/api/v2/logs
+Logs API Hook: {"goroutine":100,"file":"server/env_sampler.go","line":125,"message":"failed to start query profiler worker: failed to detect cgroup memory limit: failed to read memory cgroup from cgroups file: /proc/self/cgroup: open /proc/self/cgroup: no such file or directory","counter":33,"tenant_id":"1","timestamp":0,"severity":"WARNING","channel":"DEV","ddtags":"cluster:ABC,env:debug,node_id:1,service:CRDB-SH,source:cockroachdb,upload_id:abc-20241114000000"}
+Logs API Hook: {"goroutine":100,"file":"server/node.go","line":533,"message":"initialized store s1","counter":24,"tenant_id":"1","timestamp":0,"severity":"INFO","channel":"DEV","ddtags":"cluster:ABC,env:debug,node_id:1,service:CRDB-SH,source:cockroachdb,upload_id:abc-20241114000000"}
+Upload ID: abc-20241114000000
+debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=logs
+
+
+# Single-node - with both recent and old logs
+upload-logs
+{
+  "nodes": {
+    "1": {
+      "logs": [
+        {
+          "name": "cockroach.hostname.username.2024-07-16T17_51_43Z.048498.log",
+          "lines": [
+            "I240716 17:51:44.797342 916 sql/sqlliveness/slstorage/slstorage.go:540 ⋮ [T1,n1] 43 inserted sqlliveness session 01018071445fbd54a44ee88e906efb311d7193",
+            "I240716 17:51:44.797530 916 sql/sqlliveness/slinstance/slinstance.go:258 ⋮ [T1,n1] 44 created new SQL liveness session 01018071445fbd54a44ee88e906efb311d7193",
+            "I{{now}} 100 server/node.go:533 ⋮ [T1,n1] 24 initialized store s1",
+            "W{{now}} 100 server/env_sampler.go:125 ⋮ [T1,n1] 33 failed to start query profiler worker: failed to detect cgroup memory limit: failed to read memory cgroup from cgroups file: ‹/proc/self/cgroup›: open ‹/proc/self/cgroup›: no such file or directory"
+          ]
+        }
+      ]
+    }
+  }
+}
+----
+Create DD Archive: https://api.us5.datadoghq.com/api/v2/logs/config/archives
+Create DD Archive: {"data":{"type":"archives","attributes":{"name":"abc-20241114000000","query":"-*","destination":{"type":"gcs","path":"ABC/abc-20241114000000","bucket":"debugzip-archives","integration":{"project_id":"arjun-sandbox-424904","client_email":"datadog-archive@arjun-sandbox-424904.iam.gserviceaccount.com"}}}}}
+GCS Upload: ABC/abc-20241114000000/dt=20240716/hour=17/1/cockroach.hostname.username.2024-07-16T17_51_43Z.048498.log:
+Logs API Hook: https://http-intake.logs.us5.datadoghq.com/api/v2/logs
+Logs API Hook: {"goroutine":100,"file":"server/env_sampler.go","line":125,"message":"failed to start query profiler worker: failed to detect cgroup memory limit: failed to read memory cgroup from cgroups file: /proc/self/cgroup: open /proc/self/cgroup: no such file or directory","counter":33,"tenant_id":"1","timestamp":0,"severity":"WARNING","channel":"DEV","ddtags":"cluster:ABC,env:debug,node_id:1,service:CRDB-SH,source:cockroachdb,upload_id:abc-20241114000000"}
+Logs API Hook: {"goroutine":100,"file":"server/node.go","line":533,"message":"initialized store s1","counter":24,"tenant_id":"1","timestamp":0,"severity":"INFO","channel":"DEV","ddtags":"cluster:ABC,env:debug,node_id:1,service:CRDB-SH,source:cockroachdb,upload_id:abc-20241114000000"}
+Upload ID: abc-20241114000000
+debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=logs
+{"timestamp":1721152304,"date":"2024-07-16T17:51:44Z","message":"created new SQL liveness session 01018071445fbd54a44ee88e906efb311d7193","tags":["cluster:ABC","env:debug","node_id:1","service:CRDB-SH","source:cockroachdb","upload_id:abc-20241114000000"],"_id":"a1b2c3","attributes":{"goroutine":916,"file":"sql/sqlliveness/slinstance/slinstance.go","line":258,"counter":44,"tenant_id":"1","date":"2024-07-16T17:51:44Z","timestamp":1721152304,"channel":"DEV","severity":"INFO"}}
+{"timestamp":1721152304,"date":"2024-07-16T17:51:44Z","message":"inserted sqlliveness session 01018071445fbd54a44ee88e906efb311d7193","tags":["cluster:ABC","env:debug","node_id:1","service:CRDB-SH","source:cockroachdb","upload_id:abc-20241114000000"],"_id":"a1b2c3","attributes":{"goroutine":916,"file":"sql/sqlliveness/slstorage/slstorage.go","line":540,"counter":43,"tenant_id":"1","date":"2024-07-16T17:51:44Z","timestamp":1721152304,"channel":"DEV","severity":"INFO"}}

--- a/pkg/cli/testdata/upload/profiles
+++ b/pkg/cli/testdata/upload/profiles
@@ -11,9 +11,9 @@ upload-profiles
   }
 }
 ----
-Upload ID: 123
+Upload ID: abc-20241114000000
 debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=profiles
-{"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:debug,node_id:1,service:CRDB-SH,source:cockroachdb,upload_id:123","family":"go","version":"4"}
+{"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:debug,node_id:1,service:CRDB-SH,source:cockroachdb,upload_id:abc-20241114000000","family":"go","version":"4"}
 
 
 # Multi-node - both profiles
@@ -35,10 +35,10 @@ upload-profiles tags=foo:bar
   }
 }
 ----
-Upload ID: 123
+Upload ID: abc-20241114000000
 debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --tags=foo:bar --cluster=ABC --include=profiles
-{"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:debug,foo:bar,node_id:1,service:CRDB-SH,source:cockroachdb,upload_id:123","family":"go","version":"4"}
-{"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:debug,foo:bar,node_id:2,service:CRDB-SH,source:cockroachdb,upload_id:123","family":"go","version":"4"}
+{"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:debug,foo:bar,node_id:1,service:CRDB-SH,source:cockroachdb,upload_id:abc-20241114000000","family":"go","version":"4"}
+{"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:debug,foo:bar,node_id:2,service:CRDB-SH,source:cockroachdb,upload_id:abc-20241114000000","family":"go","version":"4"}
 
 
 # Single-node - only CPU profile
@@ -53,9 +53,9 @@ upload-profiles tags=customer:user-given-name,cluster:XYZ
   }
 }
 ----
-Upload ID: 123
+Upload ID: abc-20241114000000
 debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --tags=customer:user-given-name,cluster:XYZ --cluster=ABC --include=profiles
-{"start":"","end":"","attachments":["cpu.pprof"],"tags_profiler":"cluster:XYZ,customer:user-given-name,env:debug,foo:bar,node_id:1,service:CRDB-SH,source:cockroachdb,upload_id:123","family":"go","version":"4"}
+{"start":"","end":"","attachments":["cpu.pprof"],"tags_profiler":"cluster:XYZ,customer:user-given-name,env:debug,foo:bar,node_id:1,service:CRDB-SH,source:cockroachdb,upload_id:abc-20241114000000","family":"go","version":"4"}
 
 
 # Single-node - no profiles found
@@ -66,7 +66,7 @@ upload-profiles
   }
 }
 ----
-Upload ID: 123
+Upload ID: abc-20241114000000
 debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=profiles
 
 
@@ -83,9 +83,9 @@ upload-profiles tags=env:SH
   }
 }
 ----
-Upload ID: 123
+Upload ID: abc-20241114000000
 debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --tags=env:SH --cluster=ABC --include=profiles
-{"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:SH,node_id:1,service:CRDB-SH,source:cockroachdb,upload_id:123","family":"go","version":"4"}
+{"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:SH,node_id:1,service:CRDB-SH,source:cockroachdb,upload_id:abc-20241114000000","family":"go","version":"4"}
 
 
 # Single-node - both profiles
@@ -102,7 +102,7 @@ upload-profiles tags=ERR
 }
 ----
 Failed to upload profiles: failed to upload profiles of node 1: status: 400, body: 'runtime' is a required field
-Upload ID: 123
+Upload ID: abc-20241114000000
 debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --tags=ERR --cluster=ABC --include=profiles
 
 

--- a/pkg/cli/tsdump_upload.go
+++ b/pkg/cli/tsdump_upload.go
@@ -42,15 +42,15 @@ var (
 	// each site in datadog has a different host name. ddSiteToHostMap
 	// holds the mapping of site name to the host name.
 	ddSiteToHostMap = map[string]string{
-		"us1":     "api.datadoghq.com",
-		"us3":     "api.us3.datadoghq.com",
-		"us5":     "api.us5.datadoghq.com",
-		"eu1":     "api.datadoghq.eu",
-		"ap1":     "api.ap1.datadoghq.com",
-		"us1-fed": "api.ddog-gov.com",
+		"us1":     "datadoghq.com",
+		"us3":     "us3.datadoghq.com",
+		"us5":     "us5.datadoghq.com",
+		"eu1":     "datadoghq.eu",
+		"ap1":     "ap1.datadoghq.com",
+		"us1-fed": "ddog-gov.com",
 	}
 
-	targetURLFormat           = "https://%s/api/v2/series"
+	targetURLFormat           = "https://api.%s/api/v2/series"
 	datadogDashboardURLFormat = "https://us5.datadoghq.com/dashboard/bif-kwe-gx2/self-hosted-db-console-tsdump?" +
 		"tpl_var_cluster=%s&tpl_var_upload_id=%s&tpl_var_upload_day=%d&tpl_var_upload_month=%d&tpl_var_upload_year=%d&from_ts=%d&to_ts=%d"
 	zipFileSignature = []byte{0x50, 0x4B, 0x03, 0x04}

--- a/pkg/cli/zip_upload.go
+++ b/pkg/cli/zip_upload.go
@@ -81,7 +81,8 @@ const (
 
 	// datadog endpoint URLs
 	datadogProfileUploadURLTmpl = "https://intake.profile.%s/v1/input"
-	datadogCreateArchiveURLTmpl = "https://%s/api/v2/logs/config/archives"
+	datadogCreateArchiveURLTmpl = "https://api.%s/api/v2/logs/config/archives"
+	datadogLogIntakeURLTmpl     = "https://http-intake.logs.%s/api/v2/logs"
 
 	// datadog archive attributes
 	ddArchiveType            = "archives"
@@ -92,6 +93,19 @@ const (
 
 	gcsPathTimeFormat = "dt=20060102/hour=15"
 	zipUploadRetries  = 5
+
+	// datadog allows us to use logs API logs only for the last 72 hours. So, we
+	// are setting the oldest allowed log duration to 71 hours. The -1 hour is to
+	// keep some buffer for delays, etc.
+	datadogOldestAllowedLogDuration = 71 * time.Hour
+	datadogMaxLogLinesPerReq        = 1000
+)
+
+type logUploadType int
+
+const (
+	logUploadTypeDatadog logUploadType = iota
+	logUploadTypeGCS
 )
 
 var debugZipUploadOpts = struct {
@@ -135,7 +149,7 @@ func runDebugZipUpload(cmd *cobra.Command, args []string) error {
 	}
 
 	// a unique ID for this upload session. This should be used to tag all the artifacts uploaded in this session
-	uploadID := newUploadID(debugZipUploadOpts.clusterName, timeutil.Now())
+	uploadID := newUploadID(debugZipUploadOpts.clusterName, getCurrentTime())
 
 	// override the list of artifacts to upload if the user has provided any
 	artifactsToUpload := zipArtifactTypes
@@ -268,7 +282,7 @@ func newProfileUploadReq(
 	var (
 		body  bytes.Buffer
 		mw    = multipart.NewWriter(&body)
-		now   = timeutil.Now()
+		now   = getCurrentTime()
 		event = &profileUploadEvent{
 			Version: profileVersion,
 			Family:  profileFamily,
@@ -331,14 +345,27 @@ func newProfileUploadReq(
 func processLogFile(
 	uploadID, debugDirPath string, file fileInfo, uploadFn func(logUploadSig),
 ) (time.Time, time.Time, error) {
+	// We collect the parsed log lines in an array instead of bytes buffer.
+	// Because, now this has two use-cases. Rehydration and Logs API.
+	//
+	//   * The rehydration flow has no constraints and can use either array or buffer
+	//   * But with the logs API, there is a 1000 line limit per payload. To keep
+	//     this function agnostic of the upload method, the 1000 line limit will be
+	//     handled downstream, just before upload
 	var (
 		pathParts                            = strings.Split(strings.TrimPrefix(file.path, debugDirPath), "/")
 		inputEditMode                        = log.SelectEditMode(false /* redactable */, false /* redactInput */)
 		nodeID                               = pathParts[2]
 		fileName                             = path.Base(file.path)
-		logBuffer                            = &bytes.Buffer{}
+		logLines                             = [][]byte{}
 		localMinTimestamp, localMaxTimestamp = time.Time{}, time.Time{}
-		prevTargetPath                       = ""
+
+		// prevTargetPath and prevTimestamp are used to keep track of the
+		// previously parsed log line. This is used to determine when to conclude
+		// the current batch of logs and send them for upload. They are also sent
+		// as metadata as part of the logUploadSig.
+		prevTargetPath = ""
+		prevTimestamp  time.Time
 	)
 
 	stream, err := newFileLogStream(
@@ -360,51 +387,48 @@ func processLogFile(
 		// <cluster-name>/<upload-id>/dt=20210901/hour=15/<node_id>/<filename>
 		currTargetPath := path.Join(
 			debugZipUploadOpts.clusterName, uploadID,
-			timeutil.Unix(0, e.Time).Format(gcsPathTimeFormat), nodeID, fileName,
+			currentTimestamp.Format(gcsPathTimeFormat), nodeID, fileName,
 		)
 
 		if prevTargetPath != "" && prevTargetPath != currTargetPath {
 			// we've found a new hour, so we need to send the logs of the
 			// previous hour for upload
 			uploadFn(logUploadSig{
-				key:    prevTargetPath,
-				nodeID: nodeID,
-				data:   logBuffer.Bytes(),
+				logUploadType: getUploadType(prevTimestamp),
+				key:           prevTargetPath,
+				nodeID:        nodeID,
+				logLines:      logLines,
 			})
 
-			logBuffer.Reset()
+			logLines = [][]byte{}
 		}
 
-		rawLine, err := logEntryToJSON(e, appendUserTags(
-			append(
-				defaultDDTags, makeDDTag(uploadIDTag, uploadID), makeDDTag(nodeIDTag, nodeID),
-				makeDDTag(clusterTag, debugZipUploadOpts.clusterName),
-			), // system generated tags
+		rawLine, err := logEntryToJSON(e, appendUserTags(append(
+			defaultDDTags, makeDDTag(uploadIDTag, uploadID), makeDDTag(nodeIDTag, nodeID),
+			makeDDTag(clusterTag, debugZipUploadOpts.clusterName),
+		), // system generated tags
 			debugZipUploadOpts.tags..., // user provided tags
-		))
+		), getUploadType(currentTimestamp))
 		if err != nil {
 			fmt.Println(err)
 			continue
 		}
 
-		_, err = logBuffer.Write(append(rawLine, []byte("\n")...))
-		if err != nil {
-			fmt.Println(err)
-			continue
-		}
-
+		logLines = append(logLines, rawLine)
 		stream.pop()
+
+		prevTimestamp = currentTimestamp
 		prevTargetPath = currTargetPath
 	}
 
 	// upload the remaining logs
-	if logBuffer.Len() > 0 {
+	if len(logLines) > 0 {
 		uploadFn(logUploadSig{
-			key:    prevTargetPath,
-			data:   logBuffer.Bytes(),
-			nodeID: nodeID,
+			logUploadType: getUploadType(prevTimestamp),
+			key:           prevTargetPath,
+			nodeID:        nodeID,
+			logLines:      logLines,
 		})
-		logBuffer.Reset()
 	}
 
 	return localMinTimestamp, localMaxTimestamp, nil
@@ -484,11 +508,12 @@ func logReaderPool(
 func uploadZipLogs(ctx context.Context, uploadID string, debugDirPath string) error {
 	var (
 		// both the channels are buffered to keep the workers busy
-		gcsWorkChan = make(chan logUploadSig, debugZipUploadOpts.maxConcurrentUploads*2)
-		doneChan    = make(chan logUploadStatus, debugZipUploadOpts.maxConcurrentUploads*2)
-		writerGroup = sync.WaitGroup{}
-		totalSize   = 0
-		nodeLookup  = make(map[string]struct{})
+		gcsWorkChan                      = make(chan logUploadSig, debugZipUploadOpts.maxConcurrentUploads*2)
+		ddWorkChan                       = make(chan logUploadSig, debugZipUploadOpts.maxConcurrentUploads*2)
+		doneChan                         = make(chan logUploadStatus, debugZipUploadOpts.maxConcurrentUploads*2)
+		writerGroup                      = sync.WaitGroup{}
+		historicalLogSize, recentLogSize = 0, 0
+		nodeLookup                       = make(map[string]struct{})
 	)
 
 	go func() {
@@ -500,25 +525,48 @@ func uploadZipLogs(ctx context.Context, uploadID string, debugDirPath string) er
 
 			if sig.err != nil {
 				fmt.Fprintln(os.Stderr, "error while uploading logs:", sig.err)
+			} else if sig.logUploadType == logUploadTypeGCS {
+				historicalLogSize += sig.uploadSize
 			} else {
-				totalSize += sig.uploadSize
+				recentLogSize += sig.uploadSize
 			}
 
 			writerGroup.Done()
 		}
 	}()
 
-	// queueForUpload is responsible for receiving the logs from the
-	// logReaderPool and queuing them for upload. Currently, it just adds the
-	// logs to the gcsWorkChan but this can be extended to add work to more than
-	// on worker pool. In the near future, this will extend support to datadog
-	// logs API
+	// queueForUpload is responsible for queuing the batched logs for upload. If
+	// logs are older than the oldest allowed log duration, they are queued for
+	// upload to GCS (to follow the rehydration path). Otherwise, they are queued
+	// for upload to datadog directly (using logs API).
 	queueForUpload := func(sig logUploadSig) {
+		if sig.logUploadType == logUploadTypeDatadog {
+			if len(sig.logLines) < datadogMaxLogLinesPerReq {
+				writerGroup.Add(1)
+				ddWorkChan <- sig
+				return
+			}
+
+			// datadog's logs API only allows 1000 lines of logs per request. So, we
+			// need to split the signal accordingly. It's best to do it here because
+			// splitting the signal affects the concurrency of the upload workers.
+			for _, newSig := range sig.split() {
+				writerGroup.Add(1)
+				ddWorkChan <- newSig
+			}
+			return
+		}
+
 		writerGroup.Add(1)
 		gcsWorkChan <- sig
 	}
 
-	startGCSWriterPool(debugZipUploadOpts.maxConcurrentUploads, gcsWorkChan, doneChan)
+	// start the GCS writer pool
+	startWriterPool(gcsLogUpload, debugZipUploadOpts.maxConcurrentUploads, gcsWorkChan, doneChan)
+
+	// start the datadog writer pool
+	startWriterPool(ddLogUpload, debugZipUploadOpts.maxConcurrentUploads, ddWorkChan, doneChan)
+
 	waitForReads, err := logReaderPool(
 		debugZipUploadOpts.maxConcurrentUploads, debugDirPath, uploadID, queueForUpload,
 	)
@@ -531,18 +579,25 @@ func uploadZipLogs(ctx context.Context, uploadID string, debugDirPath string) er
 
 	writerGroup.Wait()
 	close(gcsWorkChan)
+	close(ddWorkChan)
 	close(doneChan)
 
-	if totalSize != 0 {
-		fmt.Fprintf(os.Stderr, "Upload complete! Total size: %s\n", humanReadableSize(totalSize))
+	if recentLogSize != 0 {
+		fmt.Fprintf(os.Stderr, "Logs from within the last 72 hours were directly uploaded to datadog! (%s)\n", humanReadableSize(recentLogSize))
+		fmt.Fprintf(
+			os.Stderr, "Explore the logs here: https://us5.datadoghq.com/logs?query=upload_id:%s&from_ts=%d&to_ts=%d\n",
+			uploadID, firstEventTime.UnixMilli(), lastEventTime.UnixMilli(),
+		)
+	}
 
+	if historicalLogSize != 0 {
 		if err := setupDDArchive(
 			ctx, path.Join(debugZipUploadOpts.clusterName, uploadID), uploadID,
 		); err != nil {
 			return errors.Wrap(err, "failed to setup datadog archive")
 		}
 
-		printRehydrationSteps(uploadID, uploadID, firstEventTime, lastEventTime)
+		printRehydrationSteps(humanReadableSize(historicalLogSize), uploadID, uploadID, firstEventTime, lastEventTime)
 	}
 
 	return nil
@@ -618,35 +673,74 @@ func setupDDArchive(ctx context.Context, pathPrefix, archiveName string) error {
 }
 
 type logUploadSig struct {
-	key    string
-	nodeID string
-	data   []byte
+	logUploadType logUploadType
+	key           string
+	nodeID        string
+	logLines      [][]byte
+}
+
+// split the logUploadSig into multiple signals if the number of logLines
+// exceeds the maximum allowed lines per request. Datadog has limits on both
+// number of lines and the size of the payload. But in case of CRDB logs, the
+// average size of 1000 lines is well within the limit (5MB). So, we are only
+// splitting based on the number of lines.
+func (s logUploadSig) split() []logUploadSig {
+	var (
+		noOfNewSignals = len(s.logLines)/datadogMaxLogLinesPerReq + 1
+		newSignals     = make([]logUploadSig, noOfNewSignals)
+	)
+
+	for i := 0; i < noOfNewSignals; i++ {
+		startIdx := i * datadogMaxLogLinesPerReq
+		remaining := len(s.logLines[startIdx:])
+
+		// the min function is used to make sure that the last signal doesn't end
+		// up with trailing empty logLines. For example: if there are 800 log
+		// lines remaining, logLines[x:x+1000] will result in 200 empty log lines.
+		// So, we use logLines[x:x+min(1000, 800)] instead.
+		endIdx := startIdx + min(datadogMaxLogLinesPerReq, remaining)
+
+		newSignals[i] = logUploadSig{
+			logUploadType: s.logUploadType,
+			key:           s.key,
+			nodeID:        s.nodeID,
+			logLines:      s.logLines[startIdx:endIdx],
+		}
+	}
+
+	return newSignals
 }
 
 type logUploadStatus struct {
-	err        error
-	uploadSize int
-	nodeID     string
+	logUploadType logUploadType
+	err           error
+	uploadSize    int
+	nodeID        string
 }
 
-// startGCSWriterPool creates a worker pool that can concurrently write the
-// logs to GCS. This function only orchestrates the upload process. This pool
-// is terminated when the workChan is closed
-func startGCSWriterPool(size int, workChan <-chan logUploadSig, doneChan chan<- logUploadStatus) {
+// logUploadFunc is a function type that implements the actual writing of the logs
+// to a destination. The function signature is used to abstract the actual
+// uploading logic from the writer pool.
+type logUploadFunc func(context.Context, logUploadSig) (int, error)
+
+// startWriterPool creates a worker pool that can concurrently write the logs
+// using the given writeFunc. This function only orchestrates the upload
+// process. This pool is terminated when the workChan is closed
+func startWriterPool(
+	fn logUploadFunc, size int, workChan <-chan logUploadSig, doneChan chan<- logUploadStatus,
+) {
 	for i := 0; i < size; i++ {
 		go func() {
 			for sig := range workChan {
-				doneChan <- logUploadStatus{
-					err:        writeLogsToGCS(context.Background(), sig),
-					uploadSize: len(sig.data),
-					nodeID:     sig.nodeID,
-				}
+				status := logUploadStatus{nodeID: sig.nodeID, logUploadType: sig.logUploadType}
+				status.uploadSize, status.err = fn(context.Background(), sig)
+				doneChan <- status
 			}
 		}()
 	}
 }
 
-// writeLogsToGCS is a function that writes the logs to GCS.
+// gcsLogUpload is a function that writes the logs to GCS.
 // The key in the gcsWorkerSig is the target path where the logs should be
 // uploaded.
 //
@@ -655,10 +749,11 @@ func startGCSWriterPool(size int, workChan <-chan logUploadSig, doneChan chan<- 
 // Each path will be uploaded as a separate file. The final file name will be
 // randomly generated just be for uploading. This function only does the actual
 // writing to GCS. The concurrency has to be handled by the caller.
-var writeLogsToGCS = func(ctx context.Context, sig logUploadSig) error {
+// This function implements the logUploadFunc signature.
+var gcsLogUpload = func(ctx context.Context, sig logUploadSig) (int, error) {
 	gcsClient, closeGCSClient, err := newGCSClient(ctx)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer closeGCSClient()
 
@@ -670,10 +765,11 @@ var writeLogsToGCS = func(ctx context.Context, sig logUploadSig) error {
 	retryOpts := base.DefaultRetryOptions()
 	retryOpts.MaxRetries = zipUploadRetries
 
+	data := bytes.Join(sig.logLines, []byte("\n"))
 	for retry := retry.Start(retryOpts); retry.Next(); {
 		objectWriter := gcsClient.Bucket(ddArchiveBucketName).Object(filename).NewWriter(ctx)
 		w := gzip.NewWriter(objectWriter)
-		_, err = w.Write(sig.data)
+		_, err = w.Write(data)
 		if err != nil {
 			continue
 		}
@@ -690,7 +786,64 @@ var writeLogsToGCS = func(ctx context.Context, sig logUploadSig) error {
 		break
 	}
 
-	return err
+	return len(data), err
+}
+
+// ddLogUpload wraps the uploadLogsToDatadog function and adds the required
+// formatting required for uploading multiple logs at once. This function
+// implements the logUploadFunc signature.
+func ddLogUpload(ctx context.Context, sig logUploadSig) (int, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('[')
+	buf.Write(bytes.Join(sig.logLines, []byte(",")))
+	buf.WriteByte(']')
+
+	return uploadLogsToDatadog(ctx, buf.Bytes())
+}
+
+// uploadLogsToDatadog is a generic function that uploads the given payload of
+// logs to datadog. This exists because artifacts other than logs might also
+// need to be uploaded to datadog in the form of logs (example: table dumps,
+// events etc.).
+func uploadLogsToDatadog(ctx context.Context, payload []byte) (int, error) {
+	var (
+		compressedLogs      bytes.Buffer
+		compressedlogWriter = gzip.NewWriter(&compressedLogs)
+		url                 = makeDDURL(datadogLogIntakeURLTmpl)
+	)
+
+	if _, err := compressedlogWriter.Write(payload); err != nil {
+		return 0, err
+	}
+	if err := compressedlogWriter.Close(); err != nil {
+		return 0, err
+	}
+
+	retryOpts := base.DefaultRetryOptions()
+	retryOpts.MaxRetries = zipUploadRetries
+
+	var req *http.Request
+	var err error
+	for retry := retry.Start(retryOpts); retry.Next(); {
+		req, err = http.NewRequest(http.MethodPost, url, &compressedLogs)
+		if err != nil {
+			continue
+		}
+
+		req.Header.Set(httputil.ContentTypeHeader, httputil.JSONContentType)
+		req.Header.Set(httputil.ContentEncodingHeader, httputil.GzipEncoding)
+		req.Header.Set(datadogAPIKeyHeader, debugZipUploadOpts.ddAPIKey)
+
+		if _, err = doUploadReq(req); err == nil {
+			break
+		}
+	}
+
+	if err != nil {
+		return 0, fmt.Errorf("failed to upload logs to datadog. response: %w", err)
+	}
+
+	return len(payload), nil
 }
 
 func newGCSClient(ctx context.Context) (*storage.Client, func(), error) {
@@ -712,7 +865,7 @@ func newGCSClient(ctx context.Context) (*storage.Client, func(), error) {
 	}, nil
 }
 
-type ddLogEntry struct {
+type ddArchiveLogAttrs struct {
 	logpb.Entry
 
 	Date      string `json:"date"`
@@ -726,11 +879,33 @@ type ddLogEntry struct {
 	Tags    string `json:"tags,omitempty"`
 }
 
+type ddLogsAPIEntry struct {
+	logpb.Entry
+	Timestamp int64  `json:"timestamp"`
+	Severity  string `json:"severity"`
+	Channel   string `json:"channel"`
+	DDTags    string `json:"ddtags"`
+
+	// remove the below fields via the omitempty tags
+	Time string `json:"time,omitempty"`
+	Tags string `json:"tags,omitempty"`
+}
+
 // logEntryToJSON converts a logpb.Entry to a JSON byte slice and also
 // transform a few fields to use the correct types. The JSON format is based on
 // the specification provided by datadog.
 // Refer: https://gist.github.com/ckelner/edc0e4efe4fa110f6b6b61f69d580171
-func logEntryToJSON(e logpb.Entry, tags []string) ([]byte, error) {
+func logEntryToJSON(e logpb.Entry, tags []string, lt logUploadType) ([]byte, error) {
+	if lt == logUploadTypeDatadog {
+		return json.Marshal(ddLogsAPIEntry{
+			Entry:     e,
+			Timestamp: e.Time / 1e6, // convert nanoseconds to milliseconds
+			Severity:  e.Severity.String(),
+			Channel:   e.Channel.String(),
+			DDTags:    strings.Join(tags, ","),
+		})
+	}
+
 	var message any = e.Message
 	if strings.HasPrefix(e.Message, "{") {
 		// If the message is already a JSON object, we don't want to escape it
@@ -746,19 +921,19 @@ func logEntryToJSON(e logpb.Entry, tags []string) ([]byte, error) {
 
 	return json.Marshal(struct {
 		// override the following fields in the embedded logpb.Entry struct
-		Timestamp  int64      `json:"timestamp"`
-		Date       string     `json:"date"`
-		Message    any        `json:"message"`
-		Tags       []string   `json:"tags"`
-		ID         string     `json:"_id"`
-		Attributes ddLogEntry `json:"attributes"`
+		Timestamp  int64             `json:"timestamp"`
+		Date       string            `json:"date"`
+		Message    any               `json:"message"`
+		Tags       []string          `json:"tags"`
+		ID         string            `json:"_id"`
+		Attributes ddArchiveLogAttrs `json:"attributes"`
 	}{
 		Timestamp: timestamp,
 		Date:      date,
 		Message:   message,
 		Tags:      tags,
 		ID:        newRandStr(24, false /* numericOnly */),
-		Attributes: ddLogEntry{
+		Attributes: ddArchiveLogAttrs{
 			Entry:     e,
 			Date:      date,
 			Timestamp: timestamp,
@@ -865,7 +1040,7 @@ var newRandStr = func(length int, numericOnly bool) string {
 		charSet = "0123456789"
 	}
 
-	r := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+	r := rand.New(rand.NewSource(getCurrentTime().UnixNano()))
 	b := make([]byte, length)
 	for i := range b {
 		b[i] = charSet[r.Intn(len(charSet))]
@@ -873,10 +1048,10 @@ var newRandStr = func(length int, numericOnly bool) string {
 	return string(b)
 }
 
-func printRehydrationSteps(uploadID, archiveName string, from, to time.Time) {
+func printRehydrationSteps(size, uploadID, archiveName string, from, to time.Time) {
 	msg := `
-The logs have been added to an archive and are ready for rehydration (ingestion). This has to be
-triggered manually for now. This will be automated as soon as the datadog API supports it.
+A datadog archive has been created for logs older than 72 hours and are ready for rehydration (%s).
+This has to be triggered manually for now. This will be automated as soon as the datadog API supports it.
 
 Follow these steps to trigger rehydration:
 
@@ -894,7 +1069,7 @@ You will receive an email notification once the rehydration is complete.
 	from = from.Truncate(time.Hour)            // round down to the nearest hour
 	to = to.Add(time.Hour).Truncate(time.Hour) // round up to the nearest hour
 	fmt.Fprintf(
-		os.Stderr, msg, from.Format(timeFormat), to.Format(timeFormat), archiveName, uploadID,
+		os.Stderr, msg, size, from.Format(timeFormat), to.Format(timeFormat), archiveName, uploadID,
 	)
 }
 
@@ -919,4 +1094,12 @@ func humanReadableSize(bytes int) string {
 		exp++
 	}
 	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}
+
+func getUploadType(t time.Time) logUploadType {
+	if t.Before(getCurrentTime().Add(-datadogOldestAllowedLogDuration)) {
+		return logUploadTypeGCS
+	}
+
+	return logUploadTypeDatadog
 }

--- a/pkg/cli/zip_upload_test.go
+++ b/pkg/cli/zip_upload_test.go
@@ -7,6 +7,7 @@ package cli
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -17,6 +18,7 @@ import (
 	"os"
 	"path"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -108,8 +110,8 @@ func setupZipDir(t *testing.T, inputs zipUploadTestContents) (string, func()) {
 func TestUploadZipEndToEnd(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	defer testutils.TestingHook(&newUploadID, func(string, time.Time) string {
-		return "123"
+	defer testutils.TestingHook(&getCurrentTime, func() time.Time {
+		return time.Date(2024, 11, 14, 0, 0, 0, 0, time.UTC)
 	})()
 	defer testutils.TestingHook(&newRandStr, func(l int, n bool) string {
 		if n {
@@ -133,6 +135,9 @@ func TestUploadZipEndToEnd(t *testing.T) {
 				return uploadProfileHook(t, req)
 			case "/api/v2/logs/config/archives":
 				return setupDDArchiveHook(t, req)
+			case "/api/v2/logs":
+				return setupDDLogsHook(t, req)
+
 			default:
 				return nil, fmt.Errorf(
 					"unexpected request is being made to datadog: %s", req.URL.Path,
@@ -141,7 +146,7 @@ func TestUploadZipEndToEnd(t *testing.T) {
 		},
 	)()
 
-	defer testutils.TestingHook(&writeLogsToGCS, writeLogsToGCSHook)()
+	defer testutils.TestingHook(&gcsLogUpload, writeLogsToGCSHook)()
 
 	datadriven.Walk(t, "testdata/upload", func(t *testing.T, path string) {
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
@@ -151,8 +156,14 @@ func TestUploadZipEndToEnd(t *testing.T) {
 
 			var finaloutput bytes.Buffer
 
+			// interpolate all the {{now}} placeholders with the current time
+			input := bytes.ReplaceAll(
+				[]byte(d.Input), []byte("{{now}}"),
+				[]byte(time.Now().Format("060102 15:04:05.000000")),
+			)
+
 			var testInput zipUploadTestContents
-			require.NoError(t, json.Unmarshal([]byte(d.Input), &testInput))
+			require.NoError(t, json.Unmarshal(input, &testInput))
 
 			var tags string
 			if d.HasArg("tags") {
@@ -315,27 +326,68 @@ func setupDDArchiveHook(t *testing.T, req *http.Request) ([]byte, error) {
 	t.Helper()
 
 	// validate the headers
-	require.Equal(t, "dd-api-key", req.Header.Get("DD-API-KEY"))
-	require.Equal(t, "dd-app-key", req.Header.Get("DD-APPLICATION-KEY"))
+	require.Equal(t, "dd-api-key", req.Header.Get(datadogAPIKeyHeader))
+	require.Equal(t, "dd-app-key", req.Header.Get(datadogAppKeyHeader))
 
 	var body bytes.Buffer
 	_, err := body.ReadFrom(req.Body)
 	require.NoError(t, err)
 
-	// print the request bidy so that it gets captured as a part of
+	// print the request body and the URL so that it gets captured as a part of
 	// RunWithCapture
-	fmt.Println(body.String())
+	fmt.Println("Create DD Archive:", req.URL)
+	fmt.Println("Create DD Archive:", body.String())
 	return []byte("200 OK"), nil
 }
 
-func writeLogsToGCSHook(ctx context.Context, sig logUploadSig) error {
+func setupDDLogsHook(t *testing.T, req *http.Request) ([]byte, error) {
+	t.Helper()
+
+	// validate the headers
+	require.Equal(t, "dd-api-key", req.Header.Get(datadogAPIKeyHeader))
+	require.Equal(t, "", req.Header.Get(datadogAppKeyHeader))
+
+	var body bytes.Buffer
+	gzipReader, err := gzip.NewReader(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	defer gzipReader.Close()
+
+	_, err = body.ReadFrom(gzipReader)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Println("Logs API Hook:", req.URL)
+
+	// remove timestamp from the logs to make the test deterministic
+	var lines []ddLogsAPIEntry
+	if err := json.Unmarshal(body.Bytes(), &lines); err != nil {
+		return nil, err
+	}
+
+	for _, line := range lines {
+		line.Timestamp = 0
+		raw, err := json.Marshal(line)
+		if err != nil {
+			return nil, err
+		}
+
+		fmt.Println("Logs API Hook:", string(raw))
+	}
+
+	return []byte("200 OK"), nil
+}
+
+func writeLogsToGCSHook(ctx context.Context, sig logUploadSig) (int, error) {
 	out := strings.Builder{}
 	out.WriteString(fmt.Sprintf("%s:\n", sig.key))
-	out.WriteString(fmt.Sprintf("%s\n", string(sig.data)))
+	out.WriteString(fmt.Sprintf("%s\n", string(bytes.Join(sig.logLines, []byte("\n")))))
 
 	// print the logs so that it gets captured as a part of RunWithCapture
-	fmt.Println(out.String())
-	return nil
+	fmt.Println("GCS Upload:", out.String())
+	return out.Len(), nil
 }
 
 func TestLogEntryToJSON(t *testing.T) {
@@ -353,7 +405,7 @@ func TestLogEntryToJSON(t *testing.T) {
 		Channel:  logpb.Channel_STORAGE,
 		Time:     time.Date(2024, time.August, 2, 0, 0, 0, 0, time.UTC).UnixNano(),
 		Message:  "something happend",
-	}, []string{})
+	}, []string{}, logUploadTypeGCS)
 	require.NoError(t, err)
 
 	t.Log(string(raw))
@@ -363,7 +415,7 @@ func TestLogEntryToJSON(t *testing.T) {
 		Channel:  logpb.Channel_STORAGE,
 		Time:     time.Date(2024, time.August, 2, 0, 0, 0, 0, time.UTC).UnixNano(),
 		Message:  `{"foo": "bar"}`,
-	}, []string{})
+	}, []string{}, logUploadTypeDatadog)
 	require.NoError(t, err)
 
 	t.Log(string(raw))
@@ -387,5 +439,87 @@ func TestHumanReadableSize(t *testing.T) {
 
 	for _, tc := range tt {
 		assert.Equal(t, tc.expected, humanReadableSize(tc.size))
+	}
+}
+
+func TestGetUploadType(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// this test is just to ensure that we dont have regressions in the future
+	// WRT the upload type selection logic and the threshold. The actual logic is
+	// tested in the end-to-end tests.
+
+	recentTS := time.Now()
+	oldTS := time.Now().Add(time.Hour * -72)
+
+	tt := []struct {
+		name     string
+		ts       time.Time
+		expected logUploadType
+	}{
+		{name: "datadog", ts: recentTS, expected: logUploadTypeDatadog},
+		{name: "gcs", ts: oldTS, expected: logUploadTypeGCS},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, getUploadType(tc.ts))
+		})
+	}
+}
+
+func TestLogUploadSigSplit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	makeSig := func(start, noOfLines int) logUploadSig {
+		var logLines [][]byte
+		for i := start; i < start+noOfLines; i++ {
+			logLines = append(logLines, []byte(fmt.Sprintf("%d", i)))
+		}
+
+		return logUploadSig{logLines: logLines}
+	}
+
+	tt := []struct {
+		name             string
+		input            logUploadSig
+		expectedSigCount int
+	}{
+		{
+			name:             "no lines",
+			input:            makeSig(1, 0),
+			expectedSigCount: 1,
+		},
+		{
+			name:             "within the limit",
+			input:            makeSig(1, 800),
+			expectedSigCount: 1,
+		},
+		{
+			name:             "exceeds the limit once",
+			input:            makeSig(1, 1400),
+			expectedSigCount: 2,
+		},
+		{
+			name:             "exceeds the limit twice",
+			input:            makeSig(1, 2800),
+			expectedSigCount: 3,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			splits := tc.input.split()
+			require.Len(t, splits, tc.expectedSigCount)
+
+			for i, split := range splits {
+				for j, line := range split.logLines {
+					// The content of the line is the original index when the sig was
+					// created. So, we can use this to validate the consistency of the
+					// split operation. This assertion will account for exectly what is
+					// expected in each line of each split. Nothing more, nothing less.
+					require.Equal(t, strconv.Itoa((i*datadogMaxLogLinesPerReq)+j+1), string(line))
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Recently datadog has started to support ingesting of logs that are upto
72 hours old. This commit updates the current log upload flow to use
the Logs API for logs that are within the 72 hour range. The following
are the changes made in this commit:

* In a given debug zip, the log events that occurred within the last 72
  (from the time of upload), will directly be uploaded to datadog using
  the Logs API.

* Log events older than 72 hours will continue to follow the
  Rehydration flow. I.e they will be uploaded to a GCS bucket which will
  then be declared as an archive on datadog. The Rehydration will
  manually need to be triggered for this (just like before).

* By design, no logs will be left behind in the debug zip. They will make
  their way to datadog using one of the above methods.

* There is no change in the way we read the log files. This just
  introduces a new pool of writers that are responsible for writing to
  datadog using the Logs API. The main thread distributes the log upload
  batches among the two writer pools based on the timestamps of the
  logs.

This commit only makes the functional changes required for using the
Logs API. There will also be some TUI changes required to make the UX
better. Will create a separate PR for those changes.

---

![image](https://github.com/user-attachments/assets/a5d2caa7-764f-4161-abae-ab1b9fb21b95)

Epic: CC-28996
Part of: CC-30567
Release note: None