### PR TITLE
kvserver: skip TestReplicaTombstone to run under deadlock with expiration leases

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -3309,6 +3309,9 @@ func TestReplicaTombstone(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	testutils.RunValues(t, "lease-type", roachpb.LeaseTypes(),
 		func(t *testing.T, leaseType roachpb.LeaseType) {
+			if leaseType == roachpb.LeaseExpiration {
+				skip.UnderDeadlock(t, "times out")
+			}
 			t.Run("(1) ChangeReplicasTrigger", func(t *testing.T) {
 				defer leaktest.AfterTest(t)()
 				defer log.Scope(t).Close(t)


### PR DESCRIPTION
The test TestReplicaTombstone used to run in both expiration and leader leases, however, metamorphically, it's skipped under deadlock with expiration-based leases. This commit matches the old behaviour.

Fixes: #136425

Release note: None