### PR TITLE
sql/parser: remove unused `statements.AST` interface

### DIFF
--- a/pkg/sql/parser/statements/statement.go
+++ b/pkg/sql/parser/statements/statement.go
@@ -10,9 +10,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
-type AST interface {
-}
-
 // Statement is the result of parsing a single statement. It contains the AST
 // node along with other information.
 type Statement[T any] struct {


### PR DESCRIPTION
Epic: None

Release note: None