### PR TITLE
release-23.2: log: deflake TestHTTPSinkTimeout

### DIFF
--- a/pkg/util/log/http_sink_test.go
+++ b/pkg/util/log/http_sink_test.go
@@ -116,18 +116,15 @@ func testBase(
 	Ops.Infof(context.Background(), "hello world")
 	logDuration := timeutil.Since(logStart)
 
-	// Note: deadline is passed by the caller and already contains slack
-	// to accommodate for the overhead of the logging call compared to
-	// the timeout in the HTTP request.
-	if deadline > 0 && logDuration > deadline {
+	if deadline > 0 {
+		// Note: deadline is passed by the caller and already contains slack
+		// to accommodate for the overhead of the logging call compared to
+		// the timeout in the HTTP request.
 		require.LessOrEqualf(t, logDuration, deadline,
 			"Log call exceeded timeout, expected to be less than %s, got %s", deadline.String(), logDuration.String())
-	}
-
-	// If we don't properly hang in the handler when we want to test a
-	// timeout, we'll just log very quickly. This check ensures that we
-	// catch that testing error.
-	if deadline > 0 && logDuration < *defaults.Timeout {
+		// If we don't properly hang in the handler when we want to test a
+		// timeout, we'll just log very quickly. This check ensures that we
+		// catch that testing error.
 		require.Greaterf(t, logDuration, *defaults.Timeout,
 			"Log call was too fast, expected to be greater than %s, got %s", defaults.Timeout.String(), logDuration.String())
 	}
@@ -199,7 +196,7 @@ func TestHTTPSinkTimeout(t *testing.T) {
 		},
 	}
 
-	testBase(t, defaults, nil /* testFn */, true /* hangServer */, 1*time.Second, time.Duration(0))
+	testBase(t, defaults, nil /* testFn */, true /* hangServer */, 10*time.Second, time.Duration(0))
 }
 
 // TestHTTPSinkContentTypeJSON verifies that the HTTP sink content type


### PR DESCRIPTION
Backport 1/1 commits from #128501.

/cc @cockroachdb/release

---

Previously, this test could flake when we were checking for the log to be emitted within a narrow deadline. There's no need for this check to be so short because all we need to do is make sure we eventually log. Because of CI volatility, it's not possible for this test to reliably generate a sub-second log statement under all conditions.

Resolves: #126539, #127417, #127461
Epic: None

Release note: None
