### PR TITLE
roachprod: fix fips arch on aws

### DIFF
--- a/pkg/roachprod/vm/aws/support.go
+++ b/pkg/roachprod/vm/aws/support.go
@@ -244,7 +244,11 @@ sysctl --system  # reload sysctl settings
 sudo hostnamectl set-hostname {{.VMName}}
 
 {{ if .EnableFIPS }}
-sudo ua enable fips --assume-yes
+sudo apt-get install -yq ubuntu-advantage-tools jq
+# Enable FIPS (in practice, it's often already enabled at this point).
+if [ $(sudo pro status --format json | jq '.services[] | select(.name == "fips") | .status') != '"enabled"' ]; then
+  sudo ua enable fips --assume-yes
+fi
 {{ end }}
 
 sudo sed -i 's/#LoginGraceTime .*/LoginGraceTime 0/g' /etc/ssh/sshd_config


### PR DESCRIPTION
Previously, starting a `fips` arch roachprod cluster on AWS would fail while waiting for the nodes to start. This behavior was due to the fact that `sudo ua enable fips --assume-yes` fails if fips is already enabled on the machine, so the startup script would never reach the end.

This PR fixes the startup script to detect if `fips` is already enabled like it is currently done with the GCE provider.

Epic: none
Release note: None