### PR TITLE
release-24.3: raft: add counters for flow state changes

### DIFF
--- a/docs/generated/metrics/metrics.html
+++ b/docs/generated/metrics/metrics.html
@@ -491,6 +491,9 @@
 <tr><td>STORAGE</td><td>raft.entrycache.hits</td><td>Number of successful cache lookups in the Raft entry cache</td><td>Hits</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>raft.entrycache.read_bytes</td><td>Counter of bytes in entries returned from the Raft entry cache</td><td>Bytes</td><td>COUNTER</td><td>BYTES</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>raft.entrycache.size</td><td>Number of Raft entries in the Raft entry cache</td><td>Entry Count</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
+<tr><td>STORAGE</td><td>raft.flows.entered.state_probe</td><td>The number of leader-&gt;peer flows transitioned to StateProbe</td><td>Flows</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
+<tr><td>STORAGE</td><td>raft.flows.entered.state_replicate</td><td>The number of leader-&gt;peer flows transitioned to StateReplicate</td><td>Flows</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
+<tr><td>STORAGE</td><td>raft.flows.entered.state_snapshot</td><td>The number of of leader-&gt;peer flows transitioned to StateSnapshot</td><td>Flows</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>STORAGE</td><td>raft.flows.state_probe</td><td>Number of leader-&gt;peer flows in StateProbe</td><td>Flows</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>raft.flows.state_replicate</td><td>Number of leader-&gt;peer flows in StateReplicate</td><td>Flows</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>STORAGE</td><td>raft.flows.state_snapshot</td><td>Number of leader-&gt;peer flows in StateSnapshot</td><td>Flows</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>

--- a/pkg/raft/metrics.go
+++ b/pkg/raft/metrics.go
@@ -7,11 +7,15 @@ package raft
 
 import "github.com/cockroachdb/cockroach/pkg/util/metric"
 
-// Metrics all the metrics reported in Raft.
+// Metrics contains all the metrics reported in Raft.
 type Metrics struct {
 	AcceptedFortificationResponses         *metric.Counter
 	RejectedFortificationResponses         *metric.Counter
 	SkippedFortificationDueToLackOfSupport *metric.Counter
+
+	FlowsEnteredStateProbe     *metric.Counter
+	FlowsEnteredStateReplicate *metric.Counter
+	FlowsEnteredStateSnapshot  *metric.Counter
 }
 
 var (
@@ -21,19 +25,36 @@ var (
 		Measurement: "Accepted Fortification Responses",
 		Unit:        metric.Unit_COUNT,
 	}
-
 	rejectedFortificationResponsesMeta = metric.Metadata{
 		Name:        "raft.fortification_resp.rejected",
 		Help:        "The number of rejected fortification responses. Calculated on the raft leader",
 		Measurement: "Rejected Fortification Responses",
 		Unit:        metric.Unit_COUNT,
 	}
-
 	skippedFortificationDueToLackOfSupportMeta = metric.Metadata{
 		Name: "raft.fortification.skipped_no_support",
 		Help: "The number of fortification requests that were skipped (not sent) due to lack of store" +
 			" liveness support",
 		Measurement: "Skipped Fortifications",
+		Unit:        metric.Unit_COUNT,
+	}
+
+	metaRaftFlowsEnteredProbe = metric.Metadata{
+		Name:        "raft.flows.entered.state_probe",
+		Help:        "The number of leader->peer flows transitioned to StateProbe",
+		Measurement: "Flows",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaRaftFlowsEnteredReplicate = metric.Metadata{
+		Name:        "raft.flows.entered.state_replicate",
+		Help:        "The number of leader->peer flows transitioned to StateReplicate",
+		Measurement: "Flows",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaRaftFlowsEnteredSnapshot = metric.Metadata{
+		Name:        "raft.flows.entered.state_snapshot",
+		Help:        "The number of of leader->peer flows transitioned to StateSnapshot",
+		Measurement: "Flows",
 		Unit:        metric.Unit_COUNT,
 	}
 )
@@ -45,5 +66,9 @@ func NewMetrics() *Metrics {
 		RejectedFortificationResponses: metric.NewCounter(rejectedFortificationResponsesMeta),
 		SkippedFortificationDueToLackOfSupport: metric.NewCounter(
 			skippedFortificationDueToLackOfSupportMeta),
+
+		FlowsEnteredStateProbe:     metric.NewCounter(metaRaftFlowsEnteredProbe),
+		FlowsEnteredStateReplicate: metric.NewCounter(metaRaftFlowsEnteredReplicate),
+		FlowsEnteredStateSnapshot:  metric.NewCounter(metaRaftFlowsEnteredSnapshot),
 	}
 }


### PR DESCRIPTION
Backport 2/2 commits from #137091.

/cc @cockroachdb/release

---

Resolves #136533

Release justification: improved observability