### PR TITLE
kvserver/rangefeed: rename *.buffered_stream_sender.* to *.buffered_sender.*

### DIFF
--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -95,7 +95,7 @@ var ErrBufferedSenderNotSupported = unimplemented.NewWithIssue(
 // unimplemented and disabled everywhere (#126560).
 var RangefeedUseBufferedSender = settings.RegisterBoolSetting(
 	settings.SystemOnly,
-	"kv.rangefeed.buffered_stream_sender.enabled",
+	"kv.rangefeed.buffered_sender.enabled",
 	"use buffered sender for all range feeds instead of buffering events "+
 		"separately per client per range",
 	false,


### PR DESCRIPTION
This patch renames `kv.rangefeed.buffered_stream_sender.enabled` to
`kv.rangefeed.buffered_sender.enabled` to align with variable and
struct names better.

Epic: none
Release: none