### PR TITLE
cmd/reduce: add options to specify http and sql ports

### DIFF
--- a/pkg/cmd/reduce/main.go
+++ b/pkg/cmd/reduce/main.go
@@ -47,6 +47,8 @@ var (
 	}()
 	flags             = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	binary            = flags.String("binary", "./cockroach", "path to cockroach binary")
+	httpPort          = flags.Int("http-port", 8080, "first port number for HTTP servers in demo")
+	sqlPort           = flags.Int("sql-port", 26257, "first port number for SQL servers in demo")
 	file              = flags.String("file", "", "the path to a file containing SQL queries to reduce; required")
 	outFlag           = flags.String("out", "", "if set, the path to a new file where reduced result will be written to")
 	verbose           = flags.Bool("v", false, "print progress to standard output and the original test case output if it is not interesting")
@@ -117,8 +119,8 @@ func main() {
 	}
 	reducesql.LogUnknown = *unknown
 	out, err := reduceSQL(
-		*binary, *contains, file, *workers, *verbose, *chunkReductions, *multiRegion,
-		*tlp, *costfuzz, *unoptimizedOracle,
+		*binary, *httpPort, *sqlPort, *contains, file, *workers, *verbose,
+		*chunkReductions, *multiRegion, *tlp, *costfuzz, *unoptimizedOracle,
 	)
 	if err != nil {
 		log.Fatal(err)
@@ -136,7 +138,9 @@ func main() {
 }
 
 func reduceSQL(
-	binary, contains string,
+	binary string,
+	httpPort, sqlPort int,
+	contains string,
 	file *string,
 	workers int,
 	verbose bool,
@@ -292,28 +296,22 @@ SELECT '%[1]s';
 	}
 
 	isInteresting := func(ctx context.Context, sql string) (interesting bool, logOriginalHint func()) {
-		// If not multi-region, disable license generation. Do not exit on errors so
-		// the entirety of the input SQL is processed.
-		var cmd *exec.Cmd
-		if multiRegion {
-			cmd = exec.CommandContext(ctx, binary,
-				"demo",
-				"--insecure",
-				"--empty",
-				"--nodes=9",
-				"--multitenant=false",
-				"--set=errexit=false",
-				"--format=tsv",
-			)
-		} else {
-			cmd = exec.CommandContext(ctx, binary,
-				"demo",
-				"--insecure",
-				"--empty",
-				"--set=errexit=false",
-				"--format=tsv",
-			)
+		args := []string{
+			"demo",
+			"--insecure",
+			"--empty",
+			// Do not exit on errors so the entirety of the input SQL is
+			// processed.
+			"--set=errexit=false",
+			"--format=tsv",
+			fmt.Sprintf("--http-port=%d", httpPort),
+			fmt.Sprintf("--sql-port=%d", sqlPort),
 		}
+		if multiRegion {
+			args = append(args, "--nodes=9")
+			args = append(args, "--multitenant=false")
+		}
+		cmd := exec.CommandContext(ctx, binary, args...)
 		// Disable telemetry.
 		cmd.Env = []string{"COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING", "true"}
 		sql = settings + sql


### PR DESCRIPTION
This will allow us to use the reduce utility concurrently from the same host (by allowing concurrent demo sessions when different ports are provided).

Epic: None

Release note: None