### PR TITLE
rac2: improve TestRangeController wrt match and inflight-bytes

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/BUILD.bazel
@@ -82,6 +82,7 @@ go_test(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_gogo_protobuf//jsonpb",
         "@com_github_guptarohit_asciigraph//:asciigraph",

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -189,6 +189,9 @@ type ReplicaStateInfo struct {
 	// (Match, Next) is in-flight.
 	Match uint64
 	Next  uint64
+	// InflightBytes are the bytes that have been sent but not yet persisted. It
+	// corresponds to tracker.Inflights.bytes.
+	InflightBytes uint64
 }
 
 // sendQueueStatRefreshInterval is the interval at which the send queue stats

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/close
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/close
@@ -114,21 +114,21 @@ NormalPri:
 # tracked deductions for entries in [1,3].
 set_replicas
 range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=4
-  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=4
-  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=4
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=4 match=2
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=4 match=1
   store_id=3 replica_id=3 type=VOTER_FULL state=StateSnapshot next=4
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[2,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/do_force_flush
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/do_force_flush
@@ -164,7 +164,7 @@ t1/s3: eval reg=-4.5 MiB/+16 MiB ela=-4.5 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[4,7) send_queue=[7,7) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,7) send_queue=[7,7) precise_q_size=+0 B
 eval deducted: reg=+7.5 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -183,7 +183,7 @@ LowPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[4,7) send_queue=[7,7) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,7) send_queue=[7,7) precise_q_size=+0 B
 eval deducted: reg=+4.5 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -247,7 +247,7 @@ NormalPri:
   term=1 index=5  tokens=1572864
   term=1 index=6  tokens=1572864
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[4,6) send_queue=[6,7) precise_q_size=+1.5 MiB force-flushing
+(n2,s2):2: state=replicate closed=false inflight=[1,6) send_queue=[6,7) precise_q_size=+1.5 MiB force-flushing
 eval deducted: reg=+0 B ela=+7.5 MiB
 eval original in send-q: reg=+1.5 MiB ela=+0 B
 LowPri:
@@ -279,7 +279,7 @@ NormalPri:
   term=1 index=5  tokens=1572864
   term=1 index=6  tokens=1572864
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[6,7) send_queue=[7,7) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,7) send_queue=[7,7) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+7.5 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_index
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_index
@@ -141,7 +141,7 @@ NormalPri:
   term=1 index=4  tokens=6291456
   term=1 index=5  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[2,3) send_queue=[3,6) precise_q_size=+18 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,6) precise_q_size=+18 MiB watching-for-tokens
 eval deducted: reg=+0 B ela=+30 MiB
 eval original in send-q: reg=+18 MiB ela=+0 B
 LowPri:
@@ -176,7 +176,7 @@ NormalPri:
   term=1 index=4  tokens=6291456
   term=1 index=5  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[2,3) send_queue=[3,6) precise_q_size=+18 MiB force-flushing (stop=3)
+(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,6) precise_q_size=+18 MiB force-flushing (stop=3)
 eval deducted: reg=+0 B ela=+30 MiB
 eval original in send-q: reg=+18 MiB ela=+0 B
 LowPri:
@@ -210,7 +210,7 @@ NormalPri:
   term=1 index=4  tokens=6291456
   term=1 index=5  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[3,4) send_queue=[4,6) precise_q_size=+12 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,6) precise_q_size=+12 MiB watching-for-tokens
 eval deducted: reg=+0 B ela=+30 MiB
 eval original in send-q: reg=+12 MiB ela=+0 B
 LowPri:
@@ -246,7 +246,7 @@ NormalPri:
   term=1 index=4  tokens=6291456
   term=1 index=5  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[3,4) send_queue=[4,6) precise_q_size=+12 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,6) precise_q_size=+12 MiB watching-for-tokens
 eval deducted: reg=+0 B ela=+30 MiB
 eval original in send-q: reg=+12 MiB ela=+0 B
 LowPri:
@@ -279,7 +279,7 @@ NormalPri:
   term=1 index=4  tokens=6291456
   term=1 index=5  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[3,4) send_queue=[4,6) precise_q_size=+12 MiB force-flushing (stop=4)
+(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,6) precise_q_size=+12 MiB force-flushing (stop=4)
 eval deducted: reg=+0 B ela=+30 MiB
 eval original in send-q: reg=+12 MiB ela=+0 B
 LowPri:
@@ -349,7 +349,7 @@ NormalPri:
   term=1 index=4  tokens=6291456
   term=1 index=5  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[4,5) send_queue=[5,6) precise_q_size=+6.0 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,5) send_queue=[5,6) precise_q_size=+6.0 MiB watching-for-tokens
 eval deducted: reg=+0 B ela=+30 MiB
 eval original in send-q: reg=+6.0 MiB ela=+0 B
 LowPri:
@@ -388,7 +388,7 @@ NormalPri:
   term=1 index=4  tokens=6291456
   term=1 index=5  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[4,5) send_queue=[5,6) precise_q_size=+6.0 MiB force-flushing
+(n2,s2):2: state=replicate closed=false inflight=[1,5) send_queue=[5,6) precise_q_size=+6.0 MiB force-flushing
 eval deducted: reg=+0 B ela=+30 MiB
 eval original in send-q: reg=+6.0 MiB ela=+0 B
 LowPri:
@@ -415,7 +415,7 @@ NormalPri:
   term=1 index=4  tokens=6291456
   term=1 index=5  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[5,6) send_queue=[6,6) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+30 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -447,7 +447,7 @@ t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[6,7) send_queue=[7,7) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,7) send_queue=[7,7) precise_q_size=+0 B
 eval deducted: reg=+36 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -458,7 +458,7 @@ NormalPri:
   term=1 index=5  tokens=6291456
   term=1 index=6  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[6,7) send_queue=[7,7) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,7) send_queue=[7,7) precise_q_size=+0 B
 eval deducted: reg=+6.0 MiB ela=+30 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_index_push_pull
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_index_push_pull
@@ -247,14 +247,14 @@ NormalPri:
   term=1 index=2  tokens=6291456
   term=1 index=3  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[2,3) send_queue=[3,4) precise_q_size=+6.0 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+6.0 MiB watching-for-tokens
 eval deducted: reg=+0 B ela=+18 MiB
 eval original in send-q: reg=+6.0 MiB ela=+0 B
 LowPri:
   term=1 index=1  tokens=6291456
   term=1 index=2  tokens=6291456
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[2,3) send_queue=[3,4) precise_q_size=+6.0 MiB force-flushing
+(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+6.0 MiB force-flushing
 eval deducted: reg=+0 B ela=+18 MiB
 eval original in send-q: reg=+6.0 MiB ela=+0 B
 LowPri:
@@ -300,14 +300,14 @@ NormalPri:
   term=1 index=2  tokens=6291456
   term=1 index=3  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[2,3) send_queue=[3,4) precise_q_size=+6.0 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+6.0 MiB watching-for-tokens
 eval deducted: reg=+0 B ela=+18 MiB
 eval original in send-q: reg=+6.0 MiB ela=+0 B
 LowPri:
   term=1 index=1  tokens=6291456
   term=1 index=2  tokens=6291456
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[2,3) send_queue=[3,4) precise_q_size=+6.0 MiB force-flushing
+(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+6.0 MiB force-flushing
 eval deducted: reg=+0 B ela=+18 MiB
 eval original in send-q: reg=+6.0 MiB ela=+0 B
 LowPri:
@@ -328,14 +328,14 @@ NormalPri:
   term=1 index=2  tokens=6291456
   term=1 index=3  tokens=6291456
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[2,3) send_queue=[3,4) precise_q_size=+6.0 MiB watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+6.0 MiB watching-for-tokens
 eval deducted: reg=+0 B ela=+18 MiB
 eval original in send-q: reg=+6.0 MiB ela=+0 B
 LowPri:
   term=1 index=1  tokens=6291456
   term=1 index=2  tokens=6291456
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+18 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_no_send_q_joint_config
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/force_flush_no_send_q_joint_config
@@ -157,7 +157,7 @@ t1/s4: eval reg=-1.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -166,13 +166,13 @@ NormalPri:
 ++++
 (n2,s2):2: closed
 ++++
-(n3,s3):3VOTER_DEMOTING_LEARNER: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B
+(n3,s3):3VOTER_DEMOTING_LEARNER: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
 ++++
-(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B
+(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -254,7 +254,7 @@ t1/s4: eval reg=-2.0 MiB/+16 MiB ela=-3.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -266,14 +266,14 @@ NormalPri:
 eval deducted: reg=+0 B ela=+1.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 ++++
-(n3,s3):3VOTER_DEMOTING_LEARNER: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3VOTER_DEMOTING_LEARNER: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B
+(n4,s4):4VOTER_INCOMING: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/handle_raft_event
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/handle_raft_event
@@ -115,8 +115,8 @@ NormalPri:
 # delay.
 set_replicas
 range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=4
-  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=4
-  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=4
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=4 match=3
+  store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=4 match=3
   store_id=3 replica_id=3 type=VOTER_FULL state=StateProbe next=4
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
@@ -130,11 +130,11 @@ now=200ms
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[4,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[4,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
@@ -151,11 +151,11 @@ now=400ms
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[4,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[4,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 ++++
@@ -199,14 +199,29 @@ check_state
 range_id=1 tenant_id={1} local_replica_id=1
   name=a pri=low-pri  done=false waited=false err=<nil>
 
+stream_state range_id=1
+----
+(n1,s1):1: state=replicate closed=false inflight=[5,5) send_queue=[5,5) precise_q_size=+0 B
+eval deducted: reg=+0 B ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+++++
+(n2,s2):2: state=replicate closed=false inflight=[4,5) send_queue=[5,5) precise_q_size=+0 B
+eval deducted: reg=+16 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=4  tokens=16777216
+++++
+(n3,s3):3: closed
+++++
+
 # Change the state of s3 to replicate and s2 to StateSnapshot, this should
 # trigger the operation to refresh, ignore s2 now that it is in StateProbe and
 # check s3 for available tokens as it is now in StateReplicate.
 set_replicas
 range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=5
-  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=5
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=5 match=4
   store_id=2 replica_id=2 type=VOTER_FULL state=StateSnapshot next=4
-  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=5
+  store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=5 match=4
 ----
 r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/handle_raft_event_partial_msg_app
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/handle_raft_event_partial_msg_app
@@ -86,7 +86,7 @@ t1/s3: eval reg=+14 MiB/+16 MiB ela=+6.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[4,6) send_queue=[6,6) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+5.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -96,7 +96,7 @@ NormalPri:
   term=1 index=4  tokens=1048576
   term=1 index=5  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[2,5) send_queue=[5,6) precise_q_size=+1.0 MiB
+(n2,s2):2: state=replicate closed=false inflight=[1,5) send_queue=[5,6) precise_q_size=+1.0 MiB
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 NormalPri:
@@ -160,7 +160,7 @@ t1/s3: eval reg=+13 MiB/+16 MiB ela=+5.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[6,7) send_queue=[7,7) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[5,7) send_queue=[7,7) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/leaseholder_force_flush_no_send_q
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/leaseholder_force_flush_no_send_q
@@ -101,7 +101,7 @@ t1/s3: eval reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -114,7 +114,7 @@ eval original in send-q: reg=+1.0 MiB ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -155,7 +155,7 @@ kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     : 0
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -168,7 +168,7 @@ eval original in send-q: reg=+1.0 MiB ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -207,7 +207,7 @@ t1/s3: eval reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -220,7 +220,7 @@ eval original in send-q: reg=+1.0 MiB ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/no_send_q_choice
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/no_send_q_choice
@@ -110,7 +110,7 @@ t1/s5: eval reg=-2.0 MiB/+16 MiB ela=-2.5 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -125,14 +125,14 @@ eval original in send-q: reg=+2.0 MiB ela=+0 B
 eval deducted: reg=+0 B ela=+2.0 MiB
 eval original in send-q: reg=+2.0 MiB ela=+0 B
 ++++
-(n4,s4):4: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B
+(n4,s4):4: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
 ++++
-(n5,s5):5: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B
+(n5,s5):5: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -208,7 +208,7 @@ t1/s5: eval reg=-2.0 MiB/+16 MiB ela=-3.5 MiB/+8.0 MiB
 # Replica 5 now has a send-queue.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -216,7 +216,7 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -224,7 +224,7 @@ NormalPri:
 ++++
 (n3,s3):3: closed
 ++++
-(n4,s4):4: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B
+(n4,s4):4: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/probe_state
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/probe_state
@@ -115,7 +115,7 @@ t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/quorum_without_send_q
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/quorum_without_send_q
@@ -80,7 +80,7 @@ t1/s3: eval reg=-2.0 MiB/+16 MiB ela=-2.0 MiB/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -93,7 +93,7 @@ eval original in send-q: reg=+1.0 MiB ela=+0 B
 NormalPri:
   term=1 index=1  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[2,3) send_queue=[3,3) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,3) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -155,7 +155,7 @@ t1/s3: eval reg=+0 B/+16 MiB ela=+0 B/+8.0 MiB
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/send_q_entries_without_ac
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/send_q_entries_without_ac
@@ -150,7 +150,7 @@ t1/s3: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
 # the send-queue.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[2,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -160,7 +160,7 @@ NormalPri:
 eval deducted: reg=+0 B ela=+1.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[2,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -198,7 +198,7 @@ t1/s3: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
 # Replica 2 has 10KiB of send tokens and is waiting for a scheduler event.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[2,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -208,7 +208,7 @@ NormalPri:
 eval deducted: reg=+0 B ela=+1.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[2,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -223,19 +223,19 @@ scheduled-replicas: 2
 # only composed of entries that need 0 tokens.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[2,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[2,3) send_queue=[3,4) precise_q_size=+0 B watching-for-tokens
+(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+0 B watching-for-tokens
 eval deducted: reg=+0 B ela=+1.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
   term=1 index=2  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[2,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -261,19 +261,19 @@ t1/s3: eval reg=-1.0 MiB/+16 MiB ela=-1.0 MiB/+8.0 MiB
 # Replica 2 is waiting for a scheduler event.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[2,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[2,3) send_queue=[3,4) precise_q_size=+0 B deducted=+4.0 KiB
+(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+0 B deducted=+4.0 KiB
 eval deducted: reg=+0 B ela=+1.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
   term=1 index=2  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[2,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -286,19 +286,19 @@ scheduled-replicas: 2
 # returns the 4KiB of tokens it deducted.
 handle_scheduler_event range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[2,4) send_queue=[4,4) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+1.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
   term=1 index=2  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[2,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/send_q_watcher
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/send_q_watcher
@@ -191,7 +191,7 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[2,3) send_queue=[3,4) precise_q_size=+1.0 MiB deducted=+512 KiB
+(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+1.0 MiB deducted=+512 KiB
 eval deducted: reg=+0 B ela=+3.0 MiB
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 LowPri:
@@ -224,7 +224,7 @@ NormalPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+3.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -359,7 +359,7 @@ LowPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[2,3) send_queue=[3,4) precise_q_size=+0 B watching-for-tokens
+(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+0 B watching-for-tokens
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -403,7 +403,7 @@ LowPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[2,3) send_queue=[3,4) precise_q_size=+0 B deducted=+1.1 MiB
+(n3,s3):3: state=replicate closed=false inflight=[1,3) send_queue=[3,4) precise_q_size=+0 B deducted=+1.1 MiB
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -432,7 +432,7 @@ LowPri:
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[3,4) send_queue=[4,4) precise_q_size=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,4) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/sendq_push_pull
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/sendq_push_pull
@@ -76,7 +76,7 @@ t1/s3: eval reg=+16 MiB/+16 MiB ela=+1.0 MiB/+8.0 MiB
 # send from the send-queue.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[3,5) send_queue=[5,5) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,5) send_queue=[5,5) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+5.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -86,7 +86,7 @@ NormalPri:
   term=1 index=1  tokens=1048576
   term=1 index=3  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[3,5) send_queue=[5,5) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,5) send_queue=[5,5) precise_q_size=+0 B
 eval deducted: reg=+2.0 MiB ela=+5.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -129,7 +129,7 @@ t1/s3: eval reg=+13 MiB/+16 MiB ela=+0 B/+8.0 MiB
 # mode.
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[5,6) send_queue=[6,6) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+5.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:
@@ -140,7 +140,7 @@ NormalPri:
   term=1 index=3  tokens=1048576
   term=1 index=5  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[5,6) send_queue=[6,6) precise_q_size=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+3.0 MiB ela=+5.0 MiB
 eval original in send-q: reg=+0 B ela=+0 B
 LowPri:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval_send_q
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/wait_for_eval_send_q
@@ -3,8 +3,8 @@
 # set regular streams to initially have 8MiB tokens and a limit of 8MiB
 # tokens. Replicas 2 and 3 have a send-queue.
 init regular_limit=8MiB regular_init=8MiB elastic_limit=1 elastic_init=1
-range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=2
-  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=2
+range_id=1 tenant_id=1 local_replica_id=1 next_raft_index=1
+  store_id=1 replica_id=1 type=VOTER_FULL state=StateReplicate next=1
   store_id=2 replica_id=2 type=VOTER_FULL state=StateReplicate next=1
   store_id=3 replica_id=3 type=VOTER_FULL state=StateReplicate next=1
 ----
@@ -16,19 +16,39 @@ t1/s2: eval reg=+8.0 MiB/+8.0 MiB ela=+1 B/+1 B
 t1/s3: eval reg=+8.0 MiB/+8.0 MiB ela=+1 B/+1 B
        send reg=+8.0 MiB/+8.0 MiB ela=+1 B/+1 B
 
+# Create MsgApps with different entries for each replica, so replicas 2 and 3
+# have a send-queue.
+raft_event
+range_id=1
+  entries
+    term=1 index=1 pri=NormalPri size=1MiB
+  sending
+    replica_id=1 [1,2)
+    replica_id=2 [1,1)
+    replica_id=3 [1,1)
+----
+t1/s1: eval reg=+7.0 MiB/+8.0 MiB ela=-1024 KiB/+1 B
+       send reg=+7.0 MiB/+8.0 MiB ela=-1024 KiB/+1 B
+t1/s2: eval reg=+7.0 MiB/+8.0 MiB ela=-1024 KiB/+1 B
+       send reg=+8.0 MiB/+8.0 MiB ela=+1 B/+1 B
+t1/s3: eval reg=+7.0 MiB/+8.0 MiB ela=-1024 KiB/+1 B
+       send reg=+8.0 MiB/+8.0 MiB ela=+1 B/+1 B
+
 stream_state range_id=1
 ----
 (n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
-eval deducted: reg=+0 B ela=+0 B
+eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+0 B
-eval deducted: reg=+0 B ela=+0 B
-eval original in send-q: reg=+0 B ela=+0 B
+(n2,s2):2: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+1.0 MiB ela=+0 B
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+0 B
-eval deducted: reg=+0 B ela=+0 B
-eval original in send-q: reg=+0 B ela=+0 B
+(n3,s3):3: state=replicate closed=false inflight=[1,1) send_queue=[1,2) precise_q_size=+1.0 MiB
+eval deducted: reg=+1.0 MiB ela=+0 B
+eval original in send-q: reg=+1.0 MiB ela=+0 B
 ++++
 
 # Start a high priority evaluation. It should not complete due to lack of
@@ -50,8 +70,10 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 stream_state range_id=1
 ----
 (n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
-eval deducted: reg=+0 B ela=+0 B
+eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
 ++++
 (n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
@@ -78,8 +100,10 @@ r1: [(n1,s1):1*,(n2,s2):2,(n3,s3):3]
 stream_state range_id=1
 ----
 (n1,s1):1: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
-eval deducted: reg=+0 B ela=+0 B
+eval deducted: reg=+1.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
 ++++
 (n2,s2):2: state=replicate closed=false inflight=[1,2) send_queue=[2,2) precise_q_size=+0 B
 eval deducted: reg=+0 B ela=+0 B
@@ -109,8 +133,8 @@ range_id=1
     replica_id=2 [2,3)
     replica_id=3 [2,4)
 ----
-t1/s1: eval reg=+5.0 MiB/+8.0 MiB ela=-3.0 MiB/+1 B
-       send reg=+5.0 MiB/+8.0 MiB ela=-3.0 MiB/+1 B
+t1/s1: eval reg=+4.0 MiB/+8.0 MiB ela=-4.0 MiB/+1 B
+       send reg=+4.0 MiB/+8.0 MiB ela=-4.0 MiB/+1 B
 t1/s2: eval reg=+5.0 MiB/+8.0 MiB ela=-3.0 MiB/+1 B
        send reg=+7.0 MiB/+8.0 MiB ela=-1024 KiB/+1 B
 t1/s3: eval reg=+5.0 MiB/+8.0 MiB ela=-3.0 MiB/+1 B
@@ -118,21 +142,22 @@ t1/s3: eval reg=+5.0 MiB/+8.0 MiB ela=-3.0 MiB/+1 B
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[2,5) send_queue=[5,5) precise_q_size=+0 B
-eval deducted: reg=+3.0 MiB ela=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,5) send_queue=[5,5) precise_q_size=+0 B
+eval deducted: reg=+4.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
+  term=1 index=1  tokens=1048576
   term=1 index=2  tokens=1048576
   term=1 index=3  tokens=1048576
   term=1 index=4  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[2,3) send_queue=[3,5) precise_q_size=+2.0 MiB
+(n2,s2):2: state=replicate closed=false inflight=[1,3) send_queue=[3,5) precise_q_size=+2.0 MiB
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+2.0 MiB ela=+0 B
 NormalPri:
   term=1 index=2  tokens=1048576
 ++++
-(n3,s3):3: state=replicate closed=false inflight=[2,4) send_queue=[4,5) precise_q_size=+1.0 MiB
+(n3,s3):3: state=replicate closed=false inflight=[1,4) send_queue=[4,5) precise_q_size=+1.0 MiB
 eval deducted: reg=+3.0 MiB ela=+0 B
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 NormalPri:
@@ -158,8 +183,8 @@ range_id=1
     replica_id=2 [3,6)
     replica_id=3 [4,5)
 ----
-t1/s1: eval reg=+4.0 MiB/+8.0 MiB ela=-4.0 MiB/+1 B
-       send reg=+4.0 MiB/+8.0 MiB ela=-4.0 MiB/+1 B
+t1/s1: eval reg=+3.0 MiB/+8.0 MiB ela=-5.0 MiB/+1 B
+       send reg=+3.0 MiB/+8.0 MiB ela=-5.0 MiB/+1 B
 t1/s2: eval reg=+4.0 MiB/+8.0 MiB ela=-4.0 MiB/+1 B
        send reg=+4.0 MiB/+8.0 MiB ela=-4.0 MiB/+1 B
 t1/s3: eval reg=+4.0 MiB/+8.0 MiB ela=-4.0 MiB/+1 B
@@ -167,7 +192,17 @@ t1/s3: eval reg=+4.0 MiB/+8.0 MiB ela=-4.0 MiB/+1 B
 
 stream_state range_id=1
 ----
-(n1,s1):1: state=replicate closed=false inflight=[5,6) send_queue=[6,6) precise_q_size=+0 B
+(n1,s1):1: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
+eval deducted: reg=+5.0 MiB ela=+0 B
+eval original in send-q: reg=+0 B ela=+0 B
+NormalPri:
+  term=1 index=1  tokens=1048576
+  term=1 index=2  tokens=1048576
+  term=1 index=3  tokens=1048576
+  term=1 index=4  tokens=1048576
+  term=1 index=5  tokens=1048576
+++++
+(n2,s2):2: state=replicate closed=false inflight=[1,6) send_queue=[6,6) precise_q_size=+0 B
 eval deducted: reg=+4.0 MiB ela=+0 B
 eval original in send-q: reg=+0 B ela=+0 B
 NormalPri:
@@ -176,16 +211,7 @@ NormalPri:
   term=1 index=4  tokens=1048576
   term=1 index=5  tokens=1048576
 ++++
-(n2,s2):2: state=replicate closed=false inflight=[3,6) send_queue=[6,6) precise_q_size=+0 B
-eval deducted: reg=+4.0 MiB ela=+0 B
-eval original in send-q: reg=+0 B ela=+0 B
-NormalPri:
-  term=1 index=2  tokens=1048576
-  term=1 index=3  tokens=1048576
-  term=1 index=4  tokens=1048576
-  term=1 index=5  tokens=1048576
-++++
-(n3,s3):3: state=replicate closed=false inflight=[4,5) send_queue=[5,6) precise_q_size=+1.0 MiB
+(n3,s3):3: state=replicate closed=false inflight=[1,5) send_queue=[5,6) precise_q_size=+1.0 MiB
 eval deducted: reg=+4.0 MiB ela=+0 B
 eval original in send-q: reg=+1.0 MiB ela=+0 B
 NormalPri:


### PR DESCRIPTION
This is in preparation for RangeController needing the per-replica inflight bytes. The existing test was unnecessarily and implicitly changing match. This happened in SendMsgAppRaftMuLocked, handling of set_replicas and raft_event. This is now changed to only adjust match explicitly via admit. And set_replicas will set match to 0, but there is now a provision to explicitly provide a match value, which is used to preserve an existing match value.

This permits maintaining ReplicaStateInfo.InflightBytes (which is currently only relevant to the test) in the test code, by adjusting it when match and next are changed. This is done via looking at entries in MemoryStorage. The wait_for_eval_send_q is slightly modified, since it needs to actually send the entry at index 1, so that it can be retrieved from MemoryStorage.

Informs #135814

Epic: CRDB-37515

Release note: None