### PR TITLE
server: remove alloc in setupSpanForIncomingRPC

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1998,7 +1998,9 @@ func setupSpanForIncomingRPC(
 			tracing.WithServerSpanKind)
 	}
 
-	newSpan.SetLazyTag("request", ba.ShallowCopy())
+	if newSpan != nil && !newSpan.IsNoop() {
+		newSpan.SetLazyTag("request", ba.ShallowCopy())
+	}
 	return ctx, spanForRequest{
 		// For non-local requests, we'll need to attach the recording to the
 		// outgoing BatchResponse if the request is traced. We ignore whether the


### PR DESCRIPTION
Extracted from #137569.

we were unconditionally heap allocationg `ba.ShallowCopy`, for 0.6% of allocs on oltp_write_only.

Epic: CRDB-42584