### PR TITLE
server: reapply "server: decrease nodes_ui response size"

### DIFF
--- a/pkg/server/nodes_response.go
+++ b/pkg/server/nodes_response.go
@@ -14,6 +14,47 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
+// uiNodeMetrics contains all the metrics required for the db-console frontend.
+// These will be the only node metrics returned in the serverpb.NodeResponse
+// metrics.
+var uiNodeMetrics = []string{
+	"sys.cpu.user.percent",
+	"sys.cpu.sys.percent",
+	"sys.go.allocbytes",
+	"sql.conns",
+	"sys.rss",
+}
+
+// uiStoreMetrics contains all the metrics required for the db-console frontend.
+// These will be the only node store metrics returned in the
+// serverpb.NodeResponse store_status metrics.
+var uiStoreMetrics = []string{
+	"replicas",
+	"replicas.leaders",
+	"replicas.leaseholders",
+	"ranges",
+	"ranges.unavailable",
+	"ranges.underreplicated",
+	"livebytes",
+	"keybytes",
+	"valbytes",
+	"rangekeybytes",
+	"rangevalbytes",
+	"totalbytes",
+	"intentbytes",
+	"livecount",
+	"keycount",
+	"valcount",
+	"intentcount",
+	"intentage",
+	"gcbytesage",
+	"capacity",
+	"capacity.available",
+	"capacity.used",
+	"sysbytes",
+	"syscount",
+}
+
 func nodeStatusToResp(n *statuspb.NodeStatus, hasViewClusterMetadata bool) serverpb.NodeResponse {
 	tiers := make([]serverpb.Tier, len(n.Desc.Locality.Tiers))
 	for j, t := range n.Desc.Locality.Tiers {
@@ -52,6 +93,12 @@ func nodeStatusToResp(n *statuspb.NodeStatus, hasViewClusterMetadata bool) serve
 
 	statuses := make([]serverpb.StoreStatus, len(n.StoreStatuses))
 	for i, ss := range n.StoreStatuses {
+		storeMetrics := make(map[string]float64, len(uiStoreMetrics))
+		for _, m := range uiStoreMetrics {
+			if d, ok := ss.Metrics[m]; ok {
+				storeMetrics[m] = d
+			}
+		}
 		statuses[i] = serverpb.StoreStatus{
 			Desc: serverpb.StoreDescriptor{
 				StoreID:  ss.Desc.StoreID,
@@ -64,7 +111,7 @@ func nodeStatusToResp(n *statuspb.NodeStatus, hasViewClusterMetadata bool) serve
 					Encrypted: ss.Desc.Properties.Encrypted,
 				},
 			},
-			Metrics: ss.Metrics,
+			Metrics: storeMetrics,
 		}
 		if fsprops := ss.Desc.Properties.FileStoreProperties; fsprops != nil {
 			sfsprops := &roachpb.FileStoreProperties{
@@ -80,12 +127,19 @@ func nodeStatusToResp(n *statuspb.NodeStatus, hasViewClusterMetadata bool) serve
 		}
 	}
 
+	metrics := make(map[string]float64, len(uiNodeMetrics))
+	for _, m := range uiNodeMetrics {
+		if d, ok := n.Metrics[m]; ok {
+			metrics[m] = d
+		}
+	}
+
 	resp := serverpb.NodeResponse{
 		Desc:              nodeDescriptor,
 		BuildInfo:         n.BuildInfo,
 		StartedAt:         n.StartedAt,
 		UpdatedAt:         n.UpdatedAt,
-		Metrics:           n.Metrics,
+		Metrics:           metrics,
 		StoreStatuses:     statuses,
 		Args:              nil,
 		Env:               nil,

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -543,3 +543,31 @@ WHERE id = $1 AND claim_instance_id IS NOT NULL`, jobs.UpdateTableMetadataCacheJ
 		require.Containsf(t, runningStatus, "Job completed at", "running_status not updated: %s", runningStatus)
 	})
 }
+
+// TestNodesUiMetrics tests that the metrics fields of NodesUI
+// rpcs only returns the subset of metrics needed in the UI
+func TestNodesUiMetrics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ts := serverutils.StartServerOnly(t, base.TestServerArgs{})
+
+	ctx := context.Background()
+	defer ts.Stopper().Stop(ctx)
+
+	s := ts.StatusServer().(*systemStatusServer)
+	resp, err := s.NodesUI(ctx, &serverpb.NodesRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.Nodes, 1)
+	for _, node := range resp.Nodes {
+		for _, m := range uiNodeMetrics {
+			require.Contains(t, node.Metrics, m)
+		}
+		require.Greater(t, len(node.StoreStatuses), 0)
+		for _, storeStatus := range node.StoreStatuses {
+			for _, m := range uiStoreMetrics {
+				require.Contains(t, storeStatus.Metrics, m)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This reverts commit 35d00d599205dc48ae07668689d5b87553612fcf.

This commit was originally reverted because it broke the customs chart component. This component was previously dependent on the nodes_ui metrics to populate the list of queryable metrics from TSDB. This was fixed in #135705, so this commit can be reapplied

Fixes: #129408
Epic: none
Release note: none