### PR TITLE
kvserver: deflake TestStoreRangeMergeConcurrentRequests

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -2332,8 +2332,8 @@ func TestStoreRangeMergeConcurrentRequests(t *testing.T) {
 	}
 
 	// Failures in this test often present as a deadlock. Set a short timeout to
-	// limit the damage.
-	ctx, cancel := context.WithTimeout(ctx, testutils.DefaultSucceedsSoonDuration)
+	// limit the damage, but a longer deadline for race builds.
+	ctx, cancel := context.WithTimeout(ctx, testutils.SucceedsSoonDuration())
 	defer cancel()
 
 	const numGetWorkers = 16


### PR DESCRIPTION
This commit makes the test use testutils.SucceedsSoonDuration() instead of testutils.DefaultSucceedsSoonDuration. This sets a longer timeout for race builds. This started flaking with deadline exceeded errors when running with leader leases. This is probably because the test keeps causing the store to withdraw/grant support to itself in the store liveness layer.

Trying to reproduce it locally for more than 2 hours and I couldn't, however, without this change, I was able to reproduce it withing 30 minutes.

Fixes: #136687

Release note: None