### PR TITLE
ccl: remove primary key columns from parquet output

### DIFF
--- a/pkg/ccl/changefeedccl/parquet_test.go
+++ b/pkg/ccl/changefeedccl/parquet_test.go
@@ -307,3 +307,41 @@ func TestParquetResolvedTimestamps(t *testing.T) {
 
 	cdcTest(t, testFn, feedTestForceSink("cloudstorage"))
 }
+
+func TestParquetDuplicateColumns(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE t (id INT8 PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO t VALUES (1)`)
+		foo := feed(t, f, `CREATE CHANGEFEED WITH format=parquet,initial_scan='only' AS SELECT id FROM t`)
+		defer closeFeed(t, foo)
+
+		assertPayloads(t, foo, []string{
+			`t: [1]->id:1,__crdb__event_type:"c"`,
+		})
+	}
+
+	cdcTest(t, testFn, feedTestForceSink("cloudstorage"))
+}
+
+func TestParquetNoUserDefinedPrimaryKey(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE t (id INT8)`)
+		sqlDB.Exec(t, `INSERT INTO t VALUES (9)`)
+		foo := feed(t, f, `CREATE CHANGEFEED WITH format=parquet,initial_scan='only' AS SELECT id FROM t`)
+		defer closeFeed(t, foo)
+
+		assertPayloads(t, foo, []string{
+			`t: []->id:9,__crdb__event_type:"c"`,
+		})
+	}
+
+	cdcTest(t, testFn, feedTestForceSink("cloudstorage"))
+}


### PR DESCRIPTION
Previously, in changefeeds using CDC queries and parquet, we would see duplicate columns in the output when using a user defined primary key. This was confusing and unexpected. This change has us including fewer rows in the parquet output by only including the user defined rows.

Epic: none

Fixes: #124434

Release note (bug fix): Removes duplicate columns in parquet output from changefeeds using cdc queries. Also removes columns like __crdb__event_type which are not included in outputs to other formats.