### PR TITLE
release-23.2: stats, encoding: improve UUID-decoding error

### DIFF
--- a/pkg/sql/stats/histogram.go
+++ b/pkg/sql/stats/histogram.go
@@ -6,6 +6,7 @@
 package stats
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math"
 	"sort"
@@ -92,6 +93,12 @@ func decodeUpperBound(typ *types.T, a *tree.DatumAlloc, upperBound []byte) (tree
 		datum, _, err = valueside.Decode(a, typ, upperBound)
 	} else {
 		datum, _, err = keyside.Decode(a, typ, upperBound, encoding.Ascending)
+	}
+	if err != nil {
+		err = errors.Wrapf(
+			err, "decoding histogram type %v value %v",
+			typ.Family().Name(), hex.EncodeToString(upperBound),
+		)
 	}
 	return datum, err
 }

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -3127,6 +3127,9 @@ func DecodeUUIDValue(b []byte) (remaining []byte, u uuid.UUID, err error) {
 
 // DecodeUntaggedUUIDValue decodes a value encoded by EncodeUntaggedUUIDValue.
 func DecodeUntaggedUUIDValue(b []byte) (remaining []byte, u uuid.UUID, err error) {
+	if len(b) < uuidValueEncodedLength {
+		return b, uuid.UUID{}, errors.Errorf("invalid uuid length of %d", len(b))
+	}
 	u, err = uuid.FromBytes(b[:uuidValueEncodedLength])
 	if err != nil {
 		return b, uuid.UUID{}, err


### PR DESCRIPTION
Backport 1/1 commits from #136015.

/cc @cockroachdb/release

---

Add a length check to `DecodeUUIDValue` and a more informative error wrapping to `DecodeUpperBound`, which will hopefully help us track down the cause of #128876.

The wrapped error message looks like:

```
decoding histogram version 3 type uuid value ‹666f6f›: invalid uuid length of 2
```

Informs: #128876

Epic: None

Release note: None

--- 

Release justification: low-risk debugging for error.