### PR TITLE
release-23.1: diagnostics: ignore timeout errors; extend client timeout

### DIFF
--- a/pkg/server/diagnostics/diagnostics.go
+++ b/pkg/server/diagnostics/diagnostics.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/system"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/host"
@@ -64,6 +65,10 @@ type TestingKnobs struct {
 	// OverrideReportingURL if set, overrides the URL used to report diagnostics.
 	// It is a pointer to pointer to allow overriding to the nil URL.
 	OverrideReportingURL **url.URL
+
+	// TimeSource if set will be used to set timestamp for last
+	// successful telemetry ping.
+	TimeSource timeutil.TimeSource
 }
 
 // ClusterInfo contains cluster information that will become part of URLs.

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1345,21 +1345,21 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		waitForInstanceReaderStarted,
 	)
 
-	reporter := &diagnostics.Reporter{
-		StartTime:        timeutil.Now(),
-		AmbientCtx:       &cfg.AmbientCtx,
-		Config:           cfg.BaseConfig.Config,
-		Settings:         cfg.Settings,
-		StorageClusterID: cfg.rpcContext.StorageClusterID.Get,
-		LogicalClusterID: clusterIDForSQL.Get,
-		TenantID:         cfg.rpcContext.TenantID,
-		SQLInstanceID:    cfg.nodeIDContainer.SQLInstanceID,
-		SQLServer:        pgServer.SQLServer,
-		InternalExec:     cfg.circularInternalExecutor,
-		DB:               cfg.db,
-		Recorder:         cfg.recorder,
-		Locality:         cfg.Locality,
-	}
+	reporter := diagnostics.NewDiagnosticReporter(
+		timeutil.Now(),
+		&cfg.AmbientCtx,
+		cfg.BaseConfig.Config,
+		cfg.Settings,
+		cfg.rpcContext.StorageClusterID.Get,
+		clusterIDForSQL.Get,
+		cfg.rpcContext.TenantID,
+		cfg.nodeIDContainer.SQLInstanceID,
+		pgServer.SQLServer,
+		cfg.circularInternalExecutor,
+		cfg.db,
+		cfg.recorder,
+		cfg.Locality,
+	)
 
 	if cfg.TestingKnobs.Server != nil {
 		reporter.TestingKnobs = &cfg.TestingKnobs.Server.(*TestingKnobs).DiagnosticsTestingKnobs


### PR DESCRIPTION
Backport 1/1 commits from #136219.

/cc @cockroachdb/release

---

diagnostics: ignore timeout errors; extend client timeout
Previously, we would not update the telemetry success timestamp on
http client timeouts. This can cause throttling on clusters that are
sending large payloads and timing out.

Additionally, the client timeout is extended to 1 minute from 3
seconds (default) to account for this.

Epic: None
Resolves: https://github.com/cockroachdb/cockroach/issues/136224

Release note (ops change): telemetry delivery is now considered
successful even in cases where we experience a network timeout. This
will prevent throttling in cases outside an operator's control.

---

Release justification: core deprecation; low-risk high benefit change to telemetry reporting