### PR TITLE
crosscluster/logical: close heartbeater and replanner in exec plan

### DIFF
--- a/pkg/crosscluster/logical/logical_replication_job.go
+++ b/pkg/crosscluster/logical/logical_replication_job.go
@@ -201,12 +201,14 @@ func (r *logicalReplicationResumer) ingest(
 		func() time.Duration {
 			return heartbeatFrequency.Get(&execCfg.Settings.SV)
 		})
-	defer func() {
-		_ = heartbeatSender.Stop()
-		stopReplanner()
-	}()
 
 	execPlan := func(ctx context.Context) error {
+
+		defer func() {
+			_ = heartbeatSender.Stop()
+			stopReplanner()
+		}()
+
 		rh := rowHandler{
 			replicatedTimeAtStart: replicatedTimeAtStart,
 			frontier:              frontier,


### PR DESCRIPTION
This prevents deadlock if execPlan returns nil, which it may in the future for offline intial scan.

Epic: none

Release note: none