### PR TITLE
release-24.2:  send schema workload flakes in backup-restore tests directly to foundations

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -10,6 +10,7 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -248,9 +249,19 @@ func startBackgroundWorkloads(
 	if err != nil {
 		return nil, err
 	}
+
+	handleChemaChangeError := func(err error) error {
+		// If the UNEXPECTED ERROR detail appears, the workload likely flaked.
+		// Otherwise, the workload could have failed due to other reasons like a node
+		// crash.
+		if err != nil && strings.Contains(errors.FlattenDetails(err), "UNEXPECTED ERROR") {
+			return registry.ErrorWithOwner(registry.OwnerSQLFoundations, errors.Wrapf(err, "schema change workload failed"))
+		}
+		return err
+	}
 	err = c.RunE(ctx, option.WithNodes(workloadNode), scInit.String())
 	if err != nil {
-		return nil, registry.ErrorWithOwner(registry.OwnerSQLFoundations, errors.Wrapf(err, "failed to init schema change workload"))
+		return nil, handleChemaChangeError(err)
 	}
 
 	run := func() (func(), error) {
@@ -258,7 +269,6 @@ func startBackgroundWorkloads(
 		if err != nil {
 			return nil, err
 		}
-
 		stopBank := workloadWithCancel(m, func(ctx context.Context) error {
 			return c.RunE(ctx, option.WithNodes(workloadNode), bankRun.String())
 		})
@@ -268,7 +278,7 @@ func startBackgroundWorkloads(
 		})
 		stopSC := workloadWithCancel(m, func(ctx context.Context) error {
 			if err := c.RunE(ctx, option.WithNodes(workloadNode), scRun.String()); err != nil {
-				return registry.ErrorWithOwner(registry.OwnerSQLFoundations, errors.Wrapf(err, "failed to run schema change workload"))
+				return handleChemaChangeError(err)
 			}
 			return nil
 		})


### PR DESCRIPTION
Backport:
  * 1/1 commits from "roachtest: route schema change workload flakes to foundations" (#136152)
  * 1/1 commits from "roachtest: better triage schema workload flakes in backup-restore tests" (#137094)

Please see individual PRs for details.

/cc @cockroachdb/release
