### PR TITLE
sql: prevent concurrent create objects during drop schema

### DIFF
--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -141,7 +141,10 @@ func (p *planner) waitForDescriptorSchemaChanges(
 
 	knobs := p.ExecCfg().DeclarativeSchemaChangerTestingKnobs
 	if knobs != nil && knobs.BeforeWaitingForConcurrentSchemaChanges != nil {
-		knobs.BeforeWaitingForConcurrentSchemaChanges(scs.stmts)
+		err := knobs.BeforeWaitingForConcurrentSchemaChanges(scs.stmts)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Drop all leases and locks due to the current transaction, and, in the

--- a/pkg/sql/schemachanger/scexec/testing_knobs.go
+++ b/pkg/sql/schemachanger/scexec/testing_knobs.go
@@ -20,7 +20,7 @@ type TestingKnobs struct {
 
 	// BeforeWaitingForConcurrentSchemaChanges is called at the start of waiting
 	// for concurrent schema changes to finish.
-	BeforeWaitingForConcurrentSchemaChanges func(stmts []string)
+	BeforeWaitingForConcurrentSchemaChanges func(stmts []string) error
 
 	// WhileWaitingForConcurrentSchemaChanges is called while waiting
 	// for concurrent schema changes to finish.


### PR DESCRIPTION
Previously, we allowed CREATE object operations under a schema that was being dropped concurrently. This could lead to scenarios where descriptors could be created under the schema that is being dropped, which could lead to dangling namespace entries. To address this, this patch requires CREATE operations to wait for schema changes to complete on the target schema object.

Fixes: #134494

Release note (bug fix): Create relation / type could leave dangling namespace entries if the schema was concurrently being dropped.