### PR TITLE
release-23.1: ccl/oidcccl: TestOIDCEnabled failed under stress

### DIFF
--- a/pkg/ccl/oidcccl/BUILD.bazel
+++ b/pkg/ccl/oidcccl/BUILD.bazel
@@ -55,7 +55,6 @@ go_test(
         "//pkg/server/serverpb",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/log",


### PR DESCRIPTION
Backport 1/1 commits from #131180.

/cc @cockroachdb/release

---

TestOIDCEnabled used to update the OIDC related cluster settings via SQL. This takes time to get reflected within the application handler and flakes the test under stress.

Updated the unit test to directly override cluster setting values within the application.

Fixes: #134628

Release note: None

Release justification: test fix