### PR TITLE
release-24.1: sql: do not limit set-returning UDF when it has OUT parameters

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_setof
+++ b/pkg/sql/logictest/testdata/logic_test/udf_setof
@@ -199,3 +199,41 @@ SELECT * FROM all_ab_tuple()
 2 20
 3 30
 4 40
+
+# OUT parameters should not cause a set-returning UDF to return a single row.
+subtest regression_128403
+
+statement ok
+CREATE FUNCTION f128403(OUT x INT, OUT y TEXT) RETURNS SETOF RECORD AS $$
+  SELECT t, t::TEXT FROM generate_series(1, 10) g(t);
+$$ LANGUAGE SQL;
+
+query T rowsort
+select f128403();
+----
+(1,1)
+(2,2)
+(3,3)
+(4,4)
+(5,5)
+(6,6)
+(7,7)
+(8,8)
+(9,9)
+(10,10)
+
+query IT rowsort
+SELECT * FROM f128403();
+----
+1   1
+2   2
+3   3
+4   4
+5   5
+6   6
+7   7
+8   8
+9   9
+10  10
+
+subtest end

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -284,11 +284,12 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 			panic(pgerror.Newf(pgcode.InvalidFunctionDefinition, "function result type must be %s because of OUT parameters", outParamType.Name()))
 		}
 		// Override the return types so that we do return type validation and SHOW
-		// CREATE correctly.
-		funcReturnType = outParamType
-		cf.ReturnType = &tree.RoutineReturnType{
-			Type: outParamType,
+		// CREATE correctly. Take care not to override the SetOf value if it is set.
+		if cf.ReturnType == nil {
+			cf.ReturnType = &tree.RoutineReturnType{}
 		}
+		cf.ReturnType.Type = outParamType
+		funcReturnType = outParamType
 	} else if funcReturnType == nil {
 		if cf.IsProcedure {
 			// A procedure doesn't need a return type. Use a VOID return type to avoid

--- a/pkg/sql/opt/testutils/testcat/function.go
+++ b/pkg/sql/opt/testutils/testcat/function.go
@@ -133,11 +133,12 @@ func (tc *Catalog) CreateRoutine(c *tree.CreateRoutine) {
 			panic(pgerror.Newf(pgcode.InvalidFunctionDefinition, "function result type must be %s because of OUT parameters", outParamType.Name()))
 		}
 		// Override the return types so that we do return type validation and SHOW
-		// CREATE correctly.
-		retType = outParamType
-		c.ReturnType = &tree.RoutineReturnType{
-			Type: outParamType,
+		// CREATE correctly. Make sure not to override the SetOf value if it is set.
+		if c.ReturnType == nil {
+			c.ReturnType = &tree.RoutineReturnType{}
 		}
+		c.ReturnType.Type = outParamType
+		retType = outParamType
 	} else if retType == nil {
 		if c.IsProcedure {
 			// A procedure doesn't need a return type. Use a VOID return type to avoid


### PR DESCRIPTION
Backport 1/2 commits from #137251.

/cc @cockroachdb/release

---

#### sql: do not limit set-returning UDF when it has OUT parameters

This commit fixes a bug that caused the `SetOf` option for the UDF
`ReturnType` to be overwritten if the UDF had OUT parameters. The bug
caused a `LIMIT 1` to be imposed on the UDF's final body statement, so
that the UDF returned only a single row.

Fixes #128403

Release note (bug fix): Fixed a bug existing since v24.1 that would
cause a set-returning UDF with OUT parameters to return a single row.

---

Release justification: correctness bug fix