### PR TITLE
roachtest: add io_listener_logs to pertubation/* tests

### DIFF
--- a/pkg/cmd/roachtest/tests/perturbation/framework.go
+++ b/pkg/cmd/roachtest/tests/perturbation/framework.go
@@ -262,6 +262,8 @@ func setup(p perturbation, acceptableChange float64) variations {
 	}
 	v.acceptableChange = acceptableChange
 	v.clusterSettings = make(map[string]string)
+	// Having the io_load_listener logs makes it easier to debug failures.
+	v.clusterSettings["server.debug.default_vmodule"] = "io_load_listener=1"
 	return v
 }
 


### PR DESCRIPTION
Epic: none

Release note: None