### PR TITLE
release-24.2: licenseccl: Fix test flake in TestRefreshLicenseEnforcerOnLicenseChange

### DIFF
--- a/pkg/ccl/utilccl/license_check_test.go
+++ b/pkg/ccl/utilccl/license_check_test.go
@@ -292,7 +292,6 @@ func TestRefreshLicenseEnforcerOnLicenseChange(t *testing.T) {
 				require.NoError(t, err)
 				trialLicenseExpiryTimestamp.Store(0)
 			}()
-			require.Equal(t, int64(0), trialLicenseExpiryTimestamp.Load())
 
 			tdb := sqlutils.MakeSQLRunner(sqlDB)
 


### PR DESCRIPTION
We observed a test flake in TestRefreshLicenseEnforcerOnLicenseChange where it would assert that a package atomic was zero immediately after resetting it to zero. The exact cause of this behavior is unclear, but the check wasn’t contributing to the test’s purpose. Therefore, I removed the check to align it with how the test is implemented in the master branch.

Epic: None
Closes #135809
Closes #133813 
Release note: none
Release justification: low risk test case update