### PR TITLE
kvcoord: bump test package size to large

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -119,7 +119,7 @@ gomock(
 
 go_test(
     name = "kvcoord_test",
-    size = "medium",
+    size = "large",
     srcs = [
         "batch_test.go",
         "condensable_span_set_test.go",


### PR DESCRIPTION
Recenlty, TestTxnDBDirtyWriteAnomaly started failing and it seems like the test is getting unlucky as we run into a package level timeout. Bump from a medium to a large.

Closes https://github.com/cockroachdb/cockroach/issues/136369

Release note: None