### PR TITLE
build/roachtest: upload stats after upload binaries

### DIFF
--- a/build/teamcity/util/roachtest_util.sh
+++ b/build/teamcity/util/roachtest_util.sh
@@ -108,8 +108,8 @@ function upload_binaries {
 }
 
 function upload_all {
-  upload_stats
   upload_binaries
+  upload_stats
 }
 
 # Upload any ${stats_file_name} we can find, and some binaries, no matter what happens.


### PR DESCRIPTION
When openmetrics are enabled in roachtest, we use a different service account in `upload_stats` to upload to a bucket in `cockroach-testeng-infra` rather than `cockroach-ephemeral`.
```
+ gsutil cp bin/roachprod gs://cockroach-nightly/binaries/master/linux/amd64/roachprod.b6bfe7ba6e74af63bbb7a774fe6e3f96a13eca80
04:22:20   AccessDeniedException: 403 teamcity@cockroach-testeng-infra.iam.gserviceaccount.com does not have storage.objects.list access to the Google Cloud Storage bucket. Permission 'storage.objects.list' denied on resource (or it may not exist).
```
Currently since `upload_binaries` run afterwards, it fails since the nightly bucket in present in `cockroach-ephemeral`. 

One simple solution is to swap the order of execution so that the binaries are uploaded before stats since the order doesn't really matter. 
Epic: none

Release note: None