### PR TITLE
workload/schemachange: turn on exec logging for all statements

### DIFF
--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -595,8 +595,8 @@ func runRun(gen workload.Generator, urls []string, dbName string) error {
 				}
 				continue
 			}
-			// Log the error so we get the stack trace.
-			log.Errorf(ctx, "%v", err)
+			// Log the error with %+v so we get the stack trace.
+			log.Errorf(ctx, "workload run error: %+v", err)
 			return err
 
 		case <-ticker.C:

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -3144,6 +3144,10 @@ func (es *ErrorState) Unwrap() error {
 	return es.cause
 }
 
+func (es *ErrorState) Cause() error {
+	return es.cause
+}
+
 func (es *ErrorState) Error() string {
 	return es.cause.Error()
 }

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -339,8 +339,16 @@ func (s *schemaChange) Ops(
 // setClusterSettings configures any settings required for the workload ahead
 // of starting workers.
 func (s *schemaChange) setClusterSettings(ctx context.Context, pool *workload.MultiConnPool) error {
-	_, err := pool.Get().Exec(ctx, `SET CLUSTER SETTING sql.defaults.super_regions.enabled = 'on'`)
-	return errors.WithStack(err)
+	for _, stmt := range []string{
+		`SET CLUSTER SETTING sql.defaults.super_regions.enabled = 'on'`,
+		`SET CLUSTER SETTING sql.log.all_statements.enabled = 'on'`,
+	} {
+		_, err := pool.Get().Exec(ctx, stmt)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	}
+	return nil
 }
 
 // initSeqName returns the smallest available sequence number to be


### PR DESCRIPTION
### workload: log full stack trace of error on failure

### workload/schemachange: make ErrorState implement Cause()

This will make the error formatting work more conventionally.

### workload/schemachange: turn on exec logging

This will help us see exactly which statements were executed by the
workload, including helper queries.

Epic: None
Release note: None