### PR TITLE
changefeedccl/kvfeed: add log for table that encountered schema change

### DIFF
--- a/pkg/ccl/changefeedccl/kvfeed/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvfeed/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/util/span",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 


### PR DESCRIPTION
This patch adds a log documenting the table(s) that encountered schema
changes and caused the kv feed to restart/exit, which will be useful
for debugging.

Fixes #136624
Closes #134963

Release note: None