### PR TITLE
roachtest: remove kv100 from cdc bench tests

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc_bench.go
+++ b/pkg/cmd/roachtest/tests/cdc_bench.go
@@ -98,7 +98,10 @@ func registerCDCBench(r registry.Registry) {
 	}
 
 	// Workload impact benchmarks.
-	for _, readPercent := range []int{0, 100} {
+	// TODO(#135952): Reenable readPercent 100. This benchmark historically tested
+	// kv100, but it was disabled because cdc bench can be flaky and kv100 does
+	// not provide enough value for the noise.
+	for _, readPercent := range []int{0} {
 		for _, ranges := range []int64{100, 100000} {
 			const (
 				nodes  = 5 // excluding coordinator and workload nodes


### PR DESCRIPTION
Historically CDC has benchmarked changefeeds with the kv100 read-only workload to determine the impact of changefeeds when there is no data watched. Due to the roachtest's flakiness, we're not getting much value out of continuing to benchmark this. This PR removes kv100 from the regularly run benchmark, but leaves the infrastructure in place so that it can be run in the future if desired.

Epic: none

Release note: none