### PR TITLE
kv: delete TestSendToOneClient

### DIFF
--- a/pkg/kv/kvclient/kvcoord/send_test.go
+++ b/pkg/kv/kvclient/kvcoord/send_test.go
@@ -11,135 +11,21 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangecache"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
-	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
-
-var _ kvpb.InternalServer = Node(0)
-
-type Node time.Duration
-
-func (n Node) Batch(ctx context.Context, args *kvpb.BatchRequest) (*kvpb.BatchResponse, error) {
-	if n > 0 {
-		time.Sleep(time.Duration(n))
-	}
-	return &kvpb.BatchResponse{}, nil
-}
-
-func (n Node) RangeLookup(
-	_ context.Context, _ *kvpb.RangeLookupRequest,
-) (*kvpb.RangeLookupResponse, error) {
-	panic("unimplemented")
-}
-
-func (n Node) MuxRangeFeed(server kvpb.Internal_MuxRangeFeedServer) error {
-	panic("unimplemented")
-}
-
-func (n Node) GossipSubscription(
-	_ *kvpb.GossipSubscriptionRequest, _ kvpb.Internal_GossipSubscriptionServer,
-) error {
-	panic("unimplemented")
-}
-
-func (n Node) Join(context.Context, *kvpb.JoinNodeRequest) (*kvpb.JoinNodeResponse, error) {
-	panic("unimplemented")
-}
-
-func (n Node) ResetQuorum(
-	context.Context, *kvpb.ResetQuorumRequest,
-) (*kvpb.ResetQuorumResponse, error) {
-	panic("unimplemented")
-}
-
-func (n Node) TokenBucket(
-	ctx context.Context, in *kvpb.TokenBucketRequest,
-) (*kvpb.TokenBucketResponse, error) {
-	panic("unimplemented")
-}
-
-func (n Node) GetSpanConfigs(
-	_ context.Context, _ *roachpb.GetSpanConfigsRequest,
-) (*roachpb.GetSpanConfigsResponse, error) {
-	panic("unimplemented")
-}
-
-func (n Node) GetAllSystemSpanConfigsThatApply(
-	_ context.Context, _ *roachpb.GetAllSystemSpanConfigsThatApplyRequest,
-) (*roachpb.GetAllSystemSpanConfigsThatApplyResponse, error) {
-	panic("unimplemented")
-}
-
-func (n Node) UpdateSpanConfigs(
-	_ context.Context, _ *roachpb.UpdateSpanConfigsRequest,
-) (*roachpb.UpdateSpanConfigsResponse, error) {
-	panic("unimplemented")
-}
-
-func (n Node) SpanConfigConformance(
-	context.Context, *roachpb.SpanConfigConformanceRequest,
-) (*roachpb.SpanConfigConformanceResponse, error) {
-	panic("unimplemented")
-}
-
-func (n Node) TenantSettings(
-	*kvpb.TenantSettingsRequest, kvpb.Internal_TenantSettingsServer,
-) error {
-	panic("unimplemented")
-}
-
-func (n Node) GetRangeDescriptors(
-	*kvpb.GetRangeDescriptorsRequest, kvpb.Internal_GetRangeDescriptorsServer,
-) error {
-	panic("unimplemented")
-}
-
-// TestSendToOneClient verifies that Send correctly sends a request
-// to one server using the heartbeat RPC.
-func TestSendToOneClient(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	ctx := context.Background()
-	stopper := stop.NewStopper()
-	defer stopper.Stop(ctx)
-
-	clock := hlc.NewClockForTesting(nil)
-	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
-	// This test uses the testing function sendBatch() which does not
-	// support setting the node ID on GRPCDialNode(). Disable Node ID
-	// checks to avoid log.Fatal.
-	rpcContext.TestingAllowNamedRPCToAnonymousServer = true
-
-	s, err := rpc.NewServer(ctx, rpcContext)
-	require.NoError(t, err)
-	kvpb.RegisterInternalServer(s, Node(0))
-	ln, err := netutil.ListenAndServeGRPC(rpcContext.Stopper, s, util.TestAddr)
-	require.NoError(t, err)
-	transportFactory := GRPCTransportFactory(nodedialer.New(rpcContext, func(roachpb.NodeID) (net.Addr, roachpb.Locality, error) {
-		return ln.Addr(), roachpb.Locality{}, nil
-	}))
-	reply, err := sendBatch(ctx, t, transportFactory, []net.Addr{ln.Addr()}, rpcContext)
-	require.NoError(t, err)
-	if reply == nil {
-		t.Errorf("expected reply")
-	}
-}
 
 // firstNErrorTransport is a mock transport that sends an error on
 // requests to the first N addresses, then succeeds.


### PR DESCRIPTION
The test was written in 2015 and was providing no value anymore. It was also the only test keeping the `Node` `InternalServer` mock in use. This commit deletes both.

Epic: None
Release note: None