### PR TITLE
changefeedccl: skip TestParallelIOMetrics under duress

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -9480,6 +9480,10 @@ func TestParallelIOMetrics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// This test relies on messing with timings to see pending rows build up,
+	//  so skip it when the system is loaded.
+	skip.UnderDuress(t)
+
 	// Add delay so queuing occurs, which results in the below metrics being
 	// nonzero.
 	defer testingEnableQueuingDelay()()


### PR DESCRIPTION
TestParallelIOMetrics is very flaky and relies on
altering timings, so skip it under duress.

Fixes #136397
Fixes #136352
Fixes #135681
Fixes #134937
Fixes #134188
Fixes #133335
Fixes #129917
Fixes #125295

Release note: None
