### PR TITLE
revert "roachtest/sqlsmith: print a setup query as integers"

### DIFF
--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -121,19 +121,6 @@ WITH into_db = 'defaultdb', unsafe_restore_incompatible_version;
 		for _, stmt := range setup {
 			logStmt(stmt)
 			if _, err := conn.Exec(stmt); err != nil {
-				if strings.Contains(err.Error(), "does not exist") {
-					// This is likely to be an elusive 'pq: column
-					// "crdb_internal_idx_expr" does not exist' error that we
-					// cannot reproduce. The current hypothesis is that the
-					// CREATE TABLE statement contains some non-visible
-					// characters that get lost when printing as a string, so we
-					// will log this statement as a sequence of integers so that
-					// later we can reconstruct the stmt precisely.
-					for _, char := range stmt {
-						fmt.Fprintf(smithLog, "%d ", char)
-					}
-					fmt.Fprint(smithLog, "\n\n")
-				}
 				t.Fatalf("error: %s\nstatement: %s", err.Error(), stmt)
 			}
 		}


### PR DESCRIPTION
This reverts commit e06a0bcb235093e04d7835cd81a4e9f4a60b5b71.

We no longer need it since the problem we were trying to find the reproduction of has been fixed in 8210e06508ecd01d2ea6579d0d13aff832d41c34.

Epic: None
Release note: None