### PR TITLE
roachtest: skip follower-reads/mixed-version

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -122,6 +122,7 @@ func registerFollowerReads(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:            "follower-reads/mixed-version/single-region",
 		Owner:           registry.OwnerKV,
+		Skip:            "23.1 -> 23.2 upgrades are flaky (#133092)",
 		RequiresLicense: true,
 		Cluster: r.MakeClusterSpec(
 			4, /* nodeCount */
@@ -136,6 +137,7 @@ func registerFollowerReads(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:            "follower-reads/mixed-version/survival=region/locality=global/reads=strong",
 		Owner:           registry.OwnerKV,
+		Skip:            "23.1 -> 23.2 upgrades are flaky (#133092)",
 		RequiresLicense: true,
 		Cluster: r.MakeClusterSpec(
 			6, /* nodeCount */
@@ -959,7 +961,6 @@ func runFollowerReadsMixedVersionSingleRegionTest(
 	runFollowerReadsMixedVersionTest(ctx, t, c, topology, exactStaleness,
 		// Test currently fails in shared-process deployments, see: #129167.
 		mixedversion.EnabledDeploymentModes(mixedversion.SystemOnlyDeployment),
-		mixedversion.MinimumSupportedVersion("v23.2.0"),
 	)
 }
 
@@ -982,12 +983,6 @@ func runFollowerReadsMixedVersionGlobalTableTest(
 		// Use a longer upgrade timeout to give the migrations enough time to finish
 		// considering the cross-region latency.
 		mixedversion.UpgradeTimeout(60*time.Minute),
-
-		// This test is flaky when upgrading from v23.1 to v23.2 for follower
-		// reads in shared-process deployments. There were a number of changes
-		// to tenant health checks since then which appear to have addressed
-		// this issue.
-		mixedversion.MinimumSupportedVersion("v23.2.0"),
 	)
 }
 


### PR DESCRIPTION
Previously, https://github.com/cockroachdb/cockroach/pull/137307 attempted to diable mixed version test upgrades from 23.1 to 23.2, but mixed version tests need a minimum version from an older release series (i.e. can't set a minimum version of 23.2 on branch release-23.2).

This commit reverts https://github.com/cockroachdb/cockroach/pull/137307 and skips the tests on release-23.2 instead.

Fixes: #137389
Fixes: #137390

Release note: None