### PR TITLE
cli: do not run leader leases in TestHalfOnlineLossOfQuorumRecovery

### DIFF
--- a/pkg/cli/debug_recover_loss_of_quorum_test.go
+++ b/pkg/cli/debug_recover_loss_of_quorum_test.go
@@ -462,6 +462,10 @@ func TestHalfOnlineLossOfQuorumRecovery(t *testing.T) {
 	listenerReg := listenerutil.NewListenerRegistry()
 	defer listenerReg.Close()
 
+	st := cluster.MakeTestingClusterSettings()
+	// We currently don't clear out the LeadEpoch field when recovering from a
+	// loss of quorum, so we can't run with leader leases on in this test.
+	kvserver.OverrideLeaderLeaseMetamorphism(ctx, &st.SV)
 	// Test cluster contains 3 nodes that we would turn into a single node
 	// cluster using loss of quorum recovery. To do that, we will terminate
 	// two nodes and run recovery on remaining one. Restarting node should
@@ -476,6 +480,7 @@ func TestHalfOnlineLossOfQuorumRecovery(t *testing.T) {
 	sa := make(map[int]base.TestServerArgs)
 	for i := 0; i < 3; i++ {
 		sa[i] = base.TestServerArgs{
+			Settings: st,
 			Knobs: base.TestingKnobs{
 				Server: &server.TestingKnobs{
 					StickyVFSRegistry: fs.NewStickyRegistry(),


### PR DESCRIPTION
This test can panic with a store liveness regression if the previous leader is no longer part of the range descriptor.

Closes https://github.com/cockroachdb/cockroach/issues/136598

Release note: None