### PR TITLE
workload/schemachange: fix column is referenced by the primary key flake

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -1445,14 +1445,14 @@ WITH descriptors AS (
                           FROM descriptors
                        )
                  WHERE (mut->'primaryKeySwap') IS NOT NULL
-            )
 		 -- Check for declarative primary key swaps, which will appear as
 		 -- as new primary indexes with different key columns
-     UNION SELECT count(*) > 0
+     UNION SELECT p
              FROM primaryindex AS pk, mutations AS mut
             WHERE m->'index'->'encodingType' = '1'::JSONB
                   AND m->'index'->'keyColumnIds'
-                    != p->'keyColumnIds';
+                    != p->'keyColumnIds'
+			);
 		`,
 		tableName.String(),
 	)


### PR DESCRIPTION
Previously, a fix to address this issue had a bad union, which caused us to only look at the results from the legacy schema changer. This patch fixes the union query to properly join the results from the legacy and declarative queries.

Fixes: #136824

Release note: None