### PR TITLE
tracing: add `startSpanFast` for optimized path when disabled

### DIFF
--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -102,6 +102,12 @@ func (opts *spanOptions) parentSpanID() tracingpb.SpanID {
 	return 0
 }
 
+// recordingType computes the resulting recording type of the span
+// based on various settings. Please note that some of this logic is
+// partially duplicates in `Tracer.startSpanFast` which is used for
+// spans without a parent and avoids calling this method for
+// performance reasons. If you modify this method, make sure to modify
+// `startSpanFast` as well.
 func (opts *spanOptions) recordingType() tracingpb.RecordingType {
 	if opts.recordingTypeExplicit {
 		return opts.recordingTypeOpt

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -1068,24 +1068,3 @@ func TestTracerStackHistory(t *testing.T) {
 		}
 	}
 }
-
-func BenchmarkStartSpan(b *testing.B) {
-	tr := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeActiveSpansRegistry))
-	require.True(b, tr.AlwaysTrace())
-	for i := 0; i < b.N; i++ {
-		tr.StartSpan("opName")
-	}
-	b.ReportAllocs()
-}
-
-func BenchmarkStartSpan_OpNameRegexp(b *testing.B) {
-	tr := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeActiveSpansRegistry))
-	require.True(b, tr.AlwaysTrace())
-	// Set some arbitrary regex. In our benchmark, we'll always match, but only the
-	// final clause in the regex.
-	require.NoError(b, tr.setVerboseOpNameRegexp("op1|op2|op3|^op[a-zA-Z]+"))
-	for i := 0; i < b.N; i++ {
-		tr.StartSpan("opAB")
-	}
-	b.ReportAllocs()
-}


### PR DESCRIPTION
This change attempts to reduce the impact of `StartSpanCtx` when
called with tracing disabled.

A new fast path is introduced via the `spanSpanFast` method which
avoids the more complex logic within `startSpanGeneric`.

Additionally, the regexp-based verbose tracing is modified to use an
atomic pointer instead of a mutex, and the `SpanOption` iterator is
modified to avoid extra copies.

Below are benchmark results which show the most impact on `opts=none` cpu.
```
❯ benchdiff  ./pkg/util/tracing --old ':/consolidate regexp bench' -b -r 'BenchmarkTracer_StartSpanCtx' -d 100000x -c 10
test binaries already exist for a2746cd: tracing: consolidate regexp bench into BenchmarkTr
test binaries already exist for 41fdcda: tracing: add startSpanFast for optimized path when

  pkg=1/1 iter=10/10 cockroachdb/cockroach/pkg/util/tracing \

name                                                                            old time/op    new time/op    delta
Tracer_StartSpanCtx/opts=none/parallel=true-10                                     164ns ±10%      16ns ±64%  -90.12%  (p=0.000 n=10+10)
Tracer_StartSpanCtx/opts=none/parallel=false-10                                   56.1ns ± 5%    47.7ns ± 5%  -14.96%  (p=0.000 n=10+10)
Tracer_StartSpanCtx/opts=real/parallel=true-10                                     584ns ± 3%     546ns ±20%   -6.51%  (p=0.002 n=8+9)
Tracer_StartSpanCtx/opts=real,autoparent/parallel=true-10                          636ns ± 5%     615ns ± 4%   -3.37%  (p=0.014 n=10+10)
Tracer_StartSpanCtx/opts=real,autoparent/parallel=false-10                         318ns ± 3%     308ns ± 3%   -2.92%  (p=0.001 n=10+9)
Tracer_StartSpanCtx/opts=real,autoparent,withEventListener/parallel=false-10       473ns ± 3%     460ns ± 1%   -2.79%  (p=0.000 n=10+8)
Tracer_StartSpanCtx/opts=real,manualparent,withEventListener/parallel=true-10      669ns ± 4%     651ns ± 2%   -2.71%  (p=0.014 n=9+9)
Tracer_StartSpanCtx/opts=real,manualparent,withEventListener/parallel=false-10     353ns ± 2%     348ns ± 4%   -1.32%  (p=0.019 n=9+9)
Tracer_StartSpanCtx/opts=real/parallel=false-10                                    285ns ± 3%     284ns ± 1%     ~     (p=0.923 n=10+9)
Tracer_StartSpanCtx/opts=real,logtag/parallel=false-10                             303ns ± 4%     303ns ± 3%     ~     (p=0.811 n=10+10)
Tracer_StartSpanCtx/opts=real,logtag/parallel=true-10                              590ns ± 2%     585ns ± 3%     ~     (p=0.190 n=9+9)
Tracer_StartSpanCtx/opts=real,manualparent/parallel=false-10                       338ns ± 3%     333ns ± 3%     ~     (p=0.052 n=10+10)
Tracer_StartSpanCtx/opts=real,manualparent/parallel=true-10                        651ns ± 4%     639ns ± 4%     ~     (p=0.052 n=10+10)
Tracer_StartSpanCtx/opts=real,autoparent,withEventListener/parallel=true-10        910ns ±18%     880ns ±24%     ~     (p=0.436 n=10+10)
Tracer_StartSpanCtx/opts=real,regexp/parallel=true-10                              741ns ± 3%     808ns ± 2%   +9.10%  (p=0.000 n=9+10)
Tracer_StartSpanCtx/opts=real,regexp/parallel=false-10                             500ns ± 1%     722ns ± 1%  +44.49%  (p=0.000 n=8+8)

name                                                                            old alloc/op   new alloc/op   delta
Tracer_StartSpanCtx/opts=none/parallel=false-10                                    48.0B ± 0%     48.0B ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=none/parallel=true-10                                     48.0B ± 0%     48.0B ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real/parallel=false-10                                    48.0B ± 0%     48.0B ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real/parallel=true-10                                     48.0B ± 0%     48.0B ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,logtag/parallel=false-10                             48.0B ± 0%     48.0B ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,logtag/parallel=true-10                              48.0B ± 0%     48.0B ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,autoparent/parallel=false-10                         48.0B ± 0%     48.0B ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,autoparent/parallel=true-10                          48.0B ± 0%     48.0B ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,manualparent/parallel=false-10                       48.0B ± 0%     48.0B ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,manualparent/parallel=true-10                        48.0B ± 0%     48.0B ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,autoparent,withEventListener/parallel=false-10       96.0B ± 0%     96.0B ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,autoparent,withEventListener/parallel=true-10        96.0B ± 0%     96.0B ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,manualparent,withEventListener/parallel=false-10     48.0B ± 0%     48.0B ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,manualparent,withEventListener/parallel=true-10      48.0B ± 0%     48.0B ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,regexp/parallel=false-10                             48.0B ± 0%     48.0B ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,regexp/parallel=true-10                              51.0B ± 0%     51.0B ± 0%     ~     (all equal)

name                                                                            old allocs/op  new allocs/op  delta
Tracer_StartSpanCtx/opts=none/parallel=false-10                                     1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=none/parallel=true-10                                      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real/parallel=false-10                                     1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real/parallel=true-10                                      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,logtag/parallel=false-10                              1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,logtag/parallel=true-10                               1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,autoparent/parallel=false-10                          1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,autoparent/parallel=true-10                           1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,manualparent/parallel=false-10                        1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,manualparent/parallel=true-10                         1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,autoparent,withEventListener/parallel=false-10        2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,autoparent,withEventListener/parallel=true-10         2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,manualparent,withEventListener/parallel=false-10      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,manualparent,withEventListener/parallel=true-10       1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,regexp/parallel=false-10                              1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Tracer_StartSpanCtx/opts=real,regexp/parallel=true-10                               1.00 ± 0%      1.00 ± 0%     ~     (all equal)
```

Part of: https://github.com/cockroachdb/cockroach/issues/133307
Epic: CRDB-42854

Release note: None