### PR TITLE
jobspb: mark ResolvedSpan_BoundaryType as SafeValue

### DIFF
--- a/pkg/jobs/jobspb/jobs.go
+++ b/pkg/jobs/jobspb/jobs.go
@@ -58,3 +58,6 @@ func (rse ResolvedSpanEntries) Equal(rse2 ResolvedSpanEntries) bool {
 	}
 	return true
 }
+
+// SafeValue implements the redact.SafeValue interface.
+func (ResolvedSpan_BoundaryType) SafeValue() {}

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -78,7 +78,8 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 						"Status":        {},
 					},
 					"github.com/cockroachdb/cockroach/pkg/jobs/jobspb": {
-						"Type": {},
+						"Type":                      {},
+						"ResolvedSpan_BoundaryType": {},
 					},
 					"github.com/cockroachdb/cockroach/pkg/kv/bulk": {
 						"sz":     {},


### PR DESCRIPTION
This patch marks `jobspb.ResolvedSpan_BoundaryType` as a SafeValue
so that it won't be redacted in the logs.

Informs #128597

Release note: None