### PR TITLE
kvserver: always use epoch based leases in TestRangeQuiescence

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -4337,7 +4337,8 @@ func TestRangeQuiescence(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	kvserver.ExpirationLeasesOnly.Override(ctx, &st.SV, false) // override metamorphism
+	// Only epoch based leases can be quiesced.
+	kvserver.OverrideDefaultLeaseType(ctx, &st.SV, roachpb.LeaseEpoch)
 
 	tc := testcluster.StartTestCluster(t, 3,
 		base.TestClusterArgs{


### PR DESCRIPTION
Only epoch based leases can be quiesced. Explicitly use these for TestRangeQuiescence.

References https://github.com/cockroachdb/cockroach/issues/133763

Release note: None