### PR TITLE
sql: Internal sessions exempt from disallow_full_table_scans setting

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -94,6 +94,7 @@ func NewInternalSessionData(
 	sd.SequenceState = sessiondata.NewSequenceState()
 	sd.Location = time.UTC
 	sd.StmtTimeout = 0
+	sd.DisallowFullTableScans = false
 	return sd
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -440,6 +440,27 @@ CREATE INVERTED INDEX ON opclasses(c DESC)
 statement ok
 CREATE INVERTED INDEX ON opclasses(a DESC, c)
 
+# Regression test for GH issue #137404
+subtest disallow_full_table_scans
+
+let $disallow_full_table_scans
+select value from [show cluster settings] where variable = 'sql.defaults.disallow_full_table_scans.enabled';
+
+statement ok
+SET CLUSTER SETTING sql.defaults.disallow_full_table_scans.enabled = true;
+
+statement ok
+CREATE TABLE t_disable_full_ts (id UUID PRIMARY KEY);
+
+statement ok
+CREATE INDEX ON t_disable_full_ts (id);
+
+statement ok
+SET CLUSTER SETTING sql.defaults.disallow_full_table_scans.enabled = $disallow_full_table_scans;
+
+statement ok
+DROP TABLE t_disable_full_ts
+
 subtest create_index_on_materialized_view
 
 statement ok
@@ -521,3 +542,25 @@ CREATE INDEX IF NOT EXISTS idx ON tbl_ifne (b) STORING (a)
 
 statement ok
 DROP TABLE tbl_ifne CASCADE
+
+subtest disallow_full_table_scans
+
+let $disallow_full_table_scans
+select value from [show cluster settings] where variable = 'sql.defaults.disallow_full_table_scans.enabled';
+
+statement ok
+SET CLUSTER SETTING sql.defaults.disallow_full_table_scans.enabled = true;
+
+statement ok
+CREATE TABLE t_disable_full_ts (id UUID PRIMARY KEY);
+
+statement ok
+CREATE INDEX ON t_disable_full_ts (id);
+
+statement ok
+SET CLUSTER SETTING sql.defaults.disallow_full_table_scans.enabled = $disallow_full_table_scans;
+
+statement ok
+DROP TABLE t_disable_full_ts
+
+subtest end

--- a/pkg/sql/opt/exec/execbuilder/testdata/execute_internally_builtin
+++ b/pkg/sql/opt/exec/execbuilder/testdata/execute_internally_builtin
@@ -248,4 +248,33 @@ SELECT crdb_internal.execute_internally('SHOW statement_timeout;', true);
 statement ok
 RESET CLUSTER SETTING sql.defaults.statement_timeout;
 
+subtest disallow_full_table_scans
+
+statement ok
+SET CLUSTER SETTING sql.defaults.disallow_full_table_scans.enabled = true;
+
+statement ok
+SET disallow_full_table_scans = 'true';
+
+query T
+SELECT crdb_internal.execute_internally('SHOW disallow_full_table_scans;');
+----
+off
+
+query T
+SELECT crdb_internal.execute_internally('SHOW disallow_full_table_scans;', true);
+----
+on
+
+statement ok
+RESET CLUSTER SETTING sql.defaults.disallow_full_table_scans.enabled;
+
+statement ok
+RESET disallow_full_table_scans;
+
+query T
+SELECT crdb_internal.execute_internally('SHOW disallow_full_table_scans;', true);
+----
+off
+
 subtest end


### PR DESCRIPTION
Previously, enabling the cluster setting sql.defaults.disallow_full_table_scans.enabled prevented the creation of indexes due to the internal table scans required during the process. This change ensures that the setting is bypassed for internal operations, while still applying to user queries.

Epic: None
Closes: #137404
Release note (bug fix): Internal scans are now exempt from the sql.defaults.disallow_full_table_scans.enabled setting, allowing index creation even when the cluster setting is active.