### PR TITLE
distsql: eliminate ctx allocation in setupFlow

### DIFF
--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -517,7 +517,7 @@ func NewColIndexJoin(
 	cFetcherMemoryLimit := totalMemoryLimit
 
 	var kvFetcher *row.KVFetcher
-	useStreamer, txn, err := flowCtx.UseStreamer()
+	useStreamer, txn, err := flowCtx.UseStreamer(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/colflow/explain_vec.go
+++ b/pkg/sql/colflow/explain_vec.go
@@ -50,9 +50,9 @@ func convertToVecTree(
 		// the creator.
 		&fakeBatchReceiver{},
 		localProcessors,
-		nil,       /* localVectorSources */
-		func() {}, /* onFlowCleanupEnd */
-		"",        /* statementSQL */
+		nil, /* localVectorSources */
+		nil, /* onFlowCleanupEnd */
+		"",  /* statementSQL */
 	)
 	creator := newVectorizedFlowCreator(
 		flowBase, nil /* componentCreator */, recordingStats,

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -378,7 +378,7 @@ func (f *vectorizedFlow) MemUsage() int64 {
 func (f *vectorizedFlow) Cleanup(ctx context.Context) {
 	startCleanup, endCleanup := f.FlowBase.GetOnCleanupFns()
 	startCleanup()
-	defer endCleanup()
+	defer endCleanup(ctx)
 
 	// This cleans up all the memory and disk monitoring of the vectorized flow
 	// as well as closes all the closers.

--- a/pkg/sql/execinfra/flow_context.go
+++ b/pkg/sql/execinfra/flow_context.go
@@ -52,7 +52,7 @@ type FlowCtx struct {
 	Txn *kv.Txn
 
 	// MakeLeafTxn returns a new LeafTxn, different from Txn.
-	MakeLeafTxn func() (*kv.Txn, error)
+	MakeLeafTxn func(context.Context) (*kv.Txn, error)
 
 	// Descriptors is used to look up leased table descriptors and to construct
 	// transaction bound TypeResolvers to resolve type references during flow

--- a/pkg/sql/execinfra/readerbase.go
+++ b/pkg/sql/execinfra/readerbase.go
@@ -202,13 +202,13 @@ func (h *LimitHintHelper) ReadSomeRows(rowsRead int64) error {
 
 // UseStreamer returns whether the kvstreamer.Streamer API should be used as
 // well as the txn that should be used (regardless of the boolean return value).
-func (flowCtx *FlowCtx) UseStreamer() (bool, *kv.Txn, error) {
+func (flowCtx *FlowCtx) UseStreamer(ctx context.Context) (bool, *kv.Txn, error) {
 	useStreamer := flowCtx.EvalCtx.SessionData().StreamerEnabled && flowCtx.Txn != nil &&
 		flowCtx.Txn.Type() == kv.LeafTxn && flowCtx.MakeLeafTxn != nil
 	if !useStreamer {
 		return false, flowCtx.Txn, nil
 	}
-	leafTxn, err := flowCtx.MakeLeafTxn()
+	leafTxn, err := flowCtx.MakeLeafTxn(ctx)
 	if leafTxn == nil || err != nil {
 		// leafTxn might be nil in some flows which run outside of the txn, the
 		// streamer should not be used in such cases.

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -157,7 +157,7 @@ type Flow interface {
 	// GetOnCleanupFns returns a couple of functions that should be called at
 	// the very beginning and the very end of Cleanup, respectively. Both will
 	// be non-nil.
-	GetOnCleanupFns() (startCleanup, endCleanup func())
+	GetOnCleanupFns() (startCleanup func(), endCleanup func(context.Context))
 
 	// Cleanup must be called whenever the flow is done (meaning it either
 	// completes gracefully after all processors and mailboxes exited or an
@@ -227,7 +227,7 @@ type FlowBase struct {
 	// onCleanupStart and onCleanupEnd will be called in the very beginning and
 	// the very end of Cleanup(), respectively.
 	onCleanupStart func()
-	onCleanupEnd   func()
+	onCleanupEnd   func(context.Context)
 
 	statementSQL string
 
@@ -323,7 +323,7 @@ func NewFlowBase(
 	batchSyncFlowConsumer execinfra.BatchReceiver,
 	localProcessors []execinfra.LocalProcessor,
 	localVectorSources map[int32]any,
-	onFlowCleanupEnd func(),
+	onFlowCleanupEnd func(context.Context),
 	statementSQL string,
 ) *FlowBase {
 	// We are either in a single tenant cluster, or a SQL node in a multi-tenant
@@ -642,15 +642,16 @@ func (f *FlowBase) AddOnCleanupStart(fn func()) {
 }
 
 var noopFn = func() {}
+var noopCtxFn = func(context.Context) {}
 
 // GetOnCleanupFns is part of the Flow interface.
-func (f *FlowBase) GetOnCleanupFns() (startCleanup, endCleanup func()) {
+func (f *FlowBase) GetOnCleanupFns() (startCleanup func(), endCleanup func(context.Context)) {
 	onCleanupStart, onCleanupEnd := f.onCleanupStart, f.onCleanupEnd
 	if onCleanupStart == nil {
 		onCleanupStart = noopFn
 	}
 	if onCleanupEnd == nil {
-		onCleanupEnd = noopFn
+		onCleanupEnd = noopCtxFn
 	}
 	return onCleanupStart, onCleanupEnd
 }

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -343,7 +343,7 @@ func newJoinReader(
 		// in order to ensure the lookups are ordered, so set shouldLimitBatches.
 		spec.MaintainOrdering, shouldLimitBatches = true, true
 	}
-	useStreamer, txn, err := flowCtx.UseStreamer()
+	useStreamer, txn, err := flowCtx.UseStreamer(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/rowflow/row_based_flow.go
+++ b/pkg/sql/rowflow/row_based_flow.go
@@ -492,7 +492,7 @@ func (f *rowBasedFlow) Release() {
 func (f *rowBasedFlow) Cleanup(ctx context.Context) {
 	startCleanup, endCleanup := f.FlowBase.GetOnCleanupFns()
 	startCleanup()
-	defer endCleanup()
+	defer endCleanup(ctx)
 	for i := range f.monitors {
 		f.monitors[i].Stop(ctx)
 	}


### PR DESCRIPTION
The `ctx` parameter of `setupFlow` is no longer captured by closures,
preventing it from being heap allocated.

Epic: None

Release note: None
