### PR TITLE
sql: use read timestamp from cache to read role-related system tables

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -6731,7 +6731,7 @@ CREATE TABLE crdb_internal.default_privileges (
 
 		// Cache roles ahead of time to avoid role lookup inside loop.
 		var roles []catpb.DefaultPrivilegesRole
-		if err := forEachRole(ctx, p, func(ctx context.Context, userName username.SQLUsername, isRole bool, options roleOptions, settings tree.Datum) error {
+		if err := forEachRoleAtCacheReadTS(ctx, p, func(ctx context.Context, userName username.SQLUsername, isRole bool, options roleOptions, settings tree.Datum) error {
 			// Skip the internal node user, since it can't be modified and just adds noise.
 			if userName.IsNodeUser() {
 				return nil
@@ -8797,7 +8797,7 @@ CREATE TABLE crdb_internal.kv_inherited_role_members (
 		// explicitly a member of `b`. The role `c` is also a member of `a`,
 		// but not explicitly, because it inherits the membership through `b`.
 		explicitMemberships := make(map[username.SQLUsername]map[username.SQLUsername]bool)
-		if err := forEachRoleMembership(ctx, p.InternalSQLTxn(), func(ctx context.Context, role, member username.SQLUsername, isAdmin bool) error {
+		if err := forEachRoleMembershipAtCacheReadTS(ctx, p, func(ctx context.Context, role, member username.SQLUsername, isAdmin bool) error {
 			if _, found := explicitMemberships[member]; !found {
 				explicitMemberships[member] = make(map[username.SQLUsername]bool)
 			}

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1743,3 +1743,42 @@ foo    false
 bar    true
 
 subtest end
+
+# Regression test for https://github.com/cockroachdb/cockroach/issues/136230.
+# Reading from inherited_role_members should never read any data that is not in
+# the role membership cache. We simulate a stale cache by inserting a user
+# directly into system tables.
+subtest inherited_role_members_reads_at_cache_timestamp
+
+statement ok
+CREATE USER real_user;
+GRANT admin TO real_user;
+
+query TTBB
+SELECT role, inheriting_member, member_is_explicit, member_is_admin
+FROM crdb_internal.kv_inherited_role_members
+ORDER BY role, inheriting_member
+----
+admin  real_user  true  false
+admin  root       true  true
+
+statement ok
+INSERT INTO system.users (username, user_id) VALUES ('non_cached_user', 12345);
+INSERT INTO system.role_members (role, member, role_id, member_id, "isAdmin") VALUES ('admin', 'non_cached_user', 2, 12345, true);
+
+query TTBB
+SELECT role, inheriting_member, member_is_explicit, member_is_admin
+FROM crdb_internal.kv_inherited_role_members
+ORDER BY role, inheriting_member
+----
+admin  real_user  true  false
+admin  root       true  true
+
+statement ok
+DELETE FROM system.users WHERE username = 'non_cached_user';
+DELETE FROM system.role_members WHERE member = 'non_cached_user';
+
+statement ok
+DROP USER real_user;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_default_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_default_privileges
@@ -1133,6 +1133,10 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT INSERT ON TABLES TO roach_a;
 statement ok
 DELETE FROM system.users WHERE username = 'roach_a';
 
+# Force the role membership cache to be updated.
+statement ok
+CREATE ROLE tmp;
+
 query TTTBTTTB colnames
 SELECT * FROM crdb_internal.default_privileges WHERE grantee = 'roach_a'
 ORDER BY role;

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2746,6 +2746,26 @@ oid         rolname   rolconnlimit  rolpassword  rolvaliduntil  rolbypassrls  ro
 1546506610  root      -1            ********     NULL           false         NULL
 2264919399  testuser  -1            ********     NULL           false         NULL
 
+# Regression test for https://github.com/cockroachdb/cockroach/issues/136230.
+# Reading from pg_roles should never read any data that is not in the role
+# membership cache. We simulate a stale cache by inserting a user directly into
+# system.users.
+statement ok
+INSERT INTO system.users (username, user_id) VALUES ('non_cached_user', 12345)
+
+query T
+SELECT rolname
+FROM pg_catalog.pg_roles
+ORDER BY rolname
+----
+admin
+node
+root
+testuser
+
+statement ok
+DELETE FROM system.users WHERE username = 'non_cached_user'
+
 ## pg_catalog.pg_auth_members
 
 query OOOB colnames


### PR DESCRIPTION
To populate role-related virtual tables like pg_roles, we need to make sure the timestamp we use to read the underlying system table is not newer than the timestamp that was used to populate the role membership cache. It is possible for these timestamps to differ because we use a leased descriptor to check the validity of the membership cache.

This resolves an unreleased bug where a "user does not exist" error could occur while scanning pg_roles.

fixes https://github.com/cockroachdb/cockroach/issues/136230
fixes https://github.com/cockroachdb/cockroach/issues/136192
Release note: None