### PR TITLE
kv: disable raft tracing to cockroach.log by default

### DIFF
--- a/pkg/kv/kvserver/rafttrace/rafttrace.go
+++ b/pkg/kv/kvserver/rafttrace/rafttrace.go
@@ -49,7 +49,7 @@ var LogRaftTracesToCockroachLog = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"kv.raft.trace_to_cockroach_log.enabled",
 	"when true, log raft traces to the cockroach log in addition to the trace",
-	true,
+	false,
 )
 
 // traceValue represents the trace information for a single registration.


### PR DESCRIPTION
Previously this settings was defaulted to true which would log to the cockroach log, however the related setting kv.raft.max_concurrent_traces was set to 0 so logging was disabled. We want to enable kv.raft.max_concurrent_traces first and leave this disabled to prevent filling the log. This setting is not public and we don't expect any customers to have used it.

Epic: none

Release note: None