### PR TITLE
kvserver: make TestRaftReceiveQueuesEnforceMaxLenConcurrency cheaper

### DIFF
--- a/pkg/kv/kvserver/store_raft_test.go
+++ b/pkg/kv/kvserver/store_raft_test.go
@@ -270,7 +270,7 @@ func TestRaftReceiveQueuesEnforceMaxLenConcurrency(t *testing.T) {
 	}
 	// Iterate and set different values of enforceMaxLen.
 	enforceMaxLen := false
-	for i := 0; i < 200; i++ {
+	for i := 0; i < 25; i++ {
 		// NB: SetEnforceMaxLen runs concurrently with LoadOrCreate calls.
 		qs.SetEnforceMaxLen(enforceMaxLen)
 		// Exclude all LoadOrCreate calls while checking is happening.


### PR DESCRIPTION
It was timing out, though it completes within 6s on an M1 macbook.

Fixes #137380

Epic: none

Release note: None