### PR TITLE
roachtest: fix DROP in ldr/kv0/workload=both/schema_change

### DIFF
--- a/pkg/cmd/roachtest/tests/logical_data_replication.go
+++ b/pkg/cmd/roachtest/tests/logical_data_replication.go
@@ -293,8 +293,8 @@ func TestLDRSchemaChange(
 	// and right sides.
 	setup.left.sysSQL.Exec(t, fmt.Sprintf("CREATE INDEX idx_left ON %s.%s(v, k)", ldrWorkload.dbName, ldrWorkload.tableNames[0]))
 	setup.right.sysSQL.Exec(t, fmt.Sprintf("CREATE INDEX idx_right ON %s.%s(v, k)", ldrWorkload.dbName, ldrWorkload.tableNames[0]))
-	setup.left.sysSQL.Exec(t, "DROP INDEX idx_left")
-	setup.right.sysSQL.Exec(t, "DROP INDEX idx_right")
+	setup.left.sysSQL.Exec(t, fmt.Sprintf("DROP INDEX %s.%s@idx_left", ldrWorkload.dbName, ldrWorkload.tableNames[0]))
+	setup.right.sysSQL.Exec(t, fmt.Sprintf("DROP INDEX %s.%s@idx_right", ldrWorkload.dbName, ldrWorkload.tableNames[0]))
 
 	// Verify that a non-allowlisted schema change fails.
 	setup.left.sysSQL.ExpectErr(t,


### PR DESCRIPTION
Without using a fully qualified name, the DROP command depends on being connected to the correct database, which is not always guaranteed.

fixes https://github.com/cockroachdb/cockroach/issues/134930
fixes https://github.com/cockroachdb/cockroach/issues/135152
Release note: None