### PR TITLE
wip: opt: execbuild generic lookup joins as scans

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/generic
+++ b/pkg/sql/logictest/testdata/logic_test/generic
@@ -1,5 +1,7 @@
 # LogicTest: local
 
+# TODO(mgartner): Move this file into execbuiler tests.
+
 statement ok
 CREATE TABLE t (
   k INT PRIMARY KEY,
@@ -348,7 +350,7 @@ isolation level: serializable
 priority: normal
 quality of service: regular
 ·
-• lookup join
+• lookup join (streamer)
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
@@ -363,25 +365,21 @@ quality of service: regular
 │ equality cols are key
 │ pred: c = "$2"
 │
-└── • lookup join
-    │ sql nodes: <hidden>
-    │ kv nodes: <hidden>
-    │ regions: <hidden>
-    │ actual row count: 0
-    │ KV time: 0µs
-    │ KV contention time: 0µs
-    │ KV rows decoded: 0
-    │ KV bytes read: 0 B
-    │ KV gRPC calls: 0
-    │ estimated max memory allocated: 0 B
-    │ table: t@t_a_idx
-    │ equality: ($1) = (a)
+└── • render
     │
-    └── • values
+    └── • scan
           sql nodes: <hidden>
+          kv nodes: <hidden>
           regions: <hidden>
-          actual row count: 1
-          size: 2 columns, 1 row
+          actual row count: 0
+          KV time: 0µs
+          KV contention time: 0µs
+          KV rows decoded: 0
+          KV bytes read: 0 B
+          KV gRPC calls: 0
+          estimated max memory allocated: 0 B
+          table: t@t_a_idx
+          spans: [/1 - /1]
 
 # The generic plan can be reused with different placeholder values.
 query T
@@ -399,7 +397,7 @@ isolation level: serializable
 priority: normal
 quality of service: regular
 ·
-• lookup join
+• lookup join (streamer)
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
@@ -414,25 +412,21 @@ quality of service: regular
 │ equality cols are key
 │ pred: c = "$2"
 │
-└── • lookup join
-    │ sql nodes: <hidden>
-    │ kv nodes: <hidden>
-    │ regions: <hidden>
-    │ actual row count: 0
-    │ KV time: 0µs
-    │ KV contention time: 0µs
-    │ KV rows decoded: 0
-    │ KV bytes read: 0 B
-    │ KV gRPC calls: 0
-    │ estimated max memory allocated: 0 B
-    │ table: t@t_a_idx
-    │ equality: ($1) = (a)
+└── • render
     │
-    └── • values
+    └── • scan
           sql nodes: <hidden>
+          kv nodes: <hidden>
           regions: <hidden>
-          actual row count: 1
-          size: 2 columns, 1 row
+          actual row count: 0
+          KV time: 0µs
+          KV contention time: 0µs
+          KV rows decoded: 0
+          KV bytes read: 0 B
+          KV gRPC calls: 0
+          estimated max memory allocated: 0 B
+          table: t@t_a_idx
+          spans: [/11 - /11]
 
 statement ok
 SET plan_cache_mode = force_custom_plan
@@ -960,7 +954,7 @@ isolation level: serializable
 priority: normal
 quality of service: regular
 ·
-• lookup join
+• lookup join (streamer)
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
@@ -973,7 +967,7 @@ quality of service: regular
 │ table: g@g_a_b_idx
 │ equality: (k) = (a)
 │
-└── • lookup join
+└── • lookup join (streamer)
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 0
@@ -986,7 +980,7 @@ quality of service: regular
     │ table: c@c_a_idx
     │ equality: (k) = (a)
     │
-    └── • lookup join
+    └── • lookup join (streamer)
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 0
@@ -1001,25 +995,21 @@ quality of service: regular
         │ equality cols are key
         │ pred: c = "$2"
         │
-        └── • lookup join
-            │ sql nodes: <hidden>
-            │ kv nodes: <hidden>
-            │ regions: <hidden>
-            │ actual row count: 0
-            │ KV time: 0µs
-            │ KV contention time: 0µs
-            │ KV rows decoded: 0
-            │ KV bytes read: 0 B
-            │ KV gRPC calls: 0
-            │ estimated max memory allocated: 0 B
-            │ table: t@t_a_idx
-            │ equality: ($1) = (a)
+        └── • render
             │
-            └── • values
+            └── • scan
                   sql nodes: <hidden>
+                  kv nodes: <hidden>
                   regions: <hidden>
-                  actual row count: 1
-                  size: 2 columns, 1 row
+                  actual row count: 0
+                  KV time: 0µs
+                  KV contention time: 0µs
+                  KV rows decoded: 0
+                  KV bytes read: 0 B
+                  KV gRPC calls: 0
+                  estimated max memory allocated: 0 B
+                  table: t@t_a_idx
+                  spans: [/10000 - /10000]
 
 # On the seventh execution the generic plan is reused.
 query T
@@ -1037,7 +1027,7 @@ isolation level: serializable
 priority: normal
 quality of service: regular
 ·
-• lookup join
+• lookup join (streamer)
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
@@ -1050,7 +1040,7 @@ quality of service: regular
 │ table: g@g_a_b_idx
 │ equality: (k) = (a)
 │
-└── • lookup join
+└── • lookup join (streamer)
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 0
@@ -1063,7 +1053,7 @@ quality of service: regular
     │ table: c@c_a_idx
     │ equality: (k) = (a)
     │
-    └── • lookup join
+    └── • lookup join (streamer)
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 0
@@ -1078,25 +1068,21 @@ quality of service: regular
         │ equality cols are key
         │ pred: c = "$2"
         │
-        └── • lookup join
-            │ sql nodes: <hidden>
-            │ kv nodes: <hidden>
-            │ regions: <hidden>
-            │ actual row count: 0
-            │ KV time: 0µs
-            │ KV contention time: 0µs
-            │ KV rows decoded: 0
-            │ KV bytes read: 0 B
-            │ KV gRPC calls: 0
-            │ estimated max memory allocated: 0 B
-            │ table: t@t_a_idx
-            │ equality: ($1) = (a)
+        └── • render
             │
-            └── • values
+            └── • scan
                   sql nodes: <hidden>
+                  kv nodes: <hidden>
                   regions: <hidden>
-                  actual row count: 1
-                  size: 2 columns, 1 row
+                  actual row count: 0
+                  KV time: 0µs
+                  KV contention time: 0µs
+                  KV rows decoded: 0
+                  KV bytes read: 0 B
+                  KV gRPC calls: 0
+                  estimated max memory allocated: 0 B
+                  table: t@t_a_idx
+                  spans: [/10000 - /10000]
 
 statement ok
 DEALLOCATE p
@@ -1168,26 +1154,21 @@ quality of service: regular
 • limit
 │ count: 10
 │
-└── • lookup join
-    │ sql nodes: <hidden>
-    │ kv nodes: <hidden>
-    │ regions: <hidden>
-    │ actual row count: 0
-    │ KV time: 0µs
-    │ KV contention time: 0µs
-    │ KV rows decoded: 0
-    │ KV bytes read: 0 B
-    │ KV gRPC calls: 0
-    │ estimated max memory allocated: 0 B
-    │ estimated max sql temp disk usage: 0 B
-    │ table: g@g_a_b_idx
-    │ equality: ($1) = (a)
+└── • render
     │
-    └── • values
+    └── • scan
           sql nodes: <hidden>
+          kv nodes: <hidden>
           regions: <hidden>
-          actual row count: 1
-          size: 1 column, 1 row
+          actual row count: 0
+          KV time: 0µs
+          KV contention time: 0µs
+          KV rows decoded: 0
+          KV bytes read: 0 B
+          KV gRPC calls: 0
+          estimated max memory allocated: 0 B
+          table: g@g_a_b_idx
+          spans: [/10 - /10]
 
 statement ok
 DEALLOCATE p


### PR DESCRIPTION
#### wip: opt: execbuild generic lookup joins as scans

Generic query plans substitute Scan expressions with LookupJoin+Values
expressions. This is allows the optimizer to explore optimizations for
expressions that contain placeholders. The LookupJoins are similar to
Scans, while the Values abstract away the placeholder values. This makes
exploration, statistics estimation, costing, etc. mostly _just work_
despite the placeholder values being unknown.

The performance of the resulting lookup joins are, in theory, the same
as a scan. However, in practice, lookup joins have more overhead than a
scan due to their generality. So while generic query plans provide a
performance boost by eliminating re-optimization of queries, there is a
minor performance hit due to extra overhead of the lookup joins that
generic plans contain.

This prototype aims to avoid the overhead of these generic lookup joins
in common cases by recognizing the LookupJoin+Values in a generic query
plan and planning those expressions as Scans in the execbuilder.

For sysbench's oltp_read_write workload, I measured a slight increase in
latency, but a slight reduction in allocations.

```
name                                        old time/op    new time/op    delta
Sysbench/SQL/1node_local/oltp_read_write-8    4.44ms ± 0%    4.50ms ± 0%  +1.27%  (p=0.008 n=5+5)

name                                        old alloc/op   new alloc/op   delta
Sysbench/SQL/1node_local/oltp_read_write-8    1.29MB ± 0%    1.25MB ± 0%  -3.09%  (p=0.008 n=5+5)

name                                        old allocs/op  new allocs/op  delta
Sysbench/SQL/1node_local/oltp_read_write-8     7.50k ± 0%     7.34k ± 0%  -2.07%  (p=0.008 n=5+5)
```

For sysbench's oltp_write_only workload the results are better: the
latency is essentially the same while the reduction in allocations is
more pronounced.

```
name                                        old time/op    new time/op    delta
Sysbench/SQL/1node_local/oltp_write_only-8    1.70ms ± 0%    1.69ms ± 0%  -0.80%  (p=0.008 n=5+5)

name                                        old alloc/op   new alloc/op   delta
Sysbench/SQL/1node_local/oltp_write_only-8     440kB ± 0%     405kB ± 0%  -7.89%  (p=0.008 n=5+5)

name                                        old allocs/op  new allocs/op  delta
Sysbench/SQL/1node_local/oltp_write_only-8     2.88k ± 0%     2.72k ± 0%  -5.55%  (p=0.008 n=5+5)
```

The difference in allocations makes sense. The write queries should be
the only queries that benefit from this change—they use generic query
plans with the LookupJoin+Values pattern, while the point lookups use
the "placeholder fast path" that uses Scans already and generic query
plans are not currently used for the range scans.

It's not clear to me, though, why `oltp_read_write` latency regressed.
Maybe that's just noise in the benchmark.

Release note: None
