### PR TITLE
cli/interactive_tests: add `--logs-dir` for server started with `demo -e`

### DIFF
--- a/pkg/cli/interactive_tests/test_demo_partitioning.tcl
+++ b/pkg/cli/interactive_tests/test_demo_partitioning.tcl
@@ -118,13 +118,13 @@ end_test
 
 # Test interaction of -e and license acquisition.
 start_test "Ensure we can run licensed commands with -e"
-send "$argv demo -e \"ALTER TABLE users PARTITION BY LIST (city) (PARTITION p1 VALUES IN ('new york'))\"\r"
+send "$argv demo -e \"ALTER TABLE users PARTITION BY LIST (city) (PARTITION p1 VALUES IN ('new york'))\" --log-dir=logs \r"
 eexpect "ALTER TABLE"
 eexpect $prompt
 end_test
 
 start_test "Ensure that we can run licensed commands with -e when license acquisition is disabled"
-send "$argv demo --disable-demo-license -e \"ALTER TABLE users PARTITION BY LIST (city) (PARTITION p1 VALUES IN ('new york'))\"\r"
+send "$argv demo --disable-demo-license -e \"ALTER TABLE users PARTITION BY LIST (city) (PARTITION p1 VALUES IN ('new york'))\" --log-dir=logs \r"
 eexpect "ALTER TABLE"
 eexpect $prompt
 end_test

--- a/pkg/cli/interactive_tests/test_disable_replication.tcl
+++ b/pkg/cli/interactive_tests/test_disable_replication.tcl
@@ -9,7 +9,7 @@ eexpect ":/# "
 start_test "Check that demo disables replication properly"
 # Disable multitenant until default zone config is properly propagated to
 # virtual clusters. See #110003 for more details.
-send "$argv demo --multitenant=false -e 'show zone configuration for range default'\r"
+send "$argv demo --multitenant=false -e 'show zone configuration for range default' --log-dir=logs \r"
 eexpect "num_replicas = 1"
 eexpect ":/# "
 end_test


### PR DESCRIPTION
While debugging #136739, we found that cockroach logs were missing for two ephemeral demo servers run using the `-e` (`--execute`) option. This change would help us in debugging any future failures.

Informs: #136739

Epic: None

Release note: None