### PR TITLE
roachtest: only start CRDBNodes in db-console/cypress

### DIFF
--- a/pkg/cmd/roachtest/tests/db_console.go
+++ b/pkg/cmd/roachtest/tests/db_console.go
@@ -224,7 +224,7 @@ func runDbConsoleCypress(ctx context.Context, t test.Test, c cluster.Cluster) {
 		t.Fatal("cannot be run in local mode")
 	}
 
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.CRDBNodes())
 
 	cypressTest := newDbConsoleCypressTest(t, c, "cypress/e2e/health-check/*.ts", seedQueries)
 	db, err := c.ConnE(ctx, t.L(), cypressTest.testCluster.WorkloadNode()[0])


### PR DESCRIPTION
The workload node responsible for running the docker run commands doesn't need to have crdb started on it. This node is only used for running the cypress tests, which are run against CRDBNodes only.

This should stop the test from flaking, which seems to be happening due to https://github.com/cockroachdb/cockroach/issues/134989.

While this doesn't address WHY the workload node is having this problem, it stops the node from having this problem by not running CRDB on it.

Fixes: #135143
Epic: none
Release note: none