### PR TITLE
sql: remove anonymous function allocation isPausiblePortal

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -297,18 +297,13 @@ func (ex *connExecutor) execStmtInOpenState(
 	// requires only a single heap allocation.
 	var vars localVars
 
-	// We need this to be function rather than a static bool, because a portal's
-	// "pausability" can be revoked in `dispatchToExecutionEngine()` if the
-	// underlying statement contains sub/post queries. Thus, we should evaluate
-	// whether a portal is pausable when executing the cleanup step.
-	isPausablePortal := func() bool { return portal != nil && portal.isPausable() }
 	// updateRetErrAndPayload ensures that the latest event payload and error is
 	// always recorded by portal.pauseInfo.
 	// TODO(janexing): add test for this.
 	updateRetErrAndPayload := func(err error, payload fsm.EventPayload) {
 		retPayload = payload
 		retErr = err
-		if isPausablePortal() {
+		if portal.isPausable() {
 			portal.pauseInfo.execStmtInOpenState.retPayload = payload
 			portal.pauseInfo.execStmtInOpenState.retErr = err
 		}
@@ -317,7 +312,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	// adding the function to the execStmtInOpenStateCleanup.
 	// Otherwise, perform the clean-up step within every execution.
 	processCleanupFunc := func(fName string, f func()) {
-		if !isPausablePortal() {
+		if !portal.isPausable() {
 			f()
 		} else if !portal.pauseInfo.execStmtInOpenState.cleanup.isComplete {
 			portal.pauseInfo.execStmtInOpenState.cleanup.appendFunc(namedFunc{
@@ -334,11 +329,11 @@ func (ex *connExecutor) execStmtInOpenState(
 	defer func() {
 		// This is the first defer, so it will always be called after any cleanup
 		// func being added to the stack from the defers below.
-		if isPausablePortal() && !portal.pauseInfo.execStmtInOpenState.cleanup.isComplete {
+		if portal.isPausable() && !portal.pauseInfo.execStmtInOpenState.cleanup.isComplete {
 			portal.pauseInfo.execStmtInOpenState.cleanup.isComplete = true
 		}
 		// If there's any error, do the cleanup right here.
-		if (retErr != nil || payloadHasError(retPayload)) && isPausablePortal() {
+		if (retErr != nil || payloadHasError(retPayload)) && portal.isPausable() {
 			updateRetErrAndPayload(retErr, retPayload)
 			portal.pauseInfo.resumableFlow.cleanup.run()
 			portal.pauseInfo.dispatchToExecutionEngine.cleanup.run()
@@ -351,19 +346,19 @@ func (ex *connExecutor) execStmtInOpenState(
 	// we would be checking the ones evaluated at the portal's first-time
 	// execution.
 	defer func() {
-		if isPausablePortal() {
+		if portal.isPausable() {
 			updateRetErrAndPayload(retErr, retPayload)
 		}
 	}()
 
 	vars.ast = parserStmt.AST
 	var sp *tracing.Span
-	if !isPausablePortal() || !portal.pauseInfo.execStmtInOpenState.cleanup.isComplete {
+	if !portal.isPausable() || !portal.pauseInfo.execStmtInOpenState.cleanup.isComplete {
 		ctx, sp = tracing.ChildSpan(ctx, "sql query")
 		// TODO(andrei): Consider adding the placeholders as tags too.
 		sp.SetTag("statement", attribute.StringValue(parserStmt.SQL))
 		ctx = withStatement(ctx, vars.ast)
-		if isPausablePortal() {
+		if portal.isPausable() {
 			portal.pauseInfo.execStmtInOpenState.spCtx = ctx
 		}
 		defer func() {
@@ -379,7 +374,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	}
 
 	var queryID clusterunique.ID
-	if isPausablePortal() {
+	if portal.isPausable() {
 		if !portal.pauseInfo.isQueryIDSet() {
 			portal.pauseInfo.execStmtInOpenState.queryID = ex.server.cfg.GenerateID()
 		}
@@ -426,9 +421,9 @@ func (ex *connExecutor) execStmtInOpenState(
 
 	// For pausable portal, the active query needs to be set up only when
 	// the portal is executed for the first time.
-	if !isPausablePortal() || !portal.pauseInfo.execStmtInOpenState.cleanup.isComplete {
+	if !portal.isPausable() || !portal.pauseInfo.execStmtInOpenState.cleanup.isComplete {
 		addActiveQuery()
-		if isPausablePortal() {
+		if portal.isPausable() {
 			portal.pauseInfo.execStmtInOpenState.cancelQueryFunc = vars.cancelQuery
 			portal.pauseInfo.execStmtInOpenState.cancelQueryCtx = ctx
 		}
@@ -438,7 +433,7 @@ func (ex *connExecutor) execStmtInOpenState(
 				func() {
 					// We need to check the latest errors rather than the ones evaluated
 					// when this function is created.
-					if isPausablePortal() {
+					if portal.isPausable() {
 						retErr = portal.pauseInfo.execStmtInOpenState.retErr
 						retPayload = portal.pauseInfo.execStmtInOpenState.retPayload
 					}
@@ -603,7 +598,7 @@ func (ex *connExecutor) execStmtInOpenState(
 
 	// For pausable portal, the instrumentation helper needs to be set up only
 	// when the portal is executed for the first time.
-	if !isPausablePortal() || portal.pauseInfo.execStmtInOpenState.ihWrapper == nil {
+	if !portal.isPausable() || portal.pauseInfo.execStmtInOpenState.ihWrapper == nil {
 		ctx = ih.Setup(
 			ctx, ex.server.cfg, ex.statsCollector, p, ex.stmtDiagnosticsRecorder,
 			vars.stmt.StmtNoConstants, os.ImplicitTxn.Get(),
@@ -624,7 +619,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	// ih and reuse it for all re-executions. So the planner's ih and the portal's
 	// ih should never have the same address, otherwise changing the former will
 	// change the latter, and we will never be able to persist it.
-	if isPausablePortal() {
+	if portal.isPausable() {
 		if portal.pauseInfo.execStmtInOpenState.ihWrapper == nil {
 			portal.pauseInfo.execStmtInOpenState.ihWrapper = &instrumentationHelperWrapper{
 				ctx: ctx,
@@ -644,7 +639,7 @@ func (ex *connExecutor) execStmtInOpenState(
 		// closing the correct instrumentation helper for the paused portal.
 		ihToFinish := ih
 		curRes := res
-		if isPausablePortal() {
+		if portal.isPausable() {
 			ihToFinish = &portal.pauseInfo.execStmtInOpenState.ihWrapper.ih
 			curRes = portal.pauseInfo.curRes
 			retErr = portal.pauseInfo.execStmtInOpenState.retErr
@@ -777,7 +772,7 @@ func (ex *connExecutor) execStmtInOpenState(
 
 		var bulkJobId uint64
 		var rowsAffected int
-		if isPausablePortal() {
+		if portal.isPausable() {
 			ppInfo := portal.pauseInfo
 			if p.extendedEvalCtx.Annotations == nil {
 				// This is a safety check in case resetPlanner() was
@@ -835,14 +830,14 @@ func (ex *connExecutor) execStmtInOpenState(
 
 		processCleanupFunc("set query error", func() {
 			cancelQueryCtx := ctx
-			if isPausablePortal() {
+			if portal.isPausable() {
 				cancelQueryCtx = portal.pauseInfo.execStmtInOpenState.cancelQueryCtx
 			}
 			resToPushErr := res
 			// For pausable portals, we retain the query but update the result for
 			// each execution. When the query context is cancelled and we're in the
 			// middle of an portal execution, push the error to the current result.
-			if isPausablePortal() {
+			if portal.isPausable() {
 				resToPushErr = portal.pauseInfo.curRes
 			}
 			vars.logErr = resToPushErr.ErrAllowReleased()
@@ -864,7 +859,7 @@ func (ex *connExecutor) execStmtInOpenState(
 				// error and then perform a query-cleanup step. In this case, we don't
 				// want to override the original timeout error with the query-cancelled
 				// error.
-				if isPausablePortal() && (errors.Is(resToPushErr.Err(), sqlerrors.QueryTimeoutError) ||
+				if portal.isPausable() && (errors.Is(resToPushErr.Err(), sqlerrors.QueryTimeoutError) ||
 					errors.Is(resToPushErr.Err(), sqlerrors.TxnTimeoutError)) {
 					errToPush = resToPushErr.Err()
 				}
@@ -1122,7 +1117,7 @@ func (ex *connExecutor) execStmtInOpenState(
 		}
 	}
 
-	if isPausablePortal() {
+	if portal.isPausable() {
 		p.pausablePortal = portal
 	}
 

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -325,8 +325,9 @@ func (p *PreparedPortal) size(portalName string) int64 {
 	return int64(uintptr(len(portalName)) + unsafe.Sizeof(p))
 }
 
+// isPausable checks if a portal is pausable.
 func (p *PreparedPortal) isPausable() bool {
-	return p.pauseInfo != nil
+	return p != nil && p.pauseInfo != nil
 }
 
 // cleanupFuncStack stores cleanup functions for a portal. The clean-up


### PR DESCRIPTION
These code changes move the `portal != nil` check into the isPausible method, rather than allocating an anonymous function.  We then call portal.isPausible() instead of calling the anonymous function.

Micro benchmarks:
```
                                        │    sec/op    │   sec/op     vs base              │
EndToEnd/kv-read/vectorize=on/Simple      180.7µ ±  2%   179.1µ ± 3%       ~ (p=0.805 n=7)
EndToEnd/kv-read/vectorize=on/Prepared    102.0µ ±  1%   101.7µ ± 3%       ~ (p=0.902 n=7)
EndToEnd/kv-read/vectorize=off/Simple     187.6µ ± 13%   182.3µ ± 2%  -2.87% (p=0.011 n=7)
EndToEnd/kv-read/vectorize=off/Prepared   103.6µ ± 19%   102.8µ ± 3%       ~ (p=0.456 n=7)
geomean                                   137.6µ         135.9µ       -1.23%

                                        │  before.txt  │             after.txt              │
                                        │     B/op     │     B/op      vs base              │
EndToEnd/kv-read/vectorize=on/Simple      35.67Ki ± 8%   35.60Ki ± 8%       ~ (p=0.710 n=7)
EndToEnd/kv-read/vectorize=on/Prepared    24.31Ki ± 4%   24.27Ki ± 4%       ~ (p=0.435 n=7)
EndToEnd/kv-read/vectorize=off/Simple     36.75Ki ± 6%   36.62Ki ± 6%       ~ (p=0.128 n=7)
EndToEnd/kv-read/vectorize=off/Prepared   25.56Ki ± 9%   25.52Ki ± 8%       ~ (p=0.318 n=7)
geomean                                   30.04Ki        29.98Ki       -0.22%

                                        │ before.txt │            after.txt             │
                                        │ allocs/op  │ allocs/op   vs base              │
EndToEnd/kv-read/vectorize=on/Simple      329.0 ± 7%   328.0 ± 7%       ~ (p=0.121 n=7)
EndToEnd/kv-read/vectorize=on/Prepared    232.0 ± 0%   232.0 ± 1%       ~ (p=0.364 n=7)
EndToEnd/kv-read/vectorize=off/Simple     321.0 ± 0%   320.0 ± 3%  -0.31% (p=0.020 n=7)
EndToEnd/kv-read/vectorize=off/Prepared   225.0 ± 7%   224.0 ± 7%       ~ (p=0.506 n=7)
geomean                                   272.5        271.8       -0.27%
```

Sysbench:
```
                                        │     sec/op     │   sec/op     vs base         │
Sysbench/SQL/1node_local/oltp_read_only     2.571m ± 15%   2.395m ± 5%  ~ (p=0.165 n=7)

                                        │ sys_before.txt │         sys_after.txt         │
                                        │      B/op      │     B/op      vs base         │
Sysbench/SQL/1node_local/oltp_read_only     900.7Ki ± 0%   899.9Ki ± 0%  ~ (p=0.073 n=7)

                                        │ sys_before.txt │           sys_after.txt           │
                                        │   allocs/op    │  allocs/op   vs base              │
Sysbench/SQL/1node_local/oltp_read_only      5.278k ± 0%   5.262k ± 1%  -0.30% (p=0.024 n=7)
```

Fixes: #135943
Epic: CRDB-42584

Release note: None