### PR TITLE
roachtest: use updated update_tenant_resource_limits signature in 24.2.1+

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -210,6 +210,11 @@ var (
 	// would *not* make the tenant auto upgrade.
 	tenantSupportsAutoUpgradeVersion = clusterupgrade.MustParseVersion("v24.2.0-alpha.00000000")
 
+	// updateTenantResourceLimitsDeprecatedArgsVersion is the lowest version
+	// after which the "as_of" and "as_of_consumed_tokens" arguments were removed when
+	// using the `tenant_name` overload.
+	updateTenantResourceLimitsDeprecatedArgsVersion = clusterupgrade.MustParseVersion("v24.2.1")
+
 	// Catch divergences between `stepFunc` and `Run`'s signature in
 	// `singleStepProtocol` at compile time.
 	_ = func() stepFunc {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/steps.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/steps.go
@@ -594,6 +594,13 @@ func (s disableRateLimitersStep) Run(
 		s.virtualClusterName, availableTokens, refillRate, maxBurstTokens,
 	)
 
+	if h.System.FromVersion.AtLeast(updateTenantResourceLimitsDeprecatedArgsVersion) {
+		stmt = fmt.Sprintf(
+			"SELECT crdb_internal.update_tenant_resource_limits('%s', %v, %v, %d);",
+			s.virtualClusterName, availableTokens, refillRate, maxBurstTokens,
+		)
+	}
+
 	return h.System.Exec(rng, stmt)
 }
 


### PR DESCRIPTION
The function signature of update_tenant_resource_limits was changed in v24.2.1 to deprecate the args "as_of" and "as_of_consumed_tokens". Since serverless currently only uses the `tenant_id` overload and not the `tenant_name` overload like we do in mixedversion, the args were removed completely from the latter.

This breaks backwards compatibility so this change selectively omits the removed args if the version is 24.2.1+.

Fixes: none
Epic: none
Release note: none