### PR TITLE
server: deprecate database and index fields on HotRanges proto

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -3027,9 +3027,6 @@ An event of type `hot_ranges_stats`
 |--|--|--|
 | `RangeID` |  | no |
 | `Qps` |  | no |
-| `DatabaseName` | DatabaseName is the name of the database in which the index was created. | yes |
-| `TableName` | TableName is the name of the table on which the index was created. | yes |
-| `IndexName` | IndexName is the name of the index within the scope of the given table. | yes |
 | `SchemaName` | SchemaName is the name of the schema in which the index was created. | yes |
 | `LeaseholderNodeID` | LeaseholderNodeID indicates the Node ID that is the current leaseholder for the given range. | no |
 | `WritesPerSecond` | Writes per second is the recent number of keys written per second on this range. | no |
@@ -3037,6 +3034,9 @@ An event of type `hot_ranges_stats`
 | `WriteBytesPerSecond` | Write bytes per second is the recent number of bytes written per second on this range. | no |
 | `ReadBytesPerSecond` | Read bytes per second is the recent number of bytes read per second on this range. | no |
 | `CPUTimePerSecond` | CPU time per second is the recent cpu usage in nanoseconds of this range. | no |
+| `Databases` | Databases for the range. | yes |
+| `Tables` | Tables for the range | yes |
+| `Indexes` | Indexes for the range | yes |
 
 
 #### Common fields

--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3653,9 +3653,6 @@ HotRange message describes a single hot range, ie its QPS, node ID it belongs to
 | range_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | range_id indicates Range ID that's identified as hot range. | [reserved](#support-status) |
 | node_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | node_id indicates the node that contains the current hot range. | [reserved](#support-status) |
 | qps | [double](#cockroach.server.serverpb.HotRangesResponseV2-double) |  | qps (queries per second) shows the amount of queries that interact with current range. | [reserved](#support-status) |
-| table_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | table_name has been deprecated in favor of tables = 16; | [reserved](#support-status) |
-| database_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | database_name has been deprecated in favor of databases = 17; | [reserved](#support-status) |
-| index_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | index_name has been deprecated in favor of indexes = 17; | [reserved](#support-status) |
 | replica_node_ids | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) | repeated | replica_node_ids specifies the list of node ids that contain replicas with current hot range. | [reserved](#support-status) |
 | leaseholder_node_id | [int32](#cockroach.server.serverpb.HotRangesResponseV2-int32) |  | leaseholder_node_id indicates the Node ID that is the current leaseholder for the given range. | [reserved](#support-status) |
 | schema_name | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) |  | schema_name provides the name of schema (if exists) for table in current range. | [reserved](#support-status) |

--- a/pkg/server/api_v2_ranges.go
+++ b/pkg/server/api_v2_ranges.go
@@ -436,9 +436,9 @@ type hotRangeInfo struct {
 	ReadBytesPerSecond  float64          `json:"read_bytes_per_second"`
 	CPUTimePerSecond    float64          `json:"cpu_time_per_second"`
 	LeaseholderNodeID   roachpb.NodeID   `json:"leaseholder_node_id"`
-	TableName           string           `json:"table_name"`
-	DatabaseName        string           `json:"database_name"`
-	IndexName           string           `json:"index_name"`
+	Databases           []string         `json:"databases"`
+	Tables              []string         `json:"tables"`
+	Indexes             []string         `json:"indexes"`
 	SchemaName          string           `json:"schema_name"`
 	ReplicaNodeIDs      []roachpb.NodeID `json:"replica_node_ids"`
 	StoreID             roachpb.StoreID  `json:"store_id"`
@@ -516,9 +516,9 @@ func (a *apiV2Server) listHotRanges(w http.ResponseWriter, r *http.Request) {
 				ReadBytesPerSecond:  r.ReadBytesPerSecond,
 				CPUTimePerSecond:    r.CPUTimePerSecond,
 				LeaseholderNodeID:   r.LeaseholderNodeID,
-				TableName:           r.TableName,
-				DatabaseName:        r.DatabaseName,
-				IndexName:           r.IndexName,
+				Databases:           r.Databases,
+				Tables:              r.Tables,
+				Indexes:             r.Indexes,
 				ReplicaNodeIDs:      r.ReplicaNodeIds,
 				SchemaName:          r.SchemaName,
 				StoreID:             r.StoreID,

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1481,12 +1481,6 @@ message HotRangesResponseV2 {
     double qps = 3 [
       (gogoproto.customname) = "QPS"
     ];
-    // table_name has been deprecated in favor of tables = 16;
-    string table_name = 4 [deprecated = true];
-    // database_name has been deprecated in favor of databases = 17;
-    string database_name = 5;
-    // index_name has been deprecated in favor of indexes = 17;
-    string index_name = 6;
     // replica_node_ids specifies the list of node ids that contain replicas with current hot range.
     repeated int32 replica_node_ids = 7 [
       (gogoproto.casttype) =
@@ -1527,6 +1521,9 @@ message HotRangesResponseV2 {
     repeated string tables = 17;
     // Indexes for the range
     repeated string indexes = 18;
+
+    // previously used for database, table, and index name
+    reserved 4 to 6;
   }
   // Ranges contain list of hot ranges info that has highest number of QPS.
   repeated HotRange ranges = 1;

--- a/pkg/server/structlogging/BUILD.bazel
+++ b/pkg/server/structlogging/BUILD.bazel
@@ -51,5 +51,6 @@ go_test(
         "//pkg/util/randutil",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//assert",
     ],
 )

--- a/pkg/server/structlogging/hot_ranges_log.go
+++ b/pkg/server/structlogging/hot_ranges_log.go
@@ -109,10 +109,10 @@ func (s *hotRangesLoggingScheduler) start(ctx context.Context, stopper *stop.Sto
 					hrEvent := &eventpb.HotRangesStats{
 						RangeID:             int64(r.RangeID),
 						Qps:                 r.QPS,
-						DatabaseName:        r.DatabaseName,
+						Databases:           r.Databases,
+						Tables:              r.Tables,
+						Indexes:             r.Indexes,
 						SchemaName:          r.SchemaName,
-						TableName:           r.TableName,
-						IndexName:           r.IndexName,
 						CPUTimePerSecond:    r.CPUTimePerSecond,
 						ReadBytesPerSecond:  r.ReadBytesPerSecond,
 						WriteBytesPerSecond: r.WriteBytesPerSecond,

--- a/pkg/server/structlogging/hot_ranges_log_test.go
+++ b/pkg/server/structlogging/hot_ranges_log_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
 )
 
 type hotRangesLogSpy struct {
@@ -156,10 +157,13 @@ func TestHotRangesStats(t *testing.T) {
 		// We should have gotten 5 distinct range ids, one for each split point above.
 		logs := spy.Logs()[:5]
 		for _, l := range logs {
+			assert.Equal(t, l.Databases, []string{"‹test›"})
+			assert.Equal(t, l.Tables, []string{"‹foo›"})
+			assert.Equal(t, l.Indexes, []string{"‹foo_pkey›"})
 			_, ok := rangeIDs[l.RangeID]
 			if ok {
 				t.Fatalf(`Logged ranges should be unique per node for this test.
-found range on node %d and node %d: %s %s %s %s %d`, i, l.LeaseholderNodeID, l.DatabaseName, l.SchemaName, l.TableName, l.IndexName, l.RangeID)
+found range on node %d and node %d: %s %s %s %s %d`, i, l.LeaseholderNodeID, l.Databases, l.SchemaName, l.Tables, l.Indexes, l.RangeID)
 			}
 			rangeIDs[l.RangeID] = struct{}{}
 		}

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesFilter.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesFilter.tsx
@@ -51,7 +51,7 @@ export const HotRangesFilter = (props: HotRangesFilterProps) => {
   // provided list of hot ranges.
   const databaseOptions = useMemo(
     () =>
-      Array.from(new Set(hotRanges.map(r => r.database_name)))
+      Array.from(new Set(hotRanges.map(r => r.databases).flat()))
         .filter(i => !isEmpty(i))
         .sort()
         .map(dbName => ({ label: dbName, value: dbName })),
@@ -149,18 +149,18 @@ export const HotRangesFilter = (props: HotRangesFilterProps) => {
 
       if (!isEmpty(dbNames)) {
         filtered = filtered.filter(r =>
-          dbNames.some(
-            (f: FilterCheckboxOptionItem) => f.value === r.database_name,
+          dbNames.some((f: FilterCheckboxOptionItem) =>
+            r.databases?.includes(f.value),
           ),
         );
       }
 
       if (!isEmpty(tableName)) {
-        filtered = filtered.filter(r => r.table_name?.includes(tableName));
+        filtered = filtered.filter(r => r.tables?.includes(tableName));
       }
 
       if (!isEmpty(indexName)) {
-        filtered = filtered.filter(r => r.index_name?.includes(indexName));
+        filtered = filtered.filter(r => r.indexes?.includes(indexName));
       }
 
       if (!isEmpty(localities)) {

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
@@ -245,7 +245,7 @@ const HotRangesTable = ({
           </Tooltip>
         ),
         cell: val => val.tables.join(", "),
-        sort: val => val.table_name,
+        sort: val => val.tables.join(", "),
       },
       {
         name: "index",

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -3246,42 +3246,6 @@ func (m *HotRangesStats) AppendJSONFields(printComma bool, b redact.RedactableBy
 	b = append(b, "\"Qps\":"...)
 	b = strconv.AppendFloat(b, float64(m.Qps), 'f', -1, 64)
 
-	if m.DatabaseName != "" {
-		if printComma {
-			b = append(b, ',')
-		}
-		printComma = true
-		b = append(b, "\"DatabaseName\":\""...)
-		b = append(b, redact.StartMarker()...)
-		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.DatabaseName)))))
-		b = append(b, redact.EndMarker()...)
-		b = append(b, '"')
-	}
-
-	if m.TableName != "" {
-		if printComma {
-			b = append(b, ',')
-		}
-		printComma = true
-		b = append(b, "\"TableName\":\""...)
-		b = append(b, redact.StartMarker()...)
-		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.TableName)))))
-		b = append(b, redact.EndMarker()...)
-		b = append(b, '"')
-	}
-
-	if m.IndexName != "" {
-		if printComma {
-			b = append(b, ',')
-		}
-		printComma = true
-		b = append(b, "\"IndexName\":\""...)
-		b = append(b, redact.StartMarker()...)
-		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.IndexName)))))
-		b = append(b, redact.EndMarker()...)
-		b = append(b, '"')
-	}
-
 	if m.SchemaName != "" {
 		if printComma {
 			b = append(b, ',')
@@ -3346,6 +3310,63 @@ func (m *HotRangesStats) AppendJSONFields(printComma bool, b redact.RedactableBy
 		printComma = true
 		b = append(b, "\"CPUTimePerSecond\":"...)
 		b = strconv.AppendFloat(b, float64(m.CPUTimePerSecond), 'f', -1, 64)
+	}
+
+	if len(m.Databases) > 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Databases\":["...)
+		for i, v := range m.Databases {
+			if i > 0 {
+				b = append(b, ',')
+			}
+			b = append(b, '"')
+			b = append(b, redact.StartMarker()...)
+			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(v)))))
+			b = append(b, redact.EndMarker()...)
+			b = append(b, '"')
+		}
+		b = append(b, ']')
+	}
+
+	if len(m.Tables) > 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Tables\":["...)
+		for i, v := range m.Tables {
+			if i > 0 {
+				b = append(b, ',')
+			}
+			b = append(b, '"')
+			b = append(b, redact.StartMarker()...)
+			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(v)))))
+			b = append(b, redact.EndMarker()...)
+			b = append(b, '"')
+		}
+		b = append(b, ']')
+	}
+
+	if len(m.Indexes) > 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Indexes\":["...)
+		for i, v := range m.Indexes {
+			if i > 0 {
+				b = append(b, ',')
+			}
+			b = append(b, '"')
+			b = append(b, redact.StartMarker()...)
+			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(v)))))
+			b = append(b, redact.EndMarker()...)
+			b = append(b, '"')
+		}
+		b = append(b, ']')
 	}
 
 	return printComma, b

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -736,15 +736,6 @@ message HotRangesStats {
 
   double qps = 3 [(gogoproto.jsontag) = ",includeempty"];
 
-  // DatabaseName is the name of the database in which the index was created.
-  string database_name = 4 [(gogoproto.jsontag) = ",omitempty"];
-
-  // TableName is the name of the table on which the index was created.
-  string table_name = 5 [(gogoproto.jsontag) = ",omitempty"];
-
-  // IndexName is the name of the index within the scope of the given table.
-  string index_name = 6 [(gogoproto.jsontag) = ",omitempty"];
-
   // SchemaName is the name of the schema in which the index was created.
   string schema_name = 7 [(gogoproto.jsontag) = ",omitempty"];
 
@@ -769,4 +760,17 @@ message HotRangesStats {
 
   // CPU time per second is the recent cpu usage in nanoseconds of this range.
   double cpu_time_per_second = 13 [(gogoproto.customname) = "CPUTimePerSecond", (gogoproto.jsontag) = ",omitempty"];
+
+  // Databases for the range.
+  repeated string databases = 16;
+  // Tables for the range
+  repeated string tables = 17;
+  // Indexes for the range
+  repeated string indexes = 18;
+
+  // previously used for database, table, and index name
+  // syntax reserved 4 to 6 breaks json encoding checks
+  reserved 4;
+  reserved 5;
+  reserved 6;
 }


### PR DESCRIPTION
server: deprecate database and index fields on HotRanges proto

In changeset #134106, the database, table, and index fields of the HotRanges protobuf were moved to synonymous keys so that there could be multiple of each. This means a hot range could now have multiple indexes, tables and databases contained within it in the UI.

During this change however, only the old table key of the protobuf was deprecated, the database and index fields were not flagged for deprecation. This small change fixes this oversight.

Images to verify the filter modifications:
<img width="337" alt="image" src="https://github.com/user-attachments/assets/968b7f57-8d87-4aab-8773-fe265cb91f5c" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/790dddbf-b75e-4674-a53a-c7187a417f63" />


Epic: CRDB-43151
Release note: None