### PR TITLE
sql/tests: fix secondary index key in sysbenchKV.DeleteInsert

### DIFF
--- a/pkg/sql/tests/sysbench_test.go
+++ b/pkg/sql/tests/sysbench_test.go
@@ -8,6 +8,7 @@ package tests_test
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"math/rand"
 	"os"
@@ -394,7 +395,7 @@ func (s *sysbenchKV) IndexUpdate(t tableNum, id rowID) {
 	// Construct the old and new index keys, plus the new index value.
 	oldIndexKey := s.indexKey(t, oldK, id)
 	newIndexKey := s.indexKey(t, newK, id)
-	newIndexValue := s.indexValue(newIndexKey)
+	newIndexValue := s.indexValue()
 
 	// Issue the mutation batch.
 	var b kv.Batch
@@ -436,7 +437,8 @@ func (s *sysbenchKV) DeleteInsert(t tableNum, id rowID, newK kValue, _ cValue, _
 	// Insert the new row.
 	s.encodePKValue(pkValue, newK)
 	newIndexKey := s.indexKey(t, newK, id)
-	newIndexValue := s.indexValue(newIndexKey)
+	newIndexValue := s.indexValue()
+	_ = newIndexKey // avoid unused warning, until next commit
 
 	var b2 kv.Batch
 	b2.CPut(pkKey, pkValue, nil /* expValue */)
@@ -459,36 +461,26 @@ func (s *sysbenchKV) indexKey(t tableNum, k kValue, id rowID) []byte {
 	return key
 }
 
-func (s *sysbenchKV) pkValue(rng *rand.Rand, pkKey roachpb.Key, k kValue) []byte {
+func (s *sysbenchKV) pkValue(rng *rand.Rand, k kValue) []byte {
 	const pkValueSize = 185 // measured from sysbenchSQL
 	b := randutil.RandBytes(rng, pkValueSize)
 	s.encodePKValue(b, k)
-	var v roachpb.Value
-	v.SetBytes(b)
-	v.InitChecksum(pkKey)
-	return v.RawBytes
+	return b
 }
 
 func (s *sysbenchKV) encodePKValue(b []byte, k kValue) {
 	// Replace the first 8 bytes with the k value, so that we can decode k to keep
 	// the secondary index in sync.
-	encoding.EncodeUint64Ascending(b[:8], uint64(k))
+	binary.BigEndian.PutUint64(b, uint64(k))
 }
 
 func (s *sysbenchKV) decodePKValue(b []byte) kValue {
 	// Extract the k value from the first 8 bytes. The rest is random.
-	_, k, err := encoding.DecodeUint64Ascending(b[:8])
-	if err != nil {
-		panic(errors.Wrapf(err, "decoding primary key value"))
-	}
-	return kValue(k)
+	return kValue(binary.BigEndian.Uint64(b))
 }
 
-func (s *sysbenchKV) indexValue(indexKey roachpb.Key) []byte {
-	var v roachpb.Value
-	v.SetBytes(nil)
-	v.InitChecksum(indexKey)
-	return v.RawBytes
+func (s *sysbenchKV) indexValue() []byte {
+	return make([]byte, 0)
 }
 
 func (s *sysbenchKV) prep(rng *rand.Rand) {
@@ -514,9 +506,9 @@ func (s *sysbenchKV) prepDataset(rng *rand.Rand) {
 			id := rowID(j)
 			k := randKValue(rng)
 			pkKey := s.pkKey(t, id)
-			pkValue := s.pkValue(rng, pkKey, k)
+			pkValue := s.pkValue(rng, k)
 			indexKey := s.indexKey(t, k, id)
-			indexValue := s.indexValue(indexKey)
+			indexValue := s.indexValue()
 			b.Put(pkKey, pkValue)
 			b.Put(indexKey, indexValue)
 		}


### PR DESCRIPTION
`sysbenchKV.DeleteInsert` was previously re-inserting the secondary index key that it had just deleted, instead of inserting the secondary index key that corresponds to the new primary index key.

To prevent this kind of bug in the future, we add some checks for secondary index integrity, where appropriate.

Epic: None
Release note: None