### PR TITLE
sql: validate sequence references for identity columns

### DIFF
--- a/pkg/sql/catalog/post_deserialization_changes.go
+++ b/pkg/sql/catalog/post_deserialization_changes.go
@@ -119,4 +119,8 @@ const (
 	// FixedIncorrectForeignKeyOrigins indicates that foreign key origin /
 	// reference IDs that should point to the current descriptor were fixed.
 	FixedIncorrectForeignKeyOrigins
+
+	// FixedUsesSequencesIDForIdentityColumns indicates sequence ID references
+	// are fixed for identity / serial columns.
+	FixedUsesSequencesIDForIdentityColumns
 )

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -1221,6 +1221,11 @@ func (desc *wrapper) validateColumns() error {
 					return errors.Newf("conflicting NULL/NOT NULL declarations for column %q", column.GetName())
 				}
 			}
+
+			// For generated as identity columns ensure that the column uses sequences.
+			if column.NumUsesSequences() != 1 {
+				return errors.Newf("column is identity without sequence references %q", column.GetName())
+			}
 		}
 
 		if column.HasOnUpdate() && column.IsGeneratedAsIdentity() {

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -2212,6 +2212,7 @@ func TestValidateTableDesc(t *testing.T) {
 						ID:                      1,
 						Name:                    "bar",
 						GeneratedAsIdentityType: catpb.GeneratedAsIdentityType_GENERATED_ALWAYS,
+						UsesSequenceIds:         []descpb.ID{32},
 						OnUpdateExpr:            proto.String("'blah'"),
 					},
 				},
@@ -2232,7 +2233,9 @@ func TestValidateTableDesc(t *testing.T) {
 						ID:                      1,
 						Name:                    "bar",
 						GeneratedAsIdentityType: catpb.GeneratedAsIdentityType_GENERATED_BY_DEFAULT,
-						OnUpdateExpr:            proto.String("'blah'"),
+						UsesSequenceIds:         []descpb.ID{32},
+
+						OnUpdateExpr: proto.String("'blah'"),
 					},
 				},
 				Families: []descpb.ColumnFamilyDescriptor{
@@ -3064,6 +3067,17 @@ func TestValidateTableDesc(t *testing.T) {
 					},
 				}
 			})},
+		{err: `column is identity without sequence references "bar"`,
+			desc: descpb.TableDescriptor{
+				ID:            2,
+				ParentID:      1,
+				Name:          "foo",
+				FormatVersion: descpb.InterleavedFormatVersion,
+				Columns: []descpb.ColumnDescriptor{
+					{ID: 1, Name: "bar", GeneratedAsIdentityType: catpb.GeneratedAsIdentityType_GENERATED_ALWAYS},
+				},
+				NextColumnID: 2,
+			}},
 	}
 
 	for i, d := range testData {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1359,6 +1359,7 @@ func NewTableDesc(
 	evalCtx *eval.Context,
 	sessionData *sessiondata.SessionData,
 	persistence tree.Persistence,
+	colToSequenceRefs map[tree.Name]*tabledesc.Mutable,
 	inOpts ...NewTableDescOption,
 ) (*tabledesc.Mutable, error) {
 
@@ -1653,6 +1654,14 @@ func NewTableDesc(
 			}
 			col := cdd[i].ColumnDescriptor
 			idx := cdd[i].PrimaryKeyOrUniqueIndexDescriptor
+
+			// If necessary add any sequence references for this column, which is
+			// only needed for SERIAL / IDENTITY columns on create.
+			if colToSequenceRefs != nil {
+				if seqDesc := colToSequenceRefs[d.Name]; seqDesc != nil {
+					col.UsesSequenceIds = append(col.UsesSequenceIds, seqDesc.GetID())
+				}
+			}
 
 			// Do not include virtual tables in these statistics.
 			if !descpb.IsVirtualTable(id) {
@@ -2422,6 +2431,7 @@ func newTableDesc(
 			params.EvalContext(),
 			params.SessionData(),
 			n.Persistence,
+			colNameToOwnedSeq,
 		)
 	})
 	if err != nil {

--- a/pkg/sql/importer/import_table_creation.go
+++ b/pkg/sql/importer/import_table_creation.go
@@ -176,6 +176,8 @@ func MakeSimpleTableDescriptor(
 		&evalCtx,
 		evalCtx.SessionData(), /* sessionData */
 		tree.PersistencePermanent,
+		// Sequences are unsupported here.
+		nil, /* colToSequenceRefs */
 		// We need to bypass the LOCALITY on non multi-region check here because
 		// we cannot access the database region config at import level.
 		// There is code that only allows REGIONAL BY TABLE tables to be imported,

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
@@ -903,5 +904,6 @@ func (p *planner) removeSequenceDependencies(
 	}
 	// Remove the reference from the column descriptor to the sequence descriptor.
 	col.ColumnDesc().UsesSequenceIds = []descpb.ID{}
+	col.ColumnDesc().GeneratedAsIdentityType = catpb.GeneratedAsIdentityType_NOT_IDENTITY_COLUMN
 	return nil
 }

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -72,6 +72,7 @@ func CreateTestTableDescriptor(
 			&evalCtx,
 			sessionData,
 			tree.PersistencePermanent,
+			nil, /* colToSequenceRefs */
 		)
 		return desc, err
 	case *tree.CreateSequence:

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -215,6 +215,7 @@ func (t virtualSchemaTable) initVirtualTableDesc(
 		&eval.Context{Settings: st}, /* evalCtx */
 		&sessiondata.SessionData{},  /* sessionData */
 		tree.PersistencePermanent,
+		nil, /* colToSequenceRefs */
 	)
 	if err != nil {
 		err = errors.Wrapf(err, "initVirtualDesc problem with schema: \n%s", t.schema)


### PR DESCRIPTION
Previously, when creating a table it was possible for identity columns to be missing sequence forward references. This would happen when a CREATE TABLE was used to create the identity columns. To address this, this patch adds validation to confirm that identity columns have sequence references. Additionally, an automated repair via post de-serialization is added to fix missing forward references.

Fixes: #131280

Release note: None