### PR TITLE
logictest: fix assertion that was rewritten accidentally

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
@@ -205,8 +205,8 @@ ORDER BY start_key
 /Table/106  14400
 /Table/107  14400
 /Table/110  90001
-/Table/111  90001
-/Table/112  14400
+/Table/111  1
+/Table/112  1
 
 subtest transactional_schemachanges
 


### PR DESCRIPTION
This was overwritten in cd1fac3e21067675d7ef95f4b511b75123a42ace. The test uses the `retry` directive to make sure the span configs are eventually reconciled.

fixes https://github.com/cockroachdb/cockroach/issues/135987
Release note: None