### PR TITLE
sql/catalog/lease: Add diagnostics to TestRangefeedUpdatesHandledProperlyInTheFaceOfRaces

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -2419,6 +2419,7 @@ func TestRangefeedUpdatesHandledProperlyInTheFaceOfRaces(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			log.Infof(ctx, "received descriptor update event: id=%d, version=%d", id, version)
 			if id == interestingTable.Load().(descpb.ID) && version >= 2 {
 				select {
 				case descUpdateChan <- descriptor:
@@ -2460,6 +2461,7 @@ func TestRangefeedUpdatesHandledProperlyInTheFaceOfRaces(t *testing.T) {
 	tdb1.QueryRow(t, "SELECT table_id FROM crdb_internal.tables WHERE name = $1 AND database_name = current_database()",
 		"foo").Scan(&tableID)
 	interestingTable.Store(tableID)
+	log.Infof(ctx, "tableID of interesting table is %d", tableID)
 
 	// Launch a goroutine to query foo. It will be blocked in lease acquisition.
 	selectDone := make(chan error, 1)


### PR DESCRIPTION
This change enhances diagnostics for TestRangefeedUpdatesHandledProperlyInTheFaceOfRaces. The test involves a concurrent query and an ALTER operation on the same table. The query starts first, acquiring the table descriptor lease, and is then suspended by the test. Next, the ALTER operation begins, creating a new version of the descriptor. It pauses at the end of its execution, waiting for only one version of the descriptor to remain. When the new descriptor version is detected, the query resumes, allowing the ALTER to complete.

In the failure case, the test did not detect the new version of the descriptor, even though the ALTER operation had already updated it and was waiting at waitForOneVersion. This change adds extra logging to capture the descriptor changes observed during the test, helping diagnose the issue if it recurs.

Epic: none
Closes #135777
Release note: none