### PR TITLE
roachprod: respect AWS_PROFILE env var

### DIFF
--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -496,7 +496,7 @@ func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 
 // ConfigureClusterFlags implements vm.ProviderOpts.
 func (o *ProviderOpts) ConfigureClusterFlags(flags *pflag.FlagSet, _ vm.MultipleProjectsOption) {
-	flags.StringVar(&providerInstance.Profile, ProviderName+"-profile", providerInstance.Profile,
+	flags.StringVar(&providerInstance.Profile, ProviderName+"-profile", os.Getenv("AWS_PROFILE"),
 		"Profile to manage cluster in")
 	configFlagVal := awsConfigValue{awsConfig: *DefaultConfig}
 	providerInstance.Config = &configFlagVal.awsConfig


### PR DESCRIPTION
Previously, if the AWS_PROFILE env var was set roachprod did not forward it to the `aws cli`. This change automatically sets the profile to the AWS_PROFILE env var if it is not specified via the `--aws-profile` roachprod flag.

Epic: None
Release note: None