### PR TITLE
crosscluster/logical: disallow import on ldr table

### DIFF
--- a/pkg/sql/importer/import_planning.go
+++ b/pkg/sql/importer/import_planning.go
@@ -814,6 +814,10 @@ func importPlanHook(
 				return err
 			}
 
+			if len(found.LDRJobIDs) > 0 {
+				return errors.Newf("cannot run an import on table %s which is apart of a Logical Data Replication stream", table)
+			}
+
 			// Validate target columns.
 			var intoCols []string
 			isTargetCol := make(map[string]bool)


### PR DESCRIPTION
Since LDR cannot handle an import write load or range keys produced on a rollback, this patch disallows importing into a table running LDR.

Epic: none

Release note: none