### PR TITLE
sql: include DB name in create_statement in create_type_statements

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -479,8 +479,8 @@ CREATE TYPE enum2 AS ENUM ()
 query ITTITTT
 SELECT * FROM crdb_internal.create_type_statements ORDER BY descriptor_id
 ----
-104  test  public  113  enum1  CREATE TYPE public.enum1 AS ENUM ('hello', 'hi')  {hello,hi}
-104  test  public  115  enum2  CREATE TYPE public.enum2 AS ENUM ()               {}
+104  test  public  113  enum1  CREATE TYPE test.public.enum1 AS ENUM ('hello', 'hi')  {hello,hi}
+104  test  public  115  enum2  CREATE TYPE test.public.enum2 AS ENUM ()               {}
 
 # Test the virtual index as well.
 

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -3493,7 +3493,7 @@ func writeCreateTypeDescRow(
 		return false, errors.AssertionFailedf("unknown type descriptor kind %s", typeDesc.GetKind())
 	}
 
-	name, err := tree.NewUnresolvedObjectName(2, [3]string{typeDesc.GetName(), sc.GetName()}, 0)
+	name, err := tree.NewUnresolvedObjectName(3, [3]string{typeDesc.GetName(), sc.GetName(), db.GetName()}, 0)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -1012,7 +1012,8 @@ func (c *stmtEnvCollector) PrintCreateSequence(w io.Writer, tn *tree.TableName) 
 
 func (c *stmtEnvCollector) PrintCreateUDT(w io.Writer, id oid.Oid, redactValues bool) error {
 	descID := catid.UserDefinedOIDToID(id)
-	query := fmt.Sprintf("SELECT create_statement FROM crdb_internal.create_type_statements WHERE descriptor_id = %d", descID)
+	// Use "".crdb_internal to allow for cross-DB lookups.
+	query := fmt.Sprintf(`SELECT create_statement FROM "".crdb_internal.create_type_statements WHERE descriptor_id = %d::OID`, descID)
 	if redactValues {
 		query = fmt.Sprintf("SELECT crdb_internal.redact(crdb_internal.redactable_sql_constants(create_statement)) FROM (%s)", query)
 	}
@@ -1031,7 +1032,8 @@ func (c *stmtEnvCollector) PrintCreateRoutine(
 ) error {
 	var createRoutineQuery string
 	descID := catid.UserDefinedOIDToID(id)
-	queryTemplate := "SELECT create_statement FROM crdb_internal.create_%[1]s_statements WHERE %[1]s_id = %[2]d"
+	// Use "".crdb_internal to allow for cross-DB lookups.
+	queryTemplate := `SELECT create_statement FROM "".crdb_internal.create_%[1]s_statements WHERE %[1]s_id = %[2]d::OID`
 	if procedure {
 		createRoutineQuery = fmt.Sprintf(queryTemplate, "procedure", descID)
 	} else {

--- a/pkg/sql/logictest/testdata/logic_test/composite_types
+++ b/pkg/sql/logictest/testdata/logic_test/composite_types
@@ -126,7 +126,7 @@ DROP TABLE tab
 query TTTT
 SELECT database_name, schema_name, descriptor_name, create_statement FROM crdb_internal.create_type_statements
 ----
-test  public  t   CREATE TYPE public.t AS (a INT8, b INT8)
+test  public  t  CREATE TYPE test.public.t AS (a INT8, b INT8)
 
 ## Can't drop type t because t2 depends on it
 #statement error cannot drop type \"t\" because other objects .* still depend on it

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -926,15 +926,15 @@ CREATE TYPE enum2 AS ENUM ()
 query ITTITTT
 SELECT * FROM crdb_internal.create_type_statements ORDER BY descriptor_id
 ----
-104  test  public  116  enum1  CREATE TYPE public.enum1 AS ENUM ('hello', 'hi')  {hello,hi}
-104  test  public  118  enum2  CREATE TYPE public.enum2 AS ENUM ()               {}
+104  test  public  116  enum1  CREATE TYPE test.public.enum1 AS ENUM ('hello', 'hi')  {hello,hi}
+104  test  public  118  enum2  CREATE TYPE test.public.enum2 AS ENUM ()               {}
 
 # Test the virtual index as well.
 
 query ITTITTT
 SELECT * FROM crdb_internal.create_type_statements WHERE descriptor_id = (('enum1'::regtype::oid::int) - 100000)::oid
 ----
-104  test  public  116  enum1  CREATE TYPE public.enum1 AS ENUM ('hello', 'hi')  {hello,hi}
+104  test  public  116  enum1  CREATE TYPE test.public.enum1 AS ENUM ('hello', 'hi')  {hello,hi}
 
 query ITTITTT
 SELECT * FROM crdb_internal.create_type_statements WHERE descriptor_id = 'foo'::regclass::oid
@@ -1678,3 +1678,12 @@ statement ok
 DROP USER real_user;
 
 subtest end
+
+statement ok
+CREATE TYPE other_db.public.enum1 AS ENUM ('yo');
+
+# Ensure that the cross-DB lookup of UDTs works.
+query ITTITTT
+SELECT * FROM "".crdb_internal.create_type_statements WHERE descriptor_id = (('other_db.public.enum1'::regtype::int) - 100000)::oid
+----
+121  other_db  public  151  enum1  CREATE TYPE other_db.public.enum1 AS ENUM ('yo')  {yo}

--- a/pkg/sql/logictest/testdata/logic_test/show_create_all_types
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_all_types
@@ -16,7 +16,7 @@ query T colnames
 SHOW CREATE ALL TYPES
 ----
 create_statement
-CREATE TYPE public.status AS ENUM ('open', 'closed', 'inactive');
+CREATE TYPE d.public.status AS ENUM ('open', 'closed', 'inactive');
 
 statement ok
 CREATE TYPE tableObj AS ENUM('row', 'col');
@@ -25,8 +25,8 @@ query T colnames,rowsort
 SHOW CREATE ALL TYPES
 ----
 create_statement
-CREATE TYPE public.status AS ENUM ('open', 'closed', 'inactive');
-CREATE TYPE public.tableobj AS ENUM ('row', 'col');
+CREATE TYPE d.public.status AS ENUM ('open', 'closed', 'inactive');
+CREATE TYPE d.public.tableobj AS ENUM ('row', 'col');
 
 statement ok
 DROP TYPE status
@@ -35,7 +35,7 @@ query T colnames
 SHOW CREATE ALL TYPES
 ----
 create_statement
-CREATE TYPE public.tableobj AS ENUM ('row', 'col');
+CREATE TYPE d.public.tableobj AS ENUM ('row', 'col');
 
 # type in user-defined schema
 statement ok
@@ -48,8 +48,8 @@ query T colnames,rowsort
 SHOW CREATE ALL TYPES
 ----
 create_statement
-CREATE TYPE public.tableobj AS ENUM ('row', 'col');
-CREATE TYPE s.status AS ENUM ('a', 'b', 'c');
+CREATE TYPE d.public.tableobj AS ENUM ('row', 'col');
+CREATE TYPE d.s.status AS ENUM ('a', 'b', 'c');
 
 # Make sure database names with hyphens work well.
 statement ok
@@ -83,8 +83,8 @@ query T colnames
 SHOW CREATE ALL TYPES
 ----
 create_statement
-CREATE TYPE public.address AS (street STRING, city STRING, state STRING, zipcode STRING);
-COMMENT ON TYPE public.address IS 'comment for composite type address';
+CREATE TYPE "a""bc".public.address AS (street STRING, city STRING, state STRING, zipcode STRING);
+COMMENT ON TYPE "a""bc".public.address IS 'comment for composite type address';
 
 skipif config local-legacy-schema-changer
 statement ok
@@ -103,7 +103,7 @@ query T colnames
 SHOW CREATE ALL TYPES
 ----
 create_statement
-CREATE TYPE public.roaches AS ENUM ('papa_roach', 'mama_roach', 'baby_roach');
-COMMENT ON TYPE public.roaches IS 'comment for enum type roaches';
+CREATE TYPE "a""bc".public.roaches AS ENUM ('papa_roach', 'mama_roach', 'baby_roach');
+COMMENT ON TYPE "a""bc".public.roaches IS 'comment for enum type roaches';
 
 subtest end


### PR DESCRIPTION
This commit updates how we populate `crdb_internal.create_type_statements` virtual table so that `create_statement` column included the DB name (previously only the schema and the UDT name were included). This will make it easier to reproduce stmt bundles with cross-DB references.

Also, this commit fixes how we use this virtual table during bundle creation - we now properly use `"".crdb_internal` search path and cast the type oid to `OID` type. The same fix is applied for `create_function_statements` and `create_procedure_statements` vtables.

Epic: None
Release note: None