### PR TITLE
vecstore: disable deadlock linting for inMemoryLock

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -758,6 +758,8 @@ func TestLint(t *testing.T) {
 			":!testutils/lint/passes/deferunlockcheck/testdata/src/github.com/cockroachdb/cockroach/pkg/util/syncutil/mutex_sync.go",
 			// Exception needed for goroutineStalledStates.
 			":!kv/kvserver/concurrency/concurrency_manager_test.go",
+			// See comment in inMemoryLock class.
+			":!sql/vecindex/vecstore/in_memory_lock.go",
 		)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Do not use syncutil.RWMutex in the inMemoryLock class, because deadlock detection reports spurious failures. Different partitions in the vector index can be locked in different orders by merge, split, format and other operations. In all these cases, we first acquire the in-memory store's structure lock to prevent deadlocks. But the deadlock detection package is not smart enough to realize this and reports false positives.

Epic: CRDB-42943
Fixes: #136958.
Fixes: #136960.

Release note: None