### PR TITLE
backupccl: sst sink implementation for writing keys

### DIFF
--- a/pkg/backup/backupsink/BUILD.bazel
+++ b/pkg/backup/backupsink/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "file_sst_sink.go",
         "sink_utils.go",
+        "sst_sink_key_writer.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/backup/backupsink",
     visibility = ["//visibility:public"],
@@ -31,7 +32,10 @@ go_library(
 
 go_test(
     name = "backupsink_test",
-    srcs = ["file_sst_sink_test.go"],
+    srcs = [
+        "file_sst_sink_test.go",
+        "sst_sink_key_writer_test.go",
+    ],
     embed = [":backupsink"],
     deps = [
         "//pkg/backup/backuppb",
@@ -44,6 +48,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/sql/execinfrapb",
         "//pkg/storage",
+        "//pkg/testutils",
         "//pkg/util/encoding",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",

--- a/pkg/backup/backupsink/sst_sink_key_writer.go
+++ b/pkg/backup/backupsink/sst_sink_key_writer.go
@@ -1,0 +1,276 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package backupsink
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/backup/backuppb"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/admission"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+)
+
+type SSTSinkKeyWriter struct {
+	FileSSTSink
+	// prevKey represents the last key written using WriteKey. When writing a new
+	// key, this helps determine if the last key written was mid-row. This resets
+	// on each flush.
+	prevKey roachpb.Key
+
+	// Caching the targetFileSize from the cluster settings to avoid multiple
+	// lookups during writes.
+	targetFileSize int64
+}
+
+func MakeSSTSinkKeyWriter(
+	conf SSTSinkConf, dest cloud.ExternalStorage, pacer *admission.Pacer,
+) (*SSTSinkKeyWriter, error) {
+	if conf.ElideMode == execinfrapb.ElidePrefix_None {
+		return nil, errors.New("KeyWriter does not support ElidePrefix_None")
+	}
+	return &SSTSinkKeyWriter{
+		FileSSTSink:    *MakeFileSSTSink(conf, dest, pacer),
+		targetFileSize: targetFileSize.Get(conf.Settings),
+	}, nil
+}
+
+// WriteKey writes a single key to the SST file. The key should be the full key,
+// including the prefix. Reset needs to be called prior to WriteKey whenever
+// writing keys from a new span. Keys must also be written in order.
+//
+// After writing the last key for a span, AssumeNotMidRow must be called to
+// enforce the invariant that BackupManifest_File spans do not end mid-row.
+//
+// Flush should be called before the sink is closed to ensure the SST
+// is written to the destination.
+func (s *SSTSinkKeyWriter) WriteKey(ctx context.Context, key storage.MVCCKey, value []byte) error {
+	if len(s.flushedFiles) == 0 {
+		return errors.AssertionFailedf(
+			"no BackupManifest_File to write key to, call Reset before WriteKey",
+		)
+	}
+	if !s.flushedFiles[len(s.flushedFiles)-1].Span.ContainsKey(key.Key) {
+		return errors.AssertionFailedf(
+			"key %s not in span %s, call Reset on the new span",
+			key.Key,
+			s.flushedFiles[len(s.flushedFiles)-1].Span,
+		)
+	}
+	if s.prevKey != nil && s.prevKey.Compare(key.Key) >= 0 {
+		return errors.AssertionFailedf("key %s must be greater than previous key %s", key.Key, s.prevKey)
+	}
+	// At this point, because of the Reset invariant, we can make the following
+	// assumptions about the new key:
+	// - The new key comes after the previous key.
+	// - This new key belongs to the span of the last BackupManifest_File in
+	//   s.flushedFiles.
+	s.setMidRowForPrevKey(key.Key)
+	if err := s.maybeDoSizeFlush(ctx, key.Key); err != nil {
+		return err
+	}
+
+	elidedKey, err := elideMVCCKey(key, s.conf.ElideMode)
+	if err != nil {
+		return err
+	}
+	// TODO (kev-cao): Should add some method of tracking `Rows` (and potentially
+	// `IndexEntries`).
+	keyAsRowCount := roachpb.RowCount{
+		DataSize: int64(len(key.Key)) + int64(len(value)),
+	}
+
+	if err := s.sst.PutRawMVCC(elidedKey, value); err != nil {
+		return err
+	}
+
+	s.flushedFiles[len(s.flushedFiles)-1].EntryCounts.Add(keyAsRowCount)
+	s.flushedSize += keyAsRowCount.DataSize
+	s.prevKey = append(s.prevKey[:0], key.Key...)
+	// Until the next key is written, we cannot determine if this key is mid-row.
+	// As a safeguard, we assume it is mid-row, and if it is the last key to be
+	// written in this span, the caller has the responsibility of explicitly
+	// marking the key as not mid-row by calling AssumeNotMidRow.
+	s.midRow = true
+	return nil
+}
+
+// AssumeNotMidRow marks the last key written as not mid-row. This exists to
+// ensure that the caller explicitly is aware that SSTSinkKeyWriter is unable
+// to determine if the last key written in a span is mid-row and must enforce
+// the invariant themselves.
+func (s *SSTSinkKeyWriter) AssumeNotMidRow() {
+	s.midRow = false
+}
+
+// Reset resets the SSTSinkKeyWriter to write to a new span. It ensures that an
+// open BackupManifest_File exists for the new span. It will either open a new
+// BackupManifest_File, or if the new span contiguously extends the last span,
+// it will extend it if it remains under the fileSpanByteLimit. The caller is
+// responsible for ensuring that spans that are reset on do not end mid-row
+// and calling AssumeNotMidRow before resetting to enforce this invariant.
+// Any time a new span is being written, Reset MUST be called prior to any
+// WriteKey calls.
+func (s *SSTSinkKeyWriter) Reset(ctx context.Context, newSpan roachpb.Span) error {
+	log.VEventf(ctx, 2, "resetting sink to span %s", newSpan)
+	if s.midRow {
+		return errors.AssertionFailedf("cannot reset after writing a mid-row key")
+	}
+	if err := s.maybeFlushNonExtendableSST(newSpan); err != nil {
+		return err
+	}
+	if s.flushedSize >= s.targetFileSize {
+		if err := s.doSSTSizeFlush(ctx); err != nil {
+			return err
+		}
+	}
+	if s.out == nil {
+		if err := s.open(ctx); err != nil {
+			return err
+		}
+	}
+	// At this point, we can assume the new span is either contiguous with the
+	// last span or comes after the last span (if it exists).
+	if len(s.flushedFiles) > 0 {
+		lastFile := &s.flushedFiles[len(s.flushedFiles)-1]
+		if isContiguousSpan(lastFile.Span, newSpan) &&
+			lastFile.EntryCounts.DataSize < fileSpanByteLimit {
+			log.VEventf(ctx, 2, "extending span %s to %s", lastFile.Span, newSpan)
+			s.stats.spanGrows++
+			lastFile.Span.EndKey = newSpan.EndKey
+			return nil
+		}
+	}
+
+	prefix, err := ElidedPrefix(newSpan.Key, s.conf.ElideMode)
+	if err != nil {
+		return err
+	}
+	s.elidedPrefix = append(s.elidedPrefix[:0], prefix...)
+	s.flushedFiles = append(
+		s.flushedFiles,
+		backuppb.BackupManifest_File{
+			Span: newSpan,
+			Path: s.outName,
+		},
+	)
+	s.prevKey = nil
+	return nil
+}
+
+// maybeFlushNonExtendableSST checks if the new span's startKey precedes the
+// last spans' endKey or if the two spans do not share the same prefix based on
+// the sink's ElideMode. If either of these conditions are met, the current
+// backup file is flushed and a new one is created.
+func (s *SSTSinkKeyWriter) maybeFlushNonExtendableSST(newSpan roachpb.Span) error {
+	if len(s.flushedFiles) == 0 {
+		return nil
+	}
+	lastFile := s.flushedFiles[len(s.flushedFiles)-1]
+	samePrefix, err := sameElidedPrefix(newSpan.Key, lastFile.Span.EndKey, s.conf.ElideMode)
+	if err != nil {
+		return err
+	}
+	if !samePrefix || newSpan.Key.Compare(lastFile.Span.EndKey) < 0 {
+		log.VEventf(
+			s.ctx, 1, "flushing backup file %s of size %d because new span %s is not contiguous with last span %s",
+			s.outName, s.flushedSize, newSpan, lastFile.Span,
+		)
+		s.stats.oooFlushes++
+		if err := s.Flush(s.ctx); err != nil {
+			return err
+		}
+		return nil
+	}
+	return nil
+}
+
+// maybeDoSizeFlush checks if either a BackupManifest_File needs to be flushed
+// due to reaching the fileSpanByteLimit or if the entire SST needs to be flushed
+// due to reaching targetFileSize.
+// midRow for the last key written must be updated before calling this method.
+func (s *SSTSinkKeyWriter) maybeDoSizeFlush(ctx context.Context, nextKey roachpb.Key) error {
+	if len(s.flushedFiles) == 0 {
+		return nil
+	}
+	if s.midRow {
+		return nil
+	}
+	lastFile := &s.flushedFiles[len(s.flushedFiles)-1]
+	var hardFlush = s.flushedSize >= s.targetFileSize
+	if !hardFlush && lastFile.EntryCounts.DataSize < fileSpanByteLimit {
+		return nil
+	}
+	newSpan := roachpb.Span{
+		Key:    nextKey,
+		EndKey: lastFile.Span.EndKey,
+	}
+	if lastFile.Span.ContainsKey(newSpan.Key) {
+		lastFile.Span.EndKey = newSpan.Key
+	}
+	if hardFlush {
+		if err := s.doSSTSizeFlush(ctx); err != nil {
+			return err
+		}
+	}
+	// A new span is created for the new BackupManifest_File, so a Reset is needed.
+	if err := s.Reset(ctx, newSpan); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *SSTSinkKeyWriter) doSSTSizeFlush(ctx context.Context) error {
+	log.VEventf(ctx, 1, "flushing backup file %s with size %d", s.outName, s.flushedSize)
+	s.stats.sizeFlushes++
+	return s.Flush(ctx)
+}
+
+// setMidRowForPrevKey checks if the last key written using WriteKey was mid-row
+// by using the next key to be written. If no key was previously written using
+// WriteKey, this is a no-op.
+func (s *SSTSinkKeyWriter) setMidRowForPrevKey(endKey roachpb.Key) {
+	if s.prevKey == nil {
+		return
+	}
+	endRowKey, err := keys.EnsureSafeSplitKey(endKey)
+	if err != nil {
+		// If the key does not parse a family key, it must be from reaching the end
+		// of a range and be a range boundary.
+		return
+	}
+
+	// If the end key parses as a family key but truncating to the row key does
+	// _not_ produce a row key greater than every key in the file, then one of two
+	// things has happened: we *did* stop at family key mid-row, so we copied some
+	// families after the row key but have more to get in the next file -- so we
+	// must *not* flush now -- or the file ended at a range boundary that _looks_
+	// like a family key due to a numeric suffix, so the (nonsense) truncated key
+	// is now some prefix less than the last copied key. The latter is unfortunate
+	// but should be rare given range-sized export requests.
+	s.midRow = endRowKey.Compare(s.prevKey) <= 0
+}
+
+// elideMVCCKeyPrefix elides the MVCC key prefix based on the ElideMode
+// and returns the elided key.
+func elideMVCCKey(key storage.MVCCKey, mode execinfrapb.ElidePrefix) (storage.MVCCKey, error) {
+	prefix, err := ElidedPrefix(key.Key, mode)
+	if err != nil {
+		return storage.MVCCKey{}, err
+	}
+	cutKey, ok := bytes.CutPrefix(key.Key, prefix)
+	if !ok {
+		return storage.MVCCKey{}, errors.AssertionFailedf("prefix mismatch %q does not have %q", key.Key, prefix)
+	}
+	key.Key = cutKey
+	return key, nil
+}

--- a/pkg/backup/backupsink/sst_sink_key_writer_test.go
+++ b/pkg/backup/backupsink/sst_sink_key_writer_test.go
@@ -1,0 +1,558 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package backupsink
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/backup/backuppb"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileSSTSinkWriteKey(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	// Artificially set file size limits for testing.
+	defer testutils.HookGlobal(&fileSpanByteLimit, 8<<10)()
+	targetFileSize.Override(ctx, &st.SV, 24<<10)
+
+	exceedsFileSizeVal := make([]byte, 10<<10)
+	exceedsSSTSizeVal := make([]byte, 32<<10)
+
+	type testCase struct {
+		name      string
+		exportKVs []*mvccKVSet
+		// spans of files that should have been flushed during WriteKey and before
+		// the final manual flush.
+		flushedSpans []roachpb.Spans
+		// any spans of files that will be flushed out by the manual flush.
+		unflushedSpans []roachpb.Spans
+	}
+
+	for _, tt := range []testCase{
+		{
+			name: "single-span",
+			exportKVs: []*mvccKVSet{
+				newMVCCKeySet("a", "c").withKVs([]kvAndTS{
+					{key: "a", timestamp: 10}, {key: "b", timestamp: 10},
+				}),
+			},
+			unflushedSpans: []roachpb.Spans{
+				{{Key: s2k0("a"), EndKey: s2k0("c")}},
+			},
+		},
+		// Flushes do not occur if the last key written exceeds the file size. The caller is
+		// required to make the last flush call.
+		{
+			name: "single-span-no-size-flush-last-key",
+			exportKVs: []*mvccKVSet{
+				newMVCCKeySet("a", "c").withKVs([]kvAndTS{
+					{key: "a", timestamp: 10}, {key: "b", value: exceedsSSTSizeVal, timestamp: 15},
+				}),
+			},
+			unflushedSpans: []roachpb.Spans{
+				{{Key: s2k0("a"), EndKey: s2k0("c")}},
+			},
+		},
+		// Ensure that if the size is exceeded mid-span, a flush occurs.
+		{
+			name: "single-span-size-flush-mid-span",
+			exportKVs: []*mvccKVSet{
+				newMVCCKeySet("a", "c").withKVs([]kvAndTS{
+					{key: "a", value: exceedsSSTSizeVal, timestamp: 15}, {key: "b", timestamp: 15}}),
+			},
+			flushedSpans: []roachpb.Spans{
+				{{Key: s2k0("a"), EndKey: s2k0("b")}},
+			},
+			unflushedSpans: []roachpb.Spans{
+				{{Key: s2k0("b"), EndKey: s2k0("c")}},
+			},
+		},
+		// Represents writing a series of keys and encountering each of the flush conditions.
+		{
+			name: "size-ooo-span-and-ooo-key-flush",
+			exportKVs: []*mvccKVSet{
+				newMVCCKeySet("a", "d").
+					withKVs([]kvAndTS{ // size
+						{key: "a", value: exceedsSSTSizeVal, timestamp: 10},
+						{key: "c", timestamp: 10},
+					}),
+				newMVCCKeySet("a", "d").
+					withKVs([]kvAndTS{{key: "b", timestamp: 10}}),
+				newMVCCKeySet("c", "f").
+					withKVs([]kvAndTS{{key: "e", timestamp: 10}}),
+			},
+			flushedSpans: []roachpb.Spans{
+				{{Key: s2k0("a"), EndKey: s2k0("c")}},
+				{{Key: s2k0("c"), EndKey: s2k0("d")}},
+				{{Key: s2k0("a"), EndKey: s2k0("d")}},
+			},
+			unflushedSpans: []roachpb.Spans{
+				{{Key: s2k0("c"), EndKey: s2k0("f")}},
+			},
+		},
+		// Two spans that are contiguous with each other should be merged into one span.
+		{
+			name: "extend-metadata",
+			exportKVs: []*mvccKVSet{
+				newMVCCKeySet("a", "c").withKVs([]kvAndTS{
+					{key: "a", timestamp: 10}, {key: "b", timestamp: 10},
+				}),
+				newMVCCKeySet("c", "e").withKVs([]kvAndTS{
+					{key: "c", timestamp: 10}, {key: "d", timestamp: 10},
+				}),
+			},
+			unflushedSpans: []roachpb.Spans{
+				{{Key: s2k0("a"), EndKey: s2k0("e")}},
+			},
+		},
+		// If a span overlaps its previous span, a flush must occur first. Should not occur in
+		// backup compactions.
+		{
+			name: "flush-from-overlapping-ooo-spans",
+			exportKVs: []*mvccKVSet{
+				newMVCCKeySet("a", "c").withKVs([]kvAndTS{
+					{key: "a", timestamp: 10}, {key: "b", timestamp: 10},
+				}),
+				newMVCCKeySet("b", "e").withKVs([]kvAndTS{
+					{key: "b", timestamp: 10}, {key: "c", timestamp: 10}, {key: "d", timestamp: 10},
+				}),
+			},
+			flushedSpans: []roachpb.Spans{
+				{{Key: s2k0("a"), EndKey: s2k0("c")}},
+			},
+			unflushedSpans: []roachpb.Spans{
+				{{Key: s2k0("b"), EndKey: s2k0("e")}},
+			},
+		},
+		// If a span precedes the previous span but does not overlap, a flush must
+		// occur first. Should not occur in backup compactions.
+		{
+			name: "flush-from-non-overlapping-ooo-spans",
+			exportKVs: []*mvccKVSet{
+				newMVCCKeySet("c", "e").withKVs([]kvAndTS{
+					{key: "c", timestamp: 10}, {key: "d", timestamp: 10},
+				}),
+				newMVCCKeySet("a", "c").withKVs([]kvAndTS{
+					{key: "a", timestamp: 10}, {key: "b", timestamp: 10},
+				}),
+			},
+			flushedSpans: []roachpb.Spans{
+				{{Key: s2k0("c"), EndKey: s2k0("e")}},
+			},
+			unflushedSpans: []roachpb.Spans{
+				{{Key: s2k0("a"), EndKey: s2k0("c")}},
+			},
+		},
+		// If a span is non-contiguous with the previous span, the BackupManifest_File must be
+		// flushed.
+		{
+			name: "flush-file-from-non-contiguous-in-order-spans",
+			exportKVs: []*mvccKVSet{
+				newMVCCKeySet("a", "c").withKVs([]kvAndTS{
+					{key: "a", timestamp: 10}, {key: "b", timestamp: 10},
+				}),
+				newMVCCKeySet("d", "g").withKVs([]kvAndTS{
+					{key: "d", timestamp: 10}, {key: "e", timestamp: 10},
+				}),
+			},
+			unflushedSpans: []roachpb.Spans{
+				{
+					{Key: s2k0("a"), EndKey: s2k0("c")},
+					{Key: s2k0("d"), EndKey: s2k0("g")},
+				},
+			},
+		},
+		// If a span is contiguous with the previous span and the previous span's last key
+		// exceeded the file size, the SST file must be flushed before writing the new span.
+		{
+			name: "flush-sst-before-adding-new-contiguous-file",
+			exportKVs: []*mvccKVSet{
+				newMVCCKeySet("a", "c").withKVs([]kvAndTS{
+					{key: "a", timestamp: 10}, {key: "b", timestamp: 10, value: exceedsSSTSizeVal},
+				}),
+				newMVCCKeySet("c", "e").withKVs([]kvAndTS{
+					{key: "c", timestamp: 10}, {key: "d", timestamp: 10},
+				}),
+			},
+			flushedSpans:   []roachpb.Spans{{{Key: s2k0("a"), EndKey: s2k0("c")}}},
+			unflushedSpans: []roachpb.Spans{{{Key: s2k0("c"), EndKey: s2k0("e")}}},
+		},
+		// If a span is non-contiguous with the previous span and the previous span's last key
+		// exceeded the file size, the SST file must be flushed before writing the new span.
+		{
+			name: "flush-sst-before-adding-new-non-contiguous-file",
+			exportKVs: []*mvccKVSet{
+				newMVCCKeySet("a", "c").withKVs([]kvAndTS{
+					{key: "a", timestamp: 10}, {key: "b", timestamp: 10, value: exceedsSSTSizeVal},
+				}),
+				newMVCCKeySet("d", "g").withKVs([]kvAndTS{
+					{key: "d", timestamp: 10}, {key: "e", timestamp: 10},
+				}),
+			},
+			flushedSpans:   []roachpb.Spans{{{Key: s2k0("a"), EndKey: s2k0("c")}}},
+			unflushedSpans: []roachpb.Spans{{{Key: s2k0("d"), EndKey: s2k0("g")}}},
+		},
+		// Writing keys with different prefixes should flush the previous span.
+		{
+			name: "prefixes-differ-with-eliding",
+			exportKVs: []*mvccKVSet{
+				newMVCCKeySet("2/a", "2/c").withKVs(
+					[]kvAndTS{{key: "2/a", timestamp: 10}, {key: "2/b", timestamp: 10}},
+				),
+				newMVCCKeySet("2/c", "2/e").withKVs(
+					[]kvAndTS{{key: "2/c", timestamp: 10}, {key: "2/d", timestamp: 10}},
+				),
+				newMVCCKeySet("3/e", "3/g").withKVs(
+					[]kvAndTS{{key: "3/e", timestamp: 10}, {key: "3/f", timestamp: 10}},
+				),
+			},
+			flushedSpans: []roachpb.Spans{
+				{{Key: s2k0("2/a"), EndKey: s2k0("2/e")}},
+			},
+			unflushedSpans: []roachpb.Spans{
+				{{Key: s2k0("3/e"), EndKey: s2k0("3/g")}},
+			},
+		},
+		// Flush does not occur if last key written is mid-row even if size exceeded.
+		{
+			name: "no-size-flush-if-mid-row",
+			exportKVs: []*mvccKVSet{
+				newMVCCKeySet("a", "d").
+					withRawKVs([]mvccKV{
+						kvAndTS{key: "a", timestamp: 10}.toMVCCKV(s2k0),
+						kvAndTS{key: "b", timestamp: 10, value: exceedsSSTSizeVal}.toMVCCKV(s2k0),
+						kvAndTS{key: "b", timestamp: 10}.toMVCCKV(s2k1),
+					}),
+			},
+			unflushedSpans: []roachpb.Spans{
+				{{Key: s2k0("a"), EndKey: s2k0("d")}},
+			},
+		},
+		// If size flush is blocked by mid-row key, the next key should cause a flush.
+		{
+			name: "size-flush-postponed-till-after-mid-row",
+			exportKVs: []*mvccKVSet{
+				newMVCCKeySet("a", "d").
+					withRawKVs([]mvccKV{
+						kvAndTS{key: "a", timestamp: 10}.toMVCCKV(s2k0),
+						kvAndTS{key: "b", timestamp: 10, value: exceedsSSTSizeVal}.toMVCCKV(s2k0),
+						kvAndTS{key: "b", timestamp: 10}.toMVCCKV(s2k1),
+						kvAndTS{key: "c", timestamp: 10}.toMVCCKV(s2k0),
+					}),
+			},
+			flushedSpans: []roachpb.Spans{
+				{{Key: s2k0("a"), EndKey: s2k0("c")}},
+			},
+			unflushedSpans: []roachpb.Spans{
+				{{Key: s2k0("c"), EndKey: s2k0("d")}},
+			},
+		},
+		// If fileSpanByteLimit is reached, the file should be split at the new
+		// key.
+		{
+			name: "split-file-due-to-manifest-size-limit",
+			exportKVs: []*mvccKVSet{
+				newMVCCKeySet("a", "d").
+					withKVs([]kvAndTS{
+						{key: "a", timestamp: 10},
+						{key: "b", timestamp: 10, value: exceedsFileSizeVal},
+						{key: "c", timestamp: 10},
+					}),
+			},
+			unflushedSpans: []roachpb.Spans{
+				{{Key: s2k0("a"), EndKey: s2k0("c")}, {Key: s2k0("c"), EndKey: s2k0("d")}},
+			},
+		},
+		// If a fileSpanByteLimit is reached, resetting on a new contiguous span
+		// should not extend the previous span.
+		{
+			name: "no-extend-due-to-manifest-size-limit",
+			exportKVs: []*mvccKVSet{
+				newMVCCKeySet("a", "c").
+					withKVs([]kvAndTS{
+						{key: "a", timestamp: 10},
+						{key: "b", timestamp: 10, value: exceedsFileSizeVal},
+					}),
+				newMVCCKeySet("c", "e").
+					withKVs([]kvAndTS{
+						{key: "c", timestamp: 10},
+						{key: "d", timestamp: 10},
+					}),
+			},
+			unflushedSpans: []roachpb.Spans{
+				{
+					{Key: s2k0("a"), EndKey: s2k0("c")},
+					{Key: s2k0("c"), EndKey: s2k0("e")},
+				},
+			},
+		},
+		// fileSpanByteLimit reached in the middle of writing a span, but the
+		// key is mid-row, so the file must be extended.
+		{
+			name: "extend-mid-row-despite-manifest-size-limit",
+			exportKVs: []*mvccKVSet{
+				newRawMVCCKeySet(s2k0("a"), s2k0("d")).withRawKVs([]mvccKV{
+					kvAndTS{key: "a", timestamp: 10}.toMVCCKV(s2k0),
+					kvAndTS{key: "b", timestamp: 10, value: exceedsFileSizeVal}.toMVCCKV(s2k0),
+					kvAndTS{key: "b", timestamp: 10, value: exceedsFileSizeVal}.toMVCCKV(s2k1),
+					kvAndTS{key: "c", timestamp: 10}.toMVCCKV(s2k0),
+				}),
+			},
+			unflushedSpans: []roachpb.Spans{
+				{
+					{Key: s2k0("a"), EndKey: s2k0("c")},
+					{Key: s2k0("c"), EndKey: s2k0("d")},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			sink, store := sstSinkKeyWriterTestSetup(t, st, execinfrapb.ElidePrefix_TenantAndTable)
+			defer func() {
+				require.NoError(t, sink.Close())
+			}()
+
+			for _, ek := range tt.exportKVs {
+				require.NoError(t, sink.Reset(ctx, ek.span))
+				for _, kv := range ek.kvs {
+					require.NoError(t, sink.WriteKey(ctx, kv.key, kv.value))
+				}
+				sink.AssumeNotMidRow()
+			}
+
+			progress := make([]backuppb.BackupManifest_File, 0)
+		Loop:
+			for {
+				select {
+				case p := <-sink.conf.ProgCh:
+					var progDetails backuppb.BackupManifest_Progress
+					if err := types.UnmarshalAny(&p.ProgressDetails, &progDetails); err != nil {
+						t.Fatal(err)
+					}
+
+					progress = append(progress, progDetails.Files...)
+				default:
+					break Loop
+				}
+			}
+
+			require.NoError(
+				t, checkFiles(ctx, store, progress, tt.flushedSpans, true /* eliding */),
+			)
+
+			var actualUnflushedFiles []backuppb.BackupManifest_File
+			actualUnflushedFiles = append(actualUnflushedFiles, sink.flushedFiles...)
+			require.NoError(t, sink.Flush(ctx))
+			require.NoError(
+				t, checkFiles(
+					ctx,
+					store,
+					actualUnflushedFiles,
+					tt.unflushedSpans,
+					true, /* eliding */
+				),
+			)
+			require.Empty(t, sink.flushedFiles)
+		})
+	}
+}
+
+func TestFileSSTSinkWriteKeyBadKeyFails(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	sink, _ := sstSinkKeyWriterTestSetup(t, st, execinfrapb.ElidePrefix_TenantAndTable)
+	defer func() {
+		require.NoError(t, sink.Close())
+	}()
+
+	t.Run("ooo-key", func(t *testing.T) {
+		keySet := newMVCCKeySet("a", "e").withKVs([]kvAndTS{
+			{key: "a", timestamp: 10}, {key: "b", timestamp: 10},
+			{key: "d", timestamp: 10}, {key: "c", timestamp: 10},
+		})
+
+		require.NoError(t, sink.Reset(ctx, keySet.span))
+		for idx, kv := range keySet.kvs {
+			if idx < len(keySet.kvs)-1 {
+				require.NoError(t, sink.WriteKey(ctx, kv.key, kv.value))
+			} else {
+				require.ErrorContains(
+					t,
+					sink.WriteKey(ctx, kv.key, kv.value),
+					"must be greater than previous key",
+				)
+			}
+		}
+		sink.AssumeNotMidRow()
+		require.NoError(t, sink.Flush(ctx))
+	})
+
+	t.Run("key-outside-of-span", func(t *testing.T) {
+		keySet := newMVCCKeySet("a", "c").withKVs([]kvAndTS{
+			{key: "d", timestamp: 10},
+		})
+
+		require.NoError(t, sink.Reset(ctx, keySet.span))
+		require.ErrorContains(
+			t,
+			sink.WriteKey(ctx, keySet.kvs[0].key, keySet.kvs[0].value),
+			"not in span",
+		)
+		sink.AssumeNotMidRow()
+		require.NoError(t, sink.Flush(ctx))
+	})
+
+	t.Run("write-key-before-reset", func(t *testing.T) {
+		keySet := newMVCCKeySet("a", "c").withKVs([]kvAndTS{
+			{key: "d", timestamp: 10},
+		})
+
+		require.ErrorContains(
+			t,
+			sink.WriteKey(ctx, keySet.kvs[0].key, keySet.kvs[0].value),
+			"no BackupManifest_File to write key to",
+		)
+		sink.AssumeNotMidRow()
+		require.NoError(t, sink.Flush(ctx))
+	})
+}
+
+func TestEnforceFileSSTSinkAssumeNotMidRow(t *testing.T) {
+	// Ensure that AssumeNotMidRow *must* be called before resetting or flushing.
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+
+	setA := newMVCCKeySet("a", "b").withKVs([]kvAndTS{{key: "a", timestamp: 10}})
+
+	t.Run("require-assume-not-mid-row-for-reset", func(t *testing.T) {
+		sink, _ := sstSinkKeyWriterTestSetup(t, st, execinfrapb.ElidePrefix_TenantAndTable)
+		defer func() {
+			require.NoError(t, sink.Close())
+		}()
+		require.NoError(t, sink.Reset(ctx, setA.span))
+		require.NoError(t, sink.WriteKey(ctx, setA.kvs[0].key, setA.kvs[0].value))
+
+		setB := newMVCCKeySet("b", "c").withKVs([]kvAndTS{{key: "b", timestamp: 10}})
+		require.ErrorContains(
+			t, sink.Reset(ctx, setB.span), "cannot reset after writing a mid-row key",
+		)
+		sink.AssumeNotMidRow()
+		require.NoError(t, sink.Reset(ctx, setB.span))
+		require.NoError(t, sink.Flush(ctx))
+	})
+
+	t.Run("require-assume-not-mid-row-for-flush", func(t *testing.T) {
+		sink, _ := sstSinkKeyWriterTestSetup(t, st, execinfrapb.ElidePrefix_TenantAndTable)
+		defer func() {
+			require.NoError(t, sink.Close())
+		}()
+		require.NoError(t, sink.Reset(ctx, setA.span))
+		require.NoError(t, sink.WriteKey(ctx, setA.kvs[0].key, setA.kvs[0].value))
+
+		require.ErrorContains(
+			t, sink.Flush(ctx), "backup closed file ending mid-key in",
+		)
+		sink.AssumeNotMidRow()
+		require.NoError(t, sink.Flush(ctx))
+	})
+}
+
+func sstSinkKeyWriterTestSetup(
+	t *testing.T, settings *cluster.Settings, elideMode execinfrapb.ElidePrefix,
+) (*SSTSinkKeyWriter, cloud.ExternalStorage) {
+	conf, store := sinkTestSetup(t, settings, elideMode)
+	sink, err := MakeSSTSinkKeyWriter(conf, store, nil /* pacer */)
+	require.NoError(t, err)
+	return sink, store
+}
+
+type mvccKV struct {
+	key   storage.MVCCKey
+	value []byte
+}
+
+type mvccKVSet struct {
+	span      roachpb.Span
+	kvs       []mvccKV
+	startTime hlc.Timestamp
+	endTime   hlc.Timestamp
+}
+
+func newMVCCKeySet(spanStart string, spanEnd string) *mvccKVSet {
+	return &mvccKVSet{
+		span: roachpb.Span{
+			Key:    s2k0(spanStart),
+			EndKey: s2k0(spanEnd),
+		},
+	}
+}
+
+func newRawMVCCKeySet(spanStart roachpb.Key, spanEnd roachpb.Key) *mvccKVSet {
+	return &mvccKVSet{
+		span: roachpb.Span{
+			Key:    spanStart,
+			EndKey: spanEnd,
+		},
+	}
+}
+
+func (b *mvccKVSet) withKVs(kvs []kvAndTS) *mvccKVSet {
+	return b.withKVsAndEncoding(kvs, s2k0)
+}
+
+func (b *mvccKVSet) withKVsAndEncoding(kvs []kvAndTS, enc func(string) roachpb.Key) *mvccKVSet {
+	rawKVs := make([]mvccKV, 0, len(kvs))
+	for _, kv := range kvs {
+		v := roachpb.Value{}
+		v.SetBytes(kv.value)
+		v.InitChecksum(nil)
+		rawKVs = append(rawKVs, mvccKV{
+			key: storage.MVCCKey{
+				Key:       enc(kv.key),
+				Timestamp: hlc.Timestamp{WallTime: kv.timestamp},
+			},
+			value: v.RawBytes,
+		})
+	}
+	return b.withRawKVs(rawKVs)
+}
+
+func (b *mvccKVSet) withRawKVs(kvs []mvccKV) *mvccKVSet {
+	b.kvs = kvs
+	var minTS, maxTS hlc.Timestamp
+	for _, kv := range kvs {
+		if minTS.IsEmpty() || kv.key.Timestamp.Less(minTS) {
+			minTS = kv.key.Timestamp
+		}
+		if maxTS.IsEmpty() || maxTS.Less(kv.key.Timestamp) {
+			maxTS = kv.key.Timestamp
+		}
+	}
+	b.startTime = minTS
+	b.endTime = maxTS
+	return b
+}


### PR DESCRIPTION
To support backup compactions, we need to be able to write MVCC keys to a file sink one key at a time. The current `fileSinkSST` only supports writing KV export responses, or essentially one span at a time. This commit adds an implementation that supports writing key by key.

Epic: none

Release note: None