### PR TITLE
storage: rename MakeBackupSSTWriter to MakeTransportSSTWriter

### DIFF
--- a/pkg/ccl/backupccl/backupinfo/backup_metadata.go
+++ b/pkg/ccl/backupccl/backupinfo/backup_metadata.go
@@ -150,7 +150,7 @@ func constructMetadataSST(
 	stats []*stats.TableStatisticProto,
 ) error {
 	// TODO(dt): use a seek-optimized SST writer instead.
-	sst := storage.MakeBackupSSTWriter(ctx, dest.Settings(), w)
+	sst := storage.MakeTransportSSTWriter(ctx, dest.Settings(), w)
 	defer sst.Close()
 
 	// The following steps must be done in-order, by key prefix.
@@ -291,7 +291,7 @@ func WriteDescsSST(
 		return err
 	}
 	defer w.Close()
-	descSST := storage.MakeBackupSSTWriter(ctx, dest.Settings(), w)
+	descSST := storage.MakeTransportSSTWriter(ctx, dest.Settings(), w)
 	defer descSST.Close()
 
 	if err := writeDescsToMetadata(ctx, descSST, m); err != nil {
@@ -327,7 +327,7 @@ func writeFilesSST(
 		return err
 	}
 	defer w.Close()
-	fileSST := storage.MakeBackupSSTWriter(ctx, dest.Settings(), w)
+	fileSST := storage.MakeTransportSSTWriter(ctx, dest.Settings(), w)
 	defer fileSST.Close()
 
 	// Sort and write all of the files into a single file info SST.

--- a/pkg/ccl/backupccl/bench_test.go
+++ b/pkg/ccl/backupccl/bench_test.go
@@ -88,7 +88,7 @@ func BenchmarkIteratorMemory(b *testing.B) {
 	}
 
 	writeSST := func(w io.WriteCloser, store cloud.ExternalStorage, payloadSize int, numKeys int) {
-		sst := storage.MakeBackupSSTWriter(ctx, store.Settings(), w)
+		sst := storage.MakeTransportSSTWriter(ctx, store.Settings(), w)
 
 		buf := make([]byte, payloadSize)
 		key := storage.MVCCKey{Timestamp: now}

--- a/pkg/ccl/backupccl/file_sst_sink_test.go
+++ b/pkg/ccl/backupccl/file_sst_sink_test.go
@@ -44,7 +44,7 @@ func TestFileSSTSinkExtendOneFile(t *testing.T) {
 
 	getKeys := func(prefix string, n int) []byte {
 		var b bytes.Buffer
-		sst := storage.MakeBackupSSTWriter(ctx, cluster.MakeTestingClusterSettings(), &b)
+		sst := storage.MakeTransportSSTWriter(ctx, cluster.MakeTestingClusterSettings(), &b)
 		for i := 0; i < n; i++ {
 			require.NoError(t, sst.PutUnversioned([]byte(fmt.Sprintf("%s%08d", prefix, i)), nil))
 		}
@@ -640,7 +640,7 @@ func TestFileSSTSinkCopyPointKeys(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
-			sst := storage.MakeBackupSSTWriter(ctx, settings, buf)
+			sst := storage.MakeTransportSSTWriter(ctx, settings, buf)
 			sink := fileSSTSink{sst: sst}
 			compareSST := true
 
@@ -819,7 +819,7 @@ func TestFileSSTSinkCopyRangeKeys(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
-			sst := storage.MakeBackupSSTWriter(ctx, settings, buf)
+			sst := storage.MakeTransportSSTWriter(ctx, settings, buf)
 			sink := fileSSTSink{sst: sst}
 			compareSST := true
 
@@ -995,7 +995,7 @@ func (b *exportedSpanBuilder) buildWithEncoding(stringToKey func(string) roachpb
 	ctx := context.Background()
 	settings := cluster.MakeTestingClusterSettings()
 	buf := &bytes.Buffer{}
-	sst := storage.MakeBackupSSTWriter(ctx, settings, buf)
+	sst := storage.MakeTransportSSTWriter(ctx, settings, buf)
 	for _, d := range b.keyValues {
 		v := roachpb.Value{}
 		v.SetBytes(d.value)

--- a/pkg/ccl/backupccl/restore_data_processor_test.go
+++ b/pkg/ccl/backupccl/restore_data_processor_test.go
@@ -194,7 +194,7 @@ func runTestIngest(t *testing.T, init func(*cluster.Settings)) {
 		path := strconv.FormatInt(timeutil.Now().UnixNano(), 10)
 
 		var sstFile bytes.Buffer
-		sst := storage.MakeBackupSSTWriter(ctx, cs, &sstFile)
+		sst := storage.MakeTransportSSTWriter(ctx, cs, &sstFile)
 		defer sst.Close()
 		ts := hlc.NewClockForTesting(nil).Now()
 		value := roachpb.MakeValueFromString("bar")

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -1578,7 +1578,7 @@ func runTestDBAddSSTable(
 		value.InitChecksum([]byte("foo"))
 
 		var sstFile bytes.Buffer
-		w := storage.MakeBackupSSTWriter(ctx, cs, &sstFile)
+		w := storage.MakeTransportSSTWriter(ctx, cs, &sstFile)
 		defer w.Close()
 		require.NoError(t, w.Put(key, value.RawBytes))
 		require.NoError(t, w.Finish())

--- a/pkg/storage/fingerprint_writer.go
+++ b/pkg/storage/fingerprint_writer.go
@@ -50,7 +50,7 @@ func makeFingerprintWriter(
 	// TODO(adityamaru,dt): Once
 	// https://github.com/cockroachdb/cockroach/issues/90450 has been addressed we
 	// should write to a kvBuf instead of a Backup SST writer.
-	sstWriter := MakeBackupSSTWriter(ctx, cs, f)
+	sstWriter := MakeTransportSSTWriter(ctx, cs, f)
 	return fingerprintWriter{
 		sstWriter: &sstWriter,
 		hasher:    hasher,

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -7791,7 +7791,7 @@ func MVCCExportToSST(
 ) (kvpb.BulkOpSummary, ExportRequestResumeInfo, error) {
 	ctx, span := tracing.ChildSpan(ctx, "storage.MVCCExportToSST")
 	defer span.Finish()
-	sstWriter := MakeBackupSSTWriter(ctx, cs, dest)
+	sstWriter := MakeTransportSSTWriter(ctx, cs, dest)
 	defer sstWriter.Close()
 
 	summary, resumeInfo, exportErr := mvccExportToWriter(ctx, reader, opts, &sstWriter)

--- a/pkg/storage/pebble_iterator_test.go
+++ b/pkg/storage/pebble_iterator_test.go
@@ -105,7 +105,7 @@ func TestPebbleIterator_ExternalCorruption(t *testing.T) {
 	ctx := context.Background()
 	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
 	var f bytes.Buffer
-	w := MakeBackupSSTWriter(ctx, st, &f)
+	w := MakeTransportSSTWriter(ctx, st, &f)
 
 	// Create an example sstable.
 	var rawValue [64]byte

--- a/pkg/storage/sst_test.go
+++ b/pkg/storage/sst_test.go
@@ -54,7 +54,7 @@ func TestCheckSSTConflictsMaxLockConflicts(t *testing.T) {
 	// Create SST with keys equal to intents at txn2TS.
 	cs := cluster.MakeTestingClusterSettings()
 	var sstFile bytes.Buffer
-	sstWriter := MakeBackupSSTWriter(context.Background(), cs, &sstFile)
+	sstWriter := MakeTransportSSTWriter(context.Background(), cs, &sstFile)
 	defer sstWriter.Close()
 	for _, k := range intents {
 		key := MVCCKey{Key: roachpb.Key(k), Timestamp: txn2TS}

--- a/pkg/storage/sst_writer_test.go
+++ b/pkg/storage/sst_writer_test.go
@@ -56,7 +56,7 @@ func makePebbleSST(t testing.TB, kvs []MVCCKeyValue, ingestion bool) []byte {
 	if ingestion {
 		w = MakeIngestionSSTWriter(ctx, st, f)
 	} else {
-		w = MakeBackupSSTWriter(ctx, st, &f.Buffer)
+		w = MakeTransportSSTWriter(ctx, st, &f.Buffer)
 	}
 	defer w.Close()
 


### PR DESCRIPTION
Rename MakeBackupSSTWriter to MakeTransportSSTWriter to clarify that MakeBackupSSTWriter is NOT the writer used to construct sstables persisted to object storage for a backup.

Epic: none
Release note: none