### PR TITLE
kvserver: only log for too many intents when set

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
@@ -734,7 +734,7 @@ func (tp *txnPipeliner) updateLockTracking(
 	// Similar to the in-flight writes case above, we may have gone over the
 	// rejectTxnMaxCount threshold because we don't accurately estimate the
 	// number of ranged locking reads before sending the request.
-	if tp.writeCount > rejectTxnMaxCount {
+	if rejectTxnMaxCount > 0 && tp.writeCount > rejectTxnMaxCount {
 		if tp.inflightOverBudgetEveryN.ShouldLog() || log.ExpensiveLogEnabled(ctx, 2) {
 			log.Warningf(ctx, "a transaction has exceeded the maximum number of writes "+
 				"allowed by kv.transaction.max_intents_and_locks: "+


### PR DESCRIPTION
In the fix for #135841, the code had incorrectly logged and bumped the stat even if kv.transaction.max_intents_and_locks was set at the default value of 0. This caused a lot of concerning and incorrect logs. This change correctly only logs if the setting is set.

Epic: none

Release note: None