### PR TITLE
roachtest: ignore trailing zeroes in decimals for equality comparison

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util_test.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util_test.go
@@ -124,6 +124,30 @@ func TestUnsortedMatricesDiff(t *testing.T) {
 			exactMatch:  false,
 			approxMatch: true,
 		},
+		{
+			name:        "decimals with trailing zeroes",
+			colTypes:    []string{"DECIMAL"},
+			t1:          [][]string{{"1.20"}, {"1.000"}},
+			t2:          [][]string{{"1.200"}, {"1"}},
+			exactMatch:  false,
+			approxMatch: true,
+		},
+		{
+			name:        "decimals with non-trailing zeroes",
+			colTypes:    []string{"DECIMAL"},
+			t1:          [][]string{{"10"}, {"1.000"}},
+			t2:          [][]string{{"1.0"}, {"1000"}},
+			exactMatch:  false,
+			approxMatch: false,
+		},
+		{
+			name:        "decimals with trailing zeroes in array",
+			colTypes:    []string{"[]DECIMAL"},
+			t1:          [][]string{{"1.0,1.000"}, {"3.0,4.000"}},
+			t2:          [][]string{{"1.00,1"}, {"3.00,4"}},
+			exactMatch:  false,
+			approxMatch: true,
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This commit extends `unsortedMatricesDiffWithFloatComp` helper (used by the costfuzz and unoptimized query oracle) to have a "custom" matching function for decimals and decimal arrays so that trailing zeroes are ignored. This matches the SQL equality check between such datums. Longer-term solution would be to implement matching of the full results via SQL (like we did for TLP), but that's left for the future.

Informs: #136349.
Epic: None

Release note: None