### PR TITLE
stop: grow stacks for async tasks

### DIFF
--- a/pkg/util/stop/BUILD.bazel
+++ b/pkg/util/stop/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/kv/kvpb",
         "//pkg/util/debugutil",
+        "//pkg/util/growstack",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/log/logcrash",

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/util/debugutil"
+	"github.com/cockroachdb/cockroach/pkg/util/growstack"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
@@ -486,6 +487,7 @@ func (s *Stopper) RunAsyncTaskEx(ctx context.Context, opt TaskOpts, f func(conte
 	// Call f on another goroutine.
 	taskStarted = true // Another goroutine now takes ownership of the alloc, if any.
 	go func(taskName string) {
+		growstack.Grow()
 		defer s.runPostlude()
 		defer s.startRegion(ctx, taskName).End()
 		defer sp.Finish()


### PR DESCRIPTION
Surprisingly, this seems to have helped with alloc/op, but not with CPU time, at least in the microbenchmark.

```
name                                   old time/op    new time/op    delta
Sysbench/SQL/3node/oltp_read_write-24    11.6ms ± 1%    11.6ms ± 2%    ~     (p=0.201 n=14+15)

name                                   old alloc/op   new alloc/op   delta
Sysbench/SQL/3node/oltp_read_write-24    2.20MB ± 3%    2.16MB ± 1%  -1.88%  (p=0.047 n=15+12)

name                                   old allocs/op  new allocs/op  delta
Sysbench/SQL/3node/oltp_read_write-24     11.0k ± 2%     10.8k ± 0%    ~     (p=0.069 n=15+12)
```

End-to-end testing via the `sysbench-settings` roachtest (10 runs) shows a significant improvement in qps[^1]:

  | max | mean | median | % change max | % change mean | % change median
-- | -- | -- | -- | -- | -- | --
old | 23673.17 | 22775.40 | 22684.17 |   |   |  
new | 23955.21 | 23154.03 | 23256.25 | 1.19% | 1.66% | 2.52%

[^1]: https://docs.google.com/spreadsheets/d/1QUBZHllhk5CtDfcsJqc5eOIqUO4jVdhoYXMWj4CRQaQ/edit?gid=0#gid=0

Closes #130663.

Epic: CRDB-43584