### PR TITLE
invertedidx: fix internal error on TSMatch against NULL argument

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tsvector
+++ b/pkg/sql/logictest/testdata/logic_test/tsvector
@@ -501,3 +501,9 @@ INSERT INTO t126773 (pk, v) values (1, tsvector('splendid water fowl'));
 
 statement ok
 SELECT t126773::t126773 FROM t126773;
+
+# Regression test for TSMatch operator producing an internal error with a NULL
+# argument (#132483).
+query T
+WITH cte(s) AS (SELECT NULL::TSQUERY) SELECT a FROM a, cte WHERE a @@ s;
+----

--- a/pkg/sql/opt/invertedidx/tsearch.go
+++ b/pkg/sql/opt/invertedidx/tsearch.go
@@ -54,6 +54,12 @@ func (t *tsqueryFilterPlanner) extractInvertedFilterConditionFromLeaf(
 		return inverted.NonInvertedColExpression{}, expr, nil
 	}
 	d := memo.ExtractConstDatum(constantVal)
+	if d == tree.DNull {
+		// ... @@ NULL or NULL @@ ... results in no rows, but it'd be tricky to
+		// encode that with a span expression, so we simply skip inverted index
+		// acceleration in this case (which should be pretty rare).
+		return inverted.NonInvertedColExpression{}, expr, nil
+	}
 	if !d.ResolvedType().Identical(types.TSQuery) {
 		panic(errors.AssertionFailedf(
 			"trying to apply tsvector inverted index to unsupported type %s", d.ResolvedType().SQLStringForError(),


### PR DESCRIPTION
Fixes: #132483.

Release note: None