### PR TITLE
Revert "tpcc: use stateless retries to avoid deadlocks"

### DIFF
--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -19,7 +19,6 @@ import (
 	crdbpgx "github.com/cockroachdb/cockroach-go/v2/crdb/crdbpgxv5"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser/statements"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
@@ -29,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/cockroachdb/cockroach/pkg/workload/workloadimpl"
 	"github.com/cockroachdb/errors"
-	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v5"
 	"github.com/spf13/pflag"
 	"golang.org/x/exp/rand"
@@ -47,9 +45,6 @@ const (
 
 	// Max rows that can be updated in a single txn, used while resetting the w_ytd values
 	maxRowsToUpdateTxn = 10_000
-
-	// The maximum number of times a transaction is retried.
-	maxRetries = 50
 )
 
 type tpcc struct {
@@ -1103,28 +1098,8 @@ func (w *tpcc) executeTx(
 		return fn(tx)
 	}
 
-	const warnEvery = 10
 	if w.txnRetries {
-		for i := 0; i <= maxRetries; i++ {
-			tx, err := conn.BeginTx(ctx, txOpts)
-			if err != nil {
-				return onTxnStartDuration, err
-			}
-			err = txnFuncWithStartFuncs(tx)
-			if err == nil {
-				return onTxnStartDuration, tx.Commit(ctx)
-			}
-			var pgErr *pgconn.PgError
-			if errors.As(err, &pgErr) && pgcode.MakeCode(pgErr.Code) == pgcode.SerializationFailure {
-				if i%warnEvery == 0 {
-					log.Warningf(ctx, "have retried transaction %d times, most recently because of the "+
-						"retryable error: %s. Is the transaction stuck in a retry loop?", i, err)
-				}
-				continue
-			}
-			return onTxnStartDuration, err
-		}
-		return onTxnStartDuration, err
+		return onTxnStartDuration, crdbpgx.ExecuteTx(ctx, conn, txOpts, txnFuncWithStartFuncs)
 	}
 
 	tx, err := conn.BeginTx(ctx, txOpts)


### PR DESCRIPTION
This reverts commit c8e08d10a304b38bdf8e7a75706c517a0a6e40b2.


Closes https://github.com/cockroachdb/cockroach/issues/135808
Closes https://github.com/cockroachdb/cockroach/issues/135902
Closes https://github.com/cockroachdb/cockroach/issues/135822
Closes https://github.com/cockroachdb/cockroach/issues/135813
Closes https://github.com/cockroachdb/cockroach/issues/135787
Closes https://github.com/cockroachdb/cockroach/issues/135867
Closes https://github.com/cockroachdb/cockroach/issues/135826
Closes https://github.com/cockroachdb/cockroach/issues/135824

Epic: none

Release note: None