### PR TITLE
server/license: Test license enforcement stays disabled after single node restart

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -42,7 +42,8 @@ type TestServerArgs struct {
 	// If not set (and hence the server is the only one in the cluster), the
 	// default zone config will be overridden to disable all replication - so that
 	// tests don't get log spam about ranges not being replicated enough. This
-	// is always set to true when the server is started via a TestCluster.
+	// is always set to true when the server is started via a TestCluster, unless
+	// the StartSingleNode TestClusterArgs is set.
 	PartOfCluster bool
 
 	// Listener (if nonempty) is the listener to use for all incoming RPCs.
@@ -180,6 +181,10 @@ type TestClusterArgs struct {
 	// IDs unpredictable. Even in ParallelStart mode, StartTestCluster
 	// waits for all nodes to start before returning.
 	ParallelStart bool
+	// StartSingleNode will initialize the cluster like 'cockroach
+	// start-single-node'. Attempts to add more than one node to the cluster will
+	// fail.
+	StartSingleNode bool
 
 	// ServerArgsPerNode override the default ServerArgs with the value in this
 	// map. The map's key is an index within TestCluster.Servers. If there is

--- a/pkg/server/license/BUILD.bazel
+++ b/pkg/server/license/BUILD.bazel
@@ -44,6 +44,8 @@ go_test(
         "//pkg/sql/catalog/descs",
         "//pkg/sql/isql",
         "//pkg/sql/sessiondata",
+        "//pkg/storage/fs",
+        "//pkg/testutils/listenerutil",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",

--- a/pkg/sql/catalog/descs/BUILD.bazel
+++ b/pkg/sql/catalog/descs/BUILD.bazel
@@ -136,7 +136,6 @@ go_test(
         "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_cockroachdb_errors//assert",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_lib_pq//oid",

--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -46,7 +46,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/errors/assert"
 	"github.com/lib/pq/oid"
 	"github.com/stretchr/testify/require"
 )
@@ -1266,14 +1265,14 @@ func TestDescriptorErrorWrap(t *testing.T) {
 					return err
 				}
 
-				require.False(t, assert.IsAssertionFailure(tc.err))
+				require.False(t, errors.HasAssertionFailure(tc.err))
 				err = descs.DecorateDescriptorError(mut, tc.err)
 				// Ensure err is still an error
 				require.Error(t, err)
 				// Ensure descriptor info is wrapped in the error
 				require.Contains(t, err.Error(), mut.GetName())
 				// Ensure error is promoted to assertion as expected
-				require.Equal(t, tc.isAssertion, assert.IsAssertionFailure(err))
+				require.Equal(t, tc.isAssertion, errors.HasAssertionFailure(err))
 				return nil
 			}))
 		})


### PR DESCRIPTION
## server/license: Test license enforcement stays disabled after single-node restart

This test addresses https://github.com/cockroachdb/cockroach/pull/136926, ensuring that license enforcement remains disabled for a single-node cluster even after a restart. To pass `true` for `startSingleNode` in `RunInitialSQL`, I made a minor change to testserver to allow setting `PartOfCluster` to `false`.

Epic: None
Release note: None

## sql/catalog: Address late review comment from #136488

This commit addresses a late review comment from PR https://github.com/cockroachdb/cockroach/pull/136488. The original change has been backported; this update applies the fix to the master branch.

Epic: None
Release note: None