### PR TITLE
slinstance: extend liveness TTL by 5x in race builds

### DIFF
--- a/pkg/sql/sqlliveness/slinstance/BUILD.bazel
+++ b/pkg/sql/sqlliveness/slinstance/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqlliveness/slbase",
         "//pkg/sql/sqlliveness/slstorage",
+        "//pkg/util",
         "//pkg/util/grpcutil",
         "//pkg/util/hlc",
         "//pkg/util/log",

--- a/pkg/sql/sqlliveness/slinstance/slinstance.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slstorage"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -415,7 +416,11 @@ func NewSQLInstance(
 		stopper:        stopper,
 		sessionEvents:  sessionEvents,
 		ttl: func() time.Duration {
-			return slbase.DefaultTTL.Get(&settings.SV)
+			ttl := slbase.DefaultTTL.Get(&settings.SV)
+			if util.RaceEnabled {
+				ttl *= 5
+			}
+			return ttl
 		},
 		hb: func() time.Duration {
 			return slbase.DefaultHeartBeat.Get(&settings.SV)


### PR DESCRIPTION
We just saw a couple of failures in multi-node shared-process clusters around imports where the liveness session expired before the import could complete, failing the job. I didn't find anything wrong in the logs other than symptoms of overload, so I think we should just give longer TTL to the sessions in race builds.

Fixes: #136291.

Release note: None