### PR TITLE
pgwire: parseClientProvidedSessionParameters can leak entire ReadBuffer

### DIFF
--- a/pkg/sql/pgwire/pre_serve_options.go
+++ b/pkg/sql/pgwire/pre_serve_options.go
@@ -75,6 +75,10 @@ func parseClientProvidedSessionParameters(
 
 		// Case-fold for the key for easier comparison.
 		key = strings.ToLower(key)
+		// Intentionally clone the string from above, so that the ReaderBuffer life
+		// is limited. Otherwise, the buffer will remain allocated for the life of
+		// the connection.
+		value = strings.Clone(value)
 
 		// Load the parameter.
 		switch key {


### PR DESCRIPTION
Previously, when parsing the client session parameters, we would fetch option value via ReaderBuffer.GetString. This function would return a reference to the original read buffer, so any session parameters would cause the entire message buffer to stay allocated. To address this, this patch copies the values from the read buffer, so that no references cause the entire message buffer to be kept alive.

Fixes: #137623

Release note (bug fix): Address potential memory leak parsing client session parameters for new connections.