### PR TITLE
roachtest: enable separate process deployments for several tests

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -980,10 +980,12 @@ func runFollowerReadsMixedVersionSingleRegionTest(
 ) {
 	topology := topologySpec{multiRegion: false}
 	runFollowerReadsMixedVersionTest(ctx, t, c, topology, exactStaleness,
-		// This test does not currently work with shared-process
-		// deployments (#129546), so we do not run it in separate-process
-		// mode either to reduce noise. We should reevaluate once the test
-		// works in shared-process.
+		// This test is incompatible with separate process mode as it queries metrics from
+		// TSDB. Separate process clusters currently do not write to TSDB as serverless uses
+		// third party metrics persistence solutions instead.
+		//
+		// TODO(darrylwong): Once #137625 is complete, we can switch to querying prometheus using
+		// `clusterstats` instead and re-enable separate process.
 		mixedversion.EnabledDeploymentModes(
 			mixedversion.SystemOnlyDeployment,
 			mixedversion.SharedProcessDeployment,
@@ -1016,10 +1018,12 @@ func runFollowerReadsMixedVersionGlobalTableTest(
 		// this issue.
 		mixedversion.MinimumSupportedVersion("v23.2.0"),
 
-		// This test does not currently work with shared-process
-		// deployments (#129167), so we do not run it in separate-process
-		// mode either to reduce noise. We should reevaluate once the test
-		// works in shared-process.
+		// This test is incompatible with separate process mode as it queries metrics from
+		// TSDB. Separate process clusters currently do not write to TSDB as serverless uses
+		// third party metrics persistence solutions instead.
+		//
+		// TODO(darrylwong): Once #137625 is complete, we can switch to querying prometheus using
+		// `clusterstats` instead and re-enable separate process.
 		mixedversion.EnabledDeploymentModes(
 			mixedversion.SystemOnlyDeployment,
 			mixedversion.SharedProcessDeployment,

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2658,6 +2658,15 @@ func registerBackupMixedVersion(r registry.Registry) {
 		TestSelectionOptOutSuites: registry.Suites(registry.Nightly),
 		Randomized:                true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			enabledDeploymentModes := []mixedversion.DeploymentMode{
+				mixedversion.SystemOnlyDeployment,
+				mixedversion.SharedProcessDeployment,
+			}
+			// Separate process deployments do not have node local storage.
+			if !c.IsLocal() {
+				enabledDeploymentModes = append(enabledDeploymentModes, mixedversion.SeparateProcessDeployment)
+			}
+
 			mvt := mixedversion.NewTest(
 				ctx, t, t.L(), c, c.CRDBNodes(),
 				// We use a longer upgrade timeout in this test to give the
@@ -2666,12 +2675,7 @@ func registerBackupMixedVersion(r registry.Registry) {
 				// attempted.
 				mixedversion.UpgradeTimeout(30*time.Minute),
 				mixedversion.AlwaysUseLatestPredecessors,
-				// This test sometimes flake on separate-process
-				// deployments. Needs investigation.
-				mixedversion.EnabledDeploymentModes(
-					mixedversion.SystemOnlyDeployment,
-					mixedversion.SharedProcessDeployment,
-				),
+				mixedversion.EnabledDeploymentModes(enabledDeploymentModes...),
 				// We disable cluster setting mutators because this test
 				// resets the cluster to older versions when verifying cluster
 				// backups. This makes the mixed-version context inaccurate

--- a/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
@@ -296,6 +296,9 @@ func runChangeReplicasMixedVersion(ctx context.Context, t test.Test, c cluster.C
 // mixedversion test is running on a multitenant deployment, and only
 // if required by the active version.
 func enableTenantSplitScatter(l *logger.Logger, r *rand.Rand, h *mixedversion.Helper) error {
+	// Note that although TenantsAndSystemAlignedSettingsVersion generally refers to
+	// shared process deployments, the defaults for SPLIT and SCATTER were also changed
+	// for separate process in the same version.
 	if h.Context().FromVersion.AtLeast(mixedversion.TenantsAndSystemAlignedSettingsVersion) {
 		return nil
 	}

--- a/pkg/cmd/roachtest/tests/mixed_version_decommission.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decommission.go
@@ -35,12 +35,6 @@ func runDecommissionMixedVersions(ctx context.Context, t test.Test, c cluster.Cl
 		// the `workload fixtures import` command, which is only supported
 		// reliably multi-tenant mode starting from that version.
 		mixedversion.MinimumSupportedVersion("v23.2.0"),
-		// This test sometimes flake on separate-process
-		// deployments. Needs investigation.
-		mixedversion.EnabledDeploymentModes(
-			mixedversion.SystemOnlyDeployment,
-			mixedversion.SharedProcessDeployment,
-		),
 	)
 	n1 := 1
 	n2 := 2

--- a/pkg/cmd/roachtest/tests/mixed_version_import.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_import.go
@@ -47,12 +47,6 @@ func runImportMixedVersions(ctx context.Context, t test.Test, c cluster.Cluster,
 		mixedversion.MinimumSupportedVersion("v23.2.0"),
 		// Only use the latest version of each release to work around #127029.
 		mixedversion.AlwaysUseLatestPredecessors,
-		// This test sometimes flake on separate-process
-		// deployments. Needs investigation.
-		mixedversion.EnabledDeploymentModes(
-			mixedversion.SystemOnlyDeployment,
-			mixedversion.SharedProcessDeployment,
-		),
 	)
 	runImport := func(ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper) error {
 		if err := h.Exec(r, "DROP DATABASE IF EXISTS tpcc CASCADE;"); err != nil {

--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -94,15 +94,6 @@ func registerRebalanceLoad(r registry.Registry) {
 				mixedversion.ClusterSettingOption(
 					install.ClusterSettingsOption(settings.ClusterSettings),
 				),
-				// This test does not currently work with shared-process
-				// deployments (#129389), so we do not run it in
-				// separate-process mode either to reduce noise. We should
-				// reevaluate once the test works in shared-process.
-				mixedversion.EnabledDeploymentModes(
-					mixedversion.SystemOnlyDeployment,
-					mixedversion.SharedProcessDeployment,
-				),
-
 				// Only use the latest version of each release to work around #127029.
 				mixedversion.AlwaysUseLatestPredecessors,
 			)
@@ -324,7 +315,7 @@ func rebalanceByLoad(
 func makeStoreCPUFn(
 	ctx context.Context, t test.Test, l *logger.Logger, c cluster.Cluster, numNodes, numStores int,
 ) (func(ctx context.Context) ([]float64, error), error) {
-	adminURLs, err := c.ExternalAdminUIAddr(ctx, l, c.Node(1))
+	adminURLs, err := c.ExternalAdminUIAddr(ctx, l, c.Node(1), option.VirtualClusterName(install.SystemInterfaceName))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -104,14 +104,6 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 		opts = append(
 			opts,
 			mixedversion.NumUpgrades(1),
-			// Disable separate-proces deployments in local runs, as it is
-			// currently failing on the `BACKUP` step, and we don't want to
-			// disrupt CI. Once we figure out a fix for it in nightly runs,
-			// we can re-enable it.
-			mixedversion.EnabledDeploymentModes(
-				mixedversion.SystemOnlyDeployment,
-				mixedversion.SharedProcessDeployment,
-			),
 		)
 	}
 
@@ -119,6 +111,7 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 	mvt.InMixedVersion(
 		"maybe run backup",
 		func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
+			// Separate process deployments do not have node local storage.
 			if h.DeploymentMode() != mixedversion.SeparateProcessDeployment {
 				// Verify that backups can be created in various configurations. This is
 				// important to test because changes in system tables might cause backups to


### PR DESCRIPTION
Now that we have disabled rate limiters in #136930, several tests should be unblocked on separate process mode. This change enables them.

Informs: https://github.com/cockroachdb/cockroach/issues/130968
Release note: none
Epic: none