### PR TITLE
release-24.2: TestAllRegisteredSetup: skip test under deadlock

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -113,6 +113,7 @@ func TestAllRegisteredImportFixture(t *testing.T) {
 
 func TestAllRegisteredSetup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.UnderDeadlock(t)
 
 	for _, meta := range workload.Registered() {
 		if bigInitialData(meta) {


### PR DESCRIPTION
Backport 1/1 commits from #133729.

/cc @cockroachdb/release

---

Epic: none
Release note: None

Closes:https://github.com/cockroachdb/cockroach/issues/136197

Release Justification: Test only change