### PR TITLE
release-23.2: changefeedccl: support for multiple seed brokers in kafka v2 sink

### DIFF
--- a/pkg/ccl/changefeedccl/sink_kafka_v2.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2.go
@@ -64,18 +64,19 @@ func newKafkaSinkClientV2(
 	ctx context.Context,
 	clientOpts []kgo.Opt,
 	batchCfg sinkBatchConfig,
-	bootstrapAddrs string,
+	bootstrapAddrsStr string,
 	settings *cluster.Settings,
 	knobs kafkaSinkV2Knobs,
 	mb metricsRecorderBuilder,
 	topicsForConnectionCheck []string,
 ) (*kafkaSinkClientV2, error) {
+	bootstrapBrokers := strings.Split(bootstrapAddrsStr, `,`)
 
 	baseOpts := []kgo.Opt{
 		// Disable idempotency to maintain parity with the v1 sink and not add surface area for unknowns.
 		kgo.DisableIdempotentWrite(),
 
-		kgo.SeedBrokers(bootstrapAddrs),
+		kgo.SeedBrokers(bootstrapBrokers...),
 		kgo.WithLogger(kgoLogAdapter{ctx: ctx}),
 		kgo.RecordPartitioner(newKgoChangefeedPartitioner()),
 		// 256MiB. This is the max this library allows. Note that v1 sets the sarama equivalent to math.MaxInt32.

--- a/pkg/ccl/changefeedccl/sink_kafka_v2_test.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2_test.go
@@ -259,6 +259,19 @@ func TestKafkaSinkClientV2_Naming(t *testing.T) {
 	})
 }
 
+func TestKafkaSinkClientV2_MultipleBrokers(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	fx := newKafkaSinkV2Fx(t, withRealClient(), withSinkURI("kafka://localhost:9092,localhost:9093"))
+	defer fx.close()
+
+	client := fx.bs.client.(*kafkaSinkClientV2).client.(*kgo.Client)
+	brokers := client.OptValue("SeedBrokers").([]string)
+	require.Equal(t, []string{"localhost:9092", "localhost:9093"}, brokers)
+
+}
+
 func TestKafkaSinkClientV2_Opts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -460,6 +473,7 @@ type kafkaSinkV2Fx struct {
 	batchConfig     sinkBatchConfig
 	realClient      bool
 	additionalKOpts []kgo.Opt
+	uri             string
 
 	sink *kafkaSinkClientV2
 	bs   *batchingSink
@@ -503,6 +517,12 @@ func withRealClient() fxOpt {
 	}
 }
 
+func withSinkURI(uri string) fxOpt {
+	return func(fx *kafkaSinkV2Fx) {
+		fx.uri = uri
+	}
+}
+
 func withKOptsClient(kOpts []kgo.Opt) fxOpt {
 	return func(fx *kafkaSinkV2Fx) {
 		fx.additionalKOpts = kOpts
@@ -539,13 +559,18 @@ func newKafkaSinkV2Fx(t *testing.T, opts ...fxOpt) *kafkaSinkV2Fx {
 		}
 	}
 
+	uri := "kafka://localhost:9092"
+	if fx.uri != "" {
+		uri = fx.uri
+	}
+
 	var err error
-	fx.sink, err = newKafkaSinkClientV2(ctx, fx.additionalKOpts, fx.batchConfig, "no addrs", settings, knobs, nilMetricsRecorderBuilder, nil)
+	fx.sink, err = newKafkaSinkClientV2(ctx, fx.additionalKOpts, fx.batchConfig, uri, settings, knobs, nilMetricsRecorderBuilder, nil)
 	require.NoError(t, err)
 
 	targets := makeChangefeedTargets(fx.targetNames...)
 
-	u, err := url.Parse("kafka://localhost:9092")
+	u, err := url.Parse(uri)
 	require.NoError(t, err)
 
 	q := u.Query()


### PR DESCRIPTION
Backport 1/1 commits from #136632.

/cc @cockroachdb/release

Release justification: small bug fix

---

Previously the kafka v2 sink did not support multiple seed brokers, where the v1 sink did. This PR adds this support.

Fixes: #136616

Release note (general change): add support for multiple seed brokers in the new kafka sink.
