### PR TITLE
release-23.1: roachtest: deflake activerecord test

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord_blocklist.go
+++ b/pkg/cmd/roachtest/tests/activerecord_blocklist.go
@@ -45,6 +45,7 @@ var activeRecordIgnoreList = blocklist{
 	"BasicsTest#test_default_values_are_deeply_dupped":                                                                "flaky - sometimes attempts to call a method on nil",
 	"BinaryTest#test_mixed_encoding":                                                                                                                           "flaky - sometimes complains that a relation does not exist",
 	"CockroachDB::FixturesTest#test_bulk_insert":                                                                                                               "flaky",
+	`CockroachDB::FixturesTest#test_create_fixtures`:                                                                                                           "flaky",
 	"CockroachDB::PostgresqlIntervalTest#test_column":                                                                                                          "flaky - sometimes complains that a relation does not exist",
 	"CockroachDB::PostgresqlIntervalTest#test_simple_interval":                                                                                                 "flaky - sometimes time format is wrong",
 	"CockroachDB::PostgresqlIntervalTest#test_interval_type":                                                                                                   "flaky - sometimes complains that a relation does not exist",


### PR DESCRIPTION
Backport 1/1 commits from #136688.

/cc @cockroachdb/release

---

Previously, the active record test had a test flake on CockroachDB::FixturesTest#test_create_fixtures. This patch adds that test on the ignore list.

Fixes: #136460

Release note: None
Release justification: test only change to fix a flake
