### PR TITLE
release-23.2: roachtest: update mt-upgrade test owner to db-server

### DIFF
--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -24,7 +24,7 @@ const (
 	OwnerKV               Owner = `kv`
 	OwnerAdmissionControl Owner = `admission-control`
 	OwnerObservability    Owner = `obs-prs`
-	OwnerServer           Owner = `server` // not currently staffed
+	OwnerServer           Owner = `server`
 	OwnerSQLFoundations   Owner = `sql-foundations`
 	OwnerMigrations       Owner = `migrations`
 	OwnerSQLQueries       Owner = `sql-queries`

--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -31,7 +31,7 @@ func registerMultiTenantUpgrade(r registry.Registry) {
 		Cluster:           r.MakeClusterSpec(2),
 		CompatibleClouds:  registry.AllExceptAWS,
 		Suites:            registry.Suites(registry.Nightly),
-		Owner:             registry.OwnerDisasterRecovery,
+		Owner:             registry.OwnerServer,
 		NonReleaseBlocker: false,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runMultiTenantUpgrade(ctx, t, c, t.BuildVersion())


### PR DESCRIPTION
Backport 1/1 commits from #137067.

/cc @cockroachdb/release

---

This PR updates the test ownership for the multitenant-upgrade test to the DB Server team. All future test failures will be routed to `t-db-server` for triage.

Epic: none
Release note: none
Release justification: Test only change
