### PR TITLE
crosscluster/physical: skip replicate manual split

### DIFF
--- a/pkg/ccl/crosscluster/physical/replication_stream_e2e_test.go
+++ b/pkg/ccl/crosscluster/physical/replication_stream_e2e_test.go
@@ -579,6 +579,8 @@ func TestReplicateManualSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.WithIssue(t, 135968, "flaky test")
+
 	ctx := context.Background()
 	c, cleanup := replicationtestutils.CreateTenantStreamingClusters(ctx, t, replicationtestutils.DefaultTenantStreamingClustersArgs)
 	defer cleanup()


### PR DESCRIPTION
Informs #135968

We don't use this feature anyway.

Release note: none