### PR TITLE
workload: mark repair-order-ids tpcc flag as runtime only

### DIFF
--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -263,7 +263,7 @@ var tpccMeta = workload.Meta{
 			`conns`:                    {RuntimeOnly: true},
 			`idle-conns`:               {RuntimeOnly: true},
 			`txn-retries`:              {RuntimeOnly: true},
-			`order-id-repairs`:         {RuntimeOnly: true},
+			`repair-order-ids`:         {RuntimeOnly: true},
 			`expensive-checks`:         {RuntimeOnly: true, CheckConsistencyOnly: true},
 			`local-warehouses`:         {RuntimeOnly: true},
 			`regions`:                  {RuntimeOnly: true},


### PR DESCRIPTION
This means the default value will be hidden when a cmd is generated, which
prevents backward incompatibility.

Fixes https://github.com/cockroachdb/cockroach/issues/135677
Fixes https://github.com/cockroachdb/cockroach/issues/135785

Release note: none