### PR TITLE
changefeedccl: add support for nonstandard oauthbearer kafka authentication

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -5381,6 +5381,9 @@ func TestChangefeedErrors(t *testing.T) {
 		t, `sasl_client_id must be provided when SASL is enabled using mechanism OAUTHBEARER`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_enabled=true&sasl_mechanism=OAUTHBEARER`,
 	)
+
+	// TODO: add some test cases in here for option validation
+
 	sqlDB.ExpectErrWithTimeout(
 		t, `sasl_enabled must be enabled if sasl_user is provided`,
 		`CREATE CHANGEFEED FOR foo INTO $1`, `kafka://nope/?sasl_user=a`,

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -221,6 +221,12 @@ const (
 	SinkParamSASLAwsIAMSessionName  = `sasl_aws_iam_session_name`
 	SinkParamTableNameAttribute     = `with_table_name_attribute`
 
+	// These are custom fields required for custom auth. They should not be
+	// documented.
+	SinkParamSASLCustomResource            = `sasl_custom_resource`
+	SinkParamSASLCustomClientAssertionType = `sasl_custom_client_assertion_type`
+	SinkParamSASLCustomClientAssertion     = `sasl_custom_client_assertion`
+
 	SinkSchemeConfluentKafka    = `confluent-cloud`
 	SinkParamConfluentAPIKey    = `api_key`
 	SinkParamConfluentAPISecret = `api_secret`
@@ -239,8 +245,12 @@ const (
 	Topics = `topics`
 )
 
-// Support additional mechanism on top of the default SASL mechanism.
-const SASLTypeAWSMSKIAM = "AWS_MSK_IAM"
+// Support additional mechanisms on top of the default SASL mechanisms.
+const (
+	SASLTypeAWSMSKIAM = "AWS_MSK_IAM"
+	// TODO: better but generic name
+	SASLTypeCustom = "CUSTOM"
+)
 
 func makeStringSet(opts ...string) map[string]struct{} {
 	res := make(map[string]struct{}, len(opts))

--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -858,6 +858,14 @@ func newTokenProvider(
 	}, nil
 }
 
+func newCustomTokenProvider(
+	ctx context.Context, dialConfig kafkaDialConfig,
+) (sarama.AccessTokenProvider, error) {
+	return &tokenProvider{
+		tokenSource: oauth2.ReuseTokenSource(nil, customTokenSource{dialConfig: dialConfig, ctx: ctx}),
+	}, nil
+}
+
 // Apply configures provided kafka configuration struct based on this config.
 func (c *saramaConfig) Apply(kafka *sarama.Config) error {
 	// Sarama limits the size of each message to be MaxMessageSize (1MB) bytes.
@@ -936,6 +944,15 @@ type kafkaDialConfig struct {
 	saslAwsIAMRoleArn     string
 	saslAwsRegion         string
 	saslAwsIAMSessionName string
+
+	// These are specific to the custom SASL mechanism. It also uses saslTokenURL, and saslClientID.
+	saslCustomConfig saslCustomConfig
+}
+
+type saslCustomConfig struct {
+	resource            string
+	clientAssertionType string
+	clientAssertion     string
 }
 
 func buildDialConfig(u sinkURL) (kafkaDialConfig, error) {
@@ -999,7 +1016,7 @@ func buildDefaultKafkaConfig(u sinkURL) (kafkaDialConfig, error) {
 		dialConfig.saslMechanism = sarama.SASLTypePlaintext
 	}
 	switch dialConfig.saslMechanism {
-	case sarama.SASLTypeSCRAMSHA256, sarama.SASLTypeSCRAMSHA512, sarama.SASLTypeOAuth, sarama.SASLTypePlaintext, changefeedbase.SASLTypeAWSMSKIAM:
+	case sarama.SASLTypeSCRAMSHA256, sarama.SASLTypeSCRAMSHA512, sarama.SASLTypeOAuth, sarama.SASLTypePlaintext, changefeedbase.SASLTypeAWSMSKIAM, changefeedbase.SASLTypeCustom:
 	default:
 		return kafkaDialConfig{}, errors.Errorf(`param %s must be one of %s, %s, %s, %s or %s`,
 			changefeedbase.SinkParamSASLMechanism,
@@ -1014,6 +1031,14 @@ func buildDefaultKafkaConfig(u sinkURL) (kafkaDialConfig, error) {
 	case changefeedbase.SASLTypeAWSMSKIAM:
 		requiredSASLParams = []string{changefeedbase.SinkParamSASLAwsRegion, changefeedbase.SinkParamSASLAwsIAMRoleArn,
 			changefeedbase.SinkParamSASLAwsIAMSessionName}
+	case changefeedbase.SASLTypeCustom:
+		requiredSASLParams = []string{
+			changefeedbase.SinkParamSASLClientID,
+			changefeedbase.SinkParamSASLTokenURL,
+			changefeedbase.SinkParamSASLCustomResource,
+			changefeedbase.SinkParamSASLCustomClientAssertion,
+			changefeedbase.SinkParamSASLCustomClientAssertionType,
+		}
 	default:
 		requiredSASLParams = []string{changefeedbase.SinkParamSASLUser, changefeedbase.SinkParamSASLPassword}
 	}
@@ -1034,7 +1059,8 @@ func buildDefaultKafkaConfig(u sinkURL) (kafkaDialConfig, error) {
 		}
 	}
 
-	if dialConfig.saslMechanism != sarama.SASLTypeOAuth {
+	// TODO: this can be done a little more cleanly.
+	if dialConfig.saslMechanism != sarama.SASLTypeOAuth && dialConfig.saslMechanism != changefeedbase.SASLTypeCustom {
 		oauthParams := []string{changefeedbase.SinkParamSASLClientID, changefeedbase.SinkParamSASLClientSecret,
 			changefeedbase.SinkParamSASLTokenURL, changefeedbase.SinkParamSASLGrantType,
 			changefeedbase.SinkParamSASLScopes}
@@ -1057,6 +1083,10 @@ func buildDefaultKafkaConfig(u sinkURL) (kafkaDialConfig, error) {
 	dialConfig.saslAwsRegion = u.consumeParam(changefeedbase.SinkParamSASLAwsRegion)
 	dialConfig.saslAwsIAMSessionName = u.consumeParam(changefeedbase.SinkParamSASLAwsIAMSessionName)
 	dialConfig.saslAwsIAMRoleArn = u.consumeParam(changefeedbase.SinkParamSASLAwsIAMRoleArn)
+
+	dialConfig.saslCustomConfig.resource = u.consumeParam(changefeedbase.SinkParamSASLCustomResource)
+	dialConfig.saslCustomConfig.clientAssertion = u.consumeParam(changefeedbase.SinkParamSASLCustomClientAssertion)
+	dialConfig.saslCustomConfig.clientAssertionType = u.consumeParam(changefeedbase.SinkParamSASLCustomClientAssertionType)
 
 	var decodedClientSecret []byte
 	if err := u.decodeBase64(changefeedbase.SinkParamSASLClientSecret, &decodedClientSecret); err != nil {
@@ -1289,10 +1319,12 @@ func buildKafkaConfig(
 		config.Net.SASL.User = dialConfig.saslUser
 		config.Net.SASL.Password = dialConfig.saslPassword
 
+		// Substitute our fake SASL mechanism with the backing implementation (OAuth).
 		var mechanism sarama.SASLMechanism
-		if dialConfig.saslMechanism == changefeedbase.SASLTypeAWSMSKIAM {
+		switch dialConfig.saslMechanism {
+		case changefeedbase.SASLTypeAWSMSKIAM, changefeedbase.SASLTypeCustom:
 			mechanism = sarama.SASLTypeOAuth
-		} else {
+		default:
 			mechanism = sarama.SASLMechanism(dialConfig.saslMechanism)
 		}
 
@@ -1305,9 +1337,12 @@ func buildKafkaConfig(
 			config.Net.SASL.SCRAMClientGeneratorFunc = sha256ClientGenerator
 		case sarama.SASLTypeOAuth:
 			var err error
-			if dialConfig.saslMechanism == changefeedbase.SASLTypeAWSMSKIAM {
+			switch dialConfig.saslMechanism {
+			case changefeedbase.SASLTypeAWSMSKIAM:
 				config.Net.SASL.TokenProvider, err = newAwsIAMRoleSASLTokenProvider(ctx, dialConfig)
-			} else {
+			case changefeedbase.SASLTypeCustom:
+				config.Net.SASL.TokenProvider, err = newCustomTokenProvider(ctx, dialConfig)
+			default:
 				config.Net.SASL.TokenProvider, err = newTokenProvider(ctx, dialConfig)
 			}
 			if err != nil {

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -2100,6 +2100,57 @@ func registerCDC(r registry.Registry) {
 			feed.waitForCompletion()
 		},
 	})
+
+	r.Add(registry.TestSpec{
+		Name:  "cdc/kafka-custom-auth",
+		Owner: `cdc`,
+		// Only Kafka 3 supports Arm64, but the broker setup for Oauth used only works with Kafka 2 (?)
+		Cluster:          r.MakeClusterSpec(4, spec.WorkloadNode(), spec.Arch(vm.ArchAMD64)),
+		Leases:           registry.MetamorphicLeases,
+		CompatibleClouds: registry.AllExceptAWS,
+		Suites:           registry.Suites(registry.Nightly),
+		RequiresLicense:  true,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			if c.Cloud() == spec.Local && runtime.GOARCH == "arm64" {
+				// N.B. We have to skip locally since amd64 emulation may not be available everywhere.
+				t.L().PrintfCtx(ctx, "Skipping test under ARM64")
+				return
+			}
+
+			ct := newCDCTester(ctx, t, c)
+			defer ct.Close()
+
+			// Run tpcc workload for tiny bit.  Roachtest monitor does not
+			// like when there are no tasks that were started with the monitor
+			// (This can be removed once #108530 resolved).
+			ct.runTPCCWorkload(tpccArgs{warehouses: 1, duration: "30s"})
+
+			kafkaNode := ct.sinkNodes
+			kafka := kafkaManager{
+				t:              ct.t,
+				c:              ct.cluster,
+				kafkaSinkNodes: kafkaNode,
+				mon:            ct.mon,
+				useKafka2:      true, // The broker-side oauth configuration used only works with Kafka 2
+			}
+			kafka.install(ct.ctx)
+
+			// TODO: how?
+			creds, kafkaEnv := kafka.configureOauth(ct.ctx)
+
+			kafka.start(ctx, "kafka", kafkaEnv)
+
+			feed := ct.newChangefeed(feedArgs{
+				sinkType:        kafkaSink,
+				sinkURIOverride: kafka.sinkURLOAuth(ct.ctx, creds),
+				targets:         allTpccTargets,
+				opts:            map[string]string{"initial_scan": "'only'"},
+			})
+
+			feed.waitForCompletion()
+		},
+	})
+
 	r.Add(registry.TestSpec{
 		Name:             "cdc/kafka-topics",
 		Owner:            `cdc`,
@@ -2932,6 +2983,7 @@ func (k kafkaManager) configureOauth(ctx context.Context) (clientcredentials.Con
 	// CLASSPATH allows Kafka to load in the custom implementation
 	kafkaEnv := "CLASSPATH='/home/ubuntu/kafka-oauth/target/*'"
 
+	// TODO: and here?
 	// Hydra is used as an open source OAuth server
 	clientID, clientSecret := k.configureHydraOauth(ctx)
 	tokenURL := fmt.Sprintf("http://%s:4444/oauth2/token", nodeIP)


### PR DESCRIPTION
Add support for nonstandard oauthbearer kafka authentication.

Fixes: CRDB-42903
Release note: None
