### PR TITLE
WORKSPACE: try to use Go sdk from fork branch

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -153,7 +153,6 @@ switched_rules_by_language(
 # com_github_golang_mock handled in DEPS.bzl.
 
 # Load the go dependencies and invoke them.
-load("@io_bazel_rules_go//go:def.bzl", "go_wrap_sdk")
 load(
     "@io_bazel_rules_go//go:deps.bzl",
     "go_download_sdk",
@@ -163,6 +162,7 @@ load(
     "go_register_toolchains",
     "go_rules_dependencies",
 )
+load("@io_bazel_rules_go//go:def.bzl", "go_wrap_sdk")
 
 # To point to a mirrored artifact, use:
 #

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -162,7 +162,6 @@ load(
     "go_register_toolchains",
     "go_rules_dependencies",
 )
-load("@io_bazel_rules_go//go:def.bzl", "go_wrap_sdk")
 
 # To point to a mirrored artifact, use:
 #
@@ -193,7 +192,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_wrap_sdk")
 git_repository(
     name = "custom_go_sdk",
     remote = "https://github.com/tbg/go.git",
-    branch = "go1.22.9-fork-32kbstack"
+    #branch = "go1.22.9-fork-32kbstack"
+    commit = "be41975aafe8868371973e298a1b825ad17cbe50"
 )
 
 # To use your whatever your local SDK is, use the following instead:
@@ -202,8 +202,13 @@ git_repository(
 
 go_rules_dependencies()
 
-go_register_toolchains()
 go_register_nogo(nogo = "@com_github_cockroachdb_cockroach//:crdb_nogo")
+load("@io_bazel_rules_go//go:deps.bzl", "go_wrap_sdk")
+go_wrap_sdk(
+    name = "go_sdk",
+    root_file = "@custom_go_sdk//:VERSION",
+)
+go_register_toolchains()
 
 ###############################
 # end rules_go dependencies #

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -164,18 +164,18 @@ load(
 
 # To point to a mirrored artifact, use:
 #
-go_download_sdk(
-    name = "go_sdk",
-    sdks = {
-        "darwin_amd64": ("go1.22.8.darwin-amd64.tar.gz", "5d1013d773f76c3cdc974b9afc20033595a2a334774e453be725e7c058e370be"),
-        "darwin_arm64": ("go1.22.8.darwin-arm64.tar.gz", "304a9d6bfcc5999d47b06f44f79c650173e078251a7adcdb46ba908b22bc4209"),
-        "linux_amd64": ("go1.22.8.linux-amd64.tar.gz", "ccc2e994241e6677a07e36aea2b1b3ca942fda2aafeedea6ada47e0e9f566f7b"),
-        "linux_arm64": ("go1.22.8.linux-arm64.tar.gz", "0c49cab48ff13355d346bc8aee5960491c5489120eb7bcd424dab5d341fb12c6"),
-        "windows_amd64": ("go1.22.8.windows-amd64.tar.gz", "a09ee8a15eae361f673e88bf645c4af8e119ddf9d48d4d9104802bece3818216"),
-    },
-    urls = ["https://storage.googleapis.com/public-bazel-artifacts/go/20241105-184020/{}"],
-    version = "1.22.8",
-)
+#go_download_sdk(
+#    name = "go_sdk",
+#    sdks = {
+#        "darwin_amd64": ("go1.22.8.darwin-amd64.tar.gz", "5d1013d773f76c3cdc974b9afc20033595a2a334774e453be725e7c058e370be"),
+#        "darwin_arm64": ("go1.22.8.darwin-arm64.tar.gz", "304a9d6bfcc5999d47b06f44f79c650173e078251a7adcdb46ba908b22bc4209"),
+#        "linux_amd64": ("go1.22.8.linux-amd64.tar.gz", "ccc2e994241e6677a07e36aea2b1b3ca942fda2aafeedea6ada47e0e9f566f7b"),
+#        "linux_arm64": ("go1.22.8.linux-arm64.tar.gz", "0c49cab48ff13355d346bc8aee5960491c5489120eb7bcd424dab5d341fb12c6"),
+#        "windows_amd64": ("go1.22.8.windows-amd64.tar.gz", "a09ee8a15eae361f673e88bf645c4af8e119ddf9d48d4d9104802bece3818216"),
+#    },
+#    urls = ["https://storage.googleapis.com/public-bazel-artifacts/go/20241105-184020/{}"],
+#    version = "1.22.8",
+#)
 
 # To point to a local SDK path, use the following instead. We'll call the
 # directory into which you cloned the Go repository $GODIR[1]. You'll have to
@@ -183,10 +183,10 @@ go_download_sdk(
 #
 # [1]: https://go.dev/doc/contribute#testing
 #
-#   go_local_sdk(
-#       name = "go_sdk",
-#       path = "<path to $GODIR>",
-#   )
+go_local_sdk(
+    name = "go_sdk",
+    path = "/Users/tbg/go-sdk",
+)
 
 # To use your whatever your local SDK is, use the following instead:
 #

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,6 +4,7 @@ workspace(name = "com_github_cockroachdb_cockroach")
 
 # Load the things that let us load other things.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 # Load go bazel tools. This gives us access to the go bazel SDK/toolchains.
 http_archive(
@@ -152,6 +153,7 @@ switched_rules_by_language(
 # com_github_golang_mock handled in DEPS.bzl.
 
 # Load the go dependencies and invoke them.
+load("@io_bazel_rules_go//go:def.bzl", "go_wrap_sdk")
 load(
     "@io_bazel_rules_go//go:deps.bzl",
     "go_download_sdk",
@@ -183,9 +185,15 @@ load(
 #
 # [1]: https://go.dev/doc/contribute#testing
 #
-go_local_sdk(
-    name = "go_sdk",
-    path = "/Users/tbg/go-sdk",
+# go_local_sdk(
+#     name = "go_sdk",
+#     path = "/Users/tbg/go-sdk",
+# )
+
+git_repository(
+    name = "custom_go_sdk",
+    remote = "https://github.com/tbg/go.git",
+    branch = "go1.22.9-fork-32kbstack"
 )
 
 # To use your whatever your local SDK is, use the following instead:


### PR DESCRIPTION
```
cockroach go-fork$ ./dev build short
$ bazel build //pkg/cmd/cockroach-short:cockroach-short
INFO: Invocation ID: e08df5ee-3cbc-43aa-bff1-46846a1b87cf
ERROR: Failed to load Starlark extension '@@io_bazel_rules_nogo//:scope.bzl'.
Cycle in the workspace file detected. This indicates that a repository is used prior to being defined.
The following chain of repository dependencies lead to the missing definition.
 - @@io_bazel_rules_nogo
This could either mean you have to add the '@@io_bazel_rules_nogo' repository with a statement like `http_archive` in your WORKSPACE file (note that transitive dependencies are not added automatically), or move an existing definition earlier in your WORKSPACE file.
```