### PR TITLE
sql: fix a race in TestShowTenantFingerprintsProtectsTimestamp

### DIFF
--- a/pkg/sql/show_fingerprints_test.go
+++ b/pkg/sql/show_fingerprints_test.go
@@ -149,8 +149,7 @@ func TestShowTenantFingerprintsProtectsTimestamp(t *testing.T) {
 	testingRequestFilter := func(_ context.Context, ba *kvpb.BatchRequest) *kvpb.Error {
 		for _, req := range ba.Requests {
 			if expReq := req.GetExport(); expReq != nil {
-				if expReq.ExportFingerprint && !exportStartedClosed.Load() {
-					exportStartedClosed.Store(true)
+				if expReq.ExportFingerprint && exportStartedClosed.CompareAndSwap(false, true) {
 					close(exportsStarted)
 					<-exportsResume
 				}


### PR DESCRIPTION
I think there is a possible race in `TestShowTenantFingerprintsProtectsTimestamp` where we have an atomic to make sure that we close the channel only once. If we have concurrent BatchRequests checking the `if` condition at the same time, both will try to close the channel leading to a panic. Switch to using compare-and-swap instead of load plus store.

Fixes: #136711.

Release note: None