### PR TITLE
kvserver/rangefeed: use caller-passed priority select rf priority

### DIFF
--- a/pkg/kv/kvserver/rangefeed/budget.go
+++ b/pkg/kv/kvserver/rangefeed/budget.go
@@ -366,7 +366,6 @@ func (f *BudgetFactory) CreateBudget(isSystem bool) *FeedBudget {
 	if rangeLimit == 0 {
 		return nil
 	}
-	// We use any table with reserved ID in system tenant as system case.
 	if isSystem {
 		acc := f.systemFeedBytesMon.MakeBoundAccount()
 		return NewFeedBudget(&acc, 0, f.settings)


### PR DESCRIPTION
The Priority configuration for a RangeFeed is used to select which scheduler is used and which feed budget is used. This was previously determined based on whether the tracked key was from a reserved system table.

This didn't handle dynamic system tables. But, all of the caller knows whether the rangefeed is over a system table and already set the admission header appropriately. Here we use that fact to decide whether to treat the feed as a "system" rangefeed.

Epic: none
Release note: None