### PR TITLE
sql: separate pausable portal code paths in `execStmtInOpenState`

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -138,7 +138,7 @@ func (ex *connExecutor) execStmt(
 		if portal != nil {
 			preparedStmt = portal.Stmt
 		}
-		if portal != nil && portal.isPausable() {
+		if portal.isPausable() {
 			preparedStmt = portal.Stmt
 			err = ex.execWithProfiling(ctx, ast, preparedStmt, func(ctx context.Context) error {
 				ev, payload, err = ex.execStmtInOpenStateWithPausablePortal(
@@ -148,9 +148,7 @@ func (ex *connExecutor) execStmt(
 			})
 		} else {
 			err = ex.execWithProfiling(ctx, ast, preparedStmt, func(ctx context.Context) error {
-				ev, payload, err = ex.execStmtInOpenState(
-					ctx, parserStmt, portal, pinfo, res, canAutoCommit,
-				)
+				ev, payload, err = ex.execStmtInOpenState(ctx, parserStmt, preparedStmt, pinfo, res, canAutoCommit)
 				return err
 			})
 		}
@@ -293,15 +291,11 @@ func (ex *connExecutor) execPortal(
 func (ex *connExecutor) execStmtInOpenState(
 	ctx context.Context,
 	parserStmt statements.Statement[tree.Statement],
-	portal *PreparedPortal,
+	prepared *PreparedStatement,
 	pinfo *tree.PlaceholderInfo,
 	res RestrictedCommandResult,
 	canAutoCommit bool,
 ) (retEv fsm.Event, retPayload fsm.EventPayload, retErr error) {
-	if portal != nil && portal.isPausable() {
-		return nil, nil, errors.AssertionFailedf("unexpected pausable portal")
-	}
-
 	type localVars struct {
 		logErr      error
 		cancelQuery context.CancelFunc
@@ -336,11 +330,11 @@ func (ex *connExecutor) execStmtInOpenState(
 	}
 	os := ex.machine.CurState().(stateOpen)
 
-	isExtendedProtocol := portal != nil && portal.Stmt != nil
+	isExtendedProtocol := prepared != nil
 	stmtFingerprintFmtMask := tree.FmtHideConstants | tree.FmtFlags(queryFormattingForFingerprintsMask.Get(&ex.server.cfg.Settings.SV))
 
 	if isExtendedProtocol {
-		vars.stmt = makeStatementFromPrepared(portal.Stmt, queryID)
+		vars.stmt = makeStatementFromPrepared(prepared, queryID)
 	} else {
 		vars.stmt = makeStatement(parserStmt, queryID, stmtFingerprintFmtMask)
 	}
@@ -604,7 +598,6 @@ func (ex *connExecutor) execStmtInOpenState(
 		if retEv != nil || retErr != nil {
 			return
 		}
-		// As portals are from extended protocol, we don't auto commit for them.
 		if canAutoCommit && !isExtendedProtocol {
 			retEv, retPayload = ex.handleAutoCommit(ctx, vars.ast)
 		}
@@ -872,13 +865,8 @@ func (ex *connExecutor) execStmtInOpenState(
 	// don't return any event unless an error happens, or a CALL statement
 	// performs a nested transaction COMMIT or ROLLBACK.
 
-	// For a portal (prepared stmt), since handleAOST() is called when preparing
-	// the statement, and this function is idempotent, we don't need to
-	// call it again during execution.
-	if portal == nil {
-		if err := ex.handleAOST(ctx, vars.ast); err != nil {
-			return makeErrEvent(err)
-		}
+	if err := ex.handleAOST(ctx, vars.ast); err != nil {
+		return makeErrEvent(err)
 	}
 
 	// The first order of business is to ensure proper sequencing

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -296,28 +296,16 @@ func (ex *connExecutor) execStmtInOpenState(
 	res RestrictedCommandResult,
 	canAutoCommit bool,
 ) (retEv fsm.Event, retPayload fsm.EventPayload, retErr error) {
-	type localVars struct {
-		logErr      error
-		cancelQuery context.CancelFunc
-		ast         tree.Statement
-		stmt        Statement
-	}
-
-	// vars contains local variables that are heap allocated, usually because
-	// they are referenced by closures. Grouping them into a single struct
-	// requires only a single heap allocation.
-	var vars localVars
-
-	vars.ast = parserStmt.AST
+	ast := parserStmt.AST
 	var sp *tracing.Span
 	ctx, sp = tracing.ChildSpan(ctx, "sql query")
 	// TODO(andrei): Consider adding the placeholders as tags too.
 	sp.SetTag("statement", attribute.StringValue(parserStmt.SQL))
-	ctx = withStatement(ctx, vars.ast)
+	ctx = withStatement(ctx, ast)
 	defer sp.Finish()
 
 	makeErrEvent := func(err error) (fsm.Event, fsm.EventPayload, error) {
-		ev, payload := ex.makeErrEvent(err, vars.ast)
+		ev, payload := ex.makeErrEvent(err, ast)
 		return ev, payload, nil
 	}
 
@@ -333,10 +321,11 @@ func (ex *connExecutor) execStmtInOpenState(
 	isExtendedProtocol := prepared != nil
 	stmtFingerprintFmtMask := tree.FmtHideConstants | tree.FmtFlags(queryFormattingForFingerprintsMask.Get(&ex.server.cfg.Settings.SV))
 
+	var stmt Statement
 	if isExtendedProtocol {
-		vars.stmt = makeStatementFromPrepared(prepared, queryID)
+		stmt = makeStatementFromPrepared(prepared, queryID)
 	} else {
-		vars.stmt = makeStatement(parserStmt, queryID, stmtFingerprintFmtMask)
+		stmt = makeStatement(parserStmt, queryID, stmtFingerprintFmtMask)
 	}
 
 	var queryTimeoutTicker *time.Timer
@@ -348,22 +337,23 @@ func (ex *connExecutor) execStmtInOpenState(
 	var queryDoneAfterFunc chan struct{}
 	var txnDoneAfterFunc chan struct{}
 
-	ctx, vars.cancelQuery = ctxlog.WithCancel(ctx)
-	ex.incrementStartedStmtCounter(vars.ast)
+	var cancelQuery context.CancelFunc
+	ctx, cancelQuery = ctxlog.WithCancel(ctx)
+	ex.incrementStartedStmtCounter(ast)
 	ex.state.mu.Lock()
 	ex.state.mu.stmtCount++
 	ex.state.mu.Unlock()
-	ex.addActiveQuery(parserStmt, pinfo, queryID, vars.cancelQuery)
+	ex.addActiveQuery(parserStmt, pinfo, queryID, cancelQuery)
 	defer func() {
 		if retErr == nil && !payloadHasError(retPayload) {
-			ex.incrementExecutedStmtCounter(vars.ast)
+			ex.incrementExecutedStmtCounter(ast)
 		}
 	}()
 
 	// Make sure that we always unregister the query.
 	defer func() {
-		ex.removeActiveQuery(queryID, vars.ast)
-		vars.cancelQuery()
+		ex.removeActiveQuery(queryID, ast)
+		cancelQuery()
 
 		// Note ex.metrics is Server.Metrics for the connExecutor that serves the
 		// client connection, and is Server.InternalMetrics for internal executors.
@@ -417,7 +407,7 @@ func (ex *connExecutor) execStmtInOpenState(
 
 		// Enforce license policies. Throttling can occur if there is no valid
 		// license or if the existing one has expired.
-		if isSQLOkayToThrottle(vars.ast) {
+		if isSQLOkayToThrottle(ast) {
 			if notice, err := ex.server.cfg.LicenseEnforcer.MaybeFailIfThrottled(ctx, curOpen); err != nil {
 				return makeErrEvent(err)
 			} else if notice != nil {
@@ -427,7 +417,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	}
 
 	// Special top-level handling for EXPLAIN ANALYZE.
-	if e, ok := vars.ast.(*tree.ExplainAnalyze); ok {
+	if e, ok := ast.(*tree.ExplainAnalyze); ok {
 		switch e.Mode {
 		case tree.ExplainDebug:
 			telemetry.Inc(sqltelemetry.ExplainAnalyzeDebugUseCounter)
@@ -459,21 +449,21 @@ func (ex *connExecutor) execStmtInOpenState(
 			return makeErrEvent(errors.AssertionFailedf("unsupported EXPLAIN ANALYZE mode %s", e.Mode))
 		}
 		// Strip off the explain node to execute the inner statement.
-		vars.stmt.AST = e.Statement
-		vars.ast = e.Statement
+		stmt.AST = e.Statement
+		ast = e.Statement
 		// TODO(radu): should we trim the "EXPLAIN ANALYZE (DEBUG)" part from
 		// stmt.SQL?
 
 		// Clear any ExpectedTypes we set if we prepared this statement (they
 		// reflect the column types of the EXPLAIN itself and not those of the inner
 		// statement).
-		vars.stmt.ExpectedTypes = nil
+		stmt.ExpectedTypes = nil
 	}
 
 	// Special top-level handling for EXECUTE. This must happen after the handling
 	// for EXPLAIN ANALYZE (in order to support EXPLAIN ANALYZE EXECUTE) but
 	// before setting up the instrumentation helper.
-	if e, ok := vars.ast.(*tree.Execute); ok {
+	if e, ok := ast.(*tree.Execute); ok {
 		// Replace the `EXECUTE foo` statement with the prepared statement, and
 		// continue execution.
 		name := e.Name.String()
@@ -490,22 +480,22 @@ func (ex *connExecutor) execStmtInOpenState(
 		}
 
 		// TODO(radu): what about .SQL, .NumAnnotations, .NumPlaceholders?
-		vars.stmt.Statement = ps.Statement
-		vars.stmt.Prepared = ps
-		vars.stmt.ExpectedTypes = ps.Columns
-		vars.stmt.StmtNoConstants = ps.StatementNoConstants
-		vars.stmt.StmtSummary = ps.StatementSummary
+		stmt.Statement = ps.Statement
+		stmt.Prepared = ps
+		stmt.ExpectedTypes = ps.Columns
+		stmt.StmtNoConstants = ps.StatementNoConstants
+		stmt.StmtSummary = ps.StatementSummary
 		res.ResetStmtType(ps.AST)
 
 		if e.DiscardRows {
 			ih.SetDiscardRows()
 		}
-		vars.ast = vars.stmt.Statement.AST
+		ast = stmt.Statement.AST
 	}
 
 	ctx = ih.Setup(
 		ctx, ex.server.cfg, ex.statsCollector, p, ex.stmtDiagnosticsRecorder,
-		vars.stmt.StmtNoConstants, os.ImplicitTxn.Get(),
+		stmt.StmtNoConstants, os.ImplicitTxn.Get(),
 		// This goroutine is the only one that can modify
 		// txnState.mu.priority, so we don't need to get a mutex here.
 		ex.state.mu.priority,
@@ -524,8 +514,8 @@ func (ex *connExecutor) execStmtInOpenState(
 				&ex.extraTxnState.accumulatedStats,
 				ih.collectExecStats,
 				p,
-				vars.ast,
-				vars.stmt.SQL,
+				ast,
+				stmt.SQL,
 				res,
 				retPayload,
 				retErr,
@@ -554,7 +544,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			txnTimeoutTicker = time.AfterFunc(
 				timerDuration,
 				func() {
-					vars.cancelQuery()
+					cancelQuery()
 					txnTimedOut = true
 					txnDoneAfterFunc <- struct{}{}
 				})
@@ -563,7 +553,7 @@ func (ex *connExecutor) execStmtInOpenState(
 
 	// We exempt `SET` statements from the statement timeout, particularly so as
 	// not to block the `SET statement_timeout` command itself.
-	if ex.sessionData().StmtTimeout > 0 && vars.ast.StatementTag() != "SET" {
+	if ex.sessionData().StmtTimeout > 0 && ast.StatementTag() != "SET" {
 		timerDuration :=
 			ex.sessionData().StmtTimeout - ex.phaseTimes.GetSessionPhaseTime(sessionphase.SessionQueryReceived).Elapsed()
 		// There's no need to proceed with execution if the timer has already expired.
@@ -575,7 +565,7 @@ func (ex *connExecutor) execStmtInOpenState(
 		queryTimeoutTicker = time.AfterFunc(
 			timerDuration,
 			func() {
-				vars.cancelQuery()
+				cancelQuery()
 				// Also cancel the transactions context, so that there is no danger
 				// getting stuck rolling back.
 				ex.state.txnCancelFn()
@@ -590,7 +580,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			if perr, ok := retPayload.(payloadWithError); ok {
 				execErr = perr.errorCause()
 			}
-			filter(ctx, ex.sessionData(), vars.stmt.AST.String(), execErr)
+			filter(ctx, ex.sessionData(), stmt.AST.String(), execErr)
 		}
 
 		// Do the auto-commit, if necessary. In the extended protocol, the
@@ -599,7 +589,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			return
 		}
 		if canAutoCommit && !isExtendedProtocol {
-			retEv, retPayload = ex.handleAutoCommit(ctx, vars.ast)
+			retEv, retPayload = ex.handleAutoCommit(ctx, ast)
 		}
 	}(ctx)
 
@@ -620,10 +610,10 @@ func (ex *connExecutor) execStmtInOpenState(
 		}
 	}
 
-	p.stmt = vars.stmt
-	p.semaCtx.Annotations = tree.MakeAnnotations(vars.stmt.NumAnnotations)
+	p.stmt = stmt
+	p.semaCtx.Annotations = tree.MakeAnnotations(stmt.NumAnnotations)
 	p.extendedEvalCtx.Annotations = &p.semaCtx.Annotations
-	p.semaCtx.Placeholders.Assign(pinfo, vars.stmt.NumPlaceholders)
+	p.semaCtx.Placeholders.Assign(pinfo, stmt.NumPlaceholders)
 	p.extendedEvalCtx.Placeholders = &p.semaCtx.Placeholders
 
 	// This flag informs logging decisions.
@@ -631,13 +621,14 @@ func (ex *connExecutor) execStmtInOpenState(
 	// some special plan initialization for logging.
 	dispatchToExecEngine := false
 
+	var logErr error
 	defer func() {
 		// If we did not dispatch to the execution engine, we need to initialize
 		// the plan here.
 		if !dispatchToExecEngine {
 			p.curPlan.init(&p.stmt, &p.instrumentation)
 			if p, ok := retPayload.(payloadWithError); ok {
-				vars.logErr = p.errorCause()
+				logErr = p.errorCause()
 			}
 		}
 
@@ -660,7 +651,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			rowsAffected,
 			ex.state.mu.stmtCount,
 			bulkJobId,
-			vars.logErr,
+			logErr,
 			ex.statsCollector.PhaseTimes().GetSessionPhaseTime(sessionphase.SessionQueryReceived),
 			&ex.extraTxnState.hasAdminRoleCache,
 			ex.server.TelemetryLoggingMetrics,
@@ -689,7 +680,7 @@ func (ex *connExecutor) execStmtInOpenState(
 
 		cancelQueryCtx := ctx
 		resToPushErr := res
-		vars.logErr = resToPushErr.ErrAllowReleased()
+		logErr = resToPushErr.ErrAllowReleased()
 		// Detect context cancelation and overwrite whatever error might have been
 		// set on the result before. The idea is that once the query's context is
 		// canceled, all sorts of actors can detect the cancelation and set all
@@ -701,12 +692,12 @@ func (ex *connExecutor) execStmtInOpenState(
 			// intercept the event and payload returned here to ensure that the query
 			// is not retried.
 			retEv = eventNonRetriableErr{
-				IsCommit: fsm.FromBool(isCommit(vars.ast)),
+				IsCommit: fsm.FromBool(isCommit(ast)),
 			}
 			errToPush := cancelchecker.QueryCanceledError
 			resToPushErr.SetError(errToPush)
 			retPayload = eventNonRetriableErrPayload{err: errToPush}
-			vars.logErr = errToPush
+			logErr = errToPush
 			// Cancel the txn if we are inside an implicit txn too.
 			if ex.implicitTxn() && ex.state.txnCancelFn != nil {
 				ex.state.txnCancelFn()
@@ -727,23 +718,23 @@ func (ex *connExecutor) execStmtInOpenState(
 			// A timed out query should never produce retryable errors/events/payloads
 			// so we intercept and overwrite them all here.
 			retEv = eventNonRetriableErr{
-				IsCommit: fsm.FromBool(isCommit(vars.ast)),
+				IsCommit: fsm.FromBool(isCommit(ast)),
 			}
 			res.SetError(sqlerrors.QueryTimeoutError)
 			retPayload = eventNonRetriableErrPayload{err: sqlerrors.QueryTimeoutError}
-			vars.logErr = sqlerrors.QueryTimeoutError
+			logErr = sqlerrors.QueryTimeoutError
 		} else if txnTimedOut {
 			retEv = eventNonRetriableErr{
-				IsCommit: fsm.FromBool(isCommit(vars.ast)),
+				IsCommit: fsm.FromBool(isCommit(ast)),
 			}
 			res.SetError(sqlerrors.TxnTimeoutError)
 			retPayload = eventNonRetriableErrPayload{err: sqlerrors.TxnTimeoutError}
-			vars.logErr = sqlerrors.TxnTimeoutError
+			logErr = sqlerrors.TxnTimeoutError
 		}
 
 	}(ctx, res)
 
-	switch s := vars.ast.(type) {
+	switch s := ast.(type) {
 	case *tree.BeginTransaction:
 		// BEGIN is only allowed if we are in an implicit txn.
 		if os.ImplicitTxn.Get() {
@@ -759,7 +750,7 @@ func (ex *connExecutor) execStmtInOpenState(
 
 	case *tree.CommitTransaction:
 		// CommitTransaction is executed fully here; there's no plan for it.
-		ev, payload := ex.commitSQLTransaction(ctx, vars.ast, ex.commitSQLTransactionInternal)
+		ev, payload := ex.commitSQLTransaction(ctx, ast, ex.commitSQLTransactionInternal)
 		return ev, payload, nil
 
 	case *tree.RollbackTransaction:
@@ -806,8 +797,8 @@ func (ex *connExecutor) execStmtInOpenState(
 		var typeHints tree.PlaceholderTypes
 		// We take max(len(s.Types), stmt.NumPlaceHolders) as the length of types.
 		numParams := len(s.Types)
-		if vars.stmt.NumPlaceholders > numParams {
-			numParams = vars.stmt.NumPlaceholders
+		if stmt.NumPlaceholders > numParams {
+			numParams = stmt.NumPlaceholders
 		}
 		if len(s.Types) > 0 {
 			typeHints = make(tree.PlaceholderTypes, numParams)
@@ -827,8 +818,8 @@ func (ex *connExecutor) execStmtInOpenState(
 				// string and store it in tree.Prepare.
 				SQL:             tree.AsStringWithFlags(s.Statement, tree.FmtParsable),
 				AST:             s.Statement,
-				NumPlaceholders: vars.stmt.NumPlaceholders,
-				NumAnnotations:  vars.stmt.NumAnnotations,
+				NumPlaceholders: stmt.NumPlaceholders,
+				NumAnnotations:  stmt.NumAnnotations,
 			},
 			ex.server.cfg.GenerateID(),
 			tree.FmtFlags(queryFormattingForFingerprintsMask.Get(&ex.server.cfg.Settings.SV)),
@@ -843,7 +834,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			// The call to addPreparedStmt changed the planner stmt to the
 			// statement being prepared. Set it back to the PREPARE statement,
 			// so that it's logged correctly.
-			p.stmt = vars.stmt
+			p.stmt = stmt
 			p.extendedEvalCtx.Placeholders = oldPlaceholders
 		}()
 		if _, err := ex.addPreparedStmt(
@@ -857,7 +848,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	dispatchToExecEngine = true
 
 	// Check if we need to auto-commit the transaction due to DDL.
-	if ev, payload := ex.maybeAutoCommitBeforeDDL(ctx, vars.ast); ev != nil {
+	if ev, payload := ex.maybeAutoCommitBeforeDDL(ctx, ast); ev != nil {
 		return ev, payload, nil
 	}
 
@@ -865,7 +856,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	// don't return any event unless an error happens, or a CALL statement
 	// performs a nested transaction COMMIT or ROLLBACK.
 
-	if err := ex.handleAOST(ctx, vars.ast); err != nil {
+	if err := ex.handleAOST(ctx, ast); err != nil {
 		return makeErrEvent(err)
 	}
 
@@ -976,7 +967,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	var rollbackHomeRegionSavepoint *tree.RollbackToSavepoint
 	var releaseHomeRegionSavepoint *tree.ReleaseSavepoint
 	enforceHomeRegion := p.EnforceHomeRegion()
-	_, isSelectStmt := vars.stmt.AST.(*tree.Select)
+	_, isSelectStmt := stmt.AST.(*tree.Select)
 	if enforceHomeRegion && ex.state.mu.txn.IsOpen() && isSelectStmt {
 		// Create a savepoint at a point before which rows were read so that we can
 		// roll back to it, which will allow the txn to be modified with a
@@ -1028,7 +1019,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			rec := stmtThresholdSpan.FinishAndGetRecording(tracingpb.RecordingVerbose)
 			// NB: This recording does not include the commit for implicit
 			// transactions if the statement didn't auto-commit.
-			redactableStmt := p.FormatAstAsRedactableString(vars.stmt.AST, &p.semaCtx.Annotations)
+			redactableStmt := p.FormatAstAsRedactableString(stmt.AST, &p.semaCtx.Annotations)
 			logTraceAboveThreshold(
 				ctx,
 				rec,                /* recording */
@@ -1100,7 +1091,7 @@ func (ex *connExecutor) execStmtInOpenState(
 		rc, canAutoRetry := ex.getRewindTxnCapability()
 		if canAutoRetry {
 			ev := eventRetriableErr{
-				IsCommit:     fsm.FromBool(isCommit(vars.ast)),
+				IsCommit:     fsm.FromBool(isCommit(ast)),
 				CanAutoRetry: fsm.FromBool(canAutoRetry),
 			}
 			payload := eventRetriableErrPayload{
@@ -1120,7 +1111,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	case tree.StoredProcTxnCommit:
 		// Commit the current transaction. The connExecutor will open a new
 		// transaction, and then return to executing the same CALL statement.
-		ev, payload := ex.commitSQLTransaction(ctx, vars.ast, ex.commitSQLTransactionInternal)
+		ev, payload := ex.commitSQLTransaction(ctx, ast, ex.commitSQLTransactionInternal)
 		if payload != nil {
 			return ev, payload, nil
 		}
@@ -1128,7 +1119,7 @@ func (ex *connExecutor) execStmtInOpenState(
 	case tree.StoredProcTxnRollback:
 		// Abort the current transaction. The connExecutor will open a new
 		// transaction, and then return to executing the same CALL statement.
-		ev, payload := ex.rollbackSQLTransaction(ctx, vars.ast)
+		ev, payload := ex.rollbackSQLTransaction(ctx, ast)
 		if payload != nil {
 			return ev, payload, nil
 		}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -678,16 +678,14 @@ func (ex *connExecutor) execStmtInOpenState(
 			}
 		}
 
-		cancelQueryCtx := ctx
-		resToPushErr := res
-		logErr = resToPushErr.ErrAllowReleased()
+		logErr = res.Err()
 		// Detect context cancelation and overwrite whatever error might have been
 		// set on the result before. The idea is that once the query's context is
 		// canceled, all sorts of actors can detect the cancelation and set all
 		// sorts of errors on the result. Rather than trying to impose discipline
 		// in that jungle, we just overwrite them all here with an error that's
 		// nicer to look at for the client.
-		if resToPushErr != nil && cancelQueryCtx.Err() != nil && resToPushErr.ErrAllowReleased() != nil {
+		if res != nil && ctx.Err() != nil && res.Err() != nil {
 			// Even in the cases where the error is a retryable error, we want to
 			// intercept the event and payload returned here to ensure that the query
 			// is not retried.
@@ -695,7 +693,7 @@ func (ex *connExecutor) execStmtInOpenState(
 				IsCommit: fsm.FromBool(isCommit(ast)),
 			}
 			errToPush := cancelchecker.QueryCanceledError
-			resToPushErr.SetError(errToPush)
+			res.SetError(errToPush)
 			retPayload = eventNonRetriableErrPayload{err: errToPush}
 			logErr = errToPush
 			// Cancel the txn if we are inside an implicit txn too.

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1342,18 +1342,13 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 	// requires only a single heap allocation.
 	var vars localVars
 
-	// We need this to be function rather than a static bool, because a portal's
-	// "pausability" can be revoked in `dispatchToExecutionEngine()` if the
-	// underlying statement contains sub/post queries. Thus, we should evaluate
-	// whether a portal is pausable when executing the cleanup step.
-	isPausablePortal := func() bool { return portal != nil && portal.isPausable() }
 	// updateRetErrAndPayload ensures that the latest event payload and error is
 	// always recorded by portal.pauseInfo.
 	// TODO(janexing): add test for this.
 	updateRetErrAndPayload := func(err error, payload fsm.EventPayload) {
 		retPayload = payload
 		retErr = err
-		if isPausablePortal() {
+		if portal.isPausable() {
 			portal.pauseInfo.execStmtInOpenState.retPayload = payload
 			portal.pauseInfo.execStmtInOpenState.retErr = err
 		}
@@ -1362,7 +1357,7 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 	// adding the function to the execStmtInOpenStateCleanup.
 	// Otherwise, perform the clean-up step within every execution.
 	processCleanupFunc := func(fName string, f func()) {
-		if !isPausablePortal() {
+		if !portal.isPausable() {
 			f()
 		} else if !portal.pauseInfo.execStmtInOpenState.cleanup.isComplete {
 			portal.pauseInfo.execStmtInOpenState.cleanup.appendFunc(namedFunc{
@@ -1379,11 +1374,11 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 	defer func() {
 		// This is the first defer, so it will always be called after any cleanup
 		// func being added to the stack from the defers below.
-		if isPausablePortal() && !portal.pauseInfo.execStmtInOpenState.cleanup.isComplete {
+		if portal.isPausable() && !portal.pauseInfo.execStmtInOpenState.cleanup.isComplete {
 			portal.pauseInfo.execStmtInOpenState.cleanup.isComplete = true
 		}
 		// If there's any error, do the cleanup right here.
-		if (retErr != nil || payloadHasError(retPayload)) && isPausablePortal() {
+		if (retErr != nil || payloadHasError(retPayload)) && portal.isPausable() {
 			updateRetErrAndPayload(retErr, retPayload)
 			portal.pauseInfo.resumableFlow.cleanup.run()
 			portal.pauseInfo.dispatchToExecutionEngine.cleanup.run()
@@ -1396,19 +1391,19 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 	// we would be checking the ones evaluated at the portal's first-time
 	// execution.
 	defer func() {
-		if isPausablePortal() {
+		if portal.isPausable() {
 			updateRetErrAndPayload(retErr, retPayload)
 		}
 	}()
 
 	vars.ast = parserStmt.AST
 	var sp *tracing.Span
-	if !isPausablePortal() || !portal.pauseInfo.execStmtInOpenState.cleanup.isComplete {
+	if !portal.isPausable() || !portal.pauseInfo.execStmtInOpenState.cleanup.isComplete {
 		ctx, sp = tracing.ChildSpan(ctx, "sql query")
 		// TODO(andrei): Consider adding the placeholders as tags too.
 		sp.SetTag("statement", attribute.StringValue(parserStmt.SQL))
 		ctx = withStatement(ctx, vars.ast)
-		if isPausablePortal() {
+		if portal.isPausable() {
 			portal.pauseInfo.execStmtInOpenState.spCtx = ctx
 		}
 		defer func() {
@@ -1424,7 +1419,7 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 	}
 
 	var queryID clusterunique.ID
-	if isPausablePortal() {
+	if portal.isPausable() {
 		if !portal.pauseInfo.isQueryIDSet() {
 			portal.pauseInfo.execStmtInOpenState.queryID = ex.server.cfg.GenerateID()
 		}
@@ -1460,7 +1455,7 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 
 	// For pausable portal, the active query needs to be set up only when
 	// the portal is executed for the first time.
-	if !isPausablePortal() || !portal.pauseInfo.execStmtInOpenState.cleanup.isComplete {
+	if !portal.isPausable() || !portal.pauseInfo.execStmtInOpenState.cleanup.isComplete {
 		ctx, vars.cancelQuery = ctxlog.WithCancel(ctx)
 		ex.incrementStartedStmtCounter(vars.ast)
 		ex.state.mu.Lock()
@@ -1468,7 +1463,7 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 		ex.state.mu.Unlock()
 		ex.addActiveQuery(parserStmt, pinfo, queryID, vars.cancelQuery)
 
-		if isPausablePortal() {
+		if portal.isPausable() {
 			portal.pauseInfo.execStmtInOpenState.cancelQueryFunc = vars.cancelQuery
 			portal.pauseInfo.execStmtInOpenState.cancelQueryCtx = ctx
 		}
@@ -1478,7 +1473,7 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 				func() {
 					// We need to check the latest errors rather than the ones evaluated
 					// when this function is created.
-					if isPausablePortal() {
+					if portal.isPausable() {
 						retErr = portal.pauseInfo.execStmtInOpenState.retErr
 						retPayload = portal.pauseInfo.execStmtInOpenState.retPayload
 					}
@@ -1643,7 +1638,7 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 
 	// For pausable portal, the instrumentation helper needs to be set up only
 	// when the portal is executed for the first time.
-	if !isPausablePortal() || portal.pauseInfo.execStmtInOpenState.ihWrapper == nil {
+	if !portal.isPausable() || portal.pauseInfo.execStmtInOpenState.ihWrapper == nil {
 		ctx = ih.Setup(
 			ctx, ex.server.cfg, ex.statsCollector, p, ex.stmtDiagnosticsRecorder,
 			vars.stmt.StmtNoConstants, os.ImplicitTxn.Get(),
@@ -1664,7 +1659,7 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 	// ih and reuse it for all re-executions. So the planner's ih and the portal's
 	// ih should never have the same address, otherwise changing the former will
 	// change the latter, and we will never be able to persist it.
-	if isPausablePortal() {
+	if portal.isPausable() {
 		if portal.pauseInfo.execStmtInOpenState.ihWrapper == nil {
 			portal.pauseInfo.execStmtInOpenState.ihWrapper = &instrumentationHelperWrapper{
 				ctx: ctx,
@@ -1684,7 +1679,7 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 		// closing the correct instrumentation helper for the paused portal.
 		ihToFinish := ih
 		curRes := res
-		if isPausablePortal() {
+		if portal.isPausable() {
 			ihToFinish = &portal.pauseInfo.execStmtInOpenState.ihWrapper.ih
 			curRes = portal.pauseInfo.curRes
 			retErr = portal.pauseInfo.execStmtInOpenState.retErr
@@ -1817,7 +1812,7 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 
 		var bulkJobId uint64
 		var rowsAffected int
-		if isPausablePortal() {
+		if portal.isPausable() {
 			ppInfo := portal.pauseInfo
 			if p.extendedEvalCtx.Annotations == nil {
 				// This is a safety check in case resetPlanner() was
@@ -1875,14 +1870,14 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 
 		processCleanupFunc("set query error", func() {
 			cancelQueryCtx := ctx
-			if isPausablePortal() {
+			if portal.isPausable() {
 				cancelQueryCtx = portal.pauseInfo.execStmtInOpenState.cancelQueryCtx
 			}
 			resToPushErr := res
 			// For pausable portals, we retain the query but update the result for
 			// each execution. When the query context is cancelled and we're in the
 			// middle of an portal execution, push the error to the current result.
-			if isPausablePortal() {
+			if portal.isPausable() {
 				resToPushErr = portal.pauseInfo.curRes
 			}
 			vars.logErr = resToPushErr.ErrAllowReleased()
@@ -1904,7 +1899,7 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 				// error and then perform a query-cleanup step. In this case, we don't
 				// want to override the original timeout error with the query-cancelled
 				// error.
-				if isPausablePortal() && (errors.Is(resToPushErr.Err(), sqlerrors.QueryTimeoutError) ||
+				if portal.isPausable() && (errors.Is(resToPushErr.Err(), sqlerrors.QueryTimeoutError) ||
 					errors.Is(resToPushErr.Err(), sqlerrors.TxnTimeoutError)) {
 					errToPush = resToPushErr.Err()
 				}
@@ -2162,7 +2157,7 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 		}
 	}
 
-	if isPausablePortal() {
+	if portal.isPausable() {
 		p.pausablePortal = portal
 	}
 


### PR DESCRIPTION
#### sql: add `(*connExecutor).execStmtInOpenStateWithPausablePortal`

The `execStmtInOpenStateWithPausablePortal` method has been added to
`connExecutor`. It is currently an exact copy of `execStmtInOpenState`.
Future commits will simplify both methods.

Release note: None

#### sql: remove `isPausablePortal` anonymous function in `execStmtInOpenStateWithPortal`

Release note: None

#### sql: remove pausable-portal-specific code paths in `execStmtInOpenState`

Release note: None

#### sql: remove `processCleanupFunc` in `execStmtInOpenState`

Fixes #135908

Release note: None

#### sql: remove `portal` parameter from `execStmtInOpenState`

Release note: None

#### sql: remove `localVars` struct in `execStmtInOpenState`

Refactoring in previous commits has prevented all the `localVars`
variables from escaping to the heap, except for `cancelQuery`. So the
struct is no longer needed. Removing it reduces the size of heap
allocations, since the entire struct was heap allocated previously.

Release note: None

#### sql: refactor errors in `execStmtInOpenState`

Release note: None

#### sql: add metamorphic test variable to force pausable portal logic

Release note: None