### PR TITLE
pkg/cli: add framework to upload debug zip table dumps to datadog

### DIFF
--- a/pkg/cli/testdata/table_dumps/crdb_internal.system_jobs.txt
+++ b/pkg/cli/testdata/table_dumps/crdb_internal.system_jobs.txt
@@ -1,0 +1,5 @@
+id	status	created	payload	progress	created_by_type	created_by_id	claim_session_id	claim_instance_id	num_runs	last_run
+100	running	2024-12-11 07:39:23.165132	redacted	\x10cc8b98929b9f8a03da0100	NULL	NULL	NULL	NULL	NULL	NULL
+101	running	2024-12-11 07:39:23.366318	redacted	\x10aeafa4929b9f8a03e20100	node	3	NULL	NULL	NULL	NULL
+103	running	2024-12-11 07:39:23.374069	redacted	\x10f5eba4929b9f8a03820200	NULL	NULL	NULL	NULL	NULL	NULL
+104	running	2024-12-11 07:39:23.378479	redacted	\x10af8ea5929b9f8a038a0200	NULL	NULL	NULL	NULL	NULL	NULL

--- a/pkg/cli/testdata/table_dumps/system.namespace.txt
+++ b/pkg/cli/testdata/table_dumps/system.namespace.txt
@@ -1,0 +1,6 @@
+parentID	parentSchemaID	name	id
+0	0	defaultdb	100
+0	0	movr	104
+0	0	postgres	102
+0	0	system	1
+1	0	public	29

--- a/pkg/cli/testdata/upload/profiles
+++ b/pkg/cli/testdata/upload/profiles
@@ -119,5 +119,5 @@ upload-profiles tags=foo:bar skip-cluster-name=true
   }
 }
 ----
-ERROR: cluster name is required for uploading profiles
+ERROR: cluster name is required for uploading artifacts
 debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --tags=foo:bar --include=profiles

--- a/pkg/cli/testdata/upload/tables
+++ b/pkg/cli/testdata/upload/tables
@@ -1,0 +1,22 @@
+upload-tables
+{
+  "nodes": {
+    "1": {}
+  }
+}
+----
+Logs API Hook: claim_instance_id=NULL	claim_session_id=NULL	created=2024-12-11 07:39:23.165132	created_by_id=NULL	created_by_type=NULL	ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.system_jobs	id=100	last_run=NULL	num_runs=NULL	payload=redacted	progress=map[Details:map[keyVisualizerProgress:map[]] Progress:<nil> modified_micros:1.733902763165132e+15 trace_id:0]	status=running	
+Logs API Hook: claim_instance_id=NULL	claim_session_id=NULL	created=2024-12-11 07:39:23.366318	created_by_id=3	created_by_type=node	ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.system_jobs	id=101	last_run=NULL	num_runs=NULL	payload=redacted	progress=map[Details:map[pollJobsStats:map[]] Progress:<nil> modified_micros:1.733902763366318e+15 trace_id:0]	status=running	
+Logs API Hook: claim_instance_id=NULL	claim_session_id=NULL	created=2024-12-11 07:39:23.374069	created_by_id=NULL	created_by_type=NULL	ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.system_jobs	id=103	last_run=NULL	num_runs=NULL	payload=redacted	progress=map[Details:map[update_sql_activity:map[]] Progress:<nil> modified_micros:1.733902763374069e+15 trace_id:0]	status=running	
+Logs API Hook: claim_instance_id=NULL	claim_session_id=NULL	created=2024-12-11 07:39:23.378479	created_by_id=NULL	created_by_type=NULL	ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.system_jobs	id=104	last_run=NULL	num_runs=NULL	payload=redacted	progress=map[Details:map[mvcc_statistics_progress:map[]] Progress:<nil> modified_micros:1.733902763378479e+15 trace_id:0]	status=running	
+Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:system.namespace	id=1	name=system	parentID=0	parentSchemaID=0	
+Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:system.namespace	id=100	name=defaultdb	parentID=0	parentSchemaID=0	
+Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:system.namespace	id=102	name=postgres	parentID=0	parentSchemaID=0	
+Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:system.namespace	id=104	name=movr	parentID=0	parentSchemaID=0	
+Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:system.namespace	id=29	name=public	parentID=1	parentSchemaID=0	
+Logs API Hook: https://http-intake.logs.us5.datadoghq.com/api/v2/logs
+Logs API Hook: https://http-intake.logs.us5.datadoghq.com/api/v2/logs
+Upload ID: abc-20241114000000
+debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=tables
+uploaded crdb_internal.system_jobs.txt
+uploaded system.namespace.txt

--- a/pkg/cli/zip_upload.go
+++ b/pkg/cli/zip_upload.go
@@ -6,6 +6,7 @@
 package cli
 
 import (
+	"bufio"
 	"bytes"
 	"compress/gzip"
 	"context"
@@ -19,6 +20,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -27,9 +29,11 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/system"
@@ -78,6 +82,8 @@ const (
 	nodeIDTag   = "node_id"
 	uploadIDTag = "upload_id"
 	clusterTag  = "cluster"
+	ddTagsTag   = "ddtags"
+	tableTag    = "table"
 
 	// datadog endpoint URLs
 	datadogProfileUploadURLTmpl = "https://intake.profile.%s/v1/input"
@@ -136,6 +142,7 @@ var zipArtifactTypes = []string{"logs"}
 var uploadZipArtifactFuncs = map[string]uploadZipArtifactFunc{
 	"profiles": uploadZipProfiles,
 	"logs":     uploadZipLogs,
+	"tables":   uploadZipTables,
 }
 
 // default datadog tags. Source has to be "cockroachdb" for the logs to be
@@ -190,11 +197,11 @@ func validateZipUploadReadiness() error {
 	}
 
 	if debugZipUploadOpts.ddAPIKey == "" {
-		return fmt.Errorf("datadog API key is required for uploading profiles")
+		return fmt.Errorf("datadog API key is required for uploading artifacts")
 	}
 
 	if debugZipUploadOpts.clusterName == "" {
-		return fmt.Errorf("cluster name is required for uploading profiles")
+		return fmt.Errorf("cluster name is required for uploading artifacts")
 	}
 
 	// validate the artifact types provided and fail early if any of them are not supported
@@ -603,6 +610,179 @@ func uploadZipLogs(ctx context.Context, uploadID string, debugDirPath string) er
 	return nil
 }
 
+type tsvColumnParserFn func(string) (any, error)
+
+type columnParserMap map[string]tsvColumnParserFn
+
+// makeProtoColumnParser returns a generic function that can parse a column
+// using the given proto type. This function is implemented this way because it
+// allows us to effortlessly extend support to new tables without having to
+// write a lot of boilerplate code for unmarshalling each column.
+func makeProtoColumnParser[T protoutil.Message]() tsvColumnParserFn {
+	return func(s string) (any, error) {
+		interpretedBytes, ok := interpretString(s)
+		if !ok {
+			return nil, fmt.Errorf("failed to interpret progress column: %s", s)
+		}
+
+		var zeroValue T // dummy var to infer the type of T
+		obj := reflect.New(reflect.TypeOf(zeroValue).Elem()).Interface().(T)
+		if err := protoutil.Unmarshal(interpretedBytes, obj); err != nil {
+			return nil, err
+		}
+
+		return obj, nil
+	}
+}
+
+// clusterWideTableDumps is a map of table dumps and their column parsers.
+// Column parsers are required for columns that require special interpretation.
+// For example, columns that are protobufs. If the parser is not present for a
+// column, it is assumed to be plain text.
+var clusterWideTableDumps = map[string]columnParserMap{
+	// table dumps with only plain text columns
+	"system.namespace.txt": {},
+
+	// table dumps with columns that need to be interpreted as protos
+	"crdb_internal.system_jobs.txt": {
+		"progress": makeProtoColumnParser[*jobspb.Progress](),
+	},
+}
+
+// uploadZipTables uploads the table dumps to datadog. The concurrency model
+// here is much simpler than the logs upload. We just fan-out work to a limited
+// set of workers and fan-in the errors if any. The workers read the file,
+// parse the columns and uploads the data to datadog.
+func uploadZipTables(ctx context.Context, uploadID string, debugDirPath string) error {
+	var (
+		noOfWorkers = min(debugZipUploadOpts.maxConcurrentUploads, len(clusterWideTableDumps))
+		workChan    = make(chan string, noOfWorkers*2)
+		errChan     = make(chan error, noOfWorkers*2)
+
+		errTables []string
+	)
+
+	for i := 0; i < noOfWorkers; i++ {
+		go func() {
+			for fileName := range workChan {
+				func() {
+					var wrappedErr error
+					if err := processTableDump(
+						ctx, debugDirPath, fileName, uploadID, clusterWideTableDumps[fileName],
+					); err != nil {
+						wrappedErr = fmt.Errorf("%s: %w", fileName, err)
+					}
+
+					errChan <- wrappedErr
+				}()
+			}
+		}()
+	}
+
+	for fileName := range clusterWideTableDumps {
+		workChan <- fileName
+	}
+
+	for range clusterWideTableDumps {
+		if err := <-errChan; err != nil {
+			errTables = append(errTables, err.Error())
+		}
+	}
+
+	if len(errTables) > 0 {
+		fmt.Println("Failed to upload the following table dumps:")
+		for _, err := range errTables {
+			fmt.Printf("\t- %s\n", err)
+		}
+		fmt.Println()
+	}
+
+	close(workChan)
+	close(errChan)
+	return nil
+}
+
+func processTableDump(
+	ctx context.Context, dir, fileName, uploadID string, parsers columnParserMap,
+) error {
+	f, err := os.Open(path.Join(dir, fileName))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	defaultTags := []string{"env:debug", "source:debug-zip"}
+	tableName := strings.TrimSuffix(fileName, filepath.Ext(fileName))
+	lines := [][]byte{}
+	header, iter := makeTableIterator(f)
+	if err := iter(func(row string) error {
+		cols := strings.Split(row, "\t")
+		if len(header) != len(cols) {
+			return errors.Newf("the number of headers is not matching the number of columns in the row")
+		}
+
+		headerColumnMapping := map[string]any{
+			ddTagsTag: strings.Join(append(
+				defaultTags, makeDDTag(uploadIDTag, uploadID), makeDDTag(clusterTag, debugZipUploadOpts.clusterName),
+				makeDDTag(tableTag, tableName),
+			), ","),
+		}
+		for i, h := range header {
+			if parser, ok := parsers[h]; ok {
+				colBytes, err := parser(cols[i])
+				if err != nil {
+					return err
+				}
+
+				headerColumnMapping[h] = colBytes
+				continue
+			}
+
+			headerColumnMapping[h] = cols[i]
+		}
+
+		jsonRow, err := json.Marshal(headerColumnMapping)
+		if err != nil {
+			return err
+		}
+
+		lines = append(lines, jsonRow)
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// datadog's logs API only allows 1000 lines of logs per request. So, split
+	// the lines into batches of 1000.
+	for i := 0; i < len(lines); i += datadogMaxLogLinesPerReq {
+		end := min(i+datadogMaxLogLinesPerReq, len(lines))
+		if _, err := uploadLogsToDatadog(
+			makeDDMultiLineLogPayload(lines[i:end]), debugZipUploadOpts.ddAPIKey, debugZipUploadOpts.ddSite,
+		); err != nil {
+			return err
+		}
+	}
+
+	fmt.Printf("uploaded %s\n", fileName)
+	return nil
+}
+
+// makeTableIterator returns the headers slice and an iterator
+func makeTableIterator(f io.Reader) ([]string, func(func(string) error) error) {
+	scanner := bufio.NewScanner(f)
+	scanner.Scan() // scan the first line to get the headers
+
+	return strings.Split(scanner.Text(), "\t"), func(fn func(string) error) error {
+		for scanner.Scan() {
+			if err := fn(scanner.Text()); err != nil {
+				return err
+			}
+		}
+
+		return scanner.Err()
+	}
+}
+
 type ddArchivePayload struct {
 	Type       string              `json:"type"`
 	Attributes ddArchiveAttributes `json:"attributes"`
@@ -793,12 +973,9 @@ var gcsLogUpload = func(ctx context.Context, sig logUploadSig) (int, error) {
 // formatting required for uploading multiple logs at once. This function
 // implements the logUploadFunc signature.
 func ddLogUpload(ctx context.Context, sig logUploadSig) (int, error) {
-	var buf bytes.Buffer
-	buf.WriteByte('[')
-	buf.Write(bytes.Join(sig.logLines, []byte(",")))
-	buf.WriteByte(']')
-
-	return uploadLogsToDatadog(buf.Bytes(), debugZipUploadOpts.ddAPIKey, debugZipUploadOpts.ddSite)
+	return uploadLogsToDatadog(
+		makeDDMultiLineLogPayload(sig.logLines), debugZipUploadOpts.ddAPIKey, debugZipUploadOpts.ddSite,
+	)
 }
 
 // uploadLogsToDatadog is a generic function that uploads the given payload of
@@ -1079,6 +1256,15 @@ You will receive an email notification once the rehydration is complete.
 // fine because we are validating the site early on in the flow.
 func makeDDURL(tmpl string, ddSite string) string {
 	return fmt.Sprintf(tmpl, ddSiteToHostMap[ddSite])
+}
+
+func makeDDMultiLineLogPayload(logLines [][]byte) []byte {
+	var buf bytes.Buffer
+	buf.WriteByte('[')
+	buf.Write(bytes.Join(logLines, []byte(",")))
+	buf.WriteByte(']')
+
+	return buf.Bytes()
 }
 
 // humanReadableSize converts the given number of bytes to a human readable


### PR DESCRIPTION
The `cockroach debug zip upload` command currently supports uploading the logs present in a debug zip, to datadog. Now we want to also support uploading the table dumps.

This commit implements a framework to do that. Table dumps are present in debug zips in the form of txt files. The contents of these files are in TSV format. The framework takes care of:

  * locating these files
  * parsing them - some columns need to be unmarshaled using a proto struct. The framework makes it easy to create parsers for such columns.
  * transforming them into a datadog compatible log format (each row is converted to a JSON object)
  * and uploading them to datadog (using the logs API)

The tables `crdb_internal.system_jobs` and `system.namespace` are used as examples to demonstrate how this framework is to be used. Implementation for other tables will follow in a separate PR (to avoid a huge diff)

---

### How it looks on Datadog

![image](https://github.com/user-attachments/assets/0926165d-131f-4b6b-afe7-fd31944759cf)

---

Part of: CC-28886
Epic: CC-28996
Release note: None