### PR TITLE
sql/schemachanger: Block explicit transactions for ALTER COLUMN TYPE

### DIFF
--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -27,11 +27,6 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// AlterColTypeInTxnNotSupportedErr is returned when an ALTER COLUMN TYPE
-// is tried in an explicit transaction.
-var AlterColTypeInTxnNotSupportedErr = unimplemented.NewWithIssuef(
-	49351, "ALTER COLUMN TYPE is not supported inside a transaction")
-
 // AlterColumnType takes an AlterTableAlterColumnType, determines
 // which conversion to use and applies the type conversion.
 func AlterColumnType(
@@ -208,7 +203,7 @@ func alterColumnTypeGeneral(
 
 	// Disallow ALTER COLUMN TYPE general inside a multi-statement transaction.
 	if !params.extendedEvalCtx.TxnIsSingleStmt {
-		return AlterColTypeInTxnNotSupportedErr
+		return sqlerrors.NewAlterColTypeInTxnNotSupportedErr()
 	}
 
 	if len(cmds) > 1 {

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -2455,7 +2456,7 @@ func runSchemaChangesInTxn(
 				// Don't need to do anything here, as the call to MakeMutationComplete
 				// will perform the steps for this operation.
 			} else if m.AsComputedColumnSwap() != nil {
-				return AlterColTypeInTxnNotSupportedErr
+				return sqlerrors.NewAlterColTypeInTxnNotSupportedErr()
 			} else if col := m.AsColumn(); col != nil {
 				if !doneColumnBackfill && catalog.ColumnNeedsBackfill(col) {
 					if err := columnBackfillInTxn(

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -441,7 +441,7 @@ CREATE TABLE t20 (x INT);
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 
-statement error pq: unimplemented: ALTER COLUMN TYPE is not supported inside a transaction
+statement error pq: unimplemented: ALTER COLUMN TYPE requiring a rewrite of on-disk data is not supported inside a transaction
 ALTER TABLE t20 ALTER COLUMN x TYPE STRING
 
 statement ok

--- a/pkg/sql/schemachanger/scbuild/builder_test.go
+++ b/pkg/sql/schemachanger/scbuild/builder_test.go
@@ -94,10 +94,9 @@ func TestBuildDataDriven(t *testing.T) {
 									func(sd *sessiondata.SessionData) {
 										// For setting up a builder inside tests we will ensure that the new schema
 										// changer will allow non-fully implemented operations.
-										sd.NewSchemaChangerMode = sessiondatapb.UseNewSchemaChangerUnsafe
+										sd.NewSchemaChangerMode = sessiondatapb.UseNewSchemaChangerUnsafeAlways
 										sd.ApplicationName = ""
 										sd.EnableUniqueWithoutIndexConstraints = true
-										sd.AlterColumnTypeGeneralEnabled = true
 									},
 								),
 							),

--- a/pkg/sql/schemachanger/sctest/end_to_end.go
+++ b/pkg/sql/schemachanger/sctest/end_to_end.go
@@ -135,11 +135,10 @@ func EndToEndSideEffects(t *testing.T, relTestCaseDir string, factory TestServer
 					) {
 						// For setting up a builder inside tests we will ensure that the new schema
 						// changer will allow non-fully implemented operations.
-						sd.NewSchemaChangerMode = sessiondatapb.UseNewSchemaChangerUnsafe
+						sd.NewSchemaChangerMode = sessiondatapb.UseNewSchemaChangerUnsafeAlways
 						sd.TempTablesEnabled = true
 						sd.ApplicationName = ""
 						sd.EnableUniqueWithoutIndexConstraints = true // this allows `ADD UNIQUE WITHOUT INDEX` in the testing suite.
-						sd.AlterColumnTypeGeneralEnabled = true
 					})),
 					sctestdeps.WithTestingKnobs(&scexec.TestingKnobs{
 						BeforeStage: func(p scplan.Plan, stageIdx int) error {

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -313,6 +313,12 @@ func NewAlterColTypeInCombinationNotSupportedError() error {
 			"with other ALTER TABLE commands")
 }
 
+func NewAlterColTypeInTxnNotSupportedErr() error {
+	return unimplemented.NewWithIssuef(
+		49351, "ALTER COLUMN TYPE requiring a rewrite of on-disk data is "+
+			"not supported inside a transaction")
+}
+
 const PrimaryIndexSwapDetail = `CRDB's implementation for "ADD COLUMN", "DROP COLUMN", and "ALTER PRIMARY KEY" will drop the old/current primary index and create a new one.`
 
 // NewColumnReferencedByPrimaryKeyError is returned when attempting to drop a


### PR DESCRIPTION
This introduces a block that prevents running an ALTER COLUMN TYPE operation requiring a backfill within a transaction. To support the schemachanger end-to-end tests, which need to execute ALTERs in a transaction, I added a session variable to override this default behavior.

Epic: CRDB-25314
Informs #49329
Release note: none