### PR TITLE
roachtest: various c2c/ldr improvements

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1172,7 +1172,7 @@ func registerClusterToCluster(r registry.Registry) {
 			timeout:            3 * time.Hour,
 			additionalDuration: 60 * time.Minute,
 			cutover:            30 * time.Minute,
-			clouds:             registry.AllClouds,
+			clouds:             registry.OnlyGCE,
 			suites:             registry.Suites(registry.Nightly),
 		},
 		{
@@ -1210,7 +1210,7 @@ func registerClusterToCluster(r registry.Registry) {
 			timeout:            1 * time.Hour,
 			additionalDuration: 5 * time.Minute,
 			cutover:            0,
-			clouds:             registry.AllExceptAzure,
+			clouds:             registry.OnlyGCE,
 			suites:             registry.Suites(registry.Nightly),
 		},
 		{
@@ -1343,7 +1343,7 @@ func registerClusterToCluster(r registry.Registry) {
 			cutover:                   30 * time.Second,
 			skipNodeDistributionCheck: true,
 			skip:                      "for local ad hoc testing",
-			clouds:                    registry.AllClouds,
+			clouds:                    registry.OnlyGCE,
 			suites:                    registry.Suites(registry.Nightly),
 		},
 		{

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1641,8 +1641,12 @@ func registerClusterReplicationResilience(r registry.Registry) {
 			cutover:                              3 * time.Minute,
 			expectedNodeDeaths:                   1,
 			sometimesTestFingerprintMismatchCode: true,
-			clouds:                               registry.OnlyGCE,
-			suites:                               registry.Suites(registry.Nightly),
+			// The job system can take up to 2 minutes to reclaim a job if the
+			// coordinator dies, so increase the max expected latency to account for
+			// our lovely job system.
+			maxAcceptedLatency: 4 * time.Minute,
+			clouds:             registry.OnlyGCE,
+			suites:             registry.Suites(registry.Nightly),
 		}
 
 		c2cRegisterWrapper(r, rsp.replicationSpec,

--- a/pkg/cmd/roachtest/tests/logical_data_replication.go
+++ b/pkg/cmd/roachtest/tests/logical_data_replication.go
@@ -199,7 +199,7 @@ func registerLogicalDataReplicationTests(r registry.Registry) {
 			Name:             sp.name,
 			Owner:            registry.OwnerDisasterRecovery,
 			Timeout:          60 * time.Minute,
-			CompatibleClouds: registry.AllClouds,
+			CompatibleClouds: registry.OnlyGCE,
 			Suites:           registry.Suites(registry.Nightly),
 			Cluster:          sp.clusterSpec.ToSpec(r),
 			Leases:           registry.MetamorphicLeases,

--- a/pkg/cmd/roachtest/tests/mixed_version_c2c.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_c2c.go
@@ -43,7 +43,7 @@ func registerC2CMixedVersions(r registry.Registry) {
 		additionalDuration:        0 * time.Minute,
 		cutover:                   30 * time.Second,
 		skipNodeDistributionCheck: true,
-		clouds:                    registry.AllClouds,
+		clouds:                    registry.OnlyGCE,
 		suites:                    registry.Suites(registry.Nightly),
 	}
 


### PR DESCRIPTION
commit d422abf8a75d7553b331943034c4f522f8118b0c (HEAD -> butler-pcr-gcp-only, butler/butler-pcr-gcp-only)
Author: Michael Butler <butler@cockroachlabs.com>
Date:   Wed Dec 11 10:42:07 2024 -0500

    roachtest: increase max accepted latency on c2c shutdown tests

    The node shutdown tests occasionally fail when the latency exceeds 2 minutes;
    however if the coordinator shutsdown, a new node may take up to two minutes to
    adopt the job. This patch bumps the latency to 4 mintues to account for the job
    system polling.

    Informs #132730

    Epic: none

commit cc2eb85607e7c08f31ab7fb93776f10963e0ca28
Author: Michael Butler <butler@cockroachlabs.com>
Date:   Wed Dec 11 10:38:26 2024 -0500

    roachtest: only run ldr tests on gce

    We cannot debug perf based failures on other clouds as we do not collect time
    series metrics on them.

    Epic: none

    Release note: none

commit cd89447d63c4e39f61455e7feee1b292f16367e1
Author: Michael Butler <butler@cockroachlabs.com>
Date:   Wed Dec 11 10:37:03 2024 -0500

    roachtest: only run pcr tests on gce

    We cannot debug perf based failures on other platforms without timeseries
    metrics.

    Epic: none

    Release note: none