### PR TITLE
sql: refactor avoid ResolveBlankPaddedChar in writeTextString

### DIFF
--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -102,18 +102,16 @@ func writeTextUUID(b *writeBuffer, v uuid.UUID) {
 }
 
 func writeTextString(b *writeBuffer, s string, t *types.T) {
-	if paddingNeeded([]byte(s), t) {
-		b.writePaddedData([]byte(s), t)
-	} else {
-		b.writeLengthPrefixedString(s)
+	pad := bpcharPadding(len(s), t)
+	b.putInt32(int32(len(s) + pad))
+	b.writeString(s)
+
+	// apply padding (in the form of blanks spaces) to the right of the write buffer
+	for pad > 0 {
+		n := min(pad, len(spaces))
+		b.write(spaces[:n])
+		pad -= n
 	}
-}
-
-func paddingNeeded(v []byte, t *types.T) bool {
-	blankPaddedCharType := t.Oid() == oid.T_bpchar
-	paddingNeeded := len(v) < int(t.Width())
-
-	return blankPaddedCharType && paddingNeeded
 }
 
 func writeTextTimestamp(b *writeBuffer, v time.Time) {
@@ -538,11 +536,24 @@ func writeBinaryBytes(b *writeBuffer, v []byte, t *types.T) {
 		v = []byte{0}
 	}
 
-	if paddingNeeded(v, t) {
-		b.writePaddedData(v, t)
-	} else {
-		b.writeLengthPrefixedByteSlice(v, int32(len(v)))
+	pad := bpcharPadding(len(v), t)
+	b.putInt32(int32(len(v) + pad))
+	b.write(v)
+
+	// apply padding (in the form of blanks spaces) to the right of the write buffer
+	for pad > 0 {
+		n := min(pad, len(spaces))
+		b.write(spaces[:n])
+		pad -= n
 	}
+}
+
+// bpcharPadding returns the number of spaces to pad when writing a BPCHAR datum of length n.
+func bpcharPadding(n int, t *types.T) int {
+	if t.Oid() == oid.T_bpchar && n < int(t.Width()) {
+		return int(t.Width()) - n
+	}
+	return 0
 }
 
 func writeBinaryString(b *writeBuffer, s string, t *types.T) {
@@ -552,11 +563,7 @@ func writeBinaryString(b *writeBuffer, s string, t *types.T) {
 		s = string([]byte{0})
 	}
 
-	if paddingNeeded([]byte(s), t) {
-		b.writePaddedData([]byte(s), t)
-	} else {
-		b.writeLengthPrefixedString(s)
-	}
+	writeTextString(b, s, t)
 }
 
 func writeBinaryTimestamp(b *writeBuffer, v time.Time) {

--- a/pkg/sql/pgwire/write_buffer.go
+++ b/pkg/sql/pgwire/write_buffer.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
@@ -96,42 +95,11 @@ func (b *writeBuffer) writeFromFmtCtx(fmtCtx *tree.FmtCtx) {
 	}
 }
 
-// writePaddedData checks if the data needs to be padded and calls
-// applyPadding. Else it writes the data to the write buffer.
-func (b *writeBuffer) writePaddedData(v []byte, t *types.T) {
-	// Add t.Width() as length prefix.
-	b.writeLengthPrefixedByteSlice(v, t.Width())
-
-	remainingPadLength := int(t.Width()) - len(v)
-	b.applyPadding(remainingPadLength)
-}
-
-// applyPadding applies padding (in the form of blanks spaces)
-// to the right of the values inside the write buffer
-// to fill all the remaining width from t.Width().
-func (b *writeBuffer) applyPadding(remainingPadLength int) {
-	for remainingPadLength > 0 {
-		padChunkLength := min(remainingPadLength, len(spaces))
-
-		padChunk := spaces[:padChunkLength]
-		b.write(padChunk)
-
-		remainingPadLength -= padChunkLength
-	}
-}
-
 // writeLengthPrefixedString writes a length-prefixed string. The
 // length is encoded as an int32.
 func (b *writeBuffer) writeLengthPrefixedString(s string) {
 	b.putInt32(int32(len(s)))
 	b.writeString(s)
-}
-
-// writeLengthPrefixedByteSlice writes a length-prefixed byte slice. The
-// length is encoded as an int32.
-func (b *writeBuffer) writeLengthPrefixedByteSlice(v []byte, specifiedLength int32) {
-	b.putInt32(specifiedLength)
-	b.write(v)
 }
 
 // writeLengthPrefixedDatum writes a length-prefixed Datum in its


### PR DESCRIPTION
This PR https://github.com/cockroachdb/cockroach/pull/135756 was merged with some refactoring changes that should have been done differently.  I am addressing those changes with this PR.

Microbenchmark:
```
                      │   sec/op    │    sec/op     vs base              │
WriteTextColumnarChar   24.87µ ± 1%   22.78µ ± 16%  -8.40% (p=0.024 n=7)

                      │ before.txt │           after.txt           │
                      │    B/op    │    B/op     vs base           │
WriteTextColumnarChar   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=7) ¹
¹ all samples are equal

                      │ before.txt │           after.txt           │
                      │ allocs/op  │ allocs/op   vs base           │
WriteTextColumnarChar   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=7) ¹
```

Sysbench:
```
                                        │     sec/op     │   sec/op     vs base         │
Sysbench/SQL/1node_local/oltp_read_only     2.832m ± 18%   2.693m ± 5%  ~ (p=0.097 n=7)

                                        │ sys_before.txt │           sys_after.txt            │
                                        │      B/op      │     B/op      vs base              │
Sysbench/SQL/1node_local/oltp_read_only     867.5Ki ± 0%   860.8Ki ± 0%  -0.77% (p=0.001 n=7)

                                        │ sys_before.txt │           sys_after.txt           │
                                        │   allocs/op    │  allocs/op   vs base              │
Sysbench/SQL/1node_local/oltp_read_only      4.991k ± 1%   4.952k ± 0%  -0.78% (p=0.006 n=7)
```


Epic: CRDB-42584
Informs: #134336

Release note: None