### PR TITLE
release-24.3: roachtest: skip backups in sep proc mt upgrade test

### DIFF
--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -117,13 +117,19 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 	mvt := mixedversion.NewTest(testCtx, t, t.L(), c, c.All(), opts...)
 	mvt.InMixedVersion(
-		"run backup",
+		"maybe run backup",
 		func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-			// Verify that backups can be created in various configurations. This is
-			// important to test because changes in system tables might cause backups to
-			// fail in mixed-version clusters.
-			dest := fmt.Sprintf("nodelocal://1/%d", timeutil.Now().UnixNano())
-			return h.Exec(rng, `BACKUP TO $1`, dest)
+			if h.DeploymentMode() != mixedversion.SeparateProcessDeployment {
+				// Verify that backups can be created in various configurations. This is
+				// important to test because changes in system tables might cause backups to
+				// fail in mixed-version clusters.
+				dest := fmt.Sprintf("nodelocal://1/%d", timeutil.Now().UnixNano())
+				return h.Exec(rng, `BACKUP TO $1`, dest)
+			} else {
+				// Skip the backup step in separate-process deployments, since nodelocal
+				// is not supported in pods.
+				return nil
+			}
 		})
 	mvt.InMixedVersion(
 		"test features",


### PR DESCRIPTION
Backport 1/1 commits from #135627.

/cc @cockroachdb/release

---

Separate process tenants do not have nodelocal storage so these backups to nodelocal were never supported.

Fixes: https://github.com/cockroachdb/cockroach/issues/135976
Release note: none.
Epic: none.

Release Justification: Test only change