### PR TITLE
roachprod: update `haveCredentials` in AWS provider to prefer SSO

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -122,6 +122,13 @@ func initFlags() {
 		fmt.Sprintf("use the shared user %q for ssh rather than your user %q",
 			config.SharedUser, config.OSUser.Username))
 
+	rootCmd.PersistentFlags().BoolVarP(&[]bool{false}[0], "version", "V",
+		false, "print version and exit")
+	rootCmd.PersistentFlags().BoolVarP(&config.DryRun, "dry-run", "d",
+		false, "dry-run mode (execute read-only operations; i.e., no infra changes are made)")
+	rootCmd.PersistentFlags().BoolVarP(&config.Verbose, "verbose", "v",
+		false, "verbose mode")
+
 	createCmd.Flags().DurationVarP(&createVMOpts.Lifetime,
 		"lifetime", "l", 12*time.Hour, "Lifetime of the cluster")
 	createCmd.Flags().BoolVar(&createVMOpts.SSDOpts.UseLocalSSD,
@@ -188,7 +195,7 @@ func initFlags() {
 		"Show cost estimates",
 	)
 	listCmd.Flags().BoolVarP(&listDetails,
-		"details", "d", false, "Show cluster details")
+		"details", "", false, "Show cluster details")
 	listCmd.Flags().BoolVar(&listJSON,
 		"json", false, "Show cluster specs in a json format")
 	listCmd.Flags().BoolVarP(&listMine,

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1724,6 +1724,9 @@ func validateAndConfigure(cmd *cobra.Command, args []string) {
 		}
 		providersSet[p] = struct{}{}
 	}
+	if config.DryRun {
+		config.Logger.Printf("Enabling [***Experimental***] --dry-run mode. No infra changes will be made!")
+	}
 }
 
 var updateCmd = &cobra.Command{
@@ -1801,7 +1804,7 @@ var sshKeysListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "list every SSH public key installed on clusters managed by roachprod",
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		authorizedKeys, err := gce.GetUserAuthorizedKeys()
+		authorizedKeys, err := gce.GetUserAuthorizedKeys(config.Logger)
 		if err != nil {
 			return err
 		}
@@ -1833,7 +1836,7 @@ var sshKeysAddCmd = &cobra.Command{
 		}
 
 		fmt.Printf("Adding new public key for user %s...\n", ak.User)
-		return gce.AddUserAuthorizedKey(ak)
+		return gce.AddUserAuthorizedKey(config.Logger, ak)
 	}),
 }
 
@@ -1844,7 +1847,7 @@ var sshKeysRemoveCmd = &cobra.Command{
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
 		user := args[0]
 
-		existingKeys, err := gce.GetUserAuthorizedKeys()
+		existingKeys, err := gce.GetUserAuthorizedKeys(config.Logger)
 		if err != nil {
 			return fmt.Errorf("failed to fetch existing keys: %w", err)
 		}

--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -433,7 +433,7 @@ func DestroyCluster(l *logger.Logger, c *Cluster) error {
 	// and clean-up entries prematurely.
 	stopSpinner = ui.NewDefaultSpinner(l, "Destroying DNS entries").Start()
 	dnsErr := vm.FanOutDNS(c.VMs, func(p vm.DNSProvider, vms vm.List) error {
-		return p.DeleteRecordsBySubdomain(context.Background(), c.Name)
+		return p.DeleteRecordsBySubdomain(context.Background(), l, c.Name)
 	})
 	stopSpinner()
 

--- a/pkg/roachprod/cloud/gc.go
+++ b/pkg/roachprod/cloud/gc.go
@@ -518,7 +518,7 @@ func GCDNS(l *logger.Logger, cloud *Cloud, dryrun bool) error {
 		if !ok {
 			continue
 		}
-		records, err := p.ListRecords(ctx)
+		records, err := p.ListRecords(ctx, l)
 		if err != nil {
 			return err
 		}
@@ -541,7 +541,7 @@ func GCDNS(l *logger.Logger, cloud *Cloud, dryrun bool) error {
 		sort.Strings(recordNames)
 
 		if err := destroyResource(dryrun, func() error {
-			return p.DeleteRecordsByName(ctx, recordNames...)
+			return p.DeleteRecordsByName(ctx, l, recordNames...)
 		}); err != nil {
 			return err
 		}

--- a/pkg/roachprod/clusters_cache.go
+++ b/pkg/roachprod/clusters_cache.go
@@ -86,9 +86,17 @@ func saveCluster(l *logger.Logger, c *cloud.Cluster) error {
 	err = errors.CombineErrors(err, tmpFile.Sync())
 	err = errors.CombineErrors(err, tmpFile.Close())
 	if err == nil {
+		if config.DryRun || config.Verbose {
+			l.Printf("exec: mv %s %s", tmpFile.Name(), filename)
+		}
+		
 		err = os.Rename(tmpFile.Name(), filename)
 	}
 	if err != nil {
+		if config.DryRun || config.Verbose {
+			l.Printf("exec: rm %s", tmpFile.Name())
+		}
+
 		_ = os.Remove(tmpFile.Name())
 		return err
 	}
@@ -258,5 +266,12 @@ func (localVMStorage) SaveCluster(l *logger.Logger, cluster *cloud.Cluster) erro
 // DeleteCluster is part of the local.VMStorage interface.
 func (localVMStorage) DeleteCluster(l *logger.Logger, name string) error {
 	path := clusterFilename(name)
+	if config.DryRun || config.Verbose {
+		l.Printf("exec: rm %s", path)
+	}
+	if config.DryRun {
+		return nil
+	}
+
 	return os.Remove(path)
 }

--- a/pkg/roachprod/config/config.go
+++ b/pkg/roachprod/config/config.go
@@ -31,10 +31,15 @@ var (
 	OSUser *user.User
 	// Quiet is used to disable fancy progress output.
 	Quiet = false
+
+	// DryRun disables executing commands which would otherwise cause infra. changes.
+	DryRun = false
+	// Verbose enables verbose logging. What gets logged is a superset of DryRun.
+	Verbose = false
 	// The default roachprod logger.
 	// N.B. When roachprod is used via CLI, this logger is used for all output.
-	//	When roachprod is used via API (e.g. from roachtest), this logger is used only in the few cases,
-	//	during bootstrapping, at which time the caller has not yet had a chance to configure a custom logger.
+	//			When roachprod is used via API (e.g. from roachtest), this logger is used only in the few cases,
+	//			during bootstrapping, at which time the caller has not yet had a chance to configure a custom logger.
 	Logger *logger.Logger
 	// MaxConcurrency specifies the maximum number of operations
 	// to execute on nodes concurrently, set to zero for infinite.

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -438,7 +438,7 @@ func (c *SyncedCluster) Stop(
 			return err
 		}
 
-		services, err := c.DiscoverServices(ctx, name, ServiceTypeSQL)
+		services, err := c.DiscoverServices(ctx, l, name, ServiceTypeSQL)
 		if err != nil {
 			return err
 		}
@@ -2339,6 +2339,8 @@ func (c *SyncedCluster) Logs(
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = &stderrBuf
 
+		vm.MaybeLogCmd(l, cmd)
+
 		if err := cmd.Run(); err != nil {
 			if ctx.Err() != nil {
 				return nil
@@ -2379,6 +2381,9 @@ func (c *SyncedCluster) Logs(
 		cmd.Stdout = out
 		var errBuf bytes.Buffer
 		cmd.Stderr = &errBuf
+
+		vm.MaybeLogCmd(l, cmd)
+
 		if err := cmd.Run(); err != nil && ctx.Err() == nil {
 			return errors.Wrapf(err, "failed to run cockroach debug merge-logs:\n%v", errBuf.String())
 		}
@@ -2632,7 +2637,7 @@ func (c *SyncedCluster) pgurls(
 	}
 	m := make(map[Node]string, len(hosts))
 	for node, host := range hosts {
-		desc, err := c.DiscoverService(ctx, node, virtualClusterName, ServiceTypeSQL, sqlInstance)
+		desc, err := c.DiscoverService(ctx, l, node, virtualClusterName, ServiceTypeSQL, sqlInstance)
 		if err != nil {
 			return nil, err
 		}
@@ -2667,7 +2672,7 @@ func (c *SyncedCluster) loadBalancerURL(
 	sqlInstance int,
 	auth PGAuthMode,
 ) (string, error) {
-	services, err := c.DiscoverServices(ctx, virtualClusterName, ServiceTypeSQL)
+	services, err := c.DiscoverServices(ctx, l, virtualClusterName, ServiceTypeSQL)
 	if err != nil {
 		return "", err
 	}
@@ -2801,6 +2806,8 @@ func scp(ctx context.Context, l *logger.Logger, src, dest string) (*RunResultDet
 	args = append(args, src, dest)
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 	cmd.WaitDelay = time.Second // make sure the call below returns when the context is canceled
+
+	vm.MaybeLogCmd(l, cmd)
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -2993,10 +3000,10 @@ func (c *SyncedCluster) Init(ctx context.Context, l *logger.Logger, node Node) e
 
 // allPublicAddrs returns a string that can be used when starting cockroach to
 // indicate the location of all nodes in the cluster.
-func (c *SyncedCluster) allPublicAddrs(ctx context.Context) (string, error) {
+func (c *SyncedCluster) allPublicAddrs(ctx context.Context, l *logger.Logger) (string, error) {
 	var addrs []string
 	for _, node := range c.Nodes {
-		port, err := c.NodePort(ctx, node, "" /* virtualClusterName */, 0 /* sqlInstance */)
+		port, err := c.NodePort(ctx, l, node, "" /* virtualClusterName */, 0 /* sqlInstance */)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/roachprod/install/expander.go
+++ b/pkg/roachprod/install/expander.go
@@ -206,7 +206,7 @@ func (e *expander) maybeExpandPgHost(
 
 	switch strings.ToLower(m[1]) {
 	case ":lb":
-		services, err := c.DiscoverServices(ctx, virtualClusterName, ServiceTypeSQL, ServiceInstancePredicate(sqlInstance))
+		services, err := c.DiscoverServices(ctx, l, virtualClusterName, ServiceTypeSQL, ServiceInstancePredicate(sqlInstance))
 		if err != nil {
 			return "", false, err
 		}
@@ -251,7 +251,7 @@ func (e *expander) maybeExpandPgPort(
 	if e.pgPorts == nil {
 		e.pgPorts = make(map[Node]string, len(c.VMs))
 		for _, node := range allNodes(len(c.VMs)) {
-			desc, err := c.DiscoverService(ctx, node, virtualClusterName, ServiceTypeSQL, sqlInstance)
+			desc, err := c.DiscoverService(ctx, l, node, virtualClusterName, ServiceTypeSQL, sqlInstance)
 			if err != nil {
 				return s, false, err
 			}
@@ -276,7 +276,7 @@ func (e *expander) maybeExpandUIPort(
 		e.uiPorts = make(map[Node]string, len(c.VMs))
 		for _, node := range allNodes(len(c.VMs)) {
 			// TODO(herko): Add support for separate-process services.
-			e.uiPorts[node] = fmt.Sprint(c.NodeUIPort(ctx, node, "" /* virtualClusterName */, 0 /* sqlInstance */))
+			e.uiPorts[node] = fmt.Sprint(c.NodeUIPort(ctx, l, node, "" /* virtualClusterName */, 0 /* sqlInstance */))
 		}
 	}
 

--- a/pkg/roachprod/promhelperclient/client.go
+++ b/pkg/roachprod/promhelperclient/client.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
@@ -192,10 +191,10 @@ type NodeInfo struct {
 // createClusterConfigFile creates the cluster config file per node
 func buildCreateRequest(nodes map[int]*NodeInfo, insecure bool) (io.Reader, error) {
 	configs := make([]*CCParams, 0)
-	for i, n := range nodes {
+	for _, n := range nodes {
 		params := &CCParams{
 			Targets: []string{n.Target},
-			Labels:  map[string]string{"node": strconv.Itoa(i)},
+			Labels:  map[string]string{},
 		}
 		// custom labels - this can override the default labels if needed
 		for n, v := range n.CustomLabels {

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -85,14 +85,32 @@ func Init() error {
 	// NB: This is a bit hacky, but using something like `aws iam get-user` is
 	// slow and not something we want to do at startup.
 	haveCredentials := func() bool {
+		// We assume SSO is enabled if either AWS_PROFILE is set or ~/.aws/config exists.
+		// N.B. We can't check if the user explicitly passed `--aws-profile` because CLI parsing hasn't happened yet.
+		if os.Getenv("AWS_PROFILE") != "" {
+			return true
+		}
+		const configFile = "${HOME}/.aws/config"
+		if _, err := os.Stat(os.ExpandEnv(configFile)); err == nil {
+			return true
+		}
+		// Non-SSO authentication is deprecated and will be removed in the future. However, CI continues to use it.
+		hasAuth := false
 		const credFile = "${HOME}/.aws/credentials"
 		if _, err := os.Stat(os.ExpandEnv(credFile)); err == nil {
-			return true
+			hasAuth = true
 		}
 		if os.Getenv("AWS_ACCESS_KEY_ID") != "" {
-			return true
+			hasAuth = true
 		}
-		return false
+		if !hasAuth {
+			// No known method of auth. was detected.
+			return false
+		}
+		// Non-SSO auth. is deprecated, so let's display a warning.
+		fmt.Fprintf(os.Stderr, "WARN: Non-SSO form of authentication is deprecated and will be removed in the future.\n")
+		fmt.Fprintf(os.Stderr, "WARN:\tPlease set `AWS_PROFILE` or pass `--aws-profile`.\n")
+		return true
 	}
 	if !haveCredentials() {
 		vm.Providers[ProviderName] = flagstub.New(&Provider{}, noCredentials)

--- a/pkg/roachprod/vm/aws/keys.go
+++ b/pkg/roachprod/vm/aws/keys.go
@@ -28,7 +28,8 @@ func (p *Provider) sshKeyExists(l *logger.Logger, keyName, region string) (bool,
 		"ec2", "describe-key-pairs",
 		"--region", region,
 	}
-	err := p.runJSONCommand(l, args, &data)
+	err := p.RunJSONCommand(l, args, &data)
+
 	if err != nil {
 		return false, err
 	}
@@ -72,7 +73,8 @@ func (p *Provider) sshKeyImport(l *logger.Logger, keyName, region string) error 
 		"--public-key-material", fmt.Sprintf("fileb://%s", sshPublicKeyPath),
 		"--tag-specifications", tagSpecs,
 	}
-	err = p.runJSONCommand(l, args, &data)
+	err = p.RunJSONCommand(l, args, &data)
+
 	// If two roachprod instances run at the same time with the same key, they may
 	// race to upload the key pair.
 	if err == nil || strings.Contains(err.Error(), "InvalidKeyPair.Duplicate") {

--- a/pkg/roachprod/vm/dns.go
+++ b/pkg/roachprod/vm/dns.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"strconv"
 
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/errors"
 	"golang.org/x/sync/errgroup"
 )
@@ -44,18 +45,18 @@ type DNSRecord struct {
 // management services.
 type DNSProvider interface {
 	// CreateRecords creates DNS records.
-	CreateRecords(ctx context.Context, records ...DNSRecord) error
+	CreateRecords(ctx context.Context, l *logger.Logger, records ...DNSRecord) error
 	// LookupSRVRecords looks up SRV records for the given service, proto, and
 	// subdomain. The protocol is usually "tcp" and the subdomain is usually the
 	// cluster name. The service is a combination of the virtual cluster name and
 	// type of service.
-	LookupSRVRecords(ctx context.Context, name string) ([]DNSRecord, error)
+	LookupSRVRecords(ctx context.Context, l *logger.Logger, name string) ([]DNSRecord, error)
 	// ListRecords lists all DNS records managed for the zone.
-	ListRecords(ctx context.Context) ([]DNSRecord, error)
+	ListRecords(ctx context.Context, l *logger.Logger) ([]DNSRecord, error)
 	// DeleteRecordsBySubdomain deletes all DNS records with the given subdomain.
-	DeleteRecordsBySubdomain(ctx context.Context, subdomain string) error
+	DeleteRecordsBySubdomain(ctx context.Context, l *logger.Logger, subdomain string) error
 	// DeleteRecordsByName deletes all DNS records with the given name.
-	DeleteRecordsByName(ctx context.Context, names ...string) error
+	DeleteRecordsByName(ctx context.Context, l *logger.Logger, names ...string) error
 	// Domain returns the domain name (zone) of the DNS provider.
 	Domain() string
 }

--- a/pkg/roachprod/vm/local/dns.go
+++ b/pkg/roachprod/vm/local/dns.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/lock"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
@@ -40,7 +41,9 @@ func (n *dnsProvider) Domain() string {
 }
 
 // CreateRecords is part of the vm.DNSProvider interface.
-func (n *dnsProvider) CreateRecords(_ context.Context, records ...vm.DNSRecord) error {
+func (n *dnsProvider) CreateRecords(
+	_ context.Context, _ *logger.Logger, records ...vm.DNSRecord,
+) error {
 	unlock, err := lock.AcquireFilesystemLock(n.lockFilePath)
 	if err != nil {
 		return err
@@ -59,7 +62,9 @@ func (n *dnsProvider) CreateRecords(_ context.Context, records ...vm.DNSRecord) 
 }
 
 // LookupSRVRecords is part of the vm.DNSProvider interface.
-func (n *dnsProvider) LookupSRVRecords(_ context.Context, name string) ([]vm.DNSRecord, error) {
+func (n *dnsProvider) LookupSRVRecords(
+	_ context.Context, _ *logger.Logger, name string,
+) ([]vm.DNSRecord, error) {
 	records, err := n.loadRecords()
 	if err != nil {
 		return nil, err
@@ -74,7 +79,7 @@ func (n *dnsProvider) LookupSRVRecords(_ context.Context, name string) ([]vm.DNS
 }
 
 // ListRecords is part of the vm.DNSProvider interface.
-func (n *dnsProvider) ListRecords(_ context.Context) ([]vm.DNSRecord, error) {
+func (n *dnsProvider) ListRecords(_ context.Context, _ *logger.Logger) ([]vm.DNSRecord, error) {
 	records, err := n.loadRecords()
 	if err != nil {
 		return nil, err
@@ -83,7 +88,9 @@ func (n *dnsProvider) ListRecords(_ context.Context) ([]vm.DNSRecord, error) {
 }
 
 // DeleteRecordsByName is part of the vm.DNSProvider interface.
-func (n *dnsProvider) DeleteRecordsByName(_ context.Context, names ...string) error {
+func (n *dnsProvider) DeleteRecordsByName(
+	_ context.Context, _ *logger.Logger, names ...string,
+) error {
 	unlock, err := lock.AcquireFilesystemLock(n.lockFilePath)
 	if err != nil {
 		return err
@@ -101,7 +108,9 @@ func (n *dnsProvider) DeleteRecordsByName(_ context.Context, names ...string) er
 }
 
 // DeleteRecordsBySubdomain is part of the vm.DNSProvider interface.
-func (n *dnsProvider) DeleteRecordsBySubdomain(_ context.Context, subdomain string) error {
+func (n *dnsProvider) DeleteRecordsBySubdomain(
+	_ context.Context, _ *logger.Logger, subdomain string,
+) error {
 	unlock, err := lock.AcquireFilesystemLock(n.lockFilePath)
 	if err != nil {
 		return err

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -79,8 +79,14 @@ func DeleteCluster(l *logger.Logger, name string) error {
 
 	for i := range c.VMs {
 		path := VMDir(c.Name, i+1)
-		if err := os.RemoveAll(path); err != nil {
-			return err
+
+		if config.DryRun || config.Verbose {
+			l.Printf("exec: rm -rf %s", path)
+		}
+		if !config.DryRun {
+			if err := os.RemoveAll(path); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -93,7 +99,7 @@ func DeleteCluster(l *logger.Logger, name string) error {
 	// Local clusters are expected to specifically use the local DNS provider
 	// implementation, and should clean up any DNS records in the local file
 	// system cache.
-	return p.DeleteRecordsBySubdomain(context.Background(), c.Name)
+	return p.DeleteRecordsBySubdomain(context.Background(), l, c.Name)
 }
 
 // Clusters returns a list of all known local clusters.
@@ -219,7 +225,9 @@ func (p *Provider) ListLoadBalancers(*logger.Logger, vm.List) ([]vm.ServiceAddre
 	return nil, nil
 }
 
-func (p *Provider) createVM(clusterName string, index int, creationTime time.Time) (vm.VM, error) {
+func (p *Provider) createVM(
+	l *logger.Logger, clusterName string, index int, creationTime time.Time,
+) (vm.VM, error) {
 	cVM := vm.VM{
 		Name:             "localhost",
 		CreatedAt:        creationTime,
@@ -237,9 +245,14 @@ func (p *Provider) createVM(clusterName string, index int, creationTime time.Tim
 		LocalClusterName: clusterName,
 	}
 	path := VMDir(clusterName, index+1)
-	err := os.MkdirAll(path, 0755)
-	if err != nil {
-		return vm.VM{}, err
+	if config.DryRun || config.Verbose {
+		l.Printf("exec: mkdir -p %s", path)
+	}
+	if !config.DryRun {
+		err := os.MkdirAll(path, 0755)
+		if err != nil {
+			return vm.VM{}, err
+		}
 	}
 	return cVM, nil
 }
@@ -262,7 +275,7 @@ func (p *Provider) Create(
 
 	for i := range names {
 		var err error
-		c.VMs[i], err = p.createVM(c.Name, i, now)
+		c.VMs[i], err = p.createVM(l, c.Name, i, now)
 		if err != nil {
 			return err
 		}
@@ -278,7 +291,7 @@ func (p *Provider) Grow(l *logger.Logger, vms vm.List, clusterName string, names
 	now := timeutil.Now()
 	offset := p.clusters[clusterName].VMs.Len()
 	for i := range names {
-		cVM, err := p.createVM(clusterName, i+offset, now)
+		cVM, err := p.createVM(l, clusterName, i+offset, now)
 		if err != nil {
 			return err
 		}
@@ -294,8 +307,13 @@ func (p *Provider) Shrink(l *logger.Logger, vmsToDelete vm.List, clusterName str
 			continue
 		}
 		path := VMDir(clusterName, i+1)
-		if err := os.RemoveAll(path); err != nil {
-			return err
+		if config.DryRun || config.Verbose {
+			l.Printf("exec: rm -rf %s", path)
+		}
+		if !config.DryRun {
+			if err := os.RemoveAll(path); err != nil {
+				return err
+			}
 		}
 	}
 	p.clusters[clusterName].VMs = p.clusters[clusterName].VMs[:keepCount]


### PR DESCRIPTION
Previously, `haveCredentials` (in `aws.go`) would check for
existence of `~/.aws/credentials` or `AWS_ACCESS_KEY_ID`.
When neither exists, the AWS provider is disabled.

As of recently, non-CI uses of roachprod have been
migrated over to SSO. Thus, we now check for
existence of `~/.aws/config` or `AWS_PROFILE`.
When neither exists, we fall back to the
previous logic (see above). Further, a deprecation
warning is displayed.

Epic: none
Release note: None