### PR TITLE
sql: inline `addActiveQuery` anonymous function

### DIFF
--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -1119,6 +1119,9 @@ func BenchmarkEndToEnd(b *testing.B) {
 	srv, db, _ := serverutils.StartServer(b, base.TestServerArgs{UseDatabase: "bench"})
 	defer srv.Stopper().Stop(context.Background())
 	sr := sqlutils.MakeSQLRunner(db)
+	sr.Exec(b, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false`)
+	sr.Exec(b, `SET CLUSTER SETTING sql.stats.flush.enabled = false`)
+	sr.Exec(b, `SET CLUSTER SETTING sql.metrics.statement_details.enabled = false`)
 	sr.Exec(b, `CREATE DATABASE bench`)
 	for _, schema := range schemas {
 		sr.Exec(b, schema)


### PR DESCRIPTION
#### opt/bench: disable some background work in `BenchmarkEndToEnd`

Automatic table stats collection and SQL stats (metrics) have been
disabled in the end-to-end benchmarks so that they better highlight the
performance of executing queries. Note that this will improve all the
benchmark results a bit, even though the code paths targeted by this
benchmark have not been changed.

Release note: None

#### sql: inline `addActiveQuery` anonymous function

The `addActiveQuery` anonymous function in `execStmtInOpenState`
modified the `ctx context.Context` parameter. This confused Go's escape
analysis into thinking that the `ctx` value must be heap allocated.
References to `ctx` in other closures must see the newly assigned value.
The lifetime of the closures in the function are not clear (for the
compiler or a human), and so I believe Go assumed that reassignment and
accesses could occur multiple times or at any point in the future.
Therefore, it required the value of `ctx` must not be stack allocated.

This commit inlines `addActiveQuery`, which was only invoked once. This
eliminates confusion about the `ctx` parameter during escape analysis
and it is no longer heap allocated. Note that there's likely a few
different changes to other closures that may have eliminated this
allocation, this is just one of the simpler ones.

Future work will simplify `execStmtInOpenState` further and eliminate
unnecessary allocations like this one.

Informs #135908

Release note: None
