### PR TITLE
release-24.3: backup: rewrite UDT oids in histograms when restoring table stats

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -737,8 +737,21 @@ func remapAndFilterRelevantStatistics(
 		if statShouldBeIncludedInBackupRestore(stat) {
 			tableHasStatsInBackup[stat.TableID] = struct{}{}
 			if tableRewrite, ok := descriptorRewrites[stat.TableID]; ok {
-				// Statistics imported only when table re-write is present.
+				// We only restore statistics when all necessary descriptor rewrites are
+				// present in the rewrite map.
 				stat.TableID = tableRewrite.ID
+				// We also need to remap the type OID in the histogram for UDTs.
+				if stat.HistogramData != nil && stat.HistogramData.ColumnType != nil {
+					if typ := stat.HistogramData.ColumnType; typ.UserDefined() {
+						typDescID := typedesc.GetUserDefinedTypeDescID(typ)
+						if _, ok := descriptorRewrites[typDescID]; !ok {
+							continue
+						}
+						if err := rewrite.RewriteIDsInTypesT(typ, descriptorRewrites); err != nil {
+							continue
+						}
+					}
+				}
 				relevantTableStatistics = append(relevantTableStatistics, stat)
 			}
 		}

--- a/pkg/ccl/backupccl/testdata/backup-restore/user-defined-types
+++ b/pkg/ccl/backupccl/testdata/backup-restore/user-defined-types
@@ -264,3 +264,92 @@ exec-sql
 DROP TYPE d.farewell
 ----
 pq: cannot drop type "farewell" because other objects ([d.public.t3]) still depend on it
+
+# Regression test for #137106: check that we correctly remap oids in table
+# statistics histograms for user-defined types.
+
+new-cluster name=c1
+----
+
+exec-sql cluster=c1
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = off
+----
+
+exec-sql
+CREATE DATABASE mydb
+----
+
+exec-sql
+CREATE TYPE mydb.public.e AS ENUM ('x', 'y', 'z')
+----
+
+exec-sql
+CREATE TABLE mydb.public.t (e mydb.public.e PRIMARY KEY, a mydb.public.e[], INDEX (a))
+----
+
+exec-sql
+INSERT INTO mydb.public.t VALUES ('x', '{y,z}')
+----
+
+exec-sql
+ANALYZE mydb.public.t
+----
+
+exec-sql
+BACKUP DATABASE mydb INTO 'nodelocal://1/mydb'
+----
+
+new-cluster name=c2 share-io-dir=c1
+----
+
+exec-sql cluster=c2
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = off
+----
+
+# Before restoring, create a few tables such that one of them uses the
+# descriptor ID used by UDT mydb.public.e in the other cluster.
+
+exec-sql
+CREATE DATABASE foo
+----
+
+exec-sql
+CREATE TABLE foo.public.j (j UUID PRIMARY KEY)
+----
+
+exec-sql
+CREATE TABLE foo.public.k (k UUID PRIMARY KEY)
+----
+
+exec-sql
+CREATE TABLE foo.public.l (l UUID PRIMARY KEY)
+----
+
+exec-sql
+CREATE TABLE foo.public.m (m UUID PRIMARY KEY)
+----
+
+exec-sql
+CREATE TABLE foo.public.n (n UUID PRIMARY KEY)
+----
+
+exec-sql
+RESTORE DATABASE mydb FROM LATEST IN 'nodelocal://1/mydb'
+----
+
+# Check that we can decode the histograms in the restored statistics.
+
+query-sql
+SELECT stat->'columns', stat->'histo_col_type', stat->'histo_buckets'->0->'upper_bound'
+FROM (
+  SELECT jsonb_array_elements(statistics) AS stat
+  FROM [SHOW STATISTICS USING JSON FOR TABLE mydb.public.t]
+)
+----
+["e"] "mydb.public.e" "x"
+["a"] "public.e[]" "ARRAY['y':::public.e,'z':::public.e]"
+
+query-sql cluster=c2
+SELECT * FROM mydb.public.t
+----
+x {y,z}

--- a/pkg/sql/catalog/rewrite/rewrite.go
+++ b/pkg/sql/catalog/rewrite/rewrite.go
@@ -257,7 +257,7 @@ func TableDescs(
 		// rewriteCol is a closure that performs the ID rewrite logic on a column.
 		rewriteCol := func(col *descpb.ColumnDescriptor) error {
 			// Rewrite the types.T's IDs present in the column.
-			if err := rewriteIDsInTypesT(col.Type, descriptorRewrites); err != nil {
+			if err := RewriteIDsInTypesT(col.Type, descriptorRewrites); err != nil {
 				return err
 			}
 			var newUsedSeqRefs []descpb.ID
@@ -634,9 +634,9 @@ func rewriteSequencesInFunction(
 	return fmtCtx.CloseAndGetString(), nil
 }
 
-// rewriteIDsInTypesT rewrites all ID's in the input types.T using the input
+// RewriteIDsInTypesT rewrites all ID's in the input types.T using the input
 // ID rewrite mapping.
-func rewriteIDsInTypesT(typ *types.T, descriptorRewrites jobspb.DescRewriteMap) error {
+func RewriteIDsInTypesT(typ *types.T, descriptorRewrites jobspb.DescRewriteMap) error {
 	if !typ.UserDefined() {
 		return nil
 	}
@@ -655,7 +655,7 @@ func rewriteIDsInTypesT(typ *types.T, descriptorRewrites jobspb.DescRewriteMap) 
 	types.RemapUserDefinedTypeOIDs(typ, newOID, newArrayOID)
 	// If the type is an array, then we need to rewrite the element type as well.
 	if typ.Family() == types.ArrayFamily {
-		if err := rewriteIDsInTypesT(typ.ArrayContents(), descriptorRewrites); err != nil {
+		if err := RewriteIDsInTypesT(typ.ArrayContents(), descriptorRewrites); err != nil {
 			return err
 		}
 	}
@@ -748,7 +748,7 @@ func TypeDescs(types []*typedesc.Mutable, descriptorRewrites jobspb.DescRewriteM
 			}
 		case descpb.TypeDescriptor_ALIAS:
 			// We need to rewrite any ID's present in the aliased types.T.
-			if err := rewriteIDsInTypesT(typ.Alias, descriptorRewrites); err != nil {
+			if err := RewriteIDsInTypesT(typ.Alias, descriptorRewrites); err != nil {
 				return err
 			}
 		default:
@@ -788,15 +788,15 @@ func SchemaDescs(schemas []*schemadesc.Mutable, descriptorRewrites jobspb.DescRe
 				}
 				sig.ID = fnDesc.ID
 				for _, typ := range sig.ArgTypes {
-					if err := rewriteIDsInTypesT(typ, descriptorRewrites); err != nil {
+					if err := RewriteIDsInTypesT(typ, descriptorRewrites); err != nil {
 						return err
 					}
 				}
-				if err := rewriteIDsInTypesT(sig.ReturnType, descriptorRewrites); err != nil {
+				if err := RewriteIDsInTypesT(sig.ReturnType, descriptorRewrites); err != nil {
 					return err
 				}
 				for _, typ := range sig.OutParamTypes {
-					if err := rewriteIDsInTypesT(typ, descriptorRewrites); err != nil {
+					if err := RewriteIDsInTypesT(typ, descriptorRewrites); err != nil {
 						return err
 					}
 				}
@@ -933,7 +933,7 @@ func rewriteSchemaChangerState(
 			return err
 		}
 		if err := screl.WalkTypes(t.Element(), func(t *types.T) error {
-			return rewriteIDsInTypesT(t, descriptorRewrites)
+			return RewriteIDsInTypesT(t, descriptorRewrites)
 		}); err != nil {
 			return errors.Wrap(err, "rewriting user-defined type references")
 		}
@@ -1145,11 +1145,11 @@ func FunctionDescs(
 
 		// Rewrite type IDs.
 		for _, param := range fnDesc.Params {
-			if err := rewriteIDsInTypesT(param.Type, descriptorRewrites); err != nil {
+			if err := RewriteIDsInTypesT(param.Type, descriptorRewrites); err != nil {
 				return err
 			}
 		}
-		if err := rewriteIDsInTypesT(fnDesc.ReturnType.Type, descriptorRewrites); err != nil {
+		if err := RewriteIDsInTypesT(fnDesc.ReturnType.Type, descriptorRewrites); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Backport 1/1 commits from #137242.

/cc @cockroachdb/release

---

During restore we need to rewrite any saved references to descriptor IDs and OIDs when restoring table statistics. We were rewriting references to table IDs, but not references to type OIDs for user-defined types.

Fixes: #137106

Release note (bug fix): Fix a bug that caused queries against tables with user-defined types to sometimes fail with errors after restoring those tables.

---

Release justification: fix for customer-discovered bug.