### PR TITLE
release-24.1: crosscluster/logical: type check dest tenant spec in planHookFn

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/alter_replication_job.go
+++ b/pkg/ccl/streamingccl/streamingest/alter_replication_job.go
@@ -185,6 +185,12 @@ func alterReplicationJobHook(
 		}
 	}
 
+	// Ensure the TenantSpec is type checked, even if we don't use the result.
+	_, _, _, err = exprEval.TenantSpec(ctx, alterTenantStmt.TenantSpec)
+	if err != nil {
+		return nil, nil, nil, false, err
+	}
+
 	retentionTTLSeconds := defaultRetentionTTLSeconds
 	if ret, ok := options.GetRetention(); ok {
 		retentionTTLSeconds = ret

--- a/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
@@ -606,3 +606,22 @@ func TestAlterTenantStartReplicationAfterRestore(t *testing.T) {
 	srcTime := srv.Clock().Now()
 	replicationtestutils.WaitUntilReplicatedTime(t, srcTime, db, catpb.JobID(ingestionJobID))
 }
+
+func TestAlterReplicationJobErrors(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestControlsTenantsExplicitly})
+	defer srv.Stopper().Stop(ctx)
+
+	db := sqlutils.MakeSQLRunner(sqlDB)
+
+	t.Run("alter tenant subqueries", func(t *testing.T) {
+		// Regression test for #136339
+		db.ExpectErr(t, "subqueries are not allowed", "ALTER TENANT (select 't2') START REPLICATION OF t1 ON 'foo'")
+	})
+
+}


### PR DESCRIPTION
Backport 1/1 commits from #136683.

/cc @cockroachdb/release

---

Fixes #136339

Release note: none
