### PR TITLE
Issue 114206 eliminate groupby

### DIFF
--- a/pkg/sql/opt/norm/rules/groupby.opt
+++ b/pkg/sql/opt/norm/rules/groupby.opt
@@ -163,26 +163,26 @@
 =>
 (Project $input [] (GroupingOutputCols $groupingPrivate $aggs))
 
-# EliminateGroupBy is similar to EliminateDistinct, but it operates on GroupBy
-# expressions where the grouping columns are statically known to form a strict
-# key in the GroupBy's input.
+# EliminateGroupBy is similar to EliminateDistinct,
+# but it operates on GroupBy expressions where the grouping columns
+# are statically known to form a strict key in the GroupBy's input.
 #
-# It only applies if all the aggregate functions are ConstAgg, ConstNotNullAgg,
-# or AnyNotNullAgg. These aggregate functions all evaluate to the first non-NULL
-# value encountered, and NULL if there are no such values. Because the input is
-# guaranteed to produce one row per group, these aggregate functions are
-# equivalent to projecting their input column.
+# It only applies if all aggregator functions are pass-through,
+# which we consider to be the case if they return
+# value of the input when there is only one input (e.g. ConcatAgg and XorAgg).
+# Note that the type must be preserved, so Sum and Avg aren't considered
+# pass-through because Sum(int) and Avg(int) both have decimal type.
 [EliminateGroupBy, Normalize]
 (GroupBy
     $input:*
-    $aggs:* & (AreAllAnyNotNullAggs $aggs)
+    $aggs:* & (AreAllPassThroughAggs $aggs)
     $groupingPrivate:* &
         (ColsAreStrictKey (GroupingCols $groupingPrivate) $input)
 )
 =>
 (Project
     $input
-    (ConvertAnyNotNullAggsToProjections $aggs)
+    (ConvertPassThroughAggsToProjections $aggs)
     (IntersectionCols
         (GroupingOutputCols $groupingPrivate $aggs)
         (OutputCols $input)

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -1085,7 +1085,7 @@ Final best expression
              └── y:9 = i:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
 
 # Decorrelation pattern using ANY function.
-optsteps
+optsteps disable=EliminateGroupBy
 SELECT 5=ANY(SELECT i FROM a WHERE k=x) AS r FROM xy
 ----
 ================================================================================

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -897,7 +897,7 @@ semi-join-apply
 # --------------------------------------------------
 
 # Left join caused by correlated ANY clause.
-norm expect=(TryDecorrelateProject,TryDecorrelateProjectSelect,TryDecorrelateScalarGroupBy)
+norm expect=(TryDecorrelateProject,TryDecorrelateProjectSelect,TryDecorrelateScalarGroupBy) disable=EliminateGroupBy
 SELECT 5=ANY(SELECT y FROM xy WHERE x=k) AS r FROM a
 ----
 project
@@ -980,7 +980,7 @@ project
            └── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
 # Any clause with constant.
-norm expect=(TryDecorrelateProject,TryDecorrelateProjectSelect,TryDecorrelateScalarGroupBy)
+norm expect=(TryDecorrelateProject,TryDecorrelateProjectSelect,TryDecorrelateScalarGroupBy) disable=EliminateGroupBy
 SELECT 5=ANY(SELECT y FROM xy WHERE x=k) AS r FROM a
 ----
 project
@@ -1023,7 +1023,7 @@ project
       └── CASE WHEN bool_or:14 THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:12, outer=(14)]
 
 # Any clause with variable.
-norm expect=(TryDecorrelateProject,TryDecorrelateProjectSelect,TryDecorrelateScalarGroupBy)
+norm expect=(TryDecorrelateProject,TryDecorrelateProjectSelect,TryDecorrelateScalarGroupBy) disable=EliminateGroupBy
 SELECT i=ANY(SELECT y FROM xy WHERE x=k) AS r FROM a
 ----
 project
@@ -1064,7 +1064,7 @@ project
       └── CASE WHEN bool_or:14 AND (i:2 IS NOT NULL) THEN true WHEN bool_or:14 IS NULL THEN false ELSE CAST(NULL AS BOOL) END [as=r:12, outer=(2,14)]
 
 # Any clause with more complex expression that must be cached.
-norm expect=(TryDecorrelateProject,TryDecorrelateProjectSelect,TryDecorrelateScalarGroupBy)
+norm expect=(TryDecorrelateProject,TryDecorrelateProjectSelect,TryDecorrelateScalarGroupBy) disable=EliminateGroupBy
 SELECT i*i/5=ANY(SELECT y FROM xy WHERE x=k) AS r FROM a
 ----
 project
@@ -1308,7 +1308,7 @@ project
 # --------------------------------------------------
 # TryDecorrelateProjectInnerJoin
 # --------------------------------------------------
-norm expect=TryDecorrelateProjectInnerJoin
+norm expect=TryDecorrelateProjectInnerJoin disable=EliminateGroupBy
 SELECT (SELECT sum(y + v) FROM xy, uv WHERE x=u AND x=k) FROM a
 ----
 project
@@ -1775,7 +1775,7 @@ group-by (hash)
            └── j:5
 
 # Indirectly decorrelate GROUP BY after decorrelating scalar GROUP BY.
-norm expect=TryDecorrelateGroupBy
+norm expect=TryDecorrelateGroupBy disable=EliminateGroupBy
 SELECT *
 FROM xy, uv
 WHERE x<v AND u=(SELECT max(i) FROM a WHERE k=x)
@@ -1836,7 +1836,7 @@ project
 
 # Indirectly decorrelate GROUP BY after decorrelating scalar GROUP BY. Use
 # IS DISTINCT FROM to retain left join.
-norm expect=TryDecorrelateGroupBy
+norm expect=TryDecorrelateGroupBy disable=EliminateGroupBy
 SELECT *
 FROM xy, uv
 WHERE x<v AND (SELECT max(i) FROM a WHERE k=x) IS DISTINCT FROM u
@@ -1890,7 +1890,7 @@ project
            └── u:5 IS DISTINCT FROM max:16 [outer=(5,16)]
 
 # Synthesize key when one is not present.
-norm expect=TryDecorrelateGroupBy
+norm expect=TryDecorrelateGroupBy disable=EliminateGroupBy
 SELECT *
 FROM
 (
@@ -2223,7 +2223,7 @@ group-by (hash)
            └── j:5
 
 # Synthesize key when one is not present.
-norm expect=TryDecorrelateScalarGroupBy
+norm expect=TryDecorrelateScalarGroupBy disable=EliminateGroupBy
 SELECT * FROM (SELECT i, 'foo' AS cst FROM a) WHERE 5=(SELECT max(y) FROM xy WHERE x=i)
 ----
 project
@@ -2547,7 +2547,7 @@ project
       └── filters
            └── array_agg:9 = ARRAY[] [outer=(9), constraints=(/9: [/ARRAY[] - /ARRAY[]]; tight), fd=()-->(9)]
 
-norm expect=TryDecorrelateScalarGroupBy
+norm expect=TryDecorrelateScalarGroupBy disable=EliminateGroupBy
 SELECT * FROM a WHERE 'foo'=(SELECT concat_agg(y::string) FROM xy WHERE x=k)
 ----
 project
@@ -2614,7 +2614,7 @@ project
            └── concat_agg:13 = 'foo' [outer=(13), constraints=(/13: [/'foo' - /'foo']; tight), fd=()-->(13)]
 
 # With a multi-argument aggregate.
-norm expect=TryDecorrelateScalarGroupBy
+norm expect=TryDecorrelateScalarGroupBy disable=EliminateGroupBy
 SELECT k, (SELECT string_agg(a.s, ',') FROM a WHERE a.k = a2.i) FROM a AS a2
 ----
 project
@@ -4478,7 +4478,7 @@ project
            └── (i:2 = 1) OR (canary_agg:13 IS NOT NULL) [outer=(2,13)]
 
 # Any with IS NULL.
-norm expect=HoistSelectSubquery
+norm expect=HoistSelectSubquery disable=EliminateGroupBy
 SELECT * FROM a WHERE (i = ANY(SELECT y FROM xy WHERE x=k)) IS NULL
 ----
 project
@@ -4538,7 +4538,7 @@ project
 
 # Any with tuple comparison should use IS NOT NULL (i.e., IsTupleNotNull
 # expression) instead of IS DISTINCT FROM NULL.
-norm expect=HoistSelectSubquery
+norm expect=HoistSelectSubquery disable=EliminateGroupBy
 SELECT * FROM a WHERE ((k, i) = ANY(SELECT (x, y) FROM xy WHERE x=k)) IS NULL
 ----
 project
@@ -4646,7 +4646,7 @@ select
            └── NULL
 
 # ALL with non-trivial expression on left.
-norm
+norm disable=EliminateGroupBy
 SELECT i*i/100 < ALL(SELECT y FROM xy WHERE x=k) AS r, s FROM a
 ----
 project
@@ -5127,7 +5127,7 @@ project
       └── xy.x:8 [as=x:12, outer=(8)]
 
 # Mixed correlated and uncorrelated subqueries.
-norm expect=HoistProjectSubquery
+norm expect=HoistProjectSubquery disable=EliminateGroupBy
 SELECT
     5 AS a,
     (SELECT x FROM xy WHERE x=k),
@@ -5331,7 +5331,7 @@ project
                           └── (1 / y:9)::INT8 [as=int8:12, outer=(9), immutable]
 
 # Exists in projection list.
-norm expect=HoistProjectSubquery
+norm expect=HoistProjectSubquery disable=EliminateGroupBy
 SELECT EXISTS(SELECT * FROM xy WHERE y=i) FROM a
 ----
 project
@@ -5362,7 +5362,7 @@ project
       └── canary_agg:14 IS NOT NULL [as=exists:13, outer=(14)]
 
 # Any in projection list.
-norm expect=HoistProjectSubquery
+norm expect=HoistProjectSubquery disable=EliminateGroupBy
 SELECT 5 < ANY(SELECT y FROM xy WHERE y=i) AS r FROM a
 ----
 project
@@ -5400,7 +5400,7 @@ project
 
 # Any in projection list with tuple comparison should use IS NOT NULL
 # (i.e., IsTupleNotNull expression) instead of IS DISTINCT FROM NULL.
-norm expect=HoistProjectSubquery
+norm expect=HoistProjectSubquery disable=EliminateGroupBy
 SELECT (5, 50) < ANY(SELECT x, y FROM xy WHERE y=i) AS r FROM a
 ----
 project
@@ -5680,7 +5680,7 @@ project
            └── exists:18 OR (k:1 = x:8) [outer=(1,8,18)]
 
 # Any in Join filter disjunction.
-norm expect=HoistJoinSubquery
+norm expect=HoistJoinSubquery disable=EliminateGroupBy
 SELECT j, y FROM a INNER JOIN xy ON x IN (SELECT v FROM uv WHERE u=y AND v=i) OR x IS NULL
 ----
 project
@@ -5744,7 +5744,7 @@ project
 # semi-join when constructin the Project expression. The opt directive is used
 # here because the SplitDisjunctionOfJoinTerms exploration rule must fire to
 # trigger HoistJoinSubquery.
-opt expect=HoistJoinSubquery
+opt expect=HoistJoinSubquery disable=EliminateGroupBy
 SELECT EXISTS(
   SELECT 1
   FROM a
@@ -5812,7 +5812,7 @@ union
            └── true [as=bool:43]
 
 # This is a more synthetic regression test for #130398.
-exprnorm expect=HoistJoinSubquery disable=PushFilterIntoJoinLeft
+exprnorm expect=HoistJoinSubquery disable=(PushFilterIntoJoinLeft, EliminateGroupBy)
 (SemiJoin
     (Scan [ (Table "xy") (Cols "x,y") ])
     (Select
@@ -6005,7 +6005,7 @@ project
       └── x:8 IS NOT NULL [as=column1:16, outer=(8)]
 
 # Any in values row.
-norm expect=HoistValuesSubquery
+norm expect=HoistValuesSubquery disable=EliminateGroupBy
 SELECT (VALUES (5 IN (SELECT y FROM xy WHERE x=k))) FROM a
 ----
 project
@@ -6079,7 +6079,7 @@ project
            └── generate_series(1, v:6) [outer=(6), immutable]
 
 # Zip correlation within EXISTS.
-norm expect=(HoistProjectSetSubquery,TryDecorrelateSemiJoin,TryDecorrelateProjectSet)
+norm expect=(HoistProjectSetSubquery,TryDecorrelateSemiJoin,TryDecorrelateProjectSet) disable=EliminateGroupBy
 SELECT * FROM xy WHERE EXISTS(SELECT * FROM generate_series(1, (SELECT v FROM uv WHERE u=x)))
 ----
 group-by (hash)

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -81,6 +81,14 @@ CREATE TABLE xyzbs
 )
 ----
 
+exec-ddl
+CREATE TABLE booleans (
+  k INT PRIMARY KEY,
+	a BOOL NOT NULL,
+	b BOOL
+)
+----
+
 # --------------------------------------------------
 # ConvertGroupByToDistinct
 # --------------------------------------------------
@@ -138,18 +146,16 @@ scan xy
 norm expect=EliminateJoinUnderGroupByLeft
 SELECT k, max(r1) FROM fks INNER JOIN (SELECT * FROM (VALUES (1), (2)) f(t)) ON True GROUP BY k
 ----
-group-by (hash)
+project
  ├── columns: k:1!null max:8!null
- ├── grouping columns: k:1!null
  ├── key: (1)
  ├── fd: (1)-->(8)
  ├── scan fks
  │    ├── columns: k:1!null r1:3!null
  │    ├── key: (1)
  │    └── fd: (1)-->(3)
- └── aggregations
-      └── max [as=max:8, outer=(3)]
-           └── r1:3
+ └── projections
+      └── r1:3 [as=max:8, outer=(3)]
 
 # Case with ScalarGroupBy with a sum aggregate that doesn't ignore duplicates.
 # The join can be eliminated because r1 is a foreign key referencing x, which
@@ -174,18 +180,16 @@ scalar-group-by
 norm expect=EliminateJoinUnderGroupByLeft
 SELECT x, max(y) FROM xy LEFT JOIN fks ON True GROUP BY x
 ----
-group-by (hash)
+project
  ├── columns: x:1!null max:11
- ├── grouping columns: x:1!null
  ├── key: (1)
  ├── fd: (1)-->(11)
  ├── scan xy
  │    ├── columns: x:1!null y:2
  │    ├── key: (1)
  │    └── fd: (1)-->(2)
- └── aggregations
-      └── max [as=max:11, outer=(2)]
-           └── y:2
+ └── projections
+      └── y:2 [as=max:11, outer=(2)]
 
 # LeftJoin case with a not-null foreign key equality filter and a sum aggregate.
 norm expect=EliminateJoinUnderGroupByLeft disable=EliminateJoinUnderProjectLeft
@@ -265,9 +269,8 @@ group-by (hash)
 norm expect=EliminateJoinUnderGroupByLeft
 SELECT max(y) FROM xy LEFT JOIN fks ON True GROUP BY x ORDER BY x
 ----
-group-by (streaming)
+project
  ├── columns: max:11  [hidden: x:1!null]
- ├── grouping columns: x:1!null
  ├── key: (1)
  ├── fd: (1)-->(11)
  ├── ordering: +1
@@ -276,9 +279,8 @@ group-by (streaming)
  │    ├── key: (1)
  │    ├── fd: (1)-->(2)
  │    └── ordering: +1
- └── aggregations
-      └── max [as=max:11, outer=(2)]
-           └── y:2
+ └── projections
+      └── y:2 [as=max:11, outer=(2)]
 
 # Cross join case where neither the foreign key column nor its referenced column
 # are output columns.
@@ -396,33 +398,30 @@ group-by (hash)
 norm expect-not=EliminateJoinUnderGroupByLeft
 SELECT x, max(y) FROM xy LEFT JOIN fks ON True GROUP BY x, k ORDER BY x, k
 ----
-group-by (streaming)
+sort
  ├── columns: x:1!null max:11  [hidden: k:5]
- ├── grouping columns: x:1!null k:5
  ├── key: (1,5)
- ├── fd: (1,5)-->(11)
+ ├── fd: (1)-->(11)
  ├── ordering: +1,+5
- ├── sort
- │    ├── columns: x:1!null y:2 k:5
- │    ├── key: (1,5)
- │    ├── fd: (1)-->(2)
- │    ├── ordering: +1,+5
- │    └── left-join (cross)
- │         ├── columns: x:1!null y:2 k:5
- │         ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
- │         ├── key: (1,5)
- │         ├── fd: (1)-->(2)
- │         ├── scan xy
- │         │    ├── columns: x:1!null y:2
- │         │    ├── key: (1)
- │         │    └── fd: (1)-->(2)
- │         ├── scan fks
- │         │    ├── columns: k:5!null
- │         │    └── key: (5)
- │         └── filters (true)
- └── aggregations
-      └── max [as=max:11, outer=(2)]
-           └── y:2
+ └── project
+      ├── columns: max:11 x:1!null k:5
+      ├── key: (1,5)
+      ├── fd: (1)-->(11)
+      ├── left-join (cross)
+      │    ├── columns: x:1!null y:2 k:5
+      │    ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
+      │    ├── key: (1,5)
+      │    ├── fd: (1)-->(2)
+      │    ├── scan xy
+      │    │    ├── columns: x:1!null y:2
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2)
+      │    ├── scan fks
+      │    │    ├── columns: k:5!null
+      │    │    └── key: (5)
+      │    └── filters (true)
+      └── projections
+           └── y:2 [as=max:11, outer=(2)]
 
 # --------------------------------------------------
 # EliminateJoinUnderGroupByRight
@@ -1077,14 +1076,94 @@ scan a
  ├── key: (1)
  └── fd: (1)-->(2-4), (2,4)-->(1,3), (2,3)~~>(1,4)
 
+# Eliminate the GroupBy when the aggregate functions produce the same column as
+# their input column. This tests for Max and Min aggregator functions.
+exprnorm expect=EliminateGroupBy
+(GroupBy
+    (Scan [ (Table "a") (Cols "k,i,f") ])
+    [
+        (AggregationsItem (Max (Var "i")) (LookupColumn "i"))
+        (AggregationsItem (Min (Var "f")) (LookupColumn "f"))
+    ]
+    [ (GroupingCols "k") ]
+)
+----
+scan a
+ ├── columns: k:1!null i:2!null f:3
+ ├── key: (1)
+ └── fd: (1)-->(2,3), (2,3)~~>(1)
+
+# Eliminate the GroupBy when the aggregate functions produce the same column as
+# their input column. This tests for Max and Min aggregator functions.
+exprnorm expect=EliminateGroupBy
+(GroupBy
+    (Scan [ (Table "a") (Cols "k,i,s") ])
+    [
+        (AggregationsItem (XorAgg (Var "i")) (LookupColumn "i"))
+        (AggregationsItem (ConcatAgg (Var "s")) (LookupColumn "s"))
+        (AggregationsItem (StringAgg (Var "s") (Const ", " "string")) (LookupColumn "s"))
+    ]
+    [ (GroupingCols "k") ]
+)
+----
+scan a
+ ├── columns: k:1!null i:2!null s:4!null
+ ├── key: (1)
+ └── fd: (1)-->(2,4), (2,4)-->(1)
+
+# Eliminate the GroupBy when the aggregate functions functions produce
+# the same column as their input column. This tests for bool-and and bool-or
+# aggregator functions.
+exprnorm expect=EliminateGroupBy
+(GroupBy
+    (Scan [ (Table "booleans") (Cols "k,a,b")])
+		[
+		    (AggregationsItem (BoolAnd (Var "a")) (LookupColumn "a"))
+		    (AggregationsItem (BoolOr (Var "b")) (LookupColumn "b"))
+		]
+		[ (GroupingCols "k")]
+)
+----
+scan booleans
+ ├── columns: k:1!null a:2!null b:3
+ ├── key: (1)
+ └── fd: (1)-->(2,3)
+
+# Eliminate the GroupBy when the aggregate functions produce the same column as
+# their input column and produce a new column. This tests for
+# bitwise-and, bitwise-or, and sum integer aggregator functions.
+exprnorm expect=EliminateGroupBy
+(GroupBy
+    (Scan [ (Table "a") (Cols "k,i") ])
+    [
+        (AggregationsItem (BitAndAgg (Var "i")) (LookupColumn "i"))
+        (AggregationsItem (BitOrAgg (Var "i")) (NewColumn "i_bitOr" "int"))
+        (AggregationsItem (SumInt (Var "i")) (NewColumn "i_sumInt" "int"))
+    ]
+    [ (GroupingCols "k") ]
+)
+----
+project
+ ├── columns: i_bitOr:8!null i_sumInt:9!null k:1!null i:2!null
+ ├── key: (1)
+ ├── fd: (1)-->(2), (2)==(8,9), (8)==(2,9), (9)==(2,8)
+ ├── scan a
+ │    ├── columns: k:1!null i:2!null
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── projections
+      ├── i:2 [as=i_bitOr:8, outer=(2)]
+      └── i:2 [as=i_sumInt:9, outer=(2)]
+
+
 # Eliminate the GroupBy when the aggregate functions produce a new column.
 exprnorm expect=EliminateGroupBy
 (GroupBy
     (Scan [ (Table "a") (Cols "k,i,f,s") ])
     [
         (AggregationsItem (ConstAgg (Var "i")) (NewColumn "i_agg" "int"))
-        (AggregationsItem (ConstNotNullAgg (Var "f")) (NewColumn "f_agg" "float"))
-        (AggregationsItem (AnyNotNullAgg (Var "s")) (NewColumn "s_agg" "string"))
+        (AggregationsItem (Max (Var "f")) (NewColumn "f_agg" "float"))
+        (AggregationsItem (StringAgg (Var "s") (Const ", " "string")) (NewColumn "s_agg" "string"))
     ]
     [ (GroupingCols "k") ]
 )
@@ -1164,13 +1243,41 @@ project
  └── projections
       └── CASE WHEN k:5 IS NOT NULL THEN 'Y' ELSE 'N' END [as=case:14, outer=(5)]
 
-# Don't eliminate the GroupBy if there is an aggregate function other than
-# ConstAgg, ConstNotNullAgg, or AnyNotNullAgg.
+# Don't eliminate GroupBy if there's an aggregate function that isn't pass-through
+# Here, Sum is not pass-through because Sum(int) has decimal type.
+exprnorm expect-not=EliminateGroupBy
+(GroupBy
+    (Scan [ (Table "a") (Cols "k,i,f") ])
+    [
+        (AggregationsItem (SumInt (Var "i")) (LookupColumn "i"))
+        (AggregationsItem (Sum (Var "f")) (LookupColumn "f"))
+    ]
+    [ (GroupingCols "k") ]
+)
+----
+group-by (hash)
+ ├── columns: k:1!null i:2!null f:3
+ ├── grouping columns: k:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(2,3), (2,3)~~>(1)
+ ├── scan a
+ │    ├── columns: k:1!null i:2!null f:3
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3), (2,3)~~>(1)
+ └── aggregations
+      ├── sum-int [as=i:2, outer=(2)]
+      │    └── i:2
+      └── sum [as=f:3, outer=(3)]
+           └── f:3
+
+
+# Don't eliminate GroupBy if there's an aggregate function that isn't pass-through
+# Here, Avg is not pass through because Avg(int) returns decimal type.
 exprnorm expect-not=EliminateGroupBy
 (GroupBy
     (Scan [ (Table "a") (Cols "k,i,f,s") ])
     [
-        (AggregationsItem (Sum (Var "i")) (NewColumn "sum" "int"))
+        (AggregationsItem (Avg (Var "i")) (NewColumn "avg" "int"))
         (AggregationsItem (ConstNotNullAgg (Var "f")) (NewColumn "f_agg" "float"))
         (AggregationsItem (AnyNotNullAgg (Var "s")) (NewColumn "s_agg" "string"))
     ]
@@ -1178,7 +1285,7 @@ exprnorm expect-not=EliminateGroupBy
 )
 ----
 group-by (hash)
- ├── columns: k:1!null sum:8!null f_agg:9 s_agg:10!null
+ ├── columns: k:1!null avg:8!null f_agg:9 s_agg:10!null
  ├── grouping columns: k:1!null
  ├── key: (1)
  ├── fd: (1)-->(8-10)
@@ -1187,7 +1294,7 @@ group-by (hash)
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (2,4)-->(1,3), (2,3)~~>(1,4)
  └── aggregations
-      ├── sum [as=sum:8, outer=(2)]
+      ├── avg [as=avg:8, outer=(2)]
       │    └── i:2
       ├── const-not-null-agg [as=f_agg:9, outer=(3)]
       │    └── f:3
@@ -1201,7 +1308,7 @@ exprnorm expect-not=EliminateGroupBy
     (Scan [ (Table "a") (Cols "i,f,s") ])
     [
         (AggregationsItem (ConstNotNullAgg (Var "f")) (NewColumn "f_agg" "float"))
-        (AggregationsItem (AnyNotNullAgg (Var "s")) (NewColumn "s_agg" "string"))
+        (AggregationsItem (ConcatAgg (Var "s")) (NewColumn "s_agg" "string"))
     ]
     [ (GroupingCols "i") ]
 )
@@ -1218,7 +1325,7 @@ group-by (hash)
  └── aggregations
       ├── const-not-null-agg [as=f_agg:8, outer=(3)]
       │    └── f:3
-      └── any-not-null-agg [as=s_agg:9, outer=(4)]
+      └── concat-agg [as=s_agg:9, outer=(4)]
            └── s:4
 
 # Don't eliminate the GroupBy if the grouping columns form a lax key.
@@ -1466,7 +1573,7 @@ project
 # --------------------------------------------------
 # ReduceGroupingCols
 # --------------------------------------------------
-norm expect=ReduceGroupingCols
+norm expect=ReduceGroupingCols disable=EliminateGroupBy
 SELECT k, min(i), f, s FROM a GROUP BY s, f, k
 ----
 group-by (hash)
@@ -1486,7 +1593,7 @@ group-by (hash)
       └── const-agg [as=s:4, outer=(4)]
            └── s:4
 
-norm expect=ReduceGroupingCols
+norm expect=ReduceGroupingCols disable=EliminateGroupBy
 SELECT k, sum(DISTINCT i), f, s FROM a, xy GROUP BY s, f, k
 ----
 group-by (hash)
@@ -1513,7 +1620,7 @@ group-by (hash)
            └── s:4
 
 # Eliminated columns are not part of projection.
-norm expect=ReduceGroupingCols
+norm expect=ReduceGroupingCols disable=EliminateGroupBy
 SELECT min(f) FROM a GROUP BY i, s, k
 ----
 project
@@ -1532,7 +1639,7 @@ project
                 └── f:3
 
 # All grouping columns eliminated.
-norm expect=ReduceGroupingCols
+norm expect=ReduceGroupingCols disable=EliminateGroupBy
 SELECT sum(f), i FROM a GROUP BY k, i, f HAVING k=1
 ----
 group-by (streaming)
@@ -1557,7 +1664,7 @@ group-by (streaming)
       └── const-agg [as=i:2, outer=(2)]
            └── i:2
 
-norm expect=ReduceGroupingCols
+norm expect=ReduceGroupingCols disable=EliminateGroupBy
 SELECT DISTINCT ON (k, f, s) i, f, x FROM a JOIN xy ON i=y
 ----
 distinct-on
@@ -4095,7 +4202,7 @@ scalar-group-by
 # --------------------------------------------------
 
 # Case with sum aggregate.
-norm expect=FoldGroupingOperators
+norm expect=FoldGroupingOperators disable=EliminateGroupBy
 SELECT sum(s) FROM (SELECT sum(x) FROM xy GROUP BY y) AS f(s)
 ----
 scalar-group-by
@@ -4111,7 +4218,7 @@ scalar-group-by
            └── x:1
 
 # Case with count-rows aggregate.
-norm expect=FoldGroupingOperators
+norm expect=FoldGroupingOperators disable=EliminateGroupBy
 SELECT sum_int(c) FROM (SELECT count(x) FROM xy GROUP BY y) AS f(c)
 ----
 scalar-group-by
@@ -4124,7 +4231,7 @@ scalar-group-by
       └── count-rows [as=sum_int:6]
 
 # Case with a count aggregate.
-norm expect=FoldGroupingOperators
+norm expect=FoldGroupingOperators disable=EliminateGroupBy
 SELECT sum_int(cnt) FROM (SELECT count(c2) FROM nullablecols GROUP BY c1) AS f(cnt)
 ----
 scalar-group-by
@@ -4139,7 +4246,7 @@ scalar-group-by
            └── c2:2
 
 # Case with max aggregate.
-norm expect=FoldGroupingOperators
+norm expect=FoldGroupingOperators disable=EliminateGroupBy
 SELECT max(m) FROM (SELECT max(x) FROM xy GROUP BY y) AS f(m)
 ----
 scalar-group-by
@@ -4155,7 +4262,7 @@ scalar-group-by
            └── x:1
 
 # Case with bit_and aggregate.
-norm expect=FoldGroupingOperators
+norm expect=FoldGroupingOperators disable=EliminateGroupBy
 SELECT bit_and(b) FROM (SELECT bit_and(x) FROM xy GROUP BY y) AS f(b)
 ----
 scalar-group-by
@@ -4171,7 +4278,7 @@ scalar-group-by
            └── x:1
 
 # Case with multiple aggregates.
-norm expect=FoldGroupingOperators
+norm expect=FoldGroupingOperators disable=EliminateGroupBy
 SELECT max(m), sum(s), sum_int(c)
 FROM (SELECT sum(b), count(c), max(b) FROM abc GROUP BY a)
 AS f(s, c, m)
@@ -4191,7 +4298,7 @@ scalar-group-by
       └── count-rows [as=sum_int:11]
 
 # Case with aggregation on a grouping column.
-norm expect=FoldGroupingOperators
+norm expect=FoldGroupingOperators disable=EliminateGroupBy
 SELECT max(x)
 FROM (SELECT DISTINCT ON (a) a FROM abc) AS f(x)
 ----
@@ -4208,7 +4315,7 @@ scalar-group-by
 
 # GroupBy on GroupBy case where the inner grouping columns determine the outer
 # grouping columns, but they do not intersect.
-norm expect=FoldGroupingOperators
+norm expect=FoldGroupingOperators disable=EliminateGroupBy
 SELECT sum(s) FROM (SELECT y, sum(x) AS s FROM xy GROUP BY x) GROUP BY y
 ----
 project
@@ -4227,7 +4334,7 @@ project
                 └── x:1
 
 # GroupBy on GroupBy case with multiple-column grouping.
-norm expect=FoldGroupingOperators
+norm expect=FoldGroupingOperators disable=EliminateGroupBy
 SELECT sum(s) FROM (SELECT a, sum(c) AS s FROM abc GROUP BY a, b) GROUP BY a
 ----
 project

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -458,7 +458,7 @@ project
            └── f:7 = i:2::FLOAT8 [outer=(2,7), immutable, constraints=(/7: (/NULL - ]), fd=(2)-->(7)]
 
 # Detect PruneSelectCols and PushSelectIntoProject dependency cycle.
-norm
+norm disable=EliminateGroupBy
 SELECT f, f+1.1 AS r FROM (SELECT f, k FROM a GROUP BY f, k HAVING sum(k)=100) a
 ----
 project
@@ -1672,7 +1672,7 @@ project
       └── filters
            └── k:1 = x:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
 
-norm
+norm disable=EliminateGroupBy
 SELECT k FROM (SELECT k, min(s) FROM a GROUP BY k HAVING sum(i) > 5)
 ----
 project

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -1316,7 +1316,7 @@ limit
  └── 1
 
 # Push down only conditions that do not depend on aggregations.
-norm expect=PushSelectIntoGroupBy
+norm expect=PushSelectIntoGroupBy disable=EliminateGroupBy
 SELECT * FROM (SELECT k, i, max(s) m FROM a GROUP BY k, i) a WHERE i=k AND m='foo'
 ----
 select

--- a/pkg/sql/opt/norm/testdata/rules/with
+++ b/pkg/sql/opt/norm/testdata/rules/with
@@ -1937,7 +1937,7 @@ project
       └── i:2 [as=i:5, outer=(2)]
 
 # Case with GroupBy.
-norm expect=TryAddLimitToRecursiveBranch
+norm expect=TryAddLimitToRecursiveBranch disable=EliminateGroupBy
 WITH RECURSIVE cte (i, j) AS (
   (SELECT 1, 2)
   UNION ALL


### PR DESCRIPTION
This resolves issue #114206.

We already have optimization rules that eliminate `GroupBy`s when the grouping columns are/form a key AND all aggregate functions are const-like (i.e. `ConstAgg`, `ConstNotNullAgg`, and `AnyNotNullAgg`.

This expands that optimzation rule to perform the elimination when aggregate functions effectively return the input (preserving the type) if there is only one input. For example, `Sum`, `BoolAnd`, and `ConcatAgg` are all pass-through.