### PR TITLE
ui: remove remaining links to old db pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
@@ -25,7 +25,6 @@ import {
   Count,
   intersperse,
   EncodeDatabaseTableIndexUri,
-  EncodeDatabaseTableUri,
 } from "../../util";
 
 import styles from "./plansTable.module.scss";
@@ -304,13 +303,7 @@ export function formatIndexes(indexes: string[], database: string): ReactNode {
     return (
       <span key={table}>
         {newLine}
-        <Link
-          className={cx("bold-link")}
-          to={EncodeDatabaseTableUri(database, table)}
-        >
-          {table}
-        </Link>
-        : {indexesList}
+        {table}: {indexesList}
       </span>
     );
   });

--- a/pkg/ui/workspaces/cluster-ui/src/util/format.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/format.ts
@@ -356,7 +356,7 @@ export function EncodeUriName(name: string): string {
   return encodeURIComponent(name).replace(/%25/g, "%252525");
 }
 
-export function EncodeDatabasesUri(db: string): string {
+function encodeDatabasesUri(db: string): string {
   return `/databases/${EncodeUriName(db)}`;
 }
 
@@ -366,13 +366,13 @@ export function EncodeDatabasesToIndexUri(
   table: string,
   indexName: string,
 ): string {
-  return `${EncodeDatabasesUri(db)}/${EncodeUriName(schema)}/${EncodeUriName(
+  return `${encodeDatabasesUri(db)}/${EncodeUriName(schema)}/${EncodeUriName(
     table,
   )}/${EncodeUriName(indexName)}`;
 }
 
-export function EncodeDatabaseTableUri(db: string, table: string): string {
-  return `${EncodeDatabaseUri(db)}/table/${EncodeUriName(table)}`;
+function encodeDatabaseTableUri(db: string, table: string): string {
+  return `${encodeDatabaseUri(db)}/table/${EncodeUriName(table)}`;
 }
 
 export function EncodeDatabaseTableIndexUri(
@@ -380,12 +380,12 @@ export function EncodeDatabaseTableIndexUri(
   table: string,
   indexName: string,
 ): string {
-  return `${EncodeDatabaseTableUri(db, table)}/index/${EncodeUriName(
+  return `${encodeDatabaseTableUri(db, table)}/index/${EncodeUriName(
     indexName,
   )}`;
 }
 
-export function EncodeDatabaseUri(db: string): string {
+function encodeDatabaseUri(db: string): string {
   return `/database/${EncodeUriName(db)}`;
 }
 


### PR DESCRIPTION
In the plan details of the sql statement details page we had a remaining link to the old db page. At this time we cannot link to the new pages since the sql statement plan details api does not return the id of the db or table it belongs to.

Epic: none
Fixes: #134581

Release note (ui change): Link in plan details page to legacy table page has been removed.