### PR TITLE
roachtest: deflake activerecord test

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord_blocklist.go
+++ b/pkg/cmd/roachtest/tests/activerecord_blocklist.go
@@ -24,6 +24,7 @@ var activeRecordBlocklist = blocklist{
 var activeRecordIgnoreList = blocklist{
 	`ActiveRecord::ConnectionAdapters::PostgreSQLAdapterTest#test_translate_no_connection_exception_to_not_established`:                                        "pg_terminate_backend not implemented",
 	`BasicsTest#test_default_values_are_deeply_dupped`:                                                                                                         "flaky",
+	`CockroachDB::FixturesTest#test_create_fixtures`:                                                                                                           "flaky",
 	`TestAutosaveAssociationOnAHasAndBelongsToManyAssociation#test_should_not_save_and_return_false_if_a_callback_cancelled_saving_in_either_create_or_update`: "flaky",
 	`TestAutosaveAssociationOnAHasAndBelongsToManyAssociation#test_should_not_update_children_when_parent_creation_with_no_reason`:                             "flaky",
 	`TestAutosaveAssociationOnAHasAndBelongsToManyAssociation#test_should_update_children_when_autosave_is_true_and_parent_is_new_but_child_is_not`:            "flaky",


### PR DESCRIPTION
Previously, the active record test had a test flake on CockroachDB::FixturesTest#test_create_fixtures. This patch adds that test on the ignore list.

Fixes: #136460

Release note: None