### PR TITLE
raft: defortify leaders if not live in store liveness

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1454,6 +1454,14 @@ func (r *raft) supportingFortifiedLeader() bool {
 	}
 	assertTrue(r.lead != None, "lead epoch is set but leader is not")
 	epoch, live := r.storeLiveness.SupportFor(r.lead)
+
+	if !live {
+		// If SupportFor returned !live, it means that the epoch is meaningless.
+		// This could happen if the leader's node suddenly got decommisioned. In
+		// this case, we should de-fortify the leader.
+		r.deFortify(r.lead, r.Term)
+		return false
+	}
 	assertTrue(epoch >= r.leadEpoch, "epochs in store liveness shouldn't regress")
 	return live && epoch == r.leadEpoch
 }


### PR DESCRIPTION
If we fortify a leader but we suddenly receive !live in the store liveness, it means that the node got decommissioned. We can defortify the leader.

References: #133763

Release note: None