### PR TITLE
build: build pebble test binary on correct crdb branch

### DIFF
--- a/build/teamcity/cockroach/nightlies/pebble_nightly_build_test_binary.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_build_test_binary.sh
@@ -9,6 +9,7 @@
 # This script is run by pebble_nightly_metamorphic_crossversion.sh to build test
 # binaries of the pebble metamorphic package at different branches. This script
 # takes two argments:
+#   - The crdb branch to use; the major release must match the pebble branch.
 #   - The pebble branch to build, eg "crl-release-22.1" or "master"
 #   - A destination directory into which the binary will be copied with the
 #     filename <SHA>.test.
@@ -16,18 +17,17 @@
 
 set -euo pipefail
 
-PEBBLE_BRANCH="$1"
-DEST="$2"
+CRDB_BRANCH="$1"
+PEBBLE_BRANCH="$2"
+DEST="$3"
+
+RESTORE_COMMIT=$(git rev-parse HEAD)
+git fetch origin "$CRDB_BRANCH"
+git checkout "origin/$CRDB_BRANCH"
 
 BAZEL_BIN=$(bazel info bazel-bin --config ci)
 
 bazel run @go_sdk//:bin/go get "github.com/cockroachdb/pebble@$PEBBLE_BRANCH"
-
-# Remove the patch, which doesn't work with older versions (the "unpatched"
-# config assumes the invariants tag is set). Once we remove the patch,
-# cmd/mirror/go below will not find it and it won't be referenced in the
-# resulting DEPS.bzl.
-rm -f build/patches/com_github_cockroachdb_pebble.patch
 
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)
 echo "$NEW_DEPS_BZL_CONTENT" > DEPS.bzl
@@ -45,7 +45,12 @@ bazel build --define gotags=bazel,invariants \
 cp $BAZEL_BIN/external/com_github_cockroachdb_pebble/internal/metamorphic/metamorphic_test_/metamorphic_test \
     "$DEST/$PEBBLE_SHA.test"
 chmod a+w "$DEST/$PEBBLE_SHA.test"
-echo "$PEBBLE_SHA"
 
-# Return DEPS.bzl and the patch to its previous contents.
-git checkout HEAD -- DEPS.bzl build/patches
+# Discard changes.
+git checkout .
+
+# Go back. This is important because the current tree is used for the next
+# invocation of this script.
+git checkout -q "$RESTORE_COMMIT"
+
+echo "$PEBBLE_SHA"

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_crossversion.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_crossversion.sh
@@ -8,6 +8,9 @@
 #
 # This script is run by the Pebble Nightly Crossversion Metamorphic - TeamCity
 # build configuration.
+#
+# The arguments are a list of branches to test; each item is of the format
+# "<crdb-branch>:<pebble-branch>", for example: "release-23.1:crl-release-23.1".
 
 set -euo pipefail
 
@@ -20,22 +23,32 @@ mkdir -p bin
 chmod o+rwx bin
 mkdir -p $root/artifacts
 
+tc_start_block "Build test binaries"
+
 VERSIONS=""
 LAST_SHA=""
-for branch in "$@"
+for arg in "$@"
 do
-    tc_start_block "Compile Pebble $branch metamorphic test binary"
-    SHA=$("$dir/teamcity/cockroach/nightlies/pebble_nightly_build_test_binary.sh" "$branch" "bin" | tail -n1)
-    VERSIONS="$VERSIONS -version $branch,$SHA,/test-bin/$SHA.test"
+    CRDB_BRANCH="${arg%%:*}"
+    # Extract the part after the colon
+    PEBBLE_BRANCH="${arg#*:}"
+
+    tc_start_block "Compile Pebble $CRDB_BRANCH:$PEBBLE_BRANCH metamorphic test binary"
+    SHA=$("$dir/teamcity/cockroach/nightlies/pebble_nightly_build_test_binary.sh" "$CRDB_BRANCH" "$PEBBLE_BRANCH" bin | tail -n1)
+    VERSIONS="$VERSIONS -version $PEBBLE_BRANCH,$SHA,/test-bin/$SHA.test"
     LAST_SHA="$SHA"
     echo "$PWD/bin/$SHA.test"
     stat "$PWD/bin/$SHA.test"
-    tc_end_block "Compile Pebble $branch metamorphic test binary"
+    tc_end_block "Compile Pebble $CRDB_BRANCH:$PEBBLE_BRANCH metamorphic test binary"
 done
 
 ls -l "$PWD/bin/"
 
+tc_end_block "Build test binaries"
+
+tc_start_block "Run the crossversion test"
 BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e BUILD_VCS_NUMBER=$LAST_SHA -e GITHUB_API_TOKEN -e GITHUB_REPO -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL --mount type=bind,source=$PWD/bin,target=/test-bin" \
                                run_bazel \
                                build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_crossversion_impl.sh \
                                "$VERSIONS"
+tc_end_block "Run the crossversion test"


### PR DESCRIPTION
The nightly pebble crossversion tests attempt to build Pebble
metamorphic test binaries by updating the Pebble dependency on the
CRDB master branch. This doesn't work when there are material changes
in the way Pebble is built (e.g. the patch we apply).

We now checkout the proper CRDB branch for each major release. The
corresponding change to the arguments in the teamcity configuration
will be made.

Epic: none
Release note: None