### PR TITLE
workload: fix benchmarks

### DIFF
--- a/pkg/workload/BUILD.bazel
+++ b/pkg/workload/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/sql/memsize",
         "//pkg/sql/types",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",

--- a/pkg/workload/bench_test.go
+++ b/pkg/workload/bench_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/memsize"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
@@ -35,6 +36,8 @@ func columnByteSize(col *coldata.Vec) int64 {
 	case types.BytesFamily:
 		// We subtract the overhead to be in line with Int64 and Float64 cases.
 		return col.Bytes().Size() - coldata.FlatBytesOverhead
+	case types.TimestampFamily, types.TimestampTZFamily:
+		return int64(col.Timestamp().Len()) * memsize.Time
 	default:
 		panic(fmt.Sprintf(`unhandled type %s`, t))
 	}

--- a/pkg/workload/csv_test.go
+++ b/pkg/workload/csv_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/cockroach/pkg/workload/bank"
-	"github.com/cockroachdb/cockroach/pkg/workload/tpcc"
 )
 
 func TestHandleCSV(t *testing.T) {
@@ -74,7 +73,7 @@ func BenchmarkWriteCSVRows(b *testing.B) {
 	defer cancel()
 
 	var batches []coldata.Batch
-	for _, table := range tpcc.FromWarehouses(1).Tables() {
+	for _, table := range bank.FromRows(1000).Tables() {
 		cb := coldata.NewMemBatch(nil /* types */, coldata.StandardColumnFactory)
 		var a bufalloc.ByteAllocator
 		table.InitialRows.FillBatch(0, cb, &a)


### PR DESCRIPTION
The workload benchmarks have been failing since the introduction of a timestamp type into the schema. This gets them working again.

Epic: none