### PR TITLE
randgen: limit random vector dimensions to 50 in race builds

### DIFF
--- a/pkg/util/vector/vector.go
+++ b/pkg/util/vector/vector.go
@@ -271,9 +271,10 @@ func Mult(t T, t2 T) (T, error) {
 	return ret, nil
 }
 
-// Random returns a random vector.
-func Random(rng *rand.Rand) T {
-	n := 1 + rng.Intn(1000)
+// Random returns a random vector with the number of dimensions in [1, maxDim]
+// range.
+func Random(rng *rand.Rand, maxDim int) T {
+	n := 1 + rng.Intn(maxDim)
 	v := make(T, n)
 	for i := range v {
 		for {

--- a/pkg/util/vector/vector_test.go
+++ b/pkg/util/vector/vector_test.go
@@ -66,7 +66,7 @@ func TestParseVector(t *testing.T) {
 func TestRoundtripRandomPGVector(t *testing.T) {
 	rng, _ := randutil.NewTestRand()
 	for i := 0; i < 1000; i++ {
-		v := Random(rng)
+		v := Random(rng, 1000 /* maxDim */)
 		encoded, err := Encode(nil, v)
 		assert.NoError(t, err)
 		roundtripped, err := Decode(encoded)


### PR DESCRIPTION
Previously, we would use 1000 as the maximum number of dimensions for random vectors. However, we just saw a test failure under race where vectorized cast between vector and collated string type took prohibitively long, leading to a timeout, so this commit reduces the max number of dimensions to 50 under race (significantly speeding up that test).

Fixes: #136086.

Release note: None