### PR TITLE
sql: prevent internal error in some cases with pausable portals

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2420,6 +2420,14 @@ func (ex *connExecutor) execCmd() (retErr error) {
 				Values: portal.Qargs,
 			}
 
+			if tcmd.Limit != 0 && tree.ReturnsAtMostOneRow(portal.Stmt.AST) {
+				// When a statement returns at most one row, the result row
+				// limit doesn't matter. We set it to 0 to fetch all rows, which
+				// allows us to clean up resources sooner if using a pausable
+				// portal.
+				tcmd.Limit = 0
+			}
+
 			// If this is the first-time execution of a portal without a limit set,
 			// it means all rows will be exhausted, so no need to pause this portal.
 			if tcmd.Limit == 0 && portal.pauseInfo != nil && portal.pauseInfo.curRes == nil {

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -1345,14 +1345,7 @@ func (c *conn) CreateStatementResult(
 	implicitTxn bool,
 	portalPausability sql.PortalPausablity,
 ) sql.CommandResult {
-	rowLimit := limit
-	if tree.ReturnsAtMostOneRow(stmt) {
-		// When a statement returns at most one row, the result row limit doesn't
-		// matter. We set it to 0 to fetch all rows, which allows us to clean up
-		// resources sooner if using a pausable portal.
-		rowLimit = 0
-	}
-	return c.newCommandResult(descOpt, pos, stmt, formatCodes, conv, location, rowLimit, portalName, implicitTxn, portalPausability)
+	return c.newCommandResult(descOpt, pos, stmt, formatCodes, conv, location, limit, portalName, implicitTxn, portalPausability)
 }
 
 // CreateSyncResult is part of the sql.ClientComm interface.

--- a/pkg/sql/pgwire/testdata/pgtest/multiple_active_portals
+++ b/pkg/sql/pgwire/testdata/pgtest/multiple_active_portals
@@ -1405,3 +1405,28 @@ ReadyForQuery
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 subtest end
+
+subtest internal_error_special_stmts
+
+send
+Query {"String": "CREATE TABLE IF NOT EXISTS t (k INT PRIMARY KEY);"}
+Parse {"Name": "q4", "Query": "ALTER TABLE t SCATTER;"}
+Bind {"DestinationPortal": "p4", "PreparedStatement": "q4"}
+Execute {"Portal": "p4", "MaxRows": 1}
+Execute {"Portal": "p4", "MaxRows": 1}
+Sync
+----
+
+until ignore=DataRow
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"SCATTER 1"}
+{"Type":"CommandComplete","CommandTag":"SCATTER 0"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+subtest end

--- a/pkg/sql/pgwire/testdata/pgtest/portals_crbugs
+++ b/pkg/sql/pgwire/testdata/pgtest/portals_crbugs
@@ -343,6 +343,7 @@ ReadyForQuery
 ReadyForQuery
 ReadyForQuery
 ErrorResponse
+ReadyForQuery
 ----
 {"Type":"ReadyForQuery","TxStatus":"I"}
 {"Type":"CommandComplete","CommandTag":"SET"}
@@ -368,5 +369,6 @@ ErrorResponse
 {"Type":"DataRow","Values":[{"text":"(1,1)"}]}
 {"Type":"PortalSuspended"}
 {"Type":"ErrorResponse","Code":"0A000","Message":"unimplemented: the statement for a pausable portal must be a read-only SELECT query with no sub-queries or post-queries","Detail":"cannot execute a portal while a different one is open","Hint":"You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/98911/dev"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
 
 subtest end


### PR DESCRIPTION
In 1a193fc700a8a9480b7d1a13cae3facca3242d46 we introduced the logic to reset the portal's limit to 0 for some special statements that return at most 1 row, and as a result such statements would always be treated via `commandResult` implementation. However, if the portal machinery was set up with multiple active portals enabled, it could later cause internal errors because that machinery expects to operate on the `limitedCommandResult` implementation. This commit fixes that oversight by making the decision to reset the limit earlier which will update the portal machinery to not use the pausable info.

Fixes: #136516.

(Note that I was unable to reproduce the exact error from the issue.)

Release note: None