### PR TITLE
release-24.2: sql: enforce ALTER COLUMN SET NOT NULLfor tables created in same txn

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1070,7 +1070,9 @@ func applyColumnMutation(
 		// it in the schema changer.
 		check := tabledesc.MakeNotNullCheckConstraint(tableDesc, col,
 			descpb.ConstraintValidity_Dropping, tableDesc.GetNextConstraintID())
-		tableDesc.Checks = append(tableDesc.Checks, check)
+		if tableDesc.Adding() {
+			tableDesc.Checks = append(tableDesc.Checks, check)
+		}
 		tableDesc.NextConstraintID++
 		tableDesc.AddNotNullMutation(check, descpb.DescriptorMutation_DROP)
 

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -2622,6 +2622,18 @@ func runSchemaChangesInTxn(
 	// update the table descriptor directly.
 	for _, c := range constraintAdditionMutations {
 		if ck := c.AsCheck(); ck != nil {
+			if ck.IsNotNullColumnConstraint() {
+				// Remove the  check constraint we added.
+				for i := range tableDesc.Checks {
+					if tableDesc.Checks[i].ConstraintID == ck.GetConstraintID() {
+						tableDesc.Checks = append(tableDesc.Checks[:i], tableDesc.Checks[i+1:]...)
+					}
+					colID := ck.GetReferencedColumnID(0)
+					col := catalog.FindColumnByID(tableDesc, colID)
+					col.ColumnDesc().Nullable = false
+					continue
+				}
+			}
 			tableDesc.Checks = append(tableDesc.Checks, ck.CheckDesc())
 		} else if fk := c.AsForeignKey(); fk != nil {
 			var referencedTableDesc *tabledesc.Mutable

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -3968,3 +3968,16 @@ statement error pgcode 42601 variable sub-expressions are not allowed in EXPRESS
 ALTER TABLE t_124546 ADD CONSTRAINT ident UNIQUE ( ( EXISTS ( TABLE error FOR READ ONLY ) ) DESC ) STORING ( ident , ident );
 
 subtest end
+
+subtest validate_not_null_during_sc
+
+statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(n IS NOT NULL\)
+BEGIN;
+create table t1_135692(n int);
+alter table t1_135692 alter column n set not null;
+insert into t1_135692 values (null);
+
+statement ok
+ROLLBACK;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1607,11 +1607,9 @@ BEGIN
 statement ok
 ALTER TABLE t ALTER COLUMN a DROP NOT NULL
 
-# Since the non-null constraint is dropped in the schema changer after the
-# transaction commits, it's still enforced during the rest of the transaction.
-# The error is about a check constraint because we generate a check constraint
-# when dropping not-null constraints in the schema changer.
-statement error failed to satisfy CHECK constraint \(a IS NOT NULL\)
+# Since the non-null constraint is dropped with in the txn, it will no
+# long be enforced now.
+statement ok
 INSERT INTO t VALUES (NULL)
 
 statement ok

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2378,7 +2378,13 @@ func (og *operationGenerator) setColumnNotNull(ctx context.Context, tx pgx.Tx) (
 			return nil, err
 		}
 		if colContainsNull {
-			og.candidateExpectedCommitErrors.add(pgcode.CheckViolation)
+			og.candidateExpectedCommitErrors.add(pgcode.NotNullViolation)
+		}
+		// If we are running with the legacy schema changer, the not null constraint
+		// is enforced during the job phase. So it's still possible to INSERT not null
+		// data before then.
+		if !og.useDeclarativeSchemaChanger {
+			og.potentialCommitErrors.add(pgcode.NotNullViolation)
 		}
 	}
 


### PR DESCRIPTION
Backport 2/2 commits from #136298.

/cc @cockroachdb/release

---

Previously, ALTER COLUMN SET NOT NULL could flake if a concurrent INSERT during this operation, when executing under the legacy schema changer. To address this, this path allows null violations to be a potential execution error, if the operation is run in the legacy schema changer.

This patch also updates the schema changer workload to address a test flakes that would happen if a concurrent insert happened at the same time as a SET NOT NULL operation.

Fixes: #135692

Release justification:  low risk fix for a txn scenario that lead to incorrect behaviour
