### PR TITLE
upgrades: use extra versions for upgrade tests

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -285,8 +285,19 @@ const DevelopmentBranch = true
 // TestFinalVersion).
 const finalVersion Key = -1
 
+// TestingExtraVersions may be set to true in tests which will intentionally use
+// Keys greater than Latest, which typically would crash and/or cause errors.
+// Test packages that utilize this may encounter odd behavior. Resetting it is
+// not required.
+var TestingExtraVersions = false
+
 // Version returns the roachpb.Version corresponding to a key.
 func (k Key) Version() roachpb.Version {
+	if TestingExtraVersions && k > Latest {
+		v := versionTable[Latest]
+		v.Internal += int32(k-Latest) * 2
+		return maybeApplyDevOffset(k, v)
+	}
 	version := versionTable[k]
 	return maybeApplyDevOffset(k, version)
 }

--- a/pkg/sql/catalog/dbdesc/database_desc.go
+++ b/pkg/sql/catalog/dbdesc/database_desc.go
@@ -307,7 +307,7 @@ func (desc *immutable) maybeValidateSystemDatabaseSchemaVersion(
 
 	// TODO(radu): this should really be SystemDatabaseSchemaBootstrapVersion.
 	latestVersion := clusterversion.RemoveDevOffset(clusterversion.Latest.Version())
-	if latestVersion.Less(sv) {
+	if latestVersion.Less(sv) && !clusterversion.TestingExtraVersions {
 		vea.Report(errors.AssertionFailedf(
 			`attempting to set system database schema version to version higher than the latest version (%#v): %#v`,
 			latestVersion,


### PR DESCRIPTION
Previously some of these tests were replacing existing upgrades between min and latest with their overridden impl, which resulted in the actual upgrade not running even though the cluster and schema versions would be updated to indicate it had. This causes problems for any systems in the cluster that then switch on that version and expect its effects when called by the systems run in these tests.

Instead these tests now create additional versions beyond Latest. This is its own can of worms and out-of-bounds errors but usage is currently confined to these tests and hopefully can stay that way.

Release note: none.
Epic: none.