### PR TITLE
scplan: change precedence rule for column dependents

### DIFF
--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_drop_column.go
@@ -66,7 +66,7 @@ func init() {
 
 	registerDepRule(
 		"column type dependents removed right before column type, except if part of a column type alteration ",
-		scgraph.SameStagePrecedence,
+		scgraph.Precedence,
 		"dependent", "column-type",
 		func(from, to NodeVars) rel.Clauses {
 			return rel.Clauses{


### PR DESCRIPTION
WIP; I want to see why this rule was needed.

Release note: None