### PR TITLE
sql/schemachanger: Remove feature gate for ALTER COLUMN TYPE

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/refcursor
+++ b/pkg/ccl/logictestccl/testdata/logic_test/refcursor
@@ -38,6 +38,9 @@ SELECT * FROM xy;
 statement ok
 DROP TABLE IF EXISTS xy;
 CREATE TABLE xy (x INT, y TEXT);
+
+onlyif config local-legacy-schema-changer local-mixed-24.2 local-mixed-24.3
+statement ok
 SET enable_experimental_alter_column_type_general=true;
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -170,6 +170,7 @@ CREATE TABLE t1 (date string)
 statement ok
 INSERT INTO t1 VALUES ('2024-07-26')
 
+onlyif config local-mixed-24.2 local-mixed-24.3
 statement error pq: ALTER COLUMN TYPE from string to date is only supported experimentally
 ALTER TABLE t1 ALTER COLUMN date TYPE DATE USING date::DATE
 

--- a/pkg/sql/logictest/testdata/logic_test/drop_type
+++ b/pkg/sql/logictest/testdata/logic_test/drop_type
@@ -1,5 +1,8 @@
 statement ok
 SET sql_safe_updates = false;
+
+onlyif config local-legacy-schema-changer local-mixed-24.2 local-mixed-24.3
+statement ok
 SET enable_experimental_alter_column_type_general = true;
 
 # Basic test -- create and drop a type.

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1005,6 +1005,7 @@ statement error pq: foreign key violation: "enum_origin" row x='hello' has no ma
 ALTER TABLE enum_origin ADD FOREIGN KEY (x) REFERENCES enum_referenced (x)
 
 # Tests for ALTER COLUMN SET DATA TYPE.
+onlyif config local-legacy-schema-changer local-mixed-24.2 local-mixed-24.3
 statement ok
 SET enable_experimental_alter_column_type_general = true;
 

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -909,14 +909,8 @@ ALTER TABLE tbl_alter_table_ttl_expiration_expression DROP COLUMN expire_at
 statement ok
 SET use_declarative_schema_changer = 'on'
 
-statement ok
-SET enable_experimental_alter_column_type_general = 'on'
-
 statement error cannot alter type of column "expire_at" referenced by row-level TTL expiration expression "expire_at"\nHINT: use ALTER TABLE .*
 ALTER TABLE tbl_alter_table_ttl_expiration_expression ALTER expire_at TYPE TIMESTAMP USING (expire_at AT TIME ZONE 'UTC')
-
-statement ok
-SET enable_experimental_alter_column_type_general = 'off'
 
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expiration_expression]

--- a/pkg/sql/logictest/testdata/logic_test/show_create
+++ b/pkg/sql/logictest/testdata/logic_test/show_create
@@ -129,6 +129,7 @@ c  CREATE TABLE public.c (
 
 subtest alter_column_type_not_break_show_create
 
+onlyif config local-legacy-schema-changer local-mixed-24.2 local-mixed-24.3
 statement ok
 SET enable_experimental_alter_column_type_general = true;
 

--- a/pkg/sql/logictest/testdata/logic_test/truncate_with_concurrent_mutation
+++ b/pkg/sql/logictest/testdata/logic_test/truncate_with_concurrent_mutation
@@ -87,6 +87,7 @@ CREATE TABLE t5(a int primary key, b int);
 statement ok
 SET CLUSTER SETTING jobs.debug.pausepoints = 'schemachanger.before.exec,newschemachanger.before.exec';
 
+onlyif config local-legacy-schema-changer local-mixed-24.2 local-mixed-24.3
 statement ok
 SET enable_experimental_alter_column_type_general = true;
 

--- a/pkg/sql/logictest/testdata/logic_test/udf_schema_change
+++ b/pkg/sql/logictest/testdata/logic_test/udf_schema_change
@@ -630,6 +630,7 @@ SELECT f_rtbl();
 ----
 (1,foobar,2)
 
+onlyif config local-legacy-schema-changer local-mixed-24.2 local-mixed-24.3
 statement ok
 SET enable_experimental_alter_column_type_general=true
 

--- a/pkg/sql/pgwire/testdata/pgtest/row_description
+++ b/pkg/sql/pgwire/testdata/pgtest/row_description
@@ -318,16 +318,6 @@ ReadyForQuery
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 send crdb_only
-Query {"String": "SET enable_experimental_alter_column_type_general = true"}
-----
-
-until crdb_only
-ReadyForQuery
-----
-{"Type":"CommandComplete","CommandTag":"SET"}
-{"Type":"ReadyForQuery","TxStatus":"I"}
-
-send crdb_only
 Query {"String": "ALTER TABLE tab3 ALTER COLUMN b TYPE STRING"}
 ----
 

--- a/pkg/sql/schemachanger/dml_injection_test.go
+++ b/pkg/sql/schemachanger/dml_injection_test.go
@@ -182,7 +182,6 @@ func TestAlterTableDMLInjection(t *testing.T) {
 		{
 			desc: "alter column type general",
 			setup: []string{
-				"SET enable_experimental_alter_column_type_general=TRUE",
 				"ALTER TABLE tbl ADD COLUMN new_col BIGINT NOT NULL DEFAULT 100",
 			},
 			schemaChange: "ALTER TABLE tbl ALTER COLUMN new_col SET DATA TYPE TEXT",
@@ -191,7 +190,6 @@ func TestAlterTableDMLInjection(t *testing.T) {
 		{
 			desc: "alter column type general compute",
 			setup: []string{
-				"SET enable_experimental_alter_column_type_general=TRUE",
 				"ALTER TABLE tbl ADD COLUMN new_col DATE NOT NULL DEFAULT '2013-05-06', " +
 					"ADD COLUMN new_comp DATE AS (new_col) STORED",
 			},

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_type.go
@@ -429,10 +429,11 @@ func updateColumnType(b BuildCtx, oldColType, newColType *scpb.ColumnType) {
 	b.Add(newColType)
 }
 
-// failIfExperimentalSettingNotSet checks if the setting that allows altering
-// types is enabled. If the setting is not enabled, this function will panic.
+// failIfExperimentalSettingNotSet checks if the current version requires a
+// setting to be enabled to perform an ALTER COLUMN TYPE operation.
 func failIfExperimentalSettingNotSet(b BuildCtx, oldColType, newColType *scpb.ColumnType) {
-	if !b.SessionData().AlterColumnTypeGeneralEnabled {
+	if !b.SessionData().AlterColumnTypeGeneralEnabled &&
+		!b.EvalCtx().Settings.Version.ActiveVersion(b).IsActive(clusterversion.V25_1) {
 		panic(pgerror.WithCandidateCode(
 			errors.WithHint(
 				errors.WithIssueLink(

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_column_type
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_column_type
@@ -3,7 +3,6 @@ CREATE TABLE defaultdb.act (
   k INT PRIMARY KEY,
   c1 INT4
 );
-SET enable_experimental_alter_column_type_general=TRUE;
 ----
 
 ops

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general.definition
@@ -1,6 +1,5 @@
 setup
 CREATE TABLE t (i INT PRIMARY KEY, j TEXT);
-SET enable_experimental_alter_column_type_general=TRUE;
 INSERT INTO t VALUES (1,NULL),(2,'1'),(3,'2');
 ----
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general.explain
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE t (i INT PRIMARY KEY, j TEXT);
-SET enable_experimental_alter_column_type_general=TRUE;
 INSERT INTO t VALUES (1,NULL),(2,'1'),(3,'2');
 
 /* test */

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general.explain_shape
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE t (i INT PRIMARY KEY, j TEXT);
-SET enable_experimental_alter_column_type_general=TRUE;
 INSERT INTO t VALUES (1,NULL),(2,'1'),(3,'2');
 
 /* test */

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general.side_effects
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE t (i INT PRIMARY KEY, j TEXT);
-SET enable_experimental_alter_column_type_general=TRUE;
 INSERT INTO t VALUES (1,NULL),(2,'1'),(3,'2');
 ----
 ...

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_10_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_10_of_15.explain
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE t (i INT PRIMARY KEY, j TEXT);
-SET enable_experimental_alter_column_type_general=TRUE;
 INSERT INTO t VALUES (1,NULL),(2,'1'),(3,'2');
 
 /* test */

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_11_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_11_of_15.explain
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE t (i INT PRIMARY KEY, j TEXT);
-SET enable_experimental_alter_column_type_general=TRUE;
 INSERT INTO t VALUES (1,NULL),(2,'1'),(3,'2');
 
 /* test */

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_12_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_12_of_15.explain
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE t (i INT PRIMARY KEY, j TEXT);
-SET enable_experimental_alter_column_type_general=TRUE;
 INSERT INTO t VALUES (1,NULL),(2,'1'),(3,'2');
 
 /* test */

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_13_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_13_of_15.explain
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE t (i INT PRIMARY KEY, j TEXT);
-SET enable_experimental_alter_column_type_general=TRUE;
 INSERT INTO t VALUES (1,NULL),(2,'1'),(3,'2');
 
 /* test */

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_14_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_14_of_15.explain
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE t (i INT PRIMARY KEY, j TEXT);
-SET enable_experimental_alter_column_type_general=TRUE;
 INSERT INTO t VALUES (1,NULL),(2,'1'),(3,'2');
 
 /* test */

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_15_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_15_of_15.explain
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE t (i INT PRIMARY KEY, j TEXT);
-SET enable_experimental_alter_column_type_general=TRUE;
 INSERT INTO t VALUES (1,NULL),(2,'1'),(3,'2');
 
 /* test */

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_1_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_1_of_15.explain
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE t (i INT PRIMARY KEY, j TEXT);
-SET enable_experimental_alter_column_type_general=TRUE;
 INSERT INTO t VALUES (1,NULL),(2,'1'),(3,'2');
 
 /* test */

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_2_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_2_of_15.explain
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE t (i INT PRIMARY KEY, j TEXT);
-SET enable_experimental_alter_column_type_general=TRUE;
 INSERT INTO t VALUES (1,NULL),(2,'1'),(3,'2');
 
 /* test */

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_3_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_3_of_15.explain
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE t (i INT PRIMARY KEY, j TEXT);
-SET enable_experimental_alter_column_type_general=TRUE;
 INSERT INTO t VALUES (1,NULL),(2,'1'),(3,'2');
 
 /* test */

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_4_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_4_of_15.explain
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE t (i INT PRIMARY KEY, j TEXT);
-SET enable_experimental_alter_column_type_general=TRUE;
 INSERT INTO t VALUES (1,NULL),(2,'1'),(3,'2');
 
 /* test */

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_5_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_5_of_15.explain
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE t (i INT PRIMARY KEY, j TEXT);
-SET enable_experimental_alter_column_type_general=TRUE;
 INSERT INTO t VALUES (1,NULL),(2,'1'),(3,'2');
 
 /* test */

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_6_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_6_of_15.explain
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE t (i INT PRIMARY KEY, j TEXT);
-SET enable_experimental_alter_column_type_general=TRUE;
 INSERT INTO t VALUES (1,NULL),(2,'1'),(3,'2');
 
 /* test */

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_7_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_7_of_15.explain
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE t (i INT PRIMARY KEY, j TEXT);
-SET enable_experimental_alter_column_type_general=TRUE;
 INSERT INTO t VALUES (1,NULL),(2,'1'),(3,'2');
 
 /* test */

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_8_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_8_of_15.explain
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE t (i INT PRIMARY KEY, j TEXT);
-SET enable_experimental_alter_column_type_general=TRUE;
 INSERT INTO t VALUES (1,NULL),(2,'1'),(3,'2');
 
 /* test */

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_9_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general__rollback_9_of_15.explain
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE t (i INT PRIMARY KEY, j TEXT);
-SET enable_experimental_alter_column_type_general=TRUE;
 INSERT INTO t VALUES (1,NULL),(2,'1'),(3,'2');
 
 /* test */

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr.definition
@@ -1,5 +1,4 @@
 setup
-SET enable_experimental_alter_column_type_general=TRUE;
 CREATE TABLE t (i INT PRIMARY KEY, j INT DEFAULT 99 ON UPDATE -1);
 INSERT INTO t VALUES (1,NULL),(2,1),(3,2);
 ----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr.explain
@@ -1,5 +1,4 @@
 /* setup */
-SET enable_experimental_alter_column_type_general=TRUE;
 CREATE TABLE t (i INT PRIMARY KEY, j INT DEFAULT 99 ON UPDATE -1);
 INSERT INTO t VALUES (1,NULL),(2,1),(3,2);
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr.explain_shape
@@ -1,5 +1,4 @@
 /* setup */
-SET enable_experimental_alter_column_type_general=TRUE;
 CREATE TABLE t (i INT PRIMARY KEY, j INT DEFAULT 99 ON UPDATE -1);
 INSERT INTO t VALUES (1,NULL),(2,1),(3,2);
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr.side_effects
@@ -1,5 +1,4 @@
 /* setup */
-SET enable_experimental_alter_column_type_general=TRUE;
 CREATE TABLE t (i INT PRIMARY KEY, j INT DEFAULT 99 ON UPDATE -1);
 INSERT INTO t VALUES (1,NULL),(2,1),(3,2);
 ----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_10_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_10_of_15.explain
@@ -1,5 +1,4 @@
 /* setup */
-SET enable_experimental_alter_column_type_general=TRUE;
 CREATE TABLE t (i INT PRIMARY KEY, j INT DEFAULT 99 ON UPDATE -1);
 INSERT INTO t VALUES (1,NULL),(2,1),(3,2);
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_11_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_11_of_15.explain
@@ -1,5 +1,4 @@
 /* setup */
-SET enable_experimental_alter_column_type_general=TRUE;
 CREATE TABLE t (i INT PRIMARY KEY, j INT DEFAULT 99 ON UPDATE -1);
 INSERT INTO t VALUES (1,NULL),(2,1),(3,2);
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_12_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_12_of_15.explain
@@ -1,5 +1,4 @@
 /* setup */
-SET enable_experimental_alter_column_type_general=TRUE;
 CREATE TABLE t (i INT PRIMARY KEY, j INT DEFAULT 99 ON UPDATE -1);
 INSERT INTO t VALUES (1,NULL),(2,1),(3,2);
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_13_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_13_of_15.explain
@@ -1,5 +1,4 @@
 /* setup */
-SET enable_experimental_alter_column_type_general=TRUE;
 CREATE TABLE t (i INT PRIMARY KEY, j INT DEFAULT 99 ON UPDATE -1);
 INSERT INTO t VALUES (1,NULL),(2,1),(3,2);
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_14_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_14_of_15.explain
@@ -1,5 +1,4 @@
 /* setup */
-SET enable_experimental_alter_column_type_general=TRUE;
 CREATE TABLE t (i INT PRIMARY KEY, j INT DEFAULT 99 ON UPDATE -1);
 INSERT INTO t VALUES (1,NULL),(2,1),(3,2);
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_15_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_15_of_15.explain
@@ -1,5 +1,4 @@
 /* setup */
-SET enable_experimental_alter_column_type_general=TRUE;
 CREATE TABLE t (i INT PRIMARY KEY, j INT DEFAULT 99 ON UPDATE -1);
 INSERT INTO t VALUES (1,NULL),(2,1),(3,2);
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_1_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_1_of_15.explain
@@ -1,5 +1,4 @@
 /* setup */
-SET enable_experimental_alter_column_type_general=TRUE;
 CREATE TABLE t (i INT PRIMARY KEY, j INT DEFAULT 99 ON UPDATE -1);
 INSERT INTO t VALUES (1,NULL),(2,1),(3,2);
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_2_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_2_of_15.explain
@@ -1,5 +1,4 @@
 /* setup */
-SET enable_experimental_alter_column_type_general=TRUE;
 CREATE TABLE t (i INT PRIMARY KEY, j INT DEFAULT 99 ON UPDATE -1);
 INSERT INTO t VALUES (1,NULL),(2,1),(3,2);
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_3_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_3_of_15.explain
@@ -1,5 +1,4 @@
 /* setup */
-SET enable_experimental_alter_column_type_general=TRUE;
 CREATE TABLE t (i INT PRIMARY KEY, j INT DEFAULT 99 ON UPDATE -1);
 INSERT INTO t VALUES (1,NULL),(2,1),(3,2);
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_4_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_4_of_15.explain
@@ -1,5 +1,4 @@
 /* setup */
-SET enable_experimental_alter_column_type_general=TRUE;
 CREATE TABLE t (i INT PRIMARY KEY, j INT DEFAULT 99 ON UPDATE -1);
 INSERT INTO t VALUES (1,NULL),(2,1),(3,2);
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_5_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_5_of_15.explain
@@ -1,5 +1,4 @@
 /* setup */
-SET enable_experimental_alter_column_type_general=TRUE;
 CREATE TABLE t (i INT PRIMARY KEY, j INT DEFAULT 99 ON UPDATE -1);
 INSERT INTO t VALUES (1,NULL),(2,1),(3,2);
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_6_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_6_of_15.explain
@@ -1,5 +1,4 @@
 /* setup */
-SET enable_experimental_alter_column_type_general=TRUE;
 CREATE TABLE t (i INT PRIMARY KEY, j INT DEFAULT 99 ON UPDATE -1);
 INSERT INTO t VALUES (1,NULL),(2,1),(3,2);
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_7_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_7_of_15.explain
@@ -1,5 +1,4 @@
 /* setup */
-SET enable_experimental_alter_column_type_general=TRUE;
 CREATE TABLE t (i INT PRIMARY KEY, j INT DEFAULT 99 ON UPDATE -1);
 INSERT INTO t VALUES (1,NULL),(2,1),(3,2);
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_8_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_8_of_15.explain
@@ -1,5 +1,4 @@
 /* setup */
-SET enable_experimental_alter_column_type_general=TRUE;
 CREATE TABLE t (i INT PRIMARY KEY, j INT DEFAULT 99 ON UPDATE -1);
 INSERT INTO t VALUES (1,NULL),(2,1),(3,2);
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_9_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr__rollback_9_of_15.explain
@@ -1,5 +1,4 @@
 /* setup */
-SET enable_experimental_alter_column_type_general=TRUE;
 CREATE TABLE t (i INT PRIMARY KEY, j INT DEFAULT 99 ON UPDATE -1);
 INSERT INTO t VALUES (1,NULL),(2,1),(3,2);
 

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2485,15 +2485,13 @@ func (og *operationGenerator) setColumnType(ctx context.Context, tx pgx.Tx) (*op
 		return nil, err
 	}
 
-	const setSessionVariableString = `SET enable_experimental_alter_column_type_general = true;`
-
 	tableExists, err := og.tableExists(ctx, tx, tableName)
 	if err != nil {
 		return nil, err
 	}
 	if !tableExists {
 		return makeOpStmtForSingleError(OpStmtDDL,
-			fmt.Sprintf(`%s ALTER TABLE %s ALTER COLUMN IrrelevantColumnName SET DATA TYPE IrrelevantDataType`, setSessionVariableString, tableName),
+			fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN IrrelevantColumnName SET DATA TYPE IrrelevantDataType`, tableName),
 			pgcode.UndefinedTable), nil
 	}
 	err = og.tableHasPrimaryKeySwapActive(ctx, tx, tableName)
@@ -2512,8 +2510,8 @@ func (og *operationGenerator) setColumnType(ctx context.Context, tx pgx.Tx) (*op
 	}
 	if !columnExists {
 		return makeOpStmtForSingleError(OpStmtDDL,
-			fmt.Sprintf(`%s ALTER TABLE %s ALTER COLUMN "%s" SET DATA TYPE IrrelevantTypeName`,
-				setSessionVariableString, tableName, columnForTypeChange.name),
+			fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN "%s" SET DATA TYPE IrrelevantTypeName`,
+				tableName, columnForTypeChange.name),
 			pgcode.UndefinedColumn), nil
 	}
 
@@ -2562,6 +2560,9 @@ func (og *operationGenerator) setColumnType(ctx context.Context, tx pgx.Tx) (*op
 		// Failure can occur if we attempt to alter a column that has a dependent
 		// computed column.
 		stmt.potentialExecErrors.add(pgcode.DependentObjectsStillExist)
+		// On older versions, attempts to alter the type will fail with an
+		// experimental feature failure.
+		stmt.potentialExecErrors.add(pgcode.ExperimentalFeature)
 	}
 
 	stmt.potentialExecErrors.addAll(codesWithConditions{
@@ -2569,8 +2570,8 @@ func (og *operationGenerator) setColumnType(ctx context.Context, tx pgx.Tx) (*op
 		{code: pgcode.DependentObjectsStillExist, condition: columnHasDependencies || colIsRefByComputed || hasOngoingAlterPKSchemaChange},
 	})
 
-	stmt.sql = fmt.Sprintf(`%s ALTER TABLE %s ALTER COLUMN %s SET DATA TYPE %s`,
-		setSessionVariableString, tableName.String(), columnForTypeChange.name.String(), newTypeName.SQLString())
+	stmt.sql = fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN %s SET DATA TYPE %s`,
+		tableName.String(), columnForTypeChange.name.String(), newTypeName.SQLString())
 	return stmt, nil
 }
 


### PR DESCRIPTION
Previously, altering a column’s type requiring a backfill required the enable_experimental_alter_column_type_general setting to be enabled. This restriction has been removed, as full support for ALTER COLUMN TYPE has been implemented in the Declarative Schema Changer (DSC).

The setting is still checked in mixed-version clusters, as the operation relies on 25.1 dependency rules, and when using the legacy schema changer.

Epic: CRDB-25314
Informs #49329
Release note (sql change): Altering a column’s type no longer requires enabling the enable_experimental_alter_column_type_general setting. This change makes the feature generally available.