### PR TITLE
roachtest: route schema change workload flakes to foundations

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 )
 
 var (
@@ -250,7 +251,7 @@ func startBackgroundWorkloads(
 	}
 	err = c.RunE(ctx, option.WithNodes(workloadNode), scInit.String())
 	if err != nil {
-		return nil, err
+		return nil, registry.ErrorWithOwner(registry.OwnerSQLFoundations, errors.Wrapf(err, "failed to init schema change workload"))
 	}
 
 	run := func() (func(), error) {
@@ -267,7 +268,10 @@ func startBackgroundWorkloads(
 			return c.RunE(ctx, option.WithNodes(workloadNode), tpccRun.String())
 		})
 		stopSC := workloadWithCancel(m, func(ctx context.Context) error {
-			return c.RunE(ctx, option.WithNodes(workloadNode), scRun.String())
+			if err := c.RunE(ctx, option.WithNodes(workloadNode), scRun.String()); err != nil {
+				return registry.ErrorWithOwner(registry.OwnerSQLFoundations, errors.Wrapf(err, "failed to run schema change workload"))
+			}
+			return nil
 		})
 
 		stopSystemWriter := workloadWithCancel(m, func(ctx context.Context) error {


### PR DESCRIPTION
About once a week or so, some backup-restore roachtest flakes on the schema change workload. This patch routes these flakes directly to foundations.

Epic: none

Release note: none