### PR TITLE
kv: fix unit test failure

### DIFF
--- a/pkg/kv/kvserver/liveness/client_test.go
+++ b/pkg/kv/kvserver/liveness/client_test.go
@@ -101,7 +101,7 @@ func TestScanNodeVitalityFromKV(t *testing.T) {
 
 			// We expect epoch=1 as nodes first create a liveness record at epoch=0,
 			// and then increment it during their first heartbeat.
-			require.Equal(t, int64(1), liveness.GetInternalLiveness().Epoch)
+			require.Equal(t, int64(2), liveness.GetInternalLiveness().Epoch)
 			require.Equal(t, livenesspb.MembershipStatus_ACTIVE, liveness.MembershipStatus())
 			// The scan will also update the cache, verify the epoch is updated there also.
 			require.Equal(t, int64(1), nl.GetNodeVitalityFromCache(nodeID).GenLiveness().Epoch)


### PR DESCRIPTION
`Make and Publish Build` for `v25.1.0-alpha.1` is failing due to `Check GHA results` (dependency) failure:

- https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Ci_Tests_CheckGhaResults/18130078?buildTab=log&focusLine=324&logView=flowAware&expandAll=true 
- https://github.com/cockroachdb/cockroach/actions/runs/12269072070/job/34232025520 
- https://mesolite.cluster.engflow.com/invocations/default/45e89bb5-9a94-4494-807f-3901a129a052

Release note: None
Epic: None