### PR TITLE
sql/schemachanger: Exclude schema change wait time from idle session timeout

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4069,6 +4069,8 @@ func (ex *connExecutor) waitForTxnJobs() error {
 	if len(ex.extraTxnState.jobs.created) == 0 {
 		return nil
 	}
+	ex.mu.IdleInSessionTimeout.Stop()
+	defer ex.startIdleInSessionTimeout()
 	ex.server.cfg.JobRegistry.NotifyToResume(
 		ex.ctxHolder.connCtx, ex.extraTxnState.jobs.created...,
 	)

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -156,13 +156,7 @@ func (ex *connExecutor) execStmt(
 		panic(errors.AssertionFailedf("unexpected txn state: %#v", ex.machine.CurState()))
 	}
 
-	if ex.sessionData().IdleInSessionTimeout > 0 {
-		// Cancel the session if the idle time exceeds the idle in session timeout.
-		ex.mu.IdleInSessionTimeout = timeout{time.AfterFunc(
-			ex.sessionData().IdleInSessionTimeout,
-			ex.CancelSession,
-		)}
-	}
+	ex.startIdleInSessionTimeout()
 
 	if ex.sessionData().IdleInTransactionSessionTimeout > 0 {
 		startIdleInTransactionSessionTimeout := func() {
@@ -190,6 +184,17 @@ func (ex *connExecutor) execStmt(
 	}
 
 	return ev, payload, err
+}
+
+// startIdleInSessionTimeout will start the timer for the idle in session timeout.
+func (ex *connExecutor) startIdleInSessionTimeout() {
+	if ex.sessionData().IdleInSessionTimeout > 0 {
+		// Cancel the session if the idle time exceeds the idle in session timeout.
+		ex.mu.IdleInSessionTimeout = timeout{time.AfterFunc(
+			ex.sessionData().IdleInSessionTimeout,
+			ex.CancelSession,
+		)}
+	}
 }
 
 func (ex *connExecutor) recordFailure() {

--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -488,6 +489,91 @@ func TestIdleInSessionTimeout(t *testing.T) {
 		t.Fatal("expected the connection to be killed " +
 			"but the connection is still alive")
 	}
+}
+
+func TestIdleInSessionTimeoutDuringSchemaChange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderDuress(t, "slow test")
+	ctx := context.Background()
+
+	var blockSchemaChange atomic.Bool
+	startWaitOfSchemaChange := make(chan any)
+	endWaitOfSchemaChange := make(chan any)
+
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLDeclarativeSchemaChanger: &scexec.TestingKnobs{
+				BeforeStage: func(p scplan.Plan, stageIdx int) error {
+					// We only block in the first stage of the PostCommitPhase.
+					if !blockSchemaChange.Load() || p.Params.ExecutionPhase != scop.PostCommitPhase || stageIdx != 0 {
+						return nil
+					}
+					// Notify foreground thread that we are now waiting
+					startWaitOfSchemaChange <- true
+					// Wait for the foreground thread to release us
+					<-endWaitOfSchemaChange
+					return nil
+				},
+			},
+		},
+	})
+	defer srv.Stopper().Stop(ctx)
+
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+	runner.Exec(t, "CREATE TABLE t1()")
+
+	const sessionTimeoutInSeconds = 1
+	acquireConn := func() *gosql.Conn {
+		conn, err := sqlDB.Conn(ctx)
+		require.NoError(t, err)
+		_, err = conn.ExecContext(ctx, fmt.Sprintf("SET idle_in_session_timeout = '%ds'", sessionTimeoutInSeconds))
+		require.NoError(t, err)
+		return conn
+	}
+	conn := acquireConn()
+
+	checkConnectionAndReconnect := func(expectConnection bool) {
+		// Test the connection
+		_, err := conn.ExecContext(ctx, `SELECT 1`)
+		if expectConnection {
+			require.NoError(t, err, "expected the connection to be valid, but it's not: %v", err)
+		} else {
+			require.Error(t, err, "expected the connection to be dead, but it's still alive")
+			require.Contains(t, err.Error(), "driver: bad connection",
+				"expected the error to be a connection issue: %v", err)
+			// Reestablish the connection
+			conn = acquireConn()
+		}
+	}
+	time.Sleep(2 * sessionTimeoutInSeconds * time.Second)
+	checkConnectionAndReconnect(false)
+
+	// Kick off a background thread that will block doing a schema change. It
+	// should be immune to the idle session timeout.
+	defer close(endWaitOfSchemaChange) // Close channel to unblock background thread if foreground fails
+	grp := ctxgroup.WithContext(ctx)
+	grp.GoCtx(func(ctx context.Context) error {
+		defer close(startWaitOfSchemaChange) // In case we fail before adding to this channel
+		blockSchemaChange.Swap(true)
+		_, err := conn.ExecContext(ctx, `ALTER TABLE t1 ADD COLUMN C2 BIGINT`)
+		return err
+	})
+
+	<-startWaitOfSchemaChange
+	blockSchemaChange.Swap(false) // Disable so that we don't block for another stage
+	// We are now waiting for the schema change to complete. Waiting for twice the
+	// session timeout ensures that the schema change is not affected by the idle
+	// session timeout.
+	time.Sleep(2 * sessionTimeoutInSeconds * time.Second)
+	// Tell the background thread to continue
+	endWaitOfSchemaChange <- true
+	require.NoError(t, grp.Wait())
+
+	// Test that the idle session timer is reset after the schema change.
+	checkConnectionAndReconnect(true)
+	time.Sleep(2 * sessionTimeoutInSeconds * time.Second)
+	checkConnectionAndReconnect(false)
 }
 
 func TestIdleInTransactionSessionTimeout(t *testing.T) {


### PR DESCRIPTION
Previously, the idle session timeout timer would start immediately after statement execution. If a transaction committed and had to wait for a schema change to complete, the connection could be interrupted if the idle session timeout expired during this wait.

This update pauses the idle session timer while waiting for schema change jobs to finish, ensuring connections remain active until the schema change completes.

Epic: None
Closes #135930
Release note (bug fix): The `idle_in_session_timeout` setting now excludes the time spent waiting for schema changer jobs to complete, preventing unintended session termination during schema change operations.