### PR TITLE
kvserver: bring TestReplicaCircuitBreaker_Partial_Retry to leader leases world

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1995,6 +1995,12 @@ func EpochAndLeaderLeaseType() []LeaseType {
 	return []LeaseType{LeaseEpoch, LeaseLeader}
 }
 
+// ExpirationAndLeaderLeaseType returns a list of {expiration, leader} lease
+// types.
+func ExpirationAndLeaderLeaseType() []LeaseType {
+	return []LeaseType{LeaseExpiration, LeaseLeader}
+}
+
 // Type returns the lease type.
 func (l Lease) Type() LeaseType {
 	if l.Epoch != 0 && l.Term != 0 {


### PR DESCRIPTION
This commit makes TestReplicaCircuitBreaker_Partial_Retry run with leader leases + the original expiration-based leases. We skip epoch leases because the test was made with expiration leases in mind, but both expiration leases and leader leases have similar outcomes when nodes get partitioned.

References: #133763

Release note: None