### PR TITLE
logictest: deflake as_of test

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -92,7 +92,7 @@ SELECT * FROM t
 
 # LSC and DSC would return slightly different error message when attempting to create a
 # database as of system time follower_read_timestamp() soon after a node has started.
-statement error pq: (cannot execute CREATE DATABASE in a read-only transaction|referenced descriptor ID 1: looking up ID 1: descriptor not found|database \"\[1\]\" does not exist)
+statement error pq: (cannot execute CREATE DATABASE in a read-only transaction|referenced descriptor ID 1: looking up ID 1: descriptor not found|database \"\[1\]\" does not exist|role/user \"root\" does not exist)
 CREATE DATABASE IF NOT EXISTS d2
 
 statement error pgcode 3D000 pq: database "test" does not exist


### PR DESCRIPTION
We previously adjusted the expected errors in
4728949f96da35fd64b9818927d29c1e744e1ab7. There is another assertion later in the test that needs the same update.

fixes https://github.com/cockroachdb/cockroach/issues/136576
Release note: None