### PR TITLE
kvserver: consolidate RaftTruncatedState handling

### DIFF
--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -1643,8 +1643,6 @@ message TruncateLogRequest {
   // that is not equal to ExpectedFirstIndex. This is an optimization that
   // typically allows the potentially expensive computation of the bytes being
   // discarded from the raft log to be performed once, at the leaseholder.
-  //
-  // Populated starting at cluster version LooselyCoupledRaftLogTruncation.
   uint64 expected_first_index = 4  [(gogoproto.casttype) = "RaftIndex"];
 }
 

--- a/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
+++ b/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
@@ -171,9 +171,15 @@ message ReplicatedEvalResult {
   // Sideloaded entries are not expected to be common enough that it is worth
   // the optimization to calculate the delta once (at the leaseholder).
   int64 raft_log_delta = 13;
-  // RaftExpectedFirstIndex is populated starting at cluster version
-  // LooselyCoupledRaftLogTruncation. When this is not populated, the replica
-  // should not delay enacting the truncation.
+  // RaftExpectedFirstIndex is the first index of the raft log used for
+  // computing the RaftLogDelta. It is populated only when evaluating a
+  // TruncateLogRequest.
+  //
+  // Introduced in v22.1. There can be historical truncation proposals with this
+  // field being zero.
+  // TODO(pav-kv): the likelihood of this is low, but to err on the safe side we
+  // should wait for the next below-raft migration, at which point we'll be able
+  // to say that this field is always populated.
   uint64 raft_expected_first_index = 25  [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/kv/kvpb.RaftIndex"];
 
   // MVCCHistoryMutation describes mutations of MVCC history that may violate

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -708,11 +708,11 @@ func (rlq *raftLogQueue) process(
 	}
 	b := &kv.Batch{}
 	truncRequest := &kvpb.TruncateLogRequest{
-		RequestHeader: kvpb.RequestHeader{Key: r.Desc().StartKey.AsRawKey()},
-		Index:         decision.NewFirstIndex,
-		RangeID:       r.RangeID,
+		RequestHeader:      kvpb.RequestHeader{Key: r.Desc().StartKey.AsRawKey()},
+		Index:              decision.NewFirstIndex,
+		RangeID:            r.RangeID,
+		ExpectedFirstIndex: decision.Input.FirstIndex,
 	}
-	truncRequest.ExpectedFirstIndex = decision.Input.FirstIndex
 	b.AddRawRequest(truncRequest)
 	if err := rlq.db.Run(ctx, b); err != nil {
 		return false, err


### PR DESCRIPTION
This PR simplifies handling the `RaftTruncatedState` eval result, and adds TODO to remove a zero check after the next below-raft migration.

`RaftExpectedFirstIndex` used to be zero before f9dee66 which started setting this field after a `LooselyCoupledRaftLogTruncation` version gate. Since then, the version gate has been removed, and the field is set unconditionally.

But we still need to have done at least one below-raft migration to safely say that this field can't be zero.

Related to #136109