### PR TITLE
vecstore: add encoding and decoding functions

### DIFF
--- a/pkg/sql/vecindex/quantize/rabitqpb.go
+++ b/pkg/sql/vecindex/quantize/rabitqpb.go
@@ -20,14 +20,18 @@ import (
 // trailing bits of the code are set to zero.
 type RaBitQCode []uint64
 
+// RaBitQCodeSetWidth returns the number of uint64values needed to store 1 bit
+// per dimension for a RaBitQ code.
+func RaBitQCodeSetWidth(dims int) int {
+	return (dims + 63) / 64
+}
+
 // MakeRaBitQCodeSet returns an empty set of quantization codes, where each code
 // in the set represents a quantized vector with the given number of dimensions.
 func MakeRaBitQCodeSet(dims int) RaBitQCodeSet {
 	return RaBitQCodeSet{
 		Count: 0,
-		// Calculate the number of uint64 values needed to store 1 bit per
-		// dimension.
-		Width: (dims + 63) / 64,
+		Width: RaBitQCodeSetWidth(dims),
 	}
 }
 

--- a/pkg/sql/vecindex/vecstore/BUILD.bazel
+++ b/pkg/sql/vecindex/vecstore/BUILD.bazel
@@ -28,6 +28,7 @@ go_proto_library(
 go_library(
     name = "vecstore",
     srcs = [
+        "encoding.go",
         "in_memory_store.go",
         "partition.go",
         "search_set.go",
@@ -41,6 +42,7 @@ go_library(
         "//pkg/sql/vecindex/internal",
         "//pkg/sql/vecindex/quantize",
         "//pkg/util/container/heap",
+        "//pkg/util/encoding",
         "//pkg/util/protoutil",
         "//pkg/util/syncutil",
         "//pkg/util/vector",
@@ -52,16 +54,24 @@ go_library(
 go_test(
     name = "vecstore_test",
     srcs = [
+        "encoding_test.go",
         "in_memory_store_test.go",
+        "main_test.go",
         "partition_test.go",
         "search_set_test.go",
         "vecstorepb_test.go",
     ],
     embed = [":vecstore"],
     deps = [
+        "//pkg/sql/randgen",
+        "//pkg/sql/sem/tree",
+        "//pkg/sql/types",
         "//pkg/sql/vecindex/internal",
         "//pkg/sql/vecindex/quantize",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
         "//pkg/util/num32",
+        "//pkg/util/randutil",
         "//pkg/util/vector",
         "@com_github_stretchr_testify//require",
         "@org_gonum_v1_gonum//floats/scalar",

--- a/pkg/sql/vecindex/vecstore/encoding.go
+++ b/pkg/sql/vecindex/vecstore/encoding.go
@@ -1,0 +1,137 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package vecstore
+
+import (
+	"slices"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/quantize"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/vector"
+)
+
+// EncodePartitionMetadata encodes the metadata for a partition.
+func EncodePartitionMetadata(level Level, centroid vector.T) ([]byte, error) {
+	// The encoding consists of 8 bytes for the level, and a 4-byte length,
+	// followed by 4 bytes for each dimension in the vector.
+	encMetadataSize := 8 + (4 * (len(centroid) + 1))
+	buf := make([]byte, 0, encMetadataSize)
+	buf = encoding.EncodeUint32Ascending(buf, uint32(level))
+	return vector.Encode(buf, centroid)
+}
+
+// EncodeRaBitQVector encodes a RaBitQ vector into the given byte slice.
+func EncodeRaBitQVector(
+	appendTo []byte, codeCount uint32, centroidDistance, dotProduct float32, code quantize.RaBitQCode,
+) []byte {
+	appendTo = encoding.EncodeUint32Ascending(appendTo, codeCount)
+	appendTo = encoding.EncodeUntaggedFloat32Value(appendTo, centroidDistance)
+	appendTo = encoding.EncodeUntaggedFloat32Value(appendTo, dotProduct)
+	for _, c := range code {
+		appendTo = encoding.EncodeUint64Ascending(appendTo, c)
+	}
+	return appendTo
+}
+
+// EncodeUnquantizedVector encodes a full vector into the given byte slice.
+func EncodeUnquantizedVector(
+	appendTo []byte, centroidDistance float32, v vector.T,
+) ([]byte, error) {
+	appendTo = encoding.EncodeUntaggedFloat32Value(appendTo, centroidDistance)
+	return vector.Encode(appendTo, v)
+}
+
+// EncodeChildKey encodes a child key into the given byte slice. The "appendTo"
+// slice is expected to be the prefix shared between all KV entries for a
+// partition.
+func EncodeChildKey(appendTo []byte, key ChildKey) []byte {
+	if key.PrimaryKey != nil {
+		// The primary key is already in encoded form.
+		return append(appendTo, key.PrimaryKey...)
+	}
+	return encoding.EncodeUint64Ascending(appendTo, uint64(key.PartitionKey))
+}
+
+// DecodePartitionMetadata decodes the metadata for a partition.
+func DecodePartitionMetadata(encMetadata []byte) (level Level, centroid vector.T, err error) {
+	encMetadata, decodedLevel, err := encoding.DecodeUint32Ascending(encMetadata)
+	if err != nil {
+		return 0, nil, err
+	}
+	centroid, err = vector.Decode(encMetadata)
+	if err != nil {
+		return 0, nil, err
+	}
+	return Level(decodedLevel), centroid, nil
+}
+
+// DecodeRaBitQVectorToSet decodes a RaBitQ vector entry into the given
+// RaBitQuantizedVectorSet. The vector set must have been initialized with the
+// correct number of dimensions.
+func DecodeRaBitQVectorToSet(encVector []byte, vectorSet *quantize.RaBitQuantizedVectorSet) error {
+	encVector, codeCount, err := encoding.DecodeUint32Ascending(encVector)
+	if err != nil {
+		return err
+	}
+	encVector, centroidDistance, err := encoding.DecodeUntaggedFloat32Value(encVector)
+	if err != nil {
+		return err
+	}
+	encVector, dotProduct, err := encoding.DecodeUntaggedFloat32Value(encVector)
+	if err != nil {
+		return err
+	}
+	vectorSet.CodeCounts = append(vectorSet.CodeCounts, codeCount)
+	vectorSet.CentroidDistances = append(vectorSet.CentroidDistances, centroidDistance)
+	vectorSet.DotProducts = append(vectorSet.DotProducts, dotProduct)
+	vectorSet.Codes.Data = slices.Grow(vectorSet.Codes.Data, vectorSet.Codes.Width)
+	for i := 0; i < vectorSet.Codes.Width; i++ {
+		var codeWord uint64
+		encVector, codeWord, err = encoding.DecodeUint64Ascending(encVector)
+		if err != nil {
+			return err
+		}
+		vectorSet.Codes.Data = append(vectorSet.Codes.Data, codeWord)
+	}
+	vectorSet.Codes.Count++
+	return nil
+}
+
+// DecodeUnquantizedVectorToSet decodes a full vector entry into the given
+// UnQuantizedVectorSet. The vector set must have been initialized with the
+// correct number of dimensions.
+func DecodeUnquantizedVectorToSet(
+	encVector []byte, vectorSet *quantize.UnQuantizedVectorSet,
+) error {
+	encVector, centroidDistance, err := encoding.DecodeUntaggedFloat32Value(encVector)
+	if err != nil {
+		return err
+	}
+	v, err := vector.Decode(encVector)
+	if err != nil {
+		return err
+	}
+	vectorSet.CentroidDistances = append(vectorSet.CentroidDistances, centroidDistance)
+	vectorSet.Vectors.Add(v)
+	return nil
+}
+
+// DecodeChildKey decodes a child key from the given byte slice.
+// NOTE: the returned ChildKey may reference the input slice.
+func DecodeChildKey(encChildKey []byte, level Level) (ChildKey, error) {
+	if level == LeafLevel {
+		// Leaf vectors point to the primary index. The primary key is already in
+		// encoded form, so just use it as-is.
+		return ChildKey{PrimaryKey: encChildKey}, nil
+	} else {
+		// Non-leaf vectors point to the partition key.
+		_, childPartitionKey, err := encoding.DecodeUint64Ascending(encChildKey)
+		if err != nil {
+			return ChildKey{}, err
+		}
+		return ChildKey{PartitionKey: PartitionKey(childPartitionKey)}, nil
+	}
+}

--- a/pkg/sql/vecindex/vecstore/encoding_test.go
+++ b/pkg/sql/vecindex/vecstore/encoding_test.go
@@ -1,0 +1,152 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package vecstore
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/internal"
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/quantize"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/vector"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	rnd, seed := randutil.NewTestRand()
+	t.Logf("random seed: %v", seed)
+
+	dims := rnd.Intn(100) + 1
+	count := rnd.Intn(128)
+
+	set := vector.MakeSet(dims)
+	set.AddUndefined(count)
+	for i := range count {
+		vecDatum := randgen.RandDatum(rnd, types.MakePGVector(int32(dims)), false /* nullOk */)
+		copy(set.At(i), vecDatum.(*tree.DPGVector).T)
+	}
+	testEncodeDecodeRoundTripImpl(t, rnd, &set)
+}
+
+func testEncodeDecodeRoundTripImpl(t *testing.T, rnd *rand.Rand, set *vector.Set) {
+	ctx := internal.WithWorkspace(context.Background(), &internal.Workspace{})
+	for _, quantizer := range []quantize.Quantizer{
+		quantize.NewUnQuantizer(set.Dims),
+		quantize.NewRaBitQuantizer(set.Dims, rnd.Int63()),
+	} {
+		name := strings.TrimPrefix(fmt.Sprintf("%T", quantizer), "*quantize.")
+		t.Run(name, func(t *testing.T) {
+			for _, level := range []Level{LeafLevel, Level(rnd.Intn(10)) + SecondLevel} {
+				t.Run(fmt.Sprintf("level=%d", level), func(t *testing.T) {
+					// Build the partition.
+					quantizedSet := quantizer.Quantize(ctx, set)
+					childKeys := make([]ChildKey, set.Count)
+					for i := range childKeys {
+						if level == LeafLevel {
+							pkSize := rnd.Intn(32) + 1
+							childKeys[i] = ChildKey{PrimaryKey: randutil.RandBytes(rnd, pkSize)}
+						} else {
+							childKeys[i] = ChildKey{PartitionKey: PartitionKey(rnd.Uint64())}
+						}
+					}
+					originalPartition := NewPartition(quantizer, quantizedSet, childKeys, level)
+
+					// Encode the partition.
+					encMetadata, err := EncodePartitionMetadata(level, quantizedSet.GetCentroid())
+					require.NoError(t, err)
+					encVectors := make([][]byte, set.Count)
+					encChildren := make([][]byte, len(childKeys))
+					for i := range set.Count {
+						switch quantizedSet := quantizedSet.(type) {
+						case *quantize.UnQuantizedVectorSet:
+							encVectors[i], err = EncodeUnquantizedVector([]byte(nil),
+								quantizedSet.GetCentroidDistances()[i], set.At(i),
+							)
+							require.NoError(t, err)
+						case *quantize.RaBitQuantizedVectorSet:
+							encVectors[i] = EncodeRaBitQVector([]byte(nil),
+								quantizedSet.CodeCounts[i], quantizedSet.CentroidDistances[i],
+								quantizedSet.DotProducts[i], quantizedSet.Codes.At(i),
+							)
+						}
+						encChildren[i] = EncodeChildKey([]byte(nil), childKeys[i])
+					}
+
+					// Decode the encoded partition.
+					decodedLevel, decodedCentroid, err := DecodePartitionMetadata(encMetadata)
+					require.NoError(t, err)
+					decodedChildKeys := make([]ChildKey, len(encVectors))
+					var decodedSet quantize.QuantizedVectorSet
+					switch quantizedSet.(type) {
+					case *quantize.UnQuantizedVectorSet:
+						decodedSet = &quantize.UnQuantizedVectorSet{
+							Centroid: decodedCentroid,
+							Vectors:  vector.MakeSet(set.Dims),
+						}
+						for i := range encVectors {
+							err = DecodeUnquantizedVectorToSet(
+								encVectors[i], decodedSet.(*quantize.UnQuantizedVectorSet),
+							)
+							require.NoError(t, err)
+						}
+					case *quantize.RaBitQuantizedVectorSet:
+						decodedSet = &quantize.RaBitQuantizedVectorSet{
+							Centroid: decodedCentroid,
+							Codes:    quantize.MakeRaBitQCodeSet(set.Dims),
+						}
+						for i := range encVectors {
+							err = DecodeRaBitQVectorToSet(
+								encVectors[i], decodedSet.(*quantize.RaBitQuantizedVectorSet),
+							)
+							require.NoError(t, err)
+						}
+					}
+					for i := range encChildren {
+						decodedChildKeys[i], err = DecodeChildKey(encChildren[i], decodedLevel)
+						require.NoError(t, err)
+					}
+					decodedPartition := NewPartition(quantizer, decodedSet, decodedChildKeys, decodedLevel)
+					testingAssertPartitionsEqual(t, originalPartition, decodedPartition)
+				})
+			}
+		})
+	}
+}
+
+func testingAssertPartitionsEqual(t *testing.T, l, r *Partition) {
+	q1, q2 := l.quantizedSet, r.quantizedSet
+	require.Equal(t, l.level, r.level, "levels do not match")
+	require.Equal(t, l.ChildKeys(), r.ChildKeys(), "childKeys do not match")
+	require.Equal(t, q1.GetCentroid(), q2.GetCentroid(), "centroids do not match")
+	require.Equal(t, q1.GetCount(), q2.GetCount(), "counts do not match")
+	require.Equal(t, q1.GetCentroidDistances(), q2.GetCentroidDistances(), "distances do not match")
+	switch leftSet := q1.(type) {
+	case *quantize.UnQuantizedVectorSet:
+		rightSet, ok := q2.(*quantize.UnQuantizedVectorSet)
+		require.True(t, ok, "quantized set types do not match")
+		require.True(t, leftSet.Vectors.Equal(&rightSet.Vectors), "vectors do not match")
+	case *quantize.RaBitQuantizedVectorSet:
+		rightSet, ok := q2.(*quantize.RaBitQuantizedVectorSet)
+		require.True(t, ok, "quantized set types do not match")
+		require.Equal(t, leftSet.CodeCounts, rightSet.CodeCounts, "code counts do not match")
+		require.Equal(t, leftSet.Codes, rightSet.Codes, "codes do not match")
+		require.Equal(t, leftSet.DotProducts, rightSet.DotProducts, "dot products do not match")
+	default:
+		t.Fatalf("unexpected type %T", q1)
+	}
+}

--- a/pkg/sql/vecindex/vecstore/in_memory_store_test.go
+++ b/pkg/sql/vecindex/vecstore/in_memory_store_test.go
@@ -14,12 +14,17 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/internal"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/quantize"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/vector"
 	"github.com/stretchr/testify/require"
 	"gonum.org/v1/gonum/floats/scalar"
 )
 
 func TestInMemoryStore(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	ctx := internal.WithWorkspace(context.Background(), &internal.Workspace{})
 
 	childKey2 := ChildKey{PartitionKey: 2}
@@ -256,6 +261,9 @@ func TestInMemoryStore(t *testing.T) {
 }
 
 func TestInMemoryStoreConcurrency(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	ctx := internal.WithWorkspace(context.Background(), &internal.Workspace{})
 
 	childKey10 := ChildKey{PartitionKey: 10}
@@ -307,6 +315,9 @@ func TestInMemoryStoreConcurrency(t *testing.T) {
 }
 
 func TestInMemoryStoreUpdateStats(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	ctx := context.Background()
 
 	// Insert root partition into new store.
@@ -390,6 +401,9 @@ func TestInMemoryStoreUpdateStats(t *testing.T) {
 }
 
 func TestInMemoryStoreMarshalling(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	raBitQuantizer := quantize.NewRaBitQuantizer(2, 42)
 	unquantizer := quantize.NewUnQuantizer(2)
 	store := InMemoryStore{

--- a/pkg/sql/vecindex/vecstore/main_test.go
+++ b/pkg/sql/vecindex/vecstore/main_test.go
@@ -1,0 +1,21 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package vecstore
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+//go:generate ../util/leaktest/add-leaktest.sh *_test.go
+
+func TestMain(m *testing.M) {
+	randutil.SeedForTests()
+
+	os.Exit(m.Run())
+}

--- a/pkg/sql/vecindex/vecstore/partition.go
+++ b/pkg/sql/vecindex/vecstore/partition.go
@@ -32,7 +32,7 @@ type PrimaryKey []byte
 
 // Level specifies a level in the K-means tree. Levels are numbered from leaf to
 // root, in ascending order, with the leaf level always equal to one.
-type Level uint64
+type Level uint32
 
 const (
 	// InvalidLevel is the default (invalid) value for a K-means tree level.

--- a/pkg/sql/vecindex/vecstore/partition_test.go
+++ b/pkg/sql/vecindex/vecstore/partition_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/internal"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/quantize"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/num32"
 	"github.com/cockroachdb/cockroach/pkg/util/vector"
 	"github.com/stretchr/testify/require"
@@ -18,6 +20,9 @@ import (
 )
 
 func TestPartition(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	ctx := internal.WithWorkspace(context.Background(), &internal.Workspace{})
 
 	childKey10 := ChildKey{PartitionKey: 10}

--- a/pkg/sql/vecindex/vecstore/search_set_test.go
+++ b/pkg/sql/vecindex/vecstore/search_set_test.go
@@ -8,10 +8,15 @@ package vecstore
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSearchResult(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	r1 := SearchResult{
 		QuerySquaredDistance: 1,
 		ErrorBound:           0.5,
@@ -68,6 +73,9 @@ func TestSearchResult(t *testing.T) {
 }
 
 func TestSearchStats(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	var stats SearchStats
 	stats.SearchedPartition(LeafLevel, 10)
 	stats.SearchedPartition(LeafLevel+1, 10)
@@ -84,6 +92,9 @@ func TestSearchStats(t *testing.T) {
 }
 
 func TestSearchSet(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	// Empty.
 	searchSet := SearchSet{MaxResults: 3, MaxExtraResults: 7}
 	require.Nil(t, searchSet.PopResults())

--- a/pkg/sql/vecindex/vecstore/vecstorepb_test.go
+++ b/pkg/sql/vecindex/vecstore/vecstorepb_test.go
@@ -9,10 +9,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
 )
 
 func TestIndexStats(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	// Empty stats.
 	stats := IndexStats{}
 	require.Equal(t, strings.TrimSpace(`
@@ -59,6 +64,9 @@ CV stats:
 }
 
 func TestChildKey(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	childKey1 := ChildKey{PartitionKey: 10}
 	childKey2 := ChildKey{PartitionKey: 20}
 	childKey3 := ChildKey{PrimaryKey: []byte{1, 2, 3}}

--- a/pkg/util/vector/vector_set.go
+++ b/pkg/util/vector/vector_set.go
@@ -191,3 +191,13 @@ func (vs *Set) Centroid(centroid T) T {
 	num32.Scale(1/float32(vs.Count), centroid)
 	return centroid
 }
+
+// Equal returns true if this set is equal to the other set. Two sets are equal
+// if they have the same number of dimensions, the same number of vectors, and
+// the same values in the same order.
+func (vs *Set) Equal(other *Set) bool {
+	if vs.Dims != other.Dims || vs.Count != other.Count {
+		return false
+	}
+	return slices.Equal(vs.Data, other.Data)
+}

--- a/pkg/util/vector/vector_set_test.go
+++ b/pkg/util/vector/vector_set_test.go
@@ -136,6 +136,26 @@ func TestVectorSet(t *testing.T) {
 		require.Equal(t, []float32{9, 10, 3, 4, 5, 6, 7, 8}, vs2.Data)
 	})
 
+	t.Run("Equal method", func(t *testing.T) {
+		vs := MakeSetFromRawData([]float32{1, 2, 3, 4, 5, 6}, 2)
+		vs2 := MakeSetFromRawData([]float32{1, 2, 3, 4, 5, 6}, 2)
+		vs3 := vs.Clone()
+		require.True(t, vs.Equal(&vs))
+		require.True(t, vs.Equal(&vs2))
+		require.True(t, vs.Equal(&vs3))
+
+		vs.Add(T{7, 8})
+		require.False(t, vs.Equal(&vs2))
+		require.True(t, vs.Equal(&vs))
+		vs2.Add(T{7, 8})
+		require.True(t, vs.Equal(&vs2))
+		vs.ReplaceWithLast(1)
+		require.False(t, vs.Equal(&vs2))
+		require.True(t, vs.Equal(&vs))
+		vs2.ReplaceWithLast(1)
+		require.True(t, vs.Equal(&vs2))
+	})
+
 	t.Run("check that invalid operations will panic", func(t *testing.T) {
 		vs := MakeSetFromRawData([]float32{1, 2, 3, 4, 5, 6}, 2)
 		require.Panics(t, func() { vs.At(-1) })


### PR DESCRIPTION
This commit adds a set of functions for encoding and decoding the metadata and vectors of a partition. It also adds a test to ensure that round-trip encoding and decoding a partition results in an equivalent partition.

Epic: CRDB-42943

Release note: None