### PR TITLE
kvcoord: deflake TestDistSenderReplicaStall

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker_test.go
@@ -45,7 +45,7 @@ func TestDistSenderReplicaStall(t *testing.T) {
 		// The lease won't move unless we use expiration-based leases. We also
 		// speed up the test by reducing various intervals and timeouts.
 		st := cluster.MakeTestingClusterSettings()
-		kvserver.ExpirationLeasesOnly.Override(ctx, &st.SV, true)
+		kvserver.OverrideDefaultLeaseType(ctx, &st.SV, roachpb.LeaseExpiration)
 		kvcoord.CircuitBreakersMode.Override(
 			ctx, &st.SV, kvcoord.DistSenderCircuitBreakersAllRanges,
 		)


### PR DESCRIPTION
The test runs with expiration leases but when fortification is enabled the lease doesn't move off of the stalled replica because the deadlocked leader doesn't step down while it's receiving store liveness support.

This commit ensures fortification is off when expiration leases are used for the test.

Fixes: #136564

Release note: None