### PR TITLE
bench/rttanalysis: explicitly block mock IMPORTs from running

### DIFF
--- a/pkg/bench/rttanalysis/BUILD.bazel
+++ b/pkg/bench/rttanalysis/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
     exec_properties = {"test.Pool": "large"},
     deps = [
         "//pkg/base",
+        "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/bench/rttanalysis/validate_benchmark_data_test.go
+++ b/pkg/bench/rttanalysis/validate_benchmark_data_test.go
@@ -5,6 +5,14 @@
 
 package rttanalysis
 
-import "testing"
+import (
+	"testing"
 
-func TestBenchmarkExpectation(t *testing.T) { reg.RunExpectations(t) }
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+)
+
+func TestBenchmarkExpectation(t *testing.T) {
+	defer jobs.TestingSetIDsToIgnore(map[jobspb.JobID]struct{}{3001: {}, 3002: {}})()
+	reg.RunExpectations(t)
+}


### PR DESCRIPTION
Previously this test created malformed imports and just kept them from trying to actually run -- which would panic -- by setting their backoff time very high. With the backoff time removed, this no longer works. Instead the test now has an explicit knob to configure the jobs system to not run certain jobs.

Release note: none.
Epic: none.