### PR TITLE
backup/encryption: Support AWS KMS replicas

### DIFF
--- a/pkg/backup/alter_backup_planning.go
+++ b/pkg/backup/alter_backup_planning.go
@@ -188,13 +188,16 @@ func doAlterBackupPlan(
 
 	// Add each new key user wants to add to a new data key map.
 	for _, kmsURI := range newKms {
-		masterKeyID, encryptedDataKey, err := backupencryption.GetEncryptedDataKeyFromURI(ctx,
+		masterKeyID, masterKeyID24_3Compatible, encryptedDataKey, err := backupencryption.GetEncryptedDataKeyFromURI(ctx,
 			plaintextDataKey, kmsURI, &kmsEnv)
 		if err != nil {
 			return errors.Wrap(err, "failed to encrypt data key when adding new KMS")
 		}
 
 		encryptedDataKeyByKMSMasterKeyID.AddEncryptedDataKey(backupencryption.PlaintextMasterKeyID(masterKeyID),
+			encryptedDataKey)
+
+		encryptedDataKeyByKMSMasterKeyID.AddEncryptedDataKey(backupencryption.PlaintextMasterKeyID(masterKeyID24_3Compatible),
 			encryptedDataKey)
 	}
 

--- a/pkg/backup/backup_cloud_test.go
+++ b/pkg/backup/backup_cloud_test.go
@@ -304,12 +304,12 @@ func TestCloudBackupRestoreKMSInaccessibleMetric(t *testing.T) {
 
 			// LastKMSInaccessibleErrorTime should not be set without
 			// updates_cluster_monitoring_metrics despite a KMS error.
-			sqlDB.ExpectErr(t, "failed to encrypt data key", "BACKUP INTO 'userfile:///foo' WITH OPTIONS (kms = $1)", tt.uri)
+			sqlDB.ExpectErr(t, "(failed to encrypt data key|could not describe key)", "BACKUP INTO 'userfile:///foo' WITH OPTIONS (kms = $1)", tt.uri)
 			require.Equal(t, bm.LastKMSInaccessibleErrorTime.Value(), int64(0))
 
 			// LastKMSInaccessibleErrorTime should be set with
 			// updates_cluster_monitoring_metrics.
-			sqlDB.ExpectErr(t, "failed to encrypt data key", "BACKUP INTO 'userfile:///foo' WITH OPTIONS (kms = $1, updates_cluster_monitoring_metrics)", tt.uri)
+			sqlDB.ExpectErr(t, "(failed to encrypt data key|could not describe key)", "BACKUP INTO 'userfile:///foo' WITH OPTIONS (kms = $1, updates_cluster_monitoring_metrics)", tt.uri)
 			require.GreaterOrEqual(t, bm.LastKMSInaccessibleErrorTime.Value(), testStart)
 		})
 	}

--- a/pkg/cloud/azure/azure_kms.go
+++ b/pkg/cloud/azure/azure_kms.go
@@ -195,6 +195,14 @@ func (k *azureKMS) MasterKeyID() string {
 	return k.customerMasterKeyID
 }
 
+func (k *azureKMS) MasterKeyID24_3Compatible() string {
+	return k.customerMasterKeyID
+}
+
+func (k *azureKMS) ReplicaIDs() []string {
+	return []string{k.customerMasterKeyID}
+}
+
 func (k *azureKMS) Encrypt(ctx context.Context, data []byte) ([]byte, error) {
 	val, err := k.kms.Encrypt(ctx, k.customerMasterKeyID, k.customerMasterKeyVersion, kms.KeyOperationsParameters{
 		Value:     data,

--- a/pkg/cloud/gcp/gcp_kms.go
+++ b/pkg/cloud/gcp/gcp_kms.go
@@ -151,6 +151,16 @@ func (k *gcsKMS) MasterKeyID() string {
 	return k.customerMasterKeyID
 }
 
+// MasterKeyID24_3Compatible implements the KMS interface.
+func (k *gcsKMS) MasterKeyID24_3Compatible() string {
+	return k.customerMasterKeyID
+}
+
+// ReplicaIDs implements the KMS interface.
+func (k *gcsKMS) ReplicaIDs() []string {
+	return []string{k.customerMasterKeyID}
+}
+
 // Encrypt implements the KMS interface.
 func (k *gcsKMS) Encrypt(ctx context.Context, data []byte) ([]byte, error) {
 	// Optional but recommended by GCS.

--- a/pkg/cloud/kms.go
+++ b/pkg/cloud/kms.go
@@ -20,7 +20,14 @@ import (
 type KMS interface {
 	// MasterKeyID will return the identifier used to reference the master key
 	// associated with the KMS object.
+	// Used when writing encryption metadata.
 	MasterKeyID() string
+	// TODO(benbardin): Remove when 24.3 compatibility is dropped.
+	MasterKeyID24_3Compatible() string
+	// Needed and implemented meaningfully only for AWS. Other cloud providers use
+	// the same ID for all replicas. Includes the MasterKeyID in the slice, and may duplicate it.
+	// Used when reading encryption metadata.
+	ReplicaIDs() []string
 	// Encrypt returns the ciphertext version of data after encrypting it using
 	// the KMS.
 	Encrypt(ctx context.Context, data []byte) ([]byte, error)

--- a/pkg/cloud/kms_test_utils.go
+++ b/pkg/cloud/kms_test_utils.go
@@ -74,9 +74,10 @@ func KMSEncryptDecrypt(t *testing.T, kmsURI string, env KMSEnv) {
 func CheckNoKMSAccess(t *testing.T, kmsURI string, env KMSEnv) {
 	ctx := context.Background()
 	kms, err := KMSFromURI(ctx, kmsURI, env)
-	require.NoError(t, err)
-
-	_, err = kms.Encrypt(ctx, []byte("test bytes"))
+	if err == nil {
+		// AWS will fail on initialization, but GCP and Azure will fail on Encrypt.
+		_, err = kms.Encrypt(ctx, []byte("test bytes"))
+	}
 	if err == nil {
 		t.Fatalf("expected error when encrypting with kms %s", kmsURI)
 	}


### PR DESCRIPTION
Multi-region KMS is a little bonkers on AWS. Each regional replica is a _separate_ object with a separate ID. And any given alias points to exactly one of those replicas. Each regional replica seems to store the ARNs of the other replicas locally, but aliases are only stored next to the specific replica they point to.

So this PR makes two changes to the AWS KMS adapter:
1. In writing the encryption info map, all keys will be translated to ARNs. This is because alias information appears to be stored in-region, and may not be accessible during a regional outage.
2. In reading the encryption info map, we now attempt to look up a decryption key not only on the supplied key, but also on _any replica of the supplied key_. Peer replica IDs appear to be replicated to all regions, and so should be available during a regional outage.

For backwards compatibility, we continue to write the old-style encryption info entries using KMS aliases. We'll stop doing this in 25.3.

Epic: none
Release note (enterprise change): Adds support for KMS replicas on AWS. *Breaking Change: DescribeKey permission now required.*

[Cloud unit tests](https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Nightlies_CloudUnitTests/18021415)