### PR TITLE
roachtest: show variations on github issue for perturbation/* tests

### DIFF
--- a/pkg/cmd/roachtest/tests/perturbation/add_node.go
+++ b/pkg/cmd/roachtest/tests/perturbation/add_node.go
@@ -29,8 +29,8 @@ func (a addNode) setupMetamorphic(rng *rand.Rand) variations {
 	v = v.randomize(rng)
 	//TODO(#133606): With high vcpu and large writes, the test can fail due to
 	//the disk becoming saturated leading to 1-2s of fsync stall.
-	if v.vcpu >= 16 && v.maxBlockBytes == 4096 {
-		v.maxBlockBytes = 1024
+	if v.vcpu >= 16 && v.blockSize == 4096 {
+		v.blockSize = 1024
 	}
 	return v
 }

--- a/pkg/cmd/roachtest/tests/perturbation/decommission.go
+++ b/pkg/cmd/roachtest/tests/perturbation/decommission.go
@@ -38,8 +38,8 @@ func (d decommission) setupMetamorphic(rng *rand.Rand) variations {
 	v.perturbation = d
 	//TODO(#133606): With high vcpu and large writes, the test can fail due to
 	//the disk becoming saturated leading to 1-2s of fsync stall.
-	if v.vcpu >= 16 && v.maxBlockBytes == 4096 {
-		v.maxBlockBytes = 1024
+	if v.vcpu >= 16 && v.blockSize == 4096 {
+		v.blockSize = 1024
 	}
 	return v
 }

--- a/pkg/cmd/roachtest/tests/perturbation/elastic_workload.go
+++ b/pkg/cmd/roachtest/tests/perturbation/elastic_workload.go
@@ -57,7 +57,7 @@ func (e elasticWorkload) startPerturbation(
 	startTime := timeutil.Now()
 	runCmd := fmt.Sprintf(
 		"./cockroach workload run kv --db elastic --txn-qos=background --duration=%s --max-block-bytes=%d --min-block-bytes=%d --concurrency=500 {pgurl%s}",
-		v.perturbationDuration, v.maxBlockBytes, v.maxBlockBytes, v.stableNodes())
+		v.perturbationDuration, v.blockSize, v.blockSize, v.stableNodes())
 	v.Run(ctx, option.WithNodes(v.workloadNodes()), runCmd)
 
 	// Wait a few seconds to allow the latency to resume after stopping the

--- a/pkg/cmd/roachtest/tests/perturbation/framework.go
+++ b/pkg/cmd/roachtest/tests/perturbation/framework.go
@@ -76,7 +76,7 @@ type variations struct {
 	// These fields are set up during construction.
 	seed                 int64
 	fillDuration         time.Duration
-	maxBlockBytes        int
+	blockSize            int
 	perturbationDuration time.Duration
 	validationDuration   time.Duration
 	ratioOfMax           float64
@@ -102,7 +102,7 @@ const NUM_REGIONS = 3
 
 var durationOptions = []time.Duration{10 * time.Second, 10 * time.Minute, 30 * time.Minute}
 var splitOptions = []int{1, 100, 10000}
-var maxBlockBytes = []int{1, 1024, 4096}
+var blockSize = []int{1, 1024, 4096}
 var numNodes = []int{5, 12, 30}
 var numVCPUs = []int{4, 8, 16, 32}
 var numDisks = []int{1, 2}
@@ -187,11 +187,11 @@ func (a admissionControlMode) getSettings() map[string]string {
 }
 
 func (v variations) String() string {
-	return fmt.Sprintf("seed: %d, fillDuration: %s, maxBlockBytes: %d, perturbationDuration: %s, "+
+	return fmt.Sprintf("seed: %d, fillDuration: %s, blockSize: %d, perturbationDuration: %s, "+
 		"validationDuration: %s, ratioOfMax: %f, splits: %d, numNodes: %d, numWorkloadNodes: %d, "+
 		"vcpu: %d, disks: %d, memory: %s, leaseType: %s, cloud: %v, acMode: %s, diskBandwidthLimit %s, "+
 		"perturbation: %+v",
-		v.seed, v.fillDuration, v.maxBlockBytes,
+		v.seed, v.fillDuration, v.blockSize,
 		v.perturbationDuration, v.validationDuration, v.ratioOfMax, v.splits, v.numNodes, v.numWorkloadNodes,
 		v.vcpu, v.disks, v.mem, v.leaseType, v.cloud, v.acMode, v.diskBandwidthLimit,
 		v.perturbation)
@@ -204,7 +204,7 @@ const numNodesPerWorker = 20
 // randomize will randomize the test parameters for a metamorphic run.
 func (v variations) randomize(rng *rand.Rand) variations {
 	v.splits = splitOptions[rng.Intn(len(splitOptions))]
-	v.maxBlockBytes = maxBlockBytes[rng.Intn(len(maxBlockBytes))]
+	v.blockSize = blockSize[rng.Intn(len(blockSize))]
 	v.perturbationDuration = durationOptions[rng.Intn(len(durationOptions))]
 	v.leaseType = leases[rng.Intn(len(leases))]
 	v.numNodes = numNodes[rng.Intn(len(numNodes))]
@@ -226,7 +226,7 @@ func setup(p perturbation, acceptableChange float64) variations {
 	v := variations{}
 	v.workload = kvWorkload{}
 	v.leaseType = registry.EpochLeases
-	v.maxBlockBytes = 4096
+	v.blockSize = 4096
 	v.splits = 10000
 	v.numNodes = 12
 	v.numWorkloadNodes = v.numNodes/numNodesPerWorker + 1
@@ -312,7 +312,7 @@ func (v *variations) applyEnvOverride(key string, val string) (err error) {
 	case "fillDuration":
 		v.fillDuration, err = time.ParseDuration(val)
 	case "blockSize":
-		v.maxBlockBytes, err = strconv.Atoi(val)
+		v.blockSize, err = strconv.Atoi(val)
 	case "perturbationDuration":
 		v.perturbationDuration, err = time.ParseDuration(val)
 	case "validationDuration":

--- a/pkg/cmd/roachtest/tests/perturbation/intents.go
+++ b/pkg/cmd/roachtest/tests/perturbation/intents.go
@@ -62,7 +62,7 @@ func (intents) startPerturbation(ctx context.Context, t test.Test, v variations)
 	i := 0
 	for ; timeutil.Since(startTime) < v.perturbationDuration; i++ {
 		startKey := int64(rng.Uint64())
-		bytes := make([]byte, v.maxBlockBytes)
+		bytes := make([]byte, v.blockSize)
 		for b := range bytes {
 			bytes[b] = byte(rng.Int() & 0xff)
 		}

--- a/pkg/cmd/roachtest/tests/perturbation/kv_workload.go
+++ b/pkg/cmd/roachtest/tests/perturbation/kv_workload.go
@@ -33,8 +33,14 @@ func (w kvWorkload) runWorkload(
 	ctx context.Context, v variations, duration time.Duration, maxRate int,
 ) (*workloadData, error) {
 	runCmd := fmt.Sprintf(
-		"./cockroach workload run kv --db target --display-format=incremental-json --duration=%s --max-rate=%d --tolerate-errors --max-block-bytes=%d --read-percent=50 --follower-read-percent=50 --concurrency=500 {pgurl%s}",
-		duration, maxRate, v.maxBlockBytes, v.stableNodes())
+		`./cockroach workload run kv --db target --display-format=incremental-json --duration=%s --max-rate=%d --tolerate-errors 
+		--max-block-bytes=%d --min-block-bytes=%d --read-percent=50 --follower-read-percent=50 --concurrency=500 {pgurl%s}`,
+		duration,
+		maxRate,
+		v.blockSize,
+		v.blockSize,
+		v.stableNodes(),
+	)
 	allOutput, err := v.RunWithDetails(ctx, nil, option.WithNodes(v.workloadNodes()), runCmd)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This change adds all the test variations to the github issue in addition to printing them to the log. This simplifies debugging issues.

Additionally this changes the variable `maxBlockBytes` to be `blockSize` for consistency.

Epic: none

Release note: None