### PR TITLE
stats: fix broken memory accounting in SampleReservoir

### DIFF
--- a/pkg/sql/stats/row_sampling.go
+++ b/pkg/sql/stats/row_sampling.go
@@ -57,6 +57,11 @@ type SampleReservoir struct {
 	// each row. Note that the sampled rows still contain all columns, but
 	// any columns not part of this set are given a null value.
 	sampleCols intsets.Fast
+
+	// scratch is used as the staging area for the new row to be copied into the
+	// reservoir, before we know whether the memory reservation for it will be
+	// approved.
+	scratch rowenc.EncDatumRow
 }
 
 var _ heap.Interface = &SampleReservoir{}
@@ -76,6 +81,7 @@ func (sr *SampleReservoir) Init(
 	sr.colTypes = colTypes
 	sr.memAcc = memAcc
 	sr.sampleCols = sampleCols
+	sr.scratch = make(rowenc.EncDatumRow, len(colTypes))
 }
 
 // Disable releases the memory of this SampleReservoir and sets its capacity
@@ -188,9 +194,6 @@ func (sr *SampleReservoir) SampleRow(
 		// Replace the max rank if ours is smaller.
 		if len(sr.samples) > 0 && rank < sr.samples[0].Rank {
 			if err := sr.copyRow(ctx, evalCtx, sr.samples[0].Row, row); err != nil {
-				// WARNING: At this point sr.samples[0].Row might have a mix of old and
-				// new values. The caller must call heap.Pop() to keep using the
-				// reservoir.
 				return err
 			}
 			sr.samples[0].Rank = rank
@@ -238,9 +241,14 @@ func (sr *SampleReservoir) GetNonNullDatums(
 func (sr *SampleReservoir) copyRow(
 	ctx context.Context, evalCtx *eval.Context, dst, src rowenc.EncDatumRow,
 ) error {
+	// First, we calculate how much memory has already been accounted for the
+	// "before" row (row that we're about to overwrite) as well as how much
+	// space we need for the "after" row (row that we're about to keep).
+	// Simultaneously, we're staging the "after" row into the scratch space.
+	var beforeRowSize, afterRowSize int64
 	for i := range src {
 		if !sr.sampleCols.Contains(i) {
-			dst[i].Datum = tree.DNull
+			sr.scratch[i].Datum = tree.DNull
 			continue
 		}
 		// Copy only the decoded datum to ensure that we remove any reference to
@@ -250,23 +258,27 @@ func (sr *SampleReservoir) copyRow(
 		if err := src[i].EnsureDecoded(sr.colTypes[i], &sr.da); err != nil {
 			return err
 		}
-		beforeSize := dst[i].Size()
-		dst[i] = rowenc.DatumToEncDatum(sr.colTypes[i], src[i].Datum)
-		afterSize := dst[i].Size()
+		beforeRowSize += int64(dst[i].Size())
+		sr.scratch[i] = rowenc.DatumToEncDatum(sr.colTypes[i], src[i].Datum)
+		afterSize := sr.scratch[i].Size()
 
 		// If the datum is too large, truncate it.
 		if afterSize > uintptr(maxBytesPerSample) {
-			dst[i].Datum = truncateDatum(evalCtx, dst[i].Datum, maxBytesPerSample)
-			afterSize = dst[i].Size()
+			sr.scratch[i].Datum = truncateDatum(evalCtx, sr.scratch[i].Datum, maxBytesPerSample)
+			afterSize = sr.scratch[i].Size()
 		}
-
-		// Perform memory accounting.
-		if sr.memAcc != nil {
-			if err := sr.memAcc.Resize(ctx, int64(beforeSize), int64(afterSize)); err != nil {
-				return err
-			}
+		afterRowSize += int64(afterSize)
+	}
+	// Now that we know the exact row sizes we're dealing with, we perform the
+	// memory accounting.
+	if sr.memAcc != nil {
+		if err := sr.memAcc.Resize(ctx, beforeRowSize, afterRowSize); err != nil {
+			return err
 		}
 	}
+	// The memory reservation, if needed, was approved, so we're ok to keep the
+	// row.
+	copy(dst, sr.scratch)
 	return nil
 }
 


### PR DESCRIPTION
This commit fixes the memory accounting that is done in the SampleReservoir in an edge case. In particular, previously, in `copyRow` we would update the destination row (which might be the one coming from the "samples" slice) directly when processing each datum one at a time; if we happen to reach the memory limit in the middle of the row, we would have a "corrupt" row stored in the samples, which later on could lead to incorrect adjustment of the memory account when evicting that row. In fact, we had a comment warning about this situation, but we probably didn't appreciate the memory accounting drift that could fail the stats collection job in extreme cases (and would trigger the "no bytes in account to release" sentry report).

This problem is now fixed by first calculating the "before" and "after" sizes of the modified row via copying it into the staging scratch area, then asking for the necessary memory reservation, and only if that is approved copying the row into the destination. This way at every point in time the memory accounting is precise. This extra copy per sampled row should be negligible in the grand scheme of things. Additionally, I don't think we need to clear out the scratch row after each call because the datums will be overwritten on the next call to `copyRow`, so we'll lose the references to datums shortly (if there is no next call, then the last row is kept in the samples, so we just double the count of references to the datums by not clearing the scratch).

Fixes: #128241.

Release note (bug fix): Table statistics collection in CockroachDB could previously run into `no bytes in account to release` errors in some edge cases (when the SQL memory budget, configured via `--max-sql-memory` flag, was close to being exhausted). The bug has been present since 21.2 and is now fixed.