### PR TITLE
roachprod: add sufficient tenant ids when creating v22.2 client certs

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1712,7 +1712,7 @@ VERSION=$(%[1]s version --build-tag)
 VERSION=${VERSION::5}
 TENANT_SCOPE_OPT=""
 if [[ $VERSION = v22.2 ]]; then
-       TENANT_SCOPE_OPT="--tenant-scope 1,2,3,4,11,12,13,14"
+       TENANT_SCOPE_OPT="--tenant-scope $(echo {1..100} | tr ' ' ',')"
 fi
 %[1]s cert create-ca --certs-dir=%[2]s --ca-key=%[2]s/ca.key
 %[1]s cert create-client root --certs-dir=%[2]s --ca-key=%[2]s/ca.key $TENANT_SCOPE_OPT


### PR DESCRIPTION
In v22.2, tenant ids must be specified when creating client certs. Previously, only a select number tenant ids of were specified. Those ids were chosen to match the hardcoded ids used by the old multitenant roachprod framework.

Now that the new mt framework assigns ids sequentially, we see that creating tenants with ids not specified causes auth issues on clusters bootstrapped on 22.2. Since there should be no drawback to assigning more valid tenant ids than needed, we now add tenants 1 to 100. This should be more than enough for roachprod/roachtest.

Fixes: https://github.com/cockroachdb/cockroach/issues/133282
Epic: none
Relese note: none