### PR TITLE
cli: update CLI output for tsdump upload

### DIFF
--- a/pkg/cli/tsdump_test.go
+++ b/pkg/cli/tsdump_test.go
@@ -164,7 +164,7 @@ func parseDDInput(t *testing.T, input string, w *datadogWriter) {
 			(data != nil && data.Metric != metricName ||
 				(data != nil && source != nameValueTimestamp[1])) {
 			if data != nil {
-				err := w.emitDataDogMetrics([]DatadogSeries{*data})
+				_, err := w.emitDataDogMetrics([]DatadogSeries{*data})
 				require.NoError(t, err)
 			}
 			data = &DatadogSeries{
@@ -182,7 +182,7 @@ func parseDDInput(t *testing.T, input string, w *datadogWriter) {
 			Timestamp: ts,
 		})
 	}
-	err := w.emitDataDogMetrics([]DatadogSeries{*data})
+	_, err := w.emitDataDogMetrics([]DatadogSeries{*data})
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
Previously, we are logging the first metric from tsdump datadog upload request along with the error. The communication during failure was not very clear about whether upload is succeeded or failed. This patch improves communication based on upload state. User will be able to clearly differentiate between success, partial success & failure. In case of partial success, it will list all metrics which were failed during upload. Along with it, The patch updates the retries count & back off configuration for the upload.

Epic: None
Part of: CRDB-44835
Release note: None

- Upload partial success
[partial_success.txt](https://github.com/user-attachments/files/18059610/partial_success.txt)

- Upload failed 

<img width="1842" alt="upload_failed" src="https://github.com/user-attachments/assets/e6b6c6ab-b968-41a7-9656-a979ebcfee38">

-  Upload success

<img width="1905" alt="upload_success" src="https://github.com/user-attachments/assets/31d795d5-9c54-4049-b5f1-60ed476b3995">
