### PR TITLE
rpc: increase timeout for TestClockOffsetInPingRequest

### DIFF
--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -202,7 +202,7 @@ func testClockOffsetInPingRequestInternal(t *testing.T, clientOnly bool) {
 	clientOpts := opts
 	// Experimentally, values below 50ms seem to incur flakiness.
 	clientOpts.RPCHeartbeatInterval = 100 * time.Millisecond
-	clientOpts.RPCHeartbeatTimeout = 100 * time.Millisecond
+	clientOpts.RPCHeartbeatTimeout = 200 * time.Millisecond
 	clientOpts.ClientOnly = clientOnly
 	clientOpts.OnOutgoingPing = func(ctx context.Context, req *PingRequest) error {
 		select {


### PR DESCRIPTION
Previously this test had the `RPCHeartbeatInterval` and `RPCHeartbeatTimeout` both set at 100ms. Normally the `RPCHeartbeatTimeout` is set at 3x the interval. During race builds this provides enough extra cushion that the test should pass.

Epic: none
Fixes: #136703

Release note: None