### PR TITLE
vecstore: store improvements and bug fixes

### DIFF
--- a/pkg/cmd/vecbench/main.go
+++ b/pkg/cmd/vecbench/main.go
@@ -247,12 +247,12 @@ func downloadDataset(ctx context.Context, datasetName string) {
 
 	// Use progressWriter to track download progress
 	var buf bytes.Buffer
-	progressWriter := &progressWriter{
+	writer := &progressWriter{
 		Writer: &buf,
 		Total:  attrs.Size,
 	}
 
-	if _, err = io.Copy(progressWriter, reader); err != nil {
+	if _, err = io.Copy(writer, reader); err != nil {
 		log.Fatalf("Failed to copy object data: %v", err)
 	}
 
@@ -347,15 +347,6 @@ func buildIndex(ctx context.Context, datasetName string) {
 	if err != nil {
 		panic(err)
 	}
-
-	// Insert empty root partition.
-	func() {
-		txn := beginTransaction(ctx, store)
-		defer commitTransaction(ctx, store, txn)
-		if err := index.CreateRoot(ctx, txn); err != nil {
-			panic(err)
-		}
-	}()
 
 	// Create unique primary key for each vector in a single large byte buffer.
 	primaryKeys := make([]byte, data.Train.Count*4)

--- a/pkg/cmd/vecbench/main.go
+++ b/pkg/cmd/vecbench/main.go
@@ -430,13 +430,12 @@ func loadStore(fileName string) *vecstore.InMemoryStore {
 		panic(err)
 	}
 
-	var inMemStore vecstore.InMemoryStore
-	err = inMemStore.UnmarshalBinary(data)
+	inMemStore, err := vecstore.LoadInMemoryStore(data)
 	if err != nil {
 		panic(err)
 	}
 
-	return &inMemStore
+	return inMemStore
 }
 
 // loadDataset deserializes a dataset saved as a gob file.

--- a/pkg/sql/vecindex/fixup_processor.go
+++ b/pkg/sql/vecindex/fixup_processor.go
@@ -89,6 +89,9 @@ type fixupProcessor struct {
 
 		// pendingVectors tracks pending fixups for deleting vectors.
 		pendingVectors map[string]bool
+
+		// waitForFixups broadcasts to any waiters when all fixups are processed.
+		waitForFixups sync.Cond
 	}
 
 	// --------------------------------------------------
@@ -100,10 +103,6 @@ type fixupProcessor struct {
 	// fixupsLimitHit prevents flooding the log with warning messages when the
 	// maxFixups limit has been reached.
 	fixupsLimitHit log.EveryN
-
-	// pendingCount tracks the number of pending fixups that still need to be
-	// processed.
-	pendingCount sync.WaitGroup
 
 	// --------------------------------------------------
 	// The following fields should only be accessed on a single background
@@ -135,6 +134,7 @@ func (fp *fixupProcessor) Init(index *VectorIndex, seed int64) {
 	}
 	fp.mu.pendingPartitions = make(map[partitionFixupKey]bool, maxFixups)
 	fp.mu.pendingVectors = make(map[string]bool, maxFixups)
+	fp.mu.waitForFixups.L = &fp.mu
 	fp.fixups = make(chan fixup, maxFixups)
 	fp.fixupsLimitHit = log.Every(time.Second)
 }
@@ -197,7 +197,11 @@ func (fp *fixupProcessor) Start(ctx context.Context) {
 // Wait blocks until all pending fixups have been processed by the background
 // goroutine. This is useful in testing.
 func (fp *fixupProcessor) Wait() {
-	fp.pendingCount.Wait()
+	fp.mu.Lock()
+	defer fp.mu.Unlock()
+	for len(fp.mu.pendingVectors) > 0 || len(fp.mu.pendingPartitions) > 0 {
+		fp.mu.waitForFixups.Wait()
+	}
 }
 
 // runAll processes all fixups in the queue. This should only be called by tests
@@ -270,9 +274,6 @@ func (fp *fixupProcessor) run(ctx context.Context, wait bool) (ok bool, err erro
 	fp.mu.Lock()
 	defer fp.mu.Unlock()
 
-	// Decrement the number of pending fixups.
-	fp.pendingCount.Done()
-
 	switch next.Type {
 	case splitFixup, mergeFixup:
 		key := partitionFixupKey{Type: next.Type, PartitionKey: next.PartitionKey}
@@ -280,6 +281,11 @@ func (fp *fixupProcessor) run(ctx context.Context, wait bool) (ok bool, err erro
 
 	case vectorDeleteFixup:
 		delete(fp.mu.pendingVectors, string(next.VectorKey))
+	}
+
+	// If there are no more pending fixups, notify any waiters.
+	if len(fp.mu.pendingPartitions) == 0 && len(fp.mu.pendingVectors) == 0 {
+		fp.mu.waitForFixups.Broadcast()
 	}
 
 	return true, err
@@ -318,9 +324,6 @@ func (fp *fixupProcessor) addFixup(ctx context.Context, fixup fixup) {
 	default:
 		panic(errors.AssertionFailedf("unknown fixup %d", fixup.Type))
 	}
-
-	// Increment the number of pending fixups.
-	fp.pendingCount.Add(1)
 
 	// Note that the channel send operation should never block, since it has
 	// maxFixups capacity.

--- a/pkg/sql/vecindex/vecstore/in_memory_store_test.go
+++ b/pkg/sql/vecindex/vecstore/in_memory_store_test.go
@@ -413,8 +413,7 @@ func TestInMemoryStoreMarshalling(t *testing.T) {
 	data, err := store.MarshalBinary()
 	require.NoError(t, err)
 
-	var store2 InMemoryStore
-	err = store2.UnmarshalBinary(data)
+	store2, err := LoadInMemoryStore(data)
 	require.NoError(t, err)
 
 	require.Len(t, store2.mu.partitions, 2)

--- a/pkg/sql/vecindex/vector_index.go
+++ b/pkg/sql/vecindex/vector_index.go
@@ -199,18 +199,6 @@ func (vi *VectorIndex) ProcessFixups() {
 	vi.fixups.Wait()
 }
 
-// CreateRoot creates an empty root partition in the store. This should only be
-// called once when the index is first created.
-func (vi *VectorIndex) CreateRoot(ctx context.Context, txn vecstore.Txn) error {
-	// Use the UnQuantizer because vectors in the root are not quantized.
-	dims := vi.rootQuantizer.GetRandomDims()
-	vectors := vector.MakeSet(dims)
-	rootQuantizedSet := vi.rootQuantizer.Quantize(ctx, &vectors)
-	rootPartition := vecstore.NewPartition(
-		vi.rootQuantizer, rootQuantizedSet, []vecstore.ChildKey{}, vecstore.LeafLevel)
-	return vi.store.SetRootPartition(ctx, txn, rootPartition)
-}
-
 // Insert adds a new vector with the given primary key to the index. This is
 // called within the scope of a transaction so that the index does not appear to
 // change during the insert.

--- a/pkg/sql/vecindex/vector_index_test.go
+++ b/pkg/sql/vecindex/vector_index_test.go
@@ -129,11 +129,6 @@ func (s *testState) NewIndex(d *datadriven.TestData) string {
 	s.Index, err = NewVectorIndex(s.Ctx, s.InMemStore, s.Quantizer, &s.Options, stopper)
 	require.NoError(s.T, err)
 
-	// Insert empty root partition.
-	txn := beginTransaction(s.Ctx, s.T, s.InMemStore)
-	require.NoError(s.T, s.Index.CreateRoot(s.Ctx, txn))
-	commitTransaction(s.Ctx, s.T, s.InMemStore, txn)
-
 	// Insert initial vectors.
 	return s.Insert(d)
 }


### PR DESCRIPTION
1. When a new index is created, expect the store to create an empty root
partition. While the root partition can be updated, it can never be
deleted.

2. Replace the InMemoryStore UnmarshalBinary member function with a
LoadInMemoryStore function in order to avoid bugs where unmarshaling is
attempted on an already-initialized store.

3. Fix bug where fixupProcessor.Wait can panic when there are multiple
goroutines waiting for all fixups to be processed. Switch to a sync.Cond
to support that case.

Epic: CRDB-42943

Release note: None