### PR TITLE
cli, security: add support for configurable TLS cipher suites

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -927,6 +927,17 @@ provided for node user if this flag is set.
 `,
 	}
 
+	TLSCipherSuites = FlagInfo{
+		Name: "tls-cipher-suites",
+		Description: `
+A string of comma separated list of cipher suites to be used for all incoming
+TLS connections to the node. For TLS 1.2, this should strictly be a subset of
+suites defined in security/tls_ciphersuites.go as RecommendedCipherSuites or
+OldCipherSuites. For TLS 1.3, this should be configured to a subset of ciphers
+in crypto/tls/cipher_suites.go, e.g. TLS_AES_256_GCM_SHA384.
+`,
+	}
+
 	CAKey = FlagInfo{
 		Name:        "ca-key",
 		EnvVar:      "COCKROACH_CA_KEY",

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -484,6 +484,7 @@ var startCtx struct {
 	serverListenAddr       string
 	serverRootCertDN       string
 	serverNodeCertDN       string
+	serverTLSCipherSuites  []string
 
 	// The TLS auto-handshake parameters.
 	initToken             string

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -535,6 +535,9 @@ func init() {
 		// Node cert distinguished name
 		cliflagcfg.StringFlag(f, &startCtx.serverNodeCertDN, cliflags.NodeCertDistinguishedName)
 
+		// TLS Cipher Suites configured
+		cliflagcfg.StringSliceFlag(f, &startCtx.serverTLSCipherSuites, cliflags.TLSCipherSuites)
+
 		// Cluster name verification.
 		cliflagcfg.VarFlag(f, clusterNameSetter{&baseCfg.ClusterName}, cliflags.ClusterName)
 		cliflagcfg.BoolFlag(f, &baseCfg.DisableClusterNameVerification, cliflags.DisableClusterNameVerification)
@@ -1140,6 +1143,9 @@ func extraServerFlagInit(cmd *cobra.Command) error {
 		return err
 	}
 	if err := security.SetNodeSubject(startCtx.serverNodeCertDN); err != nil {
+		return err
+	}
+	if err := security.SetTLSCipherSuitesConfigured(startCtx.serverTLSCipherSuites); err != nil {
 		return err
 	}
 	serverCfg.User = username.NodeUserName()

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -114,7 +114,7 @@ func NewServerEx(
 		if err != nil {
 			return nil, sii, err
 		}
-		grpcOpts = append(grpcOpts, grpc.Creds(credentials.NewTLS(tlsConfig)))
+		grpcOpts = append(grpcOpts, grpc.Creds(NewTLSCipherRestrictCred(tlsConfig)))
 	}
 
 	// These interceptors will be called in the order in which they appear, i.e.

--- a/pkg/rpc/tls.go
+++ b/pkg/rpc/tls.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
 	"github.com/cockroachdb/errors"
+	"google.golang.org/grpc/credentials"
 )
 
 type lazyHTTPClient struct {
@@ -324,4 +325,35 @@ func certAddrs(cert *x509.Certificate) string {
 		strings.Join(addrs, ","),
 		strings.Join(cert.DNSNames, ","),
 		cert.Subject.CommonName)
+}
+
+// TLSCipherRestrictCred allows to set transport credentials for grpc
+// connections. It accepts to a function which can be used to intercept the
+// connection and validate requirements for TLS like ciphers used.
+type TLSCipherRestrictCred struct {
+	credentials.TransportCredentials
+	fn func(conn net.Conn) error
+}
+
+// ServerHandshake performs TLS handshake for the connection
+func (cred *TLSCipherRestrictCred) ServerHandshake(
+	conn net.Conn,
+) (c net.Conn, authInfo credentials.AuthInfo, err error) {
+	if c, authInfo, err = cred.TransportCredentials.ServerHandshake(conn); err == nil {
+		if cred.fn != nil {
+			if err := cred.fn(c); err != nil {
+				_ = c.Close()
+				return nil, nil, err
+			}
+		}
+	}
+	return
+}
+
+// NewTLSCipherRestrictCred initializes a new TLSCipherRestrictCred credentials
+func NewTLSCipherRestrictCred(config *tls.Config) *TLSCipherRestrictCred {
+	return &TLSCipherRestrictCred{
+		TransportCredentials: credentials.NewTLS(config),
+		fn:                   security.TLSCipherRestrict,
+	}
 }

--- a/pkg/security/BUILD.bazel
+++ b/pkg/security/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
         "@com_github_go_ldap_ldap_v3//:ldap",
         "@org_golang_x_crypto//bcrypt",
         "@org_golang_x_crypto//ocsp",
+        "@org_golang_x_exp//slices",
         "@org_golang_x_sync//errgroup",
     ],
 )
@@ -107,6 +108,7 @@ go_test(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_go_ldap_ldap_v3//:ldap",
+        "@com_github_jackc_pgx_v4//:pgx",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_exp//rand",
     ] + select({

--- a/pkg/security/tls_test.go
+++ b/pkg/security/tls_test.go
@@ -6,14 +6,24 @@
 package security_test
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/certnames"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/jackc/pgx/v4"
 	"github.com/stretchr/testify/require"
 )
 
@@ -105,4 +115,92 @@ func verifyX509Cert(cert *x509.Certificate, dnsName string, roots *x509.CertPool
 	}
 	_, err := cert.Verify(verifyOptions)
 	return err
+}
+
+func TestTLSCipherRestrict(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	defer require.NoError(t, security.SetTLSCipherSuitesConfigured([]string{}))
+
+	// setup for db console tests
+	httpClient, err := s.GetUnauthenticatedHTTPClient()
+	require.NoError(t, err)
+	httpClient.Timeout = 2 * time.Second
+	defer httpClient.CloseIdleConnections()
+
+	secureClient, err := s.GetAuthenticatedHTTPClient(false, serverutils.SingleTenantSession)
+	require.NoError(t, err)
+	secureClient.Timeout = 2 * time.Second
+	defer secureClient.CloseIdleConnections()
+
+	urlsToTest := []string{"/_status/vars", "/index.html", "/"}
+	adminURLHTTPS := s.AdminURL().String()
+	adminURLHTTP := strings.Replace(adminURLHTTPS, "https", "http", 1)
+
+	tests := []struct {
+		name     string
+		ciphers  []string
+		wantErr  bool
+		httpsErr string
+		sqlErr   string
+		rpcErr   string
+	}{
+		{name: "no cipher set", ciphers: []string{}, wantErr: false},
+		{name: "valid ciphers", ciphers: []string{"TLS_AES_256_GCM_SHA384", "TLS_AES_128_GCM_SHA256"},
+			wantErr: false},
+		{name: "invalid ciphers", ciphers: []string{"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"}, wantErr: true,
+			httpsErr: "\": EOF",
+			sqlErr:   "failed to connect to `host=127.0.0.1 user=root database=`: failed to receive message (unexpected EOF)",
+			rpcErr:   "initial connection heartbeat failed: grpc:"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// set the custom test ciphers
+			err := security.SetTLSCipherSuitesConfigured(tt.ciphers)
+			require.NoError(t, err)
+
+			// test db console tls access for cipher restriction.
+			for _, u := range urlsToTest {
+				for _, client := range []http.Client{httpClient, secureClient} {
+					resp, err := client.Get(adminURLHTTP + u)
+					if (err == nil) == tt.wantErr {
+						defer resp.Body.Close()
+						body, err := io.ReadAll(resp.Body)
+						t.Fatalf("expected wantError=%t, got err=%v, resp=%v", tt.wantErr, err, string(body))
+					}
+					if tt.wantErr {
+						require.Contains(t, err.Error(), u+tt.httpsErr)
+					}
+				}
+			}
+
+			// test pgx connection for root user with cert auth
+			pgURL, cleanup := s.PGUrl(t, serverutils.User(username.RootUser), serverutils.ClientCerts(true))
+			defer cleanup()
+			rootConn, err := pgx.Connect(ctx, pgURL.String())
+			if (err == nil) == tt.wantErr {
+				t.Fatalf("expected wantError=%t, got err=%v", tt.wantErr, err)
+			}
+			if err != nil {
+				require.Equal(t, tt.sqlErr, err.Error())
+			} else {
+				require.NoError(t, rootConn.Close(ctx))
+			}
+
+			// test rpc connection for root user.
+			conn, err := s.RPCClientConnE(username.RootUserName())
+			if (err == nil) == tt.wantErr {
+				t.Fatalf("expected wantError=%t, got err=%v", tt.wantErr, err)
+			}
+			if err != nil {
+				require.Contains(t, err.Error(), tt.rpcErr)
+			} else {
+				require.NoError(t, conn.Close()) // nolint:grpcconnclose
+			}
+		})
+	}
 }

--- a/pkg/sql/pgwire/pre_serve.go
+++ b/pkg/sql/pgwire/pre_serve.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/hba"
@@ -496,6 +497,14 @@ func (s *PreServeConnHandler) maybeUpgradeToSecureConn(
 
 	// Finally, re-read the version/command from the client.
 	newVersion, *buf, serverErr = s.readVersion(newConn)
+	if serverErr != nil {
+		return
+	}
+	// Probe connection and determine additional restrictions.
+	serverErr = security.TLSCipherRestrict(newConn)
+	if serverErr != nil {
+		_ = newConn.Close()
+	}
 	return
 }
 

--- a/pkg/util/netutil/BUILD.bazel
+++ b/pkg/util/netutil/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/security",
         "//pkg/util/log",
         "//pkg/util/log/severity",
         "//pkg/util/netutil/addr",


### PR DESCRIPTION
cli, security: add support for configurable TLS cipher suites

fixes #136999
Epic CRDB-45351

Release Note(security,ops): We will be providing a new cockroach start command
cli flag `tls-cipher-suites` which is a string of comma separated list of cipher
suites to be used for all incoming TLS connections to the node. For TLS 1.2,
this should strictly be a subset of suites defined in
security/tls_ciphersuites.go as RecommendedCipherSuites or OldCipherSuites. For
TLS 1.3, this should be configured to a subset of ciphers in
crypto/tls/cipher_suites.go. The flag will restrict TLS connections to the node
for all 3 types of connection(i.e. sql, rpc, http) where node acts as the server
for the connections and close non-conforming ones.