### PR TITLE
vecindex: process fixup to delete dangling vectors

### DIFF
--- a/pkg/sql/vecindex/testdata/delete.ddt
+++ b/pkg/sql/vecindex/testdata/delete.ddt
@@ -182,10 +182,9 @@ search max-results=2
 ----
 vec4: 5 (centroid=1.118)
 vec1: 10 (centroid=1.5811)
-4 leaf vectors, 6 vectors, 4 full vectors, 3 partitions
+3 leaf vectors, 5 vectors, 3 full vectors, 3 partitions
 
 # Vector should now be gone from the index.
-# TODO(andyk): This will be true once fixups are added.
 format-tree
 ----
 • 1 (4.25, 3.5)
@@ -197,7 +196,6 @@ format-tree
 │
 └───• 3 (2.5, 2.5)
     │
-    ├───• vec3 (MISSING)
     └───• vec1 (1, 2)
 
 # Delete all vectors from one branch of the tree.
@@ -213,14 +211,13 @@ vec1
 │
 └───• 3 (2.5, 2.5)
     │
-    ├───• vec3 (MISSING)
     └───• vec1 (MISSING)
 
 # Search the empty branch.
 search max-results=1 beam-size=1
 (1, 2)
 ----
-2 leaf vectors, 4 vectors, 2 full vectors, 2 partitions
+1 leaf vectors, 3 vectors, 1 full vectors, 2 partitions
 
 # ----------
 # Search root partition with only missing vectors.
@@ -243,3 +240,8 @@ search max-results=1 beam-size=1
 (1, 2)
 ----
 1 leaf vectors, 1 vectors, 1 full vectors, 1 partitions
+
+# Root should be empty.
+format-tree
+----
+• 1 (0, 0)

--- a/pkg/sql/vecindex/testdata/merge.ddt
+++ b/pkg/sql/vecindex/testdata/merge.ddt
@@ -196,8 +196,7 @@ vec4
 │
 ├───• 2 (3.25, 6)
 │   │
-│   ├───• vec6 (MISSING)
-│   └───• vec5 (MISSING)
+│   └───• vec6 (MISSING)
 │
 └───• 3 (-0.3333, 3.3333)
     │
@@ -210,7 +209,7 @@ search
 (5, 2)
 ----
 vec7: 17 (centroid=1.3744)
-5 leaf vectors, 7 vectors, 4 full vectors, 3 partitions
+4 leaf vectors, 6 vectors, 3 full vectors, 3 partitions
 
 format-tree
 ----
@@ -241,14 +240,13 @@ vec1
 │
 └───• 3 (-0.3333, 3.3333)
     │
-    ├───• vec3 (-2, 8)
-    └───• vec7 (MISSING)
+    └───• vec3 (-2, 8)
 
 search
 (1, 3)
 ----
 vec3: 34 (centroid=4.9554)
-2 leaf vectors, 3 vectors, 2 full vectors, 2 partitions
+1 leaf vectors, 2 vectors, 1 full vectors, 2 partitions
 
 format-tree
 ----

--- a/pkg/sql/vecindex/vector_index.go
+++ b/pkg/sql/vecindex/vector_index.go
@@ -682,7 +682,8 @@ func (vi *VectorIndex) getRerankVectors(
 		// Exclude deleted vectors from results.
 		if candidates[i].Vector == nil {
 			// Vector was deleted, so add fixup to delete it.
-			// TODO(andyk): Enqueue a delete of a vector.
+			vi.fixups.AddDeleteVector(
+				searchCtx.Ctx, candidates[i].ParentPartitionKey, candidates[i].ChildKey.PrimaryKey)
 
 			// Move the last candidate to the current position and reduce size
 			// of slice by one.


### PR DESCRIPTION
Dangling vectors occur when a vector that's been deleted in the primary index can't be found in the secondary index. This PR triggers their deletion when they are encountered during searches to tidy up the index and decrease time spent skipping over them.

Epic: CRDB-42943

Release note: None