### PR TITLE
rowinfra: clamp default-batch-bytes-limit under duress

### DIFF
--- a/pkg/sql/rowinfra/base.go
+++ b/pkg/sql/rowinfra/base.go
@@ -40,14 +40,14 @@ const ProductionKVBatchSize KeyLimit = 100000
 
 // defaultBatchBytesLimit is the maximum number of bytes a scan request can
 // return.
-var defaultBatchBytesLimit = BytesLimit(skip.ClampMetamorphicConstantUnderStress(
+var defaultBatchBytesLimit = BytesLimit(skip.ClampMetamorphicConstantUnderDuress(
 	metamorphic.ConstantWithTestRange(
 		"default-batch-bytes-limit",
 		defaultBatchBytesLimitProductionValue, /* defaultValue */
 		1,                                     /* min */
 		64<<10,                                /* max, 64KiB */
 	),
-	1<<10, /* min, 1KiB */
+	10<<10, /* min, 10KiB */
 ))
 
 const defaultBatchBytesLimitProductionValue = 10 << 20 /* 10MiB */

--- a/pkg/testutils/skip/constants.go
+++ b/pkg/testutils/skip/constants.go
@@ -5,11 +5,11 @@
 
 package skip
 
-// ClampMetamorphicConstantUnderStress ensures that the given integer constant
+// ClampMetamorphicConstantUnderDuress ensures that the given integer constant
 // with metamorphic testing range is at least the given minimum value, when the
-// process is running under stress.
-func ClampMetamorphicConstantUnderStress(val, min int) int {
-	if Stress() && val < min {
+// process is running under duress.
+func ClampMetamorphicConstantUnderDuress(val, min int) int {
+	if Duress() && val < min {
 		return min
 	}
 	return val


### PR DESCRIPTION
This commit adjusts `default-batch-bytes-limit` metamorphic variable to be clamped when ran under duress (previously we did so only under stress, but using very small values can lead to slow tests with timeouts under race too). Additionally, it bumps the minimum clamped value from 1KiB to 10KiB (which was mentioned in the commit message of 246d030bd34feb943fc63107be54bd98fdaf7383 which introduced the clamping helper).

Fixes: #136886.

Release note: None