### PR TITLE
keys,kvserver: introduce ForceFlushIndex and RangeForceFlushKey

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -80,6 +80,8 @@ var (
 	// LocalRangeAppliedStateSuffix is the suffix for the range applied state
 	// key.
 	LocalRangeAppliedStateSuffix = []byte("rask")
+	// LocalRangeForceFlushSuffix is the suffix for the range force flush key.
+	LocalRangeForceFlushSuffix = []byte("rffk")
 	// This was previously used for the replicated RaftTruncatedState. It is no
 	// longer used and this key has been removed via a migration. See
 	// LocalRaftTruncatedStateSuffix for the corresponding unreplicated

--- a/pkg/keys/doc.go
+++ b/pkg/keys/doc.go
@@ -176,13 +176,14 @@ var _ = [...]interface{}{
 	//   range as a whole. Though they are replicated, they are unaddressable.
 	//   Typical examples are MVCC stats and the abort span. They all share
 	//   `LocalRangeIDPrefix` and `LocalRangeIDReplicatedInfix`.
-	AbortSpanKey, // "abc-"
+	AbortSpanKey,             // "abc-"
+	RangeGCThresholdKey,      // "lgc-"
+	RangeAppliedStateKey,     // "rask"
+	RangeForceFlushKey,       // "rffk"
+	RangeLeaseKey,            // "rll-"
+	RangePriorReadSummaryKey, // "rprs"
 	ReplicatedSharedLocksTransactionLatchingKey, // "rsl-"
-	RangeGCThresholdKey,                         // "lgc-"
-	RangeAppliedStateKey,                        // "rask"
-	RangeLeaseKey,                               // "rll-"
-	RangePriorReadSummaryKey,                    // "rprs"
-	RangeVersionKey,                             // "rver"
+	RangeVersionKey, // "rver"
 
 	//   2. Unreplicated range-ID local keys: These contain metadata that
 	//   pertain to just one replica of a range. They are unreplicated and

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -327,6 +327,11 @@ func RangeAppliedStateKey(rangeID roachpb.RangeID) roachpb.Key {
 	return MakeRangeIDPrefixBuf(rangeID).RangeAppliedStateKey()
 }
 
+// RangeForceFlushKey returns a system-local key for the range force flush key.
+func RangeForceFlushKey(rangeID roachpb.RangeID) roachpb.Key {
+	return MakeRangeIDPrefixBuf(rangeID).RangeForceFlushKey()
+}
+
 // RangeLeaseKey returns a system-local key for a range lease.
 func RangeLeaseKey(rangeID roachpb.RangeID) roachpb.Key {
 	return MakeRangeIDPrefixBuf(rangeID).RangeLeaseKey()
@@ -1127,6 +1132,12 @@ func (b RangeIDPrefixBuf) ReplicatedSharedLocksTransactionLatchingKey(txnID uuid
 // See comment on RangeAppliedStateKey function.
 func (b RangeIDPrefixBuf) RangeAppliedStateKey() roachpb.Key {
 	return append(b.replicatedPrefix(), LocalRangeAppliedStateSuffix...)
+}
+
+// RangeForceFlushKey returns a system-local key for the range force flush
+// key.
+func (b RangeIDPrefixBuf) RangeForceFlushKey() roachpb.Key {
+	return append(b.replicatedPrefix(), LocalRangeForceFlushSuffix...)
 }
 
 // RangeLeaseKey returns a system-local key for a range lease.

--- a/pkg/kv/kvserver/batcheval/result/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/result/BUILD.bazel
@@ -26,6 +26,8 @@ go_test(
     embed = [":result"],
     deps = [
         "//pkg/kv/kvserver/kvserverpb",
+        "//pkg/roachpb",
         "//pkg/util/leaktest",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/kv/kvserver/batcheval/result/result.go
+++ b/pkg/kv/kvserver/batcheval/result/result.go
@@ -267,6 +267,9 @@ func (p *Result) MergeAndDestroy(q Result) error {
 		if q.Replicated.State.Stats != nil {
 			return errors.AssertionFailedf("must not specify Stats")
 		}
+		if q.Replicated.State.ForceFlushIndex != (roachpb.ForceFlushIndex{}) {
+			return errors.AssertionFailedf("must not specify ForceFlushIndex")
+		}
 		if (*q.Replicated.State != kvserverpb.ReplicaState{}) {
 			log.Fatalf(context.TODO(), "unhandled EvalResult: %s",
 				pretty.Diff(*q.Replicated.State, kvserverpb.ReplicaState{}))

--- a/pkg/kv/kvserver/batcheval/result/result_test.go
+++ b/pkg/kv/kvserver/batcheval/result/result_test.go
@@ -10,7 +10,9 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEvalResultIsZero(t *testing.T) {
@@ -78,4 +80,10 @@ func TestMergeAndDestroy(t *testing.T) {
 	if f, exp := *r1.Local.Metrics, (Metrics{LeaseRequestSuccess: 9, ResolveAbort: 13}); f != exp {
 		t.Fatalf("expected %d, got %d", exp, f)
 	}
+
+	var r3 Result
+	r3.Replicated.State = &kvserverpb.ReplicaState{
+		ForceFlushIndex: roachpb.ForceFlushIndex{Index: 3},
+	}
+	require.ErrorContains(t, r0.MergeAndDestroy(r3), "must not specify ForceFlushIndex")
 }

--- a/pkg/kv/kvserver/kvserverpb/state.proto
+++ b/pkg/kv/kvserver/kvserverpb/state.proto
@@ -139,6 +139,13 @@ message ReplicaState {
   // with other related ranges to reduce load on pebble.
   roachpb.GCHint gc_hint = 15 [(gogoproto.customname) = "GCHint"];
 
+  // ForceFlushIndex is only non-empty for the Range Raft state machine cached
+  // in memory (see the comment at the top of ReplicaState). It is never used
+  // for proposer-evaluated Raft (this represents a Raft index, which is
+  // unknown to the proposer evaluator). It is persisted on the Replica with
+  // the RangeForceFlushKey.
+  roachpb.ForceFlushIndex force_flush_index = 16 [(gogoproto.nullable) = false];
+
   reserved 8, 9, 10;
 }
 

--- a/pkg/roachpb/metadata.proto
+++ b/pkg/roachpb/metadata.proto
@@ -560,3 +560,12 @@ message GCHint {
   optional util.hlc.Timestamp gc_timestamp_next = 3 [(gogoproto.nullable) = false,
     (gogoproto.customname) = "GCTimestampNext"];
 }
+
+// ForceFlushIndex represents an index up to (and including) which RACv2 must
+// force-flush send-queues being maintained for replicas for a range.
+message ForceFlushIndex {
+  option (gogoproto.equal) = true;
+  option (gogoproto.goproto_stringer) = true;
+
+  optional uint64 index = 1 [(gogoproto.nullable) = false];
+}


### PR DESCRIPTION
RangeForceFlushKey is a local Range-ID key with ForceFlushIndex as the value. It is not currently written, but is read and placed in ReplicaState.

Informs ##135601

Epic: CRDB-37515

Release note: None