### PR TITLE
cloud/amazon: Add UsePathStyle URL param to S3

### DIFF
--- a/pkg/cloud/cloudpb/external_storage.proto
+++ b/pkg/cloud/cloudpb/external_storage.proto
@@ -62,6 +62,7 @@ message ExternalStorage {
     string secret = 4;
     string temp_token = 5;
     string endpoint = 6;
+    bool use_path_style=16;
     string region = 7;
     string auth = 8;
     string server_enc_mode  = 9;


### PR DESCRIPTION
[Cloud unit tests](https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Nightlies_CloudUnitTests/18067300)

Informs: [136678](https://github.com/cockroachdb/cockroach/issues/136678)
Release note (enterprise change): Adds AWS_USE_PATH_STYLE param to S3 URI parsing.