### PR TITLE
sql/catalog: reduce NameKey allocations

### DIFF
--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -160,13 +160,24 @@ type NameKey interface {
 	GetParentSchemaID() descpb.ID
 }
 
+var _ NameKey = descpb.NameInfo{}
+
+func MakeNameInfo(nk NameKey) descpb.NameInfo {
+	if ni, ok := nk.(descpb.NameInfo); ok {
+		return ni
+	}
+	return descpb.NameInfo{
+		ParentID:       nk.GetParentID(),
+		ParentSchemaID: nk.GetParentSchemaID(),
+		Name:           nk.GetName(),
+	}
+}
+
 // NameEntry corresponds to an entry in the namespace table.
 type NameEntry interface {
 	NameKey
 	GetID() descpb.ID
 }
-
-var _ NameKey = descpb.NameInfo{}
 
 // LeasableDescriptor is an interface for objects which can be leased via the
 // descriptor leasing system.

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -350,7 +350,7 @@ func (tc *Collection) DeleteDescToBatch(
 func (tc *Collection) InsertNamespaceEntryToBatch(
 	ctx context.Context, kvTrace bool, e catalog.NameEntry, b *kv.Batch,
 ) error {
-	if ns := tc.cr.Cache().LookupNamespaceEntry(e); ns != nil {
+	if ns := tc.cr.Cache().LookupNamespaceEntry(catalog.MakeNameInfo(e)); ns != nil {
 		tc.markAsShadowedName(ns.GetID())
 	}
 	tc.markAsShadowedName(e.GetID())
@@ -373,7 +373,7 @@ func (tc *Collection) InsertNamespaceEntryToBatch(
 func (tc *Collection) UpsertNamespaceEntryToBatch(
 	ctx context.Context, kvTrace bool, e catalog.NameEntry, b *kv.Batch,
 ) error {
-	if ns := tc.cr.Cache().LookupNamespaceEntry(e); ns != nil {
+	if ns := tc.cr.Cache().LookupNamespaceEntry(catalog.MakeNameInfo(e)); ns != nil {
 		tc.markAsShadowedName(ns.GetID())
 	}
 	tc.markAsShadowedName(e.GetID())
@@ -396,7 +396,7 @@ func (tc *Collection) UpsertNamespaceEntryToBatch(
 func (tc *Collection) DeleteNamespaceEntryToBatch(
 	ctx context.Context, kvTrace bool, k catalog.NameKey, b *kv.Batch,
 ) error {
-	if ns := tc.cr.Cache().LookupNamespaceEntry(k); ns != nil {
+	if ns := tc.cr.Cache().LookupNamespaceEntry(catalog.MakeNameInfo(k)); ns != nil {
 		tc.markAsShadowedName(ns.GetID())
 	}
 	nameKey := catalogkeys.EncodeNameKey(tc.codec(), k)
@@ -659,7 +659,7 @@ func (tc *Collection) lookupDescriptorID(
 	if err != nil {
 		return descpb.InvalidID, err
 	}
-	if e := read.LookupNamespaceEntry(&key); e != nil {
+	if e := read.LookupNamespaceEntry(key); e != nil {
 		return e.GetID(), nil
 	}
 	return descpb.InvalidID, nil

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -422,21 +422,8 @@ func (tc *Collection) markAsShadowedName(id descpb.ID) {
 	}] = struct{}{}
 }
 
-func (tc *Collection) isShadowedName(nameKey catalog.NameKey) bool {
-	var k descpb.NameInfo
-	switch t := nameKey.(type) {
-	case descpb.NameInfo:
-		k = t
-	case *descpb.NameInfo:
-		k = *t
-	default:
-		k = descpb.NameInfo{
-			ParentID:       nameKey.GetParentID(),
-			ParentSchemaID: nameKey.GetParentSchemaID(),
-			Name:           nameKey.GetName(),
-		}
-	}
-	_, ok := tc.shadowedNames[k]
+func (tc *Collection) isShadowedName(nameKey descpb.NameInfo) bool {
+	_, ok := tc.shadowedNames[nameKey]
 	return ok
 }
 
@@ -976,7 +963,7 @@ func (tc *Collection) aggregateAllLayers(
 	})
 	// Add stored namespace entries which are not shadowed.
 	_ = stored.ForEachNamespaceEntry(func(e nstree.NamespaceEntry) error {
-		if tc.isShadowedName(e) {
+		if tc.isShadowedName(catalog.MakeNameInfo(e)) {
 			return nil
 		}
 		// Temporary schemas don't have descriptors and are persisted only

--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -553,7 +553,7 @@ func (tc *Collection) getNonVirtualDescriptorID(
 		return continueLookups, descpb.InvalidID, nil
 	}
 	lookupStoreCacheID := func() (continueOrHalt, descpb.ID, error) {
-		ni := &descpb.NameInfo{ParentID: parentID, ParentSchemaID: parentSchemaID, Name: name}
+		ni := descpb.NameInfo{ParentID: parentID, ParentSchemaID: parentSchemaID, Name: name}
 		if tc.isShadowedName(ni) {
 			return continueLookups, descpb.InvalidID, nil
 		}
@@ -587,11 +587,11 @@ func (tc *Collection) getNonVirtualDescriptorID(
 		if flags.layerFilters.withoutStorage {
 			return haltLookups, descpb.InvalidID, nil
 		}
-		ni := &descpb.NameInfo{ParentID: parentID, ParentSchemaID: parentSchemaID, Name: name}
+		ni := descpb.NameInfo{ParentID: parentID, ParentSchemaID: parentSchemaID, Name: name}
 		if tc.isShadowedName(ni) {
 			return haltLookups, descpb.InvalidID, nil
 		}
-		read, err := tc.cr.GetByNames(ctx, txn, []descpb.NameInfo{*ni})
+		read, err := tc.cr.GetByNames(ctx, txn, []descpb.NameInfo{ni})
 		if err != nil {
 			return haltLookups, descpb.InvalidID, err
 		}

--- a/pkg/sql/catalog/descs/system_table.go
+++ b/pkg/sql/catalog/descs/system_table.go
@@ -40,13 +40,13 @@ func (r *systemTableIDResolver) LookupSystemTableID(
 	if err := r.db.DescsTxn(ctx, func(
 		ctx context.Context, txn Txn,
 	) (err error) {
-		ni := &descpb.NameInfo{
+		ni := descpb.NameInfo{
 			ParentID:       keys.SystemDatabaseID,
 			ParentSchemaID: keys.SystemPublicSchemaID,
 			Name:           tableName,
 		}
 		read, err := txn.Descriptors().cr.GetByNames(
-			ctx, txn.KV(), []descpb.NameInfo{*ni},
+			ctx, txn.KV(), []descpb.NameInfo{ni},
 		)
 		if err != nil {
 			return err

--- a/pkg/sql/catalog/desctestutils/descriptor_test_utils.go
+++ b/pkg/sql/catalog/desctestutils/descriptor_test_utils.go
@@ -245,7 +245,7 @@ func lookupDescriptorID(
 	if err != nil {
 		return descpb.InvalidID, err
 	}
-	if e := c.LookupNamespaceEntry(&key); e != nil {
+	if e := c.LookupNamespaceEntry(key); e != nil {
 		return e.GetID(), nil
 	}
 	return descpb.InvalidID, nil

--- a/pkg/sql/catalog/internal/catkv/catalog_reader.go
+++ b/pkg/sql/catalog/internal/catkv/catalog_reader.go
@@ -37,7 +37,7 @@ type CatalogReader interface {
 
 	// IsNameInCache return true when all the by-name catalog data for this name
 	// key is known to be in the cache.
-	IsNameInCache(key catalog.NameKey) bool
+	IsNameInCache(key descpb.NameInfo) bool
 
 	// IsDescIDKnownToNotExist returns true when we know that there definitely
 	// exists no descriptor in storage with that ID.
@@ -136,7 +136,7 @@ func (cr catalogReader) IsIDInCache(_ descpb.ID) bool {
 }
 
 // IsNameInCache is part of the CatalogReader interface.
-func (cr catalogReader) IsNameInCache(_ catalog.NameKey) bool {
+func (cr catalogReader) IsNameInCache(_ descpb.NameInfo) bool {
 	return false
 }
 

--- a/pkg/sql/catalog/internal/catkv/catalog_reader_cached.go
+++ b/pkg/sql/catalog/internal/catkv/catalog_reader_cached.go
@@ -104,8 +104,8 @@ func (c *cachedCatalogReader) IsIDInCache(id descpb.ID) bool {
 }
 
 // IsNameInCache is part of the CatalogReader interface.
-func (c *cachedCatalogReader) IsNameInCache(key catalog.NameKey) bool {
-	return c.cache.LookupNamespaceEntry(catalog.MakeNameInfo(key)) != nil
+func (c *cachedCatalogReader) IsNameInCache(key descpb.NameInfo) bool {
+	return c.cache.LookupNamespaceEntry(key) != nil
 }
 
 // IsDescIDKnownToNotExist is part of the CatalogReader interface.

--- a/pkg/sql/catalog/internal/catkv/catalog_reader_test.go
+++ b/pkg/sql/catalog/internal/catkv/catalog_reader_test.go
@@ -109,7 +109,7 @@ func TestDataDriven(t *testing.T) {
 					var name string
 					var dbID, scID int
 					d.ScanArgs(t, "name_key", &dbID, &scID, &name)
-					ni := &descpb.NameInfo{
+					ni := descpb.NameInfo{
 						ParentID:       descpb.ID(dbID),
 						ParentSchemaID: descpb.ID(scID),
 						Name:           name,

--- a/pkg/sql/catalog/internal/catkv/system_database_cache.go
+++ b/pkg/sql/catalog/internal/catkv/system_database_cache.go
@@ -87,14 +87,14 @@ func (c *SystemDatabaseCache) lookupDescriptor(
 func (c *SystemDatabaseCache) lookupDescriptorID(
 	version clusterversion.ClusterVersion, key descpb.NameInfo,
 ) (descpb.ID, hlc.Timestamp) {
-	if key.GetParentID() == descpb.InvalidID &&
-		key.GetParentSchemaID() == descpb.InvalidID &&
-		key.GetName() == catconstants.SystemDatabaseName {
+	if key.ParentID == descpb.InvalidID &&
+		key.ParentSchemaID == descpb.InvalidID &&
+		key.Name == catconstants.SystemDatabaseName {
 		return keys.SystemDatabaseID, hlc.Timestamp{}
 	}
-	if key.GetParentID() == keys.SystemDatabaseID &&
-		key.GetParentSchemaID() == descpb.InvalidID &&
-		key.GetName() == catconstants.PublicSchemaName {
+	if key.ParentID == keys.SystemDatabaseID &&
+		key.ParentSchemaID == descpb.InvalidID &&
+		key.Name == catconstants.PublicSchemaName {
 		return keys.SystemPublicSchemaID, hlc.Timestamp{}
 	}
 	if c == nil {

--- a/pkg/sql/catalog/internal/catkv/system_database_cache.go
+++ b/pkg/sql/catalog/internal/catkv/system_database_cache.go
@@ -85,7 +85,7 @@ func (c *SystemDatabaseCache) lookupDescriptor(
 // lookupDescriptorID looks for the corresponding descriptor name -> ID entry in
 // the cache.
 func (c *SystemDatabaseCache) lookupDescriptorID(
-	version clusterversion.ClusterVersion, key catalog.NameKey,
+	version clusterversion.ClusterVersion, key descpb.NameInfo,
 ) (descpb.ID, hlc.Timestamp) {
 	if key.GetParentID() == descpb.InvalidID &&
 		key.GetParentSchemaID() == descpb.InvalidID &&
@@ -172,7 +172,7 @@ func (c *SystemDatabaseCache) nameCandidatesForUpdate(
 	}
 	diff := make([]nstree.NamespaceEntry, 0, len(systemNames))
 	for _, e := range systemNames {
-		if cached.LookupNamespaceEntry(e) == nil {
+		if cached.LookupNamespaceEntry(catalog.MakeNameInfo(e)) == nil {
 			diff = append(diff, e)
 		}
 	}

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1202,7 +1202,7 @@ func (m *Manager) resolveName(
 		if err != nil {
 			return err
 		}
-		if e := c.LookupNamespaceEntry(&req[0]); e != nil {
+		if e := c.LookupNamespaceEntry(req[0]); e != nil {
 			id = e.GetID()
 		}
 		return nil

--- a/pkg/sql/catalog/nstree/catalog.go
+++ b/pkg/sql/catalog/nstree/catalog.go
@@ -170,8 +170,8 @@ func (c Catalog) LookupZoneConfig(id descpb.ID) catalog.ZoneConfig {
 }
 
 // LookupNamespaceEntry looks up a descriptor ID by name.
-func (c Catalog) LookupNamespaceEntry(key catalog.NameKey) NamespaceEntry {
-	if !c.IsInitialized() || key == nil {
+func (c Catalog) LookupNamespaceEntry(key descpb.NameInfo) NamespaceEntry {
+	if !c.IsInitialized() {
 		return nil
 	}
 	e := c.byName.getByName(key.GetParentID(), key.GetParentSchemaID(), key.GetName())
@@ -257,7 +257,7 @@ func (c Catalog) Validate(
 // ValidateNamespaceEntry returns an error if the specified namespace entry
 // is invalid.
 func (c Catalog) ValidateNamespaceEntry(key catalog.NameKey) error {
-	ne := c.LookupNamespaceEntry(key)
+	ne := c.LookupNamespaceEntry(catalog.MakeNameInfo(key))
 	if ne == nil {
 		return errors.AssertionFailedf("invalid namespace entry")
 	}

--- a/pkg/sql/catalog/replication/reader_catalog.go
+++ b/pkg/sql/catalog/replication/reader_catalog.go
@@ -123,7 +123,8 @@ func SetupOrAdvanceStandbyReaderCatalog(
 					return nil
 				}
 				// Do not upsert entries if one already exists.
-				if entry := allExistingDescs.LookupNamespaceEntry(e); entry != nil && e.GetID() == entry.GetID() {
+				entry := allExistingDescs.LookupNamespaceEntry(catalog.MakeNameInfo(e))
+				if entry != nil && e.GetID() == entry.GetID() {
 					return nil
 				}
 				return errors.Wrapf(txn.Descriptors().UpsertNamespaceEntryToBatch(ctx, true, e, b), "namespace entry %v", e)


### PR DESCRIPTION
#### sql/catalog: change `LookupNamespaceEntry` parameter type

The `Catalog.LookupNamespaceEntry` method now accepts the concrete type
`descpb.NameInfo` instead of the `catalog.NameKey` interface. This,
along with future commits, will help reduce allocations.

Release note: None

#### sql/catalog: change `IsNameInCache` parameter type

The `CatalogReader.IsNameInCache` method now accepts the concrete type
`descpb.NameInfo` instead of the `catalog.NameKey` interface. This,
along with other commits, will help reduce allocations.

Release note: None

#### sql/catalog: change `(*Collection).isShadowedName` parameter type

The `(*Collection).isShadowedName` method now accepts the concrete type
`descpb.NameInfo` instead of the `catalog.NameKey` interface. This,
along with other commits, will help reduce allocations.

Informs #105867
Fixes #135905
Fixes #121300

Release note: None

#### sql/catalog: refactor `(*SystemDatabaseCache).lookupDescriptorID`

Now that `(*SystemDatabaseCache).lookupDescriptorID` accepts a
`descpb.NameInfo` parameter, it can access its exported field directly
instead of using getters.

Release note: None
