### PR TITLE
colflow: skip TestVectorizedFlowDeadlocksWhenSpilling under duress

### DIFF
--- a/pkg/sql/colflow/vectorized_flow_deadlock_test.go
+++ b/pkg/sql/colflow/vectorized_flow_deadlock_test.go
@@ -31,7 +31,7 @@ func TestVectorizedFlowDeadlocksWhenSpilling(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.UnderStress(t, "the query might take longer than timeout under stress making the test flaky")
+	skip.UnderDuress(t, "the query might take longer than timeout under duress making the test flaky")
 
 	vecFDsLimit := 8
 	envutil.TestSetEnv(t, "COCKROACH_VEC_MAX_OPEN_FDS", strconv.Itoa(vecFDsLimit))


### PR DESCRIPTION
This commit changes the skip in the test from stress to duress. By its nature, the test contains a race (between the context cancellation that happens on a 1 minute timeout and the retry mechanism in acquiring the file descriptor quota in the vectorized disk spilling), so in extreme cases the test can flake when the node is overloaded. We bumped the timeout from 10s to 1m in 9734625148d612d6a48b831f2aa6071100f8ab05 and still just saw another flake, so let's just run the test in normal config (which is acceptable for this test).

Fixes: #136104.

Release note: None