### PR TITLE
kvserver: change TestReplicaRaftOverload to use apply_to_elastic

### DIFF
--- a/pkg/kv/kvserver/client_replica_raft_overload_test.go
+++ b/pkg/kv/kvserver/client_replica_raft_overload_test.go
@@ -59,6 +59,10 @@ func TestReplicaRaftOverload(t *testing.T) {
 	{
 		_, err := tc.ServerConn(0).Exec(`SET CLUSTER SETTING admission.kv.pause_replication_io_threshold = 1.0`)
 		require.NoError(t, err)
+		// Replica pausing is disabled in apply_to_all mode, so make sure the
+		// cluster is running with a setting where replica pausing is enabled.
+		_, err = tc.ServerConn(0).Exec(`SET CLUSTER SETTING kvadmission.flow_control.mode = "apply_to_elastic"`)
+		require.NoError(t, err)
 	}
 	k := tc.ScratchRange(t)
 	tc.AddVotersOrFatal(t, k, tc.Targets(1, 2)...)


### PR DESCRIPTION
This ensures it will pass when the default mode is changed to apply_to_all.

Informs #136215

Epic: CRDB-37515

Release note: None