### PR TITLE
roachprod: remove cdrb_test for nightly

### DIFF
--- a/build/teamcity/cockroach/nightlies/roachtest_compile_component.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_compile_component.sh
@@ -100,7 +100,12 @@ case "$component" in
     ;;
   roachprod)
       # Roachprod binary.
-      bazel_args=(//pkg/cmd/roachprod --crdb_test)
+      # This binary is built to support the logic behind `roachprod update`.
+      # Hence, we do not need to add `--crdb_test` to the build args as we do
+      # for `roachtest`. Adding the build flag causes the binary to log
+      # metamorphic vars on each command invocation, which is not ideal from a
+      # user experience perspective.
+      bazel_args=(//pkg/cmd/roachprod)
       artifacts=("pkg/cmd/roachprod/roachprod_/roachprod:bin/roachprod.$os-$arch")
       ;;
   *)


### PR DESCRIPTION
Previously, we included the `--crdb_test` build flag for `roachprod`. This binary is only built to be used as part of the `roachprod update` logic. Adding the flag causes roachprod to produce a log of metamorphic vars which is not expected behaviour when using it as a CLI tool.

Informs: #124592

Epic: None
Release note: None