### PR TITLE
logictest: deflake recently added trigger EXPLAIN ANALYZE test

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers_explain
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers_explain
@@ -993,6 +993,12 @@ quality of service: regular
                               estimated row count: 1
                               label: buffer 1000000
 
+
+# Ensure that the intent on 'parent' is resolved so that we don't see any
+# contention time reported for 'delete range' below.
+statement ok
+SELECT count(*) FROM parent
+
 query T
 EXPLAIN ANALYZE (VERBOSE) DELETE FROM parent WHERE k = 2;
 ----


### PR DESCRIPTION
We just saw a failure on the recently added EXPLAIN ANALYZE test for triggers where the KV contention time was reported on `delete range` operator on the parent table. My guess is this was due to having an intent from the previous query where we updated the table, so this commit adds a scan of the table to ensure that intents are cleaned up before running the EXPLAIN ANALYZE that involves the DELETE.

Fixes: #136382.

Release note: None