### PR TITLE
kvserver: add TestFlowControlSendQueueRangeSplitMergeMixedVersion

### DIFF
--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/range_split_merge_mixed_version
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/range_split_merge_mixed_version
@@ -1,0 +1,184 @@
+echo
+----
+----
+-- This test is running with kvadmission.flow_control.mode="apply_to_elastic"
+-- and the cluster version set to the previous version. We will exhaust the
+-- elastic tokens towards s3. Then, we will split and merge the range,
+-- expecting no send queue to form for any stream, as apply_to_elastic is the
+-- flow control mode. We also expect that the split and merge will proceed
+-- without issue. Note that admission is currently blocked on n3(s3).
+
+
+(Sent 3x1 MiB BulkNormalPri put request to pre-split range)
+
+
+(Sent 1 MiB BulkNormalPri put request to pre-split range)
+
+
+-- (Splitting range.)
+
+
+-- Observe the newly split off replica, with its own three streams.
+SELECT range_id, count(*) AS streams
+    FROM crdb_internal.kv_flow_control_handles_v2
+GROUP BY (range_id)
+ORDER BY streams DESC;
+
+  range_id | stream_count  
+-----------+---------------
+  70       | 3             
+  71       | 3             
+
+
+(Sent 1 MiB BulkNormalPri put request to post-split LHS range)
+
+
+(Sent 1 MiB BulkNormalPri put request to post-split RHS range)
+
+
+-- Send queue and flow token metrics from n1, post-split and 1 MiB put on
+-- each side.
+SELECT name, crdb_internal.humanize_bytes(value::INT8)
+    FROM crdb_internal.node_metrics
+   WHERE name LIKE '%kvflowcontrol%send_queue%'
+     AND name != 'kvflowcontrol.send_queue.count'
+ORDER BY name ASC;
+
+  kvflowcontrol.send_queue.bytes                                    | 0 B  
+  kvflowcontrol.send_queue.prevent.count                            | 0 B  
+  kvflowcontrol.send_queue.scheduled.deducted_bytes                 | 0 B  
+  kvflowcontrol.send_queue.scheduled.force_flush                    | 0 B  
+  kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 0 B  
+  kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 0 B  
+  kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 0 B  
+SELECT store_id,
+     crdb_internal.humanize_bytes(available_eval_regular_tokens),
+     crdb_internal.humanize_bytes(available_eval_elastic_tokens),
+     crdb_internal.humanize_bytes(available_send_regular_tokens),
+     crdb_internal.humanize_bytes(available_send_elastic_tokens)
+  FROM crdb_internal.kv_flow_controller_v2
+  ORDER BY store_id ASC;
+
+  store_id | eval_regular_available | eval_elastic_available | send_regular_available | send_elastic_available  
+-----------+------------------------+------------------------+------------------------+-------------------------
+  1        | 16 MiB                 | 3.0 MiB                | 16 MiB                 | 3.0 MiB                 
+  2        | 16 MiB                 | 3.0 MiB                | 16 MiB                 | 3.0 MiB                 
+  3        | 16 MiB                 | 0 B                    | 16 MiB                 | 0 B                     
+
+
+-- (Merging ranges.)
+
+
+-- Send queue and flow token metrics from n1, post-split-merge.
+-- We expect to not see a force flush of the send queue for s3 again.
+SELECT name, crdb_internal.humanize_bytes(value::INT8)
+    FROM crdb_internal.node_metrics
+   WHERE name LIKE '%kvflowcontrol%send_queue%'
+     AND name != 'kvflowcontrol.send_queue.count'
+ORDER BY name ASC;
+
+  kvflowcontrol.send_queue.bytes                                    | 0 B  
+  kvflowcontrol.send_queue.prevent.count                            | 0 B  
+  kvflowcontrol.send_queue.scheduled.deducted_bytes                 | 0 B  
+  kvflowcontrol.send_queue.scheduled.force_flush                    | 0 B  
+  kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 0 B  
+  kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 0 B  
+  kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 0 B  
+SELECT store_id,
+     crdb_internal.humanize_bytes(available_eval_regular_tokens),
+     crdb_internal.humanize_bytes(available_eval_elastic_tokens),
+     crdb_internal.humanize_bytes(available_send_regular_tokens),
+     crdb_internal.humanize_bytes(available_send_elastic_tokens)
+  FROM crdb_internal.kv_flow_controller_v2
+  ORDER BY store_id ASC;
+
+  store_id | eval_regular_available | eval_elastic_available | send_regular_available | send_elastic_available  
+-----------+------------------------+------------------------+------------------------+-------------------------
+  1        | 16 MiB                 | 3.0 MiB                | 16 MiB                 | 3.0 MiB                 
+  2        | 16 MiB                 | 3.0 MiB                | 16 MiB                 | 3.0 MiB                 
+  3        | 16 MiB                 | 0 B                    | 16 MiB                 | 0 B                     
+
+
+(Sent 1 MiB BulkNormalPri put request to post-split-merge range)
+
+
+-- Send queue and flow token metrics from n1, post-split-merge. 
+-- We do not expect to see the send queue develop for s3.
+SELECT name, crdb_internal.humanize_bytes(value::INT8)
+    FROM crdb_internal.node_metrics
+   WHERE name LIKE '%kvflowcontrol%send_queue%'
+     AND name != 'kvflowcontrol.send_queue.count'
+ORDER BY name ASC;
+
+  kvflowcontrol.send_queue.bytes                                    | 0 B  
+  kvflowcontrol.send_queue.prevent.count                            | 0 B  
+  kvflowcontrol.send_queue.scheduled.deducted_bytes                 | 0 B  
+  kvflowcontrol.send_queue.scheduled.force_flush                    | 0 B  
+  kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 0 B  
+  kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 0 B  
+  kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 0 B  
+SELECT store_id,
+     crdb_internal.humanize_bytes(available_eval_regular_tokens),
+     crdb_internal.humanize_bytes(available_eval_elastic_tokens),
+     crdb_internal.humanize_bytes(available_send_regular_tokens),
+     crdb_internal.humanize_bytes(available_send_elastic_tokens)
+  FROM crdb_internal.kv_flow_controller_v2
+  ORDER BY store_id ASC;
+
+  store_id | eval_regular_available | eval_elastic_available | send_regular_available | send_elastic_available  
+-----------+------------------------+------------------------+------------------------+-------------------------
+  1        | 16 MiB                 | 3.0 MiB                | 16 MiB                 | 3.0 MiB                 
+  2        | 16 MiB                 | 3.0 MiB                | 16 MiB                 | 3.0 MiB                 
+  3        | 16 MiB                 | 0 B                    | 16 MiB                 | 0 B                     
+
+
+-- Allow admission to proceed on all nodes and wait for all tokens to be
+-- returned.
+
+
+pre-split response br=(err: <nil>), *kvpb.PutResponse pErr=<nil>
+
+
+post-split LHS response br=(err: <nil>), *kvpb.PutResponse pErr=<nil>
+
+
+post-split RHS response br=(err: <nil>), *kvpb.PutResponse pErr=<nil>
+
+
+post-merge response br=(err: <nil>), *kvpb.PutResponse pErr=<nil>
+
+
+-- Flow token metrics from n1, all tokens should be returned.
+SELECT name, crdb_internal.humanize_bytes(value::INT8)
+    FROM crdb_internal.node_metrics
+   WHERE name LIKE '%kvflowcontrol%tokens%'
+ORDER BY name ASC;
+
+  kvflowcontrol.tokens.eval.elastic.available                       | 9.0 MiB  
+  kvflowcontrol.tokens.eval.elastic.deducted                        | 21 MiB   
+  kvflowcontrol.tokens.eval.elastic.returned                        | 21 MiB   
+  kvflowcontrol.tokens.eval.elastic.returned.disconnect             | 0 B      
+  kvflowcontrol.tokens.eval.elastic.unaccounted                     | 0 B      
+  kvflowcontrol.tokens.eval.regular.available                       | 48 MiB   
+  kvflowcontrol.tokens.eval.regular.deducted                        | 0 B      
+  kvflowcontrol.tokens.eval.regular.returned                        | 0 B      
+  kvflowcontrol.tokens.eval.regular.returned.disconnect             | 0 B      
+  kvflowcontrol.tokens.eval.regular.unaccounted                     | 0 B      
+  kvflowcontrol.tokens.send.elastic.available                       | 9.0 MiB  
+  kvflowcontrol.tokens.send.elastic.deducted                        | 21 MiB   
+  kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 0 B      
+  kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 0 B      
+  kvflowcontrol.tokens.send.elastic.returned                        | 21 MiB   
+  kvflowcontrol.tokens.send.elastic.returned.disconnect             | 0 B      
+  kvflowcontrol.tokens.send.elastic.unaccounted                     | 0 B      
+  kvflowcontrol.tokens.send.regular.available                       | 48 MiB   
+  kvflowcontrol.tokens.send.regular.deducted                        | 0 B      
+  kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 0 B      
+  kvflowcontrol.tokens.send.regular.returned                        | 0 B      
+  kvflowcontrol.tokens.send.regular.returned.disconnect             | 0 B      
+  kvflowcontrol.tokens.send.regular.unaccounted                     | 0 B      
+----
+----
+
+
+# vim:ft=sql


### PR DESCRIPTION
Add a new flow control integration test, described by this comment:

```sql
-- This test is running with kvadmission.flow_control.mode="apply_to_elastic"
-- and the cluster version set to the previous version. We will exhaust the
-- elastic tokens towards s3. Then, we will split and merge the range,
-- expecting no send queue to form for any stream, as apply_to_elastic is the
-- flow control mode. We also expect that the split and merge will proceed
-- without issue. Note that admission is currently blocked on n3(s3).
```

Part of: https://github.com/cockroachdb/cockroach/issues/132614
Release note: None