### PR TITLE
tests/cdc: remove initial scan from changefeed assume role tests

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1911,9 +1911,10 @@ func registerCDC(r registry.Registry) {
 				sinkType:   pubsubSink,
 				assumeRole: "cdc-roachtest-intermediate@cockroach-ephemeral.iam.gserviceaccount.com,cdc-roachtest@cockroach-ephemeral.iam.gserviceaccount.com",
 				targets:    allTpccTargets,
+				opts:       map[string]string{"initial_scan": "'no'"},
 			})
 			ct.runFeedLatencyVerifier(feed, latencyTargets{
-				initialScanLatency: 30 * time.Minute,
+				initialScanLatency: 5 * time.Minute,
 				steadyLatency:      time.Minute,
 			})
 
@@ -1952,9 +1953,10 @@ func registerCDC(r registry.Registry) {
 				sinkType:   cloudStorageSink,
 				assumeRole: "cdc-roachtest-intermediate@cockroach-ephemeral.iam.gserviceaccount.com,cdc-roachtest@cockroach-ephemeral.iam.gserviceaccount.com",
 				targets:    allTpccTargets,
+				opts:       map[string]string{"initial_scan": "'no'"},
 			})
 			ct.runFeedLatencyVerifier(feed, latencyTargets{
-				initialScanLatency: 30 * time.Minute,
+				initialScanLatency: 5 * time.Minute,
 				steadyLatency:      time.Minute,
 			})
 			ct.waitForWorkload()


### PR DESCRIPTION
Historically, the pubsub and cloud-sink-gcs assume-role tests ran the tpcc workload for 30m, but that was lowered to 5m in #115092. However, 5m is not always long enough for the changefeed to complete an initial scan.

Since this test is designed to test permissions, it doesn't need to run an initial scan at this time. This change modifies the test to remove the initial scan and test that the changefeed made progress.

Fixes: #137000
Fixes: #136552
Fixes: #134029
Fixes: #136347

Release note: None