### PR TITLE
roachtest: run disk bandwidth roachtest nightly

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -38,7 +38,7 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 		Benchmark:        true,
 		CompatibleClouds: registry.AllExceptAzure,
 		// TODO(aaditya): change to weekly once the test stabilizes.
-		Suites:  registry.ManualOnly,
+		Suites:  registry.Suites(registry.Nightly),
 		Cluster: r.MakeClusterSpec(2, spec.CPU(8), spec.WorkloadNode(), spec.ReuseNone()),
 		Leases:  registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {


### PR DESCRIPTION
With https://github.com/cockroachdb/cockroach/issues/132332 resolved, we can turn this test back on.

Informs: #132332.

Release note: None