### PR TITLE
teamcity: add build configuration to wrap run-pgo-build

### DIFF
--- a/build/teamcity/internal/cockroach/build/ci/generate-profile-impl.sh
+++ b/build/teamcity/internal/cockroach/build/ci/generate-profile-impl.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+set -xeuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"
+
+cleanup() {
+    rm -f ~/.config/gcloud/application_default_credentials.json
+}
+trap cleanup EXIT
+
+source "$dir/teamcity-support.sh"
+google_credentials="$GOOGLE_CREDENTIALS"
+log_into_gcloud
+
+filename=$(date +"%Y%m%d%H%M%S").pprof
+
+bazel build --config ci //pkg/cmd/run-pgo-build
+_bazel/bin/pkg/cmd/run-pgo-build/run-pgo-build_/run-pgo-build -out "$filename"
+shasum -a 256 "$filename"
+
+gsutil cp "$filename" "gs://cockroach-profiles/$filename"
+rm "$filename"

--- a/build/teamcity/internal/cockroach/build/ci/generate-profile.sh
+++ b/build/teamcity/internal/cockroach/build/ci/generate-profile.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+set -xeuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+cleanup() {
+    git clean -dfx
+}
+trap cleanup EXIT
+
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e GOOGLE_CREDENTIALS -e TC_API_PASSWORD -e TC_API_USER -e TC_BUILD_BRANCH -e TC_SERVER_URL" \
+  run_bazel build/teamcity/internal/cockroach/build/ci/generate-profile-impl.sh


### PR DESCRIPTION
This build configuration wraps `run-pgo-build` to run a roachtest
with profiling enabled. The result profile is then uploaded to a GCS
bucket.

Part of: CRDB-44692
Epic: CRDB-41952
Release note: None