### PR TITLE
catalog/lease: deflake TestLeaseTxnDeadlineExtensionWithSession

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -3216,6 +3216,10 @@ SELECT * FROM T1`)
 func TestLeaseTxnDeadlineExtensionWithSession(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	// We may not see the desired transaction retry error when running under
+	// race since the txn could end up being aborted because of availability
+	// load in this configuration.
+	skip.UnderRace(t)
 
 	ctx := context.Background()
 	filterMu := syncutil.Mutex{}


### PR DESCRIPTION
Previously, the TestLeaseTxnDeadlineExtensionWithSession test could flake due to availability issues when run under race. To address this, this patch modifies the test skip under race to avoid flakes that lead to the wrong retryable error.

Fixes: #136363
Release note: None