### PR TITLE
kvserver,rac2: turn off raftReceiveQueue.maxLen enforcement in apply_…

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/wait_for_eval_config.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/wait_for_eval_config.go
@@ -40,7 +40,14 @@ type WaitForEvalConfig struct {
 		waitCategory            WaitForEvalCategory
 		waitCategoryDecreasedCh chan struct{}
 	}
+	// watcherMu is ordered before mu. cbs are executed while holding watcherMu.
+	watcherMu struct {
+		syncutil.Mutex
+		cbs []WatcherCallback
+	}
 }
+
+type WatcherCallback func(wc WaitForEvalCategory)
 
 // NewWaitForEvalConfig constructs WaitForEvalConfig.
 func NewWaitForEvalConfig(st *cluster.Settings) *WaitForEvalConfig {
@@ -59,32 +66,42 @@ func NewWaitForEvalConfig(st *cluster.Settings) *WaitForEvalConfig {
 // notifyChanged is called whenever any of the cluster settings that affect
 // WaitForEval change. It is also called for initialization.
 func (w *WaitForEvalConfig) notifyChanged() {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	// Call computeCategory while holding w.mu to serialize the computation in
-	// case of concurrent callbacks. This ensures the latest settings are used
-	// to set the current state, and we don't have a situation where a slow
-	// goroutine samples the settings, then after some arbitrary duration
-	// acquires the mutex and sets a stale state.
-	waitCategory := w.computeCategory()
-	if w.mu.waitCategoryDecreasedCh == nil {
-		// Initialization.
-		w.mu.waitCategoryDecreasedCh = make(chan struct{})
-		w.mu.waitCategory = waitCategory
-		return
-	}
-	// Not initialization.
-	if w.mu.waitCategory > waitCategory {
-		close(w.mu.waitCategoryDecreasedCh)
-		w.mu.waitCategoryDecreasedCh = make(chan struct{})
-	}
-	// Else w.mu.waitCategory <= waitCategory. Since the set of requests that
-	// are subject to replication admission/flow control is growing (or staying
-	// the same), we don't need to tell the existing waiting requests to restart
-	// their wait, using the latest value of waitCategory, since they are
-	// unaffected by the change.
+	func() {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		// Call computeCategory while holding w.mu to serialize the computation in
+		// case of concurrent callbacks. This ensures the latest settings are used
+		// to set the current state, and we don't have a situation where a slow
+		// goroutine samples the settings, then after some arbitrary duration
+		// acquires the mutex and sets a stale state.
+		waitCategory := w.computeCategory()
+		if w.mu.waitCategoryDecreasedCh == nil {
+			// Initialization.
+			w.mu.waitCategoryDecreasedCh = make(chan struct{})
+			w.mu.waitCategory = waitCategory
+			return
+		}
+		// Not initialization.
+		if w.mu.waitCategory > waitCategory {
+			close(w.mu.waitCategoryDecreasedCh)
+			w.mu.waitCategoryDecreasedCh = make(chan struct{})
+		}
+		// Else w.mu.waitCategory <= waitCategory. Since the set of requests that
+		// are subject to replication admission/flow control is growing (or staying
+		// the same), we don't need to tell the existing waiting requests to restart
+		// their wait, using the latest value of waitCategory, since they are
+		// unaffected by the change.
 
-	w.mu.waitCategory = waitCategory
+		w.mu.waitCategory = waitCategory
+	}()
+	w.watcherMu.Lock()
+	defer w.watcherMu.Unlock()
+	w.mu.RLock()
+	wc := w.mu.waitCategory
+	w.mu.RUnlock()
+	for _, cb := range w.watcherMu.cbs {
+		cb(wc)
+	}
 }
 
 // Current returns the current category, and a channel that will be closed if
@@ -109,4 +126,17 @@ func (w *WaitForEvalConfig) computeCategory() WaitForEvalCategory {
 		return AllWorkWaitsForEval
 	}
 	panic(errors.AssertionFailedf("unknown mode %v", mode))
+}
+
+// RegisterWatcher registers a callback that provides the latest state of
+// WaitForEvalCategory. The first call happens within this method, before
+// returning.
+func (w *WaitForEvalConfig) RegisterWatcher(cb WatcherCallback) {
+	w.watcherMu.Lock()
+	defer w.watcherMu.Unlock()
+	w.mu.RLock()
+	wc := w.mu.waitCategory
+	w.mu.RUnlock()
+	cb(wc)
+	w.watcherMu.cbs = append(w.watcherMu.cbs, cb)
 }

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/wait_for_eval_config_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/wait_for_eval_config_test.go
@@ -26,47 +26,65 @@ func TestWaitForEvalConfig(t *testing.T) {
 	kvflowcontrol.Enabled.Override(ctx, &st.SV, true)
 	kvflowcontrol.Mode.Override(ctx, &st.SV, kvflowcontrol.ApplyToAll)
 
+	var expectedWC WaitForEvalCategory
+
 	// All work waits for eval.
 	w := NewWaitForEvalConfig(st)
+	expectedWC = AllWorkWaitsForEval
 	wec, ch1 := w.Current()
-	require.Equal(t, AllWorkWaitsForEval, wec)
+	require.Equal(t, expectedWC, wec)
 	require.NotNil(t, ch1)
 	require.False(t, wec.Bypass(admissionpb.ElasticWorkClass))
 	require.False(t, wec.Bypass(admissionpb.RegularWorkClass))
+	cbCount := 0
+	cb := func(wc WaitForEvalCategory) {
+		cbCount++
+		require.Equal(t, expectedWC, wc)
+	}
+	w.RegisterWatcher(cb)
+	require.Equal(t, 1, cbCount)
 
 	// No work waits for eval.
+	expectedWC = NoWorkWaitsForEval
 	kvflowcontrol.Enabled.Override(ctx, &st.SV, false)
 	var ch2 <-chan struct{}
 	wec, ch2 = w.Current()
-	require.Equal(t, NoWorkWaitsForEval, wec)
+	require.Equal(t, expectedWC, wec)
 	require.NotNil(t, ch2)
 	require.NotEqual(t, ch1, ch2)
 	require.True(t, wec.Bypass(admissionpb.ElasticWorkClass))
 	require.True(t, wec.Bypass(admissionpb.RegularWorkClass))
+	require.Equal(t, 2, cbCount)
 
 	// All work waits for eval.
+	expectedWC = AllWorkWaitsForEval
 	kvflowcontrol.Enabled.Override(ctx, &st.SV, true)
 	var ch3 <-chan struct{}
 	wec, ch3 = w.Current()
-	require.Equal(t, AllWorkWaitsForEval, wec)
+	require.Equal(t, expectedWC, wec)
 	// Channel has not changed.
 	require.Equal(t, ch2, ch3)
+	require.Equal(t, 3, cbCount)
 
 	// Elastic work waits for eval.
+	expectedWC = OnlyElasticWorkWaitsForEval
 	kvflowcontrol.Mode.Override(ctx, &st.SV, kvflowcontrol.ApplyToElastic)
 	var ch4 <-chan struct{}
 	wec, ch4 = w.Current()
-	require.Equal(t, OnlyElasticWorkWaitsForEval, wec)
+	require.Equal(t, expectedWC, wec)
 	require.NotNil(t, ch4)
 	require.NotEqual(t, ch3, ch4)
 	require.False(t, wec.Bypass(admissionpb.ElasticWorkClass))
 	require.True(t, wec.Bypass(admissionpb.RegularWorkClass))
+	require.Equal(t, 4, cbCount)
 
 	// All work waits for eval.
+	expectedWC = AllWorkWaitsForEval
 	kvflowcontrol.Mode.Override(ctx, &st.SV, kvflowcontrol.ApplyToAll)
 	var ch5 <-chan struct{}
 	wec, ch5 = w.Current()
-	require.Equal(t, AllWorkWaitsForEval, wec)
+	require.Equal(t, expectedWC, wec)
 	// Channel has not changed.
 	require.Equal(t, ch4, ch5)
+	require.Equal(t, 5, cbCount)
 }

--- a/pkg/kv/kvserver/store_raft_test.go
+++ b/pkg/kv/kvserver/store_raft_test.go
@@ -9,7 +9,9 @@ package kvserver
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
@@ -19,12 +21,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/stretchr/testify/require"
@@ -220,4 +225,91 @@ func TestRaftCrossLocalityMetrics(t *testing.T) {
 			require.Equal(t, metricsDiff, expectedDiff)
 		})
 	}
+}
+
+func TestRaftReceiveQueuesEnforceMaxLenConcurrency(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	skip.UnderDuress(t, "slow test")
+	st := cluster.MakeTestingClusterSettings()
+	g := metric.NewGauge(metric.Metadata{})
+	m := mon.NewUnlimitedMonitor(context.Background(), mon.Options{
+		Name:     mon.MakeMonitorName("test"),
+		CurCount: g,
+		Settings: st,
+	})
+	qs := raftReceiveQueues{mon: m}
+	// checkingMu is locked in write mode when checking that the values of
+	// enforceMaxLen across all the queues is the expected value.
+	var checkingMu syncutil.RWMutex
+	// doneCh is used to tell the goroutines to stop, and wg is used to wait
+	// until they are done.
+	doneCh := make(chan struct{})
+	var wg sync.WaitGroup
+	// Spin up goroutines to create queues.
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			rng, _ := randutil.NewTestRand()
+			defer wg.Done()
+			// Loop until the doneCh is closed.
+			for {
+				checkingMu.RLock()
+				// Most queues will be newly created due to lack of collision in the
+				// random numbers. Newly created queues have their enforceMaxLen set
+				// in LoadOrCreate.
+				qs.LoadOrCreate(roachpb.RangeID(rng.Int63()), 10)
+				checkingMu.RUnlock()
+				select {
+				case <-doneCh:
+					return
+				default:
+				}
+			}
+		}()
+	}
+	// Iterate and set different values of enforceMaxLen.
+	enforceMaxLen := false
+	for i := 0; i < 200; i++ {
+		// NB: SetEnforceMaxLen runs concurrently with LoadOrCreate calls.
+		qs.SetEnforceMaxLen(enforceMaxLen)
+		// Exclude all LoadOrCreate calls while checking is happening.
+		checkingMu.Lock()
+		qs.m.Range(func(_ roachpb.RangeID, q *raftReceiveQueue) bool {
+			require.Equal(t, enforceMaxLen, q.getEnforceMaxLenForTesting())
+			return true
+		})
+		checkingMu.Unlock()
+		enforceMaxLen = !enforceMaxLen
+		// Do a tiny sleep after releasing the write lock. This gives some
+		// opportunity for a bunch of goroutines to acquire the read lock, so when
+		// this code loops around to call SetEnforceMaxLen, there is a higher
+		// chance of encountering concurrent LoadOrCreate.
+		time.Sleep(time.Millisecond)
+	}
+	close(doneCh)
+	wg.Wait()
+}
+
+func TestRaftReceiveQueuesEnforceMaxLen(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	st := cluster.MakeTestingClusterSettings()
+	g := metric.NewGauge(metric.Metadata{})
+	m := mon.NewUnlimitedMonitor(context.Background(), mon.Options{
+		Name:     mon.MakeMonitorName("test"),
+		CurCount: g,
+		Settings: st,
+	})
+	qs := raftReceiveQueues{mon: m}
+	qs.SetEnforceMaxLen(false)
+	q, _ := qs.LoadOrCreate(1, 2)
+	var s RaftMessageResponseStream
+	for i := 0; i < 10; i++ {
+		_, _, appended := q.Append(&kvserverpb.RaftMessageRequest{}, s)
+		require.True(t, appended)
+	}
+	qs.SetEnforceMaxLen(true)
+	_, _, appended := q.Append(&kvserverpb.RaftMessageRequest{}, s)
+	require.False(t, appended)
 }


### PR DESCRIPTION
…to_all mode

The existing maxLen enforcement is already dubious:
- Length does not equal bytes, so offers limited protection from OOMs.
- The limit is per replica and not an aggregate.
- We run a cooperative system, and historically the sender has respected RaftConfig.RaftMaxInflightBytes, which is a byte limit. The only reason for additional protection on the receiver is when there are rapid repeated leader changes for a large number of ranges for which the receiver has replicas. Even in this case, the behavior is surprising since the receive queue overflows even though the sender has done nothing wrong -- and it is very unlikely that this overflow is actually protecting against an OOM.

With RACv2 in apply_to_all mode, the senders have a 16MiB regular token pool that applies to a whole (store, tenant) pair. This is stricter than the per range defaultRaftMaxInflightBytes (32MiB), both in value, and because it is an aggregate limit. The aforementioned "only reason" is even more unnecessary. So we remove this in the case of apply_to_all.

An alternative would be to have replicaSendStream respect the receiver limit in apply_to_all mode. The complexity there is that replicaSendStream grabs a bunch of tokens equal to the byte size of the send-queue, and expects to send all those messages. To respect a count limit, it will need to quickly return tokens it can't use (since they are a shared resource), which adds complexity to the already complex token management logic.

Fixes #135851

Epic: none

Release note: None