### PR TITLE
kvserver: deflake TestScanNodeVitalityFromKV

### DIFF
--- a/pkg/kv/kvserver/liveness/BUILD.bazel
+++ b/pkg/kv/kvserver/liveness/BUILD.bazel
@@ -50,8 +50,8 @@ go_test(
     ],
     embed = [":liveness"],
     exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "large"},
-        "//conditions:default": {"test.Pool": "default"},
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
     }),
     deps = [
         "//pkg/base",


### PR DESCRIPTION
This commit bumps up the resources for the test target that includes TestScanNodeVitalityFromKV. This comes as a response to a recent test failure which signals an overloaded machine.

Fixes: #137235

Release note: None