### PR TITLE
sql/schemachanger: Fix flake in TestIdleInSessionTimeoutDuringSchemaChange

### DIFF
--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -540,8 +540,6 @@ func TestIdleInSessionTimeoutDuringSchemaChange(t *testing.T) {
 			require.NoError(t, err, "expected the connection to be valid, but it's not: %v", err)
 		} else {
 			require.Error(t, err, "expected the connection to be dead, but it's still alive")
-			require.Contains(t, err.Error(), "driver: bad connection",
-				"expected the error to be a connection issue: %v", err)
 			// Reestablish the connection
 			conn = acquireConn()
 		}


### PR DESCRIPTION
I recently added the TestIdleInSessionTimeoutDuringSchemaChange test, which occasionally flakes with the following error:

```
run_control_test.go:543:
    Error Trace: pkg/sql/run_control_test.go:543
                 pkg/sql/run_control_test.go:550
    Error:       "read tcp 127.0.0.1:58244->127.0.0.1:58238: read: connection reset by peer" does not contain "driver: bad connection"
    Test:        TestIdleInSessionTimeoutDuringSchemaChange
    Messages:    expected the error to be a connection issue: read tcp 127.0.0.1:58244->127.0.0.1:58238: read: connection reset by peer
```

The test already verifies that a connection error occurs as expected. Both "driver: bad connection" and "connection reset by peer" are valid errors in this scenario. To address the flakiness, I’ve removed the error text check entirely.

Epic: None
Release note: None