### PR TITLE
sessioninit, syntheticprivilegecache: populate cache inside of singleflight

### DIFF
--- a/pkg/sql/cacheutil/cache.go
+++ b/pkg/sql/cacheutil/cache.go
@@ -99,9 +99,9 @@ func (c *Cache[K, V]) MaybeWriteBackToCache(
 		// proceed with authentication so that users are not locked out of
 		// the database.
 		log.Ops.Warningf(ctx, "no memory available to cache info: %v", err)
-	} else {
-		c.cache[key] = value
+		return false
 	}
+	c.cache[key] = value
 	return true
 }
 

--- a/pkg/sql/syntheticprivilegecache/cache.go
+++ b/pkg/sql/syntheticprivilegecache/cache.go
@@ -85,14 +85,18 @@ func (c *Cache) Get(
 	}
 	privDesc, err := c.c.LoadValueOutsideOfCacheSingleFlight(ctx, fmt.Sprintf("%s-%d", spo.GetPath(), desc.GetVersion()),
 		func(loadCtx context.Context) (_ interface{}, retErr error) {
-			return c.readFromStorage(loadCtx, txn, spo)
+			privDesc, err := c.readFromStorage(loadCtx, txn, spo)
+			if err != nil {
+				return nil, err
+			}
+			entrySize := int64(len(spo.GetPath())) + computePrivDescSize(privDesc)
+			// Only write back to the cache if the table version is committed.
+			c.c.MaybeWriteBackToCache(ctx, []descpb.DescriptorVersion{desc.GetVersion()}, spo.GetPath(), *privDesc, entrySize)
+			return privDesc, nil
 		})
 	if err != nil {
 		return nil, err
 	}
-	entrySize := int64(len(spo.GetPath())) + computePrivDescSize(privDesc)
-	// Only write back to the cache if the table version is committed.
-	c.c.MaybeWriteBackToCache(ctx, []descpb.DescriptorVersion{desc.GetVersion()}, spo.GetPath(), *privDesc, entrySize)
 	return privDesc, nil
 }
 


### PR DESCRIPTION
While working on the role membership cache, I identified this inefficiency that affects the caching logic for these other caches also. Previously, we were loading the value in a singleflight, then _every_ goroutine that was waiting for the singleflight would each try to populate the cache with the same result. Now, the populate logic is moved inside of the singleflight, so only the singleflight leader adds the value into the cache.

Epic: None
Release note: None