### PR TITLE
ui: updates useSWR hooks to include clusterId in key

### DIFF
--- a/pkg/ui/pnpm-lock.yaml
+++ b/pkg/ui/pnpm-lock.yaml
@@ -254,6 +254,9 @@ importers:
       '@testing-library/react':
         specifier: ^12.1.0
         version: 12.1.0(react-dom@16.12.0)(react@16.12.0)
+      '@testing-library/react-hooks':
+        specifier: ^6.0.0
+        version: 6.0.0(react-dom@16.12.0)(react-test-renderer@16.13.1)(react@16.12.0)
       '@testing-library/user-event':
         specifier: ^13.5.0
         version: 13.5.0(@testing-library/dom@8.11.1)
@@ -7480,6 +7483,30 @@ packages:
       redent: 3.0.0
     dev: true
 
+  /@testing-library/react-hooks@6.0.0(react-dom@16.12.0)(react-test-renderer@16.13.1)(react@16.12.0):
+    resolution: {integrity: sha512-Y8ayCUFPiNttX9zmwP2bDv4uYzgsgOMHxAsOrD7th7Xuj1j1rHkxf+VzRqdr7zJlSeYPzl67754qAnZ9O1ahYg==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+      react-test-renderer: '>=16.9.0'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-test-renderer:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.12.13
+      '@types/react': 16.14.8
+      '@types/react-dom': 16.9.3
+      '@types/react-test-renderer': 18.3.0
+      filter-console: 0.1.1
+      react: 16.12.0
+      react-dom: 16.12.0(react@16.12.0)
+      react-error-boundary: 3.1.4(react@16.12.0)
+      react-test-renderer: 16.13.1(react@16.12.0)
+    dev: true
+
   /@testing-library/react@12.1.0(react-dom@16.12.0)(react@16.12.0):
     resolution: {integrity: sha512-Ge3Ht3qXE82Yv9lyPpQ7ZWgzo/HgOcHu569Y4ZGWcZME38iOFiOg87qnu6hTEa8jTJVL7zYovnvD3GE2nsNIoQ==}
     engines: {node: '>=12'}
@@ -8009,6 +8036,12 @@ packages:
 
   /@types/react-syntax-highlighter@11.0.5:
     resolution: {integrity: sha512-VIOi9i2Oj5XsmWWoB72p3KlZoEbdRAcechJa8Ztebw7bDl2YmR+odxIqhtJGp1q2EozHs02US+gzxJ9nuf56qg==}
+    dependencies:
+      '@types/react': 16.14.8
+    dev: true
+
+  /@types/react-test-renderer@18.3.0:
+    resolution: {integrity: sha512-HW4MuEYxfDbOHQsVlY/XtOvNHftCVEPhJF2pQXXwcUiUF+Oyb0usgp48HSgpK5rt8m9KZb22yqOeZm+rrVG8gw==}
     dependencies:
       '@types/react': 16.14.8
     dev: true
@@ -13945,6 +13978,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
+
+  /filter-console@0.1.1:
+    resolution: {integrity: sha512-zrXoV1Uaz52DqPs+qEwNJWJFAWZpYJ47UNmpN9q4j+/EYsz85uV0DC9k8tRND5kYmoVzL0W+Y75q4Rg8sRJCdg==}
+    engines: {node: '>=8'}
+    dev: true
 
   /finalhandler@1.0.6:
     resolution: {integrity: sha512-immlyyYCPWG2tajlYBhZ6cjLAv1QAclU8tKS0d27ZtPqm/+iddy16GT3xLExg+V4lIETLpPwaYQAlZHNE//dPA==}
@@ -20522,6 +20560,16 @@ packages:
       prop-types: 15.8.1
       react: 16.12.0
       react-dom: 16.12.0(react@16.12.0)
+    dev: true
+
+  /react-error-boundary@3.1.4(react@16.12.0):
+    resolution: {integrity: sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==}
+    engines: {node: '>=10', npm: '>=6'}
+    peerDependencies:
+      react: '>=16.13.1'
+    dependencies:
+      '@babel/runtime': 7.12.13
+      react: 16.12.0
     dev: true
 
   /react-error-overlay@6.0.11:

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -99,6 +99,7 @@
     "@testing-library/dom": "^8.11.1",
     "@testing-library/jest-dom": "6.5.0",
     "@testing-library/react": "^12.1.0",
+    "@testing-library/react-hooks": "^6.0.0",
     "@testing-library/user-event": "^13.5.0",
     "@types/chai": "^4.2.11",
     "@types/classnames": "^2.2.9",

--- a/pkg/ui/workspaces/cluster-ui/src/api/clusterSettingsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/clusterSettingsApi.ts
@@ -5,11 +5,10 @@
 
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import moment from "moment-timezone";
-import useSWRImmutable from "swr/immutable";
 
 import { fetchData } from "src/api";
 
-import { TimestampToMoment } from "../util";
+import { TimestampToMoment, useSwrImmutableWithClusterId } from "../util";
 
 import { ADMIN_API_PREFIX } from "./util";
 
@@ -97,8 +96,12 @@ export const useClusterSettings = (req: GetClusterSettingRequest) => {
   const protoReq = new cockroach.server.serverpb.SettingsRequest({
     keys: req.names,
   });
-  const { data, isLoading, error } = useSWRImmutable(req.names, () =>
-    getClusterSettings(protoReq, "1M").then(formatProtoResponse),
+  const { data, isLoading, error } = useSwrImmutableWithClusterId(
+    {
+      name: "clusterSettings",
+      settings: req.names,
+    },
+    () => getClusterSettings(protoReq, "1M").then(formatProtoResponse),
   );
 
   // If we don't have data we'll return a map of empty settings.

--- a/pkg/ui/workspaces/cluster-ui/src/api/databases/grantsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databases/grantsApi.ts
@@ -3,8 +3,7 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import useSWRImmutable from "swr/immutable";
-
+import { useSwrImmutableWithClusterId } from "../../util";
 import { fetchDataJSON } from "../fetchData";
 import { ResultsWithPagination, PaginationRequest } from "../types";
 
@@ -28,6 +27,16 @@ type DatabaseGrantsRequest = {
   sortBy?: GrantsSortOptions;
   sortOrder?: "asc" | "desc";
   pagination?: PaginationRequest;
+};
+
+const createKey = (req: DatabaseGrantsRequest) => {
+  const {
+    dbId,
+    pagination: { pageSize, pageNum },
+    sortBy,
+    sortOrder,
+  } = req;
+  return { name: "databaseGrants", dbId, pageSize, pageNum, sortBy, sortOrder };
 };
 
 const createDbGrantsPath = (req: DatabaseGrantsRequest): string => {
@@ -68,8 +77,8 @@ const fetchDbGrants = (
 };
 
 export const useDatabaseGrantsImmutable = (req: DatabaseGrantsRequest) => {
-  const { data, isLoading, error } = useSWRImmutable(
-    createDbGrantsPath(req),
+  const { data, isLoading, error } = useSwrImmutableWithClusterId(
+    createKey(req),
     () => fetchDbGrants(req),
   );
 
@@ -123,7 +132,7 @@ const fetchTableGrants = async (
 };
 
 export const useTableGrantsImmutable = (req: TableGrantsRequest) => {
-  const { data, isLoading, error } = useSWRImmutable(
+  const { data, isLoading, error } = useSwrImmutableWithClusterId(
     createTableGrantsPath(req),
     () => fetchTableGrants(req),
   );

--- a/pkg/ui/workspaces/cluster-ui/src/api/databases/tableIndexesApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databases/tableIndexesApi.ts
@@ -6,9 +6,8 @@
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import moment from "moment-timezone";
 import { useMemo } from "react";
-import useSWR from "swr";
 
-import { TimestampToMoment } from "src/util";
+import { TimestampToMoment, useSwrWithClusterId } from "src/util";
 
 import { getIndexStats, resetIndexStats } from "../indexDetailsApi";
 import { QualifiedIdentifier } from "../safesql";
@@ -49,8 +48,8 @@ export const useTableIndexStats = ({
   tableName,
 }: GetTableIndexesRequest) => {
   const makeRequest = dbName && tableName;
-  const { data, isLoading, error, mutate } = useSWR(
-    ["tableIndexes", dbName, tableName],
+  const { data, isLoading, error, mutate } = useSwrWithClusterId(
+    { name: "tableIndexes", dbName, tableName },
     makeRequest
       ? () =>
           getIndexStats(

--- a/pkg/ui/workspaces/cluster-ui/src/api/databases/tableMetaUpdateJobApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databases/tableMetaUpdateJobApi.ts
@@ -5,8 +5,8 @@
 
 import moment from "moment-timezone";
 import { useMemo } from "react";
-import useSWR from "swr";
 
+import { useSwrWithClusterId } from "../../util";
 import { fetchDataJSON } from "../fetchData";
 
 import {
@@ -70,7 +70,7 @@ export const convertTableMetaUpdateJobFromServer = (
 // The hook polls the API every 3 seconds if the job status is parsed as and every
 // 10 seconds otherwise.
 export const useTableMetaUpdateJob = () => {
-  const { data, isLoading, mutate } = useSWR(
+  const { data, isLoading, mutate } = useSwrWithClusterId(
     "tableMetaUpdateJob",
     getTableMetaUpdateJobInfo,
     {

--- a/pkg/ui/workspaces/cluster-ui/src/api/nodesApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/nodesApi.ts
@@ -5,13 +5,13 @@
 
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { useContext, useMemo } from "react";
-import useSWR from "swr";
 
 import { fetchData } from "src/api";
 import { getRegionFromLocality } from "src/store/nodes";
 
 import { ClusterDetailsContext } from "../contexts";
 import { NodeID, StoreID } from "../types/clusterTypes";
+import { useSwrWithClusterId } from "../util";
 
 const NODES_PATH = "_status/nodes_ui";
 
@@ -26,10 +26,9 @@ export type NodeStatus = {
 };
 
 export const useNodeStatuses = () => {
-  const clusterDetails = useContext(ClusterDetailsContext);
-  const isTenant = clusterDetails.isTenant;
-  const { data, isLoading, error } = useSWR(
-    NODES_PATH,
+  const { isTenant } = useContext(ClusterDetailsContext);
+  const { data, isLoading, error } = useSwrWithClusterId(
+    "nodesUI",
     !isTenant ? getNodes : null,
     {
       revalidateOnFocus: false,

--- a/pkg/ui/workspaces/cluster-ui/src/contexts/clusterDetailsContext.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/contexts/clusterDetailsContext.tsx
@@ -5,11 +5,13 @@
 
 import { createContext } from "react";
 
-type ClusterDetailsContextType = {
+export type ClusterDetailsContextType = {
   isTenant?: boolean;
+  clusterId?: string;
 };
 
 // This is used by CC to fill in details such as whether we have a tenant or not.
 export const ClusterDetailsContext = createContext<ClusterDetailsContextType>({
   isTenant: false,
+  clusterId: null,
 });

--- a/pkg/ui/workspaces/cluster-ui/src/util/hooks.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/util/hooks.spec.tsx
@@ -10,10 +10,23 @@ import {
   fireEvent,
   waitFor,
 } from "@testing-library/react";
+import { renderHook } from "@testing-library/react-hooks";
 import moment from "moment-timezone";
-import React from "react";
+import React, { ReactNode } from "react";
+import * as SwrModule from "swr";
+import * as SwrImmutableModule from "swr/immutable";
 
-import { useScheduleFunction } from "./hooks";
+import { ClusterDetailsContext, ClusterDetailsContextType } from "../contexts";
+
+import {
+  useScheduleFunction,
+  useSwrImmutableWithClusterId,
+  useSwrWithClusterId,
+} from "./hooks";
+
+interface Props {
+  children?: ReactNode;
+}
 
 describe("useScheduleFunction", () => {
   let mockFn: jest.Mock;
@@ -136,3 +149,197 @@ describe("useScheduleFunction", () => {
     expect(mockFn).toBeCalledTimes(0);
   });
 });
+
+describe("useSwrWithClusterId", () => {
+  const clusterId = "myClusterId";
+  const keyStr = "myKey";
+  const keyObj = { name: keyStr };
+  const keyArr = [keyStr];
+  let spyUseSWR: jest.SpyInstance;
+  let spyUseSWRImmutable: jest.SpyInstance;
+  const nullClusterIdContext: ClusterDetailsContextType = {
+    isTenant: false,
+    clusterId: null,
+  };
+  const undefinedClusterIdContext: ClusterDetailsContextType = {};
+  const clusterIdContext: ClusterDetailsContextType = {
+    isTenant: false,
+    clusterId,
+  };
+  beforeEach(() => {
+    spyUseSWR = jest.spyOn(SwrModule, "default");
+    spyUseSWRImmutable = jest.spyOn(SwrImmutableModule, "default");
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+  const testCases = [
+    // Object based keys
+    {
+      name: "object key with null cluster context",
+      ctx: nullClusterIdContext,
+      key: keyObj,
+      expectedKey: { clusterId: null, ...keyObj },
+    },
+    {
+      name: "object key with undefined cluster context",
+      ctx: undefinedClusterIdContext,
+      key: keyObj,
+      expectedKey: { clusterId: undefined, ...keyObj },
+    },
+    {
+      name: "object key with set cluster context",
+      ctx: clusterIdContext,
+      key: keyObj,
+      expectedKey: { clusterId, ...keyObj },
+    },
+
+    // Array based keys
+    {
+      name: "array key with null cluster context",
+      ctx: nullClusterIdContext,
+      key: keyArr,
+      expectedKey: [null, ...keyArr],
+    },
+    {
+      name: "array key with undefined cluster context",
+      ctx: undefinedClusterIdContext,
+      key: keyArr,
+      expectedKey: [undefined, ...keyArr],
+    },
+    {
+      name: "array key with set cluster context",
+      ctx: clusterIdContext,
+      key: keyArr,
+      expectedKey: [clusterId, ...keyArr],
+    },
+
+    // String based keys
+    {
+      name: "string key with null cluster context",
+      ctx: nullClusterIdContext,
+      key: keyStr,
+      expectedKey: [null, keyStr],
+    },
+    {
+      name: "string key with undefined cluster context",
+      ctx: undefinedClusterIdContext,
+      key: keyStr,
+      expectedKey: [undefined, keyStr],
+    },
+    {
+      name: "string key with set cluster context",
+      ctx: clusterIdContext,
+      key: keyStr,
+      expectedKey: [clusterId, keyStr],
+    },
+
+    // boolean(true) keys
+    {
+      name: "boolean (true) key with null cluster context",
+      ctx: nullClusterIdContext,
+      key: true,
+      expectedKey: [null, true],
+    },
+    {
+      name: "boolean (true) key with undefined cluster context",
+      ctx: undefinedClusterIdContext,
+      key: true,
+      expectedKey: [undefined, true],
+    },
+    {
+      name: "boolean (true) key with set cluster context",
+      ctx: clusterIdContext,
+      key: true,
+      expectedKey: [clusterId, true],
+    },
+
+    // boolean(false) keys
+    {
+      name: "boolean(false) key with null cluster context",
+      ctx: nullClusterIdContext,
+      key: false,
+      expectedKey: false,
+    },
+    {
+      name: "boolean(false) key with undefined cluster context",
+      ctx: undefinedClusterIdContext,
+      key: false,
+      expectedKey: false,
+    },
+    {
+      name: "boolean(false) key with set cluster context",
+      ctx: clusterIdContext,
+      key: false,
+      expectedKey: false,
+    },
+
+    {
+      name: "null key with null cluster context",
+      ctx: nullClusterIdContext,
+      key: null,
+      expectedKey: null,
+    },
+    {
+      name: "null key with undefined cluster context",
+      ctx: undefinedClusterIdContext,
+      key: null,
+      expectedKey: null,
+    },
+    {
+      name: "null key with set cluster context",
+      ctx: clusterIdContext,
+      key: null,
+      expectedKey: null,
+    },
+
+    {
+      name: "undefined key with null cluster context",
+      ctx: nullClusterIdContext,
+      key: undefined,
+      expectedKey: undefined,
+    },
+    {
+      name: "undefined key with undefined cluster context",
+      ctx: undefinedClusterIdContext,
+      key: undefined,
+      expectedKey: undefined,
+    },
+    {
+      name: "undefined key with set cluster context",
+      ctx: clusterIdContext,
+      key: undefined,
+      expectedKey: undefined,
+    },
+  ];
+  test.each(testCases)("$name", ({ ctx, key, expectedKey }) => {
+    const wrapper = makeContextProvidedWrapper(ctx);
+    renderHook(() => useSwrWithClusterId(key, (): void => null), {
+      wrapper,
+    });
+    expect(spyUseSWR).toHaveBeenCalledWith(
+      expectedKey,
+      expect.anything(),
+      undefined,
+    );
+
+    renderHook(() => useSwrImmutableWithClusterId(key, (): void => null), {
+      wrapper,
+    });
+    expect(spyUseSWRImmutable).toHaveBeenCalledWith(
+      expectedKey,
+      expect.anything(),
+      undefined,
+    );
+  });
+});
+
+const makeContextProvidedWrapper = (ctx: ClusterDetailsContextType) => {
+  return ({ children }: Props) => {
+    return (
+      <ClusterDetailsContext.Provider value={ctx}>
+        {children}
+      </ClusterDetailsContext.Provider>
+    );
+  };
+};

--- a/pkg/ui/workspaces/cluster-ui/src/util/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/index.ts
@@ -12,6 +12,7 @@ export * from "./docs";
 export * from "./fixLong";
 export * from "./format";
 export * from "./formatDate";
+export * from "./hooks";
 export * from "./logger";
 export * from "./requestError";
 export * from "./sql/summarize";


### PR DESCRIPTION
Previously, useSWR hooks were usings keys that didn't include cluster ids. This worked fine for DB console, but resulted in rendering bugs in cc-console. Since cc-console allows users to switch between clusters, users would temporarily see database and table metadata from previously views clusters until the useSWR hook refreshed the data.

Now that these hooks calls have been updated to include cluster id, switching between clusters will only show data relevant to that cluster.

Fixes: https://cockroachlabs.atlassian.net/browse/CC-30169
Epic: none
Release note: none