### PR TITLE
release-23.2: roachtest: disable 23.1 -> 23.2 testing for follower reads

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -959,6 +959,7 @@ func runFollowerReadsMixedVersionSingleRegionTest(
 	runFollowerReadsMixedVersionTest(ctx, t, c, topology, exactStaleness,
 		// Test currently fails in shared-process deployments, see: #129167.
 		mixedversion.EnabledDeploymentModes(mixedversion.SystemOnlyDeployment),
+		mixedversion.MinimumSupportedVersion("v23.2.0"),
 	)
 }
 

--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -981,6 +981,12 @@ func runFollowerReadsMixedVersionGlobalTableTest(
 		// Use a longer upgrade timeout to give the migrations enough time to finish
 		// considering the cross-region latency.
 		mixedversion.UpgradeTimeout(60*time.Minute),
+
+		// This test is flaky when upgrading from v23.1 to v23.2 for follower
+		// reads in shared-process deployments. There were a number of changes
+		// to tenant health checks since then which appear to have addressed
+		// this issue.
+		mixedversion.MinimumSupportedVersion("v23.2.0"),
 	)
 }
 


### PR DESCRIPTION
Backport:
  * 1/1 commits from "roachtest: disable 23.1 -> 23.2 testing for follower reads" (#133092)
  * 1/1 commits from "roachtest: disable 23.1 -> 23.2 testing for follower reads" (#134335)

Please see individual PRs for details.

/cc @cockroachdb/release

----
Release justification: testing only.