### PR TITLE
sql: allow CLOSE CURSOR in read-only txns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -1520,12 +1520,15 @@ SET SESSION AUTHORIZATION DEFAULT
 statement ok
 BEGIN
 
-# DECLARE and FETCH CURSOR should work in a read-only txn.
+# DECLARE, FETCH, and CLOSE CURSOR should work in a read-only txn.
 statement ok
 DECLARE foo CURSOR FOR SELECT 1
 
 statement ok
 FETCH 1 foo
+
+statement ok
+CLOSE foo
 
 statement ok
 COMMIT

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -768,7 +768,7 @@ func (*CannedOptPlan) StatementTag() string { return "PREPARE AS OPT PLAN" }
 func (*CloseCursor) StatementReturnType() StatementReturnType { return Ack }
 
 // StatementType implements the Statement interface.
-func (*CloseCursor) StatementType() StatementType { return TypeDCL }
+func (*CloseCursor) StatementType() StatementType { return TypeDML }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*CloseCursor) StatementTag() string { return "CLOSE" }


### PR DESCRIPTION
This is allowed in PG, so we now will allow this too. The fix is similar to what we did for DECLARE and FETCH in 50a799953f27e672e08006a791d32154f7221641.

Fixes: #137606.

Release note (bug fix): CLOSE CURSOR statements are now allowed in read-only transactions, similat to Postgres. The bug has been present since at least 23.1 version.