### PR TITLE
kvserver: deflake some NodeLiveness tests for leader leases

### DIFF
--- a/pkg/kv/kvserver/liveness/livenesspb/liveness.go
+++ b/pkg/kv/kvserver/liveness/livenesspb/liveness.go
@@ -216,6 +216,21 @@ const (
 	LossOfQuorum
 	ReplicaGCQueue
 	DistSender
+	// TestingIsAliveAndHasHeartbeated is intended to be used by tests that want
+	// to ensure that a node is alive and has heartbeated its liveness record
+	// already.
+	//
+	// This is intended to be used in place of IsAliveNotification, whose usages
+	// aren't very principled, and sometimes expect that a node has heartbeated
+	// its liveness record (by checking the epoch is != 0). Previously, we could
+	// get away with these unprincipled usages because epoch based leases would
+	// proactively heartbeat liveness records when acquiring leases. However, when
+	// using leader leases, this doesn't happen, which then makes these tests
+	// flaky.
+	//
+	// At some point, we'll want to revisit IsAliveNotification and make sure
+	// returning true when the liveness epoch is 0 is indeed well motivated.
+	TestingIsAliveAndHasHeartbeated
 )
 
 func (nv NodeVitality) IsLive(usage VitalityUsage) bool {
@@ -277,6 +292,8 @@ func (nv NodeVitality) IsLive(usage VitalityUsage) bool {
 		return nv.isAlive()
 	case DistSender:
 		return nv.isAvailableNotDraining()
+	case TestingIsAliveAndHasHeartbeated:
+		return nv.testingIsAliveAndHasHeartbeated()
 	}
 
 	// TODO(baptist): Should be an assertion that we don't know this uasge.
@@ -339,6 +356,13 @@ func (nv NodeVitality) isAlive() bool {
 		return true
 	}
 	return nv.now.Less(nv.livenessExpiration)
+}
+
+// testingIsAliveAndHasHeartbeated is like isAlive except it also ensures that
+// the node has heartbeated its liveness epoch at least once. Also see the
+// comment on TestingIsAliveAndHasHeartbeated.
+func (nv NodeVitality) testingIsAliveAndHasHeartbeated() bool {
+	return nv.isAlive() && nv.livenessEpoch != 0
 }
 
 func (nv NodeVitality) IsDecommissioning() bool {

--- a/pkg/kv/kvserver/node_liveness_test.go
+++ b/pkg/kv/kvserver/node_liveness_test.go
@@ -1120,13 +1120,17 @@ func TestNodeLivenessNoRetryOnAmbiguousResultCausedByCancellation(t *testing.T) 
 	defer s.Stopper().Stop(ctx)
 	nl := s.NodeLiveness().(*liveness.NodeLiveness)
 
+	testutils.SucceedsSoon(t, func() error {
+		return verifyLivenessServer(s, 1)
+	})
+
 	// We want to control the heartbeats.
 	nl.PauseHeartbeatLoopForTest()
 
 	sem = make(chan struct{})
 
 	l, ok := nl.Self()
-	assert.True(t, ok)
+	require.True(t, ok)
 
 	hbCtx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/pkg/kv/kvserver/node_liveness_test.go
+++ b/pkg/kv/kvserver/node_liveness_test.go
@@ -53,9 +53,10 @@ func verifyLiveness(t *testing.T, tc *testcluster.TestCluster) {
 		return nil
 	})
 }
+
 func verifyLivenessServer(s serverutils.TestServerInterface, numServers int64) error {
 	nl := s.NodeLiveness().(*liveness.NodeLiveness)
-	if !nl.GetNodeVitalityFromCache(s.NodeID()).IsLive(livenesspb.IsAliveNotification) {
+	if !nl.GetNodeVitalityFromCache(s.NodeID()).IsLive(livenesspb.TestingIsAliveAndHasHeartbeated) {
 		return errors.Errorf("node %d not live", s.NodeID())
 	}
 	if a, e := nl.Metrics().LiveNodes.Value(), numServers; a != e {
@@ -180,7 +181,7 @@ func TestNodeLivenessInitialIncrement(t *testing.T) {
 	nl, ok := tc.Servers[0].NodeLiveness().(*liveness.NodeLiveness).GetLiveness(tc.Servers[0].NodeID())
 	assert.True(t, ok)
 	if nl.Epoch != 1 {
-		t.Errorf("expected epoch to be set to 1 initially; got %d", nl.Epoch)
+		t.Fatalf("expected epoch to be set to 1 initially; got %d; liveness %s", nl.Epoch, nl)
 	}
 
 	// Restart the node and verify the epoch is incremented with initial heartbeat.


### PR DESCRIPTION
See individual commits.