### PR TITLE
kvserver: always use epoch leases for some tests 

### DIFF
--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -177,6 +177,13 @@ func OverrideDefaultLeaseType(ctx context.Context, sv *settings.Values, typ roac
 	}
 }
 
+// OverrideLeaderLeaseMetamorphism overrides the default lease type to be
+// epoch based leases, regardless of whether leader leases were metamorphically
+// enabled or not. Any
+func OverrideLeaderLeaseMetamorphism(ctx context.Context, sv *settings.Values) {
+	OverrideDefaultLeaseType(ctx, sv, roachpb.LeaseEpoch)
+}
+
 // leaseRequestHandle is a handle to an asynchronous lease request.
 type leaseRequestHandle struct {
 	p *pendingLeaseRequest


### PR DESCRIPTION
Certain tests are specifically designed for epoch based leases. For
example, they construct partitions of the NodeLiveness range's
leaseholder, or are related to quiscence. Override lease related
metamorphism for these. Tests included:

- TestRequestsOnFollowerWithNonLiveLeaseholder
- TestRaftPreVoteUnquiesceDeadLeader

References https://github.com/cockroachdb/cockroach/issues/133763

Epic: none

Release note: None