### PR TITLE
ci: fix typo in `code-cover-publish` GH action

### DIFF
--- a/.github/workflows/code-cover-publish.yaml
+++ b/.github/workflows/code-cover-publish.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/github-script@v7.0.1
         with:
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},


### PR DESCRIPTION
Epic: none

Release note: None