### PR TITLE
release-23.2: opt: propagate extra columns for lock operators

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/dangerous_statements
+++ b/pkg/sql/logictest/testdata/logic_test/dangerous_statements
@@ -15,3 +15,16 @@ ALTER TABLE foo DROP COLUMN x
 
 statement error rejected.*: SET database to empty string
 SET database = ''
+
+subtest regression_129647
+
+statement ok
+SELECT * FROM (SELECT * FROM foo WHERE x = 2) FOR UPDATE
+
+statement ok
+SELECT * FROM (SELECT * FROM (SELECT * FROM foo) WHERE x = 2) FOR UPDATE
+
+statement ok
+SELECT * FROM (SELECT * FROM (SELECT * FROM foo) WHERE x > 1) WHERE x > 2 FOR UPDATE
+
+subtest end

--- a/pkg/sql/opt/optbuilder/locking.go
+++ b/pkg/sql/opt/optbuilder/locking.go
@@ -263,11 +263,13 @@ func (b *Builder) analyzeLockArgs(
 	lockScope = inScope.push()
 	lockScope.cols = make([]scopeColumn, 0, pkCols.Len())
 
-	for i := range inScope.cols {
-		if pkCols.Contains(inScope.cols[i].id) {
-			lockScope.appendColumn(&inScope.cols[i])
+	// Make sure to check extra columns, since the primary key columns may not
+	// have been explicitly projected.
+	inScope.forEachColWithExtras(func(col *scopeColumn) {
+		if pkCols.Contains(col.id) {
+			lockScope.appendColumn(col)
 		}
-	}
+	})
 	return lockScope
 }
 

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -552,6 +552,17 @@ func (s *scope) colList() opt.ColList {
 	return colList
 }
 
+// forEachColWithExtras applies the given function to every column in the scope,
+// including extra columns.
+func (s *scope) forEachColWithExtras(fn func(col *scopeColumn)) {
+	for i := range s.cols {
+		fn(&s.cols[i])
+	}
+	for i := range s.extraCols {
+		fn(&s.extraCols[i])
+	}
+}
+
 // hasSameColumns returns true if this scope has the same columns
 // as the other scope.
 //


### PR DESCRIPTION
Backport 1/1 commits from #129768.

/cc @cockroachdb/release

---

A lock operator needs access to all primary key columns of the relations it locks. Therefore, all primary key columns should be propagated by a `SELECT` clause with locking even if they weren't explicitly projected. Previously, only explicitly projected columns were considered when handling a nested scope, as for a subquery. This could lead to an internal error when the lock operator did not have access to the expected columns. This commit fixes the bug by propgating all primary key columns, not just explicit ones.

Fixes #129647

Release note (bug fix): Fixed a bug that could cause an internal error if a table with an implicit (rowid) primary key was locked from within a subquery, like this:
```
SELECT * FROM (SELECT * FROM foo WHERE x = 2) FOR UPDATE;
```

---

Release justification: fix for internal error in read-committed