### PR TITLE
kvclient: deflake TestMuxRangeFeedDoesNotStallOnError

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -167,6 +167,7 @@ go_test(
         "//pkg/config/zonepb",
         "//pkg/gossip",
         "//pkg/gossip/simulation",
+        "//pkg/jobs",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvbase",


### PR DESCRIPTION
During setup, this test wants to ensure that there's atleast one non-local range to node 1. Previously, we'd only scatter once, which meant if we got unlucky on that scatter, the setup condition could never be satisfied. This patch moves the scatter into the succeeds soon bit where we're checking the non-local range condition.

Closes https://github.com/cockroachdb/cockroach/issues/136316

Release note: None