### PR TITLE
importer: skip TestImportComputed under race

### DIFF
--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -4806,6 +4806,8 @@ func TestImportComputed(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.UnderRace(t)
+
 	const nodes = 3
 
 	ctx := context.Background()


### PR DESCRIPTION
We just saw a test failure where this test failed seemingly due to overloaded cluster (3 node, with external process multi-tenancy). I think we should skip it under race like we do a few other tests in this file already.

Fixes: #135894.

Release note: None