### PR TITLE
server,rpc: shorten value context chains

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
@@ -368,11 +368,15 @@ func (m *rangefeedMuxer) startNodeMuxRangeFeed(
 	nodeID roachpb.NodeID,
 	stream *future.Future[muxStreamOrError],
 ) (retErr error) {
-	ctx = logtags.AddTag(ctx, "mux_n", nodeID)
+
+	tags := &logtags.Buffer{}
+	tags = tags.Add("mux_n", nodeID)
 	// Add "generation" number to the context so that log messages and stacks can
 	// differentiate between multiple instances of mux rangefeed goroutine
 	// (this can happen when one was shutdown, then re-established).
-	ctx = logtags.AddTag(ctx, "gen", atomic.AddInt64(&m.seqID, 1))
+	tags = tags.Add("gen", atomic.AddInt64(&m.seqID, 1))
+
+	ctx = logtags.AddTags(ctx, tags)
 	ctx, restore := pprofutil.SetProfilerLabelsFromCtxTags(ctx)
 	defer restore()
 

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -1926,11 +1926,12 @@ func (rpcCtx *Context) wrapCtx(
 	if remoteNodeID == 0 {
 		rnodeID = redact.SafeString("?")
 	}
-	ctx = logtags.AddTag(ctx, RemoteNodeTag, rnodeID)
-	ctx = logtags.AddTag(ctx, RemoteAddressTag, target)
-	ctx = logtags.AddTag(ctx, Class, class)
-	ctx = logtags.AddTag(ctx, RpcTag, nil)
-	return ctx
+	l := &logtags.Buffer{}
+	l = l.Add(RemoteNodeTag, rnodeID)
+	l = l.Add(RemoteAddressTag, target)
+	l = l.Add(Class, class)
+	l = l.Add(RpcTag, nil)
+	return logtags.AddTags(ctx, l)
 }
 
 // grpcDialRaw connects to the remote node.

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -2168,9 +2168,11 @@ func (n *Node) MuxRangeFeed(muxStream kvpb.Internal_MuxRangeFeedServer) error {
 				continue
 			}
 
-			streamCtx := logtags.AddTag(ctx, "r", req.RangeID)
-			streamCtx = logtags.AddTag(streamCtx, "sm", req.Replica.StoreID)
-			streamCtx = logtags.AddTag(streamCtx, "sid", req.StreamID)
+			tags := &logtags.Buffer{}
+			tags = tags.Add("r", req.RangeID)
+			tags = tags.Add("sm", req.Replica.StoreID)
+			tags = tags.Add("sid", req.StreamID)
+			streamCtx := logtags.AddTags(ctx, tags)
 
 			streamSink := sm.NewStream(req.StreamID, req.RangeID)
 


### PR DESCRIPTION
Each call to logtags.AddTag creates another valueCtx. Here, we use the AddTags function to produce 1 valueCtx when we were previously producing multiple.

This is still bit sad because the logtags.Buffer design isn't really set up for this use case, so perhaps we should push something into that library that allows us to make a log buffer without so much copying.

Epic: none
Release note: None