### PR TITLE
dev: add PGO support

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=105
+DEV_VERSION=106
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/acceptance.go
+++ b/pkg/cmd/dev/acceptance.go
@@ -72,9 +72,7 @@ func (d *dev) acceptance(cmd *cobra.Command, commandLine []string) error {
 
 	var args []string
 	args = append(args, "test", "//pkg/acceptance:acceptance_test")
-	if numCPUs != 0 {
-		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
-	}
+	addCommonBazelArguments(&args)
 	if filter != "" {
 		args = append(args, fmt.Sprintf("--test_filter=%s", filter))
 	}

--- a/pkg/cmd/dev/bench.go
+++ b/pkg/cmd/dev/bench.go
@@ -81,9 +81,7 @@ func (d *dev) bench(cmd *cobra.Command, commandLine []string) error {
 
 	var args []string
 	args = append(args, "test")
-	if numCPUs != 0 {
-		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
-	}
+	addCommonBazelArguments(&args)
 	if timeout > 0 {
 		args = append(args, fmt.Sprintf("--test_timeout=%d", int(timeout.Seconds())))
 	}

--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -188,7 +188,7 @@ func (d *dev) crossBuild(
 	volume string,
 	dockerArgs []string,
 ) error {
-	bazelArgs = append(bazelArgs, fmt.Sprintf("--config=%s", crossConfig), "--config=nolintonbuild", "-c", "opt")
+	bazelArgs = append(bazelArgs, fmt.Sprintf("--config=%s", crossConfig), "--config=nolintonbuild", "-c", "opt", "--config=pgo")
 	configArgs := getConfigArgs(bazelArgs)
 	dockerArgs, err := d.getDockerRunArgs(ctx, volume, false, dockerArgs)
 	if err != nil {
@@ -377,9 +377,7 @@ func (d *dev) getBasicBuildArgs(
 	}
 
 	args = append(args, "build")
-	if numCPUs != 0 {
-		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
-	}
+	addCommonBazelArguments(&args)
 
 	canDisableNogo := true
 	shouldBuildWithTestConfig := false

--- a/pkg/cmd/dev/compose.go
+++ b/pkg/cmd/dev/compose.go
@@ -82,9 +82,7 @@ func (d *dev) compose(cmd *cobra.Command, _ []string) error {
 
 	var args []string
 	args = append(args, "test", "//pkg/compose:compose_test")
-	if numCPUs != 0 {
-		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
-	}
+	addCommonBazelArguments(&args)
 	if filter != "" {
 		args = append(args, fmt.Sprintf("--test_filter=%s", filter))
 	}

--- a/pkg/cmd/dev/datadriven_test.go
+++ b/pkg/cmd/dev/datadriven_test.go
@@ -54,6 +54,7 @@ func TestDataDriven(t *testing.T) {
 			exec.WithDryrun(),
 			exec.WithIntercept(workspaceCmd(), crdbCheckoutPlaceholder),
 			exec.WithIntercept(bazelbinCmd(), sandboxPlaceholder),
+			exec.WithIntercept(bazelbinPgoCmd(), sandboxPlaceholder),
 		}
 		osOpts := []os.Option{
 			os.WithLogger(log.New(logger, "", 0)),
@@ -110,4 +111,8 @@ func workspaceCmd() string {
 
 func bazelbinCmd() string {
 	return fmt.Sprintf("bazel %s", shellescape.QuoteCommand([]string{"info", "bazel-bin", "--color=no"}))
+}
+
+func bazelbinPgoCmd() string {
+	return fmt.Sprintf("bazel %s", shellescape.QuoteCommand([]string{"info", "bazel-bin", "--color=no", "--config=pgo"}))
 }

--- a/pkg/cmd/dev/lint.go
+++ b/pkg/cmd/dev/lint.go
@@ -50,9 +50,7 @@ func (d *dev) lint(cmd *cobra.Command, commandLine []string) error {
 
 	var args []string
 	args = append(args, "test", "//pkg/testutils/lint:lint_test")
-	if numCPUs != 0 {
-		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
-	}
+	addCommonBazelArguments(&args)
 	args = append(args, additionalBazelArgs...)
 	args = append(args, "--nocache_test_results", "--test_arg", "-test.v")
 	if short {
@@ -120,9 +118,7 @@ func (d *dev) lint(cmd *cobra.Command, commandLine []string) error {
 	if pkg != "" && filter == "" {
 		toLint := strings.TrimPrefix(pkg, "./")
 		args := []string{"build", toLint, "--run_validations"}
-		if numCPUs != 0 {
-			args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
-		}
+		addCommonBazelArguments(&args)
 		logCommand("bazel", args...)
 		return d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
 	} else if !short && filter == "" {
@@ -134,9 +130,7 @@ func (d *dev) lint(cmd *cobra.Command, commandLine []string) error {
 			"//pkg/cmd/roachtest",
 			"--run_validations",
 		}
-		if numCPUs != 0 {
-			args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
-		}
+		addCommonBazelArguments(&args)
 		logCommand("bazel", args...)
 		return d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
 	} else if filter != "" {

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -225,9 +225,7 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 	var args []string
 	var goTags []string
 	args = append(args, "test")
-	if numCPUs != 0 {
-		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
-	}
+	addCommonBazelArguments(&args)
 	if race {
 		args = append(args, "--config=race", "--test_sharding_strategy=disabled")
 	}

--- a/pkg/cmd/dev/testdata/datadriven/dev-build
+++ b/pkg/cmd/dev/testdata/datadriven/dev-build
@@ -72,3 +72,15 @@ bazel build //pkg:all_tests --config=test --build_event_binary_file=/tmp/path
 bazel info workspace --color=no
 mkdir crdb-checkout/bin
 bazel info bazel-bin --color=no --config=test
+
+exec
+dev build cockroach-short --pgo
+----
+bazel build --config=pgo //pkg/cmd/cockroach-short:cockroach-short --build_event_binary_file=/tmp/path
+bazel info workspace --color=no
+mkdir crdb-checkout/bin
+bazel info bazel-bin --color=no --config=pgo
+rm crdb-checkout/cockroach-short
+cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach-short
+rm crdb-checkout/cockroach
+cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkout/cockroach

--- a/pkg/cmd/dev/testlogic.go
+++ b/pkg/cmd/dev/testlogic.go
@@ -204,9 +204,7 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 	}
 	args = append(args, targets...)
 	args = append(args, "--test_env=GOTRACEBACK=all")
-	if numCPUs != 0 {
-		args = append(args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
-	}
+	addCommonBazelArguments(&args)
 	if ignoreCache {
 		args = append(args, "--nocache_test_results")
 	}

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -30,7 +30,8 @@ const (
 
 var (
 	// Shared flags.
-	numCPUs int
+	numCPUs    int
+	pgoEnabled bool
 )
 
 var archivedCdepConfigurations = []configuration{
@@ -164,6 +165,7 @@ func (d *dev) getArchivedCdepString(bazelBin string) (string, error) {
 
 func addCommonBuildFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&numCPUs, "cpus", 0, "cap the number of CPU cores used for building and testing at the Bazel level (note that this has no impact on GOMAXPROCS or the functionality of any build or test action under the Bazel level)")
+	cmd.Flags().BoolVar(&pgoEnabled, "pgo", false, "build with profile-guided optimization (PGO)")
 }
 
 func addCommonTestFlags(cmd *cobra.Command) {
@@ -268,4 +270,13 @@ func (d *dev) getMergeBaseHash(ctx context.Context) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(baseBytes)), nil
+}
+
+func addCommonBazelArguments(args *[]string) {
+	if numCPUs != 0 {
+		*args = append(*args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
+	}
+	if pgoEnabled {
+		*args = append(*args, "--config=pgo")
+	}
 }


### PR DESCRIPTION
* add `--pgo` flag to basic commands so you can run builds and tests with PGO if desired
* perform `--cross` builds with PGO unconditionally

Part of: CRDB-44692
Epic: CRDB-41952
Release note: None