### PR TITLE
sql/schemachanger: Update mustRetrievePrimaryIndex to find latest pk

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -1711,4 +1711,70 @@ DROP TABLE t_droppedcol;
 statement ok
 SET use_declarative_schema_changer = $schema_changer_state
 
+subtest multi_alter_txn
+
+# Force DSC always so that we use it within a transaction
+let $schema_changer_state
+SELECT value FROM information_schema.session_variables where variable='use_declarative_schema_changer'
+
+statement ok
+set use_declarative_schema_changer = 'unsafe_always';
+
+statement ok
+CREATE TABLE t_multi_alter (c1 INT NOT NULL PRIMARY KEY, c2 TEXT NOT NULL, drop DATE, FAMILY F1 (c1, c2, drop));
+
+statement ok
+INSERT INTO t_multi_alter VALUES (10,'ten','1984-09-06'),(20,'twenty','2024-08-10');
+
+# The add column operation creates multiple primary keys, with all but one being
+# temporary. Previously, this caused the alter type to fail because it
+# encountered more primary keys than expected.
+skipif config local-mixed-24.2 local-mixed-24.3
+statement ok
+begin;
+ALTER TABLE t_multi_alter ADD COLUMN c3 TEXT DEFAULT '<default>', DROP COLUMN drop;
+ALTER TABLE t_multi_alter ALTER COLUMN c2 SET DATA TYPE BIGINT USING c1::BIGINT;
+commit;
+
+skipif config local-mixed-24.2 local-mixed-24.3
+query IIT
+select * from t_multi_alter order by c1;
+----
+10 10 <default>
+20 20 <default>
+
+skipif config local-mixed-24.2 local-mixed-24.3
+statement ok
+begin;
+ALTER TABLE t_multi_alter ALTER COLUMN c3 SET DEFAULT NULL;
+ALTER TABLE t_multi_alter ALTER COLUMN c3 SET DATA TYPE DATE USING '2024-04-22'::DATE;
+commit;
+
+skipif config local-mixed-24.2 local-mixed-24.3
+query IIT
+select * from t_multi_alter order by c1;
+----
+10 10 2024-04-22 00:00:00 +0000 +0000
+20 20 2024-04-22 00:00:00 +0000 +0000
+
+skipif config local-mixed-24.2 local-mixed-24.3
+query TT colnames
+show create table t_multi_alter
+----
+table_name  create_statement
+t_multi_alter   CREATE TABLE public.t_multi_alter (
+              c1 INT8 NOT NULL,
+              c2 INT8 NOT NULL,
+              c3 DATE NULL,
+              CONSTRAINT t_multi_alter_pkey PRIMARY KEY (c1 ASC),
+              FAMILY f1 (c1, c2, c3)
+            )
+
+statement ok
+drop table t_multi_alter;
+
+# Restore the schema changer state back.
+statement ok
+SET use_declarative_schema_changer = $schema_changer_state
+
 subtest end

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_constraint.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_constraint.go
@@ -791,21 +791,21 @@ func iterateColNamesInExpr(
 func retrieveColumnDefaultExpressionElem(
 	b BuildCtx, tableID catid.DescID, columnID catid.ColumnID,
 ) *scpb.ColumnDefaultExpression {
-	_, _, ret := scpb.FindColumnDefaultExpression(b.QueryByID(tableID).Filter(hasColumnIDAttrFilter(columnID)))
-	return ret
+	return b.QueryByID(tableID).Filter(publicTargetFilter).FilterColumnDefaultExpression().
+		Filter(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.ColumnDefaultExpression) bool {
+			return e.ColumnID == columnID
+		}).
+		MustGetZeroOrOneElement()
 }
 
 func retrieveColumnOnUpdateExpressionElem(
 	b BuildCtx, tableID catid.DescID, columnID catid.ColumnID,
 ) (columnOnUpdateExpression *scpb.ColumnOnUpdateExpression) {
-	scpb.ForEachColumnOnUpdateExpression(b.QueryByID(tableID), func(
-		current scpb.Status, target scpb.TargetStatus, e *scpb.ColumnOnUpdateExpression,
-	) {
-		if e.ColumnID == columnID {
-			columnOnUpdateExpression = e
-		}
-	})
-	return columnOnUpdateExpression
+	return b.QueryByID(tableID).Filter(publicTargetFilter).FilterColumnOnUpdateExpression().
+		Filter(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.ColumnOnUpdateExpression) bool {
+			return e.ColumnID == columnID
+		}).
+		MustGetZeroOrOneElement()
 }
 
 // ensureColCanBeUsedInOutboundFK ensures the column can be used in an outbound

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_type.go
@@ -147,7 +147,7 @@ func validateAutomaticCastForNewType(
 	// We have a USING clause, but if we have DEFAULT or ON UPDATE expressions,
 	// then we raise an error because those expressions cannot be automatically
 	// cast to the new type.
-	columnElements(b, tableID, colID).ForEach(func(
+	columnElements(b, tableID, colID).Filter(publicTargetFilter).ForEach(func(
 		_ scpb.Status, _ scpb.TargetStatus, e scpb.Element,
 	) {
 		var exprType string
@@ -306,7 +306,7 @@ func handleGeneralColumnConversion(
 	// We block any attempt to alter the type of a column that is a key column in
 	// the primary key. We can't use walkColumnDependencies here, as it doesn't
 	// differentiate between key columns and stored columns.
-	pk := mustRetrievePrimaryIndex(b, tbl.TableID)
+	pk := getLatestPrimaryIndex(b, tbl.TableID)
 	for _, keyCol := range getIndexColumns(b.QueryByID(tbl.TableID), pk.IndexID, scpb.IndexColumn_KEY) {
 		if keyCol.ColumnID == col.ColumnID {
 			panic(sqlerrors.NewAlterColumnTypeColInIndexNotSupportedErr())

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -1770,10 +1770,6 @@ func mustRetrieveColumnName(
 		MustGetOneElement()
 }
 
-func mustRetrievePrimaryIndex(b BuildCtx, tableID catid.DescID) *scpb.PrimaryIndex {
-	return b.QueryByID(tableID).FilterPrimaryIndex().MustGetOneElement()
-}
-
 func retrieveColumnNotNull(
 	b BuildCtx, tableID catid.DescID, columnID catid.ColumnID,
 ) *scpb.ColumnNotNull {


### PR DESCRIPTION
Previously, the mustRetrievePrimaryIndex helper function assumed there was always a single primary key when returning an index element. However, during operations such as adding a new column, multiple primary keys can exist temporarily, with only one being the active key. This change updates the helper to correctly identify and return the latest primary key.

This fixes an issue that was affecting ALTER COLUMN TYPE, which relied on this helper.

Epic: CRDB-25314
Closes #134753
Release note: none