### PR TITLE
kvserver: don't use leader leases in TestFlowControlCrashedNodeV2

### DIFF
--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -2713,16 +2713,16 @@ func TestFlowControlCrashedNodeV2(t *testing.T) {
 			// This test doesn't want leadership changing hands, and leader leases (by
 			// virtue of raft fortification) help ensure this. Override to disable any
 			// metamorphosis.
-			kvserver.OverrideDefaultLeaseType(ctx, &settings.SV, roachpb.LeaseLeader)
-			// Using a manual clock here ensures that StoreLiveness support, once
-			// established, never expires. By extension, leadership should stay
-			// sticky.
-			manualClock := hlc.NewHybridManualClock()
+			// TODO(arulajmani): Re-enable leader leases on this test, see #136292.
+			kvserver.OverrideLeaderLeaseMetamorphism(ctx, &settings.SV)
 			tc := testcluster.StartTestCluster(t, 2, base.TestClusterArgs{
 				ReplicationMode: base.ReplicationManual,
 				ServerArgs: base.TestServerArgs{
 					Settings: settings,
 					RaftConfig: base.RaftConfig{
+						// Suppress timeout-based elections. This test doesn't want to
+						// deal with leadership changing hands.
+						RaftElectionTimeoutTicks: 1000000,
 						// Reduce the RangeLeaseDuration to speeds up failure detection
 						// below.
 						RangeLeaseDuration: time.Second,
@@ -2741,9 +2741,6 @@ func TestFlowControlCrashedNodeV2(t *testing.T) {
 							DisableWorkQueueGranting: func() bool {
 								return true
 							},
-						},
-						Server: &server.TestingKnobs{
-							WallClock: manualClock,
 						},
 					},
 				},


### PR DESCRIPTION
`TestFlowControlCrashedNodeV2` began failing occasionally after enabling leader leases in the test.

Use epoch leases instead, until the root cause is determined and fixed. As mentioned, the cause is unknown at the time of this commit, however these logs from a failing run appear the most relevant:

```
kv/kvserver/storeliveness/support_manager.go:310 ⋮ [T1,Vsystem,n1,s1] 1529  failed to send heartbeat to store {NodeID:2 StoreID:2}
testutils/soon.go:38 ⋮ [-] 1530  SucceedsSoon: ‹handle for 74 not found›
gossip/client.go:112 ⋮ [T1,Vsystem,n1] 1531  unvalidated bootstrap gossip dial to ‹127.0.0.1:41989›
```

Informs: #136292
Release note: None