### PR TITLE
opt: minimize the number of buckets allocated when filtering histograms

### DIFF
--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -517,6 +517,22 @@ var queries = [...]benchQuery{
 		args:  []interface{}{"'abc'"},
 	},
 	{
+		name:  "single-col-histogram-bounded-range-small",
+		query: "SELECT * FROM single_col_histogram WHERE k >= $1 and k < $2",
+		args: []interface{}{
+			"'abcdefghijklmnopqrstuvwxyz___________________7325'",
+			"'abcdefghijklmnopqrstuvwxyz___________________7350'",
+		},
+	},
+	{
+		name:  "single-col-histogram-bounded-range-big",
+		query: "SELECT * FROM single_col_histogram WHERE k >= $1 and k < $2",
+		args: []interface{}{
+			"'abcdefghijklmnopqrstuvwxyz___________________7325'",
+			"'abcdefghijklmnopqrstuvwxyz___________________9000'",
+		},
+	},
+	{
 		name:    "json-insert",
 		query:   `INSERT INTO json_table(k, i, j) VALUES (1, 10, '{"a": "foo", "b": "bar", "c": [2, 3, "baz", true, false, null]}')`,
 		args:    []interface{}{},

--- a/pkg/sql/opt/props/histogram_test.go
+++ b/pkg/sql/opt/props/histogram_test.go
@@ -198,7 +198,7 @@ func TestHistogram(t *testing.T) {
 	}{
 		{
 			constraint:   "/1: [/0 - /0]",
-			buckets:      []cat.HistogramBucket{},
+			buckets:      nil,
 			count:        0,
 			maxDistinct:  0,
 			distinct:     0,
@@ -206,7 +206,7 @@ func TestHistogram(t *testing.T) {
 		},
 		{
 			constraint:   "/1: [/50 - /100]",
-			buckets:      []cat.HistogramBucket{},
+			buckets:      nil,
 			count:        0,
 			maxDistinct:  0,
 			distinct:     0,


### PR DESCRIPTION
#### opt: add new benchmark cases that filter histogram buckets

Release note: None

#### opt: minimize the number of buckets allocated when filtering histograms

When filtering a histogram, we previously allocated the same number of
buckets for the new histogram as the original histogram. Now we allocate
much fewer buckets in two ways:

  1. We allocate only the number of buckets including and after the
     first bucket that overlaps with the filtering span(s). For example,
     if the original histogram has 10 buckets and the first bucket that
     overlaps the span(s) is the bucket at index 3, then we allocate
     only 7+1 buckets (the additional bucket is the empty bucket
     representing the lower bound of the filtered histogram).

  2. In the special case where we have a single filtering span that
     overlaps a single bucket, we allocate just 2 buckets. This case is
     common for equality filters and small range filters.

Informs #136002

Release note: None
