### PR TITLE
sql/opt: implement vector search in the optimizer

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/explain_redact
+++ b/pkg/ccl/logictestccl/testdata/logic_test/explain_redact
@@ -143,7 +143,7 @@ insert p
 query T
 EXPLAIN (OPT, MEMO, REDACT) INSERT INTO p VALUES (1, 1)
 ----
-memo (optimized, ~4KB, required=[presentation: info:9] [distribution: test])
+memo (optimized, ~5KB, required=[presentation: info:9] [distribution: test])
  ├── G1: (explain G2 [distribution: test])
  │    └── [presentation: info:9] [distribution: test]
  │         ├── best: (explain G2="[distribution: test]" [distribution: test])

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -267,6 +267,10 @@ func (b *Builder) buildRelational(e memo.RelExpr) (_ execPlan, outputCols colOrd
 	case *memo.LockExpr:
 		ep, outputCols, err = b.buildLock(t)
 
+	case *memo.VectorSearchExpr, *memo.VectorPartitionSearchExpr:
+		err = unimplemented.New("vector index search",
+			"execution planning for vector index search is not yet implemented")
+
 	case *memo.BarrierExpr:
 		ep, outputCols, err = b.buildBarrier(t)
 

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -649,6 +649,8 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			f.formatMutationCols(e, tp, "return-mapping:", t.ReturnCols, t.Table)
 			f.formatOptionalColList(e, tp, "check columns:", t.CheckCols)
 			f.formatOptionalColList(e, tp, "partial index put columns:", t.PartialIndexPutCols)
+			f.formatOptionalColList(e, tp, "vector index put partition columns:", t.VectorIndexPutPartitionCols)
+			f.formatOptionalColList(e, tp, "vector index put centroid columns:", t.VectorIndexPutCentroidCols)
 			f.formatBeforeTriggers(tp, t.Table, tree.TriggerEventInsert)
 			f.formatMutationCommon(tp, &t.MutationPrivate)
 		}
@@ -666,6 +668,9 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			f.formatOptionalColList(e, tp, "check columns:", t.CheckCols)
 			f.formatOptionalColList(e, tp, "partial index put columns:", t.PartialIndexPutCols)
 			f.formatOptionalColList(e, tp, "partial index del columns:", t.PartialIndexDelCols)
+			f.formatOptionalColList(e, tp, "vector index del partition columns:", t.VectorIndexDelPartitionCols)
+			f.formatOptionalColList(e, tp, "vector index put partition columns:", t.VectorIndexPutPartitionCols)
+			f.formatOptionalColList(e, tp, "vector index put centroid columns:", t.VectorIndexPutCentroidCols)
 			f.formatBeforeTriggers(tp, t.Table, tree.TriggerEventUpdate)
 			f.formatMutationCommon(tp, &t.MutationPrivate)
 		}
@@ -690,6 +695,9 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			f.formatOptionalColList(e, tp, "check columns:", t.CheckCols)
 			f.formatOptionalColList(e, tp, "partial index put columns:", t.PartialIndexPutCols)
 			f.formatOptionalColList(e, tp, "partial index del columns:", t.PartialIndexDelCols)
+			f.formatOptionalColList(e, tp, "vector index del partition columns:", t.VectorIndexDelPartitionCols)
+			f.formatOptionalColList(e, tp, "vector index put partition columns:", t.VectorIndexPutPartitionCols)
+			f.formatOptionalColList(e, tp, "vector index put centroid columns:", t.VectorIndexPutCentroidCols)
 			f.formatBeforeTriggers(tp, t.Table, tree.TriggerEventInsert, tree.TriggerEventUpdate)
 			f.formatMutationCommon(tp, &t.MutationPrivate)
 		}
@@ -703,6 +711,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			f.formatMutationCols(e, tp, "return-mapping:", t.ReturnCols, t.Table)
 			f.formatOptionalColList(e, tp, "passthrough columns", opt.OptionalColList(t.PassthroughCols))
 			f.formatOptionalColList(e, tp, "partial index del columns:", t.PartialIndexDelCols)
+			f.formatOptionalColList(e, tp, "vector index del partition columns:", t.VectorIndexDelPartitionCols)
 			f.formatBeforeTriggers(tp, t.Table, tree.TriggerEventDelete)
 			f.formatMutationCommon(tp, &t.MutationPrivate)
 		}

--- a/pkg/sql/opt/memo/testdata/stats/vector-search
+++ b/pkg/sql/opt/memo/testdata/stats/vector-search
@@ -1,0 +1,86 @@
+exec-ddl
+CREATE TABLE t (x INT PRIMARY KEY, v VECTOR(3));
+----
+
+exec-ddl
+CREATE VECTOR INDEX ON t (v);
+----
+
+# VectorPartitionSearch produces one output row for each input row.
+build
+INSERT INTO t VALUES (1, '[1, 2, 3]');
+----
+insert t
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:5 => x:1
+ │    └── v_cast:7 => v:2
+ ├── vector index put partition columns: vector_index_put_partition1:8(int)
+ ├── vector index put centroid columns: vector_index_put_centroid1:9(vector)
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── stats: [rows=0]
+ └── vector-partition-search t@t_v_idx,vector
+      ├── columns: column1:5(int!null) v_cast:7(vector!null) vector_index_put_partition1:8(int) vector_index_put_centroid1:9(vector)
+      ├── query vector column: v_cast:7
+      ├── partition col: vector_index_put_partition1:8
+      ├── centroid col: vector_index_put_centroid1:9
+      ├── cardinality: [1 - 1]
+      ├── immutable
+      ├── stats: [rows=1]
+      ├── key: ()
+      ├── fd: ()-->(5,7-9)
+      └── project
+           ├── columns: v_cast:7(vector!null) column1:5(int!null)
+           ├── cardinality: [1 - 1]
+           ├── immutable
+           ├── stats: [rows=1]
+           ├── key: ()
+           ├── fd: ()-->(5,7)
+           ├── values
+           │    ├── columns: column1:5(int!null) column2:6(vector!null)
+           │    ├── cardinality: [1 - 1]
+           │    ├── stats: [rows=1]
+           │    ├── key: ()
+           │    ├── fd: ()-->(5,6)
+           │    └── (1, '[1,2,3]') [type=tuple{int, vector}]
+           └── projections
+                └── assignment-cast: VECTOR(3) [as=v_cast:7, type=vector, outer=(6), immutable]
+                     └── column2:6 [type=vector]
+
+build
+INSERT INTO t VALUES (1, '[1, 2, 3]'), (2, '[4, 5, 6]'), (3, '[7, 8, 9]');
+----
+insert t
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:5 => x:1
+ │    └── v_cast:7 => v:2
+ ├── vector index put partition columns: vector_index_put_partition1:8(int)
+ ├── vector index put centroid columns: vector_index_put_centroid1:9(vector)
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── stats: [rows=0]
+ └── vector-partition-search t@t_v_idx,vector
+      ├── columns: column1:5(int!null) v_cast:7(vector!null) vector_index_put_partition1:8(int) vector_index_put_centroid1:9(vector)
+      ├── query vector column: v_cast:7
+      ├── partition col: vector_index_put_partition1:8
+      ├── centroid col: vector_index_put_centroid1:9
+      ├── cardinality: [3 - 3]
+      ├── immutable
+      ├── stats: [rows=3]
+      └── project
+           ├── columns: v_cast:7(vector!null) column1:5(int!null)
+           ├── cardinality: [3 - 3]
+           ├── immutable
+           ├── stats: [rows=3]
+           ├── values
+           │    ├── columns: column1:5(int!null) column2:6(vector!null)
+           │    ├── cardinality: [3 - 3]
+           │    ├── stats: [rows=3]
+           │    ├── (1, '[1,2,3]') [type=tuple{int, vector}]
+           │    ├── (2, '[4,5,6]') [type=tuple{int, vector}]
+           │    └── (3, '[7,8,9]') [type=tuple{int, vector}]
+           └── projections
+                └── assignment-cast: VECTOR(3) [as=v_cast:7, type=vector, outer=(6), immutable]
+                     └── column2:6 [type=vector]

--- a/pkg/sql/opt/memo/testdata/stats/vector-search
+++ b/pkg/sql/opt/memo/testdata/stats/vector-search
@@ -84,3 +84,104 @@ insert t
            └── projections
                 └── assignment-cast: VECTOR(3) [as=v_cast:7, type=vector, outer=(6), immutable]
                      └── column2:6 [type=vector]
+
+# VectorSearch operators produce more candidates than requested by the LIMIT
+# clause.
+opt
+SELECT * FROM t@t_v_idx ORDER BY v <-> '[1, 2, 3]' LIMIT 1;
+----
+top-k
+ ├── columns: x:1(int!null) v:2(vector)  [hidden: column5:5(float)]
+ ├── internal-ordering: +5
+ ├── k: 1
+ ├── cardinality: [0 - 1]
+ ├── immutable
+ ├── stats: [rows=1]
+ ├── key: ()
+ ├── fd: ()-->(1,2,5)
+ └── project
+      ├── columns: column5:5(float) x:1(int!null) v:2(vector)
+      ├── immutable
+      ├── stats: [rows=2]
+      ├── key: (1)
+      ├── fd: (1)-->(2), (2)-->(5)
+      ├── index-join t
+      │    ├── columns: x:1(int!null) v:2(vector)
+      │    ├── stats: [rows=2]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2)
+      │    └── vector-search t@t_v_idx,vector
+      │         ├── columns: x:1(int!null)
+      │         ├── target nearest neighbors: 1
+      │         ├── stats: [rows=2]
+      │         ├── key: (1)
+      │         └── '[1,2,3]' [type=vector]
+      └── projections
+           └── v:2 <-> '[1,2,3]' [as=column5:5, type=float, outer=(2), immutable]
+
+opt
+SELECT * FROM t@t_v_idx ORDER BY v <-> '[1, 2, 3]' LIMIT 5;
+----
+top-k
+ ├── columns: x:1(int!null) v:2(vector)  [hidden: column5:5(float)]
+ ├── internal-ordering: +5
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── stats: [rows=5]
+ ├── key: (1)
+ ├── fd: (1)-->(2), (2)-->(5)
+ ├── ordering: +5
+ └── project
+      ├── columns: column5:5(float) x:1(int!null) v:2(vector)
+      ├── immutable
+      ├── stats: [rows=10]
+      ├── key: (1)
+      ├── fd: (1)-->(2), (2)-->(5)
+      ├── index-join t
+      │    ├── columns: x:1(int!null) v:2(vector)
+      │    ├── stats: [rows=10]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2)
+      │    └── vector-search t@t_v_idx,vector
+      │         ├── columns: x:1(int!null)
+      │         ├── target nearest neighbors: 5
+      │         ├── stats: [rows=10]
+      │         ├── key: (1)
+      │         └── '[1,2,3]' [type=vector]
+      └── projections
+           └── v:2 <-> '[1,2,3]' [as=column5:5, type=float, outer=(2), immutable]
+
+# Test a limit that is higher than the number of rows in the table.
+opt
+SELECT * FROM t@t_v_idx ORDER BY v <-> '[1, 2, 3]' LIMIT 10000;
+----
+top-k
+ ├── columns: x:1(int!null) v:2(vector)  [hidden: column5:5(float)]
+ ├── internal-ordering: +5
+ ├── k: 10000
+ ├── cardinality: [0 - 10000]
+ ├── immutable
+ ├── stats: [rows=1000]
+ ├── key: (1)
+ ├── fd: (1)-->(2), (2)-->(5)
+ ├── ordering: +5
+ └── project
+      ├── columns: column5:5(float) x:1(int!null) v:2(vector)
+      ├── immutable
+      ├── stats: [rows=1000]
+      ├── key: (1)
+      ├── fd: (1)-->(2), (2)-->(5)
+      ├── index-join t
+      │    ├── columns: x:1(int!null) v:2(vector)
+      │    ├── stats: [rows=1000]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2)
+      │    └── vector-search t@t_v_idx,vector
+      │         ├── columns: x:1(int!null)
+      │         ├── target nearest neighbors: 10000
+      │         ├── stats: [rows=1000]
+      │         ├── key: (1)
+      │         └── '[1,2,3]' [type=vector]
+      └── projections
+           └── v:2 <-> '[1,2,3]' [as=column5:5, type=float, outer=(2), immutable]

--- a/pkg/sql/opt/norm/prune_cols_funcs.go
+++ b/pkg/sql/opt/norm/prune_cols_funcs.go
@@ -68,6 +68,9 @@ func (c *CustomFuncs) neededMutationCols(
 		addCols(private.PartialIndexPutCols)
 		addCols(private.PartialIndexDelCols)
 	}
+	addCols(private.VectorIndexPutPartitionCols)
+	addCols(private.VectorIndexPutCentroidCols)
+	addCols(private.VectorIndexDelPartitionCols)
 	addCols(private.ReturnCols)
 	addCols(opt.OptionalColList(private.PassthroughCols))
 	if private.CanaryCol != 0 {

--- a/pkg/sql/opt/ops/mutation.opt
+++ b/pkg/sql/opt/ops/mutation.opt
@@ -134,6 +134,24 @@ define MutationPrivate {
     # the index.
     PartialIndexDelCols OptionalColList
 
+    # VectorIndexDelPartitionCols are columns from the Input expression
+    # containing the keys for the partitions that the deleted or updated rows
+    # should be removed from. The length is always equal to the number of vector
+    # indexes on the table.
+    VectorIndexDelPartitionCols OptionalColList
+
+    # VectorIndexPutPartitionCols are columns from the Input expression
+    # containing the keys for the partitions that the inserted or updated rows
+    # should be added to. The length is always equal to the number of vector
+    # indexes on the table.
+    VectorIndexPutPartitionCols OptionalColList
+
+    # VectorIndexPutCentroidCols are columns from the Input expression
+    # containing the centroids of the partitions that the inserted or updated
+    # rows should be added to. The length is always equal to the number of
+    # vector indexes on the table.
+    VectorIndexPutCentroidCols OptionalColList
+
     # CanaryCol is used only with the Upsert operator. It identifies the column
     # that the execution engine uses to decide whether to insert or to update.
     # If the canary column value is null for a particular input row, then a new

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -1429,6 +1429,90 @@ define RecursiveCTEPrivate {
     Deduplicate bool
 }
 
+# VectorSearch is used to perform an approximate K-nearest-neighbor search for a
+# single query vector on a vector index. It returns a set of candidate primary
+# keys which should be used in a re-ranking step that computes the exact
+# distances to the query vector, and applies the NN limit.
+[Relational, Telemetry]
+define VectorSearch {
+    # QueryVector is the scalar query vector. It is either a constant or a
+    # placeholder.
+    QueryVector ScalarExpr
+    _ VectorSearchPrivate
+}
+
+[Private]
+define VectorSearchPrivate {
+    # Table identifies the table to search. It is an id that can be passed to
+    # the Metadata.Table method in order to fetch cat.Table metadata.
+    Table TableID
+
+    # Index identifies the vector index to search. It can be passed to the
+    # cat.Table.Index() method in order to fetch the cat.Index metadata.
+    Index IndexOrdinal
+
+    # Cols is the set of columns produced by the vector search operator. This
+    # is currently always the set of primary key columns.
+    Cols ColSet
+
+    # PrefixConstraint is set iff the vector index has a prefix of non-vector
+    # columns. It contains one or more spans that each constrain every prefix
+    # column to a single value. The vector search will be conducted within each
+    # span independently.
+    PrefixConstraint Constraint
+
+    # TargetNeighborCount is the number of nearest neighbors to search for.
+    # The set of candidates returning will generally be larger than this number.
+    TargetNeighborCount int64
+}
+
+# VectorPartitionSearch is used to determine the vector-index partition that
+# contains (or should contain) each vector from the input. It is used in the
+# input of mutation operators. It always produces exactly one row for each
+# input row, containing the partition key and optionally the centroid of the
+# partition. If the input query vector is NULL, no vector search is performed,
+# and the projected output columns are NULL.
+[Relational]
+define VectorPartitionSearch {
+    Input RelExpr
+    _ VectorPartitionSearchPrivate
+}
+
+[Private]
+define VectorPartitionSearchPrivate {
+    # Table identifies the table to perform the search in.
+    Table TableID
+
+    # Index is the vector index that is used to perform the search.
+    Index IndexOrdinal
+
+    # PrefixKeyCols are the columns (produced by the input) used to create
+    # lookup keys for the non-vector prefix columns if the index is a
+    # multi-column vector index. There must be a key column for each prefix
+    # column.
+    PrefixKeyCols ColList
+
+    # QueryVectorCol is the input column that contains the query vectors.
+    # When the query vector is NULL, the partition and centroid output columns
+    # will be NULL.
+    QueryVectorCol ColumnID
+
+    # PrimaryKeyCols is the optional set of input columns used to constrain
+    # the search to a specific row. This is used for deletion from the index.
+    # In rare cases it is possible not to find the requested row, in which case
+    # the partition key will be NULL.
+    PrimaryKeyCols ColSet
+
+    # PartitionCol is the output column that contains the partition key for each
+    # vector. It is always set.
+    PartitionCol ColumnID
+
+    # CentroidCol is the output column that contains the centroid of the
+    # partition. It is only set for inserts into the index (including those
+    # performed for a SQL UPDATE or UPSERT).
+    CentroidCol ColumnID
+}
+
 # Barrier is a relational operator that simply passes through its input columns
 # with no changes. It serves as an optimization barrier, and is not included in
 # the final execution plan.

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -111,6 +111,9 @@ func (mb *mutationBuilder) buildDelete(returning *tree.ReturningExprs) {
 	// Project partial index DEL boolean columns.
 	mb.projectPartialIndexDelCols()
 
+	// Project vector index DEL columns.
+	mb.projectVectorIndexColsForDelete()
+
 	private := mb.makeMutationPrivate(returning != nil)
 	for _, col := range mb.extraAccessibleCols {
 		if col.id != 0 {

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -748,6 +748,9 @@ func (mb *mutationBuilder) buildInsert(returning *tree.ReturningExprs) {
 	// Project partial index PUT boolean columns.
 	mb.projectPartialIndexPutCols()
 
+	// Project vector index PUT columns.
+	mb.projectVectorIndexCols()
+
 	mb.buildUniqueChecksForInsert()
 
 	mb.buildFKChecksForInsert()
@@ -964,6 +967,9 @@ func (mb *mutationBuilder) buildUpsert(returning *tree.ReturningExprs) {
 	} else {
 		mb.projectPartialIndexPutCols()
 	}
+
+	// Project vector index PUT and DEL columns.
+	mb.projectVectorIndexCols()
 
 	mb.buildUniqueChecksForUpsert()
 

--- a/pkg/sql/opt/optbuilder/testdata/vector_mutation
+++ b/pkg/sql/opt/optbuilder/testdata/vector_mutation
@@ -1,0 +1,559 @@
+exec-ddl
+CREATE TABLE t (x INT PRIMARY KEY, v VECTOR(3), w VECTOR(2));
+----
+
+exec-ddl
+CREATE VECTOR INDEX ON t (v);
+----
+
+build
+INSERT INTO t VALUES (1, '[1,2,3]'), (2, '[4,5,6]');
+----
+insert t
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:6 => x:1
+ │    ├── v_cast:8 => v:2
+ │    └── w_default:9 => w:3
+ ├── vector index put partition columns: vector_index_put_partition1:10
+ ├── vector index put centroid columns: vector_index_put_centroid1:11
+ └── vector-partition-search t@t_v_idx,vector
+      ├── columns: column1:6!null v_cast:8!null w_default:9 vector_index_put_partition1:10 vector_index_put_centroid1:11
+      ├── query vector column: v_cast:8
+      ├── partition col: vector_index_put_partition1:10
+      ├── centroid col: vector_index_put_centroid1:11
+      └── project
+           ├── columns: w_default:9 column1:6!null v_cast:8!null
+           ├── project
+           │    ├── columns: v_cast:8!null column1:6!null
+           │    ├── values
+           │    │    ├── columns: column1:6!null column2:7!null
+           │    │    ├── (1, '[1,2,3]')
+           │    │    └── (2, '[4,5,6]')
+           │    └── projections
+           │         └── assignment-cast: VECTOR(3) [as=v_cast:8]
+           │              └── column2:7
+           └── projections
+                └── NULL::VECTOR(2) [as=w_default:9]
+
+build
+UPDATE t SET v = '[4,5,6]' WHERE x = 1;
+----
+update t
+ ├── columns: <none>
+ ├── fetch columns: x:6 v:7 w:8
+ ├── update-mapping:
+ │    └── v_cast:12 => v:2
+ ├── vector index del partition columns: vector_index_del_partition1:13
+ ├── vector index put partition columns: vector_index_put_partition1:14
+ ├── vector index put centroid columns: vector_index_put_centroid1:15
+ └── vector-partition-search t@t_v_idx,vector
+      ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:12!null vector_index_del_partition1:13 vector_index_put_partition1:14 vector_index_put_centroid1:15
+      ├── query vector column: v_cast:12
+      ├── partition col: vector_index_put_partition1:14
+      ├── centroid col: vector_index_put_centroid1:15
+      └── vector-partition-search t@t_v_idx,vector
+           ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:12!null vector_index_del_partition1:13
+           ├── query vector column: v:7
+           ├── primary key columns: (6)
+           ├── partition col: vector_index_del_partition1:13
+           └── project
+                ├── columns: v_cast:12!null x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                ├── project
+                │    ├── columns: v_new:11!null x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                │    ├── select
+                │    │    ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                │    │    ├── scan t
+                │    │    │    ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                │    │    │    └── flags: avoid-full-scan
+                │    │    └── filters
+                │    │         └── x:6 = 1
+                │    └── projections
+                │         └── '[4,5,6]' [as=v_new:11]
+                └── projections
+                     └── assignment-cast: VECTOR(3) [as=v_cast:12]
+                          └── v_new:11
+
+build
+DELETE FROM t WHERE x = 1;
+----
+delete t
+ ├── columns: <none>
+ ├── fetch columns: x:6 v:7 w:8
+ ├── vector index del partition columns: vector_index_del_partition1:11
+ └── vector-partition-search t@t_v_idx,vector
+      ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 vector_index_del_partition1:11
+      ├── query vector column: v:7
+      ├── primary key columns: (6)
+      ├── partition col: vector_index_del_partition1:11
+      └── select
+           ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+           ├── scan t
+           │    ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+           │    └── flags: avoid-full-scan
+           └── filters
+                └── x:6 = 1
+
+build
+UPSERT INTO t VALUES (1, '[1,2,3]'), (2, '[4,5,6]');
+----
+upsert t
+ ├── arbiter indexes: t_pkey
+ ├── columns: <none>
+ ├── canary column: x:10
+ ├── fetch columns: x:10 v:11 w:12
+ ├── insert-mapping:
+ │    ├── column1:6 => x:1
+ │    ├── v_cast:8 => v:2
+ │    └── w_default:9 => w:3
+ ├── update-mapping:
+ │    ├── v_cast:8 => v:2
+ │    └── w_default:9 => w:3
+ ├── vector index del partition columns: vector_index_del_partition1:16
+ ├── vector index put partition columns: vector_index_put_partition1:17
+ ├── vector index put centroid columns: vector_index_put_centroid1:18
+ └── vector-partition-search t@t_v_idx,vector
+      ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 upsert_x:15 vector_index_del_partition1:16 vector_index_put_partition1:17 vector_index_put_centroid1:18
+      ├── query vector column: v_cast:8
+      ├── partition col: vector_index_put_partition1:17
+      ├── centroid col: vector_index_put_centroid1:18
+      └── vector-partition-search t@t_v_idx,vector
+           ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 upsert_x:15 vector_index_del_partition1:16
+           ├── query vector column: v:11
+           ├── primary key columns: (10)
+           ├── partition col: vector_index_del_partition1:16
+           └── project
+                ├── columns: upsert_x:15 column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+                ├── left-join (hash)
+                │    ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+                │    ├── ensure-upsert-distinct-on
+                │    │    ├── columns: column1:6!null v_cast:8!null w_default:9
+                │    │    ├── grouping columns: column1:6!null
+                │    │    ├── project
+                │    │    │    ├── columns: w_default:9 column1:6!null v_cast:8!null
+                │    │    │    ├── project
+                │    │    │    │    ├── columns: v_cast:8!null column1:6!null
+                │    │    │    │    ├── values
+                │    │    │    │    │    ├── columns: column1:6!null column2:7!null
+                │    │    │    │    │    ├── (1, '[1,2,3]')
+                │    │    │    │    │    └── (2, '[4,5,6]')
+                │    │    │    │    └── projections
+                │    │    │    │         └── assignment-cast: VECTOR(3) [as=v_cast:8]
+                │    │    │    │              └── column2:7
+                │    │    │    └── projections
+                │    │    │         └── NULL::VECTOR(2) [as=w_default:9]
+                │    │    └── aggregations
+                │    │         ├── first-agg [as=v_cast:8]
+                │    │         │    └── v_cast:8
+                │    │         └── first-agg [as=w_default:9]
+                │    │              └── w_default:9
+                │    ├── scan t
+                │    │    ├── columns: x:10!null v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+                │    │    └── flags: avoid-full-scan disabled not visible index feature
+                │    └── filters
+                │         └── column1:6 = x:10
+                └── projections
+                     └── CASE WHEN x:10 IS NULL THEN column1:6 ELSE x:10 END [as=upsert_x:15]
+
+build
+INSERT INTO t VALUES (1, '[1,2,3]'), (2, '[4,5,6]')
+ON CONFLICT (x) DO UPDATE SET v = '[-4,-5,-6]';
+----
+upsert t
+ ├── arbiter indexes: t_pkey
+ ├── columns: <none>
+ ├── canary column: x:10
+ ├── fetch columns: x:10 v:11 w:12
+ ├── insert-mapping:
+ │    ├── column1:6 => x:1
+ │    ├── v_cast:8 => v:2
+ │    └── w_default:9 => w:3
+ ├── update-mapping:
+ │    └── upsert_v:18 => v:2
+ ├── vector index del partition columns: vector_index_del_partition1:20
+ ├── vector index put partition columns: vector_index_put_partition1:21
+ ├── vector index put centroid columns: vector_index_put_centroid1:22
+ └── vector-partition-search t@t_v_idx,vector
+      ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 v_cast:16!null upsert_x:17 upsert_v:18!null upsert_w:19 vector_index_del_partition1:20 vector_index_put_partition1:21 vector_index_put_centroid1:22
+      ├── query vector column: upsert_v:18
+      ├── partition col: vector_index_put_partition1:21
+      ├── centroid col: vector_index_put_centroid1:22
+      └── vector-partition-search t@t_v_idx,vector
+           ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 v_cast:16!null upsert_x:17 upsert_v:18!null upsert_w:19 vector_index_del_partition1:20
+           ├── query vector column: v:11
+           ├── primary key columns: (10)
+           ├── partition col: vector_index_del_partition1:20
+           └── project
+                ├── columns: upsert_x:17 upsert_v:18!null upsert_w:19 column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 v_cast:16!null
+                ├── project
+                │    ├── columns: v_cast:16!null column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+                │    ├── project
+                │    │    ├── columns: v_new:15!null column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+                │    │    ├── left-join (hash)
+                │    │    │    ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+                │    │    │    ├── ensure-upsert-distinct-on
+                │    │    │    │    ├── columns: column1:6!null v_cast:8!null w_default:9
+                │    │    │    │    ├── grouping columns: column1:6!null
+                │    │    │    │    ├── project
+                │    │    │    │    │    ├── columns: w_default:9 column1:6!null v_cast:8!null
+                │    │    │    │    │    ├── project
+                │    │    │    │    │    │    ├── columns: v_cast:8!null column1:6!null
+                │    │    │    │    │    │    ├── values
+                │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7!null
+                │    │    │    │    │    │    │    ├── (1, '[1,2,3]')
+                │    │    │    │    │    │    │    └── (2, '[4,5,6]')
+                │    │    │    │    │    │    └── projections
+                │    │    │    │    │    │         └── assignment-cast: VECTOR(3) [as=v_cast:8]
+                │    │    │    │    │    │              └── column2:7
+                │    │    │    │    │    └── projections
+                │    │    │    │    │         └── NULL::VECTOR(2) [as=w_default:9]
+                │    │    │    │    └── aggregations
+                │    │    │    │         ├── first-agg [as=v_cast:8]
+                │    │    │    │         │    └── v_cast:8
+                │    │    │    │         └── first-agg [as=w_default:9]
+                │    │    │    │              └── w_default:9
+                │    │    │    ├── scan t
+                │    │    │    │    ├── columns: x:10!null v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+                │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
+                │    │    │    └── filters
+                │    │    │         └── column1:6 = x:10
+                │    │    └── projections
+                │    │         └── '[-4,-5,-6]' [as=v_new:15]
+                │    └── projections
+                │         └── assignment-cast: VECTOR(3) [as=v_cast:16]
+                │              └── v_new:15
+                └── projections
+                     ├── CASE WHEN x:10 IS NULL THEN column1:6 ELSE x:10 END [as=upsert_x:17]
+                     ├── CASE WHEN x:10 IS NULL THEN v_cast:8 ELSE v_cast:16 END [as=upsert_v:18]
+                     └── CASE WHEN x:10 IS NULL THEN w_default:9 ELSE w:12 END [as=upsert_w:19]
+
+# Create another vector index, verify that mutations correctly update both
+# indexes.
+exec-ddl
+CREATE VECTOR INDEX ON t (w);
+----
+
+build
+INSERT INTO t VALUES (1, '[1,2,3]', '[10, 20]'), (2, '[4,5,6]', '[30, 40]');
+----
+insert t
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:6 => x:1
+ │    ├── v_cast:9 => v:2
+ │    └── w_cast:10 => w:3
+ ├── vector index put partition columns: vector_index_put_partition1:11 vector_index_put_partition2:13
+ ├── vector index put centroid columns: vector_index_put_centroid1:12 vector_index_put_centroid2:14
+ └── vector-partition-search t@t_w_idx,vector
+      ├── columns: column1:6!null v_cast:9!null w_cast:10!null vector_index_put_partition1:11 vector_index_put_centroid1:12 vector_index_put_partition2:13 vector_index_put_centroid2:14
+      ├── query vector column: w_cast:10
+      ├── partition col: vector_index_put_partition2:13
+      ├── centroid col: vector_index_put_centroid2:14
+      └── vector-partition-search t@t_v_idx,vector
+           ├── columns: column1:6!null v_cast:9!null w_cast:10!null vector_index_put_partition1:11 vector_index_put_centroid1:12
+           ├── query vector column: v_cast:9
+           ├── partition col: vector_index_put_partition1:11
+           ├── centroid col: vector_index_put_centroid1:12
+           └── project
+                ├── columns: v_cast:9!null w_cast:10!null column1:6!null
+                ├── values
+                │    ├── columns: column1:6!null column2:7!null column3:8!null
+                │    ├── (1, '[1,2,3]', '[10,20]')
+                │    └── (2, '[4,5,6]', '[30,40]')
+                └── projections
+                     ├── assignment-cast: VECTOR(3) [as=v_cast:9]
+                     │    └── column2:7
+                     └── assignment-cast: VECTOR(2) [as=w_cast:10]
+                          └── column3:8
+
+build
+UPDATE t SET v = '[4,5,6]', w = '[20, 40]' WHERE x = 1;
+----
+update t
+ ├── columns: <none>
+ ├── fetch columns: x:6 v:7 w:8
+ ├── update-mapping:
+ │    ├── v_cast:13 => v:2
+ │    └── w_cast:14 => w:3
+ ├── vector index del partition columns: vector_index_del_partition1:15 vector_index_del_partition2:18
+ ├── vector index put partition columns: vector_index_put_partition1:16 vector_index_put_partition2:19
+ ├── vector index put centroid columns: vector_index_put_centroid1:17 vector_index_put_centroid2:20
+ └── vector-partition-search t@t_w_idx,vector
+      ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15 vector_index_put_partition1:16 vector_index_put_centroid1:17 vector_index_del_partition2:18 vector_index_put_partition2:19 vector_index_put_centroid2:20
+      ├── query vector column: w_cast:14
+      ├── partition col: vector_index_put_partition2:19
+      ├── centroid col: vector_index_put_centroid2:20
+      └── vector-partition-search t@t_w_idx,vector
+           ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15 vector_index_put_partition1:16 vector_index_put_centroid1:17 vector_index_del_partition2:18
+           ├── query vector column: w:8
+           ├── primary key columns: (6)
+           ├── partition col: vector_index_del_partition2:18
+           └── vector-partition-search t@t_v_idx,vector
+                ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15 vector_index_put_partition1:16 vector_index_put_centroid1:17
+                ├── query vector column: v_cast:13
+                ├── partition col: vector_index_put_partition1:16
+                ├── centroid col: vector_index_put_centroid1:17
+                └── vector-partition-search t@t_v_idx,vector
+                     ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15
+                     ├── query vector column: v:7
+                     ├── primary key columns: (6)
+                     ├── partition col: vector_index_del_partition1:15
+                     └── project
+                          ├── columns: v_cast:13!null w_cast:14!null x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                          ├── project
+                          │    ├── columns: v_new:11!null w_new:12!null x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                          │    ├── select
+                          │    │    ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                          │    │    ├── scan t
+                          │    │    │    ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                          │    │    │    └── flags: avoid-full-scan
+                          │    │    └── filters
+                          │    │         └── x:6 = 1
+                          │    └── projections
+                          │         ├── '[4,5,6]' [as=v_new:11]
+                          │         └── '[20,40]' [as=w_new:12]
+                          └── projections
+                               ├── assignment-cast: VECTOR(3) [as=v_cast:13]
+                               │    └── v_new:11
+                               └── assignment-cast: VECTOR(2) [as=w_cast:14]
+                                    └── w_new:12
+
+build
+DELETE FROM t WHERE x = 1;
+----
+delete t
+ ├── columns: <none>
+ ├── fetch columns: x:6 v:7 w:8
+ ├── vector index del partition columns: vector_index_del_partition1:11 vector_index_del_partition2:12
+ └── vector-partition-search t@t_w_idx,vector
+      ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 vector_index_del_partition1:11 vector_index_del_partition2:12
+      ├── query vector column: w:8
+      ├── primary key columns: (6)
+      ├── partition col: vector_index_del_partition2:12
+      └── vector-partition-search t@t_v_idx,vector
+           ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 vector_index_del_partition1:11
+           ├── query vector column: v:7
+           ├── primary key columns: (6)
+           ├── partition col: vector_index_del_partition1:11
+           └── select
+                ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                ├── scan t
+                │    ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                │    └── flags: avoid-full-scan
+                └── filters
+                     └── x:6 = 1
+
+build
+UPSERT INTO t VALUES (1, '[1,2,3]', '[10, 20]'), (2, '[4,5,6]', '[30, 40]');;
+----
+upsert t
+ ├── arbiter indexes: t_pkey
+ ├── columns: <none>
+ ├── canary column: x:11
+ ├── fetch columns: x:11 v:12 w:13
+ ├── insert-mapping:
+ │    ├── column1:6 => x:1
+ │    ├── v_cast:9 => v:2
+ │    └── w_cast:10 => w:3
+ ├── update-mapping:
+ │    ├── v_cast:9 => v:2
+ │    └── w_cast:10 => w:3
+ ├── vector index del partition columns: vector_index_del_partition1:17 vector_index_del_partition2:20
+ ├── vector index put partition columns: vector_index_put_partition1:18 vector_index_put_partition2:21
+ ├── vector index put centroid columns: vector_index_put_centroid1:19 vector_index_put_centroid2:22
+ └── vector-partition-search t@t_w_idx,vector
+      ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17 vector_index_put_partition1:18 vector_index_put_centroid1:19 vector_index_del_partition2:20 vector_index_put_partition2:21 vector_index_put_centroid2:22
+      ├── query vector column: w_cast:10
+      ├── partition col: vector_index_put_partition2:21
+      ├── centroid col: vector_index_put_centroid2:22
+      └── vector-partition-search t@t_w_idx,vector
+           ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17 vector_index_put_partition1:18 vector_index_put_centroid1:19 vector_index_del_partition2:20
+           ├── query vector column: w:13
+           ├── primary key columns: (11)
+           ├── partition col: vector_index_del_partition2:20
+           └── vector-partition-search t@t_v_idx,vector
+                ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17 vector_index_put_partition1:18 vector_index_put_centroid1:19
+                ├── query vector column: v_cast:9
+                ├── partition col: vector_index_put_partition1:18
+                ├── centroid col: vector_index_put_centroid1:19
+                └── vector-partition-search t@t_v_idx,vector
+                     ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17
+                     ├── query vector column: v:12
+                     ├── primary key columns: (11)
+                     ├── partition col: vector_index_del_partition1:17
+                     └── project
+                          ├── columns: upsert_x:16 column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+                          ├── left-join (hash)
+                          │    ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+                          │    ├── ensure-upsert-distinct-on
+                          │    │    ├── columns: column1:6!null v_cast:9!null w_cast:10!null
+                          │    │    ├── grouping columns: column1:6!null
+                          │    │    ├── project
+                          │    │    │    ├── columns: v_cast:9!null w_cast:10!null column1:6!null
+                          │    │    │    ├── values
+                          │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
+                          │    │    │    │    ├── (1, '[1,2,3]', '[10,20]')
+                          │    │    │    │    └── (2, '[4,5,6]', '[30,40]')
+                          │    │    │    └── projections
+                          │    │    │         ├── assignment-cast: VECTOR(3) [as=v_cast:9]
+                          │    │    │         │    └── column2:7
+                          │    │    │         └── assignment-cast: VECTOR(2) [as=w_cast:10]
+                          │    │    │              └── column3:8
+                          │    │    └── aggregations
+                          │    │         ├── first-agg [as=v_cast:9]
+                          │    │         │    └── v_cast:9
+                          │    │         └── first-agg [as=w_cast:10]
+                          │    │              └── w_cast:10
+                          │    ├── scan t
+                          │    │    ├── columns: x:11!null v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+                          │    │    └── flags: avoid-full-scan disabled not visible index feature
+                          │    └── filters
+                          │         └── column1:6 = x:11
+                          └── projections
+                               └── CASE WHEN x:11 IS NULL THEN column1:6 ELSE x:11 END [as=upsert_x:16]
+
+build
+INSERT INTO t VALUES (1, '[1,2,3]', '[10, 20]'), (2, '[4,5,6]', '[30, 40]')
+ON CONFLICT (x) DO UPDATE SET v = '[-4,-5,-6]', w = '[-40, -30]';
+----
+upsert t
+ ├── arbiter indexes: t_pkey
+ ├── columns: <none>
+ ├── canary column: x:11
+ ├── fetch columns: x:11 v:12 w:13
+ ├── insert-mapping:
+ │    ├── column1:6 => x:1
+ │    ├── v_cast:9 => v:2
+ │    └── w_cast:10 => w:3
+ ├── update-mapping:
+ │    ├── upsert_v:21 => v:2
+ │    └── upsert_w:22 => w:3
+ ├── vector index del partition columns: vector_index_del_partition1:23 vector_index_del_partition2:26
+ ├── vector index put partition columns: vector_index_put_partition1:24 vector_index_put_partition2:27
+ ├── vector index put centroid columns: vector_index_put_centroid1:25 vector_index_put_centroid2:28
+ └── vector-partition-search t@t_w_idx,vector
+      ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23 vector_index_put_partition1:24 vector_index_put_centroid1:25 vector_index_del_partition2:26 vector_index_put_partition2:27 vector_index_put_centroid2:28
+      ├── query vector column: upsert_w:22
+      ├── partition col: vector_index_put_partition2:27
+      ├── centroid col: vector_index_put_centroid2:28
+      └── vector-partition-search t@t_w_idx,vector
+           ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23 vector_index_put_partition1:24 vector_index_put_centroid1:25 vector_index_del_partition2:26
+           ├── query vector column: w:13
+           ├── primary key columns: (11)
+           ├── partition col: vector_index_del_partition2:26
+           └── vector-partition-search t@t_v_idx,vector
+                ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23 vector_index_put_partition1:24 vector_index_put_centroid1:25
+                ├── query vector column: upsert_v:21
+                ├── partition col: vector_index_put_partition1:24
+                ├── centroid col: vector_index_put_centroid1:25
+                └── vector-partition-search t@t_v_idx,vector
+                     ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23
+                     ├── query vector column: v:12
+                     ├── primary key columns: (11)
+                     ├── partition col: vector_index_del_partition1:23
+                     └── project
+                          ├── columns: upsert_x:20 upsert_v:21!null upsert_w:22!null column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null
+                          ├── project
+                          │    ├── columns: v_cast:18!null w_cast:19!null column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+                          │    ├── project
+                          │    │    ├── columns: v_new:16!null w_new:17!null column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+                          │    │    ├── left-join (hash)
+                          │    │    │    ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+                          │    │    │    ├── ensure-upsert-distinct-on
+                          │    │    │    │    ├── columns: column1:6!null v_cast:9!null w_cast:10!null
+                          │    │    │    │    ├── grouping columns: column1:6!null
+                          │    │    │    │    ├── project
+                          │    │    │    │    │    ├── columns: v_cast:9!null w_cast:10!null column1:6!null
+                          │    │    │    │    │    ├── values
+                          │    │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
+                          │    │    │    │    │    │    ├── (1, '[1,2,3]', '[10,20]')
+                          │    │    │    │    │    │    └── (2, '[4,5,6]', '[30,40]')
+                          │    │    │    │    │    └── projections
+                          │    │    │    │    │         ├── assignment-cast: VECTOR(3) [as=v_cast:9]
+                          │    │    │    │    │         │    └── column2:7
+                          │    │    │    │    │         └── assignment-cast: VECTOR(2) [as=w_cast:10]
+                          │    │    │    │    │              └── column3:8
+                          │    │    │    │    └── aggregations
+                          │    │    │    │         ├── first-agg [as=v_cast:9]
+                          │    │    │    │         │    └── v_cast:9
+                          │    │    │    │         └── first-agg [as=w_cast:10]
+                          │    │    │    │              └── w_cast:10
+                          │    │    │    ├── scan t
+                          │    │    │    │    ├── columns: x:11!null v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+                          │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
+                          │    │    │    └── filters
+                          │    │    │         └── column1:6 = x:11
+                          │    │    └── projections
+                          │    │         ├── '[-4,-5,-6]' [as=v_new:16]
+                          │    │         └── '[-40,-30]' [as=w_new:17]
+                          │    └── projections
+                          │         ├── assignment-cast: VECTOR(3) [as=v_cast:18]
+                          │         │    └── v_new:16
+                          │         └── assignment-cast: VECTOR(2) [as=w_cast:19]
+                          │              └── w_new:17
+                          └── projections
+                               ├── CASE WHEN x:11 IS NULL THEN column1:6 ELSE x:11 END [as=upsert_x:20]
+                               ├── CASE WHEN x:11 IS NULL THEN v_cast:9 ELSE v_cast:18 END [as=upsert_v:21]
+                               └── CASE WHEN x:11 IS NULL THEN w_cast:10 ELSE w_cast:19 END [as=upsert_w:22]
+
+# If the indexed column is not modified, no VectorPartitionSearch is needed for
+# that index.
+build
+UPDATE t SET x = 3, v = '[1,2,3]' WHERE x = 3;
+----
+update t
+ ├── columns: <none>
+ ├── fetch columns: x:6 v:7 w:8
+ ├── update-mapping:
+ │    ├── x_new:11 => x:1
+ │    └── v_cast:13 => v:2
+ ├── vector index del partition columns: vector_index_del_partition1:14
+ ├── vector index put partition columns: vector_index_put_partition1:15
+ ├── vector index put centroid columns: vector_index_put_centroid1:16
+ └── vector-partition-search t@t_v_idx,vector
+      ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 x_new:11!null v_cast:13!null vector_index_del_partition1:14 vector_index_put_partition1:15 vector_index_put_centroid1:16
+      ├── query vector column: v_cast:13
+      ├── partition col: vector_index_put_partition1:15
+      ├── centroid col: vector_index_put_centroid1:16
+      └── vector-partition-search t@t_v_idx,vector
+           ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 x_new:11!null v_cast:13!null vector_index_del_partition1:14
+           ├── query vector column: v:7
+           ├── primary key columns: (6)
+           ├── partition col: vector_index_del_partition1:14
+           └── project
+                ├── columns: v_cast:13!null x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 x_new:11!null
+                ├── project
+                │    ├── columns: x_new:11!null v_new:12!null x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                │    ├── select
+                │    │    ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                │    │    ├── scan t
+                │    │    │    ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                │    │    │    └── flags: avoid-full-scan
+                │    │    └── filters
+                │    │         └── x:6 = 3
+                │    └── projections
+                │         ├── 3 [as=x_new:11]
+                │         └── '[1,2,3]' [as=v_new:12]
+                └── projections
+                     └── assignment-cast: VECTOR(3) [as=v_cast:13]
+                          └── v_new:12
+
+build
+UPDATE t SET x = 3 WHERE x = 3;
+----
+update t
+ ├── columns: <none>
+ ├── fetch columns: x:6 v:7 w:8
+ ├── update-mapping:
+ │    └── x_new:11 => x:1
+ └── project
+      ├── columns: x_new:11!null x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      ├── select
+      │    ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    ├── scan t
+      │    │    ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    └── flags: avoid-full-scan
+      │    └── filters
+      │         └── x:6 = 3
+      └── projections
+           └── 3 [as=x_new:11]

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -346,6 +346,9 @@ func (mb *mutationBuilder) buildUpdate(returning *tree.ReturningExprs) {
 	// Project partial index PUT and DEL boolean columns.
 	mb.projectPartialIndexPutAndDelCols()
 
+	// Project vector index PUT and DEL columns.
+	mb.projectVectorIndexCols()
+
 	mb.buildUniqueChecksForUpdate()
 
 	mb.buildFKChecksForUpdate()

--- a/pkg/sql/opt/optgen/lang/support/textmate/OptGen/Syntaxes/optgen.tmLanguage
+++ b/pkg/sql/opt/optgen/lang/support/textmate/OptGen/Syntaxes/optgen.tmLanguage
@@ -257,6 +257,11 @@
                         ProjectSet |
                         Sort |
                         TopK |
+                        VectorSearch |
+                        VectorPartitionSearch |
+                        VectorDistance |
+                        VectorCosVectorDistance |
+                        VectorNegInnerProduct |
                         Insert |
                         Update |
                         Upsert |

--- a/pkg/sql/opt/optgen/lang/support/vim/cropt.vim
+++ b/pkg/sql/opt/optgen/lang/support/vim/cropt.vim
@@ -57,6 +57,8 @@ syn keyword operator DistinctOn EnsureDistinctOn UpsertDistinctOn EnsureUpsertDi
 syn keyword operator Union SetPrivate Intersect Except UnionAll IntersectAll ExceptAll
 syn keyword operator Let Limit Offset Max1Row Explain ExplainPrivate
 syn keyword operator ShowTraceForSession ShowTracePrivate Root RowNumber RowNumberPrivate ProjectSet
-syn keyword operator Sort TopK Insert Update Upsert Delete CreateTable OpName
+syn keyword operator Sort TopK VectorSearch VectorPartitionSearch
+syn keyword operator VectorDistance VectorCosDistance VectorNegInnerProduct
+syn keyword operator Insert Update Upsert Delete CreateTable OpName
 
 let b:current_syntax = "cropt"

--- a/pkg/sql/opt/optgen/lang/support/vscode/cockroachdb.optgen-1.0.0/syntaxes/optgen.tmLanguage
+++ b/pkg/sql/opt/optgen/lang/support/vscode/cockroachdb.optgen-1.0.0/syntaxes/optgen.tmLanguage
@@ -257,6 +257,11 @@
                         ProjectSet |
                         Sort |
                         TopK |
+                        VectorSearch |
+                        VectorPartitionSearch |
+                        VectorDistance |
+                        VectorCosVectorDistance |
+                        VectorNegInnerProduct |
                         Insert |
                         Update |
                         Upsert |

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -593,6 +593,12 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 	case opt.ProjectSetOp:
 		cost = c.computeProjectSetCost(candidate.(*memo.ProjectSetExpr))
 
+	case opt.VectorSearchOp:
+		cost = c.computeVectorSearchCost(candidate.(*memo.VectorSearchExpr))
+
+	case opt.VectorPartitionSearchOp:
+		cost = c.computeVectorPartitionSearchCost(candidate.(*memo.VectorPartitionSearchExpr))
+
 	case opt.InsertOp:
 		insertExpr, _ := candidate.(*memo.InsertExpr)
 		if len(insertExpr.FastPathUniqueChecks) != 0 {
@@ -750,6 +756,18 @@ func (c *coster) computeDistributeCost(
 	//                      estimate of latency overhead, but actual measurements
 	//                      would be useful.
 	return DistributeCost
+}
+
+func (c *coster) computeVectorSearchCost(search *memo.VectorSearchExpr) memo.Cost {
+	// TODO(drewk, mw5h): implement a proper cost function.
+	return memo.Cost{C: cpuCostFactor * search.Relational().Statistics().RowCount}
+}
+
+func (c *coster) computeVectorPartitionSearchCost(
+	search *memo.VectorPartitionSearchExpr,
+) memo.Cost {
+	// TODO(drewk, mw5h): implement a proper cost function.
+	return memo.Cost{C: cpuCostFactor * search.Relational().Statistics().RowCount}
 }
 
 func (c *coster) computeScanCost(scan *memo.ScanExpr, required *physical.Required) memo.Cost {

--- a/pkg/sql/opt/xform/groupby_funcs.go
+++ b/pkg/sql/opt/xform/groupby_funcs.go
@@ -540,12 +540,13 @@ func (c *CustomFuncs) GenerateLimitedGroupByScans(
 	if !requiredOrdering.Any() && !requiredOrdering.Group(0).Intersects(gp.GroupingCols) && !requiredOrdering.Optional.Intersects(gp.GroupingCols) {
 		return
 	}
-	// Iterate over all non-inverted and non-partial secondary indexes.
+	// Iterate over all non-inverted and non-vector secondary indexes.
 	var pkCols opt.ColSet
 	var iter scanIndexIter
 	var sb indexScanBuilder
 	sb.Init(c, sp.Table)
-	iter.Init(c.e.evalCtx, c.e, c.e.mem, &c.im, sp, nil /* filters */, rejectPrimaryIndex|rejectInvertedIndexes)
+	reject := rejectPrimaryIndex | rejectInvertedIndexes | rejectVectorIndexes
+	iter.Init(c.e.evalCtx, c.e, c.e.mem, &c.im, sp, nil /* filters */, reject)
 	iter.ForEach(func(index cat.Index, filters memo.FiltersExpr, indexCols opt.ColSet, isCovering bool, constProj memo.ProjectionsExpr) {
 		// The iterator only produces pseudo-partial indexes (the predicate is
 		// true) because no filters are passed to iter.Init to imply a partial

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -407,7 +407,8 @@ func (c *CustomFuncs) generateLookupJoinsImpl(
 	var pkCols opt.ColList
 	var newScanPrivate *memo.ScanPrivate
 	var iter scanIndexIter
-	iter.Init(c.e.evalCtx, c.e, c.e.mem, &c.im, scanPrivate, on, rejectInvertedIndexes)
+	reject := rejectInvertedIndexes | rejectVectorIndexes
+	iter.Init(c.e.evalCtx, c.e, c.e.mem, &c.im, scanPrivate, on, reject)
 	iter.ForEach(func(index cat.Index, onFilters memo.FiltersExpr, indexCols opt.ColSet, _ bool, _ memo.ProjectionsExpr) {
 		// Skip indexes that do not cover all virtual projection columns, if
 		// there are any. This can happen when there are multiple virtual

--- a/pkg/sql/opt/xform/rules/limit.opt
+++ b/pkg/sql/opt/xform/rules/limit.opt
@@ -291,3 +291,41 @@
     $groupingCols
     $newOrdering
 )
+
+# GenerateVectorSearch generates VectorSearch expressions that implement
+# approximate KNN search using vector indexes. Currently, the comparison
+# must be with a constant or placeholder vector expression.
+#
+# TODO(drewk, mw5h): generate VectorSearch in more cases.
+[GenerateVectorSearch, Explore]
+(Limit
+    $project:(Project
+            $scan:(Scan
+                $scanPrivate:* & (IsCanonicalScan $scanPrivate)
+            )
+            $projections:[
+                (ProjectionsItem
+                    $distanceExpr:(VectorDistance
+                        (Variable $vectorCol:*) &
+                            (IsFixedWidthVectorCol $vectorCol)
+                        $queryVector:(Const | Placeholder)
+                    )
+                    $distanceCol:*
+                )
+            ]
+            $passthrough:*
+        ) &
+        ^(HasOuterCols $project)
+    (Const $limit:* & (IsPositiveInt $limit))
+    $ordering:* & (OrderingBySingleColAsc $ordering $distanceCol)
+)
+=>
+(TryGenerateVectorSearch
+    $scanPrivate
+    $passthrough
+    $vectorCol
+    $distanceCol
+    $distanceExpr
+    $queryVector
+    $limit
+)

--- a/pkg/sql/opt/xform/scan_funcs.go
+++ b/pkg/sql/opt/xform/scan_funcs.go
@@ -39,10 +39,11 @@ import (
 func (c *CustomFuncs) GenerateIndexScans(
 	grp memo.RelExpr, required *physical.Required, scanPrivate *memo.ScanPrivate,
 ) {
-	// Iterate over all non-inverted and non-partial secondary indexes.
+	// Iterate over all non-inverted and non-vector secondary indexes.
 	var pkCols opt.ColSet
 	var iter scanIndexIter
-	iter.Init(c.e.evalCtx, c.e, c.e.mem, &c.im, scanPrivate, nil /* filters */, rejectPrimaryIndex|rejectInvertedIndexes)
+	reject := rejectPrimaryIndex | rejectInvertedIndexes | rejectVectorIndexes
+	iter.Init(c.e.evalCtx, c.e, c.e.mem, &c.im, scanPrivate, nil /* filters */, reject)
 	iter.ForEach(func(index cat.Index, filters memo.FiltersExpr, indexCols opt.ColSet, isCovering bool, constProj memo.ProjectionsExpr) {
 		// The iterator only produces pseudo-partial indexes (the predicate is
 		// true) because no filters are passed to iter.Init to imply a partial

--- a/pkg/sql/opt/xform/scan_index_iter.go
+++ b/pkg/sql/opt/xform/scan_index_iter.go
@@ -39,6 +39,12 @@ const (
 	// rejectNonPartialIndexes excludes any non-partial indexes during
 	// iteration.
 	rejectNonPartialIndexes
+
+	// rejectVectorIndexes excludes any vector indexes during iteration.
+	rejectVectorIndexes
+
+	// rejectNonVectorIndexes excludes any non-vector indexes during iteration.
+	rejectNonVectorIndexes
 )
 
 // scanIndexIter is a helper struct that facilitates iteration over the indexes
@@ -234,6 +240,16 @@ func (it *scanIndexIter) ForEachStartingAfter(ord int, f enumerateIndexFunc) {
 
 		// Skip over non-inverted indexes if rejectNonInvertedIndexes is set.
 		if it.hasRejectFlags(rejectNonInvertedIndexes) && !index.IsInverted() {
+			continue
+		}
+
+		// Skip over vector indexes if rejectVectorIndexes is set.
+		if it.hasRejectFlags(rejectVectorIndexes) && index.IsVector() {
+			continue
+		}
+
+		// Skip over non-vector indexes if rejectNonVectorIndexes is set.
+		if it.hasRejectFlags(rejectNonVectorIndexes) && !index.IsVector() {
 			continue
 		}
 

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -2365,7 +2365,7 @@ memo (optimized, ~27KB, required=[presentation: w:12] [ordering: +13,+1])
 memo
 INSERT INTO xyz SELECT v, w, 1.0 FROM kuvw ON CONFLICT (x) DO NOTHING
 ----
-memo (optimized, ~28KB, required=[])
+memo (optimized, ~29KB, required=[])
  ├── G1: (insert G2 G3 G4 G5 xyz)
  │    └── []
  │         ├── best: (insert G2 G3 G4 G5 xyz)

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -48,11 +48,16 @@ CREATE TABLE index_tab
     data1 INT NOT NULL,
     data2 INT NOT NULL,
     geom GEOMETRY,
+    vec1 VECTOR(3),
+    vec2 VECTOR(2),
+    vec3 VECTOR(3),
     INDEX a (id, data1, data2),
     INDEX b (val, data1, data2),
     INDEX c (region, data1, data2),
     INDEX d (latitude, longitude, data1, data2),
-    INVERTED INDEX geomIdx(geom)
+    INVERTED INDEX geomIdx(geom),
+    VECTOR INDEX (vec1),
+    VECTOR INDEX (vec2)
 )
 ----
 
@@ -1227,38 +1232,38 @@ limit
  ├── ordering: +6
  ├── union-all
  │    ├── columns: val:2!null data1:6!null
- │    ├── left columns: val:46 data1:50
- │    ├── right columns: val:35 data1:39
+ │    ├── left columns: val:58 data1:62
+ │    ├── right columns: val:44 data1:48
  │    ├── cardinality: [0 - 30]
  │    ├── ordering: +6
  │    ├── limit hint: 10.00
  │    ├── union-all
- │    │    ├── columns: val:46!null data1:50!null
- │    │    ├── left columns: val:13 data1:17
- │    │    ├── right columns: val:24 data1:28
+ │    │    ├── columns: val:58!null data1:62!null
+ │    │    ├── left columns: val:16 data1:20
+ │    │    ├── right columns: val:30 data1:34
  │    │    ├── cardinality: [0 - 20]
- │    │    ├── ordering: +50
+ │    │    ├── ordering: +62
  │    │    ├── limit hint: 10.00
  │    │    ├── scan index_tab@b
- │    │    │    ├── columns: val:13!null data1:17!null
- │    │    │    ├── constraint: /13/17/18/12: [/1 - /1]
+ │    │    │    ├── columns: val:16!null data1:20!null
+ │    │    │    ├── constraint: /16/20/21/15: [/1 - /1]
  │    │    │    ├── limit: 10
- │    │    │    ├── fd: ()-->(13)
- │    │    │    ├── ordering: +17 opt(13) [actual: +17]
+ │    │    │    ├── fd: ()-->(16)
+ │    │    │    ├── ordering: +20 opt(16) [actual: +20]
  │    │    │    └── limit hint: 10.00
  │    │    └── scan index_tab@b
- │    │         ├── columns: val:24!null data1:28!null
- │    │         ├── constraint: /24/28/29/23: [/2 - /2]
+ │    │         ├── columns: val:30!null data1:34!null
+ │    │         ├── constraint: /30/34/35/29: [/2 - /2]
  │    │         ├── limit: 10
- │    │         ├── fd: ()-->(24)
- │    │         ├── ordering: +28 opt(24) [actual: +28]
+ │    │         ├── fd: ()-->(30)
+ │    │         ├── ordering: +34 opt(30) [actual: +34]
  │    │         └── limit hint: 10.00
  │    └── scan index_tab@b
- │         ├── columns: val:35!null data1:39!null
- │         ├── constraint: /35/39/40/34: [/3 - /3]
+ │         ├── columns: val:44!null data1:48!null
+ │         ├── constraint: /44/48/49/43: [/3 - /3]
  │         ├── limit: 10
- │         ├── fd: ()-->(35)
- │         ├── ordering: +39 opt(35) [actual: +39]
+ │         ├── fd: ()-->(44)
+ │         ├── ordering: +48 opt(44) [actual: +48]
  │         └── limit hint: 10.00
  └── 10
 
@@ -1267,10 +1272,10 @@ opt expect=SplitLimitedScanIntoUnionScans
 SELECT max(data1) FROM index_tab WHERE region = 'US_EAST' OR region = 'US_WEST'
 ----
 scalar-group-by
- ├── columns: max:12
+ ├── columns: max:15
  ├── cardinality: [1 - 1]
  ├── key: ()
- ├── fd: ()-->(12)
+ ├── fd: ()-->(15)
  ├── limit
  │    ├── columns: region:3!null data1:6!null
  │    ├── internal-ordering: -6
@@ -1279,28 +1284,28 @@ scalar-group-by
  │    ├── fd: ()-->(3,6)
  │    ├── union-all
  │    │    ├── columns: region:3!null data1:6!null
- │    │    ├── left columns: region:15 data1:18
- │    │    ├── right columns: region:26 data1:29
+ │    │    ├── left columns: region:18 data1:21
+ │    │    ├── right columns: region:32 data1:35
  │    │    ├── cardinality: [0 - 2]
  │    │    ├── ordering: -6
  │    │    ├── limit hint: 1.00
  │    │    ├── scan index_tab@c,rev
- │    │    │    ├── columns: region:15!null data1:18!null
- │    │    │    ├── constraint: /15/18/19/13: [/'US_EAST' - /'US_EAST']
+ │    │    │    ├── columns: region:18!null data1:21!null
+ │    │    │    ├── constraint: /18/21/22/16: [/'US_EAST' - /'US_EAST']
  │    │    │    ├── limit: 1(rev)
  │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(15,18)
+ │    │    │    ├── fd: ()-->(18,21)
  │    │    │    └── limit hint: 1.00
  │    │    └── scan index_tab@c,rev
- │    │         ├── columns: region:26!null data1:29!null
- │    │         ├── constraint: /26/29/30/24: [/'US_WEST' - /'US_WEST']
+ │    │         ├── columns: region:32!null data1:35!null
+ │    │         ├── constraint: /32/35/36/30: [/'US_WEST' - /'US_WEST']
  │    │         ├── limit: 1(rev)
  │    │         ├── key: ()
- │    │         ├── fd: ()-->(26,29)
+ │    │         ├── fd: ()-->(32,35)
  │    │         └── limit hint: 1.00
  │    └── 1
  └── aggregations
-      └── const-agg [as=max:12, outer=(6)]
+      └── const-agg [as=max:15, outer=(6)]
            └── data1:6
 
 # Case with multi-column keys in single-key spans.
@@ -1310,10 +1315,10 @@ FROM index_tab
 WHERE (latitude, longitude) = (1, 2) OR (latitude, longitude) = (4, 5)
 ----
 scalar-group-by
- ├── columns: max:12
+ ├── columns: max:15
  ├── cardinality: [1 - 1]
  ├── key: ()
- ├── fd: ()-->(12)
+ ├── fd: ()-->(15)
  ├── limit
  │    ├── columns: latitude:4!null longitude:5!null data1:6!null
  │    ├── internal-ordering: -6
@@ -1322,28 +1327,28 @@ scalar-group-by
  │    ├── fd: ()-->(4-6)
  │    ├── union-all
  │    │    ├── columns: latitude:4!null longitude:5!null data1:6!null
- │    │    ├── left columns: latitude:16 longitude:17 data1:18
- │    │    ├── right columns: latitude:27 longitude:28 data1:29
+ │    │    ├── left columns: latitude:19 longitude:20 data1:21
+ │    │    ├── right columns: latitude:33 longitude:34 data1:35
  │    │    ├── cardinality: [0 - 2]
  │    │    ├── ordering: -6
  │    │    ├── limit hint: 1.00
  │    │    ├── scan index_tab@d,rev
- │    │    │    ├── columns: latitude:16!null longitude:17!null data1:18!null
- │    │    │    ├── constraint: /16/17/18/19/13: [/1/2 - /1/2]
+ │    │    │    ├── columns: latitude:19!null longitude:20!null data1:21!null
+ │    │    │    ├── constraint: /19/20/21/22/16: [/1/2 - /1/2]
  │    │    │    ├── limit: 1(rev)
  │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(16-18)
+ │    │    │    ├── fd: ()-->(19-21)
  │    │    │    └── limit hint: 1.00
  │    │    └── scan index_tab@d,rev
- │    │         ├── columns: latitude:27!null longitude:28!null data1:29!null
- │    │         ├── constraint: /27/28/29/30/24: [/4/5 - /4/5]
+ │    │         ├── columns: latitude:33!null longitude:34!null data1:35!null
+ │    │         ├── constraint: /33/34/35/36/30: [/4/5 - /4/5]
  │    │         ├── limit: 1(rev)
  │    │         ├── key: ()
- │    │         ├── fd: ()-->(27-29)
+ │    │         ├── fd: ()-->(33-35)
  │    │         └── limit hint: 1.00
  │    └── 1
  └── aggregations
-      └── const-agg [as=max:12, outer=(6)]
+      └── const-agg [as=max:15, outer=(6)]
            └── data1:6
 
 # Case with countable multi-key spans.
@@ -1351,10 +1356,10 @@ opt expect=SplitLimitedScanIntoUnionScans
 SELECT max(data1) FROM index_tab WHERE val > 0 AND val < 4
 ----
 scalar-group-by
- ├── columns: max:12
+ ├── columns: max:15
  ├── cardinality: [1 - 1]
  ├── key: ()
- ├── fd: ()-->(12)
+ ├── fd: ()-->(15)
  ├── limit
  │    ├── columns: val:2!null data1:6!null
  │    ├── internal-ordering: -6
@@ -1363,42 +1368,42 @@ scalar-group-by
  │    ├── fd: ()-->(2,6)
  │    ├── union-all
  │    │    ├── columns: val:2!null data1:6!null
- │    │    ├── left columns: val:47 data1:51
- │    │    ├── right columns: val:36 data1:40
+ │    │    ├── left columns: val:59 data1:63
+ │    │    ├── right columns: val:45 data1:49
  │    │    ├── cardinality: [0 - 3]
  │    │    ├── ordering: -6
  │    │    ├── limit hint: 1.00
  │    │    ├── union-all
- │    │    │    ├── columns: val:47!null data1:51!null
- │    │    │    ├── left columns: val:14 data1:18
- │    │    │    ├── right columns: val:25 data1:29
+ │    │    │    ├── columns: val:59!null data1:63!null
+ │    │    │    ├── left columns: val:17 data1:21
+ │    │    │    ├── right columns: val:31 data1:35
  │    │    │    ├── cardinality: [0 - 2]
- │    │    │    ├── ordering: -51
+ │    │    │    ├── ordering: -63
  │    │    │    ├── limit hint: 1.00
  │    │    │    ├── scan index_tab@b,rev
- │    │    │    │    ├── columns: val:14!null data1:18!null
- │    │    │    │    ├── constraint: /14/18/19/13: [/1 - /1]
+ │    │    │    │    ├── columns: val:17!null data1:21!null
+ │    │    │    │    ├── constraint: /17/21/22/16: [/1 - /1]
  │    │    │    │    ├── limit: 1(rev)
  │    │    │    │    ├── key: ()
- │    │    │    │    ├── fd: ()-->(14,18)
+ │    │    │    │    ├── fd: ()-->(17,21)
  │    │    │    │    └── limit hint: 1.00
  │    │    │    └── scan index_tab@b,rev
- │    │    │         ├── columns: val:25!null data1:29!null
- │    │    │         ├── constraint: /25/29/30/24: [/2 - /2]
+ │    │    │         ├── columns: val:31!null data1:35!null
+ │    │    │         ├── constraint: /31/35/36/30: [/2 - /2]
  │    │    │         ├── limit: 1(rev)
  │    │    │         ├── key: ()
- │    │    │         ├── fd: ()-->(25,29)
+ │    │    │         ├── fd: ()-->(31,35)
  │    │    │         └── limit hint: 1.00
  │    │    └── scan index_tab@b,rev
- │    │         ├── columns: val:36!null data1:40!null
- │    │         ├── constraint: /36/40/41/35: [/3 - /3]
+ │    │         ├── columns: val:45!null data1:49!null
+ │    │         ├── constraint: /45/49/50/44: [/3 - /3]
  │    │         ├── limit: 1(rev)
  │    │         ├── key: ()
- │    │         ├── fd: ()-->(36,40)
+ │    │         ├── fd: ()-->(45,49)
  │    │         └── limit hint: 1.00
  │    └── 1
  └── aggregations
-      └── const-agg [as=max:12, outer=(6)]
+      └── const-agg [as=max:15, outer=(6)]
            └── data1:6
 
 # Case with limit ordering on more than one column.
@@ -1416,24 +1421,24 @@ limit
  ├── ordering: +6,+7
  ├── union-all
  │    ├── columns: region:3!null data1:6!null data2:7!null
- │    ├── left columns: region:14 data1:17 data2:18
- │    ├── right columns: region:25 data1:28 data2:29
+ │    ├── left columns: region:17 data1:20 data2:21
+ │    ├── right columns: region:31 data1:34 data2:35
  │    ├── cardinality: [0 - 20]
  │    ├── ordering: +6,+7
  │    ├── limit hint: 10.00
  │    ├── scan index_tab@c
- │    │    ├── columns: region:14!null data1:17!null data2:18!null
- │    │    ├── constraint: /14/17/18/12: [/'US_EAST' - /'US_EAST']
+ │    │    ├── columns: region:17!null data1:20!null data2:21!null
+ │    │    ├── constraint: /17/20/21/15: [/'US_EAST' - /'US_EAST']
  │    │    ├── limit: 10
- │    │    ├── fd: ()-->(14)
- │    │    ├── ordering: +17,+18 opt(14) [actual: +17,+18]
+ │    │    ├── fd: ()-->(17)
+ │    │    ├── ordering: +20,+21 opt(17) [actual: +20,+21]
  │    │    └── limit hint: 10.00
  │    └── scan index_tab@c
- │         ├── columns: region:25!null data1:28!null data2:29!null
- │         ├── constraint: /25/28/29/23: [/'US_WEST' - /'US_WEST']
+ │         ├── columns: region:31!null data1:34!null data2:35!null
+ │         ├── constraint: /31/34/35/29: [/'US_WEST' - /'US_WEST']
  │         ├── limit: 10
- │         ├── fd: ()-->(25)
- │         ├── ordering: +28,+29 opt(25) [actual: +28,+29]
+ │         ├── fd: ()-->(31)
+ │         ├── ordering: +34,+35 opt(31) [actual: +34,+35]
  │         └── limit hint: 10.00
  └── 10
 
@@ -1453,24 +1458,24 @@ limit
  ├── ordering: +6,+7
  ├── union-all
  │    ├── columns: region:3!null data1:6!null data2:7!null
- │    ├── left columns: region:14 data1:17 data2:18
- │    ├── right columns: region:25 data1:28 data2:29
+ │    ├── left columns: region:17 data1:20 data2:21
+ │    ├── right columns: region:31 data1:34 data2:35
  │    ├── cardinality: [0 - 20]
  │    ├── ordering: +6,+7
  │    ├── limit hint: 10.00
  │    ├── scan index_tab@c
- │    │    ├── columns: region:14!null data1:17!null data2:18!null
- │    │    ├── constraint: /14/17/18/12: [/'US_EAST'/4 - /'US_EAST']
+ │    │    ├── columns: region:17!null data1:20!null data2:21!null
+ │    │    ├── constraint: /17/20/21/15: [/'US_EAST'/4 - /'US_EAST']
  │    │    ├── limit: 10
- │    │    ├── fd: ()-->(14)
- │    │    ├── ordering: +17,+18 opt(14) [actual: +17,+18]
+ │    │    ├── fd: ()-->(17)
+ │    │    ├── ordering: +20,+21 opt(17) [actual: +20,+21]
  │    │    └── limit hint: 10.00
  │    └── scan index_tab@c
- │         ├── columns: region:25!null data1:28!null data2:29!null
- │         ├── constraint: /25/28/29/23: [/'US_WEST'/4 - /'US_WEST']
+ │         ├── columns: region:31!null data1:34!null data2:35!null
+ │         ├── constraint: /31/34/35/29: [/'US_WEST'/4 - /'US_WEST']
  │         ├── limit: 10
- │         ├── fd: ()-->(25)
- │         ├── ordering: +28,+29 opt(25) [actual: +28,+29]
+ │         ├── fd: ()-->(31)
+ │         ├── ordering: +34,+35 opt(31) [actual: +34,+35]
  │         └── limit hint: 10.00
  └── 10
 
@@ -1490,24 +1495,24 @@ limit
  ├── ordering: +6,+7
  ├── union-all
  │    ├── columns: region:3!null data1:6!null data2:7!null
- │    ├── left columns: region:14 data1:17 data2:18
- │    ├── right columns: region:25 data1:28 data2:29
+ │    ├── left columns: region:17 data1:20 data2:21
+ │    ├── right columns: region:31 data1:34 data2:35
  │    ├── cardinality: [0 - 20]
  │    ├── ordering: +6,+7
  │    ├── limit hint: 10.00
  │    ├── scan index_tab@c
- │    │    ├── columns: region:14!null data1:17!null data2:18!null
- │    │    ├── constraint: /14/17/18/12: [/'US_EAST' - /'US_EAST'/2]
+ │    │    ├── columns: region:17!null data1:20!null data2:21!null
+ │    │    ├── constraint: /17/20/21/15: [/'US_EAST' - /'US_EAST'/2]
  │    │    ├── limit: 10
- │    │    ├── fd: ()-->(14)
- │    │    ├── ordering: +17,+18 opt(14) [actual: +17,+18]
+ │    │    ├── fd: ()-->(17)
+ │    │    ├── ordering: +20,+21 opt(17) [actual: +20,+21]
  │    │    └── limit hint: 10.00
  │    └── scan index_tab@c
- │         ├── columns: region:25!null data1:28!null data2:29!null
- │         ├── constraint: /25/28/29/23: [/'US_WEST' - /'US_WEST'/2]
+ │         ├── columns: region:31!null data1:34!null data2:35!null
+ │         ├── constraint: /31/34/35/29: [/'US_WEST' - /'US_WEST'/2]
  │         ├── limit: 10
- │         ├── fd: ()-->(25)
- │         ├── ordering: +28,+29 opt(25) [actual: +28,+29]
+ │         ├── fd: ()-->(31)
+ │         ├── ordering: +34,+35 opt(31) [actual: +34,+35]
  │         └── limit hint: 10.00
  └── 10
 
@@ -1528,24 +1533,24 @@ limit
  ├── ordering: +6,+7
  ├── union-all
  │    ├── columns: region:3!null data1:6!null data2:7!null
- │    ├── left columns: region:14 data1:17 data2:18
- │    ├── right columns: region:25 data1:28 data2:29
+ │    ├── left columns: region:17 data1:20 data2:21
+ │    ├── right columns: region:31 data1:34 data2:35
  │    ├── cardinality: [0 - 20]
  │    ├── ordering: +6,+7
  │    ├── limit hint: 10.00
  │    ├── scan index_tab@c
- │    │    ├── columns: region:14!null data1:17!null data2:18!null
- │    │    ├── constraint: /14/17/18/12: [/'US_EAST'/4 - /'US_EAST'/999]
+ │    │    ├── columns: region:17!null data1:20!null data2:21!null
+ │    │    ├── constraint: /17/20/21/15: [/'US_EAST'/4 - /'US_EAST'/999]
  │    │    ├── limit: 10
- │    │    ├── fd: ()-->(14)
- │    │    ├── ordering: +17,+18 opt(14) [actual: +17,+18]
+ │    │    ├── fd: ()-->(17)
+ │    │    ├── ordering: +20,+21 opt(17) [actual: +20,+21]
  │    │    └── limit hint: 10.00
  │    └── scan index_tab@c
- │         ├── columns: region:25!null data1:28!null data2:29!null
- │         ├── constraint: /25/28/29/23: [/'US_WEST'/4 - /'US_WEST'/999]
+ │         ├── columns: region:31!null data1:34!null data2:35!null
+ │         ├── constraint: /31/34/35/29: [/'US_WEST'/4 - /'US_WEST'/999]
  │         ├── limit: 10
- │         ├── fd: ()-->(25)
- │         ├── ordering: +28,+29 opt(25) [actual: +28,+29]
+ │         ├── fd: ()-->(31)
+ │         ├── ordering: +34,+35 opt(31) [actual: +34,+35]
  │         └── limit hint: 10.00
  └── 10
 
@@ -1568,36 +1573,36 @@ top-k
  ├── ordering: +6,+7
  └── union-all
       ├── columns: latitude:4!null longitude:5 data1:6!null data2:7!null
-      ├── left columns: latitude:81 longitude:82 data1:83 data2:84
-      ├── right columns: latitude:92 longitude:93 data1:94 data2:95
+      ├── left columns: latitude:102 longitude:103 data1:104 data2:105
+      ├── right columns: latitude:116 longitude:117 data1:118 data2:119
       ├── union-all
-      │    ├── columns: latitude:81!null longitude:82!null data1:83!null data2:84!null
-      │    ├── left columns: latitude:70 longitude:71 data1:72 data2:73
-      │    ├── right columns: latitude:59 longitude:60 data1:61 data2:62
+      │    ├── columns: latitude:102!null longitude:103!null data1:104!null data2:105!null
+      │    ├── left columns: latitude:88 longitude:89 data1:90 data2:91
+      │    ├── right columns: latitude:74 longitude:75 data1:76 data2:77
       │    ├── cardinality: [0 - 30]
       │    ├── union-all
-      │    │    ├── columns: latitude:70!null longitude:71!null data1:72!null data2:73!null
-      │    │    ├── left columns: latitude:37 longitude:38 data1:39 data2:40
-      │    │    ├── right columns: latitude:48 longitude:49 data1:50 data2:51
+      │    │    ├── columns: latitude:88!null longitude:89!null data1:90!null data2:91!null
+      │    │    ├── left columns: latitude:46 longitude:47 data1:48 data2:49
+      │    │    ├── right columns: latitude:60 longitude:61 data1:62 data2:63
       │    │    ├── cardinality: [0 - 20]
       │    │    ├── scan index_tab@d
-      │    │    │    ├── columns: latitude:37!null longitude:38!null data1:39!null data2:40!null
-      │    │    │    ├── constraint: /37/38/39/40/34: [/10/11 - /10/11]
+      │    │    │    ├── columns: latitude:46!null longitude:47!null data1:48!null data2:49!null
+      │    │    │    ├── constraint: /46/47/48/49/43: [/10/11 - /10/11]
       │    │    │    ├── limit: 10
-      │    │    │    └── fd: ()-->(37,38)
+      │    │    │    └── fd: ()-->(46,47)
       │    │    └── scan index_tab@d
-      │    │         ├── columns: latitude:48!null longitude:49!null data1:50!null data2:51!null
-      │    │         ├── constraint: /48/49/50/51/45: [/10/12 - /10/12]
+      │    │         ├── columns: latitude:60!null longitude:61!null data1:62!null data2:63!null
+      │    │         ├── constraint: /60/61/62/63/57: [/10/12 - /10/12]
       │    │         ├── limit: 10
-      │    │         └── fd: ()-->(48,49)
+      │    │         └── fd: ()-->(60,61)
       │    └── scan index_tab@d
-      │         ├── columns: latitude:59!null longitude:60!null data1:61!null data2:62!null
-      │         ├── constraint: /59/60/61/62/56: [/10/13 - /10/13]
+      │         ├── columns: latitude:74!null longitude:75!null data1:76!null data2:77!null
+      │         ├── constraint: /74/75/76/77/71: [/10/13 - /10/13]
       │         ├── limit: 10
-      │         └── fd: ()-->(59,60)
+      │         └── fd: ()-->(74,75)
       └── scan index_tab@d
-           ├── columns: latitude:92!null longitude:93 data1:94!null data2:95!null
-           └── constraint: /92/93/94/95/89
+           ├── columns: latitude:116!null longitude:117 data1:118!null data2:119!null
+           └── constraint: /116/117/118/119/113
                 ├── [/-5 - /-5]
                 └── [/0 - /0]
 
@@ -1608,10 +1613,10 @@ FROM index_tab WHERE region = 'US_WEST' OR region = 'US_EAST'
 ORDER BY data1 LIMIT 10
 ----
 index-join index_tab
- ├── columns: id:1!null val:2 region:3!null latitude:4 longitude:5 data1:6!null data2:7!null geom:8
+ ├── columns: id:1!null val:2 region:3!null latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
  ├── cardinality: [0 - 10]
  ├── key: (1)
- ├── fd: (1)-->(2-8)
+ ├── fd: (1)-->(2-11)
  ├── ordering: +6
  └── limit
       ├── columns: id:1!null region:3!null data1:6!null data2:7!null
@@ -1622,26 +1627,26 @@ index-join index_tab
       ├── ordering: +6
       ├── union-all
       │    ├── columns: id:1!null region:3!null data1:6!null data2:7!null
-      │    ├── left columns: id:12 region:14 data1:17 data2:18
-      │    ├── right columns: id:23 region:25 data1:28 data2:29
+      │    ├── left columns: id:15 region:17 data1:20 data2:21
+      │    ├── right columns: id:29 region:31 data1:34 data2:35
       │    ├── cardinality: [0 - 20]
       │    ├── ordering: +6
       │    ├── limit hint: 10.00
       │    ├── scan index_tab@c
-      │    │    ├── columns: id:12!null region:14!null data1:17!null data2:18!null
-      │    │    ├── constraint: /14/17/18/12: [/'US_EAST' - /'US_EAST']
+      │    │    ├── columns: id:15!null region:17!null data1:20!null data2:21!null
+      │    │    ├── constraint: /17/20/21/15: [/'US_EAST' - /'US_EAST']
       │    │    ├── limit: 10
-      │    │    ├── key: (12)
-      │    │    ├── fd: ()-->(14), (12)-->(17,18)
-      │    │    ├── ordering: +17 opt(14) [actual: +17]
+      │    │    ├── key: (15)
+      │    │    ├── fd: ()-->(17), (15)-->(20,21)
+      │    │    ├── ordering: +20 opt(17) [actual: +20]
       │    │    └── limit hint: 10.00
       │    └── scan index_tab@c
-      │         ├── columns: id:23!null region:25!null data1:28!null data2:29!null
-      │         ├── constraint: /25/28/29/23: [/'US_WEST' - /'US_WEST']
+      │         ├── columns: id:29!null region:31!null data1:34!null data2:35!null
+      │         ├── constraint: /31/34/35/29: [/'US_WEST' - /'US_WEST']
       │         ├── limit: 10
-      │         ├── key: (23)
-      │         ├── fd: ()-->(25), (23)-->(28,29)
-      │         ├── ordering: +28 opt(25) [actual: +28]
+      │         ├── key: (29)
+      │         ├── fd: ()-->(31), (29)-->(34,35)
+      │         ├── ordering: +34 opt(31) [actual: +34]
       │         └── limit hint: 10.00
       └── 10
 
@@ -1786,26 +1791,26 @@ limit
  ├── ordering: +5
  ├── union-all
  │    ├── columns: id:1!null latitude:4!null longitude:5!null
- │    ├── left columns: id:12 latitude:15 longitude:16
- │    ├── right columns: id:23 latitude:26 longitude:27
+ │    ├── left columns: id:15 latitude:18 longitude:19
+ │    ├── right columns: id:29 latitude:32 longitude:33
  │    ├── cardinality: [0 - 20]
  │    ├── ordering: +5
  │    ├── limit hint: 10.00
  │    ├── scan index_tab@d
- │    │    ├── columns: id:12!null latitude:15!null longitude:16!null
- │    │    ├── constraint: /15/16/17/18/12: (/0/NULL - /0]
+ │    │    ├── columns: id:15!null latitude:18!null longitude:19!null
+ │    │    ├── constraint: /18/19/20/21/15: (/0/NULL - /0]
  │    │    ├── limit: 10
- │    │    ├── key: (12)
- │    │    ├── fd: ()-->(15), (12)-->(16)
- │    │    ├── ordering: +16 opt(15) [actual: +16]
+ │    │    ├── key: (15)
+ │    │    ├── fd: ()-->(18), (15)-->(19)
+ │    │    ├── ordering: +19 opt(18) [actual: +19]
  │    │    └── limit hint: 10.00
  │    └── scan index_tab@d
- │         ├── columns: id:23!null latitude:26!null longitude:27!null
- │         ├── constraint: /26/27/28/29/23: (/10/NULL - /10]
+ │         ├── columns: id:29!null latitude:32!null longitude:33!null
+ │         ├── constraint: /32/33/34/35/29: (/10/NULL - /10]
  │         ├── limit: 10
- │         ├── key: (23)
- │         ├── fd: ()-->(26), (23)-->(27)
- │         ├── ordering: +27 opt(26) [actual: +27]
+ │         ├── key: (29)
+ │         ├── fd: ()-->(32), (29)-->(33)
+ │         ├── ordering: +33 opt(32) [actual: +33]
  │         └── limit hint: 10.00
  └── 10
 
@@ -1841,7 +1846,7 @@ select
  │    ├── columns: geom:8
  │    └── inverted-filter
  │         ├── columns: id:1!null
- │         ├── inverted expression: /11
+ │         ├── inverted expression: /14
  │         │    ├── tight: false, unique: false
  │         │    └── union spans
  │         │         ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
@@ -1851,8 +1856,8 @@ select
  │         │    └── st_intersects('010100000000000000000008400000000000000840', geom:8)
  │         ├── key: (1)
  │         └── scan index_tab@geomidx,inverted
- │              ├── columns: id:1!null geom_inverted_key:11!null
- │              └── inverted constraint: /11/1
+ │              ├── columns: id:1!null geom_inverted_key:14!null
+ │              └── inverted constraint: /14/1
  │                   └── spans
  │                        ├── ["B\xfd\x10\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x10\x00\x00\x00\x00\x00\x00\x00"]
  │                        ├── ["B\xfd\x14\x00\x00\x00\x00\x00\x00\x00", "B\xfd\x14\x00\x00\x00\x00\x00\x00\x00"]
@@ -1865,15 +1870,15 @@ opt expect-not=SplitLimitedScanIntoUnionScans
 SELECT max(data1) FROM index_tab WHERE region > 'US_EAST' AND region < 'US_WEST'
 ----
 scalar-group-by
- ├── columns: max:12
+ ├── columns: max:15
  ├── cardinality: [1 - 1]
  ├── key: ()
- ├── fd: ()-->(12)
+ ├── fd: ()-->(15)
  ├── scan index_tab@c
  │    ├── columns: region:3!null data1:6!null
  │    └── constraint: /3/6/7/1: [/e'US_EAST\x00' - /'US_WEST')
  └── aggregations
-      └── max [as=max:12, outer=(6)]
+      └── max [as=max:15, outer=(6)]
            └── data1:6
 
 # No-op case because the number of keys exceeds maxScanCount.
@@ -1881,15 +1886,15 @@ opt expect-not=SplitLimitedScanIntoUnionScans
 SELECT max(data1) FROM index_tab WHERE val > 0 AND val < 300
 ----
 scalar-group-by
- ├── columns: max:12
+ ├── columns: max:15
  ├── cardinality: [1 - 1]
  ├── key: ()
- ├── fd: ()-->(12)
+ ├── fd: ()-->(15)
  ├── scan index_tab@b
  │    ├── columns: val:2!null data1:6!null
  │    └── constraint: /2/6/7/1: [/1 - /299]
  └── aggregations
-      └── max [as=max:12, outer=(6)]
+      └── max [as=max:15, outer=(6)]
            └── data1:6
 
 # No-op case because the same number of rows would be scanned by the split-up
@@ -1898,10 +1903,10 @@ opt expect-not=SplitLimitedScanIntoUnionScans
 SELECT max(data1) FROM index_tab WHERE id > 0 AND id < 4
 ----
 scalar-group-by
- ├── columns: max:12
+ ├── columns: max:15
  ├── cardinality: [1 - 1]
  ├── key: ()
- ├── fd: ()-->(12)
+ ├── fd: ()-->(15)
  ├── scan index_tab@a
  │    ├── columns: id:1!null data1:6!null
  │    ├── constraint: /1/6/7: [/1 - /3]
@@ -1909,7 +1914,7 @@ scalar-group-by
  │    ├── key: (1)
  │    └── fd: (1)-->(6)
  └── aggregations
-      └── max [as=max:12, outer=(6)]
+      └── max [as=max:15, outer=(6)]
            └── data1:6
 
 # No-op case because the scan is already limited.
@@ -1919,10 +1924,10 @@ FROM (SELECT region, data1 FROM index_tab LIMIT 10)
 WHERE region='ASIA' OR region='AUSTRALIA'
 ----
 scalar-group-by
- ├── columns: max:12
+ ├── columns: max:15
  ├── cardinality: [1 - 1]
  ├── key: ()
- ├── fd: ()-->(12)
+ ├── fd: ()-->(15)
  ├── select
  │    ├── columns: region:3!null data1:6!null
  │    ├── cardinality: [0 - 10]
@@ -1932,7 +1937,7 @@ scalar-group-by
  │    └── filters
  │         └── (region:3 = 'ASIA') OR (region:3 = 'AUSTRALIA') [outer=(3), constraints=(/3: [/'ASIA' - /'ASIA'] [/'AUSTRALIA' - /'AUSTRALIA']; tight)]
  └── aggregations
-      └── max [as=max:12, outer=(6)]
+      └── max [as=max:15, outer=(6)]
            └── data1:6
 
 # No-op case because the limit is negative.
@@ -1964,15 +1969,15 @@ opt expect-not=SplitLimitedScanIntoUnionScans
 SELECT max(data1) FROM index_tab@b
 ----
 scalar-group-by
- ├── columns: max:12
+ ├── columns: max:15
  ├── cardinality: [1 - 1]
  ├── key: ()
- ├── fd: ()-->(12)
+ ├── fd: ()-->(15)
  ├── scan index_tab@b
  │    ├── columns: data1:6!null
  │    └── flags: force-index=b
  └── aggregations
-      └── max [as=max:12, outer=(6)]
+      └── max [as=max:15, outer=(6)]
            └── data1:6
 
 # ---------------------------------------------------
@@ -3479,3 +3484,394 @@ project
       └── array_remove(array_agg:27, NULL) [as=col6s:28, outer=(27), immutable]
 
 # End Regression Test for #93410
+
+# --------------------------------------------------
+# GenerateVectorSearch
+# --------------------------------------------------
+
+opt expect=GenerateVectorSearch
+SELECT * FROM index_tab ORDER BY vec1 <-> '[3,1,2]' LIMIT 1;
+----
+top-k
+ ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11  [hidden: column15:15]
+ ├── internal-ordering: +15
+ ├── k: 1
+ ├── cardinality: [0 - 1]
+ ├── immutable
+ ├── key: ()
+ ├── fd: ()-->(1-11,15)
+ └── project
+      ├── columns: column15:15 id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(2-11), (9)-->(15)
+      ├── index-join index_tab
+      │    ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-11)
+      │    └── vector-search index_tab@index_tab_vec1_idx,vector
+      │         ├── columns: id:1!null
+      │         ├── target nearest neighbors: 1
+      │         ├── key: (1)
+      │         └── '[3,1,2]'
+      └── projections
+           └── vec1:9 <-> '[3,1,2]' [as=column15:15, outer=(9), immutable]
+
+# Case with a limit greater than 1.
+opt expect=GenerateVectorSearch
+SELECT * FROM index_tab ORDER BY vec1 <-> '[3,1,2]' LIMIT 5;
+----
+top-k
+ ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11  [hidden: column15:15]
+ ├── internal-ordering: +15
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-11), (9)-->(15)
+ ├── ordering: +15
+ └── project
+      ├── columns: column15:15 id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(2-11), (9)-->(15)
+      ├── index-join index_tab
+      │    ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-11)
+      │    └── vector-search index_tab@index_tab_vec1_idx,vector
+      │         ├── columns: id:1!null
+      │         ├── target nearest neighbors: 5
+      │         ├── key: (1)
+      │         └── '[3,1,2]'
+      └── projections
+           └── vec1:9 <-> '[3,1,2]' [as=column15:15, outer=(9), immutable]
+
+# Case with a different vector index.
+opt expect=GenerateVectorSearch
+SELECT * FROM index_tab ORDER BY vec2 <-> '[3,1,2]' LIMIT 5;
+----
+top-k
+ ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11  [hidden: column15:15]
+ ├── internal-ordering: +15
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-11), (10)-->(15)
+ ├── ordering: +15
+ └── project
+      ├── columns: column15:15 id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(2-11), (10)-->(15)
+      ├── index-join index_tab
+      │    ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-11)
+      │    └── vector-search index_tab@index_tab_vec2_idx,vector
+      │         ├── columns: id:1!null
+      │         ├── target nearest neighbors: 5
+      │         ├── key: (1)
+      │         └── '[3,1,2]'
+      └── projections
+           └── vec2:10 <-> '[3,1,2]' [as=column15:15, outer=(10), immutable]
+
+# Case with a subset of table columns requested.
+opt expect=GenerateVectorSearch
+SELECT id, vec1 FROM index_tab ORDER BY vec1 <-> '[3,1,2]' LIMIT 5;
+----
+top-k
+ ├── columns: id:1!null vec1:9  [hidden: column15:15]
+ ├── internal-ordering: +15
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(9), (9)-->(15)
+ ├── ordering: +15
+ └── project
+      ├── columns: column15:15 id:1!null vec1:9
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(9), (9)-->(15)
+      ├── index-join index_tab
+      │    ├── columns: id:1!null vec1:9
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(9)
+      │    └── vector-search index_tab@index_tab_vec1_idx,vector
+      │         ├── columns: id:1!null
+      │         ├── target nearest neighbors: 5
+      │         ├── key: (1)
+      │         └── '[3,1,2]'
+      └── projections
+           └── vec1:9 <-> '[3,1,2]' [as=column15:15, outer=(9), immutable]
+
+# Case with a placeholder vector.
+opt expect=GenerateVectorSearch
+SELECT * FROM index_tab ORDER BY vec1 <-> $1 LIMIT 5;
+----
+top-k
+ ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11  [hidden: column15:15]
+ ├── internal-ordering: +15
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable, has-placeholder
+ ├── key: (1)
+ ├── fd: (1)-->(2-11), (9)-->(15)
+ ├── ordering: +15
+ └── project
+      ├── columns: column15:15 id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      ├── immutable, has-placeholder
+      ├── key: (1)
+      ├── fd: (1)-->(2-11), (9)-->(15)
+      ├── index-join index_tab
+      │    ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      │    ├── has-placeholder
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-11)
+      │    └── vector-search index_tab@index_tab_vec1_idx,vector
+      │         ├── columns: id:1!null
+      │         ├── target nearest neighbors: 5
+      │         ├── has-placeholder
+      │         ├── key: (1)
+      │         └── $1
+      └── projections
+           └── vec1:9 <-> $1 [as=column15:15, outer=(9), immutable]
+
+# The index can be forced.
+opt expect=GenerateVectorSearch
+SELECT * FROM index_tab@index_tab_vec2_idx ORDER BY vec2 <-> '[3,1,2]' LIMIT 500;
+----
+top-k
+ ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11  [hidden: column15:15]
+ ├── internal-ordering: +15
+ ├── k: 500
+ ├── cardinality: [0 - 500]
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-11), (10)-->(15)
+ ├── ordering: +15
+ └── project
+      ├── columns: column15:15 id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(2-11), (10)-->(15)
+      ├── index-join index_tab
+      │    ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-11)
+      │    └── vector-search index_tab@index_tab_vec2_idx,vector
+      │         ├── columns: id:1!null
+      │         ├── target nearest neighbors: 500
+      │         ├── key: (1)
+      │         └── '[3,1,2]'
+      └── projections
+           └── vec2:10 <-> '[3,1,2]' [as=column15:15, outer=(10), immutable]
+
+# Forcing a different index prevents using the vector index.
+opt expect-not=GenerateVectorSearch
+SELECT * FROM index_tab@primary ORDER BY vec1 <-> '[3,1,2]' LIMIT 5;
+----
+top-k
+ ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11  [hidden: column15:15]
+ ├── internal-ordering: +15
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-11), (9)-->(15)
+ ├── ordering: +15
+ └── project
+      ├── columns: column15:15 id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(2-11), (9)-->(15)
+      ├── scan index_tab
+      │    ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      │    ├── flags: force-index=index_tab_pkey
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2-11)
+      └── projections
+           └── vec1:9 <-> '[3,1,2]' [as=column15:15, outer=(9), immutable]
+
+# No-op case with an un-indexed vector column.
+opt expect-not=GenerateVectorSearch
+SELECT * FROM index_tab ORDER BY vec3 <-> '[3,1,2]' LIMIT 5;
+----
+top-k
+ ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11  [hidden: column15:15]
+ ├── internal-ordering: +15
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-11), (11)-->(15)
+ ├── ordering: +15
+ └── project
+      ├── columns: column15:15 id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(2-11), (11)-->(15)
+      ├── scan index_tab
+      │    ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2-11)
+      └── projections
+           └── vec3:11 <-> '[3,1,2]' [as=column15:15, outer=(11), immutable]
+
+# No-op case without a limit.
+opt expect-not=GenerateVectorSearch
+SELECT * FROM index_tab ORDER BY vec1 <-> '[3,1,2]';
+----
+sort
+ ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11  [hidden: column15:15]
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-11), (9)-->(15)
+ ├── ordering: +15
+ └── project
+      ├── columns: column15:15 id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(2-11), (9)-->(15)
+      ├── scan index_tab
+      │    ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2-11)
+      └── projections
+           └── vec1:9 <-> '[3,1,2]' [as=column15:15, outer=(9), immutable]
+
+# No-op case without an ordering.
+opt expect-not=GenerateVectorSearch
+SELECT * FROM index_tab LIMIT 5;
+----
+scan index_tab
+ ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+ ├── limit: 5
+ ├── key: (1)
+ └── fd: (1)-->(2-11)
+
+# No-op case with an ordering on a non-vector column.
+opt expect-not=GenerateVectorSearch
+SELECT * FROM index_tab ORDER BY id LIMIT 5;
+----
+scan index_tab
+ ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+ ├── limit: 5
+ ├── key: (1)
+ ├── fd: (1)-->(2-11)
+ └── ordering: +1
+
+# No-op case with an ordering on an additional column.
+# TODO(drewk, mw5h): support this case.
+opt expect-not=GenerateVectorSearch
+SELECT * FROM index_tab ORDER BY vec1 <-> '[3,1,2]', id LIMIT 5;
+----
+top-k
+ ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11  [hidden: column15:15]
+ ├── internal-ordering: +15,+1
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-11), (9)-->(15)
+ ├── ordering: +15,+1
+ └── project
+      ├── columns: column15:15 id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(2-11), (9)-->(15)
+      ├── scan index_tab
+      │    ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2-11)
+      └── projections
+           └── vec1:9 <-> '[3,1,2]' [as=column15:15, outer=(9), immutable]
+
+# The query vector must be a constant or placeholder.
+opt expect-not=GenerateVectorSearch
+SELECT * FROM index_tab ORDER BY vec1 <-> (SELECT '[3,1,2]'::VECTOR(3) FROM a LIMIT 1) LIMIT 5;
+----
+top-k
+ ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11  [hidden: column23:23]
+ ├── internal-ordering: +23
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-11,23)
+ ├── ordering: +23
+ └── project
+      ├── columns: column23:23 id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(2-11,23)
+      ├── scan index_tab
+      │    ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2-11)
+      └── projections
+           └── vector-distance [as=column23:23, outer=(9), immutable, subquery]
+                ├── vec1:9
+                └── subquery
+                     └── project
+                          ├── columns: vector:22!null
+                          ├── cardinality: [0 - 1]
+                          ├── key: ()
+                          ├── fd: ()-->(22)
+                          ├── scan a@s_idx
+                          │    ├── limit: 1
+                          │    └── key: ()
+                          └── projections
+                               └── '[3,1,2]' [as=vector:22]
+
+opt expect-not=GenerateVectorSearch
+SELECT * FROM index_tab ORDER BY vec1 <-> vec2 LIMIT 5;
+----
+top-k
+ ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11  [hidden: column15:15]
+ ├── internal-ordering: +15
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-11), (9,10)-->(15)
+ ├── ordering: +15
+ └── project
+      ├── columns: column15:15 id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(2-11), (9,10)-->(15)
+      ├── scan index_tab
+      │    ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2-11)
+      └── projections
+           └── vec1:9 <-> vec2:10 [as=column15:15, outer=(9,10), immutable]
+
+# Currently, the vector column must be the left argument.
+# TODO(drewk, mw5h): add a normalization rule to flip the args.
+opt expect-not=GenerateVectorSearch
+SELECT * FROM index_tab ORDER BY '[3,1,2]' <-> vec1 LIMIT 5;
+----
+top-k
+ ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11  [hidden: column15:15]
+ ├── internal-ordering: +15
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-11), (9)-->(15)
+ ├── ordering: +15
+ └── project
+      ├── columns: column15:15 id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(2-11), (9)-->(15)
+      ├── scan index_tab
+      │    ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2-11)
+      └── projections
+           └── '[3,1,2]' <-> vec1:9 [as=column15:15, outer=(9), immutable]


### PR DESCRIPTION
#### sql/opt: implement vector search operators in the optimizer

This commit adds the optimizer representations for two operators that
will be used to support vector indexes:
1. `VectorSearchExpr` is used to search the vector index. It returns a
   set of candidate primary keys, which can be used to retrieve full
   vectors for re-ranking against the query vector.
2. `VectorPartitionSearchExpr` is used to prepare a mutation that
   modifies the vector index. It determines the partition that contains
   (or should contain) each input vector, so that the mutation "knows
   where to look".

The following commits will add optimizer tests for these expressions.

Epic: None
Release note: None

#### sql/opt: plan VectorPartitionSearch operators for mutations

This commit adds the logic that places `VectorPartitionSearch` operators
in the input of a mutation that modifies one or more vector indexes.
The operators are used to determine which partition contains, or should
contain, each vector involved in the mutation.

Epic: None
Release note: None

#### sql/opt: add rule to generate vector search operators

This commit adds the exploration rule `GenerateVectorSearch`, which
matches a `Limit` ordered by the indexed vector column of an input
`Scan` operator. The replacement expression takes the candidate primary
keys returned by the `VectorSearch` operator, and produces a KNN result
by fetching the full vectors, calculating distances to the query vector,
and feeding the result into a top-k operator.

Epic: None
Release note: None