### PR TITLE
ui: add metric assertions to overview page e2e test

### DIFF
--- a/pkg/ui/workspaces/e2e-tests/cypress/e2e/health-check/authenticated.cy.ts
+++ b/pkg/ui/workspaces/e2e-tests/cypress/e2e/health-check/authenticated.cy.ts
@@ -22,7 +22,15 @@ describe("health check: authenticated user", () => {
     cy.findByText("Capacity Usage", { selector: "h3>span" });
     cy.findByText("Node Status");
     cy.findByText("Replication Status");
-
+    // Asserts that storage used from nodes_ui metrics is populated
+    cy.get(".cluster-summary__metric.storage-used").should(
+      isTextGreaterThanZero,
+    );
+    // Asserts that storage usable from nodes_ui metrics is populated
+    cy.get(".cluster-summary__metric.storage-usable").should(
+      isTextGreaterThanZero,
+    );
+    cy.get(".cluster-summary__metric.live-nodes").should(isTextGreaterThanZero);
     // Check for sidebar contents
     cy.findByRole("navigation").within(() => {
       cy.findByRole("link", { name: "Overview" });
@@ -35,3 +43,9 @@ describe("health check: authenticated user", () => {
     });
   });
 });
+
+const isTextGreaterThanZero = (ele: JQuery<HTMLElement>) => {
+  const text = ele.get()[0].innerText;
+  const textAsFloat = parseFloat(text);
+  expect(textAsFloat).to.be.greaterThan(0);
+};


### PR DESCRIPTION
Adds assertions to the Overview page to make sure that data from nodes_ui is properly fetched and rendered on the page.

Epic: None
Release note: None