### PR TITLE
sql: allow routines to execute CTEs

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_cte
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_cte
@@ -1,0 +1,211 @@
+statement ok
+CREATE TABLE ab (a INT PRIMARY KEY, b INT);
+INSERT INTO ab VALUES (1, 10), (2, 20), (3, 30), (4, 40);
+
+statement ok
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    res INT;
+  BEGIN
+    WITH foo AS MATERIALIZED (SELECT 100) SELECT * INTO res FROM foo;
+    RETURN res;
+  END
+$$;
+
+query I
+SELECT f();
+----
+100
+
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    res INT;
+  BEGIN
+    WITH foo AS MATERIALIZED (SELECT b FROM ab WHERE a = 3) SELECT * INTO res FROM foo;
+    RETURN res;
+  END
+$$;
+
+query I
+SELECT f();
+----
+30
+
+# Multiple references to the CTE.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    res INT;
+  BEGIN
+    WITH foo (bar) AS (SELECT 1) SELECT foo.bar + foo2.bar INTO res FROM foo, foo foo2;
+    RETURN res;
+  END
+$$;
+
+query I
+SELECT f();
+----
+2
+
+# CTE with multiple branches.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    res INT;
+  BEGIN
+    WITH foo (x) AS MATERIALIZED (SELECT 1),
+    bar (x) AS MATERIALIZED (SELECT 2)
+    SELECT foo.x + bar.x INTO res FROM foo, bar;
+    RETURN res;
+  END
+$$;
+
+query I
+SELECT f();
+----
+3
+
+# Nested CTE expressions.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    res INT;
+  BEGIN
+    WITH foo (x) AS MATERIALIZED (SELECT 100)
+    SELECT * FROM (
+      WITH bar (x) AS MATERIALIZED (SELECT 200)
+      SELECT foo.x + bar.x INTO res FROM foo, bar
+    ) AS t;
+    RETURN res;
+  END
+$$;
+
+query I
+SELECT f();
+----
+300
+
+# Case with an outer CTE.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    res INT;
+  BEGIN
+    WITH foo AS MATERIALIZED (SELECT 1) SELECT * INTO res FROM foo;
+    RETURN res;
+  END
+$$;
+
+query II
+WITH bar AS (SELECT 2) SELECT f(), * FROM bar;
+----
+1  2
+
+# The outer CTE has the same name as the inner CTE.
+query II
+WITH foo AS (SELECT 2) SELECT f(), * FROM foo;
+----
+1  2
+
+# Case with a CTE inside a subquery.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    res INT;
+  BEGIN
+    SELECT (
+      WITH foo AS MATERIALIZED (SELECT b FROM ab)
+      SELECT * FROM foo
+    ) INTO res;
+    RETURN res;
+  END
+$$;
+
+# Avoid causing an error due to too many rows returned.
+statement ok
+DELETE FROM ab WHERE a > 1;
+
+query I
+SELECT f();
+----
+10
+
+statement ok
+INSERT INTO ab VALUES (2, 20), (3, 30), (4, 40);
+
+# Case with a recursive CTE.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT[] LANGUAGE PLpgSQL AS $$
+  DECLARE
+    res INT[];
+  BEGIN
+    WITH RECURSIVE foo (x, y) AS (
+      SELECT a, b FROM ab WHERE a = 1
+      UNION ALL
+      SELECT a, b FROM ab WHERE a = (SELECT max(x) + 1 FROM foo)
+    )
+    SELECT array_agg(y) INTO res FROM foo;
+    RETURN res;
+  END
+$$;
+
+query T
+SELECT f();
+----
+{10,20,30,40}
+
+# Case with PL/pgSQL IF statement branching.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f(x INT) RETURNS INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    res INT;
+  BEGIN
+    IF (SELECT b FROM ab WHERE a = 3) = x THEN
+      WITH foo AS MATERIALIZED (SELECT 100) SELECT * INTO res FROM foo;
+    ELSE
+      WITH foo AS MATERIALIZED (SELECT 200) SELECT * INTO res FROM foo;
+    END IF;
+    RETURN res;
+  END
+$$;
+
+query II
+SELECT f(20), f(30);
+----
+200  100
+
+# Case with a loop and some branching.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f(n INT) RETURNS INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    tmp INT := 0;
+    res INT := 0;
+    i INT := 0;
+  BEGIN
+    WHILE i < n LOOP
+      IF i%2 = 1 THEN
+        WITH foo AS MATERIALIZED (SELECT 100) SELECT * INTO tmp FROM foo;
+      ELSE
+        WITH foo AS MATERIALIZED (SELECT 1) SELECT * INTO tmp FROM foo;
+      END IF;
+      res := res + tmp;
+      i := i + 1;
+    END LOOP;
+    RETURN res;
+  END
+$$;
+
+query IIIIIII
+SELECT f(NULL), f(0), f(1), f(2), f(3), f(4), f(5);
+----
+0  0  1  101  102  202  203

--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_cursor
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_cursor
@@ -268,7 +268,7 @@ CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
   END
 $$ LANGUAGE PLpgSQL;
 
-statement error pgcode 0A000 pq: unimplemented: CTE usage inside a function definition
+statement ok
 CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
   DECLARE
     i INT := 3;
@@ -278,10 +278,18 @@ CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
     RETURN 0;
   END
 $$ LANGUAGE PLpgSQL;
+BEGIN;
+SELECT f();
 
-# TODO(#92961): once CTEs in routines are supported, the error should be:
-# pgcode 0A000 pq: DECLARE CURSOR must not contain data-modifying statements in WITH
-statement error pgcode 0A000 pq: unimplemented: CTE usage inside a function definition
+query I rowsort
+FETCH FORWARD 3 FROM foo;
+----
+1
+
+statement ok
+ABORT;
+
+statement error pgcode 0A000 pq: DECLARE CURSOR must not contain data-modifying statements in WITH
 CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
   DECLARE
     i INT := 3;

--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
@@ -1588,14 +1588,6 @@ CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
   END
 $$ LANGUAGE PLpgSQL;
 
-statement error pgcode 0A000 pq: unimplemented: CTE usage inside a function definition
-CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
-  BEGIN
-    WITH foo AS MATERIALIZED (SELECT * FROM xy) SELECT * FROM foo;
-    RETURN 0;
-  END
-$$ LANGUAGE PLpgSQL;
-
 statement error pgcode 0A000 pq: unimplemented: SHOW DATABASES usage inside a function definition
 CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
   BEGIN
@@ -1603,15 +1595,6 @@ CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
     RETURN 0;
   END
 $$ LANGUAGE PLpgSQL;
-
-statement error pgcode 0A000 pq: unimplemented: statement source \(square bracket syntax\) within user-defined function
-CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
-  BEGIN
-    SELECT * FROM [SHOW databases];
-    RETURN 0;
-  END
-$$ LANGUAGE PLpgSQL;
-
 
 statement error pgcode 0A000 pq: unimplemented: CREATE TABLE usage inside a function definition
 CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
@@ -1635,6 +1618,23 @@ statement error pgcode 0A000 pq: unimplemented: PREPARE usage inside a function 
 CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
   BEGIN
     PREPARE foo AS SELECT * FROM xy WHERE x = $1;
+    RETURN 0;
+  END
+$$ LANGUAGE PLpgSQL;
+
+# CTEs are allowed in functions.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    WITH foo AS MATERIALIZED (SELECT * FROM xy) SELECT * FROM foo;
+    RETURN 0;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
+  BEGIN
+    SELECT * FROM [SELECT * FROM xy];
     RETURN 0;
   END
 $$ LANGUAGE PLpgSQL;

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1457,6 +1457,13 @@ func TestTenantLogic_procedure(
 	runLogicTest(t, "procedure")
 }
 
+func TestTenantLogic_procedure_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_cte")
+}
+
 func TestTenantLogic_procedure_deps(
 	t *testing.T,
 ) {
@@ -2255,6 +2262,13 @@ func TestTenantLogic_udf_calling_udf(
 	runLogicTest(t, "udf_calling_udf")
 }
 
+func TestTenantLogic_udf_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_cte")
+}
+
 func TestTenantLogic_udf_delete(
 	t *testing.T,
 ) {
@@ -2715,6 +2729,13 @@ func TestTenantLogicCCL_plpgsql_call(
 ) {
 	defer leaktest.AfterTest(t)()
 	runCCLLogicTest(t, "plpgsql_call")
+}
+
+func TestTenantLogicCCL_plpgsql_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_cte")
 }
 
 func TestTenantLogicCCL_plpgsql_cursor(

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 31,
+    shard_count = 32,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
@@ -145,6 +145,13 @@ func TestCCLLogic_plpgsql_call(
 	runCCLLogicTest(t, "plpgsql_call")
 }
 
+func TestCCLLogic_plpgsql_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_cte")
+}
+
 func TestCCLLogic_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 31,
+    shard_count = 32,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
@@ -145,6 +145,13 @@ func TestCCLLogic_plpgsql_call(
 	runCCLLogicTest(t, "plpgsql_call")
 }
 
+func TestCCLLogic_plpgsql_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_cte")
+}
+
 func TestCCLLogic_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 32,
+    shard_count = 33,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
@@ -152,6 +152,13 @@ func TestCCLLogic_plpgsql_call(
 	runCCLLogicTest(t, "plpgsql_call")
 }
 
+func TestCCLLogic_plpgsql_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_cte")
+}
+
 func TestCCLLogic_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 30,
+    shard_count = 31,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/generated_test.go
@@ -145,6 +145,13 @@ func TestCCLLogic_plpgsql_call(
 	runCCLLogicTest(t, "plpgsql_call")
 }
 
+func TestCCLLogic_plpgsql_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_cte")
+}
+
 func TestCCLLogic_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-mixed-24.3/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-mixed-24.3/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 31,
+    shard_count = 32,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-mixed-24.3/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-mixed-24.3/generated_test.go
@@ -145,6 +145,13 @@ func TestCCLLogic_plpgsql_call(
 	runCCLLogicTest(t, "plpgsql_call")
 }
 
+func TestCCLLogic_plpgsql_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_cte")
+}
+
 func TestCCLLogic_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -1462,6 +1462,13 @@ func TestReadCommittedLogic_procedure(
 	runLogicTest(t, "procedure")
 }
 
+func TestReadCommittedLogic_procedure_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_cte")
+}
+
 func TestReadCommittedLogic_procedure_deps(
 	t *testing.T,
 ) {
@@ -2239,6 +2246,13 @@ func TestReadCommittedLogic_udf_calling_udf(
 	runLogicTest(t, "udf_calling_udf")
 }
 
+func TestReadCommittedLogic_udf_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_cte")
+}
+
 func TestReadCommittedLogic_udf_delete(
 	t *testing.T,
 ) {
@@ -2664,6 +2678,13 @@ func TestReadCommittedLogicCCL_plpgsql_call(
 ) {
 	defer leaktest.AfterTest(t)()
 	runCCLLogicTest(t, "plpgsql_call")
+}
+
+func TestReadCommittedLogicCCL_plpgsql_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_cte")
 }
 
 func TestReadCommittedLogicCCL_plpgsql_cursor(

--- a/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
@@ -1455,6 +1455,13 @@ func TestRepeatableReadLogic_procedure(
 	runLogicTest(t, "procedure")
 }
 
+func TestRepeatableReadLogic_procedure_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_cte")
+}
+
 func TestRepeatableReadLogic_procedure_deps(
 	t *testing.T,
 ) {
@@ -2232,6 +2239,13 @@ func TestRepeatableReadLogic_udf_calling_udf(
 	runLogicTest(t, "udf_calling_udf")
 }
 
+func TestRepeatableReadLogic_udf_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_cte")
+}
+
 func TestRepeatableReadLogic_udf_delete(
 	t *testing.T,
 ) {
@@ -2657,6 +2671,13 @@ func TestRepeatableReadLogicCCL_plpgsql_call(
 ) {
 	defer leaktest.AfterTest(t)()
 	runCCLLogicTest(t, "plpgsql_call")
+}
+
+func TestRepeatableReadLogicCCL_plpgsql_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_cte")
 }
 
 func TestRepeatableReadLogicCCL_plpgsql_cursor(

--- a/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 31,
+    shard_count = 32,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
@@ -145,6 +145,13 @@ func TestCCLLogic_plpgsql_call(
 	runCCLLogicTest(t, "plpgsql_call")
 }
 
+func TestCCLLogic_plpgsql_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_cte")
+}
+
 func TestCCLLogic_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local/generated_test.go
@@ -243,6 +243,13 @@ func TestCCLLogic_plpgsql_call(
 	runCCLLogicTest(t, "plpgsql_call")
 }
 
+func TestCCLLogic_plpgsql_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_cte")
+}
+
 func TestCCLLogic_plpgsql_cursor(
 	t *testing.T,
 ) {

--- a/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
+++ b/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
@@ -71,7 +71,7 @@ start_test "Ensure that memory over-allocation without monitoring crashes the se
 # (importantly, this budget must be larger than vmem).
 send "set distsql_workmem='32GiB';\r"
 eexpect SET
-send "with a as (select * from generate_series(1,10000000)) select * from a as a, a as b, a as c, a as d limit 10;\r"
+send "select a, random() AS r, repeat('a', 1000) from generate_series(1,10000000) g(a) order by r;\r"
 eexpect "connection lost"
 
 # Check that the query crashed the server
@@ -123,7 +123,7 @@ sleep 2
 set spawn_id $client_spawn_id
 send "select 1;\r"
 eexpect root@
-send "with a as (select * from generate_series(1,100000)) select * from a as a, a as b, a as c, a as d limit 10;\r"
+send "select a, random() AS r, repeat('a', 1000) from generate_series(1,10000000) g(a) order by r;\r"
 eexpect "root: memory budget exceeded"
 eexpect root@
 

--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -1095,17 +1095,12 @@ func (s *Smither) makeCreateFunc() (cf *tree.CreateRoutine, ok bool) {
 		}
 	}
 
-	// Disable CTEs temporarily, since they are not currently supported in UDFs.
-	// TODO(92961): Allow CTEs in generated statements in UDF bodies.
 	// TODO(93049): Allow UDFs to create other UDFs.
-	oldDisableWith := s.disableWith
 	oldDisableMutations := s.disableMutations
 	defer func() {
-		s.disableWith = oldDisableWith
 		s.disableUDFCreation = false
 		s.disableMutations = oldDisableMutations
 	}()
-	s.disableWith = true
 	s.disableUDFCreation = true
 	s.disableMutations = (funcVol != tree.RoutineVolatile) || s.disableMutations
 

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -57,6 +57,8 @@ func constructPlan(
 				out.execMode = rowexec.SubqueryExecModeAllRowsNormalized
 			case exec.SubqueryAllRows:
 				out.execMode = rowexec.SubqueryExecModeAllRows
+			case exec.SubqueryDiscardAllRows:
+				out.execMode = rowexec.SubqueryExecModeDiscardAllRows
 			default:
 				return nil, errors.Errorf("invalid SubqueryMode %d", in.Mode)
 			}

--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -456,7 +456,7 @@ NULL
 
 # Regression test for mixing subqueries in "inner" and "outer" contexts
 # (#66923).
-query error unimplemented: apply joins with subqueries in the \"inner\" and \"outer\" contexts are not supported
+query error more than one row returned by a subquery used as an expression
 VALUES
   (
     (
@@ -735,3 +735,75 @@ WHERE
   )
 ORDER BY tab378983._timestamptz ASC NULLS FIRST
 LIMIT 78:::INT8;
+
+# Test apply joins with subqueries/CTEs in the inner and outer plans.
+subtest inner_outer_subquery
+
+statement ok
+SET testing_optimizer_disable_rule_probability = 1.0;
+
+query ITI rowsort
+WITH foo (bar) AS MATERIALIZED (SELECT 100)
+SELECT * FROM t INNER JOIN LATERAL (
+  SELECT * FROM foo WHERE bar = k*100
+) ON TRUE;
+----
+1  one  100
+
+query ITITI rowsort
+WITH foo AS MATERIALIZED (SELECT 100)
+SELECT * FROM t INNER JOIN LATERAL (
+  SELECT *, (SELECT * FROM foo) FROM u WHERE l = k
+) ON TRUE;
+----
+1  one    1  one    100
+2  two    2  two    100
+3  three  3  three  100
+4  four   4  four   100
+5  five   5  five   100
+
+# Add a few additional subqueries.
+query ITITIII rowsort
+WITH foo AS MATERIALIZED (SELECT 100)
+SELECT *, (SELECT max(m) FROM v)
+FROM t INNER JOIN LATERAL (
+  SELECT *, (SELECT * FROM foo), (SELECT min(m) FROM v) FROM u WHERE l = k
+) ON TRUE;
+----
+1  one    1  one    100  1  5
+2  two    2  two    100  1  5
+3  three  3  three  100  1  5
+4  four   4  four   100  1  5
+5  five   5  five   100  1  5
+
+# Make the nested subquery correlated.
+query ITITIII rowsort
+WITH foo AS MATERIALIZED (SELECT 100)
+SELECT *, (SELECT max(m) FROM v)
+FROM t INNER JOIN LATERAL (
+  SELECT *, (SELECT * FROM foo), (SELECT min(m) + k FROM v) FROM u WHERE l = k
+) ON TRUE;
+----
+1  one    1  one    100  2  5
+2  two    2  two    100  3  5
+3  three  3  three  100  4  5
+4  four   4  four   100  5  5
+5  five   5  five   100  6  5
+
+# Add a CTE to the inner plan. The bound expression is correlated.
+query ITITII rowsort
+WITH foo AS MATERIALIZED (SELECT 100)
+SELECT * FROM t INNER JOIN LATERAL (
+  WITH bar AS (SELECT *, (SELECT * FROM foo) FROM u WHERE l = k) SELECT * FROM bar, foo
+) ON TRUE;
+----
+1  one    1  one    100  100
+2  two    2  two    100  100
+3  three  3  three  100  100
+4  four   4  four   100  100
+5  five   5  five   100  100
+
+statement ok
+RESET testing_optimizer_disable_rule_probability;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/procedure_cte
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_cte
@@ -1,0 +1,105 @@
+statement ok
+CREATE TABLE ab (a INT PRIMARY KEY, b INT);
+INSERT INTO ab VALUES (1, 10), (2, 20), (3, 30), (4, 40);
+
+statement ok
+CREATE PROCEDURE p(OUT ret INT) LANGUAGE SQL AS $$
+  WITH foo AS MATERIALIZED (SELECT 100) SELECT * FROM foo;
+$$;
+
+query I
+CALL p(NULL);
+----
+100
+
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p(OUT ret INT) LANGUAGE SQL AS $$
+  WITH foo AS MATERIALIZED (SELECT b FROM ab WHERE a = 3) SELECT * FROM foo;
+$$;
+
+query I
+CALL p(NULL);
+----
+30
+
+# Multiple references to the CTE.
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p(OUT ret INT) LANGUAGE SQL AS $$
+  WITH foo (bar) AS (SELECT 1) SELECT foo.bar + foo2.bar FROM foo, foo foo2;
+$$;
+
+query I
+CALL p(NULL);
+----
+2
+
+# CTE with multiple branches.
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p(OUT ret INT) LANGUAGE SQL AS $$
+  WITH foo (x) AS MATERIALIZED (SELECT 1),
+  bar (x) AS MATERIALIZED (SELECT 2)
+  SELECT foo.x + bar.x FROM foo, bar;
+$$;
+
+query I
+CALL p(NULL);
+----
+3
+
+# Nested CTE expressions.
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p(OUT ret INT) LANGUAGE SQL AS $$
+  WITH foo (x) AS MATERIALIZED (SELECT 100)
+  SELECT * FROM (
+    WITH bar (x) AS MATERIALIZED (SELECT 200)
+    SELECT foo.x + bar.x FROM foo, bar
+  ) AS t;
+$$;
+
+query I
+CALL p(NULL);
+----
+300
+
+# Case with a CTE inside a subquery.
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p(OUT ret INT) LANGUAGE SQL AS $$
+  SELECT (
+    WITH foo AS MATERIALIZED (SELECT b FROM ab)
+    SELECT * FROM foo
+  );
+$$;
+
+# Avoid causing an error due to too many rows returned.
+statement ok
+DELETE FROM ab WHERE a > 1;
+
+query I
+CALL p(NULL);
+----
+10
+
+statement ok
+INSERT INTO ab VALUES (2, 20), (3, 30), (4, 40);
+
+# Case with a recursive CTE.
+statement ok
+DROP PROCEDURE p;
+CREATE PROCEDURE p(OUT res INT[]) LANGUAGE SQL AS $$
+  WITH RECURSIVE foo (x, y) AS (
+    SELECT a, b FROM ab WHERE a = 1
+    UNION ALL
+    SELECT a, b FROM ab WHERE a = (SELECT max(x) + 1 FROM foo)
+  )
+  SELECT array_agg(y) FROM foo;
+$$;
+
+query T
+CALL p(NULL);
+----
+{10,20,30,40}

--- a/pkg/sql/logictest/testdata/logic_test/udf_cte
+++ b/pkg/sql/logictest/testdata/logic_test/udf_cte
@@ -1,0 +1,123 @@
+statement ok
+CREATE TABLE ab (a INT PRIMARY KEY, b INT);
+INSERT INTO ab VALUES (1, 10), (2, 20), (3, 30), (4, 40);
+
+statement ok
+CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$
+  WITH foo AS MATERIALIZED (SELECT 100) SELECT * FROM foo;
+$$;
+
+query I
+SELECT f();
+----
+100
+
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$
+  WITH foo AS MATERIALIZED (SELECT b FROM ab WHERE a = 3) SELECT * FROM foo;
+$$;
+
+query I
+SELECT f();
+----
+30
+
+# Multiple references to the CTE.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$
+  WITH foo (bar) AS (SELECT 1) SELECT foo.bar + foo2.bar FROM foo, foo foo2;
+$$;
+
+query I
+SELECT f();
+----
+2
+
+# CTE with multiple branches.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$
+  WITH foo (x) AS MATERIALIZED (SELECT 1),
+  bar (x) AS MATERIALIZED (SELECT 2)
+  SELECT foo.x + bar.x FROM foo, bar;
+$$;
+
+query I
+SELECT f();
+----
+3
+
+# Nested CTE expressions.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$
+  WITH foo (x) AS MATERIALIZED (SELECT 100)
+  SELECT * FROM (
+    WITH bar (x) AS MATERIALIZED (SELECT 200)
+    SELECT foo.x + bar.x FROM foo, bar
+  ) AS t;
+$$;
+
+query I
+SELECT f();
+----
+300
+
+# Case with an outer CTE.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$
+  WITH foo AS MATERIALIZED (SELECT 1) SELECT * FROM foo;
+$$;
+
+query II
+WITH bar AS (SELECT 2) SELECT f(), * FROM bar;
+----
+1  2
+
+# The outer CTE has the same name as the inner CTE.
+query II
+WITH foo AS (SELECT 2) SELECT f(), * FROM foo;
+----
+1  2
+
+# Case with a CTE inside a subquery.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$
+  SELECT (
+    WITH foo AS MATERIALIZED (SELECT b FROM ab)
+    SELECT * FROM foo
+  );
+$$;
+
+# Avoid causing an error due to too many rows returned.
+statement ok
+DELETE FROM ab WHERE a > 1;
+
+query I
+SELECT f();
+----
+10
+
+statement ok
+INSERT INTO ab VALUES (2, 20), (3, 30), (4, 40);
+
+# Case with a recursive CTE.
+statement ok
+DROP FUNCTION f;
+CREATE FUNCTION f() RETURNS INT[] LANGUAGE SQL AS $$
+  WITH RECURSIVE foo (x, y) AS (
+    SELECT a, b FROM ab WHERE a = 1
+    UNION ALL
+    SELECT a, b FROM ab WHERE a = (SELECT max(x) + 1 FROM foo)
+  )
+  SELECT array_agg(y) FROM foo;
+$$;
+
+query T
+SELECT f();
+----
+{10,20,30,40}

--- a/pkg/sql/logictest/testdata/logic_test/udf_unsupported
+++ b/pkg/sql/logictest/testdata/logic_test/udf_unsupported
@@ -113,18 +113,6 @@ CREATE FUNCTION err() RETURNS VOID LANGUAGE SQL AS 'PREPARE p AS SELECT * FROM t
 subtest end
 
 
-subtest cte
-
-# CTEs are not currently supported in UDF bodies.
-statement error pgcode 0A000 unimplemented: CTE usage inside a function definition
-CREATE FUNCTION err() RETURNS INT LANGUAGE SQL AS 'WITH s AS (SELECT a FROM t) SELECT a FROM s'
-
-statement error pgcode 0A000 unimplemented: statement source \(square bracket syntax\) within user-defined function
-CREATE FUNCTION err() RETURNS INT LANGUAGE SQL AS 'SELECT a FROM [SELECT 1] a(a)'
-
-subtest end
-
-
 subtest recursion
 
 # Recursive UDFs are not currently supported.

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1431,6 +1431,13 @@ func TestLogic_procedure(
 	runLogicTest(t, "procedure")
 }
 
+func TestLogic_procedure_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_cte")
+}
+
 func TestLogic_procedure_deps(
 	t *testing.T,
 ) {
@@ -2206,6 +2213,13 @@ func TestLogic_udf_calling_udf(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "udf_calling_udf")
+}
+
+func TestLogic_udf_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_cte")
 }
 
 func TestLogic_udf_delete(

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1431,6 +1431,13 @@ func TestLogic_procedure(
 	runLogicTest(t, "procedure")
 }
 
+func TestLogic_procedure_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_cte")
+}
+
 func TestLogic_procedure_deps(
 	t *testing.T,
 ) {
@@ -2213,6 +2220,13 @@ func TestLogic_udf_calling_udf(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "udf_calling_udf")
+}
+
+func TestLogic_udf_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_cte")
 }
 
 func TestLogic_udf_delete(

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1445,6 +1445,13 @@ func TestLogic_procedure(
 	runLogicTest(t, "procedure")
 }
 
+func TestLogic_procedure_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_cte")
+}
+
 func TestLogic_procedure_deps(
 	t *testing.T,
 ) {
@@ -2227,6 +2234,13 @@ func TestLogic_udf_calling_udf(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "udf_calling_udf")
+}
+
+func TestLogic_udf_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_cte")
 }
 
 func TestLogic_udf_delete(

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1410,6 +1410,13 @@ func TestLogic_procedure(
 	runLogicTest(t, "procedure")
 }
 
+func TestLogic_procedure_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_cte")
+}
+
 func TestLogic_procedure_deps(
 	t *testing.T,
 ) {
@@ -2206,6 +2213,13 @@ func TestLogic_udf_calling_udf(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "udf_calling_udf")
+}
+
+func TestLogic_udf_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_cte")
 }
 
 func TestLogic_udf_delete(

--- a/pkg/sql/logictest/tests/local-mixed-24.3/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-24.3/generated_test.go
@@ -1431,6 +1431,13 @@ func TestLogic_procedure(
 	runLogicTest(t, "procedure")
 }
 
+func TestLogic_procedure_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_cte")
+}
+
 func TestLogic_procedure_deps(
 	t *testing.T,
 ) {
@@ -2227,6 +2234,13 @@ func TestLogic_udf_calling_udf(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "udf_calling_udf")
+}
+
+func TestLogic_udf_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_cte")
 }
 
 func TestLogic_udf_delete(

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1445,6 +1445,13 @@ func TestLogic_procedure(
 	runLogicTest(t, "procedure")
 }
 
+func TestLogic_procedure_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_cte")
+}
+
 func TestLogic_procedure_deps(
 	t *testing.T,
 ) {
@@ -2241,6 +2248,13 @@ func TestLogic_udf_calling_udf(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "udf_calling_udf")
+}
+
+func TestLogic_udf_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_cte")
 }
 
 func TestLogic_udf_delete(

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1599,6 +1599,13 @@ func TestLogic_procedure(
 	runLogicTest(t, "procedure")
 }
 
+func TestLogic_procedure_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "procedure_cte")
+}
+
 func TestLogic_procedure_deps(
 	t *testing.T,
 ) {
@@ -2458,6 +2465,13 @@ func TestLogic_udf_calling_udf(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "udf_calling_udf")
+}
+
+func TestLogic_udf_cte(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "udf_cte")
 }
 
 func TestLogic_udf_delete(

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -3176,16 +3176,12 @@ func (b *Builder) buildWith(with *memo.WithExpr) (_ execPlan, outputCols colOrdM
 	// remove it, since subquery execution also guarantees complete execution.
 
 	// Add the buffer as a subquery so it gets executed ahead of time, and is
-	// available to be referenced by other queries.
+	// available to be referenced by other queries. Use SubqueryDiscardAllRows to
+	// avoid buffering the results in the subquery, since the bufferNode will
+	// already save the rows.
 	b.subqueries = append(b.subqueries, exec.Subquery{
 		ExprNode: with.OriginalExpr,
-		// TODO(justin): this is wasteful: both the subquery and the bufferNode
-		// will buffer up all the results.  This should be fixed by either making
-		// the buffer point directly to the subquery results or adding a new
-		// subquery mode that reads and discards all rows. This could possibly also
-		// be fixed by ensuring that bufferNode exhausts its input (and forcing it
-		// to behave like a spoolNode) and using the EXISTS mode.
-		Mode:     exec.SubqueryAllRows,
+		Mode:     exec.SubqueryDiscardAllRows,
 		Root:     buffer,
 		RowCount: int64(with.Relational().Statistics().RowCountIfAvailable()),
 	})

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -865,18 +865,22 @@ func (b *Builder) buildSubquery(
 			if err != nil {
 				return err
 			}
-			if len(eb.subqueries) > 0 {
-				return expectedLazyRoutineError("subquery")
+			for i := range eb.subqueries {
+				if eb.subqueries[i].Mode != exec.SubqueryDiscardAllRows {
+					return expectedLazyRoutineError("subquery")
+				}
 			}
 			if len(eb.cascades) > 0 {
 				return expectedLazyRoutineError("cascade")
+			}
+			if len(eb.triggers) > 0 {
+				return expectedLazyRoutineError("trigger")
 			}
 			if len(eb.checks) > 0 {
 				return expectedLazyRoutineError("check")
 			}
 			plan, err := b.factory.ConstructPlan(
-				ePlan.root, nil /* subqueries */, nil /* cascades */, nil /* checks */, nil, /* triggers */
-				inputRowCount, eb.flags,
+				ePlan.root, eb.subqueries, eb.cascades, eb.triggers, eb.checks, inputRowCount, eb.flags,
 			)
 			if err != nil {
 				return err
@@ -1160,7 +1164,6 @@ func (b *Builder) buildRoutinePlanGenerator(
 
 			// Copy the expression into a new memo. Replace parameter references
 			// with argument datums.
-			addedWithBindings := false
 			var replaceFn norm.ReplaceFunc
 			replaceFn = func(e opt.Expr) opt.Expr {
 				switch t := e.(type) {
@@ -1185,11 +1188,15 @@ func (b *Builder) buildRoutinePlanGenerator(
 					// We lazily add these With expressions to the metadata here
 					// because the call to Factory.CopyAndReplace below clears With
 					// expressions in the metadata.
-					if allowOuterWithRefs && !addedWithBindings {
+					if allowOuterWithRefs {
 						b.mem.Metadata().ForEachWithBinding(func(id opt.WithID, expr opt.Expr) {
-							f.Metadata().AddWithBinding(id, expr)
+							// Make sure to check for an existing With binding, since we may
+							// have already rewritten the bound expression and added it to the
+							// new memo if the associated WithExpr is part of the routine.
+							if !f.Metadata().HasWithBinding(id) {
+								f.Metadata().AddWithBinding(id, expr)
+							}
 						})
-						addedWithBindings = true
 					}
 					// Fall through.
 				}
@@ -1238,8 +1245,10 @@ func (b *Builder) buildRoutinePlanGenerator(
 				}
 				return err
 			}
-			if len(eb.subqueries) > 0 {
-				return expectedLazyRoutineError("subquery")
+			for j := range eb.subqueries {
+				if eb.subqueries[j].Mode != exec.SubqueryDiscardAllRows {
+					return expectedLazyRoutineError("subquery")
+				}
 			}
 			var stmtForDistSQLDiagram string
 			if i < len(stmtStr) {

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -610,7 +610,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: SELECT * FROM (SELECT tp.table_catalog AS database_name, tp.table_schema AS schema_name, tp.table_name, tp.grantee, tp.privilege_type, tp.is_grantable::BOOL, CASE WHEN s.sequence_name IS NOT NULL THEN 'sequence' ELSE 'table' END AS object_type FROM "".information_schema.table_privileges AS tp LEFT JOIN "".information_schema.sequences AS s ON (((tp.table_catalog = s.sequence_catalog) AND (tp.table_schema = s.sequence_schema)) AND (tp.table_name = s.sequence_name))) WHERE (database_name, schema_name, table_name) IN (('test', 'public', 'foo'),)
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ label: buffer 1 (r)

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -626,7 +626,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: INSERT INTO xyz SELECT a, b, c FROM abc RETURNING z
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ columns: (z)

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
@@ -356,7 +356,7 @@ vectorized: true
 ├── • subquery
 │   │ id: @S1
 │   │ original sql: SELECT * FROM ltable WHERE lk > 2
-│   │ exec mode: all rows
+│   │ exec mode: discard all rows
 │   │
 │   └── • buffer
 │       │ columns: (lk, geom1, geom2)

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial_dist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial_dist
@@ -290,7 +290,7 @@ vectorized: true
 ├── • subquery
 │   │ id: @S1
 │   │ original sql: SELECT * FROM ltable WHERE lk > 2
-│   │ exec mode: all rows
+│   │ exec mode: discard all rows
 │   │
 │   └── • buffer
 │       │ label: buffer 1 (q)

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -942,7 +942,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: SELECT a FROM t FOR UPDATE
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ columns: (a)
@@ -972,7 +972,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: SELECT a FROM t FOR UPDATE
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ columns: (a)
@@ -1006,7 +1006,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: SELECT a FROM t FOR UPDATE
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ columns: (a)

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update_read_committed
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update_read_committed
@@ -157,7 +157,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: SELECT aisle FROM supermarket WHERE person = 'matilda' FOR UPDATE
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ columns: (aisle)
@@ -243,7 +243,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: SELECT 'matilda' AS person
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ columns: (person)

--- a/pkg/sql/opt/exec/execbuilder/testdata/spool
+++ b/pkg/sql/opt/exec/execbuilder/testdata/spool
@@ -25,7 +25,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: INSERT INTO t SELECT * FROM t2 RETURNING x
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ label: buffer 1 (a)
@@ -56,7 +56,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: DELETE FROM t RETURNING x
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ label: buffer 1 (a)
@@ -88,7 +88,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: UPDATE t SET x = x + 1 RETURNING x
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ label: buffer 1 (a)
@@ -124,7 +124,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: UPSERT INTO t VALUES (2), (3) RETURNING x
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ label: buffer 1 (a)
@@ -154,7 +154,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: INSERT INTO t SELECT * FROM t2 RETURNING x
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ label: buffer 1
@@ -184,7 +184,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: DELETE FROM t RETURNING x
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ label: buffer 1
@@ -214,7 +214,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: UPDATE t SET x = x + 1 RETURNING x
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ label: buffer 1
@@ -249,7 +249,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: UPSERT INTO t VALUES (2), (3) RETURNING x
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ label: buffer 1
@@ -278,7 +278,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: INSERT INTO t SELECT * FROM t2 RETURNING x
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ label: buffer 1
@@ -312,7 +312,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: INSERT INTO t SELECT * FROM t2 RETURNING x
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ label: buffer 1
@@ -347,7 +347,7 @@ vectorized: true
 ├── • subquery
 │   │ id: @S1
 │   │ original sql: INSERT INTO t SELECT * FROM t2 RETURNING x
-│   │ exec mode: all rows
+│   │ exec mode: discard all rows
 │   │
 │   └── • buffer
 │       │ label: buffer 1 (a)
@@ -363,7 +363,7 @@ vectorized: true
 └── • subquery
     │ id: @S2
     │ original sql: INSERT INTO t SELECT x + 1 FROM a RETURNING x
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ label: buffer 2 (b)
@@ -391,7 +391,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: INSERT INTO t SELECT * FROM t2 RETURNING x
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ label: buffer 1
@@ -425,7 +425,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: INSERT INTO t SELECT * FROM t2 RETURNING x
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ label: buffer 1
@@ -459,7 +459,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: INSERT INTO t SELECT * FROM t2 RETURNING x + 10 AS r
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ label: buffer 1
@@ -492,7 +492,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: INSERT INTO t SELECT * FROM t2 RETURNING x + 10 AS r
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ label: buffer 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/sql_fn
+++ b/pkg/sql/opt/exec/execbuilder/testdata/sql_fn
@@ -23,7 +23,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: ALTER TABLE test.public.my_spatial_table ADD COLUMN geom1 GEOMETRY(POINT,4326)
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ columns: ()
@@ -181,7 +181,7 @@ vectorized: true
 ├── • subquery
 │   │ id: @S1
 │   │ original sql: ALTER TABLE my_spatial_table ADD COLUMN geom7 GEOMETRY(POINT,4326)
-│   │ exec mode: all rows
+│   │ exec mode: discard all rows
 │   │
 │   └── • buffer
 │       │ columns: ()
@@ -194,7 +194,7 @@ vectorized: true
 └── • subquery
     │ id: @S2
     │ original sql: ALTER TABLE my_spatial_table ADD COLUMN geom8 GEOMETRY(POINT,4326)
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ columns: ()

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -382,7 +382,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: UPDATE abc SET a = c RETURNING a
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ columns: (a)

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -636,7 +636,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: UPSERT INTO xyz SELECT a, b, c FROM abc RETURNING z
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ columns: (z)

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -228,7 +228,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: SELECT * FROM (SELECT database_name, 'database' AS object_type, grantee, privilege_type, is_grantable::BOOL FROM "".crdb_internal.cluster_database_privileges) WHERE database_name IN ('t',)
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ label: buffer 1 (r)

--- a/pkg/sql/opt/exec/execbuilder/testdata/with
+++ b/pkg/sql/opt/exec/execbuilder/testdata/with
@@ -33,7 +33,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: SELECT a FROM y
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ columns: (a)
@@ -80,7 +80,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: INSERT INTO x VALUES (1) RETURNING a
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ columns: (a)
@@ -260,7 +260,7 @@ vectorized: true
 └── • subquery
     │ id: @S1
     │ original sql: SELECT 1 UNION ALL SELECT id + 1 FROM x WHERE id < 3
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ label: buffer 3 (x)

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -134,6 +134,8 @@ func emitInternal(
 			mode = "any rows"
 		case exec.SubqueryAllRows:
 			mode = "all rows"
+		case exec.SubqueryDiscardAllRows:
+			mode = "discard all rows"
 		default:
 			return errors.Errorf("invalid SubqueryMode %d", s.Mode)
 		}

--- a/pkg/sql/opt/exec/explain/testdata/gists
+++ b/pkg/sql/opt/exec/explain/testdata/gists
@@ -920,7 +920,7 @@ explain(shape):
 └── • subquery
     │ id: @S1
     │ original sql: INSERT INTO abc SELECT a, b, c FROM abc RETURNING a
-    │ exec mode: all rows
+    │ exec mode: discard all rows
     │
     └── • buffer
         │ label: buffer 1

--- a/pkg/sql/opt/exec/explain/testdata/gists_tpce
+++ b/pkg/sql/opt/exec/explain/testdata/gists_tpce
@@ -221,7 +221,7 @@ explain(shape):
 ├── • subquery
 │   │ id: @S1
 │   │ original sql: UPDATE last_trade SET lt_vol = lt_vol + _, lt_price = _::DECIMAL, lt_dts = '_'::TIMESTAMP WHERE lt_s_symb = '_' RETURNING _
-│   │ exec mode: all rows
+│   │ exec mode: discard all rows
 │   │
 │   └── • buffer
 │       │ label: buffer 1 (update_last_trade)
@@ -242,7 +242,7 @@ explain(shape):
 ├── • subquery
 │   │ id: @S2
 │   │ original sql: SELECT tr_t_id, tr_bid_price::FLOAT8, tr_tt_id, tr_qty FROM trade_request WHERE (tr_s_symb = '_') AND ((((tr_tt_id = _::VARCHAR(3)) AND (tr_bid_price >= _::DECIMAL)) OR ((tr_tt_id = _::VARCHAR(3)) AND (tr_bid_price <= _::DECIMAL))) OR ((tr_tt_id = _::VARCHAR(3)) AND (tr_bid_price >= _::DECIMAL)))
-│   │ exec mode: all rows
+│   │ exec mode: discard all rows
 │   │
 │   └── • buffer
 │       │ label: buffer 2 (request_list)
@@ -259,7 +259,7 @@ explain(shape):
 ├── • subquery
 │   │ id: @S3
 │   │ original sql: DELETE FROM trade_request WHERE tr_t_id IN (SELECT tr_t_id FROM request_list) RETURNING _
-│   │ exec mode: all rows
+│   │ exec mode: discard all rows
 │   │
 │   └── • buffer
 │       │ label: buffer 3 (delete_trade_request)
@@ -282,7 +282,7 @@ explain(shape):
 ├── • subquery
 │   │ id: @S4
 │   │ original sql: INSERT INTO trade_history(th_t_id, th_st_id, th_dts) (SELECT tr_t_id, '_', '_'::TIMESTAMP FROM request_list) RETURNING _
-│   │ exec mode: all rows
+│   │ exec mode: discard all rows
 │   │
 │   └── • buffer
 │       │ label: buffer 5 (insert_trade_history)
@@ -303,7 +303,7 @@ explain(shape):
 ├── • subquery
 │   │ id: @S5
 │   │ original sql: UPDATE trade SET t_st_id = '_', t_dts = '_'::TIMESTAMP WHERE t_id IN (SELECT tr_t_id FROM request_list) RETURNING _
-│   │ exec mode: all rows
+│   │ exec mode: discard all rows
 │   │
 │   └── • buffer
 │       │ label: buffer 7 (update_trade_submitted)

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -175,6 +175,10 @@ const (
 	// SubqueryAllRows - the subquery is an argument to ARRAY. The result is a
 	// tuple of rows.
 	SubqueryAllRows
+	// SubqueryDiscardAllRows - the subquery is executed for its side effects
+	// (e.g. it is adding to a bufferNode). The result is empty, and will never be
+	// used.
+	SubqueryDiscardAllRows
 )
 
 // TableColumnOrdinal is the 0-based ordinal index of a cat.Table column.

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -546,6 +546,11 @@ func (m *Memo) CopyNextRankFrom(other *Memo) {
 	m.curRank = other.curRank
 }
 
+// CopyNextWithIDFrom copies the next WithID from the other memo.
+func (m *Memo) CopyNextWithIDFrom(other *Memo) {
+	m.curWithID = other.curWithID
+}
+
 // RequestColStat calculates and returns the column statistic calculated on the
 // relational expression.
 func (m *Memo) RequestColStat(

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -1155,6 +1155,13 @@ func (md *Metadata) WithBinding(id WithID) Expr {
 	return res
 }
 
+// HasWithBinding returns true if the given WithID is already bound to an
+// expression.
+func (md *Metadata) HasWithBinding(id WithID) bool {
+	_, ok := md.withBindings[id]
+	return ok
+}
+
 // ForEachWithBinding calls fn with each bound (WithID, Expr) pair in the
 // metadata.
 func (md *Metadata) ForEachWithBinding(fn func(WithID, Expr)) {

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -322,6 +322,10 @@ func (f *Factory) CopyMetadataFrom(from *memo.Memo) {
 	// existing expressions.
 	f.mem.CopyNextRankFrom(from)
 
+	// Copy the next With ID to the target memo so that new CTE expressions built
+	// with the new memo will not share With IDs with existing expressions.
+	f.mem.CopyNextWithIDFrom(from)
+
 	// Copy all metadata to the target memo so that referenced tables and
 	// columns can keep the same ids they had in the "from" memo. Scalar
 	// expressions in the metadata cannot have placeholders, so we simply copy

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -204,11 +204,6 @@ func (b *Builder) buildDataSource(
 		// This is the special '[ ... ]' syntax. We treat this as syntactic sugar
 		// for a top-level CTE, so it cannot refer to anything in the input scope.
 		// See #41078.
-		if b.insideFuncDef {
-			panic(unimplemented.NewWithIssue(
-				92961, "statement source (square bracket syntax) within user-defined function",
-			))
-		}
 		emptyScope := b.allocScope()
 		innerScope := b.buildStmt(source.Statement, nil /* desiredTypes */, emptyScope)
 		if len(innerScope.cols) == 0 {

--- a/pkg/sql/opt/optbuilder/with.go
+++ b/pkg/sql/opt/optbuilder/with.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
 )
 
@@ -123,9 +122,6 @@ func (b *Builder) buildCTEs(
 ) (outScope *scope, correlatedCTEs cteSources) {
 	if with == nil {
 		return inScope, nil
-	}
-	if b.insideFuncDef {
-		panic(unimplemented.New("user-defined functions", "CTE usage inside a function definition"))
 	}
 
 	outScope = inScope.push()

--- a/pkg/sql/rowexec/subquery.go
+++ b/pkg/sql/rowexec/subquery.go
@@ -28,4 +28,9 @@ const (
 	// columns, unless there is exactly 1 column in which case the result type is
 	// that column's type. If there are no rows, the result is NULL.
 	SubqueryExecModeOneRow
+	// SubqueryExecModeDiscardAllRows indicates that the subquery is being
+	// executed for its side effects. The subquery should be executed until it
+	// produces all rows, but the rows should not be saved, and the result will
+	// never be checked.
+	SubqueryExecModeDiscardAllRows
 )

--- a/pkg/sql/schemachanger/scbuild/build.go
+++ b/pkg/sql/schemachanger/scbuild/build.go
@@ -103,7 +103,11 @@ func Build(
 
 	// Generate redacted statement.
 	{
-		an.ValidateAnnotations()
+		if _, ok := n.(*tree.CreateRoutine); !ok {
+			// This validation fails for references to CTEs, which need not be
+			// qualified.
+			an.ValidateAnnotations()
+		}
 		currentStatementID := uint32(len(els.statements) - 1)
 		els.statements[currentStatementID].RedactedStatement = string(
 			dependencies.AstFormatter().FormatAstAsRedactableString(an.GetStatement(), &an.annotation))


### PR DESCRIPTION
#### sql: allow eager subqueries in nested/inner plans

The `planComponents.subqueryPlans` list allows sub-plans to be eagerly
executed before the main query, with the results made available through
that same list.

The term "subquery" is overloaded. There are actually two users of this
mechanism: subquery expressions (e.g. basic subqueries, `EXISTS`) and
`With` expressions. From this point, "subquery" will refer to a subquery
expression, and "subqueryPlan" will refer to any eagerly executed sub-plan.

Subqueries make use of the `subqueryPlan`'s cached result at the point in the
main plan where the subquery was invoked. `With` expressions don't actually
access the result through `subqueryPlan`'s result cache; instead, the
`subqueryPlan` is executed only to populate a buffer.

With #66442 we disallowed nested/"inner" plans (like for apply-joins) from
adding to `subqueryPlans` if the main query already populated it with at least
one plan. This restriction isn't actually necessary. When executing an "inner"
plan, we can ignore the `subqueryPlans` of the main query for the following
reasons:
1. If the `subqueryPlan` originated from a subquery expression, it is only
   referenced in the main query, and not in the "inner" plan. This is implied
   by the fact that subqueries are only invoked in one location in the query.
2. If the `subqueryPlan` originated from a `With` expression, it could be
   referenced by the "inner" plan. However, the result is not propagated
   by referencing `subqueryPlans`, and the main query will ensure that it
   is executed once to populate the buffer.

This commit removes the unnecessary error that occurred when both inner and
outer plans had eager subqueries. It also removes the logic that populated
the inner plan with the outer plan's subqueries, since this is not necessary,
as explained.

Fixes #66447

Release note (sql change): It is now possible to execute queries with
correlated joins with sub-queries or CTEs in both the "inner" and "outer"
context. Errors with the following message:
```
unimplemented: apply joins with subqueries in the "inner" and "outer" contexts are not supported
```
will no longer occur.

#### sql: avoid buffering CTE rows in two places

Previously, we used `exec.SubqueryAllRows` mode to ensure that the bound
expression for a CTE was executed to completion. This caused the
subquery-execution machinery to buffer the rows in addition to the
`bufferNode` that is already part of the plan. This commit adds a new
subquery execution mode `SubqueryDiscardAllRows`, which is used to
ensure that the expression executes to completion without saving the
resulting rows.

Informs #92961

Release note: None

#### sql: allow routines to execute CTEs

This commit enables CTE usage within routines, including UDFs and SPs.
After `allow eager subqueries in nested/inner plans`, this mostly amounts
to ensuring that inner and outer `WithIDs` do not conflict, as well as
that inner CTEs are correctly rewritten with routine arguments.

Fixes #92961

Release note (sql change): It is now possible to include a CTE within
the body of a UDF or stored procedure.