### PR TITLE
kvserver: run TestReplicateRestartAfterTruncation with leader leases

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -2300,12 +2300,6 @@ func runReplicateRestartAfterTruncation(t *testing.T, removeBeforeTruncateAndReA
 					WallClock:         manualClock,
 				},
 			},
-			RaftConfig: base.RaftConfig{
-				// Don't timeout raft leaders or range leases. This test expects
-				// tc.Servers[0] to hold the range lease for the range under test.
-				RaftElectionTimeoutTicks: 1000000,
-				RangeLeaseDuration:       time.Minute,
-			},
 		}
 	}
 	tc := testcluster.StartTestCluster(t, 3,


### PR DESCRIPTION
This test was setting an extremely high RaftElectionTimeoutTicks value, but this doesn't work with raft fortification. That's because we won't campaign until StoreLiveness support is established, and the first time a replica is ticked we won't have this. The high
RaftElectionTimeoutTicks in this test wasn't useful in practice, so let's just remove it.

Note that this change also applies to the ReAdd version of the test.

References https://github.com/cockroachdb/cockroach/issues/133763

Release note: None