### PR TITLE
[DNM] sql: add fast checks for memo staleness

### DIFF
--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -27,7 +27,7 @@ exp,benchmark
 8,AlterTableUnsplit/alter_table_unsplit_at_1_value
 11,AlterTableUnsplit/alter_table_unsplit_at_2_values
 14,AlterTableUnsplit/alter_table_unsplit_at_3_values
-5,Audit/select_from_an_audit_table
+2-4,Audit/select_from_an_audit_table
 26,CreateRole/create_role_with_1_option
 29,CreateRole/create_role_with_2_options
 32,CreateRole/create_role_with_3_options
@@ -52,7 +52,7 @@ exp,benchmark
 17,DropView/drop_2_views
 17,DropView/drop_3_views
 5,GenerateObjects/generate_1000_tables_-_this_test_should_use_the_same_number_of_RTTs_as_for_10_tables
-11,GenerateObjects/generate_100_tables_from_template
+8-10,GenerateObjects/generate_100_tables_from_template
 5,GenerateObjects/generate_10_tables
 16,GenerateObjects/generate_10x10_schemas_and_tables_in_existing_db
 5,GenerateObjects/generate_50000_tables
@@ -125,9 +125,9 @@ exp,benchmark
 20,Truncate/truncate_2_column_0_rows
 20,Truncate/truncate_2_column_1_rows
 20,Truncate/truncate_2_column_2_rows
-3,UDFResolution/select_from_udf
-5,UseManyRoles/use_2_roles
-3,UseManyRoles/use_50_roles
+0,UDFResolution/select_from_udf
+2,UseManyRoles/use_2_roles
+0,UseManyRoles/use_50_roles
 1,VirtualTableQueries/select_crdb_internal.invalid_objects_with_1_fk
 1,VirtualTableQueries/select_crdb_internal.tables_with_1_fk
 5,VirtualTableQueries/virtual_table_cache_with_point_lookups

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -210,6 +210,13 @@ func (tc *Collection) ReleaseAll(ctx context.Context) {
 	tc.skipValidationOnWrite = false
 }
 
+// GetLeaseGeneration provides an integer which will change whenever new
+// descriptor versions are available. This can be used for fast comparisons
+// to make sure previously looked up information is still valid.
+func (tc *Collection) GetLeaseGeneration() int64 {
+	return tc.leased.lm.GetLeaseGeneration()
+}
+
 // HasUncommittedTables returns true if the Collection contains uncommitted
 // tables.
 func (tc *Collection) HasUncommittedTables() (has bool) {

--- a/pkg/sql/catalog/descs/leased_descriptors.go
+++ b/pkg/sql/catalog/descs/leased_descriptors.go
@@ -38,6 +38,8 @@ type LeaseManager interface {
 	) (decrAfterWait func())
 
 	GetSafeReplicationTS() hlc.Timestamp
+
+	GetLeaseGeneration() int64
 }
 
 type deadlineHolder interface {

--- a/pkg/sql/catalog/lease/count.go
+++ b/pkg/sql/catalog/lease/count.go
@@ -274,23 +274,7 @@ func countLeasesByRegion(
 		} else {
 			err = queryRegionRows(ctx)
 		}
-		if err != nil {
-			if regionliveness.IsQueryTimeoutErr(err) {
-				// Probe and mark the region potentially.
-				probeErr := prober.ProbeLiveness(ctx, region)
-				if probeErr != nil {
-					err = errors.WithSecondaryError(err, probeErr)
-					return err
-				}
-				return errors.Wrapf(err, "count-lease timed out reading from a region")
-			} else if regionliveness.IsMissingRegionEnumErr(err) {
-				// Skip this region because we were unable to find region in
-				// type descriptor. Since the database regions are cached, they
-				// may be stale and have dropped regions.
-				log.Infof(ctx, "count-lease is skipping region %s because of the "+
-					"following error %v", region, err)
-				return nil
-			}
+		if err := handleRegionLivenessErrors(ctx, prober, region, err); err != nil {
 			return err
 		}
 		if values == nil {
@@ -324,4 +308,31 @@ func getCountLeaseColumns(usesOldSchema bool) string {
 	}
 	sb.WriteString(`, count(distinct sql_instance_id), ifnull(min(sql_instance_id),0)`)
 	return sb.String()
+}
+
+// handleRegionLivenessErrors handles errors that are linked to region liveness
+// timeouts.
+func handleRegionLivenessErrors(
+	ctx context.Context, prober regionliveness.Prober, region string, err error,
+) error {
+	if err != nil {
+		if regionliveness.IsQueryTimeoutErr(err) {
+			// Probe and mark the region potentially.
+			probeErr := prober.ProbeLiveness(ctx, region)
+			if probeErr != nil {
+				err = errors.WithSecondaryError(err, probeErr)
+				return err
+			}
+			return errors.Wrapf(err, "count-lease timed out reading from a region")
+		} else if regionliveness.IsMissingRegionEnumErr(err) {
+			// Skip this region because we were unable to find region in
+			// type descriptor. Since the database regions are cached, they
+			// may be stale and have dropped regions.
+			log.Infof(ctx, "count-lease is skipping region %s because of the "+
+				"following error %v", region, err)
+			return nil
+		}
+		return err
+	}
+	return err
 }

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -2454,6 +2454,7 @@ func TestRangefeedUpdatesHandledProperlyInTheFaceOfRaces(t *testing.T) {
 
 	db1 := tc.ServerConn(0)
 	tdb1 := sqlutils.MakeSQLRunner(db1)
+	tdb1.Exec(t, "SET CLUSTER SETTING sql.catalog.descriptor_wait_for_initial_version.enabled=false")
 	db2 := tc.ServerConn(1)
 
 	// Create a couple of descriptors.

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -52,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirecancel"
+	"github.com/cockroachdb/cockroach/pkg/sql/regions"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/asof"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
@@ -4042,8 +4043,17 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 			handleErr(err)
 		}
 		ex.statsCollector.PhaseTimes().SetSessionPhaseTime(sessionphase.SessionEndPostCommitJob, crtime.NowMono())
-		if err := ex.waitOneVersionForNewVersionDescriptorsWithoutJobs(descIDsInJobs); err != nil {
-			return advanceInfo{}, err
+		if ex.extraTxnState.descCollection.HasUncommittedDescriptors() {
+			cachedRegions, err := regions.NewCachedDatabaseRegions(ex.Ctx(), ex.server.cfg.DB, ex.server.cfg.LeaseManager)
+			if err != nil {
+				return advanceInfo{}, err
+			}
+			if err := ex.waitOneVersionForNewVersionDescriptorsWithoutJobs(descIDsInJobs, cachedRegions); err != nil {
+				return advanceInfo{}, err
+			}
+			if err := ex.waitForInitialVersionForNewDescriptors(cachedRegions); err != nil {
+				return advanceInfo{}, err
+			}
 		}
 
 		fallthrough

--- a/pkg/sql/conn_executor_jobs.go
+++ b/pkg/sql/conn_executor_jobs.go
@@ -6,10 +6,13 @@
 package sql
 
 import (
+	"time"
+
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/regions"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/errors"
 )
 
@@ -21,7 +24,7 @@ import (
 // thing for affected descriptors. But, in some scenario, jobs are not created
 // for mutated descriptors.
 func (ex *connExecutor) waitOneVersionForNewVersionDescriptorsWithoutJobs(
-	descIDsInJobs catalog.DescriptorIDSet,
+	descIDsInJobs catalog.DescriptorIDSet, cachedRegions *regions.CachedDatabaseRegions,
 ) error {
 	withNewVersion, err := ex.extraTxnState.descCollection.GetOriginalPreviousIDVersionsForUncommitted()
 	if err != nil {
@@ -30,10 +33,6 @@ func (ex *connExecutor) waitOneVersionForNewVersionDescriptorsWithoutJobs(
 	// If no schema change occurred, then nothing needs to be done here.
 	if len(withNewVersion) == 0 {
 		return nil
-	}
-	cachedRegions, err := regions.NewCachedDatabaseRegions(ex.Ctx(), ex.server.cfg.DB, ex.server.cfg.LeaseManager)
-	if err != nil {
-		return err
 	}
 	for _, idVersion := range withNewVersion {
 		if descIDsInJobs.Contains(idVersion.ID) {
@@ -50,6 +49,28 @@ func (ex *connExecutor) waitOneVersionForNewVersionDescriptorsWithoutJobs(
 				continue
 			}
 			return err
+		}
+	}
+	return nil
+}
+
+func (ex *connExecutor) waitForInitialVersionForNewDescriptors(
+	cachedRegions *regions.CachedDatabaseRegions,
+) error {
+	// Detect any tables that have just been created, we will confirm that all
+	// nodes that have leased the schema for them out are aware of the new object.
+	// This guarantees that any cache optimizer memos are discarded once the
+	// user transaction completes.
+	for _, tbl := range ex.extraTxnState.descCollection.GetUncommittedTables() {
+		if tbl.GetVersion() == 1 {
+			err := ex.planner.LeaseMgr().WaitForInitialVersion(ex.Ctx(), tbl.GetID(), retry.Options{
+				InitialBackoff: time.Millisecond,
+				MaxBackoff:     time.Second,
+				Multiplier:     1.5,
+			}, cachedRegions)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/sql/logictest/testdata/logic_test/schema_repair
+++ b/pkg/sql/logictest/testdata/logic_test/schema_repair
@@ -1,5 +1,10 @@
 subtest lost_table_data
 
+# This test will intentionally corrupt descriptors, so the initial version
+# can *never* be acquired.
+statement ok
+SET CLUSTER SETTING sql.catalog.descriptor_wait_for_initial_version.enabled=false
+
 statement ok
 CREATE TABLE corruptdesc (v INT8)
 

--- a/pkg/sql/opt/cat/BUILD.bazel
+++ b/pkg/sql/opt/cat/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/cat",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/config",
         "//pkg/config/zonepb",
         "//pkg/geo/geopb",
         "//pkg/roachpb",

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -92,6 +92,8 @@ type Catalog interface {
 	// to return a new cat.Database type similar to ResolveSchema.
 	LookupDatabaseName(ctx context.Context, flags Flags, name string) (tree.Name, error)
 
+	GetLeaseGeneration() int64
+
 	// ResolveSchema locates a schema with the given name and returns it along
 	// with the resolved SchemaName (which has all components filled in).
 	// If the SchemaName is empty, returns the current database/schema (if one is

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -92,8 +92,6 @@ type Catalog interface {
 	// to return a new cat.Database type similar to ResolveSchema.
 	LookupDatabaseName(ctx context.Context, flags Flags, name string) (tree.Name, error)
 
-	GetLeaseGeneration() int64
-
 	// ResolveSchema locates a schema with the given name and returns it along
 	// with the resolved SchemaName (which has all components filled in).
 	// If the SchemaName is empty, returns the current database/schema (if one is

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -457,7 +457,6 @@ func (m *Memo) IsStale(
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}
-
 	// Memo is stale if the fingerprint of any object in the memo's metadata has
 	// changed, or if the current user no longer has sufficient privilege to
 	// access the object.

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -180,7 +180,7 @@ func TestMemoIsStale(t *testing.T) {
 	ctx := context.Background()
 	stale := func() {
 		t.Helper()
-		if isStale, err := o.Memo().IsStale(ctx, &evalCtx, catalog); err != nil {
+		if isStale, err := o.Memo().IsStale(ctx, &evalCtx, catalog, nil); err != nil {
 			t.Fatal(err)
 		} else if !isStale {
 			t.Errorf("memo should be stale")
@@ -192,7 +192,7 @@ func TestMemoIsStale(t *testing.T) {
 		var o2 xform.Optimizer
 		opttestutils.BuildQuery(t, &o2, catalog, &evalCtx, query)
 
-		if isStale, err := o2.Memo().IsStale(ctx, &evalCtx, catalog); err != nil {
+		if isStale, err := o2.Memo().IsStale(ctx, &evalCtx, catalog, nil); err != nil {
 			t.Fatal(err)
 		} else if isStale {
 			t.Errorf("memo should not be stale")
@@ -201,7 +201,7 @@ func TestMemoIsStale(t *testing.T) {
 
 	notStale := func() {
 		t.Helper()
-		if isStale, err := o.Memo().IsStale(ctx, &evalCtx, catalog); err != nil {
+		if isStale, err := o.Memo().IsStale(ctx, &evalCtx, catalog, nil); err != nil {
 			t.Fatal(err)
 		} else if isStale {
 			t.Errorf("memo should not be stale")
@@ -529,7 +529,7 @@ func TestMemoIsStale(t *testing.T) {
 
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
-	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)
+	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog, nil)
 	if exp := "user does not have privilege"; !testutils.IsError(err, exp) {
 		t.Fatalf("expected %q error, but got %+v", exp, err)
 	}
@@ -538,7 +538,7 @@ func TestMemoIsStale(t *testing.T) {
 
 	// User no longer has execution privilege on a UDF.
 	catalog.RevokeExecution(catalog.Function("one").Oid)
-	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)
+	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog, nil)
 	if exp := "user does not have privilege to execute function"; !testutils.IsError(err, exp) {
 		t.Fatalf("expected %q error, but got %+v", exp, err)
 	}

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -51,8 +51,9 @@ type Catalog struct {
 	counter    int
 	enumTypes  map[string]*types.T
 
-	udfs           map[string]*tree.ResolvedFunctionDefinition
-	revokedUDFOids intsets.Fast
+	udfs                  map[string]*tree.ResolvedFunctionDefinition
+	revokedUDFOids        intsets.Fast
+	uniqueLeaseGeneration int64
 }
 
 type dataSource interface {
@@ -451,6 +452,14 @@ func (tc *Catalog) AddSequence(seq *Sequence) {
 			"sequence %q already exists", tree.ErrString(&seq.SeqName)))
 	}
 	tc.testSchema.dataSources[fq] = seq
+}
+
+// CompareDataSourcesFingerprint always assume that the fingerprints are changing
+// on us.
+func (tc *Catalog) CompareDataSourcesFingerprint(
+	a *cat.DataSourcesFingerprint, b *cat.DataSourcesFingerprint,
+) bool {
+	return false
 }
 
 // ExecuteMultipleDDL parses the given semicolon-separated DDL SQL statements

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -139,7 +139,7 @@ func (p *planner) prepareUsingOptimizer(
 			if !pm.TypeHints.Identical(p.semaCtx.Placeholders.TypeHints) {
 				opc.log(ctx, "query cache hit but type hints don't match")
 			} else {
-				isStale, err := cachedData.Memo.IsStale(ctx, p.EvalContext(), opc.catalog)
+				isStale, err := cachedData.Memo.IsStale(ctx, p.EvalContext(), opc.catalog, nil)
 				if err != nil {
 					return 0, err
 				}
@@ -652,7 +652,7 @@ func (opc *optPlanningCtx) chooseValidPreparedMemo(ctx context.Context) (*memo.M
 			// A generic plan does not yet exist.
 			return nil, nil
 		}
-		isStale, err := prep.GenericMemo.IsStale(ctx, opc.p.EvalContext(), opc.catalog)
+		isStale, err := prep.GenericMemo.IsStale(ctx, opc.p.EvalContext(), opc.catalog, &prep.GenericFingerPrint)
 		if err != nil {
 			return nil, err
 		} else if !isStale {
@@ -666,7 +666,7 @@ func (opc *optPlanningCtx) chooseValidPreparedMemo(ctx context.Context) (*memo.M
 	}
 
 	if prep.BaseMemo != nil {
-		isStale, err := prep.BaseMemo.IsStale(ctx, opc.p.EvalContext(), opc.catalog)
+		isStale, err := prep.BaseMemo.IsStale(ctx, opc.p.EvalContext(), opc.catalog, &prep.BaseFingerPrint)
 		if err != nil {
 			return nil, err
 		} else if !isStale {
@@ -791,7 +791,7 @@ func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ e
 		// Consult the query cache.
 		cachedData, ok := p.execCfg.QueryCache.Find(&p.queryCacheSession, opc.p.stmt.SQL)
 		if ok {
-			if isStale, err := cachedData.Memo.IsStale(ctx, p.EvalContext(), opc.catalog); err != nil {
+			if isStale, err := cachedData.Memo.IsStale(ctx, p.EvalContext(), opc.catalog, nil); err != nil {
 				return nil, err
 			} else if isStale {
 				opc.log(ctx, "query cache hit but needed update")

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
@@ -54,9 +55,13 @@ type PreparedStatement struct {
 	// optimizer during prepare of a SQL statement.
 	BaseMemo *memo.Memo
 
+	BaseFingerPrint cat.DataSourcesFingerprint
+
 	// GenericMemo, if present, is a fully-optimized memo that can be executed
 	// as-is.
 	GenericMemo *memo.Memo
+
+	GenericFingerPrint cat.DataSourcesFingerprint
 
 	// IdealGenericPlan is true if GenericMemo is guaranteed to be optimal
 	// across all executions of the prepared statement. Ideal generic plans are

--- a/pkg/sql/regions/region_provider_test.go
+++ b/pkg/sql/regions/region_provider_test.go
@@ -214,6 +214,10 @@ func (f fakeLeaseManager) GetSafeReplicationTS() hlc.Timestamp {
 	return hlc.Timestamp{}
 }
 
+func (f fakeLeaseManager) GetLeaseGeneration() int64 {
+	return 0
+}
+
 var _ descs.LeaseManager = (*fakeLeaseManager)(nil)
 
 type fakeSystemDatabase struct {

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"sort"
 	"sync"
+	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -71,6 +72,10 @@ type TableStatisticsCache struct {
 
 	// Used when decoding KV from the range feed.
 	datumAlloc tree.DatumAlloc
+
+	// generation is incremented any time the statistics cache is
+	// modified.
+	generation atomic.Int64
 }
 
 // The cache stores *cacheEntry objects. The fields are protected by the
@@ -135,6 +140,12 @@ func (sc *TableStatisticsCache) Clear() {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 	sc.mu.cache.Clear()
+}
+
+// GetGeneration returns the current generation, which will change if any
+// modifications happen to the cache.
+func (sc *TableStatisticsCache) GetGeneration() int64 {
+	return sc.generation.Load()
 }
 
 // Start begins watching for updates in the stats table.
@@ -322,6 +333,7 @@ func (sc *TableStatisticsCache) getTableStatsFromCache(
 		if e.isStale(forecast, udtCols) {
 			// Evict the cache entry and build it again.
 			sc.mu.cache.Del(tableID)
+			sc.generation.Add(1)
 		} else {
 			return e.stats, e.err
 		}
@@ -422,6 +434,7 @@ func (sc *TableStatisticsCache) addCacheEntryLocked(
 		log.VEventf(ctx, 1, "reading statistics for table %d", tableID)
 		stats, udts, err = sc.getTableStatsFromDB(ctx, tableID, forecast, sc.settings)
 		log.VEventf(ctx, 1, "finished reading statistics for table %d", tableID)
+		sc.generation.Add(1)
 	}()
 
 	e.mustWait = false
@@ -451,6 +464,7 @@ func (sc *TableStatisticsCache) refreshCacheEntry(
 ) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
+	defer sc.generation.Add(1)
 
 	// If the stats don't already exist in the cache, don't bother performing
 	// the refresh. If e.err is not nil, the stats are in the process of being
@@ -524,6 +538,7 @@ func (sc *TableStatisticsCache) InvalidateTableStats(ctx context.Context, tableI
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 	sc.mu.cache.Del(tableID)
+	sc.generation.Add(1)
 }
 
 const (


### PR DESCRIPTION
This patch adds the following:

1. Updates the lease manager to expose a generation ID which allows you to know if any descriptors changed
2. Updates the table stats cache to add a generation ID to determine if any new stats were added
3. Updates the IsStale check to confirm if either the generation IDs have changed, search_path has changed or current database has changed. If everything was the same in the last execution, the full CheckDependencies can be skipped
4. Updates the schema changer logic to lease new descriptors if the schema is already leased. This allows invalidation to work within a search path if new objects are made.