### PR TITLE
ccl/multiregion: Skip backup tests under deadlock

### DIFF
--- a/pkg/ccl/multiregionccl/region_test.go
+++ b/pkg/ccl/multiregionccl/region_test.go
@@ -924,6 +924,7 @@ func testRegionAddDropWithConcurrentBackupOps(
 	},
 ) {
 	skip.UnderRace(t, "times out under race")
+	skip.UnderDeadlock(t)
 
 	testCases := []struct {
 		name      string


### PR DESCRIPTION
The TestAddRegionSucceedWithConcurrentBackupOps test has occasionally timed out when run with the --deadlock option. Since this increases runtime without yielding evidence of actual issues, I am disabling this mode to prevent further issues.

Epic: none
Closes #137520
Release note: none