### PR TITLE
kvserver: use leader leases in various flow control tests

### DIFF
--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -3087,15 +3087,18 @@ func TestFlowControlRaftMembershipV2(t *testing.T) {
 			settings := cluster.MakeTestingClusterSettings()
 			var disableWorkQueueGranting atomic.Bool
 			disableWorkQueueGranting.Store(true)
+			// This test doesn't want leadership changing hands, and leader leases (by
+			// virtue of raft fortification) help ensure this. Override to disable any
+			// metamorphosis.
+			kvserver.OverrideDefaultLeaseType(ctx, &settings.SV, roachpb.LeaseLeader)
+			// Using a manual clock here ensures that StoreLiveness support, once
+			// established, never expires. By extension, leadership should stay
+			// sticky.
+			manualClock := hlc.NewHybridManualClock()
 			tc := testcluster.StartTestCluster(t, 5, base.TestClusterArgs{
 				ReplicationMode: base.ReplicationManual,
 				ServerArgs: base.TestServerArgs{
 					Settings: settings,
-					RaftConfig: base.RaftConfig{
-						// Suppress timeout-based elections. This test doesn't want to deal
-						// with leadership changing hands unless intentional.
-						RaftElectionTimeoutTicks: 1000000,
-					},
 					Knobs: base.TestingKnobs{
 						Store: &kvserver.StoreTestingKnobs{
 							FlowControlTestingKnobs: &kvflowcontrol.TestingKnobs{
@@ -3110,6 +3113,9 @@ func TestFlowControlRaftMembershipV2(t *testing.T) {
 							DisableWorkQueueGranting: func() bool {
 								return disableWorkQueueGranting.Load()
 							},
+						},
+						Server: &server.TestingKnobs{
+							WallClock: manualClock,
 						},
 					},
 				},

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -1596,7 +1596,7 @@ func TestFlowControlQuiescedRange(t *testing.T) {
 	disableFallbackTokenDispatch.Store(true)
 
 	st := cluster.MakeTestingClusterSettings()
-	kvserver.ExpirationLeasesOnly.Override(ctx, &st.SV, false) // override metamorphism
+	kvserver.OverrideDefaultLeaseType(ctx, &st.SV, roachpb.LeaseEpoch) // override metamorphism
 	kvflowcontrol.Enabled.Override(ctx, &st.SV, true)
 
 	tc := testcluster.StartTestCluster(t, numNodes, base.TestClusterArgs{
@@ -1736,7 +1736,7 @@ func TestFlowControlUnquiescedRange(t *testing.T) {
 	disablePiggybackTokenDispatch.Store(true)
 
 	st := cluster.MakeTestingClusterSettings()
-	kvserver.ExpirationLeasesOnly.Override(ctx, &st.SV, false) // override metamorphism
+	kvserver.OverrideDefaultLeaseType(ctx, &st.SV, roachpb.LeaseEpoch) // override metamorphism
 	kvflowcontrol.Enabled.Override(ctx, &st.SV, true)
 
 	tc := testcluster.StartTestCluster(t, numNodes, base.TestClusterArgs{
@@ -3472,7 +3472,7 @@ func TestFlowControlUnquiescedRangeV2(t *testing.T) {
 
 			settings := cluster.MakeTestingClusterSettings()
 			// Override metamorphism to allow range quiescence.
-			kvserver.ExpirationLeasesOnly.Override(ctx, &settings.SV, false)
+			kvserver.OverrideDefaultLeaseType(ctx, &settings.SV, roachpb.LeaseEpoch)
 			tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
 				ReplicationMode: base.ReplicationManual,
 				ServerArgs: base.TestServerArgs{


### PR DESCRIPTION
See individual commits for details. 