### PR TITLE
ci: deadmansnitch for code-cover-publish Github Action

### DIFF
--- a/.github/workflows/code-cover-publish.yaml
+++ b/.github/workflows/code-cover-publish.yaml
@@ -56,3 +56,7 @@ jobs:
           parent: false
           destination: 'crl-codecover-public/pr-cockroach/'
           process_gcloudignore: false
+
+      - name: 'Call DeadManSnitch'
+        run: |
+          curl -X GET 'https://nosnch.in/c2d75963ee' -d 'message=Code coverage uploaded to GCS'


### PR DESCRIPTION
Before the fix provided by #137298, this Github Action was silently failing.

This PR configures a call to DeadManSnitch service to report when the Github Action was last successful. The service is configured to alert CRL internal team when no ping was seen in the last 24h.

Epic: none
Release note: None