### PR TITLE
[prototype] sql: eliminate goroutine handoff between pgwire and connExecutor

### DIFF
--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -533,7 +533,7 @@ func (r *limitedCommandResult) AddRow(ctx context.Context, row tree.Datums) erro
 	}
 	r.seenTuples++
 
-	if r.seenTuples == r.limit {
+	if r.seenTuples == r.limit && false {
 		// If we've seen up to the limit of rows, send a "portal suspended" message
 		// and wait for another exec portal message.
 		r.conn.bufferPortalSuspended()


### PR DESCRIPTION
This commit contains a prototype which eliminates the goroutine handoff through the `sql.StmtBuf` between the pgwire frontend goroutine (looping in `(*pgwire.Server).serveImpl`) and the `connExecutor` goroutine (looping in `(*sql.connExecutor).run`) [^1]. Instead, it replaces the handoff with a direct function call from the pgwire goroutine through into the connExecutor for each pgwire command. For now, it only does so for a few commands, but we could in theory do this for all commands.

Doing so avoids passing through the goroutine scheduler on each statement execution, which has some cost in microbenchmarks and which I had hypothesized would have an even greater cost in loaded systems which are placing pressure on the goroutine scheduler (see `runtime.findrunnable`). In fact, it avoids 4 different goroutine handoffs per statement execution, because each statement execution in a workload like sysbench which uses prepared statements involves the following four pgwire commands:
- `ClientMsgBind`
- `ClientMsgDescribe`
- `ClientMsgExecute`
- `ClientMsgSync`

These commands are all pipelined from the SQL client, so it is possible that we benefit from some concurrency and that the `connExecutor` goroutine is not preempted between each command (due to an empty `StmtBuf`). Regardless, goroutine handoffs on the hot path of statement execution are not ideal.

I have not yet completed the archaeology exercise to dig up why the system was architected this way back in 2017 when the connExecutor was introduced. My hazy memory is that it was a combination of:
1. thinking that the separation between the pgwire goroutine and the connExecutor goroutine was a clean design.
2. thinking that the conncurrency benefits of the two goroutines was "important".
3. thinking that the ability to "rewind" the pgwire command execution was important for automatic transaction retries and the readahead was imporant to recognize opportunities for optimizations like 1PC.
4. a desire to continue reading from the pgwire connection during statement execution to detect cancellation or disconnection.

Some of these reasons are probably still valid and some of them likely no longer apply to the current system.

----

Unfortunately, this change only appears to have a meaningful positive impact on performance in microbenchmarks.
```
name                                            old time/op    new time/op    delta
Sysbench/SQL/1node_local/oltp_begin_commit-10      134µs ± 2%      99µs ± 2%  -25.83%  (p=0.000 n=8+10)
Sysbench/SQL/1node_remote/oltp_begin_commit-10     132µs ± 1%      99µs ± 2%  -25.37%  (p=0.000 n=10+10)
Sysbench/SQL/3node/oltp_begin_commit-10            134µs ± 2%     102µs ± 1%  -23.94%  (p=0.000 n=9+10)
Sysbench/SQL/1node_local/oltp_point_select-10      142µs ± 2%     112µs ± 2%  -20.95%  (p=0.000 n=9+9)
Sysbench/SQL/1node_remote/oltp_point_select-10     186µs ± 2%     158µs ± 2%  -15.46%  (p=0.000 n=9+9)
Sysbench/SQL/3node/oltp_point_select-10            191µs ± 4%     163µs ± 2%  -14.82%  (p=0.000 n=9+9)
Sysbench/SQL/1node_local/oltp_read_only-10        2.24ms ± 1%    2.10ms ± 1%   -6.28%  (p=0.000 n=9+10)
Sysbench/SQL/1node_local/oltp_write_only-10       1.88ms ± 2%    1.82ms ± 2%   -2.93%  (p=0.000 n=9+10)
Sysbench/SQL/1node_remote/oltp_write_only-10      2.26ms ± 2%    2.22ms ± 3%   -1.71%  (p=0.003 n=9+9)
Sysbench/SQL/3node/oltp_write_only-10             2.66ms ± 2%    2.62ms ± 3%   -1.64%  (p=0.034 n=10+8)
Sysbench/SQL/1node_remote/oltp_read_write-10      6.32ms ± 2%    6.23ms ± 2%   -1.38%  (p=0.029 n=10+10)
Sysbench/SQL/1node_local/oltp_read_write-10       4.93ms ±10%    5.08ms ± 4%     ~     (p=0.274 n=10+8)
Sysbench/SQL/1node_remote/oltp_read_only-10       3.69ms ±16%    3.78ms ± 3%     ~     (p=0.633 n=10+8)
Sysbench/SQL/3node/oltp_read_only-10              3.73ms ±13%    3.95ms ± 6%     ~     (p=0.173 n=10+8)
Sysbench/SQL/3node/oltp_read_write-10             6.01ms ± 2%    6.06ms ±12%     ~     (p=0.968 n=10+9)

name                                            old alloc/op   new alloc/op   delta
Sysbench/SQL/1node_remote/oltp_begin_commit-10    14.6kB ± 0%    11.0kB ± 0%  -24.31%  (p=0.000 n=10+10)
Sysbench/SQL/1node_local/oltp_begin_commit-10     14.5kB ± 0%    11.0kB ± 0%  -24.27%  (p=0.000 n=9+10)
Sysbench/SQL/3node/oltp_begin_commit-10           15.5kB ± 1%    12.1kB ± 5%  -21.98%  (p=0.000 n=8+10)
Sysbench/SQL/1node_local/oltp_point_select-10     27.5kB ± 0%    23.3kB ± 0%  -15.33%  (p=0.000 n=8+9)
Sysbench/SQL/1node_remote/oltp_point_select-10    40.7kB ± 0%    36.3kB ± 0%  -10.71%  (p=0.000 n=9+10)
Sysbench/SQL/3node/oltp_point_select-10           42.1kB ± 1%    37.7kB ± 1%  -10.53%  (p=0.000 n=10+8)
Sysbench/SQL/3node/oltp_write_only-10             1.47MB ± 2%    1.44MB ± 2%   -1.78%  (p=0.008 n=10+9)
Sysbench/SQL/1node_local/oltp_write_only-10        472kB ± 2%     464kB ± 1%   -1.66%  (p=0.000 n=10+9)
Sysbench/SQL/1node_remote/oltp_write_only-10       756kB ± 0%     750kB ± 0%   -0.79%  (p=0.000 n=9+9)
Sysbench/SQL/1node_local/oltp_read_only-10         878kB ± 0%     873kB ± 0%   -0.53%  (p=0.000 n=9+10)
Sysbench/SQL/1node_remote/oltp_read_only-10       1.33MB ± 0%    1.32MB ± 1%   -0.24%  (p=0.029 n=10+10)
Sysbench/SQL/1node_remote/oltp_read_write-10      2.00MB ± 0%    2.00MB ± 0%   -0.20%  (p=0.013 n=10+9)
Sysbench/SQL/1node_local/oltp_read_write-10       1.26MB ± 1%    1.26MB ± 0%     ~     (p=0.165 n=10+10)
Sysbench/SQL/3node/oltp_read_only-10              1.35MB ± 3%    1.36MB ± 1%     ~     (p=0.065 n=9+10)
Sysbench/SQL/3node/oltp_read_write-10             2.51MB ± 2%    2.49MB ± 1%     ~     (p=0.065 n=10+9)

name                                            old allocs/op  new allocs/op  delta
Sysbench/SQL/3node/oltp_begin_commit-10              123 ± 0%       109 ± 1%  -11.63%  (p=0.000 n=9+10)
Sysbench/SQL/1node_remote/oltp_begin_commit-10       115 ± 0%       102 ± 0%  -11.30%  (p=0.000 n=10+10)
Sysbench/SQL/1node_local/oltp_begin_commit-10        114 ± 0%       102 ± 0%  -10.53%  (p=0.000 n=9+10)
Sysbench/SQL/1node_local/oltp_point_select-10        236 ± 0%       223 ± 0%   -5.51%  (p=0.000 n=9+9)
Sysbench/SQL/3node/oltp_point_select-10              438 ± 0%       423 ± 0%   -3.39%  (p=0.000 n=10+8)
Sysbench/SQL/1node_remote/oltp_point_select-10       427 ± 0%       414 ± 0%   -3.04%  (p=0.000 n=9+10)
Sysbench/SQL/1node_local/oltp_write_only-10        2.85k ± 0%     2.84k ± 0%   -0.53%  (p=0.000 n=10+10)
Sysbench/SQL/3node/oltp_write_only-10              9.13k ± 0%     9.08k ± 1%   -0.51%  (p=0.013 n=9+10)
Sysbench/SQL/1node_remote/oltp_write_only-10       6.73k ± 0%     6.72k ± 0%   -0.22%  (p=0.000 n=9+9)
Sysbench/SQL/1node_local/oltp_read_only-10         4.74k ± 0%     4.73k ± 0%   -0.12%  (p=0.045 n=10+10)
Sysbench/SQL/1node_local/oltp_read_write-10        7.56k ± 0%     7.56k ± 0%     ~     (p=0.858 n=10+9)
Sysbench/SQL/1node_remote/oltp_read_only-10        7.48k ± 0%     7.49k ± 0%     ~     (p=0.733 n=10+9)
Sysbench/SQL/1node_remote/oltp_read_write-10       14.4k ± 0%     14.4k ± 0%     ~     (p=0.753 n=10+10)
Sysbench/SQL/3node/oltp_read_only-10               7.66k ± 1%     7.72k ± 1%     ~     (p=0.076 n=10+9)
Sysbench/SQL/3node/oltp_read_write-10              17.0k ± 0%     16.9k ± 1%     ~     (p=0.546 n=9+9)
```

These gains to not translate to end-to-end benchmarks:
```
name                                            old queries/s  new queries/s  delta
sysbench/oltp_read_write/nodes=3/cpu=8/conc=64     18.5k ± 5%     18.1k ± 6%   ~     (p=0.167 n=9+8)

name                                            old avg_ms/op  new avg_ms/op  delta
sysbench/oltp_read_write/nodes=3/cpu=8/conc=64      69.3 ± 5%      70.8 ± 6%   ~     (p=0.167 n=9+8)

name                                            old p95_ms/op  new p95_ms/op  delta
sysbench/oltp_read_write/nodes=3/cpu=8/conc=64       109 ± 6%       113 ± 7%   ~     (p=0.099 n=9+8)
```

[^1]: for more details, see https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/life_of_a_query.md#postgresql-client-protocol.