### PR TITLE
sql/server: Fix license disable bug for single node clusters

### DIFF
--- a/pkg/server/initial_sql.go
+++ b/pkg/server/initial_sql.go
@@ -26,6 +26,10 @@ import (
 func (s *topLevelServer) RunInitialSQL(
 	ctx context.Context, startSingleNode bool, adminUser, adminPassword string,
 ) error {
+	if startSingleNode {
+		s.sqlServer.disableLicenseEnforcement(ctx)
+	}
+
 	newCluster := s.InitialStart() && s.NodeID() == kvstorage.FirstNodeID
 	if !newCluster || s.cfg.DisableSQLServer {
 		// The initial SQL code only runs the first time the cluster is initialized.
@@ -42,9 +46,6 @@ func (s *topLevelServer) RunInitialSQL(
 		}
 		log.Ops.Infof(ctx, "Replication was disabled for this cluster.\n"+
 			"When/if adding nodes in the future, update zone configurations to increase the replication factor.")
-
-		// Disable license enforcement too
-		s.sqlServer.disableLicenseEnforcement(ctx)
 	}
 
 	if adminUser != "" && !s.Insecure() {


### PR DESCRIPTION
License enforcement is intended to be disabled for single-node setups. However, when starting CockroachDB with start-single-node, license enforcement was only disabled on the initial startup. Subsequent restarts of the cluster did not correctly disable licensing. This fix addresses and resolves that issue.

This should be backported all the way back to 23.1.

Epic: None
Release note (bug fix): Fixed an issue where license enforcement was not consistently disabled for single-node clusters started with start-single-node, ensuring proper behavior on cluster restarts.