### PR TITLE
roachtest: backup-restore/small-ranges gather debug zip files

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -186,6 +186,11 @@ func backupRestoreRoundTrip(
 					m.ExpectDeaths(int32(n))
 				}
 
+				// Between each reset grab a debug zip from the cluster.
+				zipPath := fmt.Sprintf("debug-%d.zip", timeutil.Now().Unix())
+				if err := testUtils.cluster.FetchDebugZip(ctx, t.L(), zipPath); err != nil {
+					t.L().Printf("failed to fetch a debug zip: %v", err)
+				}
 				if err := testUtils.resetCluster(ctx, t.L(), clusterupgrade.CurrentVersion(), expectDeathsFn, []install.ClusterSettingOption{}); err != nil {
 					return err
 				}


### PR DESCRIPTION
Previously, if the backup-restore tests had workload errors before the cluster was wiped then only debug zip data from after wiping the cluster would be kept. This would make workload issues impossible to diagnose / resolve if the problem was inside the CRDB code base, To address this, this patch adds logic to take a debug zip before wiping the cluster.

Fixes: #134928

Release note: None