### PR TITLE
ccl/changefeedccl/cdcevent: Fix flake in TestEventColumnOrderingWithSchemaChanges

### DIFF
--- a/pkg/ccl/changefeedccl/cdcevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdcevent/BUILD.bazel
@@ -78,6 +78,7 @@ go_test(
         "//pkg/sql/schemachanger/scplan",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sqltestutils",
         "//pkg/sql/types",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",


### PR DESCRIPTION
This commit addresses a test flake in TestEventColumnOrderingWithSchemaChanges. The test relies on the SCHEMA CHANGE GC job, which triggers the RangeFeedDeleteRange event. Since this job runs asynchronously, delays in its execution occasionally caused the test to fail.

To mitigate this, the test has been updated to ensure the job starts more promptly. Additionally, debugging aids have been added to facilitate future investigations if the test fails again.

Epic: None
Closes #136371 
Release note: None