### PR TITLE
roachtest: make test selection and select probability mutually exclusive

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -250,9 +250,7 @@ func testsToRun(
 		return nil, errors.Newf("%s", msg)
 	}
 
-	// selective-tests is considered only if the select-probability is 1.0. This is because select probability already
-	// takes care of running limited tests.
-	if roachtestflags.SelectiveTests && roachtestflags.SelectProbability == 1.0 {
+	if roachtestflags.SelectiveTests {
 		fmt.Printf("selective Test enabled\n")
 		// the test categorization must be complete in 30 seconds
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -514,5 +512,11 @@ func validateAndConfigure(cmd *cobra.Command, args []string) {
 			printErrAndExit(fmt.Errorf("unsupported option value %q for option %q; Usage: %s",
 				roachtestflags.UseSpotVM, spotFlagInfo.Name, spotFlagInfo.Usage))
 		}
+	}
+
+	// Test selection and select probability flags are mutually exclusive.
+	selectProbFlagInfo := roachtestflags.Changed(&roachtestflags.SelectProbability)
+	if roachtestflags.SelectiveTests && selectProbFlagInfo != nil {
+		printErrAndExit(fmt.Errorf("select-probability and selective-tests=true are incompatible. Disable one of them"))
 	}
 }

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -87,7 +87,7 @@ var (
 	SelectiveTests = false
 	_              = registerRunFlag(&SelectiveTests, FlagInfo{
 		Name:  "selective-tests",
-		Usage: `Use selective tests to run based on previous test execution. this is considered only if the select-probability is 1.0`,
+		Usage: `Use selective tests to run based on previous test execution. Incompatible with --select-probability`,
 	})
 
 	SuccessfulTestsSelectPct = 0.35
@@ -451,8 +451,8 @@ var (
 	_                         = registerRunFlag(&SelectProbability, FlagInfo{
 		Name: "select-probability",
 		Usage: `
-			The probability of a matched test being selected to run. Note: this will
-			run at least one test per prefix.`,
+			The probability of a matched test being selected to run. Incompatible with --selective-tests.
+			Note: this will run at least one test per prefix.`,
 	})
 
 	UseSpotVM = NeverUseSpot


### PR DESCRIPTION
If both selective-tests is set to true and select-probability is set, disable test selection (selective-tests) and only use select-probability.

Release note: none
Epic: none
Fixes: none