### PR TITLE
storage: fix incorrect mount association

### DIFF
--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -148,6 +148,7 @@ go_test(
         "read_as_of_iterator_test.go",
         "sst_test.go",
         "sst_writer_test.go",
+        "store_properties_test.go",
         "temp_engine_test.go",
     ],
     data = glob(["testdata/**"]),

--- a/pkg/storage/store_properties_test.go
+++ b/pkg/storage/store_properties_test.go
@@ -1,0 +1,67 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestPathIsInside(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		base, target string
+		expected     bool
+	}{
+		{
+			base:     "/",
+			target:   "/cockroach/cockroach-data",
+			expected: true,
+		},
+		{
+			base:     "/cockroach",
+			target:   "/cockroach/cockroach-data",
+			expected: true,
+		},
+		{
+			base:     "/cockroach/cockroach-data",
+			target:   "/cockroach/cockroach-data",
+			expected: true,
+		},
+		{
+			base:     "/cockroach/cockroach-data/foo",
+			target:   "/cockroach/cockroach-data",
+			expected: false,
+		},
+		{
+			base:     "/cockroach/cockroach-data1",
+			target:   "/cockroach/cockroach-data",
+			expected: false,
+		},
+		{
+			base:     "/run/user/1001",
+			target:   "/cockroach/cockroach-data",
+			expected: false,
+		},
+		{
+			base:     "/..foo",
+			target:   "/..foo/data",
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			result := pathIsInside(filepath.FromSlash(tc.base), filepath.FromSlash(tc.target))
+			if result != tc.expected {
+				t.Fatalf("%q, %q: expected %t, got %t", tc.base, tc.target, tc.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We use `filepath.Rel` to associate a data directory with a mountpoint,
but the code incorrectly tolerates a result which starts with `../`.
This commit adds a check for this case.

Fixes: #137021

Release note (bug fix): Fixed bug that causes an incorrect filesystem
to be logged as part of the store information.