### PR TITLE
sql/tests: manually split ranges in `BenchmarkSysbench/KV`

### DIFF
--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -126,6 +126,7 @@ go_test(
         "//pkg/util/allstacks",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",
+        "//pkg/util/hlc",
         "//pkg/util/ioctx",
         "//pkg/util/json",
         "//pkg/util/leaktest",


### PR DESCRIPTION
Split between each table and index to ensure cross-range transactions.

Epic: None
Release note: None