### PR TITLE
changefeedccl: fix schema change boundary race condition

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "parquet.go",
         "parquet_sink_cloudstorage.go",
         "protected_timestamps.go",
+        "resolved_span_frontier.go",
         "retry.go",
         "scheduled_changefeed.go",
         "schema_registry.go",

--- a/pkg/ccl/changefeedccl/resolved_span_frontier.go
+++ b/pkg/ccl/changefeedccl/resolved_span_frontier.go
@@ -1,0 +1,115 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package changefeedccl
+
+import (
+	"context"
+	"slices"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/errors"
+)
+
+// frontierResolvedSpanFrontier wraps a schemaChangeFrontier with additional
+// checks specific to how change frontiers processes schema changes.
+type frontierResolvedSpanFrontier struct {
+	schemaChangeFrontier
+
+	// backfills is a sorted list of timestamps for ongoing backfills.
+	// Usually there will only be one, but since aggregators run
+	// backfills in parallel without synchronization, there may be
+	// multiple backfills happening at one time.
+	backfills []hlc.Timestamp
+}
+
+// newFrontierResolvedSpanFrontier returns a new frontierResolvedSpanFrontier.
+func newFrontierResolvedSpanFrontier(
+	initialHighWater hlc.Timestamp, spans ...roachpb.Span,
+) (*frontierResolvedSpanFrontier, error) {
+	scf, err := makeSchemaChangeFrontier(initialHighWater, spans...)
+	if err != nil {
+		return nil, err
+	}
+	return &frontierResolvedSpanFrontier{
+		schemaChangeFrontier: *scf,
+	}, nil
+}
+
+// ForwardResolvedSpan forwards the progress of a resolved span and also does
+// some boundary validation.
+func (f *frontierResolvedSpanFrontier) ForwardResolvedSpan(
+	ctx context.Context, r jobspb.ResolvedSpan,
+) (bool, error) {
+	switch boundaryType := r.BoundaryType; boundaryType {
+	case jobspb.ResolvedSpan_NONE:
+	case jobspb.ResolvedSpan_BACKFILL:
+		// The change frontier collects resolved spans from all the change
+		// aggregators. Since a BACKFILL schema change does not cause an
+		// aggregator to shut down, an aggregator may encounter a second
+		// schema change (and send resolved spans for that second schema
+		// change) before the frontier has received resolved spans for the
+		// first BACKFILL schema change from all aggregators. Thus, as long as
+		// it is a BACKFILL we have already seen, then it is fine for it to be
+		// an earlier timestamp than the latest boundary.
+		boundaryTS := r.Timestamp
+		_, ok := slices.BinarySearchFunc(f.backfills, boundaryTS, func(elem hlc.Timestamp, ts hlc.Timestamp) int {
+			return elem.Compare(ts)
+		})
+		if ok {
+			break
+		}
+		if err := f.assertBoundaryNotEarlier(ctx, r); err != nil {
+			return false, err
+		}
+		f.backfills = append(f.backfills, boundaryTS)
+		f.boundaryTime = r.Timestamp
+		f.boundaryType = r.BoundaryType
+	case jobspb.ResolvedSpan_EXIT, jobspb.ResolvedSpan_RESTART:
+		// EXIT and RESTART are final boundaries that cause the changefeed
+		// processors to all move to draining and so should not be followed
+		// by any other boundaries.
+		if err := f.assertBoundaryNotEarlier(ctx, r); err != nil {
+			return false, err
+		}
+		f.boundaryTime = r.Timestamp
+		f.boundaryType = r.BoundaryType
+	default:
+		return false, errors.AssertionFailedf("unknown boundary type: %v", boundaryType)
+	}
+	f.latestTs.Forward(r.Timestamp)
+	frontierChanged, err := f.Forward(r.Span, r.Timestamp)
+	if err != nil {
+		return false, err
+	}
+	// If the frontier changed, we check if the frontier has advanced past any known backfills.
+	if frontierChanged {
+		frontier := f.Frontier()
+		i, _ := slices.BinarySearchFunc(f.backfills, frontier, func(elem hlc.Timestamp, ts hlc.Timestamp) int {
+			return elem.Compare(ts)
+		})
+		f.backfills = f.backfills[i:]
+	}
+	return frontierChanged, nil
+}
+
+// InBackfill returns whether a resolved span is part of an ongoing backfill
+// (either an initial scan backfill or a schema change backfill).
+// NB: Since the frontierResolvedSpanFrontier consolidates the frontiers of
+// multiple change aggregators, there may be more than one concurrent backfill
+// happening at different timestamps.
+func (f *frontierResolvedSpanFrontier) InBackfill(r jobspb.ResolvedSpan) bool {
+	boundaryTS := r.Timestamp
+	_, ok := slices.BinarySearchFunc(f.backfills, boundaryTS, func(elem hlc.Timestamp, ts hlc.Timestamp) int {
+		return elem.Compare(ts)
+	})
+	if ok {
+		return true
+	}
+
+	return f.schemaChangeFrontier.InBackfill(r)
+}

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1356,6 +1356,64 @@ func runCDCKafkaAuth(ctx context.Context, t test.Test, c cluster.Cluster) {
 	}
 }
 
+// runCDCMultipleSchemaChanges is a regression test for #136847.
+func runCDCMultipleSchemaChanges(ctx context.Context, t test.Test, c cluster.Cluster) {
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
+
+	db := c.Conn(ctx, t.L(), 1)
+	sqlDB := sqlutils.MakeSQLRunner(db)
+
+	sqlDB.Exec(t, "SET CLUSTER SETTING kv.rangefeed.enabled = true")
+
+	tableNames := []string{"a", "b", "c", "d", "e", "f", "g", "h"}
+	for _, tableName := range tableNames {
+		createStmt := fmt.Sprintf(`CREATE TABLE %s (
+	id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+	col TIMESTAMP(6) NULL
+)`, tableName)
+		sqlDB.Exec(t, createStmt)
+	}
+
+	var jobID int
+	sqlDB.QueryRow(t,
+		fmt.Sprintf("CREATE CHANGEFEED FOR %s INTO 'null://'", strings.Join(tableNames, ", ")),
+	).Scan(&jobID)
+
+	alterStmts := []string{"SET sql_safe_updates = false"}
+	for _, tableName := range tableNames {
+		alterStmts = append(alterStmts, fmt.Sprintf(`ALTER TABLE %s DROP col`, tableName))
+	}
+	sqlDB.ExecMultiple(t, alterStmts...)
+	timeAfterSchemaChanges := timeutil.Now()
+
+	t.L().Printf("waiting for changefeed highwater to pass %s", timeAfterSchemaChanges)
+highwaterLoop:
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		case <-time.After(30 * time.Second):
+			info, err := getChangefeedInfo(db, jobID)
+			require.NoError(t, err)
+			status := info.GetStatus()
+			if status != "running" {
+				errorStr := info.GetError()
+				// Wait for job error to be populated.
+				if errorStr == "" {
+					t.L().Printf("changefeed status is %s instead of running, no error set yet", status)
+					continue
+				}
+				t.Fatalf("changefeed status is %s instead of running: %s", status, errorStr)
+			}
+			hw := info.GetHighWater()
+			if hw.After(timeAfterSchemaChanges) {
+				break highwaterLoop
+			}
+			t.L().Printf("changefeed highwater is %s <= %s", hw, timeAfterSchemaChanges)
+		}
+	}
+}
+
 func registerCDC(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:      "cdc/initial-scan-only",
@@ -2251,6 +2309,16 @@ func registerCDC(r registry.Registry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runCDCSchemaRegistry(ctx, t, c)
 		},
+	})
+	r.Add(registry.TestSpec{
+		Name:             "cdc/multiple-schema-changes",
+		Owner:            registry.OwnerCDC,
+		Benchmark:        false,
+		Cluster:          r.MakeClusterSpec(3, spec.CPU(16)),
+		CompatibleClouds: registry.AllClouds,
+		Suites:           registry.Suites(registry.Nightly),
+		Timeout:          1 * time.Hour,
+		Run:              runCDCMultipleSchemaChanges,
 	})
 }
 


### PR DESCRIPTION
This patch fixes an issue where a schema change could incorrectly
cause a changefeed to fail with an assertion error like `received
boundary timestamp ... of type ... before reaching existing boundary
of type ...` due to a race condition between aggregators sending
resolved spans for multiple schema change descriptor updates to
the change frontier.

Fixes #136847

Release note (bug fix): An issue where a schema change could
incorrectly cause a changefeed to fail with an assertion error
like `received boundary timestamp ... of type ... before reaching
existing boundary of type ...` has now been fixed.