### PR TITLE
roachtest: increase wait in restore pause test

### DIFF
--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -199,7 +199,7 @@ func registerRestore(r registry.Registry) {
 							}
 						}
 						require.NoError(t, err)
-						testutils.SucceedsSoon(t, func() error {
+						testutils.SucceedsWithin(t, func() error {
 							var status string
 							sql.QueryRow(t, `SELECT status FROM [SHOW JOB $1]`, jobID).Scan(&status)
 							if status != "paused" {
@@ -208,7 +208,7 @@ func registerRestore(r registry.Registry) {
 							t.L().Printf("paused RESTORE job")
 							pauseIndex++
 							return nil
-						})
+						}, 2*time.Minute)
 
 						t.L().Printf("resuming RESTORE job")
 						sql.Exec(t, `RESUME JOB $1`, jobID)


### PR DESCRIPTION
PR #135191 effectively changed how long the test would wait for the job to reach a paused state from 1m45s to 45s. This changes the wait back to 2 minutes.

I looked into why it was sometimes taking nearly a minute to reach the paused state. If a status update races with the cancel/pause loop, the job will fail and will not enter the paused state until the adopt loop runs (see #136348 for details).

Fixes: #136348
Release Note: None
Release Justification: Test Only Change