### PR TITLE
kvprober: establish store liveness support in initTestServer()

### DIFF
--- a/pkg/kv/kvprober/BUILD.bazel
+++ b/pkg/kv/kvprober/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "//pkg/kv",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
+        "//pkg/kv/kvserver/storeliveness/storelivenesspb",
         "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",


### PR DESCRIPTION
If leader leases is enabled, the peer might take a couple of seconds before it can establish store liveness support
before campaigning. This commit waits till store liveness support is established inside initTestServer() before it
proceeds.

Fixes: #136731

Release note: None