### PR TITLE
roachtest: fix resize operation in run-operation command

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -71,6 +71,7 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus/promhttp",
         "@com_github_slack_go_slack//:slack",
         "@com_github_spf13_cobra//:cobra",
+        "@in_gopkg_yaml_v2//:yaml_v2",
         "@org_golang_x_sync//errgroup",
         "@org_golang_x_sys//unix",
     ],

--- a/pkg/cmd/roachtest/operation/BUILD.bazel
+++ b/pkg/cmd/roachtest/operation/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/cmd/roachtest/cluster",
         "//pkg/cmd/roachtest/option",
         "//pkg/roachprod/install",
         "//pkg/roachprod/logger",

--- a/pkg/cmd/roachtest/operation/operation_interface.go
+++ b/pkg/cmd/roachtest/operation/operation_interface.go
@@ -6,6 +6,7 @@
 package operation
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
@@ -28,4 +29,5 @@ type Operation interface {
 
 	L() *logger.Logger
 	Status(args ...interface{})
+	WorkloadCluster() cluster.Cluster
 }

--- a/pkg/cmd/roachtest/operation_impl.go
+++ b/pkg/cmd/roachtest/operation_impl.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
@@ -46,6 +47,8 @@ type operationImpl struct {
 
 		status string
 	}
+
+	workLoadCluster *clusterImpl
 }
 
 func (o *operationImpl) ClusterCockroach() string {
@@ -140,6 +143,14 @@ func (o *operationImpl) Failed() bool {
 	defer o.mu.RUnlock()
 
 	return len(o.mu.failures) > 0
+}
+
+// WorkloadCluster can return nil if o.workLoadCluster is not set.
+func (o *operationImpl) WorkloadCluster() cluster.Cluster {
+	if o.workLoadCluster == nil {
+		return nil
+	}
+	return o.workLoadCluster
 }
 
 var _ operation.Operation = &operationImpl{}

--- a/pkg/cmd/roachtest/operations/resize.go
+++ b/pkg/cmd/roachtest/operations/resize.go
@@ -72,6 +72,11 @@ func resizeCluster(
 	if err != nil {
 		o.Fatal(err)
 	}
+	// Grow command generate new certificates, update certificate on workload cluster.
+	if wc := o.WorkloadCluster(); wc != nil {
+		_ = c.Get(ctx, o.L(), "certs", path.Join(tmpDir, "certs"), c.Node(1))
+		wc.Put(ctx, path.Join(tmpDir, "certs"), "./", wc.All())
+	}
 	newNodes := c.Range(origClusterSize+1, origClusterSize+growCount)
 
 	// Copy the required files to the new nodes.
@@ -80,7 +85,7 @@ func resizeCluster(
 
 	// Start the new nodes.
 	startOpts := o.StartOpts()
-	startOpts.RoachprodOpts.IsRestart = true
+	startOpts.RoachprodOpts.IsRestart = false
 	c.Start(ctx, o.L(), startOpts, o.ClusterSettings(), newNodes)
 
 	return &cleanupResize{growCount: growCount, origClusterSize: origClusterSize}

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -383,6 +383,13 @@ var (
 		Usage: "Execute operations indefinitely until the command is terminated, (default false).",
 	})
 
+	WorkloadCluster string = ""
+	_                      = registerRunOpsFlag(&WorkloadCluster, FlagInfo{
+		Name: "workload-cluster",
+		Usage: "Specify the name of the workload cluster. The workload cluster is the one running operations and " +
+			"workloads, such as TPC-C, on the cluster",
+	})
+
 	SideEyeApiToken string = ""
 	_                      = registerRunFlag(&SideEyeApiToken, FlagInfo{
 		Name: "side-eye-token",

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -1774,7 +1774,8 @@ func (p *Provider) Grow(l *logger.Logger, vms vm.List, clusterName string, names
 		if addCount == 0 {
 			continue
 		}
-		createArgs := []string{"compute", "instance-groups", "managed", "create-instance", "--zone", group.Zone, groupName}
+		createArgs := []string{"compute", "instance-groups", "managed", "create-instance", "--zone", group.Zone, groupName,
+			"--project", project}
 		for i := 0; i < addCount; i++ {
 			name := names[0]
 			names = names[1:]


### PR DESCRIPTION
The current implementation of the resize operation fails after creating new VMs. This PR addresses the errors encountered when joining a new node to the cluster. The changes include:
- Read start flags of cockroach by passing a config file.
- Introduces flag `workload-cluster` which enables operation to perform certain actions like updating certificates on workload nodes.

Sample yaml config for roachtest operation:
```yaml
startopts:
  roachprodopts:
    storecount: 4
    enablefluentsink: true
    walfailover: among-stores
    sqlport: 26257
```

Epic: none

Release note: None