### PR TITLE
release-23.2: sql/schemachanger: Exclude schema change wait time from idle session timeout

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3895,64 +3895,71 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 			return advanceInfo{}, err
 		}
 
-		handleErr := func(err error) {
-			if implicitTxn {
-				// The schema change/job failed but it was also the only
-				// operation in the transaction. In this case, the transaction's
-				// error is the schema change error.
-				// TODO (lucy): I'm not sure the above is true. What about DROP TABLE
-				// with multiple tables?
-				res.SetError(err)
-			} else {
-				// The schema change/job failed but everything else in the
-				// transaction was actually committed successfully already. At
-				// this point, it is too late to cancel the transaction. In
-				// effect, we have violated the "A" of ACID.
-				//
-				// This situation is sufficiently serious that we cannot let the
-				// error that caused the schema change to fail flow back to the
-				// client as-is. We replace it by a custom code dedicated to
-				// this situation. Replacement occurs because this error code is
-				// a "serious error" and the code computation logic will give it
-				// a higher priority.
-				//
-				// We also print out the original error code as prefix of the
-				// error message, in case it was a serious error.
-				newErr := pgerror.Wrapf(err,
-					pgcode.TransactionCommittedWithSchemaChangeFailure,
-					"transaction committed but schema change aborted with error: (%s)",
-					pgerror.GetPGCode(err))
-				newErr = errors.WithHint(newErr,
-					"Some of the non-DDL statements may have committed successfully, "+
-						"but some of the DDL statement(s) failed.\nManual inspection may be "+
-						"required to determine the actual state of the database.")
-				newErr = errors.WithIssueLink(newErr,
-					errors.IssueLink{IssueURL: "https://github.com/cockroachdb/cockroach/issues/42061"})
-				res.SetError(newErr)
+		if ai, err := func() (advanceInfo, error) {
+			ex.mu.IdleInSessionTimeout.Stop()
+			defer ex.startIdleInSessionTimeout()
+			handleErr := func(err error) {
+				if implicitTxn {
+					// The schema change/job failed but it was also the only
+					// operation in the transaction. In this case, the transaction's
+					// error is the schema change error.
+					// TODO (lucy): I'm not sure the above is true. What about DROP TABLE
+					// with multiple tables?
+					res.SetError(err)
+				} else {
+					// The schema change/job failed but everything else in the
+					// transaction was actually committed successfully already. At
+					// this point, it is too late to cancel the transaction. In
+					// effect, we have violated the "A" of ACID.
+					//
+					// This situation is sufficiently serious that we cannot let the
+					// error that caused the schema change to fail flow back to the
+					// client as-is. We replace it by a custom code dedicated to
+					// this situation. Replacement occurs because this error code is
+					// a "serious error" and the code computation logic will give it
+					// a higher priority.
+					//
+					// We also print out the original error code as prefix of the
+					// error message, in case it was a serious error.
+					newErr := pgerror.Wrapf(err,
+						pgcode.TransactionCommittedWithSchemaChangeFailure,
+						"transaction committed but schema change aborted with error: (%s)",
+						pgerror.GetPGCode(err))
+					newErr = errors.WithHint(newErr,
+						"Some of the non-DDL statements may have committed successfully, "+
+							"but some of the DDL statement(s) failed.\nManual inspection may be "+
+							"required to determine the actual state of the database.")
+					newErr = errors.WithIssueLink(newErr,
+						errors.IssueLink{IssueURL: "https://github.com/cockroachdb/cockroach/issues/42061"})
+					res.SetError(newErr)
+				}
 			}
-		}
-		ex.notifyStatsRefresherOfNewTables(ex.Ctx())
+			ex.notifyStatsRefresherOfNewTables(ex.Ctx())
 
-		// If there is any descriptor has new version. We want to make sure there is
-		// only one version of the descriptor in all nodes. In schema changer jobs,
-		// `WaitForOneVersion` has been called for the descriptors included in jobs.
-		// So we just need to do this for descriptors not in jobs.
-		// We need to get descriptor IDs in jobs before jobs are run because we have
-		// operations in declarative schema changer removing descriptor IDs from job
-		// payload as it's done with the descriptors.
-		descIDsInJobs, err := ex.descIDsInSchemaChangeJobs()
-		if err != nil {
-			return advanceInfo{}, err
-		}
-		ex.statsCollector.PhaseTimes().SetSessionPhaseTime(sessionphase.SessionStartPostCommitJob, timeutil.Now())
-		if err := ex.server.cfg.JobRegistry.Run(
-			ex.ctxHolder.connCtx, ex.extraTxnState.jobs.created,
-		); err != nil {
-			handleErr(err)
-		}
-		ex.statsCollector.PhaseTimes().SetSessionPhaseTime(sessionphase.SessionEndPostCommitJob, timeutil.Now())
-		if err := ex.waitOneVersionForNewVersionDescriptorsWithoutJobs(descIDsInJobs); err != nil {
-			return advanceInfo{}, err
+			// If there is any descriptor has new version. We want to make sure there is
+			// only one version of the descriptor in all nodes. In schema changer jobs,
+			// `WaitForOneVersion` has been called for the descriptors included in jobs.
+			// So we just need to do this for descriptors not in jobs.
+			// We need to get descriptor IDs in jobs before jobs are run because we have
+			// operations in declarative schema changer removing descriptor IDs from job
+			// payload as it's done with the descriptors.
+			descIDsInJobs, err := ex.descIDsInSchemaChangeJobs()
+			if err != nil {
+				return advanceInfo{}, err
+			}
+			ex.statsCollector.PhaseTimes().SetSessionPhaseTime(sessionphase.SessionStartPostCommitJob, timeutil.Now())
+			if err := ex.server.cfg.JobRegistry.Run(
+				ex.ctxHolder.connCtx, ex.extraTxnState.jobs.created,
+			); err != nil {
+				handleErr(err)
+			}
+			ex.statsCollector.PhaseTimes().SetSessionPhaseTime(sessionphase.SessionEndPostCommitJob, timeutil.Now())
+			if err := ex.waitOneVersionForNewVersionDescriptorsWithoutJobs(descIDsInJobs); err != nil {
+				return advanceInfo{}, err
+			}
+			return advanceInfo{}, nil
+		}(); err != nil {
+			return ai, err
 		}
 
 		fallthrough

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -155,13 +155,7 @@ func (ex *connExecutor) execStmt(
 		panic(errors.AssertionFailedf("unexpected txn state: %#v", ex.machine.CurState()))
 	}
 
-	if ex.sessionData().IdleInSessionTimeout > 0 {
-		// Cancel the session if the idle time exceeds the idle in session timeout.
-		ex.mu.IdleInSessionTimeout = timeout{time.AfterFunc(
-			ex.sessionData().IdleInSessionTimeout,
-			ex.CancelSession,
-		)}
-	}
+	ex.startIdleInSessionTimeout()
 
 	if ex.sessionData().IdleInTransactionSessionTimeout > 0 {
 		startIdleInTransactionSessionTimeout := func() {
@@ -189,6 +183,17 @@ func (ex *connExecutor) execStmt(
 	}
 
 	return ev, payload, err
+}
+
+// startIdleInSessionTimeout will start the timer for the idle in session timeout.
+func (ex *connExecutor) startIdleInSessionTimeout() {
+	if ex.sessionData().IdleInSessionTimeout > 0 {
+		// Cancel the session if the idle time exceeds the idle in session timeout.
+		ex.mu.IdleInSessionTimeout = timeout{time.AfterFunc(
+			ex.sessionData().IdleInSessionTimeout,
+			ex.CancelSession,
+		)}
+	}
 }
 
 func (ex *connExecutor) recordFailure() {

--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -24,6 +24,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -31,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -483,6 +487,89 @@ func TestIdleInSessionTimeout(t *testing.T) {
 		t.Fatal("expected the connection to be killed " +
 			"but the connection is still alive")
 	}
+}
+
+func TestIdleInSessionTimeoutDuringSchemaChange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	skip.UnderDuress(t, "slow test")
+	ctx := context.Background()
+
+	var blockSchemaChange atomic.Bool
+	startWaitOfSchemaChange := make(chan any)
+	endWaitOfSchemaChange := make(chan any)
+
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLDeclarativeSchemaChanger: &scexec.TestingKnobs{
+				BeforeStage: func(p scplan.Plan, stageIdx int) error {
+					// We only block in the first stage of the PostCommitPhase.
+					if !blockSchemaChange.Load() || p.Params.ExecutionPhase != scop.PostCommitPhase || stageIdx != 0 {
+						return nil
+					}
+					// Notify foreground thread that we are now waiting
+					startWaitOfSchemaChange <- true
+					// Wait for the foreground thread to release us
+					<-endWaitOfSchemaChange
+					return nil
+				},
+			},
+		},
+	})
+	defer srv.Stopper().Stop(ctx)
+
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+	runner.Exec(t, "CREATE TABLE t1()")
+
+	const sessionTimeoutInSeconds = 1
+	acquireConn := func() *gosql.Conn {
+		conn, err := sqlDB.Conn(ctx)
+		require.NoError(t, err)
+		_, err = conn.ExecContext(ctx, fmt.Sprintf("SET idle_in_session_timeout = '%ds'", sessionTimeoutInSeconds))
+		require.NoError(t, err)
+		return conn
+	}
+	conn := acquireConn()
+
+	checkConnectionAndReconnect := func(expectConnection bool) {
+		// Test the connection
+		_, err := conn.ExecContext(ctx, `SELECT 1`)
+		if expectConnection {
+			require.NoError(t, err, "expected the connection to be valid, but it's not: %v", err)
+		} else {
+			require.Error(t, err, "expected the connection to be dead, but it's still alive")
+			// Reestablish the connection
+			conn = acquireConn()
+		}
+	}
+	time.Sleep(2 * sessionTimeoutInSeconds * time.Second)
+	checkConnectionAndReconnect(false)
+
+	// Kick off a background thread that will block doing a schema change. It
+	// should be immune to the idle session timeout.
+	defer close(endWaitOfSchemaChange) // Close channel to unblock background thread if foreground fails
+	grp := ctxgroup.WithContext(ctx)
+	grp.GoCtx(func(ctx context.Context) error {
+		defer close(startWaitOfSchemaChange) // In case we fail before adding to this channel
+		blockSchemaChange.Swap(true)
+		_, err := conn.ExecContext(ctx, `ALTER TABLE t1 ADD COLUMN C2 BIGINT`)
+		return err
+	})
+
+	<-startWaitOfSchemaChange
+	blockSchemaChange.Swap(false) // Disable so that we don't block for another stage
+	// We are now waiting for the schema change to complete. Waiting for twice the
+	// session timeout ensures that the schema change is not affected by the idle
+	// session timeout.
+	time.Sleep(2 * sessionTimeoutInSeconds * time.Second)
+	// Tell the background thread to continue
+	endWaitOfSchemaChange <- true
+	require.NoError(t, grp.Wait())
+
+	// Test that the idle session timer is reset after the schema change.
+	checkConnectionAndReconnect(true)
+	time.Sleep(2 * sessionTimeoutInSeconds * time.Second)
+	checkConnectionAndReconnect(false)
 }
 
 func TestIdleInTransactionSessionTimeout(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #136463.

/cc @cockroachdb/release

---

Previously, the idle session timeout timer would start immediately after statement execution. If a transaction committed and had to wait for a schema change to complete, the connection could be interrupted if the idle session timeout expired during this wait.

This update pauses the idle session timer while waiting for schema change jobs to finish, ensuring connections remain active until the schema change completes.

Epic: None
Closes #135930
Release note (bug fix): The `idle_in_session_timeout` setting now excludes the time spent waiting for schema changer jobs to complete, preventing unintended session termination during schema change operations.
Release justification: low-risk bug that was reported by a customer using 23.2