### PR TITLE
kvserver/rangefeed: reduce nesting in buffered sender

### DIFF
--- a/pkg/kv/kvserver/rangefeed/buffered_sender.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_sender.go
@@ -122,17 +122,16 @@ func (bs *BufferedSender) run(
 		case <-bs.notifyDataC:
 			for {
 				e, success := bs.popFront()
-				if success {
-					err := bs.sender.Send(e.ev)
-					e.alloc.Release(ctx)
-					if e.ev.Error != nil {
-						onError(e.ev.StreamID)
-					}
-					if err != nil {
-						return err
-					}
-				} else {
+				if !success {
 					break
+				}
+				err := bs.sender.Send(e.ev)
+				e.alloc.Release(ctx)
+				if e.ev.Error != nil {
+					onError(e.ev.StreamID)
+				}
+				if err != nil {
+					return err
 				}
 			}
 		}


### PR DESCRIPTION
This patch refactors the for loop in the buffered sender to break early on the
unhappy path, enhancing code clarity.

Release note: none
Epic: none