### PR TITLE
roachtest: use new ruby version for activerecord test

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -111,11 +111,11 @@ func registerActiveRecord(r registry.Registry) {
 			t,
 			c,
 			node,
-			"install ruby 3.1",
+			"install ruby 3.3",
 			`mkdir -p ruby-install && \
         curl -fsSL https://github.com/postmodern/ruby-install/archive/v0.9.1.tar.gz | tar --strip-components=1 -C ruby-install -xz && \
         sudo make -C ruby-install install && \
-        sudo ruby-install --system ruby 3.1.4 && \
+        sudo ruby-install --system ruby 3.3.6 && \
         sudo gem update --system`,
 		); err != nil {
 			t.Fatal(err)
@@ -146,7 +146,7 @@ func registerActiveRecord(r registry.Registry) {
 			c,
 			node,
 			"installing bundler",
-			`cd /mnt/data1/activerecord-cockroachdb-adapter/ && sudo gem install bundler:2.4.9`,
+			`cd /mnt/data1/activerecord-cockroachdb-adapter/ && sudo gem install bundler:2.5.23`,
 		); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
The latest version of this package needs ruby3.3 in order to pick up this change:
https://github.com/ruby/ruby/commit/7e5c662a6f2e8435f8103bc16185bed6759cc557

Otherwise, these tests fail with:
```
ArgumentError: wrong number of arguments (given 2, expected 0..1)
    /usr/local/lib/ruby/3.1.0/random/formatter.rb:213:in `alphanumeric'
    /usr/local/lib/ruby/gems/3.1.0/bundler/gems/rails-6cfa24f9dfdd/activesupport/lib/active_support/core_ext/securerandom.rb:20:in `base58'
    ...
```

fixes https://github.com/cockroachdb/cockroach/issues/136562
fixes https://github.com/cockroachdb/cockroach/issues/136876
fixes https://github.com/cockroachdb/cockroach/issues/136560
Release note: None