### PR TITLE
changefeedccl: migrate pts records to include new tables

### DIFF
--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -84,6 +84,10 @@ type TestingKnobs struct {
 	// its PTS record from the deprecated style to the new style.
 	PreserveDeprecatedPts func() bool
 
+	// PreservePTSTargets is used to prevent a changefeed from upgrading
+	// its PTS record to include all required targets.
+	PreservePTSTargets func() bool
+
 	// PulsarClientSkipCreation skips creating the sink client when
 	// dialing.
 	PulsarClientSkipCreation bool


### PR DESCRIPTION
Update the pts records of running feeds when the
set of targets changes, such as when we add new
system tables to protect.

Fixes: #133578
Part of: #128806

Release note (general change): The pts records of
running feeds are now updated when the set of
targets changes, such as when system tables
are added to the protected tables list.
