### PR TITLE
docgen: remove unused BEGIN diagram

### DIFF
--- a/docs/generated/sql/bnf/BUILD.bazel
+++ b/docs/generated/sql/bnf/BUILD.bazel
@@ -73,7 +73,6 @@ FILES = [
     "backup",
     "backup_options",
     "begin_transaction",
-    "begin_stmt",
     "call",
     "cancel_all_jobs",
     "cancel_job",

--- a/docs/generated/sql/bnf/begin_stmt.bnf
+++ b/docs/generated/sql/bnf/begin_stmt.bnf
@@ -1,2 +1,0 @@
-begin_stmt ::=
-	'START' 'TRANSACTION' begin_transaction

--- a/pkg/gen/bnf.bzl
+++ b/pkg/gen/bnf.bzl
@@ -72,7 +72,6 @@ BNF_SRCS = [
     "//docs/generated/sql/bnf:analyze_stmt.bnf",
     "//docs/generated/sql/bnf:backup.bnf",
     "//docs/generated/sql/bnf:backup_options.bnf",
-    "//docs/generated/sql/bnf:begin_stmt.bnf",
     "//docs/generated/sql/bnf:begin_transaction.bnf",
     "//docs/generated/sql/bnf:call.bnf",
     "//docs/generated/sql/bnf:cancel_all_jobs.bnf",

--- a/pkg/gen/diagrams.bzl
+++ b/pkg/gen/diagrams.bzl
@@ -72,7 +72,6 @@ DIAGRAMS_SRCS = [
     "//docs/generated/sql/bnf:analyze.html",
     "//docs/generated/sql/bnf:backup.html",
     "//docs/generated/sql/bnf:backup_options.html",
-    "//docs/generated/sql/bnf:begin.html",
     "//docs/generated/sql/bnf:begin_transaction.html",
     "//docs/generated/sql/bnf:call.html",
     "//docs/generated/sql/bnf:cancel.html",

--- a/pkg/gen/docs.bzl
+++ b/pkg/gen/docs.bzl
@@ -85,7 +85,6 @@ DOCS_SRCS = [
     "//docs/generated/sql/bnf:analyze_stmt.bnf",
     "//docs/generated/sql/bnf:backup.bnf",
     "//docs/generated/sql/bnf:backup_options.bnf",
-    "//docs/generated/sql/bnf:begin_stmt.bnf",
     "//docs/generated/sql/bnf:begin_transaction.bnf",
     "//docs/generated/sql/bnf:call.bnf",
     "//docs/generated/sql/bnf:cancel_all_jobs.bnf",


### PR DESCRIPTION
 #137135 added `begin_stmt` to the .bzl files for SQL diagram generation. However, this diagram is no longer used, and doesn't seem to be generated by `docgen` upon local testing. Removing `begin_stmt` and `begin_stmt.bnf` worked in https://github.com/cockroachdb/cockroach/pull/137111, so this PR applies the same update to `master` and backports to 24.1-3. (cc @rickystewart)

Epic: none
Release note: None