### PR TITLE
crosscluster: reduce replan flow threshold from 0.1 to 0.01

### DIFF
--- a/pkg/crosscluster/settings.go
+++ b/pkg/crosscluster/settings.go
@@ -61,7 +61,7 @@ var ReplanThreshold = settings.RegisterFloatSetting(
 	"stream_replication.replan_flow_threshold",
 	"fraction of nodes in the producer or consumer job that would need to change to refresh the"+
 		" physical execution plan. If set to 0, the physical plan will not automatically refresh.",
-	0.1,
+	0.01,
 	settings.NonNegativeFloatWithMaximum(1),
 	settings.WithName("physical_replication.consumer.replan_flow_threshold"),
 )
@@ -120,7 +120,7 @@ var LogicalReplanThreshold = settings.RegisterFloatSetting(
 	"logical_replication.replan_flow_threshold",
 	"fraction of nodes in the producer or consumer job that would need to change to refresh the"+
 		" physical execution plan. If set to 0, the physical plan will not automatically refresh.",
-	0.1,
+	0.01,
 	settings.NonNegativeFloatWithMaximum(1),
 )
 


### PR DESCRIPTION
Previously, if a potential distsql plan for LDR or PCR had more than 90% the same src and dest nodes participating, then the new plan would not be used. This bumps the threshold to 99% for both LDR and PCR, as we want want to eagerly join a new node to the replication party.

Fixes: #136530

Release note: none