### PR TITLE
release-24.1: changefeedccl: deflake TestChangefeedContinuousTelemetryOnTermination

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -273,7 +273,7 @@ func (ca *changeAggregator) wrapMetricsController(
 		return ca.sliMetrics, err
 	}
 
-	recorderWithTelemetry, err := wrapMetricsRecorderWithTelemetry(ctx, job, ca.flowCtx.Cfg.Settings, recorder)
+	recorderWithTelemetry, err := wrapMetricsRecorderWithTelemetry(ctx, job, ca.flowCtx.Cfg.Settings, recorder, ca.knobs)
 	if err != nil {
 		return ca.sliMetrics, err
 	}

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -6056,26 +6056,62 @@ func TestChangefeedContinuousTelemetry(t *testing.T) {
 	cdcTest(t, testFn, feedTestOmitSinks("sinkless"))
 }
 
+type testTelemetryLogger struct {
+	telemetryLogger
+	afterIncEmittedCounters func(numMessages int, numBytes int)
+}
+
+var _ telemetryLogger = (*testTelemetryLogger)(nil)
+
+func (t *testTelemetryLogger) incEmittedCounters(numMessages int, numBytes int) {
+	t.telemetryLogger.incEmittedCounters(numMessages, numBytes)
+	t.afterIncEmittedCounters(numMessages, numBytes)
+}
+
 func TestChangefeedContinuousTelemetryOnTermination(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.WithIssue(t, 120837)
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		interval := 24 * time.Hour
 		continuousTelemetryInterval.Override(context.Background(), &s.Server.ClusterSettings().SV, interval)
-		beforeCreate := timeutil.Now()
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
 		sqlDB.Exec(t, `CREATE TABLE foo (id INT PRIMARY KEY)`)
 
+		var seen atomic.Bool
+		waitForIncEmittedCounters := func() error {
+			if !seen.Load() {
+				return errors.Newf("emitted counters have not been incremented yet")
+			}
+			return nil
+		}
+		// Synchronization to prevent a race between the changefeed closing
+		// and the telemetry logger getting emitted counts after messages
+		// have been emitted to the sink.
+		s.TestingKnobs.DistSQL.(*execinfra.TestingKnobs).Changefeed.(*TestingKnobs).
+			WrapTelemetryLogger = func(logger telemetryLogger) telemetryLogger {
+			return &testTelemetryLogger{
+				telemetryLogger: logger,
+				afterIncEmittedCounters: func(numMessages int, _ int) {
+					if numMessages > 0 {
+						seen.Store(true)
+					}
+				},
+			}
+		}
+
 		// Insert a row and wait for logs to be created.
+		beforeFirstLog := timeutil.Now()
 		foo := feed(t, f, `CREATE CHANGEFEED FOR foo`)
 		jobID := foo.(cdctest.EnterpriseTestFeed).JobID()
 		sqlDB.Exec(t, `INSERT INTO foo VALUES (1)`)
-		verifyLogsWithEmittedBytesAndMessages(t, jobID, beforeCreate.UnixNano(), interval.Nanoseconds(), false)
+		testutils.SucceedsSoon(t, waitForIncEmittedCounters)
+		verifyLogsWithEmittedBytesAndMessages(t, jobID, beforeFirstLog.UnixNano(), interval.Nanoseconds(), false /* closing */)
 
 		// Insert more rows. No logs should be created for these since we recently
 		// published them above and the interval is 24h.
+		afterFirstLog := timeutil.Now()
+		seen.Store(false)
 		sqlDB.Exec(t, `INSERT INTO foo VALUES (2)`)
 		sqlDB.Exec(t, `INSERT INTO foo VALUES (3)`)
 		assertPayloads(t, foo, []string{
@@ -6083,11 +6119,11 @@ func TestChangefeedContinuousTelemetryOnTermination(t *testing.T) {
 			`foo: [2]->{"after": {"id": 2}}`,
 			`foo: [3]->{"after": {"id": 3}}`,
 		})
+		testutils.SucceedsSoon(t, waitForIncEmittedCounters)
 
 		// Close the changefeed and ensure logs were created after closing.
-		beforeClose := timeutil.Now()
 		require.NoError(t, foo.Close())
-		verifyLogsWithEmittedBytesAndMessages(t, jobID, beforeClose.UnixNano(), interval.Nanoseconds(), true)
+		verifyLogsWithEmittedBytesAndMessages(t, jobID, afterFirstLog.UnixNano(), interval.Nanoseconds(), true /* closing */)
 	}
 
 	cdcTest(t, testFn, feedTestOmitSinks("sinkless"))

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -1271,9 +1271,7 @@ func verifyLogsWithEmittedBytesAndMessages(
 			emittedBytes += msg.EmittedBytes
 			emittedMessages += msg.EmittedMessages
 			require.Equal(t, interval, msg.LoggingInterval)
-			if closing {
-				require.Equal(t, true, msg.Closing)
-			}
+			require.Equal(t, closing, msg.Closing)
 		}
 		if emittedBytes == 0 || emittedMessages == 0 {
 			return errors.Newf(

--- a/pkg/ccl/changefeedccl/telemetry.go
+++ b/pkg/ccl/changefeedccl/telemetry.go
@@ -10,17 +10,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/timers"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/util/cidr"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/rcrowley/go-metrics"
 )
 
 type sinkTelemetryData struct {
@@ -39,13 +36,9 @@ type periodicTelemetryLogger struct {
 }
 
 type telemetryLogger interface {
-	// recordEmittedBytes records the number of emitted bytes without
-	// publishing logs.
-	recordEmittedBytes(numBytes int)
-
-	// recordEmittedMessages records the number of emitted messages without
-	// publishing logs.
-	recordEmittedMessages(numMessages int)
+	// incEmittedCounters increments the counters for emitted messages and bytes
+	// without publishing logs.
+	incEmittedCounters(numMessages int, numBytes int)
 
 	// maybeFlushLogs flushes buffered metrics to logs depending
 	// on the semantics of the implementation.
@@ -69,18 +62,14 @@ func makePeriodicTelemetryLogger(
 	}, nil
 }
 
-// recordEmittedBytes implements the telemetryLogger interface.
-func (ptl *periodicTelemetryLogger) recordEmittedBytes(numBytes int) {
+// incEmittedCounters implements the telemetryLogger interface.
+func (ptl *periodicTelemetryLogger) incEmittedCounters(numMessages, numBytes int) {
+	ptl.sinkTelemetryData.emittedMessages.Add(int64(numMessages))
 	ptl.sinkTelemetryData.emittedBytes.Add(int64(numBytes))
 }
 
 func (ptl *periodicTelemetryLogger) resetEmittedBytes() int64 {
 	return ptl.sinkTelemetryData.emittedBytes.Swap(0)
-}
-
-// recordEmittedMessages implements the telemetryLogger interface.
-func (ptl *periodicTelemetryLogger) recordEmittedMessages(numMessages int) {
-	ptl.sinkTelemetryData.emittedMessages.Add(int64(numMessages))
 }
 
 func (ptl *periodicTelemetryLogger) resetEmittedMessages() int64 {
@@ -135,21 +124,25 @@ func (ptl *periodicTelemetryLogger) close() {
 }
 
 func wrapMetricsRecorderWithTelemetry(
-	ctx context.Context, job *jobs.Job, s *cluster.Settings, mb metricsRecorder,
+	ctx context.Context, job *jobs.Job, s *cluster.Settings, mb metricsRecorder, knobs TestingKnobs,
 ) (*telemetryMetricsRecorder, error) {
+	var logger telemetryLogger
 	logger, err := makePeriodicTelemetryLogger(ctx, job, s)
 	if err != nil {
 		return &telemetryMetricsRecorder{}, err
 	}
+	if knobs.WrapTelemetryLogger != nil {
+		logger = knobs.WrapTelemetryLogger(logger)
+	}
 	return &telemetryMetricsRecorder{
+		metricsRecorder: mb,
 		telemetryLogger: logger,
-		inner:           mb,
 	}, nil
 }
 
 type telemetryMetricsRecorder struct {
-	telemetryLogger *periodicTelemetryLogger
-	inner           metricsRecorder
+	metricsRecorder
+	telemetryLogger telemetryLogger
 }
 
 var _ metricsRecorder = (*telemetryMetricsRecorder)(nil)
@@ -158,23 +151,10 @@ func (r *telemetryMetricsRecorder) close() {
 	r.telemetryLogger.close()
 }
 
-func (r *telemetryMetricsRecorder) recordMessageSize(sz int64) {
-	r.inner.recordMessageSize(sz)
-}
-
-func (r *telemetryMetricsRecorder) makeCloudstorageFileAllocCallback() func(delta int64) {
-	return r.inner.makeCloudstorageFileAllocCallback()
-}
-
-func (r *telemetryMetricsRecorder) recordInternalRetry(numMessages int64, reducedBatchSize bool) {
-	r.inner.recordInternalRetry(numMessages, reducedBatchSize)
-}
-
 func (r *telemetryMetricsRecorder) recordOneMessage() recordOneMessageCallback {
 	return func(mvcc hlc.Timestamp, bytes int, compressedBytes int) {
-		r.inner.recordOneMessage()(mvcc, bytes, compressedBytes)
-		r.telemetryLogger.recordEmittedBytes(bytes)
-		r.telemetryLogger.recordEmittedMessages(1)
+		r.metricsRecorder.recordOneMessage()(mvcc, bytes, compressedBytes)
+		r.telemetryLogger.incEmittedCounters(1 /* numMessages */, bytes)
 		r.telemetryLogger.maybeFlushLogs()
 	}
 }
@@ -182,61 +162,18 @@ func (r *telemetryMetricsRecorder) recordOneMessage() recordOneMessageCallback {
 func (r *telemetryMetricsRecorder) recordEmittedBatch(
 	startTime time.Time, numMessages int, mvcc hlc.Timestamp, bytes int, compressedBytes int,
 ) {
-	r.inner.recordEmittedBatch(startTime, numMessages, mvcc, bytes, compressedBytes)
-	r.telemetryLogger.recordEmittedBytes(bytes)
-	r.telemetryLogger.recordEmittedMessages(numMessages)
+	r.metricsRecorder.recordEmittedBatch(startTime, numMessages, mvcc, bytes, compressedBytes)
+	r.telemetryLogger.incEmittedCounters(numMessages, bytes)
 	r.telemetryLogger.maybeFlushLogs()
 }
 
-func (r *telemetryMetricsRecorder) recordResolvedCallback() func() {
-	return r.inner.recordResolvedCallback()
-}
-
-func (r *telemetryMetricsRecorder) recordFlushRequestCallback() func() {
-	return r.inner.recordFlushRequestCallback()
-}
-
-func (r *telemetryMetricsRecorder) getBackfillCallback() func() func() {
-	return r.inner.getBackfillCallback()
-}
-
-func (r *telemetryMetricsRecorder) getBackfillRangeCallback() func(int64) (func(), func()) {
-	return r.inner.getBackfillRangeCallback()
-}
-
-func (r *telemetryMetricsRecorder) recordSizeBasedFlush() {
-	r.inner.recordSizeBasedFlush()
-}
-
-func (r *telemetryMetricsRecorder) recordSinkIOInflightChange(delta int64) {
-	r.inner.recordSinkIOInflightChange(delta)
-}
-
-func (r *telemetryMetricsRecorder) newParallelIOMetricsRecorder() parallelIOMetricsRecorder {
-	return r.inner.newParallelIOMetricsRecorder()
-}
-
-func (r *telemetryMetricsRecorder) getKafkaThrottlingMetrics(
-	settings *cluster.Settings,
-) metrics.Histogram {
-	return r.inner.getKafkaThrottlingMetrics(settings)
-}
-
-func (r *telemetryMetricsRecorder) netMetrics() *cidr.NetMetrics {
-	return r.inner.netMetrics()
-}
-
-func (r *telemetryMetricsRecorder) timers() *timers.ScopedTimers {
-	return r.inner.timers()
-}
-
-// continuousTelemetryInterval determines the interval at which each node emits telemetry events
-// during the lifespan of each enterprise changefeed.
+// continuousTelemetryInterval determines the interval at which each node emits
+// periodic telemetry events during the lifespan of each enterprise changefeed.
 var continuousTelemetryInterval = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,
 	"changefeed.telemetry.continuous_logging.interval",
 	"determines the interval at which each node emits continuous telemetry events"+
-		" during the lifespan of every enterprise changefeed; setting a zero value disables",
+		" during the lifespan of every enterprise changefeed; setting a zero value disables logging",
 	24*time.Hour,
 	settings.NonNegativeDuration,
 )

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -96,6 +96,9 @@ type TestingKnobs struct {
 
 	// AsyncFlushSync is called in async flush goroutines as a way to provide synchronization between them.
 	AsyncFlushSync func()
+
+	// WrapTelemetryLogger is used to wrap the periodic telemetry logger in tests.
+	WrapTelemetryLogger func(logger telemetryLogger) telemetryLogger
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
Backport 1/1 commits from #135961.

/cc @cockroachdb/release

---

This patch adds some synchronization logic to deflake
`TestChangefeedContinuousTelemetryOnTermination`.
It also simplifies the periodic telemetry logger code.

Fixes: #120837

Release note: None

----

Release justification: testing improvement and code simplification
