### PR TITLE
changefeedccl: add sql smith to TestChangefeedNemeses

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdctest/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ccl/changefeedccl/changefeedbase",
+        "//pkg/internal/sqlsmith",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/kv/kvclient/rangefeed",


### PR DESCRIPTION
This patch adds sql smith to TestChangefeedNemeses to generate random data,
improving changefeed test coverage. Note that finger printer validator is
currently incompatible with sql smith, so we have to disable fprint validator to
be used with sql smith. To retain test coverage, sql smith has been added as a
new subtest.

Epic: none
Release note: none