### PR TITLE
kvserver: disable pre-campaign checks in TestElectionAfterRestart 

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -640,6 +640,11 @@ type RaftConfig struct {
 	//
 	// -1 to disable.
 	RaftDelaySplitToSuppressSnapshot time.Duration
+
+	// TestingDisablePreCampaignStoreLivenessCheck may be used by tests to disable
+	// the check performed by a peer before campaigning to ensure it has
+	// StoreLiveness support from a majority quorum.
+	TestingDisablePreCampaignStoreLivenessCheck bool
 }
 
 // SetDefaults initializes unset fields.

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -5731,6 +5731,15 @@ func TestElectionAfterRestart(t *testing.T) {
 				RaftConfig: base.RaftConfig{
 					RaftElectionTimeoutTicks: electionTimeoutTicks,
 					RaftTickInterval:         raftTickInterval,
+					// Without this knob, elections triggered the first time around are
+					// guaranteed to fail as we won't have StoreLiveness support. This
+					// doesn't work with the expectation in this test to not see any
+					// timeout based elections for the ranges its tracking -- we are
+					// guaranteed to see timeout related elections for all ranges who
+					// failed the first time around when we didn't have StoreLiveness
+					// support. In some sense, leader leases is breaking the spirit of
+					// this test -- maybe we should get rid of it entirely?
+					TestingDisablePreCampaignStoreLivenessCheck: true,
 				},
 				Knobs: base.TestingKnobs{
 					Server: &server.TestingKnobs{

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -8145,6 +8145,9 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 	cfg := TestStoreConfig(nil)
 	// Disable ticks which would interfere with the manual ticking in this test.
 	cfg.RaftTickInterval = time.Hour
+	// Disable pre-campaign store liveness checks because we're disabling ticking
+	// above, and we don't want the first election attempt to guaranteed fail.
+	cfg.TestingDisablePreCampaignStoreLivenessCheck = true
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 	tc.StartWithStoreConfig(ctx, t, stopper, cfg)

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -413,11 +413,12 @@ func newRaftConfig(
 		MaxInflightBytes:            storeCfg.RaftMaxInflightBytes,
 		Storage:                     strg,
 		Logger:                      logger,
-		StoreLiveness:               storeLiveness,
-		PreVote:                     true,
-		CheckQuorum:                 storeCfg.RaftEnableCheckQuorum,
-		CRDBVersion:                 storeCfg.Settings.Version,
-		Metrics:                     metrics,
+		TestingDisablePreCampaignStoreLivenessCheck: storeCfg.TestingDisablePreCampaignStoreLivenessCheck,
+		StoreLiveness: storeLiveness,
+		PreVote:       true,
+		CheckQuorum:   storeCfg.RaftEnableCheckQuorum,
+		CRDBVersion:   storeCfg.Settings.Version,
+		Metrics:       metrics,
 	}
 }
 

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -251,6 +251,11 @@ type Config struct {
 	// See: https://github.com/etcd-io/raft/issues/80
 	DisableConfChangeValidation bool
 
+	// TestingDisablePreCampaignStoreLivenessCheck may be used by tests to disable
+	// the check performed by a peer before campaigning to ensure it has
+	// StoreLiveness support from a majority quorum.
+	TestingDisablePreCampaignStoreLivenessCheck bool
+
 	// StoreLiveness is a reference to the store liveness fabric.
 	StoreLiveness raftstoreliveness.StoreLiveness
 
@@ -424,6 +429,11 @@ type raft struct {
 	randomizedElectionTimeout int64
 	disableProposalForwarding bool
 
+	// testingDisablePreCampaignStoreLivenessCheck may be used by tests to disable
+	// the check performed by a peer before campaigning to ensure it has
+	// StoreLiveness support from a majority quorum.
+	testingDisablePreCampaignStoreLivenessCheck bool
+
 	tick func()
 	step stepFunc
 
@@ -459,9 +469,10 @@ func newRaft(c *Config) *raft {
 		preVote:                     c.PreVote,
 		disableProposalForwarding:   c.DisableProposalForwarding,
 		disableConfChangeValidation: c.DisableConfChangeValidation,
-		storeLiveness:               c.StoreLiveness,
-		crdbVersion:                 c.CRDBVersion,
-		metrics:                     c.Metrics,
+		testingDisablePreCampaignStoreLivenessCheck: c.TestingDisablePreCampaignStoreLivenessCheck,
+		storeLiveness: c.StoreLiveness,
+		crdbVersion:   c.CRDBVersion,
+		metrics:       c.Metrics,
 	}
 	lastID := r.raftLog.lastEntryID()
 
@@ -1412,7 +1423,7 @@ func (r *raft) hup(t CampaignType) {
 	// only make an exception if this is a leadership transfer, because otherwise
 	// the transfer might fail if the new leader doesn't already have support.
 	if t != campaignTransfer && r.fortificationTracker.RequireQuorumSupportOnCampaign() &&
-		!r.fortificationTracker.QuorumSupported() {
+		!r.fortificationTracker.QuorumSupported() && !r.testingDisablePreCampaignStoreLivenessCheck {
 		r.logger.Debugf("%x cannot campaign since it's not supported by a quorum in store liveness", r.id)
 		return
 	}


### PR DESCRIPTION
Without doing so, elections triggered the first time around are
guaranteed to fail as we won't have StoreLiveness support. This
doesn't work with the expectation in this test to not see any
timeout based elections for the ranges its tracking -- we are
guaranteed to see timeout related elections for all ranges who
failed the first time around when we didn't have StoreLiveness
support. In some sense, leader leases is breaking the spirit of
this test -- maybe we should get rid of it entirely?

Epic: none

Release note: None