### PR TITLE
logictest: remove unnecessary flaky assertion from synthetic_privileges test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/synthetic_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/synthetic_privileges
@@ -303,19 +303,6 @@ BEGIN TRANSACTION PRIORITY HIGH ISOLATION LEVEL SERIALIZABLE;
 statement ok
 GRANT SELECT ON crdb_internal.feature_usage TO testuser4
 
-query TTTT
-SELECT username, path, privileges, grant_options FROM system.privileges ORDER BY 1,2
-----
-public     /vtable/crdb_internal/feature_usage  {}                                         {}
-root       /global/                             {MODIFYCLUSTERSETTING}                     {}
-testuser   /externalconn/foo                    {USAGE}                                    {}
-testuser   /global/                             {MODIFYCLUSTERSETTING}                     {}
-testuser   /vtable/crdb_internal/tables         {SELECT}                                   {}
-testuser2  /externalconn/foo                    {USAGE}                                    {}
-testuser2  /global/                             {MODIFYCLUSTERSETTING}                     {}
-testuser3  /global/                             {EXTERNALCONNECTION,MODIFYCLUSTERSETTING}  {}
-testuser4  /vtable/crdb_internal/feature_usage  {SELECT}                                   {}
-
 # This should not cache the uncommitted privilege.
 query B
 SELECT has_table_privilege('testuser4', 'crdb_internal.feature_usage', 'SELECT')
@@ -324,18 +311,6 @@ true
 
 statement ok
 ROLLBACK
-
-query TTTT
-SELECT username, path, privileges, grant_options FROM system.privileges ORDER BY 1,2
-----
-public     /vtable/crdb_internal/feature_usage  {}                                         {}
-root       /global/                             {MODIFYCLUSTERSETTING}                     {}
-testuser   /externalconn/foo                    {USAGE}                                    {}
-testuser   /global/                             {MODIFYCLUSTERSETTING}                     {}
-testuser   /vtable/crdb_internal/tables         {SELECT}                                   {}
-testuser2  /externalconn/foo                    {USAGE}                                    {}
-testuser2  /global/                             {MODIFYCLUSTERSETTING}                     {}
-testuser3  /global/                             {EXTERNALCONNECTION,MODIFYCLUSTERSETTING}  {}
 
 query B
 SELECT has_table_privilege('testuser4', 'crdb_internal.feature_usage', 'SELECT')


### PR DESCRIPTION
There's no need to read from the system table directly; the test checks what it needs by using the has_table_privilege function.

fixes https://github.com/cockroachdb/cockroach/issues/133912
fixes https://github.com/cockroachdb/cockroach/issues/136183
Release note: None