### PR TITLE
sql: add crdb_internal.pretty_key/1

### DIFF
--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6090,6 +6090,20 @@ SELECT
 			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
 			Volatility: volatility.Immutable,
 		},
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "raw_key", Typ: types.Bytes},
+			},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return tree.NewDString(catalogkeys.PrettyKey(
+					nil, /* valDirs */
+					roachpb.Key(tree.MustBeDBytes(args[0])),
+					-1)), nil
+			},
+			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
+			Volatility: volatility.Immutable,
+		},
 	),
 	// Return if a key belongs to a system table, which should make it to print
 	// within redacted output.

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2606,6 +2606,7 @@ var builtinOidsArray = []string{
 	2643: `crdb_internal.type_is_indexable(oid: oid) -> bool`,
 	2644: `crdb_internal.range_stats_with_errors(key: bytes) -> jsonb`,
 	2645: `crdb_internal.lease_holder_with_errors(key: bytes) -> jsonb`,
+	2646: `crdb_internal.pretty_key(raw_key: bytes) -> string`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid


### PR DESCRIPTION
While I'm sure it is useful to others, every call I've ever made to crdb_internal.pretty_key has used 0 or -1 as the second argument. Here, I've added an overload so that I can type 3-4 fewer characters.

Epic: none
Release note: None