### PR TITLE
sql: reduce allocations in `(*schemaResolver).LookupObject`

### DIFF
--- a/pkg/sql/catalog/descs/helpers.go
+++ b/pkg/sql/catalog/descs/helpers.go
@@ -100,7 +100,7 @@ func getObjectPrefix(
 
 // PrefixAndType looks up an immutable type descriptor by its full name.
 func PrefixAndType(
-	ctx context.Context, g ByNameGetter, name tree.ObjectName,
+	ctx context.Context, g ByNameGetter, name *tree.TypeName,
 ) (catalog.ResolvedObjectPrefix, catalog.TypeDescriptor, error) {
 	p, err := getObjectPrefix(ctx, g, name.Catalog(), name.Schema())
 	if err != nil || p.Schema == nil {
@@ -112,7 +112,7 @@ func PrefixAndType(
 
 // PrefixAndMutableType looks up a mutable type descriptor by its full name.
 func PrefixAndMutableType(
-	ctx context.Context, g MutableByNameGetter, name tree.ObjectName,
+	ctx context.Context, g MutableByNameGetter, name *tree.TypeName,
 ) (catalog.ResolvedObjectPrefix, *typedesc.Mutable, error) {
 	p, err := getObjectPrefix(ctx, ByNameGetter(g), name.Catalog(), name.Schema())
 	if err != nil || p.Schema == nil {
@@ -124,7 +124,7 @@ func PrefixAndMutableType(
 
 // PrefixAndTable looks up an immutable table descriptor by its full name.
 func PrefixAndTable(
-	ctx context.Context, g ByNameGetter, name tree.ObjectName,
+	ctx context.Context, g ByNameGetter, name *tree.TableName,
 ) (catalog.ResolvedObjectPrefix, catalog.TableDescriptor, error) {
 	p, err := getObjectPrefix(ctx, g, name.Catalog(), name.Schema())
 	if err != nil || p.Schema == nil {
@@ -136,7 +136,7 @@ func PrefixAndTable(
 
 // PrefixAndMutableTable looks up a mutable table descriptor by its full name.
 func PrefixAndMutableTable(
-	ctx context.Context, g MutableByNameGetter, name tree.ObjectName,
+	ctx context.Context, g MutableByNameGetter, name *tree.TableName,
 ) (catalog.ResolvedObjectPrefix, *tabledesc.Mutable, error) {
 	p, err := getObjectPrefix(ctx, ByNameGetter(g), name.Catalog(), name.Schema())
 	if err != nil || p.Schema == nil {

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -162,17 +162,20 @@ func (sr *schemaResolver) LookupObject(
 		b = b.WithOffline()
 	}
 	g := b.MaybeGet()
-	tn := tree.MakeQualifiedTypeName(dbName, scName, obName)
 	switch flags.DesiredObjectKind {
 	case tree.TableObject:
-		prefix, desc, err = descs.PrefixAndTable(ctx, g, &tn)
+		tn := tree.NewTableNameWithSchema(tree.Name(dbName), tree.Name(scName), tree.Name(obName))
+		prefix, desc, err = descs.PrefixAndTable(ctx, g, tn)
 	case tree.TypeObject:
-		prefix, desc, err = descs.PrefixAndType(ctx, g, &tn)
+		tn := tree.NewQualifiedTypeName(dbName, scName, obName)
+		prefix, desc, err = descs.PrefixAndType(ctx, g, tn)
 	case tree.AnyObject:
-		prefix, desc, err = descs.PrefixAndTable(ctx, g, &tn)
+		tn := tree.NewTableNameWithSchema(tree.Name(dbName), tree.Name(scName), tree.Name(obName))
+		prefix, desc, err = descs.PrefixAndTable(ctx, g, tn)
 		if err != nil {
 			if sqlerrors.IsUndefinedRelationError(err) || errors.Is(err, catalog.ErrDescriptorWrongType) {
-				prefix, desc, err = descs.PrefixAndType(ctx, g, &tn)
+				tn := tree.NewQualifiedTypeName(dbName, scName, obName)
+				prefix, desc, err = descs.PrefixAndType(ctx, g, tn)
 			}
 		}
 	default:


### PR DESCRIPTION
Previously, the `PrefixAnd*` functions had parameters with the interface
type `tree.ObjectName`, causing the corresponding arguments to escape to
the heap. Now the functions parameters are the concrete types
`*tree.TableName` and `*tree.TypeName`, reducing allocations at
callsites.

Informs #105867

Release note: None
