### PR TITLE
roachtest: fix line break in pertubation/* tests

### DIFF
--- a/pkg/cmd/roachtest/tests/perturbation/kv_workload.go
+++ b/pkg/cmd/roachtest/tests/perturbation/kv_workload.go
@@ -33,8 +33,8 @@ func (w kvWorkload) runWorkload(
 	ctx context.Context, v variations, duration time.Duration, maxRate int,
 ) (*workloadData, error) {
 	runCmd := fmt.Sprintf(
-		`./cockroach workload run kv --db target --display-format=incremental-json --duration=%s --max-rate=%d --tolerate-errors 
-		--max-block-bytes=%d --min-block-bytes=%d --read-percent=50 --follower-read-percent=50 --concurrency=500 {pgurl%s}`,
+		`./cockroach workload run kv --db target --display-format=incremental-json --duration=%s --max-rate=%d --tolerate-errors `+
+			`--max-block-bytes=%d --min-block-bytes=%d --read-percent=50 --follower-read-percent=50 --concurrency=500 {pgurl%s}`,
 		duration,
 		maxRate,
 		v.blockSize,


### PR DESCRIPTION
As part of 10082caa5d7 a line break was introduced that broke the workload command. This fixes that issue.

Epic: none

Release note: None