### PR TITLE
tracker: optimize QuorumActive check

### DIFF
--- a/pkg/raft/tracker/progresstracker.go
+++ b/pkg/raft/tracker/progresstracker.go
@@ -110,7 +110,9 @@ func (p *ProgressTracker) Visit(f func(id pb.PeerID, pr *Progress)) {
 // QuorumActive returns true if the quorum is active from the view of the local
 // raft state machine. Otherwise, it returns false.
 func (p *ProgressTracker) QuorumActive() bool {
-	votes := map[pb.PeerID]bool{}
+	// TODO(pav-kv): avoid this allocation altogether. There could be a version of
+	// VoteResult which can iterate the progress map directly.
+	votes := make(map[pb.PeerID]bool, len(p.progress))
 	for id, pr := range p.progress {
 		if pr.IsLearner {
 			continue

--- a/pkg/raft/tracker/progresstracker.go
+++ b/pkg/raft/tracker/progresstracker.go
@@ -111,13 +111,12 @@ func (p *ProgressTracker) Visit(f func(id pb.PeerID, pr *Progress)) {
 // raft state machine. Otherwise, it returns false.
 func (p *ProgressTracker) QuorumActive() bool {
 	votes := map[pb.PeerID]bool{}
-	p.Visit(func(id pb.PeerID, pr *Progress) {
+	for id, pr := range p.progress {
 		if pr.IsLearner {
-			return
+			continue
 		}
 		votes[id] = pr.RecentActive
-	})
-
+	}
 	return p.config.Voters.VoteResult(votes) == quorum.VoteWon
 }
 


### PR DESCRIPTION
This PR removes unnecessary sorting from the `QuorumActive` check, and pre-allocates the map of votes once.

Epic: none
Release note: none