### PR TITLE
schemachanger: delay resolution of IndexID for subzone configs

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -1407,3 +1407,15 @@ statement ok
 RESET use_declarative_schema_changer;
 
 subtest end
+
+# Regression test for #137541: in some cases (like for sequences), we cannot
+# default to getting the primary index on our physical table.
+subtest bad_partition_on_sequence
+
+statement ok
+CREATE SEQUENCE IF NOT EXISTS "foo_seq";
+
+statement error partition "nonexistent" does not exist on table "foo_seq"
+ALTER PARTITION nonexistent OF TABLE foo_seq CONFIGURE ZONE USING DEFAULT;
+
+subtest end

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/configure_zone.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/configure_zone.go
@@ -181,9 +181,6 @@ func astToZoneConfigObject(b BuildCtx, n *tree.SetZoneConfig) (zoneConfigObject,
 	}
 
 	izo := indexZoneConfigObj{tableZoneConfigObj: tzo}
-	// We are an index object. Determine the index ID and fill this
-	// information out in our zoneConfigObject.
-	izo.fillIndexFromZoneSpecifier(b, zs)
 	if targetsIndex && !zs.TargetsPartition() {
 		return &izo, nil
 	}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/partition_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/partition_zone_config.go
@@ -292,10 +292,11 @@ func (pzo *partitionZoneConfigObj) applyZoneConfig(
 	copyFromParentList []tree.Name,
 	setters []func(c *zonepb.ZoneConfig),
 ) (*zonepb.ZoneConfig, error) {
-	// We are configuring a partition. Determine the index ID and fill this
-	// information out in our zoneConfigObject.
+	pzo.fillIndexFromPartition(b, n)
+	// Fill out the indexID based off of the corresponding index name; we either
+	// resolved the name fully above or it had been specified by the user.
+	pzo.fillIndexFromZoneSpecifier(b, n.ZoneSpecifier)
 	pzo.panicIfNoPartitionExistsOnIdx(b, n)
-	pzo.panicIfBadPartitionReference(b, n)
 	indexID := pzo.indexID
 	tempIndexID := mustRetrieveIndexElement(b, pzo.getTargetID(), indexID).TemporaryIndexID
 
@@ -412,8 +413,6 @@ func (pzo *partitionZoneConfigObj) panicIfNoPartitionExistsOnIdx(
 	b BuildCtx, n *tree.SetZoneConfig,
 ) {
 	zs := n.ZoneSpecifier
-	// If we allow StarIndex to be set in the DSC, we will have to guard against
-	// that here as well.
 	if zs.TargetsPartition() && len(zs.TableOrIndex.Index) != 0 {
 		partitionName := string(zs.Partition)
 		var indexes []scpb.IndexPartitioning
@@ -442,18 +441,20 @@ func (pzo *partitionZoneConfigObj) panicIfNoPartitionExistsOnIdx(
 	}
 }
 
-// panicIfBadPartitionReference panics if the partition referenced in a
-// ALTER PARTITION ... OF TABLE does not exist or if it exists on multiple
-// indexes. Otherwise, we find the existing index and save in to our AST.
-// In cases where we find the partition existing on two indexes, we check
-// to ensure that we are not in a backfill case before panicking.
-func (pzo *partitionZoneConfigObj) panicIfBadPartitionReference(b BuildCtx, n *tree.SetZoneConfig) {
+// fillIndexFromPartition finds the existing index for the given partition name
+// in an `ALTER PARTITION ... OF TABLE` and saves in to our AST. In cases where
+// we find the partition existing on two indexes, we check to ensure that we are
+// not in a backfill case before panicking. Otherwise, we panic if the partition
+// referenced does not exist or if it exists on multiple (2+) indexes.
+func (pzo *partitionZoneConfigObj) fillIndexFromPartition(b BuildCtx, n *tree.SetZoneConfig) {
 	zs := &n.ZoneSpecifier
 	// Backward compatibility for ALTER PARTITION ... OF TABLE. Determine which
 	// index has the specified partition.
 	//
-	// If we allow StarIndex to be set in the DSC, we will have to guard against
-	// that here as well.
+	// TODO(#130842): If we allow StarIndex to be set in the DSC, we will have to
+	// guard against that here as well (as in the case for StarIndex, we will have
+	// a TableOrIndex.Index name of len 0, but since we are referring to
+	// _multiple_ indexes, we want to skip this particular check).
 	if zs.TargetsPartition() && len(zs.TableOrIndex.Index) == 0 {
 		partitionName := string(zs.Partition)
 
@@ -479,9 +480,6 @@ func (pzo *partitionZoneConfigObj) panicIfBadPartitionReference(b BuildCtx, n *t
 			idx := indexes[0]
 			idxName := mustRetrieveIndexNameElem(b, pzo.tableID, idx.IndexID)
 			zs.TableOrIndex.Index = tree.UnrestrictedName(idxName.Name)
-			// Our index name has changed -- find the corresponding indexID
-			// and fill that out.
-			pzo.fillIndexFromZoneSpecifier(b, n.ZoneSpecifier)
 		case 2:
 			// Sort our indexes to guarantee proper ordering; in the case of a
 			// backfill, we want to ensure that the temporary index is always
@@ -498,9 +496,6 @@ func (pzo *partitionZoneConfigObj) panicIfBadPartitionReference(b BuildCtx, n *t
 			if isCorrespondingTemporaryIndex(b, pzo.tableID, maybeTempIdx.IndexID, idx.IndexID) {
 				idxName := mustRetrieveIndexNameElem(b, pzo.tableID, idx.IndexID)
 				zs.TableOrIndex.Index = tree.UnrestrictedName(idxName.Name)
-				// Our index name has changed -- find the corresponding indexID
-				// and fill that out.
-				pzo.fillIndexFromZoneSpecifier(b, n.ZoneSpecifier)
 				break
 			}
 			// We are not in a backfill case -- the partition we are referencing


### PR DESCRIPTION
This patch ensures that we delay the resolution of an index's
ID to each subzones' individual logic instead of doing it eagerly inside
of our AST to zoneConfigObject conversion. This way, we can determine
validity of a partition name correctly in the case where our physical
table does not have indexes (like for a sequence).

Epic: None
Fixes: https://github.com/cockroachdb/cockroach/issues/137541

Release note: None