### PR TITLE
raft: make PreCandidate ignore MsgDefortifyLeader

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -2127,9 +2127,11 @@ func stepLeader(r *raft, m pb.Message) error {
 // stepCandidate is shared by StateCandidate and StatePreCandidate; the difference is
 // whether they respond to MsgVoteResp or MsgPreVoteResp.
 func stepCandidate(r *raft, m pb.Message) error {
-	if IsMsgFromLeader(m.Type) {
+	if IsMsgFromLeader(m.Type) && m.Type != pb.MsgDeFortifyLeader {
 		// If this is a message from a leader of r.Term, transition to a follower
 		// with the sender of the message as the leader, then process the message.
+		// One exception is MsgDeFortifyLeader where it doesn't mean that there is
+		// currently an active leader for this term.
 		assertTrue(m.Term == r.Term, "message term should equal current term")
 		r.becomeFollower(m.Term, m.From)
 		return r.step(r, m) // stepFollower


### PR DESCRIPTION
Right now if a PreCandidate receives a message from a leader, it becomes a follower again since there is an active leader. However, MsgDefortifyLeader should be a special case because it doesn't really say that there is an active leader since it's only sent by non-leaders when they step down.

Fixes: #136087

Release note: None