### PR TITLE
crosscluster: prevent DROP statements from running on LDR tables

### DIFF
--- a/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
@@ -706,16 +706,19 @@ func TestRandomTables(t *testing.T) {
 
 	sqlA := s.SQLConn(t, serverutils.DBName("a"))
 
-	tableName := "rand_table"
+	var tableName, streamStartStmt string
 	rng, _ := randutil.NewPseudoRand()
 
-	streamStartStmt := fmt.Sprintf("CREATE LOGICAL REPLICATION STREAM FROM TABLE %[1]s ON $1 INTO TABLE %[1]s", tableName)
 	dbAURL, cleanup := s.PGUrl(t, serverutils.DBName("a"))
 	defer cleanup()
 
 	// Keep retrying until the random table satisfies all the static checks
 	// we make when creating the replication stream.
+	var i int
 	for {
+		tableName = fmt.Sprintf("rand_table_%d", i)
+		streamStartStmt = fmt.Sprintf("CREATE LOGICAL REPLICATION STREAM FROM TABLE %[1]s ON $1 INTO TABLE %[1]s", tableName)
+		i++
 		createStmt := randgen.RandCreateTableWithName(
 			ctx,
 			rng,
@@ -731,8 +734,6 @@ func TestRandomTables(t *testing.T) {
 		err := runnerB.DB.QueryRowContext(ctx, streamStartStmt, dbAURL.String()).Scan(&jobBID)
 		if err != nil {
 			t.Log(err)
-			runnerA.Exec(t, fmt.Sprintf("DROP TABLE %s", tableName))
-			runnerB.Exec(t, fmt.Sprintf("DROP TABLE %s", tableName))
 			continue
 		}
 
@@ -2002,8 +2003,17 @@ func TestUserDefinedTypes(t *testing.T) {
 			dbB.CheckQueryResults(t, "SELECT * FROM data", [][]string{{"1", "one", "(3,cat)"}, {"2", "two", "(4,dog)"}})
 			dbA.CheckQueryResults(t, "SELECT * FROM data", [][]string{{"1", "one", "(3,cat)"}, {"2", "two", "(4,dog)"}})
 
+			var jobBID jobspb.JobID
+			dbB.QueryRow(t,
+				"SELECT job_id FROM [SHOW JOBS]"+
+					"WHERE job_type = 'REPLICATION STREAM PRODUCER' "+
+					"AND status = 'running' "+
+					"AND description = 'History Retention for Logical Replication of data'",
+			).Scan(&jobBID)
+
 			dbA.Exec(t, "CANCEL JOB $1", jobAID)
 			jobutils.WaitForJobToCancel(t, dbA, jobAID)
+			jobutils.WaitForJobToFail(t, dbB, jobBID)
 
 			dbA.Exec(t, "DROP TABLE data")
 			dbB.Exec(t, "DROP TABLE data")
@@ -2256,6 +2266,12 @@ func TestLogicalReplicationCreationChecks(t *testing.T) {
 	dbA.ExpectErr(t,
 		"this schema change is disallowed on table tab because it is referenced by one or more logical replication jobs",
 		"CREATE UNIQUE INDEX unique_idx ON tab(composite_col)",
+	)
+
+	// Dropping the table is blocked.
+	dbA.ExpectErr(t,
+		"this schema change is disallowed on table tab because it is referenced by one or more logical replication jobs",
+		"DROP TABLE tab",
 	)
 
 	// Creating triggers is also blocked.

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -71,6 +71,10 @@ func (p *planner) DropTable(ctx context.Context, n *tree.DropTable) (planNode, e
 
 	for _, toDel := range td {
 		droppedDesc := toDel.desc
+		// Disallow the DROP if this table's schema is locked.
+		if err := checkSchemaChangeIsAllowed(droppedDesc, n); err != nil {
+			return nil, err
+		}
 		for _, fk := range droppedDesc.InboundForeignKeys() {
 			if _, ok := td[fk.GetOriginTableID()]; !ok {
 				if err := p.canRemoveFKBackreference(ctx, droppedDesc.Name, fk, n.DropBehavior); err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/schema_locked
+++ b/pkg/sql/logictest/testdata/logic_test/schema_locked
@@ -32,6 +32,9 @@ t  CREATE TABLE public.t (
    ) WITH (schema_locked = true)
 
 statement ok
+ALTER TABLE t RESET (schema_locked)
+
+statement ok
 DROP TABLE t;
 
 # This subtest ensures storage parameter "schema_locked" can only be set/reset
@@ -58,6 +61,9 @@ ALTER TABLE t SET (schema_locked=f);
 
 statement ok
 ROLLBACK
+
+statement ok
+ALTER TABLE t RESET (schema_locked)
 
 statement ok
 DROP TABLE t
@@ -116,6 +122,9 @@ statement ok
 COMMENT ON TABLE t IS 't is a table';
 COMMENT ON INDEX t@idx IS 'idx is an index';
 COMMENT ON COLUMN t.i IS 'i is a column';
+
+statement ok
+ALTER TABLE t RESET (schema_locked)
 
 statement ok
 DROP TABLE t;

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_table.go
@@ -32,6 +32,7 @@ func DropTable(b BuildCtx, n *tree.DropTable) {
 			b.MarkNameAsNonExistent(name)
 			continue
 		}
+		panicIfSchemaChangeIsDisallowed(elts, n)
 		// Mutate the AST to have the fully resolved name from above, which will be
 		// used for both event logging and errors.
 		name.ObjectNamePrefix = b.NamePrefix(tbl)

--- a/pkg/sql/sem/tree/schema_helpers_test.go
+++ b/pkg/sql/sem/tree/schema_helpers_test.go
@@ -74,6 +74,10 @@ func TestIsAllowedLDRSchemaChange(t *testing.T) {
 			stmt:      "ALTER TABLE t RESET (ttl, ttl_expiration_expression)",
 			isAllowed: false,
 		},
+		{
+			stmt:      "DROP TABLE t",
+			isAllowed: false,
+		},
 	} {
 		t.Run(tc.stmt, func(t *testing.T) {
 			stmt, err := parser.ParseOne(tc.stmt)


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/134743
Release note (bug fix): A table that is participating in a logical replication stream can no longer be dropped. Previously this was allowed, which would cause all the replicated rows to end up in the dead-letter queue.