### PR TITLE
release-24.3: security: bugfix, ensure cert expiry metrics reflect reloaded certs

### DIFF
--- a/pkg/security/certificate_metrics_test.go
+++ b/pkg/security/certificate_metrics_test.go
@@ -14,24 +14,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
 )
 
-// TestMetricsValues asserts that with the appropriate certificates on disk,
-// the correct expiration and ttl values are set on the metrics vars that are
-// exposed to our collectors. It uses a single key pair to approximate the
-// behavior across other key pairs.
-func TestMetricsValues(t *testing.T) {
-	defer leaktest.AfterTest(t)()
+func writeTestCerts(t *testing.T, certsDir string) {
 
-	// required to read certs from disk in tests
-	securityassets.ResetLoader()
-	defer ResetTest()
-
-	// now is unix 1, each expiration is +1 after that.
-	// this means an expiration is 1 + cert offset, and ttl is expiration - 1.
-	now := timeutil.Unix(1, 0)
-
-	certsDir := t.TempDir()
 	for offset, certName := range []string{
 		"ca",
 		"ca-client",
@@ -55,6 +42,25 @@ func TestMetricsValues(t *testing.T) {
 			t.Fatalf("#%d: could not write file %s: %v", offset, keyFile, err)
 		}
 	}
+}
+
+// TestMetricsValues asserts that with the appropriate certificates on disk,
+// the correct expiration and ttl values are set on the metrics vars that are
+// exposed to our collectors. It uses a single key pair to approximate the
+// behavior across other key pairs.
+func TestMetricsValues(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// required to read certs from disk in tests
+	securityassets.ResetLoader()
+	defer ResetTest()
+
+	// now is unix 1, each expiration is +1 after that.
+	// this means an expiration is 1 + cert offset, and ttl is expiration - 1.
+	now := timeutil.Unix(1, 0)
+
+	certsDir := t.TempDir()
+	writeTestCerts(t, certsDir)
 
 	cm, err := security.NewCertificateManager(
 		certsDir,
@@ -96,4 +102,58 @@ func TestMetricsValues(t *testing.T) {
 		}
 	}
 
+}
+
+// TestCertificateReload verifies that when the certificate manager's
+// underlying ceritificates change, the original metrics references (which are
+// the ones registered) also reflect the TTLs on the new certificates.
+func TestCertificateReload(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// required to read certs from disk in tests
+	securityassets.ResetLoader()
+	defer ResetTest()
+
+	// now is unix 1, each expiration is +1 after that.
+	// this means an expiration is 1 + cert offset, and ttl is expiration - 1.
+	now := timeutil.Unix(1, 0)
+
+	certsDir := t.TempDir()
+	// writeTestCerts writes the ca certificate with an expiration of 2.
+	writeTestCerts(t, certsDir)
+
+	cm, err := security.NewCertificateManager(
+		certsDir,
+		security.CommandTLSSettings{},
+		security.WithTimeSource(timeutil.NewManualTime(now)),
+		security.ForTenant(1),
+	)
+	if err != nil {
+		t.Error(err)
+	}
+
+	caCertExpiration := cm.Metrics().CAExpiration
+	caCertTTL := cm.Metrics().CATTL
+
+	// Validate the starting values, with an expiration of 2 and a now of 1,
+	// expiration = 2, ttl = 1.
+	require.Equal(t, 2, int(caCertExpiration.Value()))
+	require.Equal(t, 1, int(caCertTTL.Value()))
+
+	// overwrite the ca certificate with an expiration of 1000.
+	certFile := "ca.crt"
+	expiration := 1000
+	_, certBytes := makeTestCert(t, "", 0, nil, timeutil.Unix(int64(expiration), 0))
+	if err := os.WriteFile(filepath.Join(certsDir, certFile), certBytes, 0700); err != nil {
+		t.Fatalf("could not write file %s: %v", certFile, err)
+	}
+
+	// reload certificates after new one is written.
+	err = cm.LoadCertificates()
+	require.NoError(t, err)
+
+	// Validate the values after reload, with an expiration of 1000 and a now of 1,
+	// expiration = 1000, ttl = 999.
+	require.Equal(t, 1000, int(caCertExpiration.Value()))
+	require.Equal(t, 999, int(caCertTTL.Value()))
 }


### PR DESCRIPTION
Backport 1/1 commits from #135596.

/cc @cockroachdb/release

---

security: bugfix, ensure cert expiry metrics reflect reloaded certs

The PR #130110 added certificate TTL metrics alongside our existing expiration metrics. Prior to that change, the certificate metrics values were updated on each metrics load. Afterwards, new metrics objects were created for each load of certificates.

This created a bug in that the new expiration values would not be found in any of the system exhaust (metrics scrape or tsdb) because the registered metrics objects were the ones created on startup.

This new change instead allows the metrics to close the whole CertificateManager object, so that they only need to be created once, and therefore the initial registration of metrics reflects persistently valid values.

Release note (bug fix): security.certificate.* metrics will now be updated if a node loads new certificates while running.

Epic: none
Fixes: #135093

Release justification: Fixes a bug in the certificate metrics.
