### PR TITLE
*: delete unused `.proto` imports

### DIFF
--- a/pkg/inspectz/inspectzpb/BUILD.bazel
+++ b/pkg/inspectz/inspectzpb/BUILD.bazel
@@ -10,7 +10,6 @@ proto_library(
     deps = [
         "//pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb:kvflowinspectpb_proto",
         "//pkg/kv/kvserver/storeliveness/storelivenesspb:storelivenesspb_proto",
-        "@go_googleapis//google/api:annotations_proto",
     ],
 )
 
@@ -23,7 +22,6 @@ go_proto_library(
     deps = [
         "//pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb",
         "//pkg/kv/kvserver/storeliveness/storelivenesspb",
-        "@org_golang_google_genproto//googleapis/api/annotations:go_default_library",
     ],
 )
 

--- a/pkg/inspectz/inspectzpb/inspectz.proto
+++ b/pkg/inspectz/inspectzpb/inspectz.proto
@@ -7,7 +7,6 @@ syntax = "proto3";
 package cockroach.inspectz.inspectzpb;
 option go_package = "github.com/cockroachdb/cockroach/pkg/inspectz/inspectzpb";
 
-import "google/api/annotations.proto";
 import "kv/kvserver/kvflowcontrol/kvflowinspectpb/kvflowinspect.proto";
 import "kv/kvserver/storeliveness/storelivenesspb/service.proto";
 

--- a/pkg/keyvisualizer/keyvispb/BUILD.bazel
+++ b/pkg/keyvisualizer/keyvispb/BUILD.bazel
@@ -11,7 +11,6 @@ proto_library(
         "//pkg/roachpb:roachpb_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
         "@com_google_protobuf//:timestamp_proto",
-        "@go_googleapis//google/api:annotations_proto",
     ],
 )
 
@@ -24,7 +23,6 @@ go_proto_library(
     deps = [
         "//pkg/roachpb",
         "@com_github_gogo_protobuf//gogoproto",
-        "@org_golang_google_genproto//googleapis/api/annotations:go_default_library",
     ],
 )
 

--- a/pkg/keyvisualizer/keyvispb/key_visualizer.proto
+++ b/pkg/keyvisualizer/keyvispb/key_visualizer.proto
@@ -10,7 +10,6 @@ option go_package = "github.com/cockroachdb/cockroach/pkg/keyvisualizer/keyvispb
 
 import "roachpb/data.proto";
 import "gogoproto/gogo.proto";
-import "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
 
 message UpdateBoundariesRequest {

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -130,7 +130,6 @@ proto_library(
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
         "@com_google_protobuf//:duration_proto",
         "@com_google_protobuf//:timestamp_proto",
-        "@go_googleapis//google/api:annotations_proto",
     ],
 )
 
@@ -149,7 +148,6 @@ go_proto_library(
         "//pkg/util/hlc",
         "@com_github_cockroachdb_errors//errorspb",
         "@com_github_gogo_protobuf//gogoproto",
-        "@org_golang_google_genproto//googleapis/api/annotations:go_default_library",
     ],
 )
 

--- a/pkg/roachpb/span_stats.proto
+++ b/pkg/roachpb/span_stats.proto
@@ -9,7 +9,6 @@ option go_package = "github.com/cockroachdb/cockroach/pkg/roachpb";
 
 import "storage/enginepb/mvcc.proto";
 import "gogoproto/gogo.proto";
-import "google/api/annotations.proto";
 import "roachpb/data.proto";
 
 // SpanStatsRequest is used to request a SpanStatsResponse for the given key

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -24,16 +24,13 @@ import "server/status/statuspb/status.proto";
 import "sql/appstatspb/app_stats.proto";
 import "sql/contentionpb/contention.proto";
 import "sql/sqlstats/insights/insights.proto";
-import "storage/enginepb/engine.proto";
 import "storage/enginepb/mvcc.proto";
-import "storage/enginepb/rocksdb.proto";
 import "kv/kvserver/kvserverpb/lease_status.proto";
 import "kv/kvserver/kvserverpb/state.proto";
 import "kv/kvserver/liveness/livenesspb/liveness.proto";
 import "util/hlc/timestamp.proto";
 import "util/log/logpb/log.proto";
 import "util/unresolved_addr.proto";
-import "util/tracing/tracingpb/tracing.proto";
 
 import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";

--- a/pkg/sql/catalog/catenumpb/BUILD.bazel
+++ b/pkg/sql/catalog/catenumpb/BUILD.bazel
@@ -11,7 +11,6 @@ proto_library(
     ],
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_gogo_protobuf//gogoproto:gogo_proto"],
 )
 
 go_proto_library(
@@ -20,9 +19,6 @@ go_proto_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb",
     proto = ":catenumpb_proto",
     visibility = ["//visibility:public"],
-    deps = [
-        "@com_github_gogo_protobuf//gogoproto",
-    ],
 )
 
 go_library(

--- a/pkg/sql/catalog/catenumpb/index.proto
+++ b/pkg/sql/catalog/catenumpb/index.proto
@@ -8,8 +8,6 @@ syntax = "proto3";
 package cockroach.sql.catalog.catpb;
 option go_package = "github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb";
 
-import "gogoproto/gogo.proto";
-
 // IndexColumn contains an enum used to represent the direction of a column
 // in an index key.
 message IndexColumn {

--- a/pkg/sql/catalog/catpb/enum.proto
+++ b/pkg/sql/catalog/catpb/enum.proto
@@ -11,8 +11,6 @@ syntax = "proto3";
 package cockroach.sql.catalog.catpb;
 option go_package = "github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb";
 
-import "gogoproto/gogo.proto";
-
 // SystemColumnKind is an enum representing the different kind of system
 // columns that can be synthesized by the execution engine.
 enum SystemColumnKind {

--- a/pkg/sql/execinfrapb/processors_changefeeds.proto
+++ b/pkg/sql/execinfrapb/processors_changefeeds.proto
@@ -17,7 +17,6 @@ option go_package = "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb";
 import "jobs/jobspb/jobs.proto";
 import "roachpb/data.proto";
 import "sql/execinfrapb/data.proto";
-import "sql/sessiondatapb/session_data.proto";
 import "util/hlc/timestamp.proto";
 import "gogoproto/gogo.proto";
 

--- a/pkg/sql/execinfrapb/processors_ttl.proto
+++ b/pkg/sql/execinfrapb/processors_ttl.proto
@@ -16,7 +16,6 @@ option go_package = "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb";
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/duration.proto";
-import "google/protobuf/timestamp.proto";
 import "roachpb/data.proto";
 import "jobs/jobspb/jobs.proto";
 

--- a/pkg/sql/sem/semenumpb/BUILD.bazel
+++ b/pkg/sql/sem/semenumpb/BUILD.bazel
@@ -10,7 +10,6 @@ proto_library(
     ],
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_gogo_protobuf//gogoproto:gogo_proto"],
 )
 
 go_proto_library(
@@ -19,7 +18,6 @@ go_proto_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/sem/semenumpb",
     proto = ":semenumpb_proto",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_gogo_protobuf//gogoproto"],
 )
 
 go_library(

--- a/pkg/sql/sem/semenumpb/constraint.proto
+++ b/pkg/sql/sem/semenumpb/constraint.proto
@@ -12,8 +12,6 @@ syntax = "proto3";
 package cockroach.sql.sem.semenumpb;
 option go_package = "github.com/cockroachdb/cockroach/pkg/sql/sem/semenumpb";
 
-import "gogoproto/gogo.proto";
-
 // ForeignKeyAction describes the action which should be taken when a foreign
 // key constraint reference is acted upon.
 enum ForeignKeyAction {

--- a/pkg/sql/sem/semenumpb/trigger.proto
+++ b/pkg/sql/sem/semenumpb/trigger.proto
@@ -12,8 +12,6 @@ syntax = "proto3";
 package cockroach.sql.sem.semenumpb;
 option go_package = "github.com/cockroachdb/cockroach/pkg/sql/sem/semenumpb";
 
-import "gogoproto/gogo.proto";
-
 // TriggerActionTime describes the timing of a trigger: before, after, or
 // instead of the event.
 enum TriggerActionTime {


### PR DESCRIPTION
A ton of these warnings have accumulated. Let's quash them all.

Epic: none
Release note: None