### PR TITLE
sqlsmith: extend PLpgSQL support

### DIFF
--- a/pkg/cmd/smith/main.go
+++ b/pkg/cmd/smith/main.go
@@ -51,6 +51,7 @@ Options:
 var (
 	flags      = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	expr       = flags.Bool("expr", false, "generate expressions instead of statements")
+	udfs       = flags.Bool("udfs", false, "generate only CREATE FUNCTION statements")
 	num        = flags.Int("num", 1, "number of statements / expressions to generate")
 	url        = flags.String("url", "", "database to fetch schema from")
 	execStmts  = flags.Bool("exec-stmts", false, "execute each generated statement against the db specified by url")
@@ -194,6 +195,10 @@ func main() {
 		fmt.Println("-- expr")
 		for i := 0; i < *num; i++ {
 			fmt.Print(sep, smither.GenerateExpr(), "\n")
+		}
+	} else if *udfs {
+		for i := 0; i < *num; i++ {
+			fmt.Print(sep, smither.GenerateUDF(), ";\n")
 		}
 	} else {
 		for i := 0; i < *num; i++ {

--- a/pkg/internal/sqlsmith/plpgsql.go
+++ b/pkg/internal/sqlsmith/plpgsql.go
@@ -39,6 +39,14 @@ func (s *Smither) makePLpgSQLBlock(scope plpgsqlBlockScope) *ast.Block {
 	}
 }
 
+func (s *Smither) makePLpgSQLVarName(prefix string, scope plpgsqlBlockScope) tree.Name {
+	varName := s.name(prefix)
+	for scope.hasVariable(string(varName)) {
+		varName = s.name(prefix)
+	}
+	return varName
+}
+
 func (s *Smither) makePLpgSQLDeclarations(
 	scope plpgsqlBlockScope,
 ) ([]ast.Statement, plpgsqlBlockScope) {
@@ -50,10 +58,7 @@ func (s *Smither) makePLpgSQLDeclarations(
 	// TODO(#106368): add support for cursor declarations.
 	decls := make([]ast.Statement, numDecls)
 	for i := 0; i < numDecls; i++ {
-		varName := s.name("decl")
-		for newScope.hasVariable(string(varName)) {
-			varName = s.name("decl")
-		}
+		varName := s.makePLpgSQLVarName("decl", newScope)
 		varTyp := s.randType()
 		for varTyp.Identical(types.AnyTuple) || varTyp.Family() == types.CollatedStringFamily {
 			// TODO(#114874): allow record types here when they are supported.
@@ -134,6 +139,8 @@ var (
 		{1, makePLpgSQLBlock},
 		{2, makePLpgSQLReturn},
 		{2, makePLpgSQLIf},
+		{2, makePLpgSQLWhile},
+		{2, makePLpgSQLForLoop},
 		{5, makePLpgSQLNull},
 		{10, makePLpgSQLAssign},
 		{10, makePLpgSQLExecSQL},
@@ -172,13 +179,44 @@ func makePLpgSQLAssign(s *Smither, scope plpgsqlBlockScope) (stmt ast.Statement,
 }
 
 func makePLpgSQLExecSQL(s *Smither, scope plpgsqlBlockScope) (stmt ast.Statement, ok bool) {
-	// TODO(#106368): add support for SELECT/RETURNING INTO statements.
 	const maxRetries = 5
 	var sqlStmt tree.Statement
 	for i := 0; i < maxRetries; i++ {
-		sqlStmt, ok = s.makeSQLStmtForRoutine(scope.vol, scope.refs)
+		var desiredTypes []*types.T
+		var targets []ast.Variable
+		if s.coin() {
+			// Support INTO syntax. Pick a subset of variables to assign into.
+			usedVars := make(map[string]struct{})
+			numNonConstVars := len(scope.vars) - len(scope.constants)
+			for len(usedVars) < numNonConstVars {
+				// Pick non-constant variable that hasn't been used yet.
+				var varName string
+				for {
+					varName = scope.vars[s.rnd.Intn(len(scope.vars))]
+					if scope.variableIsConstant(varName) {
+						continue
+					}
+					if _, used := usedVars[varName]; used {
+						continue
+					}
+					usedVars[varName] = struct{}{}
+					desiredTypes = append(desiredTypes, scope.varTypes[varName])
+					targets = append(targets, tree.Name(varName))
+					break
+				}
+				if s.coin() {
+					break
+				}
+			}
+		}
+		sqlStmt, ok = s.makeSQLStmtForRoutine(scope.vol, scope.refs, desiredTypes)
 		if ok {
-			return &ast.Execute{SqlStmt: sqlStmt}, true
+			return &ast.Execute{
+				SqlStmt: sqlStmt,
+				// Strict option won't matter if targets is empty.
+				Strict: s.d6() == 1,
+				Target: targets,
+			}, true
 		}
 	}
 	return nil, false
@@ -186,6 +224,37 @@ func makePLpgSQLExecSQL(s *Smither, scope plpgsqlBlockScope) (stmt ast.Statement
 
 func makePLpgSQLNull(_ *Smither, _ plpgsqlBlockScope) (stmt ast.Statement, ok bool) {
 	return &ast.Null{}, true
+}
+
+func makePLpgSQLForLoop(s *Smither, scope plpgsqlBlockScope) (stmt ast.Statement, ok bool) {
+	// TODO(#105246): add support for other query and cursor FOR loops.
+	control := ast.IntForLoopControl{
+		Reverse: s.coin(),
+		Lower:   s.makePLpgSQLExpr(scope, types.Int),
+		Upper:   s.makePLpgSQLExpr(scope, types.Int),
+	}
+	if s.coin() {
+		control.Step = s.makePLpgSQLExpr(scope, types.Int)
+	}
+	newScope := scope.makeChild(1 /* numNewVars */)
+	loopVarName := s.makePLpgSQLVarName("loop", newScope)
+	newScope.addVariable(string(loopVarName), types.Int, false /* constant */)
+	const maxLoopStmts = 3
+	return &ast.ForLoop{
+		// TODO(#106368): optionally add a label.
+		Target:  []ast.Variable{loopVarName},
+		Control: &control,
+		Body:    s.makePLpgSQLStatements(newScope, maxLoopStmts),
+	}, true
+}
+
+func makePLpgSQLWhile(s *Smither, scope plpgsqlBlockScope) (stmt ast.Statement, ok bool) {
+	const maxLoopStmts = 3
+	return &ast.While{
+		// TODO(#106368): optionally add a label.
+		Condition: s.makePLpgSQLCond(scope),
+		Body:      s.makePLpgSQLStatements(scope, maxLoopStmts),
+	}, true
 }
 
 // plpgsqlBlockScope holds the information needed to ensure that generated

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -228,6 +228,16 @@ func (s *Smither) GenerateExpr() tree.TypedExpr {
 	return makeScalar(s, s.randScalarType(), nil)
 }
 
+// GenerateUDF returns a random CREATE FUNCTION statement.
+func (s *Smither) GenerateUDF() tree.Statement {
+	for {
+		routine, ok := s.makeCreateFunc()
+		if ok {
+			return routine
+		}
+	}
+}
+
 type nameGenInfo struct {
 	g     randident.NameGenerator
 	count int


### PR DESCRIPTION
**cmd/smith: add an option to only generate UDFs**

This can be helpful when extending PLpgSQL support in sqlsmith.

Release note: None

**sqlsmith: extend PLpgSQL support**

This commit adds support for WHILE and FOR (int) loops as well as SELECT INTO / RETURNING INTO variant of statements.

Addresses: #106368.
Epic: None

Release note: None