### PR TITLE
release-24.3.0-rc: kv: print traced query when failing the TestProxyTracing

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -4847,6 +4847,9 @@ func TestProxyTracing(t *testing.T) {
 		}
 		kvserver.RangefeedEnabled.Override(ctx, &st.SV, true)
 		kvserver.RangeFeedRefreshInterval.Override(ctx, &st.SV, 10*time.Millisecond)
+		// Disable follower reads to ensure that the request is proxied, and not
+		// answered locally due to follower reads.
+		kvserver.FollowerReadsEnabled.Override(ctx, &st.SV, false)
 		closedts.TargetDuration.Override(ctx, &st.SV, 10*time.Millisecond)
 		closedts.SideTransportCloseInterval.Override(ctx, &st.SV, 10*time.Millisecond)
 

--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -4829,6 +4829,8 @@ func TestProxyTracing(t *testing.T) {
 		st := cluster.MakeTestingClusterSettings()
 		switch leaseType {
 		case roachpb.LeaseExpiration:
+			skip.UnderRace(t, "too slow")
+			skip.UnderDeadlock(t, "too slow")
 			kvserver.ExpirationLeasesOnly.Override(ctx, &st.SV, true)
 		case roachpb.LeaseEpoch:
 			// With epoch leases this test doesn't work reliably. It passes

--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -4914,6 +4914,22 @@ func TestProxyTracing(t *testing.T) {
 			return nil
 		}
 
+		printTrace := func() {
+			t.Log("started printing a trace")
+			rows, err := conn.QueryContext(ctx, "SELECT message, tag, location FROM [SHOW TRACE FOR SESSION]")
+			require.NoError(t, err)
+			defer rows.Close()
+
+			// Iterate over the results and print them
+			for rows.Next() {
+				var msg, tag, loc string
+				err := rows.Scan(&msg, &tag, &loc)
+				require.NoError(t, err)
+				t.Logf("msg: %s, tag: %s, loc: %s", msg, tag, loc)
+			}
+			require.NoError(t, rows.Err())
+		}
+
 		// Wait until the leaseholder for the test table ranges are on n3.
 		testutils.SucceedsSoon(t, func() error {
 			return checkLeaseCount(3, numRanges)
@@ -4923,7 +4939,6 @@ func TestProxyTracing(t *testing.T) {
 
 		_, err = conn.Exec("SET TRACING = on; SELECT FROM t where i = 987654321; SET TRACING = off")
 		require.NoError(t, err)
-
 		// Expect the "proxy request complete" message to be in the trace and that it
 		// comes from the proxy node n2.
 		var msg, tag, loc string
@@ -4933,6 +4948,10 @@ func TestProxyTracing(t *testing.T) {
 			AND location LIKE '%server/node%'
 			AND tag LIKE '%n2%'`,
 		).Scan(&msg, &tag, &loc); err != nil {
+			// If we fail for any reason, print the trace to help debugging.
+			printTrace()
+			// Make sure that node 3 still holds the leases.
+			require.NoError(t, checkLeaseCount(3, numRanges))
 			if errors.Is(err, gosql.ErrNoRows) {
 				t.Fatalf("request succeeded without proxying")
 			}


### PR DESCRIPTION
Backport 3/3 commits from #135846, #135858, #135921.

/cc @cockroachdb/release

---

This commit prints the traced query when TestProxyTracing test fails. This should help with debugging the failures.

References: #135493

Release note: None

---

This commit disables deadlock/race runs for TestProxyTracing when running with expiration leases. The main reason is that it consumes resources unnecessarily.

References: https://github.com/cockroachdb/cockroach/issues/135493

Release note: None

---

This commit disables follower reads for the test TestProxyTracing. We noticed that sometimes, the test gets slow, and by the time we issue a read request, it's served via follower reads instead of proxying it to the leaseholder.

Fixes: #135493

Release note: None

Release justification: backporting the test deflaking changes
