### PR TITLE
release-23.1: catalog/lease: deflake TestDescriptorRefreshOnRetry

### DIFF
--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -106,6 +106,7 @@ go_test(
         "//pkg/sql/rowenc/keyside",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
+        "//pkg/sql/stats",
         "//pkg/sql/tests",
         "//pkg/sql/types",
         "//pkg/storage",


### PR DESCRIPTION
Backport 1/1 commits from #137059.

/cc @cockroachdb/release

Release justification: test only change

---

The test was flaky since the background thread to refresh leases could run and cause the acquisition counts to be off.

fixes https://github.com/cockroachdb/cockroach/issues/137033
Release note: None
