### PR TITLE
release-24.3.1-rc: roachtest: make disk bandwidth test manual only

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -41,8 +41,8 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 		Benchmark:        true,
 		CompatibleClouds: registry.AllExceptAzure,
 		// TODO(aaditya): change to weekly once the test stabilizes.
-		Suites:          registry.Suites(registry.Nightly),
-		Cluster:         r.MakeClusterSpec(2, spec.CPU(8), spec.WorkloadNode()),
+		Suites:          registry.ManualOnly,
+		Cluster:         r.MakeClusterSpec(2, spec.CPU(8), spec.WorkloadNode(), spec.ReuseNone()),
 		RequiresLicense: true,
 		Leases:          registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {


### PR DESCRIPTION
Backport 1/1 commits from #137288.

/cc @cockroachdb/release

Release justification: test-only change

---

This test is a little too noisy until we make further improvements to the disk bandwidth limiter.

Fixes: #136064.

Release note: None
