### PR TITLE
crosscluster/physical: skip TestStreamingReplanOnLag

### DIFF
--- a/pkg/ccl/crosscluster/physical/replication_stream_e2e_test.go
+++ b/pkg/ccl/crosscluster/physical/replication_stream_e2e_test.go
@@ -863,6 +863,7 @@ func TestStreamingReplanOnLag(t *testing.T) {
 
 	skip.UnderDuressWithIssue(t, 115850, "time to scatter ranges takes too long under duress")
 	skip.UnderMetamorphic(t, "time to scatter ranges takes too long under non-default settings")
+	skip.WithIssue(t, 115850)
 
 	ctx := context.Background()
 	args := replicationtestutils.DefaultTenantStreamingClustersArgs


### PR DESCRIPTION
We should be asserting this in a roachtest as this test is too dang flakey.

Epic: none

Release note: none