### PR TITLE
sql/sem/tree: prevent heap escape of DatumAlloc method inputs

### DIFF
--- a/pkg/sql/sem/tree/datum_alloc.go
+++ b/pkg/sql/sem/tree/datum_alloc.go
@@ -150,7 +150,9 @@ func (a *DatumAlloc) NewDatums(num int) Datums {
 // NewDInt allocates a DInt.
 func (a *DatumAlloc) NewDInt(v DInt) *DInt {
 	if a == nil {
-		return &v
+		r := new(DInt)
+		*r = v
+		return r
 	}
 	buf := &a.dintAlloc
 	if len(*buf) == 0 {
@@ -171,7 +173,9 @@ func (a *DatumAlloc) NewDInt(v DInt) *DInt {
 // NewDPGLSN allocates a DPGLSN.
 func (a *DatumAlloc) NewDPGLSN(v DPGLSN) *DPGLSN {
 	if a == nil {
-		return &v
+		r := new(DPGLSN)
+		*r = v
+		return r
 	}
 	buf := &a.dpglsnAlloc
 	if len(*buf) == 0 {
@@ -190,7 +194,9 @@ func (a *DatumAlloc) NewDPGLSN(v DPGLSN) *DPGLSN {
 // NewDFloat allocates a DFloat.
 func (a *DatumAlloc) NewDFloat(v DFloat) *DFloat {
 	if a == nil {
-		return &v
+		r := new(DFloat)
+		*r = v
+		return r
 	}
 	buf := &a.dfloatAlloc
 	if len(*buf) == 0 {
@@ -227,7 +233,9 @@ func (a *DatumAlloc) newString() *string {
 // NewDString allocates a DString.
 func (a *DatumAlloc) NewDString(v DString) *DString {
 	if a == nil {
-		return &v
+		r := new(DString)
+		*r = v
+		return r
 	}
 	r := (*DString)(a.newString())
 	*r = v
@@ -255,7 +263,9 @@ func (a *DatumAlloc) NewDRefCursor(v DString) Datum {
 // NewDBytes allocates a DBytes.
 func (a *DatumAlloc) NewDBytes(v DBytes) *DBytes {
 	if a == nil {
-		return &v
+		r := new(DBytes)
+		*r = v
+		return r
 	}
 	r := (*DBytes)(a.newString())
 	*r = v
@@ -265,7 +275,9 @@ func (a *DatumAlloc) NewDBytes(v DBytes) *DBytes {
 // NewDEncodedKey allocates a DEncodedKey.
 func (a *DatumAlloc) NewDEncodedKey(v DEncodedKey) *DEncodedKey {
 	if a == nil {
-		return &v
+		r := new(DEncodedKey)
+		*r = v
+		return r
 	}
 	r := (*DEncodedKey)(a.newString())
 	*r = v
@@ -275,7 +287,9 @@ func (a *DatumAlloc) NewDEncodedKey(v DEncodedKey) *DEncodedKey {
 // NewDBitArray allocates a DBitArray.
 func (a *DatumAlloc) NewDBitArray(v DBitArray) *DBitArray {
 	if a == nil {
-		return &v
+		r := new(DBitArray)
+		*r = v
+		return r
 	}
 	buf := &a.dbitArrayAlloc
 	if len(*buf) == 0 {
@@ -294,7 +308,9 @@ func (a *DatumAlloc) NewDBitArray(v DBitArray) *DBitArray {
 // NewDDecimal allocates a DDecimal.
 func (a *DatumAlloc) NewDDecimal(v DDecimal) *DDecimal {
 	if a == nil {
-		return &v
+		r := new(DDecimal)
+		*r = v
+		return r
 	}
 	buf := &a.ddecimalAlloc
 	if len(*buf) == 0 {
@@ -315,7 +331,9 @@ func (a *DatumAlloc) NewDDecimal(v DDecimal) *DDecimal {
 // NewDDate allocates a DDate.
 func (a *DatumAlloc) NewDDate(v DDate) *DDate {
 	if a == nil {
-		return &v
+		r := new(DDate)
+		*r = v
+		return r
 	}
 	buf := &a.ddateAlloc
 	if len(*buf) == 0 {
@@ -336,7 +354,9 @@ func (a *DatumAlloc) NewDDate(v DDate) *DDate {
 // NewDEnum allocates a DEnum.
 func (a *DatumAlloc) NewDEnum(v DEnum) *DEnum {
 	if a == nil {
-		return &v
+		r := new(DEnum)
+		*r = v
+		return r
 	}
 	buf := &a.denumAlloc
 	if len(*buf) == 0 {
@@ -357,7 +377,9 @@ func (a *DatumAlloc) NewDEnum(v DEnum) *DEnum {
 // NewDBox2D allocates a DBox2D.
 func (a *DatumAlloc) NewDBox2D(v DBox2D) *DBox2D {
 	if a == nil {
-		return &v
+		r := new(DBox2D)
+		*r = v
+		return r
 	}
 	buf := &a.dbox2dAlloc
 	if len(*buf) == 0 {
@@ -376,7 +398,9 @@ func (a *DatumAlloc) NewDBox2D(v DBox2D) *DBox2D {
 // NewDGeography allocates a DGeography.
 func (a *DatumAlloc) NewDGeography(v DGeography) *DGeography {
 	if a == nil {
-		return &v
+		r := new(DGeography)
+		*r = v
+		return r
 	}
 	buf := &a.dgeographyAlloc
 	if len(*buf) == 0 {
@@ -440,7 +464,9 @@ func (a *DatumAlloc) DoneInitNewDGeo(so *geopb.SpatialObject) {
 // NewDGeometry allocates a DGeometry.
 func (a *DatumAlloc) NewDGeometry(v DGeometry) *DGeometry {
 	if a == nil {
-		return &v
+		r := new(DGeometry)
+		*r = v
+		return r
 	}
 	buf := &a.dgeometryAlloc
 	if len(*buf) == 0 {
@@ -485,7 +511,9 @@ func (a *DatumAlloc) giveBytesToEWKB(so *geopb.SpatialObject) {
 // NewDTime allocates a DTime.
 func (a *DatumAlloc) NewDTime(v DTime) *DTime {
 	if a == nil {
-		return &v
+		r := new(DTime)
+		*r = v
+		return r
 	}
 	buf := &a.dtimeAlloc
 	if len(*buf) == 0 {
@@ -504,7 +532,9 @@ func (a *DatumAlloc) NewDTime(v DTime) *DTime {
 // NewDTimeTZ allocates a DTimeTZ.
 func (a *DatumAlloc) NewDTimeTZ(v DTimeTZ) *DTimeTZ {
 	if a == nil {
-		return &v
+		r := new(DTimeTZ)
+		*r = v
+		return r
 	}
 	buf := &a.dtimetzAlloc
 	if len(*buf) == 0 {
@@ -523,7 +553,9 @@ func (a *DatumAlloc) NewDTimeTZ(v DTimeTZ) *DTimeTZ {
 // NewDTimestamp allocates a DTimestamp.
 func (a *DatumAlloc) NewDTimestamp(v DTimestamp) *DTimestamp {
 	if a == nil {
-		return &v
+		r := new(DTimestamp)
+		*r = v
+		return r
 	}
 	buf := &a.dtimestampAlloc
 	if len(*buf) == 0 {
@@ -544,7 +576,9 @@ func (a *DatumAlloc) NewDTimestamp(v DTimestamp) *DTimestamp {
 // NewDTimestampTZ allocates a DTimestampTZ.
 func (a *DatumAlloc) NewDTimestampTZ(v DTimestampTZ) *DTimestampTZ {
 	if a == nil {
-		return &v
+		r := new(DTimestampTZ)
+		*r = v
+		return r
 	}
 	buf := &a.dtimestampTzAlloc
 	if len(*buf) == 0 {
@@ -565,7 +599,9 @@ func (a *DatumAlloc) NewDTimestampTZ(v DTimestampTZ) *DTimestampTZ {
 // NewDInterval allocates a DInterval.
 func (a *DatumAlloc) NewDInterval(v DInterval) *DInterval {
 	if a == nil {
-		return &v
+		r := new(DInterval)
+		*r = v
+		return r
 	}
 	buf := &a.dintervalAlloc
 	if len(*buf) == 0 {
@@ -586,7 +622,9 @@ func (a *DatumAlloc) NewDInterval(v DInterval) *DInterval {
 // NewDUuid allocates a DUuid.
 func (a *DatumAlloc) NewDUuid(v DUuid) *DUuid {
 	if a == nil {
-		return &v
+		r := new(DUuid)
+		*r = v
+		return r
 	}
 	buf := &a.duuidAlloc
 	if len(*buf) == 0 {
@@ -607,7 +645,9 @@ func (a *DatumAlloc) NewDUuid(v DUuid) *DUuid {
 // NewDIPAddr allocates a DIPAddr.
 func (a *DatumAlloc) NewDIPAddr(v DIPAddr) *DIPAddr {
 	if a == nil {
-		return &v
+		r := new(DIPAddr)
+		*r = v
+		return r
 	}
 	buf := &a.dipnetAlloc
 	if len(*buf) == 0 {
@@ -626,7 +666,9 @@ func (a *DatumAlloc) NewDIPAddr(v DIPAddr) *DIPAddr {
 // NewDJSON allocates a DJSON.
 func (a *DatumAlloc) NewDJSON(v DJSON) *DJSON {
 	if a == nil {
-		return &v
+		r := new(DJSON)
+		*r = v
+		return r
 	}
 	buf := &a.djsonAlloc
 	if len(*buf) == 0 {
@@ -647,7 +689,9 @@ func (a *DatumAlloc) NewDJSON(v DJSON) *DJSON {
 // NewDTuple allocates a DTuple.
 func (a *DatumAlloc) NewDTuple(v DTuple) *DTuple {
 	if a == nil {
-		return &v
+		r := new(DTuple)
+		*r = v
+		return r
 	}
 	buf := &a.dtupleAlloc
 	if len(*buf) == 0 {
@@ -666,7 +710,9 @@ func (a *DatumAlloc) NewDTuple(v DTuple) *DTuple {
 // NewDOid allocates a DOid.
 func (a *DatumAlloc) NewDOid(v DOid) Datum {
 	if a == nil {
-		return &v
+		r := new(DOid)
+		*r = v
+		return r
 	}
 	buf := &a.doidAlloc
 	if len(*buf) == 0 {


### PR DESCRIPTION
The changes in commit e17d713c made the inputs of `DatumAlloc` methods
always escape to the heap, even in the case where the receiver is not
`nil`. This commit fixes this by explicitly allocating a datum only when
the receive is nil, and copying the input value into it.

Here's one benchmark to show that this fixes the regression in
allocations:

Before:

```
BenchmarkMaterializer/int6/hasNulls=false/useSel=true              1376446 ns/op  357.09 MB/s  1095462 B/op  61462 allocs/op
BenchmarkMaterializer/int6/hasNulls=false/useSel=true/batchSize=1     3876 ns/op  123.84 MB/s     2736 B/op     82 allocs/op
```

After:

```
BenchmarkMaterializer/int6/hasNulls=false/useSel=true              798796 ns/op  615.33 MB/s  603869 B/op  22 allocs/op
BenchmarkMaterializer/int6/hasNulls=false/useSel=true/batchSize=1  3351 ns/op    143.23 MB/s    2256 B/op  22 allocs/op
```

Epic: None

Release note: None
