### PR TITLE
kvserver: increase loqrecovery_test test timeout

### DIFF
--- a/pkg/kv/kvserver/loqrecovery/BUILD.bazel
+++ b/pkg/kv/kvserver/loqrecovery/BUILD.bazel
@@ -58,6 +58,7 @@ go_library(
 
 go_test(
     name = "loqrecovery_test",
+    size = "large",
     srcs = [
         "apply_test.go",
         "collect_raft_log_test.go",


### PR DESCRIPTION
The test target loqrecovery_test sometimes times out after running for 5 minutes (medium size). Looking at the logs it seems the test is working fine when it timed out. This is probably because we introduced leader leases to run in these tests, it might have caused some tests to take longer than usual.

Fixes: #136679

Release note: None