### PR TITLE
kv,sql,storage: avoid various allocs

### DIFF
--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -225,6 +225,8 @@ type ProposalData struct {
 	lastReproposal *ProposalData
 }
 
+func (*ProposalData) isAbandonToken() {}
+
 // Context returns the context associated with the proposal. The context may
 // change during the lifetime of the proposal.
 func (proposal *ProposalData) Context() context.Context {

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -306,35 +306,37 @@ func (r *Replica) evalAndPropose(
 	// invoked when the command is applied. There are a handful of cases where
 	// the command may not be applied (or even processed): the process crashes
 	// or the local replica is removed from the range.
-	abandon := func(proposal *ProposalData) {
-		// The proposal may or may not be in the Replica's proposals map.
-		// Instead of trying to look it up, simply modify the captured object
-		// directly. The raftMu must be locked to modify the context of a
-		// proposal because as soon as we propose a command to Raft, ownership
-		// passes to the "below Raft" machinery.
-		//
-		// See the comment on ProposalData.
-		r.raftMu.Lock()
-		defer r.raftMu.Unlock()
-		r.mu.Lock()
-		defer r.mu.Unlock()
-		// When the caller abandons the request, it Finishes its trace. By that
-		// time, multiple reproposals can have occurred, and still running and
-		// attempting to post tracing updates through the context. This can cause a
-		// "use after Finish" race in the span. All the (re-)proposal contexts have
-		// been unbound except for the latest one. Unbind it to eliminate the race.
-		//
-		// See https://github.com/cockroachdb/cockroach/issues/107521
-		last := proposal
-		if p := proposal.lastReproposal; p != nil {
-			last = p
-		}
-		// TODO(radu): Should this context be created via tracer.ForkSpan?
-		// We'd need to make sure the span is finished eventually.
-		ctx := r.AnnotateCtx(context.TODO())
-		last.ctx.Store(&ctx)
+
+	return proposalCh, func() { r.abandon(proposal) }, idKey, writeBytes, nil
+}
+
+func (r *Replica) abandon(proposal *ProposalData) {
+	// The proposal may or may not be in the Replica's proposals map.
+	// Instead of trying to look it up, simply modify the captured object
+	// directly. The raftMu must be locked to modify the context of a
+	// proposal because as soon as we propose a command to Raft, ownership
+	// passes to the "below Raft" machinery.
+	//
+	// See the comment on ProposalData.
+	r.raftMu.Lock()
+	defer r.raftMu.Unlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// When the caller abandons the request, it Finishes its trace. By that
+	// time, multiple reproposals can have occurred, and still running and
+	// attempting to post tracing updates through the context. This can cause a
+	// "use after Finish" race in the span. All the (re-)proposal contexts have
+	// been unbound except for the latest one. Unbind it to eliminate the race.
+	//
+	// See https://github.com/cockroachdb/cockroach/issues/107521
+	last := proposal
+	if p := proposal.lastReproposal; p != nil {
+		last = p
 	}
-	return proposalCh, func() { abandon(proposal) }, idKey, writeBytes, nil
+	// TODO(radu): Should this context be created via tracer.ForkSpan?
+	// We'd need to make sure the span is finished eventually.
+	ctx := r.AnnotateCtx(context.TODO())
+	last.ctx.Store(&ctx)
 }
 
 func (r *Replica) encodePriorityForRACv2() bool {

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -145,14 +145,17 @@ func (r *Replica) evalAndPropose(
 	// from this point on.
 	proposal.ec = makeReplicatedEndCmds(r, g, *st, timeutil.Now())
 
-	log.VEventf(proposal.Context(), 2,
-		"proposing command to write %d new keys, %d new values, %d new intents, "+
-			"write batch size=%d bytes",
-		proposal.command.ReplicatedEvalResult.Delta.KeyCount,
-		proposal.command.ReplicatedEvalResult.Delta.ValCount,
-		proposal.command.ReplicatedEvalResult.Delta.IntentCount,
-		proposal.command.WriteBatch.Size(),
-	)
+	if log.ExpensiveLogEnabled(proposal.Context(), 2) {
+		// Local copies to avoid allocating to heap if not logging.
+		kc := proposal.command.ReplicatedEvalResult.Delta.KeyCount
+		vc := proposal.command.ReplicatedEvalResult.Delta.ValCount
+		ic := proposal.command.ReplicatedEvalResult.Delta.IntentCount
+		sz := proposal.command.WriteBatch.Size()
+		log.VEventf(proposal.Context(), 2,
+			"proposing command to write %d new keys, %d new values, %d new intents, "+
+				"write batch size=%d bytes", kc, vc, ic, sz,
+		)
+	}
 	// NB: if ba.AsyncConsensus is true, we will tell admission control about
 	// writes that may not have happened yet. We consider this ok, since (a) the
 	// typical lag in consensus is expected to be small compared to the time

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -306,7 +306,7 @@ func (r *Replica) evalAndPropose(
 	// invoked when the command is applied. There are a handful of cases where
 	// the command may not be applied (or even processed): the process crashes
 	// or the local replica is removed from the range.
-	abandon := func() {
+	abandon := func(proposal *ProposalData) {
 		// The proposal may or may not be in the Replica's proposals map.
 		// Instead of trying to look it up, simply modify the captured object
 		// directly. The raftMu must be locked to modify the context of a
@@ -334,7 +334,7 @@ func (r *Replica) evalAndPropose(
 		ctx := r.AnnotateCtx(context.TODO())
 		last.ctx.Store(&ctx)
 	}
-	return proposalCh, abandon, idKey, writeBytes, nil
+	return proposalCh, func() { abandon(proposal) }, idKey, writeBytes, nil
 }
 
 func (r *Replica) encodePriorityForRACv2() bool {

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -258,7 +258,10 @@ func (r *Replica) evalAndPropose(
 			"command is too large: %d bytes (max: %d)", quotaSize, maxSize,
 		))
 	}
-	log.VEventf(proposal.Context(), 2, "acquiring proposal quota (%d bytes)", quotaSize)
+	if log.ExpensiveLogEnabled(proposal.Context(), 2) {
+		quotaSize := quotaSize // avoid heap alloc when conditional not taken
+		log.VEventf(proposal.Context(), 2, "acquiring proposal quota (%d bytes)", quotaSize)
+	}
 	var err error
 	proposal.quotaAlloc, err = r.maybeAcquireProposalQuota(ctx, ba, quotaSize)
 	if err != nil {

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -184,9 +184,11 @@ func (r *Replica) evalAndPropose(
 
 		// Fork the proposal's context span so that the proposal's context
 		// can outlive the original proposer's context.
-		ctx, sp := tracing.ForkSpan(ctx, "async consensus")
-		proposal.ctx.Store(&ctx)
-		proposal.sp = sp
+		if s := tracing.SpanFromContext(ctx); s != nil && !s.IsNoop() {
+			ctx, sp := tracing.ForkSpan(ctx, "async consensus")
+			proposal.ctx.Store(&ctx)
+			proposal.sp = sp
+		}
 		if proposal.sp != nil {
 			// We can't leak this span if we fail to hand the proposal to the
 			// replication layer, so finish it later in this method if we are to

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -185,7 +185,7 @@ func (r *Replica) executeWriteBatch(
 	// the concurrency guard will be assumed by Raft, so provide the guard to
 	// evalAndPropose. If we return with an error from executeWriteBatch, we
 	// also return the guard which the caller reassumes ownership of.
-	ch, abandon, _, writeBytes, pErr := r.evalAndPropose(ctx, ba, g, &st, ui, tok.Move(ctx))
+	ch, abandonTok, _, writeBytes, pErr := r.evalAndPropose(ctx, ba, g, &st, ui, tok.Move(ctx))
 	if pErr != nil {
 		if cErr, ok := pErr.GetDetail().(*kvpb.ReplicaCorruptionError); ok {
 			// Need to unlock here because setCorruptRaftMuLock needs readOnlyCmdMu not held.
@@ -340,7 +340,7 @@ func (r *Replica) executeWriteBatch(
 						}
 					})
 			}
-			abandon()
+			r.abandon(abandonTok)
 			dur := timeutil.Since(startTime)
 			log.VEventf(ctx, 2, "context cancellation after %.2fs of attempting command %s",
 				dur.Seconds(), ba)
@@ -351,7 +351,7 @@ func (r *Replica) executeWriteBatch(
 		case <-shouldQuiesce:
 			// If shutting down, return an AmbiguousResultError, which indicates
 			// to the caller that the command may have executed.
-			abandon()
+			r.abandon(abandonTok)
 			log.VEventf(ctx, 2, "shutdown cancellation after %0.1fs of attempting command %s",
 				timeutil.Since(startTime).Seconds(), ba)
 			return nil, nil, nil, kvpb.NewError(kvpb.NewAmbiguousResultErrorf(

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1998,7 +1998,9 @@ func setupSpanForIncomingRPC(
 			tracing.WithServerSpanKind)
 	}
 
-	newSpan.SetLazyTag("request", ba.ShallowCopy())
+	if newSpan != nil && !newSpan.IsNoop() {
+		newSpan.SetLazyTag("request", ba.ShallowCopy())
+	}
 	return ctx, spanForRequest{
 		// For non-local requests, we'll need to attach the recording to the
 		// outgoing BatchResponse if the request is traced. We ignore whether the

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2696,6 +2696,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	var err error
 
 	if ppInfo := getPausablePortalInfo(); ppInfo != nil {
+		ctx := ctx // heap alloc only in case of pausable portal
 		if !ppInfo.dispatchToExecutionEngine.cleanup.isComplete {
 			err = ex.makeExecPlan(ctx, planner)
 			if flags := planner.curPlan.flags; err == nil && (flags.IsSet(planFlagContainsMutation) || flags.IsSet(planFlagIsDDL)) {
@@ -2883,6 +2884,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	ex.extraTxnState.rowsWritten += stats.rowsWritten
 
 	if ppInfo := getPausablePortalInfo(); ppInfo != nil && !ppInfo.dispatchToExecutionEngine.cleanup.isComplete {
+		ctx := ctx // alloc only in case of pausable portal
 		// We need to ensure that we're using the planner bound to the first-time
 		// execution of a portal.
 		curPlanner := *planner

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2698,6 +2698,7 @@ func (st *SessionTracing) Enabled() bool {
 // logical planning starts.
 func (st *SessionTracing) TracePlanStart(ctx context.Context, stmtTag string) {
 	if st.enabled {
+		stmtTag := stmtTag // alloc only if taken
 		log.VEventf(ctx, 2, "planning starts: %s", stmtTag)
 	}
 }
@@ -2735,7 +2736,10 @@ func (st *SessionTracing) TraceRetryInformation(ctx context.Context, retries int
 // TraceExecStart conditionally emits a trace message at the moment
 // plan execution starts.
 func (st *SessionTracing) TraceExecStart(ctx context.Context, engine redact.SafeString) {
-	log.VEventfDepth(ctx, 2, 1, "execution starts: %s engine", engine)
+	if log.ExpensiveLogEnabledVDepth(ctx, 2, 1) {
+		engine := engine // heap alloc only if needed
+		log.VEventfDepth(ctx, 2, 1, "execution starts: %s engine", engine)
+	}
 }
 
 // TraceExecConsume creates a context for TraceExecRowsResult below.


### PR DESCRIPTION
```
$ benchdiff --old lastmerge  ./pkg/sql/tests -b -r 'Sysbench/SQL/3node/oltp_write_only' -d 1000x -c 20
test binaries already exist for 9354770: Merge #137344
test binaries already exist for 1b46187: server: remove alloc in setupSpanForIncomingRPC

  pkg=1/1 iter=20/20 cockroachdb/cockroach/pkg/sql/tests -

name                                   old time/op    new time/op    delta
Sysbench/SQL/3node/oltp_write_only-24    4.42ms ± 3%    4.43ms ± 3%    ~     (p=0.687 n=19+20)

name                                   old alloc/op   new alloc/op   delta
Sysbench/SQL/3node/oltp_write_only-24     956kB ± 3%     954kB ± 3%    ~     (p=0.134 n=18+19)

name                                   old allocs/op  new allocs/op  delta
Sysbench/SQL/3node/oltp_write_only-24     6.17k ± 1%     6.09k ± 1%  -1.31%  (p=0.000 n=16+16)
```

- **kvserver: avoid an alloc**
- **kvserver: step 1 in reducing abandon() alloc**
- **kvserver: step 2 in removing abandon() alloc**
- **kvserver: avoid allocation due to `abandon` closure in hot path**
- **kvserver: avoid Veventf-related allocs**
- **kvserverbase: make tracing alloc in hot path conditional**
- **sql: avoid ctx moving to heap in dispatchToExecutionEngine**
- **sql: avoid some vevent-related allocs**
- **storage: pool unlimited standalone BoundAccounts**
- **mvcc: remove minor allocation in MVCCGarbageCollect**
- **server: remove alloc in setupSpanForIncomingRPC**

Epic: CRDB-42584