### PR TITLE
roachprod: infer architecture from cloud provider

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -337,19 +337,16 @@ hosts file.
 				return clusterVMs[0].MachineType
 			}
 			cpuArch := func(clusterVMs vm.List) string {
-				// Display CPU architecture and family.
-				if clusterVMs[0].CPUArch == "" {
-					// N.B. Either a local cluster or unsupported cloud provider.
-					return ""
-				}
+				// Building CPU info column to displays "CPU family (CPU arch)"
+				// Arch AMD64 is the default, so don't display it.
+				var archParts []string
 				if clusterVMs[0].CPUFamily != "" {
-					return clusterVMs[0].CPUFamily
+					archParts = append(archParts, clusterVMs[0].CPUFamily)
 				}
 				if clusterVMs[0].CPUArch != vm.ArchAMD64 {
-					return string(clusterVMs[0].CPUArch)
+					archParts = append(archParts, fmt.Sprintf("(%s)", clusterVMs[0].CPUArch))
 				}
-				// AMD64 is the default, so don't display it.
-				return ""
+				return strings.Join(archParts, " ")
 			}
 			// Align columns right and separate with at least two spaces.
 			tw := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', tabwriter.AlignRight)

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -3013,6 +3013,13 @@ func (c *SyncedCluster) WithNodes(nodes Nodes) *SyncedCluster {
 	return &clusterCopy
 }
 
+func (c *SyncedCluster) GetCPUArchitecture(l *logger.Logger) (vm.CPUArch, error) {
+	if len(c.VMs) == 0 {
+		return vm.ArchUnknown, nil
+	}
+	return c.VMs[0].GetCPUArchitecture(l)
+}
+
 // GenFilenameFromArgs given a list of cmd args, returns an alphahumeric string up to
 // `maxLen` in length with hyphen delimiters, suitable for use in a filename.
 // e.g. ["/bin/bash", "-c", "'sudo dmesg > dmesg.txt'"] -> binbash-c-sudo-dmesg

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -592,16 +592,29 @@ func Stage(
 	}
 
 	os := "linux"
-	arch := "amd64"
-
 	if c.IsLocal() {
 		os = runtime.GOOS
-		arch = runtime.GOARCH
 	}
+
+	// Default arch to the CPU architecture of the cluster's first VM
+	// Architecture is determined using:
+	// - AWS & GCP: provider's cloud APIs (a.k.a machine-type describe)
+	// - Azure: hardcoded ARM64 machine-types
+	// - Local: runtime.GOARCH
+	detectedArch, err := c.GetCPUArchitecture(l)
+	if err != nil {
+		l.Printf("WARN: unable to detect remote architecture: %s", err)
+	}
+	arch := string(detectedArch)
+
 	if stageOS != "" {
 		os = stageOS
 	}
 	if stageArch != "" {
+		if stageArch != arch {
+			// Warn if requested arch != cluster arch; should we error out?
+			l.Printf("WARN: specified arch (%s) != cluster arch (%s)", stageArch, arch)
+		}
 		arch = stageArch
 	}
 	// N.B. it's technically possible to stage a binary for a different OS/arch; e.g., emulated amd64 on mac silicon.

--- a/pkg/roachprod/vm/aws/BUILD.bazel
+++ b/pkg/roachprod/vm/aws/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/util/retry",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "@com_github_aws_aws_sdk_go_v2_service_ec2//types",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_spf13_pflag//:pflag",
         "@org_golang_x_sync//errgroup",

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
@@ -259,6 +260,10 @@ type Provider struct {
 
 	// aws accounts to perform action in, used by gcCmd only as it clean ups multiple aws accounts
 	AccountIDs []string
+
+	// ProviderMachineTypeSpecsCache is used to cache specs about machine types.
+	// The primary use case is to get CPU architecture from cloud provider.
+	machineTypeSpecsCache ProviderMachineTypeSpecsCache
 }
 
 func (p *Provider) SupportsSpotVMs() bool {
@@ -670,6 +675,38 @@ func (p *Provider) Create(
 	}
 	if len(regions) < 1 {
 		return errors.Errorf("Please specify a valid region.")
+	}
+
+	// Auto-detect architecture from machine-type, check that it's compatible
+	// with the requested arch (if any), and stores the value in opts.Arch
+	machineTypeArch, err := p.getCPUArchFromMachineType(l, machineType, regions[0], NarrowCacheKey)
+	if err != nil {
+		return errors.Wrapf(
+			err,
+			"unable to infer architecture based on machine type %s in region %s",
+			providerOpts.MachineType,
+			regions[0],
+		)
+	}
+	switch opts.Arch {
+	case "":
+		// No arch requested, default to the one from the machine type
+		opts.Arch = string(machineTypeArch)
+	case string(vm.ArchFIPS):
+		// FIPS requested, this is only supported for x86_64 arch
+		if machineTypeArch != vm.ArchAMD64 {
+			return errors.Errorf(
+				vm.IncompatibleArchRequestError,
+				p.Name(), providerOpts.MachineType, machineTypeArch, opts.Arch,
+			)
+		}
+	default:
+		if machineTypeArch != vm.ParseArch(opts.Arch) {
+			return errors.Errorf(
+				vm.IncompatibleArchRequestError,
+				p.Name(), providerOpts.MachineType, machineTypeArch, opts.Arch,
+			)
+		}
 	}
 
 	// Distribute the nodes amongst availability zones.
@@ -1151,11 +1188,15 @@ func (p *Provider) listRegion(
 				RemoteUser:             opts.RemoteUserName,
 				VPC:                    in.VpcID,
 				MachineType:            in.InstanceType,
-				CPUArch:                vm.ParseArch(in.Architecture),
 				Zone:                   in.Placement.AvailabilityZone,
 				NonBootAttachedVolumes: nonBootableVolumes,
 				Preemptible:            in.InstanceLifecycle == "spot",
 			}
+			cpuArch, err := p.GetVMArchitecture(l, &m)
+			if err != nil {
+				return nil, errors.Wrap(err, "unable to determine the VM CPU architecture")
+			}
+			m.CPUArch = cpuArch
 			ret = append(ret, m)
 		}
 	}
@@ -1254,13 +1295,7 @@ func (p *Provider) runInstance(
 		return *fl
 	}
 	imageID := withFlagOverride(az.Region.AMI_X86_64, &providerOpts.ImageAMI)
-	useArmAMI := strings.Index(machineType, "6g.") == 1 || strings.Index(machineType, "6gd.") == 1 ||
-		strings.Index(machineType, "7g.") == 1 || strings.Index(machineType, "7gd.") == 1
-	if useArmAMI && (opts.Arch != "" && opts.Arch != string(vm.ArchARM64)) {
-		return errors.Errorf("machine type %s is arm64, but requested arch is %s", machineType, opts.Arch)
-	}
-	//TODO(srosenberg): remove this once we have a better way to detect ARM64 machines
-	if useArmAMI {
+	if opts.Arch == string(vm.ArchARM64) {
 		imageID = withFlagOverride(az.Region.AMI_ARM64, &providerOpts.ImageAMI)
 		// N.B. use arbitrary instanceIdx to suppress the same info for every other instance being created.
 		if instanceIdx == 0 {
@@ -1736,4 +1771,139 @@ func (p *Provider) DeleteLoadBalancer(*logger.Logger, vm.List, int) error {
 func (p *Provider) ListLoadBalancers(*logger.Logger, vm.List) ([]vm.ServiceAddress, error) {
 	// This Provider has no concept of load balancers yet, return an empty list.
 	return nil, nil
+}
+
+func (p *Provider) GetVMArchitecture(l *logger.Logger, v *vm.VM) (vm.CPUArch, error) {
+
+	// If VM is tagged with arch FIPS, we use it
+	archLabel, ok := v.Labels["arch"]
+	if ok && archLabel == "fips" {
+		return vm.ArchFIPS, nil
+	}
+
+	// Otherwise, we query the CPU architecture from the machine type
+	az, ok := p.Config.AZByName[v.Zone]
+	if !ok {
+		return vm.ArchUnknown, fmt.Errorf("no region in %v corresponds to availability zone %v",
+			p.Config.regionNames(), v.Zone)
+	}
+
+	return p.getCPUArchFromMachineType(l, v.MachineType, az.Region.Name, WideCacheKey)
+}
+
+func (p *Provider) getCPUArchFromMachineType(
+	l *logger.Logger, machineType, region string, ckl CacheKeyLookup,
+) (vm.CPUArch, error) {
+
+	specs, err := p.getMachineTypeSpecs(l, machineType, region, ckl)
+	if err != nil {
+		return vm.ArchUnknown, errors.Wrapf(err, "unable to get aws instance type specs for %s ", machineType)
+	}
+
+	// If architecture is specified in machine-type struct, let's use it.
+	if len(specs.ProcessorInfo.SupportedArchitectures) == 0 {
+		return vm.ArchUnknown, errors.New("CPU architecture not provided by AWS API")
+	}
+
+	// Some AWS instance types state they support multiple architectures
+	// (e.g. c3 returns 'i386' and 'x86_64'), we gently discard whatever is
+	// unknown, and grab the first one that we manage ('x86_64', in the example).
+	for _, supportedArch := range specs.ProcessorInfo.SupportedArchitectures {
+		parsed := vm.ParseArch(string(supportedArch))
+		if parsed != vm.ArchUnknown {
+			return parsed, nil
+		}
+	}
+
+	return vm.ArchUnknown, nil
+}
+
+func (p *Provider) getMachineTypeSpecs(
+	l *logger.Logger, machineType, region string, ckl CacheKeyLookup,
+) (*MachineTypeSpecs, error) {
+	return p.machineTypeSpecsCache.fetchFromProviderWithCache(l, p, machineType, region, ckl)
+}
+
+type ProviderMachineTypeSpecsCache struct {
+	syncutil.Mutex
+	cache map[string]*MachineTypeSpecs
+}
+
+type MachineTypeSpecs ec2types.InstanceTypeInfo
+
+type CacheKeyLookup string
+
+const (
+	NarrowCacheKey CacheKeyLookup = "NARROW_CACHE_KEY"
+	WideCacheKey   CacheKeyLookup = "WIDE_CACHE_KEY"
+)
+
+// fetchFromProviderWithCache fetches the machine-type's specs from the provider
+// and caches the result to return it on later calls.
+// As the machine type availability depends on the region, the caching of each call
+// happens on both a `WideCacheKey` and a `NarrowCacheKey` cache key. This allows
+// to improve cache hits when the only goal is to get machine type specs (specs
+// are homogeneous across all regions), but also leave the opportunity to the user
+// to make sure that a machine type is available in a specific region by specifying
+// `NarrowCacheKey` and ensure that the result was fetched for this specific region.
+func (mts *ProviderMachineTypeSpecsCache) fetchFromProviderWithCache(
+	l *logger.Logger, p *Provider, machineType, region string, ckl CacheKeyLookup,
+) (*MachineTypeSpecs, error) {
+
+	mts.Lock()
+	defer mts.Unlock()
+
+	if mts.cache == nil {
+		mts.cache = make(map[string]*MachineTypeSpecs)
+	}
+
+	// We require an "{instance-type}-{region}" combination to describe
+	// the instance type (as required by AWS), but store the cached results
+	// under two different keys:
+	// - a narrow one "{instance-type}-{region}"
+	// - a wide one "{instance-type}"
+	// The justification behind this is that instance types are homogeneous
+	// across all regions, so we can increase cache hits when we don't actually
+	// care about the region, but we can also request a narrow cache key when
+	// we want to ensure that this instance type is available in a specific
+	// region.
+	buildCacheKeys := func(machineType, region string) map[CacheKeyLookup]string {
+		return map[CacheKeyLookup]string{
+			WideCacheKey:   machineType,
+			NarrowCacheKey: machineType + "-" + region,
+		}
+	}
+	cacheKeys := buildCacheKeys(machineType, region)
+
+	if cachedSpecs, ok := mts.cache[cacheKeys[ckl]]; ok {
+		return cachedSpecs, nil
+	}
+
+	// Query awscli to get machine-type specs:
+	// Running:
+	// 		aws ec2 describe-instance-types
+	//			--instance-types t4g.medium --region us-east-1
+
+	specs := struct {
+		InstanceTypes []*MachineTypeSpecs
+	}{}
+	args := []string{
+		"ec2",
+		"describe-instance-types",
+		"--instance-types", machineType,
+		"--region", region,
+	}
+	if err := p.runJSONCommand(l, args, &specs); err != nil {
+		return nil, err
+	}
+
+	if len(specs.InstanceTypes) == 0 {
+		return nil, fmt.Errorf("unable to describe instance type %s", machineType)
+	}
+
+	for _, cacheKey := range cacheKeys {
+		mts.cache[cacheKey] = specs.InstanceTypes[0]
+	}
+
+	return specs.InstanceTypes[0], nil
 }

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -645,10 +645,13 @@ func (p *Provider) List(l *logger.Logger, opts vm.ListOptions) (vm.List, error) 
 			RemoteUser:  remoteUser,
 			VPC:         "global",
 			MachineType: string(found.HardwareProfile.VMSize),
-			CPUArch:     CpuArchFromAzureMachineType(string(found.HardwareProfile.VMSize)),
 			// We add a fake availability-zone suffix since other roachprod
 			// code assumes particular formats. For example, "eastus2z".
 			Zone: *found.Location + "z",
+		}
+		m.CPUArch, err = p.GetVMArchitecture(l, &m)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to determine the VM CPU architecture")
 		}
 
 		if createdPtr := found.Tags[vm.TagCreated]; createdPtr == nil {
@@ -762,6 +765,10 @@ func (p *Provider) List(l *logger.Logger, opts vm.ListOptions) (vm.List, error) 
 	}
 
 	return ret, nil
+}
+
+func (p *Provider) GetVMArchitecture(l *logger.Logger, v *vm.VM) (vm.CPUArch, error) {
+	return CpuArchFromAzureMachineType(v.MachineType), nil
 }
 
 // Name implements vm.Provider.

--- a/pkg/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/roachprod/vm/flagstub/flagstub.go
@@ -171,3 +171,8 @@ func (p *provider) ProjectActive(project string) bool {
 func (p *provider) CreateProviderOpts() vm.ProviderOpts {
 	return nil
 }
+
+// GetVMArchitecture is part of the vm.Provider interface.
+func (p *provider) GetVMArchitecture(l *logger.Logger, v *vm.VM) (vm.CPUArch, error) {
+	return vm.ArchUnknown, nil
+}

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -17,6 +17,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/ui"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/flagstub"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/pflag"
@@ -110,6 +112,8 @@ func Init() error {
 	providerInstance.defaultProject = defaultDefaultProject
 	providerInstance.metadataProject = defaultMetadataProject
 	providerInstance.defaultServiceAccount = defaultDefaultServiceAccount
+
+	providerInstance.machineTypeSpecsCache = &ProviderMachineTypeSpecsCache{}
 
 	initialized = true
 	vm.Providers[ProviderName] = providerInstance
@@ -285,8 +289,8 @@ func (jsonVM *jsonVM) toVM(
 		RemoteUser:             remoteUser,
 		VPC:                    vpc,
 		MachineType:            machineType,
-		CPUArch:                vm.ParseArch(cpuPlatform),
 		CPUFamily:              strings.Replace(strings.ToLower(cpuPlatform), "intel ", "", 1),
+		CPUArch:                vm.ArchUnknown, /* Filled in by caller func with the VM struct */
 		Zone:                   zone,
 		Project:                project,
 		NonBootAttachedVolumes: volumes,
@@ -373,6 +377,10 @@ type Provider struct {
 	// The service account to use if the default project is in use and no
 	// ServiceAccount was specified.
 	defaultServiceAccount string
+
+	// ProviderMachineTypeSpecsCache is used to cache specs about machine types.
+	// The primary use case is to get CPU architecture from cloud provider
+	machineTypeSpecsCache *ProviderMachineTypeSpecsCache
 }
 
 // LogEntry represents a single log entry from the gcloud logging(stack driver)
@@ -471,6 +479,225 @@ func (p *Provider) GetVMSpecs(
 		vmSpecs[name] = vmSpec
 	}
 	return vmSpecs, nil
+}
+
+func (p *Provider) GetVMArchitecture(l *logger.Logger, v *vm.VM) (vm.CPUArch, error) {
+
+	// If VM is tagged with arch FIPS, we use it
+	archLabel, ok := v.Labels["arch"]
+	if ok && archLabel == "fips" {
+		return vm.ArchFIPS, nil
+	}
+
+	// Otherwise, we query the CPU architecture from the machine type
+	return p.getCPUArchFromMachineType(v.MachineType, v.Zone, WideCacheKey)
+}
+
+func (p *Provider) getCPUArchFromMachineType(
+	machineType, zone string, ckl CacheKeyLookup,
+) (vm.CPUArch, error) {
+
+	// Note: zone is specified as an empty string as machine type architectures are the same
+	// across all zones and we want to have as many cache hits as possible
+	metadata, err := p.getMachineTypeSpecs(machineType, p.GetProject(), zone, ckl)
+	if err != nil {
+		return vm.ArchUnknown, err
+	}
+
+	// If arch is unspecified, GCP's default is amd64
+	if metadata.Architecture == "" {
+		return vm.ParseArch(string(vm.ArchAMD64)), nil
+	}
+
+	// Sanitize returned arch and return
+	return vm.ParseArch(metadata.Architecture), nil
+}
+
+func (p *Provider) getMachineTypeSpecs(
+	machineType, project, zone string, ckl CacheKeyLookup,
+) (*MachineTypeSpecs, error) {
+	return p.machineTypeSpecsCache.fetchFromProviderWithCache(machineType, project, zone, ckl)
+}
+
+type ProviderMachineTypeSpecsCache struct {
+	syncutil.Mutex
+	cache map[string]*MachineTypeSpecs
+}
+
+type MachineTypeSpecs struct {
+	Architecture                 string
+	Description                  string
+	GuestCpus                    int
+	Kind                         string
+	MaximumPersistentDisks       int
+	MaximumPersistentDisksSizeGb string
+	MemoryMb                     int
+	Name                         string
+	Zone                         string
+}
+
+type CacheKeyLookup string
+
+const (
+	NarrowCacheKey CacheKeyLookup = "NARROW_CACHE_KEY"
+	WideCacheKey   CacheKeyLookup = "WIDE_CACHE_KEY"
+)
+
+// fetchFromProviderWithCache fetches the machine-type's specs from the provider
+// and caches the result to return it on later calls.
+// As the machine type availability depends on the zone, the caching of each call
+// happens on both a `WideCacheKey` and a `NarrowCacheKey` cache key. This allows
+// to improve cache hits when the only goal is to get machine type specs (specs
+// are homogeneous across all zones), but also leave the opportunity to the user
+// to make sure that a machine type is available in a specific zone by specifying
+// `NarrowCacheKey` and ensure that the result was fetched for this specific zone.
+func (mts *ProviderMachineTypeSpecsCache) fetchFromProviderWithCache(
+	machineType, project, zone string, ckl CacheKeyLookup,
+) (*MachineTypeSpecs, error) {
+
+	mts.Lock()
+	defer mts.Unlock()
+
+	if mts.cache == nil {
+		mts.cache = make(map[string]*MachineTypeSpecs)
+	}
+
+	// We require an "{instance-type}-{project}-{zone}" combination to describe
+	// the instance type (as required by GCP), but store the cached results
+	// under two different keys:
+	// - a narrow one "{instance-type}-{project}-{zone}"
+	// - a wide one "{instance-type}-{project}"
+	// The justification behind this is that instance types are homogeneous
+	// across all zones, so we can increase cache hits when we don't actually
+	// care about the zone, but we can also request a narrow cache key when
+	// we want to ensure that this instance type is available in a specific zone
+	buildCacheKeys := func(machineType, project, zone string) map[CacheKeyLookup]string {
+		return map[CacheKeyLookup]string{
+			WideCacheKey:   machineType + "-" + project,
+			NarrowCacheKey: machineType + "-" + project + "-" + zone,
+		}
+	}
+	cacheKeys := buildCacheKeys(machineType, project, zone)
+
+	if cachedSpecs, ok := mts.cache[cacheKeys[ckl]]; ok {
+		return cachedSpecs, nil
+	}
+
+	// Query GCP to get machine type specs:
+	// Running:
+	// 		gcloud compute machine-types describe t2a-standard-4 \
+	//  		--project cockroach-ephemeral --zone us-east1-b \
+	// 			--format json
+	//
+	// Note: GCP requires a zone to describe a machine type, though during
+	// cluster creation, roachprod's takes a `--gce-machine-type` as input and
+	// guesses the CPU architecture from it. Only then, the zone is inferred
+	// from an hardcoded CPU architecture/zone mapping.
+	// As we're want to know the architecture from the machine type before
+	// knowing the zone, we try the default zone for both amd64 and arm64
+	// architectures. These calls are parallelized.
+	//
+	// In cases where we know the zone already (e.g. `roachprod list`), we use
+	// the supplied zone to query, making sure that we won't hit a zone in which
+	// the instance type is not available.
+
+	var zonesIteration []string
+	if zone != "" {
+		zonesIteration = []string{zone}
+	} else {
+		zonesIteration = []string{
+			DefaultZones(string(vm.ArchAMD64))[0],
+			DefaultZones(string(vm.ArchARM64))[0],
+		}
+	}
+
+	// gcloudQueryResult is the struct we use to pass around the query results.
+	// As we might iterate over multiple zones, we parallelize the calls and sink
+	// the results back via a channel.
+	type gcloudQueryResult struct {
+		specs *MachineTypeSpecs
+		err   error
+	}
+	resChan := make(chan gcloudQueryResult)
+	wg := sync.WaitGroup{}
+
+	for _, zone := range zonesIteration {
+		wg.Add(1)
+		go func(resChan chan<- gcloudQueryResult, machineType, project, zone string) {
+			args := []string{
+				"compute",
+				"machine-types",
+				"describe",
+				machineType,
+				"--project", project,
+				"--zone", zone,
+				"--format", "json",
+			}
+			specs := &MachineTypeSpecs{}
+			if err := runJSONCommand(args, &specs); err != nil {
+				if strings.Contains(err.Error(), "was not found") {
+					resChan <- gcloudQueryResult{
+						specs: nil,
+						err:   nil,
+					}
+					return
+				}
+				resChan <- gcloudQueryResult{
+					specs: nil,
+					err:   err,
+				}
+				return
+			}
+
+			resChan <- gcloudQueryResult{
+				specs: specs,
+				err:   nil,
+			}
+
+		}(resChan, machineType, project, zone)
+	}
+
+	// This goroutine sinks the gcloud query results into slices.
+	errs := []error{}
+	fetchedSpecs := []*MachineTypeSpecs{}
+	go func(resChan <-chan gcloudQueryResult) {
+		for res := range resChan {
+			if res.err != nil {
+				errs = append(errs, res.err)
+			}
+			if res.specs != nil {
+				fetchedSpecs = append(fetchedSpecs, res.specs)
+			}
+			wg.Done()
+		}
+	}(resChan)
+
+	// After waiting for all parallelized executions, we close the result channel,
+	// which will end the above sink results goroutine
+	wg.Wait()
+	close(resChan)
+
+	if len(errs) > 0 {
+		return nil, errors.Wrapf(
+			errors.Join(errs...),
+			"unable to query machine type specs in %d zones",
+			len(zonesIteration),
+		)
+	}
+
+	if len(fetchedSpecs) == 0 {
+		return nil, fmt.Errorf(
+			"machine type '%s' not found in any of the following zones: %s",
+			machineType,
+			strings.Join(zonesIteration, ","),
+		)
+	}
+
+	for _, cacheKey := range cacheKeys {
+		mts.cache[cacheKey] = fetchedSpecs[0]
+	}
+
+	return fetchedSpecs[0], nil
 }
 
 func buildFilterCliArgs(
@@ -660,6 +887,8 @@ type describeVolumeCommandResponse struct {
 	PhysicalBlockSizeBytes string            `json:"physicalBlockSizeBytes"`
 	SelfLink               string            `json:"selfLink"`
 	SizeGB                 string            `json:"sizeGb"`
+	SourceImage            string            `json:"sourceImage"`
+	SourceImageID          string            `json:"sourceImageId"`
 	Status                 string            `json:"status"`
 	Type                   string            `json:"type"`
 	Zone                   string            `json:"zone"`
@@ -873,16 +1102,17 @@ type instanceDisksResponse struct {
 	Disks []attachDiskCmdDisk `json:"disks"`
 }
 type attachDiskCmdDisk struct {
-	AutoDelete bool   `json:"autoDelete"`
-	Boot       bool   `json:"boot"`
-	DeviceName string `json:"deviceName"`
-	DiskSizeGB string `json:"diskSizeGb"`
-	Index      int    `json:"index"`
-	Interface  string `json:"interface"`
-	Kind       string `json:"kind"`
-	Mode       string `json:"mode"`
-	Source     string `json:"source"`
-	Type       string `json:"type"`
+	Architecture string `json:"architecture"`
+	AutoDelete   bool   `json:"autoDelete"`
+	Boot         bool   `json:"boot"`
+	DeviceName   string `json:"deviceName"`
+	DiskSizeGB   string `json:"diskSizeGb"`
+	Index        int    `json:"index"`
+	Interface    string `json:"interface"`
+	Kind         string `json:"kind"`
+	Mode         string `json:"mode"`
+	Source       string `json:"source"`
+	Type         string `json:"type"`
 }
 
 func (p *Provider) AttachVolume(l *logger.Logger, volume vm.Volume, vm *vm.VM) (string, error) {
@@ -1144,11 +1374,6 @@ func (o *ProviderOpts) ConfigureClusterFlags(flags *pflag.FlagSet, opt vm.Multip
 	)
 }
 
-// useArmAMI returns true if the machine type is an arm64 machine type.
-func (o *ProviderOpts) useArmAMI() bool {
-	return strings.HasPrefix(strings.ToLower(o.MachineType), "t2a-")
-}
-
 // ConfigureClusterCleanupFlags is part of ProviderOpts. This implementation is a no-op.
 func (o *ProviderOpts) ConfigureClusterCleanupFlags(flags *pflag.FlagSet) {
 }
@@ -1270,7 +1495,7 @@ func computeLabelsArg(opts vm.CreateOpts, providerOpts *ProviderOpts) (string, e
 // computeZones computes the zones to be passed to the gcloud commands during
 // cluster creation. It's possible that only a subset of the zones get used
 // depending on how many nodes are requested.
-func computeZones(opts vm.CreateOpts, providerOpts *ProviderOpts) ([]string, error) {
+func (p *Provider) computeZones(opts vm.CreateOpts, providerOpts *ProviderOpts) ([]string, error) {
 	zones, err := vm.ExpandZonesFlag(providerOpts.Zones)
 	if err != nil {
 		return nil, err
@@ -1282,13 +1507,16 @@ func computeZones(opts vm.CreateOpts, providerOpts *ProviderOpts) ([]string, err
 			zones = []string{DefaultZones(opts.Arch)[0]}
 		}
 	}
-	if providerOpts.useArmAMI() {
-		if len(providerOpts.Zones) == 0 {
-			zones = []string{"us-central1-a"}
-		}
 
-		if !IsSupportedT2AZone(providerOpts.Zones) {
-			return nil, errors.Newf("T2A instances are not supported outside of [%s]", strings.Join(SupportedT2AZones, ","))
+	// For each zone, check that the instance type is supported
+	for _, zone := range providerOpts.Zones {
+		if _, err := p.getMachineTypeSpecs(
+			providerOpts.MachineType, p.GetProject(), zone, NarrowCacheKey,
+		); err != nil {
+			return nil, errors.Newf(
+				"Instance type %s is not supported in zone %s. Available zones for arch %s: [%s]",
+				providerOpts.MachineType, zone, opts.Arch, strings.Join(DefaultZones(opts.Arch), ","),
+			)
 		}
 	}
 	return zones, nil
@@ -1308,22 +1536,15 @@ func (p *Provider) computeInstanceArgs(
 	image := providerOpts.Image
 	imageProject := defaultImageProject
 
-	if opts.Arch == string(vm.ArchARM64) && !providerOpts.useArmAMI() {
-		return nil, cleanUpFn, errors.Errorf("Requested arch is arm64, but machine type is %s. Do specify a t2a VM", providerOpts.MachineType)
-	}
-
-	if providerOpts.useArmAMI() && (opts.Arch != "" && opts.Arch != string(vm.ArchARM64)) {
-		return nil, cleanUpFn, errors.Errorf("machine type %s is arm64, but requested arch is %s", providerOpts.MachineType, opts.Arch)
-	}
-	if providerOpts.useArmAMI() && opts.SSDOpts.UseLocalSSD {
-		return nil, cleanUpFn, errors.New("local SSDs are not supported with T2A instances, use --local-ssd=false")
-	}
-	if providerOpts.useArmAMI() {
+	if opts.Arch == string(vm.ArchARM64) {
+		if opts.SSDOpts.UseLocalSSD {
+			return nil, cleanUpFn, errors.New("local SSDs are not supported with T2A instances, use --local-ssd=false")
+		}
 		if providerOpts.MinCPUPlatform != "" {
 			l.Printf("WARNING: --gce-min-cpu-platform is ignored for T2A instances")
 			providerOpts.MinCPUPlatform = ""
 		}
-		// TODO(srosenberg): remove this once we have a better way to detect ARM64 machines
+
 		image = ARM64Image
 		l.Printf("Using ARM64 AMI: %s for machine type: %s", image, providerOpts.MachineType)
 	}
@@ -1568,6 +1789,37 @@ func (p *Provider) Create(
 		}
 	}
 
+	// Auto-detect architecture from machine-type, check that it's compatible
+	// with the requested arch (if any), and stores the value in opts.Arch
+	machineTypeArch, err := p.getCPUArchFromMachineType(providerOpts.MachineType, "", WideCacheKey)
+	if err != nil {
+		return errors.Wrapf(
+			err,
+			"Unable to infer architecture based on machine type %s",
+			providerOpts.MachineType,
+		)
+	}
+	switch opts.Arch {
+	case "":
+		// No arch requested, default to the one from the machine type
+		opts.Arch = string(machineTypeArch)
+	case string(vm.ArchFIPS):
+		// FIPS requested, this is only supported for x86_64 arch
+		if machineTypeArch != vm.ArchAMD64 {
+			return errors.Errorf(
+				vm.IncompatibleArchRequestError,
+				p.Name(), providerOpts.MachineType, machineTypeArch, opts.Arch,
+			)
+		}
+	default:
+		if machineTypeArch != vm.ParseArch(opts.Arch) {
+			return errors.Errorf(
+				vm.IncompatibleArchRequestError,
+				p.Name(), providerOpts.MachineType, machineTypeArch, opts.Arch,
+			)
+		}
+	}
+
 	instanceArgs, cleanUpFn, err := p.computeInstanceArgs(l, opts, providerOpts)
 	if cleanUpFn != nil {
 		defer cleanUpFn()
@@ -1575,7 +1827,7 @@ func (p *Provider) Create(
 	if err != nil {
 		return err
 	}
-	zones, err := computeZones(opts, providerOpts)
+	zones, err := p.computeZones(opts, providerOpts)
 	if err != nil {
 		return err
 	}
@@ -2665,7 +2917,13 @@ func (p *Provider) List(l *logger.Logger, opts vm.ListOptions) (vm.List, error) 
 				// The former is a subset of the latter. Some information like `Labels` will be missing.
 				disks = toDescribeVolumeCommandResponse(jsonVM.Disks, jsonVM.Zone)
 			}
-			vms = append(vms, *jsonVM.toVM(prj, disks, defaultOpts, p.publicDomain))
+			v := jsonVM.toVM(prj, disks, defaultOpts, p.publicDomain)
+			vmArch, err := p.GetVMArchitecture(l, v)
+			if err != nil {
+				return nil, errors.Wrap(err, "unable to determine the VM CPU architecture")
+			}
+			v.CPUArch = vmArch
+			vms = append(vms, *v)
 		}
 	}
 

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -174,6 +175,10 @@ func (p *Provider) AttachVolume(*logger.Logger, vm.Volume, *vm.VM) (string, erro
 	return "", nil
 }
 
+func (p *Provider) GetVMArchitecture(l *logger.Logger, v *vm.VM) (vm.CPUArch, error) {
+	return vm.ParseArch(runtime.GOARCH), nil
+}
+
 // No-op implementation of vm.ProviderOpts
 type providerOpts struct{}
 
@@ -235,6 +240,7 @@ func (p *Provider) createVM(clusterName string, index int, creationTime time.Tim
 		MachineType:      ProviderName,
 		Zone:             ProviderName,
 		LocalClusterName: clusterName,
+		CPUArch:          vm.ParseArch(runtime.GOARCH),
 	}
 	path := VMDir(clusterName, index+1)
 	err := os.MkdirAll(path, 0755)


### PR DESCRIPTION
Previously, roachprod required manually providing an argument `--arch` to the `create` and `stage` commands. This allowed to tag the cluster at creation, and to potentially display the information during `list`.

This was leading to errors  as the system relied on an optional tagging mechanism at creation to display the information, and as there was no guardrails during staging if the user tried to push a binary built with the wrong architecture.

To address this issue, this patch brings a GetVMArchitecture() to the Provider interface that's used to implement a way of detecting the CPU arch per Provider:
- on AWS and GCP, this is done by querying the cloud APIs to get the instance type specs
- Azure doesn't expose an API to get the architecture, so it is achieved with hardcoded matches on the instance-type
- local clusters rely on the environment runtime

As querying the cloud APIs for each machine type takes time, an in-memory cache is implemented to avoid querying the cloud API multiple times for the same machine type.
As an added bonus, the same mechanism is now used to ensure that machine types are available in the requested regions/zones instead of relying on potentially outdated hardcoded conditions.

Note that the current `--arch` argument is also used to create `FIPS` clusters, so the detection mechanism still checks for an `arch=fips` tag before proceeding to detecting the actual CPU architecture. The `stage` command now automatically populates the correct binaries for fips, amd64 and arm64 architectures and does not require passing the `arch` argument anymore.

Epic: none
Fixes: #105472
Release note: None