### PR TITLE
release-23.2: jobspb: mark ResolvedSpan_BoundaryType as SafeValue

### DIFF
--- a/pkg/jobs/jobspb/jobs.go
+++ b/pkg/jobs/jobspb/jobs.go
@@ -30,3 +30,6 @@ func (fes RestoreFrontierEntries) Equal(fes2 RestoreFrontierEntries) bool {
 	}
 	return true
 }
+
+// SafeValue implements the redact.SafeValue interface.
+func (ResolvedSpan_BoundaryType) SafeValue() {}

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -75,7 +75,8 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 						"Status":        {},
 					},
 					"github.com/cockroachdb/cockroach/pkg/jobs/jobspb": {
-						"Type": {},
+						"Type":                      {},
+						"ResolvedSpan_BoundaryType": {},
 					},
 					"github.com/cockroachdb/cockroach/pkg/kv/bulk": {
 						"sz":     {},


### PR DESCRIPTION
Backport 1/1 commits from #137375.

/cc @cockroachdb/release

---

This patch marks `jobspb.ResolvedSpan_BoundaryType` as a SafeValue
so that it won't be redacted in the logs.

Informs #128597

Release note: None

---

Release justification: logging improvement
