### PR TITLE
roachtest: respect ctx cancelation in admission-control/elastic-io

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
@@ -124,6 +124,11 @@ func registerElasticIO(r registry.Registry) {
 				// Sleep initially for stability to be achieved, before measuring.
 				time.Sleep(5 * time.Minute)
 				for {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					default:
+					}
 					time.Sleep(10 * time.Second)
 					val, err := getMetricVal(subLevelMetric)
 					if err != nil {


### PR DESCRIPTION
Fixes #136557.

Release note: None