### PR TITLE
kvserver: unset TruncatedState in snapshots

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -3258,16 +3258,6 @@ func (r *Replica) followerSendSnapshot(
 	defer snap.Close()
 	log.Event(ctx, "generated snapshot")
 
-	// We avoid shipping over the past Raft log in the snapshot by changing the
-	// truncated state (we're allowed to -- it's an unreplicated key and not
-	// subject to mapping across replicas). The actual sending happens in
-	// kvBatchSnapshotStrategy.Send and results in no log entries being sent at
-	// all. Note that Metadata.Index is really the applied index of the replica.
-	snap.State.TruncatedState = &kvserverpb.RaftTruncatedState{
-		Index: kvpb.RaftIndex(snap.RaftSnap.Metadata.Index),
-		Term:  kvpb.RaftTerm(snap.RaftSnap.Metadata.Term),
-	}
-
 	// See comment on DeprecatedUsingAppliedStateKey for why we need to set this
 	// explicitly for snapshots going out to followers.
 	snap.State.DeprecatedUsingAppliedStateKey = true

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -342,10 +342,15 @@ func snapshot(
 		return OutgoingSnapshot{}, errors.Mark(errors.Errorf("couldn't find range descriptor"), errMarkSnapshotError)
 	}
 
+	// TODO(sep-raft-log): do not load the state that is not useful for sending
+	// snapshots, e.g. RaftTruncatedState.
 	state, err := rsl.Load(ctx, snap, &desc)
 	if err != nil {
 		return OutgoingSnapshot{}, err
 	}
+	// There is no need in sending TruncatedState because the receiver assigns it
+	// to match snap.RaftSnap.Metadata.{Index,Term}. See (*Replica).applySnapshot.
+	state.TruncatedState = nil
 
 	return OutgoingSnapshot{
 		EngineSnap: snap,


### PR DESCRIPTION
The snapshot handling code in `applySnapshot` already [uses](https://github.com/cockroachdb/cockroach/blob/cc4e3469ddca4c83f9bf0a1c3a7cd3c0a641dcde/pkg/kv/kvserver/replica_raftstorage.go#L843-L851) the snapshot metadata `{Index,Term}` to set the `TruncatedState`, so sending one in a snapshot is not necessary.

This also removes one dependency before `TruncatedState` moves out of `ReplicaState`.

Part of #97613