### PR TITLE
colexec: add cancellation check to top K sort and merge join

### DIFF
--- a/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
@@ -14236,10 +14236,12 @@ func (o *mergeJoinExceptAllOp) Next() coldata.Batch {
 			// If this is the first batch or we're done with the current batch,
 			// get the next batch.
 			if o.proberState.lBatch == nil || (o.proberState.lLength != 0 && o.proberState.lIdx == o.proberState.lLength) {
+				o.cancelChecker.CheckEveryCall()
 				o.proberState.lIdx, o.proberState.lBatch = 0, o.InputOne.Next()
 				o.proberState.lLength = o.proberState.lBatch.Length()
 			}
 			if o.proberState.rBatch == nil || (o.proberState.rLength != 0 && o.proberState.rIdx == o.proberState.rLength) {
+				o.cancelChecker.CheckEveryCall()
 				o.proberState.rIdx, o.proberState.rBatch = 0, o.InputTwo.Next()
 				o.proberState.rLength = o.proberState.rBatch.Length()
 			}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
@@ -15383,10 +15383,12 @@ func (o *mergeJoinFullOuterOp) Next() coldata.Batch {
 			// If this is the first batch or we're done with the current batch,
 			// get the next batch.
 			if o.proberState.lBatch == nil || (o.proberState.lLength != 0 && o.proberState.lIdx == o.proberState.lLength) {
+				o.cancelChecker.CheckEveryCall()
 				o.proberState.lIdx, o.proberState.lBatch = 0, o.InputOne.Next()
 				o.proberState.lLength = o.proberState.lBatch.Length()
 			}
 			if o.proberState.rBatch == nil || (o.proberState.rLength != 0 && o.proberState.rIdx == o.proberState.rLength) {
+				o.cancelChecker.CheckEveryCall()
 				o.proberState.rIdx, o.proberState.rBatch = 0, o.InputTwo.Next()
 				o.proberState.rLength = o.proberState.rBatch.Length()
 			}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
@@ -10917,10 +10917,12 @@ func (o *mergeJoinInnerOp) Next() coldata.Batch {
 			// If this is the first batch or we're done with the current batch,
 			// get the next batch.
 			if o.proberState.lBatch == nil || (o.proberState.lLength != 0 && o.proberState.lIdx == o.proberState.lLength) {
+				o.cancelChecker.CheckEveryCall()
 				o.proberState.lIdx, o.proberState.lBatch = 0, o.InputOne.Next()
 				o.proberState.lLength = o.proberState.lBatch.Length()
 			}
 			if o.proberState.rBatch == nil || (o.proberState.rLength != 0 && o.proberState.rIdx == o.proberState.rLength) {
+				o.cancelChecker.CheckEveryCall()
 				o.proberState.rIdx, o.proberState.rBatch = 0, o.InputTwo.Next()
 				o.proberState.rLength = o.proberState.rBatch.Length()
 			}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
@@ -11627,10 +11627,12 @@ func (o *mergeJoinIntersectAllOp) Next() coldata.Batch {
 			// If this is the first batch or we're done with the current batch,
 			// get the next batch.
 			if o.proberState.lBatch == nil || (o.proberState.lLength != 0 && o.proberState.lIdx == o.proberState.lLength) {
+				o.cancelChecker.CheckEveryCall()
 				o.proberState.lIdx, o.proberState.lBatch = 0, o.InputOne.Next()
 				o.proberState.lLength = o.proberState.lBatch.Length()
 			}
 			if o.proberState.rBatch == nil || (o.proberState.rLength != 0 && o.proberState.rIdx == o.proberState.rLength) {
+				o.cancelChecker.CheckEveryCall()
 				o.proberState.rIdx, o.proberState.rBatch = 0, o.InputTwo.Next()
 				o.proberState.rLength = o.proberState.rBatch.Length()
 			}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
@@ -13146,10 +13146,12 @@ func (o *mergeJoinLeftAntiOp) Next() coldata.Batch {
 			// If this is the first batch or we're done with the current batch,
 			// get the next batch.
 			if o.proberState.lBatch == nil || (o.proberState.lLength != 0 && o.proberState.lIdx == o.proberState.lLength) {
+				o.cancelChecker.CheckEveryCall()
 				o.proberState.lIdx, o.proberState.lBatch = 0, o.InputOne.Next()
 				o.proberState.lLength = o.proberState.lBatch.Length()
 			}
 			if o.proberState.rBatch == nil || (o.proberState.rLength != 0 && o.proberState.rIdx == o.proberState.rLength) {
+				o.cancelChecker.CheckEveryCall()
 				o.proberState.rIdx, o.proberState.rBatch = 0, o.InputTwo.Next()
 				o.proberState.rLength = o.proberState.rBatch.Length()
 			}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
@@ -13173,10 +13173,12 @@ func (o *mergeJoinLeftOuterOp) Next() coldata.Batch {
 			// If this is the first batch or we're done with the current batch,
 			// get the next batch.
 			if o.proberState.lBatch == nil || (o.proberState.lLength != 0 && o.proberState.lIdx == o.proberState.lLength) {
+				o.cancelChecker.CheckEveryCall()
 				o.proberState.lIdx, o.proberState.lBatch = 0, o.InputOne.Next()
 				o.proberState.lLength = o.proberState.lBatch.Length()
 			}
 			if o.proberState.rBatch == nil || (o.proberState.rLength != 0 && o.proberState.rIdx == o.proberState.rLength) {
+				o.cancelChecker.CheckEveryCall()
 				o.proberState.rIdx, o.proberState.rBatch = 0, o.InputTwo.Next()
 				o.proberState.rLength = o.proberState.rBatch.Length()
 			}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
@@ -10870,10 +10870,12 @@ func (o *mergeJoinLeftSemiOp) Next() coldata.Batch {
 			// If this is the first batch or we're done with the current batch,
 			// get the next batch.
 			if o.proberState.lBatch == nil || (o.proberState.lLength != 0 && o.proberState.lIdx == o.proberState.lLength) {
+				o.cancelChecker.CheckEveryCall()
 				o.proberState.lIdx, o.proberState.lBatch = 0, o.InputOne.Next()
 				o.proberState.lLength = o.proberState.lBatch.Length()
 			}
 			if o.proberState.rBatch == nil || (o.proberState.rLength != 0 && o.proberState.rIdx == o.proberState.rLength) {
+				o.cancelChecker.CheckEveryCall()
 				o.proberState.rIdx, o.proberState.rBatch = 0, o.InputTwo.Next()
 				o.proberState.rLength = o.proberState.rBatch.Length()
 			}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
@@ -13077,10 +13077,12 @@ func (o *mergeJoinRightAntiOp) Next() coldata.Batch {
 			// If this is the first batch or we're done with the current batch,
 			// get the next batch.
 			if o.proberState.lBatch == nil || (o.proberState.lLength != 0 && o.proberState.lIdx == o.proberState.lLength) {
+				o.cancelChecker.CheckEveryCall()
 				o.proberState.lIdx, o.proberState.lBatch = 0, o.InputOne.Next()
 				o.proberState.lLength = o.proberState.lBatch.Length()
 			}
 			if o.proberState.rBatch == nil || (o.proberState.rLength != 0 && o.proberState.rIdx == o.proberState.rLength) {
+				o.cancelChecker.CheckEveryCall()
 				o.proberState.rIdx, o.proberState.rBatch = 0, o.InputTwo.Next()
 				o.proberState.rLength = o.proberState.rBatch.Length()
 			}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
@@ -13127,10 +13127,12 @@ func (o *mergeJoinRightOuterOp) Next() coldata.Batch {
 			// If this is the first batch or we're done with the current batch,
 			// get the next batch.
 			if o.proberState.lBatch == nil || (o.proberState.lLength != 0 && o.proberState.lIdx == o.proberState.lLength) {
+				o.cancelChecker.CheckEveryCall()
 				o.proberState.lIdx, o.proberState.lBatch = 0, o.InputOne.Next()
 				o.proberState.lLength = o.proberState.lBatch.Length()
 			}
 			if o.proberState.rBatch == nil || (o.proberState.rLength != 0 && o.proberState.rIdx == o.proberState.rLength) {
+				o.cancelChecker.CheckEveryCall()
 				o.proberState.rIdx, o.proberState.rBatch = 0, o.InputTwo.Next()
 				o.proberState.rLength = o.proberState.rBatch.Length()
 			}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
@@ -10830,10 +10830,12 @@ func (o *mergeJoinRightSemiOp) Next() coldata.Batch {
 			// If this is the first batch or we're done with the current batch,
 			// get the next batch.
 			if o.proberState.lBatch == nil || (o.proberState.lLength != 0 && o.proberState.lIdx == o.proberState.lLength) {
+				o.cancelChecker.CheckEveryCall()
 				o.proberState.lIdx, o.proberState.lBatch = 0, o.InputOne.Next()
 				o.proberState.lLength = o.proberState.lBatch.Length()
 			}
 			if o.proberState.rBatch == nil || (o.proberState.rLength != 0 && o.proberState.rIdx == o.proberState.rLength) {
+				o.cancelChecker.CheckEveryCall()
 				o.proberState.rIdx, o.proberState.rBatch = 0, o.InputTwo.Next()
 				o.proberState.rLength = o.proberState.rBatch.Length()
 			}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
@@ -1366,10 +1366,12 @@ func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next() coldata.Batch {
 			// If this is the first batch or we're done with the current batch,
 			// get the next batch.
 			if o.proberState.lBatch == nil || (o.proberState.lLength != 0 && o.proberState.lIdx == o.proberState.lLength) {
+				o.cancelChecker.CheckEveryCall()
 				o.proberState.lIdx, o.proberState.lBatch = 0, o.InputOne.Next()
 				o.proberState.lLength = o.proberState.lBatch.Length()
 			}
 			if o.proberState.rBatch == nil || (o.proberState.rLength != 0 && o.proberState.rIdx == o.proberState.rLength) {
+				o.cancelChecker.CheckEveryCall()
 				o.proberState.rIdx, o.proberState.rBatch = 0, o.InputTwo.Next()
 				o.proberState.rLength = o.proberState.rBatch.Length()
 			}

--- a/pkg/sql/colexec/sorttopk.eg.go
+++ b/pkg/sql/colexec/sorttopk.eg.go
@@ -114,6 +114,7 @@ func spool_true(t *topKSorter) {
 	// or more distinct and complete groups, and then use a K-N size heap to find
 	// the remaining top K-N rows.
 	{
+		t.cancelChecker.CheckEveryCall()
 		t.inputBatch = t.Input.Next()
 		t.orderState.distincterInput.SetBatch(t.inputBatch)
 		t.orderState.distincter.Next()
@@ -176,6 +177,7 @@ func spool_true(t *topKSorter) {
 		remainingRows -= uint64(fromLength)
 		if fromLength == t.inputBatch.Length() {
 			{
+				t.cancelChecker.CheckEveryCall()
 				t.inputBatch = t.Input.Next()
 				t.orderState.distincterInput.SetBatch(t.inputBatch)
 				t.orderState.distincter.Next()
@@ -276,6 +278,7 @@ func spool_true(t *topKSorter) {
 			break
 		}
 		{
+			t.cancelChecker.CheckEveryCall()
 			t.inputBatch = t.Input.Next()
 			t.orderState.distincterInput.SetBatch(t.inputBatch)
 			t.orderState.distincter.Next()
@@ -313,6 +316,7 @@ func spool_false(t *topKSorter) {
 	// or more distinct and complete groups, and then use a K-N size heap to find
 	// the remaining top K-N rows.
 	{
+		t.cancelChecker.CheckEveryCall()
 		t.inputBatch = t.Input.Next()
 		t.firstUnprocessedTupleIdx = 0
 	}
@@ -332,6 +336,7 @@ func spool_false(t *topKSorter) {
 		remainingRows -= uint64(fromLength)
 		if fromLength == t.inputBatch.Length() {
 			{
+				t.cancelChecker.CheckEveryCall()
 				t.inputBatch = t.Input.Next()
 				t.firstUnprocessedTupleIdx = 0
 			}
@@ -390,6 +395,7 @@ func spool_false(t *topKSorter) {
 			},
 		)
 		{
+			t.cancelChecker.CheckEveryCall()
 			t.inputBatch = t.Input.Next()
 			t.firstUnprocessedTupleIdx = 0
 		}

--- a/pkg/sql/colexec/sorttopk.go
+++ b/pkg/sql/colexec/sorttopk.go
@@ -117,6 +117,8 @@ type topKSorter struct {
 	emitted int
 	output  coldata.Batch
 
+	cancelChecker colexecutils.CancelChecker
+
 	exportedFromTopK  int
 	exportedFromBatch int
 	windowedBatch     coldata.Batch
@@ -150,6 +152,7 @@ func (t *topKSorter) Init(ctx context.Context) {
 		t.orderState.distincter.Init(t.Ctx)
 		t.orderState.group = make([]int, t.k)
 	}
+	t.cancelChecker.Init(t.Ctx)
 }
 
 func (t *topKSorter) Next() coldata.Batch {

--- a/pkg/sql/colexec/sorttopk_tmpl.go
+++ b/pkg/sql/colexec/sorttopk_tmpl.go
@@ -27,6 +27,7 @@ import (
 // execgen:template<partialOrder>
 // execgen:inline
 func nextBatch(t *topKSorter, partialOrder bool) {
+	t.cancelChecker.CheckEveryCall()
 	t.inputBatch = t.Input.Next()
 	if partialOrder {
 		t.orderState.distincterInput.SetBatch(t.inputBatch)


### PR DESCRIPTION
This commit adds the cancellation check to the top K sorter and the merge joiner to be performed on every input batch they read. I think that these two are the only buffering operators that currently don't have any cancellation checks:
- for hash joins and hash aggregation we have the check when performing the hashing
- for ordered aggregator, buffered window functions, cross join, external sort and other disk-backed operators we do the check on each input batch
- for general sort we do the check in the PDQ sort of each column.

Fixes: #136457.

Release note (bug fix): CockroachDB now better respects `statement_timeout` limit on queries involving the top K sort and merge join operations.