### PR TITLE
sql: fix panic catching in SHOW HISTOGRAM

### DIFF
--- a/pkg/sql/show_histogram.go
+++ b/pkg/sql/show_histogram.go
@@ -38,7 +38,7 @@ func (p *planner) ShowHistogram(ctx context.Context, n *tree.ShowHistogram) (pla
 		name:    fmt.Sprintf("SHOW HISTOGRAM %d", n.HistogramID),
 		columns: showHistogramColumns,
 
-		constructor: func(ctx context.Context, p *planner) (planNode, error) {
+		constructor: func(ctx context.Context, p *planner) (_ planNode, err error) {
 			row, err := p.InternalSQLTxn().QueryRowEx(
 				ctx,
 				"read-histogram",


### PR DESCRIPTION
This commit fixes an oversight in #135944 where an error from catching a panic in `SHOW HISTOGRAM` was not correctly propagated.

Informs #135940

Release note: None