### PR TITLE
release-24.3: roachtest: take a side-eye snapshot when an online restore test is slow

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -672,6 +672,10 @@ type clusterImpl struct {
 	grafanaTags               []string
 	disableGrafanaAnnotations atomic.Bool
 
+	// sideEyeClient, if set, is the client used to communicate with the Side-Eye
+	// debugging service.
+	sideEyeClient *sideeyeclient.SideEyeClient
+
 	// State that can be accessed concurrently (in particular, read from the UI
 	// HTML generator).
 	mu struct {
@@ -798,10 +802,18 @@ type clusterFactory struct {
 	// sem is a semaphore throttling the creation of clusters (because AWS has
 	// ridiculous API calls limits).
 	sem chan struct{}
+	// sideEyeClient, if set, is the client used to communicate with the Side-Eye
+	// debugging service.
+	sideEyeClient *sideeyeclient.SideEyeClient
 }
 
 func newClusterFactory(
-	user string, clustersID string, artifactsDir string, r *clusterRegistry, concurrentCreations int,
+	user string,
+	clustersID string,
+	artifactsDir string,
+	r *clusterRegistry,
+	concurrentCreations int,
+	sideEyeClient *sideeyeclient.SideEyeClient,
 ) *clusterFactory {
 	secs := timeutil.Now().Unix()
 	var prefix string
@@ -811,10 +823,11 @@ func newClusterFactory(
 		prefix = fmt.Sprintf("%s-%d-", user, secs)
 	}
 	return &clusterFactory{
-		sem:          make(chan struct{}, concurrentCreations),
-		namePrefix:   prefix,
-		artifactsDir: artifactsDir,
-		r:            r,
+		sem:           make(chan struct{}, concurrentCreations),
+		namePrefix:    prefix,
+		artifactsDir:  artifactsDir,
+		r:             r,
+		sideEyeClient: sideEyeClient,
 	}
 }
 
@@ -988,7 +1001,8 @@ func (f *clusterFactory) newCluster(
 			destroyState: destroyState{
 				owned: true,
 			},
-			l: l,
+			sideEyeClient: f.sideEyeClient,
+			l:             l,
 		}
 		c.status("creating cluster")
 
@@ -3170,13 +3184,17 @@ func (c *clusterImpl) UpdateSideEyeEnvironmentName(
 // swallowed.
 //
 // Returns the URL of the captured snapshot, or "" if not successful.
-func (c *clusterImpl) CaptureSideEyeSnapshot(
-	ctx context.Context, l *logger.Logger, client *sideeyeclient.SideEyeClient,
-) string {
+func (c *clusterImpl) CaptureSideEyeSnapshot(ctx context.Context) string {
+	l := c.t.L()
 	l.PrintfCtx(ctx, "capturing snapshot of the cluster with Side-Eye...")
 
 	if c.arch == vm.ArchARM64 {
 		l.Printf("Side-Eye does not support ARM64 machines; skipping snapshot")
+		return ""
+	}
+
+	if c.sideEyeClient == nil {
+		l.Printf("WARNING: Side-Eye client is not configured")
 		return ""
 	}
 
@@ -3186,7 +3204,7 @@ func (c *clusterImpl) CaptureSideEyeSnapshot(
 		return ""
 	}
 
-	snapURL, ok := roachprod.CaptureSideEyeSnapshot(ctx, l, envName, client)
+	snapURL, ok := roachprod.CaptureSideEyeSnapshot(ctx, l, envName, c.sideEyeClient)
 	if !ok {
 		return ""
 	}

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -207,4 +207,7 @@ type Cluster interface {
 
 	// GetPreemptedVMs gets any VMs that were part of the cluster but preempted by cloud vendor.
 	GetPreemptedVMs(ctx context.Context, l *logger.Logger) ([]vm.PreemptedVM, error)
+
+	// CaptureSideEyeSnapshot triggers a side-eye snapshot if side-eye is enabled in the enviroment.
+	CaptureSideEyeSnapshot(ctx context.Context) string
 }

--- a/pkg/cmd/roachtest/clusterstats/mocks_generated_cluster_test.go
+++ b/pkg/cmd/roachtest/clusterstats/mocks_generated_cluster_test.go
@@ -159,6 +159,20 @@ func (mr *MockClusterMockRecorder) CRDBNodes() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CRDBNodes", reflect.TypeOf((*MockCluster)(nil).CRDBNodes))
 }
 
+// CaptureSideEyeSnapshot mocks base method.
+func (m *MockCluster) CaptureSideEyeSnapshot(arg0 context.Context) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CaptureSideEyeSnapshot", arg0)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// CaptureSideEyeSnapshot indicates an expected call of CaptureSideEyeSnapshot.
+func (mr *MockClusterMockRecorder) CaptureSideEyeSnapshot(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaptureSideEyeSnapshot", reflect.TypeOf((*MockCluster)(nil).CaptureSideEyeSnapshot), arg0)
+}
+
 // Cloud mocks base method.
 func (m *MockCluster) Cloud() spec.Cloud {
 	m.ctrl.T.Helper()

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -338,7 +338,7 @@ func (r *testRunner) Run(
 
 	clusterFactory := newClusterFactory(
 		clustersOpt.user, clustersOpt.clusterID, lopt.artifactsDir,
-		r.cr, numConcurrentClusterCreations(),
+		r.cr, numConcurrentClusterCreations(), r.sideEyeClient,
 	)
 
 	n := len(tests)
@@ -1546,11 +1546,7 @@ func (r *testRunner) teardownTest(
 	if timedOut || t.Failed() || roachtestflags.AlwaysCollectArtifacts {
 		snapURL := ""
 		if timedOut {
-			// If the Side-Eye integration was configured, capture a snapshot of the
-			// cluster to help with debugging.
-			if r.sideEyeClient != nil {
-				snapURL = c.CaptureSideEyeSnapshot(ctx, t.L(), r.sideEyeClient)
-			}
+			snapURL = c.CaptureSideEyeSnapshot(ctx)
 		}
 
 		err := r.collectArtifacts(ctx, t, c, timedOut, time.Hour)

--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -557,7 +557,6 @@ func runRestore(
 			if _, err := db.Exec("SET CLUSTER SETTING kv.range_merge.skip_external_bytes.enabled=true"); err != nil {
 				return err
 			}
-
 		}
 		opts := ""
 		if runOnline {
@@ -567,6 +566,13 @@ func runRestore(
 			return errors.Wrapf(err, "failed to add some empty tables")
 		}
 		restoreStartTime = timeutil.Now()
+		if runOnline && sp.linkPhaseTimeout != 0 {
+			timer := time.AfterFunc(sp.linkPhaseTimeout, func() {
+				c.CaptureSideEyeSnapshot(ctx)
+			})
+			defer timer.Stop()
+		}
+
 		restoreCmd := rd.restoreCmd(fmt.Sprintf("DATABASE %s", sp.backup.workload.DatabaseName()), opts)
 		t.L().Printf("Running %s", restoreCmd)
 		if _, err = db.ExecContext(ctx, restoreCmd); err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #137216.

/cc @cockroachdb/release

---

Online restore will fail the test if the link phase is too slow. Roachtest takes side-eye snapshots on timeouts, but this doesn't apply to the link phase of online restore because the timeout is enforced by the tests.

Part of: #136767
Fixes: #137602
Release justification: test only change