### PR TITLE
backup: skip running tests under deadlock when they begin a test cluster

### DIFF
--- a/pkg/backup/backuptestutils/BUILD.bazel
+++ b/pkg/backup/backuptestutils/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/kv/kvserver",
         "//pkg/sql/sqlstats",
         "//pkg/testutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util",

--- a/pkg/backup/backuptestutils/testutils.go
+++ b/pkg/backup/backuptestutils/testutils.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -101,6 +102,11 @@ func WithSkipInvalidDescriptorCheck() BackupTestArg {
 func StartBackupRestoreTestCluster(
 	t testing.TB, clusterSize int, args ...BackupTestArg,
 ) (*testcluster.TestCluster, *sqlutils.SQLRunner, string, func()) {
+
+	// Because the deadlock detector can increase the runtime of a test by 10-100x
+	// and has not found anything in recent memory for backup/restore tests.
+	skip.UnderDeadlock(t)
+
 	ctx := logtags.AddTag(context.Background(), "start-backup-restore-test-cluster", nil)
 	opts := backupTestOptions{}
 	for _, a := range args {


### PR DESCRIPTION
Deadlock can lengthen the runtime of a test cluster test by 10 to 100x and has not found a bug in recent memory in backup code.

Fixes #136877
Fixes #136677
Fixes #136566
Fixes #136565

Epic: none

Release note: none