### PR TITLE
sql/sem/tree: fix tuple pretty print when tuple has 1 element

### DIFF
--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -1120,9 +1120,6 @@ func (node *Array) doc(p *PrettyCfg) pretty.Doc {
 
 func (node *Tuple) doc(p *PrettyCfg) pretty.Doc {
 	exprDoc := p.Doc(&node.Exprs)
-	if len(node.Exprs) == 1 {
-		exprDoc = pretty.Concat(exprDoc, pretty.Text(","))
-	}
 	d := p.bracket("(", exprDoc, ")")
 	if len(node.Labels) > 0 {
 		labels := make([]pretty.Doc, len(node.Labels))

--- a/pkg/sql/sem/tree/pretty_test.go
+++ b/pkg/sql/sem/tree/pretty_test.go
@@ -255,6 +255,17 @@ func TestPrettyExprs(t *testing.T) {
 			Expr: tree.NewDString("foo"),
 			Type: types.MakeCollatedString(types.String, "en"),
 		}: `CAST('foo':::STRING AS STRING) COLLATE en`,
+		&tree.Tuple{
+			Exprs: []tree.Expr{
+				tree.NewStrVal("val1"),
+			},
+		}: `('val1')`,
+		&tree.Tuple{
+			Exprs: []tree.Expr{
+				tree.NewStrVal("val1"),
+				tree.NewStrVal("val2"),
+			},
+		}: `('val1', 'val2')`,
 	}
 
 	for expr, pretty := range tests {


### PR DESCRIPTION
When using `sql/sem/tree.Tuple` to generate SQL statements for IN operators, the produced output is incorrect if the tuple only has one element. The output includes an extra `,`.

As an example, the following

```go
&tree.Tuple{
        Exprs: []tree.Expr{
                tree.NewStrVal("val1"),
        },
}

```

Is incorrectly mapped to `('val1',)` instead of `('val1')`.

Because of the extra `,`, sql parsers fail to parse the input.

This commit aims to fix these conditions and remove the trailing `,`.

Fixes #135939 