### PR TITLE
roachtest: use correct warehouse number in import

### DIFF
--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -150,7 +150,7 @@ func registerImportTPCC(r registry.Registry) {
 			} else {
 				defer hc.Done()
 			}
-			cmd := fmt.Sprintf(workloadStr, 1)
+			cmd := fmt.Sprintf(workloadStr, warehouses)
 			// Tick once before starting the import, and once after to capture the
 			// total elapsed time. This is used by roachperf to compute and display
 			// the average MB/sec per node.


### PR DESCRIPTION
In 0a948740dddb3fc1d3e77ecb0f1f0e8b0e505049 we introduced a bug which hard-coded that we'd always use 1 warehouse in tpcc import roachtests. This is now fixed.

Epic: None

Release note: None