### PR TITLE
release-24.3: sql: inline `addActiveQuery` anonymous function

### DIFF
--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -1067,6 +1067,9 @@ func BenchmarkEndToEnd(b *testing.B) {
 	srv, db, _ := serverutils.StartServer(b, base.TestServerArgs{UseDatabase: "bench"})
 	defer srv.Stopper().Stop(context.Background())
 	sr := sqlutils.MakeSQLRunner(db)
+	sr.Exec(b, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false`)
+	sr.Exec(b, `SET CLUSTER SETTING sql.stats.flush.enabled = false`)
+	sr.Exec(b, `SET CLUSTER SETTING sql.metrics.statement_details.enabled = false`)
 	sr.Exec(b, `CREATE DATABASE bench`)
 	for _, schema := range schemas {
 		sr.Exec(b, schema)


### PR DESCRIPTION
Backport 1/2 commits from #136730.

/cc @cockroachdb/release

---

#### opt/bench: disable some background work in `BenchmarkEndToEnd`

Automatic table stats collection and SQL stats (metrics) have been
disabled in the end-to-end benchmarks so that they better highlight the
performance of executing queries. Note that this will improve all the
benchmark results a bit, even though the code paths targeted by this
benchmark have not been changed.

Release note: None

Epic: None

---

Release justification: Test-only change.

