### PR TITLE
release-23.1: raftlog: close Engine in TestIteratorEmptyLog

### DIFF
--- a/pkg/kv/kvserver/raftlog/encoding_test.go
+++ b/pkg/kv/kvserver/raftlog/encoding_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/stretchr/testify/require"
@@ -31,6 +32,7 @@ import (
 //	RaftAdmissionMetaOverhead/bytes=1.0_MiB,raft-ac-10   148µs ± 4%   151µs ± 5%     ~     (p=0.095 n=5+5)
 //	RaftAdmissionMetaOverhead/bytes=2.0_MiB,raft-ac-10   290µs ± 3%   292µs ± 1%     ~     (p=0.151 n=5+5)
 func BenchmarkRaftAdmissionMetaOverhead(b *testing.B) {
+	defer leaktest.AfterTest(b)()
 	defer log.Scope(b).Close(b)
 
 	const KiB = 1 << 10

--- a/pkg/kv/kvserver/raftlog/entry_bench_test.go
+++ b/pkg/kv/kvserver/raftlog/entry_bench_test.go
@@ -9,9 +9,12 @@ package raftlog
 import (
 	"fmt"
 	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 func BenchmarkNewEntry(b *testing.B) {
+	defer leaktest.AfterTest(b)()
 	ent, metaB := mkBenchEnt(b)
 	b.ResetTimer()
 	for _, fromRawValue := range []bool{false, true} {

--- a/pkg/kv/kvserver/raftlog/entry_test.go
+++ b/pkg/kv/kvserver/raftlog/entry_test.go
@@ -9,11 +9,14 @@ package raftlog
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/raft/v3/raftpb"
 )
 
 func TestNewEntry(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
 	// TODO(replication): Add more cases.
 	testcases := map[string]struct {
 		data        []byte

--- a/pkg/kv/kvserver/raftlog/iter_test.go
+++ b/pkg/kv/kvserver/raftlog/iter_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/stretchr/testify/require"
@@ -144,9 +145,11 @@ func (it *modelIter) Entry() raftpb.Entry {
 }
 
 func TestIteratorEmptyLog(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
 	eng := storage.NewDefaultInMemForTesting()
+	defer eng.Close()
 	for _, hi := range []uint64{0, 1} {
 		it := NewIterator(rangeID, eng, IterOptions{Hi: hi})
 		ok, err := it.SeekGE(0)
@@ -159,6 +162,7 @@ func TestIteratorEmptyLog(t *testing.T) {
 // TestIterator sets up a few raft logs and iterates all conceivable chunks of
 // them with both the real and a model iterator, comparing the results.
 func TestIterator(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
 	for _, tc := range []struct {


### PR DESCRIPTION
An in-memory engine was leaked from this test, leading to flakiness in other tests when running the full package's unit tests. Also, add leaktest to this package's unit tests to catch this class of bug more readily.

Fix #134801.
Epic: none
Release note: none
Release justification: non-production code changes