### PR TITLE
sql: remove unused dropOwnedByNode

### DIFF
--- a/pkg/sql/drop_owned_by.go
+++ b/pkg/sql/drop_owned_by.go
@@ -9,16 +9,9 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 )
-
-// dropOwnedByNode represents a DROP OWNED BY <role(s)> statement.
-type dropOwnedByNode struct {
-	// TODO(angelaw): Uncomment when implementing - commenting out due to linting error.
-	//n *tree.DropOwnedBy
-}
 
 func (p *planner) DropOwnedBy(ctx context.Context) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
@@ -32,11 +25,3 @@ func (p *planner) DropOwnedBy(ctx context.Context) (planNode, error) {
 	// TODO(angelaw): Implementation.
 	return nil, unimplemented.NewWithIssue(55381, "drop owned by is not yet implemented")
 }
-
-func (n *dropOwnedByNode) startExec(params runParams) error {
-	// TODO(angelaw): Implementation.
-	return nil
-}
-func (n *dropOwnedByNode) Next(runParams) (bool, error) { return false, nil }
-func (n *dropOwnedByNode) Values() tree.Datums          { return tree.Datums{} }
-func (n *dropOwnedByNode) Close(context.Context)        {}

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -432,7 +432,6 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&ordinalityNode{}):                          "ordinality",
 	reflect.TypeOf(&projectSetNode{}):                          "project set",
 	reflect.TypeOf(&reassignOwnedByNode{}):                     "reassign owned by",
-	reflect.TypeOf(&dropOwnedByNode{}):                         "drop owned by",
 	reflect.TypeOf(&recursiveCTENode{}):                        "recursive cte",
 	reflect.TypeOf(&refreshMaterializedViewNode{}):             "refresh materialized view",
 	reflect.TypeOf(&relocateNode{}):                            "relocate",


### PR DESCRIPTION
`DROP OWNED BY` is supported only in the declarative schema changer and
`dropOwnedByNode` is not used, so it has been removed.

Epic: None

Release note: None
