### PR TITLE
roachtest/cdc: remove dead cluster settings from roachtest/cdc

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1043,8 +1043,6 @@ func runCDCInitialScanRollingRestart(
 		`ALTER TABLE large SCATTER`,
 		fmt.Sprintf(`CREATE TABLE small (id PRIMARY KEY) AS SELECT generate_series(%d, %d)`, largeRowCount+1, largeRowCount+smallRowCount),
 		`ALTER TABLE small SCATTER`,
-		`SET CLUSTER SETTING jobs.registry.retry.initial_delay = '.1s'`,
-		`SET CLUSTER SETTING jobs.registry.retry.max_delay = '.4s'`,
 	}
 	switch checkpointType {
 	case cdcNormalCheckpoint:

--- a/pkg/jobs/config.go
+++ b/pkg/jobs/config.go
@@ -22,8 +22,6 @@ const (
 	gcIntervalSettingKey           = "jobs.registry.interval.gc"
 	retentionTimeSettingKey        = "jobs.retention_time"
 	cancelUpdateLimitKey           = "jobs.cancel_update_limit"
-	retryInitialDelaySettingKey    = "jobs.registry.retry.initial_delay"
-	retryMaxDelaySettingKey        = "jobs.registry.retry.max_delay"
 	executionErrorsMaxEntriesKey   = "jobs.execution_errors.max_entries"
 	executionErrorsMaxEntrySizeKey = "jobs.execution_errors.max_entry_size"
 	debugPausePointsSettingKey     = "jobs.debug.pausepoints"


### PR DESCRIPTION
**roachtest/cdc: remove dead cluster settings from roachtest/cdc**

Previously, we removed relevant cluster settings to
`jobs.registry.retry.initial_delay` and `jobs.registry.retry.max_delay`
in https://github.com/cockroachdb/cockroach/pull/135825 but didn't remove its usage from
`cdc/initial-scan-rolling-restart`. This patch removes its
usage from roachtest/cdc.

Fixes: https://github.com/cockroachdb/cockroach/issues/135973
Fixes: https://github.com/cockroachdb/cockroach/issues/135974
Release note: none

---

**jobs: remove retryInitialDelaySettingKey and retryMaxDelaySettingKey**

Previously, we removed relevant cluster settings to
`jobs.registry.retry.initial_delay` and `jobs.registry.retry.max_delay`
in https://github.com/cockroachdb/cockroach/pull/135825. This patch cleans up by removing the unused
constant values referencing them.

Epic: none
Release note: none