### PR TITLE
roachtest: remove verbose logging for tpcc-nowait/isolation-level=mixed

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -683,10 +683,6 @@ func registerTPCC(r registry.Registry) {
 				ExtraRunArgs:    "--wait=false",
 				SetupType:       usingImport,
 				ExpensiveChecks: true,
-				// Increase the vmodule level around transaction pushes so that if we do
-				// see a transaction retry error, we can debug it. This may affect perf,
-				// so we should not use this as a performance test.
-				ExtraStartArgs: []string{"--vmodule=cmd_push_txn=2,queue=2,transaction=2,lock_table_waiter=2,manager=2"},
 				WorkloadInstances: func() (ret []workloadInstance) {
 					isoLevels := []string{"read_uncommitted", "read_committed", "repeatable_read", "snapshot", "serializable"}
 					for i, isoLevel := range isoLevels {


### PR DESCRIPTION
The logging verbosity for this test was increased to debug a previous failure of this test involving transaction deadlocks. This issue is not mitigated and the test is failing for a different reason (`RETRY_ASYNC_WRITE_FAILURE - missing intent`). The logging verbosity results in logs from the time of the new failure being removed.

This commit restores the regular logging. Based on what we find out, we may bump up logging verbosity for other files.

Informs: #131585

Release note: None