### PR TITLE
sql/catalog: Avoid marking out-of-memory errors as assertions

### DIFF
--- a/pkg/sql/catalog/descs/BUILD.bazel
+++ b/pkg/sql/catalog/descs/BUILD.bazel
@@ -136,6 +136,7 @@ go_test(
         "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_errors//assert",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_lib_pq//oid",

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -261,10 +261,7 @@ func (tc *Collection) AddUncommittedDescriptor(
 		return nil
 	}
 	defer func() {
-		if err != nil {
-			err = errors.NewAssertionErrorWithWrappedErrf(err, "adding uncommitted %s %q (%d) version %d",
-				desc.DescriptorType(), desc.GetName(), desc.GetID(), desc.GetVersion())
-		}
+		err = DecorateDescriptorError(desc, err)
 	}()
 	if tc.synthetic.getSyntheticByID(desc.GetID()) != nil {
 		return errors.AssertionFailedf(
@@ -1334,4 +1331,20 @@ func NewHistoricalInternalExecTxnRunner(
 		execHistoricalTxn: fn,
 		readAsOf:          readAsOf,
 	}
+}
+
+// DecorateDescriptorError will ensure that if we have an error we will wrap
+// additional context about the descriptor to aid in debugging.
+func DecorateDescriptorError(desc catalog.MutableDescriptor, err error) error {
+	if err != nil {
+		err = errors.Wrapf(err, "adding uncommitted %s %q (%d) version %d",
+			desc.DescriptorType(), desc.GetName(), desc.GetID(), desc.GetVersion())
+		// If this error doesn't have a pgerror code attached to it, lets ensure
+		// that it's marked as an assertion error. This ensures it gets flagged for
+		// things like sentry reports.
+		if pgerror.GetPGCode(err) == pgcode.Uncategorized {
+			err = errors.NewAssertionErrorWithWrappedErrf(err, "unexpected error occurred")
+		}
+	}
+	return err
 }

--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -45,6 +45,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/assert"
 	"github.com/lib/pq/oid"
 	"github.com/stretchr/testify/require"
 )
@@ -1220,6 +1222,63 @@ SELECT id
 		require.NoError(t, txn.Descriptors().AddUncommittedDescriptor(ctx, scDesc))
 		return nil
 	}))
+}
+
+func TestDescriptorErrorWrap(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
+
+	tdb := sqlutils.MakeSQLRunner(sqlDB)
+	tdb.Exec(t, `CREATE DATABASE db`)
+	tdb.Exec(t, `USE db`)
+	tdb.Exec(t, `CREATE SCHEMA schema`)
+	tdb.Exec(t, `CREATE TABLE db.schema.table()`)
+
+	monitor := mon.NewMonitor(mon.Options{
+		Name:     "test_monitor",
+		Settings: cluster.MakeTestingClusterSettings(),
+	})
+	monitor.Start(ctx, nil, mon.NewStandaloneBudget(1))
+	ba := monitor.MakeBoundAccount()
+
+	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
+	for _, tc := range []struct {
+		desc        string
+		err         error
+		isAssertion bool
+	}{
+		{"bare error", errors.New("bare error is treated as an assertion"), true},
+		{"out of memory", ba.Grow(ctx, monitor.Limit()), false},
+		{"pgcode error", sqlerrors.NewAlterColTypeInCombinationNotSupportedError(), false},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			require.NoError(t, sql.DescsTxn(ctx, &execCfg, func(
+				ctx context.Context, txn isql.Txn, descriptors *descs.Collection,
+			) error {
+				tn := tree.MakeTableNameWithSchema("db", "schema", "table")
+				_, mut, err := descs.PrefixAndMutableTable(ctx, descriptors.MutableByName(txn.KV()), &tn)
+				if err != nil {
+					return err
+				}
+
+				require.False(t, assert.IsAssertionFailure(tc.err))
+				err = descs.DecorateDescriptorError(mut, tc.err)
+				// Ensure err is still an error
+				require.Error(t, err)
+				// Ensure descriptor info is wrapped in the error
+				require.Contains(t, err.Error(), mut.GetName())
+				// Ensure error is promoted to assertion as expected
+				require.Equal(t, tc.isAssertion, assert.IsAssertionFailure(err))
+				return nil
+			}))
+		})
+	}
+	monitor.Stop(ctx)
 }
 
 func getSchemaNames(defaultDBSchemaNames map[descpb.ID]string) []string {

--- a/pkg/sql/catalog/descs/uncommitted_descriptors.go
+++ b/pkg/sql/catalog/descs/uncommitted_descriptors.go
@@ -148,17 +148,17 @@ func (ud *uncommittedDescriptors) upsert(
 	// Perform some sanity checks to ensure the version counters are correct.
 	if original == nil {
 		if !mut.IsNew() {
-			return errors.New("non-new descriptor does not exist in storage yet")
+			return errors.AssertionFailedf("non-new descriptor does not exist in storage yet")
 		}
 		if mut.GetVersion() != 1 {
 			return errors.New("new descriptor version should be 1")
 		}
 	} else {
 		if mut.IsNew() {
-			return errors.New("new descriptor already exists in storage")
+			return errors.AssertionFailedf("new descriptor already exists in storage")
 		}
 		if mut.GetVersion() != original.GetVersion()+1 {
-			return errors.Newf("expected uncommitted version %d, instead got %d",
+			return errors.AssertionFailedf("expected uncommitted version %d, instead got %d",
 				original.GetVersion()+1, mut.GetVersion())
 		}
 	}


### PR DESCRIPTION
Previously, all errors originating from AddUncommittedDescriptor were wrapped as assertions, leading to unnecessary Sentry reports for user-facing errors such as exceeding the memory budget. This change ensures that only errors without an associated pgcode are wrapped as assertions, preventing false-positive reports.

Epic: none
Closes #136073
Release note: none