### PR TITLE
kvserver: disable StoreLiveness for ranges that use expiration leases

### DIFF
--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -696,3 +696,15 @@ func NewRangefeedTxnPusher(
 		span: span,
 	}
 }
+
+// SupportFromEnabled exports (replicaRLockedStoreLiveness).SupportFromEnabled
+// for testing purposes.
+func (r *Replica) SupportFromEnabled() bool {
+	return (*replicaRLockedStoreLiveness)(r).SupportFromEnabled()
+}
+
+// RaftFortificationEnabledForRangeID exports raftFortificationEnabledForRangeID
+// for use in tests.
+func RaftFortificationEnabledForRangeID(fracEnabled float64, rangeID roachpb.RangeID) bool {
+	return raftFortificationEnabledForRangeID(fracEnabled, rangeID)
+}

--- a/pkg/kv/kvserver/replica_store_liveness.go
+++ b/pkg/kv/kvserver/replica_store_liveness.go
@@ -89,6 +89,16 @@ func (r *replicaRLockedStoreLiveness) SupportFromEnabled() bool {
 	if !r.store.storeLiveness.SupportFromEnabled(context.TODO()) {
 		return false
 	}
+	if (*Replica)(r).shouldUseExpirationLeaseRLocked() {
+		// If this range wants to use an expiration based lease, either because it's
+		// one of the system ranges (NodeLiveness, Meta) or because the cluster
+		// setting to always use expiration based leases is turned on, then do not
+		// fortify the leader. There's no benefit to doing so because we aren't
+		// going to acquire a leader lease on top of it. On the other hand, by not
+		// fortifying, we ensure there's no StoreLiveness dependency for these
+		// ranges.
+		return false
+	}
 	fracEnabled := RaftLeaderFortificationFractionEnabled.Get(&r.store.ClusterSettings().SV)
 	fortifyEnabled := raftFortificationEnabledForRangeID(fracEnabled, r.RangeID)
 	return fortifyEnabled

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -547,9 +547,14 @@ type StoreTestingKnobs struct {
 	// raft group for that replica.
 	RaftReportUnreachableBypass func(roachpb.ReplicaID) bool
 
-	// DisableUpdateLastUpdateTimesMapOnRaftGroupStep disables updating the
-	// lastUpdateTimes map when a raft group is stepped.
-	DisableUpdateLastUpdateTimesMapOnRaftGroupStep bool
+	// DisableUpdateLastUpdateTimesMapOnRaftGroupStep, if set, is invoked with the
+	// replica whose raft group is being stepped. It returns whether the
+	// lastUpdateTimes map should be not be updated upon stepping the raft group.
+	//
+	// This testing knob is used to simulate the leader not sending or receiving
+	// messages because it has no updates and heartbeats are turned off. This
+	// simulation is only meaningful for ranges that use leader leases.
+	DisableUpdateLastUpdateTimesMapOnRaftGroupStep func(r *Replica) bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
This patch first extracts a few stateless functions, which previously lived on the Replica struct, to compute whether a range should use an expiration based lease or not. We then use these functions to disable StoreLiveness for ranges that use expiration based leases.

Note that this approach works even if the cluster setting to enable expiration based leases unconditionally is flipped within a leadership term, as this is no different than the cluster setting to enable raft fortification being toggled within a leadership term.

Closes https://github.com/cockroachdb/cockroach/issues/137121

Release note: None