### PR TITLE
release-24.1: ci: fix private roachtest nightly

### DIFF
--- a/build/teamcity/internal/cockroach/nightlies/private_roachtest_impl.sh
+++ b/build/teamcity/internal/cockroach/nightlies/private_roachtest_impl.sh
@@ -10,7 +10,14 @@ set -exuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 
+# N.B. export variables like `root` s.t. they can be used by scripts called below.
+set -a
 source "$dir/teamcity-support.sh"
+set +a
+
+if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
+  ssh-keygen -q -C "private-roachtest-nightly-bazel $(date)" -N "" -f ~/.ssh/id_rsa
+fi
 
 $root/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh amd64
 


### PR DESCRIPTION
Backport 1/1 commits from #135913.

/cc @cockroachdb/release

---

It appears a change to TC wrapper scripts in [1]
may have caused the `root` var. to become unbound. This PR adds the missing `source` statement.

[1] https://github.com/cockroachdb/cockroach/pull/124592

Epic: none

Release note: None
Release justification: test-only change
