### PR TITLE
release: automatically merge `releases.yaml`

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -1,0 +1,52 @@
+# This Workflow automatically merges pull requests, submitted by certain users
+# if they pass certain criteria.
+# WARNING: If you change this file, it is mandatory to file a CREQ request to
+# approve the changes.
+name: Automerge pkg/testutils/release/cockroach_releases.yaml
+
+on:
+  pull_request:
+    branches: [ release-* ]
+    paths:
+    # Trigger the workflow only for certain files. First we need to exclude all
+    # files, then add the files we care about.
+    - "!**"
+    - "pkg/testutils/release/cockroach_releases.yaml"
+    - "pkg/sql/logictest/REPOSITORIES.bzl"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'cockroach-teamcity' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Fetch all branches so it is possible to checkout the default branch files.
+          fetch-depth: 0
+      # The next steps tries to reproduce the steps taken to generate the
+      # files. We restore the source tree to its original state on the base
+      # branch, run the commands to regenerate the change, and verify the
+      # result matches the PR contents (git diff does not show any changes).
+      - name: Regenerate the patch
+        run: |
+          set -euxo pipefail
+          git restore --source="origin/${{ github.base_ref }}" -- .
+          git diff || true
+          bazel build //pkg/cmd/release
+          $(bazel info bazel-bin)/pkg/cmd/release/release_/release update-releases-file
+          git diff || true
+      - name: Verify nothing changed
+        run: git diff --exit-code
+      - name: Approve a PR
+        run: gh pr review --approve "${{github.event.pull_request.html_url}}"
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable auto-merge
+        # TODO: this step won't work, because auto merge or merge queue are not enabled.
+        run: gh pr merge --auto --merge "${{github.event.pull_request.html_url}}"
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Previously, we automatically generated PRs with `releases.yaml` bumps and required to review them before merging. With 5-6 concurrent branches this became time consuming.

This PR adds a new workflow, triggered when `releases.yaml` is updated. The workflow verifies, that only expected changes are introduced by restoring the tree state to its PR base, then applying the steps we run as a part of automation. If the resulted files introduce no new changes, the PR can be automatically merged.

NB: to make this workflow work, we need to enable either merge queue (this can be done per branch) or automatic merges (globally).

Epic: none
Release note: None