### PR TITLE
util/mon: introduce `MonitorName` and reduce allocations

### DIFF
--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -166,7 +166,7 @@ func CreateDocker(
 	cli.NegotiateAPIVersion(ctx)
 
 	clusterID := uuid.MakeV4()
-	clusterIDS := clusterID.Short()
+	clusterIDS := clusterID.Short().String()
 
 	if volumesDir == "" {
 		volumesDir, err = os.MkdirTemp(datapathutils.DebuggableTempDir(), fmt.Sprintf("cockroach-acceptance-%s", clusterIDS))

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -8391,7 +8391,7 @@ func TestReadBackupManifestMemoryMonitoring(t *testing.T) {
 	require.NoError(t, err)
 
 	m := mon.NewMonitor(mon.Options{
-		Name:     "test-monitor",
+		Name:     mon.MakeMonitorName("test-monitor"),
 		Settings: st,
 	})
 	m.Start(ctx, nil, mon.NewStandaloneBudget(128<<20))

--- a/pkg/backup/backuputils/memory_backed_quota_pool.go
+++ b/pkg/backup/backuputils/memory_backed_quota_pool.go
@@ -33,7 +33,7 @@ type MemoryBackedQuotaPool struct {
 // NewMemoryBackedQuotaPool creates a MemoryBackedQuotaPool from a parent
 // monitor m with a limit.
 func NewMemoryBackedQuotaPool(
-	ctx context.Context, m *mon.BytesMonitor, name redact.RedactableString, limit int64,
+	ctx context.Context, m *mon.BytesMonitor, name redact.SafeString, limit int64,
 ) *MemoryBackedQuotaPool {
 	q := MemoryBackedQuotaPool{
 		quotaPool: quotapool.NewIntPool(fmt.Sprintf("%s-pool", name), 0),

--- a/pkg/backup/backuputils/memory_backed_quota_pool_test.go
+++ b/pkg/backup/backuputils/memory_backed_quota_pool_test.go
@@ -21,7 +21,7 @@ import (
 
 func getMemoryMonitor(limit int64) *mon.BytesMonitor {
 	return mon.NewMonitor(mon.Options{
-		Name:      "test-mon",
+		Name:      mon.MakeMonitorName("test-mon"),
 		Limit:     limit,
 		Increment: 1,
 		Settings:  cluster.MakeTestingClusterSettings(),

--- a/pkg/backup/restore_data_processor.go
+++ b/pkg/backup/restore_data_processor.go
@@ -150,7 +150,9 @@ func newRestoreDataProcessor(
 		progCh: make(chan backuppb.RestoreProgress, maxConcurrentRestoreWorkers),
 	}
 
-	rd.qp = backuputils.NewMemoryBackedQuotaPool(ctx, flowCtx.Cfg.BackupMonitor, "restore-mon", 0)
+	rd.qp = backuputils.NewMemoryBackedQuotaPool(
+		ctx, flowCtx.Cfg.BackupMonitor, "restore-mon", 0,
+	)
 	if err := rd.Init(ctx, rd, post, restoreDataOutputTypes, flowCtx, processorID, nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{input},

--- a/pkg/backup/restore_data_processor_test.go
+++ b/pkg/backup/restore_data_processor_test.go
@@ -270,7 +270,7 @@ func runTestIngest(t *testing.T, init func(*cluster.Settings)) {
 			Settings: s.ClusterSettings(),
 			Codec:    s.Codec(),
 			BackupMonitor: mon.NewUnlimitedMonitor(ctx, mon.Options{
-				Name:     "test",
+				Name:     mon.MakeMonitorName("test"),
 				Settings: s.ClusterSettings(),
 			}),
 			BulkSenderLimiter: limit.MakeConcurrentRequestLimiter("test", math.MaxInt),
@@ -408,7 +408,9 @@ func runTestIngest(t *testing.T, init func(*cluster.Settings)) {
 					},
 				},
 				spec: mockRestoreDataSpec,
-				qp:   backuputils.NewMemoryBackedQuotaPool(ctx, nil /* m */, "restore-mon", 0 /* limit */),
+				qp: backuputils.NewMemoryBackedQuotaPool(
+					ctx, nil /* m */, "restore-mon", 0, /* limit */
+				),
 			}
 			sst, res, err := mockRestoreDataProcessor.openSSTs(ctx, restoreSpanEntry, nil)
 			require.NoError(t, err)

--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -1058,11 +1058,11 @@ func InheritTempStorageConfig(
 func newTempStorageConfig(
 	ctx context.Context, st *cluster.Settings, inMemory bool, useStore StoreSpec, maxSizeBytes int64,
 ) TempStorageConfig {
-	var monitorName redact.RedactableString
+	var monitorName mon.MonitorName
 	if inMemory {
-		monitorName = "in-mem temp storage"
+		monitorName = mon.MakeMonitorName("in-mem temp storage")
 	} else {
-		monitorName = "temp disk storage"
+		monitorName = mon.MakeMonitorName("temp disk storage")
 	}
 	monitor := mon.NewMonitor(mon.Options{
 		Name:      monitorName,

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -498,7 +498,7 @@ func DefaultTestTempStorageConfigWithSize(
 	st *cluster.Settings, maxSizeBytes int64,
 ) TempStorageConfig {
 	monitor := mon.NewMonitor(mon.Options{
-		Name:      "in-mem temp storage",
+		Name:      mon.MakeMonitorName("in-mem temp storage"),
 		Res:       mon.DiskResource,
 		Increment: 1024 * 1024,
 		Settings:  st,

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -8331,7 +8331,7 @@ func TestChangefeedPredicateWithSchemaChange(t *testing.T) {
 
 func startMonitorWithBudget(budget int64) *mon.BytesMonitor {
 	mm := mon.NewMonitor(mon.Options{
-		Name:      "test-mm",
+		Name:      mon.MakeMonitorName("test-mm"),
 		Limit:     budget,
 		Increment: 128, /* small allocation increment */
 		Settings:  cluster.MakeTestingClusterSettings(),

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
@@ -68,7 +68,7 @@ func makeRangeFeedEvent(rnd *rand.Rand, valSize int, prevValSize int) *kvpb.Rang
 
 func getBoundAccountWithBudget(budget int64) (account mon.BoundAccount, cleanup func()) {
 	mm := mon.NewMonitor(mon.Options{
-		Name:      "test-mm",
+		Name:      mon.MakeMonitorName("test-mm"),
 		Limit:     budget,
 		Increment: 128, /* small allocation increment */
 		Settings:  cluster.MakeTestingClusterSettings(),

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -116,7 +116,7 @@ func TestKVFeed(t *testing.T) {
 	runTest := func(t *testing.T, tc testCase) {
 		settings := cluster.MakeTestingClusterSettings()
 		mm := mon.NewUnlimitedMonitor(context.Background(), mon.Options{
-			Name:     "test",
+			Name:     mon.MakeMonitorName("test"),
 			Settings: settings,
 		})
 		metrics := kvevent.MakeMetrics(time.Minute)

--- a/pkg/kv/bulk/kv_buf_test.go
+++ b/pkg/kv/bulk/kv_buf_test.go
@@ -51,10 +51,11 @@ func TestKvBuf(t *testing.T) {
 	src, totalSize := makeTestData(50000)
 
 	ctx := context.Background()
-	noneMonitor := mon.NewMonitor(mon.Options{Name: "none"})
+	noneMonitor := mon.NewMonitor(mon.Options{Name: mon.MakeMonitorName("none")})
 	noneMonitor.StartNoReserved(ctx, nil /* pool */)
 	none := noneMonitor.MakeEarmarkedBoundAccount()
-	lots := mon.NewUnlimitedMonitor(ctx, mon.Options{Name: "lots"}).MakeEarmarkedBoundAccount()
+	lots := mon.NewUnlimitedMonitor(ctx, mon.Options{Name: mon.MakeMonitorName("lots")}).
+		MakeEarmarkedBoundAccount()
 
 	// Write everything to our buf.
 	b := kvBuf{}

--- a/pkg/kv/bulk/sst_batcher_test.go
+++ b/pkg/kv/bulk/sst_batcher_test.go
@@ -47,7 +47,7 @@ func TestDuplicateHandling(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	mem := mon.NewUnlimitedMonitor(ctx, mon.Options{Name: "lots"})
+	mem := mon.NewUnlimitedMonitor(ctx, mon.Options{Name: mon.MakeMonitorName("lots")})
 	reqs := limit.MakeConcurrentRequestLimiter("reqs", 1000)
 	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
@@ -307,7 +307,7 @@ func runTestImport(t *testing.T, batchSizeValue int64) {
 			))
 
 			ts := hlc.Timestamp{WallTime: 100}
-			mem := mon.NewUnlimitedMonitor(ctx, mon.Options{Name: "lots"})
+			mem := mon.NewUnlimitedMonitor(ctx, mon.Options{Name: mon.MakeMonitorName("lots")})
 			reqs := limit.MakeConcurrentRequestLimiter("reqs", 1000)
 			b, err := bulk.MakeBulkAdder(
 				ctx, kvDB, mockCache, s.ClusterSettings(), ts,
@@ -373,7 +373,7 @@ func TestImportEpochIngestion(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	mem := mon.NewUnlimitedMonitor(ctx, mon.Options{Name: "lots"})
+	mem := mon.NewUnlimitedMonitor(ctx, mon.Options{Name: mon.MakeMonitorName("lots")})
 	reqs := limit.MakeConcurrentRequestLimiter("reqs", 1000)
 	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)

--- a/pkg/kv/kvclient/kvstreamer/results_buffer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/results_buffer_test.go
@@ -44,7 +44,7 @@ func TestInOrderResultsBuffer(t *testing.T) {
 	require.NoError(t, err)
 	defer tempEngine.Close()
 	memMonitor := mon.NewMonitor(mon.Options{
-		Name:     "test-mem",
+		Name:     mon.MakeMonitorName("test-mem"),
 		Res:      mon.MemoryResource,
 		Settings: st,
 	})
@@ -52,7 +52,7 @@ func TestInOrderResultsBuffer(t *testing.T) {
 	defer memMonitor.Stop(ctx)
 	memAcc := memMonitor.MakeBoundAccount()
 	diskMonitor := mon.NewMonitor(mon.Options{
-		Name:     "test-disk",
+		Name:     mon.MakeMonitorName("test-disk"),
 		Res:      mon.DiskResource,
 		Settings: st,
 	})

--- a/pkg/kv/kvclient/kvstreamer/streamer_accounting_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_accounting_test.go
@@ -64,7 +64,7 @@ func TestStreamerMemoryAccounting(t *testing.T) {
 	}
 
 	monitor := mon.NewMonitor(mon.Options{
-		Name:     "streamer",
+		Name:     mon.MakeMonitorName("streamer"),
 		Settings: cluster.MakeTestingClusterSettings(),
 	})
 	monitor.Start(ctx, nil /* pool */, mon.NewStandaloneBudget(math.MaxInt64))

--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -193,7 +193,7 @@ func TestStreamerBudgetErrorInEnqueue(t *testing.T) {
 	// Imitate a root SQL memory monitor with 1MiB size.
 	const rootPoolSize = 1 << 20 /* 1MiB */
 	rootMemMonitor := mon.NewMonitor(mon.Options{
-		Name:     "root",
+		Name:     mon.MakeMonitorName("root"),
 		Settings: cluster.MakeTestingClusterSettings(),
 	})
 	rootMemMonitor.Start(ctx, nil /* pool */, mon.NewStandaloneBudget(rootPoolSize))

--- a/pkg/kv/kvclient/rangefeed/db_adapter_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/db_adapter_external_test.go
@@ -34,7 +34,7 @@ import (
 
 func startMonitorWithBudget(budget int64) *mon.BytesMonitor {
 	mm := mon.NewMonitor(mon.Options{
-		Name:      "test-mm",
+		Name:      mon.MakeMonitorName("test-mm"),
 		Limit:     budget,
 		Increment: 128, /* small allocation increment */
 		Settings:  cluster.MakeTestingClusterSettings(),

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -993,7 +993,7 @@ func (c *cluster) detectDeadlocks() {
 						if i > 0 {
 							chainBuf.WriteString("->")
 						}
-						chainBuf.WriteString(id.Short())
+						chainBuf.WriteString(id.Short().String())
 					}
 					log.Eventf(origPush.ctx, "dependency cycle detected %s", redact.Safe(chainBuf.String()))
 				}

--- a/pkg/kv/kvserver/rangefeed/budget_test.go
+++ b/pkg/kv/kvserver/rangefeed/budget_test.go
@@ -17,7 +17,7 @@ import (
 
 func getMemoryMonitor(s *cluster.Settings) *mon.BytesMonitor {
 	return mon.NewMonitor(mon.Options{
-		Name:      "rangefeed",
+		Name:      mon.MakeMonitorName("rangefeed"),
 		Increment: 1,
 		Settings:  s,
 	})

--- a/pkg/kv/kvserver/rangefeed/event_queue_test.go
+++ b/pkg/kv/kvserver/rangefeed/event_queue_test.go
@@ -135,7 +135,7 @@ func TestEventQueue(t *testing.T) {
 		ctx := context.Background()
 		s := cluster.MakeTestingClusterSettings()
 		m := mon.NewMonitor(mon.Options{
-			Name:      "rangefeed",
+			Name:      mon.MakeMonitorName("rangefeed"),
 			Increment: 1,
 			Settings:  s,
 		})

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -1091,7 +1091,7 @@ func TestBudgetReleaseOnProcessorStop(t *testing.T) {
 	testutils.RunValues(t, "feed type", testTypes, func(t *testing.T, rt rangefeedTestType) {
 		s := cluster.MakeTestingClusterSettings()
 		m := mon.NewMonitor(mon.Options{
-			Name:      "rangefeed",
+			Name:      mon.MakeMonitorName("rangefeed"),
 			Res:       mon.MemoryResource,
 			Increment: 1,
 			Limit:     math.MaxInt64,

--- a/pkg/kv/kvserver/replica_tscache.go
+++ b/pkg/kv/kvserver/replica_tscache.go
@@ -452,7 +452,7 @@ func (r *Replica) applyTimestampCache(
 		} else {
 			conflictMsg := "conflicting txn unknown"
 			if conflictingTxn != uuid.Nil {
-				conflictMsg = "conflicting txn: " + conflictingTxn.Short()
+				conflictMsg = "conflicting txn: " + conflictingTxn.Short().String()
 			}
 			log.VEventf(ctx, 2, "bumped write timestamp to %s; %s", bumpedTS, redact.Safe(conflictMsg))
 		}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1546,7 +1546,7 @@ func NewStore(
 	s.replRankingsByTenant = NewReplicaRankingsMap()
 
 	s.raftRecvQueues.mon = mon.NewUnlimitedMonitor(ctx, mon.Options{
-		Name:     "raft-receive-queue",
+		Name:     mon.MakeMonitorName("raft-receive-queue"),
 		CurCount: s.metrics.RaftRcvdQueuedBytes,
 		Settings: cfg.Settings,
 	})

--- a/pkg/kv/kvserver/store_raft_test.go
+++ b/pkg/kv/kvserver/store_raft_test.go
@@ -36,7 +36,7 @@ func TestRaftReceiveQueue(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	g := metric.NewGauge(metric.Metadata{})
 	m := mon.NewUnlimitedMonitor(context.Background(), mon.Options{
-		Name:     "test",
+		Name:     mon.MakeMonitorName("test"),
 		CurCount: g,
 		Settings: st,
 	})

--- a/pkg/kv/kvserver/ts_maintenance_queue.go
+++ b/pkg/kv/kvserver/ts_maintenance_queue.go
@@ -92,7 +92,7 @@ func newTimeSeriesMaintenanceQueue(
 		replicaCountFn: store.ReplicaCount,
 		db:             db,
 		mem: mon.NewUnlimitedMonitor(context.Background(), mon.Options{
-			Name:     "timeseries-maintenance-queue",
+			Name:     mon.MakeMonitorName("timeseries-maintenance-queue"),
 			Settings: store.cfg.Settings,
 		}),
 	}

--- a/pkg/kv/kvserver/ts_maintenance_queue_test.go
+++ b/pkg/kv/kvserver/ts_maintenance_queue_test.go
@@ -282,7 +282,7 @@ func TestTimeSeriesMaintenanceQueueServer(t *testing.T) {
 	}
 
 	memMon := mon.NewMonitor(mon.Options{
-		Name:     "test",
+		Name:     mon.MakeMonitorName("test"),
 		Settings: cluster.MakeTestingClusterSettings(),
 	})
 	memMon.Start(context.Background(), nil /* pool */, mon.NewStandaloneBudget(math.MaxInt64))

--- a/pkg/kv/kvserver/txnwait/queue.go
+++ b/pkg/kv/kvserver/txnwait/queue.go
@@ -543,7 +543,7 @@ func (q *Queue) MaybeWaitForPush(
 
 	pusherStr := "non-txn"
 	if req.PusherTxn.ID != (uuid.UUID{}) {
-		pusherStr = req.PusherTxn.ID.Short()
+		pusherStr = req.PusherTxn.ID.Short().String()
 	}
 	log.VEventf(
 		ctx,
@@ -729,7 +729,7 @@ func (q *Queue) waitForPush(
 			_, haveDependency := push.mu.dependents[req.PusheeTxn.ID]
 			dependents := make([]string, 0, len(push.mu.dependents))
 			for id := range push.mu.dependents {
-				dependents = append(dependents, id.Short())
+				dependents = append(dependents, id.Short().String())
 			}
 			log.VEventf(
 				ctx,

--- a/pkg/security/cert_expiry_cache_test.go
+++ b/pkg/security/cert_expiry_cache_test.go
@@ -226,7 +226,7 @@ func newCache(
 	defer stopper.Stop(ctx)
 	security.ClientCertExpirationCacheCapacity.Override(ctx, &st.SV, int64(capacity))
 	parentMon := mon.NewUnlimitedMonitor(ctx, mon.Options{
-		Name:     "test",
+		Name:     mon.MakeMonitorName("test"),
 		Settings: st,
 	})
 	cache := security.NewClientCertExpirationCache(ctx, st, stopper, clock, parentMon)

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -226,7 +226,7 @@ func newAdminServer(
 	// TODO(knz): We do not limit memory usage by admin operations
 	// yet. Is this wise?
 	server.memMonitor = mon.NewUnlimitedMonitor(context.Background(), mon.Options{
-		Name:     "admin",
+		Name:     mon.MakeMonitorName("admin"),
 		Settings: cs,
 	})
 	return server

--- a/pkg/server/profiler/memory_monitoring_profiler_test.go
+++ b/pkg/server/profiler/memory_monitoring_profiler_test.go
@@ -21,7 +21,7 @@ func addMonitor(
 	t *testing.T,
 	ctx context.Context,
 	st *cluster.Settings,
-	name redact.RedactableString,
+	name redact.SafeString,
 	parent *mon.BytesMonitor,
 	usedBytes int64,
 	reservedBytes int64,

--- a/pkg/server/profiler/memory_monitoring_profiler_test.go
+++ b/pkg/server/profiler/memory_monitoring_profiler_test.go
@@ -21,13 +21,13 @@ func addMonitor(
 	t *testing.T,
 	ctx context.Context,
 	st *cluster.Settings,
-	name string,
+	name redact.RedactableString,
 	parent *mon.BytesMonitor,
 	usedBytes int64,
 	reservedBytes int64,
 ) *mon.BytesMonitor {
 	m := mon.NewMonitor(mon.Options{
-		Name:      redact.RedactableString(name),
+		Name:      mon.MakeMonitorName(name),
 		Increment: 1,
 		Settings:  st,
 	})

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -437,7 +437,7 @@ var vmoduleSetting = settings.RegisterStringSetting(
 func newRootSQLMemoryMonitor(opts monitorAndMetricsOptions) monitorAndMetrics {
 	rootSQLMetrics := sql.MakeBaseMemMetrics("root", opts.histogramWindowInterval)
 	rootSQLMemoryMonitor := mon.NewMonitor(mon.Options{
-		Name:     "root",
+		Name:     mon.MakeMonitorName("root"),
 		CurCount: rootSQLMetrics.CurBytesCount,
 		MaxHist:  rootSQLMetrics.MaxBytesHist,
 		Settings: opts.settings,
@@ -1178,7 +1178,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	// returning the memory allocated to internalDBMonitor since the
 	// parent monitor is being closed anyway.
 	internalDBMonitor := mon.NewMonitor(mon.Options{
-		Name:       "internal sql executor",
+		Name:       mon.MakeMonitorName("internal sql executor"),
 		CurCount:   internalMemMetrics.CurBytesCount,
 		MaxHist:    internalMemMetrics.MaxBytesHist,
 		Settings:   cfg.Settings,

--- a/pkg/sql/buffer.go
+++ b/pkg/sql/buffer.go
@@ -26,13 +26,14 @@ type bufferNode struct {
 	currentRow tree.Datums
 
 	// label is a string used to describe the node in an EXPLAIN plan.
-	// TODO(yuzefovich): make this redact.RedactableString.
+	// TODO(yuzefovich/mgartner): make this redact.SafeString.
 	label string
 }
 
 func (n *bufferNode) startExec(params runParams) error {
 	n.typs = planTypes(n.plan)
-	n.rows.Init(params.ctx, n.typs, params.extendedEvalCtx, redact.Sprint(n.label))
+	n.rows.Init(params.ctx, n.typs, params.extendedEvalCtx,
+		redact.SafeString(redact.Sprint(n.label).Redact()))
 	return nil
 }
 

--- a/pkg/sql/buffer_util.go
+++ b/pkg/sql/buffer_util.go
@@ -31,10 +31,7 @@ type rowContainerHelper struct {
 }
 
 func (c *rowContainerHelper) Init(
-	ctx context.Context,
-	typs []*types.T,
-	evalContext *extendedEvalContext,
-	opName redact.RedactableString,
+	ctx context.Context, typs []*types.T, evalContext *extendedEvalContext, opName redact.SafeString,
 ) {
 	c.initMonitors(ctx, evalContext, opName)
 	distSQLCfg := &evalContext.DistSQLPlanner.distSQLSrv.ServerConfig
@@ -49,10 +46,7 @@ func (c *rowContainerHelper) Init(
 // InitWithDedup is a variant of init that is used if row deduplication
 // functionality is needed (see addRowWithDedup).
 func (c *rowContainerHelper) InitWithDedup(
-	ctx context.Context,
-	typs []*types.T,
-	evalContext *extendedEvalContext,
-	opName redact.RedactableString,
+	ctx context.Context, typs []*types.T, evalContext *extendedEvalContext, opName redact.SafeString,
 ) {
 	c.initMonitors(ctx, evalContext, opName)
 	distSQLCfg := &evalContext.DistSQLPlanner.distSQLSrv.ServerConfig
@@ -81,7 +75,7 @@ func (c *rowContainerHelper) InitWithParentMon(
 	typs []*types.T,
 	parent *mon.BytesMonitor,
 	evalContext *extendedEvalContext,
-	opName redact.RedactableString,
+	opName redact.SafeString,
 ) {
 	distSQLCfg := &evalContext.DistSQLPlanner.distSQLSrv.ServerConfig
 	// TODO(yuzefovich): currently the memory usage of c.memMonitor and
@@ -89,13 +83,13 @@ func (c *rowContainerHelper) InitWithParentMon(
 	// Fix it.
 	c.memMonitor = execinfra.NewLimitedMonitorNoFlowCtx(
 		ctx, parent, distSQLCfg, evalContext.SessionData(),
-		redact.Sprintf("%s-limited", opName),
+		opName+"-limited",
 	)
 	c.unlimitedMemMonitor = execinfra.NewMonitor(
-		ctx, parent, redact.Sprintf("%s-unlimited", opName),
+		ctx, parent, opName+"-unlimited",
 	)
 	c.diskMonitor = execinfra.NewMonitor(
-		ctx, distSQLCfg.ParentDiskMonitor, redact.Sprintf("%s-disk", opName),
+		ctx, distSQLCfg.ParentDiskMonitor, opName+"-disk",
 	)
 	c.rows = &rowcontainer.DiskBackedRowContainer{}
 	c.rows.Init(
@@ -106,7 +100,7 @@ func (c *rowContainerHelper) InitWithParentMon(
 }
 
 func (c *rowContainerHelper) initMonitors(
-	ctx context.Context, evalContext *extendedEvalContext, opName redact.RedactableString,
+	ctx context.Context, evalContext *extendedEvalContext, opName redact.SafeString,
 ) {
 	distSQLCfg := &evalContext.DistSQLPlanner.distSQLSrv.ServerConfig
 	// TODO(yuzefovich): currently the memory usage of c.memMonitor and
@@ -114,13 +108,13 @@ func (c *rowContainerHelper) initMonitors(
 	// Fix it.
 	c.memMonitor = execinfra.NewLimitedMonitorNoFlowCtx(
 		ctx, evalContext.Planner.Mon(), distSQLCfg, evalContext.SessionData(),
-		redact.Sprintf("%s-limited", opName),
+		opName+"-limited",
 	)
 	c.unlimitedMemMonitor = execinfra.NewMonitor(
-		ctx, evalContext.Planner.Mon(), redact.Sprintf("%s-unlimited", opName),
+		ctx, evalContext.Planner.Mon(), opName+"-unlimited",
 	)
 	c.diskMonitor = execinfra.NewMonitor(
-		ctx, distSQLCfg.ParentDiskMonitor, redact.Sprintf("%s-disk", opName),
+		ctx, distSQLCfg.ParentDiskMonitor, opName+"-disk",
 	)
 }
 

--- a/pkg/sql/cacheutil/cache_test.go
+++ b/pkg/sql/cacheutil/cache_test.go
@@ -21,7 +21,7 @@ import (
 func TestCache(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	memoryMonitor := mon.NewMonitor(mon.Options{
-		Name:     "test-mem",
+		Name:     mon.MakeMonitorName("test-mem"),
 		Settings: st,
 	})
 	stopper := &stop.Stopper{}

--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -599,7 +599,7 @@ func TestCollectionProperlyUsesMemoryMonitoring(t *testing.T) {
 
 	// Create a monitor to be used to track memory usage in a Collection.
 	monitor := mon.NewMonitor(mon.Options{
-		Name:     "test_monitor",
+		Name:     mon.MakeMonitorName("test_monitor"),
 		Settings: cluster.MakeTestingClusterSettings(),
 	})
 
@@ -1240,7 +1240,7 @@ func TestDescriptorErrorWrap(t *testing.T) {
 	tdb.Exec(t, `CREATE TABLE db.schema.table()`)
 
 	monitor := mon.NewMonitor(mon.Options{
-		Name:     "test_monitor",
+		Name:     mon.MakeMonitorName("test_monitor"),
 		Settings: cluster.MakeTestingClusterSettings(),
 	})
 	monitor.Start(ctx, nil, mon.NewStandaloneBudget(1))

--- a/pkg/sql/catalog/descs/factory.go
+++ b/pkg/sql/catalog/descs/factory.go
@@ -82,7 +82,7 @@ func NewCollectionFactory(
 		spanConfigSplitter: spanConfigSplitter,
 		spanConfigLimiter:  spanConfigLimiter,
 		defaultMonitor: mon.NewUnlimitedMonitor(ctx, mon.Options{
-			Name:     "CollectionFactoryDefaultUnlimitedMonitor",
+			Name:     mon.MakeMonitorName("CollectionFactoryDefaultUnlimitedMonitor"),
 			Settings: settings,
 		}),
 		defaultDescriptorSessionDataProvider: defaultDescriptorSessionDataProvider,

--- a/pkg/sql/closed_session_cache_test.go
+++ b/pkg/sql/closed_session_cache_test.go
@@ -46,7 +46,7 @@ func TestSessionCacheBasic(t *testing.T) {
 
 				st := &cluster.Settings{}
 				monitor := mon.NewUnlimitedMonitor(ctx, mon.Options{
-					Name:     "test",
+					Name:     mon.MakeMonitorName("test"),
 					Settings: st,
 				})
 				cache = NewClosedSessionCache(st, monitor, time.Now)

--- a/pkg/sql/colexec/colexecargs/monitor_registry.go
+++ b/pkg/sql/colexec/colexecargs/monitor_registry.go
@@ -103,7 +103,7 @@ func (r *MonitorRegistry) CreateExtraMemAccountForSpillStrategy(
 	// Iterate backwards since most likely that we want to create an account
 	// bound to the most recently created monitor.
 	for i := len(r.monitors) - 1; i >= 0; i-- {
-		if r.monitors[i].Name() == monitorName {
+		if r.monitors[i].Name() == mon.MakeMonitorName(redact.RedactableString(monitorName)) {
 			bufferingMemAccount := r.monitors[i].MakeBoundAccount()
 			r.accounts = append(r.accounts, &bufferingMemAccount)
 			return &bufferingMemAccount
@@ -220,7 +220,7 @@ func (r *MonitorRegistry) AssertInvariants() {
 	// Check that all memory monitor names are unique (colexec.diskSpillerBase
 	// relies on this in order to catch "memory budget exceeded" errors only
 	// from "its own" component).
-	names := make(map[string]struct{}, len(r.monitors))
+	names := make(map[mon.MonitorName]struct{}, len(r.monitors))
 	for _, m := range r.monitors {
 		if _, seen := names[m.Name()]; seen {
 			colexecerror.InternalError(errors.AssertionFailedf("monitor named %q encountered twice", m.Name()))

--- a/pkg/sql/colexec/colexecargs/monitor_registry.go
+++ b/pkg/sql/colexec/colexecargs/monitor_registry.go
@@ -39,10 +39,10 @@ func (r *MonitorRegistry) NewStreamingMemAccount(flowCtx *execinfra.FlowCtx) *mo
 // getMemMonitorName returns a unique (for this MonitorRegistry) memory monitor
 // name.
 func (r *MonitorRegistry) getMemMonitorName(
-	opName redact.RedactableString, processorID int32, suffix redact.RedactableString,
-) redact.RedactableString {
-	return opName + "-" + redact.RedactableString(strconv.Itoa(int(processorID))) + "-" +
-		suffix + "-" + redact.RedactableString(strconv.Itoa(len(r.monitors)))
+	opName redact.SafeString, processorID int32, suffix redact.SafeString,
+) redact.SafeString {
+	return opName + "-" + redact.SafeString(strconv.Itoa(int(processorID))) + "-" +
+		suffix + "-" + redact.SafeString(strconv.Itoa(len(r.monitors)))
 }
 
 // CreateMemAccountForSpillStrategy instantiates a memory monitor and a memory
@@ -51,11 +51,8 @@ func (r *MonitorRegistry) getMemMonitorName(
 // used, this will be 1. The receiver is updated to have references to both
 // objects. Memory monitor name is also returned.
 func (r *MonitorRegistry) CreateMemAccountForSpillStrategy(
-	ctx context.Context,
-	flowCtx *execinfra.FlowCtx,
-	opName redact.RedactableString,
-	processorID int32,
-) (*mon.BoundAccount, redact.RedactableString) {
+	ctx context.Context, flowCtx *execinfra.FlowCtx, opName redact.SafeString, processorID int32,
+) (*mon.BoundAccount, redact.SafeString) {
 	monitorName := r.getMemMonitorName(opName, processorID, "limited" /* suffix */)
 	bufferingOpMemMonitor := execinfra.NewLimitedMonitor(
 		ctx, flowCtx.Mon, flowCtx, monitorName,
@@ -74,9 +71,9 @@ func (r *MonitorRegistry) CreateMemAccountForSpillStrategyWithLimit(
 	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	limit int64,
-	opName redact.RedactableString,
+	opName redact.SafeString,
 	processorID int32,
-) (*mon.BoundAccount, redact.RedactableString) {
+) (*mon.BoundAccount, redact.SafeString) {
 	if flowCtx.Cfg.TestingKnobs.ForceDiskSpill {
 		if limit != 1 {
 			colexecerror.InternalError(errors.AssertionFailedf(
@@ -98,12 +95,12 @@ func (r *MonitorRegistry) CreateMemAccountForSpillStrategyWithLimit(
 // is expected that such a monitor with a such name was already created by the
 // MonitorRegistry. If no such monitor is found, then nil is returned.
 func (r *MonitorRegistry) CreateExtraMemAccountForSpillStrategy(
-	monitorName string,
+	monitorName redact.SafeString,
 ) *mon.BoundAccount {
 	// Iterate backwards since most likely that we want to create an account
 	// bound to the most recently created monitor.
 	for i := len(r.monitors) - 1; i >= 0; i-- {
-		if r.monitors[i].Name() == mon.MakeMonitorName(redact.RedactableString(monitorName)) {
+		if r.monitors[i].Name() == mon.MakeMonitorName(monitorName) {
 			bufferingMemAccount := r.monitors[i].MakeBoundAccount()
 			r.accounts = append(r.accounts, &bufferingMemAccount)
 			return &bufferingMemAccount
@@ -123,7 +120,7 @@ func (r *MonitorRegistry) CreateExtraMemAccountForSpillStrategy(
 func (r *MonitorRegistry) CreateUnlimitedMemAccounts(
 	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
-	opName redact.RedactableString,
+	opName redact.SafeString,
 	processorID int32,
 	numAccounts int,
 ) []*mon.BoundAccount {
@@ -135,10 +132,7 @@ func (r *MonitorRegistry) CreateUnlimitedMemAccounts(
 // CreateUnlimitedMemAccount is a light wrapper around
 // CreateUnlimitedMemAccounts when only a single account is desired.
 func (r *MonitorRegistry) CreateUnlimitedMemAccount(
-	ctx context.Context,
-	flowCtx *execinfra.FlowCtx,
-	opName redact.RedactableString,
-	processorID int32,
+	ctx context.Context, flowCtx *execinfra.FlowCtx, opName redact.SafeString, processorID int32,
 ) *mon.BoundAccount {
 	return r.CreateUnlimitedMemAccounts(ctx, flowCtx, opName, processorID, 1 /* numAccounts */)[0]
 }
@@ -146,16 +140,13 @@ func (r *MonitorRegistry) CreateUnlimitedMemAccount(
 // CreateUnlimitedMemAccountsWithName is similar to CreateUnlimitedMemAccounts
 // with the only difference that the monitor name is provided by the caller.
 func (r *MonitorRegistry) CreateUnlimitedMemAccountsWithName(
-	ctx context.Context, flowCtx *execinfra.FlowCtx, name redact.RedactableString, numAccounts int,
+	ctx context.Context, flowCtx *execinfra.FlowCtx, name redact.SafeString, numAccounts int,
 ) (*mon.BytesMonitor, []*mon.BoundAccount) {
 	return r.createUnlimitedMemAccounts(ctx, flowCtx, name+"-unlimited", numAccounts)
 }
 
 func (r *MonitorRegistry) createUnlimitedMemAccounts(
-	ctx context.Context,
-	flowCtx *execinfra.FlowCtx,
-	monitorName redact.RedactableString,
-	numAccounts int,
+	ctx context.Context, flowCtx *execinfra.FlowCtx, monitorName redact.SafeString, numAccounts int,
 ) (*mon.BytesMonitor, []*mon.BoundAccount) {
 	bufferingOpUnlimitedMemMonitor := execinfra.NewMonitor(
 		ctx, flowCtx.Mon, monitorName,
@@ -171,10 +162,7 @@ func (r *MonitorRegistry) createUnlimitedMemAccounts(
 
 // CreateDiskMonitor instantiates an unlimited disk monitor.
 func (r *MonitorRegistry) CreateDiskMonitor(
-	ctx context.Context,
-	flowCtx *execinfra.FlowCtx,
-	opName redact.RedactableString,
-	processorID int32,
+	ctx context.Context, flowCtx *execinfra.FlowCtx, opName redact.SafeString, processorID int32,
 ) *mon.BytesMonitor {
 	monitorName := r.getMemMonitorName(opName, processorID, "disk" /* suffix */)
 	opDiskMonitor := execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, monitorName)
@@ -188,10 +176,7 @@ func (r *MonitorRegistry) CreateDiskMonitor(
 // Note that the memory monitor name is not returned (unlike above) because no
 // caller actually needs it.
 func (r *MonitorRegistry) CreateDiskAccount(
-	ctx context.Context,
-	flowCtx *execinfra.FlowCtx,
-	opName redact.RedactableString,
-	processorID int32,
+	ctx context.Context, flowCtx *execinfra.FlowCtx, opName redact.SafeString, processorID int32,
 ) *mon.BoundAccount {
 	opDiskMonitor := r.CreateDiskMonitor(ctx, flowCtx, opName, processorID)
 	opDiskAccount := opDiskMonitor.MakeBoundAccount()
@@ -202,7 +187,7 @@ func (r *MonitorRegistry) CreateDiskAccount(
 // CreateDiskAccounts instantiates an unlimited disk monitor and disk accounts
 // to be used for disk spilling infrastructure in vectorized engine.
 func (r *MonitorRegistry) CreateDiskAccounts(
-	ctx context.Context, flowCtx *execinfra.FlowCtx, name redact.RedactableString, numAccounts int,
+	ctx context.Context, flowCtx *execinfra.FlowCtx, name redact.SafeString, numAccounts int,
 ) (*mon.BytesMonitor, []*mon.BoundAccount) {
 	diskMonitor := execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, name)
 	r.monitors = append(r.monitors, diskMonitor)

--- a/pkg/sql/colexec/colexecdisk/disk_spiller.go
+++ b/pkg/sql/colexec/colexecdisk/disk_spiller.go
@@ -75,7 +75,7 @@ import (
 func NewOneInputDiskSpiller(
 	input colexecop.Operator,
 	inMemoryOp colexecop.BufferingInMemoryOperator,
-	inMemoryMemMonitorName redact.RedactableString,
+	inMemoryMemMonitorName redact.SafeString,
 	diskBackedOpConstructor func(input colexecop.Operator) colexecop.Operator,
 	diskBackedReuseMode colexecop.BufferingOpReuseMode,
 	spillingCallbackFn func(),
@@ -143,7 +143,7 @@ func NewOneInputDiskSpiller(
 func NewTwoInputDiskSpiller(
 	inputOne, inputTwo colexecop.Operator,
 	inMemoryOp colexecop.BufferingInMemoryOperator,
-	inMemoryMemMonitorNames []redact.RedactableString,
+	inMemoryMemMonitorNames []redact.SafeString,
 	diskBackedOpConstructor func(inputOne, inputTwo colexecop.Operator) colexecop.Operator,
 	spillingCallbackFn func(),
 ) colexecop.ClosableOperator {

--- a/pkg/sql/colfetcher/cfetcher_wrapper.go
+++ b/pkg/sql/colfetcher/cfetcher_wrapper.go
@@ -245,7 +245,7 @@ func newCFetcherWrapper(
 	// the cFetcherWrapper is responsible for performing the correct accounting
 	// against the memory account provided by the caller.
 	detachedFetcherMon := mon.NewMonitor(mon.Options{
-		Name:     "cfetcher-wrapper-detached-monitor",
+		Name:     mon.MakeMonitorName("cfetcher-wrapper-detached-monitor"),
 		Settings: st,
 	})
 	detachedFetcherMon.Start(ctx, nil /* pool */, mon.NewStandaloneBudget(math.MaxInt64))

--- a/pkg/sql/colflow/draining_test.go
+++ b/pkg/sql/colflow/draining_test.go
@@ -36,7 +36,7 @@ func TestDrainingAfterRemoteError(t *testing.T) {
 	// This ensures that the query will run into "out of temporary storage"
 	// error.
 	diskMonitor := mon.NewMonitor(mon.Options{
-		Name:     "test-disk",
+		Name:     mon.MakeMonitorName("test-disk"),
 		Res:      mon.DiskResource,
 		Settings: st,
 	})

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -791,13 +792,14 @@ func (s *vectorizedFlowCreator) setupRouter(
 	}
 
 	// HashRouter memory monitor names are the concatenated output stream IDs.
-	var streamIDs redact.RedactableString
+	var sb strings.Builder
 	for i, s := range output.Streams {
 		if i > 0 {
-			streamIDs = streamIDs + ","
+			sb.WriteByte(',')
 		}
-		streamIDs = redact.Sprintf("%s%d", streamIDs, s.StreamID)
+		sb.WriteString(s.StreamID.String())
 	}
+	streamIDs := redact.SafeString(sb.String())
 	mmName := "hash-router-[" + streamIDs + "]"
 
 	numOutputs := len(output.Streams)

--- a/pkg/sql/colflow/vectorized_flow_space_test.go
+++ b/pkg/sql/colflow/vectorized_flow_space_test.go
@@ -74,7 +74,7 @@ func TestVectorizeInternalMemorySpaceError(t *testing.T) {
 					sources = append(sources, colexecutils.NewFixedNumTuplesNoInputOp(testAllocator, 0 /* numTuples */, nil /* opToInitialize */))
 				}
 				memMon := mon.NewMonitor(mon.Options{
-					Name:     "MemoryMonitor",
+					Name:     mon.MakeMonitorName("MemoryMonitor"),
 					Settings: st,
 				})
 				if success {
@@ -202,7 +202,7 @@ func TestVectorizeAllocatorSpaceError(t *testing.T) {
 					sources = append(sources, colexecop.NewRepeatableBatchSource(testAllocator, batch, typs))
 				}
 				memMon := mon.NewMonitor(mon.Options{
-					Name:     "MemoryMonitor",
+					Name:     mon.MakeMonitorName("MemoryMonitor"),
 					Settings: st,
 				})
 				flowCtx.Cfg.TestingKnobs = execinfra.TestingKnobs{}

--- a/pkg/sql/colmem/adjust_memory_usage_test.go
+++ b/pkg/sql/colmem/adjust_memory_usage_test.go
@@ -37,7 +37,7 @@ func TestAdjustMemoryUsage(t *testing.T) {
 	limitedMemMonitorName := "test-limited"
 	limit := int64(100000)
 	limitedMemMonitor := mon.NewMonitorInheritWithLimit(
-		redact.RedactableString(limitedMemMonitorName), limit, unlimitedMemMonitor, false, /* longLiving */
+		redact.SafeString(limitedMemMonitorName), limit, unlimitedMemMonitor, false, /* longLiving */
 	)
 	limitedMemMonitor.StartNoReserved(ctx, unlimitedMemMonitor)
 	defer limitedMemMonitor.Stop(ctx)

--- a/pkg/sql/colmem/allocator_test.go
+++ b/pkg/sql/colmem/allocator_test.go
@@ -42,7 +42,7 @@ func getAllocator(increment int64) (_ *colmem.Allocator, _ *mon.BoundAccount, cl
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	testMemMonitor := mon.NewMonitor(mon.Options{
-		Name:      "test-mem",
+		Name:      mon.MakeMonitorName("test-mem"),
 		Increment: increment,
 		Settings:  st,
 	})

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1030,19 +1030,19 @@ func (s *Server) newConnExecutor(
 	// Create the various monitors.
 	// The session monitors are started in activate().
 	sessionRootMon := mon.NewMonitor(mon.Options{
-		Name:     "session root",
+		Name:     mon.MakeMonitorName("session root"),
 		CurCount: memMetrics.CurBytesCount,
 		MaxHist:  memMetrics.MaxBytesHist,
 		Settings: s.cfg.Settings,
 	})
 	sessionMon := mon.NewMonitor(mon.Options{
-		Name:     "session",
+		Name:     mon.MakeMonitorName("session"),
 		CurCount: memMetrics.SessionCurBytesCount,
 		MaxHist:  memMetrics.SessionMaxBytesHist,
 		Settings: s.cfg.Settings,
 	})
 	sessionPreparedMon := mon.NewMonitor(mon.Options{
-		Name:      "session prepared statements",
+		Name:      mon.MakeMonitorName("session prepared statements"),
 		CurCount:  memMetrics.SessionPreparedCurBytesCount,
 		MaxHist:   memMetrics.SessionPreparedMaxBytesHist,
 		Increment: 1024,
@@ -1050,7 +1050,7 @@ func (s *Server) newConnExecutor(
 	})
 	// The txn monitor is started in txnState.resetForNewSQLTxn().
 	txnMon := mon.NewMonitor(mon.Options{
-		Name:     "txn",
+		Name:     mon.MakeMonitorName("txn"),
 		CurCount: memMetrics.TxnCurBytesCount,
 		MaxHist:  memMetrics.TxnMaxBytesHist,
 		Settings: s.cfg.Settings,

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -287,7 +287,7 @@ func startConnExecutor(
 	defer tempEngine.Close()
 	ambientCtx := log.MakeTestingAmbientCtxWithNewTracer()
 	pool := mon.NewUnlimitedMonitor(ctx, mon.Options{
-		Name:     "test",
+		Name:     mon.MakeMonitorName("test"),
 		Settings: st,
 	})
 	// This pool should never be Stop()ed because, if the test is failing, memory

--- a/pkg/sql/copy_from.go
+++ b/pkg/sql/copy_from.go
@@ -518,7 +518,7 @@ func (c *copyMachine) initMonitoring(ctx context.Context, parentMon *mon.BytesMo
 	// Create a monitor for the COPY command so it can be tracked separate from transaction or session.
 	memMetrics := &MemoryMetrics{}
 	c.copyMon = mon.NewMonitor(mon.Options{
-		Name:     "copy",
+		Name:     mon.MakeMonitorName("copy"),
 		CurCount: memMetrics.CurBytesCount,
 		MaxHist:  memMetrics.MaxBytesHist,
 		Settings: c.p.ExecCfg().Settings,

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -8705,7 +8705,7 @@ CREATE TABLE crdb_internal.node_memory_monitors (
 		monitorStateCb := func(monitor mon.MonitorState) error {
 			return addRow(
 				tree.NewDInt(tree.DInt(monitor.Level)),
-				tree.NewDString(monitor.Name),
+				tree.NewDString(monitor.Name.String()),
 				tree.NewDInt(tree.DInt(monitor.ID)),
 				tree.NewDInt(tree.DInt(monitor.ParentID)),
 				tree.NewDInt(tree.DInt(monitor.Used)),

--- a/pkg/sql/delete_preserving_index_test.go
+++ b/pkg/sql/delete_preserving_index_test.go
@@ -624,7 +624,7 @@ func TestMergeProcessor(t *testing.T) {
 		execCfg := server.ExecutorConfig().(sql.ExecutorConfig)
 		evalCtx := eval.Context{Settings: settings, Codec: codec}
 		mm := mon.NewUnlimitedMonitor(ctx, mon.Options{
-			Name:     "MemoryMonitor",
+			Name:     mon.MakeMonitorName("MemoryMonitor"),
 			Settings: settings,
 		})
 		flowCtx := execinfra.FlowCtx{

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -236,7 +236,7 @@ func (ds *ServerImpl) setupFlow(
 	}
 
 	monitor = mon.NewMonitor(mon.Options{
-		Name:     "flow " + redact.RedactableString(req.Flow.FlowID.Short()),
+		Name:     "flow " + redact.RedactableString(req.Flow.FlowID.Short().String()),
 		CurCount: ds.Metrics.CurBytesCount,
 		MaxHist:  ds.Metrics.MaxBytesHist,
 		Settings: ds.Settings,
@@ -366,7 +366,7 @@ func (ds *ServerImpl) setupFlow(
 	}
 
 	if !f.IsLocal() {
-		flowCtx.AmbientContext.AddLogTag("f", flowCtx.ID.Short())
+		flowCtx.AmbientContext.AddLogTag("f", flowCtx.ID.Short().String())
 		if req.JobTag != "" {
 			flowCtx.AmbientContext.AddLogTag("job", req.JobTag)
 		}

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -75,7 +75,7 @@ func NewServer(
 		flowRegistry:      flowinfra.NewFlowRegistry(),
 		remoteFlowRunner:  remoteFlowRunner,
 		memMonitor: mon.NewMonitor(mon.Options{
-			Name: "distsql",
+			Name: mon.MakeMonitorName("distsql"),
 			// Note that we don't use 'sql.mem.distsql.*' metrics here since
 			// that would double count them with the 'flow' monitor in
 			// setupFlow.
@@ -236,7 +236,7 @@ func (ds *ServerImpl) setupFlow(
 	}
 
 	monitor = mon.NewMonitor(mon.Options{
-		Name:     "flow " + redact.RedactableString(req.Flow.FlowID.Short().String()),
+		Name:     mon.MakeMonitorNameWithID("flow ", req.Flow.FlowID.Short()),
 		CurCount: ds.Metrics.CurBytesCount,
 		MaxHist:  ds.Metrics.MaxBytesHist,
 		Settings: ds.Settings,

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -948,7 +948,7 @@ func (pb *ProcessorBaseNoHelper) ConsumerClosed() {
 // memory monitor with the given name and start it. The returned monitor must
 // be closed.
 func NewMonitor(
-	ctx context.Context, parent *mon.BytesMonitor, name redact.RedactableString,
+	ctx context.Context, parent *mon.BytesMonitor, name redact.SafeString,
 ) *mon.BytesMonitor {
 	monitor := mon.NewMonitorInheritWithLimit(name, 0 /* limit */, parent, false /* longLiving */)
 	monitor.StartNoReserved(ctx, parent)
@@ -962,7 +962,7 @@ func NewMonitor(
 // ServerConfig.TestingKnobs.ForceDiskSpill is set or
 // ServerConfig.TestingKnobs.MemoryLimitBytes if not.
 func NewLimitedMonitor(
-	ctx context.Context, parent *mon.BytesMonitor, flowCtx *FlowCtx, name redact.RedactableString,
+	ctx context.Context, parent *mon.BytesMonitor, flowCtx *FlowCtx, name redact.SafeString,
 ) *mon.BytesMonitor {
 	limitedMon := mon.NewMonitorInheritWithLimit(name, GetWorkMemLimit(flowCtx), parent, false /* longLiving */)
 	limitedMon.StartNoReserved(ctx, parent)
@@ -973,7 +973,7 @@ func NewLimitedMonitor(
 // guarantees that the monitor's limit is at least minMemoryLimit bytes.
 // flowCtx.Mon is used as the parent for the new monitor.
 func NewLimitedMonitorWithLowerBound(
-	ctx context.Context, flowCtx *FlowCtx, name redact.RedactableString, minMemoryLimit int64,
+	ctx context.Context, flowCtx *FlowCtx, name redact.SafeString, minMemoryLimit int64,
 ) *mon.BytesMonitor {
 	memoryLimit := GetWorkMemLimit(flowCtx)
 	if memoryLimit < minMemoryLimit {
@@ -991,7 +991,7 @@ func NewLimitedMonitorNoFlowCtx(
 	parent *mon.BytesMonitor,
 	config *ServerConfig,
 	sd *sessiondata.SessionData,
-	name redact.RedactableString,
+	name redact.SafeString,
 ) *mon.BytesMonitor {
 	// Create a fake FlowCtx populating only the required fields.
 	flowCtx := &FlowCtx{

--- a/pkg/sql/execinfra/testutils.go
+++ b/pkg/sql/execinfra/testutils.go
@@ -82,7 +82,7 @@ func (r *RepeatableRowSource) ConsumerClosed() {}
 // moved).
 func NewTestMemMonitor(ctx context.Context, st *cluster.Settings) *mon.BytesMonitor {
 	memMonitor := mon.NewMonitor(mon.Options{
-		Name:     "test-mem",
+		Name:     mon.MakeMonitorName("test-mem"),
 		Settings: st,
 	})
 	memMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
@@ -93,7 +93,7 @@ func NewTestMemMonitor(ctx context.Context, st *cluster.Settings) *mon.BytesMoni
 // tests.
 func NewTestDiskMonitor(ctx context.Context, st *cluster.Settings) *mon.BytesMonitor {
 	diskMonitor := mon.NewMonitor(mon.Options{
-		Name:     "test-disk",
+		Name:     mon.MakeMonitorName("test-disk"),
 		Res:      mon.DiskResource,
 		Settings: st,
 	})

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -86,7 +86,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 
 func newFlowCtxForExplainPurposes(ctx context.Context, p *planner) *execinfra.FlowCtx {
 	monitor := mon.NewMonitor(mon.Options{
-		Name:     "explain",
+		Name:     mon.MakeMonitorName("explain"),
 		Settings: p.execCfg.Settings,
 	})
 	// Note that we do not use planner's monitor here in order to not link any

--- a/pkg/sql/importer/exportparquet_test.go
+++ b/pkg/sql/importer/exportparquet_test.go
@@ -392,7 +392,7 @@ func TestMemoryMonitor(t *testing.T) {
 	// Arrange for a small memory budget.
 	budget := int64(4096)
 	mm := mon.NewMonitor(mon.Options{
-		Name:      "test-mm",
+		Name:      mon.MakeMonitorName("test-mm"),
 		Limit:     budget,
 		Increment: 128, /* small allocation increment */
 		Settings:  cluster.MakeTestingClusterSettings(),

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -180,7 +180,7 @@ func MakeInternalExecutorMemMonitor(
 	memMetrics MemoryMetrics, settings *cluster.Settings,
 ) *mon.BytesMonitor {
 	return mon.NewMonitor(mon.Options{
-		Name:       "internal SQL executor",
+		Name:       mon.MakeMonitorName("internal SQL executor"),
 		CurCount:   memMetrics.CurBytesCount,
 		MaxHist:    memMetrics.MaxBytesHist,
 		Settings:   settings,

--- a/pkg/sql/pgwire/pre_serve.go
+++ b/pkg/sql/pgwire/pre_serve.go
@@ -139,7 +139,7 @@ func NewPreServeConnHandler(
 		getTLSConfig:             getTLSConfig,
 
 		tenantIndependentConnMonitor: mon.NewMonitor(mon.Options{
-			Name:       "pre-conn",
+			Name:       mon.MakeMonitorName("pre-conn"),
 			CurCount:   metrics.PreServeCurBytes,
 			MaxHist:    metrics.PreServeMaxBytes,
 			Increment:  int64(connReservationBatchSize) * baseSQLMemoryBudget,

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -433,7 +433,7 @@ func MakeServer(
 		},
 	}
 	server.sqlMemoryPool = mon.NewMonitor(mon.Options{
-		Name: "sql",
+		Name: mon.MakeMonitorName("sql"),
 		// Note that we don't report metrics on this monitor. The reason for this is
 		// that we report metrics on the sum of all the child monitors of this pool.
 		// This monitor is the "main sql" monitor. It's a child of the root memory
@@ -449,7 +449,7 @@ func MakeServer(
 	server.SQLServer = sql.NewServer(executorConfig, server.sqlMemoryPool)
 
 	server.tenantSpecificConnMonitor = mon.NewMonitor(mon.Options{
-		Name:       "conn",
+		Name:       mon.MakeMonitorName("conn"),
 		CurCount:   server.tenantMetrics.ConnMemMetrics.CurBytesCount,
 		MaxHist:    server.tenantMetrics.ConnMemMetrics.MaxBytesHist,
 		Increment:  int64(connReservationBatchSize) * baseSQLMemoryBudget,

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -353,7 +353,7 @@ func NewInternalPlanner(
 // Returns a cleanup function that must be called once the caller is done with
 // the planner.
 func newInternalPlanner(
-	// TODO(yuzefovich): make this redact.RedactableString.
+	// TODO(yuzefovich/mgartner): make this redact.SafeString.
 	opName string,
 	txn *kv.Txn,
 	user username.SQLUsername,
@@ -403,7 +403,11 @@ func newInternalPlanner(
 	}
 
 	plannerMon := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName(redact.Sprintf("internal-planner.%s.%s", user, opName)),
+		Name: mon.MakeMonitorName(
+			"internal-planner." +
+				redact.SafeString(user.Normalized()) + "." +
+				redact.SafeString(opName),
+		),
 		CurCount: memMetrics.CurBytesCount,
 		MaxHist:  memMetrics.MaxBytesHist,
 		Settings: execCfg.Settings,

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -403,7 +403,7 @@ func newInternalPlanner(
 	}
 
 	plannerMon := mon.NewMonitor(mon.Options{
-		Name:     redact.Sprintf("internal-planner.%s.%s", user, opName),
+		Name:     mon.MakeMonitorName(redact.Sprintf("internal-planner.%s.%s", user, opName)),
 		CurCount: memMetrics.CurBytesCount,
 		MaxHist:  memMetrics.MaxBytesHist,
 		Settings: execCfg.Settings,

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -403,11 +403,7 @@ func newInternalPlanner(
 	}
 
 	plannerMon := mon.NewMonitor(mon.Options{
-		Name: mon.MakeMonitorName(
-			"internal-planner." +
-				redact.SafeString(user.Normalized()) + "." +
-				redact.SafeString(opName),
-		),
+		Name:     mon.MakeMonitorName("internal-planner." + redact.SafeString(opName)),
 		CurCount: memMetrics.CurBytesCount,
 		MaxHist:  memMetrics.MaxBytesHist,
 		Settings: execCfg.Settings,

--- a/pkg/sql/row/fetcher_test.go
+++ b/pkg/sql/row/fetcher_test.go
@@ -347,7 +347,7 @@ func TestRowFetcherMemoryLimits(t *testing.T) {
 	// we can test whether scans of wide tables are prevented if
 	// we have insufficient memory to do them.
 	memMon := mon.NewMonitor(mon.Options{
-		Name:     "test",
+		Name:     mon.MakeMonitorName("test"),
 		Settings: settings,
 	})
 	memMon.Start(ctx, nil, mon.NewStandaloneBudget(1<<20))

--- a/pkg/sql/rowcontainer/disk_row_container_test.go
+++ b/pkg/sql/rowcontainer/disk_row_container_test.go
@@ -94,21 +94,21 @@ func compareRowToEncRow(
 
 func getMemoryMonitor(st *cluster.Settings) *mon.BytesMonitor {
 	return mon.NewMonitor(mon.Options{
-		Name:     "test-mem",
+		Name:     mon.MakeMonitorName("test-mem"),
 		Settings: st,
 	})
 }
 
 func getUnlimitedMemoryMonitor(st *cluster.Settings) *mon.BytesMonitor {
 	return mon.NewUnlimitedMonitor(context.Background(), mon.Options{
-		Name:     "test-mem",
+		Name:     mon.MakeMonitorName("test-mem"),
 		Settings: st,
 	})
 }
 
 func getDiskMonitor(st *cluster.Settings) *mon.BytesMonitor {
 	return mon.NewMonitor(mon.Options{
-		Name:     "test-disk",
+		Name:     mon.MakeMonitorName("test-disk"),
 		Res:      mon.DiskResource,
 		Settings: st,
 	})

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -42,7 +42,7 @@ func (s *sorterBase) init(
 	self execinfra.RowSource,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
-	processorName redact.RedactableString,
+	processorName redact.SafeString,
 	input execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
 	ordering colinfo.ColumnOrdering,
@@ -56,7 +56,7 @@ func (s *sorterBase) init(
 
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The processor will overflow to disk if this limit is not enough.
-	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx, redact.Sprintf("%s-limited", processorName))
+	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx, processorName+"-limited")
 	if err := s.ProcessorBase.Init(
 		ctx, self, post, input.OutputTypes(), flowCtx, processorID, memMonitor, opts,
 	); err != nil {
@@ -64,8 +64,8 @@ func (s *sorterBase) init(
 		return err
 	}
 
-	s.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon, redact.Sprintf("%s-unlimited", processorName))
-	s.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, redact.Sprintf("%s-disk", processorName))
+	s.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon, processorName+"-unlimited")
+	s.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, processorName+"-disk")
 	rc := rowcontainer.DiskBackedRowContainer{}
 	rc.Init(
 		ordering,

--- a/pkg/sql/rowexec/windower_test.go
+++ b/pkg/sql/rowexec/windower_test.go
@@ -36,7 +36,7 @@ func TestWindowerAccountingForResults(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	monitor := mon.NewMonitor(mon.Options{
-		Name:      "test-monitor",
+		Name:      mon.MakeMonitorName("test-monitor"),
 		Limit:     100000,
 		Increment: 5000,
 		Settings:  st,

--- a/pkg/sql/rowflow/routers_test.go
+++ b/pkg/sql/rowflow/routers_test.go
@@ -784,7 +784,7 @@ func TestRouterDiskSpill(t *testing.T) {
 	// rowContainer. This is a bytes value that will ensure we fall back to disk
 	// but use memory for at least a couple of rows.
 	monitor := mon.NewMonitor(mon.Options{
-		Name:      "test-monitor",
+		Name:      mon.MakeMonitorName("test-monitor"),
 		Limit:     (numRows - routerRowBufSize) / 2,
 		Increment: 1,
 		Settings:  st,

--- a/pkg/sql/rowflow/row_based_flow.go
+++ b/pkg/sql/rowflow/row_based_flow.go
@@ -463,14 +463,14 @@ func (f *rowBasedFlow) setupRouter(
 	for i := range spec.Streams {
 		memoryMonitors[i] = execinfra.NewLimitedMonitor(
 			ctx, f.Mon, &f.FlowCtx,
-			redact.Sprintf("router-limited-%d", spec.Streams[i].StreamID),
+			"router-limited-"+redact.SafeString(spec.Streams[i].StreamID.String()),
 		)
 		unlimitedMemMonitors[i] = execinfra.NewMonitor(
-			ctx, f.Mon, redact.Sprintf("router-unlimited-%d", spec.Streams[i].StreamID),
+			ctx, f.Mon, "router-unlimited-"+redact.SafeString(spec.Streams[i].StreamID.String()),
 		)
 		diskMonitors[i] = execinfra.NewMonitor(
 			ctx, f.DiskMonitor,
-			redact.Sprintf("router-disk-%d", spec.Streams[i].StreamID),
+			"router-disk-"+redact.SafeString(spec.Streams[i].StreamID.String()),
 		)
 	}
 	f.monitors = append(f.monitors, memoryMonitors...)

--- a/pkg/sql/schemachanger/scbuild/builder_test.go
+++ b/pkg/sql/schemachanger/scbuild/builder_test.go
@@ -312,7 +312,7 @@ func TestBuildIsMemoryMonitored(t *testing.T) {
 	tdb.Exec(t, `use system;`)
 
 	monitor := mon.NewMonitor(mon.Options{
-		Name:     "test-sc-build-mon",
+		Name:     mon.MakeMonitorName("test-sc-build-mon"),
 		Settings: s.ClusterSettings(),
 	})
 	monitor.Start(ctx, nil, mon.NewStandaloneBudget(5*1024*1024 /* 5MiB */))

--- a/pkg/sql/schemachanger/scplan/plan_test.go
+++ b/pkg/sql/schemachanger/scplan/plan_test.go
@@ -274,7 +274,7 @@ func TestExplainPlanIsMemoryMonitored(t *testing.T) {
 	})
 
 	monitor := mon.NewMonitor(mon.Options{
-		Name:     "test-sc-plan-mon",
+		Name:     mon.MakeMonitorName("test-sc-plan-mon"),
 		Settings: tt.ClusterSettings(),
 	})
 	monitor.Start(ctx, nil, mon.NewStandaloneBudget(5.243e+6 /* 5MiB */))

--- a/pkg/sql/sem/builtins/show_create_all_tables_builtin_test.go
+++ b/pkg/sql/sem/builtins/show_create_all_tables_builtin_test.go
@@ -22,7 +22,7 @@ func TestTopologicalSort(t *testing.T) {
 
 	ctx := context.Background()
 	monitor := mon.NewMonitor(mon.Options{
-		Name:     "test-mem",
+		Name:     mon.MakeMonitorName("test-mem"),
 		Settings: cluster.MakeTestingClusterSettings(),
 	})
 	monitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -427,7 +427,7 @@ func (ec *Context) MustGetPlaceholderValue(ctx context.Context, p *tree.Placehol
 // MakeTestingEvalContext returns an EvalContext that includes a MemoryMonitor.
 func MakeTestingEvalContext(st *cluster.Settings) Context {
 	monitor := mon.NewMonitor(mon.Options{
-		Name:     "test-monitor",
+		Name:     mon.MakeMonitorName("test-monitor"),
 		Settings: st,
 	})
 	return MakeTestingEvalContextWithMon(st, monitor)

--- a/pkg/sql/sqlstats/sslocal/sql_stats.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats.go
@@ -60,7 +60,7 @@ func newSQLStats(
 	anomalies *insights.AnomalyDetector,
 ) *SQLStats {
 	monitor := mon.NewMonitor(mon.Options{
-		Name:       "SQLStats",
+		Name:       mon.MakeMonitorName("SQLStats"),
 		CurCount:   curMemBytesCount,
 		MaxHist:    maxMemBytesHist,
 		Settings:   st,

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -439,7 +439,7 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 
 	st := cluster.MakeTestingClusterSettings()
 	monitor := mon.NewUnlimitedMonitor(ctx, mon.Options{
-		Name:     "test",
+		Name:     mon.MakeMonitorName("test"),
 		Settings: st,
 	})
 
@@ -557,7 +557,7 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	updater := st.MakeUpdater()
 	monitor := mon.NewUnlimitedMonitor(ctx, mon.Options{
-		Name:     "test",
+		Name:     mon.MakeMonitorName("test"),
 		Settings: st,
 	})
 
@@ -1717,7 +1717,7 @@ func TestSQLStats_ConsumeStats(t *testing.T) {
 
 	st := cluster.MakeTestingClusterSettings()
 	monitor := mon.NewUnlimitedMonitor(context.Background(), mon.Options{
-		Name:     "test",
+		Name:     mon.MakeMonitorName("test"),
 		Settings: st,
 	})
 	insightsProvider := insights.New(st, insights.NewMetrics(), nil)

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
@@ -86,7 +86,7 @@ func TestRecordTransaction(t *testing.T) {
 }
 
 func testMonitor(
-	ctx context.Context, name redact.RedactableString, settings *cluster.Settings,
+	ctx context.Context, name redact.SafeString, settings *cluster.Settings,
 ) *mon.BytesMonitor {
 	return mon.NewUnlimitedMonitor(ctx, mon.Options{
 		Name:     mon.MakeMonitorName(name),

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
@@ -85,9 +85,11 @@ func TestRecordTransaction(t *testing.T) {
 	})
 }
 
-func testMonitor(ctx context.Context, name string, settings *cluster.Settings) *mon.BytesMonitor {
+func testMonitor(
+	ctx context.Context, name redact.RedactableString, settings *cluster.Settings,
+) *mon.BytesMonitor {
 	return mon.NewUnlimitedMonitor(ctx, mon.Options{
-		Name:     redact.RedactableString(name),
+		Name:     mon.MakeMonitorName(name),
 		Settings: settings,
 	})
 }

--- a/pkg/sql/stats/row_sampling_test.go
+++ b/pkg/sql/stats/row_sampling_test.go
@@ -107,7 +107,7 @@ func TestSampleReservoir(t *testing.T) {
 			for _, mem := range []int64{1 << 8, 1 << 10, 1 << 12} {
 				t.Run(fmt.Sprintf("n=%d/k=%d/mem=%d", n, k, mem), func(t *testing.T) {
 					monitor := mon.NewMonitor(mon.Options{
-						Name:      "test-monitor",
+						Name:      mon.MakeMonitorName("test-monitor"),
 						Limit:     mem,
 						Increment: 1,
 						Settings:  st,
@@ -201,7 +201,7 @@ func TestSampleReservoirMemAccounting(t *testing.T) {
 		{getStringDatum(maxBytesPerSample), getStringDatum(0)}, // rank 1
 	}
 	monitor := mon.NewMonitor(mon.Options{
-		Name:      "test-monitor",
+		Name:      mon.MakeMonitorName("test-monitor"),
 		Limit:     memLimit,
 		Increment: 1,
 		Settings:  st,

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -60,7 +60,7 @@ func makeTestContext(stopper *stop.Stopper) testContext {
 		clock:  clock,
 		mockDB: kv.NewDB(ambient, factory, clock, stopper),
 		mon: mon.NewMonitor(mon.Options{
-			Name:     "test root mon",
+			Name:     mon.MakeMonitorName("test root mon"),
 			Settings: settings,
 		}),
 		tracer:   ambient.Tracer,
@@ -75,7 +75,7 @@ func (tc *testContext) createOpenState(typ txnType) (fsm.State, *txnState) {
 	ctx := tracing.ContextWithSpan(tc.ctx, sp)
 
 	txnStateMon := mon.NewMonitor(mon.Options{
-		Name:     "test mon",
+		Name:     mon.MakeMonitorName("test mon"),
 		Settings: cluster.MakeTestingClusterSettings(),
 	})
 	txnStateMon.StartNoReserved(tc.ctx, tc.mon)
@@ -117,7 +117,7 @@ func (tc *testContext) createCommitWaitState() (fsm.State, *txnState, error) {
 
 func (tc *testContext) createNoTxnState() (fsm.State, *txnState) {
 	txnStateMon := mon.NewMonitor(mon.Options{
-		Name:     "test mon",
+		Name:     mon.MakeMonitorName("test mon"),
 		Settings: cluster.MakeTestingClusterSettings(),
 	})
 	ts := txnState{mon: txnStateMon, connCtx: tc.ctx}

--- a/pkg/storage/col_mvcc.go
+++ b/pkg/storage/col_mvcc.go
@@ -440,7 +440,7 @@ func mvccScanToCols(
 		// If we don't have the monitor, then we create a "fake" one that is not
 		// connected to the memory accounting system.
 		monitor = mon.NewMonitor(mon.Options{
-			Name:     "mvcc-scan-to-cols",
+			Name:     mon.MakeMonitorName("mvcc-scan-to-cols"),
 			Settings: st,
 		})
 		monitor.Start(ctx, nil /* pool */, mon.NewStandaloneBudget(math.MaxInt64))

--- a/pkg/storage/enginepb/mvcc.go
+++ b/pkg/storage/enginepb/mvcc.go
@@ -62,7 +62,7 @@ func TxnSeqIsIgnored(seq TxnSeq, ignored []IgnoredSeqNumRange) bool {
 
 // Short returns a prefix of the transaction's ID.
 func (t TxnMeta) Short() redact.SafeString {
-	return redact.SafeString(t.ID.Short())
+	return redact.SafeString(t.ID.Short().String())
 }
 
 // Total returns the range size as the sum of the key and value

--- a/pkg/storage/pebble_mvcc_scanner_test.go
+++ b/pkg/storage/pebble_mvcc_scanner_test.go
@@ -183,7 +183,7 @@ func scannerWithAccount(
 	ctx context.Context, st *cluster.Settings, scanner *pebbleMVCCScanner, limitBytes int64,
 ) (cleanup func()) {
 	m := mon.NewMonitor(mon.Options{
-		Name:      "test",
+		Name:      mon.MakeMonitorName("test"),
 		Increment: 1,
 		Settings:  st,
 	})

--- a/pkg/ts/db_test.go
+++ b/pkg/ts/db_test.go
@@ -74,11 +74,11 @@ type testModelRunner struct {
 func newTestModelRunner(t *testing.T) testModelRunner {
 	st := cluster.MakeTestingClusterSettings()
 	workerMonitor := mon.NewUnlimitedMonitor(context.Background(), mon.Options{
-		Name:     "timeseries-test-worker",
+		Name:     mon.MakeMonitorName("timeseries-test-worker"),
 		Settings: st,
 	})
 	resultMonitor := mon.NewUnlimitedMonitor(context.Background(), mon.Options{
-		Name:     "timeseries-test-result",
+		Name:     mon.MakeMonitorName("timeseries-test-result"),
 		Settings: st,
 	})
 	return testModelRunner{

--- a/pkg/ts/query_test.go
+++ b/pkg/ts/query_test.go
@@ -396,7 +396,7 @@ func TestQueryWorkerMemoryConstraint(t *testing.T) {
 		{
 			// Swap model's memory monitor in order to adjust allocation size.
 			adjustedMon := mon.NewMonitor(mon.Options{
-				Name:      "timeseries-test-worker-adjusted",
+				Name:      mon.MakeMonitorName("timeseries-test-worker-adjusted"),
 				Increment: 1,
 				Settings:  cluster.MakeTestingClusterSettings(),
 			})
@@ -469,7 +469,7 @@ func TestQueryWorkerMemoryMonitor(t *testing.T) {
 		// Create a limited bytes monitor.
 		memoryBudget := int64(100 * 1024)
 		limitedMon := mon.NewMonitor(mon.Options{
-			Name:      "timeseries-test-limited",
+			Name:      mon.MakeMonitorName("timeseries-test-limited"),
 			Limit:     memoryBudget,
 			Increment: 100,
 			Settings:  cluster.MakeTestingClusterSettings(),

--- a/pkg/ts/rollup_test.go
+++ b/pkg/ts/rollup_test.go
@@ -267,7 +267,7 @@ func TestRollupMemoryConstraint(t *testing.T) {
 	// Construct a memory monitor that will be used to measure the high-water
 	// mark of memory usage for the rollup process.
 	adjustedMon := mon.NewMonitor(mon.Options{
-		Name:      "timeseries-test-worker-adjusted",
+		Name:      mon.MakeMonitorName("timeseries-test-worker-adjusted"),
 		Increment: 1,
 		Settings:  cluster.MakeTestingClusterSettings(),
 	})

--- a/pkg/util/mon/BUILD.bazel
+++ b/pkg/util/mon/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/util/log/logcrash",
         "//pkg/util/metric",
         "//pkg/util/syncutil",
+        "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_dustin_go_humanize//:go-humanize",

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -280,20 +280,18 @@ type BytesMonitor struct {
 // MonitorName is used to identify monitors in logging messages. It consists of
 // a string name and an optional ID.
 type MonitorName struct {
-	// TODO(mgartner): This should probably be a safe string instead of a
-	// redactable string.
-	name redact.RedactableString
+	name redact.SafeString
 	id   uuid.Short
 }
 
 // MakeMonitorName constructs a MonitorName with the given name.
-func MakeMonitorName(name redact.RedactableString) MonitorName {
+func MakeMonitorName(name redact.SafeString) MonitorName {
 	return MonitorName{name: name}
 }
 
 // MakeMonitorNameWithID constructs a MonitorName with the given name and
 // ID.
-func MakeMonitorNameWithID(name redact.RedactableString, id uuid.Short) MonitorName {
+func MakeMonitorNameWithID(name redact.SafeString, id uuid.Short) MonitorName {
 	return MonitorName{name: name, id: id}
 }
 
@@ -304,7 +302,7 @@ func (mn MonitorName) String() string {
 
 // SafeFormat implements the redact.SafeFormatter interface.
 func (mn MonitorName) SafeFormat(w redact.SafePrinter, r rune) {
-	mn.name.SafeFormat(w, r)
+	w.SafeString(mn.name)
 	var nullShort uuid.Short
 	if mn.id != nullShort {
 		w.SafeString(redact.SafeString(mn.id.String()))
@@ -497,7 +495,7 @@ func NewMonitor(args Options) *BytesMonitor {
 // those chunks would be reported as used by pool while downstream monitors will
 // not.
 func NewMonitorInheritWithLimit(
-	name redact.RedactableString, limit int64, m *BytesMonitor, longLiving bool,
+	name redact.SafeString, limit int64, m *BytesMonitor, longLiving bool,
 ) *BytesMonitor {
 	res := MemoryResource
 	if m.mu.tracksDisk {

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 	"github.com/dustin/go-humanize"
@@ -245,7 +246,7 @@ type BytesMonitor struct {
 	}
 
 	// name identifies this monitor in logging messages.
-	name redact.RedactableString
+	name MonitorName
 
 	// reserved indicates how many bytes were already reserved for this
 	// monitor before it was instantiated. Allocations registered to
@@ -276,9 +277,43 @@ type BytesMonitor struct {
 	settings *cluster.Settings
 }
 
+// MonitorName is used to identify monitors in logging messages. It consists of
+// a string name and an optional ID.
+type MonitorName struct {
+	// TODO(mgartner): This should probably be a safe string instead of a
+	// redactable string.
+	name redact.RedactableString
+	id   uuid.Short
+}
+
+// MakeMonitorName constructs a MonitorName with the given name.
+func MakeMonitorName(name redact.RedactableString) MonitorName {
+	return MonitorName{name: name}
+}
+
+// MakeMonitorNameWithID constructs a MonitorName with the given name and
+// ID.
+func MakeMonitorNameWithID(name redact.RedactableString, id uuid.Short) MonitorName {
+	return MonitorName{name: name, id: id}
+}
+
+// String returns the monitor name as a string.
+func (mn MonitorName) String() string {
+	return redact.StringWithoutMarkers(mn)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (mn MonitorName) SafeFormat(w redact.SafePrinter, r rune) {
+	mn.name.SafeFormat(w, r)
+	var nullShort uuid.Short
+	if mn.id != nullShort {
+		w.SafeString(redact.SafeString(mn.id.String()))
+	}
+}
+
 const (
 	// Consult with SQL Queries before increasing these values.
-	expectedMonitorSize = 160
+	expectedMonitorSize = 168
 	expectedAccountSize = 24
 )
 
@@ -314,7 +349,7 @@ type MonitorState struct {
 	// root.
 	Level int
 	// Name is the name of the monitor.
-	Name string
+	Name MonitorName
 	// ID is the "id" of the monitor (its address converted to int64).
 	ID int64
 	// ParentID is the "id" of the parent monitor (parent's address converted to
@@ -364,7 +399,7 @@ func (mm *BytesMonitor) traverseTree(level int, monitorStateCb func(MonitorState
 	}
 	monitorState := MonitorState{
 		Level:            level,
-		Name:             string(mm.name),
+		Name:             mm.name,
 		ID:               int64(id),
 		ParentID:         int64(parentID),
 		Used:             mm.mu.curAllocated,
@@ -414,7 +449,7 @@ var DefaultPoolAllocationSize = envutil.EnvOrDefaultInt64("COCKROACH_ALLOCATION_
 type Options struct {
 	// Name is used to annotate log messages, can be used to distinguish
 	// monitors.
-	Name redact.RedactableString
+	Name MonitorName
 	// Res specifies what kind of resource the monitor is tracking allocations
 	// for (e.g. memory or disk). If unset, MemoryResource is assumed.
 	Res   Resource
@@ -469,7 +504,7 @@ func NewMonitorInheritWithLimit(
 		res = DiskResource
 	}
 	return NewMonitor(Options{
-		Name:       name,
+		Name:       MakeMonitorName(name),
 		Res:        res,
 		Limit:      limit,
 		CurCount:   nil, // CurCount is not inherited as we don't want to double count allocations
@@ -516,9 +551,9 @@ func (mm *BytesMonitor) Start(ctx context.Context, pool *BytesMonitor, reserved 
 	mm.mu.stopped = false
 	mm.reserved = reserved
 	if log.V(2) {
-		poolname := redact.RedactableString("(none)")
+		poolname := redact.SafeString("(none)")
 		if pool != nil {
-			poolname = pool.name
+			poolname = redact.SafeString(pool.name.String())
 		}
 		log.InfofDepth(ctx, 1, "%s: starting monitor, reserved %s, pool %s",
 			mm.name,
@@ -589,8 +624,8 @@ func (mm *BytesMonitor) Stop(ctx context.Context) {
 }
 
 // Name returns the name of the monitor.
-func (mm *BytesMonitor) Name() string {
-	return string(mm.name)
+func (mm *BytesMonitor) Name() MonitorName {
+	return mm.name
 }
 
 // Limit returns the memory limit of the monitor.

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -278,18 +278,13 @@ type BytesMonitor struct {
 
 const (
 	// Consult with SQL Queries before increasing these values.
-	expectedMonitorSize     = 160
-	expectedMonitorSizeRace = 168
-	expectedAccountSize     = 24
+	expectedMonitorSize = 160
+	expectedAccountSize = 24
 )
 
 func init() {
 	monitorSize := unsafe.Sizeof(BytesMonitor{})
-	if util.RaceEnabled {
-		if monitorSize != expectedMonitorSizeRace {
-			panic(errors.AssertionFailedf("expected monitor size to be %d under race, found %d", expectedMonitorSizeRace, monitorSize))
-		}
-	} else {
+	if !util.RaceEnabled {
 		if monitorSize != expectedMonitorSize {
 			panic(errors.AssertionFailedf("expected monitor size to be %d, found %d", expectedMonitorSize, monitorSize))
 		}

--- a/pkg/util/mon/bytes_usage_test.go
+++ b/pkg/util/mon/bytes_usage_test.go
@@ -415,7 +415,7 @@ func TestReservedAccountCleared(t *testing.T) {
 }
 
 func getMonitor(
-	ctx context.Context, st *cluster.Settings, name redact.RedactableString, parent *BytesMonitor,
+	ctx context.Context, st *cluster.Settings, name redact.SafeString, parent *BytesMonitor,
 ) *BytesMonitor {
 	var reservedBytes int64
 	if parent == nil {
@@ -427,7 +427,7 @@ func getMonitor(
 func getMonitorEx(
 	ctx context.Context,
 	st *cluster.Settings,
-	name redact.RedactableString,
+	name redact.SafeString,
 	parent *BytesMonitor,
 	reservedBytes int64,
 ) *BytesMonitor {
@@ -444,7 +444,7 @@ func getMonitorUsed(
 	t *testing.T,
 	ctx context.Context,
 	st *cluster.Settings,
-	name redact.RedactableString,
+	name redact.SafeString,
 	parent *BytesMonitor,
 	usedBytes, reservedBytes int64,
 ) *BytesMonitor {
@@ -559,7 +559,7 @@ func TestBytesMonitorNoDeadlocks(t *testing.T) {
 					return
 				default:
 					func() {
-						m := getMonitor(ctx, st, redact.RedactableString(fmt.Sprintf("m%d", i)), root)
+						m := getMonitor(ctx, st, redact.SafeString(fmt.Sprintf("m%d", i)), root)
 						defer m.Stop(ctx)
 						numOps := rng.Intn(10 + 1)
 						var reserved int64
@@ -636,7 +636,7 @@ func BenchmarkTraverseTree(b *testing.B) {
 			allMonitors[level] = make([]*BytesMonitor, 0, len(allMonitors[level-1])*numChildrenPerMonitor)
 			for parent, parentMon := range allMonitors[level-1] {
 				for child := 0; child < numChildrenPerMonitor; child++ {
-					name := redact.RedactableString(fmt.Sprintf("child%d_parent%d", child, parent))
+					name := redact.SafeString(fmt.Sprintf("child%d_parent%d", child, parent))
 					allMonitors[level] = append(allMonitors[level], getMonitor(ctx, st, name, parentMon))
 				}
 			}

--- a/pkg/util/mon/bytes_usage_test.go
+++ b/pkg/util/mon/bytes_usage_test.go
@@ -47,7 +47,7 @@ func TestMemoryAllocations(t *testing.T) {
 	var paramHeader func()
 
 	m := NewMonitor(Options{
-		Name:     "test",
+		Name:     MakeMonitorName("test"),
 		Settings: st,
 	})
 	m.StartNoReserved(ctx, nil /* pool */)
@@ -158,7 +158,7 @@ func TestMemoryAllocations(t *testing.T) {
 					// We start with a fresh monitor for every set of
 					// parameters.
 					m = NewMonitor(Options{
-						Name:      "test",
+						Name:      MakeMonitorName("test"),
 						Increment: pa,
 						Settings:  st,
 					})
@@ -318,7 +318,7 @@ func TestBytesMonitor(t *testing.T) {
 	}
 
 	limitedMonitor := NewMonitor(Options{
-		Name:      "testlimit",
+		Name:      MakeMonitorName("testlimit"),
 		Limit:     10,
 		Increment: 1,
 		Settings:  cluster.MakeTestingClusterSettings(),
@@ -343,7 +343,7 @@ func TestMemoryAllocationEdgeCases(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	m := NewMonitor(Options{
-		Name:      "test",
+		Name:      MakeMonitorName("test"),
 		Increment: 1e9,
 		Settings:  st,
 	})
@@ -367,7 +367,7 @@ func TestMultiSharedGauge(t *testing.T) {
 	minAllocation := int64(1000)
 
 	parent := NewMonitor(Options{
-		Name:      "root",
+		Name:      MakeMonitorName("root"),
 		CurCount:  resourceGauge,
 		Increment: minAllocation,
 		Settings:  cluster.MakeTestingClusterSettings(),
@@ -395,7 +395,7 @@ func TestReservedAccountCleared(t *testing.T) {
 	require.NoError(t, reserved.Grow(ctx, 100))
 
 	m := NewMonitor(Options{
-		Name:      "test",
+		Name:      MakeMonitorName("test"),
 		Increment: 1,
 		Settings:  st,
 	})
@@ -415,7 +415,7 @@ func TestReservedAccountCleared(t *testing.T) {
 }
 
 func getMonitor(
-	ctx context.Context, st *cluster.Settings, name string, parent *BytesMonitor,
+	ctx context.Context, st *cluster.Settings, name redact.RedactableString, parent *BytesMonitor,
 ) *BytesMonitor {
 	var reservedBytes int64
 	if parent == nil {
@@ -425,10 +425,14 @@ func getMonitor(
 }
 
 func getMonitorEx(
-	ctx context.Context, st *cluster.Settings, name string, parent *BytesMonitor, reservedBytes int64,
+	ctx context.Context,
+	st *cluster.Settings,
+	name redact.RedactableString,
+	parent *BytesMonitor,
+	reservedBytes int64,
 ) *BytesMonitor {
 	m := NewMonitor(Options{
-		Name:      redact.RedactableString(name),
+		Name:      MakeMonitorName(name),
 		Increment: 1,
 		Settings:  st,
 	})
@@ -440,7 +444,7 @@ func getMonitorUsed(
 	t *testing.T,
 	ctx context.Context,
 	st *cluster.Settings,
-	name string,
+	name redact.RedactableString,
 	parent *BytesMonitor,
 	usedBytes, reservedBytes int64,
 ) *BytesMonitor {
@@ -472,7 +476,8 @@ func TestBytesMonitorTree(t *testing.T) {
 			for i := 0; i < e.Level; i++ {
 				sb.WriteString("-")
 			}
-			sb.WriteString(e.Name + "\n")
+			sb.WriteString(e.Name.String())
+			sb.WriteString("\n")
 		}
 		return sb.String()
 	}
@@ -554,7 +559,7 @@ func TestBytesMonitorNoDeadlocks(t *testing.T) {
 					return
 				default:
 					func() {
-						m := getMonitor(ctx, st, fmt.Sprintf("m%d", i), root)
+						m := getMonitor(ctx, st, redact.RedactableString(fmt.Sprintf("m%d", i)), root)
 						defer m.Stop(ctx)
 						numOps := rng.Intn(10 + 1)
 						var reserved int64
@@ -609,7 +614,7 @@ func TestBytesMonitorNoDeadlocks(t *testing.T) {
 func BenchmarkBoundAccountGrow(b *testing.B) {
 	ctx := context.Background()
 	m := NewMonitor(Options{
-		Name:      "test",
+		Name:      MakeMonitorName("test"),
 		Increment: 1e9,
 		Settings:  cluster.MakeTestingClusterSettings(),
 	})
@@ -631,7 +636,7 @@ func BenchmarkTraverseTree(b *testing.B) {
 			allMonitors[level] = make([]*BytesMonitor, 0, len(allMonitors[level-1])*numChildrenPerMonitor)
 			for parent, parentMon := range allMonitors[level-1] {
 				for child := 0; child < numChildrenPerMonitor; child++ {
-					name := fmt.Sprintf("child%d_parent%d", child, parent)
+					name := redact.RedactableString(fmt.Sprintf("child%d_parent%d", child, parent))
 					allMonitors[level] = append(allMonitors[level], getMonitor(ctx, st, name, parentMon))
 				}
 			}
@@ -671,7 +676,7 @@ func TestLimit(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 
 	m := NewMonitor(Options{
-		Name:     "test",
+		Name:     MakeMonitorName("test"),
 		Settings: st,
 	})
 
@@ -684,7 +689,7 @@ func TestLimit(t *testing.T) {
 	m.Stop(ctx)
 
 	m2 := NewMonitor(Options{
-		Name:     "test",
+		Name:     MakeMonitorName("test"),
 		Settings: st,
 	})
 

--- a/pkg/util/uuid/uuid_test.go
+++ b/pkg/util/uuid/uuid_test.go
@@ -28,6 +28,7 @@ func TestUUID(t *testing.T) {
 	t.Run("Variant", testUUIDVariant)
 	t.Run("SetVersion", testUUIDSetVersion)
 	t.Run("SetVariant", testUUIDSetVariant)
+	t.Run("Short", testUUIDShort)
 }
 
 func testUUIDBytes(t *testing.T) {
@@ -43,6 +44,14 @@ func testUUIDString(t *testing.T) {
 	want := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
 	if got != want {
 		t.Errorf("%v.String() = %q, want %q", NamespaceDNS, got, want)
+	}
+}
+
+func testUUIDShort(t *testing.T) {
+	got := NamespaceDNS.Short().String()
+	want := "6ba7b810"
+	if got != want {
+		t.Errorf("%v.Short() = %q, want %q", NamespaceDNS, got, want)
 	}
 }
 

--- a/pkg/util/uuid/uuid_wrapper.go
+++ b/pkg/util/uuid/uuid_wrapper.go
@@ -7,6 +7,7 @@ package uuid
 
 import (
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -14,9 +15,29 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// Short returns the first eight characters of the output of String().
-func (u UUID) Short() string {
-	return u.String()[:8]
+const (
+	shortSize    = 4
+	shortStrSize = 8
+)
+
+type Short struct {
+	b [shortSize]byte
+}
+
+// String returns the 8-character hexidecimal representation of the abbreviated
+// UUID.
+func (s Short) String() string {
+	var b [shortStrSize]byte
+	hex.Encode(b[:], s.b[:])
+	return string(b[:])
+}
+
+// Short returns an abbreviated version of the UUID containing the first four
+// bytes.
+func (u UUID) Short() Short {
+	return Short{
+		b: [shortSize]byte(u[0:shortSize]),
+	}
 }
 
 // ShortStringer implements fmt.Stringer to output Short() on String().
@@ -24,7 +45,7 @@ type ShortStringer UUID
 
 // String is part of fmt.Stringer.
 func (s ShortStringer) String() string {
-	return UUID(s).Short()
+	return UUID(s).Short().String()
 }
 
 var _ fmt.Stringer = ShortStringer{}


### PR DESCRIPTION
#### util/uuid: add `Short` type and `(UUID).Short` method

The `uuid.Short` type and `(UUID).Short` method have been added. These
allow for shortened UUIDs to be represented in 4 bytes without
allocating a string.

Release note: None

#### util/mon: remove `BytesMonitor` size assertion under race

The size of `BytesMonitor` in race builds is not really a concern for
us. We are only concerned with its size in production builds. This
commit removes this unneeded assertion.

Release note: None

#### util/mon: introduce `MonitorName`

The `MonitorName` type is now used for naming memory monitors. This type
includes an optional short UUID, helping reduce allocations in a hot
path that added the first 8 bytes of a UUID to the monitor name. Now,
the short UUID is included in `MonitorName` allocation free. Allocations
to combine the short UUID with the name's prefix in a contiguous string
are only incurred if expensive logging is enabled.

Fixes #136628

Release note: None

#### util/mon: use `redact.SafeString` for monitor names

Monitor names are now created with `redact.SafeString`s instead of
`redact.RedactableString`s. The `redact.SafeString` type is a better fit
because monitor names should never contain sensitive information. The
type system now forces callers to confirm that the given name is safe.

Release note: None

#### sql: remove username from internal planner monitor name

The username is not necessary for this monitor name. The op name should
be sufficient in tracking down the source of this planner and monitor.

Release note: None