### PR TITLE
roachtest: rm redundant cpu profiling in rebalance/by-load tests

### DIFF
--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -119,17 +119,8 @@ func registerRebalanceLoad(r registry.Registry) {
 				})
 			mvt.Run()
 		} else {
-			// Enable collecting CPU profiles when the CPU utilization exceeds 90%.
-			// This helps debug failures which occur as a result of mismatches
-			// between allocation (QPS/replica CPU) and hardware signals e.g. see
-			// #111900. The setting names changed between v22.2 and v23.1, we can't
-			// easily setup CPU profiling in mixed version tests.
-			//
-			// TODO(kvoli): Remove this setup once CPU profiling is enabled by default
-			// on perf roachtests #97699.
-			settings.ClusterSettings["server.cpu_profile.duration"] = "2s"
-			settings.ClusterSettings["server.cpu_profile.interval"] = "2"
-			settings.ClusterSettings["server.cpu_profile.cpu_usage_combined_threshold"] = "90"
+			// Note that CPU profiling is already enabled by default, should there be
+			// a failure it will be available in the artifacts.
 			c.Start(ctx, t.L(), startOpts, settings, roachNodes)
 			require.NoError(t, rebalanceByLoad(
 				ctx, t, t.L(), c, rebalanceMode, maxDuration,


### PR DESCRIPTION
After #97699 was resolved, the cpu profiling parameter declaration in the `rebalance/by-load/*` roachtests became redundant.

Remove the declaration and use the default settings instead.

Informs: #133054
Informs: #132633
Informs: #135055
Informs: #135869
Informs: #135811
Informs: #133004
Informs: #135791
Informs: #132019

Release note: None