### PR TITLE
kvserver: enable leader leases for TestRangefeedCheckpointsRecoverFromLeaseExpiration

### DIFF
--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -1467,8 +1467,6 @@ func TestRangefeedCheckpointsRecoverFromLeaseExpiration(t *testing.T) {
 
 	st := cluster.MakeTestingClusterSettings()
 	kvserver.ExpirationLeasesOnly.Override(ctx, &st.SV, false) // override metamorphism
-	// TODO(arul): Dig into why this isn't passing.
-	kvserver.OverrideLeaderLeaseMetamorphism(ctx, &st.SV)
 
 	var storeLivenessHeartbeatsOff atomic.Value
 	cargs := aggressiveResolvedTimestampManuallyReplicatedClusterArgs


### PR DESCRIPTION
Leader leases were disabled for this test in https://github.com/cockroachdb/cockroach/pull/133353. After stressing the test (including under race), this commit re-enables leader leases.

Part of: #133763

Release note: None