### PR TITLE
stats, encoding: improve UUID-decoding error

### DIFF
--- a/pkg/sql/stats/histogram.go
+++ b/pkg/sql/stats/histogram.go
@@ -7,6 +7,7 @@ package stats
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"math"
 	"sort"
@@ -134,6 +135,12 @@ func DecodeUpperBound(
 		datum, _, err = valueside.Decode(a, typ, upperBound)
 	} else {
 		datum, _, err = keyside.Decode(a, typ, upperBound, encoding.Ascending)
+	}
+	if err != nil {
+		err = errors.Wrapf(
+			err, "decoding histogram version %d type %v value %v",
+			int(version), typ.Family().Name(), hex.EncodeToString(upperBound),
+		)
 	}
 	return datum, err
 }

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -3162,6 +3162,9 @@ func DecodeUUIDValue(b []byte) (remaining []byte, u uuid.UUID, err error) {
 
 // DecodeUntaggedUUIDValue decodes a value encoded by EncodeUntaggedUUIDValue.
 func DecodeUntaggedUUIDValue(b []byte) (remaining []byte, u uuid.UUID, err error) {
+	if len(b) < uuidValueEncodedLength {
+		return b, uuid.UUID{}, errors.Errorf("invalid uuid length of %d", len(b))
+	}
 	u, err = uuid.FromBytes(b[:uuidValueEncodedLength])
 	if err != nil {
 		return b, uuid.UUID{}, err


### PR DESCRIPTION
Add a length check to `DecodeUUIDValue` and a more informative error wrapping to `DecodeUpperBound`, which will hopefully help us track down the cause of #128876.

The wrapped error message looks like:

```
decoding histogram version 3 type uuid value ‹666f6f›: invalid uuid length of 2
```

Informs: #128876

Epic: None

Release note: None