### PR TITLE
release-24.2: CODEOWNERS: don't tag SQL Foundations for workload unit test failures

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -171,7 +171,7 @@
 /pkg/cli/testutils.go        @cockroachdb/test-eng
 /pkg/cli/tsdump.go           @cockroachdb/obs-prs
 /pkg/cli/userfile.go         @cockroachdb/disaster-recovery
-/pkg/cli/workload*           @cockroachdb/sql-foundations
+/pkg/cli/workload*           @cockroachdb/test-eng
 /pkg/cli/zip*.go             @cockroachdb/obs-prs    @cockroachdb/cli-prs
 
 # Beware to not assign the entire server package directory to a single
@@ -419,7 +419,7 @@
 #!/pkg/ccl/testutilsccl/     @cockroachdb/test-eng-noreview
 /pkg/ccl/testutilsccl/alter_* @cockroachdb/sql-foundations
 #!/pkg/ccl/utilccl/          @cockroachdb/unowned
-/pkg/ccl/workloadccl/        @cockroachdb/test-eng #! @cockroachdb/sql-foundations-noreview
+/pkg/ccl/workloadccl/        @cockroachdb/test-eng
 /pkg/ccl/benchccl/rttanalysisccl/     @cockroachdb/sql-foundations
 #!/pkg/clusterversion/       @cockroachdb/dev-inf-noreview  @cockroachdb/kv-prs-noreview @cockroachdb/test-eng-prs
 /pkg/cmd/allocsim/           @cockroachdb/kv-prs
@@ -500,7 +500,7 @@
 /pkg/cmd/uptodate/           @cockroachdb/dev-inf
 #!/pkg/cmd/urlcheck/           @cockroachdb/docs-infra-prs
 /pkg/cmd/whoownsit/          @cockroachdb/test-eng
-/pkg/cmd/workload/           @cockroachdb/test-eng #! @cockroachdb/sql-foundations-noreview
+/pkg/cmd/workload/           @cockroachdb/test-eng
 #!/pkg/cmd/wraprules/          @cockroachdb/obs-prs-noreview
 #!/pkg/cmd/zerosum/            @cockroachdb/kv-noreview
 /pkg/col/                    @cockroachdb/sql-queries-prs
@@ -583,7 +583,7 @@
 /pkg/util/admission/         @cockroachdb/admission-control
 /pkg/util/schedulerlatency/  @cockroachdb/admission-control
 /pkg/util/mon                @cockroachdb/sql-queries-prs
-/pkg/workload/               @cockroachdb/test-eng #! @cockroachdb/sql-foundations-noreview
+/pkg/workload/               @cockroachdb/test-eng
 /pkg/obs/                    @cockroachdb/obs-prs
 /pkg/ccl/auditloggingccl     @cockroachdb/obs-prs
 /pkg/cmd/drt*                @cockroachdb/test-eng


### PR DESCRIPTION
Backport 1/1 commits from #136845.

/cc @cockroachdb/release

Release justification: non production change

---

This will reduce noise on issues such as: https://github.com/cockroachdb/cockroach/issues/136843, https://github.com/cockroachdb/cockroach/issues/136541, https://github.com/cockroachdb/cockroach/issues/136710, https://github.com/cockroachdb/cockroach/issues/136599

Epic: None
Release note: None
