### PR TITLE
raft: set electionElapsed to electionTimeout in defortify() regardless of state

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -2524,20 +2524,18 @@ func (r *raft) deFortify(from pb.PeerID, term uint64) {
 
 	r.resetLeadEpoch()
 
-	if r.state != pb.StateLeader {
-		// The peer is not fortifying the leader anymore. As a result:
-		// 1. We don't want to wait out an entire election timeout before
-		//    campaigning.
-		// 2. But we do want to take advantage of randomized election timeouts built
-		//    into raft to prevent hung elections.
-		// We achieve both of these goals by "forwarding" electionElapsed to begin
-		// at r.electionTimeout. Also see atRandomizedElectionTimeout.
-		r.logger.Debugf(
-			"%d setting election elapsed to start from %d ticks after store liveness support expired",
-			r.id, r.electionTimeout,
-		)
-		r.electionElapsed = r.electionTimeout
-	}
+	// The peer is not fortifying the leader anymore. As a result:
+	// 1. We don't want to wait out an entire election timeout before
+	//    campaigning.
+	// 2. But we do want to take advantage of randomized election timeouts built
+	//    into raft to prevent hung elections.
+	// We achieve both of these goals by "forwarding" electionElapsed to begin
+	// at r.electionTimeout. Also see atRandomizedElectionTimeout.
+	r.logger.Debugf(
+		"%d setting election elapsed to start from %d ticks after store liveness support expired",
+		r.id, r.electionTimeout,
+	)
+	r.electionElapsed = r.electionTimeout
 }
 
 // restore recovers the state machine from a snapshot. It restores the log and the

--- a/pkg/raft/testdata/de_fortification_basic.txt
+++ b/pkg/raft/testdata/de_fortification_basic.txt
@@ -1031,6 +1031,7 @@ stabilize
   INFO 1 [logterm: 4, index: 5, vote: 0] cast MsgVote for 2 [logterm: 4, index: 5] at term 5
 > 3 receiving messages
   2->3 MsgVote Term:5 Log:4/5
+  DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 3 [term: 4] received a MsgVote message with higher term from 2 [term: 5], advancing term
   INFO 3 became follower at term 5
   INFO 3 [logterm: 4, index: 5, vote: 0] cast MsgVote for 2 [logterm: 4, index: 5] at term 5

--- a/pkg/raft/testdata/fortification_followers_dont_prevote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_prevote.txt
@@ -292,6 +292,7 @@ stabilize
 > 1 receiving messages
   2->1 MsgFortifyLeader Term:2 Log:0/0
   INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 2 [term: 2], new leader indicated, advancing term
+  DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 1 became follower at term 2
   2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 3 receiving messages

--- a/pkg/raft/testdata/fortification_followers_dont_vote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_vote.txt
@@ -238,6 +238,7 @@ stabilize
 > 1 receiving messages
   2->1 MsgFortifyLeader Term:3 Log:0/0
   INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 2 [term: 3], new leader indicated, advancing term
+  DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 1 became follower at term 3
   2->1 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
 > 3 receiving messages

--- a/pkg/raft/testdata/fortification_support_tracking.txt
+++ b/pkg/raft/testdata/fortification_support_tracking.txt
@@ -219,6 +219,7 @@ stabilize
 > 1 receiving messages
   2->1 MsgFortifyLeader Term:2 Log:0/0
   INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 2 [term: 2], new leader indicated, advancing term
+  DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 1 became follower at term 2
   2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 3 receiving messages

--- a/pkg/raft/testdata/prevote.txt
+++ b/pkg/raft/testdata/prevote.txt
@@ -103,6 +103,7 @@ deliver-msgs 1 2
 ----
 2->1 MsgAppResp Term:1 Log:0/12 Commit:11
 3->1 MsgPreVote Term:2 Log:1/11
+DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 1 [logterm: 1, index: 12, vote: 1] rejected MsgPreVote from 3 [logterm: 1, index: 11] at term 1
 3->2 MsgPreVote Term:2 Log:1/11
 DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired

--- a/pkg/raft/testdata/prevote_checkquorum.txt
+++ b/pkg/raft/testdata/prevote_checkquorum.txt
@@ -156,6 +156,7 @@ stabilize
 > 1 receiving messages
   3->1 MsgFortifyLeader Term:2 Log:0/0
   INFO 1 [term: 1] received a MsgFortifyLeader message with higher term from 3 [term: 2], new leader indicated, advancing term
+  DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 1 became follower at term 2
   3->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 2 receiving messages
@@ -360,6 +361,7 @@ stabilize
 > 3 receiving messages
   2->3 MsgFortifyLeader Term:3 Log:0/0
   INFO 3 [term: 2] received a MsgFortifyLeader message with higher term from 2 [term: 3], new leader indicated, advancing term
+  DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 3 became follower at term 3
   2->3 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
 > 1 handling Ready


### PR DESCRIPTION
Previously, we use to set electionElapsed to electionTimeout inside defortify() only when we are not the leader. We did this as an extra defense because we didn't want to increment the electionTimeout when we are the leader. However, there is no need for this extra complexity since in all cases where we call defortify when we are the leader, we either immediately step down (which resets the electionElapsed to 0), or we are okay performing a checkQuorum (in the case where a leader receive a MsgPreVote from a higher term while it's not in leader-lease)

Epic: None

Release note: None