### PR TITLE
roachtest/tests: increase ts util http timeout

### DIFF
--- a/pkg/cmd/roachtest/tests/ts_util.go
+++ b/pkg/cmd/roachtest/tests/ts_util.go
@@ -142,7 +142,7 @@ func getMetricsWithSamplePeriod(
 	}
 	var response tspb.TimeSeriesQueryResponse
 	client := roachtestutil.DefaultHTTPClient(
-		c, t.L(), roachtestutil.HTTPTimeout(500*time.Millisecond),
+		c, t.L(), roachtestutil.HTTPTimeout(5*time.Second),
 		roachtestutil.VirtualCluster(virtualCluster),
 	)
 	err := client.PostProtobuf(ctx, url, &request, &response)


### PR DESCRIPTION
Increases the timeout to get metrics from 500ms to 5s.

Epic: none

Fixes: #134047
Fixes: #134190

Release note: None