### PR TITLE
pkg/cloud: Add no-op AWS_USE_PATH_STYLE param for forwards compatibility

### DIFF
--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -51,6 +51,8 @@ const (
 	AWSTempTokenParam = "AWS_SESSION_TOKEN"
 	// AWSEndpointParam is the query parameter for the 'endpoint' in an AWS URI.
 	AWSEndpointParam = "AWS_ENDPOINT"
+	// AWSEndpointParam is the query parameter for UsePathStyle in S3 options.
+	AWSUsePathStyle = "AWS_USE_PATH_STYLE"
 
 	// AWSServerSideEncryptionMode is the query parameter in an AWS URI, for the
 	// mode to be used for server side encryption. It can either be AES256 or
@@ -332,6 +334,8 @@ func parseS3URL(uri *url.URL) (cloudpb.ExternalStorage, error) {
 	// contain spaces. We can convert any space characters we see to +
 	// characters to recover the original secret.
 	conf.S3Config.Secret = strings.Replace(conf.S3Config.Secret, " ", "+", -1)
+
+	s3URL.ConsumeParam(AWSUsePathStyle) // No-op on this CRDB version, but needed for mixed-version clusters with 24.3.
 
 	// Validate that all the passed in parameters are supported.
 	if unknownParams := s3URL.RemainingQueryParams(); len(unknownParams) > 0 {

--- a/pkg/cloud/amazon/s3_storage_test.go
+++ b/pkg/cloud/amazon/s3_storage_test.go
@@ -378,6 +378,26 @@ func TestPutS3Endpoint(t *testing.T) {
 	)
 }
 
+func TestS3UsePathStyle(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	q := make(url.Values)
+	q.Add(AWSUsePathStyle, "true")
+	q.Add(cloud.AuthParam, "implicit")
+	u := url.URL{
+		Scheme:   "s3",
+		Host:     "bucket",
+		Path:     "test",
+		RawQuery: q.Encode(),
+	}
+
+	user := username.RootUserName()
+	_, err := cloud.ExternalStorageConfFromURI(u.String(), user)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestS3DisallowCustomEndpoints(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 


### PR DESCRIPTION
Note backport to 24.2.

Informs: #136678
Release note (enterprise change): Adds no-op AWS_USE_PATH_STYLE param for forwards compatibility with 24.3.