### PR TITLE
ui: sync metric presets with query params

### DIFF
--- a/pkg/cmd/dev/testdata/datadriven/ui
+++ b/pkg/cmd/dev/testdata/datadriven/ui
@@ -3,7 +3,7 @@ dev ui watch
 ----
 bazel info workspace --color=no
 pnpm --dir crdb-checkout/pkg/ui install
-bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui-lib //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl-lib
+bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui-lib //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl-lib //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client_files //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl_files //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
 bazel info bazel-bin --color=no
 bazel info workspace --color=no
 cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.js
@@ -37,7 +37,7 @@ dev ui watch --secure
 ----
 bazel info workspace --color=no
 pnpm --dir crdb-checkout/pkg/ui install
-bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui-lib //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl-lib
+bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui-lib //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl-lib //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client_files //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl_files //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
 bazel info bazel-bin --color=no
 bazel info workspace --color=no
 cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.js
@@ -55,7 +55,7 @@ dev ui watch --db http://example.crdb.io:4848
 ----
 bazel info workspace --color=no
 pnpm --dir crdb-checkout/pkg/ui install
-bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui-lib //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl-lib
+bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui-lib //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl-lib //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client_files //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl_files //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
 bazel info bazel-bin --color=no
 bazel info workspace --color=no
 cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.js
@@ -73,7 +73,7 @@ dev ui watch --port 12345
 ----
 bazel info workspace --color=no
 pnpm --dir crdb-checkout/pkg/ui install
-bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui-lib //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl-lib
+bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui-lib //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl-lib //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client_files //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl_files //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
 bazel info bazel-bin --color=no
 bazel info workspace --color=no
 cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.js
@@ -91,7 +91,7 @@ dev ui watch --cluster-ui-dst /path/to/foo --cluster-ui-dst /path/to/bar
 ----
 bazel info workspace --color=no
 pnpm --dir crdb-checkout/pkg/ui install
-bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui-lib //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl-lib
+bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui-lib //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl-lib //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client_files //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl_files //pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl
 bazel info bazel-bin --color=no
 bazel info workspace --color=no
 cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.js

--- a/pkg/cmd/dev/ui.go
+++ b/pkg/cmd/dev/ui.go
@@ -312,6 +312,10 @@ Replaces 'make ui-watch'.`,
 			}
 			if !isOss {
 				args = append(args, "//pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl-lib")
+				args = append(args, "//pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client_files")
+				args = append(args, "//pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client")
+				args = append(args, "//pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl_files")
+				args = append(args, "//pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl")
 			}
 			logCommand("bazel", args...)
 			err = d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScaleDropdown.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScaleDropdown.spec.tsx
@@ -153,7 +153,12 @@ describe("<TimeScaleDropdown> component", function () {
         name: "next time interval",
       }),
     );
-    expect(mockSetTimeScale).toHaveBeenCalledTimes(2);
+    userEvent.click(
+      getByRole("button", {
+        name: "next time interval",
+      }),
+    );
+    expect(mockSetTimeScale).toHaveBeenCalledTimes(3);
     getByText("Past Hour");
   });
 

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScaleDropdown.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeScaleDropdown.tsx
@@ -162,70 +162,61 @@ export const TimeScaleDropdown: React.FC<TimeScaleDropdownProps> = ({
     );
 
     const seconds = windowSize.asSeconds();
-    let selected = {};
     let key = currentScale.key;
     let endTime = moment.utc(currentWindow.end);
     // Dynamic moving window should be off unless the window extends to the current time.
     let isMoving = false;
 
-    const now = moment.utc();
     switch (direction) {
       case ArrowDirection.RIGHT:
         endTime = endTime.add(seconds, "seconds");
+        key = "Custom";
         break;
       case ArrowDirection.LEFT:
         endTime = endTime.subtract(seconds, "seconds");
+        key = "Custom";
         break;
       case ArrowDirection.CENTER:
-        // CENTER is used to set the time window to the current time.
-        endTime = now;
-        // Only predefined time ranges are considered to be moving window (ie Past Hour, Past 3 days, etc).
-        // Custom time window has specific start/end time and constant duration, and in this case we
-        // move time window with the same duration with end time = now() and keep it fixed as before.
-        if (key !== "Custom") {
-          isMoving = true;
-        }
+        // Clicking `NOW` always makes the metric view become live.
+        isMoving = true;
+
+        key = Object.keys(defaultTimeScaleOptions).reduce(
+          (closest, current) => {
+            const currentDiff = Math.abs(
+              defaultTimeScaleOptions[current].windowSize.asSeconds() -
+                windowSize.asSeconds(),
+            );
+            const closestDiff = Math.abs(
+              defaultTimeScaleOptions[closest].windowSize.asSeconds() -
+                windowSize.asSeconds(),
+            );
+            return currentDiff < closestDiff ? current : closest;
+          },
+        );
         break;
       default:
         getLogger().error("Unknown direction: ", direction);
     }
 
-    // If the timescale extends into the future then fallback to a default
-    // timescale. Otherwise set the key to "Custom" so it appears correctly.
-    // If endTime + windowValid > now. Unclear why this uses windowValid instead of windowSize.
-    if (endTime.isSameOrAfter(now.subtract(currentScale.windowValid))) {
-      const foundTimeScale = Object.entries(options).find(
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        ([_, value]) => value.windowSize.asSeconds() === windowSize.asSeconds(),
-      );
-      if (foundTimeScale) {
-        /**
-         * This code can be hit by:
-         *  - Select a default option, then click the left arrow, then click the right arrow.
-         * This (or the parent if block) is *not* hit by:
-         *  - Select a default time, click left, select a custom time of the same range, then click right. The arrow is
-         *    not disabled, but the clause doesn't seem to be true.
-         */
-        selected = { key: foundTimeScale[0], ...foundTimeScale[1] };
-        isMoving = true;
-      } else {
-        // This code might not be possible to hit, due to the right arrow being disabled
-        key = "Custom";
-      }
+    let timeScale: TimeScale;
+    if (isMoving) {
+      timeScale = {
+        ...defaultTimeScaleOptions[key],
+        key: key,
+        fixedWindowEnd: false,
+      };
     } else {
-      key = "Custom";
+      timeScale = {
+        ...currentScale,
+        fixedWindowEnd: endTime,
+        windowSize,
+        key,
+      };
+      if (adjustTimeScaleOnChange) {
+        timeScale = adjustTimeScaleOnChange(timeScale, currentWindow);
+      }
     }
 
-    let timeScale: TimeScale = {
-      ...currentScale,
-      fixedWindowEnd: isMoving ? false : endTime,
-      windowSize,
-      key,
-      ...selected,
-    };
-    if (adjustTimeScaleOnChange) {
-      timeScale = adjustTimeScaleOnChange(timeScale, currentWindow);
-    }
     setTimeScale(timeScale);
   };
 

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/timeScaleDropdownWithSearchParams/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/timeScaleDropdownWithSearchParams/index.tsx
@@ -12,7 +12,7 @@ import {
   findClosestTimeScale,
 } from "@cockroachlabs/cluster-ui";
 import moment from "moment-timezone";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
 import { useHistory } from "react-router-dom";
 import { createSelector } from "reselect";
@@ -21,15 +21,65 @@ import { PayloadAction } from "src/interfaces/action";
 import { AdminUIState } from "src/redux/state";
 import * as timewindow from "src/redux/timeScale";
 
+// toQueryParamTimescale converts a preset name to a query param
+// format, replacing spaces with dashes.
+function toQueryParamTimescale(str: string): string {
+  return str.toLowerCase().replace(/\s+/g, "-");
+}
+
+const findPreset = (s: string): string | undefined => {
+  return Object.keys(defaultTimeScaleOptions).find(key => {
+    if (toQueryParamTimescale(key) === s) {
+      return defaultTimeScaleOptions[key];
+    }
+  });
+};
+
 // The time scale dropdown from cluster-ui that updates route params as
 // options are selected.
+// The query params formats we support are the following:
+//   `?start=unix_timestamp&end=unix_timestamp`
+//   `?preset=string`
+//
+// When the component is loaded, we will inspect the query params and
+// populate the time scale dropdown. If the user manipulates the
+// component and modifies items, the query params will be sync-ed.
 const TimeScaleDropdownWithSearchParams = (
   props: TimeScaleDropdownProps,
 ): React.ReactElement => {
   const history = useHistory();
 
+  // `queryParamsRead` tracks whether this component has synced state
+  // from the location bar's query params. We do this on initial mount
+  // just once. Once done, we make sure that future redux store updates
+  // get pushed to the query params. This prevents confusion about
+  // bi-directional updates. Any component outside of this one can just
+  // update redux state and the query params will sync.
+  const [queryParamsRead, setQueryParamsRead] = useState(false);
+
   useEffect(() => {
-    const setDatesByQueryParams = (dates: Partial<TimeWindow>) => {
+    if (queryParamsRead) {
+      return;
+    }
+    const setDatesByQueryParams = (
+      dates?: Partial<TimeWindow>,
+      preset?: string,
+    ) => {
+      if (preset) {
+        const presetTimescale = findPreset(preset);
+        if (!presetTimescale) {
+          return;
+        }
+        const presetOption = defaultTimeScaleOptions[presetTimescale];
+
+        props.setTimeScale({
+          ...presetOption,
+          key: presetTimescale,
+          fixedWindowEnd: false,
+        });
+        return;
+      }
+
       const now = moment.utc();
       // `currentWindow` is derived from `scale`, and does not have to do with the `currentWindow` for the metrics page.
       const currentWindow: TimeWindow = {
@@ -76,41 +126,69 @@ const TimeScaleDropdownWithSearchParams = (
     const urlSearchParams = new URLSearchParams(history.location.search);
     const queryStart = urlSearchParams.get("start");
     const queryEnd = urlSearchParams.get("end");
+    const preset = urlSearchParams.get("preset");
 
-    // Only set the timescale if the url params exist.
-    if (queryStart !== null && queryEnd !== null) {
-      const start = queryStart && moment.unix(Number(queryStart)).utc();
-      const end = queryEnd && moment.unix(Number(queryEnd)).utc();
+    if (queryStart && queryEnd) {
+      const start = moment.unix(Number(queryStart)).utc();
+      const end = moment.unix(Number(queryEnd)).utc();
       setDatesByQueryParams({ start, end });
+    } else if (preset) {
+      setDatesByQueryParams({}, preset);
+    } else {
+      // Set query params from the redux store if there aren't any
+      // present in the URL.
+      onTimeScaleChange(props.currentScale);
     }
 
+    setQueryParamsRead(true);
     // Passing an empty array of dependencies will cause this effect
     // to only run on the initial render.
     /* eslint react-hooks/exhaustive-deps: "off" */
   }, []);
 
+  // This will get triggered if the redux store updates the
+  // currentScale, we sync the query params to match.
+  useEffect(() => {
+    if (queryParamsRead) {
+      onTimeScaleChange(props.currentScale);
+    }
+  }, [props.currentScale]);
+
   const onTimeScaleChange = (timeScale: TimeScale) => {
+    if (!timeScale.fixedWindowEnd) {
+      const preset = findClosestTimeScale(
+        defaultTimeScaleOptions,
+        timeScale.windowSize.asSeconds(),
+      ).key;
+      const { pathname, search } = history.location;
+      const urlParams = new URLSearchParams(search);
+      urlParams.set("preset", toQueryParamTimescale(preset));
+      urlParams.delete("start");
+      urlParams.delete("end");
+      history.push({
+        pathname,
+        search: urlParams.toString(),
+      });
+    } else {
+      const duration = timeScale.windowSize;
+      const dateEnd = timeScale.fixedWindowEnd || moment.utc();
+      const { pathname, search } = history.location;
+      const urlParams = new URLSearchParams(search);
+      const seconds = duration.clone().asSeconds();
+      const end = dateEnd.clone();
+      const start = moment.utc(end).subtract(seconds, "seconds").format("X");
+      urlParams.set("start", start);
+      urlParams.set("end", moment.utc(dateEnd).format("X"));
+      urlParams.delete("preset");
+      history.push({
+        pathname,
+        search: urlParams.toString(),
+      });
+    }
+
+    // Pushes changes to the session storage.
     props.setTimeScale(timeScale);
   };
-
-  useEffect(() => {
-    // When history or props change, this effect will
-    // convert the start and end of the current time scale and
-    // write them to the URL as query params.
-    const duration = props.currentScale.windowSize;
-    const dateEnd = props.currentScale.fixedWindowEnd || moment.utc();
-    const { pathname, search } = history.location;
-    const urlParams = new URLSearchParams(search);
-    const seconds = duration.clone().asSeconds();
-    const end = dateEnd.clone();
-    const start = moment.utc(end).subtract(seconds, "seconds").format("X");
-    urlParams.set("start", start);
-    urlParams.set("end", moment.utc(dateEnd).format("X"));
-    history.push({
-      pathname,
-      search: urlParams.toString(),
-    });
-  }, [history, props]);
 
   return <TimeScaleDropdown {...props} setTimeScale={onTimeScaleChange} />;
 };


### PR DESCRIPTION
Previously, metric timescale preset like "Past 1 Hour or "Past 2 Days"
could not be effectively modeled in the query params which capture the
timescale dropdown state. As a result, copy-pasting a live view
wouldn't work, and clicking the "Now" button wouldn't make the view
snap to an appropriate lookback period.

This change adds this functionality and modifies the behavior of the
"Now" button to better match what most people expect. Now, when a
preset a selected, the query parms will appropriately update to hold
`?preset=past-6-hours` for instance.

Code was modified in 2 places:

1. The `TimeScaleDropdownWithSearchParams` component now fully owns
the query param state. It syncs "down" from it at initial render just
once to grab whatever params were requested in the URL if any. After
that, it only syncs in the other direction based on updates to the
redux state. This naturally syncs updates from the "drag-to-zoom"
callback on the line graph, for example.

2. The `TimeScaleDropdown` component interprets the "Now" button
differently. Clicking it will force the selection of the closest
preset interval matching the currently open one.

Resolves: https://github.com/cockroachdb/cockroach/issues/131112
Epic: None

Release note (ui change): Copy-pasting links to preset timescale
views on the DB Console metrics page will now reflect those presets
accurately (i.e. a URL looking at "last 6 hours" will always show the
last 6 hours and update automatically). Clicking the "Now" button on
the Metrics page will automatically select the live updating preset
most closely matching the current inverval. If you are viewing an
arbitrary 4 hour interval, the "last 6 hours" preset will be selected.