### PR TITLE
crosscluster: remove pointless mu

### DIFF
--- a/pkg/ccl/crosscluster/producer/BUILD.bazel
+++ b/pkg/ccl/crosscluster/producer/BUILD.bazel
@@ -64,7 +64,6 @@ go_library(
         "//pkg/util/protoutil",
         "//pkg/util/rangedesc",
         "//pkg/util/span",
-        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "//pkg/util/uuid",


### PR DESCRIPTION
This was needed when we had scan parallelism but we went with processor parallelism instead.

Release note: none.
Epic: none.