### PR TITLE
sql: add promise_unique decorator function

### DIFF
--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -562,6 +562,15 @@ func (b *Builder) buildFunction(
 		args[i] = b.buildScalar(pexpr.(tree.TypedExpr), inScope, nil, nil, colRefs)
 	}
 
+	/*
+		if def.Name == "promise_unique" {
+			if len(args) != 1 {
+				panic(errors.AssertionFailedf("wrong number of args"))
+			}
+			return b.finishBuildScalar(f, args[0], inScope, outScope, outCol)
+		}
+	*/
+
 	// Construct a private FuncOpDef that refers to a resolved function overload.
 	out = b.factory.ConstructFunction(args, &memo.FunctionPrivate{
 		Name:       def.Name,

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -8938,6 +8938,17 @@ WHERE object_id = table_descriptor_id
 			Volatility: volatility.Stable,
 		},
 	),
+	"promise_unique": makeBuiltin(defProps(),
+		tree.Overload{
+			Types:      tree.ParamTypes{{Name: "val", Typ: types.Any}},
+			ReturnType: tree.IdentityReturnType(0),
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return args[0], nil
+			},
+			Info:       "marks the value as unique",
+			Volatility: volatility.Volatile,
+		},
+	),
 }
 
 var lengthImpls = func(incBitOverload bool) builtinDefinition {

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2606,6 +2606,7 @@ var builtinOidsArray = []string{
 	2643: `crdb_internal.type_is_indexable(oid: oid) -> bool`,
 	2644: `crdb_internal.range_stats_with_errors(key: bytes) -> jsonb`,
 	2645: `crdb_internal.lease_holder_with_errors(key: bytes) -> jsonb`,
+	2646: `promise_unique(val: anyelement) -> anyelement`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid


### PR DESCRIPTION
Add a do-nothing function which decorates a column to indicate that it is unique enough to skip uniqueness checks. Here's a demonstrantion:

```
demo@127.0.0.1:26257/demoapp/defaultdb> CREATE TABLE t (a INT PRIMARY KEY, b INT) LOCALITY REGIONAL BY ROW;
CREATE TABLE

Time: 44ms total (execution 42ms / network 2ms)

demo@127.0.0.1:26257/demoapp/defaultdb> EXPLAIN (OPT) INSERT INTO t VALUES (1, 1);
                                          info
----------------------------------------------------------------------------------------
  insert t
   ├── values
   │    └── (1, 1, 'us-east1', true)
   └── unique-checks
        └── unique-checks-item: t(a)
             └── distribute
                  └── project
                       └── project
                            └── inner-join (cross)
                                 ├── values
                                 │    └── (1,)
                                 ├── scan t
                                 │    ├── constraint: /14/12
                                 │    │    ├── [/'europe-west1'/1 - /'europe-west1'/1]
                                 │    │    └── [/'us-west1'/1 - /'us-west1'/1]
                                 │    └── limit: 1
                                 └── filters (true)
(17 rows)

Time: 14ms total (execution 14ms / network 0ms)

demo@127.0.0.1:26257/demoapp/defaultdb> EXPLAIN (OPT) INSERT INTO t VALUES (promise_unique(1), 1);
                         info
------------------------------------------------------
  insert t
   └── values
        └── (promise_unique(1), 1, 'us-east1', true)
(3 rows)

Time: 1ms total (execution 0ms / network 0ms)

demo@127.0.0.1:26257/demoapp/defaultdb> EXPLAIN (OPT) INSERT INTO t SELECT promise_unique(1), 1;
                         info
------------------------------------------------------
  insert t
   └── values
        └── (promise_unique(1), 1, 'us-east1', true)
(3 rows)

Time: 1ms total (execution 1ms / network 0ms)
```

This is a prototype and there are some problems. One problem is that there is no "uniqueness type checking" to prove that within the query the unique value remains unique. E.g. optbuilder is happy to build a plan inserting multiple rows with the same ostensibly-unique value:

```
demo@127.0.0.1:26257/demoapp/defaultdb> EXPLAIN (OPT) INSERT INTO t SELECT promise_unique(1), generate_series(0, 1);
                    info
---------------------------------------------
  insert t
   └── project
        ├── project-set
        │    ├── values
        │    │    └── ()
        │    └── zip
        │         └── generate_series(0, 1)
        └── projections
             ├── true
             ├── 'us-east1'
             └── promise_unique(1)
(11 rows)

Time: 2ms total (execution 1ms / network 0ms)
```