### PR TITLE
catalog/descs: avoid log.Fatal for invalid descriptor error

### DIFF
--- a/pkg/sql/catalog/descs/leased_descriptors.go
+++ b/pkg/sql/catalog/descs/leased_descriptors.go
@@ -256,7 +256,7 @@ func (ld *leasedDescriptors) getResult(
 	expiration := ldesc.Expiration(ctx)
 	readTimestamp := txn.ReadTimestamp()
 	if expiration.LessEq(txn.ReadTimestamp()) {
-		log.Fatalf(ctx, "bad descriptor for T=%s, expiration=%s", readTimestamp, expiration)
+		return nil, false, errors.AssertionFailedf("bad descriptor for id=%d readTimestamp=%s, expiration=%s", ldesc.GetID(), readTimestamp, expiration)
 	}
 
 	ld.cache.Upsert(ldesc, ldesc.Underlying().SkipNamespace())


### PR DESCRIPTION
Rather than crashing the whole process, we can use an assertion error for this. The log.Fatal was initially added in 5d205ed62d5, in a time far before we were careful about avoiding node crashes.

fixes https://github.com/cockroachdb/cockroach/issues/136962
fixes https://github.com/cockroachdb/cockroach/issues/136961

Release note: None