### PR TITLE
workload: only use sql_instances table for node count

### DIFF
--- a/pkg/ccl/workloadccl/BUILD.bazel
+++ b/pkg/ccl/workloadccl/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//pkg/security/username",
         "//pkg/settings/cluster",
         "//pkg/util/ctxgroup",
-        "//pkg/util/errorutil",
         "//pkg/util/humanizeutil",
         "//pkg/util/limit",
         "//pkg/util/log",


### PR DESCRIPTION
When using leader leases, gossip liveness entries appear to be added later during early startup. As a result, getNodeCount would occasionally return 0, resulting in downstream problems.

The sql_instances table is populated as part of SQLServer startup and thus will almost surely be populated if we are talking to a live SQL node.

This makes workload incompatible with versions before v23.1.

Epic: none

Fixes #136663