### PR TITLE
roachtest: make disk bandwidth test manual only

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -38,7 +38,7 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 		Benchmark:        true,
 		CompatibleClouds: registry.AllExceptAzure,
 		// TODO(aaditya): change to weekly once the test stabilizes.
-		Suites:          registry.Suites(registry.Nightly),
+		Suites:          registry.ManualOnly,
 		Cluster:         r.MakeClusterSpec(2, spec.CPU(8), spec.WorkloadNode(), spec.ReuseNone()),
 		RequiresLicense: true,
 		Leases:          registry.MetamorphicLeases,


### PR DESCRIPTION
This test is a little too noisy until we make further improvements to the disk bandwidth limiter.

Fixes: #136064.

Release note: None