### PR TITLE
kv: only declare abort span key when txn has locks

### DIFF
--- a/pkg/kv/kvserver/batcheval/declare.go
+++ b/pkg/kv/kvserver/batcheval/declare.go
@@ -171,7 +171,10 @@ func DeclareKeysForRefresh(
 func DeclareKeysForBatch(
 	rs ImmutableRangeState, header *kvpb.Header, latchSpans *spanset.SpanSet,
 ) error {
-	if header.Txn != nil {
+	// If the batch is transactional and has acquired locks, we will check if the
+	// transaction has been aborted during evaluation (see checkIfTxnAborted), so
+	// declare a read latch on the AbortSpan key.
+	if header.Txn != nil && header.Txn.IsLocking() {
 		header.Txn.AssertInitialized(context.TODO())
 		latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{
 			Key: keys.AbortSpanKey(rs.GetRangeID(), header.Txn.ID),


### PR DESCRIPTION
Informs #122719.

This commit updates `DeclareKeysForBatch` to only declare the abort span key when the transaction has acquired locks and will need to check the abort span. We were previously declaring the abort span key for all batches, even if we did not intend to check the abort span.

This is a short-term patch until we get around to reworking abort span access more thoroughly (see #122719).

```
name                                           old time/op    new time/op    delta
Sysbench/KV/1node_local/oltp_read_only-10         334µs ± 4%     325µs ± 4%  -2.63%  (p=0.035 n=10+9)
Sysbench/KV/1node_local/oltp_read_write-10        863µs ± 9%     860µs ±15%    ~     (p=0.661 n=10+9)
Sysbench/KV/1node_local/oltp_point_select-10     15.6µs ± 4%    15.9µs ±12%    ~     (p=0.529 n=10+10)
Sysbench/SQL/1node_local/oltp_read_only-10       1.88ms ±26%    1.80ms ± 5%    ~     (p=1.000 n=10+9)
Sysbench/SQL/1node_local/oltp_read_write-10      4.22ms ± 5%    4.18ms ±11%    ~     (p=0.400 n=9+10)
Sysbench/SQL/1node_local/oltp_point_select-10     114µs ± 5%     120µs ±21%    ~     (p=0.796 n=10+10)

name                                           old alloc/op   new alloc/op   delta
Sysbench/KV/1node_local/oltp_read_write-10        487kB ± 0%     484kB ± 1%  -0.55%  (p=0.011 n=8+9)
Sysbench/KV/1node_local/oltp_read_only-10         260kB ± 0%     259kB ± 1%  -0.50%  (p=0.011 n=8+10)
Sysbench/SQL/1node_local/oltp_point_select-10    27.8kB ± 0%    27.6kB ± 0%  -0.47%  (p=0.000 n=10+10)
Sysbench/SQL/1node_local/oltp_read_only-10        878kB ± 0%     876kB ± 0%  -0.25%  (p=0.003 n=10+10)
Sysbench/SQL/1node_local/oltp_read_write-10      1.25MB ± 1%    1.25MB ± 1%    ~     (p=0.146 n=10+8)
Sysbench/KV/1node_local/oltp_point_select-10     4.68kB ± 1%    4.68kB ± 2%    ~     (p=0.474 n=9+9)

name                                           old allocs/op  new allocs/op  delta
Sysbench/KV/1node_local/oltp_read_only-10           522 ± 0%       507 ± 0%  -2.72%  (p=0.000 n=10+10)
Sysbench/KV/1node_local/oltp_read_write-10        1.51k ± 0%     1.50k ± 0%  -0.92%  (p=0.000 n=10+10)
Sysbench/SQL/1node_local/oltp_point_select-10       238 ± 0%       237 ± 0%  -0.42%  (p=0.000 n=10+10)
Sysbench/SQL/1node_local/oltp_read_only-10        4.76k ± 0%     4.74k ± 0%  -0.39%  (p=0.000 n=10+10)
Sysbench/SQL/1node_local/oltp_read_write-10       7.55k ± 0%     7.53k ± 0%  -0.24%  (p=0.003 n=10+10)
Sysbench/KV/1node_local/oltp_point_select-10       29.0 ± 0%      29.0 ± 0%    ~     (all equal)
```

Release note: None