### PR TITLE
kvnemesis: increase the retry backoff for aborted txns

### DIFF
--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -145,7 +145,7 @@ func applyOp(ctx context.Context, env *Env, db *kv.DB, op *Operation) {
 		// epochs of the same transaction to avoid waiting while holding locks.
 		retryOnAbort := retry.StartWithCtx(ctx, retry.Options{
 			InitialBackoff: 1 * time.Millisecond,
-			MaxBackoff:     250 * time.Millisecond,
+			MaxBackoff:     10 * time.Second,
 		})
 		var savedTxn *kv.Txn
 		txnErr := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/pull/135173, we tried introducing a backoff in the transaction retry mechanism (in `db.Txn`) in order to help with large transactions that repeatedly get in a deadlock (as seen in #133431). This wasn't enough as we continue to see this type of failure in #136266.

This commit increases the kvnemesis-specific retry backoff, which is meant to prevent thrashing of aborted transactions. We do see transactions getting aborted as part of deadlock resolution in both of the failures mentioned above, so hopefully this will help. Both failures above are rare and hard to repro.

Fixes: https://github.com/cockroachdb/cockroach/issues/136266

Release note: None