### PR TITLE
changefeedccl: add support for nonstandard oauthbearer kafka authentication

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -5381,6 +5381,9 @@ func TestChangefeedErrors(t *testing.T) {
 		t, `sasl_client_id must be provided when SASL is enabled using mechanism OAUTHBEARER`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_enabled=true&sasl_mechanism=OAUTHBEARER`,
 	)
+
+	// TODO: add some test cases in here for option validation
+
 	sqlDB.ExpectErrWithTimeout(
 		t, `sasl_enabled must be enabled if sasl_user is provided`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_user=a`,

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -221,6 +221,12 @@ const (
 	SinkParamSASLAwsIAMSessionName  = `sasl_aws_iam_session_name`
 	SinkParamTableNameAttribute     = `with_table_name_attribute`
 
+	// These are custom fields required by ID Anywhere. They should not be
+	// documented.
+	SinkParamSASLIDAnywhereResource            = `sasl_id_anywhere_resource`
+	SinkParamSASLIDAnywhereClientAssertionType = `sasl_id_anywhere_client_assertion_type`
+	SinkParamSASLIDAnywhereClientAssertion     = `sasl_id_anywhere_client_assertion`
+
 	SinkSchemeConfluentKafka    = `confluent-cloud`
 	SinkParamConfluentAPIKey    = `api_key`
 	SinkParamConfluentAPISecret = `api_secret`
@@ -239,8 +245,11 @@ const (
 	Topics = `topics`
 )
 
-// Support additional mechanism on top of the default SASL mechanism.
-const SASLTypeAWSMSKIAM = "AWS_MSK_IAM"
+// Support additional mechanisms on top of the default SASL mechanisms.
+const (
+	SASLTypeAWSMSKIAM  = "AWS_MSK_IAM"
+	SASLTypeIDAnywhere = "ID_ANYWHERE"
+)
 
 func makeStringSet(opts ...string) map[string]struct{} {
 	res := make(map[string]struct{}, len(opts))

--- a/pkg/ccl/changefeedccl/sink_kafka_v2.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2.go
@@ -9,9 +9,12 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
+	"fmt"
 	"hash/fnv"
 	"io"
 	"net"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -39,6 +42,7 @@ import (
 	sasloauth "github.com/twmb/franz-go/pkg/sasl/oauth"
 	saslplain "github.com/twmb/franz-go/pkg/sasl/plain"
 	saslscram "github.com/twmb/franz-go/pkg/sasl/scram"
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 )
 
@@ -452,6 +456,17 @@ func buildKgoConfig(
 				return nil, err
 			}
 			s = sasloauth.Oauth(tp)
+		// This is another "fake" mechanism we use to signify that we're using
+		// the ID Anywhere identity provider, which is not OAUTH-compliant and requires special handling.
+		case changefeedbase.SASLTypeIDAnywhere:
+			tp, err := newIDAnywhereOauthTokenProvider(ctx, dialConfig)
+			if err != nil {
+				return nil, err
+			}
+			s = sasloauth.Oauth(tp)
+			// DBG
+			tokres, tokerr := tp(ctx)
+			fmt.Printf("DBG: tokres: %+#v, tokerr: %v\n", tokres, tokerr)
 		// TODO(#126991): Remove this sarama dependency.
 		case sarama.SASLTypeOAuth:
 			tp, err := newKgoOauthTokenProvider(ctx, dialConfig)
@@ -459,6 +474,9 @@ func buildKgoConfig(
 				return nil, err
 			}
 			s = sasloauth.Oauth(tp)
+			// DBG
+			tokres, tokerr := tp(ctx)
+			fmt.Printf("DBG: tokres: %+#v, tokerr: %v\n", tokres, tokerr)
 		case sarama.SASLTypePlaintext, "":
 			s = saslplain.Plain(func(ctc context.Context) (saslplain.Auth, error) {
 				return saslplain.Auth{
@@ -701,6 +719,120 @@ func newKgoAWSIAMRoleOauthTokenProvider(
 			return sasloauth.Auth{}, err
 		}
 		return sasloauth.Auth{Token: token}, nil
+	}, nil
+}
+
+type idAnywhereTokenSource struct {
+	dialConfig kafkaDialConfig
+	// The oauth2.TokenSource API seems to require us to keep a context in here.
+	ctx    context.Context
+	client *http.Client
+}
+
+// Token implements the oauth2.TokenSource interface.
+func (iats idAnywhereTokenSource) Token() (*oauth2.Token, error) {
+	tokenURL, err := url.Parse(iats.dialConfig.saslTokenURL)
+	if err != nil {
+		return nil, errors.Wrap(err, "malformed token url")
+	}
+
+	bodyParams := url.Values{
+		"grant_type":            {"client_credentials"},
+		"client_id":             {iats.dialConfig.saslClientID},
+		"client_assertion_type": {iats.dialConfig.saslIDAnywhereConfig.clientAssertionType},
+		"client_assertion":      {iats.dialConfig.saslIDAnywhereConfig.clientAssertion},
+		"resource":              {iats.dialConfig.saslIDAnywhereConfig.resource},
+	}
+
+	req, err := http.NewRequestWithContext(iats.ctx, "POST", tokenURL.String(), strings.NewReader(bodyParams.Encode()))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create oauth token request")
+	}
+	req.Header.Set("Content-Type", "application/www-url-encoded")
+	res, err := iats.client.Do(req)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to make oauth token request")
+	}
+	body, err := io.ReadAll(io.LimitReader(res.Body, 1<<20))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read oauth response body")
+	}
+	if err := res.Body.Close(); err != nil {
+		return nil, errors.Wrap(err, "failed to close oauth response body")
+	}
+
+	// The endpoint returns JSON; this format was given to us by the customer.
+	var resp struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, errors.Wrapf(err, "failed to parse oauth response")
+	}
+	if resp.AccessToken == "" {
+		return nil, errors.Errorf("no access token in oauth response")
+	}
+
+	tok := &oauth2.Token{AccessToken: resp.AccessToken, TokenType: resp.TokenType}
+
+	if resp.ExpiresIn > 0 {
+		tok.Expiry = time.Now().Add(time.Duration(resp.ExpiresIn) * time.Second)
+	}
+
+	return tok, nil
+}
+
+var _ oauth2.TokenSource = idAnywhereTokenSource{}
+
+func newIDAnywhereOauthTokenProvider(
+	ctx context.Context, dialConfig kafkaDialConfig,
+) (func(ctx context.Context) (sasloauth.Auth, error), error) {
+	// this works, but the content type is not what they want. the library
+	// (correctly) sets it to `application/x-www-form-urlencoded`, but
+	// idanywhere wants `application/www-url-encoded`. So we have to just make
+	// the request ourselves.
+	// TODO: confirm that they need that specific content type
+
+	// tokenURL, err := url.Parse(dialConfig.saslTokenURL)
+	// if err != nil {
+	// 	return nil, errors.Wrap(err, "malformed token url")
+	// }
+
+	// endpointParams := url.Values{
+	// 	// "grant_type": {"client_credentials"}, // This is set by default in the library but just documenting it for now in case we need to do custom shit.
+	// 	// "client_id":             {dialConfig.saslClientID}, // included by authstyle=inparams below
+	// 	"client_assertion_type": {dialConfig.saslIDAnywhereConfig.clientAssertionType},
+	// 	"client_assertion":      {dialConfig.saslIDAnywhereConfig.clientAssertion},
+	// 	"resource":              {dialConfig.saslIDAnywhereConfig.resource},
+	// }
+
+	// cfg := clientcredentials.Config{
+	// 	ClientID:       dialConfig.saslClientID,
+	// 	TokenURL:       tokenURL.String(),
+	// 	EndpointParams: endpointParams,
+	// 	AuthStyle:      oauth2.AuthStyleInParams,
+	// }
+	// ts := cfg.TokenSource(ctx)
+
+	// return func(ctx context.Context) (sasloauth.Auth, error) {
+	// 	tok, err := ts.Token()
+	// 	if err != nil {
+	// 		return sasloauth.Auth{}, err
+	// 	}
+	// 	return sasloauth.Auth{Token: tok.AccessToken}, nil
+	// }, nil
+
+	// TODO: not sure if the reuse stuff is necessary. the normal oauth token source wraps itself with that so like maybe?
+	// im not even sure if the idanywhere stuff returns expiry info either...
+	// -> probably not necessary; see https://docs.confluent.io/legacy/platform/5.2.4/kafka/authentication_sasl/authentication_sasl_oauth.html#token-refresh-for-sasl-oauthbearer
+	ts := oauth2.ReuseTokenSource(nil, idAnywhereTokenSource{dialConfig: dialConfig, ctx: ctx, client: &http.Client{}})
+	return func(ctx context.Context) (sasloauth.Auth, error) {
+		tok, err := ts.Token()
+		if err != nil {
+			return sasloauth.Auth{}, err
+		}
+		return sasloauth.Auth{Token: tok.AccessToken}, nil
 	}, nil
 }
 

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -2100,6 +2100,57 @@ func registerCDC(r registry.Registry) {
 			feed.waitForCompletion()
 		},
 	})
+
+	r.Add(registry.TestSpec{
+		Name:  "cdc/kafka-id-anywhere",
+		Owner: `cdc`,
+		// Only Kafka 3 supports Arm64, but the broker setup for Oauth used only works with Kafka 2 (?)
+		Cluster:          r.MakeClusterSpec(4, spec.WorkloadNode(), spec.Arch(vm.ArchAMD64)),
+		Leases:           registry.MetamorphicLeases,
+		CompatibleClouds: registry.AllExceptAWS,
+		Suites:           registry.Suites(registry.Nightly),
+		RequiresLicense:  true,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.Cloud() == spec.Local && runtime.GOARCH == "arm64" {
+				// N.B. We have to skip locally since amd64 emulation may not be available everywhere.
+				t.L().PrintfCtx(ctx, "Skipping test under ARM64")
+				return
+			}
+
+			ct := newCDCTester(ctx, t, c)
+			defer ct.Close()
+
+			// Run tpcc workload for tiny bit.  Roachtest monitor does not
+			// like when there are no tasks that were started with the monitor
+			// (This can be removed once #108530 resolved).
+			ct.runTPCCWorkload(tpccArgs{warehouses: 1, duration: "30s"})
+
+			kafkaNode := ct.sinkNodes
+			kafka := kafkaManager{
+				t:              ct.t,
+				c:              ct.cluster,
+				kafkaSinkNodes: kafkaNode,
+				mon:            ct.mon,
+				useKafka2:      true, // The broker-side oauth configuration used only works with Kafka 2
+			}
+			kafka.install(ct.ctx)
+
+			// TODO: how?
+			creds, kafkaEnv := kafka.configureOauth(ct.ctx)
+
+			kafka.start(ctx, "kafka", kafkaEnv)
+
+			feed := ct.newChangefeed(feedArgs{
+				sinkType:        kafkaSink,
+				sinkURIOverride: kafka.sinkURLOAuth(ct.ctx, creds),
+				targets:         allTpccTargets,
+				opts:            map[string]string{"initial_scan": "'only'"},
+			})
+
+			feed.waitForCompletion()
+		},
+	})
+
 	r.Add(registry.TestSpec{
 		Name:             "cdc/kafka-topics",
 		Owner:            `cdc`,
@@ -2932,6 +2983,7 @@ func (k kafkaManager) configureOauth(ctx context.Context) (clientcredentials.Con
 	// CLASSPATH allows Kafka to load in the custom implementation
 	kafkaEnv := "CLASSPATH='/home/ubuntu/kafka-oauth/target/*'"
 
+	// TODO: and here?
 	// Hydra is used as an open source OAuth server
 	clientID, clientSecret := k.configureHydraOauth(ctx)
 	tokenURL := fmt.Sprintf("http://%s:4444/oauth2/token", nodeIP)


### PR DESCRIPTION
Add support for nonstandard oauthbearer kafka authentication.

Fixes: TODO: create issue from treq https://cockroachlabs.atlassian.net/browse/TREQ-750

Release note: None
