### PR TITLE
sql: add cluster setting for autocommit_before_ddl default

### DIFF
--- a/pkg/sql/conn_executor_ddl.go
+++ b/pkg/sql/conn_executor_ddl.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
@@ -18,6 +19,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/fsm"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+)
+
+var defaultAutocommitBeforeDDL = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"sql.defaults.autocommit_before_ddl.enabled",
+	"default value for autocommit_before_ddl session setting; "+
+		"forces transactions to autocommit before running any DDL statement",
+	false,
 )
 
 // maybeAutoCommitBeforeDDL checks if the current transaction needs to be

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1385,7 +1385,9 @@ var varGen = map[string]sessionVar{
 			m.SetAutoCommitBeforeDDL(b)
 			return nil
 		},
-		GlobalDefault: globalFalse,
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatBoolAsPostgresSetting(defaultAutocommitBeforeDDL.Get(sv))
+		},
 	},
 
 	// See https://www.postgresql.org/docs/10/static/ddl-schemas.html#DDL-SCHEMAS-PATH


### PR DESCRIPTION
### settings: allow new non-public sql.defaults cluster settings

This patch allows non-public sql.defaults settings to be added. This is
useful for being able to rollout changes to session variable
defaults in Cockroach Cloud clusters. The rollout automation framework
relies on cluster settings.

### sql: add cluster setting for autocommit_before_ddl default

This setting will be used to gradually rollout a change to the default
value of the autocommit_before_ddl session variable across the
CockroachCloud fleet.

part of https://github.com/cockroachdb/cockroach/issues/133180
Release note: None

