### PR TITLE
kvserver: start factoring out log append lifecycle code

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -66,6 +66,7 @@ go_library(
         "replica_raft_overload.go",
         "replica_raft_quiesce.go",
         "replica_raftlog.go",
+        "replica_raftlog_writes.go",
         "replica_raftstorage.go",
         "replica_range_lease.go",
         "replica_rangefeed.go",

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -180,7 +180,7 @@ type LogStore struct {
 	RangeID     roachpb.RangeID
 	Engine      storage.Engine
 	Sideload    SideloadStorage
-	StateLoader StateLoader
+	StateLoader StateLoader // used only for writes under raftMu
 	SyncWaiter  *SyncWaiterLoop
 	EntryCache  *raftentry.Cache
 	Settings    *cluster.Settings

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -314,7 +314,17 @@ type Replica struct {
 		// depending on which lock is being held.
 		stateLoader stateloader.StateLoader
 		// on-disk storage for sideloaded SSTables. Always non-nil.
+		// TODO(pav-kv): remove, since this is duplicated in logStorage.
 		sideloaded logstore.SideloadStorage
+		// logStorage provides access to the raft log storage. Set once upon Replica
+		// creation, and is never nil.
+		//
+		// TODO(pav-kv): move log state (such as shMu.lastIndexNotDurable) into the
+		// log storage type. Make the log storage type observe the writes and
+		// maintain this state, as opposed to doing it from a few places in Replica
+		// (like handleRaftReady).
+		logStorage *logstore.LogStore
+
 		// stateMachine is used to apply committed raft entries.
 		stateMachine replicaStateMachine
 		// decoder is used to decode committed raft entries.

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -890,10 +890,9 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	replicaStateInfoMap := r.raftMu.replicaStateScratchForFlowControl
 	var raftNodeBasicState replica_rac2.RaftNodeBasicState
 	var logSnapshot raft.LogSnapshot
+
 	r.mu.Lock()
 	rac2ModeForReady := r.mu.currentRACv2Mode
-	// TODO(pav-kv): state can be retrieved without Replica.mu.
-	state := r.asLogStorage().stateRaftMuLocked() // used for append below
 	leaderID := r.mu.leaderID
 	lastLeaderID := leaderID
 	err := r.withRaftGroupLocked(func(raftGroup *raft.RawNode) (bool, error) {
@@ -1051,6 +1050,8 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	// Grab the known leaseholder before applying to the state machine.
 	startingLeaseholderID := r.shMu.state.Lease.Replica.ReplicaID
 	refreshReason := noReason
+
+	state := r.asLogStorage().stateRaftMuLocked()
 	if hasMsg(msgStorageAppend) {
 		app := logstore.MakeMsgStorageAppend(msgStorageAppend)
 		cb := (*replicaSyncCallback)(r)

--- a/pkg/kv/kvserver/replica_raftlog.go
+++ b/pkg/kv/kvserver/replica_raftlog.go
@@ -27,6 +27,11 @@ import (
 // TODO(pav-kv): make it a proper type, and integrate with the logstore package.
 type replicaLogStorage Replica
 
+// asLogStorage returns the raft.LogStorage implementation of this replica.
+func (r *Replica) asLogStorage() *replicaLogStorage {
+	return (*replicaLogStorage)(r)
+}
+
 // Entries implements the raft.LogStorage interface.
 //
 // NB: maxBytes is advisory, and this method returns at least one entry (unless
@@ -87,7 +92,7 @@ func (r *replicaLogStorage) entriesLocked(
 func (r *Replica) raftEntriesLocked(
 	lo, hi kvpb.RaftIndex, maxBytes uint64,
 ) ([]raftpb.Entry, error) {
-	return (*replicaLogStorage)(r).entriesLocked(lo, hi, maxBytes)
+	return r.asLogStorage().entriesLocked(lo, hi, maxBytes)
 }
 
 // Term implements the raft.LogStorage interface.
@@ -119,7 +124,7 @@ func (r *replicaLogStorage) termLocked(i kvpb.RaftIndex) (kvpb.RaftTerm, error) 
 
 // raftTermLocked implements the Term() call.
 func (r *Replica) raftTermLocked(i kvpb.RaftIndex) (kvpb.RaftTerm, error) {
-	return (*replicaLogStorage)(r).termLocked(i)
+	return r.asLogStorage().termLocked(i)
 }
 
 // GetTerm returns the term of the entry at the given index in the raft log.

--- a/pkg/kv/kvserver/replica_raftlog_writes.go
+++ b/pkg/kv/kvserver/replica_raftlog_writes.go
@@ -1,0 +1,39 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvserver
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
+)
+
+// stateRaftMuLocked returns the current raft log storage state.
+func (r *replicaLogStorage) stateRaftMuLocked() logstore.RaftState {
+	return logstore.RaftState{
+		LastIndex: r.shMu.lastIndexNotDurable,
+		LastTerm:  r.shMu.lastTermNotDurable,
+		ByteSize:  r.shMu.raftLogSize,
+	}
+}
+
+// appendRaftMuLocked carries out a raft log append, and returns the new raft
+// log storage state.
+func (r *replicaLogStorage) appendRaftMuLocked(
+	ctx context.Context, app logstore.MsgStorageAppend, stats *logstore.AppendStats,
+) (logstore.RaftState, error) {
+	state := r.stateRaftMuLocked()
+	cb := (*replicaSyncCallback)(r)
+	return r.raftMu.logStorage.StoreEntries(ctx, state, app, cb, stats)
+}
+
+// updateStateRaftMuLockedMuLocked updates the in-memory reflection of the raft
+// log storage state.
+func (r *replicaLogStorage) updateStateRaftMuLockedMuLocked(state logstore.RaftState) {
+	r.shMu.lastIndexNotDurable = state.LastIndex
+	r.shMu.lastTermNotDurable = state.LastTerm
+	r.shMu.raftLogSize = state.ByteSize
+}

--- a/pkg/kv/kvserver/replica_raftlog_writes.go
+++ b/pkg/kv/kvserver/replica_raftlog_writes.go
@@ -11,6 +11,41 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 )
 
+// Raft log storage writes are carried out under raftMu which blocks all other
+// writes for this raft instance. Note that it does not prevent concurrent log
+// reads from within RawNode when it only holds Replica.mu. However, RawNode
+// never attempts to read log indices that have pending writes. See also the
+// replicaRaftStorage comment for more details.
+//
+// TODO(#131063): there is one subtle exception - the log can be compacted
+// concurrently with reading from its "readable" prefix. Incorrect ordering of
+// raftMu/mu updates during log compactions can cause read attempts for deleted
+// indices. We should fix it.
+//
+// For performance reasons, the raft log storage state (such as the last index)
+// needs to be accessible under Replica.mu. When appending is done, the state
+// needs to be transferred into the Replica.mu section.
+//
+// Appends can truncate a suffix of the log and overwrite it with entries
+// proposed by a new leader. An important corollary is that the log state
+// observed by Replica.mu-only sections is stale, because there can be a
+// concurrent raftMu writer changing these indices/entries.
+//
+// TODO(pav-kv): audit if there are any places relying on this stale raft log
+// state too heavily. The consistent source of truth about the raft log state
+// under Replica.mu is the RawNode / unstable, and preferably should be used.
+//
+// Raft log storage writes are asynchronous, in a limited sense. The write
+// batches are committed to Pebble immediately, but flush/sync is communicated
+// asynchronously (with a few synchronous case exceptions, see the code down the
+// appendRaftMuLocked stack).
+//
+// The sync acknowledgements from storage are stashed in Replica.localMsgs and
+// delivered back to RawNode by deliverLocalRaftMsgsRaftMuLockedReplicaMuLocked
+// at the next opportunity.
+//
+// TODO(pav-kv): move and describe raft log compaction lifecycle code here.
+
 // stateRaftMuLocked returns the current raft log storage state.
 func (r *replicaLogStorage) stateRaftMuLocked() logstore.RaftState {
 	return logstore.RaftState{

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -738,14 +738,26 @@ func (r *Replica) applySnapshot(
 	// performance implications are not likely to be drastic. If our
 	// feelings about this ever change, we can add a LastIndex field to
 	// raftpb.SnapshotMetadata.
-	r.shMu.lastIndexNotDurable = state.RaftAppliedIndex
-
-	// TODO(sumeer): We should be able to set this to
+	// TODO(pav-kv): the above comment seems stale, and needs an update.
+	//
+	// TODO(sumeer): We should be able to set the last term to
 	// nonemptySnap.Metadata.Term. See
 	// https://github.com/cockroachdb/cockroach/pull/75675#pullrequestreview-867926687
 	// for a discussion regarding this.
-	r.shMu.lastTermNotDurable = invalidLastTerm
-	r.shMu.raftLogSize = 0
+	r.asLogStorage().updateStateRaftMuLockedMuLocked(logstore.RaftState{
+		LastIndex: state.RaftAppliedIndex,
+		LastTerm:  invalidLastTerm,
+		ByteSize:  0, // the log is empty now
+	})
+	r.shMu.raftTruncState = truncState
+	// Snapshots typically have fewer log entries than the leaseholder. The next
+	// time we hold the lease, recompute the log size before making decisions.
+	//
+	// TODO(pav-kv): does this assume that snapshots can contain log entries,
+	// which is no longer true? The comment needs an update, and the decision to
+	// set this flag to false revisited.
+	r.shMu.raftLogSizeTrusted = false
+
 	// Update the store stats for the data in the snapshot.
 	r.store.metrics.subtractMVCCStats(ctx, r.tenantMetricsRef, *r.shMu.state.Stats)
 	r.store.metrics.addMVCCStats(ctx, r.tenantMetricsRef, *state.Stats)
@@ -755,10 +767,6 @@ func (r *Replica) applySnapshot(
 	// by r.leasePostApply, but we called those above, so now it's safe to
 	// wholesale replace r.mu.state.
 	r.shMu.state = state
-	r.shMu.raftTruncState = truncState
-	// Snapshots typically have fewer log entries than the leaseholder. The next
-	// time we hold the lease, recompute the log size before making decisions.
-	r.shMu.raftLogSizeTrusted = false
 
 	// Invoke the leasePostApply method to ensure we properly initialize the
 	// replica according to whether it holds the lease. We allow jumps in the


### PR DESCRIPTION
This PR refactors the raft log append path in `Replica`:
- Creates a `logstore.LogStore` once instead of creating it every time when appending.
- Moves the code bits relevant to log append (getting the state, calling storage append, updating the state) to a new file.
- Adds a comment describing the log append lifecycle.

Part of #136109