### PR TITLE
logictest: fix recently introduced flake

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_join
@@ -284,7 +284,7 @@ EXPLAIN (VEC)
 RESET vectorize
 
 statement ok
-CREATE TABLE kv (k INT PRIMARY KEY, v INT);
+CREATE TABLE kv (k INT PRIMARY KEY, v INT, FAMILY (k, v));
 ALTER TABLE kv SPLIT AT SELECT i FROM generate_series(1,5) AS g(i);
 ALTER TABLE kv EXPERIMENTAL_RELOCATE SELECT ARRAY[i], i FROM generate_series(1, 5) as g(i);
 


### PR DESCRIPTION
In a recently added test on some physical planning decisions, if we happened to apply the column family mutation to CREATE TABLE stmt, we'd get unexpected distsql plan.

Fixes: #137684.

Release note: None