### PR TITLE
roachtest: tpcc/large-schema-benchmark not emitting histogram

### DIFF
--- a/pkg/cmd/roachtest/tests/large_schema_benchmark.go
+++ b/pkg/cmd/roachtest/tests/large_schema_benchmark.go
@@ -197,10 +197,15 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 				mon.Go(func(ctx context.Context) error {
 					waitEnabled := "--wait 0.0"
 					var wlInstance []workloadInstance
+					disableHistogram := false
 					// Inactive databases will intentionally have wait time on
 					// them and not include them in our histograms.
 					if dbListType == inactiveDbListType {
 						waitEnabled = "--wait 1.0"
+
+						// disable histogram since they shouldn't be included
+						disableHistogram = true
+
 						// Use a different prometheus port for the inactive databases,
 						// this will not be measured.
 						wlInstance = append(
@@ -217,7 +222,7 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 						Warehouses:        len(c.All()) - 1,
 						SkipSetup:         true,
 						DisablePrometheus: true,
-						DisableHistogram:  true, // We setup the flag above.
+						DisableHistogram:  disableHistogram, // We setup the flag above.
 						WorkloadInstances: wlInstance,
 						Duration:          time.Minute * 60,
 						ExtraRunArgs: fmt.Sprintf("--db-list-file=%s --txn-preamble-file=%s --admin-urls=%q "+

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -304,8 +304,8 @@ func runTPCC(
 				MaybeFlag(opts.DB != "", "db", opts.DB).
 				Flag("warehouses", opts.Warehouses).
 				MaybeFlag(!opts.DisableHistogram, "histograms", histogramsPath).
-				MaybeFlag(t.ExportOpenmetrics(), "histogram-export-format", "openmetrics").
-				MaybeFlag(t.ExportOpenmetrics(), "openmetrics-labels", clusterstats.GetOpenmetricsLabelString(t, c, labelsMap)).
+				MaybeFlag(!opts.DisableHistogram && t.ExportOpenmetrics(), "histogram-export-format", "openmetrics").
+				MaybeFlag(!opts.DisableHistogram && t.ExportOpenmetrics(), "openmetrics-labels", clusterstats.GetOpenmetricsLabelString(t, c, labelsMap)).
 				Flag("ramp", rampDur).
 				Flag("duration", opts.Duration).
 				Flag("prometheus-port", workloadInstances[i].prometheusPort).


### PR DESCRIPTION
`tpcc/large-schema-benchmark` stopped emitting benchmark file after https://github.com/cockroachdb/cockroach/pull/133035. It was discovered that `DisableHistogram` was set true for every case and therefore `runTPCC` was skipping setting up the histogram args.

Epic: none

Release note: None