### PR TITLE
release-24.3: crosscluster/logical: type check dest tenant spec in planHookFn

### DIFF
--- a/pkg/ccl/crosscluster/physical/alter_replication_job.go
+++ b/pkg/ccl/crosscluster/physical/alter_replication_job.go
@@ -200,6 +200,12 @@ func alterReplicationJobHook(
 		}
 	}
 
+	// Ensure the TenantSpec is type checked, even if we don't use the result.
+	_, _, _, err = exprEval.TenantSpec(ctx, alterTenantStmt.TenantSpec)
+	if err != nil {
+		return nil, nil, nil, false, err
+	}
+
 	retentionTTLSeconds := defaultRetentionTTLSeconds
 	if ret, ok := options.GetRetention(); ok {
 		retentionTTLSeconds = ret


### PR DESCRIPTION
Backport 1/1 commits from #136683.

/cc @cockroachdb/release

---

Fixes #136339

Release note: none
