### PR TITLE
kvserver: make SubsumeRequest do a write

### DIFF
--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -2113,7 +2113,7 @@ func (r *RefreshRangeRequest) flags() flag {
 	return isRead | isTxn | isRange | updatesTSCache
 }
 
-func (*SubsumeRequest) flags() flag    { return isRead | isAlone | updatesTSCache }
+func (*SubsumeRequest) flags() flag    { return isWrite | isAlone | updatesTSCache }
 func (*RangeStatsRequest) flags() flag { return isRead }
 func (*QueryResolvedTimestampRequest) flags() flag {
 	return isRead | isRange | requiresClosedTSOlderThanStorageSnapshot

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -5774,9 +5774,10 @@ func TestFlowControlSendQueueRangeSplitMerge(t *testing.T) {
 -- We will exhaust the tokens across all streams while admission is blocked on
 -- n3, using a single 4 MiB (deduction, the write itself is small) write. Then,
 -- we will write a 1 MiB put to the range, split it, write a 1 MiB put to the
--- LHS range, merge the ranges, and write a 1 MiB put to the merged range. We
--- expect that at each stage where a send queue develops n1->s3, the send queue
--- will be flushed by the range merge and range split range operations.`)
+-- LHS range, and a 1MiB put to the RHS range, merge the ranges, and write a 1
+-- MiB put to the merged range. We expect that at each stage where a send
+-- queue develops n1->s3, the send queue will be flushed by the range merge
+-- and range split range operations.`)
 	h.comment(`
 -- Start by exhausting the tokens from n1->s3 and blocking admission on s3.
 -- (Issuing 4x1MiB regular, 3x replicated write that's not admitted on s3.)`)
@@ -5838,13 +5839,11 @@ ORDER BY streams DESC;
 	h.waitForAllTokensReturnedForStreamsV2(ctx, 0, /* serverIdx */
 		testingMkFlowStream(0), testingMkFlowStream(1))
 
-	// TODO(kvoli): Uncomment once we resolve the subsume wait for application
-	// issue. See #136649.
-	// h.comment(`(Sending 1 MiB put request to post-split RHS range)`)
-	// h.put(ctx, roachpb.Key(right.StartKey), 1, admissionpb.NormalPri)
-	// h.comment(`(Sent 1 MiB put request to post-split RHS range)`)
-	// h.waitForAllTokensReturnedForStreamsV2(ctx, 0, /* serverIdx */
-	// 	testingMkFlowStream(0), testingMkFlowStream(1))
+	h.comment(`(Sending 1 MiB put request to post-split RHS range)`)
+	h.put(ctx, roachpb.Key(right.StartKey), 1, admissionpb.NormalPri)
+	h.comment(`(Sent 1 MiB put request to post-split RHS range)`)
+	h.waitForAllTokensReturnedForStreamsV2(ctx, 0, /* serverIdx */
+		testingMkFlowStream(0), testingMkFlowStream(1))
 
 	h.comment(`
 -- Send queue and flow token metrics from n1, post-split and 1 MiB put on

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue_range_split_merge
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/send_queue_range_split_merge
@@ -4,9 +4,10 @@ echo
 -- We will exhaust the tokens across all streams while admission is blocked on
 -- n3, using a single 4 MiB (deduction, the write itself is small) write. Then,
 -- we will write a 1 MiB put to the range, split it, write a 1 MiB put to the
--- LHS range, merge the ranges, and write a 1 MiB put to the merged range. We
--- expect that at each stage where a send queue develops n1->s3, the send queue
--- will be flushed by the range merge and range split range operations.
+-- LHS range, and a 1MiB put to the RHS range, merge the ranges, and write a 1
+-- MiB put to the merged range. We expect that at each stage where a send
+-- queue develops n1->s3, the send queue will be flushed by the range merge
+-- and range split range operations.
 
 
 -- Start by exhausting the tokens from n1->s3 and blocking admission on s3.
@@ -115,6 +116,12 @@ SELECT store_id,
 (Sent 1 MiB put request to post-split LHS range)
 
 
+(Sending 1 MiB put request to post-split RHS range)
+
+
+(Sent 1 MiB put request to post-split RHS range)
+
+
 -- Send queue and flow token metrics from n1, post-split and 1 MiB put on
 -- each side.
 SELECT name, crdb_internal.humanize_bytes(value::INT8)
@@ -123,7 +130,7 @@ SELECT name, crdb_internal.humanize_bytes(value::INT8)
      AND name != 'kvflowcontrol.send_queue.count'
 ORDER BY name ASC;
 
-  kvflowcontrol.send_queue.bytes                                    | 1.0 MiB  
+  kvflowcontrol.send_queue.bytes                                    | 2.0 MiB  
   kvflowcontrol.send_queue.prevent.count                            | 0 B      
   kvflowcontrol.send_queue.scheduled.deducted_bytes                 | 0 B      
   kvflowcontrol.send_queue.scheduled.force_flush                    | 0 B      
@@ -142,7 +149,7 @@ SELECT store_id,
 -----------+------------------------+------------------------+------------------------+-------------------------
   1        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
   2        | 4.0 MiB                | 2.0 MiB                | 4.0 MiB                | 2.0 MiB                 
-  3        | 0 B                    | -4.0 MiB               | 0 B                    | -3.0 MiB                
+  3        | 0 B                    | -5.0 MiB               | 0 B                    | -3.0 MiB                
 
 
 -- (Merging ranges.)
@@ -160,7 +167,7 @@ ORDER BY name ASC;
   kvflowcontrol.send_queue.prevent.count                            | 0 B      
   kvflowcontrol.send_queue.scheduled.deducted_bytes                 | 0 B      
   kvflowcontrol.send_queue.scheduled.force_flush                    | 0 B      
-  kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 2.0 MiB  
+  kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 3.0 MiB  
   kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 0 B      
   kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 0 B      
 SELECT store_id,
@@ -196,7 +203,7 @@ ORDER BY name ASC;
   kvflowcontrol.send_queue.prevent.count                            | 0 B      
   kvflowcontrol.send_queue.scheduled.deducted_bytes                 | 0 B      
   kvflowcontrol.send_queue.scheduled.force_flush                    | 0 B      
-  kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 2.0 MiB  
+  kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 3.0 MiB  
   kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 0 B      
   kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 0 B      
 SELECT store_id,
@@ -228,7 +235,7 @@ ORDER BY name ASC;
   kvflowcontrol.send_queue.prevent.count                            | 0 B      
   kvflowcontrol.send_queue.scheduled.deducted_bytes                 | 0 B      
   kvflowcontrol.send_queue.scheduled.force_flush                    | 0 B      
-  kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 2.0 MiB  
+  kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 3.0 MiB  
   kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 0 B      
   kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 0 B      
 SELECT store_id,


### PR DESCRIPTION
It writes to the replicated Range-ID local key, RangeForceFlushKey, so that all writes preceding the SubsumeRequest are force-flushed to all RHS replicas. This is needed since the merge txn waits for all replicas to apply the writes, since a missing write cannot be tolerated when the RHS range ceases to exist (by getting merged with the LHS).

Long commentary is added explaining why this is safe, and some existing commentary is improved.

Informs #135601

Epic: CRDB-37515

Release note: None