### PR TITLE
roachtest: make disk bandwidth test manual only

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -41,7 +41,7 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 		Benchmark:        true,
 		CompatibleClouds: registry.AllExceptAzure,
 		// TODO(aaditya): change to weekly once the test stabilizes.
-		Suites:          registry.Suites(registry.Nightly),
+		Suites:          registry.ManualOnly,
 		Cluster:         r.MakeClusterSpec(2, spec.CPU(8), spec.WorkloadNode()),
 		RequiresLicense: true,
 		Leases:          registry.MetamorphicLeases,


### PR DESCRIPTION
For the v24.3 version, this test fails consistently since the version is missing improvements to the disk accounting in AC, where we adjust for disk error. Since we can't backport the fix, making this test manual only on this branch will reduce the noise.

Fixes: #136559.

Release note: None