### PR TITLE
roachtest: remove transaction rate verification from cdc/ledger test

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1789,7 +1789,6 @@ func registerCDC(r registry.Registry) {
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
 
-			workloadStart := timeutil.Now()
 			ct.runLedgerWorkload(ledgerArgs{duration: "28m"})
 
 			alterStmt := "ALTER DATABASE ledger CONFIGURE ZONE USING range_max_bytes = 805306368, range_min_bytes = 134217728"
@@ -1810,11 +1809,6 @@ func registerCDC(r registry.Registry) {
 				steadyLatency:      time.Minute,
 			})
 			ct.waitForWorkload()
-
-			workloadEnd := timeutil.Now()
-			verifyTxnPerSecond(
-				ctx, c, t, ct.crdbNodes.RandNode(), workloadStart, workloadEnd, 575, 0.05,
-			)
 		},
 	})
 	r.Add(registry.TestSpec{


### PR DESCRIPTION
The cdc/ledger roachtest was flaky. It would sometimes fail because it did not process enough transactions per second. We prefer to rely on cdcbench roachtests to verify our performance. To address this, we removed this assertion from this test.

Fixes: #129974
Fixes: #130471
Fixes: #134754
Fixes: #136343

Epic: None

Release note: None