### PR TITLE
workload: handle timestamp native type in CSV writer and a benchmark

### DIFF
--- a/pkg/workload/BUILD.bazel
+++ b/pkg/workload/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/sql/memsize",
         "//pkg/sql/types",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",

--- a/pkg/workload/bench_test.go
+++ b/pkg/workload/bench_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/memsize"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
@@ -24,9 +25,9 @@ func columnByteSize(col *coldata.Vec) int64 {
 	case types.IntFamily:
 		switch t.Width() {
 		case 0, 64:
-			return int64(len(col.Int64()) * 8)
+			return int64(len(col.Int64())) * memsize.Int64
 		case 16:
-			return int64(len(col.Int16()) * 2)
+			return int64(len(col.Int16())) * memsize.Int16
 		default:
 			panic(fmt.Sprintf("unexpected int width: %d", t.Width()))
 		}
@@ -35,6 +36,8 @@ func columnByteSize(col *coldata.Vec) int64 {
 	case types.BytesFamily:
 		// We subtract the overhead to be in line with Int64 and Float64 cases.
 		return col.Bytes().Size() - coldata.FlatBytesOverhead
+	case types.TimestampTZFamily:
+		return int64(col.Timestamp().Len()) * memsize.Time
 	default:
 		panic(fmt.Sprintf(`unhandled type %s`, t))
 	}

--- a/pkg/workload/csv.go
+++ b/pkg/workload/csv.go
@@ -84,6 +84,8 @@ func colDatumToCSVString(col *coldata.Vec, rowIdx int) string {
 		// See the HACK comment in ColBatchToRows.
 		bytes := col.Bytes().Get(rowIdx)
 		return *(*string)(unsafe.Pointer(&bytes))
+	case types.TimestampTZFamily:
+		return col.Timestamp()[rowIdx].Format(timestampOutputFormat)
 	}
 	panic(fmt.Sprintf(`unhandled type %s`, col.Type()))
 }


### PR DESCRIPTION
In ef3946c5a0705a4e338f766b28c100152f1acb60 we forgot to update two spots to handle the native timestamp type in the CSV writer and a benchmark.

Fixes: #135975.
Fixes: #135979.
Fixes: #135984.

Release note: None