### PR TITLE
rowcontainer: add accounting for some memory use in DiskRowContainer

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/results_buffer.go
+++ b/pkg/kv/kvclient/kvstreamer/results_buffer.go
@@ -377,7 +377,7 @@ type ResultDiskBuffer interface {
 // TestResultDiskBufferConstructor constructs a ResultDiskBuffer for tests. It
 // is injected to be rowcontainer.NewKVStreamerResultDiskBuffer in order to
 // avoid an import cycle.
-var TestResultDiskBufferConstructor func(diskmap.Factory, *mon.BytesMonitor) ResultDiskBuffer
+var TestResultDiskBufferConstructor func(_ diskmap.Factory, memAcc mon.BoundAccount, diskMonitor *mon.BytesMonitor) ResultDiskBuffer
 
 // inOrderResultsBuffer is a resultsBuffer that returns the Results in the same
 // order as the original requests were Enqueued into the Streamer (in other

--- a/pkg/sql/buffer_util.go
+++ b/pkg/sql/buffer_util.go
@@ -23,10 +23,11 @@ import (
 // should be used by planNodes (or similar components) whenever they need to
 // buffer data. init or initWithDedup must be called before the first use.
 type rowContainerHelper struct {
-	memMonitor  *mon.BytesMonitor
-	diskMonitor *mon.BytesMonitor
-	rows        *rowcontainer.DiskBackedRowContainer
-	scratch     rowenc.EncDatumRow
+	memMonitor          *mon.BytesMonitor
+	unlimitedMemMonitor *mon.BytesMonitor
+	diskMonitor         *mon.BytesMonitor
+	rows                *rowcontainer.DiskBackedRowContainer
+	scratch             rowenc.EncDatumRow
 }
 
 func (c *rowContainerHelper) Init(
@@ -39,8 +40,8 @@ func (c *rowContainerHelper) Init(
 	distSQLCfg := &evalContext.DistSQLPlanner.distSQLSrv.ServerConfig
 	c.rows = &rowcontainer.DiskBackedRowContainer{}
 	c.rows.Init(
-		colinfo.NoOrdering, typs, &evalContext.Context,
-		distSQLCfg.TempStorage, c.memMonitor, c.diskMonitor,
+		colinfo.NoOrdering, typs, &evalContext.Context, distSQLCfg.TempStorage,
+		c.memMonitor, c.unlimitedMemMonitor, c.diskMonitor,
 	)
 	c.scratch = make(rowenc.EncDatumRow, len(typs))
 }
@@ -65,8 +66,8 @@ func (c *rowContainerHelper) InitWithDedup(
 		ordering[i].Direction = encoding.Ascending
 	}
 	c.rows.Init(
-		ordering, typs, &evalContext.Context,
-		distSQLCfg.TempStorage, c.memMonitor, c.diskMonitor,
+		ordering, typs, &evalContext.Context, distSQLCfg.TempStorage,
+		c.memMonitor, c.unlimitedMemMonitor, c.diskMonitor,
 	)
 	c.rows.DoDeDuplicate()
 	c.scratch = make(rowenc.EncDatumRow, len(typs))
@@ -83,19 +84,23 @@ func (c *rowContainerHelper) InitWithParentMon(
 	opName redact.RedactableString,
 ) {
 	distSQLCfg := &evalContext.DistSQLPlanner.distSQLSrv.ServerConfig
-	// TODO(yuzefovich): currently the memory usage of c.memMonitor doesn't
-	// count against sql.mem.distsql.current metric. Fix it.
+	// TODO(yuzefovich): currently the memory usage of c.memMonitor and
+	// c.unlimitedMemMonitor don't count against sql.mem.distsql.current metric.
+	// Fix it.
 	c.memMonitor = execinfra.NewLimitedMonitorNoFlowCtx(
 		ctx, parent, distSQLCfg, evalContext.SessionData(),
 		redact.Sprintf("%s-limited", opName),
+	)
+	c.unlimitedMemMonitor = execinfra.NewMonitor(
+		ctx, parent, redact.Sprintf("%s-unlimited", opName),
 	)
 	c.diskMonitor = execinfra.NewMonitor(
 		ctx, distSQLCfg.ParentDiskMonitor, redact.Sprintf("%s-disk", opName),
 	)
 	c.rows = &rowcontainer.DiskBackedRowContainer{}
 	c.rows.Init(
-		colinfo.NoOrdering, typs, &evalContext.Context,
-		distSQLCfg.TempStorage, c.memMonitor, c.diskMonitor,
+		colinfo.NoOrdering, typs, &evalContext.Context, distSQLCfg.TempStorage,
+		c.memMonitor, c.unlimitedMemMonitor, c.diskMonitor,
 	)
 	c.scratch = make(rowenc.EncDatumRow, len(typs))
 }
@@ -104,11 +109,15 @@ func (c *rowContainerHelper) initMonitors(
 	ctx context.Context, evalContext *extendedEvalContext, opName redact.RedactableString,
 ) {
 	distSQLCfg := &evalContext.DistSQLPlanner.distSQLSrv.ServerConfig
-	// TODO(yuzefovich): currently the memory usage of c.memMonitor doesn't
-	// count against sql.mem.distsql.current metric. Fix it.
+	// TODO(yuzefovich): currently the memory usage of c.memMonitor and
+	// c.unlimitedMemMonitor don't count against sql.mem.distsql.current metric.
+	// Fix it.
 	c.memMonitor = execinfra.NewLimitedMonitorNoFlowCtx(
 		ctx, evalContext.Planner.Mon(), distSQLCfg, evalContext.SessionData(),
 		redact.Sprintf("%s-limited", opName),
+	)
+	c.unlimitedMemMonitor = execinfra.NewMonitor(
+		ctx, evalContext.Planner.Mon(), redact.Sprintf("%s-unlimited", opName),
 	)
 	c.diskMonitor = execinfra.NewMonitor(
 		ctx, distSQLCfg.ParentDiskMonitor, redact.Sprintf("%s-disk", opName),
@@ -156,6 +165,7 @@ func (c *rowContainerHelper) Close(ctx context.Context) {
 	if c.rows != nil {
 		c.rows.Close(ctx)
 		c.memMonitor.Stop(ctx)
+		c.unlimitedMemMonitor.Stop(ctx)
 		c.diskMonitor.Stop(ctx)
 		c.rows = nil
 	}

--- a/pkg/sql/colfetcher/BUILD.bazel
+++ b/pkg/sql/colfetcher/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/col/typeconv",
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/kv/kvclient/kvstreamer",
         "//pkg/kv/kvpb",
         "//pkg/roachpb",
         "//pkg/settings",

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvstreamer"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
@@ -539,8 +540,18 @@ func NewColIndexJoin(
 		if flowCtx.EvalCtx.SessionData().StreamerAlwaysMaintainOrdering {
 			maintainOrdering = true
 		}
-		if maintainOrdering && diskMonitor == nil {
-			return nil, errors.AssertionFailedf("diskMonitor is nil when ordering needs to be maintained")
+		var diskBuffer kvstreamer.ResultDiskBuffer
+		if maintainOrdering {
+			if diskMonitor == nil {
+				return nil, errors.AssertionFailedf("diskMonitor is nil when ordering needs to be maintained")
+			}
+			// Explicitly create a separate memory account bound to the
+			// unlimited monitor here - this passes ownership to the disk buffer
+			// which will close the acc.
+			diskBufferMemAcc := streamerBudgetAcc.Monitor().MakeBoundAccount()
+			diskBuffer = rowcontainer.NewKVStreamerResultDiskBuffer(
+				flowCtx.Cfg.TempStorage, diskBufferMemAcc, diskMonitor,
+			)
 		}
 		kvFetcher = row.NewStreamingKVFetcher(
 			flowCtx.Cfg.DistSender,
@@ -556,9 +567,7 @@ func NewColIndexJoin(
 			maintainOrdering,
 			true, /* singleRowLookup */
 			int(spec.FetchSpec.MaxKeysPerRow),
-			rowcontainer.NewKVStreamerResultDiskBuffer(
-				flowCtx.Cfg.TempStorage, diskMonitor,
-			),
+			diskBuffer,
 			kvFetcherMemAcc,
 			spec.FetchSpec.External,
 			tableArgs.RequiresRawMVCCValues(),

--- a/pkg/sql/rowcontainer/BUILD.bazel
+++ b/pkg/sql/rowcontainer/BUILD.bazel
@@ -63,6 +63,7 @@ go_test(
         "//pkg/roachpb",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog/colinfo",
+        "//pkg/sql/execinfra",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/randgen",

--- a/pkg/sql/rowcontainer/BUILD.bazel
+++ b/pkg/sql/rowcontainer/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
         "disk_row_container_test.go",
         "hash_row_container_test.go",
         "kvstreamer_result_disk_buffer_test.go",
+        "main_test.go",
         "numbered_row_container_test.go",
         "row_container_test.go",
     ],

--- a/pkg/sql/rowcontainer/disk_row_container.go
+++ b/pkg/sql/rowcontainer/disk_row_container.go
@@ -35,8 +35,11 @@ type DiskRowContainer struct {
 	diskAcc mon.BoundAccount
 	// bufferedRows buffers writes to the diskMap.
 	bufferedRows diskmap.SortedDiskMapBatchWriter
-	scratchKey   []byte
-	scratchVal   []byte
+	// memAcc keeps track of memory usage of scratchKey, scratchVal, and keys
+	// stored in deDupCache if applicable.
+	memAcc     mon.BoundAccount
+	scratchKey []byte
+	scratchVal []byte
 
 	// For computing mean encoded row bytes.
 	totalEncodedRowBytes uint64
@@ -71,9 +74,9 @@ type DiskRowContainer struct {
 	// contains all the key strings that are potentially buffered in bufferedRows.
 	// Since we need to de-duplicate for every insert attempt, we don't want to
 	// keep flushing bufferedRows after every insert.
-	// There is currently no memory-accounting for the deDupCache, just like there
-	// is none for the bufferedRows. Both will be approximately the same size.
 	deDupCache map[string]int
+
+	deDupCacheAccountedFor int64
 
 	diskMonitor *mon.BytesMonitor
 	engine      diskmap.Factory
@@ -87,12 +90,16 @@ var _ DeDupingRowContainer = &DiskRowContainer{}
 // MakeDiskRowContainer creates a DiskRowContainer with the given engine as the
 // underlying store that rows are stored on.
 // Arguments:
+//   - memAcc is used to monitor this DiskRowContainer's memory usage. It must
+//     be bound to an unlimited memory monitor. The container takes ownership of
+//     the account.
 //   - diskMonitor is used to monitor this DiskRowContainer's disk usage.
 //   - types is the schema of rows that will be added to this container.
 //   - ordering is the output ordering; the order in which rows should be sorted.
 //   - e is the underlying store that rows are stored on.
 func MakeDiskRowContainer(
 	ctx context.Context,
+	memAcc mon.BoundAccount,
 	diskMonitor *mon.BytesMonitor,
 	typs []*types.T,
 	ordering colinfo.ColumnOrdering,
@@ -103,6 +110,7 @@ func MakeDiskRowContainer(
 		diskMap:      diskMap,
 		diskAcc:      diskMonitor.MakeBoundAccount(),
 		bufferedRows: diskMap.NewBatchWriter(),
+		memAcc:       memAcc,
 		types:        typs,
 		ordering:     ordering,
 		diskMonitor:  diskMonitor,
@@ -204,8 +212,12 @@ func (d *DiskRowContainer) AddRow(ctx context.Context, row rowenc.EncDatumRow) e
 	// calls to AddRowWithDeDup() de-duplicate wrt this cache.
 	if d.deDuplicate {
 		if d.bufferedRows.NumPutsSinceFlush() == 0 {
-			d.clearDeDupCache()
+			d.clearDeDupCache(ctx)
 		} else {
+			if err := d.memAcc.Grow(ctx, int64(len(d.scratchKey))); err != nil {
+				return err
+			}
+			d.deDupCacheAccountedFor += int64(len(d.scratchKey))
 			d.deDupCache[string(d.scratchKey)] = int(d.rowID)
 		}
 	}
@@ -265,8 +277,12 @@ func (d *DiskRowContainer) AddRowWithDeDup(
 		return 0, err
 	}
 	if d.bufferedRows.NumPutsSinceFlush() == 0 {
-		d.clearDeDupCache()
+		d.clearDeDupCache(ctx)
 	} else {
+		if err = d.memAcc.Grow(ctx, int64(len(d.scratchKey))); err != nil {
+			return 0, err
+		}
+		d.deDupCacheAccountedFor += int64(len(d.scratchKey))
 		d.deDupCache[string(d.scratchKey)] = int(d.rowID)
 	}
 	d.totalEncodedRowBytes += uint64(len(d.scratchKey) + len(d.scratchVal))
@@ -275,23 +291,32 @@ func (d *DiskRowContainer) AddRowWithDeDup(
 	return idx, nil
 }
 
-func (d *DiskRowContainer) clearDeDupCache() {
+func (d *DiskRowContainer) clearDeDupCache(ctx context.Context) {
 	for k := range d.deDupCache {
 		delete(d.deDupCache, k)
 	}
+	d.memAcc.Shrink(ctx, d.deDupCacheAccountedFor)
+	d.deDupCacheAccountedFor = 0
 }
 
 func (d *DiskRowContainer) testingFlushBuffer(ctx context.Context) {
 	if err := d.bufferedRows.Flush(); err != nil {
 		log.Fatalf(ctx, "%v", err)
 	}
-	d.clearDeDupCache()
+	d.clearDeDupCache(ctx)
 }
 
-func (d *DiskRowContainer) encodeRow(ctx context.Context, row rowenc.EncDatumRow) error {
+func (d *DiskRowContainer) encodeRow(ctx context.Context, row rowenc.EncDatumRow) (retErr error) {
 	if len(row) != len(d.types) {
 		log.Fatalf(ctx, "invalid row length %d, expected %d", len(row), len(d.types))
 	}
+	oldScratchMemUse := int64(cap(d.scratchKey) + cap(d.scratchVal))
+	defer func() {
+		if retErr == nil {
+			newScratchMemUse := int64(cap(d.scratchKey) + cap(d.scratchVal))
+			retErr = d.memAcc.Resize(ctx, oldScratchMemUse, newScratchMemUse)
+		}
+	}()
 
 	for i, orderInfo := range d.ordering {
 		col := orderInfo.ColIdx
@@ -340,7 +365,8 @@ func (d *DiskRowContainer) Sort(context.Context) {}
 func (d *DiskRowContainer) Reorder(ctx context.Context, ordering colinfo.ColumnOrdering) error {
 	// We need to create a new DiskRowContainer since its ordering can only be
 	// changed at initialization.
-	newContainer, err := MakeDiskRowContainer(ctx, d.diskMonitor, d.types, ordering, d.engine)
+	memAcc := d.memAcc.Monitor().MakeBoundAccount()
+	newContainer, err := MakeDiskRowContainer(ctx, memAcc, d.diskMonitor, d.types, ordering, d.engine)
 	if err != nil {
 		return err
 	}
@@ -393,7 +419,10 @@ func (d *DiskRowContainer) UnsafeReset(ctx context.Context) error {
 	}
 	d.diskAcc.Clear(ctx)
 	d.bufferedRows = d.diskMap.NewBatchWriter()
-	d.clearDeDupCache()
+	d.scratchKey = nil
+	d.scratchVal = nil
+	d.clearDeDupCache(ctx)
+	d.memAcc.Clear(ctx)
 	d.lastReadKey = nil
 	d.rowID = 0
 	d.totalEncodedRowBytes = 0
@@ -411,6 +440,7 @@ func (d *DiskRowContainer) Close(ctx context.Context) {
 		d.diskMap.Close(ctx)
 	}
 	d.diskAcc.Close(ctx) // diskAcc is never nil
+	d.memAcc.Close(ctx)  // memAcc is never nil
 }
 
 // diskRowIterator iterates over the rows in a DiskRowContainer.

--- a/pkg/sql/rowcontainer/disk_row_container_test.go
+++ b/pkg/sql/rowcontainer/disk_row_container_test.go
@@ -169,13 +169,11 @@ func TestDiskRowContainer(t *testing.T) {
 			// Test with different orderings so that we have a mix of key and
 			// value encodings.
 			for _, ordering := range orderings {
-				typs := make([]*types.T, numCols)
-				for i := range typs {
-					typs[i] = randgen.RandSortingType(rng)
-				}
+				typs := randgen.RandSortingTypes(rng, numCols)
 				row := randgen.RandEncDatumRowOfTypes(rng, typs)
 				func() {
-					d, _ := MakeDiskRowContainer(ctx, diskMonitor, typs, ordering, tempEngine)
+					memAcc := evalCtx.TestingMon.MakeBoundAccount()
+					d, _ := MakeDiskRowContainer(ctx, memAcc, diskMonitor, typs, ordering, tempEngine)
 					defer d.Close(ctx)
 					if err := d.AddRow(ctx, row); err != nil {
 						t.Fatal(err)
@@ -238,7 +236,8 @@ func TestDiskRowContainer(t *testing.T) {
 			types := randgen.RandSortingTypes(rng, numCols)
 			rows := randgen.RandEncDatumRowsOfTypes(rng, numRows, types)
 			func() {
-				d, _ := MakeDiskRowContainer(ctx, diskMonitor, types, ordering, tempEngine)
+				memAcc := evalCtx.TestingMon.MakeBoundAccount()
+				d, _ := MakeDiskRowContainer(ctx, memAcc, diskMonitor, types, ordering, tempEngine)
 				defer d.Close(ctx)
 				for i := 0; i < len(rows); i++ {
 					if err := d.AddRow(ctx, rows[i]); err != nil {
@@ -320,7 +319,8 @@ func TestDiskRowContainer(t *testing.T) {
 		// Use random types and random rows.
 		types := randgen.RandSortingTypes(rng, numCols)
 		numRows, rows := makeUniqueRows(t, &evalCtx, rng, numRows, types, ordering)
-		d, _ := MakeDiskRowContainer(ctx, diskMonitor, types, ordering, tempEngine)
+		memAcc := evalCtx.TestingMon.MakeBoundAccount()
+		d, _ := MakeDiskRowContainer(ctx, memAcc, diskMonitor, types, ordering, tempEngine)
 		defer d.Close(ctx)
 		d.DoDeDuplicate()
 		addRowsRepeatedly := func() {
@@ -361,8 +361,9 @@ func TestDiskRowContainer(t *testing.T) {
 		// Use random types and random rows.
 		types := randgen.RandSortingTypes(rng, numCols)
 		rows := randgen.RandEncDatumRowsOfTypes(rng, numRows, types)
+		memAcc := evalCtx.TestingMon.MakeBoundAccount()
 		// There are no ordering columns when using the numberedRowIterator.
-		d, _ := MakeDiskRowContainer(ctx, diskMonitor, types, nil, tempEngine)
+		d, _ := MakeDiskRowContainer(ctx, memAcc, diskMonitor, types, nil, tempEngine)
 		defer d.Close(ctx)
 		for i := 0; i < numRows; i++ {
 			require.NoError(t, d.AddRow(ctx, rows[i]))
@@ -432,6 +433,7 @@ func TestDiskRowContainerDiskFull(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
+	evalCtx := eval.MakeTestingEvalContext(st)
 	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil /* statsCollector */)
 	if err != nil {
 		t.Fatal(err)
@@ -442,8 +444,10 @@ func TestDiskRowContainerDiskFull(t *testing.T) {
 	monitor := getDiskMonitor(st)
 	monitor.Start(ctx, nil, mon.NewStandaloneBudget(0 /* capacity */))
 
+	memAcc := evalCtx.TestingMon.MakeBoundAccount()
 	d, _ := MakeDiskRowContainer(
 		ctx,
+		memAcc,
 		monitor,
 		[]*types.T{types.Int},
 		colinfo.ColumnOrdering{colinfo.ColumnOrderInfo{ColIdx: 0, Direction: encoding.Ascending}},
@@ -476,7 +480,8 @@ func TestDiskRowContainerFinalIterator(t *testing.T) {
 	diskMonitor.Start(ctx, nil /* pool */, mon.NewStandaloneBudget(math.MaxInt64))
 	defer diskMonitor.Stop(ctx)
 
-	d, _ := MakeDiskRowContainer(ctx, diskMonitor, types.OneIntCol, nil /* ordering */, tempEngine)
+	memAcc := evalCtx.TestingMon.MakeBoundAccount()
+	d, _ := MakeDiskRowContainer(ctx, memAcc, diskMonitor, types.OneIntCol, nil /* ordering */, tempEngine)
 	defer d.Close(ctx)
 
 	const numCols = 1
@@ -587,6 +592,7 @@ func TestDiskRowContainerUnsafeReset(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
+	evalCtx := eval.MakeTestingEvalContext(st)
 	tempEngine, _, err := storage.NewTempEngine(ctx, base.DefaultTestTempStorageConfig(st), base.DefaultTestStoreSpec, nil /* statsCollector */)
 	if err != nil {
 		t.Fatal(err)
@@ -596,7 +602,8 @@ func TestDiskRowContainerUnsafeReset(t *testing.T) {
 	monitor := getDiskMonitor(st)
 	monitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 
-	d, _ := MakeDiskRowContainer(ctx, monitor, types.OneIntCol, nil /* ordering */, tempEngine)
+	memAcc := evalCtx.TestingMon.MakeBoundAccount()
+	d, _ := MakeDiskRowContainer(ctx, memAcc, monitor, types.OneIntCol, nil /* ordering */, tempEngine)
 	defer d.Close(ctx)
 
 	const (

--- a/pkg/sql/rowcontainer/disk_row_container_test.go
+++ b/pkg/sql/rowcontainer/disk_row_container_test.go
@@ -349,7 +349,7 @@ func TestDiskRowContainer(t *testing.T) {
 		addRowsRepeatedly()
 		// Reset and add the rows in a different order.
 		require.NoError(t, d.UnsafeReset(ctx))
-		rand.Shuffle(len(rows), func(i, j int) {
+		rng.Shuffle(len(rows), func(i, j int) {
 			rows[i], rows[j] = rows[j], rows[i]
 		})
 		addRowsRepeatedly()
@@ -420,7 +420,7 @@ func makeUniqueRows(
 	}
 	rows = deDupedRows
 	// Shuffle so that not adding in sorted order.
-	rand.Shuffle(len(rows), func(i, j int) {
+	rng.Shuffle(len(rows), func(i, j int) {
 		rows[i], rows[j] = rows[j], rows[i]
 	})
 	return len(rows), rows

--- a/pkg/sql/rowcontainer/hash_row_container.go
+++ b/pkg/sql/rowcontainer/hash_row_container.go
@@ -515,7 +515,8 @@ type HashDiskRowContainer struct {
 	DiskRowContainer
 	columnEncoder
 
-	diskMonitor *mon.BytesMonitor
+	unlimitedMemMonitor *mon.BytesMonitor
+	diskMonitor         *mon.BytesMonitor
 	// shouldMark specifies whether the caller cares about marking rows. If not,
 	// rows are stored with one less column (which usually specifies that row's
 	// mark).
@@ -528,15 +529,16 @@ var _ HashRowContainer = &HashDiskRowContainer{}
 
 var encodedTrue = encoding.EncodeBoolValue(nil, encoding.NoColumnID, true)
 
-// MakeHashDiskRowContainer creates a HashDiskRowContainer with the given engine
+// makeHashDiskRowContainer creates a HashDiskRowContainer with the given engine
 // as the underlying store that rows are stored on. shouldMark specifies whether
 // the HashDiskRowContainer should set itself up to mark rows.
-func MakeHashDiskRowContainer(
-	diskMonitor *mon.BytesMonitor, e diskmap.Factory,
+func makeHashDiskRowContainer(
+	unlimitedMemMonitor, diskMonitor *mon.BytesMonitor, e diskmap.Factory,
 ) HashDiskRowContainer {
 	return HashDiskRowContainer{
-		diskMonitor: diskMonitor,
-		engine:      e,
+		unlimitedMemMonitor: unlimitedMemMonitor,
+		diskMonitor:         diskMonitor,
+		engine:              e,
 	}
 }
 
@@ -563,7 +565,8 @@ func (h *HashDiskRowContainer) Init(
 	}
 
 	var err error
-	h.DiskRowContainer, err = MakeDiskRowContainer(ctx, h.diskMonitor, storedTypes, storedEqColsToOrdering(storedEqCols), h.engine)
+	memAcc := h.unlimitedMemMonitor.MakeBoundAccount()
+	h.DiskRowContainer, err = MakeDiskRowContainer(ctx, memAcc, h.diskMonitor, storedTypes, storedEqColsToOrdering(storedEqCols), h.engine)
 	return err
 }
 
@@ -817,11 +820,12 @@ type HashDiskBackedRowContainer struct {
 	storedEqCols columns
 	encodeNull   bool
 
-	evalCtx       *eval.Context
-	memoryMonitor *mon.BytesMonitor
-	diskMonitor   *mon.BytesMonitor
-	engine        diskmap.Factory
-	scratchEncRow rowenc.EncDatumRow
+	evalCtx             *eval.Context
+	memoryMonitor       *mon.BytesMonitor
+	unlimitedMemMonitor *mon.BytesMonitor
+	diskMonitor         *mon.BytesMonitor
+	engine              diskmap.Factory
+	scratchEncRow       rowenc.EncDatumRow
 
 	// allRowsIterators keeps track of all iterators created via
 	// NewAllRowsIterator(). If the container spills to disk, these become
@@ -838,15 +842,17 @@ var _ HashRowContainer = &HashDiskBackedRowContainer{}
 func NewHashDiskBackedRowContainer(
 	evalCtx *eval.Context,
 	memoryMonitor *mon.BytesMonitor,
+	unlimitedMemMonitor *mon.BytesMonitor,
 	diskMonitor *mon.BytesMonitor,
 	engine diskmap.Factory,
 ) *HashDiskBackedRowContainer {
 	return &HashDiskBackedRowContainer{
-		evalCtx:          evalCtx,
-		memoryMonitor:    memoryMonitor,
-		diskMonitor:      diskMonitor,
-		engine:           engine,
-		allRowsIterators: make([]*AllRowsIterator, 0, 1),
+		evalCtx:             evalCtx,
+		memoryMonitor:       memoryMonitor,
+		unlimitedMemMonitor: unlimitedMemMonitor,
+		diskMonitor:         diskMonitor,
+		engine:              engine,
+		allRowsIterators:    make([]*AllRowsIterator, 0, 1),
 	}
 }
 
@@ -949,7 +955,7 @@ func (h *HashDiskBackedRowContainer) SpillToDisk(ctx context.Context) error {
 	if h.UsingDisk() {
 		return errors.New("already using disk")
 	}
-	hdrc := MakeHashDiskRowContainer(h.diskMonitor, h.engine)
+	hdrc := makeHashDiskRowContainer(h.unlimitedMemMonitor, h.diskMonitor, h.engine)
 	defer func() {
 		if h.src != &hdrc {
 			// For whatever reason, we weren't able to spill, so in order to not

--- a/pkg/sql/rowcontainer/hash_row_container_test.go
+++ b/pkg/sql/rowcontainer/hash_row_container_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
@@ -40,6 +41,7 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 	}
 	defer tempEngine.Close()
 
+	unlimitedMemMonitor := execinfra.NewTestMemMonitor(ctx, st)
 	// These monitors are started and stopped by subtests.
 	memoryMonitor := getMemoryMonitor(st)
 	diskMonitor := getDiskMonitor(st)
@@ -52,7 +54,7 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 	ordering := colinfo.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}}
 
 	getRowContainer := func() *HashDiskBackedRowContainer {
-		rc := NewHashDiskBackedRowContainer(&evalCtx, memoryMonitor, diskMonitor, tempEngine)
+		rc := NewHashDiskBackedRowContainer(&evalCtx, memoryMonitor, unlimitedMemMonitor, diskMonitor, tempEngine)
 		err = rc.Init(
 			ctx,
 			false, /* shouldMark */
@@ -310,6 +312,7 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 	}
 	defer tempEngine.Close()
 
+	unlimitedMemMonitor := execinfra.NewTestMemMonitor(ctx, st)
 	// These monitors are started and stopped by subtests.
 	memoryMonitor := getMemoryMonitor(st)
 	diskMonitor := getDiskMonitor(st)
@@ -323,7 +326,7 @@ func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 	ordering := colinfo.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}}
 
 	getRowContainer := func() *HashDiskBackedRowContainer {
-		rc := NewHashDiskBackedRowContainer(&evalCtx, memoryMonitor, diskMonitor, tempEngine)
+		rc := NewHashDiskBackedRowContainer(&evalCtx, memoryMonitor, unlimitedMemMonitor, diskMonitor, tempEngine)
 		err = rc.Init(
 			ctx,
 			true, /* shouldMark */

--- a/pkg/sql/rowcontainer/main_test.go
+++ b/pkg/sql/rowcontainer/main_test.go
@@ -1,0 +1,18 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package rowcontainer
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	randutil.SeedForTests()
+	os.Exit(m.Run())
+}

--- a/pkg/sql/rowcontainer/numbered_row_container.go
+++ b/pkg/sql/rowcontainer/numbered_row_container.go
@@ -53,6 +53,8 @@ type DiskBackedNumberedRowContainer struct {
 //   - engine is the underlying store that rows are stored on when the container
 //     spills to disk.
 //   - memoryMonitor is used to monitor this container's memory usage.
+//   - unlimitedMemMonitor is used to monitor the memory usage of the disk row
+//     containers if spilling to disk occurs.
 //   - diskMonitor is used to monitor this container's disk usage.
 func NewDiskBackedNumberedRowContainer(
 	deDup bool,
@@ -60,6 +62,7 @@ func NewDiskBackedNumberedRowContainer(
 	evalCtx *eval.Context,
 	engine diskmap.Factory,
 	memoryMonitor *mon.BytesMonitor,
+	unlimitedMemMonitor *mon.BytesMonitor,
 	diskMonitor *mon.BytesMonitor,
 ) *DiskBackedNumberedRowContainer {
 	d := &DiskBackedNumberedRowContainer{
@@ -68,7 +71,7 @@ func NewDiskBackedNumberedRowContainer(
 		rowIterMemAcc: memoryMonitor.MakeBoundAccount(),
 	}
 	d.rc = &DiskBackedRowContainer{}
-	d.rc.Init(nil /*ordering*/, types, evalCtx, engine, memoryMonitor, diskMonitor)
+	d.rc.Init(nil /* ordering */, types, evalCtx, engine, memoryMonitor, unlimitedMemMonitor, diskMonitor)
 	if deDup {
 		ordering := make(colinfo.ColumnOrdering, len(types))
 		for i := range types {
@@ -76,7 +79,7 @@ func NewDiskBackedNumberedRowContainer(
 			ordering[i].Direction = encoding.Ascending
 		}
 		deduper := &DiskBackedRowContainer{}
-		deduper.Init(ordering, types, evalCtx, engine, memoryMonitor, diskMonitor)
+		deduper.Init(ordering, types, evalCtx, engine, memoryMonitor, unlimitedMemMonitor, diskMonitor)
 		deduper.DoDeDuplicate()
 		d.deduper = deduper
 	}

--- a/pkg/sql/rowcontainer/numbered_row_container_test.go
+++ b/pkg/sql/rowcontainer/numbered_row_container_test.go
@@ -111,7 +111,7 @@ func TestNumberedRowContainerDeDuping(t *testing.T) {
 			require.Equal(t, rows[accesses[i]].String(types), row.String(types))
 		}
 		// Reset and reorder the rows for the next pass.
-		rand.Shuffle(numRows, func(i, j int) {
+		rng.Shuffle(numRows, func(i, j int) {
 			rows[i], rows[j] = rows[j], rows[i]
 		})
 		require.NoError(t, rc.UnsafeReset(ctx))
@@ -205,7 +205,7 @@ func TestNumberedRowContainerIteratorCaching(t *testing.T) {
 		fmt.Printf("hits: %d, misses: %d, maxCacheSize: %d\n",
 			rc.rowIter.hitCount, rc.rowIter.missCount, rc.rowIter.maxCacheSize)
 		// Reset and reorder the rows for the next pass.
-		rand.Shuffle(numRows, func(i, j int) {
+		rng.Shuffle(numRows, func(i, j int) {
 			rows[i], rows[j] = rows[j], rows[i]
 		})
 		require.NoError(t, rc.UnsafeReset(ctx))
@@ -310,7 +310,7 @@ func TestCompareNumberedAndIndexedRowContainers(t *testing.T) {
 			}
 		}
 		// Reset and reorder the rows for the next pass.
-		rand.Shuffle(numRows, func(i, j int) {
+		rng.Shuffle(numRows, func(i, j int) {
 			rows[i], rows[j] = rows[j], rows[i]
 		})
 		for _, rc := range containers {

--- a/pkg/sql/rowcontainer/row_container.go
+++ b/pkg/sql/rowcontainer/row_container.go
@@ -418,8 +418,9 @@ type DiskBackedRowContainer struct {
 
 	// The following fields are used to create a DiskRowContainer when spilling
 	// to disk.
-	engine      diskmap.Factory
-	diskMonitor *mon.BytesMonitor
+	engine              diskmap.Factory
+	unlimitedMemMonitor *mon.BytesMonitor
+	diskMonitor         *mon.BytesMonitor
 }
 
 var _ ReorderableRowContainer = &DiskBackedRowContainer{}
@@ -435,6 +436,8 @@ var _ DeDupingRowContainer = &DiskBackedRowContainer{}
 //   - memoryMonitor is used to monitor the DiskBackedRowContainer's memory usage.
 //     If this monitor denies an allocation, the DiskBackedRowContainer will
 //     spill to disk.
+//   - unlimitedMemMonitor is used to monitor the memory usage of the internal
+//     disk row container if the DiskBackedRowContainer spills to disk.
 //   - diskMonitor is used to monitor the DiskBackedRowContainer's disk usage if
 //     and when it spills to disk.
 func (f *DiskBackedRowContainer) Init(
@@ -443,6 +446,7 @@ func (f *DiskBackedRowContainer) Init(
 	evalCtx *eval.Context,
 	engine diskmap.Factory,
 	memoryMonitor *mon.BytesMonitor,
+	unlimitedMemMonitor *mon.BytesMonitor,
 	diskMonitor *mon.BytesMonitor,
 ) {
 	mrc := MemRowContainer{}
@@ -450,6 +454,7 @@ func (f *DiskBackedRowContainer) Init(
 	f.mrc = &mrc
 	f.src = &mrc
 	f.engine = engine
+	f.unlimitedMemMonitor = unlimitedMemMonitor
 	f.diskMonitor = diskMonitor
 	f.encodings = make([]catenumpb.DatumEncoding, len(ordering))
 	for i, orderInfo := range ordering {
@@ -617,6 +622,10 @@ func (f *DiskBackedRowContainer) spillIfMemErr(ctx context.Context, err error) (
 	if !sqlerrors.IsOutOfMemoryError(err) {
 		return false, nil
 	}
+	if f.UsingDisk() {
+		// Return the original error if we already spilled to disk.
+		return false, err
+	}
 	if spillErr := f.SpillToDisk(ctx); spillErr != nil {
 		return false, spillErr
 	}
@@ -630,7 +639,8 @@ func (f *DiskBackedRowContainer) SpillToDisk(ctx context.Context) error {
 	if f.UsingDisk() {
 		return errors.New("already using disk")
 	}
-	drc, err := MakeDiskRowContainer(ctx, f.diskMonitor, f.mrc.types, f.mrc.ordering, f.engine)
+	memAcc := f.unlimitedMemMonitor.MakeBoundAccount()
+	drc, err := MakeDiskRowContainer(ctx, memAcc, f.diskMonitor, f.mrc.types, f.mrc.ordering, f.engine)
 	if err != nil {
 		return err
 	}
@@ -718,6 +728,8 @@ var _ IndexedRowContainer = &DiskBackedIndexedRowContainer{}
 //   - engine is the underlying store that rows are stored on when the container
 //     spills to disk.
 //   - memoryMonitor is used to monitor this container's memory usage.
+//   - unlimitedMemMonitor is used to track memory usage of the internal disk
+//     row container if DiskBackedIndexedRowContainer spills to disk.
 //   - diskMonitor is used to monitor this container's disk usage.
 func NewDiskBackedIndexedRowContainer(
 	ordering colinfo.ColumnOrdering,
@@ -725,6 +737,7 @@ func NewDiskBackedIndexedRowContainer(
 	evalCtx *eval.Context,
 	engine diskmap.Factory,
 	memoryMonitor *mon.BytesMonitor,
+	unlimitedMemMonitor *mon.BytesMonitor,
 	diskMonitor *mon.BytesMonitor,
 ) *DiskBackedIndexedRowContainer {
 	d := DiskBackedIndexedRowContainer{}
@@ -735,7 +748,7 @@ func NewDiskBackedIndexedRowContainer(
 	d.storedTypes[len(d.storedTypes)-1] = types.Int
 	d.scratchEncRow = make(rowenc.EncDatumRow, len(d.storedTypes))
 	d.DiskBackedRowContainer = &DiskBackedRowContainer{}
-	d.DiskBackedRowContainer.Init(ordering, d.storedTypes, evalCtx, engine, memoryMonitor, diskMonitor)
+	d.DiskBackedRowContainer.Init(ordering, d.storedTypes, evalCtx, engine, memoryMonitor, unlimitedMemMonitor, diskMonitor)
 	d.maxCacheSize = maxIndexedRowsCacheSize
 	d.cacheMemAcc = memoryMonitor.MakeBoundAccount()
 	return &d

--- a/pkg/sql/rowcontainer/row_container_test.go
+++ b/pkg/sql/rowcontainer/row_container_test.go
@@ -231,6 +231,7 @@ func TestDiskBackedRowContainer(t *testing.T) {
 			&evalCtx,
 			tempEngine,
 			memoryMonitor,
+			evalCtx.TestingMon,
 			diskMonitor,
 		)
 		cleanup = func(ctx context.Context) {
@@ -439,6 +440,7 @@ func TestDiskBackedRowContainerDeDuping(t *testing.T) {
 		&evalCtx,
 		tempEngine,
 		memoryMonitor,
+		evalCtx.TestingMon,
 		diskMonitor,
 	)
 	defer rc.Close(ctx)
@@ -527,7 +529,7 @@ func TestDiskBackedIndexedRowContainer(t *testing.T) {
 	}
 	defer tempEngine.Close()
 
-	memoryMonitor := getMemoryMonitor(st)
+	unlimitedMemMonitor := getMemoryMonitor(st)
 	diskMonitor := getDiskMonitor(st)
 
 	const numTestRuns = 10
@@ -537,8 +539,8 @@ func TestDiskBackedIndexedRowContainer(t *testing.T) {
 	newOrdering := colinfo.ColumnOrdering{{ColIdx: 1, Direction: encoding.Ascending}}
 
 	rng, _ := randutil.NewTestRand()
-	memoryMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
-	defer memoryMonitor.Stop(ctx)
+	unlimitedMemMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
+	defer unlimitedMemMonitor.Stop(ctx)
 	diskMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
 	defer diskMonitor.Stop(ctx)
 
@@ -555,7 +557,7 @@ func TestDiskBackedIndexedRowContainer(t *testing.T) {
 			}
 
 			func() {
-				rc := NewDiskBackedIndexedRowContainer(ordering, types, &evalCtx, tempEngine, memoryMonitor, diskMonitor)
+				rc := NewDiskBackedIndexedRowContainer(ordering, types, &evalCtx, tempEngine, unlimitedMemMonitor, unlimitedMemMonitor, diskMonitor)
 				defer rc.Close(ctx)
 				mid := numRows / 2
 				for i := 0; i < mid; i++ {
@@ -621,7 +623,7 @@ func TestDiskBackedIndexedRowContainer(t *testing.T) {
 			}
 
 			func() {
-				rc := NewDiskBackedIndexedRowContainer(ordering, types, &evalCtx, tempEngine, memoryMonitor, diskMonitor)
+				rc := NewDiskBackedIndexedRowContainer(ordering, types, &evalCtx, tempEngine, unlimitedMemMonitor, unlimitedMemMonitor, diskMonitor)
 				defer rc.Close(ctx)
 				for _, row := range rows {
 					if err := rc.AddRow(ctx, row); err != nil {
@@ -733,7 +735,7 @@ func TestDiskBackedIndexedRowContainer(t *testing.T) {
 			}
 
 			func() {
-				rc := NewDiskBackedIndexedRowContainer(ordering, types, &evalCtx, tempEngine, memMonitor, diskMonitor)
+				rc := NewDiskBackedIndexedRowContainer(ordering, types, &evalCtx, tempEngine, memMonitor, unlimitedMemMonitor, diskMonitor)
 				defer rc.Close(ctx)
 				if err := rc.SpillToDisk(ctx); err != nil {
 					t.Fatal(err)
@@ -803,7 +805,7 @@ func TestDiskBackedIndexedRowContainer(t *testing.T) {
 			storedTypes[len(typs)] = types.OneIntCol[0]
 
 			func() {
-				rc := NewDiskBackedIndexedRowContainer(ordering, typs, &evalCtx, tempEngine, memoryMonitor, diskMonitor)
+				rc := NewDiskBackedIndexedRowContainer(ordering, typs, &evalCtx, tempEngine, unlimitedMemMonitor, unlimitedMemMonitor, diskMonitor)
 				defer rc.Close(ctx)
 				for i := 0; i < numRows; i++ {
 					if err := rc.AddRow(ctx, rows[i]); err != nil {
@@ -844,7 +846,7 @@ func TestDiskBackedIndexedRowContainer(t *testing.T) {
 			storedTypes[len(typs)] = types.OneIntCol[0]
 
 			func() {
-				d := NewDiskBackedIndexedRowContainer(ordering, typs, &evalCtx, tempEngine, memoryMonitor, diskMonitor)
+				d := NewDiskBackedIndexedRowContainer(ordering, typs, &evalCtx, tempEngine, unlimitedMemMonitor, unlimitedMemMonitor, diskMonitor)
 				defer d.Close(ctx)
 				if err := d.SpillToDisk(ctx); err != nil {
 					t.Fatal(err)
@@ -1007,7 +1009,7 @@ func BenchmarkDiskBackedIndexedRowContainer(b *testing.B) {
 	accessPattern := generateAccessPattern(numRows)
 
 	b.Run("InMemory", func(b *testing.B) {
-		rc := NewDiskBackedIndexedRowContainer(nil, types.OneIntCol, &evalCtx, tempEngine, memoryMonitor, diskMonitor)
+		rc := NewDiskBackedIndexedRowContainer(nil, types.OneIntCol, &evalCtx, tempEngine, memoryMonitor, memoryMonitor, diskMonitor)
 		defer rc.Close(ctx)
 		for i := 0; i < len(rows); i++ {
 			if err := rc.AddRow(ctx, rows[i]); err != nil {
@@ -1029,7 +1031,7 @@ func BenchmarkDiskBackedIndexedRowContainer(b *testing.B) {
 	})
 
 	b.Run("OnDiskWithCache", func(b *testing.B) {
-		rc := NewDiskBackedIndexedRowContainer(nil, types.OneIntCol, &evalCtx, tempEngine, memoryMonitor, diskMonitor)
+		rc := NewDiskBackedIndexedRowContainer(nil, types.OneIntCol, &evalCtx, tempEngine, memoryMonitor, memoryMonitor, diskMonitor)
 		defer rc.Close(ctx)
 		if err := rc.SpillToDisk(ctx); err != nil {
 			b.Fatal(err)
@@ -1054,7 +1056,7 @@ func BenchmarkDiskBackedIndexedRowContainer(b *testing.B) {
 	})
 
 	b.Run("OnDiskWithoutCache", func(b *testing.B) {
-		rc := NewDiskBackedIndexedRowContainer(nil, types.OneIntCol, &evalCtx, tempEngine, memoryMonitor, diskMonitor)
+		rc := NewDiskBackedIndexedRowContainer(nil, types.OneIntCol, &evalCtx, tempEngine, memoryMonitor, memoryMonitor, diskMonitor)
 		defer rc.Close(ctx)
 		if err := rc.SpillToDisk(ctx); err != nil {
 			b.Fatal(err)

--- a/pkg/sql/rowcontainer/row_container_test.go
+++ b/pkg/sql/rowcontainer/row_container_test.go
@@ -463,7 +463,7 @@ func TestDiskBackedRowContainerDeDuping(t *testing.T) {
 			require.Equal(t, i, idx)
 		}
 		// Reset and reorder the rows for the next run.
-		rand.Shuffle(numRows, func(i, j int) {
+		rng.Shuffle(numRows, func(i, j int) {
 			rows[i], rows[j] = rows[j], rows[i]
 		})
 		require.NoError(t, rc.UnsafeReset(ctx))

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -60,7 +60,8 @@ type hashJoiner struct {
 
 	runningState hashJoinerState
 
-	diskMonitor *mon.BytesMonitor
+	unlimitedMemMonitor *mon.BytesMonitor
+	diskMonitor         *mon.BytesMonitor
 
 	leftSource, rightSource execinfra.RowSource
 
@@ -147,9 +148,10 @@ func newHashJoiner(
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The hashJoiner will overflow to disk if this limit is not enough.
 	h.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx, "hashjoiner-limited")
+	h.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon, "hashjoiner-unlimited")
 	h.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, "hashjoiner-disk")
 	h.hashTable = rowcontainer.NewHashDiskBackedRowContainer(
-		h.FlowCtx.EvalCtx, h.MemMonitor, h.diskMonitor, h.FlowCtx.Cfg.TempStorage,
+		h.FlowCtx.EvalCtx, h.MemMonitor, h.unlimitedMemMonitor, h.diskMonitor, h.FlowCtx.Cfg.TempStorage,
 	)
 
 	// If the trace is recording, instrument the hashJoiner to collect stats.
@@ -459,6 +461,9 @@ func (h *hashJoiner) close() {
 			h.emittingRightUnmatchedState.iter.Close()
 		}
 		h.MemMonitor.Stop(h.Ctx())
+		if h.unlimitedMemMonitor != nil {
+			h.unlimitedMemMonitor.Stop(h.Ctx())
+		}
 		if h.diskMonitor != nil {
 			h.diskMonitor.Stop(h.Ctx())
 		}

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -62,8 +62,9 @@ type invertedJoiner struct {
 
 	fetchSpec fetchpb.IndexFetchSpec
 
-	runningState invertedJoinerState
-	diskMonitor  *mon.BytesMonitor
+	runningState        invertedJoinerState
+	unlimitedMemMonitor *mon.BytesMonitor
+	diskMonitor         *mon.BytesMonitor
 
 	// prefixEqualityCols are the ordinals of the columns from the join input
 	// that represent join values for the non-inverted prefix columns of
@@ -318,6 +319,7 @@ func newInvertedJoiner(
 
 	// Initialize memory monitors and row container for index rows.
 	ij.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx, "invertedjoiner-limited")
+	ij.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon, "invertedjoiner-unlimited")
 	ij.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, "invertedjoiner-disk")
 	ij.indexRows = rowcontainer.NewDiskBackedNumberedRowContainer(
 		true, /* deDup */
@@ -325,6 +327,7 @@ func newInvertedJoiner(
 		ij.FlowCtx.EvalCtx,
 		ij.FlowCtx.Cfg.TempStorage,
 		ij.MemMonitor,
+		ij.unlimitedMemMonitor,
 		ij.diskMonitor,
 	)
 
@@ -749,6 +752,9 @@ func (ij *invertedJoiner) close() {
 			ij.indexRows.Close(ij.Ctx())
 		}
 		ij.MemMonitor.Stop(ij.Ctx())
+		if ij.unlimitedMemMonitor != nil {
+			ij.unlimitedMemMonitor.Stop(ij.Ctx())
+		}
 		if ij.diskMonitor != nil {
 			ij.diskMonitor.Stop(ij.Ctx())
 		}
@@ -777,7 +783,7 @@ func (ij *invertedJoiner) execStatsForTrace() *execinfrapb.ComponentStats {
 			KVCPUTime:           optional.MakeTimeValue(fis.kvCPUTime),
 		},
 		Exec: execinfrapb.ExecStats{
-			MaxAllocatedMem:  optional.MakeUint(uint64(ij.MemMonitor.MaximumBytes())),
+			MaxAllocatedMem:  optional.MakeUint(uint64(ij.MemMonitor.MaximumBytes() + ij.unlimitedMemMonitor.MaximumBytes())),
 			MaxAllocatedDisk: optional.MakeUint(uint64(ij.diskMonitor.MaximumBytes())),
 		},
 		Output: ij.OutputHelper.Stats(),

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -97,8 +97,9 @@ type joinReader struct {
 	// used by buffered rows in joinReaderOrderingStrategy. If the memory limit is
 	// exceeded, the joinReader will spill to disk. diskMonitor is used to monitor
 	// the disk utilization in this case.
-	limitedMemMonitor *mon.BytesMonitor
-	diskMonitor       *mon.BytesMonitor
+	limitedMemMonitor   *mon.BytesMonitor
+	unlimitedMemMonitor *mon.BytesMonitor
+	diskMonitor         *mon.BytesMonitor
 
 	fetchSpec      fetchpb.IndexFetchSpec
 	splitFamilyIDs []descpb.FamilyID
@@ -545,11 +546,12 @@ func newJoinReader(
 
 		var diskBuffer kvstreamer.ResultDiskBuffer
 		if jr.streamerInfo.maintainOrdering {
+			diskBufferMemAcc := jr.streamerInfo.unlimitedMemMonitor.MakeBoundAccount()
 			jr.streamerInfo.diskMonitor = execinfra.NewMonitor(
 				ctx, jr.FlowCtx.DiskMonitor, "streamer-disk", /* name */
 			)
 			diskBuffer = rowcontainer.NewKVStreamerResultDiskBuffer(
-				jr.FlowCtx.Cfg.TempStorage, jr.streamerInfo.diskMonitor,
+				jr.FlowCtx.Cfg.TempStorage, diskBufferMemAcc, jr.streamerInfo.diskMonitor,
 			)
 		}
 		singleRowLookup := readerType == indexJoinReaderType || spec.LookupColumnsAreKey
@@ -726,6 +728,7 @@ func (jr *joinReader) initJoinReaderStrategy(
 	// disk, it releases all of the memory reservations, so we make the
 	// corresponding memory monitor not hold on to any bytes.
 	jr.limitedMemMonitor.RelinquishAllOnReleaseBytes()
+	jr.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon, "joinreader-unlimited")
 	jr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, "joinreader-disk")
 	drc := rowcontainer.NewDiskBackedNumberedRowContainer(
 		false, /* deDup */
@@ -733,6 +736,7 @@ func (jr *joinReader) initJoinReaderStrategy(
 		jr.FlowCtx.EvalCtx,
 		jr.FlowCtx.Cfg.TempStorage,
 		jr.limitedMemMonitor,
+		jr.unlimitedMemMonitor,
 		jr.diskMonitor,
 	)
 	if limit < mon.DefaultPoolAllocationSize {
@@ -1226,6 +1230,9 @@ func (jr *joinReader) close() {
 		if jr.MemMonitor != nil {
 			jr.MemMonitor.Stop(jr.Ctx())
 		}
+		if jr.unlimitedMemMonitor != nil {
+			jr.unlimitedMemMonitor.Stop(jr.Ctx())
+		}
 		if jr.diskMonitor != nil {
 			jr.diskMonitor.Stop(jr.Ctx())
 		}
@@ -1260,6 +1267,9 @@ func (jr *joinReader) execStatsForTrace() *execinfrapb.ComponentStats {
 	// Note that there is no need to include the maximum bytes of
 	// jr.limitedMemMonitor because it is a child of jr.MemMonitor.
 	ret.Exec.MaxAllocatedMem.Add(jr.MemMonitor.MaximumBytes())
+	if jr.unlimitedMemMonitor != nil {
+		ret.Exec.MaxAllocatedMem.Add(jr.unlimitedMemMonitor.MaximumBytes())
+	}
 	if jr.diskMonitor != nil {
 		ret.Exec.MaxAllocatedDisk.Add(jr.diskMonitor.MaximumBytes())
 	}

--- a/pkg/sql/rowexec/zigzagjoiner_test.go
+++ b/pkg/sql/rowexec/zigzagjoiner_test.go
@@ -91,11 +91,10 @@ func TestZigzagJoiner(t *testing.T) {
 		return offsetFunc
 	}
 
-	sqlutils.CreateTableDebug(t, sqlDB, "empty",
+	sqlutils.CreateTable(t, sqlDB, "empty",
 		"a INT, b INT, x INT, c INT, d INT, PRIMARY KEY (a,b), INDEX c (c), INDEX d (d)",
 		0,
 		sqlutils.ToRowFn(aFn, bFn, cFn, dFn),
-		true, /* shouldPrint */
 	)
 
 	// Drop a column to test https://github.com/cockroachdb/cockroach/issues/37196
@@ -109,58 +108,51 @@ func TestZigzagJoiner(t *testing.T) {
 	_, err = sqlDB.Exec("CREATE INDEX d ON test.empty(d)")
 	require.NoError(t, err)
 
-	sqlutils.CreateTableDebug(t, sqlDB, "single",
+	sqlutils.CreateTable(t, sqlDB, "single",
 		"a INT, b INT, c INT, d INT, PRIMARY KEY (a,b), INDEX c (c), INDEX d (d)",
 		1,
 		sqlutils.ToRowFn(aFn, bFn, cFn, dFn),
-		true, /* shouldPrint */
 	)
 
-	sqlutils.CreateTableDebug(t, sqlDB, "small",
+	sqlutils.CreateTable(t, sqlDB, "small",
 		"a INT, b INT, c INT, d INT, PRIMARY KEY (a,b), INDEX c (c), INDEX d (d)",
 		10,
 		sqlutils.ToRowFn(aFn, bFn, cFn, dFn),
-		true, /* shouldPrint */
 	)
 
-	sqlutils.CreateTableDebug(t, sqlDB, "med",
+	sqlutils.CreateTable(t, sqlDB, "med",
 		"a INT, b INT, c INT, d INT, PRIMARY KEY (a,b), INDEX c (c), INDEX d (d)",
 		22,
 		sqlutils.ToRowFn(aFn, bFn, cFn, dFn),
-		true, /* shouldPrint */
 	)
 
-	sqlutils.CreateTableDebug(t, sqlDB, "overlapping",
+	sqlutils.CreateTable(t, sqlDB, "overlapping",
 		"a INT, b INT, c INT, d INT, PRIMARY KEY (a, b), INDEX ac (a, c), INDEX d (d)",
 		22,
 		sqlutils.ToRowFn(aFn, bFn, cFn, dFn),
-		true, /* shouldPrint */
 	)
 
-	sqlutils.CreateTableDebug(t, sqlDB, "comp",
+	sqlutils.CreateTable(t, sqlDB, "comp",
 		"a INT, b INT, c INT, d INT, PRIMARY KEY (a, b), INDEX cab (c, a, b), INDEX d (d)",
 		22,
 		sqlutils.ToRowFn(aFn, bFn, cFn, dFn),
-		true, /* shouldPrint */
 	)
 
-	sqlutils.CreateTableDebug(t, sqlDB, "rev",
+	sqlutils.CreateTable(t, sqlDB, "rev",
 		"a INT, b INT, c INT, d INT, PRIMARY KEY (a, b), INDEX cba (c, b, a), INDEX d (d)",
 		22,
 		sqlutils.ToRowFn(aFn, bFn, cFn, dFn),
-		true, /* shouldPrint */
 	)
 
 	offset := 44
-	sqlutils.CreateTableDebug(t, sqlDB, "offset",
+	sqlutils.CreateTable(t, sqlDB, "offset",
 		"a INT, b INT, c INT, d INT, PRIMARY KEY (a,b), INDEX c (c), INDEX d (d)",
 		20,
 		sqlutils.ToRowFn(offsetFn(aFn, offset), offsetFn(bFn, offset), offsetFn(cFn, offset), offsetFn(dFn, offset)),
-		true, /* shouldPrint */
 	)
 
 	unqOffset := 20
-	sqlutils.CreateTableDebug(t, sqlDB, "unq",
+	sqlutils.CreateTable(t, sqlDB, "unq",
 		"a INT, b INT, c INT UNIQUE, d INT, PRIMARY KEY (a, b), INDEX cb (c, b), INDEX d (d)",
 		20,
 		sqlutils.ToRowFn(
@@ -169,21 +161,18 @@ func TestZigzagJoiner(t *testing.T) {
 			offsetFn(identity, unqOffset),
 			offsetFn(dFn, unqOffset),
 		),
-		true, /* shouldPrint */
 	)
 
-	sqlutils.CreateTableDebug(t, sqlDB, "t2",
+	sqlutils.CreateTable(t, sqlDB, "t2",
 		"b INT, a INT, PRIMARY KEY (b, a)",
 		10,
 		sqlutils.ToRowFn(bFn, aFn),
-		true, /* shouldPrint */
 	)
 
-	sqlutils.CreateTableDebug(t, sqlDB, "nullable",
+	sqlutils.CreateTable(t, sqlDB, "nullable",
 		"a INT, b INT, e INT, d INT, PRIMARY KEY (a, b), INDEX e (e), INDEX d (d)",
 		10,
 		sqlutils.ToRowFn(aFn, bFn, eFn, dFn),
-		true, /* shouldPrint */
 	)
 
 	empty := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, "test", "empty")

--- a/pkg/sql/rowflow/routers_test.go
+++ b/pkg/sql/rowflow/routers_test.go
@@ -58,7 +58,7 @@ func setupRouter(
 		memoryMonitors[i] = evalCtx.TestingMon
 		diskMonitors[i] = diskMonitor
 	}
-	r, err := makeRouter(&spec, streams, memoryMonitors, diskMonitors)
+	r, err := makeRouter(&spec, streams, memoryMonitors, memoryMonitors, diskMonitors)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -682,6 +682,7 @@ func TestRouterBlocks(t *testing.T) {
 				&tc.spec,
 				recvs,
 				[]*mon.BytesMonitor{evalCtx.TestingMon, evalCtx.TestingMon},
+				[]*mon.BytesMonitor{evalCtx.TestingMon, evalCtx.TestingMon},
 				[]*mon.BytesMonitor{diskMonitor, diskMonitor},
 			)
 			if err != nil {
@@ -821,7 +822,10 @@ func TestRouterDiskSpill(t *testing.T) {
 		// Initialize the RowChannel with the minimal buffer size so as to block
 		// writes to the channel (after the first one).
 		rowChan.InitWithBufSizeAndNumSenders(types.OneIntCol, 1 /* chanBufSize */, 1 /* numSenders */)
-		rb.setupStreams(&spec, []execinfra.RowReceiver{&rowChan}, []*mon.BytesMonitor{monitor}, []*mon.BytesMonitor{diskMonitor})
+		rb.setupStreams(
+			&spec, []execinfra.RowReceiver{&rowChan}, []*mon.BytesMonitor{monitor},
+			[]*mon.BytesMonitor{extraMemMonitor}, []*mon.BytesMonitor{diskMonitor},
+		)
 		rb.init(ctx, &flowCtx, 0 /* processorID */, types.OneIntCol)
 		// output is the sole router output in this test.
 		output := &rb.outputs[0]
@@ -997,7 +1001,7 @@ func TestRangeRouterInit(t *testing.T) {
 				recvs[i] = &chans[i]
 				spec.Streams[i] = execinfrapb.StreamEndpointSpec{StreamID: execinfrapb.StreamID(i)}
 			}
-			_, err := makeRouter(&spec, recvs, []*mon.BytesMonitor{nil, nil}, []*mon.BytesMonitor{nil, nil})
+			_, err := makeRouter(&spec, recvs, []*mon.BytesMonitor{nil, nil}, []*mon.BytesMonitor{nil, nil}, []*mon.BytesMonitor{nil, nil})
 			if !testutils.IsError(err, tc.err) {
 				t.Fatalf("got %v, expected %v", err, tc.err)
 			}

--- a/pkg/testutils/sqlutils/table_gen_test.go
+++ b/pkg/testutils/sqlutils/table_gen_test.go
@@ -37,7 +37,7 @@ func TestIntToEnglish(t *testing.T) {
 func TestGenValues(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var buf bytes.Buffer
-	genValues(&buf, 7, 11, ToRowFn(RowIdxFn, RowModuloFn(3), RowEnglishFn), false /* shouldPrint */)
+	genValues(&buf, 7, 11, ToRowFn(RowIdxFn, RowModuloFn(3), RowEnglishFn))
 	expected := `(7:::INT8,1:::INT8,'seven':::STRING),(8:::INT8,2:::INT8,'eight':::STRING),(9:::INT8,0:::INT8,'nine':::STRING),(10:::INT8,1:::INT8,'one-zero':::STRING),(11:::INT8,2:::INT8,'one-one':::STRING)`
 	if buf.String() != expected {
 		t.Errorf("expected '%s', got '%s'", expected, buf.String())


### PR DESCRIPTION
**sqlutils: remove option to print contents in CreateTable**

This was used only in a single test and I don't think we need this since it only pollutes the output.

Release note: None

**rowcontainer: make tests deterministic**

We were using global rand for shuffle and forgot to properly set randutil seed for tests.

Release note: None

**rowcontainer: add accounting for some memory use in DiskRowContainer**

This commit adds memory accounting for `scratchKey`, `scratchVal`, and keys stored in `deDupCache` if applicable in the disk row container in response to an OOM we saw during a roachtest run when we were spilling large geometry values to disk.

This required introducing a separate memory account bound to an unlimited memory monitor for this purpose. This is needed since the limited memory monitor we have in scope reached its limit, and that's why the row container had to spill to disk; however, we cannot spill the in-memory state of the disk row container, so it will only count against the root SQL memory monitor.

Fixes: #133337.

Release note: None