### PR TITLE
kvserver: explicitly run tests with epoch leases

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -1319,7 +1319,7 @@ func TestRequestsOnFollowerWithNonLiveLeaseholder(t *testing.T) {
 
 	st := cluster.MakeTestingClusterSettings()
 	// This test is specifically designed for epoch based leases.
-	kvserver.OverrideLeaderLeaseMetamorphism(ctx, &st.SV)
+	kvserver.OverrideDefaultLeaseType(ctx, &st.SV, roachpb.LeaseEpoch)
 
 	manualClock := hlc.NewHybridManualClock()
 	clusterArgs := base.TestClusterArgs{
@@ -6890,7 +6890,7 @@ func TestRaftPreVoteUnquiesceDeadLeader(t *testing.T) {
 	// This test is specifically designed for epoch based leases, as they're the
 	// only lease type for which we have quiescence.
 	st := cluster.MakeTestingClusterSettings()
-	kvserver.OverrideLeaderLeaseMetamorphism(ctx, &st.SV)
+	kvserver.OverrideDefaultLeaseType(ctx, &st.SV, roachpb.LeaseEpoch)
 	kvserver.TransferExpirationLeasesFirstEnabled.Override(ctx, &st.SV, false)
 
 	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{


### PR DESCRIPTION
This patch explicitly runs a couple of tests
(TestRaftPreVoteUnquiesceDeadLeader and
TestRequestsOnFollowerWithNonLiveLeaseholder) with epoch based leases. These were broken by 3904daa7feeb1b9d537337daec3ade121c76171e.

Closes https://github.com/cockroachdb/cockroach/issues/136582 
Closes https://github.com/cockroachdb/cockroach/issues/136548

Release note: None