### PR TITLE
kvserver: avoid allocation due to abandon closure in hot path

### DIFF
--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -225,6 +225,8 @@ type ProposalData struct {
 	lastReproposal *ProposalData
 }
 
+func (*ProposalData) isAbandonToken() {}
+
 // Context returns the context associated with the proposal. The context may
 // change during the lifetime of the proposal.
 func (proposal *ProposalData) Context() context.Context {

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -303,35 +303,37 @@ func (r *Replica) evalAndPropose(
 	// invoked when the command is applied. There are a handful of cases where
 	// the command may not be applied (or even processed): the process crashes
 	// or the local replica is removed from the range.
-	abandon := func(proposal *ProposalData) {
-		// The proposal may or may not be in the Replica's proposals map.
-		// Instead of trying to look it up, simply modify the captured object
-		// directly. The raftMu must be locked to modify the context of a
-		// proposal because as soon as we propose a command to Raft, ownership
-		// passes to the "below Raft" machinery.
-		//
-		// See the comment on ProposalData.
-		r.raftMu.Lock()
-		defer r.raftMu.Unlock()
-		r.mu.Lock()
-		defer r.mu.Unlock()
-		// When the caller abandons the request, it Finishes its trace. By that
-		// time, multiple reproposals can have occurred, and still running and
-		// attempting to post tracing updates through the context. This can cause a
-		// "use after Finish" race in the span. All the (re-)proposal contexts have
-		// been unbound except for the latest one. Unbind it to eliminate the race.
-		//
-		// See https://github.com/cockroachdb/cockroach/issues/107521
-		last := proposal
-		if p := proposal.lastReproposal; p != nil {
-			last = p
-		}
-		// TODO(radu): Should this context be created via tracer.ForkSpan?
-		// We'd need to make sure the span is finished eventually.
-		ctx := r.AnnotateCtx(context.TODO())
-		last.ctx.Store(&ctx)
+
+	return proposalCh, func() { r.abandon(proposal) }, idKey, writeBytes, nil
+}
+
+func (r *Replica) abandon(proposal *ProposalData) {
+	// The proposal may or may not be in the Replica's proposals map.
+	// Instead of trying to look it up, simply modify the captured object
+	// directly. The raftMu must be locked to modify the context of a
+	// proposal because as soon as we propose a command to Raft, ownership
+	// passes to the "below Raft" machinery.
+	//
+	// See the comment on ProposalData.
+	r.raftMu.Lock()
+	defer r.raftMu.Unlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// When the caller abandons the request, it Finishes its trace. By that
+	// time, multiple reproposals can have occurred, and still running and
+	// attempting to post tracing updates through the context. This can cause a
+	// "use after Finish" race in the span. All the (re-)proposal contexts have
+	// been unbound except for the latest one. Unbind it to eliminate the race.
+	//
+	// See https://github.com/cockroachdb/cockroach/issues/107521
+	last := proposal
+	if p := proposal.lastReproposal; p != nil {
+		last = p
 	}
-	return proposalCh, func() { abandon(proposal) }, idKey, writeBytes, nil
+	// TODO(radu): Should this context be created via tracer.ForkSpan?
+	// We'd need to make sure the span is finished eventually.
+	ctx := r.AnnotateCtx(context.TODO())
+	last.ctx.Store(&ctx)
 }
 
 func (r *Replica) encodePriorityForRACv2() bool {

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -91,7 +91,7 @@ func (r *Replica) evalAndPropose(
 	tok TrackedRequestToken,
 ) (
 	chan proposalResult,
-	func(),
+	abandonToken,
 	kvserverbase.CmdIDKey,
 	*kvadmission.StoreWriteBytes,
 	*kvpb.Error,
@@ -138,7 +138,7 @@ func (r *Replica) evalAndPropose(
 		proposal.ec = makeUnreplicatedEndCmds(r, g, *st)
 		pr := makeProposalResult(proposal.Local.Reply, pErr, intents, endTxns)
 		proposal.finishApplication(ctx, pr)
-		return proposalCh, func() {}, "", nil, nil
+		return proposalCh, nil, "", nil, nil
 	}
 
 	// Make it a truly replicated proposal. We measure the replication latency
@@ -304,10 +304,24 @@ func (r *Replica) evalAndPropose(
 	// the command may not be applied (or even processed): the process crashes
 	// or the local replica is removed from the range.
 
-	return proposalCh, func() { r.abandon(proposal) }, idKey, writeBytes, nil
+	return proposalCh, abandonToken(proposal), idKey, writeBytes, nil
 }
 
-func (r *Replica) abandon(proposal *ProposalData) {
+// abandonToken is an interface used for allowing callers to "abandon" an
+// in-flight proposal. The underlying *ProposalData (the only implementor of
+// this interface) must not be touched directly.
+type abandonToken interface {
+	isAbandonToken()
+}
+
+// abandon abandons the proposal associated with the abandon token.
+func (r *Replica) abandon(tok abandonToken) {
+	if tok == nil {
+		// A nil abandonToken is a no-op. This occurs when a write command ends up
+		// not needing to make any mutation to the state machine.
+		return
+	}
+	proposal := tok.(*ProposalData)
 	// The proposal may or may not be in the Replica's proposals map.
 	// Instead of trying to look it up, simply modify the captured object
 	// directly. The raftMu must be locked to modify the context of a

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -303,7 +303,7 @@ func (r *Replica) evalAndPropose(
 	// invoked when the command is applied. There are a handful of cases where
 	// the command may not be applied (or even processed): the process crashes
 	// or the local replica is removed from the range.
-	abandon := func() {
+	abandon := func(proposal *ProposalData) {
 		// The proposal may or may not be in the Replica's proposals map.
 		// Instead of trying to look it up, simply modify the captured object
 		// directly. The raftMu must be locked to modify the context of a
@@ -331,7 +331,7 @@ func (r *Replica) evalAndPropose(
 		ctx := r.AnnotateCtx(context.TODO())
 		last.ctx.Store(&ctx)
 	}
-	return proposalCh, abandon, idKey, writeBytes, nil
+	return proposalCh, func() { abandon(proposal) }, idKey, writeBytes, nil
 }
 
 func (r *Replica) encodePriorityForRACv2() bool {

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -185,7 +185,7 @@ func (r *Replica) executeWriteBatch(
 	// the concurrency guard will be assumed by Raft, so provide the guard to
 	// evalAndPropose. If we return with an error from executeWriteBatch, we
 	// also return the guard which the caller reassumes ownership of.
-	ch, abandon, _, writeBytes, pErr := r.evalAndPropose(ctx, ba, g, &st, ui, tok.Move(ctx))
+	ch, abandonTok, _, writeBytes, pErr := r.evalAndPropose(ctx, ba, g, &st, ui, tok.Move(ctx))
 	if pErr != nil {
 		if cErr, ok := pErr.GetDetail().(*kvpb.ReplicaCorruptionError); ok {
 			// Need to unlock here because setCorruptRaftMuLock needs readOnlyCmdMu not held.
@@ -340,7 +340,7 @@ func (r *Replica) executeWriteBatch(
 						}
 					})
 			}
-			abandon()
+			r.abandon(abandonTok)
 			dur := timeutil.Since(startTime)
 			log.VEventf(ctx, 2, "context cancellation after %.2fs of attempting command %s",
 				dur.Seconds(), ba)
@@ -351,7 +351,7 @@ func (r *Replica) executeWriteBatch(
 		case <-shouldQuiesce:
 			// If shutting down, return an AmbiguousResultError, which indicates
 			// to the caller that the command may have executed.
-			abandon()
+			r.abandon(abandonTok)
 			log.VEventf(ctx, 2, "shutdown cancellation after %0.1fs of attempting command %s",
 				timeutil.Since(startTime).Seconds(), ba)
 			return nil, nil, nil, kvpb.NewError(kvpb.NewAmbiguousResultErrorf(


### PR DESCRIPTION
On each raft write, we were returning a heap-allocated closure. Now we return the `*ProposalData`, opaquely wrapped as a `abandonToken` (to avoid access to the struct, which would race with below-raft access), which can be passed to newly introduced `(*Replica).abandon`.

Extracted from https://github.com/cockroachdb/cockroach/pull/137569.

Epic: CRDB-42584