### PR TITLE
roachtest: update mt-upgrade test owner to db-server

### DIFF
--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -25,7 +25,7 @@ const (
 	OwnerAdmissionControl   Owner = `admission-control`
 	OwnerObservability      Owner = `obs-prs`
 	OwnerObservabilityIndia Owner = `obs-india-prs`
-	OwnerServer             Owner = `server` // not currently staffed
+	OwnerServer             Owner = `server`
 	OwnerSQLFoundations     Owner = `sql-foundations`
 	OwnerMigrations         Owner = `migrations`
 	OwnerProductSecurity    Owner = `product-security`

--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -32,7 +32,7 @@ func registerMultiTenantUpgrade(r registry.Registry) {
 		Cluster:          r.MakeClusterSpec(7),
 		CompatibleClouds: registry.CloudsWithServiceRegistration,
 		Suites:           registry.Suites(registry.Nightly),
-		Owner:            registry.OwnerDisasterRecovery,
+		Owner:            registry.OwnerServer,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runMultitenantUpgrade(ctx, t, c)
 		},


### PR DESCRIPTION
This PR updates the test ownership for the multitenant-upgrade test to the DB Server team. All future test failures will be routed to `t-db-server` for triage.

Epic: none
Release note: none