### PR TITLE
cliccl: use latest version for the TestList

### DIFF
--- a/pkg/ccl/cliccl/ear_test.go
+++ b/pkg/ccl/cliccl/ear_test.go
@@ -137,7 +137,7 @@ func TestList(t *testing.T) {
 	require.NoError(t, err)
 	env, err := fs.InitEnv(ctx, vfs.Default, dir, fs.EnvConfig{EncryptionOptions: encOpts}, nil /* statsCollector */)
 	require.NoError(t, err)
-	p, err := storage.Open(ctx, env, cluster.MakeClusterSettings())
+	p, err := storage.Open(ctx, env, cluster.MakeTestingClusterSettings())
 	require.NoError(t, err)
 
 	// Write a key and flush, to create a table in the store.


### PR DESCRIPTION
We were using `MakeClusterSettings()` which initializes the cluster at
the minimum supported version. Switching to
`MakeTestingClusterSettings()` which initializes at the latest
version. It makes more sense for the test to change when the latest
version changes.

Epic: none
Release note: None