### PR TITLE
roachtest: update activerecord blocklist

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord_blocklist.go
+++ b/pkg/cmd/roachtest/tests/activerecord_blocklist.go
@@ -18,29 +18,7 @@ package tests
 // in the test log.
 
 var activeRecordBlocklist = blocklist{
-	`ActiveRecord::CockroachDB::Migration::PGChangeSchemaTest#test_change_string_to_date`:                                               "unknown",
-	`ActiveRecord::CockroachDB::Migration::PGChangeSchemaTest#test_change_type_with_array`:                                              "unknown",
-	`ActiveRecord::CockroachDB::Migration::PGChangeSchemaTest#test_change_type_with_symbol`:                                             "unknown",
-	`ActiveRecord::CockroachDB::Migration::PGChangeSchemaTest#test_change_type_with_symbol_using_datetime`:                              "unknown",
-	`ActiveRecord::CockroachDB::Migration::PGChangeSchemaTest#test_change_type_with_symbol_using_datetime_with_timestamptz_as_default`:  "unknown",
-	`ActiveRecord::CockroachDB::Migration::PGChangeSchemaTest#test_change_type_with_symbol_using_timestamp_with_timestamptz_as_default`: "unknown",
-	`ActiveRecord::CockroachDB::Migration::PGChangeSchemaTest#test_change_type_with_symbol_with_timestamptz`:                            "unknown",
-	`ActiveRecord::CockroachDB::Migration::PGChangeSchemaTest#test_change_type_with_symbol_with_timestamptz_as_default`:                 "unknown",
-	`CompatibilityTest4_2#test_datetime_doesnt_set_precision_on_change_column`:                                                          "unknown",
-	`CompatibilityTest4_2#test_options_are_not_validated`:                                                                               "unknown",
-	`CompatibilityTest5_0#test_datetime_doesnt_set_precision_on_change_column`:                                                          "unknown",
-	`CompatibilityTest5_0#test_options_are_not_validated`:                                                                               "unknown",
-	`CompatibilityTest5_1#test_datetime_doesnt_set_precision_on_change_column`:                                                          "unknown",
-	`CompatibilityTest5_1#test_options_are_not_validated`:                                                                               "unknown",
-	`CompatibilityTest5_2#test_datetime_doesnt_set_precision_on_change_column`:                                                          "unknown",
-	`CompatibilityTest5_2#test_options_are_not_validated`:                                                                               "unknown",
-	`CompatibilityTest6_0#test_datetime_doesnt_set_precision_on_change_column`:                                                          "unknown",
-	`CompatibilityTest6_0#test_options_are_not_validated`:                                                                               "unknown",
-	`CompatibilityTest6_1#test_datetime_doesnt_set_precision_on_change_column`:                                                          "unknown",
-	`CompatibilityTest6_1#test_options_are_not_validated`:                                                                               "unknown",
-	`CompatibilityTest7_0#test_datetime_sets_precision_6_on_change_column`:                                                              "unknown",
-	`CompatibilityTest7_0#test_options_are_not_validated`:                                                                               "unknown",
-	`PostGISTest#test_point_to_json`:                                                                                                    "unknown",
+	`PostGISTest#test_point_to_json`: "unknown",
 }
 
 var activeRecordIgnoreList = blocklist{


### PR DESCRIPTION
This refreshes the blocklist for the activerecord test. A bunch of tests that failed previously now are passing.

I had a clean run with this update to roachtest:
```
2024/11/29 14:31:43 orm_helpers.go:191: Tests run on Cockroach v25.1.0-alpha.00000000-dev-5d084bd4e20dcedd1dde7549a2b63010f1ab8e15
Tests run against activerecord 7.2.1
8487 Total Tests Run
8486 tests passed
1 test failed
60 tests skipped
5 tests ignored
0 tests passed unexpectedly
0 tests failed unexpectedly
0 tests expected failed but skipped
0 tests expected failed but not run
```

Epic: None
Closes #136066
Release note: none