### PR TITLE
crosscluster/physical: update tokens when altering topology

### DIFF
--- a/pkg/ccl/crosscluster/physical/stream_ingestion_dist_test.go
+++ b/pkg/ccl/crosscluster/physical/stream_ingestion_dist_test.go
@@ -540,7 +540,9 @@ func TestRepartition(t *testing.T) {
 			{p(1, 1, 0), p(2, 1, 0), p(3, 1, 0)},
 			{p(1, 43, 0), p(2, 44, 0), p(3, 38, 0)},
 		} {
-			got := repartitionTopology(streamclient.Topology{Partitions: input}, parts)
+			got, err := repartitionTopology(streamclient.Topology{Partitions: input}, parts)
+
+			require.NoError(t, err)
 
 			var expectedSpans, gotSpans roachpb.Spans
 			for _, part := range input {


### PR DESCRIPTION
Release note: none.
Epic: none.

This regressed in #135637 which was assigning all conusmer sub-partitions the whole partition due to sharing the original token.