### PR TITLE
sql: arrayVariadicBuiltin was not correctly marked on DistsqlBlocklist

### DIFF
--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -10130,8 +10130,8 @@ func arrayVariadicBuiltin(impls func(*types.T) []tree.Overload) builtinDefinitio
 	}
 	// Prevent usage in DistSQL because it cannot handle arrays of untyped tuples.
 	tupleOverload := impls(types.AnyTuple)
-	for _, t := range tupleOverload {
-		t.DistsqlBlocklist = true
+	for i := range tupleOverload {
+		tupleOverload[i].DistsqlBlocklist = true
 	}
 	overloads = append(overloads, tupleOverload...)
 	return makeBuiltin(


### PR DESCRIPTION
Previously, the arrayVariadicBuiltin was not correctly set on the DistsqlBlocklist, since the range loop was modifying a copy of the overload. This patch sets correctly sets the DistsqlBlocklist flag on this builtin.

Fixes: #136601

Release note: None