### PR TITLE
changefeedccl: fix kafka v2 sink does not allow negative GZIP compression levels #136492

### DIFF
--- a/pkg/ccl/changefeedccl/sink_kafka_v2.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2.go
@@ -6,6 +6,7 @@
 package changefeedccl
 
 import (
+	"compress/gzip"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -28,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
-	"github.com/klauspost/compress/gzip"
 	"github.com/klauspost/compress/zstd"
 	"github.com/rcrowley/go-metrics"
 	"github.com/twmb/franz-go/pkg/kadm"
@@ -569,8 +569,8 @@ func validateCompressionLevel(compressionType compressionCodec, level int) error
 	case sarama.CompressionNone:
 		return nil
 	case sarama.CompressionGZIP:
-		if level < gzip.NoCompression || level > gzip.BestCompression {
-			return errors.Errorf(`invalid gzip compression level: %d`, level)
+		if level < gzip.HuffmanOnly || level > gzip.BestCompression {
+			return errors.Errorf(`invalid gzipgzip compression level: %d`, level)
 		}
 	case sarama.CompressionSnappy:
 		return errors.Errorf(`snappy does not support compression levels`)

--- a/pkg/ccl/changefeedccl/sink_kafka_v2.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2.go
@@ -570,7 +570,7 @@ func validateCompressionLevel(compressionType compressionCodec, level int) error
 		return nil
 	case sarama.CompressionGZIP:
 		if level < gzip.HuffmanOnly || level > gzip.BestCompression {
-			return errors.Errorf(`invalid gzipgzip compression level: %d`, level)
+			return errors.Errorf(`invalid gzip compression level: %d`, level)
 		}
 	case sarama.CompressionSnappy:
 		return errors.Errorf(`snappy does not support compression levels`)

--- a/pkg/ccl/changefeedccl/sink_kafka_v2_test.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2_test.go
@@ -449,6 +449,18 @@ func TestKafkaSinkClientV2_CompressionOpts(t *testing.T) {
 			expected: kgo.GzipCompression().WithLevel(9),
 		},
 		{
+			name:     "gzip level -1",
+			codec:    "GZIP",
+			level:    "-1",
+			expected: kgo.GzipCompression().WithLevel(-1),
+		},
+		{
+			name:     "gzip level -2",
+			codec:    "GZIP",
+			level:    "-2",
+			expected: kgo.GzipCompression().WithLevel(-2),
+		},
+		{
 			name:     "snappy no level",
 			codec:    "SNAPPY",
 			expected: kgo.SnappyCompression(),
@@ -479,6 +491,12 @@ func TestKafkaSinkClientV2_CompressionOpts(t *testing.T) {
 			name:      "invalid gzip level",
 			codec:     "GZIP",
 			level:     "100",
+			shouldErr: true,
+		},
+		{
+			name:      "invalid gzip level '-3'",
+			codec:     "GZIP",
+			level:     "-3",
 			shouldErr: true,
 		},
 		{


### PR DESCRIPTION
## Fix: Support for Negative GZIP Compression Levels in Kafka v2 Sink #136492

This update fixes a bug in the Kafka v2 sink where negative GZIP compression levels were not supported within the expected range of `[-2, 9]`. Previously, the v2 sink could not handle negative compression levels properly due to differences in the underlying compression libraries used between v1 and v2 sinks.

### Background
Our Kafka v1 sink implementation, which relies on the `sarama` library, uses the `klauspost/compress` library that supports a compression level of `-3`. However, our v2 sink has transitioned to using `franz-go`, which utilizes the standard library's `compression/gzip`, and does not support the `-3` level. This discrepancy led to confusion and a bug when using similar configurations across different sink versions.

### Changes Made
- **Compression Level Support**: The Kafka v2 sink now properly supports compression levels in the range of `[-2, 9]`, aligning with the capabilities of the Go standard library’s gzip package.

### Documentation Changes Required
- **Update Compression Level Documentation**: It is necessary to update the documentation for Kafka GZIP compression levels. The current range needs to be adjusted to reflect the removal of `-3` from the supported levels in the Kafka v2 sink documentation.

### Testing
- **Unit Tests**: Comprehensive unit tests have been added and passed to confirm that the Kafka v2 sink now correctly handles all compression levels within the newly supported range.
  - [x] All unit tests related to GZIP compression settings pass successfully.