### PR TITLE
ci: bump dependency for `code-cover-pubish` GH action

### DIFF
--- a/.github/workflows/code-cover-publish.yaml
+++ b/.github/workflows/code-cover-publish.yaml
@@ -19,7 +19,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     steps:
       - name: 'Download artifact'
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v7.0.1
         with:
           script: |
             var artifacts = await github.actions.listWorkflowRunArtifacts({
@@ -30,7 +30,7 @@ jobs:
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "cover"
             })[0];
-            var download = await github.actions.downloadArtifact({
+            var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,


### PR DESCRIPTION
`actions/github-script` started failing auth on `downloadArtifact`
as of several weeks ago. Bumping to the latest version (v7.0.1)
seems to resolve it.

Epic: none
Release note: None