### PR TITLE
rac2,replica_rac2: add ForceFlushIndexChangedLocked to Processor, Ran…

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_index
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_index
@@ -1,0 +1,478 @@
+# Initialize a range with three replicas, none of which have send tokens.
+init regular_init=0 elastic_init=0
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
+t1/s1: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+# Append five entries. Replica 1 has no send tokens, but is not allowed to
+# form a send-queue since it is the leader. Replica 3 also has no send tokens,
+# but is not allowed to form a send-queue to maintain quorum.
+raft_event pull-mode
+range_id=1
+  entries
+    term=1 index=1 pri=NormalPri size=6MiB
+    term=1 index=2 pri=NormalPri size=6MiB
+    term=1 index=3 pri=NormalPri size=6MiB
+    term=1 index=4 pri=NormalPri size=6MiB
+    term=1 index=5 pri=NormalPri size=6MiB
+----
+t1/s1: eval reg=-30 MiB/+16 MiB ela=-30 MiB/+8.0 MiB
+       send reg=-30 MiB/+16 MiB ela=-30 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-30 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=-30 MiB/+16 MiB ela=-30 MiB/+8.0 MiB
+       send reg=-30 MiB/+16 MiB ela=-30 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+30 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,6) precise_q_size=+30 MiB watching-for-tokens
+eval deducted: reg=+0 B ela=+30 MiB
+eval original in send-q: reg=+30 MiB ela=+0 B
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+30 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+++++
+MsgApps sent in pull mode:
+ to: 3, lowPri: false entries: [1 2 3 4 5]
+++++
+
+# Force flush up to index 2. Replica 2 starts force-flushing.
+set_force_flush_index range_id=1 index=2
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+30 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,6) precise_q_size=+30 MiB force-flushing (stop=2)
+eval deducted: reg=+0 B ela=+30 MiB
+eval original in send-q: reg=+30 MiB ela=+0 B
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+30 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+++++
+schedule-controller-event-count: 1
+scheduled-replicas: 2
+
+# Scheduler event. Entry at index 1 is popped from replica 2.
+handle_scheduler_event range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+30 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,6) precise_q_size=+24 MiB force-flushing (stop=2)
+eval deducted: reg=+0 B ela=+30 MiB
+eval original in send-q: reg=+24 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+30 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+++++
+MsgApps sent in pull mode:
+ to: 2, lowPri: true entries: [1]
+++++
+schedule-controller-event-count: 2
+scheduled-replicas: 2
+
+# Scheduler event. Entry at index 2 is popped from replica 2, and force-flush
+# stops.
+handle_scheduler_event range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+30 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[2,3) send_queue=[3,6) precise_q_size=+18 MiB watching-for-tokens
+eval deducted: reg=+0 B ela=+30 MiB
+eval original in send-q: reg=+18 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+30 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+++++
+MsgApps sent in pull mode:
+ to: 2, lowPri: true entries: [2]
+++++
+schedule-controller-event-count: 2
+
+# Force flush up to index 3. Replica 2 starts force-flushing.
+set_force_flush_index range_id=1 index=3
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+30 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[2,3) send_queue=[3,6) precise_q_size=+18 MiB force-flushing (stop=3)
+eval deducted: reg=+0 B ela=+30 MiB
+eval original in send-q: reg=+18 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+30 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+++++
+schedule-controller-event-count: 3
+scheduled-replicas: 2
+
+# Scheduler event. Entry at index 3 is popped from replica 2, and force-flush
+# stops.
+handle_scheduler_event range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+30 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[3,4) send_queue=[4,6) precise_q_size=+12 MiB watching-for-tokens
+eval deducted: reg=+0 B ela=+30 MiB
+eval original in send-q: reg=+12 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+30 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+++++
+MsgApps sent in pull mode:
+ to: 2, lowPri: true entries: [3]
+++++
+schedule-controller-event-count: 3
+
+# Force flush up to index 3, which is a noop.
+set_force_flush_index range_id=1 index=3
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+30 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[3,4) send_queue=[4,6) precise_q_size=+12 MiB watching-for-tokens
+eval deducted: reg=+0 B ela=+30 MiB
+eval original in send-q: reg=+12 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+30 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+++++
+schedule-controller-event-count: 3
+
+# Force flush up to index 4. Replica 2 starts force-flushing.
+set_force_flush_index range_id=1 index=4
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+30 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[3,4) send_queue=[4,6) precise_q_size=+12 MiB force-flushing (stop=4)
+eval deducted: reg=+0 B ela=+30 MiB
+eval original in send-q: reg=+12 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+30 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+++++
+schedule-controller-event-count: 4
+scheduled-replicas: 2
+
+# Transition replica 3 to StateSnapshot. Replica 2 needs to force-flush, but
+# since it is already force-flushing, nothing changes.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=4
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=6
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=4
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateSnapshot next=6
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+30 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,6) precise_q_size=+12 MiB force-flushing (stop=4)
+eval deducted: reg=+0 B ela=+30 MiB
+eval original in send-q: reg=+12 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+++++
+(n3,s3):3: closed
+++++
+schedule-controller-event-count: 4
+scheduled-replicas: 2
+
+# Scheduler event. Entry at index 4 is popped from replica 2, and force-flush
+# stops.
+handle_scheduler_event range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+30 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[4,5) send_queue=[5,6) precise_q_size=+6.0 MiB watching-for-tokens
+eval deducted: reg=+0 B ela=+30 MiB
+eval original in send-q: reg=+6.0 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+++++
+(n3,s3):3: closed
+++++
+MsgApps sent in pull mode:
+ to: 2, lowPri: true entries: [4]
+++++
+schedule-controller-event-count: 4
+
+# Schedule a raft event. It will get replica 2 to start force-flushing again.
+raft_event pull-mode
+range_id=1
+----
+t1/s1: eval reg=-30 MiB/+16 MiB ela=-30 MiB/+8.0 MiB
+       send reg=-30 MiB/+16 MiB ela=-30 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-30 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-24 MiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+30 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[4,5) send_queue=[5,6) precise_q_size=+6.0 MiB force-flushing
+eval deducted: reg=+0 B ela=+30 MiB
+eval original in send-q: reg=+6.0 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+++++
+(n3,s3):3: closed
+++++
+schedule-controller-event-count: 5
+scheduled-replicas: 2
+
+# Entry 5 is popped and force-flushing stops.
+handle_scheduler_event range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+30 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[5,6) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+0 B ela=+30 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+++++
+(n3,s3):3: closed
+++++
+MsgApps sent in pull mode:
+ to: 2, lowPri: true entries: [5]
+++++
+schedule-controller-event-count: 5
+
+# Add another entry. Neither replica is allowed to form a send-queue.
+raft_event pull-mode
+range_id=1
+  entries
+    term=1 index=6 pri=NormalPri size=6MiB
+----
+t1/s1: eval reg=-36 MiB/+16 MiB ela=-36 MiB/+8.0 MiB
+       send reg=-36 MiB/+16 MiB ela=-36 MiB/+8.0 MiB
+t1/s2: eval reg=-6.0 MiB/+16 MiB ela=-36 MiB/+8.0 MiB
+       send reg=-6.0 MiB/+16 MiB ela=-36 MiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[6,7) send_queue=[7,7) precise_q_size=+0 B
+eval deducted: reg=+36 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+  term=1 index=6  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[6,7) send_queue=[7,7) precise_q_size=+0 B
+eval deducted: reg=+6.0 MiB ela=+30 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+  term=1 index=4  tokens=6291456
+  term=1 index=5  tokens=6291456
+NormalPri:
+  term=1 index=6  tokens=6291456
+++++
+(n3,s3):3: closed
+++++
+MsgApps sent in pull mode:
+ to: 2, lowPri: false entries: [6]
+++++
+schedule-controller-event-count: 5

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_index_push_pull
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_index_push_pull
@@ -1,0 +1,349 @@
+# Initialize a range with three replicas, none of which have send tokens.
+init regular_init=0 elastic_init=0
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
+t1/s1: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+# Replica 1 is the leader so sending [1,1) is ignored and everything is
+# considered sent (the leader does not see MsgApps for itself).
+raft_event
+range_id=1
+  entries
+    term=1 index=1 pri=NormalPri size=6MiB
+    term=1 index=2 pri=NormalPri size=6MiB
+    term=1 index=3 pri=NormalPri size=6MiB
+  sending
+    replica_id=1 [1,1)
+    replica_id=2 [1,1)
+    replica_id=3 [1,1)
+----
+t1/s1: eval reg=-18 MiB/+16 MiB ela=-18 MiB/+8.0 MiB
+       send reg=-18 MiB/+16 MiB ela=-18 MiB/+8.0 MiB
+t1/s2: eval reg=-18 MiB/+16 MiB ela=-18 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=-18 MiB/+16 MiB ela=-18 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+# Replicas 2 and 3 have a send-queue which is possible in push mode.
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+eval deducted: reg=+18 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,4) precise_q_size=+18 MiB
+eval deducted: reg=+18 MiB ela=+0 B
+eval original in send-q: reg=+18 MiB ela=+0 B
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,1) send_queue=[1,4) precise_q_size=+18 MiB
+eval deducted: reg=+18 MiB ela=+0 B
+eval original in send-q: reg=+18 MiB ela=+0 B
+++++
+
+# Force flush up to index 1. Still in push-mode so it has no effect.
+set_force_flush_index range_id=1 index=1 push-mode
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+eval deducted: reg=+18 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,4) precise_q_size=+18 MiB
+eval deducted: reg=+18 MiB ela=+0 B
+eval original in send-q: reg=+18 MiB ela=+0 B
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,1) send_queue=[1,4) precise_q_size=+18 MiB
+eval deducted: reg=+18 MiB ela=+0 B
+eval original in send-q: reg=+18 MiB ela=+0 B
+++++
+
+# Switch to pull mode.
+raft_event pull-mode
+range_id=1
+----
+t1/s1: eval reg=-18 MiB/+16 MiB ela=-18 MiB/+8.0 MiB
+       send reg=-18 MiB/+16 MiB ela=-18 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-18 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=-18 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+# Replica 3 starts force-flushing with no limit, since it was necessary for
+# quorum. Replica 2 is force-flushing up to index 1.
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+eval deducted: reg=+18 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,4) precise_q_size=+18 MiB force-flushing (stop=1)
+eval deducted: reg=+0 B ela=+18 MiB
+eval original in send-q: reg=+18 MiB ela=+0 B
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,1) send_queue=[1,4) precise_q_size=+18 MiB force-flushing
+eval deducted: reg=+0 B ela=+18 MiB
+eval original in send-q: reg=+18 MiB ela=+0 B
+++++
+schedule-controller-event-count: 1
+scheduled-replicas: 2 3
+
+# Update the force-flush index to 2. This propagates to replica 2. Also, since
+# replica 2 is seen to be force-flushing, the second-pass decision (see code),
+# decides replica 3 does not need to force-flush for quorum. So both have a
+# stop index of 2.
+set_force_flush_index range_id=1 index=2
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+eval deducted: reg=+18 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,4) precise_q_size=+18 MiB force-flushing (stop=2)
+eval deducted: reg=+0 B ela=+18 MiB
+eval original in send-q: reg=+18 MiB ela=+0 B
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,1) send_queue=[1,4) precise_q_size=+18 MiB force-flushing (stop=2)
+eval deducted: reg=+0 B ela=+18 MiB
+eval original in send-q: reg=+18 MiB ela=+0 B
+++++
+schedule-controller-event-count: 1
+scheduled-replicas: 2 3
+
+# Scheduler event. Entry at index 1 is popped from replicas 2, 3.
+handle_scheduler_event range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+eval deducted: reg=+18 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+12 MiB force-flushing (stop=2)
+eval deducted: reg=+0 B ela=+18 MiB
+eval original in send-q: reg=+12 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+12 MiB force-flushing (stop=2)
+eval deducted: reg=+0 B ela=+18 MiB
+eval original in send-q: reg=+12 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+++++
+MsgApps sent in pull mode:
+ to: 2, lowPri: true entries: [1]
+ to: 3, lowPri: true entries: [1]
+++++
+schedule-controller-event-count: 2
+scheduled-replicas: 2 3
+
+# Switch back to push mode. Force-flushing stops.
+raft_event
+range_id=1
+----
+t1/s1: eval reg=-18 MiB/+16 MiB ela=-18 MiB/+8.0 MiB
+       send reg=-18 MiB/+16 MiB ela=-18 MiB/+8.0 MiB
+t1/s2: eval reg=-12 MiB/+16 MiB ela=-18 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-6.0 MiB/+8.0 MiB
+t1/s3: eval reg=-12 MiB/+16 MiB ela=-18 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-6.0 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+eval deducted: reg=+18 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+12 MiB
+eval deducted: reg=+12 MiB ela=+6.0 MiB
+eval original in send-q: reg=+12 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+12 MiB
+eval deducted: reg=+12 MiB ela=+6.0 MiB
+eval original in send-q: reg=+12 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+++++
+schedule-controller-event-count: 2
+scheduled-replicas: 2 3
+
+# Switch back to pull mode. Force-flushing resumes. Replica 3 needs to
+# force-flush for quorum, so the stopping point is infinity.
+raft_event pull-mode
+range_id=1
+----
+t1/s1: eval reg=-18 MiB/+16 MiB ela=-18 MiB/+8.0 MiB
+       send reg=-18 MiB/+16 MiB ela=-18 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-18 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-6.0 MiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=-18 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-6.0 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+eval deducted: reg=+18 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+12 MiB force-flushing (stop=2)
+eval deducted: reg=+0 B ela=+18 MiB
+eval original in send-q: reg=+12 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+12 MiB force-flushing
+eval deducted: reg=+0 B ela=+18 MiB
+eval original in send-q: reg=+12 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+++++
+schedule-controller-event-count: 2
+scheduled-replicas: 2 3
+
+# Scheduler event. Entry at index 2 is popped from replicas 2, 3. Replica 2
+# stops force-flushing.
+handle_scheduler_event range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+eval deducted: reg=+18 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[2,3) send_queue=[3,4) precise_q_size=+6.0 MiB watching-for-tokens
+eval deducted: reg=+0 B ela=+18 MiB
+eval original in send-q: reg=+6.0 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+++++
+(n3,s3):3: state=replicate closed=false inflight=[2,3) send_queue=[3,4) precise_q_size=+6.0 MiB force-flushing
+eval deducted: reg=+0 B ela=+18 MiB
+eval original in send-q: reg=+6.0 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+++++
+MsgApps sent in pull mode:
+ to: 2, lowPri: true entries: [2]
+ to: 3, lowPri: true entries: [2]
+++++
+schedule-controller-event-count: 3
+scheduled-replicas: 3
+
+# Switch back to push mode and then back to pull mode. Replica 2 should not be
+# force-flushing and replica 3 should be force-flushing.
+raft_event
+range_id=1
+----
+t1/s1: eval reg=-18 MiB/+16 MiB ela=-18 MiB/+8.0 MiB
+       send reg=-18 MiB/+16 MiB ela=-18 MiB/+8.0 MiB
+t1/s2: eval reg=-6.0 MiB/+16 MiB ela=-18 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-12 MiB/+8.0 MiB
+t1/s3: eval reg=-6.0 MiB/+16 MiB ela=-18 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-12 MiB/+8.0 MiB
+
+raft_event pull-mode
+range_id=1
+----
+t1/s1: eval reg=-18 MiB/+16 MiB ela=-18 MiB/+8.0 MiB
+       send reg=-18 MiB/+16 MiB ela=-18 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-18 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-12 MiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=-18 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-12 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+eval deducted: reg=+18 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[2,3) send_queue=[3,4) precise_q_size=+6.0 MiB watching-for-tokens
+eval deducted: reg=+0 B ela=+18 MiB
+eval original in send-q: reg=+6.0 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+++++
+(n3,s3):3: state=replicate closed=false inflight=[2,3) send_queue=[3,4) precise_q_size=+6.0 MiB force-flushing
+eval deducted: reg=+0 B ela=+18 MiB
+eval original in send-q: reg=+6.0 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+++++
+schedule-controller-event-count: 3
+scheduled-replicas: 3
+
+# Replica 3 stops force-flushing.
+handle_scheduler_event range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+eval deducted: reg=+18 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+++++
+(n2,s2):2: state=replicate closed=false inflight=[2,3) send_queue=[3,4) precise_q_size=+6.0 MiB watching-for-tokens
+eval deducted: reg=+0 B ela=+18 MiB
+eval original in send-q: reg=+6.0 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+++++
+(n3,s3):3: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B
+eval deducted: reg=+0 B ela=+18 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=1  tokens=6291456
+  term=1 index=2  tokens=6291456
+  term=1 index=3  tokens=6291456
+++++
+MsgApps sent in pull mode:
+ to: 3, lowPri: true entries: [3]
+++++
+schedule-controller-event-count: 3

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -138,8 +138,9 @@ type testRangeControllerFactory struct {
 func (f *testRangeControllerFactory) New(
 	ctx context.Context, state rangeControllerInitState,
 ) rac2.RangeController {
-	fmt.Fprintf(f.b, " RangeControllerFactory.New(replicaSet=%s, leaseholder=%s, nextRaftIndex=%d)\n",
-		state.replicaSet, state.leaseholder, state.nextRaftIndex)
+	fmt.Fprintf(f.b,
+		" RangeControllerFactory.New(replicaSet=%s, leaseholder=%s, nextRaftIndex=%d, forceFlushIndex=%d)\n",
+		state.replicaSet, state.leaseholder, state.nextRaftIndex, state.forceFlushIndex)
 	rc := &testRangeController{b: f.b, waited: true}
 	f.rcs = append(f.rcs, rc)
 	return rc
@@ -225,6 +226,10 @@ func (c *testRangeController) SetLeaseholderRaftMuLocked(
 	ctx context.Context, replica roachpb.ReplicaID,
 ) {
 	fmt.Fprintf(c.b, " RangeController.SetLeaseholderRaftMuLocked(%s)\n", replica)
+}
+
+func (c *testRangeController) ForceFlushIndexChangedLocked(ctx context.Context, index uint64) {
+	fmt.Fprintf(c.b, " RangeController.ForceFlushIndexChangedLocked(%d)\n", index)
 }
 
 func (c *testRangeController) CloseRaftMuLocked(ctx context.Context) {

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
@@ -296,7 +296,7 @@ Raft: term: 52 leader: 5 leaseholder: 10 mark: {Term:51 Index:28} next-unstable:
 handle-raft-ready-and-admit entries=v1/i28/t46/pri0/time2/len100 leader-term=52
 ----
 HandleRaftReady:
- RangeControllerFactory.New(replicaSet=[(n1,s2):5,(n11,s11):11], leaseholder=10, nextRaftIndex=28)
+ RangeControllerFactory.New(replicaSet=[(n1,s2):5,(n11,s11):11], leaseholder=10, nextRaftIndex=28, forceFlushIndex=0)
  RangeController.AdmitRaftMuLocked(5, term:52, admitted:[LowPri:26,NormalPri:26,AboveNormalPri:26,HighPri:26])
  RangeController.HandleRaftEventRaftMuLocked([28])
 .....
@@ -392,7 +392,7 @@ handle-raft-ready-and-admit
 ----
 HandleRaftReady:
  RangeController.CloseRaftMuLocked
- RangeControllerFactory.New(replicaSet=[(n1,s2):5,(n11,s11):11], leaseholder=10, nextRaftIndex=29)
+ RangeControllerFactory.New(replicaSet=[(n1,s2):5,(n11,s11):11], leaseholder=10, nextRaftIndex=29, forceFlushIndex=0)
  RangeController.HandleRaftEventRaftMuLocked([])
 .....
 
@@ -500,7 +500,7 @@ LogTracker: mark:{Term:50 Index:25}, stable:24, admitted:[24 24 24 24]
 # RangeController is created.
 set-enabled-level enabled-level=v1-encoding
 ----
- RangeControllerFactory.New(replicaSet=[(n11,s11):11,(n13,s13):13], leaseholder=5, nextRaftIndex=26)
+ RangeControllerFactory.New(replicaSet=[(n11,s11):11,(n13,s13):13], leaseholder=5, nextRaftIndex=26, forceFlushIndex=0)
 
 set-raft-state log-term=50 log-index=26 next-unstable-index=27
 ----


### PR DESCRIPTION
…geController

This is used to set the highest index up to which all send-queues in pull mode must be force-flushed.

Informs #135601

Epic: CRDB-37515

Release note: None