### PR TITLE
rac2: ignore MsgApps when constructing RaftEvent in MsgAppPull mode

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
@@ -1853,6 +1853,15 @@ func TestRaftEventFromMsgStorageAppendAndMsgAppsBasic(t *testing.T) {
 		})
 		require.Equal(t, []raftpb.Message{outboundMsgs[0], outboundMsgs[3], outboundMsgs[2]}, msgApps)
 		checkSnapAndMap(event)
+		// Outbound msgs contains MsgApps for followers, but they are ignored
+		// since in pull mode.
+		event = RaftEventFromMsgStorageAppendAndMsgApps(
+			MsgAppPull, 19, appendMsg, outboundMsgs, logSnap, msgAppScratch, infoMap)
+		require.Equal(t, uint64(10), event.Term)
+		require.Equal(t, appendMsg.Snapshot, event.Snap)
+		require.Equal(t, appendMsg.Entries, event.Entries)
+		require.Nil(t, event.MsgApps)
+		checkSnapAndMap(event)
 	}
 }
 


### PR DESCRIPTION
There can be stale MsgApps even when the replica is in StateReplicate, and these are not relevant and serve only to confuse the downstream code.

Fixes #136322

Epic: CRDB-37515

Release note: None