### PR TITLE
multitenant: add can_prepare_txns tenant capability

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_capability
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_capability
@@ -37,6 +37,7 @@ can_admin_split            true
 can_admin_unsplit          false
 can_check_consistency      false
 can_debug_process          false
+can_prepare_txns           false
 can_use_nodelocal_storage  false
 can_view_all_metrics       false
 can_view_node_info         false
@@ -64,6 +65,7 @@ can_admin_split            true
 can_admin_unsplit          false
 can_check_consistency      false
 can_debug_process          false
+can_prepare_txns           false
 can_use_nodelocal_storage  false
 can_view_all_metrics       false
 can_view_node_info         false
@@ -84,6 +86,7 @@ can_admin_split            false
 can_admin_unsplit          false
 can_check_consistency      false
 can_debug_process          false
+can_prepare_txns           false
 can_use_nodelocal_storage  false
 can_view_all_metrics       false
 can_view_node_info         false
@@ -111,6 +114,7 @@ can_admin_split            true
 can_admin_unsplit          false
 can_check_consistency      false
 can_debug_process          false
+can_prepare_txns           false
 can_use_nodelocal_storage  false
 can_view_all_metrics       false
 can_view_node_info         false
@@ -138,6 +142,7 @@ can_admin_split            true
 can_admin_unsplit          false
 can_check_consistency      false
 can_debug_process          false
+can_prepare_txns           false
 can_use_nodelocal_storage  false
 can_view_all_metrics       false
 can_view_node_info         false
@@ -165,6 +170,7 @@ can_admin_split            true
 can_admin_unsplit          false
 can_check_consistency      false
 can_debug_process          false
+can_prepare_txns           false
 can_use_nodelocal_storage  false
 can_view_all_metrics       false
 can_view_node_info         true
@@ -185,6 +191,7 @@ can_admin_split            false
 can_admin_unsplit          false
 can_check_consistency      false
 can_debug_process          false
+can_prepare_txns           false
 can_use_nodelocal_storage  false
 can_view_all_metrics       false
 can_view_node_info         false
@@ -205,6 +212,7 @@ can_admin_split            false
 can_admin_unsplit          false
 can_check_consistency      false
 can_debug_process          false
+can_prepare_txns           false
 can_use_nodelocal_storage  false
 can_view_all_metrics       false
 can_view_node_info         false
@@ -225,6 +233,7 @@ can_admin_split            false
 can_admin_unsplit          false
 can_check_consistency      false
 can_debug_process          false
+can_prepare_txns           false
 can_use_nodelocal_storage  false
 can_view_all_metrics       false
 can_view_node_info         false
@@ -246,6 +255,7 @@ can_admin_split            true
 can_admin_unsplit          true
 can_check_consistency      true
 can_debug_process          true
+can_prepare_txns           true
 can_use_nodelocal_storage  true
 can_view_all_metrics       true
 can_view_node_info         true
@@ -289,6 +299,7 @@ can_admin_split            true
 can_admin_unsplit          false
 can_check_consistency      false
 can_debug_process          false
+can_prepare_txns           false
 can_use_nodelocal_storage  false
 can_view_all_metrics       false
 can_view_node_info         false
@@ -320,6 +331,7 @@ can_admin_split            true
 can_admin_unsplit          false
 can_check_consistency      false
 can_debug_process          false
+can_prepare_txns           false
 can_use_nodelocal_storage  false
 can_view_all_metrics       false
 can_view_node_info         false
@@ -356,6 +368,7 @@ can_admin_split            true
 can_admin_unsplit          false
 can_check_consistency      false
 can_debug_process          false
+can_prepare_txns           false
 can_use_nodelocal_storage  false
 can_view_all_metrics       false
 can_view_node_info         false
@@ -376,6 +389,7 @@ can_admin_split            false
 can_admin_unsplit          false
 can_check_consistency      false
 can_debug_process          false
+can_prepare_txns           false
 can_use_nodelocal_storage  false
 can_view_all_metrics       false
 can_view_node_info         false
@@ -396,6 +410,7 @@ can_admin_split            true
 can_admin_unsplit          true
 can_check_consistency      true
 can_debug_process          true
+can_prepare_txns           true
 can_use_nodelocal_storage  true
 can_view_all_metrics       true
 can_view_node_info         true

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2206,13 +2206,6 @@ func TestTenantLogic_tuple(
 	runLogicTest(t, "tuple")
 }
 
-func TestTenantLogic_two_phase_commit(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "two_phase_commit")
-}
-
 func TestTenantLogic_txn(
 	t *testing.T,
 ) {

--- a/pkg/ccl/multitenantccl/tenantcapabilitiesccl/capabilities_test.go
+++ b/pkg/ccl/multitenantccl/tenantcapabilitiesccl/capabilities_test.go
@@ -8,6 +8,7 @@ package tenantcapabilitiesccl
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -112,7 +113,10 @@ func TestDataDriven(t *testing.T) {
 				})
 				_, err := tenantSQLDB.Exec(d.Input)
 				if err != nil {
-					return err.Error()
+					errStr := err.Error()
+					// Redact transaction IDs from error strings, for determinism.
+					errStr = regexp.MustCompile(`\[txn: [0-9a-f]+]`).ReplaceAllString(errStr, `[txn: ‹×›]`)
+					return errStr
 				}
 
 			case "exec-sql-tenant":

--- a/pkg/ccl/multitenantccl/tenantcapabilitiesccl/testdata/can_prepare_txns
+++ b/pkg/ccl/multitenantccl/tenantcapabilitiesccl/testdata/can_prepare_txns
@@ -1,0 +1,133 @@
+query-sql-system
+SELECT * FROM [SHOW TENANT [10] WITH CAPABILITIES] WHERE capability_name = 'can_prepare_txns'
+----
+10 cluster-10 ready external can_prepare_txns false
+
+exec-sql-tenant
+CREATE TABLE t(a INT PRIMARY KEY)
+----
+ok
+
+# By default, we should not be able to prepare transactions.
+exec-privileged-op-tenant
+BEGIN
+----
+ok
+
+exec-privileged-op-tenant
+INSERT INTO t VALUES (1)
+----
+ok
+
+exec-privileged-op-tenant
+PREPARE TRANSACTION 'txn1'
+----
+pq: ba: QueryIntent [/Tenant/10/Table/104/1/1/0], EndTxn(commit) [/Tenant/10/Table/104/1/1/0], [txn: ‹×›], [can-forward-ts] RPC error: rpc error: code = Unauthenticated desc = client tenant does not have capability "can_prepare_txns" (*kvpb.EndTxnRequest)
+
+
+# Grant the capability.
+update-capabilities
+ALTER TENANT [10] GRANT CAPABILITY can_prepare_txns=true
+----
+ok
+
+exec-privileged-op-tenant
+BEGIN
+----
+ok
+
+exec-privileged-op-tenant
+INSERT INTO t VALUES (1)
+----
+ok
+
+exec-privileged-op-tenant
+PREPARE TRANSACTION 'txn2'
+----
+ok
+
+exec-privileged-op-tenant
+ROLLBACK PREPARED 'txn2'
+----
+ok
+
+
+# Revoke the capability using REVOKE syntax.
+update-capabilities
+ALTER TENANT [10] REVOKE CAPABILITY can_prepare_txns
+----
+ok
+
+# Prepared transactions should no longer work.
+exec-privileged-op-tenant
+BEGIN
+----
+ok
+
+exec-privileged-op-tenant
+INSERT INTO t VALUES (1)
+----
+ok
+
+exec-privileged-op-tenant
+PREPARE TRANSACTION 'txn3'
+----
+pq: ba: QueryIntent [/Tenant/10/Table/104/1/1/0], EndTxn(commit) [/Tenant/10/Table/104/1/1/0], [txn: ‹×›], [can-forward-ts] RPC error: rpc error: code = Unauthenticated desc = client tenant does not have capability "can_prepare_txns" (*kvpb.EndTxnRequest)
+
+
+# However, transactions that have not acquired locks are able to be prepared,
+# since they don't actually prepare a transaction record in the KV layer. This
+# isn't necessarily intentional, but it is also not harmful or worth changing.
+exec-privileged-op-tenant
+BEGIN
+----
+ok
+
+exec-privileged-op-tenant
+SELECT * FROM t
+----
+ok
+
+exec-privileged-op-tenant
+PREPARE TRANSACTION 'txn4'
+----
+ok
+
+exec-privileged-op-tenant
+COMMIT PREPARED 'txn4'
+----
+ok
+
+
+# Grant the capability one more time.
+update-capabilities
+ALTER TENANT [10] GRANT CAPABILITY can_prepare_txns
+----
+ok
+
+exec-privileged-op-tenant
+BEGIN
+----
+ok
+
+exec-privileged-op-tenant
+INSERT INTO t VALUES (1)
+----
+ok
+
+exec-privileged-op-tenant
+PREPARE TRANSACTION 'txn5'
+----
+ok
+
+# Revoke the capability one more time, which will **not** prevent us from
+# committing (or rolling back) the already prepared transaction.
+update-capabilities
+ALTER TENANT [10] REVOKE CAPABILITY can_prepare_txns
+----
+ok
+
+exec-privileged-op-tenant
+COMMIT PREPARED 'txn5'
+----
+ok

--- a/pkg/multitenant/tenantcapabilities/capabilities.go
+++ b/pkg/multitenant/tenantcapabilities/capabilities.go
@@ -92,6 +92,10 @@ const (
 	// metrics, but this implementation is simpler).
 	CanViewAllMetrics // can_view_all_metrics
 
+	// CanPrepareTxns describes the ability of a tenant to prepare transactions as
+	// part of the XA two-phase commit protocol.
+	CanPrepareTxns // can_prepare_txns
+
 	MaxCapabilityID ID = iota - 1
 )
 
@@ -124,6 +128,7 @@ var capabilities = [MaxCapabilityID + 1]Capability{
 	TenantSpanConfigBounds: spanConfigBoundsCapability(TenantSpanConfigBounds),
 	CanDebugProcess:        boolCapability(CanDebugProcess),
 	CanViewAllMetrics:      boolCapability(CanViewAllMetrics),
+	CanPrepareTxns:         boolCapability(CanPrepareTxns),
 }
 
 // EnableAll enables maximum access to services.

--- a/pkg/multitenant/tenantcapabilities/id_string.go
+++ b/pkg/multitenant/tenantcapabilities/id_string.go
@@ -25,7 +25,8 @@ func _() {
 	_ = x[TenantSpanConfigBounds-10]
 	_ = x[CanDebugProcess-11]
 	_ = x[CanViewAllMetrics-12]
-	_ = x[MaxCapabilityID-12]
+	_ = x[CanPrepareTxns-13]
+	_ = x[MaxCapabilityID-13]
 }
 
 func (i ID) String() string {
@@ -54,6 +55,8 @@ func (i ID) String() string {
 		return "can_debug_process"
 	case CanViewAllMetrics:
 		return "can_view_all_metrics"
+	case CanPrepareTxns:
+		return "can_prepare_txns"
 	default:
 		return "ID(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
@@ -72,7 +75,8 @@ var stringToCapabilityIDMap = map[string]ID{
 	"span_config_bounds":        10,
 	"can_debug_process":         11,
 	"can_view_all_metrics":      12,
-	"MaxCapabilityID":           12,
+	"can_prepare_txns":          13,
+	"MaxCapabilityID":           13,
 }
 
 var IDs = []ID{
@@ -82,6 +86,7 @@ var IDs = []ID{
 	CanAdminUnsplit,
 	CanCheckConsistency,
 	CanDebugProcess,
+	CanPrepareTxns,
 	CanUseNodelocalStorage,
 	CanViewAllMetrics,
 	CanViewNodeInfo,

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/testdata/authorizer_enabled
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/testdata/authorizer_enabled
@@ -8,7 +8,7 @@ client tenant does not have capability "can_admin_scatter" (*kvpb.AdminScatterRe
 
 has-capability-for-batch ten=10 cmds=(Merge)
 ----
-client tenant does not have capability "ID(14)" (*kvpb.MergeRequest)
+client tenant does not have capability "ID(15)" (*kvpb.MergeRequest)
 
 has-node-status-capability ten=10
 ----
@@ -38,7 +38,7 @@ ok
 
 has-capability-for-batch ten=10 cmds=(Merge)
 ----
-client tenant does not have capability "ID(14)" (*kvpb.MergeRequest)
+client tenant does not have capability "ID(15)" (*kvpb.MergeRequest)
 
 has-node-status-capability ten=10
 ----

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/testdata/basic
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiesauthorizer/testdata/basic
@@ -1,8 +1,8 @@
-upsert ten=10 can_admin_relocate_range=true can_admin_scatter=true can_admin_split=true can_admin_unsplit=true can_view_node_info=true can_view_tsdb_metrics=true
+upsert ten=10 can_admin_relocate_range=true can_admin_scatter=true can_admin_split=true can_admin_unsplit=true can_view_node_info=true can_view_tsdb_metrics=true can_prepare_txns=true
 ----
 ok
 
-upsert ten=11 can_admin_relocate_range=false can_admin_scatter=false can_admin_split=false can_admin_unsplit=false can_view_node_info=false can_view_tsdb_metrics=false
+upsert ten=11 can_admin_relocate_range=false can_admin_scatter=false can_admin_split=false can_admin_unsplit=false can_view_node_info=false can_view_tsdb_metrics=false can_prepare_txns=false
 ----
 ok
 
@@ -67,7 +67,7 @@ ok
 
 # Lastly, flip tenant 10's capability for splits; ensure it can no longer issue
 # splits as a result.
-upsert ten=10 can_admin_relocate_range=false can_admin_scatter=true can_admin_split=false can_admin_unsplit=false can_view_node_info=true can_view_tsdb_metrics=true
+upsert ten=10 can_admin_relocate_range=false can_admin_scatter=true can_admin_split=false can_admin_unsplit=false can_view_node_info=true can_view_tsdb_metrics=true can_prepare_txns=true
 ----
 ok
 
@@ -108,6 +108,35 @@ client tenant does not have capability "can_admin_unsplit" (*kvpb.AdminUnsplitRe
 has-capability-for-batch ten=10 cmds=(Scan, ConditionalPut)
 ----
 ok
+
+# Tenant 10 should be able to prepare transactions, but tenant 11 should not.
+has-capability-for-batch ten=10 cmds=(EndTxn)
+----
+ok
+
+has-capability-for-batch ten=10 cmds=(EndTxn{Prepare})
+----
+ok
+
+has-capability-for-batch ten=11 cmds=(EndTxn)
+----
+ok
+
+has-capability-for-batch ten=11 cmds=(EndTxn{Prepare})
+----
+client tenant does not have capability "can_prepare_txns" (*kvpb.EndTxnRequest)
+
+upsert ten=10 can_admin_relocate_range=false can_admin_scatter=true can_admin_split=false can_admin_unsplit=false can_view_node_info=true can_view_tsdb_metrics=true can_prepare_txns=false
+----
+ok
+
+has-capability-for-batch ten=10 cmds=(EndTxn)
+----
+ok
+
+has-capability-for-batch ten=10 cmds=(EndTxn{Prepare})
+----
+client tenant does not have capability "can_prepare_txns" (*kvpb.EndTxnRequest)
 
 has-node-status-capability ten=10
 ----

--- a/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/capabilities.proto
+++ b/pkg/multitenant/tenantcapabilities/tenantcapabilitiespb/capabilities.proto
@@ -95,6 +95,10 @@ message TenantCapabilities {
   // CanViewAllMetrics, if set to true, grants the tenant the ability
   // to query any metrics from the host.
   bool can_view_all_metrics = 12;
+
+  // CanPrepareTxns, if set to true, grants the tenant the ability to prepare
+  // transactions as part of the XA two-phase commit protocol.
+  bool can_prepare_txns = 13;
 };
 
 // SpanConfigBound is used to constrain the possible values a SpanConfig may

--- a/pkg/multitenant/tenantcapabilities/values.go
+++ b/pkg/multitenant/tenantcapabilities/values.go
@@ -55,6 +55,8 @@ func GetValueByID(t *tenantcapabilitiespb.TenantCapabilities, id ID) (Value, err
 		return (*boolValue)(&t.CanDebugProcess), nil
 	case CanViewAllMetrics:
 		return (*boolValue)(&t.CanViewAllMetrics), nil
+	case CanPrepareTxns:
+		return (*boolValue)(&t.CanPrepareTxns), nil
 	default:
 		return nil, errors.AssertionFailedf("unknown capability: %q", id.String())
 	}

--- a/pkg/sql/logictest/testdata/logic_test/two_phase_commit
+++ b/pkg/sql/logictest/testdata/logic_test/two_phase_commit
@@ -1,4 +1,4 @@
-# LogicTest: !local-mixed-24.3
+# LogicTest: !3node-tenant-default-configs !local-mixed-24.3
 
 query T
 SHOW max_prepared_transactions


### PR DESCRIPTION
Informs #22329.

This commit adds a new `can_prepare_txns` tenant capability, so that we adon't allow secondary tenants to prepare transactions by default. Allowing aan untrusted tenant to prepare transactions would allow it to block the aprogress of system-wide backups, so it is too dangerous to allow by default.

Release note: None