### PR TITLE
lint: check that upgrade tests use SkipWhenMinSupportedVersionIsAtLeast

### DIFF
--- a/pkg/upgrade/upgrades/v25_1_prepared_transactions_table_test.go
+++ b/pkg/upgrade/upgrades/v25_1_prepared_transactions_table_test.go
@@ -24,6 +24,8 @@ func TestPreparedTransactionsTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	clusterversion.SkipWhenMinSupportedVersionIsAtLeast(t, 25, 1)
+
 	clusterArgs := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{


### PR DESCRIPTION
This test verifies that all version-specific tests in
pkg/upgrade/upgrades contain a
`SkipWhenMinSupportedVersionIsAtLeast()` check. This check makes it
easier to bump the minimum supported version (specifically it allows
cleaning up the deprecated upgrades in a separate PR).

Epic: none
Release note: None