### PR TITLE
release-24.3: scpb: ensure IndexZoneConfig fields do not overlap

### DIFF
--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -754,15 +754,17 @@ message TableZoneConfig {
 message IndexZoneConfig {
   uint32 table_id = 1 [(gogoproto.customname) = "TableID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
   uint32 index_id = 2 [(gogoproto.customname) = "IndexID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.IndexID"];
-  cockroach.config.zonepb.Subzone subzone = 3 [(gogoproto.nullable) = false];
-  // `subzone_spans` is used solely for zone config writes. These spans are
-  // recreated for the table zone config during each configuration change.
-  repeated cockroach.config.zonepb.SubzoneSpan subzone_spans = 4 [(gogoproto.nullable) = false];
+  cockroach.config.zonepb.Subzone subzone = 4 [(gogoproto.nullable) = false];
+  repeated cockroach.config.zonepb.SubzoneSpan subzone_spans = 5 [(gogoproto.nullable) = false];
   // `seq_num` is used to differentiate different subzone config elements tied
   // to the same index. E.g. If we attempt to update an index subzone config,
   // our solution is to drop the existing element and add a new element, with
   // different `seq_num`.
-  uint32 seq_num = 5;
+  uint32 seq_num = 6;
+  // In v24.3, we deprecated this field ID (previously: partition_name) in favor
+  // of creating a new element that represents partitions --
+  // PartitionZoneConfig.
+  reserved 3;
 }
 
 message PartitionZoneConfig {


### PR DESCRIPTION
Backport 1/1 commits from #135933.

/cc @cockroachdb/release

---

In [#134522](https://github.com/cockroachdb/cockroach/pull/134472), we added a fix to ensure that we cleaned up backrefs properly for our `IndexZoneConfig` element, but in doing so, we created an overlap of field ID `3` between v24.2+. This patch ensures that we do not re-use the same field ID for a different field in our IndexZoneConfig element by marking it as `reserved`.

Fixes: #133003
Fixes: #135807

Release note: None

---

Release justification: low-risk bug fix for off-by-default feature
