### PR TITLE
sql/schemachanger: log schema change job latency in structured log

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -1686,6 +1686,9 @@ An event of type `finish_schema_change` is recorded when a previously initiated 
 change has completed.
 
 
+| Field | Description | Sensitive |
+|--|--|--|
+| `LatencyNanos` | The amount of time the schema change job took to complete. | no |
 
 
 #### Common fields
@@ -1704,6 +1707,9 @@ An event of type `finish_schema_change_rollback` is recorded when a previously
 initiated schema change rollback has completed.
 
 
+| Field | Description | Sensitive |
+|--|--|--|
+| `LatencyNanos` | The amount of time the schema change job took to rollback. | no |
 
 
 #### Common fields
@@ -1868,6 +1874,7 @@ encounters a problem and is reversed.
 |--|--|--|
 | `Error` | The error encountered that caused the schema change to be reversed. The specific format of the error is variable and can change across releases without warning. | yes |
 | `SQLSTATE` | The SQLSTATE code for the error. | no |
+| `LatencyNanos` | The amount of time the schema change job took before being reverted. | no |
 
 
 #### Common fields

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -117,10 +117,15 @@ WHERE "eventType" = 'alter_table'
 1  {"EventType": "alter_table", "MutationID": 1, "Statement": "ALTER TABLE test.public.a ADD COLUMN val INT8", "TableName": "test.public.a", "Tag": "ALTER TABLE", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ----
 1  {"EventType": "finish_schema_change", "InstanceID": 1}
+
+# Verify that LatencyNanos is populated.
+statement ok
+SELECT 1 / coalesce((info::JSONB->'LatencyNanos')::INT, 0) FROM system.eventlog
+WHERE "eventType" = 'finish_schema_change'
 
 query I
 SELECT "reportingID" FROM system.eventlog
@@ -156,20 +161,20 @@ ORDER BY "timestamp", info
 1  {"EventType": "create_index", "IndexName": "foo", "MutationID": 1, "Statement": "ALTER TABLE test.public.a ADD CONSTRAINT foo UNIQUE (val)", "TableName": "test.public.a", "Tag": "ALTER TABLE", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'  FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ----
 1  {"EventType": "finish_schema_change", "InstanceID": 1}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'Error'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'Error' - 'LatencyNanos'
   FROM system.eventlog
 WHERE "eventType" = 'reverse_schema_change'
 ----
 1  {"EventType": "reverse_schema_change", "InstanceID": 1, "SQLSTATE": "23505"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change_rollback'
 ----
 1  {"EventType": "finish_schema_change_rollback", "InstanceID": 1}
@@ -188,7 +193,7 @@ WHERE "eventType" = 'create_index'
 1  {"EventType": "create_index", "IndexName": "a_foo", "MutationID": 1, "Statement": "CREATE INDEX a_foo ON test.public.a (val)", "TableName": "test.public.a", "Tag": "CREATE INDEX", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ORDER BY "timestamp", info
 ----
@@ -206,7 +211,7 @@ WHERE "eventType" = 'create_index'
 1  {"EventType": "create_index", "IndexName": "a_val_idx", "MutationID": 1, "Statement": "CREATE INDEX ON test.public.a (val)", "TableName": "test.public.a", "Tag": "CREATE INDEX", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ORDER BY "timestamp", info
 ----
@@ -228,7 +233,7 @@ WHERE "eventType" = 'drop_index'
 1  {"EventType": "drop_index", "IndexName": "a_foo", "MutationID": 1, "Statement": "DROP INDEX test.public.a@a_foo", "TableName": "test.public.a", "Tag": "DROP INDEX", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ORDER BY "timestamp", info
 ----

--- a/pkg/sql/logictest/testdata/logic_test/event_log_legacy
+++ b/pkg/sql/logictest/testdata/logic_test/event_log_legacy
@@ -117,10 +117,15 @@ WHERE "eventType" = 'alter_table'
 1  {"EventType": "alter_table", "MutationID": 1, "Statement": "ALTER TABLE test.public.a ADD COLUMN val INT8", "TableName": "test.public.a", "Tag": "ALTER TABLE", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ----
 1  {"EventType": "finish_schema_change", "InstanceID": 1, "MutationID": 1}
+
+# Verify that LatencyNanos is populated.
+statement ok
+SELECT 1 / coalesce((info::JSONB->'LatencyNanos')::INT, 0) FROM system.eventlog
+WHERE "eventType" = 'finish_schema_change'
 
 query I
 SELECT "reportingID" FROM system.eventlog
@@ -156,13 +161,13 @@ ORDER BY "timestamp", info
 1  {"EventType": "alter_table", "MutationID": 2, "Statement": "ALTER TABLE test.public.a ADD CONSTRAINT foo UNIQUE (val)", "TableName": "test.public.a", "Tag": "ALTER TABLE", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'  FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos'  FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ----
 1  {"EventType": "finish_schema_change", "InstanceID": 1, "MutationID": 1}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'Error'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'Error' - 'LatencyNanos'
   FROM system.eventlog
 WHERE "eventType" = 'reverse_schema_change'
 ----
@@ -170,7 +175,7 @@ WHERE "eventType" = 'reverse_schema_change'
 
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change_rollback'
 ----
 1  {"EventType": "finish_schema_change_rollback", "InstanceID": 1, "MutationID": 2}
@@ -189,7 +194,7 @@ WHERE "eventType" = 'create_index'
 1  {"EventType": "create_index", "IndexName": "a_foo", "MutationID": 3, "Statement": "CREATE INDEX a_foo ON test.public.a (val)", "TableName": "test.public.a", "Tag": "CREATE INDEX", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ORDER BY "timestamp", info
 ----
@@ -207,7 +212,7 @@ WHERE "eventType" = 'create_index'
 1  {"EventType": "create_index", "IndexName": "a_val_idx", "MutationID": 4, "Statement": "CREATE INDEX ON test.public.a (val)", "TableName": "test.public.a", "Tag": "CREATE INDEX", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ORDER BY "timestamp", info
 ----
@@ -229,7 +234,7 @@ WHERE "eventType" = 'drop_index'
 1  {"EventType": "drop_index", "IndexName": "a_foo", "MutationID": 5, "Statement": "DROP INDEX test.public.a@a_foo", "TableName": "test.public.a", "Tag": "DROP INDEX", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ORDER BY "timestamp", info
 ----

--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -1100,12 +1100,17 @@ statement ok
 DROP VIEW v1ev CASCADE;
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos'
 FROM system.eventlog
 ORDER BY "timestamp", info DESC
 ----
 1  {"CascadeDroppedViews": ["test.public.v4ev"], "EventType": "drop_view", "Statement": "DROP VIEW test.public.v1ev CASCADE", "Tag": "DROP VIEW", "User": "root", "ViewName": "test.public.v1ev"}
 1  {"EventType": "finish_schema_change", "InstanceID": 1}
+
+# Verify that LatencyNanos is populated.
+statement ok
+SELECT 1 / coalesce((info::JSONB->'LatencyNanos')::INT, 0) FROM system.eventlog
+WHERE "eventType" = 'finish_schema_change'
 
 statement ok
 CREATE VIEW v1ev AS (SELECT name FROM T1EV);
@@ -1120,7 +1125,7 @@ statement ok
 DROP TABLE t1ev,t2ev CASCADE;
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos'
 FROM system.eventlog
 ORDER BY timestamp, info DESC;
 ----
@@ -1139,7 +1144,7 @@ statement ok
 ALTER TABLE fooev ADD COLUMN j INT
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos'
 FROM system.eventlog
 ORDER BY timestamp, info DESC;
 ----
@@ -1187,7 +1192,7 @@ statement ok
 DROP DATABASE db2 cascade;
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos'
 FROM system.eventlog
 ORDER BY timestamp, info DESC;
 ----

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -1299,6 +1299,9 @@ func (s *TestState) logEvent(event logpb.EventPayload) error {
 		// Remove common details from text output, they're never decorated.
 		if inM, ok := in.(map[string]interface{}); ok {
 			delete(inM, "common")
+
+			// Also remove latency measurement, since it's not deterministic.
+			delete(inM, "latencyNanos")
 		}
 	})
 	if err != nil {

--- a/pkg/sql/schemachanger/scjob/job.go
+++ b/pkg/sql/schemachanger/scjob/job.go
@@ -141,11 +141,13 @@ func (n *newSchemaChangeResumer) run(ctx context.Context, execCtxI interface{}) 
 		return nil
 	}
 
+	startTime := timeutil.FromUnixMicros(payload.StartedMicros)
 	err := scrun.RunSchemaChangesInJob(
 		ctx,
 		execCfg.DeclarativeSchemaChangerTestingKnobs,
 		n.deps,
 		n.job.ID(),
+		startTime,
 		payload.DescriptorIDs,
 		n.rollbackCause,
 	)

--- a/pkg/sql/schemachanger/scrun/BUILD.bazel
+++ b/pkg/sql/schemachanger/scrun/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/util/log/logpb",
         "//pkg/util/mon",
         "//pkg/util/protoutil",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
     ],

--- a/pkg/sql/schemachanger/sctest/BUILD.bazel
+++ b/pkg/sql/schemachanger/sctest/BUILD.bazel
@@ -53,6 +53,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/syncutil",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/schemachanger/sctest/end_to_end.go
+++ b/pkg/sql/schemachanger/sctest/end_to_end.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/datadriven"
 	"github.com/stretchr/testify/require"
 )
@@ -312,6 +313,7 @@ func execStatementWithTestDeps(
 	var state scpb.CurrentState
 	var logSchemaChangesFn scbuild.LogSchemaChangerEventsFn
 	var err error
+	startTime := timeutil.Now()
 
 	deps.WithTxn(func(s *sctestdeps.TestState) {
 		// Run statement phase.
@@ -338,7 +340,7 @@ func execStatementWithTestDeps(
 		deps.IncrementPhase()
 		deps.LogSideEffectf("# begin %s", deps.Phase())
 		err = scrun.RunSchemaChangesInJob(
-			ctx, deps.TestingKnobs(), deps, jobID, job.DescriptorIDs, nil, /* rollbackCause */
+			ctx, deps.TestingKnobs(), deps, jobID, startTime, job.DescriptorIDs, nil, /* rollbackCause */
 		)
 		require.NoError(t, err, "error in mock schema change job execution")
 		deps.LogSideEffectf("# end %s", deps.Phase())

--- a/pkg/util/log/eventpb/ddl_events.proto
+++ b/pkg/util/log/eventpb/ddl_events.proto
@@ -421,6 +421,8 @@ message ReverseSchemaChange {
   string error = 4 [(gogoproto.jsontag) = ",omitempty"];
   // The SQLSTATE code for the error.
   string sqlstate = 5 [(gogoproto.customname) = "SQLSTATE", (gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+  // The amount of time the schema change job took before being reverted.
+  int64 latency_nanos = 6 [(gogoproto.jsontag) = ",omitempty"];
 }
 
 // FinishSchemaChange is recorded when a previously initiated schema
@@ -428,6 +430,8 @@ message ReverseSchemaChange {
 message FinishSchemaChange {
   CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
   CommonSchemaChangeEventDetails sc = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  // The amount of time the schema change job took to complete.
+  int64 latency_nanos = 3 [(gogoproto.jsontag) = ",omitempty"];
 }
 
 // FinishSchemaChangeRollback is recorded when a previously
@@ -435,6 +439,8 @@ message FinishSchemaChange {
 message FinishSchemaChangeRollback {
   CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
   CommonSchemaChangeEventDetails sc = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  // The amount of time the schema change job took to rollback.
+  int64 latency_nanos = 3 [(gogoproto.jsontag) = ",omitempty"];
 }
 
 

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -3145,6 +3145,15 @@ func (m *FinishSchemaChange) AppendJSONFields(printComma bool, b redact.Redactab
 
 	printComma, b = m.CommonSchemaChangeEventDetails.AppendJSONFields(printComma, b)
 
+	if m.LatencyNanos != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"LatencyNanos\":"...)
+		b = strconv.AppendInt(b, int64(m.LatencyNanos), 10)
+	}
+
 	return printComma, b
 }
 
@@ -3154,6 +3163,15 @@ func (m *FinishSchemaChangeRollback) AppendJSONFields(printComma bool, b redact.
 	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
 
 	printComma, b = m.CommonSchemaChangeEventDetails.AppendJSONFields(printComma, b)
+
+	if m.LatencyNanos != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"LatencyNanos\":"...)
+		b = strconv.AppendInt(b, int64(m.LatencyNanos), 10)
+	}
 
 	return printComma, b
 }
@@ -4284,6 +4302,15 @@ func (m *ReverseSchemaChange) AppendJSONFields(printComma bool, b redact.Redacta
 		b = append(b, "\"SQLSTATE\":\""...)
 		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.SQLSTATE)))
 		b = append(b, '"')
+	}
+
+	if m.LatencyNanos != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"LatencyNanos\":"...)
+		b = strconv.AppendInt(b, int64(m.LatencyNanos), 10)
 	}
 
 	return printComma, b


### PR DESCRIPTION
part of https://github.com/cockroachdb/cockroach/issues/134326
Release note (ops change): When a schema change job is completed, rolls back, or encounteres a failure, the time taken since the job began is now logged in a structured log in the SQL_SCHEMA log channel.