### PR TITLE
kvserver: fix missing RaftTruncatedState in RangeInfo

### DIFF
--- a/pkg/kv/kvserver/kvserverpb/state.proto
+++ b/pkg/kv/kvserver/kvserverpb/state.proto
@@ -204,6 +204,7 @@ message RangeInfo {
   // circuit breaker on the source Replica is tripped.
   string circuit_breaker_error = 20;
   repeated int32 paused_replicas = 21 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.ReplicaID"];
+  // Next tag: 22
 }
 
 // RangeSideTransportInfo describes a range's closed timestamp info communicated

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1705,6 +1705,12 @@ func (r *Replica) State(ctx context.Context) kvserverpb.RangeInfo {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	ri.ReplicaState = *(protoutil.Clone(&r.shMu.state)).(*kvserverpb.ReplicaState)
+	// TODO(#97613): add a dedicated TruncatedState field to RangeInfo when the
+	// TruncatedState field is removed from ReplicaState. We can't do it right now
+	// because the ReplicaState is embedded into RangeInfo, and this confuses the
+	// proto compiler.
+	ri.TruncatedState = (protoutil.Clone(&r.shMu.raftTruncState)).(*kvserverpb.RaftTruncatedState)
+
 	ri.LastIndex = r.shMu.lastIndexNotDurable
 	ri.NumPending = uint64(r.numPendingProposalsRLocked())
 	ri.RaftLogSize = r.shMu.raftLogSize


### PR DESCRIPTION
Fixes #137022
Related to #97613
Epic: none
Release note: none