### PR TITLE
clusterversion: make SkipWhenMinSupportedVersionIsAtLeast take Key

### DIFF
--- a/pkg/clusterversion/testutils.go
+++ b/pkg/clusterversion/testutils.go
@@ -5,10 +5,7 @@
 
 package clusterversion
 
-import (
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
-)
+import "github.com/cockroachdb/cockroach/pkg/testutils/skip"
 
 // TestingClusterVersion is a ClusterVersion that tests can use when they don't
 // want to go through a Settings object.
@@ -22,10 +19,9 @@ var TestingClusterVersion = ClusterVersion{
 // Used for upgrade tests that require support for a previous version; it allows
 // experimenting with bumping MinSupported and limiting how many things must be
 // fixed in the same PR that bumps it.
-func SkipWhenMinSupportedVersionIsAtLeast(t skip.SkippableTest, major, minor int) {
+func SkipWhenMinSupportedVersionIsAtLeast(t skip.SkippableTest, v Key) {
 	t.Helper()
-	v := roachpb.Version{Major: int32(major), Minor: int32(minor)}
-	if MinSupported.Version().AtLeast(v) {
-		skip.IgnoreLint(t, "test disabled when MinVersion >= %d.%d", major, minor)
+	if MinSupported.Version().AtLeast(v.Version()) {
+		skip.IgnoreLintf(t, "test disabled when MinVersion >= %s", v)
 	}
 }

--- a/pkg/upgrade/upgrades/v25_1_prepared_transactions_table_test.go
+++ b/pkg/upgrade/upgrades/v25_1_prepared_transactions_table_test.go
@@ -24,7 +24,7 @@ func TestPreparedTransactionsTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	clusterversion.SkipWhenMinSupportedVersionIsAtLeast(t, 25, 1)
+	clusterversion.SkipWhenMinSupportedVersionIsAtLeast(t, clusterversion.V25_1)
 
 	clusterArgs := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{


### PR DESCRIPTION
Using the int 24 or 25 doesn't work because of offsetting, ie. 1000024>25, even though 24 < 25. Instead let's just use Keys -- the only way we really want code to talk about versions anyway. We can and should let MinSupported be a key > 0, so this should still allow the desired behavior of simply raising MinSupported and have the test start skipping itself.

Release note: none.
Epic: none.