### PR TITLE
release: update docker labels for Red Hat Connect images

### DIFF
--- a/build/deploy-redhat/Dockerfile.in
+++ b/build/deploy-redhat/Dockerfile.in
@@ -6,6 +6,7 @@ RUN microdnf install -y yum && \
   rm -rf /var/cache/yum
 
 LABEL name="CockroachDB"
+LABEL maintainer="Cockroach Labs"
 LABEL vendor="Cockroach Labs"
 LABEL summary="CockroachDB is a distributed SQL database."
 LABEL description="CockroachDB is a PostgreSQL wire-compatable distributed SQL database."

--- a/build/teamcity/internal/cockroach/release/publish/publish-redhat-release.sh
+++ b/build/teamcity/internal/cockroach/release/publish/publish-redhat-release.sh
@@ -54,6 +54,7 @@ cat build/deploy-redhat/Dockerfile
 docker build --no-cache \
   --pull \
   --label release=$rhel_release \
+  --label version=$version \
   --tag="${rhel_repository}:${version}" \
   build/deploy-redhat
 tc_end_block "Rebuild docker image"


### PR DESCRIPTION
Recently Red Hat Connect stopped accepting our docker images, because they introduced a new requirement for labels. The current publishing tasks fail with the following error:

> HasRequiredLabel: Failed
> Checking if the required labels (name, vendor, version, release,
summary, description, maintainer) are present in the container metadata and that they do not violate Red Hat trademark.

This PR adds a new static label "maintainer" and dynamically adds the "version" label.

Fixes: RE-769
Release note: None
Release justification: release automation changes