### PR TITLE
kv: mark subsume as isWrite

### DIFF
--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -2113,7 +2113,7 @@ func (r *RefreshRangeRequest) flags() flag {
 	return isRead | isTxn | isRange | updatesTSCache
 }
 
-func (*SubsumeRequest) flags() flag    { return isRead | isAlone | updatesTSCache }
+func (*SubsumeRequest) flags() flag    { return isWrite | isAlone | updatesTSCache }
 func (*RangeStatsRequest) flags() flag { return isRead }
 func (*QueryResolvedTimestampRequest) flags() flag {
 	return isRead | isRange | requiresClosedTSOlderThanStorageSnapshot


### PR DESCRIPTION
Now that `Subsume` is required to force flush all replication streams up
to the lease applied index it froze the range at (https://github.com/cockroachdb/cockroach/pull/136321),
`SubsumeRequest` also needs to be marked as a write in order to pass
through the replication code path, which updates the range controller
force flush index and replicates the force flush index.

Part of: https://github.com/cockroachdb/cockroach/issues/132614
Release note: None