### PR TITLE
pkg/util/allstacks: wrap the stack traces with debugutil.SafeStack

### DIFF
--- a/pkg/util/allstacks/BUILD.bazel
+++ b/pkg/util/allstacks/BUILD.bazel
@@ -5,4 +5,5 @@ go_library(
     srcs = ["allstacks.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/allstacks",
     visibility = ["//visibility:public"],
+    deps = ["//pkg/util/debugutil"],
 )

--- a/pkg/util/allstacks/allstacks.go
+++ b/pkg/util/allstacks/allstacks.go
@@ -5,18 +5,22 @@
 
 package allstacks
 
-import "runtime"
+import (
+	"runtime"
+
+	"github.com/cockroachdb/cockroach/pkg/util/debugutil"
+)
 
 // Get returns all stacks, except if that takes more than 512mb of memory, in
 // which case it returns only 512mb worth of stacks (clipping the last stack
 // if necessary).
-func Get() []byte {
+func Get() debugutil.SafeStack {
 	return GetWithBuf(nil)
 }
 
 // GetWithBuf is like Get, but tries to use the provided slice first, allocating
 // a new, larger, slice only if necessary.
-func GetWithBuf(buf []byte) []byte {
+func GetWithBuf(buf []byte) debugutil.SafeStack {
 	buf = buf[:cap(buf)]
 	// We don't know how big the traces are, so grow a few times if they don't
 	// fit. Start large, though.

--- a/pkg/util/debugutil/debugutil.go
+++ b/pkg/util/debugutil/debugutil.go
@@ -45,6 +45,9 @@ func init() {
 	}(os.Getppid()))
 }
 
+// SafeStack is an alias for []byte that handles redaction. Use this type
+// instead of []byte when you are sure that the stack trace does not contain
+// sensitive information.
 type SafeStack []byte
 
 func (s SafeStack) SafeValue() {}
@@ -57,5 +60,5 @@ func (s SafeStack) SafeValue() {}
 // frequently, even if called only in error-handling pathways. Use sporadically
 // and only when necessary.
 func Stack() SafeStack {
-	return SafeStack(debug.Stack())
+	return debug.Stack()
 }


### PR DESCRIPTION
The functions `Get()` and `GetWithBuf()` internally call `runtime.Stack()` to fetch the calling go routine's stack trace.

This commit changes the return type of both the function from `[]byte` to `debugutil.SafeStack` (introduced in #136288). This will ensure that the stack traces generated using these function are not redacted.

Part of: CRDB-15292
Epic: CRDB-37533
Release note: None