### PR TITLE
roachtest: remove RequiresLicense test spec

### DIFF
--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -94,12 +94,6 @@ type TestSpec struct {
 	// still be run regularly.
 	NonReleaseBlocker bool
 
-	// RequiresLicense indicates that the test requires an
-	// enterprise license to run correctly. Use this to ensure
-	// tests will fail-early if COCKROACH_DEV_LICENSE is not set
-	// in the environment.
-	RequiresLicense bool
-
 	// RequiresDeprecatedWorkload indicates that the test requires
 	// the 'workload' binary to be present for the test to run. Use
 	// this to ensure tests will fail-early if a 'workload' binary

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -36,7 +36,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/util/allstacks"
@@ -297,13 +296,6 @@ func (r *testRunner) Run(
 	// Validate options.
 	if len(tests) == 0 {
 		return fmt.Errorf("no test matched filters")
-	}
-
-	hasDevLicense := config.CockroachDevLicense != ""
-	for _, t := range tests {
-		if t.RequiresLicense && !hasDevLicense {
-			return fmt.Errorf("test %q requires an enterprise license, set COCKROACH_DEV_LICENSE", t.Name)
-		}
 	}
 
 	if err := clustersOpt.validate(); err != nil {

--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -29,7 +29,6 @@ func registerAcceptance(r registry.Registry) {
 		timeout            time.Duration
 		encryptionSupport  registry.EncryptionSupport
 		defaultLeases      bool
-		requiresLicense    bool
 		randomized         bool
 		workloadNode       bool
 		incompatibleClouds registry.CloudSet
@@ -148,7 +147,6 @@ func registerAcceptance(r registry.Registry) {
 				CompatibleClouds:  registry.AllClouds.Remove(tc.incompatibleClouds),
 				Suites:            registry.Suites(registry.Nightly, registry.Quick, registry.Acceptance),
 				Randomized:        tc.randomized,
-				RequiresLicense:   tc.requiresLicense,
 			}
 
 			if tc.timeout != 0 {

--- a/pkg/cmd/roachtest/tests/admission_control_database_drop.go
+++ b/pkg/cmd/roachtest/tests/admission_control_database_drop.go
@@ -43,7 +43,6 @@ func registerDatabaseDrop(r registry.Registry) {
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Weekly),
 		Cluster:          clusterSpec,
-		RequiresLicense:  true,
 		SnapshotPrefix:   "droppable-database-tpce-100k",
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			snapshots, err := c.ListSnapshots(ctx, vm.VolumeSnapshotListOpts{

--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -38,10 +38,9 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 		Benchmark:        true,
 		CompatibleClouds: registry.AllExceptAzure,
 		// TODO(aaditya): change to weekly once the test stabilizes.
-		Suites:          registry.ManualOnly,
-		Cluster:         r.MakeClusterSpec(2, spec.CPU(8), spec.WorkloadNode(), spec.ReuseNone()),
-		RequiresLicense: true,
-		Leases:          registry.MetamorphicLeases,
+		Suites:  registry.ManualOnly,
+		Cluster: r.MakeClusterSpec(2, spec.CPU(8), spec.WorkloadNode(), spec.ReuseNone()),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.Spec().NodeCount != 2 {
 				t.Fatalf("expected 2 nodes, found %d", c.Spec().NodeCount)

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_cdc.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_cdc.go
@@ -32,7 +32,6 @@ func registerElasticControlForCDC(r registry.Registry) {
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Weekly),
 		Cluster:          r.MakeClusterSpec(4, spec.CPU(8), spec.WorkloadNode()),
-		RequiresLicense:  true,
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.Spec().NodeCount < 4 {

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
@@ -40,9 +40,8 @@ func registerElasticIO(r registry.Registry) {
 		Suites: registry.Suites(registry.Nightly),
 		// Tags:      registry.Tags(`weekly`),
 		// Second node is solely for Prometheus.
-		Cluster:         r.MakeClusterSpec(2, spec.CPU(8), spec.WorkloadNode()),
-		RequiresLicense: true,
-		Leases:          registry.MetamorphicLeases,
+		Cluster: r.MakeClusterSpec(2, spec.CPU(8), spec.WorkloadNode()),
+		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.IsLocal() {
 				t.Skip("IO overload test is not meant to run locally")

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -46,9 +46,8 @@ func registerIndexBackfill(r registry.Registry) {
 		// TODO(aaditya): Revisit this as part of #111614.
 		//Suites:           registry.Suites(registry.Weekly),
 		//Tags:             registry.Tags(`weekly`),
-		Cluster:         clusterSpec,
-		RequiresLicense: true,
-		SnapshotPrefix:  "index-backfill-tpce-100k",
+		Cluster:        clusterSpec,
+		SnapshotPrefix: "index-backfill-tpce-100k",
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			snapshots, err := c.ListSnapshots(ctx, vm.VolumeSnapshotListOpts{
 				// TODO(irfansharif): Search by taking in the other parts of the

--- a/pkg/cmd/roachtest/tests/admission_control_intent_resolution.go
+++ b/pkg/cmd/roachtest/tests/admission_control_intent_resolution.go
@@ -41,7 +41,6 @@ func registerIntentResolutionOverload(r registry.Registry) {
 		// Tags:      registry.Tags(`weekly`),
 		// Second node is solely for Prometheus.
 		Cluster:          r.MakeClusterSpec(2, spec.CPU(8), spec.WorkloadNode()),
-		RequiresLicense:  true,
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),

--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -82,7 +82,6 @@ func registerBackupRestoreRoundTrip(r registry.Registry) {
 			Owner:             registry.OwnerDisasterRecovery,
 			Cluster:           r.MakeClusterSpec(4, spec.WorkloadNode()),
 			EncryptionSupport: registry.EncryptionMetamorphic,
-			RequiresLicense:   true,
 			NativeLibs:        registry.LibGEOS,
 			// See https://github.com/cockroachdb/cockroach/issues/105968
 			CompatibleClouds:           registry.Clouds(spec.GCE, spec.Local),

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1358,11 +1358,10 @@ func runCDCKafkaAuth(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 func registerCDC(r registry.Registry) {
 	r.Add(registry.TestSpec{
-		Name:            "cdc/initial-scan-only",
-		Owner:           registry.OwnerCDC,
-		Benchmark:       true,
-		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode(), spec.Arch(vm.ArchAMD64)),
-		RequiresLicense: true,
+		Name:      "cdc/initial-scan-only",
+		Owner:     registry.OwnerCDC,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode(), spec.Arch(vm.ArchAMD64)),
 		// This test uses google cloudStorageSink because it is the fastest,
 		// but it is not a requirement for this test. The sink could be
 		// chosen on a per cloud basis if we want to run this on other clouds.
@@ -1392,7 +1391,6 @@ func registerCDC(r registry.Registry) {
 		Name:             "cdc/initial-scan-rolling-restart/normal-checkpoint",
 		Owner:            registry.OwnerCDC,
 		Cluster:          r.MakeClusterSpec(4),
-		RequiresLicense:  true,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Timeout:          30 * time.Minute,
@@ -1404,7 +1402,6 @@ func registerCDC(r registry.Registry) {
 		Name:             "cdc/initial-scan-rolling-restart/shutdown-checkpoint",
 		Owner:            registry.OwnerCDC,
 		Cluster:          r.MakeClusterSpec(4),
-		RequiresLicense:  true,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Timeout:          30 * time.Minute,
@@ -1418,7 +1415,6 @@ func registerCDC(r registry.Registry) {
 		Benchmark:        true,
 		Cluster:          r.MakeClusterSpec(4, spec.WorkloadNode(), spec.CPU(16)),
 		Leases:           registry.MetamorphicLeases,
-		RequiresLicense:  true,
 		CompatibleClouds: registry.AllClouds,
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -1448,7 +1444,6 @@ func registerCDC(r registry.Registry) {
 		Benchmark:        true,
 		Cluster:          r.MakeClusterSpec(4, spec.WorkloadNode(), spec.CPU(16)),
 		Leases:           registry.MetamorphicLeases,
-		RequiresLicense:  true,
 		CompatibleClouds: registry.OnlyAWS,
 		Suites:           registry.ManualOnly,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -1480,7 +1475,6 @@ func registerCDC(r registry.Registry) {
 		Benchmark:        true,
 		Cluster:          r.MakeClusterSpec(4, spec.WorkloadNode(), spec.CPU(16)),
 		Leases:           registry.MetamorphicLeases,
-		RequiresLicense:  true,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -1505,11 +1499,10 @@ func registerCDC(r registry.Registry) {
 		},
 	})
 	r.Add(registry.TestSpec{
-		Name:            "cdc/initial-scan-only/parquet",
-		Owner:           registry.OwnerCDC,
-		Benchmark:       true,
-		Cluster:         r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode(), spec.Arch(vm.ArchAMD64)),
-		RequiresLicense: true,
+		Name:      "cdc/initial-scan-only/parquet",
+		Owner:     registry.OwnerCDC,
+		Benchmark: true,
+		Cluster:   r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode(), spec.Arch(vm.ArchAMD64)),
 		// This test uses google cloudStorageSink because it is the fastest,
 		// but it is not a requirement for this test. The sink could be
 		// chosen on a per cloud basis if we want to run this on other clouds.
@@ -1539,7 +1532,6 @@ func registerCDC(r registry.Registry) {
 		Owner:            registry.OwnerCDC,
 		Benchmark:        true,
 		Cluster:          r.MakeClusterSpec(4, spec.CPU(16), spec.WorkloadNode(), spec.Arch(vm.ArchAMD64)),
-		RequiresLicense:  true,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -1584,7 +1576,6 @@ func registerCDC(r registry.Registry) {
 		// TODO(radu): fix this.
 		CompatibleClouds: registry.AllClouds,
 		Suites:           registry.ManualOnly,
-		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
@@ -1611,7 +1602,6 @@ func registerCDC(r registry.Registry) {
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
-		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
@@ -1634,7 +1624,6 @@ func registerCDC(r registry.Registry) {
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
-		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
@@ -1665,7 +1654,6 @@ func registerCDC(r registry.Registry) {
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
-		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
@@ -1744,7 +1732,6 @@ func registerCDC(r registry.Registry) {
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
-		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
@@ -1783,7 +1770,6 @@ func registerCDC(r registry.Registry) {
 		Leases:                     registry.MetamorphicLeases,
 		CompatibleClouds:           registry.AllExceptAWS,
 		Suites:                     registry.Suites(registry.Nightly),
-		RequiresLicense:            true,
 		RequiresDeprecatedWorkload: true, // uses ledger
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
@@ -1819,7 +1805,6 @@ func registerCDC(r registry.Registry) {
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
-		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
@@ -1850,7 +1835,6 @@ func registerCDC(r registry.Registry) {
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
-		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
@@ -1889,7 +1873,6 @@ func registerCDC(r registry.Registry) {
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
-		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
@@ -1930,7 +1913,6 @@ func registerCDC(r registry.Registry) {
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
-		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
@@ -1962,7 +1944,6 @@ func registerCDC(r registry.Registry) {
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
-		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
@@ -2006,7 +1987,6 @@ func registerCDC(r registry.Registry) {
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
-		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runCDCKafkaAuth(ctx, t, c)
 		},
@@ -2018,7 +1998,6 @@ func registerCDC(r registry.Registry) {
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.OnlyAWS,
 		Suites:           registry.Suites(registry.Nightly),
-		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.All())
 			mskMgr := newMSKManager(ctx, t)
@@ -2054,7 +2033,6 @@ func registerCDC(r registry.Registry) {
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
-		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.Cloud() == spec.Local && runtime.GOARCH == "arm64" {
 				// N.B. We have to skip locally since amd64 emulation may not be available everywhere.
@@ -2101,7 +2079,6 @@ func registerCDC(r registry.Registry) {
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
-		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
@@ -2249,7 +2226,6 @@ func registerCDC(r registry.Registry) {
 			ct.waitForWorkload()
 			ct.verifyMetrics(ctx, verifyMetricsNonZero("changefeed_network_bytes_in", "changefeed_network_bytes_out"))
 		},
-		RequiresLicense: true,
 	})
 	r.Add(registry.TestSpec{
 		Name:             "cdc/bank",
@@ -2258,7 +2234,6 @@ func registerCDC(r registry.Registry) {
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
-		RequiresLicense:  true,
 		Timeout:          60 * time.Minute,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runCDCBank(ctx, t, c)
@@ -2271,7 +2246,6 @@ func registerCDC(r registry.Registry) {
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
-		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runCDCSchemaRegistry(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/cdc_bench.go
+++ b/pkg/cmd/roachtest/tests/cdc_bench.go
@@ -88,7 +88,6 @@ func registerCDCBench(r registry.Registry) {
 				Cluster:          r.MakeClusterSpec(nodes+1, spec.CPU(cpus)),
 				CompatibleClouds: registry.AllExceptAWS,
 				Suites:           registry.Suites(registry.Weekly),
-				RequiresLicense:  true,
 				Timeout:          4 * time.Hour, // Allow for the initial import and catchup scans with 100k ranges.
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runCDCBenchScan(ctx, t, c, scanType, rows, ranges, format)
@@ -119,7 +118,6 @@ func registerCDCBench(r registry.Registry) {
 				Cluster:          r.MakeClusterSpec(nodes+2, spec.CPU(cpus)),
 				CompatibleClouds: registry.AllExceptAWS,
 				Suites:           registry.Suites(registry.Weekly),
-				RequiresLicense:  true,
 				Timeout:          time.Hour,
 				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runCDCBenchWorkload(ctx, t, c, ranges, readPercent, "", "", nullSink)
@@ -137,7 +135,6 @@ func registerCDCBench(r registry.Registry) {
 					Cluster:          r.MakeClusterSpec(nodes+2, spec.CPU(cpus)),
 					CompatibleClouds: registry.AllExceptAWS,
 					Suites:           registry.Suites(registry.Weekly),
-					RequiresLicense:  true,
 					Timeout:          time.Hour,
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						runCDCBenchWorkload(ctx, t, c, ranges, readPercent, server, format, nullSink)
@@ -153,7 +150,6 @@ func registerCDCBench(r registry.Registry) {
 					Cluster:          r.MakeClusterSpec(nodes+3, spec.CPU(cpus)),
 					CompatibleClouds: registry.AllExceptAWS,
 					Suites:           registry.Suites(registry.Weekly),
-					RequiresLicense:  true,
 					Timeout:          time.Hour,
 					Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 						runCDCBenchWorkload(ctx, t, c, ranges, readPercent, server, format, kafkaSink)

--- a/pkg/cmd/roachtest/tests/cdc_filtering.go
+++ b/pkg/cmd/roachtest/tests/cdc_filtering.go
@@ -39,7 +39,6 @@ func registerCDCFiltering(r registry.Registry) {
 			Cluster:          r.MakeClusterSpec(3),
 			CompatibleClouds: registry.AllClouds,
 			Suites:           registry.Suites(registry.Nightly),
-			RequiresLicense:  true,
 			Run:              runCDCSessionFiltering(ignoreFiltering),
 		})
 		r.Add(registry.TestSpec{
@@ -48,7 +47,6 @@ func registerCDCFiltering(r registry.Registry) {
 			Cluster:          r.MakeClusterSpec(3),
 			CompatibleClouds: registry.AllClouds,
 			Suites:           registry.Suites(registry.Nightly),
-			RequiresLicense:  true,
 			Run:              runCDCTTLFiltering(ttlFilteringClusterSetting, ignoreFiltering),
 		})
 		r.Add(registry.TestSpec{
@@ -57,7 +55,6 @@ func registerCDCFiltering(r registry.Registry) {
 			Cluster:          r.MakeClusterSpec(3),
 			CompatibleClouds: registry.AllClouds,
 			Suites:           registry.Suites(registry.Nightly),
-			RequiresLicense:  true,
 			Run:              runCDCTTLFiltering(ttlFilteringTableStorageParam, ignoreFiltering),
 		})
 	}

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -1128,7 +1128,6 @@ func c2cRegisterWrapper(
 		CompatibleClouds:          sp.clouds,
 		Suites:                    sp.suites,
 		TestSelectionOptOutSuites: sp.suites,
-		RequiresLicense:           true,
 		Run:                       run,
 	})
 }

--- a/pkg/cmd/roachtest/tests/costfuzz.go
+++ b/pkg/cmd/roachtest/tests/costfuzz.go
@@ -45,7 +45,6 @@ func registerCostFuzz(r registry.Registry) {
 			Owner:            registry.OwnerSQLQueries,
 			Timeout:          timeOut,
 			RedactResults:    redactResults,
-			RequiresLicense:  true,
 			Cluster:          clusterSpec,
 			CompatibleClouds: registry.AllExceptAWS,
 			Suites:           registry.Suites(registry.Nightly),

--- a/pkg/cmd/roachtest/tests/disagg_rebalance.go
+++ b/pkg/cmd/roachtest/tests/disagg_rebalance.go
@@ -28,7 +28,6 @@ func registerDisaggRebalance(r registry.Registry) {
 		Suites:            registry.Suites(registry.Nightly),
 		Owner:             registry.OwnerStorage,
 		Cluster:           disaggRebalanceSpec,
-		RequiresLicense:   true,
 		EncryptionSupport: registry.EncryptionAlwaysDisabled,
 		Timeout:           4 * time.Hour,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/export_parquet.go
+++ b/pkg/cmd/roachtest/tests/export_parquet.go
@@ -32,7 +32,6 @@ func registerExportParquet(r registry.Registry) {
 		CompatibleClouds: registry.AllClouds,
 		Suites:           registry.ManualOnly,
 		Cluster:          r.MakeClusterSpec(4, spec.CPU(8)),
-		RequiresLicense:  false,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.Spec().NodeCount < 4 {
 				t.Fatalf("expected at least 4 nodes, found %d", c.Spec().NodeCount)
@@ -125,7 +124,6 @@ func registerExportParquet(r registry.Registry) {
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Cluster:          r.MakeClusterSpec(4, spec.CPU(8)),
-		RequiresLicense:  false,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.Spec().NodeCount < 4 {
 				t.Fatalf("expected at least 4 nodes, found %d", c.Spec().NodeCount)

--- a/pkg/cmd/roachtest/tests/fixtures.go
+++ b/pkg/cmd/roachtest/tests/fixtures.go
@@ -64,7 +64,6 @@ func registerFixtures(r registry.Registry) {
 		Suites:           registry.Suites(registry.Fixtures),
 		Owner:            registry.OwnerTestEng,
 		Cluster:          r.MakeClusterSpec(4),
-		RequiresLicense:  true,
 		Run:              runFixtures,
 	})
 }

--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -50,9 +50,8 @@ func registerFollowerReads(r registry.Registry) {
 			name = name + "/insufficient-quorum"
 		}
 		r.Add(registry.TestSpec{
-			Name:            name,
-			Owner:           registry.OwnerKV,
-			RequiresLicense: true,
+			Name:  name,
+			Owner: registry.OwnerKV,
 			Cluster: r.MakeClusterSpec(
 				6, /* nodeCount */
 				spec.CPU(4),
@@ -120,9 +119,8 @@ func registerFollowerReads(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:            "follower-reads/mixed-version/single-region",
-		Owner:           registry.OwnerKV,
-		RequiresLicense: true,
+		Name:  "follower-reads/mixed-version/single-region",
+		Owner: registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(
 			4, /* nodeCount */
 			spec.CPU(2),
@@ -134,9 +132,8 @@ func registerFollowerReads(r registry.Registry) {
 	})
 
 	r.Add(registry.TestSpec{
-		Name:            "follower-reads/mixed-version/survival=region/locality=global/reads=strong",
-		Owner:           registry.OwnerKV,
-		RequiresLicense: true,
+		Name:  "follower-reads/mixed-version/survival=region/locality=global/reads=strong",
+		Owner: registry.OwnerKV,
 		Cluster: r.MakeClusterSpec(
 			6, /* nodeCount */
 			spec.CPU(4),

--- a/pkg/cmd/roachtest/tests/kerberos_connection_stress.go
+++ b/pkg/cmd/roachtest/tests/kerberos_connection_stress.go
@@ -42,7 +42,6 @@ func registerKerberosConnectionStressTest(r registry.Registry) {
 		// Cannot be run locally as it is dependent on Linux.
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
-		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runKerberosConnectionStressTest(ctx, t, c, numNodes, 1)
 		},

--- a/pkg/cmd/roachtest/tests/large_schema_benchmark.go
+++ b/pkg/cmd/roachtest/tests/large_schema_benchmark.go
@@ -73,7 +73,6 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Weekly),
 		Timeout:          testTimeout,
-		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			numWorkers := (len(c.All()) - 1) * 10
 			// Number of tables per-database from the TPCC template.

--- a/pkg/cmd/roachtest/tests/logical_data_replication.go
+++ b/pkg/cmd/roachtest/tests/logical_data_replication.go
@@ -203,7 +203,6 @@ func registerLogicalDataReplicationTests(r registry.Registry) {
 			Suites:           registry.Suites(registry.Nightly),
 			Cluster:          sp.clusterSpec.ToSpec(r),
 			Leases:           registry.MetamorphicLeases,
-			RequiresLicense:  true,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				rng, seed := randutil.NewPseudoRand()
 				t.L().Printf("random seed is %d", seed)

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2649,7 +2649,6 @@ func registerBackupMixedVersion(r registry.Registry) {
 		Owner:             registry.OwnerDisasterRecovery,
 		Cluster:           r.MakeClusterSpec(5, spec.WorkloadNode()),
 		EncryptionSupport: registry.EncryptionMetamorphic,
-		RequiresLicense:   true,
 		NativeLibs:        registry.LibGEOS,
 		// Uses gs://cockroach-fixtures-us-east1. See:
 		// https://github.com/cockroachdb/cockroach/issues/105968

--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -69,7 +69,6 @@ func registerCDCMixedVersions(r registry.Registry) {
 		Timeout:          3 * time.Hour,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
-		RequiresLicense:  true,
 		Randomized:       true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runCDCMixedVersions(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/multi_region_system_database.go
+++ b/pkg/cmd/roachtest/tests/multi_region_system_database.go
@@ -27,7 +27,6 @@ func registerMultiRegionSystemDatabase(r registry.Registry) {
 		Name:             "schemachange/multiregion/system-database",
 		Owner:            registry.OwnerSQLFoundations,
 		Timeout:          time.Hour * 1,
-		RequiresLicense:  true,
 		Cluster:          clusterSpec,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Weekly),

--- a/pkg/cmd/roachtest/tests/multitenant.go
+++ b/pkg/cmd/roachtest/tests/multitenant.go
@@ -399,7 +399,6 @@ func registerMultiTenantMultiregion(r registry.Registry) {
 		),
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		Leases:            registry.MetamorphicLeases,
-		RequiresLicense:   true,
 		CompatibleClouds:  registry.OnlyGCE,
 		Suites:            registry.Suites(registry.Nightly, registry.Quick),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/pg_regress.go
+++ b/pkg/cmd/roachtest/tests/pg_regress.go
@@ -469,7 +469,6 @@ func registerPGRegress(r registry.Registry) {
 		// some diffs include line numbers, so we don't treat failures as
 		// blockers for now.
 		NonReleaseBlocker: true,
-		RequiresLicense:   true,
 		CompatibleClouds:  registry.AllExceptAWS,
 		Suites:            registry.Suites(registry.Weekly),
 		Leases:            registry.MetamorphicLeases,

--- a/pkg/cmd/roachtest/tests/prune_dangling_snapshots_and_disks.go
+++ b/pkg/cmd/roachtest/tests/prune_dangling_snapshots_and_disks.go
@@ -30,7 +30,6 @@ func registerPruneDanglingSnapshotsAndDisks(r registry.Registry) {
 		Cluster:          clusterSpec,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
-		RequiresLicense:  true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			snapshots, err := c.ListSnapshots(ctx, vm.VolumeSnapshotListOpts{
 				CreatedBefore: timeutil.Now().Add(-1 * roachprod.SnapshotTTL),

--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -328,7 +328,6 @@ WITH into_db = 'defaultdb', unsafe_restore_incompatible_version;
 			Leases:           registry.MetamorphicLeases,
 			NativeLibs:       registry.LibGEOS,
 			Timeout:          time.Minute * 20,
-			RequiresLicense:  true,
 			// NB: sqlsmith failures should never block a release.
 			NonReleaseBlocker: true,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/tlp.go
+++ b/pkg/cmd/roachtest/tests/tlp.go
@@ -34,7 +34,6 @@ func registerTLP(r registry.Registry) {
 		Name:             "tlp",
 		Owner:            registry.OwnerSQLQueries,
 		Timeout:          time.Hour * 1,
-		RequiresLicense:  true,
 		Cluster:          r.MakeClusterSpec(1),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),

--- a/pkg/cmd/roachtest/tests/unoptimized_query_oracle.go
+++ b/pkg/cmd/roachtest/tests/unoptimized_query_oracle.go
@@ -54,7 +54,6 @@ func registerUnoptimizedQueryOracle(r registry.Registry) {
 				Owner:            registry.OwnerSQLQueries,
 				NativeLibs:       registry.LibGEOS,
 				Timeout:          time.Hour * 1,
-				RequiresLicense:  true,
 				Cluster:          clusterSpec,
 				CompatibleClouds: registry.AllExceptAWS,
 				Suites:           registry.Suites(registry.Nightly),

--- a/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
+++ b/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
@@ -228,7 +228,6 @@ func registerValidateSystemSchemaAfterVersionUpgradeSeparateProcess(r registry.R
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Cluster:          r.MakeClusterSpec(3),
-		RequiresLicense:  false,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runValidateSystemSchemaAfterVersionUpgradeSeparateProcess(ctx, t, c)
 		},


### PR DESCRIPTION
As of #135326, roachprod will now generate an
enterprise license if one is not supplied, making
the test spec no longer need.

Release note: none
Epic: none
Fixes: none