### PR TITLE
kvserver,rac2,tracker: use RaftMaxInflightBytes when force-flushing

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/close
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/close
@@ -49,7 +49,7 @@ t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -57,7 +57,7 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -65,7 +65,7 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -86,22 +86,34 @@ t1/s2: eval reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
 t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
        send reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
 
+# Send an empty event so that replicaSendStreams are aware of the update to
+# match.
+raft_event
+range_id=1
+----
+t1/s1: eval reg=+15 MiB/+16 MiB ela=+7.0 MiB/+8.0 MiB
+       send reg=+15 MiB/+16 MiB ela=+7.0 MiB/+8.0 MiB
+t1/s2: eval reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
+       send reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
+t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+       send reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[3,4) (1.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[2,4) send_queue=[4,4) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[2,4) (2.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -122,13 +134,13 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[3,4) (1.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[2,4) send_queue=[4,4) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[2,4) (2.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/do_force_flush
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/do_force_flush
@@ -32,7 +32,7 @@ t1/s3: eval reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -44,7 +44,7 @@ NormalPri:
 eval deducted: reg=+0 B ela=+3.0 MiB
 eval original in send-q: reg=+3.0 MiB ela=+0 B
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -69,7 +69,7 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -91,7 +91,7 @@ scheduled-replicas: 2
 # true.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -99,7 +99,7 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+3.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -125,7 +125,7 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -133,7 +133,7 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+3.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -141,7 +141,7 @@ LowPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
@@ -164,7 +164,7 @@ t1/s3: eval reg=-4.5 MiB/+16 MiB ela=-4.5 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,7) send_queue=[7,7) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,7) (7.5 MiB) send_queue=[7,7) precise_q_size=+0 B
 eval deducted: reg=+7.5 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -175,7 +175,7 @@ NormalPri:
   term=1 index=5  tokens=1572864
   term=1 index=6  tokens=1572864
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,7) precise_q_size=+4.5 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,7) precise_q_size=+4.5 MiB watching-for-tokens
 eval deducted: reg=+0 B ela=+7.5 MiB
 eval original in send-q: reg=+4.5 MiB ela=+0 B
 LowPri:
@@ -183,7 +183,7 @@ LowPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,7) send_queue=[7,7) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,7) (7.5 MiB) send_queue=[7,7) precise_q_size=+0 B
 eval deducted: reg=+4.5 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -207,7 +207,7 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,7) send_queue=[7,7) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,7) (7.5 MiB) send_queue=[7,7) precise_q_size=+0 B
 eval deducted: reg=+7.5 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -218,7 +218,7 @@ NormalPri:
   term=1 index=5  tokens=1572864
   term=1 index=6  tokens=1572864
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,7) precise_q_size=+4.5 MiB force-flushing
+(n2,s2):2: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,7) precise_q_size=+4.5 MiB force-flushing
 eval deducted: reg=+0 B ela=+7.5 MiB
 eval original in send-q: reg=+4.5 MiB ela=+0 B
 LowPri:
@@ -236,7 +236,7 @@ scheduled-replicas: 2
 # event. Replica 2 schedules itself again.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,7) send_queue=[7,7) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,7) (7.5 MiB) send_queue=[7,7) precise_q_size=+0 B
 eval deducted: reg=+7.5 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -247,7 +247,7 @@ NormalPri:
   term=1 index=5  tokens=1572864
   term=1 index=6  tokens=1572864
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,6) send_queue=[6,7) precise_q_size=+1.5 MiB force-flushing
+(n2,s2):2: state=replicate closed=false inflight=[1,6) (6.0 MiB) send_queue=[6,7) precise_q_size=+1.5 MiB force-flushing
 eval deducted: reg=+0 B ela=+7.5 MiB
 eval original in send-q: reg=+1.5 MiB ela=+0 B
 LowPri:
@@ -268,7 +268,7 @@ scheduled-replicas: 2
 # Another scheduler event. The send-queue is empty and force flushing stops.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,7) send_queue=[7,7) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,7) (7.5 MiB) send_queue=[7,7) precise_q_size=+0 B
 eval deducted: reg=+7.5 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -279,7 +279,7 @@ NormalPri:
   term=1 index=5  tokens=1572864
   term=1 index=6  tokens=1572864
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,7) send_queue=[7,7) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,7) (7.5 MiB) send_queue=[7,7) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+7.5 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_choice
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_choice
@@ -55,19 +55,19 @@ t1/s5: eval reg=+0 B/+16 MiB ela=-1.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -102,13 +102,13 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -157,19 +157,19 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
@@ -187,19 +187,19 @@ scheduled-replicas: 5
 # Scheduler event doesn't do anything since no one is force-flushing.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
@@ -243,13 +243,13 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -282,19 +282,19 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
@@ -357,13 +357,13 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -396,7 +396,7 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -431,13 +431,13 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
@@ -468,7 +468,7 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -503,17 +503,17 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
@@ -542,7 +542,7 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -580,7 +580,7 @@ t1/s5: eval reg=-1.0 MiB/+16 MiB ela=-1.5 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_index
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_index
@@ -34,7 +34,7 @@ t1/s3: eval reg=-30 MiB/+16 MiB ela=-30 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,6) (30 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+30 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -48,7 +48,7 @@ NormalPri:
 eval deducted: reg=+0 B ela=+30 MiB
 eval original in send-q: reg=+30 MiB ela=+0 B
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,6) (30 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+30 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -65,7 +65,7 @@ MsgApps sent in pull mode:
 # Force flush up to index 2. Replica 2 starts force-flushing.
 set_force_flush_index range_id=1 index=2
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,6) (30 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+30 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -79,7 +79,7 @@ NormalPri:
 eval deducted: reg=+0 B ela=+30 MiB
 eval original in send-q: reg=+30 MiB ela=+0 B
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,6) (30 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+30 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -95,7 +95,7 @@ scheduled-replicas: 2
 # Scheduler event. Entry at index 1 is popped from replica 2.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,6) (30 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+30 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -105,13 +105,13 @@ NormalPri:
   term=1 index=4  tokens=6291456
   term=1 index=5  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,6) precise_q_size=+24 MiB force-flushing (stop=2)
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (6.0 MiB) send_queue=[2,6) precise_q_size=+24 MiB force-flushing (stop=2)
 eval deducted: reg=+0 B ela=+30 MiB
 eval original in send-q: reg=+24 MiB ela=+0 B
 LowPri:
   term=1 index=1  tokens=6291456
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,6) (30 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+30 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -131,7 +131,7 @@ scheduled-replicas: 2
 # stops.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,6) (30 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+30 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -141,14 +141,14 @@ NormalPri:
   term=1 index=4  tokens=6291456
   term=1 index=5  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,6) precise_q_size=+18 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,3) (12 MiB) send_queue=[3,6) precise_q_size=+18 MiB watching-for-tokens
 eval deducted: reg=+0 B ela=+30 MiB
 eval original in send-q: reg=+18 MiB ela=+0 B
 LowPri:
   term=1 index=1  tokens=6291456
   term=1 index=2  tokens=6291456
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,6) (30 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+30 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -166,7 +166,7 @@ schedule-controller-event-count: 2
 # Force flush up to index 3. Replica 2 starts force-flushing.
 set_force_flush_index range_id=1 index=3
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,6) (30 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+30 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -176,14 +176,14 @@ NormalPri:
   term=1 index=4  tokens=6291456
   term=1 index=5  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,6) precise_q_size=+18 MiB force-flushing (stop=3)
+(n2,s2):2: state=replicate closed=false inflight=[1,3) (12 MiB) send_queue=[3,6) precise_q_size=+18 MiB force-flushing (stop=3)
 eval deducted: reg=+0 B ela=+30 MiB
 eval original in send-q: reg=+18 MiB ela=+0 B
 LowPri:
   term=1 index=1  tokens=6291456
   term=1 index=2  tokens=6291456
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,6) (30 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+30 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -200,7 +200,7 @@ scheduled-replicas: 2
 # stops.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,6) (30 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+30 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -210,7 +210,7 @@ NormalPri:
   term=1 index=4  tokens=6291456
   term=1 index=5  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,6) precise_q_size=+12 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,4) (18 MiB) send_queue=[4,6) precise_q_size=+12 MiB watching-for-tokens
 eval deducted: reg=+0 B ela=+30 MiB
 eval original in send-q: reg=+12 MiB ela=+0 B
 LowPri:
@@ -218,7 +218,7 @@ LowPri:
   term=1 index=2  tokens=6291456
   term=1 index=3  tokens=6291456
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,6) (30 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+30 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -236,7 +236,7 @@ schedule-controller-event-count: 3
 # Force flush up to index 3, which is a noop.
 set_force_flush_index range_id=1 index=3
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,6) (30 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+30 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -246,7 +246,7 @@ NormalPri:
   term=1 index=4  tokens=6291456
   term=1 index=5  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,6) precise_q_size=+12 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,4) (18 MiB) send_queue=[4,6) precise_q_size=+12 MiB watching-for-tokens
 eval deducted: reg=+0 B ela=+30 MiB
 eval original in send-q: reg=+12 MiB ela=+0 B
 LowPri:
@@ -254,7 +254,7 @@ LowPri:
   term=1 index=2  tokens=6291456
   term=1 index=3  tokens=6291456
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,6) (30 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+30 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -269,7 +269,7 @@ schedule-controller-event-count: 3
 # Force flush up to index 4. Replica 2 starts force-flushing.
 set_force_flush_index range_id=1 index=4
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,6) (30 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+30 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -279,7 +279,7 @@ NormalPri:
   term=1 index=4  tokens=6291456
   term=1 index=5  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,6) precise_q_size=+12 MiB force-flushing (stop=4)
+(n2,s2):2: state=replicate closed=false inflight=[1,4) (18 MiB) send_queue=[4,6) precise_q_size=+12 MiB force-flushing (stop=4)
 eval deducted: reg=+0 B ela=+30 MiB
 eval original in send-q: reg=+12 MiB ela=+0 B
 LowPri:
@@ -287,7 +287,7 @@ LowPri:
   term=1 index=2  tokens=6291456
   term=1 index=3  tokens=6291456
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,6) (30 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+30 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -312,7 +312,7 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,6) (30 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+30 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -322,7 +322,7 @@ NormalPri:
   term=1 index=4  tokens=6291456
   term=1 index=5  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,6) precise_q_size=+12 MiB force-flushing (stop=4)
+(n2,s2):2: state=replicate closed=false inflight=[1,4) (18 MiB) send_queue=[4,6) precise_q_size=+12 MiB force-flushing (stop=4)
 eval deducted: reg=+0 B ela=+30 MiB
 eval original in send-q: reg=+12 MiB ela=+0 B
 LowPri:
@@ -339,7 +339,7 @@ scheduled-replicas: 2
 # stops.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,6) (30 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+30 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -349,7 +349,7 @@ NormalPri:
   term=1 index=4  tokens=6291456
   term=1 index=5  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,5) send_queue=[5,6) precise_q_size=+6.0 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,5) (24 MiB) send_queue=[5,6) precise_q_size=+6.0 MiB watching-for-tokens
 eval deducted: reg=+0 B ela=+30 MiB
 eval original in send-q: reg=+6.0 MiB ela=+0 B
 LowPri:
@@ -378,7 +378,7 @@ t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,6) (30 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+30 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -388,7 +388,7 @@ NormalPri:
   term=1 index=4  tokens=6291456
   term=1 index=5  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,5) send_queue=[5,6) precise_q_size=+6.0 MiB force-flushing
+(n2,s2):2: state=replicate closed=false inflight=[1,5) (24 MiB) send_queue=[5,6) precise_q_size=+6.0 MiB force-flushing
 eval deducted: reg=+0 B ela=+30 MiB
 eval original in send-q: reg=+6.0 MiB ela=+0 B
 LowPri:
@@ -405,7 +405,7 @@ scheduled-replicas: 2
 # Entry 5 is popped and force-flushing stops.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,6) (30 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+30 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -415,7 +415,7 @@ NormalPri:
   term=1 index=4  tokens=6291456
   term=1 index=5  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,6) (30 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+30 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -447,7 +447,7 @@ t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,7) send_queue=[7,7) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,7) (36 MiB) send_queue=[7,7) precise_q_size=+0 B
 eval deducted: reg=+36 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -458,7 +458,7 @@ NormalPri:
   term=1 index=5  tokens=6291456
   term=1 index=6  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,7) send_queue=[7,7) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,7) (36 MiB) send_queue=[7,7) precise_q_size=+0 B
 eval deducted: reg=+6.0 MiB ela=+30 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_index_push_pull
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_index_push_pull
@@ -36,7 +36,7 @@ t1/s3: eval reg=-18 MiB/+16 MiB ela=-18 MiB/+8.0 MiB
 # Replicas 2 and 3 have a send-queue which is possible in push mode.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (18 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+18 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -56,7 +56,7 @@ eval original in send-q: reg=+18 MiB ela=+0 B
 # Force flush up to index 1. Still in push-mode so it has no effect.
 set_force_flush_index range_id=1 index=1 push-mode
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (18 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+18 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -88,7 +88,7 @@ t1/s3: eval reg=+0 B/+16 MiB ela=-18 MiB/+8.0 MiB
 # quorum. Replica 2 is force-flushing up to index 1.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (18 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+18 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -113,7 +113,7 @@ scheduled-replicas: 2 3
 # stop index of 2.
 set_force_flush_index range_id=1 index=2
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (18 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+18 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -135,7 +135,7 @@ scheduled-replicas: 2 3
 # Scheduler event. Entry at index 1 is popped from replicas 2, 3.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (18 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+18 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -143,13 +143,13 @@ NormalPri:
   term=1 index=2  tokens=6291456
   term=1 index=3  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+12 MiB force-flushing (stop=2)
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (6.0 MiB) send_queue=[2,4) precise_q_size=+12 MiB force-flushing (stop=2)
 eval deducted: reg=+0 B ela=+18 MiB
 eval original in send-q: reg=+12 MiB ela=+0 B
 LowPri:
   term=1 index=1  tokens=6291456
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+12 MiB force-flushing (stop=2)
+(n3,s3):3: state=replicate closed=false inflight=[1,2) (6.0 MiB) send_queue=[2,4) precise_q_size=+12 MiB force-flushing (stop=2)
 eval deducted: reg=+0 B ela=+18 MiB
 eval original in send-q: reg=+12 MiB ela=+0 B
 LowPri:
@@ -175,7 +175,7 @@ t1/s3: eval reg=-12 MiB/+16 MiB ela=-18 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (18 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+18 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -183,13 +183,13 @@ NormalPri:
   term=1 index=2  tokens=6291456
   term=1 index=3  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+12 MiB
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (6.0 MiB) send_queue=[2,4) precise_q_size=+12 MiB
 eval deducted: reg=+12 MiB ela=+6.0 MiB
 eval original in send-q: reg=+12 MiB ela=+0 B
 LowPri:
   term=1 index=1  tokens=6291456
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+12 MiB
+(n3,s3):3: state=replicate closed=false inflight=[1,2) (6.0 MiB) send_queue=[2,4) precise_q_size=+12 MiB
 eval deducted: reg=+12 MiB ela=+6.0 MiB
 eval original in send-q: reg=+12 MiB ela=+0 B
 LowPri:
@@ -212,7 +212,7 @@ t1/s3: eval reg=+0 B/+16 MiB ela=-18 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (18 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+18 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -220,13 +220,13 @@ NormalPri:
   term=1 index=2  tokens=6291456
   term=1 index=3  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+12 MiB force-flushing (stop=2)
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (6.0 MiB) send_queue=[2,4) precise_q_size=+12 MiB force-flushing (stop=2)
 eval deducted: reg=+0 B ela=+18 MiB
 eval original in send-q: reg=+12 MiB ela=+0 B
 LowPri:
   term=1 index=1  tokens=6291456
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+12 MiB force-flushing
+(n3,s3):3: state=replicate closed=false inflight=[1,2) (6.0 MiB) send_queue=[2,4) precise_q_size=+12 MiB force-flushing
 eval deducted: reg=+0 B ela=+18 MiB
 eval original in send-q: reg=+12 MiB ela=+0 B
 LowPri:
@@ -239,7 +239,7 @@ scheduled-replicas: 2 3
 # stops force-flushing.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (18 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+18 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -247,14 +247,14 @@ NormalPri:
   term=1 index=2  tokens=6291456
   term=1 index=3  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+6.0 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,3) (12 MiB) send_queue=[3,4) precise_q_size=+6.0 MiB watching-for-tokens
 eval deducted: reg=+0 B ela=+18 MiB
 eval original in send-q: reg=+6.0 MiB ela=+0 B
 LowPri:
   term=1 index=1  tokens=6291456
   term=1 index=2  tokens=6291456
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+6.0 MiB force-flushing
+(n3,s3):3: state=replicate closed=false inflight=[1,3) (12 MiB) send_queue=[3,4) precise_q_size=+6.0 MiB force-flushing
 eval deducted: reg=+0 B ela=+18 MiB
 eval original in send-q: reg=+6.0 MiB ela=+0 B
 LowPri:
@@ -292,7 +292,7 @@ t1/s3: eval reg=+0 B/+16 MiB ela=-18 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (18 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+18 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -300,14 +300,14 @@ NormalPri:
   term=1 index=2  tokens=6291456
   term=1 index=3  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+6.0 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,3) (12 MiB) send_queue=[3,4) precise_q_size=+6.0 MiB watching-for-tokens
 eval deducted: reg=+0 B ela=+18 MiB
 eval original in send-q: reg=+6.0 MiB ela=+0 B
 LowPri:
   term=1 index=1  tokens=6291456
   term=1 index=2  tokens=6291456
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+6.0 MiB force-flushing
+(n3,s3):3: state=replicate closed=false inflight=[1,3) (12 MiB) send_queue=[3,4) precise_q_size=+6.0 MiB force-flushing
 eval deducted: reg=+0 B ela=+18 MiB
 eval original in send-q: reg=+6.0 MiB ela=+0 B
 LowPri:
@@ -320,7 +320,7 @@ scheduled-replicas: 3
 # Replica 3 stops force-flushing.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (18 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+18 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -328,14 +328,14 @@ NormalPri:
   term=1 index=2  tokens=6291456
   term=1 index=3  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+6.0 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,3) (12 MiB) send_queue=[3,4) precise_q_size=+6.0 MiB watching-for-tokens
 eval deducted: reg=+0 B ela=+18 MiB
 eval original in send-q: reg=+6.0 MiB ela=+0 B
 LowPri:
   term=1 index=1  tokens=6291456
   term=1 index=2  tokens=6291456
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) (18 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+18 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_no_send_q_joint_config
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_no_send_q_joint_config
@@ -52,13 +52,13 @@ t1/s4: eval reg=+0 B/+16 MiB ela=-2.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -89,7 +89,7 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3VOTER_DEMOTING_LEARNER,(n4,s4):4VOTER_INCOMIN
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -120,7 +120,7 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3VOTER_DEMOTING_LEARNER,(n4,s4):4VOTER_INCOMIN
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -128,11 +128,11 @@ NormalPri:
 ++++
 (n2,s2):2: closed
 ++++
-(n3,s3):3VOTER_DEMOTING_LEARNER: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n3,s3):3VOTER_DEMOTING_LEARNER: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
@@ -157,7 +157,7 @@ t1/s4: eval reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -166,13 +166,13 @@ NormalPri:
 ++++
 (n2,s2):2: closed
 ++++
-(n3,s3):3VOTER_DEMOTING_LEARNER: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n3,s3):3VOTER_DEMOTING_LEARNER: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
 ++++
-(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -197,24 +197,24 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3VOTER_DEMOTING_LEARNER,(n4,s4):4VOTER_INCOMIN
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n3,s3):3VOTER_DEMOTING_LEARNER: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n3,s3):3VOTER_DEMOTING_LEARNER: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
 ++++
-(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -254,7 +254,7 @@ t1/s4: eval reg=-2.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -262,18 +262,18 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+1.0 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,4) precise_q_size=+1.0 MiB watching-for-tokens
 eval deducted: reg=+0 B ela=+1.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 ++++
-(n3,s3):3VOTER_DEMOTING_LEARNER: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3VOTER_DEMOTING_LEARNER: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -299,7 +299,7 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3VOTER_DEMOTING_LEARNER,(n4,s4):4VOTER_INCOMIN
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -307,13 +307,13 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+1.0 MiB force-flushing
+(n2,s2):2: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,4) precise_q_size=+1.0 MiB force-flushing
 eval deducted: reg=+0 B ela=+1.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 ++++
 (n3,s3):3VOTER_DEMOTING_LEARNER: closed
 ++++
-(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -336,7 +336,7 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3VOTER_DEMOTING_LEARNER,(n4,s4):4VOTER_INCOMIN
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -344,7 +344,7 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+1.0 MiB force-flushing
+(n2,s2):2: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,4) precise_q_size=+1.0 MiB force-flushing
 eval deducted: reg=+0 B ela=+1.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 ++++
@@ -368,7 +368,7 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3VOTER_DEMOTING_LEARNER,(n4,s4):4VOTER_INCOMIN
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -376,15 +376,15 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+1.0 MiB force-flushing
+(n2,s2):2: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,4) precise_q_size=+1.0 MiB force-flushing
 eval deducted: reg=+0 B ela=+1.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 ++++
-(n3,s3):3VOTER_DEMOTING_LEARNER: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3VOTER_DEMOTING_LEARNER: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
@@ -402,7 +402,7 @@ r1: [(n1,s1):1*,(n2,s2):2,(n4,s4):4]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -410,11 +410,11 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+1.0 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,4) precise_q_size=+1.0 MiB watching-for-tokens
 eval deducted: reg=+0 B ela=+1.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 ++++
-(n4,s4):4: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n4,s4):4: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_pause
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_pause
@@ -1,0 +1,611 @@
+# Initialize a range with three replicas, none of which have send tokens.
+init regular_init=0 elastic_init=0 max_inflight_bytes=2MiB
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
+t1/s1: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+# Append entries. Replica 1 has no send tokens, but is not allowed to form a
+# send-queue since it is the leader. Replica 3 also has no send tokens, but is
+# not allowed to form a send-queue to maintain quorum.
+raft_event pull-mode
+range_id=1
+  entries
+    term=1 index=1 pri=NormalPri size=1.5MiB
+    term=1 index=2 pri=NormalPri size=1.5MiB
+    term=1 index=3 pri=NormalPri size=1.5MiB
+    term=1 index=4 pri=NormalPri size=1.5MiB
+    term=1 index=5 pri=NormalPri size=1.5MiB
+----
+t1/s1: eval reg=-7.5 MiB/+16 MiB ela=-7.5 MiB/+8.0 MiB
+       send reg=-7.5 MiB/+16 MiB ela=-7.5 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-7.5 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+t1/s3: eval reg=-7.5 MiB/+16 MiB ela=-7.5 MiB/+8.0 MiB
+       send reg=-7.5 MiB/+16 MiB ela=-7.5 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,6) (7.5 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+7.5 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,6) precise_q_size=+7.5 MiB watching-for-tokens
+eval deducted: reg=+0 B ela=+7.5 MiB
+eval original in send-q: reg=+7.5 MiB ela=+0 B
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,6) (7.5 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+7.5 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+MsgApps sent in pull mode:
+ to: 3, lowPri: false entries: [1 2 3 4 5]
+++++
+
+# Transition replica 3 to StateSnapshot. Replica 2 needs to force-flush, so
+# force-flush becomes true and it schedules itself (scheduled-replicas value
+# below).
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=6
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=6
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateSnapshot next=6
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,6) (7.5 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+7.5 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,6) precise_q_size=+7.5 MiB force-flushing
+eval deducted: reg=+0 B ela=+7.5 MiB
+eval original in send-q: reg=+7.5 MiB ela=+0 B
+++++
+(n3,s3):3: closed
+++++
+schedule-controller-event-count: 1
+scheduled-replicas: 2
+
+# Scheduler event. 3MiB is dequeued, since force-flush grabs up to 4MiB of
+# entries. The replica does not schedule itself again since the
+# max-inflight-bytes limit of 2MiB has been reached.
+handle_scheduler_event range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,6) (7.5 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+7.5 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,3) (3.0 MiB) send_queue=[3,6) precise_q_size=+4.5 MiB force-flushing
+eval deducted: reg=+0 B ela=+7.5 MiB
+eval original in send-q: reg=+4.5 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+++++
+(n3,s3):3: closed
+++++
+MsgApps sent in pull mode:
+ to: 2, lowPri: true entries: [1 2]
+++++
+schedule-controller-event-count: 1
+
+# Send an empty event. Nothing will happen because force-flush is paused.
+raft_event pull-mode
+range_id=1
+----
+t1/s1: eval reg=-7.5 MiB/+16 MiB ela=-7.5 MiB/+8.0 MiB
+       send reg=-7.5 MiB/+16 MiB ela=-7.5 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-7.5 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-3.0 MiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[1,6) (7.5 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+7.5 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,3) (3.0 MiB) send_queue=[3,6) precise_q_size=+4.5 MiB force-flushing
+eval deducted: reg=+0 B ela=+7.5 MiB
+eval original in send-q: reg=+4.5 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+++++
+(n3,s3):3: closed
+++++
+schedule-controller-event-count: 1
+
+# Admit an entry so that s2 has only 1.5MiB inflight, which is less than the
+# max-inflight-bytes of 2MiB and unpauses force-flush.
+admit
+range_id=1
+  store_id=1 term=1 to_index=1 pri=NormalPri
+  store_id=2 term=1 to_index=1 pri=NormalPri
+----
+t1/s1: eval reg=-6.0 MiB/+16 MiB ela=-6.0 MiB/+8.0 MiB
+       send reg=-6.0 MiB/+16 MiB ela=-6.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-7.5 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-3.0 MiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+raft_event pull-mode
+range_id=1
+----
+t1/s1: eval reg=-6.0 MiB/+16 MiB ela=-6.0 MiB/+8.0 MiB
+       send reg=-6.0 MiB/+16 MiB ela=-6.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-7.5 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-3.0 MiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+# Replica 3 schedules itself, as force-flush is unpaused.
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[2,6) (6.0 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+6.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n2,s2):2: state=replicate closed=false inflight=[2,3) (1.5 MiB) send_queue=[3,6) precise_q_size=+4.5 MiB force-flushing
+eval deducted: reg=+0 B ela=+7.5 MiB
+eval original in send-q: reg=+4.5 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+++++
+(n3,s3):3: closed
+++++
+schedule-controller-event-count: 2
+scheduled-replicas: 2
+
+# Two more entries are send and force-flush pauses. Note that sending 1 entry
+# exceeds the max-inflight-bytes, but the code is a coarse graned
+# pause/unpause, so each scheduled event can send up to 4MiB when unpaused.
+handle_scheduler_event range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[2,6) (6.0 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+6.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n2,s2):2: state=replicate closed=false inflight=[2,5) (4.5 MiB) send_queue=[5,6) precise_q_size=+1.5 MiB force-flushing
+eval deducted: reg=+0 B ela=+7.5 MiB
+eval original in send-q: reg=+1.5 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+++++
+(n3,s3):3: closed
+++++
+MsgApps sent in pull mode:
+ to: 2, lowPri: true entries: [3 4]
+++++
+schedule-controller-event-count: 2
+
+# Noop since force flush is paused.
+handle_scheduler_event range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[2,6) (6.0 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+6.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n2,s2):2: state=replicate closed=false inflight=[2,5) (4.5 MiB) send_queue=[5,6) precise_q_size=+1.5 MiB force-flushing
+eval deducted: reg=+0 B ela=+7.5 MiB
+eval original in send-q: reg=+1.5 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+++++
+(n3,s3):3: closed
+++++
+schedule-controller-event-count: 2
+
+# Admit an entry. Force-flush stays paused since inflight bytes is 3MiB.
+admit
+range_id=1
+  store_id=2 term=1 to_index=2 pri=NormalPri
+----
+t1/s1: eval reg=-6.0 MiB/+16 MiB ela=-6.0 MiB/+8.0 MiB
+       send reg=-6.0 MiB/+16 MiB ela=-6.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-7.5 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-6.0 MiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+raft_event pull-mode
+range_id=1
+----
+t1/s1: eval reg=-6.0 MiB/+16 MiB ela=-6.0 MiB/+8.0 MiB
+       send reg=-6.0 MiB/+16 MiB ela=-6.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-7.5 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-6.0 MiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[2,6) (6.0 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+6.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n2,s2):2: state=replicate closed=false inflight=[3,5) (3.0 MiB) send_queue=[5,6) precise_q_size=+1.5 MiB force-flushing
+eval deducted: reg=+0 B ela=+7.5 MiB
+eval original in send-q: reg=+1.5 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+++++
+(n3,s3):3: closed
+++++
+schedule-controller-event-count: 2
+
+# Admit another entry, and inflight bytes drops to 1.5MiB, unpausing force-flush.
+admit
+range_id=1
+  store_id=2 term=1 to_index=3 pri=NormalPri
+----
+t1/s1: eval reg=-6.0 MiB/+16 MiB ela=-6.0 MiB/+8.0 MiB
+       send reg=-6.0 MiB/+16 MiB ela=-6.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-7.5 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-6.0 MiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+raft_event pull-mode
+range_id=1
+----
+t1/s1: eval reg=-6.0 MiB/+16 MiB ela=-6.0 MiB/+8.0 MiB
+       send reg=-6.0 MiB/+16 MiB ela=-6.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-7.5 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-6.0 MiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+
+# Since force-flush unpauses, replica 3 schedules itself.
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[2,6) (6.0 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+6.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n2,s2):2: state=replicate closed=false inflight=[4,5) (1.5 MiB) send_queue=[5,6) precise_q_size=+1.5 MiB force-flushing
+eval deducted: reg=+0 B ela=+7.5 MiB
+eval original in send-q: reg=+1.5 MiB ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+++++
+(n3,s3):3: closed
+++++
+schedule-controller-event-count: 3
+scheduled-replicas: 2
+
+# Scheduler event causes an entry to be sent and the send-queue becomes empty,
+# so no more need to force-flush.
+handle_scheduler_event range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[2,6) (6.0 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+6.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n2,s2):2: state=replicate closed=false inflight=[4,6) (3.0 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+0 B ela=+7.5 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n3,s3):3: closed
+++++
+MsgApps sent in pull mode:
+ to: 2, lowPri: true entries: [5]
+++++
+schedule-controller-event-count: 3
+
+# Return replica 3 to StateReplicate.
+set_replicas pull-mode
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=6
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=6 match=1
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=6 match=3
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
+----
+r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
+
+# Replica 3 has a send-queue but does not need to force-flush.
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[2,6) (6.0 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+6.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n2,s2):2: state=replicate closed=false inflight=[4,6) (3.0 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+0 B ela=+7.5 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,1) send_queue=[1,6) precise_q_size=+0 B watching-for-tokens
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+schedule-controller-event-count: 3
+
+# Force flush up to index 3. Replica 3 starts force-flushing and schedules itself.
+set_force_flush_index range_id=1 index=3
+----
+(n1,s1):1: state=replicate closed=false inflight=[2,6) (6.0 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+6.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n2,s2):2: state=replicate closed=false inflight=[4,6) (3.0 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+0 B ela=+7.5 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,1) send_queue=[1,6) precise_q_size=+0 B force-flushing (stop=3)
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+schedule-controller-event-count: 4
+scheduled-replicas: 3
+
+# Scheduler event. Replica 3 sends two entries, but does not schedule itself
+# again because max-inflight-bytes is reached.
+handle_scheduler_event range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[2,6) (6.0 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+6.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n2,s2):2: state=replicate closed=false inflight=[4,6) (3.0 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+0 B ela=+7.5 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,3) (3.0 MiB) send_queue=[3,6) precise_q_size=+0 B force-flushing (stop=3)
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+++++
+MsgApps sent in pull mode:
+ to: 3, lowPri: true entries: [1 2]
+++++
+schedule-controller-event-count: 4
+
+# Noop.
+raft_event pull-mode
+range_id=1
+----
+t1/s1: eval reg=-6.0 MiB/+16 MiB ela=-6.0 MiB/+8.0 MiB
+       send reg=-6.0 MiB/+16 MiB ela=-6.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-7.5 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-7.5 MiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-3.0 MiB/+8.0 MiB
+
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[2,6) (6.0 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+6.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n2,s2):2: state=replicate closed=false inflight=[4,6) (3.0 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+0 B ela=+7.5 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n3,s3):3: state=replicate closed=false inflight=[1,3) (3.0 MiB) send_queue=[3,6) precise_q_size=+0 B force-flushing (stop=3)
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+++++
+schedule-controller-event-count: 4
+
+# Admit one entry on replica 3, so inflight bytes is 1.5MiB which is below the
+# max-inflight-bytes threshold.
+admit
+range_id=1
+  store_id=3 term=1 to_index=1 pri=NormalPri
+----
+t1/s1: eval reg=-6.0 MiB/+16 MiB ela=-6.0 MiB/+8.0 MiB
+       send reg=-6.0 MiB/+16 MiB ela=-6.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-7.5 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-7.5 MiB/+8.0 MiB
+t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-3.0 MiB/+8.0 MiB
+
+# Advance force-flush-index. The raft event causes the replicaSendStream to
+# see the advancement, and to see that max-inflight-bytes is small enough to
+# unpause force-flush. So it schedules itself.
+set_force_flush_index range_id=1 index=4
+----
+(n1,s1):1: state=replicate closed=false inflight=[2,6) (6.0 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+6.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n2,s2):2: state=replicate closed=false inflight=[4,6) (3.0 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+0 B ela=+7.5 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n3,s3):3: state=replicate closed=false inflight=[2,3) (1.5 MiB) send_queue=[3,6) precise_q_size=+0 B force-flushing (stop=4)
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+++++
+schedule-controller-event-count: 5
+scheduled-replicas: 3
+
+# Scheduler event cause replica 3 to send two entries, and since
+# force-flush-index is reached, force-flushing stops.
+handle_scheduler_event range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[2,6) (6.0 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+6.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n2,s2):2: state=replicate closed=false inflight=[4,6) (3.0 MiB) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+0 B ela=+7.5 MiB
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+  term=1 index=5  tokens=1572864
+++++
+(n3,s3):3: state=replicate closed=false inflight=[2,5) (4.5 MiB) send_queue=[5,6) precise_q_size=+0 B watching-for-tokens
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+LowPri:
+  term=1 index=1  tokens=1572864
+  term=1 index=2  tokens=1572864
+  term=1 index=3  tokens=1572864
+  term=1 index=4  tokens=1572864
+++++
+MsgApps sent in pull mode:
+ to: 3, lowPri: true entries: [3 4]
+++++
+schedule-controller-event-count: 5

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/handle_raft_event
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/handle_raft_event
@@ -51,7 +51,7 @@ t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
 # replica stream (1,2,3).
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -59,7 +59,7 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -67,7 +67,7 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -91,6 +91,18 @@ t1/s2: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
 t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
        send reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
 
+# Send an empty event so that replicaSendStreams are aware of the update to
+# match.
+raft_event
+range_id=1
+----
+t1/s1: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s2: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+       send reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
+
 stream_state range_id=1
 ----
 (n1,s1):1: state=replicate closed=false inflight=[4,4) send_queue=[4,4) precise_q_size=+0 B
@@ -101,7 +113,7 @@ eval original in send-q: reg=+0 B ela=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -138,7 +150,7 @@ eval original in send-q: reg=+0 B ela=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n3,s3):3: state=probeRecentlyNoSendQ closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=probeRecentlyNoSendQ closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
@@ -199,13 +211,25 @@ check_state
 range_id=1 tenant_id={1} local_replica_id=1
   name=a pri=low-pri  done=false waited=false err=<nil>
 
+# Send an empty event so that replicaSendStreams are aware of the update to
+# match.
+raft_event
+range_id=1
+----
+t1/s1: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s2: eval reg=+0 B/+16 MiB ela=-8.0 MiB/+8.0 MiB
+       send reg=+0 B/+16 MiB ela=-8.0 MiB/+8.0 MiB
+t1/s3: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+
 stream_state range_id=1
 ----
 (n1,s1):1: state=replicate closed=false inflight=[5,5) send_queue=[5,5) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[4,5) send_queue=[5,5) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[4,5) (16 MiB) send_queue=[5,5) precise_q_size=+0 B
 eval deducted: reg=+16 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -246,7 +270,7 @@ range_id=1 tenant_id={1} local_replica_id=1
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[5,8) send_queue=[8,8) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[5,8) (3.0 MiB) send_queue=[8,8) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -256,7 +280,7 @@ NormalPri:
 ++++
 (n2,s2):2: closed
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[5,8) send_queue=[8,8) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[5,8) (3.0 MiB) send_queue=[8,8) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -268,7 +292,7 @@ NormalPri:
 # Schedule replica 2 for scheduler event. The schedule-controller-event-count becomes 1.
 internal_schedule_replica range_id=1 replica_id=2
 ----
-(n1,s1):1: state=replicate closed=false inflight=[5,8) send_queue=[8,8) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[5,8) (3.0 MiB) send_queue=[8,8) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -278,7 +302,7 @@ NormalPri:
 ++++
 (n2,s2):2: closed
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[5,8) send_queue=[8,8) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[5,8) (3.0 MiB) send_queue=[8,8) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -294,7 +318,7 @@ scheduled-replicas: 2
 # tracked in scheduled-replicas.
 internal_schedule_replica range_id=1 replica_id=3
 ----
-(n1,s1):1: state=replicate closed=false inflight=[5,8) send_queue=[8,8) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[5,8) (3.0 MiB) send_queue=[8,8) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -304,7 +328,7 @@ NormalPri:
 ++++
 (n2,s2):2: closed
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[5,8) send_queue=[8,8) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[5,8) (3.0 MiB) send_queue=[8,8) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -319,7 +343,7 @@ scheduled-replicas: 2 3
 # scheduled-replicas.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[5,8) send_queue=[8,8) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[5,8) (3.0 MiB) send_queue=[8,8) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -329,7 +353,7 @@ NormalPri:
 ++++
 (n2,s2):2: closed
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[5,8) send_queue=[8,8) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[5,8) (3.0 MiB) send_queue=[8,8) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/handle_raft_event_partial_msg_app
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/handle_raft_event_partial_msg_app
@@ -38,7 +38,7 @@ t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
 # while r2 and r3 have partial entry tracking.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -46,14 +46,14 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+1.0 MiB
+(n2,s2):2: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,4) precise_q_size=+1.0 MiB
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+2.0 MiB
+(n3,s3):3: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,4) precise_q_size=+2.0 MiB
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+2.0 MiB ela=+0 B
 NormalPri:
@@ -86,7 +86,7 @@ t1/s3: eval reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,6) (5.0 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+5.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -96,13 +96,13 @@ NormalPri:
   term=1 index=4  tokens=1048576
   term=1 index=5  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,5) send_queue=[5,6) precise_q_size=+1.0 MiB
+(n2,s2):2: state=replicate closed=false inflight=[1,5) (4.0 MiB) send_queue=[5,6) precise_q_size=+1.0 MiB
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 NormalPri:
   term=1 index=4  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,6) precise_q_size=+2.0 MiB
+(n3,s3):3: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,6) precise_q_size=+2.0 MiB
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+2.0 MiB ela=+0 B
 ++++
@@ -123,9 +123,21 @@ t1/s2: eval reg=+15 MiB/+16 MiB ela=+7.0 MiB/+8.0 MiB
 t1/s3: eval reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
        send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
 
+# Send an empty event so that replicaSendStreams are aware of the update to
+# match.
+raft_event
+range_id=1
+----
+t1/s1: eval reg=+15 MiB/+16 MiB ela=+7.0 MiB/+8.0 MiB
+       send reg=+15 MiB/+16 MiB ela=+7.0 MiB/+8.0 MiB
+t1/s2: eval reg=+15 MiB/+16 MiB ela=+7.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s3: eval reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[5,6) send_queue=[6,6) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[5,6) (1.0 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -160,21 +172,21 @@ t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[5,7) send_queue=[7,7) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[5,7) (2.0 MiB) send_queue=[7,7) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=5  tokens=1048576
   term=1 index=6  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[5,7) send_queue=[7,7) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[5,7) (2.0 MiB) send_queue=[7,7) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=5  tokens=1048576
   term=1 index=6  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[4,7) send_queue=[7,7) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[4,7) (3.0 MiB) send_queue=[7,7) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -189,6 +201,18 @@ range_id=1
   store_id=1 term=1 to_index=6 pri=NormalPri
   store_id=2 term=1 to_index=6 pri=NormalPri
   store_id=3 term=1 to_index=6 pri=NormalPri
+----
+t1/s1: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s2: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+t1/s3: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+       send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
+
+# Send an empty event so that replicaSendStreams are aware of the update to
+# match.
+raft_event
+range_id=1
 ----
 t1/s1: eval reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB
        send reg=+16 MiB/+16 MiB ela=+8.0 MiB/+8.0 MiB

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/leaseholder_force_flush_no_send_q
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/leaseholder_force_flush_no_send_q
@@ -47,19 +47,19 @@ t1/s3: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -101,20 +101,20 @@ t1/s3: eval reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,3) precise_q_size=+1.0 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,3) precise_q_size=+1.0 MiB watching-for-tokens
 eval deducted: reg=+1.0 MiB ela=+1.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -155,20 +155,20 @@ kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     : 0
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,3) precise_q_size=+1.0 MiB force-flushing
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,3) precise_q_size=+1.0 MiB force-flushing
 eval deducted: reg=+1.0 MiB ela=+1.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -207,20 +207,20 @@ t1/s3: eval reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,3) precise_q_size=+1.0 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,3) precise_q_size=+1.0 MiB watching-for-tokens
 eval deducted: reg=+1.0 MiB ela=+1.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/no_send_q_choice
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/no_send_q_choice
@@ -39,7 +39,7 @@ t1/s5: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -53,13 +53,13 @@ eval original in send-q: reg=+1.0 MiB ela=+0 B
 eval deducted: reg=+0 B ela=+1.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 ++++
-(n4,s4):4: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n4,s4):4: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n5,s5):5: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n5,s5):5: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -110,7 +110,7 @@ t1/s5: eval reg=-2.0 MiB/+16 MiB ela=-2.5 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -125,14 +125,14 @@ eval original in send-q: reg=+2.0 MiB ela=+0 B
 eval deducted: reg=+0 B ela=+2.0 MiB
 eval original in send-q: reg=+2.0 MiB ela=+0 B
 ++++
-(n4,s4):4: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n4,s4):4: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
 ++++
-(n5,s5):5: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n5,s5):5: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -161,27 +161,27 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4,(n5,s5):5]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
 (n3,s3):3: closed
 ++++
-(n4,s4):4: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n4,s4):4: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
 ++++
-(n5,s5):5: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n5,s5):5: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -208,7 +208,7 @@ t1/s5: eval reg=-2.0 MiB/+16 MiB ela=-3.5 MiB/+8.0 MiB
 # Replica 5 now has a send-queue.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -216,7 +216,7 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -224,7 +224,7 @@ NormalPri:
 ++++
 (n3,s3):3: closed
 ++++
-(n4,s4):4: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n4,s4):4: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -232,7 +232,7 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n5,s5):5: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+1.0 MiB watching-for-tokens
+(n5,s5):5: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,4) precise_q_size=+1.0 MiB watching-for-tokens
 eval deducted: reg=+2.0 MiB ela=+1.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 NormalPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/non_voter_send_q
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/non_voter_send_q
@@ -50,13 +50,13 @@ t1/s4: eval reg=+0 B/+16 MiB ela=-1.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -87,7 +87,7 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3,(n4,s4):4NON_VOTER]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -122,7 +122,7 @@ t1/s4: eval reg=+0 B/+16 MiB ela=-1.0 MiB/+8.0 MiB
 # Note the deducted value. Replica 4 is waiting for a scheduler event.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -144,7 +144,7 @@ scheduled-replicas: 3 4
 # Scheduler event. The non-voter now has an empty send-queue.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -152,13 +152,13 @@ NormalPri:
 ++++
 (n2,s2):2: closed
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+1.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
   term=1 index=1  tokens=1048576
 ++++
-(n4,s4):4NON_VOTER: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n4,s4):4NON_VOTER: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+1.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/probe_state
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/probe_state
@@ -28,7 +28,7 @@ t1/s3: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -38,7 +38,7 @@ NormalPri:
 eval deducted: reg=+0 B ela=+1.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -60,7 +60,7 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -68,7 +68,7 @@ NormalPri:
 ++++
 (n2,s2):2: closed
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -87,7 +87,7 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -95,7 +95,7 @@ NormalPri:
 ++++
 (n2,s2):2: closed
 ++++
-(n3,s3):3: state=probeRecentlyNoSendQ closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n3,s3):3: state=probeRecentlyNoSendQ closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
@@ -115,7 +115,7 @@ t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -124,7 +124,7 @@ NormalPri:
 ++++
 (n2,s2):2: closed
 ++++
-(n3,s3):3: state=probeRecentlyNoSendQ closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n3,s3):3: state=probeRecentlyNoSendQ closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
@@ -142,18 +142,18 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,3) precise_q_size=+0 B watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,3) precise_q_size=+0 B watching-for-tokens
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n3,s3):3: state=probeRecentlyNoSendQ closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n3,s3):3: state=probeRecentlyNoSendQ closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
@@ -181,18 +181,18 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,3) precise_q_size=+0 B force-flushing
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,3) precise_q_size=+0 B force-flushing
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,3) precise_q_size=+0 B watching-for-tokens
+(n3,s3):3: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,3) precise_q_size=+0 B watching-for-tokens
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/quorum_without_send_q
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/quorum_without_send_q
@@ -41,19 +41,19 @@ t1/s3: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -80,20 +80,20 @@ t1/s3: eval reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,3) precise_q_size=+1.0 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,3) precise_q_size=+1.0 MiB watching-for-tokens
 eval deducted: reg=+1.0 MiB ela=+1.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -120,14 +120,14 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 # Replica 2 is told to force-flush.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,3) precise_q_size=+1.0 MiB force-flushing
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,3) precise_q_size=+1.0 MiB force-flushing
 eval deducted: reg=+1.0 MiB ela=+1.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 NormalPri:
@@ -155,7 +155,7 @@ t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -163,7 +163,7 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+2.0 MiB force-flushing
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,4) precise_q_size=+2.0 MiB force-flushing
 eval deducted: reg=+1.0 MiB ela=+2.0 MiB
 eval original in send-q: reg=+2.0 MiB ela=+0 B
 NormalPri:
@@ -186,7 +186,7 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 # Replica 2 is told to stop force-flushing.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -194,13 +194,13 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+2.0 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,4) precise_q_size=+2.0 MiB watching-for-tokens
 eval deducted: reg=+1.0 MiB ela=+2.0 MiB
 eval original in send-q: reg=+2.0 MiB ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/scheduler_event_push
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/scheduler_event_push
@@ -29,7 +29,7 @@ t1/s3: eval reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+1.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -41,7 +41,7 @@ NormalPri:
 eval deducted: reg=+0 B ela=+2.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+1.0 MiB
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+1.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -67,7 +67,7 @@ t1/s3: eval reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+1.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -79,7 +79,7 @@ NormalPri:
 eval deducted: reg=+0 B ela=+2.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+1.0 MiB
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+1.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -94,7 +94,7 @@ scheduled-replicas: 2
 # return the deducted tokens.
 handle_scheduler_event range_id=1 push-mode
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+1.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -106,7 +106,7 @@ NormalPri:
 eval deducted: reg=+1.0 MiB ela=+1.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+1.0 MiB
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+1.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -142,7 +142,7 @@ t1/s3: eval reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+1.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -154,7 +154,7 @@ NormalPri:
 eval deducted: reg=+0 B ela=+2.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+1.0 MiB
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+1.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/send_q_entries_without_ac
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/send_q_entries_without_ac
@@ -30,15 +30,15 @@ t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
 # available.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
@@ -58,11 +58,11 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
@@ -85,11 +85,11 @@ t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
 # Note the deducted value of 4KiB. Replica 3 is waiting for a scheduler event.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
@@ -104,15 +104,15 @@ scheduled-replicas: 3
 # returns 4KiB.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
@@ -150,17 +150,17 @@ t1/s3: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
 # the send-queue.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+1.0 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,4) precise_q_size=+1.0 MiB watching-for-tokens
 eval deducted: reg=+0 B ela=+1.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -198,17 +198,17 @@ t1/s3: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
 # Replica 2 has 10KiB of send tokens and is waiting for a scheduler event.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+1.0 MiB deducted=+10 KiB
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,4) precise_q_size=+1.0 MiB deducted=+10 KiB
 eval deducted: reg=+0 B ela=+1.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -223,19 +223,19 @@ scheduled-replicas: 2
 # only composed of entries that need 0 tokens.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+0 B watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,4) precise_q_size=+0 B watching-for-tokens
 eval deducted: reg=+0 B ela=+1.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
   term=1 index=2  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -261,19 +261,19 @@ t1/s3: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
 # Replica 2 is waiting for a scheduler event.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+0 B deducted=+4.0 KiB
+(n2,s2):2: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,4) precise_q_size=+0 B deducted=+4.0 KiB
 eval deducted: reg=+0 B ela=+1.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
   term=1 index=2  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -286,19 +286,19 @@ scheduled-replicas: 2
 # returns the 4KiB of tokens it deducted.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+1.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
   term=1 index=2  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/send_q_watcher
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/send_q_watcher
@@ -30,7 +30,7 @@ t1/s3: eval reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -42,7 +42,7 @@ NormalPri:
 eval deducted: reg=+0 B ela=+3.0 MiB
 eval original in send-q: reg=+3.0 MiB ela=+0 B
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -70,7 +70,7 @@ t1/s3: eval reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
 # using these tokens.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -82,7 +82,7 @@ NormalPri:
 eval deducted: reg=+0 B ela=+3.0 MiB
 eval original in send-q: reg=+3.0 MiB ela=+0 B
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -97,7 +97,7 @@ scheduled-replicas: 2
 # tokens were deducted, to we will deduct an additional 512KiB.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -105,13 +105,13 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+2.0 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,4) precise_q_size=+2.0 MiB watching-for-tokens
 eval deducted: reg=+0 B ela=+3.0 MiB
 eval original in send-q: reg=+2.0 MiB ela=+0 B
 LowPri:
   term=1 index=1  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -152,7 +152,7 @@ t1/s3: eval reg=-3.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
 # event.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -160,13 +160,13 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+2.0 MiB deducted=+1.5 MiB
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,4) precise_q_size=+2.0 MiB deducted=+1.5 MiB
 eval deducted: reg=+0 B ela=+3.0 MiB
 eval original in send-q: reg=+2.0 MiB ela=+0 B
 LowPri:
   term=1 index=1  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -183,7 +183,7 @@ scheduled-replicas: 2
 # waiting for a scheduler event.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -191,14 +191,14 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+1.0 MiB deducted=+512 KiB
+(n2,s2):2: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,4) precise_q_size=+1.0 MiB deducted=+512 KiB
 eval deducted: reg=+0 B ela=+3.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 LowPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -216,7 +216,7 @@ scheduled-replicas: 2
 # be deducted.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -224,7 +224,7 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+3.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -232,7 +232,7 @@ LowPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -267,7 +267,7 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -275,7 +275,7 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+3.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -283,7 +283,7 @@ LowPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+0 B watching-for-tokens
+(n3,s3):3: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,4) precise_q_size=+0 B watching-for-tokens
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
@@ -316,7 +316,7 @@ t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
 # Note the deducted value of 4KiB. Replica 3 is waiting for a scheduler event.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -324,7 +324,7 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+3.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -332,7 +332,7 @@ LowPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+0 B deducted=+4.0 KiB
+(n3,s3):3: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,4) precise_q_size=+0 B deducted=+4.0 KiB
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
@@ -343,7 +343,7 @@ scheduled-replicas: 3
 # was actually 1MiB.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -351,7 +351,7 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+3.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -359,7 +359,7 @@ LowPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+0 B watching-for-tokens
+(n3,s3):3: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,4) precise_q_size=+0 B watching-for-tokens
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -387,7 +387,7 @@ t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
 # event.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -395,7 +395,7 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+3.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -403,7 +403,7 @@ LowPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+0 B deducted=+1.1 MiB
+(n3,s3):3: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,4) precise_q_size=+0 B deducted=+1.1 MiB
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -416,7 +416,7 @@ scheduled-replicas: 3
 # It no longer has a send-queue.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -424,7 +424,7 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+3.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -432,7 +432,7 @@ LowPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/send_stream_stats
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/send_stream_stats
@@ -37,7 +37,7 @@ t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -47,7 +47,7 @@ NormalPri:
 ++++
 (n2,s2):2: closed
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,4) precise_q_size=+2.0 MiB
+(n3,s3):3: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,4) precise_q_size=+2.0 MiB
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+2.0 MiB ela=+0 B
 NormalPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/sendq_push_pull
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/sendq_push_pull
@@ -36,7 +36,7 @@ t1/s3: eval reg=+15 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
 # another regular eval tokens.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) (3.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+2.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -44,7 +44,7 @@ LowPri:
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,3) (3.0 MiB) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+2.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -76,7 +76,7 @@ t1/s3: eval reg=+16 MiB/+16 MiB ela=+1.0 MiB/+8.0 MiB
 # send from the send-queue.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,5) send_queue=[5,5) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,5) (7.0 MiB) send_queue=[5,5) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+5.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -86,7 +86,7 @@ NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,5) send_queue=[5,5) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,5) (7.0 MiB) send_queue=[5,5) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+5.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -129,7 +129,7 @@ t1/s3: eval reg=+13 MiB/+16 MiB ela=+0 B/+8.0 MiB
 # mode.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,6) (8.0 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+5.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -140,7 +140,7 @@ NormalPri:
   term=1 index=3  tokens=1048576
   term=1 index=5  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,6) (8.0 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+5.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -151,7 +151,7 @@ NormalPri:
   term=1 index=3  tokens=1048576
   term=1 index=5  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,6) precise_q_size=+7.0 MiB
+(n3,s3):3: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,6) precise_q_size=+7.0 MiB
 eval deducted: reg=+3.0 MiB ela=+5.0 MiB
 eval original in send-q: reg=+2.0 MiB ela=+5.0 MiB
 NormalPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval_send_q
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval_send_q
@@ -36,7 +36,7 @@ t1/s3: eval reg=+7.0 MiB/+8.0 MiB ela=-1024 KiB/+1 B
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -69,13 +69,13 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
@@ -99,17 +99,17 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,2) (1.0 MiB) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
@@ -142,7 +142,7 @@ t1/s3: eval reg=+5.0 MiB/+8.0 MiB ela=-3.0 MiB/+1 B
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,5) send_queue=[5,5) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,5) (4.0 MiB) send_queue=[5,5) precise_q_size=+0 B
 eval deducted: reg=+4.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -151,13 +151,13 @@ NormalPri:
   term=1 index=3  tokens=1048576
   term=1 index=4  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,5) precise_q_size=+2.0 MiB
+(n2,s2):2: state=replicate closed=false inflight=[1,3) (2.0 MiB) send_queue=[3,5) precise_q_size=+2.0 MiB
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+2.0 MiB ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,5) precise_q_size=+1.0 MiB
+(n3,s3):3: state=replicate closed=false inflight=[1,4) (3.0 MiB) send_queue=[4,5) precise_q_size=+1.0 MiB
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 NormalPri:
@@ -192,7 +192,7 @@ t1/s3: eval reg=+4.0 MiB/+8.0 MiB ela=-4.0 MiB/+1 B
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,6) (5.0 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+5.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -202,7 +202,7 @@ NormalPri:
   term=1 index=4  tokens=1048576
   term=1 index=5  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,6) (5.0 MiB) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+4.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -211,7 +211,7 @@ NormalPri:
   term=1 index=4  tokens=1048576
   term=1 index=5  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,5) send_queue=[5,6) precise_q_size=+1.0 MiB
+(n3,s3):3: state=replicate closed=false inflight=[1,5) (4.0 MiB) send_queue=[5,6) precise_q_size=+1.0 MiB
 eval deducted: reg=+4.0 MiB ela=+0 B
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 NormalPri:

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -1211,6 +1211,7 @@ type RangeControllerFactoryImpl struct {
 	scheduler                  rac2.Scheduler
 	sendTokenWatcher           *rac2.SendTokenWatcher
 	waitForEvalConfig          *rac2.WaitForEvalConfig
+	raftMaxInflightBytes       uint64
 	knobs                      *kvflowcontrol.TestingKnobs
 }
 
@@ -1223,6 +1224,7 @@ func NewRangeControllerFactoryImpl(
 	scheduler rac2.Scheduler,
 	sendTokenWatcher *rac2.SendTokenWatcher,
 	waitForEvalConfig *rac2.WaitForEvalConfig,
+	raftMaxInflightBytes uint64,
 	knobs *kvflowcontrol.TestingKnobs,
 ) RangeControllerFactoryImpl {
 	return RangeControllerFactoryImpl{
@@ -1234,6 +1236,7 @@ func NewRangeControllerFactoryImpl(
 		scheduler:                  scheduler,
 		sendTokenWatcher:           sendTokenWatcher,
 		waitForEvalConfig:          waitForEvalConfig,
+		raftMaxInflightBytes:       raftMaxInflightBytes,
 		knobs:                      knobs,
 	}
 }
@@ -1258,6 +1261,7 @@ func (f RangeControllerFactoryImpl) New(
 			EvalWaitMetrics:        f.evalWaitMetrics,
 			RangeControllerMetrics: f.rangeControllerMetrics,
 			WaitForEvalConfig:      f.waitForEvalConfig,
+			RaftMaxInflightBytes:   f.raftMaxInflightBytes,
 			ReplicaMutexAsserter:   state.muAsserter,
 			Knobs:                  f.knobs,
 		},

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/raft_node.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/raft_node.go
@@ -33,9 +33,10 @@ func MakeReplicaStateInfos(rn *raft.RawNode, infoMap map[roachpb.ReplicaID]rac2.
 	clear(infoMap)
 	rn.WithBasicProgress(func(peerID raftpb.PeerID, progress tracker.BasicProgress) {
 		infoMap[roachpb.ReplicaID(peerID)] = rac2.ReplicaStateInfo{
-			Match: progress.Match,
-			Next:  progress.Next,
-			State: progress.State,
+			State:         progress.State,
+			Match:         progress.Match,
+			Next:          progress.Next,
+			InflightBytes: progress.InflightBytes,
 		}
 	})
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1579,6 +1579,7 @@ func NewStore(
 		(*racV2Scheduler)(s.scheduler),
 		s.cfg.KVFlowSendTokenWatcher,
 		s.cfg.KVFlowWaitForEvalConfig,
+		s.cfg.RaftMaxInflightBytes,
 		s.TestingKnobs().FlowControlTestingKnobs,
 	)
 

--- a/pkg/raft/tracker/progress.go
+++ b/pkg/raft/tracker/progress.go
@@ -447,4 +447,7 @@ type BasicProgress struct {
 	Next uint64
 	// State corresponds to Progress.State.
 	State StateType
+	// InflightBytes are the bytes that have been sent but not yet persisted. It
+	// corresponds to tracker.Inflights.bytes.
+	InflightBytes uint64
 }

--- a/pkg/raft/tracker/progresstracker.go
+++ b/pkg/raft/tracker/progresstracker.go
@@ -144,9 +144,10 @@ func (p *ProgressTracker) LearnerNodes() []pb.PeerID {
 func (p *ProgressTracker) WithBasicProgress(visitor func(id pb.PeerID, pr BasicProgress)) {
 	for id, p := range p.progress {
 		visitor(id, BasicProgress{
-			Match: p.Match,
-			Next:  p.Next,
-			State: p.State,
+			Match:         p.Match,
+			Next:          p.Next,
+			State:         p.State,
+			InflightBytes: p.Inflights.bytes,
 		})
 	}
 }


### PR DESCRIPTION
This limit is roughly respected, in that force-flush is paused when the
limit is exceeded, and unpaused when ready handling indicates that the
replicaSendStream is back within the limit.

Informs https://github.com/cockroachdb/cockroach/issues/135814

Epic: none

Release note: None