### PR TITLE
kvserver: deflake TestReplicaCircuitBreaker_RangeFeed

### DIFF
--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -1154,7 +1154,7 @@ func (cbt *circuitBreakerTest) TripBreaker(idx int) {
 
 func (cbt *circuitBreakerTest) UntripsSoon(t *testing.T, method func(idx int) error, idx int) {
 	t.Helper()
-	testutils.SucceedsSoon(t, func() error {
+	testutils.SucceedsWithin(t, func() error {
 		t.Helper()
 		err := method(idx)
 		// All errors coming out should be annotated as coming from
@@ -1170,7 +1170,7 @@ func (cbt *circuitBreakerTest) UntripsSoon(t *testing.T, method func(idx int) er
 			t.Fatalf("saw unexpected error %+v", err)
 		}
 		return err
-	})
+	}, 2*testutils.SucceedsSoonDuration())
 }
 
 func (cbt *circuitBreakerTest) WaitForProposals(t *testing.T, idx int) {


### PR DESCRIPTION
This commit extends the timeout for the function tc.UntripsSoon(). I noticed that with leader leases, this function could take a little longer than before to finish successfully. Especially if we just restart the server.

Fixes: #137372

Release note: None