### PR TITLE
roachtest: change perturbation tests to terminate on migration

### DIFF
--- a/pkg/cmd/roachtest/tests/perturbation/framework.go
+++ b/pkg/cmd/roachtest/tests/perturbation/framework.go
@@ -272,7 +272,7 @@ func RegisterTests(r registry.Registry) {
 }
 
 func (v variations) makeClusterSpec() spec.ClusterSpec {
-	opts := append(v.specOptions, spec.CPU(v.vcpu), spec.SSD(v.disks), spec.Mem(v.mem))
+	opts := append(v.specOptions, spec.CPU(v.vcpu), spec.SSD(v.disks), spec.Mem(v.mem), spec.TerminateOnMigration())
 	return spec.MakeClusterSpec(v.numNodes+v.numWorkloadNodes, opts...)
 }
 


### PR DESCRIPTION
Perturbation tests are latency sensitive and they will fail if there is a node live migration. This change removes the possibility of them migrating in the middle of a test and causing a latency blip.

Epic: none
Fixes: #136092

Release note: None