### PR TITLE
loq: clear LeadEpoch when re-writing the RangeDescriptor

### DIFF
--- a/pkg/kv/kvserver/loqrecovery/server_integration_test.go
+++ b/pkg/kv/kvserver/loqrecovery/server_integration_test.go
@@ -587,7 +587,7 @@ func TestRetrieveApplyStatus(t *testing.T) {
 
 	// We currently don't clear out the LeadEpoch field when recovering from a
 	// loss of quorum, so we can't run with leader leases on in this test.
-	tc, _, _ := prepTestCluster(ctx, t, 5, true /* disableLeaderLease */)
+	tc, _, _ := prepTestCluster(ctx, t, 5, false /* disableLeaderLease */)
 	defer tc.Stopper().Stop(ctx)
 
 	// Use scratch range to ensure we have a range that loses quorum.


### PR DESCRIPTION
If the fortified leader is removed from the RangeDescriptor, SupportFor() will return epoch=0. This will fire an assertion since supportFor epochs should never regress.
This commit changes the LoQ behaviour where it resets the LeadEpoch when rewriting the ReplicaDescriptor.

Fixes: #136908

Release note: None